### PR TITLE
Harden the MVP audio pipeline: fix review findings (lifecycle races, stream truncation, secret handling)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,10 @@ jobs:
       # Go 1.26 modules. Building from source under the same Go toolchain
       # used for the project sidesteps both problems and keeps the lint
       # binary's "built with" version aligned with the project target.
+      # Pinned (not @latest) so a new lint release can't change what CI
+      # enforces — or what code it runs — without a reviewed bump.
       - name: Install golangci-lint v2
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
       - name: Run golangci-lint
         run: golangci-lint run ./...

--- a/cmd/glyphoxa/seed.go
+++ b/cmd/glyphoxa/seed.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -53,13 +54,24 @@ func databaseURL() string {
 }
 
 // appCipher builds the AES-256-GCM cipher from the single app secret
-// ($GLYPHOXA_SECRET, ADR-0004). The secret is hashed to a 32-byte key with
-// SHA-256 so any-length secret yields a valid AES-256 key.
+// ($GLYPHOXA_SECRET, ADR-0004). The secret must be a base64-encoded 32-byte
+// random key — NOT a passphrase: an unsalted, unstretched hash of a human
+// passphrase would let anyone holding leaked ciphertext brute-force the
+// credentials offline. Requiring full-entropy keys removes that class of
+// attack instead of papering over it with a KDF cost factor.
+//
+// Generate one with: openssl rand -base64 32
 func appCipher() (*crypto.Cipher, error) {
 	secret := os.Getenv("GLYPHOXA_SECRET")
 	if secret == "" {
-		return nil, fmt.Errorf("seed: set $GLYPHOXA_SECRET (the app credential-encryption secret, ADR-0004)")
+		return nil, fmt.Errorf("seed: set $GLYPHOXA_SECRET (the app credential-encryption secret, ADR-0004); generate one with `openssl rand -base64 32`")
 	}
-	key := sha256.Sum256([]byte(secret))
-	return crypto.New(key[:])
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(secret))
+	if err != nil {
+		return nil, fmt.Errorf("seed: $GLYPHOXA_SECRET must be base64 (generate with `openssl rand -base64 32`): %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("seed: $GLYPHOXA_SECRET must decode to exactly 32 bytes (a full-entropy AES-256 key, e.g. `openssl rand -base64 32`), got %d", len(key))
+	}
+	return crypto.New(key)
 }

--- a/docs/agents/live-npc-run.md
+++ b/docs/agents/live-npc-run.md
@@ -106,7 +106,7 @@ the NPC once (in addition to the three keyring keys above), then run:
 ```sh
 # Postgres connection string and the app credential-encryption secret.
 export GLYPHOXA_DATABASE_URL="postgres://user:pass@host:5432/glyphoxa?sslmode=disable"
-export GLYPHOXA_SECRET="<app secret>"   # ADR-0004 single app secret
+export GLYPHOXA_SECRET="$(openssl rand -base64 32)"   # ADR-0004 single app secret (base64, 32 bytes)
 
 ./glyphoxa migrate up          # apply the schema (idempotent)
 ./glyphoxa seed                # create the demo Tenant/Campaign + Bart (idempotent)
@@ -155,8 +155,10 @@ come from the environment (above) / the OS keyring (task #10); the encrypted
 (ADR-0004), which the control-plane (task #6) will populate and decrypt. So
 seeding the NPC does **not** put any secret in the database.
 
-`GLYPHOXA_SECRET` is only used to seal/open those placeholders; any string works
-locally (it is SHA-256'd to a 32-byte AES key).
+`GLYPHOXA_SECRET` is only used to seal/open those placeholders. It must be a
+base64-encoded 32-byte random key (`openssl rand -base64 32`) — a full-entropy
+AES-256 key, never a passphrase, so leaked ciphertext cannot be brute-forced
+offline. Keep the value you seed with: the same key opens the blobs later.
 
 ## What to expect (audible build)
 

--- a/docs/devs/voice-tests.md
+++ b/docs/devs/voice-tests.md
@@ -118,7 +118,7 @@ func, `Feed(frame)` is the audio loop, and the reply behaviour is injected as a
 ```go
 conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
     orchestrator.WithDetector(detector),
-    orchestrator.WithReply(func(e voiceevent.AddressRouted) []orchestrator.Reply { /* … */ }),
+    orchestrator.WithReply(func(ctx context.Context, e voiceevent.AddressRouted) []orchestrator.Reply { /* … */ }),
     orchestrator.WithErrorHandler(func(err error) { t.Errorf("reply dispatch: %v", err) }),
 )
 t.Cleanup(conv.Register(t.Context()))

--- a/internal/storage/crypto/crypto.go
+++ b/internal/storage/crypto/crypto.go
@@ -17,8 +17,13 @@ import (
 // ErrKeySize is returned when the secret is not a valid AES-256 key.
 var ErrKeySize = errors.New("crypto: secret must be exactly 32 bytes (AES-256)")
 
-// Cipher seals and opens credential blobs. The nonce is prepended to the
-// ciphertext, so a sealed value is self-contained: nonce || ciphertext || tag.
+// version1 identifies the current sealed-blob format. The leading version byte
+// makes key/algorithm rotation possible without a column migration: a future
+// format bumps the byte and Open dispatches on it.
+const version1 = 0x01
+
+// Cipher seals and opens credential blobs. A sealed value is self-contained:
+// version || nonce || ciphertext || tag.
 type Cipher struct {
 	aead cipher.AEAD
 }
@@ -39,24 +44,29 @@ func New(key []byte) (*Cipher, error) {
 	return &Cipher{aead: aead}, nil
 }
 
-// Seal encrypts plaintext, returning nonce||ciphertext suitable for the
-// provider_config.credentials_ciphertext bytea column.
+// Seal encrypts plaintext, returning version||nonce||ciphertext suitable for
+// the provider_config.credentials_ciphertext bytea column.
 func (c *Cipher) Seal(plaintext []byte) ([]byte, error) {
-	nonce := make([]byte, c.aead.NonceSize())
+	buf := make([]byte, 1+c.aead.NonceSize())
+	buf[0] = version1
+	nonce := buf[1:]
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("crypto: read nonce: %w", err)
 	}
-	// Seal appends the ciphertext+tag to nonce, so the nonce is the prefix.
-	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+	// Seal appends the ciphertext+tag to the version||nonce prefix.
+	return c.aead.Seal(buf, nonce, plaintext, nil), nil
 }
 
 // Open decrypts a value produced by Seal.
 func (c *Cipher) Open(sealed []byte) ([]byte, error) {
 	ns := c.aead.NonceSize()
-	if len(sealed) < ns {
+	if len(sealed) < 1+ns {
 		return nil, errors.New("crypto: sealed value too short")
 	}
-	nonce, ciphertext := sealed[:ns], sealed[ns:]
+	if sealed[0] != version1 {
+		return nil, fmt.Errorf("crypto: unknown sealed-blob version %#x", sealed[0])
+	}
+	nonce, ciphertext := sealed[1:1+ns], sealed[1+ns:]
 	plaintext, err := c.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("crypto: open: %w", err)

--- a/internal/storage/crypto/crypto_test.go
+++ b/internal/storage/crypto/crypto_test.go
@@ -101,3 +101,18 @@ func TestLast4(t *testing.T) {
 		}
 	}
 }
+
+// TestOpenRejectsUnknownVersion pins the sealed-blob versioning: the leading
+// version byte exists so key/algorithm rotation can dispatch on it, which only
+// works if unknown versions are rejected loudly instead of fed to the AEAD.
+func TestOpenRejectsUnknownVersion(t *testing.T) {
+	c := newCipher(t)
+	sealed, err := c.Seal([]byte("data"))
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	sealed[0] = 0x7f
+	if _, err := c.Open(sealed); err == nil {
+		t.Fatal("Open accepted an unknown sealed-blob version")
+	}
+}

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/gemini"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 )
@@ -29,12 +30,12 @@ const (
 	SeedCampaignName = "The Prancing Pony"
 
 	// llmProvider / llmModel record the DEPLOYMENT LLM in provider_config.
-	// Deployment is Gemini (no Anthropic key exists); the live adapter is task
-	// #13. buildConversation still wires the Anthropic adapter (the only one in
-	// this tree) — this DB data is recorded but not yet consumed by adapter
-	// selection. See the #5 seam note in wirenpc.go.
-	llmProvider = "gemini"
-	llmModel    = "gemini-2.0-flash"
+	// They reference the gemini adapter's own identifiers so the seeded row can
+	// never drift from what buildConversation actually wires (the DB value is
+	// recorded but not yet consumed by adapter selection — see the #5 seam note
+	// in wirenpc.go — so silent drift here would mislead later).
+	llmProvider = gemini.ProviderID
+	llmModel    = gemini.DefaultModel
 
 	// ttsModel / sttModel are the ElevenLabs models the Voice / STT configs record.
 	ttsModel = "eleven_multilingual_v2"

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -222,7 +222,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// (line above), and pipe.Run's own deferred cancel stops the Conversation
 	// first — so teardown order is conv-stop → pump.Close() → sess.Close(), which
 	// is the deterministic ordering the pump's Close() contract requires.
-	pump := wire.NewPlaybackPump(sess, cdc)
+	pump := wire.NewPlaybackPump(sess, cdc, log)
 	defer pump.Close()
 	teeSynth := wire.NewTeeSynthesizer(ttseleven.New(""), pump)
 
@@ -329,8 +329,9 @@ func buildConversation(log *slog.Logger, npc npcSpec, synth tts.Synthesizer) (*o
 
 	detector := orchestrator.NewAddressDetector(npcMatcher(npc))
 
-	// grants would degrade to a single completion through the same path. The
-	// `dice` grant stays in code: Tool Grants are a #6 table, not yet seeded.
+	// The `dice` grant stays in code: Tool Grants are a #6 table, not yet
+	// seeded. With no grants the tool engine degrades to a single completion
+	// through the same path.
 	//
 	// Gemini is the live LLM provider (see the function doc): it reads
 	// GEMINI_API_KEY at request time (BYOK, ADR-0004); export it from the keyring

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -18,8 +18,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
@@ -107,7 +109,21 @@ type Config struct {
 	// an error (it runs inside a bus callback), so a failed completion returns
 	// no reply and is surfaced here. A nil OnError drops the error silently.
 	OnError func(error)
+
+	// TurnTimeout bounds one turn's LLM work (including any tool-use rounds a
+	// tool-backed Engine runs). The turn's context is cancelled when it elapses,
+	// unwinding the in-flight provider call, and the turn yields no reply (the
+	// deadline error goes to OnError). Zero applies [DefaultTurnTimeout];
+	// negative disables the deadline (the turn is still cancellable via the
+	// caller's ctx, e.g. barge-in).
+	TurnTimeout time.Duration
 }
+
+// DefaultTurnTimeout is the per-turn LLM deadline applied when
+// [Config.TurnTimeout] is zero. A voice turn that takes this long is dead in
+// conversational terms anyway; the deadline exists so a hung provider can never
+// wedge the reply path forever.
+const DefaultTurnTimeout = 60 * time.Second
 
 // Replier is the stateful Agent loop. Each addressed utterance appends a user
 // message and the assistant's reply to a running conversation, so the recent
@@ -152,12 +168,28 @@ func NewReplier(cfg Config) *Replier {
 // one blocking LLM call, and returns the spoken reply. On a route for a
 // different Agent it returns nil (says nothing); on an LLM failure it returns
 // nil and reports via [Config.OnError].
+//
+// The turn runs under ctx — with barge-in wired, the per-turn floor context,
+// so a barge cancels the LLM call itself — further bounded by
+// [Config.TurnTimeout] so a hung provider cannot hold the turn open forever.
 func (r *Replier) Reply() orchestrator.ReplyFunc {
-	return func(e voiceevent.AddressRouted) []orchestrator.Reply {
+	return func(ctx context.Context, e voiceevent.AddressRouted) []orchestrator.Reply {
 		if e.Target.AgentID != r.cfg.Persona.AgentID {
 			return nil // not addressed to this Agent
 		}
-		return r.turn(context.Background(), e.Text)
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		timeout := r.cfg.TurnTimeout
+		if timeout == 0 {
+			timeout = DefaultTurnTimeout
+		}
+		if timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		return r.turn(ctx, e.Text)
 	}
 }
 
@@ -204,7 +236,9 @@ type providerEngine struct {
 }
 
 // Generate implements [Engine]. It runs one completion and returns the
-// accumulated assistant text.
+// accumulated assistant text. A stream that ends without an [llm.EventDone] —
+// an [llm.EventError], a ctx cancellation, or a silent truncation — is an
+// error: a partial sentence must never be spoken as the Agent's full reply.
 func (e providerEngine) Generate(ctx context.Context, messages []llm.Message) (string, error) {
 	stream, err := e.provider.Complete(ctx, llm.Request{
 		Model:     e.model,
@@ -215,10 +249,26 @@ func (e providerEngine) Generate(ctx context.Context, messages []llm.Message) (s
 		return "", err
 	}
 	var b strings.Builder
+	var done bool
+	var streamErr error
 	for ev := range stream {
-		if ev.Type == llm.EventText {
+		switch ev.Type {
+		case llm.EventText:
 			b.WriteString(ev.Text)
+		case llm.EventDone:
+			done = true
+		case llm.EventError:
+			streamErr = errors.New(ev.Err)
 		}
+	}
+	if streamErr != nil {
+		return "", streamErr
+	}
+	if !done {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return "", errors.New("agent: completion stream ended without done event (truncated response)")
 	}
 	return b.String(), nil
 }

--- a/pkg/voice/agent/agent_test.go
+++ b/pkg/voice/agent/agent_test.go
@@ -23,8 +23,9 @@ type fakeProvider struct {
 	mu       sync.Mutex
 	requests []llm.Request
 
-	reply string // text streamed back, split into per-word EventText deltas
-	err   error  // returned from Complete when non-nil
+	reply    string // text streamed back, split into per-word EventText deltas
+	err      error  // returned from Complete when non-nil
+	truncate bool   // close the stream without EventDone (mid-stream failure)
 }
 
 func (f *fakeProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
@@ -48,7 +49,9 @@ func (f *fakeProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.
 			}
 			ch <- llm.StreamEvent{Type: llm.EventText, Text: text}
 		}
-		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+		if !f.truncate {
+			ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+		}
 	}()
 	return ch, nil
 }
@@ -108,7 +111,7 @@ func TestReply_NotAddressed_ReturnsNilAndSkipsProvider(t *testing.T) {
 		Synthesizer: stubSynth{},
 	})
 
-	got := r.Reply()(routed("someone-else", "Hello there."))
+	got := r.Reply()(t.Context(), routed("someone-else", "Hello there."))
 	if got != nil {
 		t.Errorf("reply for unaddressed route = %+v, want nil", got)
 	}
@@ -130,7 +133,7 @@ func TestReply_Addressed_AssemblesSystemPromptAndAccumulatesText(t *testing.T) {
 		Synthesizer: stubSynth{},
 	})
 
-	got := r.Reply()(routed("bart", "Hello, innkeeper."))
+	got := r.Reply()(t.Context(), routed("bart", "Hello, innkeeper."))
 	if len(got) != 1 {
 		t.Fatalf("got %d replies, want 1", len(got))
 	}
@@ -178,8 +181,8 @@ func TestReply_MultiTurn_CarriesHistory(t *testing.T) {
 	})
 	reply := r.Reply()
 
-	reply(routed("bart", "Do you have rooms?"))
-	reply(routed("bart", "And a meal?"))
+	reply(t.Context(), routed("bart", "Do you have rooms?"))
+	reply(t.Context(), routed("bart", "And a meal?"))
 
 	req := prov.lastRequest(t)
 	// Expect: system, user "Do you have rooms?", assistant "Aye.", user "And a meal?".
@@ -221,9 +224,9 @@ func TestReply_HistoryTurns_BoundsTranscript(t *testing.T) {
 	})
 	reply := r.Reply()
 
-	reply(routed("bart", "first-utterance"))
-	reply(routed("bart", "second-utterance"))
-	reply(routed("bart", "third-utterance"))
+	reply(t.Context(), routed("bart", "first-utterance"))
+	reply(t.Context(), routed("bart", "second-utterance"))
+	reply(t.Context(), routed("bart", "third-utterance"))
 
 	req := prov.lastRequest(t)
 	var joined string
@@ -251,7 +254,7 @@ func TestReply_ProviderError_ReturnsNilAndReportsError(t *testing.T) {
 		OnError:     func(err error) { gotErr = err },
 	})
 
-	got := r.Reply()(routed("bart", "Hello."))
+	got := r.Reply()(t.Context(), routed("bart", "Hello."))
 	if got != nil {
 		t.Errorf("reply on provider error = %+v, want nil", got)
 	}
@@ -268,7 +271,7 @@ func TestReply_EmptyCompletion_ReturnsNil(t *testing.T) {
 		Provider:    &fakeProvider{reply: ""},
 		Synthesizer: stubSynth{},
 	})
-	if got := r.Reply()(routed("bart", "Hello.")); got != nil {
+	if got := r.Reply()(t.Context(), routed("bart", "Hello.")); got != nil {
 		t.Errorf("reply for empty completion = %+v, want nil", got)
 	}
 }
@@ -276,3 +279,85 @@ func TestReply_EmptyCompletion_ReturnsNil(t *testing.T) {
 // Compile-time assertion: the loop produces a value usable by the orchestrator
 // reply seam without an adapter.
 var _ orchestrator.ReplyFunc = (&agent.Replier{}).Reply()
+
+// TestReply_TruncatedStream_ReturnsNilAndReportsError pins the truncation
+// contract on the default engine: a stream that closes without [llm.EventDone]
+// (mid-stream network failure) must not be spoken as a complete reply — the
+// turn yields nothing and the failure surfaces via OnError.
+func TestReply_TruncatedStream_ReturnsNilAndReportsError(t *testing.T) {
+	var gotErr error
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    &fakeProvider{reply: "Half a sentence that never", truncate: true},
+		Synthesizer: stubSynth{},
+		OnError:     func(err error) { gotErr = err },
+	})
+
+	got := r.Reply()(t.Context(), routed("bart", "Hello."))
+	if got != nil {
+		t.Errorf("reply for truncated stream = %+v, want nil", got)
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "without done") {
+		t.Errorf("OnError got %v, want a truncation error", gotErr)
+	}
+}
+
+// ctxCaptureEngine records the ctx the Replier hands the Engine, so tests can
+// pin the per-turn deadline and ctx propagation.
+type ctxCaptureEngine struct {
+	ctx   context.Context
+	reply string
+}
+
+func (e *ctxCaptureEngine) Generate(ctx context.Context, _ []llm.Message) (string, error) {
+	e.ctx = ctx
+	return e.reply, nil
+}
+
+// TestReply_TurnTimeout_AppliesDeadlineAndPropagatesCtx pins the hung-provider
+// guard: the Engine's ctx must descend from the caller's turn ctx (so barge-in
+// cancellation reaches the LLM call) and carry the TurnTimeout deadline (so a
+// hung provider can never hold the turn open forever).
+func TestReply_TurnTimeout_AppliesDeadlineAndPropagatesCtx(t *testing.T) {
+	eng := &ctxCaptureEngine{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+	})
+
+	type ctxKey struct{}
+	parent := context.WithValue(t.Context(), ctxKey{}, "turn")
+	if got := r.Reply()(parent, routed("bart", "Hello.")); len(got) != 1 {
+		t.Fatalf("reply = %+v, want one sentence", got)
+	}
+
+	if eng.ctx.Value(ctxKey{}) != "turn" {
+		t.Error("engine ctx does not descend from the caller's turn ctx")
+	}
+	deadline, ok := eng.ctx.Deadline()
+	if !ok {
+		t.Fatal("engine ctx has no deadline; a hung provider would block the turn forever")
+	}
+	if remaining := time.Until(deadline); remaining > agent.DefaultTurnTimeout {
+		t.Errorf("deadline %v out past DefaultTurnTimeout %v", remaining, agent.DefaultTurnTimeout)
+	}
+}
+
+// TestReply_TurnTimeoutNegative_DisablesDeadline pins the documented escape
+// hatch: TurnTimeout < 0 leaves the turn bounded only by the caller's ctx.
+func TestReply_TurnTimeoutNegative_DisablesDeadline(t *testing.T) {
+	eng := &ctxCaptureEngine{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+		TurnTimeout: -1,
+	})
+	if got := r.Reply()(t.Context(), routed("bart", "Hello.")); len(got) != 1 {
+		t.Fatalf("reply = %+v, want one sentence", got)
+	}
+	if _, ok := eng.ctx.Deadline(); ok {
+		t.Error("engine ctx has a deadline despite TurnTimeout < 0")
+	}
+}

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -22,6 +22,7 @@ package agenttool
 
 import (
 	"context"
+	"errors"
 
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
@@ -40,8 +41,9 @@ type providerAdapter struct {
 // Generate implements [tool.Provider]. It issues one streaming completion for
 // the conversation and declared Tools, drains the stream, and returns the
 // accumulated assistant text plus any tool calls the model requested. A
-// Provider start error propagates; a mid-stream close simply ends accumulation
-// (matching the adapter's documented behaviour).
+// Provider start error propagates. A stream that ends without an
+// [llm.EventDone] — an [llm.EventError], a ctx cancellation, or a silent
+// truncation — is an error, never a partial answer presented as complete.
 func (a providerAdapter) Generate(ctx context.Context, messages []tool.Message, tools []tool.Decl) (tool.AssistantMessage, error) {
 	stream, err := a.provider.Complete(ctx, llm.Request{
 		Model:     a.model,
@@ -55,6 +57,8 @@ func (a providerAdapter) Generate(ctx context.Context, messages []tool.Message, 
 
 	var out tool.AssistantMessage
 	var text []byte
+	var done bool
+	var streamErr error
 	for ev := range stream {
 		switch ev.Type {
 		case llm.EventText:
@@ -65,7 +69,20 @@ func (a providerAdapter) Generate(ctx context.Context, messages []tool.Message, 
 				Name:  ev.ToolCall.Name,
 				Input: ev.ToolCall.Input,
 			})
+		case llm.EventDone:
+			done = true
+		case llm.EventError:
+			streamErr = errors.New(ev.Err)
 		}
+	}
+	if streamErr != nil {
+		return tool.AssistantMessage{}, streamErr
+	}
+	if !done {
+		if err := ctx.Err(); err != nil {
+			return tool.AssistantMessage{}, err
+		}
+		return tool.AssistantMessage{}, errors.New("agenttool: completion stream ended without done event (truncated response)")
 	}
 	out.Text = string(text)
 	return out, nil

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -198,7 +198,7 @@ func TestEngine_AsAgentEngine_DrivesReplier(t *testing.T) {
 		Engine:      eng,
 		Synthesizer: stubSynth{},
 	})
-	got := r.Reply()(addressed("bart", "Any rooms free?"))
+	got := r.Reply()(t.Context(), addressed("bart", "Any rooms free?"))
 	if len(got) != 1 || strings.TrimSpace(got[0].Sentence) != "Aye, two rooms upstairs." {
 		t.Fatalf("reply = %+v, want one spoken sentence from the tool engine", got)
 	}
@@ -206,5 +206,54 @@ func TestEngine_AsAgentEngine_DrivesReplier(t *testing.T) {
 	reqs := prov.requests()
 	if len(reqs) == 0 || reqs[0].Messages[0].Role != llm.RoleSystem {
 		t.Errorf("engine did not receive an assembled system prompt; first req = %+v", reqs)
+	}
+}
+
+// truncatingProvider streams some text and closes without [llm.EventDone] — a
+// mid-stream failure as the [llm.Provider] contract describes it.
+type truncatingProvider struct{}
+
+func (truncatingProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 1)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: "Half a sen"}
+	close(ch)
+	return ch, nil
+}
+
+// TestEngine_TruncatedStream_ReturnsError pins the truncation contract on the
+// tool-loop bridge: a stream that ends without EventDone must fail the
+// generation, never hand the loop (and ultimately TTS) a partial answer.
+func TestEngine_TruncatedStream_ReturnsError(t *testing.T) {
+	reg := tool.NewRegistry()
+	grants := tool.NewGrantSet(reg)
+	eng := agenttool.NewEngine(truncatingProvider{}, grants, "m", 0, 0)
+
+	_, err := eng.Generate(t.Context(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
+	if err == nil || !strings.Contains(err.Error(), "without done") {
+		t.Fatalf("Generate on truncated stream = %v, want truncation error", err)
+	}
+}
+
+// errorEventProvider terminates the stream with an [llm.EventError].
+type errorEventProvider struct{}
+
+func (errorEventProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: "Half a sen"}
+	ch <- llm.StreamEvent{Type: llm.EventError, Err: "provider: read stream: connection reset"}
+	close(ch)
+	return ch, nil
+}
+
+// TestEngine_EventError_PropagatesAsError pins that a terminal EventError
+// surfaces as the generation error, carrying the provider's message.
+func TestEngine_EventError_PropagatesAsError(t *testing.T) {
+	reg := tool.NewRegistry()
+	grants := tool.NewGrantSet(reg)
+	eng := agenttool.NewEngine(errorEventProvider{}, grants, "m", 0, 0)
+
+	_, err := eng.Generate(t.Context(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
+	if err == nil || !strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("Generate on EventError = %v, want the provider's error", err)
 	}
 }

--- a/pkg/voice/llm/anthropic/anthropic.go
+++ b/pkg/voice/llm/anthropic/anthropic.go
@@ -10,8 +10,10 @@
 package anthropic
 
 import (
+	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -57,9 +59,26 @@ type Option func(*Client)
 func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
 
 // WithHTTPClient supplies a custom http.Client. The default has no overall
-// timeout because streaming completions are long-lived; per-call deadlines
-// must come from the request context.
+// timeout because streaming completions are long-lived — but it does bound
+// dialing, TLS, and time-to-first-response-header (see [New]); the per-call
+// deadline for the whole exchange must come from the request context.
 func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connection-establishment phases so a black-holed
+// endpoint fails in seconds instead of hanging a turn. No overall Timeout: that
+// would also cap healthy long-lived SSE streams — the end-to-end bound is the
+// caller's ctx deadline (the agent loop's TurnTimeout).
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
 
 // WithModel sets the default model used when [llm.Request.Model] is empty.
 func WithModel(m string) Option { return func(c *Client) { c.model = m } }
@@ -77,7 +96,7 @@ func New(apiKey string, opts ...Option) *Client {
 		apiKey:  apiKey,
 		baseURL: DefaultBaseURL,
 		model:   DefaultModel,
-		http:    &http.Client{},
+		http:    defaultHTTPClient(),
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/voice/llm/anthropic/anthropic_test.go
+++ b/pkg/voice/llm/anthropic/anthropic_test.go
@@ -387,3 +387,63 @@ func TestComplete_Non2xx_WrapsOpAndStatus(t *testing.T) {
 func sse(data string) string {
 	return "event: x\ndata: " + data + "\n\n"
 }
+
+// TestComplete_MalformedFrame_EmitsEventError pins the truncation contract: a
+// frame that fails to decode must surface as a terminal [llm.EventError], not a
+// silent channel close — consumers would otherwise speak the partial text as a
+// complete reply (and `-tags=record` would bake it into a cassette).
+func TestComplete_MalformedFrame_EmitsEventError(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Half a sen"}}`),
+		sse(`{not json`),
+	)
+	defer srv.Close()
+
+	c := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	events := collect(t, ch)
+	last := events[len(events)-1]
+	if last.Type != llm.EventError {
+		t.Fatalf("last event type = %v, want EventError", last.Type)
+	}
+	if last.Err == "" {
+		t.Error("EventError carries no message")
+	}
+	for _, ev := range events {
+		if ev.Type == llm.EventDone {
+			t.Error("stream emitted EventDone despite the malformed frame")
+		}
+	}
+}
+
+// TestComplete_ServerErrorEvent_EmitsEventError pins that an in-band Anthropic
+// error frame terminates the stream with an [llm.EventError] (not a silent
+// close), carrying the server's payload for diagnosis.
+func TestComplete_ServerErrorEvent_EmitsEventError(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`),
+	)
+	defer srv.Close()
+
+	c := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	events := collect(t, ch)
+	if len(events) != 1 || events[0].Type != llm.EventError {
+		t.Fatalf("events = %+v, want exactly one EventError", events)
+	}
+	if !strings.Contains(events[0].Err, "overloaded_error") {
+		t.Errorf("EventError %q does not carry the server payload", events[0].Err)
+	}
+}

--- a/pkg/voice/llm/anthropic/complete.go
+++ b/pkg/voice/llm/anthropic/complete.go
@@ -13,6 +13,19 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 )
 
+const (
+	// maxLineBytes caps one SSE line (one frame). Anthropic carries an entire
+	// input_json_delta on a single data: line, so this must comfortably exceed
+	// any legitimate tool-argument delta.
+	maxLineBytes = 1024 * 1024
+
+	// maxStreamBytes caps the whole response stream. A voice turn's completion
+	// is a few KiB; 16 MiB is far past any legitimate reply and exists so a
+	// misbehaving or hostile endpoint (WithBaseURL gateways) cannot stream
+	// unboundedly into memory.
+	maxStreamBytes = 16 * 1024 * 1024
+)
+
 // messagesBody mirrors the Anthropic POST /v1/messages request body for a
 // streaming completion. System travels out-of-band per the API (a top-level
 // field, not a message), so the adapter lifts the [llm.RoleSystem] message out
@@ -228,8 +241,11 @@ func readErrorResponse(resp *http.Response, op string) error {
 
 // streamEvents reads the Anthropic SSE response from r, decodes each event, and
 // emits the corresponding [llm.StreamEvent] on ch. It closes ch on stream end
-// (after an [llm.EventDone]), ctx cancellation, or the first read/parse error;
-// r is closed before return so the connection is released to the pool.
+// (after an [llm.EventDone]) or ctx cancellation; any read/parse failure, a
+// server error frame, or a response exceeding maxStreamBytes emits a terminal
+// [llm.EventError] first so consumers never mistake a truncated stream for a
+// complete reply. r is closed before return so the connection is released to
+// the pool.
 //
 // SSE framing: each event is a "data: <json>\n" line (the "event:" line is
 // redundant with the JSON "type" field, so it is ignored). Decoding tracks
@@ -258,17 +274,30 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 		}
 	}
 
+	fail := func(msg string) {
+		send(llm.StreamEvent{Type: llm.EventError, Err: msg})
+	}
+
 	sc := bufio.NewScanner(r)
 	// SSE lines are small, but a tool_use input or a long text delta can exceed
 	// bufio's default 64KiB token cap; raise the ceiling so a big block does
 	// not truncate the stream.
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+
+	// total bounds the whole response body so a misbehaving (or hostile)
+	// endpoint cannot grow memory without limit: each line is capped by the
+	// scanner, this caps the number of lines.
+	var total int
 
 	for sc.Scan() {
 		if err := ctx.Err(); err != nil {
 			return
 		}
 		line := sc.Text()
+		if total += len(line); total > maxStreamBytes {
+			fail(fmt.Sprintf("anthropic: response stream exceeded %d bytes", maxStreamBytes))
+			return
+		}
 		data, ok := strings.CutPrefix(line, "data:")
 		if !ok {
 			continue // event:, id:, blank separator, or retry: lines
@@ -280,7 +309,8 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 
 		var ev sseEvent
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
-			return // a malformed frame ends the stream early, like the tts read path
+			fail("anthropic: malformed SSE frame: " + err.Error())
+			return
 		}
 
 		switch ev.Type {
@@ -326,8 +356,12 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 				}
 			}
 		case "error":
-			return // a mid-stream error event closes the channel early
+			fail("anthropic: server error event: " + data)
+			return
 		}
+	}
+	if err := sc.Err(); err != nil {
+		fail("anthropic: read stream: " + err.Error())
 	}
 }
 

--- a/pkg/voice/llm/gemini/complete.go
+++ b/pkg/voice/llm/gemini/complete.go
@@ -13,6 +13,19 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 )
 
+const (
+	// maxLineBytes caps one SSE line (one chunk). A whole tool-argument or
+	// content delta rides on a single data: line, so this must comfortably
+	// exceed any legitimate delta.
+	maxLineBytes = 1024 * 1024
+
+	// maxStreamBytes caps the whole response stream. A voice turn's completion
+	// is a few KiB; 16 MiB is far past any legitimate reply and exists so a
+	// misbehaving or hostile endpoint (WithBaseURL gateways) cannot stream
+	// unboundedly into memory.
+	maxStreamBytes = 16 * 1024 * 1024
+)
+
 // chatBody mirrors the OpenAI-compatible POST /chat/completions request body for
 // a streaming completion. The system prompt rides as a "system"-role message
 // (unlike Anthropic's top-level field), so the adapter keeps it in the message
@@ -228,8 +241,10 @@ func readErrorResponse(resp *http.Response, op string) error {
 
 // streamEvents reads the OpenAI-compatible SSE response from r, decodes each
 // chunk, and emits the corresponding [llm.StreamEvent] on ch. It closes ch on
-// stream end (after an [llm.EventDone]), ctx cancellation, or the first
-// read/parse error; r is closed before return so the connection is released.
+// stream end (after an [llm.EventDone]) or ctx cancellation; any read/parse
+// failure or a response exceeding maxStreamBytes emits a terminal
+// [llm.EventError] first so consumers never mistake a truncated stream for a
+// complete reply. r is closed before return so the connection is released.
 //
 // SSE framing: each event is a "data: <json>\n" line. A terminal "data: [DONE]"
 // sentinel marks the end. Tool calls stream incrementally: the first delta for a
@@ -287,17 +302,30 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 		return true
 	}
 
+	fail := func(msg string) {
+		send(llm.StreamEvent{Type: llm.EventError, Err: msg})
+	}
+
 	sc := bufio.NewScanner(r)
 	// SSE lines are small, but a long content delta or tool-argument chunk can
 	// exceed bufio's default 64KiB token cap; raise the ceiling so a big chunk
 	// does not truncate the stream.
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+
+	// total bounds the whole response body so a misbehaving (or hostile)
+	// endpoint cannot grow memory without limit: each line is capped by the
+	// scanner, this caps the number of lines.
+	var total int
 
 	for sc.Scan() {
 		if err := ctx.Err(); err != nil {
 			return
 		}
 		line := sc.Text()
+		if total += len(line); total > maxStreamBytes {
+			fail(fmt.Sprintf("gemini: response stream exceeded %d bytes", maxStreamBytes))
+			return
+		}
 		data, ok := strings.CutPrefix(line, "data:")
 		if !ok {
 			continue // event:, id:, blank separator, or retry: lines
@@ -312,7 +340,8 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 
 		var chunk sseChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			return // a malformed frame ends the stream early, like the tts read path
+			fail("gemini: malformed SSE frame: " + err.Error())
+			return
 		}
 		if len(chunk.Choices) == 0 {
 			continue // e.g. a usage-only trailing chunk
@@ -349,6 +378,9 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 				return
 			}
 		}
+	}
+	if err := sc.Err(); err != nil {
+		fail("gemini: read stream: " + err.Error())
 	}
 }
 

--- a/pkg/voice/llm/gemini/gemini.go
+++ b/pkg/voice/llm/gemini/gemini.go
@@ -23,8 +23,10 @@
 package gemini
 
 import (
+	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -71,9 +73,26 @@ type Option func(*Client)
 func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
 
 // WithHTTPClient supplies a custom http.Client. The default has no overall
-// timeout because streaming completions are long-lived; per-call deadlines must
-// come from the request context.
+// timeout because streaming completions are long-lived — but it does bound
+// dialing, TLS, and time-to-first-response-header (see [New]); the per-call
+// deadline for the whole exchange must come from the request context.
 func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connection-establishment phases so a black-holed
+// endpoint fails in seconds instead of hanging a turn. No overall Timeout: that
+// would also cap healthy long-lived SSE streams — the end-to-end bound is the
+// caller's ctx deadline (the agent loop's TurnTimeout).
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
 
 // WithModel sets the default model used when [llm.Request.Model] is empty.
 func WithModel(m string) Option { return func(c *Client) { c.model = m } }
@@ -91,7 +110,7 @@ func New(apiKey string, opts ...Option) *Client {
 		apiKey:  apiKey,
 		baseURL: DefaultBaseURL,
 		model:   DefaultModel,
-		http:    &http.Client{},
+		http:    defaultHTTPClient(),
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/voice/llm/gemini/gemini_test.go
+++ b/pkg/voice/llm/gemini/gemini_test.go
@@ -392,3 +392,37 @@ func TestComplete_Non2xx_WrapsOpAndStatus(t *testing.T) {
 func sse(data string) string {
 	return "data: " + data + "\n\n"
 }
+
+// TestComplete_MalformedFrame_EmitsEventError pins the truncation contract: a
+// frame that fails to decode must surface as a terminal [llm.EventError], not a
+// silent channel close — consumers would otherwise speak the partial text as a
+// complete reply (and `-tags=record` would bake it into a cassette).
+func TestComplete_MalformedFrame_EmitsEventError(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"choices":[{"delta":{"content":"Half a sen"}}]}`),
+		sse(`{not json`),
+	)
+	defer srv.Close()
+
+	c := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	events := collect(t, ch)
+	last := events[len(events)-1]
+	if last.Type != llm.EventError {
+		t.Fatalf("last event type = %v, want EventError", last.Type)
+	}
+	if last.Err == "" {
+		t.Error("EventError carries no message")
+	}
+	for _, ev := range events {
+		if ev.Type == llm.EventDone {
+			t.Error("stream emitted EventDone despite the malformed frame")
+		}
+	}
+}

--- a/pkg/voice/llm/llm.go
+++ b/pkg/voice/llm/llm.go
@@ -163,6 +163,13 @@ const (
 	// carries the provider's reason (e.g. "end_turn", "tool_use", "max_tokens")
 	// so the tool-use loop can decide whether to continue.
 	EventDone
+
+	// EventError marks a mid-stream failure — a transport error, a malformed
+	// frame, or a response exceeding the provider's size bounds — with the
+	// detail in [StreamEvent.Err]. It is terminal: the provider closes the
+	// channel right after. Consumers must treat the accumulated text as
+	// truncated and fail the turn rather than present it as a complete reply.
+	EventError
 )
 
 // StreamEvent is one item in a [Provider] completion stream. The active fields
@@ -179,6 +186,10 @@ type StreamEvent struct {
 
 	// StopReason is the provider's completion reason on an [EventDone].
 	StopReason string
+
+	// Err is the failure description on an [EventError]. A string, not an
+	// error, so cassette recordings serialize it faithfully (ADR-0021).
+	Err string
 }
 
 // Provider is the hot-path interface implemented by every LLM provider and by
@@ -190,7 +201,10 @@ type StreamEvent struct {
 // it to release the implementation's goroutines — mirroring
 // [github.com/MrWong99/Glyphoxa/pkg/voice/tts.Synthesizer]. A non-nil error is
 // returned only when the call cannot be started (missing key, bad request,
-// non-2xx response); a mid-stream failure closes the channel early.
+// non-2xx response); a mid-stream failure emits an [EventError] and then
+// closes the channel. A channel that closes with neither an [EventDone] nor an
+// [EventError] was cancelled via ctx; consumers must not treat any of these
+// early-closed streams' accumulated text as a complete reply.
 type Provider interface {
 	Complete(ctx context.Context, req Request) (<-chan StreamEvent, error)
 }

--- a/pkg/voice/manager.go
+++ b/pkg/voice/manager.go
@@ -20,6 +20,14 @@ type Manager struct {
 
 	mu       sync.Mutex
 	sessions map[snowflake.ID]*Session
+	// opening holds one mutex per guild, serializing concurrent Opens for the
+	// SAME guild end-to-end (close-stale → CreateConn → newSession → store).
+	// Without it two racing Opens both pass the existing-session check, both
+	// CreateConn for the guild, and the loser's Session is overwritten in the
+	// map without ever being Closed — leaking its Inbound consumer forever.
+	// Opens for different guilds stay concurrent. Entries are tiny and guilds
+	// are few, so the map is never pruned.
+	opening map[snowflake.ID]*sync.Mutex
 }
 
 // ManagerOption configures a [Manager] in [NewManager].
@@ -159,7 +167,20 @@ func newManager(vm voiceManager, opts ...ManagerOption) *Manager {
 		logger:   cfg.logger,
 		defaults: cfg.defaults,
 		sessions: make(map[snowflake.ID]*Session),
+		opening:  make(map[snowflake.ID]*sync.Mutex),
 	}
+}
+
+// guildMu returns the per-guild mutex serializing [Manager.Open] for one guild.
+func (m *Manager) guildMu(guild snowflake.ID) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mu, ok := m.opening[guild]
+	if !ok {
+		mu = &sync.Mutex{}
+		m.opening[guild] = mu
+	}
+	return mu
 }
 
 // Open joins guild's voice channel and returns its Session. If a Session for
@@ -171,17 +192,27 @@ func (m *Manager) Open(ctx context.Context, guild, channel snowflake.ID, opts ..
 		opt(&cfg)
 	}
 
+	// Serialize the whole open sequence per guild (see Manager.opening). m.mu
+	// itself must not be held across Close/CreateConn/newSession — Close blocks
+	// on a playback Stop, and newSession blocks on the voice gateway.
+	gmu := m.guildMu(guild)
+	gmu.Lock()
+	defer gmu.Unlock()
+
 	m.mu.Lock()
-	if existing, ok := m.sessions[guild]; ok {
+	existing, replace := m.sessions[guild]
+	if replace {
 		// Drop the stale Session before opening a fresh connection so we never
-		// hold two for one Guild. Release the lock around Close — it blocks on a
-		// playback Stop and must not deadlock with a concurrent Open.
+		// hold two for one Guild.
 		delete(m.sessions, guild)
-		m.mu.Unlock()
-		_ = existing.Close()
-		m.mu.Lock()
 	}
 	m.mu.Unlock()
+	if replace {
+		_ = existing.Close()
+		// Release disgo's conn for the displaced session (mirrors Manager.Close)
+		// so CreateConn below hands back a fresh one, not the closed husk.
+		m.vm.RemoveConn(guild)
+	}
 
 	conn := m.vm.CreateConn(guild)
 	sess, err := newSession(ctx, guild, channel, conn, cfg)

--- a/pkg/voice/manager_test.go
+++ b/pkg/voice/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/disgoorg/snowflake/v2"
@@ -111,5 +112,47 @@ func TestManagerOpenReplacesExisting(t *testing.T) {
 	got, ok := m.Get(testGuild)
 	if !ok || got != second {
 		t.Fatal("Get should return the replacement session")
+	}
+}
+
+// TestManagerOpenConcurrentSameGuild_NoLeak pins the per-guild Open
+// serialization: racing Opens for one guild must never leave a Session alive
+// outside the map (its Inbound consumer would block forever). Exactly one
+// winner survives in the Manager; every other Session ends Closed.
+func TestManagerOpenConcurrentSameGuild_NoLeak(t *testing.T) {
+	fm := mock.NewManager()
+	m := newTestManager(fm)
+
+	const n = 8
+	sessions := make([]*Session, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := m.Open(context.Background(), testGuild, testChannel)
+			if err != nil {
+				t.Errorf("Open %d: %v", i, err)
+				return
+			}
+			sessions[i] = s
+		}(i)
+	}
+	wg.Wait()
+
+	winner, ok := m.Get(testGuild)
+	if !ok {
+		t.Fatal("no session left in the manager")
+	}
+	for i, s := range sessions {
+		if s == nil || s == winner {
+			continue
+		}
+		if s.State() != Closed {
+			t.Errorf("session %d neither won nor was closed — leaked (state %v)", i, s.State())
+		}
+	}
+	if winner.State() == Closed {
+		t.Error("the winning session is closed")
 	}
 }

--- a/pkg/voice/orchestrator/barge.go
+++ b/pkg/voice/orchestrator/barge.go
@@ -22,6 +22,15 @@ import (
 //
 // Per ADR-0027 an Agent's own TTS never triggers a barge: only inbound
 // participant audio is VAD'd, so every speech_start here is a human's.
+//
+// Multi-speaker caveat: [voiceevent.VADSpeechStart]/[voiceevent.VADSpeechEnd]
+// carry no speaker identity because the current wiring runs ONE VAD session
+// over all participants' interleaved frames — the transitions describe the
+// mix, not a person. The confirm window is therefore only meaningful with the
+// single-active-speaker assumption of the MVP slice; do not tune
+// confirmWindow > 0 for a multi-speaker table until per-participant VAD
+// sessions (ADR-0019, deferred) attribute these events, or one speaker's
+// pause can disarm a window another speaker's interruption armed.
 type BargeIn struct {
 	floor   *Floor
 	confirm time.Duration

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -196,12 +196,18 @@ type Reply struct {
 // "what do we say back" behaviour without touching any other stage: it is the
 // strategy seam of the reply reactor.
 //
+// ctx is the turn's context: with barge-in wired ([WithBargeIn]) it is the
+// per-turn floor context, so a human reclaiming the floor cancels any LLM call
+// in flight, not just the TTS/playback downstream of it. Implementations must
+// honor it (and should derive their own deadline — a hung provider must not
+// hold the turn forever).
+//
 // In v1.0 the production ReplyFunc is the Agent loop (Hot Context assembly +
 // Persona injection + LLM dispatch, ADR-0019 slice 1); tests supply a closure
 // returning a canned line. Per ADR-0025 a multi-Agent address can yield an
 // Ensemble Turn — the slice return type leaves room for that to grow behind the
 // same seam.
-type ReplyFunc func(voiceevent.AddressRouted) []Reply
+type ReplyFunc func(ctx context.Context, e voiceevent.AddressRouted) []Reply
 
 // Replier is the [Reactor] that runs a [ReplyFunc] on every
 // [voiceevent.AddressRouted] and dispatches each resulting [Reply] through the
@@ -263,7 +269,7 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 // stopping early if ctx is cancelled (a barge-in yielded the floor mid-turn). A
 // dispatch failure is reported through the ErrorFunc and does not stop the rest.
 func (r *Replier) dispatchAll(ctx context.Context, e voiceevent.AddressRouted) {
-	for _, rep := range r.reply(e) {
+	for _, rep := range r.reply(ctx, e) {
 		if ctx.Err() != nil {
 			return
 		}

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -215,7 +215,7 @@ func TestBind_TearsDownInReverseOrder(t *testing.T) {
 func TestReplier_BindCancelUnsubscribes(t *testing.T) {
 	h := voicetest.New(t)
 	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
-	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+	reply := func(context.Context, voiceevent.AddressRouted) []orchestrator.Reply {
 		return []orchestrator.Reply{{Sentence: "hi"}}
 	}
 	cancel := orchestrator.NewReplier(ttsStage, reply, nil).Bind(t.Context(), h.Bus)
@@ -250,7 +250,7 @@ func (selectiveSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
 func TestReplier_DispatchErrorReportedAndDoesNotStopRemaining(t *testing.T) {
 	h := voicetest.New(t)
 	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
-	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+	reply := func(context.Context, voiceevent.AddressRouted) []orchestrator.Reply {
 		return []orchestrator.Reply{{Sentence: "boom"}, {Sentence: "ok"}}
 	}
 	var errs []error
@@ -275,7 +275,7 @@ func TestReplier_DispatchErrorReportedAndDoesNotStopRemaining(t *testing.T) {
 func TestReplier_NilErrorFuncDropsErrorWithoutPanic(t *testing.T) {
 	h := voicetest.New(t)
 	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
-	reply := func(voiceevent.AddressRouted) []orchestrator.Reply {
+	reply := func(context.Context, voiceevent.AddressRouted) []orchestrator.Reply {
 		return []orchestrator.Reply{{Sentence: "boom"}, {Sentence: "ok"}}
 	}
 	t.Cleanup(orchestrator.NewReplier(ttsStage, reply, nil).Bind(t.Context(), h.Bus))

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -123,7 +123,7 @@ func TestSTT_TTRPGIntro_TranscribesBothLanguages(t *testing.T) {
 			// TTS cassette segment is matched positionally, so a second dispatch
 			// would exhaust it — sync.Once pins "one reply".
 			var answered sync.Once
-			reply := func(e voiceevent.AddressRouted) []orchestrator.Reply {
+			reply := func(_ context.Context, e voiceevent.AddressRouted) []orchestrator.Reply {
 				var out []orchestrator.Reply
 				if e.Target.AgentRole == "butler" {
 					answered.Do(func() {

--- a/pkg/voice/playback.go
+++ b/pkg/voice/playback.go
@@ -31,6 +31,15 @@ type Source interface {
 // Opus payload — the framing disgo's dca-style streams and our TTS encoder
 // emit. A clean EOF at a frame boundary ends the source; EOF mid-frame is a
 // truncation error.
+//
+// ctx is checked between frames, NOT during a blocking Read: NextFrame runs on
+// disgo's sender goroutine, and a Read that never returns wedges that
+// goroutine beyond the reach of [Playback.Stop] and [Session.Close] — no
+// further outbound audio can flow until it unblocks. r must therefore be
+// memory-backed or otherwise prompt/closable (a file, bytes.Reader, or a pipe
+// whose writer is bounded). Do NOT wrap a network stream directly; buffer it
+// through a goroutine that owns the socket (and can be killed via its own ctx)
+// instead.
 func OpusReader(r io.Reader) Source {
 	return &opusReader{r: r}
 }

--- a/pkg/voice/session.go
+++ b/pkg/voice/session.go
@@ -55,8 +55,10 @@ type Session struct {
 	state atomic.Uint32 // State
 
 	// playMu serializes Play callers so the "interrupt current, install next"
-	// sequence is atomic with respect to other Play calls. The provider's slot
-	// swap is itself atomic; playMu only orders the surrounding bookkeeping.
+	// sequence is atomic with respect to other Play calls, and serializes Play
+	// against Close so a Play that passed the Closed check can never install a
+	// slot into an already-torn-down provider. The provider's slot swap is
+	// itself atomic; playMu orders the surrounding bookkeeping.
 	playMu  sync.Mutex
 	current atomic.Pointer[Playback]
 
@@ -149,6 +151,15 @@ func (s *Session) State() State { return State(s.state.Load()) }
 // channel. It is idempotent and safe to call concurrently with [Session.Play].
 func (s *Session) Close() error {
 	s.closeOnce.Do(func() {
+		// Hold playMu for the whole teardown so Close serializes with Play.
+		// Without it, Play could pass its Closed check, lose the CPU while
+		// Close runs to completion, then install a fresh slot into a provider
+		// whose sender goroutine is gone — a playback whose Done never closes,
+		// permanently wedging anyone waiting on it (e.g. the wire.PlaybackPump
+		// worker, and through it PlaybackPump.Close).
+		s.playMu.Lock()
+		defer s.playMu.Unlock()
+
 		s.state.Store(uint32(Closed))
 
 		// Interrupt the active playback before tearing the connection down so

--- a/pkg/voice/vad/silero/runtime.go
+++ b/pkg/voice/vad/silero/runtime.go
@@ -44,7 +44,12 @@ var onnxArtifacts = map[string]onnxArtifact{
 }
 
 // runtimeMu serialises concurrent ensureRuntime calls within one process so
-// two callers don't race on the cache-population step.
+// two callers don't race on the cache-population step. Cross-PROCESS safety
+// (e.g. `go test ./...` running several package binaries on a cold cache) is
+// handled differently: extraction lands in a private temp dir that is renamed
+// into place atomically, so a concurrent process either sees the complete lib
+// dir or none at all — never a half-written .so (dlopen on a truncated
+// library segfaults in native code).
 var runtimeMu sync.Mutex
 
 // ensureRuntime returns a path to libonnxruntime.so, populating the per-user
@@ -92,11 +97,50 @@ func ensureRuntime() (string, error) {
 // the pinned hash, and extracts every entry under "lib/" into destLibDir.
 // Other entries (headers, docs, license) are skipped — only the runtime is
 // needed at execution time.
+//
+// Publication is atomic: extraction goes into a sibling temp dir which is then
+// renamed onto destLibDir, so another process can never observe (and dlopen) a
+// partially-written library. If a concurrent process wins the rename, its
+// result is used and ours is discarded.
 func downloadAndExtract(artifact onnxArtifact, destLibDir string) error {
-	if err := os.MkdirAll(destLibDir, 0o755); err != nil {
+	parent := filepath.Dir(destLibDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}
+	tmpDir, err := os.MkdirTemp(parent, "lib.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create staging dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) // no-op after a successful rename
 
+	if err := fetchInto(artifact, tmpDir); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, onnxLibName)); err != nil {
+		return fmt.Errorf("tarball did not contain %s: %w", onnxLibName, err)
+	}
+
+	if err := os.Rename(tmpDir, destLibDir); err != nil {
+		// A concurrent process may have published first (destLibDir exists and
+		// is complete — publication is all-or-nothing); use its result.
+		if _, statErr := os.Stat(filepath.Join(destLibDir, onnxLibName)); statErr == nil {
+			return nil
+		}
+		// destLibDir exists but is unusable (e.g. debris from a pre-atomic
+		// version that crashed mid-extract): clear it and retry once.
+		if removeErr := os.RemoveAll(destLibDir); removeErr != nil {
+			return fmt.Errorf("publish runtime: %w (and clearing stale dir: %v)", err, removeErr)
+		}
+		if err := os.Rename(tmpDir, destLibDir); err != nil {
+			return fmt.Errorf("publish runtime: %w", err)
+		}
+	}
+	return nil
+}
+
+// fetchInto downloads and verifies the artifact tarball, extracting its lib/
+// entries into destLibDir (the private staging dir).
+func fetchInto(artifact onnxArtifact, destLibDir string) error {
 	resp, err := http.Get(artifact.url)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", artifact.url, err)

--- a/pkg/voice/voicecassette/llm.go
+++ b/pkg/voice/voicecassette/llm.go
@@ -212,7 +212,15 @@ func HashLLMRequest(req llm.Request) string {
 	}
 	// json.Marshal renders struct fields in declaration order and emits
 	// json.RawMessage verbatim, so the bytes are stable across runs.
-	b, _ := json.Marshal(h)
+	b, err := json.Marshal(h)
+	if err != nil {
+		// Marshal fails only on invalid RawMessage JSON in tool inputs/schemas.
+		// Hashing the empty bytes instead would collapse every such request to
+		// ONE hash — silently replaying the wrong recorded exchange, the exact
+		// failure the hash-keyed cassette exists to prevent. This is test
+		// infrastructure fed by fixed fixtures: fail loudly at the source.
+		panic(fmt.Sprintf("voicecassette: hash llm request: %v", err))
+	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
 }

--- a/pkg/voice/wire/codec/codec.go
+++ b/pkg/voice/wire/codec/codec.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/hraban/opus"
@@ -61,6 +62,23 @@ const (
 	// maxEncodedBytes bounds one encoded Opus packet; 4000 is libopus's
 	// recommended max for a single frame.
 	maxEncodedBytes = 4000
+
+	// reframeGap is the per-speaker PTS discontinuity beyond which the
+	// reframer's leftover tail is discarded: it belongs to an utterance that
+	// ended (Discord stops sending frames during silence), and carrying up to
+	// ~32 ms of it into the next utterance would prefix minutes-old audio onto
+	// a fresh frame. PTS also restarts at zero when a speaker rejoins, which
+	// shows up as a negative delta and resets the same way.
+	reframeGap = 500 * time.Millisecond
+
+	// streamIdleTTL is how long a speaker's decode state may sit unused before
+	// it is pruned. Without pruning the per-speaker map grows monotonically
+	// for the Codec's lifetime (libopus decoder + scratch per user ever heard).
+	streamIdleTTL = 5 * time.Minute
+
+	// pruneEvery is the sweep cadence, counted in DecodeInbound calls (~50/s
+	// per speaker): cheap enough to keep the sweep off the hot path's tail.
+	pruneEvery = 4096
 )
 
 // Codec implements [wire.Codec]. Inbound decoding keeps one libopus decoder per
@@ -75,6 +93,7 @@ const (
 type Codec struct {
 	mu       sync.Mutex
 	decoders map[snowflake.ID]*inboundStream
+	calls    int // DecodeInbound calls since the last idle-stream sweep
 }
 
 // New returns a Codec ready to transcode. It implements [wire.Codec].
@@ -91,6 +110,10 @@ type inboundStream struct {
 	dec     *opus.Decoder
 	reframe *dsp.Reframer
 	pcm     []int16 // reused decode scratch buffer
+
+	lastPTS  time.Duration // last frame's per-speaker PTS, for gap detection
+	hasPTS   bool          // lastPTS holds a real value (PTS zero is valid)
+	lastSeen time.Time     // wall clock of the last decode, for idle pruning
 }
 
 // DecodeInbound decodes one Opus frame to 16 kHz mono PCM and returns the
@@ -106,6 +129,19 @@ func (c *Codec) DecodeInbound(frame gxvoice.Frame) ([]audio.Frame, error) {
 	if err != nil {
 		return nil, err
 	}
+	stream.lastSeen = time.Now()
+
+	// A PTS jump (speaker paused; Discord sends nothing during silence) or a
+	// PTS restart (speaker rejoined; negative delta) is a stream discontinuity:
+	// drop the reframer's leftover tail so the previous utterance's last
+	// samples never prefix the new one.
+	if stream.hasPTS {
+		if delta := frame.PTS - stream.lastPTS; delta < 0 || delta > reframeGap {
+			stream.reframe.Reset()
+		}
+	}
+	stream.lastPTS = frame.PTS
+	stream.hasPTS = true
 
 	n, err := stream.dec.Decode(frame.Opus, stream.pcm)
 	if err != nil {
@@ -128,9 +164,20 @@ func (c *Codec) DecodeInbound(frame gxvoice.Frame) ([]audio.Frame, error) {
 }
 
 // streamFor returns the per-speaker decode state, creating it on first sight.
+// Every pruneEvery calls it also sweeps streams idle past streamIdleTTL, so
+// the map tracks current speakers rather than everyone the Codec ever heard.
 func (c *Codec) streamFor(user snowflake.ID) (*inboundStream, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.calls++; c.calls >= pruneEvery {
+		c.calls = 0
+		cutoff := time.Now().Add(-streamIdleTTL)
+		for id, s := range c.decoders {
+			if id != user && s.lastSeen.Before(cutoff) {
+				delete(c.decoders, id)
+			}
+		}
+	}
 	if s, ok := c.decoders[user]; ok {
 		return s, nil
 	}
@@ -141,9 +188,10 @@ func (c *Codec) streamFor(user snowflake.ID) (*inboundStream, error) {
 		return nil, fmt.Errorf("codec: new Opus decoder: %w", err)
 	}
 	s := &inboundStream{
-		dec:     dec,
-		reframe: dsp.NewReframer(vadFrameSamples),
-		pcm:     make([]int16, maxDecodedSamples),
+		dec:      dec,
+		reframe:  dsp.NewReframer(vadFrameSamples),
+		pcm:      make([]int16, maxDecodedSamples),
+		lastSeen: time.Now(),
 	}
 	c.decoders[user] = s
 	return s, nil

--- a/pkg/voice/wire/codec/dsp/reframe.go
+++ b/pkg/voice/wire/codec/dsp/reframe.go
@@ -53,3 +53,8 @@ func (r *Reframer) Flush() []int16 {
 
 // Buffered reports how many samples are held but not yet emitted.
 func (r *Reframer) Buffered() int { return len(r.buf) }
+
+// Reset discards any buffered samples. Used on a stream discontinuity (a
+// speaker resuming after a gap): the leftover tail belongs to the previous
+// utterance and must not prefix the new one.
+func (r *Reframer) Reset() { r.buf = r.buf[:0:0] }

--- a/pkg/voice/wire/playback.go
+++ b/pkg/voice/wire/playback.go
@@ -75,12 +75,16 @@ func playSentence(ctx context.Context, p sessionPlayer, codec Codec, chunks <-ch
 	src, err := codec.PlaybackSource(chunks)
 	if err != nil {
 		// A codec-less build reports ErrCodecUnavailable here; surface it so the
-		// caller fails visibly rather than silently muting the NPC.
+		// caller fails visibly rather than silently muting the NPC. Drain the
+		// sentence first: the tee's lockstep forwarder blocks on this channel
+		// until someone consumes it, and on this path no playback ever will.
+		go drain(chunks)
 		return fmt.Errorf("wire.PlaySentence: build playback source: %w", err)
 	}
 
 	pb, err := p.Play(ctx, src)
 	if err != nil {
+		go drain(chunks) // same contract: an unplayed sentence must still be drained
 		return fmt.Errorf("wire.PlaySentence: play: %w", err)
 	}
 

--- a/pkg/voice/wire/pump.go
+++ b/pkg/voice/wire/pump.go
@@ -2,6 +2,9 @@ package wire
 
 import (
 	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"sync"
 
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
@@ -28,6 +31,7 @@ import (
 type PlaybackPump struct {
 	player sessionPlayer
 	codec  Codec
+	logger *slog.Logger
 
 	queue chan playJob
 	stop  chan struct{} // closed by Close to tell the worker to exit
@@ -42,23 +46,28 @@ type playJob struct {
 
 // NewPlaybackPump builds a pump speaking on sess via codec and starts its worker.
 // Call [PlaybackPump.Close] at teardown to stop the worker. sess and codec must
-// be non-nil.
-func NewPlaybackPump(sess *gxvoice.Session, codec Codec) *PlaybackPump {
+// be non-nil. logger receives a warning per failed sentence playback (a mute
+// NPC must be diagnosable, not silent); nil discards them.
+func NewPlaybackPump(sess *gxvoice.Session, codec Codec, logger *slog.Logger) *PlaybackPump {
 	if sess == nil {
 		panic("wire.NewPlaybackPump: session must not be nil")
 	}
-	return newPump(realPlayer{sess}, codec)
+	return newPump(realPlayer{sess}, codec, logger)
 }
 
 // newPump is the testable core over the sessionPlayer seam, so the cross-
 // sentence serialization can be exercised with a fake player and no live Session.
-func newPump(player sessionPlayer, codec Codec) *PlaybackPump {
+func newPump(player sessionPlayer, codec Codec, logger *slog.Logger) *PlaybackPump {
 	if codec == nil {
 		panic("wire.NewPlaybackPump: codec must not be nil")
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	p := &PlaybackPump{
 		player: player,
 		codec:  codec,
+		logger: logger,
 		// Cap 1 is provably sufficient: the orchestrator's TTS.Dispatch does not
 		// return (and so the Replier does not Dispatch the next sentence, which is
 		// what triggers the next HandleSentence) until the tee's forward goroutine
@@ -98,19 +107,47 @@ func (p *PlaybackPump) HandleSentence(ctx context.Context, chunks <-chan tts.Aud
 
 // run is the single serial worker: it plays one sentence to completion before
 // taking the next, which is what serializes playback and preserves order. It
-// exits when Close signals stop, finishing any in-flight sentence first.
+// exits when Close signals stop, finishing any in-flight sentence first and
+// draining any job still queued (its tee forwarder must never be orphaned).
 func (p *PlaybackPump) run() {
 	defer close(p.done)
 	for {
 		select {
 		case job := <-p.queue:
+			// Stop wins over a dequeued job: a select with both arms ready picks
+			// randomly, and a sentence enqueued just before Close must be dropped
+			// (drained), not spoken into the teardown — Close's contract is
+			// "finish the IN-FLIGHT sentence", and a queued one hasn't started.
+			select {
+			case <-p.stop:
+				go drain(job.chunks)
+				continue
+			default:
+			}
 			// playSentence blocks until this sentence's playback finishes or is
 			// interrupted; only then do we take the next, so Session.Play never
 			// auto-interrupts a still-playing sentence. A playback error is not
-			// fatal to the loop — one bad sentence must not silence the rest.
-			_ = playSentence(job.ctx, p.player, p.codec, job.chunks)
+			// fatal to the loop — one bad sentence must not silence the rest —
+			// but it must not be invisible either: a persistent failure here is
+			// "the NPC went mute", so warn on everything except the expected
+			// barge-in interrupt and ctx cancellation.
+			if err := playSentence(job.ctx, p.player, p.codec, job.chunks); err != nil &&
+				!errors.Is(err, gxvoice.ErrInterrupted) && !errors.Is(err, context.Canceled) {
+				p.logger.Warn("wire: sentence playback failed", "err", err)
+			}
 		case <-p.stop:
-			return
+			// A job can already sit in queue when stop closes (enqueued before
+			// Close, never dequeued because this select picked the stop arm).
+			// Abandoning it undrained would block the tee's lockstep forwarder
+			// on its chunk channel — drain everything left before exiting.
+			for {
+				select {
+				case job := <-p.queue:
+					go drain(job.chunks)
+				default:
+					return
+				}
+			}
 		}
 	}
 }

--- a/pkg/voice/wire/pump_test.go
+++ b/pkg/voice/wire/pump_test.go
@@ -21,7 +21,7 @@ func openChunks() (chan tts.AudioChunk, <-chan tts.AudioChunk) {
 // off sentence one. Order must also hold.
 func TestPlaybackPump_SerializesSentences(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{})
+	pump := newPump(p, fakeCodec{}, nil)
 	defer pump.Close()
 
 	c1, ro1 := openChunks()
@@ -67,7 +67,7 @@ func TestPlaybackPump_SerializesSentences(t *testing.T) {
 // sentence in flight beyond the playing one — see the cap-1 rationale).
 func TestPlaybackPump_HandleSentenceReturnsPromptly(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{})
+	pump := newPump(p, fakeCodec{}, nil)
 	defer pump.Close()
 
 	_, ro1 := openChunks()
@@ -96,7 +96,7 @@ func TestPlaybackPump_HandleSentenceReturnsPromptly(t *testing.T) {
 // rather than blocking the (lockstep) producer.
 func TestPlaybackPump_CloseStopsWorker(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{})
+	pump := newPump(p, fakeCodec{}, nil)
 
 	pump.Close()
 	pump.Close() // idempotent, must not panic or block
@@ -115,5 +115,52 @@ func TestPlaybackPump_CloseStopsWorker(t *testing.T) {
 	case <-sent:
 	case <-time.After(time.Second):
 		t.Fatal("post-Close HandleSentence did not drain the channel")
+	}
+}
+
+// TestPlaybackPump_CloseDrainsQueuedJob pins the teardown contract for a
+// sentence that was enqueued but never dequeued when Close fired: it must be
+// drained (unblocking the tee's lockstep forwarder), not abandoned, and not
+// spoken into the teardown.
+func TestPlaybackPump_CloseDrainsQueuedJob(t *testing.T) {
+	p := newFakePlayer()
+	pump := newPump(p, fakeCodec{}, nil)
+
+	// Worker busy on s1.
+	_, ro1 := openChunks()
+	pump.HandleSentence(context.Background(), ro1)
+	pb1 := p.waitPlay(t)
+
+	// s2 sits in the queue behind it, with its producer mid-send (the tee's
+	// lockstep forward goroutine).
+	c2, ro2 := openChunks()
+	pump.HandleSentence(context.Background(), ro2)
+	sent := make(chan struct{})
+	go func() { c2 <- tts.AudioChunk{}; close(sent) }()
+
+	// Close while s2 is still queued; stop is signalled before Close blocks on
+	// the worker, then finishing s1 lets the worker observe it.
+	closed := make(chan struct{})
+	go func() { pump.Close(); close(closed) }()
+	select {
+	case <-pump.stop:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not signal stop")
+	}
+	pb1.finish(nil)
+
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("queued sentence not drained after Close; the tee forwarder would block forever")
+	}
+	close(c2)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return")
+	}
+	if got := p.plays.Load(); got != 1 {
+		t.Fatalf("plays = %d, want 1 (a queued-but-unstarted sentence must be dropped at Close, not spoken)", got)
 	}
 }


### PR DESCRIPTION
## Hardening pass on the PR #14 MVP

Fixes every finding from the post-merge security/quality review of the audio pipeline, so the next phase builds on a solid base. All changes are pinned by new tests.

### High-severity fixes
- **Reply path could hang forever** — `orchestrator.ReplyFunc` now receives the turn context (the per-turn floor ctx under barge-in), so a barge cancels the in-flight LLM call, not just TTS/playback. The agent loop adds `Config.TurnTimeout` (default 60 s) and both LLM adapters' default HTTP clients bound dial/TLS/response-header phases — a black-holed provider fails in seconds instead of wedging the pipeline.
- **`Session.Play` raced `Session.Close`** — Close never took `playMu`, so Play could install a playback into a torn-down provider whose `Done()` never closes, permanently wedging `PlaybackPump.Close`. Close now serializes with Play.
- **ONNX runtime cache race (observed crash)** — concurrent test *processes* on a cold cache could dlopen a half-written `libonnxruntime.so` (segfault reproduced in this session). Extraction now publishes atomically via temp-dir + rename.
- **Silent stream truncation** — a mid-stream network blip used to be spoken as a confident partial reply (and `-tags=record` would bake it into a cassette). `llm.StreamEvent` gains a terminal `EventError`; adapters emit it on scanner errors, malformed frames, server error frames, and a new 16 MiB whole-stream cap; consumers fail the turn on `EventError` or a stream ending without `EventDone`.

### Security tightening
- `GLYPHOXA_SECRET` must now be a base64-encoded 32-byte random key (`openssl rand -base64 32`) — it was an unsalted, unstretched `SHA-256(passphrase)`, offline-brute-forceable from leaked ciphertext. Sealed blobs gain a format-version byte so future key rotation needs no column migration.
- SSE responses are size-bounded (hostile/buggy `WithBaseURL` gateways can no longer grow memory without limit).
- CI pins golangci-lint to v2.12.2 instead of `@latest`.

### Quality fixes
- `Manager.Open` serialized per guild: racing Opens can no longer leak an un-closed Session (and the replace path now releases disgo's conn).
- The TTS tee's lockstep forwarder can no longer be orphaned: the pump drains jobs queued at Close (stop takes priority over a dequeued job), and `playSentence` drains on its error paths. Playback failures are now logged (`NewPlaybackPump` gains a logger) instead of leaving the NPC silently mute.
- Codec: per-speaker reframer resets on PTS gaps (no more minutes-old ~32 ms audio prefixing a new utterance); idle speaker decoders are pruned after 5 minutes.
- Seed references `gemini.ProviderID`/`DefaultModel` so the DB row can't drift from the wired adapter (it recorded `gemini-2.0-flash` while runtime used 2.5-flash).
- `HashLLMRequest` panics on marshal failure instead of collapsing malformed requests to one hash (wrong-cassette replays).
- `OpusReader` documents its blocking-read constraint; `BargeIn` documents the single-mixed-VAD constraint on tuning `confirmWindow > 0`.

### Breaking API changes (pre-1.0, internal consumers updated)
- `orchestrator.ReplyFunc` now takes `(context.Context, voiceevent.AddressRouted)`.
- `wire.NewPlaybackPump` takes a `*slog.Logger`.
- `glyphoxa seed` rejects non-base64 / non-32-byte `GLYPHOXA_SECRET`.

### Verification
- `go build ./...` + `go vet ./...` + `go vet -tags=record ./...` — clean
- `go test -race ./...` — green (20 packages), including a cold-cache parallel run across the silero-loading packages that previously segfaulted
- `go build/test -race -tags "opus nolibopusfile" ./pkg/voice/wire/...` — green (real libopus)
- golangci-lint v2.12.2 — 0 issues; `go mod tidy` — no changes

https://claude.ai/code/session_019F4zqsCVmmNBkYMYgsUGpN

---
_Generated by [Claude Code](https://claude.ai/code/session_019F4zqsCVmmNBkYMYgsUGpN)_