### PR TITLE
Formalize voice bus wiring: typed reactors composed into a Conversation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,6 +33,7 @@ Resume-from-here doc for the interactive design grilling. Decisions are recorded
 | [0023](docs/adr/0023-tts-provider-matrix-elevenlabs-openai.md) | TTS provider matrix v1.0: ElevenLabs + OpenAI (amends ADR-0004) | TTS interlude |
 | [0024](docs/adr/0024-address-detection-deterministic-fuzzy-chain.md) | Address Detection: deterministic fuzzy chain on raw STT | Q13.4 |
 | [0025](docs/adr/0025-ensemble-turns-speculative-lead-reaction.md) | Ensemble turns: speculative lead + cross-talk reaction | Q13.4 |
+| [0026](docs/adr/0026-bus-wiring-reactors-and-conversation.md) | Voice bus wiring: typed reactors composed into a Conversation | slice 1 wiring |
 
 ## Open questions
 

--- a/docs/adr/0026-bus-wiring-reactors-and-conversation.md
+++ b/docs/adr/0026-bus-wiring-reactors-and-conversation.md
@@ -1,0 +1,25 @@
+# Voice bus wiring: typed reactors composed into a Conversation
+
+The orchestrator stages publish onto a shared `voiceevent.Bus` (ADR-0020), but the *reactive glue* between them — "buffer frames between `vad.speech_start` and `vad.speech_end`, then transcribe"; "on `address.routed`, speak a reply" — lived inline in the slice-1 pipeline test. That made the cross-stage behaviour untyped (`switch e.(type)`), un-reusable, and impossible to change in one place. This ADR formalizes the wiring as a layered API so voice-interaction behaviour can be changed all at once or one interaction at a time, behind a stable seam.
+
+Three layers, smallest to largest:
+
+1. **`voiceevent.On[E](bus, func(E))`** — a typed subscription primitive. It narrows the bus's one-callback-receives-everything delivery to one callback per concrete event type, the way one `net/http` handler binds one route, and replaces the type switch a raw subscriber would write. Every reactor is built from it.
+
+2. **`orchestrator.Reactor`** — `Bind(ctx, bus) (cancel func())`: one self-contained bus interaction that subscribes on `Bind` and tears down via the returned `cancel`. The existing `AddressDetector` already had this shape (constructor-subscribe + `Close`) and is regularized to the interface (`STTFinal → AddressRouted`). Its siblings are `Segmenter` (speech transitions → `STT`, and the audio-frame sink via `Process`) and `Replier` (`address.routed → TTS`, behaviour injected as a `ReplyFunc`). `orchestrator.Bind(ctx, bus, reactors…)` composes any subset — the **"in parts"** knob.
+
+3. **`orchestrator.Conversation`** — the façade. It holds the stages, builds the default reactor set (segmenter + optional detector + optional replier), and exposes `Register(ctx) (cancel func())` to wire them all at once plus `Feed(frame)` for the audio loop. Behaviour is swapped with functional options (`WithDetector`, `WithReply`, `WithErrorHandler`) — the **"all at once"** knob.
+
+**Idioms borrowed.** Typed narrowing over an untyped channel (`On`, cf. `errors.As`); `Bind`/`Register` returning a `cancel func()` exactly like `Bus.Subscribe`, `context.WithCancel`, and `signal.NotifyContext`; handler composition like `net/http` and `io.MultiWriter`; functional options like `grpc.Dial`. No DSL and no framework — the wiring stays plain Go that participates in `go test` (ADR-0020).
+
+**Context & errors.** The `ctx` passed to `Register`/`Bind` governs the bound reactions and is the context handed to the STT/TTS calls a reactor triggers (so cancelling it lets an in-flight provider call unwind); teardown stays explicit — cancelling `ctx` does not unsubscribe, only the returned `cancel` does. A bus callback cannot return an error, so a stage call a reactor fires from inside a callback (the `Replier`'s `TTS.Dispatch`) reports failure through an optional `ErrorFunc`; the `Segmenter`'s `STT.Transcribe` runs inside `Process` and returns its error to the audio loop directly.
+
+**Synchronous, single bus.** `Bus.Publish` is synchronous and reentrant-safe — it copies subscribers under lock, then calls them unlocked — so a reactor publishing the next event from inside a callback (`STTFinal → AddressRouted → TTSInvoked`) works without deadlock. The flip side: a reactor doing slow work (a live `TTS.Dispatch`, a network STT) blocks the publishing goroutine, and ADR-0020's bus contract is "callbacks must not block". A production async-dispatch boundary is therefore left to a later tracer bullet; v1.0 keeps the synchronous wiring the existing tracer bullets rely on.
+
+**Considered options:**
+
+- **One manager struct with the policy baked in** — simplest, matches the original sketch, but bakes "what to say" and "how to segment" into branches; rejected as the *only* layer because changing one interaction means editing the struct. Kept as the `Conversation` façade, with the swappable bits injected as strategies/options.
+- **A typed event mux (`http.ServeMux` analogue)** — one subscription fanning out to many typed handlers by reflection. It only earns its keep when several handlers need the *same* event in a defined order; the voice chain is sequential republishing, not same-event fan-out, so the mux adds reflection for no gain yet. `On` covers the typed-dispatch need without it.
+- **Reactors only, no façade** — maximally à-la-carte, but every caller re-assembles the default pipeline by hand. Kept as the middle layer; the `Conversation` removes that boilerplate for the common case.
+
+**Why layered.** Primitive → unit → bundle lets a caller reach for exactly the level they need: `On` for an ad-hoc subscriber, a hand-picked `Bind(…)` to change one interaction, or `Conversation` to swap the whole reactive layer. Each layer is independently testable, and the slice-1 pipeline test now drives the `Conversation` end to end instead of spelling the wiring out inline.

--- a/docs/devs/voice-tests.md
+++ b/docs/devs/voice-tests.md
@@ -107,6 +107,28 @@ func (s stubRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcri
 }
 ```
 
+## Wire the full pipeline (VAD → STT → address → TTS)
+
+Don't hand-roll the cross-stage bus glue. `orchestrator.Conversation` bundles the
+reactive wiring (ADR-0026): `Register(ctx)` installs it and returns a teardown
+func, `Feed(frame)` is the audio loop, and the reply behaviour is injected as a
+`ReplyFunc`. Model on `TestSTT_TTRPGIntro_TranscribesBothLanguages` in
+[`stt_test.go`](../../pkg/voice/orchestrator/stt_test.go):
+
+```go
+conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+    orchestrator.WithDetector(detector),
+    orchestrator.WithReply(func(e voiceevent.AddressRouted) []orchestrator.Reply { /* … */ }),
+    orchestrator.WithErrorHandler(func(err error) { t.Errorf("reply dispatch: %v", err) }),
+)
+t.Cleanup(conv.Register(t.Context()))
+for _, f := range frames { conv.Feed(f) }
+```
+
+To exercise one interaction in isolation, drop to the `Reactor` layer and
+compose with `orchestrator.Bind(ctx, bus, reactors…)`; for an ad-hoc typed
+subscription use `voiceevent.On[E](bus, fn)` directly.
+
 ## Adding fixtures
 
 ### A new cassette — `tests/voice-cassettes/`

--- a/pkg/voice/orchestrator/address.go
+++ b/pkg/voice/orchestrator/address.go
@@ -1,15 +1,17 @@
 package orchestrator
 
 import (
+	"context"
 	"regexp"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
-// AddressDetector subscribes to [voiceevent.STTFinal] events on the bus,
-// decides which Agent the utterance addresses, and republishes the choice
-// as [voiceevent.AddressRouted] using the shared event taxonomy (ADR-0020).
+// AddressDetector is a [Reactor] that subscribes to [voiceevent.STTFinal]
+// events, decides which Agent the utterance addresses, and republishes the
+// choice as [voiceevent.AddressRouted] using the shared event taxonomy
+// (ADR-0020).
 //
 // Per CONTEXT.md "Address Detection" the routing options are exactly the
 // Agents present in the Voice Session: a Character NPC if a participant
@@ -22,28 +24,28 @@ import (
 // DESIGN.md; this stub gives downstream stages a routing event to consume
 // without committing to an algorithm. The first NPC matched wins —
 // disambiguation across multiply-named utterances is also Q13.4.
+//
+// Per ADR-0026 the detector is a Reactor: construction validates the targets
+// and compiles the matchers but touches no bus; [AddressDetector.Bind] installs
+// the STTFinal subscription and returns its teardown. This lets the whole
+// reactive layer be wired uniformly — standalone, in a hand-picked subset via
+// [Bind], or bundled by a [Conversation].
 type AddressDetector struct {
-	bus         *voiceevent.Bus
 	butler      voiceevent.AddressTarget
 	npcs        []voiceevent.AddressTarget
 	npcMatchers []*regexp.Regexp // parallel to npcs; one whole-word matcher per NPC name
-	unsubscribe func()
 }
 
-// NewAddressDetector wires the detector to bus and subscribes it to
-// [voiceevent.STTFinal] events for the lifetime of the returned value.
-// The caller must invoke Close to release the subscription (typically via
-// t.Cleanup in tests).
+// NewAddressDetector validates the routing targets and compiles one whole-word
+// matcher per NPC name. It installs nothing — call [AddressDetector.Bind] to
+// subscribe it to a bus.
 //
 // butler must carry AgentRole "butler"; npcs is the list of Character NPC
 // Agents currently active in the Voice Session, each carrying AgentRole
-// "character" and a non-empty display Name. Passing a nil bus, an empty
-// Butler Name, or any NPC without a Name panics — these are construction
-// errors caught at wiring time, not runtime conditions.
-func NewAddressDetector(bus *voiceevent.Bus, butler voiceevent.AddressTarget, npcs []voiceevent.AddressTarget) *AddressDetector {
-	if bus == nil {
-		panic("orchestrator.NewAddressDetector: bus must not be nil")
-	}
+// "character" and a non-empty display Name. An empty Butler Name, or any NPC
+// without a Name or with the wrong role, panics — these are construction errors
+// caught at wiring time, not runtime conditions.
+func NewAddressDetector(butler voiceevent.AddressTarget, npcs []voiceevent.AddressTarget) *AddressDetector {
 	if butler.AgentRole != "butler" {
 		panic(`orchestrator.NewAddressDetector: butler.AgentRole must be "butler"`)
 	}
@@ -61,32 +63,31 @@ func NewAddressDetector(bus *voiceevent.Bus, butler voiceevent.AddressTarget, np
 		matchers[i] = regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(npc.Name) + `\b`)
 	}
 
-	d := &AddressDetector{
-		bus:         bus,
+	return &AddressDetector{
 		butler:      butler,
 		npcs:        npcs,
 		npcMatchers: matchers,
 	}
-	d.unsubscribe = bus.Subscribe(func(e voiceevent.Event) {
-		final, ok := e.(voiceevent.STTFinal)
-		if !ok {
-			return
-		}
+}
+
+// Bind subscribes the detector to [voiceevent.STTFinal] on bus and returns a
+// function that removes the subscription. It implements [Reactor]; bus must be
+// non-nil.
+//
+// Routing is a pure function of the transcript text, so the detector ignores
+// ctx — it is accepted only to satisfy the Reactor contract (other reactors
+// thread it into the STT/TTS calls they trigger).
+func (d *AddressDetector) Bind(_ context.Context, bus *voiceevent.Bus) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.AddressDetector.Bind: bus must not be nil")
+	}
+	return voiceevent.On(bus, func(final voiceevent.STTFinal) {
 		bus.Publish(voiceevent.AddressRouted{
 			At:     time.Now(),
 			Text:   final.Text,
 			Target: d.routeFor(final.Text),
 		})
 	})
-	return d
-}
-
-// Close releases the bus subscription. Calling more than once is a no-op.
-func (d *AddressDetector) Close() {
-	if d.unsubscribe != nil {
-		d.unsubscribe()
-		d.unsubscribe = nil
-	}
 }
 
 func (d *AddressDetector) routeFor(text string) voiceevent.AddressTarget {

--- a/pkg/voice/orchestrator/address_test.go
+++ b/pkg/voice/orchestrator/address_test.go
@@ -58,8 +58,8 @@ func transcribeClip(t *testing.T, h *voicetest.Harness, clipName, cassetteName s
 // detector's coupling is the STTFinal subscription, not an imperative call.
 func TestAddressDetector_HelloTest_RoutesToButler(t *testing.T) {
 	h := voicetest.New(t)
-	d := orchestrator.NewAddressDetector(h.Bus, butlerTarget, []voiceevent.AddressTarget{bartTarget})
-	t.Cleanup(d.Close)
+	d := orchestrator.NewAddressDetector(butlerTarget, []voiceevent.AddressTarget{bartTarget})
+	t.Cleanup(d.Bind(t.Context(), h.Bus))
 
 	transcribeClip(t, h, "hello-test", "stt-hello-test")
 
@@ -81,8 +81,8 @@ func TestAddressDetector_HelloTest_RoutesToButler(t *testing.T) {
 // default Butler route.
 func TestAddressDetector_BartTest_RoutesToCharacterNPC(t *testing.T) {
 	h := voicetest.New(t)
-	d := orchestrator.NewAddressDetector(h.Bus, butlerTarget, []voiceevent.AddressTarget{bartTarget})
-	t.Cleanup(d.Close)
+	d := orchestrator.NewAddressDetector(butlerTarget, []voiceevent.AddressTarget{bartTarget})
+	t.Cleanup(d.Bind(t.Context(), h.Bus))
 
 	transcribeClip(t, h, "bart-test", "stt-bart-test")
 

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -1,0 +1,97 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Conversation bundles the slice-1 reactive wiring behind one façade: the
+// segmenter (VAD speech transitions → STT), an optional address detector
+// (STTFinal → AddressRouted), and an optional replier (AddressRouted → TTS).
+// It is the "all at once" knob — [Conversation.Register] installs the whole
+// reactive layer with a single call and [Conversation.Feed] is the audio loop's
+// entry point. To change one interaction in isolation, drop to the [Reactor]
+// layer and compose with [Bind] instead (ADR-0026).
+//
+// Behaviour is configured with functional options at construction
+// ([WithDetector], [WithReply], [WithErrorHandler]); the stages themselves are
+// supplied by the caller, who owns their lifetime.
+type Conversation struct {
+	bus *voiceevent.Bus
+	tts *TTS
+
+	seg      *Segmenter
+	detector *AddressDetector
+	reply    ReplyFunc
+	onError  ErrorFunc
+}
+
+// Option configures a [Conversation] at construction.
+type Option func(*Conversation)
+
+// WithDetector adds an address detector to the conversation, wiring
+// STTFinal → AddressRouted. Without it the conversation transcribes but never
+// routes.
+func WithDetector(d *AddressDetector) Option {
+	return func(c *Conversation) { c.detector = d }
+}
+
+// WithReply adds a reply reactor driven by fn, wiring AddressRouted → TTS. It
+// requires the conversation to have been given a non-nil TTS stage; Register
+// panics otherwise. Without it the conversation routes but never speaks.
+func WithReply(fn ReplyFunc) Option {
+	return func(c *Conversation) { c.reply = fn }
+}
+
+// WithErrorHandler sets the [ErrorFunc] used to report failures from stage calls
+// the reactors fire inside bus callbacks (currently the replier's TTS dispatch).
+// Without it such failures are dropped silently.
+func WithErrorHandler(fn ErrorFunc) Option {
+	return func(c *Conversation) { c.onError = fn }
+}
+
+// NewConversation wires the stages into a conversation on bus. bus, vad, and stt
+// must be non-nil; ttsStage may be nil only when no [WithReply] option is given.
+// All non-nil arguments are owned by the caller.
+func NewConversation(bus *voiceevent.Bus, vad *VAD, stt *STT, ttsStage *TTS, opts ...Option) *Conversation {
+	if bus == nil {
+		panic("orchestrator.NewConversation: bus must not be nil")
+	}
+	c := &Conversation{
+		bus: bus,
+		tts: ttsStage,
+		seg: NewSegmenter(vad, stt),
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Register installs the conversation's reactors on the bus and returns a single
+// teardown func. ctx governs the bound reactions and is the context handed to
+// the STT/TTS calls they trigger; teardown stays explicit via the returned
+// cancel (ADR-0026). Register must be called before [Conversation.Feed].
+func (c *Conversation) Register(ctx context.Context) (cancel func()) {
+	reactors := []Reactor{c.seg}
+	if c.detector != nil {
+		reactors = append(reactors, c.detector)
+	}
+	if c.reply != nil {
+		if c.tts == nil {
+			panic("orchestrator.Conversation.Register: WithReply set but no TTS stage was provided")
+		}
+		reactors = append(reactors, NewReplier(c.tts, c.reply, c.onError))
+	}
+	return Bind(ctx, c.bus, reactors...)
+}
+
+// Feed pushes one PCM frame into the conversation. It drives the VAD stage and
+// segments utterances to STT (see [Segmenter.Process]); the rest of the pipeline
+// — routing and reply — follows on the bus. Errors originate in the VAD or STT
+// stage and are returned to the audio loop.
+func (c *Conversation) Feed(frame audio.Frame) error {
+	return c.seg.Process(frame)
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -1,0 +1,217 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Reactor is one self-contained bus interaction in the voice pipeline: it turns
+// events the call-driven stages publish (VAD, STT, TTS) into the next stage's
+// call. The address detector (STTFinal → AddressRouted), the [Segmenter]
+// (speech transitions → STT), and the [Replier] (AddressRouted → TTS) are the
+// reactors that wire slice 1 (ADR-0019, ADR-0026).
+//
+// Bind installs the reactor's subscriptions on bus and returns a function that
+// removes them; nothing happens until Bind is called. The ctx governs the
+// reactions' lifetime and is the context handed to any STT/TTS call the reactor
+// triggers — cancelling it lets an in-flight provider call unwind — but
+// teardown stays explicit: cancelling ctx does not unsubscribe, only the
+// returned cancel does. This mirrors [voiceevent.Bus.Subscribe], which also
+// hands back its own unsubscribe func.
+type Reactor interface {
+	Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
+}
+
+// Bind installs every reactor on bus and returns a single function that tears
+// them all down, in reverse order. It is the "in parts" entry point: compose
+// any hand-picked subset of reactors without the [Conversation] facade.
+func Bind(ctx context.Context, bus *voiceevent.Bus, reactors ...Reactor) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.Bind: bus must not be nil")
+	}
+	cancels := make([]func(), len(reactors))
+	for i, r := range reactors {
+		cancels[i] = r.Bind(ctx, bus)
+	}
+	return func() {
+		for i := len(cancels) - 1; i >= 0; i-- {
+			cancels[i]()
+		}
+	}
+}
+
+// ErrorFunc reports an error from a stage call a reactor fires from inside a
+// bus callback. Bus callbacks cannot return an error, so a reactor whose
+// triggered call fails — the [Replier]'s [TTS.Dispatch] — surfaces it here
+// instead. A nil ErrorFunc drops the error silently. (The [Segmenter]'s
+// [STT.Transcribe] runs inside [Segmenter.Process] and returns its error to the
+// caller directly, so it needs no ErrorFunc.)
+type ErrorFunc func(error)
+
+// Segmenter turns the VAD stage's frame-level transitions into utterance-sized
+// batches for STT. It is both a frame sink and a [Reactor]: callers feed PCM
+// via [Segmenter.Process], which drives the wrapped VAD stage, and
+// [Segmenter.Bind] subscribes to the VADSpeechStart / VADSpeechEnd events that
+// stage publishes. Frames that arrive while speech is active are buffered; the
+// completed batch is handed to [STT.Transcribe] when speech ends.
+//
+// This is the bus-driven form of the accumulate-between-VAD-events loop the
+// slice-1 pipeline test used to spell out inline (ADR-0026).
+type Segmenter struct {
+	vad *VAD
+	stt *STT
+
+	mu sync.Mutex
+	// ctx is the context handed to STT.Transcribe when a segment flushes. It is
+	// the conversation's lifetime context, captured at Bind and cleared by the
+	// returned cancel; storing it lets Process stay frame-only (ctx-free) so the
+	// audio loop reads as a plain range over frames.
+	ctx       context.Context
+	listening bool
+	buf       []audio.Frame
+}
+
+// NewSegmenter wires vad and stt together. Both must be non-nil; passing nil
+// for either panics. The caller owns the wrapped stages.
+func NewSegmenter(vad *VAD, stt *STT) *Segmenter {
+	if vad == nil {
+		panic("orchestrator.NewSegmenter: vad must not be nil")
+	}
+	if stt == nil {
+		panic("orchestrator.NewSegmenter: stt must not be nil")
+	}
+	return &Segmenter{vad: vad, stt: stt}
+}
+
+// Bind subscribes the segmenter to the VAD speech transitions on bus and records
+// ctx as the context handed to STT.Transcribe on flush. It implements
+// [Reactor]; bus must be non-nil. The subscriptions only flip the speech-active
+// flag — the actual buffering and flush happen in [Segmenter.Process] so a
+// recognizer error can be returned to the audio loop rather than swallowed in a
+// callback.
+func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.Segmenter.Bind: bus must not be nil")
+	}
+	s.mu.Lock()
+	s.ctx = ctx
+	s.mu.Unlock()
+
+	unsubStart := voiceevent.On(bus, func(voiceevent.VADSpeechStart) {
+		s.mu.Lock()
+		s.listening = true
+		s.mu.Unlock()
+	})
+	unsubEnd := voiceevent.On(bus, func(voiceevent.VADSpeechEnd) {
+		s.mu.Lock()
+		s.listening = false
+		s.mu.Unlock()
+	})
+	return func() {
+		unsubStart()
+		unsubEnd()
+		s.mu.Lock()
+		s.ctx = nil
+		s.mu.Unlock()
+	}
+}
+
+// Process feeds one PCM frame through the wrapped VAD stage and accumulates
+// utterance audio. The VAD stage publishes the speech transitions synchronously,
+// so by the time it returns the speech-active flag is up to date: while active
+// the frame is buffered; on the first frame after speech ends the buffered
+// utterance is flushed to [STT.Transcribe]. The frame that ends speech is not
+// part of the utterance and is not buffered.
+//
+// A recognizer error is returned to the caller; the buffer is cleared either
+// way so a failed utterance does not bleed into the next one.
+func (s *Segmenter) Process(frame audio.Frame) error {
+	if err := s.vad.Process(frame); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if s.listening {
+		s.buf = append(s.buf, frame)
+		s.mu.Unlock()
+		return nil
+	}
+	seg := s.buf
+	s.buf = nil
+	ctx := s.ctx
+	s.mu.Unlock()
+
+	if len(seg) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.stt.Transcribe(ctx, seg)
+}
+
+// Reply is one thing an addressed Agent should say: a single sentence and the
+// Voice to render it with. A [ReplyFunc] returns zero or more Replies per
+// routing decision.
+type Reply struct {
+	Sentence string
+	Voice    tts.Voice
+}
+
+// ReplyFunc decides what an addressed Agent says in response to one
+// [voiceevent.AddressRouted] decision. Returning nil (or an empty slice) says
+// nothing — the right answer when the route is not for this Agent or the turn
+// has already been answered. Swapping the ReplyFunc swaps the pipeline's entire
+// "what do we say back" behaviour without touching any other stage: it is the
+// strategy seam of the reply reactor.
+//
+// In v1.0 the production ReplyFunc is the Agent loop (Hot Context assembly +
+// Persona injection + LLM dispatch, ADR-0019 slice 1); tests supply a closure
+// returning a canned line. Per ADR-0025 a multi-Agent address can yield an
+// Ensemble Turn — the slice return type leaves room for that to grow behind the
+// same seam.
+type ReplyFunc func(voiceevent.AddressRouted) []Reply
+
+// Replier is the [Reactor] that runs a [ReplyFunc] on every
+// [voiceevent.AddressRouted] and dispatches each resulting [Reply] through the
+// TTS stage.
+type Replier struct {
+	tts     *TTS
+	reply   ReplyFunc
+	onError ErrorFunc
+}
+
+// NewReplier wires ttsStage and reply together. Both must be non-nil; passing
+// nil for either panics. onError may be nil, in which case a [TTS.Dispatch]
+// failure is dropped silently.
+func NewReplier(ttsStage *TTS, reply ReplyFunc, onError ErrorFunc) *Replier {
+	if ttsStage == nil {
+		panic("orchestrator.NewReplier: tts must not be nil")
+	}
+	if reply == nil {
+		panic("orchestrator.NewReplier: reply must not be nil")
+	}
+	return &Replier{tts: ttsStage, reply: reply, onError: onError}
+}
+
+// Bind subscribes the replier to [voiceevent.AddressRouted] on bus and returns a
+// function that removes the subscription. It implements [Reactor]; bus must be
+// non-nil. Each [Reply] the [ReplyFunc] returns is dispatched in order under
+// ctx; a dispatch failure is reported through the ErrorFunc (callbacks cannot
+// return errors) and does not stop the remaining replies.
+func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.Replier.Bind: bus must not be nil")
+	}
+	return voiceevent.On(bus, func(e voiceevent.AddressRouted) {
+		for _, rep := range r.reply(e) {
+			if err := r.tts.Dispatch(ctx, rep.Sentence, rep.Voice); err != nil && r.onError != nil {
+				r.onError(err)
+			}
+		}
+	})
+}

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -2,6 +2,7 @@ package orchestrator_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -63,8 +64,12 @@ func TestSTT_HelloTest_EmitsFinal(t *testing.T) {
 	)
 }
 
-// TestSTT_TTRPGIntro_TranscribesBothLanguages tests that the STT stage can transcribe the TTRPG intro clip in both languages.
-// It includes the full audio pipeline with audio -> VAD -> STT -> AddressDetection -> TTS
+// TestSTT_TTRPGIntro_TranscribesBothLanguages drives the full slice-1 voice
+// pipeline — audio → VAD → STT → address detection → TTS — through the
+// [orchestrator.Conversation] façade (ADR-0026) rather than spelling the bus
+// wiring out inline. Feeding frames is all the test does imperatively; the
+// conversation segments utterances, transcribes, routes, and replies on the
+// bus. The assertions read the recorded event log the same way as before.
 func TestSTT_TTRPGIntro_TranscribesBothLanguages(t *testing.T) {
 	for _, testCase := range []struct {
 		clipName string
@@ -90,98 +95,73 @@ func TestSTT_TTRPGIntro_TranscribesBothLanguages(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.clipName, func(t *testing.T) {
-			// VAD and loading of audio sample + test harness
+			// VAD + audio sample + test harness.
 			vadStage, h, frames := voicetest.NewVADRig(t, testCase.clipName)
 
-			// Address detection
-			detector := orchestrator.NewAddressDetector(h.Bus, voiceevent.AddressTarget{
-				AgentID:   "but1",
-				AgentRole: "butler",
-				Name:      "Glyphoxa Butler",
-			}, []voiceevent.AddressTarget{
-				{
-					AgentID:   "distraction",
-					AgentRole: "character",
-					Name:      "Jamalaka",
-				},
-			})
-			t.Cleanup(detector.Close)
-
-			// STT to transcribe audio chunks
+			// STT transcribes each VAD-segmented utterance.
 			recognizer := voicecassette.LoadSTT(t, "stt-"+testCase.clipName)
 			sttStage := orchestrator.NewSTT(h.Bus, recognizer)
 
-			// TTS to generate response when butler is addressed
+			// TTS speaks the Butler's reply.
 			synthesizer := voicecassette.LoadTTS(t, "tts-"+testCase.clipName)
 			ttsStage := orchestrator.NewTTS(h.Bus, synthesizer)
 			voice := voicetest.LiveElevenLabsVoice()
-			dispatchOnce := sync.Once{}
 
-			// Full voice pipeline via bus subscription.
-			// 1. When VAD detects voice it collects the played frames.
-			// 2. Once VAD turns off again all collected samples are processed in STT
-			// 3. All STTFinal events are collected to a full transcript
-			// 4. If the address detection picks up a message targeted at the butler a TTS response is generated
-			listening := false
-			allTranscripts := ""
-			t.Cleanup(h.Bus.Subscribe(func(e voiceevent.Event) {
-				switch event := e.(type) {
-				case voiceevent.VADSpeechStart:
-					listening = true
-				case voiceevent.VADSpeechEnd:
-					listening = false
-				case voiceevent.STTFinal:
-					if allTranscripts == "" {
-						allTranscripts = event.Text
-					} else {
-						allTranscripts += " " + event.Text
-					}
-				case voiceevent.AddressRouted:
-					if event.Target.AgentRole != "butler" {
-						t.Error("address detection tried to route to npc")
-						return
-					}
-					dispatchOnce.Do(func() {
-						if err := ttsStage.Dispatch(t.Context(), testCase.response, voice); err != nil {
-							t.Fatalf("tts failed to generate response: %v", err)
-						}
+			// Address detection: the Butler is the default route; Jamalaka is an
+			// active NPC who is never named, so every utterance routes to the Butler.
+			detector := orchestrator.NewAddressDetector(
+				voiceevent.AddressTarget{AgentID: "but1", AgentRole: "butler", Name: "Glyphoxa Butler"},
+				[]voiceevent.AddressTarget{
+					{AgentID: "distraction", AgentRole: "character", Name: "Jamalaka"},
+				},
+			)
+
+			// Reply strategy: answer the Butler exactly once per turn. The single
+			// TTS cassette segment is matched positionally, so a second dispatch
+			// would exhaust it — sync.Once pins "one reply".
+			var answered sync.Once
+			reply := func(e voiceevent.AddressRouted) []orchestrator.Reply {
+				var out []orchestrator.Reply
+				if e.Target.AgentRole == "butler" {
+					answered.Do(func() {
+						out = []orchestrator.Reply{{Sentence: testCase.response, Voice: voice}}
 					})
 				}
-			}))
-
-			framesSinceLastVad := make([]audio.Frame, 0, len(frames))
-			for _, frame := range frames {
-				if err := vadStage.Process(frame); err != nil {
-					t.Fatalf("unexpected error during vad processing: %v", err)
-				}
-				if listening {
-					framesSinceLastVad = append(framesSinceLastVad, frame)
-				} else if len(framesSinceLastVad) > 0 {
-					// Listening must have switched off since we have leftover frames with listening == false.
-					// This signals a finished utterance to give to STT.
-					if err := sttStage.Transcribe(t.Context(), framesSinceLastVad); err != nil {
-						t.Fatalf("unexpected error during stt processing: %v", err)
-					}
-					framesSinceLastVad = make([]audio.Frame, 0, len(frames))
-				}
-			}
-			if listening {
-				t.Error("VAD should have emitted a VADSpeechEnd last")
+				return out
 			}
 
-			// VAD is the most basic thing that should have been noticed
+			// Wire the whole reactive pipeline onto the bus in one call.
+			conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+				orchestrator.WithDetector(detector),
+				orchestrator.WithReply(reply),
+				orchestrator.WithErrorHandler(func(err error) { t.Errorf("reply dispatch: %v", err) }),
+			)
+			t.Cleanup(conv.Register(t.Context()))
+
+			for i, frame := range frames {
+				if err := conv.Feed(frame); err != nil {
+					t.Fatalf("frame %d: conv.Feed: %v", i, err)
+				}
+			}
+
+			// VAD is the most basic thing that should have been noticed.
 			voicetest.AssertEventOccurred[voiceevent.VADSpeechStart](t, h)
 			voicetest.AssertEventOccurred[voiceevent.VADSpeechEnd](t, h)
 
-			// STT should have been triggered at least once and the transcripts should match
+			// STT should have been triggered at least once and the transcripts should match.
 			voicetest.AssertEventOccurred[voiceevent.STTFinal](t, h)
 			want := voicetest.NormalizeTranscript(testCase.want)
-			actual := voicetest.NormalizeTranscript(allTranscripts)
+			actual := voicetest.NormalizeTranscript(joinTranscripts(h))
 			if !voicetest.WordsMatch(want, actual, 0.7) {
 				t.Errorf("stt transcript diverged beyond tolerance (<70%% word overlap).\nwant: %q\ngot: %q", want, actual)
 			}
 
-			// Address detection should have found the butler
+			// Every routing decision went to the Butler — no NPC is named in the clip.
+			for _, e := range h.Events() {
+				if routed, ok := e.(voiceevent.AddressRouted); ok && routed.Target.AgentRole != "butler" {
+					t.Errorf("address detection routed to %q, want butler", routed.Target.AgentRole)
+				}
+			}
 			voicetest.AssertEvent(t, h,
 				func(e voiceevent.AddressRouted) bool {
 					return e.Target.AgentRole == "butler" && e.Target.Name == "Glyphoxa Butler"
@@ -189,7 +169,7 @@ func TestSTT_TTRPGIntro_TranscribesBothLanguages(t *testing.T) {
 				"address.routed exists for Glyphoxa Butler",
 			)
 
-			// TTS should have been dispatched
+			// TTS should have been dispatched with the reply.
 			voicetest.AssertEvent(t, h,
 				func(e voiceevent.TTSInvoked) bool {
 					return e.Sentence == testCase.response
@@ -198,6 +178,23 @@ func TestSTT_TTRPGIntro_TranscribesBothLanguages(t *testing.T) {
 			)
 		})
 	}
+}
+
+// joinTranscripts concatenates the text of every STTFinal observed by h, in
+// arrival order, into a single transcript for whole-utterance assertions.
+func joinTranscripts(h *voicetest.Harness) string {
+	var b strings.Builder
+	for _, e := range h.Events() {
+		final, ok := e.(voiceevent.STTFinal)
+		if !ok {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(final.Text)
+	}
+	return b.String()
 }
 
 // TestSTT_EmptyTranscript_StillPublishes pins the contract documented on

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -153,3 +153,19 @@ func (b *Bus) Subscribe(fn func(Event)) (unsubscribe func()) {
 		b.mu.Unlock()
 	}
 }
+
+// On registers fn for every subsequent Publish of an event whose concrete type
+// is E, narrowing the bus's untyped delivery to a single event type. Events of
+// any other type are ignored. The returned function removes the subscription;
+// calling it more than once is a no-op.
+//
+// On is the typed building block the orchestrator's reactive wiring is composed
+// from: it replaces the switch-on-e.(type) a raw [Bus.Subscribe] callback would
+// otherwise spell out, the same way one net/http handler binds one route.
+func On[E Event](bus *Bus, fn func(E)) (unsubscribe func()) {
+	return bus.Subscribe(func(e Event) {
+		if typed, ok := e.(E); ok {
+			fn(typed)
+		}
+	})
+}

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -100,6 +100,42 @@ func TestBus_PublishFansOutToMultipleSubscribers(t *testing.T) {
 	}
 }
 
+func TestOn_DeliversOnlyMatchingType(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus()
+	var starts []VADSpeechStart
+	t.Cleanup(On(bus, func(e VADSpeechStart) { starts = append(starts, e) }))
+
+	bus.Publish(VADSpeechStart{Probability: 0.9})
+	bus.Publish(VADSpeechEnd{Probability: 0.1}) // ignored: different type
+	bus.Publish(STTFinal{Text: "hi"})           // ignored: different type
+	bus.Publish(VADSpeechStart{Probability: 0.8})
+
+	if len(starts) != 2 {
+		t.Fatalf("typed handler received %d events, want 2", len(starts))
+	}
+	if starts[0].Probability != 0.9 || starts[1].Probability != 0.8 {
+		t.Errorf("typed handler got %+v, want probabilities 0.9 then 0.8", starts)
+	}
+}
+
+func TestOn_UnsubscribeStopsDelivery(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus()
+	var n int
+	unsub := On(bus, func(VADSpeechStart) { n++ })
+
+	bus.Publish(VADSpeechStart{})
+	unsub()
+	bus.Publish(VADSpeechStart{})
+
+	if n != 1 {
+		t.Errorf("after unsubscribe got %d events, want 1", n)
+	}
+}
+
 func TestBus_ConcurrentPublishAndSubscribe(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The reactive glue between voice stages — "accumulate frames between `vad.speech_start`/`vad.speech_end` then transcribe", "on `address.routed`, speak a reply" — lived inline in the slice-1 pipeline test as an untyped `switch e.(type)` loop. This PR formalizes those bus interactions into a layered API so voice-interaction behaviour can be changed **all at once** or **one interaction at a time**, behind a stable seam. Decision recorded in **ADR-0026**.

Three layers, smallest to largest:

1. **`voiceevent.On[E](bus, fn)`** — typed subscription primitive; narrows the bus's one-callback-receives-everything delivery to one callback per concrete event type (replaces the type switch a raw subscriber writes).
2. **`orchestrator.Reactor`** — `Bind(ctx, bus) (cancel func())`, one self-contained bus interaction. `AddressDetector` is regularized to it (constructor no longer subscribes; `Close` → the `Bind` cancel). New siblings: `Segmenter` (VAD speech transitions → STT, and the audio-frame sink via `Process`) and `Replier` (`address.routed` → TTS, behaviour injected as a `ReplyFunc`). `orchestrator.Bind(ctx, bus, reactors…)` composes any subset — the "in parts" knob.
3. **`orchestrator.Conversation`** — the façade bundling the default reactor set, with `Register(ctx)`/`Feed(frame)` and functional options (`WithDetector`, `WithReply`, `WithErrorHandler`) — the "all at once" knob.

Idioms borrowed from the stdlib / common Go: typed narrowing (cf. `errors.As`), `cancel func()` teardown (cf. `Bus.Subscribe`, `signal.NotifyContext`), handler composition (cf. `net/http`, `io.MultiWriter`), functional options (cf. `grpc.Dial`).

The `TestSTT_TTRPGIntro_TranscribesBothLanguages` pipeline test is refactored to drive the `Conversation` end to end as the proof; `docs/devs/voice-tests.md` documents the new wiring.

### Notes / decisions worth a look
- **Breaking change to `AddressDetector`**: `NewAddressDetector(butler, npcs)` (bus moved to `Bind`); `Close()` removed in favour of the `Bind` cancel func. Both call sites (its own tests + the pipeline test) are updated.
- **ctx & errors**: `ctx` passed to `Register`/`Bind` governs the reactions and is handed to the STT/TTS calls a reactor triggers; teardown stays explicit. A bus callback can't return an error, so the `Replier`'s `TTS.Dispatch` failure surfaces via an optional `ErrorFunc` (the `Segmenter`'s `STT.Transcribe` runs in `Process` and returns its error directly).
- **Synchronous bus kept** for v1.0 (matches existing tracer bullets); a production async-dispatch boundary is called out in the ADR as a later tracer bullet.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/voice/orchestrator/... ./pkg/voice/voiceevent/...`
- [x] `gofmt -l pkg/` clean
- [x] `go test ./pkg/voice/...` (replay mode) — all pass
- [x] `go test -race ./pkg/voice/orchestrator/... ./pkg/voice/voiceevent/...` — clean
- [x] New unit tests for `voiceevent.On` (typed delivery + unsubscribe)

https://claude.ai/code/session_01AfvD2PU3KKkt44KrqDz7TB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfvD2PU3KKkt44KrqDz7TB)_