### PR TITLE
fix(voice): tolerant transcript assertions; harden cassette re-record

### DIFF
--- a/pkg/voice/orchestrator/address_test.go
+++ b/pkg/voice/orchestrator/address_test.go
@@ -18,6 +18,16 @@ var (
 	bartTarget   = voiceevent.AddressTarget{AgentID: "npc-bart", AgentRole: "character", Name: "Bart"}
 )
 
+// Canonical spoken text of each fixture clip — the meta.yaml script with its
+// audio tags removed. ADR-0020 keeps meta.yaml documentation-only, so the
+// ground truth lives here in Go. Transcript assertions compare against these
+// after [voicetest.NormalizeTranscript], so a re-recorded cassette only fails
+// when the transcribed words change, not when a provider tweaks punctuation.
+const (
+	helloUtterance = "Glyphoxa, roll a perception check for me."
+	bartUtterance  = "Bart, what's the special tonight?"
+)
+
 // transcribeClip wires the STT cassette for clipName through the orchestrator
 // STT stage attached to h.Bus. Used by TB7/TB8 to feed the bus a real
 // STTFinal — the surface the AddressDetector subscribes to — without
@@ -40,7 +50,7 @@ func transcribeClip(t *testing.T, h *voicetest.Harness, clipName, cassetteName s
 // TestAddressDetector_HelloTest_RoutesToButler is TB7: a GM utterance with
 // no Character NPC named must route to the Butler (CONTEXT.md "Address
 // Detection"). The hello-test clip's transcript ("Glyphoxa, roll a
-// perception check for me.") names the Butler — the detector still routes
+// perception check for me") names the Butler — the detector still routes
 // there because no Character NPC matched, not because it special-cased the
 // Butler's display Name.
 //
@@ -53,14 +63,14 @@ func TestAddressDetector_HelloTest_RoutesToButler(t *testing.T) {
 
 	transcribeClip(t, h, "hello-test", "stt-hello-test")
 
-	const wantText = "Glyphoxa, roll a perception check for me."
+	want := voicetest.NormalizeTranscript(helloUtterance)
 	voicetest.AssertEvent(t, h,
 		func(e voiceevent.AddressRouted) bool {
-			return e.Text == wantText &&
+			return voicetest.NormalizeTranscript(e.Text) == want &&
 				e.Target.AgentRole == "butler" &&
 				e.Target.AgentID == butlerTarget.AgentID
 		},
-		"address.routed → Butler for utterance "+wantText,
+		"address.routed → Butler for utterance "+helloUtterance,
 	)
 }
 
@@ -76,14 +86,14 @@ func TestAddressDetector_BartTest_RoutesToCharacterNPC(t *testing.T) {
 
 	transcribeClip(t, h, "bart-test", "stt-bart-test")
 
-	const wantText = "Bart, what's the special tonight?"
+	want := voicetest.NormalizeTranscript(bartUtterance)
 	voicetest.AssertEvent(t, h,
 		func(e voiceevent.AddressRouted) bool {
-			return e.Text == wantText &&
+			return voicetest.NormalizeTranscript(e.Text) == want &&
 				e.Target.AgentRole == "character" &&
 				e.Target.AgentID == bartTarget.AgentID &&
 				e.Target.Name == bartTarget.Name
 		},
-		"address.routed → Bart (character) for utterance "+wantText,
+		"address.routed → Bart (character) for utterance "+bartUtterance,
 	)
 }

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -30,9 +30,13 @@ func (s stubRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcri
 // [voiceevent.STTFinal] (ADR-0020).
 //
 // The cassette under tests/voice-cassettes/stt-hello-test.yaml pins both the
-// audio fingerprint and the expected transcript text. Re-recording will
-// happen under `-tags=record` once a real STT provider adapter lands; for
-// now the cassette is the authoritative expectation.
+// audio fingerprint and the transcript text; re-recording happens under
+// `-tags=record` against the live ElevenLabs scribe_v2 adapter (ADR-0021).
+// The assertion compares the bus event against the clip's known utterance
+// after normalization (see [voicetest.NormalizeTranscript]) so it pins the
+// transcribed words while tolerating provider-specific casing, spacing, and
+// punctuation — scribe_v2 drops this utterance's trailing period, which an
+// exact-match assertion would (and did) flag as a spurious failure.
 func TestSTT_HelloTest_EmitsFinal(t *testing.T) {
 	h := voicetest.New(t)
 
@@ -51,10 +55,10 @@ func TestSTT_HelloTest_EmitsFinal(t *testing.T) {
 		t.Fatalf("stage.Transcribe: %v", err)
 	}
 
-	const want = "Glyphoxa, roll a perception check for me."
+	want := voicetest.NormalizeTranscript(helloUtterance)
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.STTFinal) bool { return e.Text == want },
-		"stt.final with text "+want,
+		func(e voiceevent.STTFinal) bool { return voicetest.NormalizeTranscript(e.Text) == want },
+		"stt.final matching utterance "+helloUtterance,
 	)
 }
 

--- a/pkg/voice/voicecassette/record_notes.go
+++ b/pkg/voice/voicecassette/record_notes.go
@@ -1,0 +1,58 @@
+//go:build record
+
+package voicecassette
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// appendProvenance returns notes with a dated "Re-recorded against ElevenLabs
+// <model> on <date>." line appended for reviewer context. The append is
+// idempotent within a day: re-running -tags=record twice on the same date
+// must not accrete duplicate stamps (the recorder loads the existing notes,
+// which on the second run already carry the line). Re-records on a later date
+// still append, preserving the refresh history.
+func appendProvenance(notes, model string) string {
+	line := fmt.Sprintf("Re-recorded against ElevenLabs %s on %s.",
+		model, time.Now().UTC().Format("2006-01-02"))
+	switch {
+	case notes == "":
+		return line
+	case strings.Contains(notes, line):
+		return notes
+	default:
+		return notes + "\n\n" + line
+	}
+}
+
+// leadingComment returns the cassette file's leading block of YAML comments —
+// the contiguous run of blank or "#" lines before the first key — with their
+// newlines intact, or "" if the file is absent or starts with content.
+//
+// yaml.Marshal silently drops comments, so the record path re-prepends this
+// block when rewriting a cassette; without it every -tags=record run strips
+// the hand-authored header that explains what the cassette pins and how to
+// refresh it. The file is read at write time, before the recorder overwrites
+// it, so the block reflects whatever a human last committed.
+func leadingComment(name string) string {
+	path := filepath.Join(cassettesDir(), name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.SplitAfter(string(data), "\n") {
+		if line == "" { // trailing piece after the final newline
+			break
+		}
+		if t := strings.TrimSpace(line); t != "" && !strings.HasPrefix(t, "#") {
+			break
+		}
+		b.WriteString(line)
+	}
+	return b.String()
+}

--- a/pkg/voice/voicecassette/stt_record.go
+++ b/pkg/voice/voicecassette/stt_record.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
@@ -22,9 +21,10 @@ import (
 // at test cleanup with the captured (audio_sha256, transcript) pair. The
 // ELEVENLABS_API_KEY environment variable supplies credentials.
 //
-// Any existing cassette's Notes field is preserved (with a "Re-recorded
-// against ElevenLabs scribe_v2 on <date>" provenance line appended) so
-// reviewer-facing context survives the refresh.
+// Any existing cassette's Notes field and leading header comments are
+// preserved (with an idempotent dated "Re-recorded against ElevenLabs
+// scribe_v2 on <date>" provenance line appended) so reviewer-facing context
+// survives the refresh.
 func LoadSTT(t *testing.T, name string) stt.Recognizer {
 	t.Helper()
 	existing, _ := loadSTTCassetteFromDisk(t, name, false)
@@ -74,11 +74,13 @@ func (r *STTRecorder) Transcribe(ctx context.Context, frames []audio.Frame) (stt
 	return tr, nil
 }
 
-// write serialises the captured (hash, transcript) pair plus preserved
-// Notes + a fresh provenance line to tests/voice-cassettes/<name>.yaml. A
-// no-op if Transcribe was never called — recording a test that never
-// invoked the recognizer would clobber the existing fixture with an empty
-// audio_sha256.
+// write serialises the captured (hash, transcript) pair to
+// tests/voice-cassettes/<name>.yaml, preserving the existing Notes (with an
+// idempotent dated provenance line, see appendProvenance) and re-prepending
+// the hand-authored header comment block that yaml.Marshal drops (see
+// leadingComment). A no-op if Transcribe was never called — recording a test
+// that never invoked the recognizer would clobber the existing fixture with
+// an empty audio_sha256.
 func (r *STTRecorder) write() error {
 	if !r.captured {
 		return nil
@@ -86,19 +88,13 @@ func (r *STTRecorder) write() error {
 	out := STTCassette{
 		AudioSHA256: r.hash,
 		Transcript:  r.transcript,
-		Notes:       r.existing.Notes,
+		Notes:       appendProvenance(r.existing.Notes, "scribe_v2"),
 	}
-	stamp := time.Now().UTC().Format("2006-01-02")
-	provenance := fmt.Sprintf("Re-recorded against ElevenLabs scribe_v2 on %s.", stamp)
-	if out.Notes == "" {
-		out.Notes = provenance
-	} else {
-		out.Notes = out.Notes + "\n\n" + provenance
-	}
-	data, err := yaml.Marshal(out)
+	body, err := yaml.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshal cassette: %w", err)
 	}
+	data := append([]byte(leadingComment(r.name)), body...)
 	path := filepath.Join(cassettesDir(), r.name+".yaml")
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)

--- a/pkg/voice/voicecassette/stt_record_test.go
+++ b/pkg/voice/voicecassette/stt_record_test.go
@@ -97,6 +97,88 @@ func TestSTTRecorder_WriteOnCleanup(t *testing.T) {
 	}
 }
 
+// TestSTTRecorder_WritePreservesHeaderComment pins the comment-preservation
+// fix: yaml.Marshal drops comments, so a naive rewrite strips the
+// hand-authored header that explains what the cassette pins. write() must
+// re-prepend the existing file's leading comment block verbatim while still
+// refreshing the body with the captured values.
+func TestSTTRecorder_WritePreservesHeaderComment(t *testing.T) {
+	dir := t.TempDir()
+	orig := cassettesDir
+	cassettesDir = func() string { return dir }
+	t.Cleanup(func() { cassettesDir = orig })
+
+	name := "stt-headed-record"
+	header := "# Cassette for TBx — pins the headed clip.\n#\n# audio_sha256 fingerprints the PCM stream.\n"
+	seed := header + "audio_sha256: deadbeef\ntranscript: stale text\nnotes: prior note\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed cassette: %v", err)
+	}
+
+	r := &STTRecorder{
+		name:       name,
+		hash:       "freshhash",
+		transcript: "fresh transcript",
+		captured:   true,
+		existing:   STTCassette{Notes: "prior note"},
+	}
+	if err := r.write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, name+".yaml"))
+	if err != nil {
+		t.Fatalf("read written cassette: %v", err)
+	}
+	if !strings.HasPrefix(string(raw), header) {
+		t.Errorf("rewritten cassette dropped the header comment block; got:\n%s", raw)
+	}
+	var got STTCassette
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal written cassette: %v", err)
+	}
+	if got.AudioSHA256 != "freshhash" || got.Transcript != "fresh transcript" {
+		t.Errorf("body not refreshed: %+v", got)
+	}
+}
+
+// TestSTTRecorder_WriteProvenanceIdempotentSameDay pins the idempotency fix:
+// re-running -tags=record twice on the same date (the second run loads notes
+// the first run already stamped) must not accrete duplicate provenance lines.
+func TestSTTRecorder_WriteProvenanceIdempotentSameDay(t *testing.T) {
+	dir := t.TempDir()
+	orig := cassettesDir
+	cassettesDir = func() string { return dir }
+	t.Cleanup(func() { cassettesDir = orig })
+
+	name := "stt-idempotent-record"
+	// Notes as a prior same-day record would have left them: hand-authored
+	// text plus today's provenance stamp already appended.
+	existing := appendProvenance("hand-authored note", "scribe_v2")
+	r := &STTRecorder{
+		name:       name,
+		hash:       "h",
+		transcript: "tr",
+		captured:   true,
+		existing:   STTCassette{Notes: existing},
+	}
+	if err := r.write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, name+".yaml"))
+	if err != nil {
+		t.Fatalf("read written cassette: %v", err)
+	}
+	var got STTCassette
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal written cassette: %v", err)
+	}
+	if n := strings.Count(got.Notes, "Re-recorded against ElevenLabs scribe_v2"); n != 1 {
+		t.Errorf("provenance stamp appears %d times, want 1; notes:\n%s", n, got.Notes)
+	}
+}
+
 // TestSTTRecorder_NoCallsNoWrite verifies the guard that prevents an empty
 // recording (test never invoked the recognizer) from clobbering the
 // existing fixture with an empty audio_sha256.

--- a/pkg/voice/voicecassette/tts_record.go
+++ b/pkg/voice/voicecassette/tts_record.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
@@ -23,8 +22,9 @@ import (
 //
 // Per ADR-0021's TTS cassette policy only the dispatched sentences are
 // persisted; rendered audio is drained and discarded. Any existing cassette's
-// Notes field is preserved (with a "recorded against eleven_v3 on <date>"
-// provenance line appended) so reviewer-facing context survives the refresh.
+// Notes field and leading header comments are preserved (with an idempotent
+// dated "Re-recorded against ElevenLabs eleven_v3 on <date>" provenance line
+// appended) so reviewer-facing context survives the refresh.
 func LoadTTS(t *testing.T, name string) tts.Synthesizer {
 	t.Helper()
 	existing, _ := loadTTSCassetteFromDisk(t, name, false)
@@ -80,29 +80,25 @@ func (r *TTSRecorder) AudioMarkupPrompt(voice tts.Voice) string {
 	return r.client.AudioMarkupPrompt(voice)
 }
 
-// write serialises the captured sentences (plus preserved Notes + a fresh
-// provenance line) to tests/voice-cassettes/<name>.yaml. A no-op if
-// Synthesize was never called — recording a test that never dispatched a
-// sentence would clobber the existing fixture with an empty list.
+// write serialises the captured sentences to tests/voice-cassettes/<name>.yaml,
+// preserving the existing Notes (with an idempotent dated provenance line, see
+// appendProvenance) and re-prepending the hand-authored header comment block
+// that yaml.Marshal drops (see leadingComment). A no-op if Synthesize was
+// never called — recording a test that never dispatched a sentence would
+// clobber the existing fixture with an empty list.
 func (r *TTSRecorder) write() error {
 	if len(r.sentences) == 0 {
 		return nil
 	}
 	out := TTSCassette{
 		Sentences: r.sentences,
-		Notes:     r.existing.Notes,
+		Notes:     appendProvenance(r.existing.Notes, "eleven_v3"),
 	}
-	stamp := time.Now().UTC().Format("2006-01-02")
-	provenance := fmt.Sprintf("Re-recorded against ElevenLabs eleven_v3 on %s.", stamp)
-	if out.Notes == "" {
-		out.Notes = provenance
-	} else {
-		out.Notes = out.Notes + "\n\n" + provenance
-	}
-	data, err := yaml.Marshal(out)
+	body, err := yaml.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshal cassette: %w", err)
 	}
+	data := append([]byte(leadingComment(r.name)), body...)
 	path := filepath.Join(cassettesDir(), r.name+".yaml")
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)

--- a/pkg/voice/voicetest/transcript.go
+++ b/pkg/voice/voicetest/transcript.go
@@ -1,0 +1,31 @@
+package voicetest
+
+import (
+	"strings"
+	"unicode"
+)
+
+// NormalizeTranscript folds a transcript to a canonical form for tolerant
+// equality in tests: it lowercases, drops every rune that is not a letter or
+// number, and collapses runs of whitespace to single spaces.
+//
+// STT assertions compare the words a recognizer produced against an expected
+// utterance. Pinning the exact string couples the test to provider-specific
+// casing, punctuation, and spacing — e.g. ElevenLabs scribe_v2 transcribes
+// the hello-test clip without a trailing period. Comparing normalized forms
+// asserts the recognizer got the words right while tolerating that cosmetic
+// variation, so a re-recorded cassette (ADR-0021) only fails the test when the
+// transcribed words genuinely change.
+func NormalizeTranscript(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}

--- a/pkg/voice/voicetest/transcript_test.go
+++ b/pkg/voice/voicetest/transcript_test.go
@@ -1,0 +1,35 @@
+package voicetest_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+func TestNormalizeTranscript(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"lowercases", "Glyphoxa ROLL", "glyphoxa roll"},
+		{"drops trailing period", "roll a perception check for me.", "roll a perception check for me"},
+		{"drops interior punctuation", "Bart, what's the special tonight?", "bart whats the special tonight"},
+		{"collapses whitespace", "  roll   a\tcheck\n", "roll a check"},
+		{
+			// The exact drift that broke the hello-test assertion: scribe_v2
+			// returned the utterance without its trailing period.
+			name: "period-only difference is equal after normalization",
+			in:   "Glyphoxa, roll a perception check for me",
+			want: voicetest.NormalizeTranscript("Glyphoxa, roll a perception check for me."),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := voicetest.NormalizeTranscript(tc.in); got != tc.want {
+				t.Errorf("NormalizeTranscript(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/voice-cassettes/stt-bart-test.yaml
+++ b/tests/voice-cassettes/stt-bart-test.yaml
@@ -5,13 +5,13 @@
 # 32 ms-framed bart-test clip (16 kHz, mono, 16-bit). A mismatch fails the
 # test and points at -tags=record.
 #
-# transcript is hand-authored from tests/voice-clips/bart-test/meta.yaml's
-# script. Re-record with a live STT provider (-tags=record) once a Deepgram
-# or whisper.cpp adapter ships.
+# transcript is recorded from the live ElevenLabs scribe_v2 adapter under
+# -tags=record (ADR-0021); re-run that to refresh it.
 audio_sha256: c49e6cc75851d37e8a1749ee6e420205f3839069c068c60d2dadb824106ae283
-transcript: "Bart, what's the special tonight?"
+transcript: Bart, what's the special tonight?
 notes: |-
-  Hand-authored for TB8 plumbing bring-up; no live STT provider was hit
-  (the audio was generated via ElevenLabs Mark/eleven_v3 to give the
-  address detector something to match "Bart" against). Update on first
-  -tags=record run against a real STT adapter.
+    Plumbing bring-up cassette for TB8 (ADR-0021). The clip's audio was
+    generated via ElevenLabs Mark/eleven_v3 to give the address detector a
+    "Bart" mention to match.
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-05-21.

--- a/tests/voice-cassettes/stt-hello-test.yaml
+++ b/tests/voice-cassettes/stt-hello-test.yaml
@@ -5,11 +5,12 @@
 # 32 ms-framed hello-test clip (16 kHz, mono, 16-bit). A mismatch fails the
 # test and points at -tags=record.
 #
-# transcript is hand-authored from tests/voice-clips/hello-test/meta.yaml's
-# script. Re-record with a live STT provider (-tags=record) once a Deepgram
-# or whisper.cpp adapter ships.
+# transcript is recorded from the live ElevenLabs scribe_v2 adapter under
+# -tags=record (ADR-0021); re-run that to refresh it. scribe_v2 returns this
+# utterance without a trailing period.
 audio_sha256: e1767e868f6c1997f297a4524afab77cd9398692a536bd6a5b385308c0d37ba2
-transcript: "Glyphoxa, roll a perception check for me."
+transcript: Glyphoxa, roll a perception check for me
 notes: |-
-  Hand-authored for TB5 plumbing bring-up; no live provider was hit. Update
-  on first -tags=record run against a real STT adapter.
+    Plumbing bring-up cassette for TB5 (ADR-0021).
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-05-21.

--- a/tests/voice-cassettes/tts-hello-test.yaml
+++ b/tests/voice-cassettes/tts-hello-test.yaml
@@ -6,13 +6,14 @@
 # observable in cassette mode — see ADR-0021).
 #
 # A sentence mismatch or running past the end of this list fails the test and
-# points at -tags=record. Re-record with a live TTS provider (-tags=record)
-# once the ElevenLabs or OpenAI adapter ships.
+# points at -tags=record. Re-record against the live ElevenLabs eleven_v3
+# adapter with -tags=record to refresh it.
 sentences:
-  - "Of course — roll a d20 and add your wisdom modifier."
+    - Of course — roll a d20 and add your wisdom modifier.
 notes: |-
-  Hand-authored for TB6 plumbing bring-up; no live provider was hit. The
-  sentence is the canonical Butler reply to the hello-test prompt
-  ("Glyphoxa, roll a perception check for me.") and pairs with
-  stt-hello-test.yaml on the input side. Update on first -tags=record run
-  against a real TTS adapter.
+    Plumbing bring-up cassette for TB6 (ADR-0021). The sentence is the
+    canonical Butler reply to the hello-test prompt ("Glyphoxa, roll a
+    perception check for me") and pairs with stt-hello-test.yaml on the input
+    side.
+
+    Re-recorded against ElevenLabs eleven_v3 on 2026-05-21.


### PR DESCRIPTION
## Why

`go test -tags=record ./...` failed on the hello-test STT tracer bullets. They exact-matched a hardcoded transcript copy that drifted when the cassette was re-recorded against the live ElevenLabs scribe_v2 adapter (#4): scribe_v2 omits the utterance's trailing period, so `e.Text == "…me."` failed in both replay and record. (The `not frame-aligned` log lines were unrelated noise — informational `t.Logf`, not the failure.)

## What

**Tolerant content assertions.** TB5/TB7/TB8 now compare the bus event against the clip's ground-truth utterance through `voicetest.NormalizeTranscript` (case/whitespace/punctuation-insensitive) instead of exact-matching a literal:

```go
want := voicetest.NormalizeTranscript(helloUtterance)
voicetest.AssertEvent(t, h,
    func(e voiceevent.STTFinal) bool { return voicetest.NormalizeTranscript(e.Text) == want },
    "stt.final matching utterance "+helloUtterance,
)
```

This pins the transcribed **words** while tolerating provider formatting quirks; a re-recorded cassette only fails when the words genuinely change, and under `-tags=record` it doubles as a live scribe_v2 drift check. Ground-truth utterances live as Go consts since ADR-0020 keeps `meta.yaml` documentation-only.

**Hardened the `-tags=record` write path** the drift exposed (shared `record_notes.go`):
- `appendProvenance` dedupes the dated stamp — re-recording twice the same day no longer accretes duplicate `Re-recorded against …` lines.
- `leadingComment` re-prepends the YAML header comment block that `yaml.Marshal` was silently dropping on every refresh.

**Cassettes** reduced to the one genuine change (hello transcript loses its period); bart/tts content unchanged, prose de-staled to reflect the scribe_v2/eleven_v3 re-record.

## Test plan
- `go test ./...` — green
- `go test ./pkg/voice/voicetest/` — new `NormalizeTranscript` table test (incl. the period-only case)
- `go test -tags=record ./pkg/voice/voicecassette/` — green (httptest stand-in, no live API); new tests pin header-comment preservation + same-day provenance idempotency
- `go vet -tags=record ./...`, `gofmt -l` — clean

Not run: `go test -tags=record ./...` (paid live ElevenLabs calls). Now safe to run for a canonical tool-generated cassette refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)