### PR TITLE
fix(web): harden auth cookie and provider URL handling

### DIFF
--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -68,19 +68,13 @@ func (s *Server) handleDiscordCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Clear the state cookie.
-	http.SetCookie(w, &http.Cookie{
-		Name:   "glyphoxa_oauth_state",
-		Value:  "",
-		Path:   "/",
-		MaxAge: -1,
-	})
+	clearAuthCookie(w, "glyphoxa_oauth_state")
 
 	var inviteToken string
 	if ic, err := r.Cookie("glyphoxa_invite"); err == nil {
 		inviteToken = ic.Value
 	}
-	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_invite", Value: "", Path: "/", MaxAge: -1})
+	clearAuthCookie(w, "glyphoxa_invite")
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -318,4 +312,19 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"data": user})
+}
+
+// clearAuthCookie expires a cookie using the same security flags it was set
+// with, so the Set-Cookie response matches the original cookie's scope and
+// does not silently widen it.
+func clearAuthCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/internal/web/handlers_oauth.go
+++ b/internal/web/handlers_oauth.go
@@ -68,13 +68,13 @@ func (s *Server) handleGoogleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_oauth_state", Value: "", Path: "/", MaxAge: -1})
+	clearAuthCookie(w, "glyphoxa_oauth_state")
 
 	var inviteToken string
 	if ic, err := r.Cookie("glyphoxa_invite"); err == nil {
 		inviteToken = ic.Value
 	}
-	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_invite", Value: "", Path: "/", MaxAge: -1})
+	clearAuthCookie(w, "glyphoxa_invite")
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -221,13 +221,13 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_oauth_state", Value: "", Path: "/", MaxAge: -1})
+	clearAuthCookie(w, "glyphoxa_oauth_state")
 
 	var inviteToken string
 	if ic, err := r.Cookie("glyphoxa_invite"); err == nil {
 		inviteToken = ic.Value
 	}
-	http.SetCookie(w, &http.Cookie{Name: "glyphoxa_invite", Value: "", Path: "/", MaxAge: -1})
+	clearAuthCookie(w, "glyphoxa_invite")
 
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internal/web/handlers_providers.go
+++ b/internal/web/handlers_providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -82,29 +83,23 @@ func testProviderConnection(r *http.Request, providerType, provider, apiKey, bas
 }
 
 func testLLMProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
-	var url string
+	var endpoint string
 	var authHeader string
 
 	switch provider {
 	case "openai":
-		url = "https://api.openai.com/v1/models"
-		if baseURL != "" {
-			url = baseURL + "/v1/models"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.openai.com", "/v1/models")
 		authHeader = "Bearer " + apiKey
 	case "anthropic":
-		url = "https://api.anthropic.com/v1/models"
-		if baseURL != "" {
-			url = baseURL + "/v1/models"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.anthropic.com", "/v1/models")
 		authHeader = apiKey // Anthropic uses x-api-key header
 	case "google", "gemini":
-		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1/models?key=%s", apiKey)
+		endpoint = fmt.Sprintf("https://generativelanguage.googleapis.com/v1/models?key=%s", url.QueryEscape(apiKey))
 	default:
 		return fmt.Errorf("unsupported LLM provider: %s", provider)
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -133,23 +128,17 @@ func testLLMProvider(r *http.Request, client *http.Client, provider, apiKey, bas
 }
 
 func testSTTProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
-	var url string
+	var endpoint string
 	switch provider {
 	case "deepgram":
-		url = "https://api.deepgram.com/v1/projects"
-		if baseURL != "" {
-			url = baseURL + "/v1/projects"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.deepgram.com", "/v1/projects")
 	case "whisper", "openai":
-		url = "https://api.openai.com/v1/models"
-		if baseURL != "" {
-			url = baseURL + "/v1/models"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.openai.com", "/v1/models")
 	default:
 		return fmt.Errorf("unsupported STT provider: %s", provider)
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -176,23 +165,17 @@ func testSTTProvider(r *http.Request, client *http.Client, provider, apiKey, bas
 }
 
 func testTTSProvider(r *http.Request, client *http.Client, provider, apiKey, baseURL string) error {
-	var url string
+	var endpoint string
 	switch provider {
 	case "elevenlabs":
-		url = "https://api.elevenlabs.io/v1/voices"
-		if baseURL != "" {
-			url = baseURL + "/v1/voices"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.elevenlabs.io", "/v1/voices")
 	case "openai":
-		url = "https://api.openai.com/v1/models"
-		if baseURL != "" {
-			url = baseURL + "/v1/models"
-		}
+		endpoint = buildProviderURL(baseURL, "https://api.openai.com", "/v1/models")
 	default:
 		return fmt.Errorf("unsupported TTS provider: %s", provider)
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}

--- a/internal/web/urlvalidation.go
+++ b/internal/web/urlvalidation.go
@@ -86,6 +86,26 @@ func isBlockedCIDR(ip net.IP) bool {
 	return false
 }
 
+// buildProviderURL composes the outbound URL from an optional user-supplied
+// baseURL (already validated by validateBaseURL) plus a constant path suffix.
+// Query, fragment, and userinfo from baseURL are stripped so user-controlled
+// parts of the URL cannot reach the request beyond scheme/host/path.
+func buildProviderURL(baseURL, defaultHostURL, path string) string {
+	if baseURL == "" {
+		return defaultHostURL + path
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return defaultHostURL + path
+	}
+	clean := url.URL{
+		Scheme: parsed.Scheme,
+		Host:   parsed.Host,
+		Path:   parsed.Path + path,
+	}
+	return clean.String()
+}
+
 // validateBaseURL checks that a user-supplied base URL is safe to use
 // for outbound HTTP requests. It rejects private IPs, internal DNS
 // names, cloud metadata endpoints, and Kubernetes service addresses

--- a/internal/web/urlvalidation_test.go
+++ b/internal/web/urlvalidation_test.go
@@ -327,6 +327,78 @@ func TestValidateBaseURL(t *testing.T) {
 	}
 }
 
+func TestBuildProviderURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		baseURL        string
+		defaultHostURL string
+		path           string
+		want           string
+	}{
+		{
+			name:           "empty baseURL uses default",
+			baseURL:        "",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://api.openai.com/v1/models",
+		},
+		{
+			name:           "baseURL host replaces default",
+			baseURL:        "https://proxy.example.com",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://proxy.example.com/v1/models",
+		},
+		{
+			name:           "baseURL path is preserved (Azure-style)",
+			baseURL:        "https://my.openai.azure.com/openai",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://my.openai.azure.com/openai/v1/models",
+		},
+		{
+			name:           "baseURL query string is stripped",
+			baseURL:        "https://proxy.example.com?foo=bar&x=y",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://proxy.example.com/v1/models",
+		},
+		{
+			name:           "baseURL fragment is stripped",
+			baseURL:        "https://proxy.example.com#evil",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://proxy.example.com/v1/models",
+		},
+		{
+			name:           "baseURL userinfo is stripped",
+			baseURL:        "https://user:pass@proxy.example.com",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://proxy.example.com/v1/models",
+		},
+		{
+			name:           "baseURL with port",
+			baseURL:        "https://proxy.example.com:8443",
+			defaultHostURL: "https://api.openai.com",
+			path:           "/v1/models",
+			want:           "https://proxy.example.com:8443/v1/models",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildProviderURL(tt.baseURL, tt.defaultHostURL, tt.path)
+			if got != tt.want {
+				t.Errorf("buildProviderURL(%q, %q, %q) = %q, want %q", tt.baseURL, tt.defaultHostURL, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsPrivateIP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Bundled fix addressing open CodeQL alerts in `internal/web/`:

**Cookie security** (alerts #6–#14)
- `handlers_auth.go` and `handlers_oauth.go` cleared OAuth state / invite cookies by calling `http.SetCookie` with only `Name`, `Value`, `Path`, `MaxAge` — dropping the `HttpOnly`, `Secure`, and `SameSite` flags that the cookies were originally set with.
- Without those flags, the expiry response silently widens the cookie's scope (e.g. it becomes accessible to JavaScript or over plain HTTP), which CodeQL flagged as `go/cookie-secure-not-set` and `go/cookie-httponly-not-set`.
- Introduced a shared `clearAuthCookie(w, name)` helper that expires the cookie with the same security flags, and rewrote the 6 call sites to use it.

**SSRF / request forgery** (alerts #15–#17)
- `handlers_providers.go` built outbound URLs as `baseURL + "/v1/models"` etc. Even though `validateBaseURL` already rejects private IPs, internal DNS, and cloud metadata endpoints, the old concatenation let a user-supplied `baseURL` embed arbitrary query strings, fragments, or userinfo that would be carried into the outbound request.
- New `buildProviderURL(baseURL, defaultHostURL, path)` helper parses `baseURL`, keeps only `scheme + host + path`, and appends a constant path suffix. Query, fragment, and userinfo are discarded.
- The Google Gen Language URL now `url.QueryEscape`s the API key instead of string-interpolating it.
- Preserves the Azure-OpenAI-style config (where baseURL has a path prefix like `/openai`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/web/...`
- [x] `gofmt -l` (clean)
- [x] `golangci-lint run ./internal/web/...` (0 issues)
- [x] `go test -race -count=1 ./internal/web/...` (all pass)
- [x] New `TestBuildProviderURL` covers query/fragment/userinfo stripping, Azure-style path preservation, and port retention.
- [ ] CodeQL re-scan on CI should drop alerts #6–#14 and #15–#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)