### PR TITLE
Add Docker build and goreleaser release pipelines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Binaries and build artifacts
+bin/
+dist/
+*.exe
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+coverage.html
+
+# IDE and editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Environment
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git and CI
+.git/
+.github/
+.gitignore
+
+# Docs and non-build files
+docs/
+research/
+assets/
+examples/
+*.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/mrwong99/glyphoxa
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-cross
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,65 @@
+version: 2
+
+builds:
+  - id: glyphoxa
+    main: ./cmd/glyphoxa
+    binary: glyphoxa
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CC=x86_64-linux-gnu-gcc
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=o64-clang
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=oa64-clang
+    ldflags:
+      - -s -w
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: MrWong99
+    name: glyphoxa
+  draft: false
+  prerelease: auto
+  name_template: "{{ .Version }}"
+  header: |
+    # Release {{ .Version }}
+  footer: |
+    # Glyphoxa Docker image
+    docker pull ghcr.io/mrwong99/glyphoxa:v{{ .Version }}
+
+    Release Date: {{ .Date }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.26 AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 go build -o /out/glyphoxa -ldflags='-s -w -linkmode external -extldflags "-static"' ./cmd/glyphoxa
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/glyphoxa /usr/local/bin/glyphoxa
+
+ENTRYPOINT ["glyphoxa"]


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile with `golang:1.26` build stage (CGO_ENABLED=1) and `distroless/static-debian12:nonroot` runtime
- Add Docker publish workflow pushing to `ghcr.io/mrwong99/glyphoxa` with floating `main` tag and semver tags on `v*`
- Add goreleaser config for cross-compiling binaries (linux/darwin, amd64/arm64) using `goreleaser-cross`
- Add release workflow triggered on `v*` tags to create GitHub Releases with binaries and checksums

## Test plan

- [x] Docker build succeeds locally
- [x] Docker image runs correctly (`--help` works in distroless)
- [ ] Push to `main` triggers Docker workflow and pushes `main` tag to GHCR
- [ ] Pushing a `v*` tag triggers both Docker and release workflows
- [ ] Goreleaser produces binaries for all 4 platform/arch combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)