### PR TITLE
fix(ci): restrict auto-fix workflow to same-repo PRs

### DIFF
--- a/.github/workflows/ci-failure-auto-fix.yml
+++ b/.github/workflows/ci-failure-auto-fix.yml
@@ -15,9 +15,15 @@ permissions:
 
 jobs:
   auto-fix:
+    # Only run for PRs whose head branch lives in this repository. Fork PRs
+    # carry untrusted code, and this job checks out that code into a
+    # privileged context (contents: write + pull-requests: write + secrets),
+    # which CodeQL flags as actions/untrusted-checkout/high. Push access to
+    # this repo is already restricted, so any in-repo branch is trusted.
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0] &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

`ci-failure-auto-fix.yml` triggers on `workflow_run`, checks out the PR's head branch, and runs `claude-code-action` with `contents: write`, `pull-requests: write`, `issues: write`, plus the `CLAUDE_CODE_OAUTH_TOKEN` secret. When the PR comes from a fork, the checkout pulls untrusted code into that privileged context — a malicious build script in `package.json`, `go generate`, or a `pre-commit` hook could run with those permissions.

CodeQL flagged this as `actions/untrusted-checkout/high` (alert #2).

## Fix

Gate the job on `github.event.workflow_run.head_repository.full_name == github.repository`. Push access to this repo is already restricted, so any in-repo branch (including dependabot's) is trusted. Fork PRs will no longer trigger auto-fix — they'll need a human to open an in-repo branch instead.

## Test plan

- [x] YAML syntax valid (GitHub will parse on merge).
- [ ] CodeQL re-scan on CI should drop alert #2.
- [ ] Future dependabot/in-repo PRs should continue to trigger auto-fix unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)