### PR TITLE
chore(ci): record-live cron once a week instead of nightly

### DIFF
--- a/.github/workflows/record-live.yml
+++ b/.github/workflows/record-live.yml
@@ -8,7 +8,7 @@ name: record-live
 # wants to re-record cassettes from a feature branch.
 on:
   schedule:
-    - cron: "0 6 * * *" # 06:00 UTC — outside European working hours.
+    - cron: "0 6 * * 1" # Monday 06:00 UTC (08:00 CEST / 07:00 CET).
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

- Drop the nightly cron on record-live.yml down to a once-a-week Monday-morning sweep (`0 6 * * 1` UTC = 08:00 CEST / 07:00 CET).

## Why

Nightly was overkill for a project this size, and every fire spends ElevenLabs credits. Once-a-week vendor-drift detection is enough — and `workflow_dispatch` is still wired for on-demand reruns whenever you want to re-record from a feature branch.

## Test plan

- [x] YAML still parses
- [ ] Next Monday 06:00 UTC: workflow fires; until then verify the cron schedule on the Actions UI shows "Next run: Monday"

🤖 Generated with [Claude Code](https://claude.com/claude-code)