### PR TITLE
feat(voice/stt): ElevenLabs scribe_v2 adapter + cassette record path

### DIFF
--- a/pkg/voice/stt/elevenlabs/elevenlabs.go
+++ b/pkg/voice/stt/elevenlabs/elevenlabs.go
@@ -1,0 +1,72 @@
+// Package elevenlabs implements the v2 STT provider surface against the
+// ElevenLabs HTTP API, targeting the scribe_v2 model.
+//
+// The [Client] satisfies [stt.Recognizer]: utterance-scoped batch
+// transcription that maps one-to-one to a POST /v1/speech-to-text call. The
+// orchestrator's STT stage forwards [audio.Frame]s and republishes the
+// returned [stt.Transcript] as [voiceevent.STTFinal] per ADR-0020.
+//
+// Authentication is BYOK per ADR-0004: callers either pass the API key to
+// [New] or set ELEVENLABS_API_KEY. [New] never fails so that cassette-replay
+// test binaries can link this package without an API key configured —
+// missing-key errors surface at request time instead, matching the TTS
+// adapter's posture.
+package elevenlabs
+
+import (
+	"net/http"
+	"os"
+)
+
+const (
+	// DefaultBaseURL is the ElevenLabs production API root.
+	DefaultBaseURL = "https://api.elevenlabs.io"
+
+	// APIKeyEnv is the environment variable [New] consults when its apiKey
+	// argument is empty. Shared with the TTS adapter — one BYOK key per
+	// ElevenLabs Tenant covers every Component the provider offers.
+	APIKeyEnv = "ELEVENLABS_API_KEY"
+
+	// ProviderID is the stable identifier for this STT adapter. Matches the
+	// TTS adapter's ProviderID because a single ElevenLabs Provider Config
+	// covers every Component (ADR-0004).
+	ProviderID = "elevenlabs"
+)
+
+// Client is the ElevenLabs STT adapter. Construct with [New]; the zero value
+// is not usable. Safe for concurrent use across goroutines.
+type Client struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+// Option mutates a [Client] during construction.
+type Option func(*Client)
+
+// WithBaseURL overrides the API base URL. Useful for tests (httptest server)
+// and self-hosted ElevenLabs deployments.
+func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
+
+// WithHTTPClient supplies a custom http.Client. The default has no overall
+// timeout; per-call deadlines must come from the request context.
+func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// New constructs a [Client]. If apiKey is empty it falls back to the
+// ELEVENLABS_API_KEY environment variable; if that is also empty, the
+// returned client still links — calls return a "missing API key" error
+// rather than panicking on construction.
+func New(apiKey string, opts ...Option) *Client {
+	if apiKey == "" {
+		apiKey = os.Getenv(APIKeyEnv)
+	}
+	c := &Client{
+		apiKey:  apiKey,
+		baseURL: DefaultBaseURL,
+		http:    &http.Client{},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}

--- a/pkg/voice/stt/elevenlabs/elevenlabs_test.go
+++ b/pkg/voice/stt/elevenlabs/elevenlabs_test.go
@@ -1,0 +1,246 @@
+package elevenlabs_test
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+)
+
+// frame16k32ms is a helper that builds one [audio.Frame] of 16 kHz / 32 ms
+// mono PCM filled with the supplied samples (length must be 512).
+func frame16k32ms(t *testing.T, samples []int16) audio.Frame {
+	t.Helper()
+	f, err := audio.NewFrame(samples, 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// Compile-time assertion: [elevenlabs.Client] satisfies [stt.Recognizer],
+// which is the only contract the orchestrator's STT stage depends on.
+var _ stt.Recognizer = (*elevenlabs.Client)(nil)
+
+// TestNew_NoKey_NoEnv_TranscribeReturnsMissingKeyError pins the same
+// link-time-safety property the TTS adapter has: New must not panic without
+// an API key (cassette-replay test binaries link this package
+// unconditionally); the missing-key error surfaces at the first request.
+func TestNew_NoKey_NoEnv_TranscribeReturnsMissingKeyError(t *testing.T) {
+	t.Setenv("ELEVENLABS_API_KEY", "")
+	c := elevenlabs.New("")
+	_, err := c.Transcribe(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Transcribe without API key returned nil error")
+	}
+	if !strings.Contains(err.Error(), "missing API key") {
+		t.Errorf("error %q does not mention missing API key", err)
+	}
+}
+
+// TestTranscribe_HappyPath_ReturnsResponseText pins the smallest end-to-end
+// loop: the adapter posts to /v1/speech-to-text and decodes the response's
+// "text" field into [stt.Transcript.Text]. Request-shape assertions live in
+// a separate test (TB3); this one cares only about the response decode.
+func TestTranscribe_HappyPath_ReturnsResponseText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"language_code":"en","language_probability":0.98,"text":"hello world"}`))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("k", elevenlabs.WithBaseURL(srv.URL))
+	frames := []audio.Frame{frame16k32ms(t, make([]int16, 512))}
+
+	tr, err := c.Transcribe(context.Background(), frames)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if tr.Text != "hello world" {
+		t.Errorf("Transcript.Text = %q, want %q", tr.Text, "hello world")
+	}
+}
+
+// TestTranscribe_RequestShape_PinsMultipartAndRawPCMBytes is the
+// adapter↔ElevenLabs API contract: the request must carry the BYOK key in
+// xi-api-key, target scribe_v2, declare file_format=pcm_s16le_16, and the
+// `file` part bytes must be the concatenated little-endian int16 sample
+// stream of the input frames — no WAV wrap, no re-ordering.
+//
+// Pinning this in a test (rather than only in code) catches accidental
+// drift on either side: if a future refactor wraps the body as WAV or
+// switches to scribe_v1, this fires.
+func TestTranscribe_RequestShape_PinsMultipartAndRawPCMBytes(t *testing.T) {
+	// Two distinguishable frames so byte-order matters: frame 0 = 0..511,
+	// frame 1 = 1000..1511. Concatenated LE int16 stream is what we expect
+	// to see in the `file` part.
+	const samplesPerFrame = 512
+	mk := func(start int) []int16 {
+		s := make([]int16, samplesPerFrame)
+		for i := range s {
+			s[i] = int16(start + i)
+		}
+		return s
+	}
+	frames := []audio.Frame{
+		frame16k32ms(t, mk(0)),
+		frame16k32ms(t, mk(1000)),
+	}
+
+	var wantPCM []byte
+	for _, f := range frames {
+		for _, s := range f.Samples() {
+			var buf [2]byte
+			binary.LittleEndian.PutUint16(buf[:], uint16(s))
+			wantPCM = append(wantPCM, buf[:]...)
+		}
+	}
+
+	var sawAPIKey atomic.Value
+	var sawModel atomic.Value
+	var sawFileFormat atomic.Value
+	var sawFileBytes atomic.Value
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/speech-to-text" {
+			t.Errorf("path = %q, want /v1/speech-to-text", r.URL.Path)
+		}
+		sawAPIKey.Store(r.Header.Get("xi-api-key"))
+
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		if vs := r.MultipartForm.Value["model_id"]; len(vs) == 1 {
+			sawModel.Store(vs[0])
+		}
+		if vs := r.MultipartForm.Value["file_format"]; len(vs) == 1 {
+			sawFileFormat.Store(vs[0])
+		}
+		files := r.MultipartForm.File["file"]
+		if len(files) != 1 {
+			t.Fatalf("multipart files[\"file\"] len = %d, want 1", len(files))
+		}
+		fh, err := files[0].Open()
+		if err != nil {
+			t.Fatalf("file part open: %v", err)
+		}
+		defer fh.Close()
+		got, err := io.ReadAll(fh)
+		if err != nil {
+			t.Fatalf("file part read: %v", err)
+		}
+		sawFileBytes.Store(got)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"ok"}`))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("expected-key", elevenlabs.WithBaseURL(srv.URL))
+	if _, err := c.Transcribe(context.Background(), frames); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+
+	if got, _ := sawAPIKey.Load().(string); got != "expected-key" {
+		t.Errorf("xi-api-key = %q, want %q", got, "expected-key")
+	}
+	if got, _ := sawModel.Load().(string); got != "scribe_v2" {
+		t.Errorf("model_id = %q, want %q", got, "scribe_v2")
+	}
+	if got, _ := sawFileFormat.Load().(string); got != "pcm_s16le_16" {
+		t.Errorf("file_format = %q, want %q", got, "pcm_s16le_16")
+	}
+	gotBytes, _ := sawFileBytes.Load().([]byte)
+	if len(gotBytes) != len(wantPCM) {
+		t.Fatalf("file bytes len = %d, want %d", len(gotBytes), len(wantPCM))
+	}
+	for i := range gotBytes {
+		if gotBytes[i] != wantPCM[i] {
+			t.Fatalf("file bytes differ at offset %d: got 0x%02x want 0x%02x", i, gotBytes[i], wantPCM[i])
+		}
+	}
+}
+
+// TestNew_EnvFallback_HeaderCarriesEnvKey mirrors the TTS adapter:
+// New("") consults ELEVENLABS_API_KEY and the resolved key reaches the
+// outbound request's xi-api-key header.
+func TestNew_EnvFallback_HeaderCarriesEnvKey(t *testing.T) {
+	t.Setenv("ELEVENLABS_API_KEY", "env-key-abc")
+
+	var seenKey atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenKey.Store(r.Header.Get("xi-api-key"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":""}`))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("", elevenlabs.WithBaseURL(srv.URL))
+	if _, err := c.Transcribe(context.Background(), nil); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if got, _ := seenKey.Load().(string); got != "env-key-abc" {
+		t.Errorf("xi-api-key header = %q, want %q", got, "env-key-abc")
+	}
+}
+
+// TestNew_ExplicitKeyWinsOverEnv pins the precedence rule: an explicit key
+// passed to New beats whatever ELEVENLABS_API_KEY is set to.
+func TestNew_ExplicitKeyWinsOverEnv(t *testing.T) {
+	t.Setenv("ELEVENLABS_API_KEY", "env-key")
+
+	var seenKey atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenKey.Store(r.Header.Get("xi-api-key"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":""}`))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("explicit-key", elevenlabs.WithBaseURL(srv.URL))
+	if _, err := c.Transcribe(context.Background(), nil); err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if got, _ := seenKey.Load().(string); got != "explicit-key" {
+		t.Errorf("xi-api-key header = %q, want %q", got, "explicit-key")
+	}
+}
+
+// TestTranscribe_Non2xx_WrapsOpAndStatus pins the error-surface shape:
+// a non-2xx response yields an error that names the operation and the HTTP
+// status, with a snippet of the body for diagnostic context. Test harnesses
+// and on-call reviewers grep for this shape, so it is a contract.
+func TestTranscribe_Non2xx_WrapsOpAndStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"invalid_api_key"}`))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("bad-key", elevenlabs.WithBaseURL(srv.URL))
+	_, err := c.Transcribe(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Transcribe with 401 returned nil error")
+	}
+	got := err.Error()
+	for _, must := range []string{"Transcribe", "401", "invalid_api_key"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("error %q missing required substring %q", got, must)
+		}
+	}
+}

--- a/pkg/voice/stt/elevenlabs/transcribe.go
+++ b/pkg/voice/stt/elevenlabs/transcribe.go
@@ -1,0 +1,112 @@
+package elevenlabs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+)
+
+// Model is the canonical ElevenLabs Scribe v2 model identifier — the v1.0
+// successor to scribe_v1 and the model the adapter targets unconditionally.
+const Model = "scribe_v2"
+
+// FileFormatPCMS16LE16 is the ElevenLabs `file_format` value that accepts a
+// raw little-endian signed-16-bit PCM stream at 16 kHz mono — matches
+// [audio.Frame] natively, so no WAV header / re-encoding is needed.
+const FileFormatPCMS16LE16 = "pcm_s16le_16"
+
+// Transcribe implements [stt.Recognizer]. One call → one POST
+// /v1/speech-to-text request → one [stt.Transcript].
+//
+// Frames are streamed verbatim as `file_format=pcm_s16le_16`: the underlying
+// little-endian int16 samples are concatenated in frame order and uploaded
+// as the multipart `file` part. No vendor-side resampling is invoked because
+// the orchestrator's STT stage already feeds frames at the rate the
+// recognizer requires.
+//
+// Returns a non-nil error when the call cannot be started (missing key) or
+// when the response is non-2xx; on success returns the response's `text`
+// field verbatim.
+func (c *Client) Transcribe(ctx context.Context, frames []audio.Frame) (stt.Transcript, error) {
+	if c.apiKey == "" {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: missing API key (set %s or pass it to New)", APIKeyEnv)
+	}
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if err := mw.WriteField("model_id", Model); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write model_id: %w", err)
+	}
+	if err := mw.WriteField("file_format", FileFormatPCMS16LE16); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write file_format: %w", err)
+	}
+	filePart, err := mw.CreateFormFile("file", "utterance.pcm")
+	if err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: create file part: %w", err)
+	}
+	if err := writePCM16LE(filePart, frames); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write PCM: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: close multipart: %w", err)
+	}
+
+	u := strings.TrimRight(c.baseURL, "/") + "/v1/speech-to-text"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, &body)
+	if err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: build request: %w", err)
+	}
+	req.Header.Set("xi-api-key", c.apiKey)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return stt.Transcript{}, readErrorResponse(resp, "Transcribe")
+	}
+
+	var decoded struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: decode body: %w", err)
+	}
+	return stt.Transcript{Text: decoded.Text}, nil
+}
+
+// writePCM16LE emits the concatenated little-endian int16 sample stream of
+// frames to w in frame order. Buffered scratch keeps the encoding loop free
+// of per-sample allocations.
+func writePCM16LE(w io.Writer, frames []audio.Frame) error {
+	var buf [2]byte
+	for _, f := range frames {
+		for _, s := range f.Samples() {
+			binary.LittleEndian.PutUint16(buf[:], uint16(s))
+			if _, err := w.Write(buf[:]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// readErrorResponse reads up to 512 bytes of a non-2xx response body for
+// diagnostic context and wraps it as an error naming the operation.
+func readErrorResponse(resp *http.Response, op string) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("elevenlabs.%s: HTTP %d %s: %s",
+		op, resp.StatusCode, resp.Status, strings.TrimSpace(string(snippet)))
+}

--- a/pkg/voice/voicecassette/stt_internal_test.go
+++ b/pkg/voice/voicecassette/stt_internal_test.go
@@ -1,0 +1,47 @@
+package voicecassette
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+)
+
+// silenceFrame is a deterministic frame of zero samples, useful for
+// hash-mismatch tests that want input distinct from a real clip's PCM.
+func silenceFrame(t *testing.T, sampleRate, frameMs int) audio.Frame {
+	t.Helper()
+	n := sampleRate * frameMs / 1000
+	f, err := audio.NewFrame(make([]int16, n), sampleRate, frameMs)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// TestSTTRecognizer_HashMismatchPointsAtRecord pins the replay matcher's
+// contract: when the incoming frames hash to something other than the
+// cassette's recorded audio_sha256, the error must direct the caller at
+// the re-record workflow.
+//
+// Whitebox so the test runs in both default and -tags=record builds —
+// LoadSTT swaps implementations across build tags, but the replay matcher
+// itself does not, and that's what's under test.
+func TestSTTRecognizer_HashMismatchPointsAtRecord(t *testing.T) {
+	t.Parallel()
+	r := &STTRecognizer{
+		name: "stt-fixture",
+		cassette: STTCassette{
+			AudioSHA256: "deadbeef",
+			Transcript:  "ignored",
+		},
+	}
+	_, err := r.Transcribe(context.Background(), []audio.Frame{silenceFrame(t, 16000, 32)})
+	if err == nil {
+		t.Fatal("Transcribe with wrong audio returned nil error")
+	}
+	if !strings.Contains(err.Error(), "-tags=record") {
+		t.Errorf("error %q does not point at -tags=record", err)
+	}
+}

--- a/pkg/voice/voicecassette/stt_record.go
+++ b/pkg/voice/voicecassette/stt_record.go
@@ -1,0 +1,107 @@
+//go:build record
+
+package voicecassette
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadSTT in -tags=record builds returns an [STTRecorder] that proxies
+// every Transcribe call to a live ElevenLabs scribe_v2 client, captures
+// the resulting transcript, and rewrites tests/voice-cassettes/<name>.yaml
+// at test cleanup with the captured (audio_sha256, transcript) pair. The
+// ELEVENLABS_API_KEY environment variable supplies credentials.
+//
+// Any existing cassette's Notes field is preserved (with a "Re-recorded
+// against ElevenLabs scribe_v2 on <date>" provenance line appended) so
+// reviewer-facing context survives the refresh.
+func LoadSTT(t *testing.T, name string) stt.Recognizer {
+	t.Helper()
+	existing, _ := loadSTTCassetteFromDisk(t, name, false)
+	r := &STTRecorder{
+		name:     name,
+		client:   elevenlabs.New(""),
+		existing: existing,
+	}
+	t.Cleanup(func() {
+		if err := r.write(); err != nil {
+			t.Fatalf("voicecassette.LoadSTT(%q): record write: %v", name, err)
+		}
+	})
+	return r
+}
+
+// STTRecorder is the -tags=record counterpart to [STTRecognizer]: it
+// forwards every Transcribe call to a live [elevenlabs.Client] and
+// captures the (frame hash, returned text) pair so the cassette can be
+// rewritten at test cleanup.
+//
+// One cassette pins one utterance, so calling Transcribe multiple times
+// against the same recorder overwrites — the last call wins, matching the
+// fact that replay mode also re-hashes-and-compares on each call without
+// tracking position.
+type STTRecorder struct {
+	name       string
+	client     *elevenlabs.Client
+	existing   STTCassette
+	hash       string
+	transcript string
+	captured   bool
+}
+
+// Transcribe implements [stt.Recognizer]. Forwards to the live client,
+// captures the frame hash and the returned transcript text, and returns
+// the live result so the test under record mode exercises the orchestrator
+// against real provider output.
+func (r *STTRecorder) Transcribe(ctx context.Context, frames []audio.Frame) (stt.Transcript, error) {
+	tr, err := r.client.Transcribe(ctx, frames)
+	if err != nil {
+		return stt.Transcript{}, fmt.Errorf("voicecassette: STTRecorder live Transcribe for cassette %q: %w", r.name, err)
+	}
+	r.hash = HashFrames(frames)
+	r.transcript = tr.Text
+	r.captured = true
+	return tr, nil
+}
+
+// write serialises the captured (hash, transcript) pair plus preserved
+// Notes + a fresh provenance line to tests/voice-cassettes/<name>.yaml. A
+// no-op if Transcribe was never called — recording a test that never
+// invoked the recognizer would clobber the existing fixture with an empty
+// audio_sha256.
+func (r *STTRecorder) write() error {
+	if !r.captured {
+		return nil
+	}
+	out := STTCassette{
+		AudioSHA256: r.hash,
+		Transcript:  r.transcript,
+		Notes:       r.existing.Notes,
+	}
+	stamp := time.Now().UTC().Format("2006-01-02")
+	provenance := fmt.Sprintf("Re-recorded against ElevenLabs scribe_v2 on %s.", stamp)
+	if out.Notes == "" {
+		out.Notes = provenance
+	} else {
+		out.Notes = out.Notes + "\n\n" + provenance
+	}
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshal cassette: %w", err)
+	}
+	path := filepath.Join(cassettesDir(), r.name+".yaml")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/voice/voicecassette/stt_record_test.go
+++ b/pkg/voice/voicecassette/stt_record_test.go
@@ -1,0 +1,117 @@
+//go:build record
+
+package voicecassette
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSTTRecorder_WriteOnCleanup wires the recorder against an httptest
+// server standing in for the ElevenLabs API and asserts the end-to-end
+// record loop: dispatched frames are forwarded, the live transcript is
+// captured, and the on-disk cassette is rewritten at cleanup with the
+// captured (audio_sha256, transcript) pair plus preserved Notes + a
+// provenance stamp.
+//
+// Whitebox by necessity — we construct [STTRecorder] directly to inject a
+// fake-base-URL client, which the LoadSTT entry point does not expose.
+func TestSTTRecorder_WriteOnCleanup(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"text":"live transcription"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	orig := cassettesDir
+	cassettesDir = func() string { return dir }
+	t.Cleanup(func() { cassettesDir = orig })
+
+	name := "stt-record-test"
+	client := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	r := &STTRecorder{
+		name:     name,
+		client:   client,
+		existing: STTCassette{Notes: "preserved provenance"},
+	}
+
+	samples := make([]int16, 512)
+	for i := range samples {
+		samples[i] = int16(i)
+	}
+	frame, err := audio.NewFrame(samples, 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	frames := []audio.Frame{frame}
+	wantHash := HashFrames(frames)
+
+	tr, err := r.Transcribe(context.Background(), frames)
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if tr.Text != "live transcription" {
+		t.Errorf("Transcript.Text = %q, want %q", tr.Text, "live transcription")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("HTTP calls = %d, want 1", got)
+	}
+
+	if err := r.write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, name+".yaml"))
+	if err != nil {
+		t.Fatalf("read written cassette: %v", err)
+	}
+	var got STTCassette
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal written cassette: %v", err)
+	}
+	if got.AudioSHA256 != wantHash {
+		t.Errorf("AudioSHA256 = %q, want %q", got.AudioSHA256, wantHash)
+	}
+	if got.Transcript != "live transcription" {
+		t.Errorf("Transcript = %q, want %q", got.Transcript, "live transcription")
+	}
+	if !strings.Contains(got.Notes, "preserved provenance") {
+		t.Errorf("Notes lost preserved content: %q", got.Notes)
+	}
+	if !strings.Contains(got.Notes, "Re-recorded against ElevenLabs scribe_v2") {
+		t.Errorf("Notes missing provenance stamp: %q", got.Notes)
+	}
+}
+
+// TestSTTRecorder_NoCallsNoWrite verifies the guard that prevents an empty
+// recording (test never invoked the recognizer) from clobbering the
+// existing fixture with an empty audio_sha256.
+func TestSTTRecorder_NoCallsNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	orig := cassettesDir
+	cassettesDir = func() string { return dir }
+	t.Cleanup(func() { cassettesDir = orig })
+
+	name := "stt-empty-record"
+	r := &STTRecorder{name: name, client: elevenlabs.New("test-key")}
+	if err := r.write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, name+".yaml")); !os.IsNotExist(err) {
+		t.Errorf("write created file despite zero captures: err=%v", err)
+	}
+}

--- a/pkg/voice/voicecassette/stt_replay.go
+++ b/pkg/voice/voicecassette/stt_replay.go
@@ -1,0 +1,23 @@
+//go:build !record
+
+package voicecassette
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+)
+
+// LoadSTT reads tests/voice-cassettes/<name>.yaml and returns a
+// [stt.Recognizer] that replays it.
+//
+// Default (replay) build: returns a [*STTRecognizer] that re-hashes the
+// frames it is fed and returns the cassette's pinned transcript on match.
+// Missing, malformed, or empty cassettes fail the test. To rewrite a
+// cassette against the live ElevenLabs API, rebuild with `-tags=record` —
+// see stt_record.go.
+func LoadSTT(t *testing.T, name string) stt.Recognizer {
+	t.Helper()
+	c, _ := loadSTTCassetteFromDisk(t, name, true)
+	return &STTRecognizer{name: name, cassette: c}
+}

--- a/pkg/voice/voicecassette/voicecassette.go
+++ b/pkg/voice/voicecassette/voicecassette.go
@@ -70,23 +70,35 @@ type STTRecognizer struct {
 	cassette STTCassette
 }
 
-// LoadSTT reads tests/voice-cassettes/<name>.yaml and returns a recognizer
-// that replays it. Missing or malformed cassettes fail the test.
-func LoadSTT(t *testing.T, name string) *STTRecognizer {
+// loadSTTCassetteFromDisk reads tests/voice-cassettes/<name>.yaml and
+// returns the decoded cassette. When mustExist is true (replay mode) every
+// failure path — missing file, malformed YAML, empty audio_sha256 — is
+// fatal. When mustExist is false (record mode), a missing file yields
+// (zero, false) because the recorder will write a fresh cassette;
+// malformed existing files still fail so a corrupted fixture is never
+// silently overwritten.
+//
+// One function instead of two so neither build configuration (default
+// replay vs -tags=record) sees an unused helper — only one of LoadSTT's
+// build-tag variants is compiled at a time.
+func loadSTTCassetteFromDisk(t *testing.T, name string, mustExist bool) (STTCassette, bool) {
 	t.Helper()
 	path := filepath.Join(cassettesDir(), name+".yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if !mustExist && os.IsNotExist(err) {
+			return STTCassette{}, false
+		}
 		t.Fatalf("voicecassette.LoadSTT(%q): %v", name, err)
 	}
 	var c STTCassette
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		t.Fatalf("voicecassette.LoadSTT(%q): unmarshal: %v", name, err)
 	}
-	if c.AudioSHA256 == "" {
+	if mustExist && c.AudioSHA256 == "" {
 		t.Fatalf("voicecassette.LoadSTT(%q): cassette has empty audio_sha256", name)
 	}
-	return &STTRecognizer{name: name, cassette: c}
+	return c, true
 }
 
 // Transcribe implements [stt.Recognizer]. Returns the pinned transcript on

--- a/pkg/voice/voicecassette/voicecassette_test.go
+++ b/pkg/voice/voicecassette/voicecassette_test.go
@@ -1,8 +1,6 @@
 package voicecassette_test
 
 import (
-	"context"
-	"strings"
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
@@ -37,18 +35,3 @@ func TestHashFrames_StableAcrossFraming(t *testing.T) {
 	}
 }
 
-func TestSTTRecognizer_HashMismatchPointsAtRecord(t *testing.T) {
-	t.Parallel()
-
-	// hello-test is loaded by name but we feed *silence* instead of the
-	// clip's PCM. The cassette must refuse to replay and the error must
-	// nudge the caller to re-record.
-	r := voicecassette.LoadSTT(t, "stt-hello-test")
-	_, err := r.Transcribe(context.Background(), []audio.Frame{silenceFrame(t, 16000, 32)})
-	if err == nil {
-		t.Fatal("Transcribe with wrong audio returned nil error")
-	}
-	if !strings.Contains(err.Error(), "-tags=record") {
-		t.Errorf("error %q does not point at -tags=record", err)
-	}
-}

--- a/pkg/voice/voicecassette/voicecassette_test.go
+++ b/pkg/voice/voicecassette/voicecassette_test.go
@@ -34,4 +34,3 @@ func TestHashFrames_StableAcrossFraming(t *testing.T) {
 		t.Errorf("hash differs across reframings:\n  32ms x1: %s\n  16ms x2: %s", a, b)
 	}
 }
-


### PR DESCRIPTION
## Summary

Mirrors PR #2 (TTS) for the STT row of the BYOK provider matrix (ADR-0004). Lands a live ElevenLabs Speech-to-Text adapter satisfying `stt.Recognizer`, plus the previously-forward-looking `-tags=record` cassette refresh path for STT.

- **`pkg/voice/stt/elevenlabs`** — `Client` satisfies `stt.Recognizer`. `Transcribe` posts `POST /v1/speech-to-text` as `multipart/form-data` with `model_id=scribe_v2` and `file_format=pcm_s16le_16` — the input frames' little-endian int16 samples are concatenated and uploaded verbatim as the `file` part, so no WAV wrap and no resampling: 16 kHz mono `audio.Frame`s map onto ElevenLabs's lowest-latency input format natively. Response `text` field becomes `stt.Transcript.Text` (`language_code`, `words`, etc. ignored for v1.0 since the orchestrator's STT stage only republishes text per ADR-0020).
- **`pkg/voice/voicecassette` split into `stt_replay.go` + `stt_record.go`** — `LoadSTT` now returns `stt.Recognizer`; the default build replays the YAML cassette (unchanged hash-and-match behaviour) and `-tags=record` returns an `STTRecorder` that forwards each `Transcribe` call to a live `elevenlabs.Client`, captures `(audio_sha256, transcript)`, and rewrites `tests/voice-cassettes/<name>.yaml` at test cleanup — preserving existing `notes` and appending a `Re-recorded against ElevenLabs scribe_v2 on YYYY-MM-DD` provenance line. Matches the exact pattern from PR #2's `TTSRecorder`.
- **`TestSTTRecognizer_HashMismatchPointsAtRecord`** moved from black-box `voicecassette_test.go` to whitebox `stt_internal_test.go` so it exercises the replay matcher under both default and `-tags=record` builds (the old test would have called the recorder under record mode and missed the contract it was meant to pin).
- **BYOK auth per ADR-0004.** `elevenlabs.New(apiKey, opts...)` mirrors the TTS adapter: explicit key wins, `ELEVENLABS_API_KEY` fallback, construction never panics so cassette-replay binaries can link unconditionally.
- **No new external dependencies.** Stdlib `net/http` + `mime/multipart`.

## Test plan

- [x] `go build ./...` and `go build -tags=record ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — replay path passes, including new elevenlabs unit + httptest tests (response decode, full request-shape contract pinning multipart fields + byte-exact PCM stream, env-key fallback + explicit-key precedence, 401 surface)
- [x] `go test -tags=record ./pkg/voice/voicecassette/ ./pkg/voice/stt/elevenlabs/` — record-mode tests pass with an httptest-backed fake ElevenLabs (`STTRecorder` round-trips audio hash + transcript through written YAML, preserves notes + provenance stamp; no-write guard fires when `Transcribe` was never called)
- [x] `go test -tags=record ./pkg/voice/orchestrator/` without `ELEVENLABS_API_KEY` surfaces the documented "missing API key" error path (matches PR #2's pre-existing behaviour for TTS — by design, the documented workflow is `ELEVENLABS_API_KEY=… go test -tags=record …`)
- [ ] Live record run to refresh the hand-authored `stt-hello-test` + `stt-bart-test` cassettes against real scribe_v2 output — deliberately held back for a separate review-friendly diff once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)