### PR TITLE
Full codebase review: bugfixes, hardening, and coverage

### DIFF
--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -95,3 +95,11 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 func (c *Conversation) Feed(frame audio.Frame) error {
 	return c.seg.Process(frame)
 }
+
+// Flush transcribes any utterance still buffered because the audio stream ended
+// while speech was active (see [Segmenter.Flush]). Call it once after the last
+// [Conversation.Feed] — at end of call, or when a clip is exhausted mid-speech —
+// so the final turn is not silently lost. With nothing buffered it is a no-op.
+func (c *Conversation) Flush() error {
+	return c.seg.Flush()
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -145,6 +145,33 @@ func (s *Segmenter) Process(frame audio.Frame) error {
 	ctx := s.ctx
 	s.mu.Unlock()
 
+	return s.transcribe(ctx, seg)
+}
+
+// Flush transcribes any buffered utterance audio immediately, regardless of
+// whether speech is still active, and clears the buffer. It is the
+// end-of-stream counterpart to [Segmenter.Process]: when the audio loop stops
+// while the speaker is still mid-utterance (the call ends, a clip is cut off
+// before its trailing silence), the wrapped VAD never observes a speech-end
+// transition, so the buffered final utterance would otherwise be dropped. Call
+// Flush once after the last [Segmenter.Process]. With no buffered audio it is a
+// no-op; the recognizer error, if any, is returned.
+func (s *Segmenter) Flush() error {
+	s.mu.Lock()
+	seg := s.buf
+	s.buf = nil
+	s.listening = false
+	ctx := s.ctx
+	s.mu.Unlock()
+
+	return s.transcribe(ctx, seg)
+}
+
+// transcribe hands a flushed segment to STT under ctx. An empty segment is a
+// no-op (a speech-end with nothing buffered, or a redundant Flush). A nil ctx —
+// the segmenter was never bound, or was already torn down — falls back to a
+// background context so a late flush still completes rather than panicking.
+func (s *Segmenter) transcribe(ctx context.Context, seg []audio.Frame) error {
 	if len(seg) == 0 {
 		return nil
 	}

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
 )
 
 // scriptedVAD is a [vad.SessionHandle] that returns a predetermined sequence of
@@ -171,6 +173,116 @@ func TestSegmenter_BufferClearedAfterFlushError(t *testing.T) {
 	if got := len(rec.calls[1]); got != 1 {
 		t.Errorf("second utterance had %d frames, want 1 (first utterance must not bleed in)", got)
 	}
+}
+
+// recordReactor is a [orchestrator.Reactor] whose teardown appends its name to
+// a shared log, so a test can observe Bind's teardown ordering.
+type recordReactor struct {
+	name string
+	log  *[]string
+}
+
+func (r recordReactor) Bind(context.Context, *voiceevent.Bus) func() {
+	return func() { *r.log = append(*r.log, r.name) }
+}
+
+// TestBind_TearsDownInReverseOrder pins the documented contract that Bind's
+// returned cancel tears reactors down in reverse registration order.
+func TestBind_TearsDownInReverseOrder(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var log []string
+	cancel := orchestrator.Bind(t.Context(), bus,
+		recordReactor{name: "a", log: &log},
+		recordReactor{name: "b", log: &log},
+		recordReactor{name: "c", log: &log},
+	)
+	cancel()
+
+	want := []string{"c", "b", "a"}
+	if len(log) != len(want) {
+		t.Fatalf("teardown order = %v, want %v", log, want)
+	}
+	for i := range want {
+		if log[i] != want[i] {
+			t.Fatalf("teardown order = %v, want %v (reverse of registration)", log, want)
+		}
+	}
+}
+
+// TestReplier_BindCancelUnsubscribes proves the reactor stops reacting after
+// its returned cancel runs: an AddressRouted published post-teardown drives no
+// further TTS dispatch.
+func TestReplier_BindCancelUnsubscribes(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+		return []orchestrator.Reply{{Sentence: "hi"}}
+	}
+	cancel := orchestrator.NewReplier(ttsStage, reply, nil).Bind(t.Context(), h.Bus)
+
+	h.Bus.Publish(voiceevent.AddressRouted{})
+	cancel()
+	h.Bus.Publish(voiceevent.AddressRouted{})
+
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+}
+
+// selectiveSynth is a [tts.Synthesizer] that fails Synthesize for sentences in
+// failOn and otherwise returns an already-closed audio channel.
+type selectiveSynth struct {
+	failOn map[string]bool
+}
+
+func (s selectiveSynth) Synthesize(_ context.Context, req tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	if s.failOn[req.Sentence] {
+		return nil, errors.New("synth failed")
+	}
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (selectiveSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestReplier_DispatchErrorReportedAndDoesNotStopRemaining pins the documented
+// error contract: a failing Dispatch is surfaced via the ErrorFunc and the
+// remaining replies in the same turn are still dispatched.
+func TestReplier_DispatchErrorReportedAndDoesNotStopRemaining(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
+	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+		return []orchestrator.Reply{{Sentence: "boom"}, {Sentence: "ok"}}
+	}
+	var errs []error
+	replier := orchestrator.NewReplier(ttsStage, reply, func(e error) { errs = append(errs, e) })
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{})
+
+	if len(errs) != 1 {
+		t.Fatalf("ErrorFunc saw %d errors, want 1", len(errs))
+	}
+	// The first reply failed (no event); the second still dispatched.
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TTSInvoked) bool { return e.Sentence == "ok" },
+		"tts.invoked for the reply after the failed one",
+	)
+}
+
+// TestReplier_NilErrorFuncDropsErrorWithoutPanic pins that a nil ErrorFunc is
+// tolerated: a dispatch failure is dropped silently and later replies proceed.
+func TestReplier_NilErrorFuncDropsErrorWithoutPanic(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
+	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+		return []orchestrator.Reply{{Sentence: "boom"}, {Sentence: "ok"}}
+	}
+	t.Cleanup(orchestrator.NewReplier(ttsStage, reply, nil).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{}) // must not panic on the dropped error
+
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
 }
 
 // TestSegmenter_ConcurrentFeedAndFlush is a -race probe: an audio loop feeding

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -1,0 +1,185 @@
+package orchestrator_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// scriptedVAD is a [vad.SessionHandle] that returns a predetermined sequence of
+// event types, one per ProcessFrame call, so a test can drive the segmenter's
+// speech-active state deterministically without a real detector. Frames past
+// the script report silence.
+type scriptedVAD struct {
+	events []vad.VADEventType
+	i      int
+}
+
+func (s *scriptedVAD) ProcessFrame(audio.Frame) (vad.VADEvent, error) {
+	typ := vad.VADSilence
+	if s.i < len(s.events) {
+		typ = s.events[s.i]
+		s.i++
+	}
+	return vad.VADEvent{Type: typ}, nil
+}
+
+func (s *scriptedVAD) Reset()       {}
+func (s *scriptedVAD) Close() error { return nil }
+
+// recordingRecognizer captures the frame batch of every Transcribe call so a
+// test can assert which frames a flush handed to STT. It optionally returns err.
+type recordingRecognizer struct {
+	err   error
+	calls [][]audio.Frame
+}
+
+func (r *recordingRecognizer) Transcribe(_ context.Context, frames []audio.Frame) (stt.Transcript, error) {
+	r.calls = append(r.calls, append([]audio.Frame(nil), frames...))
+	return stt.Transcript{Text: "ok"}, r.err
+}
+
+// segFrame returns a 32 ms / 16 kHz frame (512 samples), the framing the rest
+// of the orchestrator tests use.
+func segFrame(t *testing.T) audio.Frame {
+	t.Helper()
+	f, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// newSegmenterRig wires a segmenter over the scripted VAD and recording
+// recognizer onto a fresh bus, bound for the test's lifetime.
+func newSegmenterRig(t *testing.T, script ...vad.VADEventType) (*orchestrator.Segmenter, *recordingRecognizer) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	vadStage := orchestrator.NewVAD(bus, &scriptedVAD{events: script})
+	sttStage := orchestrator.NewSTT(bus, rec)
+	seg := orchestrator.NewSegmenter(vadStage, sttStage)
+	t.Cleanup(seg.Bind(t.Context(), bus))
+	return seg, rec
+}
+
+func feed(t *testing.T, seg *orchestrator.Segmenter, n int) {
+	t.Helper()
+	for i := range n {
+		if err := seg.Process(segFrame(t)); err != nil {
+			t.Fatalf("frame %d: Process: %v", i, err)
+		}
+	}
+}
+
+// TestSegmenter_FlushTranscribesTrailingUtterance is the regression test for the
+// dropped-final-turn bug: the audio loop stops while speech is still active (no
+// speech-end transition ever fires), so Process never flushes. Without an
+// explicit Flush the buffered utterance is lost; with it, the buffered frames
+// reach STT.
+func TestSegmenter_FlushTranscribesTrailingUtterance(t *testing.T) {
+	// Speech starts and continues, but the stream ends before any speech-end.
+	seg, rec := newSegmenterRig(t, vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue)
+	feed(t, seg, 3)
+
+	if len(rec.calls) != 0 {
+		t.Fatalf("before Flush: %d transcribe calls, want 0 (speech still active)", len(rec.calls))
+	}
+
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("after Flush: %d transcribe calls, want 1", len(rec.calls))
+	}
+	if got := len(rec.calls[0]); got != 3 {
+		t.Errorf("flushed segment had %d frames, want 3 (all buffered speech)", got)
+	}
+}
+
+// TestSegmenter_FlushIsNoOpWhenEmpty pins that Flush with nothing buffered — no
+// audio fed, or already flushed by a speech-end — does not invoke STT, so a
+// defensive end-of-stream Flush after a clean turn is harmless.
+func TestSegmenter_FlushIsNoOpWhenEmpty(t *testing.T) {
+	seg, rec := newSegmenterRig(t)
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush on empty: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("empty Flush made %d transcribe calls, want 0", len(rec.calls))
+	}
+}
+
+// TestSegmenter_ProcessFlushesOnSpeechEnd pins the normal path: the frame that
+// ends speech triggers the flush and is itself excluded from the utterance, and
+// a redundant Flush afterwards is a no-op (the buffer was already drained).
+func TestSegmenter_ProcessFlushesOnSpeechEnd(t *testing.T) {
+	seg, rec := newSegmenterRig(t, vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechEnd)
+	feed(t, seg, 3)
+
+	if len(rec.calls) != 1 {
+		t.Fatalf("%d transcribe calls, want 1 (flush on speech-end)", len(rec.calls))
+	}
+	if got := len(rec.calls[0]); got != 2 {
+		t.Errorf("utterance had %d frames, want 2 (the speech-end frame is excluded)", got)
+	}
+
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("redundant Flush: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Errorf("redundant Flush re-transcribed: %d calls, want 1", len(rec.calls))
+	}
+}
+
+// TestSegmenter_BufferClearedAfterFlushError pins the "a failed utterance does
+// not bleed into the next" contract: when STT errors on flush, the buffer is
+// still cleared, so the following utterance contains only its own frames.
+func TestSegmenter_BufferClearedAfterFlushError(t *testing.T) {
+	seg, rec := newSegmenterRig(t,
+		vad.VADSpeechStart, vad.VADSpeechEnd, // first utterance: 1 frame, then end
+		vad.VADSpeechStart, vad.VADSpeechEnd, // second utterance: 1 frame, then end
+	)
+	rec.err = errors.New("boom")
+
+	// First utterance: frame 0 buffered, frame 1 ends speech and flushes → error.
+	if err := seg.Process(segFrame(t)); err != nil {
+		t.Fatalf("frame 0: %v", err)
+	}
+	if err := seg.Process(segFrame(t)); err == nil {
+		t.Fatal("frame 1: expected the recognizer error to propagate")
+	}
+
+	// Second utterance must not carry the first's frame.
+	if err := seg.Process(segFrame(t)); err != nil {
+		t.Fatalf("frame 2: %v", err)
+	}
+	if err := seg.Process(segFrame(t)); err == nil {
+		t.Fatal("frame 3: expected the recognizer error to propagate")
+	}
+
+	if len(rec.calls) != 2 {
+		t.Fatalf("%d transcribe calls, want 2", len(rec.calls))
+	}
+	if got := len(rec.calls[1]); got != 1 {
+		t.Errorf("second utterance had %d frames, want 1 (first utterance must not bleed in)", got)
+	}
+}
+
+// TestSegmenter_ConcurrentFeedAndFlush is a -race probe: an audio loop feeding
+// frames while a separate goroutine flushes must not race on the shared buffer.
+func TestSegmenter_ConcurrentFeedAndFlush(t *testing.T) {
+	seg, _ := newSegmenterRig(t, vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); feed(t, seg, 3) }()
+	go func() { defer wg.Done(); _ = seg.Flush() }()
+	wg.Wait()
+}

--- a/pkg/voice/orchestrator/tts.go
+++ b/pkg/voice/orchestrator/tts.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
@@ -20,7 +21,9 @@ import (
 type TTS struct {
 	bus         *voiceevent.Bus
 	synthesizer tts.Synthesizer
-	nextIndex   int
+
+	mu        sync.Mutex
+	nextIndex int
 }
 
 // NewTTS wires synthesizer into bus. Both must be non-nil; passing nil panics.
@@ -63,12 +66,20 @@ func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) er
 	if err != nil {
 		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
 	}
+	// Assign the per-turn index under the lock so concurrent dispatches (an
+	// Ensemble Turn or a barge-in canceller, both anticipated below) get
+	// distinct, monotonically increasing indices. Only a successful synthesis
+	// consumes an index — the error path above returns before this.
+	s.mu.Lock()
+	index := s.nextIndex
+	s.nextIndex++
+	s.mu.Unlock()
+
 	s.bus.Publish(voiceevent.TTSInvoked{
 		At:       time.Now(),
 		Sentence: sentence,
-		Index:    s.nextIndex,
+		Index:    index,
 	})
-	s.nextIndex++
 	for range ch {
 	}
 	return nil

--- a/pkg/voice/orchestrator/tts_test.go
+++ b/pkg/voice/orchestrator/tts_test.go
@@ -2,13 +2,29 @@ package orchestrator_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
 )
+
+// closedChanSynth is a [tts.Synthesizer] that accepts any sentence and returns
+// an already-closed audio channel, so Dispatch's drain returns immediately. It
+// lets the index-assignment contract be tested without a cassette's positional
+// sentence match.
+type closedChanSynth struct{}
+
+func (closedChanSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (closedChanSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
 
 // TestTTS_HelloTest_DispatchesSentence is TB6: the first TTS tracer bullet,
 // per ADR-0021's TTS cassette policy.
@@ -40,4 +56,46 @@ func TestTTS_HelloTest_DispatchesSentence(t *testing.T) {
 		},
 		"tts.invoked with sentence "+sentence+" at index 0",
 	)
+}
+
+// TestTTS_ConcurrentDispatch_AssignsUniqueIndices pins that the per-turn index
+// is assigned race-free: concurrent Dispatch calls (an Ensemble Turn or a
+// barge-in canceller, both anticipated on the stage) must each publish a
+// distinct index covering exactly 0..N-1, never a duplicate or a gap. Run under
+// -race it also guards the nextIndex field itself.
+func TestTTS_ConcurrentDispatch_AssignsUniqueIndices(t *testing.T) {
+	h := voicetest.New(t)
+	stage := orchestrator.NewTTS(h.Bus, closedChanSynth{})
+	voice := voicetest.LiveElevenLabsVoice()
+
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			if err := stage.Dispatch(context.Background(), "line", voice); err != nil {
+				t.Errorf("Dispatch: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[int]bool, n)
+	for _, e := range h.Events() {
+		if inv, ok := e.(voiceevent.TTSInvoked); ok {
+			if seen[inv.Index] {
+				t.Errorf("duplicate TTS index %d", inv.Index)
+			}
+			seen[inv.Index] = true
+		}
+	}
+	if len(seen) != n {
+		t.Fatalf("saw %d distinct indices, want %d", len(seen), n)
+	}
+	for i := range n {
+		if !seen[i] {
+			t.Errorf("missing index %d (indices must be a gapless 0..%d)", i, n-1)
+		}
+	}
 }

--- a/pkg/voice/tts/elevenlabs/internal_test.go
+++ b/pkg/voice/tts/elevenlabs/internal_test.go
@@ -1,9 +1,86 @@
 package elevenlabs
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"io"
 	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 )
+
+// oddChunkReader hands out at most chunk bytes per Read so read boundaries land
+// mid-sample, exercising streamPCM's odd-byte carry-over.
+type oddChunkReader struct {
+	data  []byte
+	chunk int
+}
+
+func (r *oddChunkReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	n := min(r.chunk, len(p), len(r.data))
+	copy(p, r.data[:n])
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func (r *oddChunkReader) Close() error { return nil }
+
+// TestStreamPCM_OddSizedReadsReassembleExactly is the regression test for the
+// sample-desync bug: streamPCM used to mask off the trailing byte of every odd
+// read and discard it, shifting and corrupting all subsequent samples. With the
+// carry-over fix, an even-length stream delivered in odd-sized reads must
+// reassemble byte-for-byte.
+func TestStreamPCM_OddSizedReadsReassembleExactly(t *testing.T) {
+	t.Parallel()
+	// 1000 distinct bytes (even length = a whole number of int16 samples).
+	want := make([]byte, 1000)
+	for i := range want {
+		want[i] = byte(i % 251) // 251 is prime → no accidental period alignment
+	}
+
+	for _, chunk := range []int{1, 3, 5, 7, 4095} {
+		src := make([]byte, len(want))
+		copy(src, want)
+		r := &oddChunkReader{data: src, chunk: chunk}
+		ch := make(chan tts.AudioChunk)
+		go streamPCM(context.Background(), r, ch, 24000)
+
+		var got []byte
+		for c := range ch {
+			if len(c.PCM)%2 != 0 {
+				t.Errorf("chunk=%d: emitted an odd-length PCM chunk (%d bytes)", chunk, len(c.PCM))
+			}
+			got = append(got, c.PCM...)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("chunk=%d: reassembled stream differs from source (%d of %d bytes)",
+				chunk, len(got), len(want))
+		}
+	}
+}
+
+// TestStreamPCM_TrailingOddByteDropped pins the documented edge: a stream with
+// an odd total length (a truncated final sample) emits all whole samples and
+// drops only the single dangling byte — never more.
+func TestStreamPCM_TrailingOddByteDropped(t *testing.T) {
+	t.Parallel()
+	want := []byte{1, 2, 3, 4, 5} // 5 bytes: two whole samples + one dangling
+	r := &oddChunkReader{data: append([]byte(nil), want...), chunk: 2}
+	ch := make(chan tts.AudioChunk)
+	go streamPCM(context.Background(), r, ch, 24000)
+
+	var got []byte
+	for c := range ch {
+		got = append(got, c.PCM...)
+	}
+	if !bytes.Equal(got, want[:4]) {
+		t.Errorf("reassembled %v, want %v (final dangling byte dropped)", got, want[:4])
+	}
+}
 
 func TestSampleRateFromOutputFormat(t *testing.T) {
 	t.Parallel()

--- a/pkg/voice/tts/elevenlabs/synthesize.go
+++ b/pkg/voice/tts/elevenlabs/synthesize.go
@@ -113,28 +113,47 @@ func streamPCM(ctx context.Context, r io.ReadCloser, ch chan<- tts.AudioChunk, s
 	defer r.Close()
 
 	buf := make([]byte, streamReadBuffer)
+	carried := false // buf[0] holds the low byte of a sample split across reads
 	for {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		n, err := r.Read(buf)
-		if n > 0 {
-			// Defensively drop any trailing byte that would make the chunk an
-			// odd byte count — downstream [audio.FromPCM16LE] requires even.
-			n &^= 1
-			if n > 0 {
-				chunk := make([]byte, n)
-				copy(chunk, buf[:n])
+		// Reserve buf[0] for a byte carried over from the previous read so a
+		// sample straddling a read boundary stays aligned (each int16 PCM sample
+		// is two bytes; downstream [audio.FromPCM16LE] requires an even count).
+		off := 0
+		if carried {
+			off = 1
+		}
+		n, err := r.Read(buf[off:])
+		total := off + n
+		if total > 0 {
+			// Emit a whole number of samples; hold any trailing odd byte for the
+			// next read instead of dropping it (dropping would shift — and so
+			// corrupt — every subsequent sample).
+			emit := total &^ 1
+			if emit > 0 {
+				chunk := make([]byte, emit)
+				copy(chunk, buf[:emit])
 				select {
 				case <-ctx.Done():
 					return
 				case ch <- tts.AudioChunk{PCM: chunk, SampleRate: sampleRate, Channels: 1}:
 				}
 			}
+			// Carry the leftover low byte to the front for the next read. Done
+			// after the copy above so the emitted chunk keeps its first byte.
+			if emit < total {
+				buf[0] = buf[emit]
+				carried = true
+			} else {
+				carried = false
+			}
 		}
 		if err != nil {
 			// Includes io.EOF for normal completion and any mid-stream error;
-			// per ADR-0022 we close the channel early either way.
+			// per ADR-0022 we close the channel early either way. A final
+			// dangling byte (a truncated last sample) is intentionally dropped.
 			return
 		}
 	}

--- a/pkg/voice/vad/silero/runtime_test.go
+++ b/pkg/voice/vad/silero/runtime_test.go
@@ -1,0 +1,159 @@
+package silero
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSafeName(t *testing.T) {
+	cases := map[string]bool{
+		"libonnxruntime.so":   true,
+		"libonnxruntime.so.1": true,
+		"":                    false,
+		".":                   false,
+		"..":                  false,
+		"../evil":             false,
+		"foo/bar":             false,
+		"a..b":                false, // conservative: any ".." substring is rejected
+		"/etc/passwd":         false,
+	}
+	for name, want := range cases {
+		if got := safeName(name); got != want {
+			t.Errorf("safeName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// tarEntry describes one entry to write into a synthetic release tarball.
+type tarEntry struct {
+	name string
+	typ  byte
+	body string // for regular files
+	link string // for symlinks
+}
+
+// writeTarGz writes entries into a gzip-compressed tar at a temp path and
+// returns the path, mirroring the shape of a Microsoft ONNX Runtime release
+// (a single top-level directory containing lib/, headers, docs).
+func writeTarGz(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "artifact.tgz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create tarball: %v", err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Typeflag: e.typ, Mode: 0o644}
+		switch e.typ {
+		case tar.TypeReg:
+			hdr.Size = int64(len(e.body))
+		case tar.TypeSymlink:
+			hdr.Linkname = e.link
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if e.typ == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return path
+}
+
+// TestExtractLibFromTarball_ExtractsAndFlattensLib proves the happy path: a
+// regular file under "<top>/lib/" is written into destLibDir flattened to its
+// base name, while a within-lib symlink is recreated and non-lib entries are
+// skipped.
+func TestExtractLibFromTarball_ExtractsAndFlattensLib(t *testing.T) {
+	tgz := writeTarGz(t, []tarEntry{
+		{name: "onnxruntime-1.25.1/lib/libonnxruntime.so.1", typ: tar.TypeReg, body: "ELF-bytes"},
+		{name: "onnxruntime-1.25.1/lib/libonnxruntime.so", typ: tar.TypeSymlink, link: "libonnxruntime.so.1"},
+		{name: "onnxruntime-1.25.1/include/onnxruntime.h", typ: tar.TypeReg, body: "header"},
+		{name: "onnxruntime-1.25.1/LICENSE", typ: tar.TypeReg, body: "license"},
+	})
+	dest := t.TempDir()
+
+	if err := extractLibFromTarball(tgz, dest); err != nil {
+		t.Fatalf("extractLibFromTarball: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "libonnxruntime.so.1"))
+	if err != nil {
+		t.Fatalf("read extracted lib: %v", err)
+	}
+	if string(got) != "ELF-bytes" {
+		t.Errorf("extracted content = %q, want %q", got, "ELF-bytes")
+	}
+
+	link, err := os.Readlink(filepath.Join(dest, "libonnxruntime.so"))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if link != "libonnxruntime.so.1" {
+		t.Errorf("symlink target = %q, want %q", link, "libonnxruntime.so.1")
+	}
+
+	// Non-lib entries must not be extracted.
+	for _, skipped := range []string{"onnxruntime.h", "LICENSE"} {
+		if _, err := os.Stat(filepath.Join(dest, skipped)); !os.IsNotExist(err) {
+			t.Errorf("non-lib entry %q was extracted (err=%v), want skipped", skipped, err)
+		}
+	}
+}
+
+// TestExtractLibFromTarball_RejectsEscapingSymlink pins the symlink-escape
+// guard: a lib symlink whose target tries to leave the destination is rejected
+// rather than created.
+func TestExtractLibFromTarball_RejectsEscapingSymlink(t *testing.T) {
+	for _, target := range []string{"../../etc/passwd", "/etc/passwd"} {
+		t.Run(target, func(t *testing.T) {
+			tgz := writeTarGz(t, []tarEntry{
+				{name: "onnxruntime-1.25.1/lib/evil.so", typ: tar.TypeSymlink, link: target},
+			})
+			err := extractLibFromTarball(tgz, t.TempDir())
+			if err == nil {
+				t.Fatalf("escaping symlink target %q was accepted, want rejection", target)
+			}
+			if !strings.Contains(err.Error(), "unsafe symlink target") {
+				t.Errorf("error %q does not name the unsafe symlink target", err)
+			}
+		})
+	}
+}
+
+// TestExtractLibFromTarball_FlattensTraversalName proves a lib entry whose path
+// contains traversal components cannot escape destLibDir: filepath.Base reduces
+// it to a single safe component written inside the destination.
+func TestExtractLibFromTarball_FlattensTraversalName(t *testing.T) {
+	dest := t.TempDir()
+	tgz := writeTarGz(t, []tarEntry{
+		{name: "onnxruntime-1.25.1/lib/../../../../tmp/escaped.so", typ: tar.TypeReg, body: "x"},
+	})
+
+	if err := extractLibFromTarball(tgz, dest); err != nil {
+		t.Fatalf("extractLibFromTarball: %v", err)
+	}
+	// The entry is flattened to its base name inside dest, never written outside.
+	if _, err := os.Stat(filepath.Join(dest, "escaped.so")); err != nil {
+		t.Errorf("flattened entry not found in dest: %v", err)
+	}
+	if _, err := os.Stat("/tmp/escaped.so"); err == nil {
+		t.Error("entry escaped to /tmp/escaped.so — traversal not contained")
+		os.Remove("/tmp/escaped.so")
+	}
+}

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -108,11 +108,30 @@ func (TTSInvoked) EventName() string { return "tts.invoked" }
 // Bus is an in-process pub/sub channel. Subscribers register a callback;
 // Publish invokes every callback synchronously in the calling goroutine.
 //
+// Delivery guarantees:
+//   - Synchronous: Publish returns only after every callback has run.
+//   - Ordered: callbacks run in subscription order (the order Subscribe was
+//     called), so a deterministic pipeline stays deterministic — the same
+//     value the [Glyphoxa address matcher] is built around. Tests and the SSE
+//     relay therefore observe a stable fan-out order.
+//   - Re-entrant: a callback may itself call Publish; the nested delivery runs
+//     to completion (depth-first) before the outer fan-out continues. Note this
+//     means a subscriber listening to several event types can observe a caused
+//     event (e.g. AddressRouted) before the outer cause (STTFinal) finishes
+//     fanning out.
+//   - Snapshot: the subscriber set is snapshotted under lock at the start of
+//     each Publish. A subscriber added or removed concurrently with — or from
+//     inside — a Publish either sees that event or doesn't, atomically; one
+//     removed mid-fan-out still receives the in-flight event.
+//
 // Bus is safe for concurrent use. Callbacks must not block — slow consumers
-// (e.g. SSE writers) must do their own buffering.
+// (e.g. SSE writers) must do their own buffering — and must not panic: a panic
+// propagates to the publisher and aborts delivery to the remaining subscribers.
+//
+// [Glyphoxa address matcher]: github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator/address
 type Bus struct {
 	mu   sync.Mutex
-	subs map[*subscription]struct{}
+	subs []*subscription // subscribers in registration order; unsubscribe compacts
 }
 
 type subscription struct {
@@ -121,16 +140,16 @@ type subscription struct {
 
 // NewBus returns an empty Bus.
 func NewBus() *Bus {
-	return &Bus{subs: map[*subscription]struct{}{}}
+	return &Bus{}
 }
 
-// Publish delivers e to every current subscriber. Subscribers added or removed
-// concurrently with Publish either see e or don't, atomically.
+// Publish delivers e to every current subscriber, in subscription order, in the
+// calling goroutine. See [Bus] for the full delivery contract.
 func (b *Bus) Publish(e Event) {
 	b.mu.Lock()
-	fns := make([]func(Event), 0, len(b.subs))
-	for s := range b.subs {
-		fns = append(fns, s.fn)
+	fns := make([]func(Event), len(b.subs))
+	for i, s := range b.subs {
+		fns[i] = s.fn
 	}
 	b.mu.Unlock()
 
@@ -139,17 +158,25 @@ func (b *Bus) Publish(e Event) {
 	}
 }
 
-// Subscribe registers fn for every subsequent Publish. The returned function
-// removes the subscription; calling it more than once is a no-op.
+// Subscribe registers fn for every subsequent Publish, after any
+// already-registered subscribers. The returned function removes the
+// subscription; calling it more than once is a no-op.
 func (b *Bus) Subscribe(fn func(Event)) (unsubscribe func()) {
 	s := &subscription{fn: fn}
 	b.mu.Lock()
-	b.subs[s] = struct{}{}
+	b.subs = append(b.subs, s)
 	b.mu.Unlock()
 
 	return func() {
 		b.mu.Lock()
-		delete(b.subs, s)
+		for i, cur := range b.subs {
+			if cur == s {
+				// Compact in place; Publish has already copied the fn values it
+				// is mid-delivery on, so this never disturbs an in-flight fan-out.
+				b.subs = append(b.subs[:i], b.subs[i+1:]...)
+				break
+			}
+		}
 		b.mu.Unlock()
 	}
 }

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -136,6 +136,94 @@ func TestOn_UnsubscribeStopsDelivery(t *testing.T) {
 	}
 }
 
+// TestBus_DeliversInSubscriptionOrder pins the ordering guarantee: subscribers
+// are invoked in the order Subscribe was called, every Publish, so a
+// deterministic pipeline stays deterministic.
+func TestBus_DeliversInSubscriptionOrder(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus()
+	var order []int
+	for i := range 5 {
+		id := i
+		t.Cleanup(bus.Subscribe(func(Event) { order = append(order, id) }))
+	}
+
+	for range 3 {
+		order = order[:0]
+		bus.Publish(VADSpeechStart{})
+		for i := range 5 {
+			if order[i] != i {
+				t.Fatalf("delivery order = %v, want 0..4 (subscription order)", order)
+			}
+		}
+	}
+}
+
+// TestBus_UnsubscribeDuringPublishKeepsSnapshot pins the snapshot guarantee: a
+// subscriber removed by another subscriber's callback mid-fan-out still
+// receives the in-flight event, and is gone from the next Publish.
+func TestBus_UnsubscribeDuringPublishKeepsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus()
+	var victimCalls int
+	var unsubVictim func()
+	// First subscriber removes the victim during the fan-out.
+	t.Cleanup(bus.Subscribe(func(Event) {
+		if unsubVictim != nil {
+			unsubVictim()
+		}
+	}))
+	unsubVictim = bus.Subscribe(func(Event) { victimCalls++ })
+
+	bus.Publish(VADSpeechStart{}) // victim was snapshotted before removal → still called
+	if victimCalls != 1 {
+		t.Fatalf("victim got %d calls on the publish that removed it, want 1 (snapshot)", victimCalls)
+	}
+
+	bus.Publish(VADSpeechStart{}) // now removed → not called
+	if victimCalls != 1 {
+		t.Errorf("victim got %d calls after removal, want 1", victimCalls)
+	}
+}
+
+// TestBus_ReentrantPublishCompletesDepthFirst pins re-entrancy: a callback that
+// publishes a second event (the live AddressDetector → AddressRouted path) does
+// not deadlock, and the nested delivery completes before the outer fan-out
+// continues to the next subscriber.
+func TestBus_ReentrantPublishCompletesDepthFirst(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus()
+	var log []string
+	// Subscriber A republishes a different event type on the first STTFinal.
+	published := false
+	t.Cleanup(On(bus, func(STTFinal) {
+		log = append(log, "A:stt")
+		if !published {
+			published = true
+			bus.Publish(AddressRouted{}) // nested
+		}
+	}))
+	t.Cleanup(On(bus, func(AddressRouted) { log = append(log, "B:routed") }))
+	// Subscriber C (registered after A) sees the outer STTFinal only after the
+	// nested AddressRouted fan-out has completed.
+	t.Cleanup(On(bus, func(STTFinal) { log = append(log, "C:stt") }))
+
+	bus.Publish(STTFinal{})
+
+	want := []string{"A:stt", "B:routed", "C:stt"}
+	if len(log) != len(want) {
+		t.Fatalf("delivery log = %v, want %v", log, want)
+	}
+	for i := range want {
+		if log[i] != want[i] {
+			t.Fatalf("delivery log = %v, want %v (nested publish must complete depth-first)", log, want)
+		}
+	}
+}
+
 func TestBus_ConcurrentPublishAndSubscribe(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/voice/voicetest/clip.go
+++ b/pkg/voice/voicetest/clip.go
@@ -31,17 +31,37 @@ type Clip struct {
 // log it, fail the test, or pad it, so a clipped fixture cannot hide as a
 // passing test.
 //
-// The clip must be mono 16-bit PCM; otherwise the test is failed.
+// The clip must be mono 16-bit PCM and samplesPerFrame must be a whole number
+// of milliseconds at the clip's sample rate; otherwise the test is failed.
 func (c *Clip) FramesOf(t *testing.T, samplesPerFrame int) (frames []audio.Frame, tailSamples int) {
 	t.Helper()
+	frames, tailSamples, err := c.framesOf(samplesPerFrame)
+	if err != nil {
+		t.Fatalf("voicetest.FramesOf(%q): %v", c.Name, err)
+	}
+	return frames, tailSamples
+}
+
+// framesOf is the pure core of [Clip.FramesOf]: it validates the clip and frame
+// size and slices the PCM, returning an error instead of failing a test so the
+// logic is unit-testable without a *testing.T.
+func (c *Clip) framesOf(samplesPerFrame int) (frames []audio.Frame, tailSamples int, err error) {
 	if c.Channels != 1 {
-		t.Fatalf("voicetest.FramesOf(%q): clip has %d channels, want 1 (mono PCM only)", c.Name, c.Channels)
+		return nil, 0, fmt.Errorf("clip has %d channels, want 1 (mono PCM only)", c.Channels)
 	}
 	if c.BitDepth != 16 {
-		t.Fatalf("voicetest.FramesOf(%q): clip is %d-bit, want 16-bit PCM", c.Name, c.BitDepth)
+		return nil, 0, fmt.Errorf("clip is %d-bit, want 16-bit PCM", c.BitDepth)
 	}
 	if samplesPerFrame <= 0 {
-		t.Fatalf("voicetest.FramesOf(%q): samplesPerFrame must be > 0, got %d", c.Name, samplesPerFrame)
+		return nil, 0, fmt.Errorf("samplesPerFrame must be > 0, got %d", samplesPerFrame)
+	}
+	// audio.NewFrame validates len(samples) == SampleRate*frameMs/1000, so the
+	// frame duration must be a whole number of milliseconds. Reject a frame size
+	// that isn't, rather than deriving a truncated frameMs below and failing the
+	// decode with a confusing per-frame error.
+	if samplesPerFrame*1000%c.SampleRate != 0 {
+		return nil, 0, fmt.Errorf("samplesPerFrame=%d at %d Hz is %.4g ms, not a whole number of milliseconds; choose a frame size that divides evenly",
+			samplesPerFrame, c.SampleRate, float64(samplesPerFrame)*1000/float64(c.SampleRate))
 	}
 	bytesPerFrame := samplesPerFrame * 2
 	fullFrames := len(c.PCM) / bytesPerFrame
@@ -52,13 +72,13 @@ func (c *Clip) FramesOf(t *testing.T, samplesPerFrame int) (frames []audio.Frame
 	frames = make([]audio.Frame, 0, fullFrames)
 	for i := range fullFrames {
 		off := i * bytesPerFrame
-		f, err := audio.FromPCM16LE(c.PCM[off:off+bytesPerFrame], c.SampleRate, frameMs)
-		if err != nil {
-			t.Fatalf("voicetest.FramesOf(%q): decode frame %d: %v", c.Name, i, err)
+		f, e := audio.FromPCM16LE(c.PCM[off:off+bytesPerFrame], c.SampleRate, frameMs)
+		if e != nil {
+			return nil, 0, fmt.Errorf("decode frame %d: %w", i, e)
 		}
 		frames = append(frames, f)
 	}
-	return frames, tailSamples
+	return frames, tailSamples, nil
 }
 
 // LoadClip resolves and decodes tests/voice-clips/<name>/audio.wav, failing

--- a/pkg/voice/voicetest/clip_internal_test.go
+++ b/pkg/voice/voicetest/clip_internal_test.go
@@ -1,0 +1,76 @@
+package voicetest
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFramesOf_WholeMsConfig pins the happy-path framing math: a whole-ms frame
+// size splits the PCM into the expected number of frames and reports the
+// leftover partial frame as tailSamples rather than dropping it.
+func TestFramesOf_WholeMsConfig(t *testing.T) {
+	// 16 kHz / 32 ms = 512 samples = 1024 bytes per frame. 2.5 frames of data.
+	c := &Clip{Name: "synthetic", SampleRate: 16000, Channels: 1, BitDepth: 16,
+		PCM: make([]byte, 1024*2+512)}
+
+	frames, tail, err := c.framesOf(512)
+	if err != nil {
+		t.Fatalf("framesOf: %v", err)
+	}
+	if len(frames) != 2 {
+		t.Errorf("got %d full frames, want 2", len(frames))
+	}
+	if tail != 256 { // 512 leftover bytes / 2 bytes per sample
+		t.Errorf("tailSamples = %d, want 256", tail)
+	}
+	for i, f := range frames {
+		if got := len(f.Samples()); got != 512 {
+			t.Errorf("frame %d has %d samples, want 512", i, got)
+		}
+		if f.FrameMs() != 32 {
+			t.Errorf("frame %d FrameMs = %d, want 32", i, f.FrameMs())
+		}
+	}
+}
+
+// TestFramesOf_RejectsNonWholeMs is the regression test for the lossy frameMs
+// derivation: a frame size that is not a whole number of milliseconds at the
+// clip's rate must be rejected up front with a clear message, not surface as a
+// confusing per-frame decode failure.
+func TestFramesOf_RejectsNonWholeMs(t *testing.T) {
+	// 44100 Hz / 512 samples ≈ 11.61 ms — not whole.
+	c := &Clip{Name: "synthetic", SampleRate: 44100, Channels: 1, BitDepth: 16,
+		PCM: make([]byte, 1024*4)}
+
+	_, _, err := c.framesOf(512)
+	if err == nil {
+		t.Fatal("expected an error for a non-whole-ms frame size, got nil")
+	}
+	if !strings.Contains(err.Error(), "whole number of milliseconds") {
+		t.Errorf("error %q does not explain the whole-ms requirement", err)
+	}
+}
+
+func TestFramesOf_RejectsBadClip(t *testing.T) {
+	cases := []struct {
+		name string
+		clip *Clip
+		spf  int
+		want string
+	}{
+		{"stereo", &Clip{SampleRate: 16000, Channels: 2, BitDepth: 16}, 512, "channels"},
+		{"8-bit", &Clip{SampleRate: 16000, Channels: 1, BitDepth: 8}, 512, "16-bit"},
+		{"zero frame size", &Clip{SampleRate: 16000, Channels: 1, BitDepth: 16}, 0, "must be > 0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := tc.clip.framesOf(tc.spf)
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A full review-and-improvement pass over the codebase after the address-matcher merge (#11). Seven focused, independently-reviewable commits: two confirmed data-corruption/data-loss bugs, one concurrency hardening, one latent test-helper bug, a security-relevant test gap, a determinism improvement to the event bus, and reactor coverage. Each commit ships its own tests.

## Bugs fixed

- **`streamPCM` corrupted audio on odd-sized reads** (`tts/elevenlabs`). The streamer masked off the trailing byte of every `Read` (`n &^= 1`) and discarded it. Since `io.Reader.Read` may return an odd count for a normal chunked HTTP body, the dropped byte was the low half of a real `int16` sample — shifting and corrupting *every* subsequent sample. Now the leftover byte is carried to the next read; only a genuinely truncated final sample is dropped.
- **Final utterance dropped at end of stream** (`orchestrator`). The `Segmenter` only flushed buffered audio to STT on a VAD speech-end transition. If the audio loop stopped while speech was still active (call ends, clip cut off before its trailing silence), the buffered final utterance was silently lost. Added `Segmenter.Flush` / `Conversation.Flush` to drain it; callers invoke once after the last `Feed`.
- **Unsynchronized `TTS.nextIndex`** (`orchestrator`). Read-incremented with no lock; a second concurrent `Dispatch` (Ensemble Turns / barge-in, both anticipated by the stage's own doc) would race and corrupt the per-turn index. Now assigned under a mutex on the success path only.
- **`FramesOf` lossy frame duration** (`voicetest`). Derived `frameMs` via integer division; a non-whole-ms frame size (e.g. 512 samples @ 44.1 kHz) failed with a confusing per-frame decode error. Now rejected up front with a clear message; pure logic extracted for unit testing.

## Improvements

- **Deterministic event Bus.** `Publish` fanned out in random map-iteration order — a latent flakiness source on a platform whose address matcher is built on determinism. Switched to a registration-ordered slice (preserving snapshot-under-lock semantics) and documented the full delivery contract (synchronous, ordered, re-entrant depth-first, snapshot, no-block/no-panic).

## Tests added

- `streamPCM` odd-read reassembly + trailing-byte edge.
- `Segmenter` in isolation (first unit tests): trailing-flush, empty no-op, speech-end exclusion, buffer-cleared-on-error, `-race` feed/flush probe.
- `TTS` concurrent-dispatch gapless-index probe.
- `FramesOf` framing math + whole-ms rejection + mono/16-bit/size guards.
- `silero` tarball extraction & `safeName` (path-traversal / symlink-escape security boundary; coverage 53% → 69%).
- Bus order / unsubscribe-during-publish / re-entrant-publish characterization.
- `Bind` reverse-order teardown; `Replier` error reporting, continue-after-failure, nil-ErrorFunc, and cancel-unsubscribes.

Coverage: orchestrator 82.6% → 85.1%, silero 53.4% → 69.2%.

## Validation

`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./pkg/voice/orchestrator/... ./pkg/voice/voiceevent/`, and `golangci-lint run ./...` all pass. `go mod tidy` is a no-op.

## Known follow-ups (not in this PR)

- `SynthesizeDialogue` parses `seed`/`language_code`/pronunciation locators via `mergeSettings` but only forwards a subset to the body — left unchanged pending confirmation of the text-to-dialogue endpoint schema (adding fields it rejects would 422).
- `elevenlabs` dialogue/clone/design/voices request-construction logic is still largely untested (network-adjacent but `httptest`-able).
- Harness assertion *failure* paths can't be unit-tested without an internal failer seam (`testing.TB` can't be faked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
