### PR TITLE
Voice latency: fix the 20s self-cancel, make turn failures observable, cut baseline LLM rounds

### DIFF
--- a/docs/latency-investigation/audio-process.md
+++ b/docs/latency-investigation/audio-process.md
@@ -401,3 +401,28 @@ would withhold dice when needed), so the tool path is intact when dice IS asked
 for. The locked `tool.Loop` / `GrantSet` seams are untouched — `Without` is
 additive and the gate lives entirely in the bridge. Cold-connection prewarm
 (doc #5) remains a separate follow-up.
+
+**`response_latency` now ends audible-on-wire (task #7 — P1 item #5, Luk's
+definition).** The SLO was measuring "audio handed to the pump" (`FirstAudio`),
+which excludes the codec encode, the pump's real-time 20 ms pacing, and the
+Discord send tail — the span the user never experiences. Per Luk ("I stop talking
+until the first TTS opus packets are streamed back to Discord") the boundary moved
+to the **first Opus packet pulled to the Discord send path**: a new
+`voiceevent.FirstOpus` is published by a `voice.Source` decorator in
+`wire.playSentenceBus` on the first non-EOF frame disgo's sender pulls (the
+audible-on-wire moment), and the subscriber's `response_latency` now ends there
+instead of at `FirstAudio`. `FirstAudio` is retained for what it still owns — the
+per-sentence `tts_ttfb` pairing and the turn-lifecycle `first_audio` success
+outcome (which still gates `abandoned`). So the headline number finally measures
+speech-end → audible-on-wire, while the lifecycle/ttfb semantics are unchanged.
+
+**Barge-in timer residual (won't-fix, recorded).** `BargeIn` re-arms a fresh
+timer goroutine + channel on every `speech_start` while a confirm window is armed.
+That is a bounded allocation nit under multi-segment churn, **not** a leak. It is
+deliberately left as-is: the per-arm channel identity (`b.pending == done`) is the
+supersede disambiguator, and a single reusable `time.AfterFunc` cannot carry
+per-scheduling identity, so a "cleanup" to one timer would trade the nit for a
+correctness risk (a stale just-elapsed callback firing the barge against a freshly
+re-armed window). The eventual shape, if the churn ever matters, is a single
+long-lived worker goroutine draining one timer's channel plus a re-arm channel —
+its own scoped change with its own tests, not a rider on a latency hot-fix.

--- a/docs/latency-investigation/audio-process.md
+++ b/docs/latency-investigation/audio-process.md
@@ -384,3 +384,20 @@ when the turn dies of its own error before audio). The subscriber maps these to
 turn that vanished with **no** signal at all (TTL-reaped). A `TurnEnded` arriving
 *after* first audio (a barge mid-playback) is a normal interruption and does not
 re-count the turn (first-audio is terminal).
+
+**The `dice` grant is now conditional (task #5 — baseline root cause #4).** The
+unconditional grant declared the dice Tool to Gemini on *every* turn, so even a
+plain "how much for a room?" could draw an empty tool-call round before first
+audio (a round that streams no prose — seconds of avoidable baseline latency).
+The fix gates the grant per turn in the `agenttool.Engine`: it holds two loops
+over the same provider adapter (full grants, and grants with `dice` dropped via
+the new pure `tool.GrantSet.Without`) and picks the dice-less loop unless the
+**current** user utterance shows dice intent (`needsDice` — explicit `NdM`/`d20`
+notation or a recall-biased ttrpg keyword set; latest user message only, so an
+old roll doesn't arm later turns). A plain conversational turn is then
+structurally a single LLM round. The gate is biased for high recall (a false
+positive only costs the round we paid unconditionally before; a false negative
+would withhold dice when needed), so the tool path is intact when dice IS asked
+for. The locked `tool.Loop` / `GrantSet` seams are untouched — `Without` is
+additive and the gate lives entirely in the bridge. Cold-connection prewarm
+(doc #5) remains a separate follow-up.

--- a/docs/latency-investigation/audio-process.md
+++ b/docs/latency-investigation/audio-process.md
@@ -1,0 +1,340 @@
+# Latency investigation — audio process / concept (the 20 s)
+
+**Author:** audio-process (Agent Team `glyphoxa-latency`)
+**Branch:** `lat/audio-process`
+**Evidence:** `glyphoxa-livetest-20260610.log`, `glyphoxa-livetest-20260610-metrics.txt`
+**Date:** 2026-06-10
+
+---
+
+## TL;DR
+
+The 20 s the user lived through and the 2.3 s the metric reported are **not the
+same turns**. The metric only records a turn that produced first audio; the turns
+that made the user wait produced **no audio at all** because their TTS calls were
+**cancelled or rejected**, so they emit zero `response_latency` samples *by
+design*. The 20 s lives in those invisible, self-cancelled turns — not in slow
+Gemini reasoning.
+
+The single recorded turn ran in **1.599 s** — *faster* than even ADR-0035's
+trivial single-call Gemini floor (~1.9 s). The turn that worked was fine.
+The problem is the turns that never finished.
+
+**Ranked root causes**
+
+1. **`WithBargeIn(0)` + a single shared VAD session self-cancels the turn the user
+   is waiting for** (the `context canceled` at 22:36:17). The user's *own
+   continuing speech* — or a VAD split of one utterance — fires `VADSpeechStart`
+   while Bart holds the floor, and a 0 ms confirm window yields instantly →
+   the in-flight TTS POST is cancelled. **This is the 20 s.**
+2. **Per-segment turns + `Floor.Take` supersession self-cancel** — independent of
+   barge-in. Each STT segment opens a *new* `TurnID` and a *new* `Floor.Take`,
+   which cancels the previous turn. One utterance VAD-split into two segments =
+   the first turn cancelled by the second. The `vadMinSilenceFrames` 15→12 loosening
+   makes mid-utterance splits *more* likely.
+3. **Survivorship-biased SLO metric + near-empty logs** — the instrumentation
+   *cannot see* (1) and (2). This is itself a primary finding: the 20 s was
+   invisible, so it looked like 2.3 s.
+4. **Baseline latency is mediocre (seconds, not 20 s): H2 multi-round Gemini with
+   the `dice` tool granted.** A tool-call round streams *no* prose, so first audio
+   waits for round-0 thinking + tool exec + round-1 thinking. Explains why even a
+   *surviving* turn isn't snappy; does **not** explain 20 s.
+5. **The `eleven_v3` empty-tag 400 (22:36:40)** — now fixed on this branch
+   (`f744942`), but it was a third silent failure mode the same night.
+
+---
+
+## 1. Reconcile the trace — it already tells the whole story
+
+Three reply attempts that night, laid against the metric series:
+
+| wall-clock | event (log) | metric effect |
+|---|---|---|
+| ~22:36:17 | TTS **`context canceled`** (Synthesize POST aborted mid-flight) | **no sample** |
+| ~22:36:38 | TTS success → first audio | `turns=1 sum=1.599 s` |
+| ~22:36:40 | TTS **HTTP 400 empty-text** (`eleven_v3` tag-only sentence) | **no sample** |
+
+Two of three attempts produced **zero audio** and therefore zero
+`response_latency` samples. The user heard nothing across the cancellations and
+waited; the metric faithfully recorded the *one* turn that squeaked through at
+1.599 s. The headline "p50 2.3 s" is a survivor average over a sample of one.
+
+The metric did not "miss" the 20 s turns. By construction
+(`internal/observe/subscriber.go:33-37`) a turn that never emits `FirstAudio`
+records no `response_latency`. That comment calls it "the correct *cancelled = no
+audible response* behaviour" — correct for a *barge-in* (the user chose to cut
+Bart), **wrong** as the sole record when the cancel is the system silencing
+*itself*. Same event, opposite meaning, and the metric can't tell them apart.
+
+---
+
+## 2. Root cause #1 — `WithBargeIn(0)` self-cancels the turn (the 20 s)
+
+### The wiring
+
+`internal/wirenpc/wirenpc.go:429` wires `orchestrator.WithBargeIn(0)` — a **zero**
+confirm window. In `pkg/voice/orchestrator/barge.go:67-71`:
+
+```go
+if b.confirm <= 0 {
+    b.fire(bus)   // yield the floor the instant speech_start fires
+    return
+}
+```
+
+`fire` → `Floor.Yield()` → cancels the per-turn context
+(`pkg/voice/orchestrator/floor.go:63-73`). That context threads through TTS
+synthesis (`orchestrator/reactor.go:354` → `TTS.Dispatch` → ElevenLabs
+`Synthesize`), so cancelling it aborts the in-flight HTTP POST — **exactly** the
+`elevenlabs.Synthesize: ... context canceled` in the 22:36:17 log line.
+
+### Why it fires on the user's *own* voice
+
+ADR-0027 and the `barge.go:23-33` doc assert "an Agent's own TTS never triggers a
+barge: only inbound participant audio is VAD'd, so every speech_start here is a
+human's." **True but insufficient.** The barge fires on a *human's* speech_start —
+and the human is *still talking*. The real sequence in a live channel:
+
+1. User says "Bart, what's a room cost, and have you seen Gandalf?"
+2. VAD ends the first speech segment at an internal pause → STT → AddressRouted →
+   Bart's turn **takes the floor** (`reactor.go:313`).
+3. User continues ("…and have you seen Gandalf?") → fresh **`VADSpeechStart`** —
+   floor is active → 0 ms window → **instant `Yield()`** → Bart's turn cancelled,
+   TTS POST aborted. No audio.
+4. Repeat for every continuation / restart. The user perceives a long silence.
+   Eventually a real gap lets one turn run uninterrupted → the 1.599 s survivor.
+
+The guard `if !b.floor.Active()` (`barge.go:64`) only checks *whether* Bart holds
+the floor — not *who* is speaking or *whether it's the same utterance that
+triggered him*. The single shared VAD session (one session over all participants'
+interleaved frames — `barge.go:26-33`) cannot attribute speech to a speaker, so it
+**cannot distinguish "a third party interrupted Bart" from "the addressing user is
+still finishing their own sentence."** With a 0 ms window the latter always wins.
+
+This is the #1 hypothesis: a concrete mechanism, a matching log line, and a fix
+already named in the code (`wirenpc.go:427-428`: "the ~250 ms confirm window is
+the next tuning step").
+
+---
+
+## 3. Root cause #2 — per-segment turns + `Floor.Take` supersession
+
+Independent of barge-in. `pkg/voice/orchestrator/stt.go:52-56` publishes **one
+`STTFinal` per STT segment, each with a fresh `NewTurnID()`**. Each routed segment
+opens a new turn, and `Floor.Take` (`floor.go:33-43`) **supersedes** any turn still
+holding the floor — it cancels the prior turn's context.
+
+So if one spoken utterance is VAD-split into two segments (two `STTFinal` → two
+`AddressRouted` → two `Take`s), the **second segment's turn cancels the first
+segment's turn mid-synthesis** — another `context canceled`, with no barge involved
+at all. The `vadMinSilenceFrames` 15→12 change (`wirenpc.go:50-64`) explicitly
+lowers the silence hangover; the file's own comment warns that values this low can
+split "a single utterance at an internal pause." Lower hangover ⇒ more splits ⇒
+more self-cancelling turn pairs.
+
+Either #1 or #2 produces the same observable: a TTS `context canceled`, no audio,
+no metric sample, a waiting user. They likely **both** fired that night.
+
+---
+
+## 4. Root cause #3 — the metric boundary and the empty logs (why it was invisible)
+
+### The SLO is survivorship-biased
+
+`response_latency = first FirstAudio − STTFinal.SpeechEndAt`, recorded only when a
+`FirstAudio` lands (`subscriber.go:186-195`). A turn that is cancelled, errors in
+TTS, or is abandoned **emits nothing**. The series therefore measures *only
+successful turns* and is structurally blind to the exact failures that produce the
+worst user-perceived latency. A p50 over survivors will always look healthy while
+users rage at silence.
+
+### The boundary is also the wrong *end* of the SLO
+
+Even for a survivor, `FirstAudio` is stamped when the first chunk **crosses to the
+playback pump** (`wire/tee.go:127-130`), *before* the `play <- chunk` send, codec
+encode, Opus framing, Discord jitter buffer, and network tail. The metric measures
+"audio handed to the pump," **not "audio audible to the user."** The pump's
+real-time 20 ms pacing, the encode, and Discord's buffer all sit *outside* the
+measured span. So the SLO boundary is wrong on **both** ends: it ignores
+failed/cancelled turns (start side: no sample) and it stops short of audible
+(end side: pre-pump). The "≤1.2 s p50 speech-end→first-audio" target
+(`voicebench/report.go:35`) is measuring a span the user never experiences.
+
+### The 1.599 < Gemini-floor anomaly
+
+The one recorded turn (1.599 s) is *below* ADR-0035's trivial single-call ttft
+(~1.9 s, p50). Two readings, both worth noting: (a) the in-pipeline warm path may
+genuinely beat a cold raw call; or (b) `SpeechEndAt` is stamped at the *segment's*
+speech-end, which for a split utterance is an *internal* pause — a late, drifting
+span start that *undercounts* latency. Either way it reinforces: the SLO start
+boundary is not trustworthy, and the numbers it does produce can't be read against
+the budget.
+
+### The logs show nothing
+
+Post-Sprint-2 cleanup left INFO nearly empty (the live log is **4 lines** for an
+entire session — two of them the cancel/400 WARNs). There is **no per-turn timing
+trace**: no speech-end, no address-routed, no per-round LLM start/stop, no
+TTSInvoked, no FirstAudio, no turn-cancelled reason. So neither the metric nor the
+logs could explain the 20 s. **The thin logs are themselves a primary finding.**
+
+---
+
+## 5. Root cause #4 — baseline latency: H2 multi-round Gemini with `dice` granted
+
+This explains why a *surviving* turn isn't snappy; it does **not** explain 20 s.
+
+`wirenpc.go:395-402` grants the `dice` tool on every turn. The B1 streaming path
+runs through `tool.Loop.RunStream` (`pkg/tool/loop.go:86-142`), which streams prose
+from **every round in order** — but a round that ends in a tool call emits **no
+prose** (`loop.go:73-77`: "the model emits the call with no prose preamble, so in
+practice only the final answer's prose is spoken"). So when the model calls a tool:
+
+```
+round 0:  Gemini thinking + tool-call emission (no prose)  → dice executes
+round 1:  Gemini thinking + final prose                    → first sentence → first audio
+```
+
+First audio waits for **round-0 thinking + round-0 generation + tool exec +
+round-1 thinking + round-1 first sentence**. At `reasoning_effort:"low"` each round
+carries a ~1.9–2.9 s floor (ADR-0035's own trivial-tier numbers), so a tool turn is
+plausibly **4–6 s to first audio** before any TTS round-trip. ADR-0035 even names
+the trade: `low` *adds* ~1 s to already-fast turns (it's a thinking *floor*, not
+just a ceiling). That floor lands on top of the H2 round count.
+
+**Is the cap effective?** ADR-0035's live A/B says yes for the *tail* (reasoning-
+bait p95 9.3 s→5.5 s). But that A/B is a **raw single call** — one-line system
+prompt, no history, no tools, no orchestrator (ADR-0035:22-23). It does **not**
+measure the in-pipeline multi-round path. The cap flattens per-call thinking; it
+does nothing about the *number* of rounds. **H1 (per-call thinking) is mitigated;
+H2 (round count) is not, and the `dice` grant arms H2 on every turn.**
+
+B1 sentence-streaming **is** genuinely end-to-end (`agent/agent.go:296-303` segments
+deltas and dispatches per sentence; the tee publishes FirstAudio on the first chunk
+— `tee.go:127-130`). It is **not** buffering the whole completion. So B1 works as
+designed; its blind spot is precisely the tool-call round, which streams nothing.
+
+---
+
+## ADR / assumption challenges
+
+- **ADR-0027 (barge-in confirm window).** The "Agent's own TTS never triggers a
+  barge" claim is true but creates a false sense of safety. With **one shared VAD
+  session** and `confirm=0`, the *addressing user's own continued speech* cancels
+  the turn they triggered. The ADR's own multi-speaker caveat (`barge.go:28-33`)
+  already says don't tune `confirm>0` without per-participant VAD — but `confirm=0`
+  is *worse*, not safer: it removes the only debounce. **Recommendation: never ship
+  `confirm=0` against a live mic.** A non-zero window (≥250 ms) is the minimum;
+  ideally gate barge on speaker ≠ the turn's addresser once per-participant VAD
+  (ADR-0019, deferred) lands.
+
+- **ADR-0019 (single shared VAD session, per-participant deferred).** Deferring
+  per-participant VAD is the upstream cause of both #1 and #2: without speaker
+  attribution, the orchestrator can't tell "interruption" from "same speaker
+  continuing," and can't coalesce one speaker's split segments into one turn.
+  This deferral is now load-bearing for latency, not just for multi-speaker
+  correctness. **Recommendation: promote it, or add a same-utterance guard.**
+
+- **ADR-0012 / per-segment turn identity.** A fresh `TurnID` + `Floor.Take` per STT
+  segment means the *unit of a turn is a VAD segment, not a user utterance*. That's
+  fine when segments are utterances; it self-destructs when VAD over-splits. There
+  is no "coalesce consecutive segments from the same speaker within N ms" step.
+  **Recommendation: add an utterance-assembly / turn-debounce stage** so one
+  utterance = one turn.
+
+- **ADR-0032 (observability).** The metric set is the right *shape* but has a
+  **survivorship hole**: it counts successes and omits failures. For a real-time
+  product the failure/abandon rate is the headline operational signal, and it's
+  absent. **Recommendation: add a turn-lifecycle counter** (below). Also reconsider
+  the `response_latency` end boundary (pre-pump, not audible).
+
+- **ADR-0035 (thinking cap).** Sound for H1/the tail; **does not address H2**
+  (round count). The live A/B is a raw call, not the pipeline — it proves the
+  mechanism, not the SLO. **Recommendation: drop the `dice` grant from the default
+  voice NPC** (or gate it behind an address-detected dice intent) so the common
+  conversational turn is single-round; and/or set `WithThinkingBudget(0)` for the
+  reply round to kill the trivial-turn floor the ADR itself flags.
+
+---
+
+## Fix plan (ranked, smallest-blast-radius first)
+
+**P0 — stop the self-cancel (the 20 s).**
+1. Set `WithBargeIn(250ms)` (or larger) in `wirenpc.go:429`; **never `0`** live.
+   This alone removes the dominant self-cancel: a user finishing their own sentence
+   no longer sustains 250 ms of *new* speech past their own pause without it being a
+   real interruption.
+2. Add a **same-utterance / turn-debounce guard**: coalesce STT segments from the
+   same speaker arriving within a short window into one turn, OR suppress barge for
+   the first ~N ms after the floor is taken when no *other* speaker is detected.
+   This closes root cause #2 (segment-split supersession) which `confirm>0` alone
+   does not.
+
+**P1 — make the 20 s visible next time (instrumentation).**
+3. **Turn-lifecycle counter** `glyphoxa_voice_turn_total{outcome,reason}` where
+   `outcome ∈ {first_audio, cancelled, tts_error, abandoned, max_rounds}` and
+   `reason ∈ {barge, supersede, ctx_deadline, provider_4xx, provider_5xx}`. Emit it
+   from the same `StageSubscriber` (it already sees STTFinal → no-FirstAudio turns;
+   the Sweep at `subscriber.go:224` already finds abandoned turns — count them
+   instead of silently reaping). This is the single change that would have shown the
+   two failed attempts that night.
+4. **Per-turn structured timing log** (one INFO line per turn at turn-end): `turn_id,
+   speech_end, address_routed_at, llm_round_count, round_durations[], tts_invoked_at[],
+   first_audio_at | cancel_reason`. Restores the per-turn timeline Sprint-2 cleanup
+   removed, gated so it's one line/turn (not the old 741-call-site noise).
+5. Add a **user-audible end boundary**: stamp a second timestamp when the first Opus
+   frame is handed to `Session.Play` (post-encode), so the SLO can distinguish
+   "handed to pump" from "on the wire." Keep both; the audible one is the real SLO.
+
+**P1 — baseline latency.**
+6. Drop the unconditional `dice` grant from the conversational NPC (or gate it on a
+   detected dice intent) so the common turn is single-round → no empty tool-call
+   round before first audio.
+7. Pre-warm the ElevenLabs + Gemini connections at join time (a tiny no-op / cached
+   handshake) so the first real turn doesn't pay cold-connection setup.
+
+**P2 — already landed / verify.**
+8. The empty-`eleven_v3`-tag 400 fix (`f744942`) is on this branch; confirm it's the
+   live build. It removes the third silent-failure mode (22:36:40).
+
+---
+
+## Reproduction needed to *prove* #1/#2
+
+A definitive root-cause needs a repro that drives the live pipeline with per-stage
+timestamps and the **same-speaker-continues** condition the metric can't see.
+
+**Harness design (no paid loop required to prove the cancel mechanism):**
+
+- **Mechanism-level (free, keyless):** a local test that wires the real
+  orchestrator + `WithBargeIn(0)` + a `Floor`, feeds **two `VADSpeechStart` events
+  with the floor held** (simulating the same speaker continuing), and asserts the
+  in-flight turn's context is cancelled and **no `FirstAudio`** is emitted. Same for
+  two back-to-back `STTFinal` segments (asserting the second `Floor.Take`
+  supersedes the first). This proves #1 and #2 deterministically, against the real
+  code, **with zero API spend** — the cancel is pure orchestrator logic. Build this
+  first; it converts the hypotheses into a passing/failing assertion.
+
+- **Stage-timestamp repro (one paid live run, coordinated via team-lead):** run the
+  live NPC with the P1 per-turn timing log enabled, drive real Gemini + ElevenLabs,
+  and have a human deliberately (a) speak one long run-on utterance with internal
+  pauses, and (b) speak a clean single utterance with a real gap after. The log will
+  show segment-split turns cancelling each other in (a) and a clean survivor in (b),
+  with real per-stage ms. This closes the loop on wall-clock and quantifies the H2
+  baseline. **Do not run paid loops unsupervised — route the live run through
+  team-lead.**
+
+The free mechanism-level repro is the deliverable that *proves* the diagnosis; the
+paid run only *quantifies* it.
+
+---
+
+## Coordination
+
+Shared with teammate `code-quality`: the VAD-trigger / `Floor.Take` supersession
+race and the `WithBargeIn(0)` self-cancel are squarely a code-level
+concurrency/lifecycle issue as well as a concept one — they should confirm the
+race at the code level (does a second `Take` reliably cancel the first mid-`Dispatch`,
+and is there any window where the cancelled POST's goroutine leaks). The
+instrumentation gaps (survivorship metric, empty logs) are the seam between our two
+reports.

--- a/docs/latency-investigation/audio-process.md
+++ b/docs/latency-investigation/audio-process.md
@@ -338,3 +338,38 @@ race at the code level (does a second `Take` reliably cancel the first mid-`Disp
 and is there any window where the cancelled POST's goroutine leaks). The
 instrumentation gaps (survivorship metric, empty logs) are the seam between our two
 reports.
+
+---
+
+## Implemented (task #1) — and the residual it leaves
+
+Three commits on `lat/audio-process` land the P0/P1 fixes above:
+
+- **P0.1** — `WithBargeIn(0)` → `250ms` (`bargeConfirmWindow`), pinned non-zero
+  by a test. Closes root cause #1.
+- **P0.2** — a **floor coalesce window** (`NewFloorWithCoalesce` /
+  `WithBargeInCoalesce`, 600 ms live): a `Floor.Take` landing within the window of
+  the previous one **yields to** the in-flight turn instead of superseding it.
+  Closes the root-cause-#2 self-cancel without restructuring per-segment turn
+  identity (the floor-seam debounce, chosen over a Segmenter utterance-assembly
+  stage which would tangle with the locked S2 turn-identity seam).
+- **P1.3/P1.4** — `glyphoxa_voice_turn_total{outcome,reason}` (the survivorship
+  counterpart) + `WithTurnLog` one-line-per-turn timing trace.
+
+**Known residual — the coalesced segment's text is dropped.** The coalesce window
+saves the *first* segment's turn from cancellation, but it does so by **yielding
+the late segment** — that segment is never spoken, so when VAD over-splits
+"*Bart, what's a room cost…*" / "*…and have you seen Gandalf?*", Bart answers only
+the **first half**. The fix is deliberately *visible*, not silent: the yielded
+segment emits `voiceevent.TurnYielded{TurnID, Text}`, which the metrics subscriber
+records as a **distinct `turn_total{outcome="yielded",reason="supersession_grace"}`**
+(not `abandoned`) and logs at INFO **with the dropped transcript**
+(`yielded_text=…`). So the over-split rate and the exact text lost are both
+measurable.
+
+This is the data the *next* iteration needs to justify **real utterance
+coalescing**: instead of dropping the late segment, assemble consecutive
+same-speaker segments into one turn (or route the late segment's text into the
+in-flight turn's Hot Context before its LLM call) so one utterance = one *complete*
+turn. That belongs to the S2 Hot Context seam and per-participant VAD (ADR-0019),
+not the floor — out of task #1's blast radius, tracked as a follow-up.

--- a/docs/latency-investigation/audio-process.md
+++ b/docs/latency-investigation/audio-process.md
@@ -361,11 +361,11 @@ saves the *first* segment's turn from cancellation, but it does so by **yielding
 the late segment** — that segment is never spoken, so when VAD over-splits
 "*Bart, what's a room cost…*" / "*…and have you seen Gandalf?*", Bart answers only
 the **first half**. The fix is deliberately *visible*, not silent: the yielded
-segment emits `voiceevent.TurnYielded{TurnID, Text}`, which the metrics subscriber
-records as a **distinct `turn_total{outcome="yielded",reason="supersession_grace"}`**
-(not `abandoned`) and logs at INFO **with the dropped transcript**
-(`yielded_text=…`). So the over-split rate and the exact text lost are both
-measurable.
+segment emits `voiceevent.TurnEnded{Reason: supersede_coalesced, Text}`, which the
+metrics subscriber records as a **distinct
+`turn_total{outcome="yielded",reason="supersession_grace"}`** (not `abandoned`)
+and logs at INFO **with the dropped transcript** (`yielded_text=…`). So the
+over-split rate and the exact text lost are both measurable.
 
 This is the data the *next* iteration needs to justify **real utterance
 coalescing**: instead of dropping the late segment, assemble consecutive
@@ -373,3 +373,14 @@ same-speaker segments into one turn (or route the late segment's text into the
 in-flight turn's Hot Context before its LLM call) so one utterance = one *complete*
 turn. That belongs to the S2 Hot Context seam and per-participant VAD (ADR-0019),
 not the floor — out of task #1's blast radius, tracked as a follow-up.
+
+**Turn-end reasons are now precise (task #4).** The single `voiceevent.TurnEnded`
+event carries a bounded `Reason` published by the seam that knows the cause —
+`barge` (the `BargeIn`, via the `Floor` now returning the cut turn's `TurnID` from
+`Yield`), `supersede_coalesced` (the `Replier`'s coalesced branch), and
+`tts_error` / `provider_error` (the `Replier`'s dispatch / producer error paths
+when the turn dies of its own error before audio). The subscriber maps these to
+`turn_total{outcome,reason}`, so `no_first_audio` is now only the fallback for a
+turn that vanished with **no** signal at all (TTL-reaped). A `TurnEnded` arriving
+*after* first audio (a barge mid-playback) is a normal interruption and does not
+re-count the turn (first-audio is terminal).

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 require (
 	github.com/hraban/opus v0.0.0-20251117090126-c76ea7e21bf3
 	github.com/prometheus/client_golang v1.23.2
+	go.uber.org/goleak v1.3.0
 )
 
 require (

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -59,6 +59,10 @@ type PrometheusRecorder struct {
 	providerCalls  *prometheus.CounterVec // stage, provider, outcome
 	providerErrors *prometheus.CounterVec // stage, provider
 
+	// turn lifecycle (StageRecorder): the survivorship counterpart to
+	// response_latency — every turn records one terminal outcome.
+	turnTotal *prometheus.CounterVec // outcome, reason
+
 	// embedding backlog: spec-complete stub (ADR-0032). The persistence/embedding
 	// layer isn't coded yet, so nothing Sets this — registered so the /metrics
 	// surface matches ADR-0032 and a reviewer diffing the two sees no gap.
@@ -130,6 +134,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 
 	r.providerCalls = counterVec("provider_calls_total", "Vendor calls by stage, provider and outcome.", "stage", "provider", "outcome")
 	r.providerErrors = counterVec("provider_errors_total", "Vendor call errors by stage and provider.", "stage", "provider")
+	r.turnTotal = counterVec("turn_total", "Turns by terminal outcome and reason — the survivorship counterpart to response_latency (which records only turns that reached first audio).", "outcome", "reason")
 
 	r.embeddingBacklog = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace, // process-level, not a voice subsystem metric (ADR-0032)
@@ -142,7 +147,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		r.playbackTotal, r.bargeCancels,
 		r.responseLatency, r.vadHangover, r.addressDetect, r.codecDecode,
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
-		r.providerCalls, r.providerErrors, r.embeddingBacklog,
+		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
 		// Standard runtime collectors so /metrics also reports process/Go health.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
@@ -209,6 +214,9 @@ func (r *PrometheusRecorder) ProviderCall(s Stage, p Provider, o Outcome) {
 }
 func (r *PrometheusRecorder) ProviderError(s Stage, p Provider) {
 	r.providerErrors.WithLabelValues(string(s), string(p)).Inc()
+}
+func (r *PrometheusRecorder) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
+	r.turnTotal.WithLabelValues(string(outcome), string(reason)).Inc()
 }
 
 // Static assertions that the one adapter satisfies both contracts. The

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -49,6 +49,8 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.TTSTimeToFirstByte(ProviderElevenLabs, 250*time.Millisecond)
 	rec.ProviderCall(StageLLM, ProviderGemini, OutcomeOK)
 	rec.ProviderError(StageTTS, ProviderElevenLabs)
+	rec.TurnOutcome(TurnFirstAudio, ReasonNone)
+	rec.TurnOutcome(TurnAbandoned, ReasonNoFirstAudio)
 
 	out := scrape(t, rec)
 
@@ -69,6 +71,8 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_voice_tts_ttfb_seconds_bucket{provider="elevenlabs"`,
 		`glyphoxa_voice_provider_calls_total{outcome="ok",provider="gemini",stage="llm"} 1`,
 		`glyphoxa_voice_provider_errors_total{provider="elevenlabs",stage="tts"} 1`,
+		`glyphoxa_voice_turn_total{outcome="first_audio",reason="none"} 1`,
+		`glyphoxa_voice_turn_total{outcome="abandoned",reason="no_first_audio"} 1`,
 		`glyphoxa_embedding_backlog 0`,
 	}
 	for _, want := range wantSubstrings {

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -51,6 +51,7 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.ProviderError(StageTTS, ProviderElevenLabs)
 	rec.TurnOutcome(TurnFirstAudio, ReasonNone)
 	rec.TurnOutcome(TurnAbandoned, ReasonNoFirstAudio)
+	rec.TurnOutcome(TurnYielded, ReasonSupersessionGrace)
 
 	out := scrape(t, rec)
 
@@ -73,6 +74,7 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_voice_provider_errors_total{provider="elevenlabs",stage="tts"} 1`,
 		`glyphoxa_voice_turn_total{outcome="first_audio",reason="none"} 1`,
 		`glyphoxa_voice_turn_total{outcome="abandoned",reason="no_first_audio"} 1`,
+		`glyphoxa_voice_turn_total{outcome="yielded",reason="supersession_grace"} 1`,
 		`glyphoxa_embedding_backlog 0`,
 	}
 	for _, want := range wantSubstrings {

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -52,6 +52,9 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.TurnOutcome(TurnFirstAudio, ReasonNone)
 	rec.TurnOutcome(TurnAbandoned, ReasonNoFirstAudio)
 	rec.TurnOutcome(TurnYielded, ReasonSupersessionGrace)
+	rec.TurnOutcome(TurnAbandoned, ReasonBarge)
+	rec.TurnOutcome(TurnAbandoned, ReasonTTSError)
+	rec.TurnOutcome(TurnAbandoned, ReasonProviderError)
 
 	out := scrape(t, rec)
 
@@ -75,6 +78,9 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_voice_turn_total{outcome="first_audio",reason="none"} 1`,
 		`glyphoxa_voice_turn_total{outcome="abandoned",reason="no_first_audio"} 1`,
 		`glyphoxa_voice_turn_total{outcome="yielded",reason="supersession_grace"} 1`,
+		`glyphoxa_voice_turn_total{outcome="abandoned",reason="barge"} 1`,
+		`glyphoxa_voice_turn_total{outcome="abandoned",reason="tts_error"} 1`,
+		`glyphoxa_voice_turn_total{outcome="abandoned",reason="provider_error"} 1`,
 		`glyphoxa_embedding_backlog 0`,
 	}
 	for _, want := range wantSubstrings {

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -96,22 +96,30 @@ const (
 
 // TurnReason is the bounded sub-reason label on the turn-lifecycle counter,
 // narrowing WHY a turn ended in its outcome. Kept deliberately small (ADR-0032
-// cardinality): the bus subscriber can attribute only what the bus reveals;
-// precise cancel attribution (barge vs supersede vs provider 4xx/5xx) needs a
-// TurnID-carrying turn-end event and is a follow-up.
+// cardinality): each value is published by the seam that knows the cause (the
+// orchestrator's BargeIn / Replier via [voiceevent.TurnEnded]); only a turn that
+// vanishes with no signal at all falls back to the coarse no_first_audio.
 type TurnReason string
 
 const (
 	// ReasonNone is the no-further-detail reason (the success path).
 	ReasonNone TurnReason = "none"
-	// ReasonNoFirstAudio: reaped without ever emitting first audio. The coarse
-	// catch-all for the abandoned outcome until a precise cancel reason is on the
-	// bus.
+	// ReasonNoFirstAudio: reaped by the TTL sweep without ever emitting first audio
+	// AND with no turn-end signal — the coarse fallback for a turn that simply
+	// vanished (the precise reasons below cover turns that ended for a known cause).
 	ReasonNoFirstAudio TurnReason = "no_first_audio"
 	// ReasonSupersessionGrace: the yielded outcome's reason — the floor's
 	// same-utterance coalesce window folded this late segment into the in-flight
 	// turn (it did not supersede it).
 	ReasonSupersessionGrace TurnReason = "supersession_grace"
+	// ReasonBarge: the turn was cut by a confirmed human barge-in before audio.
+	ReasonBarge TurnReason = "barge"
+	// ReasonTTSError: the turn's TTS synthesis failed (a real provider/synth error,
+	// not a context cancel).
+	ReasonTTSError TurnReason = "tts_error"
+	// ReasonProviderError: the reply producer (LLM round / tool loop) failed before
+	// the turn could produce audio.
+	ReasonProviderError TurnReason = "provider_error"
 )
 
 // StageRecorder records the orchestrator's per-stage / per-turn latency

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -68,6 +68,43 @@ const (
 	OutcomeTimeout Outcome = "timeout"
 )
 
+// TurnOutcome is the bounded result label on the turn-lifecycle counter
+// (glyphoxa_voice_turn_total). It is the survivorship counterpart to
+// response_latency: that histogram records ONLY turns that reached first audio,
+// so a turn cancelled / errored / abandoned before audio emits no sample and is
+// invisible. This counter records EVERY turn's terminal state, so the
+// failed/abandoned rate — the headline operational signal for a real-time voice
+// product — is observable next to the survivor latency (ADR-0032; latency
+// investigation root cause #3).
+type TurnOutcome string
+
+const (
+	// TurnFirstAudio: the turn reached first audio (it also recorded a
+	// response_latency sample). The success state.
+	TurnFirstAudio TurnOutcome = "first_audio"
+	// TurnAbandoned: the turn opened (STTFinal) but never reached first audio and
+	// was reaped by the TTL sweep — cancelled (barge/supersede), errored in TTS, or
+	// never synthesized. These are the turns the survivorship-biased
+	// response_latency cannot see.
+	TurnAbandoned TurnOutcome = "abandoned"
+)
+
+// TurnReason is the bounded sub-reason label on the turn-lifecycle counter,
+// narrowing WHY a turn ended in its outcome. Kept deliberately small (ADR-0032
+// cardinality): the bus subscriber can attribute only what the bus reveals;
+// precise cancel attribution (barge vs supersede vs provider 4xx/5xx) needs a
+// TurnID-carrying turn-end event and is a follow-up.
+type TurnReason string
+
+const (
+	// ReasonNone is the no-further-detail reason (the success path).
+	ReasonNone TurnReason = "none"
+	// ReasonNoFirstAudio: reaped without ever emitting first audio. The coarse
+	// catch-all for the abandoned outcome until a precise cancel reason is on the
+	// bus.
+	ReasonNoFirstAudio TurnReason = "no_first_audio"
+)
+
 // StageRecorder records the orchestrator's per-stage / per-turn latency
 // histograms and the provider-call counters. It is the contract the bus-driven
 // sibling subscriber (latency spans) and the provider adapters (provider calls,
@@ -142,6 +179,13 @@ type StageRecorder interface {
 	//  glyphoxa_voice_provider_errors_total{stage,provider})
 	ProviderCall(stage Stage, provider Provider, outcome Outcome)
 	ProviderError(stage Stage, provider Provider)
+
+	// TurnOutcome counts one turn's terminal state, the survivorship counterpart
+	// to ResponseLatency: every turn records exactly one outcome, so the
+	// failed/abandoned rate is visible next to the survivor latency.
+	// (glyphoxa_voice_turn_total{outcome,reason}) — WIRED by the bus subscriber
+	// (first_audio on the first FirstAudio per turn, abandoned on a TTL reap).
+	TurnOutcome(outcome TurnOutcome, reason TurnReason)
 }
 
 // Discard is the no-op StageRecorder used when none is configured, so call sites
@@ -160,6 +204,7 @@ func (Discard) LLMRound(Provider, int, bool, time.Duration) {}
 func (Discard) LLMTurn(Provider, time.Duration)             {}
 func (Discard) ProviderCall(Stage, Provider, Outcome)       {}
 func (Discard) ProviderError(Stage, Provider)               {}
+func (Discard) TurnOutcome(TurnOutcome, TurnReason)         {}
 
 // Static assertion that the no-op satisfies the contract.
 var _ StageRecorder = Discard{}

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -87,6 +87,11 @@ const (
 	// never synthesized. These are the turns the survivorship-biased
 	// response_latency cannot see.
 	TurnAbandoned TurnOutcome = "abandoned"
+	// TurnYielded: a late segment of one VAD-over-split utterance that the floor's
+	// coalesce grace window folded into the turn already speaking (root cause #2).
+	// It was never spoken — distinct from abandoned so the over-split rate (and the
+	// dropped-text residual) is observable on its own.
+	TurnYielded TurnOutcome = "yielded"
 )
 
 // TurnReason is the bounded sub-reason label on the turn-lifecycle counter,
@@ -103,6 +108,10 @@ const (
 	// catch-all for the abandoned outcome until a precise cancel reason is on the
 	// bus.
 	ReasonNoFirstAudio TurnReason = "no_first_audio"
+	// ReasonSupersessionGrace: the yielded outcome's reason — the floor's
+	// same-utterance coalesce window folded this late segment into the in-flight
+	// turn (it did not supersede it).
+	ReasonSupersessionGrace TurnReason = "supersession_grace"
 )
 
 // StageRecorder records the orchestrator's per-stage / per-turn latency

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -2,6 +2,7 @@ package observe
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -39,6 +40,7 @@ type StageSubscriber struct {
 	rec StageRecorder
 	now func() time.Time
 	ttl time.Duration
+	log *slog.Logger
 
 	mu    sync.Mutex
 	turns map[string]*turnState
@@ -49,9 +51,12 @@ type StageSubscriber struct {
 type turnState struct {
 	speechEndAt  time.Time // STTFinal.SpeechEndAt; zero ⇒ no headline sample
 	sttFinalAt   time.Time
+	routedAt     time.Time // AddressRouted.At; zero until routed (for the turn-end log)
+	firstAudioAt time.Time // first FirstAudio.At; zero ⇒ never reached audio
 	role         AgentRole
 	roleKnown    bool // set at AddressRouted; gates the headline (needs the role label)
 	headlineDone bool // first FirstAudio consumed for response_latency
+	outcomeDone  bool // terminal TurnOutcome already recorded (first_audio); blocks a double-count at reap
 
 	// pendingTTS is the MOST-RECENT unmatched TTSInvoked time awaiting its
 	// FirstAudio for per-sentence tts_ttfb (zero = none pending). We keep only the
@@ -76,16 +81,40 @@ type turnState struct {
 const defaultTurnTTL = 60 * time.Second
 
 // NewStageSubscriber builds a subscriber recording onto rec. A nil rec is
-// replaced with [Discard] so it is always safe to construct.
-func NewStageSubscriber(rec StageRecorder) *StageSubscriber {
+// replaced with [Discard] so it is always safe to construct. opts configure
+// optional behaviour (e.g. [WithTurnLog]).
+func NewStageSubscriber(rec StageRecorder, opts ...StageSubscriberOption) *StageSubscriber {
 	if rec == nil {
 		rec = Discard{}
 	}
-	return &StageSubscriber{
+	s := &StageSubscriber{
 		rec:   rec,
 		now:   time.Now,
 		ttl:   defaultTurnTTL,
+		log:   slog.New(slog.DiscardHandler),
 		turns: make(map[string]*turnState),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// StageSubscriberOption configures a [StageSubscriber] at construction.
+type StageSubscriberOption func(*StageSubscriber)
+
+// WithTurnLog enables the one-line-per-turn structured INFO timeline log
+// (turn_id, speech_end → routed → first_audio, or the abandoned reap), the
+// per-turn timing trace Sprint-2 log cleanup removed. A 20s wait is then
+// debuggable from the logs even when the survivorship-biased response_latency
+// histogram shows nothing for the failed turns. A nil logger disables it (the
+// default). It is one line per turn-end, not the old per-call-site noise.
+func WithTurnLog(log *slog.Logger) StageSubscriberOption {
+	return func(s *StageSubscriber) {
+		if log == nil {
+			log = slog.New(slog.DiscardHandler)
+		}
+		s.log = log
 	}
 }
 
@@ -137,6 +166,7 @@ func (s *StageSubscriber) onAddressRouted(e voiceevent.AddressRouted) {
 	}
 	t.role = normalizeRole(e.Target.AgentRole)
 	t.roleKnown = true
+	t.routedAt = e.At
 	t.lastSeen = s.now()
 
 	// address_detect = route decision − transcript. Only when we have the
@@ -189,10 +219,47 @@ func (s *StageSubscriber) onFirstAudio(e voiceevent.FirstAudio) {
 		return
 	}
 	t.headlineDone = true
+	t.firstAudioAt = e.At
+
+	// Turn-lifecycle outcome: this turn reached audio (the success state, the
+	// counterpart to the survivorship-biased response_latency). Recorded once;
+	// outcomeDone blocks the TTL reap from also counting it as abandoned.
+	if !t.outcomeDone {
+		t.outcomeDone = true
+		s.rec.TurnOutcome(TurnFirstAudio, ReasonNone)
+		s.logTurn(e.TurnID, t, "first_audio")
+	}
+
 	if t.speechEndAt.IsZero() || !t.roleKnown {
 		return
 	}
 	s.rec.ResponseLatency(t.role, e.At.Sub(t.speechEndAt))
+}
+
+// logTurn emits the one-line per-turn timing trace at turn-end. Called under
+// s.mu. outcome is "first_audio" (reached audio) or "abandoned" (reaped without
+// it). Durations are relative to speech-end (the SLO span start) when known.
+func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
+	attrs := []any{
+		"turn_id", turnID,
+		"outcome", outcome,
+		"role", string(t.role),
+	}
+	if !t.speechEndAt.IsZero() {
+		attrs = append(attrs, "speech_end", t.speechEndAt)
+		if !t.routedAt.IsZero() {
+			attrs = append(attrs, "routed_after", t.routedAt.Sub(t.speechEndAt))
+		}
+		if !t.firstAudioAt.IsZero() {
+			attrs = append(attrs, "first_audio_after", t.firstAudioAt.Sub(t.speechEndAt))
+		}
+	}
+	if t.firstAudioAt.IsZero() {
+		// The debuggable signal the thin Sprint-2 logs lacked: a turn that opened
+		// and never produced audio (the invisible 20s self-cancel).
+		attrs = append(attrs, "no_audio", true)
+	}
+	s.log.Info("voice turn end", attrs...)
 }
 
 // Start runs the TTL [StageSubscriber.Sweep] on a ticker until ctx is cancelled,
@@ -228,6 +295,16 @@ func (s *StageSubscriber) Sweep() int {
 	reaped := 0
 	for id, t := range s.turns {
 		if t.lastSeen.Before(cutoff) {
+			// A turn reaped without ever recording a terminal outcome never reached
+			// first audio: it was cancelled (barge/supersede), errored in TTS, or
+			// never synthesized — the exact failures response_latency cannot see.
+			// Count it as abandoned (outcomeDone gates the success turns, which keep
+			// their state alive for later-sentence ttfb pairing and are reaped here
+			// without re-counting).
+			if !t.outcomeDone {
+				s.rec.TurnOutcome(TurnAbandoned, ReasonNoFirstAudio)
+				s.logTurn(id, t, "abandoned")
+			}
 			delete(s.turns, id)
 			reaped++
 		}

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -56,7 +56,9 @@ type turnState struct {
 	role         AgentRole
 	roleKnown    bool // set at AddressRouted; gates the headline (needs the role label)
 	headlineDone bool // first FirstAudio consumed for response_latency
-	outcomeDone  bool // terminal TurnOutcome already recorded (first_audio); blocks a double-count at reap
+	outcomeDone  bool // terminal TurnOutcome already recorded (first_audio/yielded); blocks a double-count at reap
+
+	yieldedText string // TurnYielded.Text: the dropped late-segment transcript (logged at turn-end)
 
 	// pendingTTS is the MOST-RECENT unmatched TTSInvoked time awaiting its
 	// FirstAudio for per-sentence tts_ttfb (zero = none pending). We keep only the
@@ -128,6 +130,7 @@ func (s *StageSubscriber) Subscribe(bus *voiceevent.Bus) (unsubscribe func()) {
 		voiceevent.On(bus, s.onAddressRouted),
 		voiceevent.On(bus, s.onTTSInvoked),
 		voiceevent.On(bus, s.onFirstAudio),
+		voiceevent.On(bus, s.onTurnYielded),
 	}
 	return func() {
 		for _, u := range unsubs {
@@ -236,9 +239,36 @@ func (s *StageSubscriber) onFirstAudio(e voiceevent.FirstAudio) {
 	s.rec.ResponseLatency(t.role, e.At.Sub(t.speechEndAt))
 }
 
+// onTurnYielded records the terminal outcome of a late segment the floor's
+// coalesce grace window folded into the turn already speaking (root cause #2).
+// The segment never reaches TTS, so it would otherwise be reaped as `abandoned`
+// — record it once as the distinct `yielded` outcome (outcomeDone blocks the
+// reap from re-counting it) and keep its dropped transcript for the turn-end log.
+func (s *StageSubscriber) onTurnYielded(e voiceevent.TurnYielded) {
+	if e.TurnID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.turns[e.TurnID]
+	if t == nil {
+		t = &turnState{}
+		s.turns[e.TurnID] = t
+	}
+	t.lastSeen = s.now()
+	t.yieldedText = e.Text
+	if t.outcomeDone {
+		return
+	}
+	t.outcomeDone = true
+	s.rec.TurnOutcome(TurnYielded, ReasonSupersessionGrace)
+	s.logTurn(e.TurnID, t, "yielded")
+}
+
 // logTurn emits the one-line per-turn timing trace at turn-end. Called under
-// s.mu. outcome is "first_audio" (reached audio) or "abandoned" (reaped without
-// it). Durations are relative to speech-end (the SLO span start) when known.
+// s.mu. outcome is "first_audio" (reached audio), "abandoned" (reaped without
+// it), or "yielded" (coalesced away by the floor grace window). Durations are
+// relative to speech-end (the SLO span start) when known.
 func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
 	attrs := []any{
 		"turn_id", turnID,
@@ -258,6 +288,11 @@ func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
 		// The debuggable signal the thin Sprint-2 logs lacked: a turn that opened
 		// and never produced audio (the invisible 20s self-cancel).
 		attrs = append(attrs, "no_audio", true)
+	}
+	if t.yieldedText != "" {
+		// The dropped late-segment transcript: the residual a yielded turn loses
+		// until real utterance coalescing routes it into the surviving turn.
+		attrs = append(attrs, "yielded_text", t.yieldedText)
 	}
 	s.log.Info("voice turn end", attrs...)
 }

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -130,7 +130,7 @@ func (s *StageSubscriber) Subscribe(bus *voiceevent.Bus) (unsubscribe func()) {
 		voiceevent.On(bus, s.onAddressRouted),
 		voiceevent.On(bus, s.onTTSInvoked),
 		voiceevent.On(bus, s.onFirstAudio),
-		voiceevent.On(bus, s.onTurnYielded),
+		voiceevent.On(bus, s.onTurnEnded),
 	}
 	return func() {
 		for _, u := range unsubs {
@@ -239,12 +239,14 @@ func (s *StageSubscriber) onFirstAudio(e voiceevent.FirstAudio) {
 	s.rec.ResponseLatency(t.role, e.At.Sub(t.speechEndAt))
 }
 
-// onTurnYielded records the terminal outcome of a late segment the floor's
-// coalesce grace window folded into the turn already speaking (root cause #2).
-// The segment never reaches TTS, so it would otherwise be reaped as `abandoned`
-// — record it once as the distinct `yielded` outcome (outcomeDone blocks the
-// reap from re-counting it) and keep its dropped transcript for the turn-end log.
-func (s *StageSubscriber) onTurnYielded(e voiceevent.TurnYielded) {
+// onTurnEnded records the terminal outcome of a turn that ended for a KNOWN
+// reason (barge / supersede-coalesced / tts or provider error), published by the
+// seam that knows the cause. It records the outcome+reason once (outcomeDone
+// blocks the TTL reap — and a later end signal — from re-counting it) so the
+// counter attributes WHY a turn died instead of the coarse no-first-audio
+// catch-all. A turn-end arriving AFTER first audio (e.g. a barge mid-playback) is
+// a normal interruption: outcomeDone is already set, so it is ignored.
+func (s *StageSubscriber) onTurnEnded(e voiceevent.TurnEnded) {
 	if e.TurnID == "" {
 		return
 	}
@@ -256,13 +258,36 @@ func (s *StageSubscriber) onTurnYielded(e voiceevent.TurnYielded) {
 		s.turns[e.TurnID] = t
 	}
 	t.lastSeen = s.now()
-	t.yieldedText = e.Text
+	if e.Text != "" {
+		t.yieldedText = e.Text
+	}
 	if t.outcomeDone {
 		return
 	}
 	t.outcomeDone = true
-	s.rec.TurnOutcome(TurnYielded, ReasonSupersessionGrace)
-	s.logTurn(e.TurnID, t, "yielded")
+	outcome, reason, label := turnEndOutcome(e.Reason)
+	s.rec.TurnOutcome(outcome, reason)
+	s.logTurn(e.TurnID, t, label)
+}
+
+// turnEndOutcome maps a wire [voiceevent.TurnEndReason] to the bounded metric
+// outcome+reason and the log label. A coalesced end is its own `yielded` outcome
+// (it never reached TTS); the failure reasons are all `abandoned` (no audio) with
+// the precise cause. An unknown reason collapses to abandoned/no_first_audio
+// rather than leaking an unbounded label.
+func turnEndOutcome(r voiceevent.TurnEndReason) (TurnOutcome, TurnReason, string) {
+	switch r {
+	case voiceevent.TurnEndSupersedeCoalesced:
+		return TurnYielded, ReasonSupersessionGrace, "yielded"
+	case voiceevent.TurnEndBarge:
+		return TurnAbandoned, ReasonBarge, "abandoned"
+	case voiceevent.TurnEndTTSError:
+		return TurnAbandoned, ReasonTTSError, "abandoned"
+	case voiceevent.TurnEndProviderError:
+		return TurnAbandoned, ReasonProviderError, "abandoned"
+	default:
+		return TurnAbandoned, ReasonNoFirstAudio, "abandoned"
+	}
 }
 
 // logTurn emits the one-line per-turn timing trace at turn-end. Called under

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -52,11 +52,13 @@ type turnState struct {
 	speechEndAt  time.Time // STTFinal.SpeechEndAt; zero ⇒ no headline sample
 	sttFinalAt   time.Time
 	routedAt     time.Time // AddressRouted.At; zero until routed (for the turn-end log)
-	firstAudioAt time.Time // first FirstAudio.At; zero ⇒ never reached audio
+	firstAudioAt time.Time // first FirstAudio.At (handed-to-pump); zero ⇒ never reached audio
+	firstOpusAt  time.Time // first FirstOpus.At (audible-on-wire, the SLO end); zero ⇒ never reached the wire
 	role         AgentRole
-	roleKnown    bool // set at AddressRouted; gates the headline (needs the role label)
-	headlineDone bool // first FirstAudio consumed for response_latency
-	outcomeDone  bool // terminal TurnOutcome already recorded (first_audio/yielded); blocks a double-count at reap
+	roleKnown      bool // set at AddressRouted; gates the headline (needs the role label)
+	firstAudioDone bool // first FirstAudio consumed (success outcome + firstAudioAt)
+	latencyDone    bool // first FirstOpus consumed for the response_latency SLO sample
+	outcomeDone    bool // terminal TurnOutcome already recorded (first_audio/yielded); blocks a double-count at reap
 
 	yieldedText string // TurnYielded.Text: the dropped late-segment transcript (logged at turn-end)
 
@@ -130,6 +132,7 @@ func (s *StageSubscriber) Subscribe(bus *voiceevent.Bus) (unsubscribe func()) {
 		voiceevent.On(bus, s.onAddressRouted),
 		voiceevent.On(bus, s.onTTSInvoked),
 		voiceevent.On(bus, s.onFirstAudio),
+		voiceevent.On(bus, s.onFirstOpus),
 		voiceevent.On(bus, s.onTurnEnded),
 	}
 	return func() {
@@ -198,6 +201,8 @@ func (s *StageSubscriber) onFirstAudio(e voiceevent.FirstAudio) {
 	if e.TurnID == "" {
 		return
 	}
+	var logAttrs []any
+	defer func() { s.flushLog(logAttrs) }() // registered first → runs after Unlock (LIFO)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t := s.turns[e.TurnID]
@@ -216,23 +221,48 @@ func (s *StageSubscriber) onFirstAudio(e voiceevent.FirstAudio) {
 		t.pendingTTS = time.Time{}
 	}
 
-	// Headline response latency: the FIRST FirstAudio of the turn only, and only
-	// when the span start is valid (non-zero SpeechEndAt) and the role is known.
-	if t.headlineDone {
+	// First-audio is the turn-lifecycle SUCCESS signal ("this turn produced
+	// audio"), recorded once; the headline response-latency SLO ends later, at the
+	// first Opus packet on the wire (onFirstOpus). outcomeDone blocks the TTL reap
+	// from also counting this turn as abandoned.
+	if t.firstAudioDone {
 		return
 	}
-	t.headlineDone = true
+	t.firstAudioDone = true
 	t.firstAudioAt = e.At
 
-	// Turn-lifecycle outcome: this turn reached audio (the success state, the
-	// counterpart to the survivorship-biased response_latency). Recorded once;
-	// outcomeDone blocks the TTL reap from also counting it as abandoned.
 	if !t.outcomeDone {
 		t.outcomeDone = true
 		s.rec.TurnOutcome(TurnFirstAudio, ReasonNone)
-		s.logTurn(e.TurnID, t, "first_audio")
+		logAttrs = s.turnLogAttrs(e.TurnID, t, "first_audio")
 	}
+}
 
+// onFirstOpus records the headline response-latency SLO sample: the FIRST Opus
+// packet of the turn reaching the Discord send path (audible-on-wire) minus the
+// turn's VAD speech-end (Luk's definition, task #7). It is the audible-on-wire
+// end the old handed-to-pump FirstAudio boundary undercounted. Recorded once per
+// turn, and only when the span start is valid (non-zero SpeechEndAt) and the role
+// label is known. A turn whose audio never reaches the wire (barge-cancelled
+// before any frame) emits no FirstOpus and so records no sample — correctly, the
+// user heard nothing.
+func (s *StageSubscriber) onFirstOpus(e voiceevent.FirstOpus) {
+	if e.TurnID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.turns[e.TurnID]
+	if t == nil {
+		// FirstOpus with no opened turn (STTFinal lost): nothing to anchor against.
+		return
+	}
+	t.lastSeen = s.now()
+	if t.latencyDone {
+		return
+	}
+	t.latencyDone = true
+	t.firstOpusAt = e.At
 	if t.speechEndAt.IsZero() || !t.roleKnown {
 		return
 	}
@@ -250,6 +280,8 @@ func (s *StageSubscriber) onTurnEnded(e voiceevent.TurnEnded) {
 	if e.TurnID == "" {
 		return
 	}
+	var logAttrs []any
+	defer func() { s.flushLog(logAttrs) }() // registered first → runs after Unlock (LIFO)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t := s.turns[e.TurnID]
@@ -267,7 +299,7 @@ func (s *StageSubscriber) onTurnEnded(e voiceevent.TurnEnded) {
 	t.outcomeDone = true
 	outcome, reason, label := turnEndOutcome(e.Reason)
 	s.rec.TurnOutcome(outcome, reason)
-	s.logTurn(e.TurnID, t, label)
+	logAttrs = s.turnLogAttrs(e.TurnID, t, label)
 }
 
 // turnEndOutcome maps a wire [voiceevent.TurnEndReason] to the bounded metric
@@ -290,11 +322,14 @@ func turnEndOutcome(r voiceevent.TurnEndReason) (TurnOutcome, TurnReason, string
 	}
 }
 
-// logTurn emits the one-line per-turn timing trace at turn-end. Called under
-// s.mu. outcome is "first_audio" (reached audio), "abandoned" (reaped without
-// it), or "yielded" (coalesced away by the floor grace window). Durations are
-// relative to speech-end (the SLO span start) when known.
-func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
+// turnLogAttrs builds the slog attrs for the one-line per-turn timing trace at
+// turn-end. Called under s.mu (it reads turnState), but it does NO I/O: the
+// caller emits s.log.Info AFTER releasing the lock (see [StageSubscriber.flushLog])
+// so the per-turn log write never happens under the mutex. outcome is
+// "first_audio" (reached audio), "abandoned" (reaped without it), or "yielded"
+// (coalesced away by the floor grace window). Durations are relative to
+// speech-end (the SLO span start) when known.
+func (s *StageSubscriber) turnLogAttrs(turnID string, t *turnState, outcome string) []any {
 	attrs := []any{
 		"turn_id", turnID,
 		"outcome", outcome,
@@ -308,6 +343,9 @@ func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
 		if !t.firstAudioAt.IsZero() {
 			attrs = append(attrs, "first_audio_after", t.firstAudioAt.Sub(t.speechEndAt))
 		}
+		if !t.firstOpusAt.IsZero() {
+			attrs = append(attrs, "first_opus_after", t.firstOpusAt.Sub(t.speechEndAt))
+		}
 	}
 	if t.firstAudioAt.IsZero() {
 		// The debuggable signal the thin Sprint-2 logs lacked: a turn that opened
@@ -319,7 +357,17 @@ func (s *StageSubscriber) logTurn(turnID string, t *turnState, outcome string) {
 		// until real utterance coalescing routes it into the surviving turn.
 		attrs = append(attrs, "yielded_text", t.yieldedText)
 	}
-	s.log.Info("voice turn end", attrs...)
+	return attrs
+}
+
+// flushLog emits a per-turn log line for attrs built under the lock, if any. It
+// MUST be called after s.mu is released — register it as a deferred call BEFORE
+// the deferred Unlock so LIFO ordering runs Unlock first, then this. A nil attrs
+// (no log was due) is a no-op.
+func (s *StageSubscriber) flushLog(attrs []any) {
+	if attrs != nil {
+		s.log.Info("voice turn end", attrs...)
+	}
 }
 
 // Start runs the TTL [StageSubscriber.Sweep] on a ticker until ctx is cancelled,
@@ -349,6 +397,14 @@ func (s *StageSubscriber) Start(ctx context.Context) {
 // (tests). Safe for concurrent use. Returns the number of turns reaped (for
 // tests / a debug gauge).
 func (s *StageSubscriber) Sweep() int {
+	// Collect the per-turn log lines for reaped turns under the lock, emit them
+	// after releasing it — the per-turn log write must not happen under s.mu.
+	var pending [][]any
+	defer func() {
+		for _, attrs := range pending {
+			s.flushLog(attrs)
+		}
+	}()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cutoff := s.now().Add(-s.ttl)
@@ -363,7 +419,7 @@ func (s *StageSubscriber) Sweep() int {
 			// without re-counting).
 			if !t.outcomeDone {
 				s.rec.TurnOutcome(TurnAbandoned, ReasonNoFirstAudio)
-				s.logTurn(id, t, "abandoned")
+				pending = append(pending, s.turnLogAttrs(id, t, "abandoned"))
 			}
 			delete(s.turns, id)
 			reaped++

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -49,12 +49,12 @@ type StageSubscriber struct {
 // turnState is the per-TurnID timing state, opened at STTFinal and closed when
 // the headline sample lands (or reaped by TTL). lastSeen drives expiry.
 type turnState struct {
-	speechEndAt  time.Time // STTFinal.SpeechEndAt; zero ⇒ no headline sample
-	sttFinalAt   time.Time
-	routedAt     time.Time // AddressRouted.At; zero until routed (for the turn-end log)
-	firstAudioAt time.Time // first FirstAudio.At (handed-to-pump); zero ⇒ never reached audio
-	firstOpusAt  time.Time // first FirstOpus.At (audible-on-wire, the SLO end); zero ⇒ never reached the wire
-	role         AgentRole
+	speechEndAt    time.Time // STTFinal.SpeechEndAt; zero ⇒ no headline sample
+	sttFinalAt     time.Time
+	routedAt       time.Time // AddressRouted.At; zero until routed (for the turn-end log)
+	firstAudioAt   time.Time // first FirstAudio.At (handed-to-pump); zero ⇒ never reached audio
+	firstOpusAt    time.Time // first FirstOpus.At (audible-on-wire, the SLO end); zero ⇒ never reached the wire
+	role           AgentRole
 	roleKnown      bool // set at AddressRouted; gates the headline (needs the role label)
 	firstAudioDone bool // first FirstAudio consumed (success outcome + firstAudioAt)
 	latencyDone    bool // first FirstOpus consumed for the response_latency SLO sample

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -264,6 +264,38 @@ func TestStageSubscriberFirstAudioOutcome(t *testing.T) {
 	}
 }
 
+// TestStageSubscriberYieldedOutcome pins the coalesced-segment path: a
+// TurnYielded records the distinct `yielded` outcome (not abandoned), and a
+// later TTL reap of its state must not re-count it.
+func TestStageSubscriberYieldedOutcome(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	sub := NewStageSubscriber(rec)
+	sub.Subscribe(bus)
+
+	clock := base
+	sub.now = func() time.Time { return clock }
+
+	// A late segment of one over-split utterance: opened, routed, then coalesced.
+	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "late", SpeechEndAt: clock})
+	bus.Publish(voiceevent.AddressRouted{At: clock, TurnID: "late", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	bus.Publish(voiceevent.TurnYielded{At: clock, TurnID: "late", Text: "and have you seen Gandalf"})
+
+	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnYielded || got[0].reason != ReasonSupersessionGrace {
+		t.Fatalf("turn outcomes = %+v, want one [yielded supersession_grace]", got)
+	}
+	// No response_latency sample for a yielded (unspoken) segment.
+	if len(rec.responseLat) != 0 {
+		t.Fatalf("yielded segment recorded a latency sample: %+v", rec.responseLat)
+	}
+	// Reaping the yielded turn's state must not re-count it as abandoned.
+	clock = base.Add(2 * defaultTurnTTL)
+	sub.Sweep()
+	if got := rec.outcomes(); len(got) != 1 {
+		t.Fatalf("reap of a yielded turn re-counted the outcome: %+v", got)
+	}
+}
+
 // TestStageSubscriberTurnLog pins the per-turn timing trace: WithTurnLog emits
 // exactly one INFO line per turn-end, carrying the timing spine — and, for a
 // turn that never produced audio, the no_audio marker that makes a 20s
@@ -287,18 +319,28 @@ func TestStageSubscriberTurnLog(t *testing.T) {
 	// An abandoned turn (no audio): reaped and logged with the no_audio marker.
 	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "dead", SpeechEndAt: clock})
 	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "dead", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+
+	// A coalesced (yielded) segment: logged at turn-end with its dropped transcript
+	// — the residual a yielded turn loses until real utterance coalescing.
+	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "late", SpeechEndAt: clock})
+	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "late", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	bus.Publish(voiceevent.TurnYielded{At: clock.Add(60 * time.Millisecond), TurnID: "late", Text: "have you seen Gandalf"})
+
 	clock = base.Add(2 * defaultTurnTTL)
 	sub.Sweep()
 
 	out := buf.String()
-	if got := strings.Count(out, "voice turn end"); got != 2 {
-		t.Fatalf("turn-end log lines = %d, want 2\n%s", got, out)
+	if got := strings.Count(out, "voice turn end"); got != 3 {
+		t.Fatalf("turn-end log lines = %d, want 3\n%s", got, out)
 	}
 	if !strings.Contains(out, `turn_id=ok`) || !strings.Contains(out, "first_audio_after=600ms") {
 		t.Fatalf("surviving turn line missing turn_id/first_audio_after:\n%s", out)
 	}
 	if !strings.Contains(out, `turn_id=dead`) || !strings.Contains(out, "no_audio=true") {
 		t.Fatalf("abandoned turn line missing turn_id/no_audio marker:\n%s", out)
+	}
+	if !strings.Contains(out, `turn_id=late`) || !strings.Contains(out, "outcome=yielded") || !strings.Contains(out, "Gandalf") {
+		t.Fatalf("yielded turn line missing turn_id/outcome/dropped transcript:\n%s", out)
 	}
 }
 

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -1,7 +1,9 @@
 package observe
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +19,12 @@ type recordingStage struct {
 	responseLat   []labeledDur
 	addressDetect []time.Duration
 	ttsTTFB       []labeledDur
+	turnOutcomes  []turnOutcomeRec
+}
+
+type turnOutcomeRec struct {
+	outcome TurnOutcome
+	reason  TurnReason
 }
 
 type labeledDur struct {
@@ -50,6 +58,17 @@ func (r *recordingStage) LLMRound(Provider, int, bool, time.Duration) {}
 func (r *recordingStage) LLMTurn(Provider, time.Duration)             {}
 func (r *recordingStage) ProviderCall(Stage, Provider, Outcome)       {}
 func (r *recordingStage) ProviderError(Stage, Provider)               {}
+func (r *recordingStage) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.turnOutcomes = append(r.turnOutcomes, turnOutcomeRec{outcome, reason})
+}
+
+func (r *recordingStage) outcomes() []turnOutcomeRec {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]turnOutcomeRec(nil), r.turnOutcomes...)
+}
 
 var _ StageRecorder = (*recordingStage)(nil)
 
@@ -202,9 +221,84 @@ func TestStageSubscriberSweepReapsAbandonedTurns(t *testing.T) {
 	if len(rec.responseLat) != 0 {
 		t.Fatalf("abandoned turn recorded a sample: %+v", rec.responseLat)
 	}
+	// The survivorship counterpart: the reaped no-audio turn is counted as
+	// abandoned so the failure is visible even though response_latency saw nothing.
+	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnAbandoned || got[0].reason != ReasonNoFirstAudio {
+		t.Fatalf("turn outcomes = %+v, want one [abandoned no_first_audio]", got)
+	}
 	// A second sweep is a no-op (state already gone).
 	if got := sub.Sweep(); got != 0 {
 		t.Fatalf("double-reap: %d", got)
+	}
+}
+
+// TestStageSubscriberFirstAudioOutcome pins the success counterpart: a turn that
+// reaches first audio records exactly one first_audio outcome, and a later reap
+// of its (kept-alive) state does NOT re-count it as abandoned.
+func TestStageSubscriberFirstAudioOutcome(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	sub := NewStageSubscriber(rec)
+	sub.Subscribe(bus)
+
+	clock := base
+	sub.now = func() time.Time { return clock }
+
+	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "live", SpeechEndAt: clock})
+	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "live", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	bus.Publish(voiceevent.TTSInvoked{At: clock.Add(400 * time.Millisecond), TurnID: "live", Index: 0})
+	bus.Publish(voiceevent.FirstAudio{At: clock.Add(600 * time.Millisecond), TurnID: "live"})
+	// A second sentence's first audio must NOT re-count the outcome.
+	bus.Publish(voiceevent.TTSInvoked{At: clock.Add(900 * time.Millisecond), TurnID: "live", Index: 1})
+	bus.Publish(voiceevent.FirstAudio{At: clock.Add(1000 * time.Millisecond), TurnID: "live"})
+
+	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnFirstAudio || got[0].reason != ReasonNone {
+		t.Fatalf("turn outcomes = %+v, want one [first_audio none]", got)
+	}
+
+	// Reaping the completed turn's kept-alive state must not add an abandoned count.
+	clock = base.Add(2 * defaultTurnTTL)
+	sub.Sweep()
+	if got := rec.outcomes(); len(got) != 1 {
+		t.Fatalf("reap of a completed turn re-counted the outcome: %+v", got)
+	}
+}
+
+// TestStageSubscriberTurnLog pins the per-turn timing trace: WithTurnLog emits
+// exactly one INFO line per turn-end, carrying the timing spine — and, for a
+// turn that never produced audio, the no_audio marker that makes a 20s
+// self-cancel debuggable from the logs (the trace Sprint-2 cleanup removed).
+func TestStageSubscriberTurnLog(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	sub := NewStageSubscriber(rec, WithTurnLog(log))
+	sub.Subscribe(bus)
+
+	clock := base
+	sub.now = func() time.Time { return clock }
+
+	// A surviving turn: one line with first_audio timing.
+	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "ok", SpeechEndAt: clock})
+	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "ok", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	bus.Publish(voiceevent.FirstAudio{At: clock.Add(600 * time.Millisecond), TurnID: "ok"})
+
+	// An abandoned turn (no audio): reaped and logged with the no_audio marker.
+	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "dead", SpeechEndAt: clock})
+	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "dead", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	clock = base.Add(2 * defaultTurnTTL)
+	sub.Sweep()
+
+	out := buf.String()
+	if got := strings.Count(out, "voice turn end"); got != 2 {
+		t.Fatalf("turn-end log lines = %d, want 2\n%s", got, out)
+	}
+	if !strings.Contains(out, `turn_id=ok`) || !strings.Contains(out, "first_audio_after=600ms") {
+		t.Fatalf("surviving turn line missing turn_id/first_audio_after:\n%s", out)
+	}
+	if !strings.Contains(out, `turn_id=dead`) || !strings.Contains(out, "no_audio=true") {
+		t.Fatalf("abandoned turn line missing turn_id/no_audio marker:\n%s", out)
 	}
 }
 

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -86,18 +86,62 @@ func TestStageSubscriberHeadlineAndStages(t *testing.T) {
 	bus.Publish(voiceevent.AddressRouted{At: base.Add(750 * time.Millisecond), TurnID: "T1", Target: voiceevent.AddressTarget{AgentRole: "character"}})
 	bus.Publish(voiceevent.TTSInvoked{At: base.Add(1200 * time.Millisecond), TurnID: "T1", Index: 0})
 	bus.Publish(voiceevent.FirstAudio{At: base.Add(1500 * time.Millisecond), TurnID: "T1"})
+	// First opus on the wire lands AFTER first-audio-to-pump (codec encode + pacing).
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(1600 * time.Millisecond), TurnID: "T1"})
 
-	// response_latency = firstAudio(1500ms) − speechEnd(0) = 1.5s, role=character.
-	if len(rec.responseLat) != 1 || rec.responseLat[0].label != "character" || rec.responseLat[0].d != 1500*time.Millisecond {
-		t.Fatalf("response_latency = %+v, want one [character 1.5s]", rec.responseLat)
+	// response_latency now ends at FirstOpus (audible-on-wire): 1600ms − speechEnd(0)
+	// = 1.6s, role=character — NOT the 1.5s handed-to-pump FirstAudio moment.
+	if len(rec.responseLat) != 1 || rec.responseLat[0].label != "character" || rec.responseLat[0].d != 1600*time.Millisecond {
+		t.Fatalf("response_latency = %+v, want one [character 1.6s] (FirstOpus boundary)", rec.responseLat)
 	}
 	// address_detect = 750ms − 700ms = 50ms.
 	if len(rec.addressDetect) != 1 || rec.addressDetect[0] != 50*time.Millisecond {
 		t.Fatalf("address_detect = %v, want [50ms]", rec.addressDetect)
 	}
-	// tts_ttfb = 1500ms − 1200ms = 300ms, elevenlabs.
+	// tts_ttfb still pairs TTSInvoked↔FirstAudio = 1500ms − 1200ms = 300ms, elevenlabs.
 	if len(rec.ttsTTFB) != 1 || rec.ttsTTFB[0].label != "elevenlabs" || rec.ttsTTFB[0].d != 300*time.Millisecond {
 		t.Fatalf("tts_ttfb = %+v, want one [elevenlabs 300ms]", rec.ttsTTFB)
+	}
+}
+
+// TestStageSubscriberFirstOpusBoundary pins task #7: the response_latency span
+// ends at FirstOpus (audible-on-wire), and FirstAudio alone does NOT record a
+// latency sample — only the success outcome.
+func TestStageSubscriberFirstOpusBoundary(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	NewStageSubscriber(rec).Subscribe(bus)
+
+	bus.Publish(voiceevent.STTFinal{At: base, TurnID: "T", SpeechEndAt: base})
+	bus.Publish(voiceevent.AddressRouted{At: base, TurnID: "T", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+
+	// FirstAudio alone: the turn produced audio (success outcome) but the SLO has
+	// not ended yet — no latency sample.
+	bus.Publish(voiceevent.FirstAudio{At: base.Add(800 * time.Millisecond), TurnID: "T"})
+	if len(rec.responseLat) != 0 {
+		t.Fatalf("FirstAudio alone recorded a latency sample %+v; the SLO ends at FirstOpus", rec.responseLat)
+	}
+	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnFirstAudio {
+		t.Fatalf("FirstAudio must record the first_audio success outcome, got %+v", got)
+	}
+
+	// FirstOpus on the wire ends the span: 1200 − 0 = 1.2s.
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(1200 * time.Millisecond), TurnID: "T"})
+	if len(rec.responseLat) != 1 || rec.responseLat[0].d != 1200*time.Millisecond {
+		t.Fatalf("response_latency = %+v, want one 1.2s sample at the FirstOpus boundary", rec.responseLat)
+	}
+}
+
+// TestStageSubscriberFirstOpusNoOpenTurnIgnored proves a FirstOpus for a turn the
+// subscriber never opened (STTFinal lost) is a safe no-op.
+func TestStageSubscriberFirstOpusNoOpenTurnIgnored(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	NewStageSubscriber(rec).Subscribe(bus)
+
+	bus.Publish(voiceevent.FirstOpus{At: base, TurnID: "ghost"}) // no STTFinal first
+	if len(rec.responseLat) != 0 {
+		t.Fatalf("FirstOpus with no opened turn recorded %+v, want nothing", rec.responseLat)
 	}
 }
 
@@ -114,9 +158,10 @@ func TestStageSubscriberInterleavedTurnsUseOwnSpeechEnd(t *testing.T) {
 	bus.Publish(voiceevent.AddressRouted{At: base.Add(550 * time.Millisecond), TurnID: "A", Target: voiceevent.AddressTarget{AgentRole: "butler"}})
 	bus.Publish(voiceevent.STTFinal{At: base.Add(2500 * time.Millisecond), TurnID: "B", SpeechEndAt: endB})
 	bus.Publish(voiceevent.AddressRouted{At: base.Add(2550 * time.Millisecond), TurnID: "B", Target: voiceevent.AddressTarget{AgentRole: "character"}})
-	// B's audio lands FIRST (its LLM was faster), then A's.
-	bus.Publish(voiceevent.FirstAudio{At: base.Add(3 * time.Second), TurnID: "B"})         // 3000 − 2000 = 1.0s
-	bus.Publish(voiceevent.FirstAudio{At: base.Add(3500 * time.Millisecond), TurnID: "A"}) // 3500 − 0 = 3.5s
+	// B's audio reaches the wire FIRST (its LLM was faster), then A's. The SLO
+	// ends at FirstOpus per turn, each anchored to its OWN speechEnd.
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(3 * time.Second), TurnID: "B"})         // 3000 − 2000 = 1.0s
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(3500 * time.Millisecond), TurnID: "A"}) // 3500 − 0 = 3.5s
 
 	got := map[string]time.Duration{}
 	for _, l := range rec.responseLat {
@@ -131,8 +176,8 @@ func TestStageSubscriberInterleavedTurnsUseOwnSpeechEnd(t *testing.T) {
 }
 
 func TestStageSubscriberHeadlineExactlyOnce(t *testing.T) {
-	// Multiple sentences ⇒ multiple FirstAudio for one turn: response_latency must
-	// fire ONCE (first), the rest feed tts_ttfb only.
+	// Multiple sentences ⇒ multiple FirstAudio for one turn (each feeds tts_ttfb),
+	// and multiple FirstOpus (only the FIRST sets the response_latency sample).
 	rec := &recordingStage{}
 	bus := voiceevent.NewBus()
 	NewStageSubscriber(rec).Subscribe(bus)
@@ -143,9 +188,10 @@ func TestStageSubscriberHeadlineExactlyOnce(t *testing.T) {
 		at := base.Add(time.Duration(i+1) * 100 * time.Millisecond)
 		bus.Publish(voiceevent.TTSInvoked{At: at, TurnID: "T", Index: i})
 		bus.Publish(voiceevent.FirstAudio{At: at.Add(50 * time.Millisecond), TurnID: "T"})
+		bus.Publish(voiceevent.FirstOpus{At: at.Add(80 * time.Millisecond), TurnID: "T"})
 	}
 	if len(rec.responseLat) != 1 {
-		t.Fatalf("response_latency fired %d times, want exactly 1", len(rec.responseLat))
+		t.Fatalf("response_latency fired %d times, want exactly 1 (first FirstOpus only)", len(rec.responseLat))
 	}
 	if len(rec.ttsTTFB) != 3 {
 		t.Fatalf("tts_ttfb fired %d times, want 3 (one per sentence)", len(rec.ttsTTFB))
@@ -189,6 +235,7 @@ func TestStageSubscriberZeroSpeechEndSkipped(t *testing.T) {
 	bus.Publish(voiceevent.STTFinal{At: base, TurnID: "T", Text: "flush"}) // SpeechEndAt zero
 	bus.Publish(voiceevent.AddressRouted{At: base, TurnID: "T", Target: voiceevent.AddressTarget{AgentRole: "butler"}})
 	bus.Publish(voiceevent.FirstAudio{At: base.Add(time.Second), TurnID: "T"})
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(1100 * time.Millisecond), TurnID: "T"})
 
 	if len(rec.responseLat) != 0 {
 		t.Fatalf("response_latency = %+v, want none (zero SpeechEndAt skipped)", rec.responseLat)
@@ -394,8 +441,9 @@ func TestStageSubscriberTurnLog(t *testing.T) {
 }
 
 func TestStageSubscriberConcurrentFirstAudioRace(t *testing.T) {
-	// FirstAudio publishes off the tee's forward goroutine — concurrent deliveries
-	// across turns. -race guards the shared per-turn map.
+	// FirstAudio (tee goroutine) and FirstOpus (disgo sender goroutine) both publish
+	// off non-subscriber goroutines — concurrent deliveries across turns. -race
+	// guards the shared per-turn map.
 	rec := &recordingStage{}
 	bus := voiceevent.NewBus()
 	NewStageSubscriber(rec).Subscribe(bus)
@@ -412,6 +460,7 @@ func TestStageSubscriberConcurrentFirstAudioRace(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			bus.Publish(voiceevent.FirstAudio{At: base.Add(time.Second), TurnID: turnID(i)})
+			bus.Publish(voiceevent.FirstOpus{At: base.Add(1100 * time.Millisecond), TurnID: turnID(i)})
 		}(i)
 	}
 	wg.Wait()
@@ -468,6 +517,7 @@ func TestStageSubscriberEndToEndPrometheus(t *testing.T) {
 	bus.Publish(voiceevent.AddressRouted{At: base.Add(40 * time.Millisecond), TurnID: "T", Target: voiceevent.AddressTarget{AgentRole: "character"}})
 	bus.Publish(voiceevent.TTSInvoked{At: base.Add(900 * time.Millisecond), TurnID: "T"})
 	bus.Publish(voiceevent.FirstAudio{At: base.Add(1100 * time.Millisecond), TurnID: "T"})
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(1200 * time.Millisecond), TurnID: "T"})
 
 	out := scrape(t, rec)
 	wants := []string{

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -176,8 +176,11 @@ func TestStageSubscriberInterleavedTurnsUseOwnSpeechEnd(t *testing.T) {
 }
 
 func TestStageSubscriberHeadlineExactlyOnce(t *testing.T) {
-	// Multiple sentences ⇒ multiple FirstAudio for one turn (each feeds tts_ttfb),
-	// and multiple FirstOpus (only the FIRST sets the response_latency sample).
+	// A multi-sentence turn: each sentence has its own playback Source, so each
+	// publishes its own FirstAudio (feeds tts_ttfb) AND its own FirstOpus (the
+	// per-Source once-guard — see wire.TestPlaySentenceBus_TwoSentencesPublishPerSource).
+	// The headline-SLO dedup lives HERE: only the FIRST FirstOpus per turn sets the
+	// response_latency sample (latencyDone). Three sentences ⇒ one sample.
 	rec := &recordingStage{}
 	bus := voiceevent.NewBus()
 	NewStageSubscriber(rec).Subscribe(bus)

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -265,8 +265,8 @@ func TestStageSubscriberFirstAudioOutcome(t *testing.T) {
 }
 
 // TestStageSubscriberYieldedOutcome pins the coalesced-segment path: a
-// TurnYielded records the distinct `yielded` outcome (not abandoned), and a
-// later TTL reap of its state must not re-count it.
+// TurnEnded(supersede_coalesced) records the distinct `yielded` outcome (not
+// abandoned), and a later TTL reap of its state must not re-count it.
 func TestStageSubscriberYieldedOutcome(t *testing.T) {
 	rec := &recordingStage{}
 	bus := voiceevent.NewBus()
@@ -279,7 +279,7 @@ func TestStageSubscriberYieldedOutcome(t *testing.T) {
 	// A late segment of one over-split utterance: opened, routed, then coalesced.
 	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "late", SpeechEndAt: clock})
 	bus.Publish(voiceevent.AddressRouted{At: clock, TurnID: "late", Target: voiceevent.AddressTarget{AgentRole: "character"}})
-	bus.Publish(voiceevent.TurnYielded{At: clock, TurnID: "late", Text: "and have you seen Gandalf"})
+	bus.Publish(voiceevent.TurnEnded{At: clock, TurnID: "late", Reason: voiceevent.TurnEndSupersedeCoalesced, Text: "and have you seen Gandalf"})
 
 	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnYielded || got[0].reason != ReasonSupersessionGrace {
 		t.Fatalf("turn outcomes = %+v, want one [yielded supersession_grace]", got)
@@ -293,6 +293,55 @@ func TestStageSubscriberYieldedOutcome(t *testing.T) {
 	sub.Sweep()
 	if got := rec.outcomes(); len(got) != 1 {
 		t.Fatalf("reap of a yielded turn re-counted the outcome: %+v", got)
+	}
+}
+
+// TestStageSubscriberTurnEndedReasons pins the precise-reason mapping: each
+// TurnEnded reason records the right outcome+reason, and a turn-end arriving
+// AFTER first audio is ignored (the turn already counted first_audio).
+func TestStageSubscriberTurnEndedReasons(t *testing.T) {
+	cases := []struct {
+		name        string
+		reason      voiceevent.TurnEndReason
+		wantOutcome TurnOutcome
+		wantReason  TurnReason
+	}{
+		{"barge", voiceevent.TurnEndBarge, TurnAbandoned, ReasonBarge},
+		{"tts_error", voiceevent.TurnEndTTSError, TurnAbandoned, ReasonTTSError},
+		{"provider_error", voiceevent.TurnEndProviderError, TurnAbandoned, ReasonProviderError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingStage{}
+			bus := voiceevent.NewBus()
+			NewStageSubscriber(rec).Subscribe(bus)
+
+			bus.Publish(voiceevent.STTFinal{At: base, TurnID: "T", SpeechEndAt: base})
+			bus.Publish(voiceevent.AddressRouted{At: base, TurnID: "T", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+			bus.Publish(voiceevent.TurnEnded{At: base, TurnID: "T", Reason: tc.reason})
+
+			if got := rec.outcomes(); len(got) != 1 || got[0].outcome != tc.wantOutcome || got[0].reason != tc.wantReason {
+				t.Fatalf("outcomes = %+v, want one [%s %s]", got, tc.wantOutcome, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestStageSubscriberTurnEndedAfterFirstAudioIgnored proves a barge mid-playback
+// (after first audio) does not re-count the turn: first_audio is terminal.
+func TestStageSubscriberTurnEndedAfterFirstAudioIgnored(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	NewStageSubscriber(rec).Subscribe(bus)
+
+	bus.Publish(voiceevent.STTFinal{At: base, TurnID: "T", SpeechEndAt: base})
+	bus.Publish(voiceevent.AddressRouted{At: base.Add(50 * time.Millisecond), TurnID: "T", Target: voiceevent.AddressTarget{AgentRole: "character"}})
+	bus.Publish(voiceevent.FirstAudio{At: base.Add(600 * time.Millisecond), TurnID: "T"})
+	// Barge after audio began: normal interruption, not a failure.
+	bus.Publish(voiceevent.TurnEnded{At: base.Add(900 * time.Millisecond), TurnID: "T", Reason: voiceevent.TurnEndBarge})
+
+	if got := rec.outcomes(); len(got) != 1 || got[0].outcome != TurnFirstAudio {
+		t.Fatalf("outcomes = %+v, want one [first_audio none] (post-audio barge must not re-count)", got)
 	}
 }
 
@@ -324,7 +373,7 @@ func TestStageSubscriberTurnLog(t *testing.T) {
 	// — the residual a yielded turn loses until real utterance coalescing.
 	bus.Publish(voiceevent.STTFinal{At: clock, TurnID: "late", SpeechEndAt: clock})
 	bus.Publish(voiceevent.AddressRouted{At: clock.Add(50 * time.Millisecond), TurnID: "late", Target: voiceevent.AddressTarget{AgentRole: "character"}})
-	bus.Publish(voiceevent.TurnYielded{At: clock.Add(60 * time.Millisecond), TurnID: "late", Text: "have you seen Gandalf"})
+	bus.Publish(voiceevent.TurnEnded{At: clock.Add(60 * time.Millisecond), TurnID: "late", Reason: voiceevent.TurnEndSupersedeCoalesced, Text: "have you seen Gandalf"})
 
 	clock = base.Add(2 * defaultTurnTTL)
 	sub.Sweep()

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -298,7 +298,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// the handlers (deferred unsubscribe); Start runs the TTL sweep for the run's
 	// lifetime so abandoned/barged turns don't leak per-turn state. A nil
 	// StageMetrics (keyless) makes the subscriber a no-op via observe.Discard.
-	stageSub := observe.NewStageSubscriber(cfg.StageMetrics)
+	stageSub := observe.NewStageSubscriber(cfg.StageMetrics, observe.WithTurnLog(log))
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(ctx)
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -80,6 +80,19 @@ const (
 	// interruption; it is the minimum until per-participant VAD (ADR-0019) can gate
 	// barge on speaker != the turn's addresser.
 	bargeConfirmWindow = 250 * time.Millisecond
+
+	// floorCoalesceWindow closes root cause #2 of the latency investigation: a
+	// turn's unit is a VAD segment, not a user utterance, so one utterance split by
+	// VAD into two STT segments opens two turns and the second's Floor.Take cancels
+	// the first mid-synthesis (a self-cancel with no barge). A Floor.Take landing
+	// within this window of the previous one is treated as the same utterance
+	// continuing and yields to the in-flight turn instead of superseding it, so one
+	// utterance maps to one turn. Sized a hair above the end-of-speech hangover
+	// (vadMinSilenceFrames*vadFrameMs = 12*32 = 384ms) so two segments split at an
+	// internal pause coalesce, while a genuine new utterance after a real
+	// conversational gap (turn-taking pauses run hundreds of ms longer) still opens
+	// its own turn.
+	floorCoalesceWindow = 600 * time.Millisecond
 )
 
 // BartPersona is the Character NPC Persona (CONTEXT.md "Persona") for the MVP
@@ -442,7 +455,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		// speaker identity) cancel the turn it had just triggered, which is the 20s
 		// self-cancel the latency investigation found. With B1 a confirmed barge
 		// cancels mid-generation, not just pending dispatch.
-		orchestrator.WithBargeIn(bargeConfirmWindow),
+		orchestrator.WithBargeInCoalesce(bargeConfirmWindow, floorCoalesceWindow),
 		orchestrator.WithErrorHandler(func(err error) {
 			log.Warn("reply dispatch failed", "err", err)
 		}),

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/disgoorg/disgo"
 	"github.com/disgoorg/disgo/bot"
@@ -66,6 +67,19 @@ const (
 	// elevenGeorgeVoiceID is the ElevenLabs "George" public preset — a neutral
 	// stand-in voice for the NPC.
 	elevenGeorgeVoiceID = "JBFqnCBsd6RMkjVDRZzb"
+
+	// bargeConfirmWindow is how long continuous inbound speech must persist before
+	// it counts as a barge and yields Bart's floor (ADR-0027). It must be > 0
+	// against a live mic: with a single shared VAD session (ADR-0019) the events
+	// carry no speaker identity, so the addressing user's OWN continued speech —
+	// or a VAD split of one utterance into two segments — fires a fresh
+	// speech_start while Bart holds the floor. A zero window yields on that instant
+	// and cancels the in-flight TTS POST (the "context canceled" self-cancel that
+	// produced the 20s wait — see docs/latency-investigation/audio-process.md).
+	// 250ms debounces a speaker finishing their own sentence from a genuine
+	// interruption; it is the minimum until per-participant VAD (ADR-0019) can gate
+	// barge on speaker != the turn's addresser.
+	bargeConfirmWindow = 250 * time.Millisecond
 )
 
 // BartPersona is the Character NPC Persona (CONTEXT.md "Persona") for the MVP
@@ -422,11 +436,13 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		// agent.StreamingEngine (it streams the final answer round), so ReplyStream
 		// dispatches each sentence as it lands.
 		orchestrator.WithReplyStream(replier.ReplyStream()),
-		// Barge-in (ADR-0027): a human talking over Bart cancels his turn. Start
-		// with an instant cut (0 confirm window) to validate the async-turn path
-		// live; the ~250ms confirm window is the next tuning step. With B1 a barge
-		// now cancels mid-generation, not just pending dispatch.
-		orchestrator.WithBargeIn(0),
+		// Barge-in (ADR-0027): a human talking over Bart cancels his turn. The
+		// confirm window must be > 0 against a live mic — a zero window let the
+		// addressing user's own continued speech (single shared VAD session, no
+		// speaker identity) cancel the turn it had just triggered, which is the 20s
+		// self-cancel the latency investigation found. With B1 a confirmed barge
+		// cancels mid-generation, not just pending dispatch.
+		orchestrator.WithBargeIn(bargeConfirmWindow),
 		orchestrator.WithErrorHandler(func(err error) {
 			log.Warn("reply dispatch failed", "err", err)
 		}),

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -283,13 +283,15 @@ func Run(ctx context.Context, cfg Config) error {
 	// (line above), and pipe.Run's own deferred cancel stops the Conversation
 	// first — so teardown order is conv-stop → pump.Close() → sess.Close(), which
 	// is the deterministic ordering the pump's Close() contract requires.
-	pump := wire.NewPlaybackPump(sess, cdc, log)
-	defer pump.Close()
-
 	// The orchestrator bus is created here (not inside buildConversation) so the
-	// tee can publish FirstAudio (A3 hook 1) onto the same bus the conversation's
+	// tee can publish FirstAudio (A3 hook 1) and the pump can publish FirstOpus
+	// (task #7, the audible-on-wire SLO end) onto the same bus the conversation's
 	// stages publish on and the metrics subscriber reads.
 	bus := voiceevent.NewBus()
+
+	pump := wire.NewPlaybackPump(sess, cdc, log, bus)
+	defer pump.Close()
+
 	teeSynth := wire.NewTeeSynthesizer(ttseleven.New(""), pump, bus)
 
 	// Attach the orchestrator-sibling latency subscriber (A2/#10): it derives the

--- a/internal/wirenpc/wirenpc_test.go
+++ b/internal/wirenpc/wirenpc_test.go
@@ -7,6 +7,18 @@ import (
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 )
 
+// TestBargeConfirmWindow_NonZero pins the live-mic invariant the latency
+// investigation established: the wired barge-in confirm window must be > 0. A
+// zero window lets the addressing user's own continued speech cancel the turn it
+// just triggered (single shared VAD session, no speaker identity), which was the
+// 20s self-cancel (docs/latency-investigation/audio-process.md). This test fails
+// loudly if anyone re-introduces WithBargeIn(0) for the live loop.
+func TestBargeConfirmWindow_NonZero(t *testing.T) {
+	if bargeConfirmWindow <= 0 {
+		t.Fatalf("bargeConfirmWindow = %v, must be > 0 against a live mic (a 0 window self-cancels the addressing user's own turn)", bargeConfirmWindow)
+	}
+}
+
 // TestNPCVoice_Emits48kPCM pins the live NPC's TTS output format at pcm_48000 so
 // the outbound codec path stays encode-only (Discord's Opus encoder runs at
 // 48 kHz; matching the TTS rate avoids a resampler on the live demo). It also

--- a/pkg/tool/grant.go
+++ b/pkg/tool/grant.go
@@ -48,6 +48,23 @@ func NewGrantSet(registry *Registry, grants ...Grant) *GrantSet {
 	return &GrantSet{registry: registry, grants: m}
 }
 
+// Without returns a derived GrantSet identical to this one but with the named
+// Tool's grant removed, sharing the same [Registry]. The receiver is not
+// mutated — it returns a copy — so a caller can narrow grants for one turn (e.g.
+// drop an unneeded Tool so it is never declared to the model, saving a wasted
+// tool-call round) without affecting any other turn. Removing a name that is not
+// granted is a no-op copy.
+func (gs *GrantSet) Without(toolName string) *GrantSet {
+	m := make(map[string]Grant, len(gs.grants))
+	for name, g := range gs.grants {
+		if name == toolName {
+			continue
+		}
+		m[name] = g
+	}
+	return &GrantSet{registry: gs.registry, grants: m}
+}
+
 // resolve returns the [Tool] and per-grant config for name, and whether the
 // Agent is both granted name and the Tool is registered. A grant for an
 // unregistered Tool, or no grant at all, returns ok=false — the loop treats

--- a/pkg/tool/registry_test.go
+++ b/pkg/tool/registry_test.go
@@ -77,6 +77,40 @@ func TestGrantSetGrantStripping(t *testing.T) {
 	}
 }
 
+func TestGrantSetWithoutIsPureAndDrops(t *testing.T) {
+	r := NewRegistry()
+	r.MustRegister(stubTool{name: "dice", readOnly: true})
+	r.MustRegister(stubTool{name: "writer", readOnly: true})
+
+	full := NewGrantSet(r, Grant{ToolName: "dice"}, Grant{ToolName: "writer"})
+	gated := full.Without("dice")
+
+	// The derived set drops only the named grant.
+	if _, _, ok := gated.resolve("dice"); ok {
+		t.Error("Without(dice) must drop the dice grant")
+	}
+	if _, _, ok := gated.resolve("writer"); !ok {
+		t.Error("Without(dice) must keep other grants")
+	}
+	if d := gated.Declarations(); len(d) != 1 || d[0].Name != "writer" {
+		t.Errorf("gated Declarations = %+v, want only writer", d)
+	}
+
+	// The original is untouched (purity): Without returns a copy.
+	if _, _, ok := full.resolve("dice"); !ok {
+		t.Error("Without must not mutate the receiver; dice must still resolve on the original")
+	}
+	if d := full.Declarations(); len(d) != 2 {
+		t.Errorf("original Declarations = %+v, want both grants intact", d)
+	}
+
+	// Removing a name that is not granted is a no-op copy.
+	same := full.Without("ghost")
+	if d := same.Declarations(); len(d) != 2 {
+		t.Errorf("Without(ungranted) = %+v, want an unchanged copy of both grants", d)
+	}
+}
+
 func TestGrantSetSkipsUnregisteredGrant(t *testing.T) {
 	r := NewRegistry()
 	// Grant names a tool that was never registered: grants access to nothing.

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -195,20 +195,37 @@ func (r *Replier) Reply() orchestrator.ReplyFunc {
 		if e.Target.AgentID != r.cfg.Persona.AgentID {
 			return nil // not addressed to this Agent
 		}
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		timeout := r.cfg.TurnTimeout
-		if timeout == 0 {
-			timeout = DefaultTurnTimeout
-		}
-		if timeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, timeout)
-			defer cancel()
-		}
+		ctx, cancel := r.withTurnTimeout(ctx)
+		defer cancel()
 		return r.turn(ctx, e.Text)
 	}
+}
+
+// withTurnTimeout bounds one turn's work with [Config.TurnTimeout] (zero applies
+// [DefaultTurnTimeout]; negative disables the deadline). It also substitutes a
+// background context for a nil one so a turn always has a valid parent. The
+// returned cancel must be called when the turn ends (defer) — it releases the
+// timer and, on the disabled-deadline path, is the no-op cancel of the
+// passed-through context.
+//
+// Both the batch ([Replier.Reply]) and streaming ([Replier.ReplyStream]) entry
+// points go through here so the per-turn deadline is identical on both — the
+// streaming path is the one production wires ([orchestrator.WithReplyStream]),
+// and the Gemini adapter's HTTP client has no overall timeout by design,
+// relying on exactly this ctx deadline to bound a thinking-then-stalling
+// completion (gemini.defaultHTTPClient).
+func (r *Replier) withTurnTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout := r.cfg.TurnTimeout
+	if timeout == 0 {
+		timeout = DefaultTurnTimeout
+	}
+	if timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return context.WithCancel(ctx)
 }
 
 // turn runs one Agent turn for the given utterance text: it appends the user
@@ -255,6 +272,12 @@ func (r *Replier) ReplyStream() orchestrator.StreamReplyFunc {
 		if e.Target.AgentID != r.cfg.Persona.AgentID {
 			return nil // not addressed to this Agent
 		}
+		// Bound the streaming turn with the same per-turn deadline as the batch
+		// path: production wires this path, and without it a thinking-then-stalling
+		// provider completion runs unbounded (the Gemini client has no overall HTTP
+		// timeout by design), so a wedged turn would never produce first audio.
+		ctx, cancel := r.withTurnTimeout(ctx)
+		defer cancel()
 		return r.streamTurn(ctx, e.Text, dispatch)
 	}
 }

--- a/pkg/voice/agent/agent_test.go
+++ b/pkg/voice/agent/agent_test.go
@@ -552,6 +552,27 @@ func (e *ctxCaptureEngine) Generate(ctx context.Context, _ []llm.Message) (strin
 	return e.reply, nil
 }
 
+// ctxCaptureStreamEngine is the [StreamingEngine] counterpart of
+// [ctxCaptureEngine]: it records the ctx the Replier hands the streaming path so
+// the per-turn deadline can be pinned for ReplyStream just as it is for Reply.
+type ctxCaptureStreamEngine struct {
+	ctx   context.Context
+	reply string
+}
+
+func (e *ctxCaptureStreamEngine) Generate(ctx context.Context, _ []llm.Message) (string, error) {
+	e.ctx = ctx
+	return e.reply, nil
+}
+
+func (e *ctxCaptureStreamEngine) GenerateStream(ctx context.Context, _ []llm.Message, onText func(string) error) (string, error) {
+	e.ctx = ctx
+	if err := onText(e.reply); err != nil {
+		return e.reply, err
+	}
+	return e.reply, nil
+}
+
 // TestReply_TurnTimeout_AppliesDeadlineAndPropagatesCtx pins the hung-provider
 // guard: the Engine's ctx must descend from the caller's turn ctx (so barge-in
 // cancellation reaches the LLM call) and carry the TurnTimeout deadline (so a
@@ -579,6 +600,57 @@ func TestReply_TurnTimeout_AppliesDeadlineAndPropagatesCtx(t *testing.T) {
 	}
 	if remaining := time.Until(deadline); remaining > agent.DefaultTurnTimeout {
 		t.Errorf("deadline %v out past DefaultTurnTimeout %v", remaining, agent.DefaultTurnTimeout)
+	}
+}
+
+// TestReplyStream_TurnTimeout_AppliesDeadlineAndPropagatesCtx is the streaming
+// twin of TestReply_TurnTimeout_*: the production path wires ReplyStream
+// (orchestrator.WithReplyStream), and the Gemini client has no overall HTTP
+// timeout by design, so the per-turn deadline MUST be applied here too — without
+// it a thinking-then-stalling completion runs unbounded and never produces first
+// audio (the survivorship-biased latency the 20s live test hit).
+func TestReplyStream_TurnTimeout_AppliesDeadlineAndPropagatesCtx(t *testing.T) {
+	eng := &ctxCaptureStreamEngine{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+	})
+
+	type ctxKey struct{}
+	parent := context.WithValue(t.Context(), ctxKey{}, "turn")
+	if err := r.ReplyStream()(parent, routed("bart", "Hello."), func(orchestrator.Reply) error { return nil }); err != nil {
+		t.Fatalf("ReplyStream returned %v", err)
+	}
+
+	if eng.ctx.Value(ctxKey{}) != "turn" {
+		t.Error("engine ctx does not descend from the caller's turn ctx")
+	}
+	deadline, ok := eng.ctx.Deadline()
+	if !ok {
+		t.Fatal("streaming engine ctx has no deadline; a hung provider would block the turn forever")
+	}
+	if remaining := time.Until(deadline); remaining > agent.DefaultTurnTimeout {
+		t.Errorf("deadline %v out past DefaultTurnTimeout %v", remaining, agent.DefaultTurnTimeout)
+	}
+}
+
+// TestReplyStream_TurnTimeoutNegative_DisablesDeadline mirrors the batch escape
+// hatch on the streaming path: TurnTimeout < 0 leaves the turn bounded only by
+// the caller's ctx.
+func TestReplyStream_TurnTimeoutNegative_DisablesDeadline(t *testing.T) {
+	eng := &ctxCaptureStreamEngine{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+		TurnTimeout: -1,
+	})
+	if err := r.ReplyStream()(t.Context(), routed("bart", "Hello."), func(orchestrator.Reply) error { return nil }); err != nil {
+		t.Fatalf("ReplyStream returned %v", err)
+	}
+	if _, ok := eng.ctx.Deadline(); ok {
+		t.Error("streaming engine ctx has a deadline despite TurnTimeout < 0")
 	}
 }
 

--- a/pkg/voice/agent/sentence.go
+++ b/pkg/voice/agent/sentence.go
@@ -109,13 +109,29 @@ func isSpace(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 }
 
-// hasSpeakable reports whether s contains any letter or digit — i.e. something
-// worth synthesizing. A run of only punctuation/whitespace is not dispatched, so
-// the pump never speaks a silent or punctuation-only utterance.
+// hasSpeakable reports whether s contains any letter or digit OUTSIDE a bracketed
+// tag — i.e. something the TTS will actually voice. A run of only
+// punctuation/whitespace, only emojis, or only bracketed audio/speaker tags
+// (eleven_v3 markup like "[laughs]" or "[Bart]") is not dispatched: ElevenLabs
+// strips speaker tags and emojis and then rejects the request if nothing
+// remains ("input_text_empty", HTTP 400), so a tag-only sentence would drop the
+// whole reply. Letters/digits inside "[...]" are therefore not counted as
+// speakable; a sentence with real words plus a tag ("Aye! [laughs]") still
+// qualifies on the words outside the brackets.
 func hasSpeakable(s string) bool {
+	depth := 0
 	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return true
+		switch r {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/voice/agent/sentence_test.go
+++ b/pkg/voice/agent/sentence_test.go
@@ -101,6 +101,27 @@ func TestSentenceSplitter_EmptyAndWhitespaceOnly(t *testing.T) {
 	}
 }
 
+func TestSentenceSplitter_TagOnlySentenceFiltered(t *testing.T) {
+	// eleven_v3 audio/speaker tags ("[laughs]", "[Bart]") contain letters but
+	// ElevenLabs strips speaker tags + emojis and then rejects empty input
+	// (input_text_empty, HTTP 400) — which drops the whole reply. A sentence that
+	// is only such a tag must not be dispatched, via a terminator or the Flush tail.
+	if got := feed("[laughs]. "); got != nil {
+		t.Errorf("tag-only sentence → %q, want nil (ElevenLabs strips it to empty)", got)
+	}
+	if got := feed("[laughs]"); got != nil {
+		t.Errorf("tag-only Flush tail → %q, want nil", got)
+	}
+	// Real words plus a trailing tag: keep the words, drop the tag-only tail.
+	if got := feed("Aye! [laughs]"); !reflect.DeepEqual(got, []string{"Aye!"}) {
+		t.Errorf("words then tag → %q, want [\"Aye!\"]", got)
+	}
+	// A tag preceding real speech keeps the sentence (ElevenLabs voices the rest).
+	if got := feed("[Bart] Hello there."); !reflect.DeepEqual(got, []string{"[Bart] Hello there."}) {
+		t.Errorf("tag then words → %q, want [\"[Bart] Hello there.\"]", got)
+	}
+}
+
 func TestSentenceSplitter_TrailingTerminatorNoSpace(t *testing.T) {
 	// A terminator at end-of-input (no following space) still closes the sentence.
 	got := feed("Done.")

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -175,8 +175,26 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 
 // Engine is the [agent.Engine] that drives the tool-use loop. Build with
 // [NewEngine] and pass as [agent.Config].Engine.
+//
+// It holds two pre-built loops over the same provider adapter: full (every
+// granted Tool declared) and gated (the dice Tool dropped). Per turn it picks
+// gated unless the latest user utterance shows dice intent ([needsDice]) — so a
+// plain conversational turn never declares dice and is structurally a single LLM
+// round, removing the empty tool-call round before first audio (latency
+// investigation baseline finding #4). If the grants never included dice the two
+// loops are identical and the pick is a no-op.
 type Engine struct {
-	loop *tool.Loop
+	full  *tool.Loop // every granted Tool declared
+	gated *tool.Loop // grants minus the dice Tool
+}
+
+// loopFor selects the loop for this turn: the full grants when the utterance
+// plausibly needs dice, the dice-less grants otherwise.
+func (e *Engine) loopFor(messages []llm.Message) *tool.Loop {
+	if needsDice(messages) {
+		return e.full
+	}
+	return e.gated
 }
 
 // EngineOption configures a [NewEngine]. The only option today is
@@ -218,15 +236,25 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 	for _, o := range opts {
 		o(&cfg)
 	}
-	loop := tool.NewLoop(providerAdapter{
+	adapter := providerAdapter{
 		provider:  provider,
 		model:     model,
 		maxTokens: maxTokens,
 		rec:       cfg.rec,
 		provName:  cfg.provName,
-	}, grants)
-	loop.MaxRounds = maxRounds
-	return &Engine{loop: loop}
+	}
+	newLoop := func(g *tool.GrantSet) *tool.Loop {
+		l := tool.NewLoop(adapter, g)
+		l.MaxRounds = maxRounds
+		return l
+	}
+	// Two loops over the same adapter: full grants, and grants with dice dropped.
+	// Per turn (Generate/GenerateStream) the dice gate picks between them so a
+	// non-dice utterance never declares the dice Tool — one round, not two.
+	return &Engine{
+		full:  newLoop(grants),
+		gated: newLoop(grants.Without(diceToolName)),
+	}
 }
 
 // Generate implements [agent.Engine]. It converts the assembled Hot Context to
@@ -234,7 +262,7 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 // per-turn round counter into ctx so the adapter's LLMRound spans index from 0
 // for this turn and never share state with a concurrent turn (barge-in).
 func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, error) {
-	return e.loop.Run(withRoundCounter(ctx), toToolMessages(messages))
+	return e.loopFor(messages).Run(withRoundCounter(ctx), toToolMessages(messages))
 }
 
 // GenerateStream implements [agent.StreamingEngine] (B1): it runs the same
@@ -244,7 +272,7 @@ func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, 
 // [Engine.Generate], so the A3 LLMRound / provider-call metrics are recorded
 // identically on the streaming production path. Returns the full final text.
 func (e *Engine) GenerateStream(ctx context.Context, messages []llm.Message, onText func(delta string) error) (string, error) {
-	return e.loop.RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
+	return e.loopFor(messages).RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
 }
 
 // toToolMessages converts the agent loop's [llm.Message]s into [tool.Message]s.

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -426,8 +426,8 @@ func TestEngine_DiceGate_HistoryDiceDoesNotArmCurrentTurn(t *testing.T) {
 	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
-		{Role: llm.RoleUser, Text: "Roll a d20."},               // older turn: had dice intent
-		{Role: llm.RoleAssistant, Text: "You rolled a 14."},     // its answer
+		{Role: llm.RoleUser, Text: "Roll a d20."},                // older turn: had dice intent
+		{Role: llm.RoleAssistant, Text: "You rolled a 14."},      // its answer
 		{Role: llm.RoleUser, Text: "Great, point me to a room."}, // current turn: plain
 	}); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -365,6 +365,79 @@ func TestEngine_NoTools_SingleGenerationReturnsText(t *testing.T) {
 	}
 }
 
+// TestEngine_DiceGate_PlainTurnOffersNoDiceAndIsSingleRound is the core #5 pin:
+// a conversational utterance with no dice intent must NOT declare the dice Tool,
+// so the model cannot emit an empty tool-call round before its answer — the turn
+// is structurally a single LLM round. This is the baseline-latency win.
+func TestEngine_DiceGate_PlainTurnOffersNoDiceAndIsSingleRound(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "Ale's a copper, traveler.", stop: "end_turn"},
+	}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+
+	got, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleSystem, Text: "You are Bart."},
+		{Role: llm.RoleUser, Text: "How much for a room and a pint?"},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "Ale's a copper, traveler." {
+		t.Errorf("text = %q, want the single-round answer", got)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 1 {
+		t.Fatalf("provider called %d times, want 1 (a plain turn must be one round)", len(reqs))
+	}
+	if len(reqs[0].Tools) != 0 {
+		t.Errorf("plain turn declared tools %+v, want none (dice gated out)", reqs[0].Tools)
+	}
+}
+
+// TestEngine_DiceGate_KeywordIntentOffersDice proves the gate's recall: an
+// utterance with ttrpg roll intent but no explicit NdM (a "saving throw") still
+// arms the dice Tool, so the tool path is not broken when dice IS needed.
+func TestEngine_DiceGate_KeywordIntentOffersDice(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "You steady your nerves.", stop: "end_turn"},
+	}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Make a saving throw against the poison."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 2 {
+		t.Fatalf("provider called %d times, want 2 (dice intent → tool round-trip)", len(reqs))
+	}
+	if len(reqs[0].Tools) != 1 || reqs[0].Tools[0].Name != "dice" {
+		t.Errorf("keyword-intent turn tools = %+v, want the dice decl offered", reqs[0].Tools)
+	}
+}
+
+// TestEngine_DiceGate_HistoryDiceDoesNotArmCurrentTurn pins that the gate keys on
+// the CURRENT utterance only: a dice roll three messages ago must not keep dice
+// declared on a later plain turn.
+func TestEngine_DiceGate_HistoryDiceDoesNotArmCurrentTurn(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{{text: "Right this way.", stop: "end_turn"}}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Roll a d20."},               // older turn: had dice intent
+		{Role: llm.RoleAssistant, Text: "You rolled a 14."},     // its answer
+		{Role: llm.RoleUser, Text: "Great, point me to a room."}, // current turn: plain
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 1 || len(reqs[0].Tools) != 0 {
+		t.Errorf("history dice armed the current plain turn: reqs=%d tools=%+v, want 1 req / 0 tools", len(reqs), reqs[0].Tools)
+	}
+}
+
 // TestEngine_AsAgentEngine_DrivesReplier pins that the bridge slots into the
 // agent loop via agent.Config.Engine — the production wiring path — so an
 // addressed utterance flows utterance → Hot Context → tool loop → spoken reply.

--- a/pkg/voice/agenttool/dicegate.go
+++ b/pkg/voice/agenttool/dicegate.go
@@ -1,0 +1,71 @@
+package agenttool
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// diceToolName is the [tool.Tool.Name] of the built-in dice Tool, gated per turn
+// by [needsDice]. Kept here (not imported from pkg/tool) so the gate names what
+// it drops without widening this package's coupling.
+const diceToolName = "dice"
+
+// dicePattern matches an explicit NdM / dM die notation anywhere in the text:
+// an optional count, a 'd', then sides (a number or '%' for d100). Word
+// boundaries keep it from firing inside unrelated words (e.g. "add", "model").
+var dicePattern = regexp.MustCompile(`(?i)\b\d*d(\d+|%)\b`)
+
+// diceKeywords are the lowercase substrings whose presence in an utterance marks
+// plausible dice intent. The set is biased for HIGH RECALL: a false positive
+// only costs the (rare) extra tool-call round the system already paid
+// unconditionally before this gate, whereas a false negative would withhold the
+// dice Tool when it is genuinely needed — breaking the tool path. So the keep-IN
+// side is generous (anything ttrpg-roll-shaped) and the keep-OUT side is
+// conservative. Tune here.
+var diceKeywords = []string{
+	"roll", "dice", "die", "d20", "d6", "d100",
+	// ttrpg cues that imply a roll even without the word "roll":
+	"saving throw", "initiative", "advantage", "disadvantage",
+	"to hit", "attack roll", "ability check", "skill check",
+}
+
+// needsDice reports whether the latest user utterance in the assembled Hot
+// Context plausibly needs the dice Tool, so the [Engine] offers dice only then —
+// a plain conversational turn is left a single LLM round (no empty tool-call
+// round before first audio; latency investigation baseline finding #4).
+//
+// It inspects ONLY the most recent user message (the turn's actual request);
+// older history must not keep dice armed for every subsequent turn. Matching is
+// case-insensitive over explicit die notation (2d6, d20, d%) and a small,
+// recall-biased keyword set. An empty/absent user message yields false (nothing
+// to roll for).
+func needsDice(messages []llm.Message) bool {
+	text := latestUserText(messages)
+	if text == "" {
+		return false
+	}
+	if dicePattern.MatchString(text) {
+		return true
+	}
+	lower := strings.ToLower(text)
+	for _, kw := range diceKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// latestUserText returns the Text of the last user-role message, or "" if there
+// is none. It is the turn's current request — the only thing the dice gate
+// should consider (a dice roll three turns ago must not arm dice now).
+func latestUserText(messages []llm.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == llm.RoleUser {
+			return messages[i].Text
+		}
+	}
+	return ""
+}

--- a/pkg/voice/agenttool/dicegate_test.go
+++ b/pkg/voice/agenttool/dicegate_test.go
@@ -1,0 +1,62 @@
+package agenttool
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+func TestNeedsDice(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		// Explicit die notation.
+		{"d20", "Roll a d20 for me.", true},
+		{"NdM", "I attack with 2d6 damage.", true},
+		{"d100", "Give me a d100.", true},
+		{"d-percent", "Roll d% for the table.", true},
+		{"bare die word", "Throw the dice.", true},
+
+		// ttrpg roll intent without explicit notation.
+		{"saving throw", "Make a saving throw against the poison.", true},
+		{"initiative", "Everyone roll initiative.", true},
+		{"check", "Give me an ability check.", true},
+		{"to hit", "What's my to hit?", true},
+
+		// Plain conversation — must NOT arm dice.
+		{"room price", "How much for a room and a pint?", false},
+		{"greeting", "Hello Bart, how are you?", false},
+		{"rumors", "Heard any good rumors lately?", false},
+
+		// False-positive guards: dice-shaped substrings inside unrelated words.
+		{"model not d-something", "Tell me about your business model.", false},
+		{"add not a die", "Can you add another log to the fire?", false},
+		{"addled", "The traveler looks addled.", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := needsDice([]llm.Message{{Role: llm.RoleUser, Text: tc.text}})
+			if got != tc.want {
+				t.Errorf("needsDice(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNeedsDice_LatestUserOnly proves the gate inspects only the most recent
+// user message, not the whole history: an old dice turn must not arm a later
+// plain turn, and the system prompt is ignored.
+func TestNeedsDice_LatestUserOnly(t *testing.T) {
+	msgs := []llm.Message{
+		{Role: llm.RoleSystem, Text: "You are Bart. Roll dice when asked."}, // system mentions dice — ignored
+		{Role: llm.RoleUser, Text: "Roll a d20."},                            // older user turn
+		{Role: llm.RoleAssistant, Text: "You rolled a 14."},
+		{Role: llm.RoleUser, Text: "Thanks, where's the bar?"}, // current: plain
+	}
+	if needsDice(msgs) {
+		t.Error("needsDice must key on the latest user message (plain), not history or the system prompt")
+	}
+}

--- a/pkg/voice/agenttool/dicegate_test.go
+++ b/pkg/voice/agenttool/dicegate_test.go
@@ -52,7 +52,7 @@ func TestNeedsDice(t *testing.T) {
 func TestNeedsDice_LatestUserOnly(t *testing.T) {
 	msgs := []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart. Roll dice when asked."}, // system mentions dice — ignored
-		{Role: llm.RoleUser, Text: "Roll a d20."},                            // older user turn
+		{Role: llm.RoleUser, Text: "Roll a d20."},                           // older user turn
 		{Role: llm.RoleAssistant, Text: "You rolled a 14."},
 		{Role: llm.RoleUser, Text: "Thanks, where's the bar?"}, // current: plain
 	}

--- a/pkg/voice/orchestrator/barge.go
+++ b/pkg/voice/orchestrator/barge.go
@@ -122,9 +122,16 @@ func (b *BargeIn) disarm() {
 	b.mu.Unlock()
 }
 
-// fire yields the floor and, if a turn was actually cancelled, announces it.
+// fire yields the floor and, if a turn was actually cancelled, announces it: the
+// BargeDetected observability signal (ADR-0027) and a TurnEnded carrying the cut
+// turn's TurnID + the barge reason, so the metrics subscriber attributes this
+// turn's death to the barge rather than the coarse no-first-audio catch-all.
 func (b *BargeIn) fire(bus *voiceevent.Bus) {
-	if b.floor.Yield() {
-		bus.Publish(voiceevent.BargeDetected{At: time.Now()})
+	turnID, yielded := b.floor.Yield()
+	if !yielded {
+		return
 	}
+	now := time.Now()
+	bus.Publish(voiceevent.BargeDetected{At: now})
+	bus.Publish(voiceevent.TurnEnded{At: now, TurnID: turnID, Reason: voiceevent.TurnEndBarge})
 }

--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -31,6 +31,27 @@ func TestBargeIn_InstantYieldsActiveFloor(t *testing.T) {
 	voicetest.AssertEventCount[voiceevent.BargeDetected](t, h, 1)
 }
 
+// TestBargeIn_PublishesTurnEndedWithTurnID pins the barge attribution path
+// (task #4): a confirmed barge publishes a TurnEnded carrying the cut turn's
+// TurnID and the barge reason, so the metrics subscriber records why the turn
+// died instead of the coarse no-first-audio catch-all.
+func TestBargeIn_PublishesTurnEndedWithTurnID(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	// The turn holds the floor with its TurnID in ctx, as the reply reactor wires it.
+	parent := voiceevent.WithTurnID(context.Background(), "T42")
+	_, release, _ := floor.Take(parent)
+	defer release()
+
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.VADSpeechStart{})
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "T42" && e.Reason == voiceevent.TurnEndBarge },
+		"turn.ended (barge) carrying the cut turn's TurnID",
+	)
+}
+
 // TestBargeIn_NoFloorNoBarge proves a speech_start with no Agent speaking is a
 // normal utterance onset, not a barge: nothing is cancelled, nothing emitted.
 func TestBargeIn_NoFloorNoBarge(t *testing.T) {

--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -16,7 +16,7 @@ import (
 func TestBargeIn_InstantYieldsActiveFloor(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
-	turnCtx, release := floor.Take(context.Background())
+	turnCtx, release, _ := floor.Take(context.Background())
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
@@ -48,7 +48,7 @@ func TestBargeIn_NoFloorNoBarge(t *testing.T) {
 func TestBargeIn_SoftOverlapDoesNotCancel(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
-	turnCtx, release := floor.Take(context.Background())
+	turnCtx, release, _ := floor.Take(context.Background())
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 200*time.Millisecond).Bind(t.Context(), h.Bus))
@@ -66,7 +66,7 @@ func TestBargeIn_SoftOverlapDoesNotCancel(t *testing.T) {
 func TestBargeIn_ConfirmWindowCrossingCancels(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
-	turnCtx, release := floor.Take(context.Background())
+	turnCtx, release, _ := floor.Take(context.Background())
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 20*time.Millisecond).Bind(t.Context(), h.Bus))

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -32,8 +32,12 @@ type Conversation struct {
 	// floor is non-nil when barge-in is enabled ([WithBargeIn]): the replier runs
 	// turns on it (async, cancelable) and a [BargeIn] reactor yields it on a human
 	// interruption. bargeConfirm is that reactor's confirm window (0 = instant).
-	floor        *Floor
-	bargeConfirm time.Duration
+	// floorCoalesce is the floor's same-utterance coalesce window (0 = plain
+	// supersession); see [Floor] and [WithBargeInCoalesce].
+	floor         *Floor
+	bargeConfirm  time.Duration
+	floorCoalesce time.Duration
+	bargeEnabled  bool
 }
 
 // Option configures a [Conversation] at construction.
@@ -70,10 +74,31 @@ func WithReplyStream(fn StreamReplyFunc) Option {
 // the turn's TTS and playback. confirmWindow is how long continuous speech must
 // persist before it counts as a barge (0 yields instantly on onset). It requires
 // [WithReply]; without a replier there is no turn to interrupt.
+//
+// The floor uses plain supersession (no coalesce window); for the live loop,
+// where one utterance can VAD-split into several turns, prefer
+// [WithBargeInCoalesce] to keep one utterance mapped to one turn.
 func WithBargeIn(confirmWindow time.Duration) Option {
 	return func(c *Conversation) {
-		c.floor = NewFloor()
 		c.bargeConfirm = confirmWindow
+		c.floorCoalesce = 0
+		c.floor = nil // built in Register from the configured windows
+		c.bargeEnabled = true
+	}
+}
+
+// WithBargeInCoalesce is [WithBargeIn] plus a floor coalesce window (root cause
+// #2 of the latency investigation): a per-turn [Floor.Take] arriving within
+// coalesceWindow of the previous one is treated as the SAME utterance continuing
+// and yields to the in-flight turn instead of superseding it (see [Floor]). This
+// stops a VAD over-split of one utterance from self-cancelling its own first
+// turn mid-synthesis. A zero coalesceWindow is identical to [WithBargeIn].
+func WithBargeInCoalesce(confirmWindow, coalesceWindow time.Duration) Option {
+	return func(c *Conversation) {
+		c.bargeConfirm = confirmWindow
+		c.floorCoalesce = coalesceWindow
+		c.floor = nil // built in Register from the configured windows
+		c.bargeEnabled = true
 	}
 }
 
@@ -124,11 +149,18 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 		} else {
 			replier = NewReplier(c.tts, c.reply, c.onError)
 		}
-		if c.floor != nil {
+		if c.bargeEnabled {
 			// Barge-in mode: the replier runs turns on the floor, and the BargeIn
 			// reactor yields it on a human interruption. Bind BargeIn before the
 			// replier so a speech_start is evaluated for a yield ahead of any new
-			// turn it might otherwise route.
+			// turn it might otherwise route. The floor is built here (not at option
+			// time) so the coalesce window — possibly set by a later option — is in
+			// effect.
+			if c.floorCoalesce > 0 {
+				c.floor = NewFloorWithCoalesce(c.floorCoalesce)
+			} else {
+				c.floor = NewFloor()
+			}
 			replier.floor = c.floor
 			reactors = append(reactors, NewBargeIn(c.floor, c.bargeConfirm))
 		}

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -1,0 +1,16 @@
+package orchestrator
+
+import "time"
+
+// SetClock overrides the floor's clock for deterministic coalesce-window tests
+// (external test package). Production code always uses the real time.Now.
+func (f *Floor) SetClock(now func() time.Time) {
+	f.mu.Lock()
+	f.now = now
+	f.mu.Unlock()
+}
+
+// SetFloor installs floor on the replier for the barge-in/coalesce wiring tests
+// (external test package). Production wiring sets r.floor inside
+// Conversation.Register.
+func (r *Replier) SetFloor(floor *Floor) { r.floor = floor }

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -65,11 +65,13 @@ func NewFloorWithCoalesce(window time.Duration) *Floor {
 //
 // With a coalesce window ([NewFloorWithCoalesce]) a Take landing within that
 // window of the previous one is a split-utterance continuation: it does NOT
-// cancel the in-flight turn. The returned context comes back already cancelled
-// and the returned release is a no-op on the floor, so the caller's dispatch loop
-// sees ctx.Err() != nil and says nothing while the turn already speaking keeps
-// the floor.
-func (f *Floor) Take(parent context.Context) (context.Context, func()) {
+// cancel the in-flight turn. The returned context comes back already cancelled,
+// the returned release is a no-op on the floor, and coalesced is true — so the
+// caller can see this Take yielded (rather than took) the floor and react (e.g.
+// publish [voiceevent.TurnYielded] for the dropped segment) instead of speaking
+// it, while the turn already holding the floor keeps it. On a normal take
+// coalesced is false.
+func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(), coalesced bool) {
 	ctx, cancel := context.WithCancel(parent)
 
 	f.mu.Lock()
@@ -82,7 +84,7 @@ func (f *Floor) Take(parent context.Context) (context.Context, func()) {
 		f.lastTake = f.now()
 		f.mu.Unlock()
 		cancel()
-		return ctx, func() {} // no-op: this turn never held the floor
+		return ctx, func() {}, true // no-op release: this turn never held the floor
 	}
 	if f.cancel != nil {
 		f.cancel() // supersede a turn that is still unwinding
@@ -93,7 +95,7 @@ func (f *Floor) Take(parent context.Context) (context.Context, func()) {
 	f.lastTake = f.now()
 	f.mu.Unlock()
 
-	release := func() {
+	release = func() {
 		f.mu.Lock()
 		// Only clear if this turn still holds the floor: a later Take (or a
 		// Yield) may already have moved on, and a stale release must not wipe a
@@ -104,7 +106,7 @@ func (f *Floor) Take(parent context.Context) (context.Context, func()) {
 		f.mu.Unlock()
 		cancel()
 	}
-	return ctx, release
+	return ctx, release, false
 }
 
 // Yield cancels the turn currently holding the floor and reports whether one was

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 // Floor is the single conversational floor an Agent turn holds while it speaks.
@@ -30,10 +32,11 @@ import (
 // window (the [NewFloor] default) keeps the plain always-supersede behaviour the
 // barge path and the tracer-bullet tests rely on.
 type Floor struct {
-	mu       sync.Mutex
-	cancel   context.CancelFunc // non-nil while a turn holds the floor
-	gen      uint64             // increments per Take; guards stale releases
-	lastTake time.Time          // when the current holder took the floor (coalesce anchor)
+	mu         sync.Mutex
+	cancel     context.CancelFunc // non-nil while a turn holds the floor
+	gen        uint64             // increments per Take; guards stale releases
+	lastTake   time.Time          // when the current holder took the floor (coalesce anchor)
+	holderTurn string             // TurnID of the turn currently holding the floor (for Yield → barge attribution)
 
 	// coalesce is the same-utterance debounce window; 0 disables it (plain
 	// supersession). now is the clock, overridable in tests.
@@ -68,9 +71,12 @@ func NewFloorWithCoalesce(window time.Duration) *Floor {
 // cancel the in-flight turn. The returned context comes back already cancelled,
 // the returned release is a no-op on the floor, and coalesced is true — so the
 // caller can see this Take yielded (rather than took) the floor and react (e.g.
-// publish [voiceevent.TurnYielded] for the dropped segment) instead of speaking
+// publish [voiceevent.TurnEnded] for the dropped segment) instead of speaking
 // it, while the turn already holding the floor keeps it. On a normal take
 // coalesced is false.
+//
+// The turn's TurnID is recovered from parent ([voiceevent.TurnIDFrom]) and held
+// so [Floor.Yield] can attribute a barge to the turn it cancelled.
 func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(), coalesced bool) {
 	ctx, cancel := context.WithCancel(parent)
 
@@ -93,6 +99,7 @@ func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(
 	gen := f.gen
 	f.cancel = cancel
 	f.lastTake = f.now()
+	f.holderTurn = voiceevent.TurnIDFrom(parent)
 	f.mu.Unlock()
 
 	release = func() {
@@ -110,19 +117,23 @@ func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(
 }
 
 // Yield cancels the turn currently holding the floor and reports whether one was
-// held. It is the barge-in action: a true result means an Agent was actually
-// speaking and has now been cut; false means the floor was free, so nothing was
-// interrupted (and no BargeDetected should be emitted).
-func (f *Floor) Yield() bool {
+// held, along with that turn's TurnID. It is the barge-in action: yielded=true
+// means an Agent was actually speaking and has now been cut (and turnID is the
+// turn that was cut, so the caller can attribute the barge); yielded=false means
+// the floor was free, so nothing was interrupted (turnID is empty and no
+// BargeDetected/TurnEnded should be emitted).
+func (f *Floor) Yield() (turnID string, yielded bool) {
 	f.mu.Lock()
 	c := f.cancel
+	turnID = f.holderTurn
 	f.cancel = nil
+	f.holderTurn = ""
 	f.mu.Unlock()
 	if c == nil {
-		return false
+		return "", false
 	}
 	c()
-	return true
+	return turnID, true
 }
 
 // Active reports whether a turn currently holds the floor (an Agent is

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -44,6 +44,17 @@ type Floor struct {
 	now      func() time.Time
 }
 
+// clock returns the floor's time source, defaulting to [time.Now] so a
+// zero-value Floor{} (no constructor) does not panic on a nil now in [Floor.Take]
+// — the constructors set it, but a bare Floor{} is otherwise fully usable, so the
+// clock must be too. Called under f.mu.
+func (f *Floor) clock() time.Time {
+	if f.now == nil {
+		return time.Now()
+	}
+	return f.now()
+}
+
 // NewFloor returns an unheld floor with no coalesce window: every [Floor.Take]
 // supersedes the prior turn (the original behaviour).
 func NewFloor() *Floor { return &Floor{now: time.Now} }
@@ -81,13 +92,13 @@ func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(
 	ctx, cancel := context.WithCancel(parent)
 
 	f.mu.Lock()
-	if f.cancel != nil && f.coalesce > 0 && f.now().Sub(f.lastTake) < f.coalesce {
+	if f.cancel != nil && f.coalesce > 0 && f.clock().Sub(f.lastTake) < f.coalesce {
 		// Same-utterance re-take inside the coalesce window: yield to the turn
 		// already holding the floor instead of superseding it. Cancel only THIS
 		// (the late segment's) context and leave the holder untouched. Refresh the
 		// anchor so a run of closely-spaced splits keeps coalescing (each segment
 		// is within the window of the previous one, not just the first).
-		f.lastTake = f.now()
+		f.lastTake = f.clock()
 		f.mu.Unlock()
 		cancel()
 		return ctx, func() {}, true // no-op release: this turn never held the floor
@@ -98,7 +109,7 @@ func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(
 	f.gen++
 	gen := f.gen
 	f.cancel = cancel
-	f.lastTake = f.now()
+	f.lastTake = f.clock()
 	f.holderTurn = voiceevent.TurnIDFrom(parent)
 	f.mu.Unlock()
 

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // Floor is the single conversational floor an Agent turn holds while it speaks.
@@ -15,14 +16,45 @@ import (
 //
 // Floor is safe for concurrent use: a turn is taken on one goroutine and may be
 // yielded from another (the inbound VAD goroutine).
+//
+// Coalesce window (root cause #2 of the latency investigation): a turn's unit is
+// a VAD segment, not a user utterance, so one spoken utterance VAD-split into two
+// segments produces two [Replier] dispatches and two [Floor.Take]s — and the
+// second Take's supersession cancels the first segment's turn mid-synthesis (a
+// self-cancel with no barge involved). When a coalesce window is configured
+// ([NewFloorWithCoalesce]) a Take arriving within that window of the previous one
+// is treated as the SAME utterance continuing: it does not supersede the
+// in-flight turn but yields to it — the new turn's context comes back already
+// cancelled so its reply is suppressed and the turn already speaking keeps the
+// floor. One utterance then maps to one turn even when VAD over-splits it. A zero
+// window (the [NewFloor] default) keeps the plain always-supersede behaviour the
+// barge path and the tracer-bullet tests rely on.
 type Floor struct {
-	mu     sync.Mutex
-	cancel context.CancelFunc // non-nil while a turn holds the floor
-	gen    uint64             // increments per Take; guards stale releases
+	mu       sync.Mutex
+	cancel   context.CancelFunc // non-nil while a turn holds the floor
+	gen      uint64             // increments per Take; guards stale releases
+	lastTake time.Time          // when the current holder took the floor (coalesce anchor)
+
+	// coalesce is the same-utterance debounce window; 0 disables it (plain
+	// supersession). now is the clock, overridable in tests.
+	coalesce time.Duration
+	now      func() time.Time
 }
 
-// NewFloor returns an unheld floor.
-func NewFloor() *Floor { return &Floor{} }
+// NewFloor returns an unheld floor with no coalesce window: every [Floor.Take]
+// supersedes the prior turn (the original behaviour).
+func NewFloor() *Floor { return &Floor{now: time.Now} }
+
+// NewFloorWithCoalesce returns an unheld floor whose [Floor.Take] coalesces a
+// re-take arriving within window of the previous take into the turn already
+// holding the floor, rather than superseding it (see [Floor] — root cause #2).
+// A non-positive window behaves like [NewFloor].
+func NewFloorWithCoalesce(window time.Duration) *Floor {
+	if window < 0 {
+		window = 0
+	}
+	return &Floor{coalesce: window, now: time.Now}
+}
 
 // Take derives a per-turn context from parent and installs it as the held floor,
 // returning that context and a release function. A new Take supersedes any turn
@@ -30,16 +62,35 @@ func NewFloor() *Floor { return &Floor{} }
 // at once. release clears the floor (only if this turn still holds it) and
 // cancels the turn's context; it is idempotent and must be called when the turn
 // ends, conventionally via defer.
+//
+// With a coalesce window ([NewFloorWithCoalesce]) a Take landing within that
+// window of the previous one is a split-utterance continuation: it does NOT
+// cancel the in-flight turn. The returned context comes back already cancelled
+// and the returned release is a no-op on the floor, so the caller's dispatch loop
+// sees ctx.Err() != nil and says nothing while the turn already speaking keeps
+// the floor.
 func (f *Floor) Take(parent context.Context) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(parent)
 
 	f.mu.Lock()
+	if f.cancel != nil && f.coalesce > 0 && f.now().Sub(f.lastTake) < f.coalesce {
+		// Same-utterance re-take inside the coalesce window: yield to the turn
+		// already holding the floor instead of superseding it. Cancel only THIS
+		// (the late segment's) context and leave the holder untouched. Refresh the
+		// anchor so a run of closely-spaced splits keeps coalescing (each segment
+		// is within the window of the previous one, not just the first).
+		f.lastTake = f.now()
+		f.mu.Unlock()
+		cancel()
+		return ctx, func() {} // no-op: this turn never held the floor
+	}
 	if f.cancel != nil {
 		f.cancel() // supersede a turn that is still unwinding
 	}
 	f.gen++
 	gen := f.gen
 	f.cancel = cancel
+	f.lastTake = f.now()
 	f.mu.Unlock()
 
 	release := func() {

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
@@ -31,11 +32,18 @@ func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
 
 func TestFloor_YieldCancelsHeldTurnAndReportsTrue(t *testing.T) {
 	f := orchestrator.NewFloor()
-	ctx, release, _ := f.Take(context.Background())
+	// The turn carries its TurnID in the parent ctx (as the production reply
+	// reactor does) so Yield can attribute the barge to the cut turn.
+	parent := voiceevent.WithTurnID(context.Background(), "T7")
+	ctx, release, _ := f.Take(parent)
 	defer release()
 
-	if !f.Yield() {
+	turnID, yielded := f.Yield()
+	if !yielded {
 		t.Fatal("Yield must report true when a turn was held")
+	}
+	if turnID != "T7" {
+		t.Fatalf("Yield returned turnID %q, want the held turn's T7 (barge attribution)", turnID)
 	}
 	if ctx.Err() == nil {
 		t.Fatal("Yield must cancel the held turn ctx")
@@ -47,8 +55,8 @@ func TestFloor_YieldCancelsHeldTurnAndReportsTrue(t *testing.T) {
 
 func TestFloor_YieldOnFreeFloorReportsFalse(t *testing.T) {
 	f := orchestrator.NewFloor()
-	if f.Yield() {
-		t.Fatal("Yield on a free floor must report false")
+	if turnID, yielded := f.Yield(); yielded || turnID != "" {
+		t.Fatalf("Yield on a free floor must report (\"\", false), got (%q, %v)", turnID, yielded)
 	}
 }
 

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -3,6 +3,7 @@ package orchestrator_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 )
@@ -67,6 +68,118 @@ func TestFloor_TakeSupersedesPreviousTurn(t *testing.T) {
 	}
 	if !f.Active() {
 		t.Fatal("floor must remain held by the new turn")
+	}
+}
+
+// TestFloor_CoalesceWindowKeepsInFlightTurn pins root cause #2's fix: a re-Take
+// landing inside the coalesce window (one utterance VAD-split into two segments)
+// must NOT cancel the in-flight turn. The late segment's context comes back
+// already cancelled (its reply is suppressed) and the original turn keeps the
+// floor.
+func TestFloor_CoalesceWindowKeepsInFlightTurn(t *testing.T) {
+	now := time.Unix(0, 0)
+	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
+	f.SetClock(func() time.Time { return now })
+
+	ctx1, release1 := f.Take(context.Background())
+	defer release1()
+
+	// Second segment arrives 100ms later — inside the 500ms window.
+	now = now.Add(100 * time.Millisecond)
+	ctx2, release2 := f.Take(context.Background())
+	defer release2()
+
+	if ctx1.Err() != nil {
+		t.Fatal("a re-take inside the coalesce window must NOT cancel the in-flight turn")
+	}
+	if ctx2.Err() == nil {
+		t.Fatal("the coalesced (late-segment) turn's ctx must come back cancelled so its reply is suppressed")
+	}
+	if !f.Active() {
+		t.Fatal("the original turn must still hold the floor after a coalesced re-take")
+	}
+	// The coalesced turn's release is a no-op on the floor: it must not free the
+	// holder.
+	release2()
+	if !f.Active() {
+		t.Fatal("a coalesced turn's release must not clear the in-flight turn's floor")
+	}
+	if ctx1.Err() != nil {
+		t.Fatal("a coalesced turn's release must not cancel the in-flight turn")
+	}
+}
+
+// TestFloor_CoalesceWindowExpiresToSupersession proves the window is bounded: a
+// re-Take after the window elapses is a genuine new utterance and supersedes the
+// prior turn as normal.
+func TestFloor_CoalesceWindowExpiresToSupersession(t *testing.T) {
+	now := time.Unix(0, 0)
+	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
+	f.SetClock(func() time.Time { return now })
+
+	ctx1, release1 := f.Take(context.Background())
+	defer release1()
+
+	// Real conversational gap: past the window.
+	now = now.Add(800 * time.Millisecond)
+	ctx2, release2 := f.Take(context.Background())
+	defer release2()
+
+	if ctx1.Err() == nil {
+		t.Fatal("a re-take past the coalesce window must supersede the prior turn")
+	}
+	if ctx2.Err() != nil {
+		t.Fatalf("the new turn's ctx must be live: %v", ctx2.Err())
+	}
+	if !f.Active() {
+		t.Fatal("the new turn must hold the floor")
+	}
+}
+
+// TestFloor_CoalesceChainKeepsCoalescing proves a run of closely-spaced splits
+// all coalesce: each segment is within the window of the previous one (the anchor
+// is refreshed), not just the first, so a 3-segment over-split still maps to one
+// turn.
+func TestFloor_CoalesceChainKeepsCoalescing(t *testing.T) {
+	now := time.Unix(0, 0)
+	f := orchestrator.NewFloorWithCoalesce(300 * time.Millisecond)
+	f.SetClock(func() time.Time { return now })
+
+	ctx1, release1 := f.Take(context.Background())
+	defer release1()
+
+	// Segment 2 at +200ms (inside window of seg1), segment 3 at +400ms (outside
+	// window of seg1 but inside window of seg2 — anchor refreshed).
+	now = now.Add(200 * time.Millisecond)
+	_, r2 := f.Take(context.Background())
+	defer r2()
+	now = now.Add(200 * time.Millisecond)
+	_, r3 := f.Take(context.Background())
+	defer r3()
+
+	if ctx1.Err() != nil {
+		t.Fatal("a chain of splits inside the rolling window must all coalesce; the first turn must survive")
+	}
+	if !f.Active() {
+		t.Fatal("the original turn must still hold the floor after a coalesced chain")
+	}
+}
+
+// TestFloor_ZeroCoalesceIsPlainSupersession guards the default: NewFloor (and a
+// zero coalesce window) keeps the always-supersede behaviour the barge path and
+// the tracer-bullet tests depend on, even on a back-to-back re-take.
+func TestFloor_ZeroCoalesceIsPlainSupersession(t *testing.T) {
+	f := orchestrator.NewFloorWithCoalesce(0)
+	ctx1, release1 := f.Take(context.Background())
+	defer release1()
+	ctx2, release2 := f.Take(context.Background())
+	defer release2()
+
+	if ctx1.Err() == nil {
+		t.Fatal("a zero coalesce window must supersede the prior turn (no debounce)")
+	}
+	if ctx2.Err() != nil {
+		t.Fatalf("the new turn's ctx must be live: %v", ctx2.Err())
 	}
 }
 

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -13,7 +13,7 @@ func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
 	if f.Active() {
 		t.Fatal("a fresh floor must be inactive")
 	}
-	ctx, release := f.Take(context.Background())
+	ctx, release, _ := f.Take(context.Background())
 	if !f.Active() {
 		t.Fatal("floor must be active after Take")
 	}
@@ -31,7 +31,7 @@ func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
 
 func TestFloor_YieldCancelsHeldTurnAndReportsTrue(t *testing.T) {
 	f := orchestrator.NewFloor()
-	ctx, release := f.Take(context.Background())
+	ctx, release, _ := f.Take(context.Background())
 	defer release()
 
 	if !f.Yield() {
@@ -54,12 +54,15 @@ func TestFloor_YieldOnFreeFloorReportsFalse(t *testing.T) {
 
 func TestFloor_TakeSupersedesPreviousTurn(t *testing.T) {
 	f := orchestrator.NewFloor()
-	ctx1, release1 := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background())
 	defer release1()
 
-	ctx2, release2 := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background())
 	defer release2()
 
+	if coalesced {
+		t.Fatal("a plain (no-coalesce) Take must never report coalesced")
+	}
 	if ctx1.Err() == nil {
 		t.Fatal("a new Take must cancel the previous turn's ctx")
 	}
@@ -81,14 +84,20 @@ func TestFloor_CoalesceWindowKeepsInFlightTurn(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1 := f.Take(context.Background())
+	ctx1, release1, c1 := f.Take(context.Background())
 	defer release1()
+	if c1 {
+		t.Fatal("the first Take must not coalesce (nothing is holding the floor)")
+	}
 
 	// Second segment arrives 100ms later — inside the 500ms window.
 	now = now.Add(100 * time.Millisecond)
-	ctx2, release2 := f.Take(context.Background())
+	ctx2, release2, c2 := f.Take(context.Background())
 	defer release2()
 
+	if !c2 {
+		t.Fatal("a re-take inside the coalesce window must report coalesced=true so the caller can announce TurnYielded")
+	}
 	if ctx1.Err() != nil {
 		t.Fatal("a re-take inside the coalesce window must NOT cancel the in-flight turn")
 	}
@@ -117,14 +126,17 @@ func TestFloor_CoalesceWindowExpiresToSupersession(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1 := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background())
 	defer release1()
 
 	// Real conversational gap: past the window.
 	now = now.Add(800 * time.Millisecond)
-	ctx2, release2 := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background())
 	defer release2()
 
+	if coalesced {
+		t.Fatal("a re-take past the coalesce window is a genuine new turn, not coalesced")
+	}
 	if ctx1.Err() == nil {
 		t.Fatal("a re-take past the coalesce window must supersede the prior turn")
 	}
@@ -145,18 +157,21 @@ func TestFloor_CoalesceChainKeepsCoalescing(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(300 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1 := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background())
 	defer release1()
 
 	// Segment 2 at +200ms (inside window of seg1), segment 3 at +400ms (outside
 	// window of seg1 but inside window of seg2 — anchor refreshed).
 	now = now.Add(200 * time.Millisecond)
-	_, r2 := f.Take(context.Background())
+	_, r2, c2 := f.Take(context.Background())
 	defer r2()
 	now = now.Add(200 * time.Millisecond)
-	_, r3 := f.Take(context.Background())
+	_, r3, c3 := f.Take(context.Background())
 	defer r3()
 
+	if !c2 || !c3 {
+		t.Fatalf("every segment in the rolling window must coalesce: seg2=%v seg3=%v", c2, c3)
+	}
 	if ctx1.Err() != nil {
 		t.Fatal("a chain of splits inside the rolling window must all coalesce; the first turn must survive")
 	}
@@ -170,11 +185,14 @@ func TestFloor_CoalesceChainKeepsCoalescing(t *testing.T) {
 // the tracer-bullet tests depend on, even on a back-to-back re-take.
 func TestFloor_ZeroCoalesceIsPlainSupersession(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(0)
-	ctx1, release1 := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background())
 	defer release1()
-	ctx2, release2 := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background())
 	defer release2()
 
+	if coalesced {
+		t.Fatal("a zero coalesce window must never coalesce")
+	}
 	if ctx1.Err() == nil {
 		t.Fatal("a zero coalesce window must supersede the prior turn (no debounce)")
 	}
@@ -185,8 +203,8 @@ func TestFloor_ZeroCoalesceIsPlainSupersession(t *testing.T) {
 
 func TestFloor_StaleReleaseDoesNotClearNewerTurn(t *testing.T) {
 	f := orchestrator.NewFloor()
-	_, release1 := f.Take(context.Background())
-	_, release2 := f.Take(context.Background())
+	_, release1, _ := f.Take(context.Background())
+	_, release2, _ := f.Take(context.Background())
 	defer release2()
 
 	// Releasing the first (already-superseded) turn must not wipe the second

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
+// TestFloor_ZeroValueUsable proves a bare Floor{} (no constructor) does not panic
+// on its nil clock in Take — the clock defaults to time.Now. Guards the sharp
+// edge code-quality flagged: the constructors set now, but the type must be
+// usable zero-valued too.
+func TestFloor_ZeroValueUsable(t *testing.T) {
+	var f orchestrator.Floor // zero value, now == nil
+	ctx, release, coalesced := f.Take(context.Background())
+	defer release()
+	if coalesced {
+		t.Fatal("a zero-value floor has no coalesce window; Take must not coalesce")
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("turn ctx must be live: %v", ctx.Err())
+	}
+	if !f.Active() {
+		t.Fatal("floor must be active after Take on a zero-value floor")
+	}
+}
+
 func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
 	f := orchestrator.NewFloor()
 	if f.Active() {

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -310,7 +310,18 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		// Barge-in: take the floor and run the turn on its own goroutine so the
 		// inbound loop keeps feeding VAD during playback. A barge cancels turnCtx,
 		// which unwinds TTS synthesis and playback and breaks the dispatch loop.
-		turnCtx, release := r.floor.Take(ctx)
+		turnCtx, release, coalesced := r.floor.Take(ctx)
+		if coalesced {
+			// The floor's same-utterance grace window folded this late segment into
+			// the turn already speaking (one utterance VAD-split into two). The
+			// segment is NOT spoken; announce it so the metrics subscriber records a
+			// distinct `yielded` outcome (not `abandoned`) and logs the dropped
+			// transcript — the known residual until real utterance coalescing routes
+			// this text into the surviving turn. No goroutine is spawned.
+			release() // no-op on the floor, but keeps the take/release pairing honest
+			bus.Publish(voiceevent.TurnYielded{At: time.Now(), TurnID: e.TurnID, Text: e.Text})
+			return
+		}
 		go func() {
 			defer release()
 			r.dispatchAll(turnCtx, e)

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -319,45 +319,66 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 			// transcript — the known residual until real utterance coalescing routes
 			// this text into the surviving turn. No goroutine is spawned.
 			release() // no-op on the floor, but keeps the take/release pairing honest
-			bus.Publish(voiceevent.TurnYielded{At: time.Now(), TurnID: e.TurnID, Text: e.Text})
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSupersedeCoalesced, Text: e.Text})
 			return
 		}
 		go func() {
 			defer release()
-			r.dispatchAll(turnCtx, e)
+			reason := r.dispatchAll(turnCtx, e)
+			// Announce a turn that died of its own error (a real TTS/provider
+			// failure) before producing audio — so the metrics subscriber records
+			// the precise reason, not the coarse no-first-audio catch-all. A turn
+			// cancelled by a barge or a supersede is NOT reported here (ctx.Err() !=
+			// nil): the barge publishes its own TurnEnded, and the subscriber's
+			// first-audio/TTL guards handle the rest. A clean turn reports nothing.
+			if reason != "" && turnCtx.Err() == nil {
+				bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: reason})
+			}
 		}()
 	})
 }
 
-// dispatchAll renders one routing decision under ctx. With a streaming strategy
-// it drives the producer, dispatching each sentence as it arrives; otherwise it
-// renders every [Reply] the batch [ReplyFunc] returns, in order. Both stop early
-// if ctx is cancelled (a barge-in yielded the floor mid-turn). A dispatch
-// failure is reported through the ErrorFunc and does not stop the rest.
-func (r *Replier) dispatchAll(ctx context.Context, e voiceevent.AddressRouted) {
+// dispatchAll renders one routing decision under ctx, returning the turn-end
+// reason if the turn failed of its own error (empty on a clean turn or a
+// ctx-cancel). With a streaming strategy it drives the producer, dispatching each
+// sentence as it arrives; otherwise it renders every [Reply] the batch
+// [ReplyFunc] returns, in order. Both stop early if ctx is cancelled (a barge-in
+// yielded the floor mid-turn). A dispatch failure is reported through the
+// ErrorFunc and does not stop the rest.
+func (r *Replier) dispatchAll(ctx context.Context, e voiceevent.AddressRouted) voiceevent.TurnEndReason {
 	if r.replyStream != nil {
-		r.dispatchStream(ctx, e)
-		return
+		return r.dispatchStream(ctx, e)
 	}
+	var reason voiceevent.TurnEndReason
 	for _, rep := range r.reply(ctx, e) {
 		if ctx.Err() != nil {
-			return
+			return ""
 		}
-		if err := r.tts.Dispatch(ctx, rep.Sentence, rep.Voice); err != nil && r.onError != nil {
-			r.onError(err)
+		if err := r.tts.Dispatch(ctx, rep.Sentence, rep.Voice); err != nil {
+			if r.onError != nil {
+				r.onError(err)
+			}
+			// A synth failure on one sentence is non-fatal to the turn, but record
+			// it as the turn-end reason if no later sentence recovers with audio.
+			if ctx.Err() == nil {
+				reason = voiceevent.TurnEndTTSError
+			}
 		}
 	}
+	return reason
 }
 
 // dispatchStream drives the streaming reply strategy for one routing decision
-// (B1). It hands the producer a dispatch callback that synthesizes one sentence
-// at a time under ctx — serially, so the [PlaybackPump]'s single-in-flight
-// contract and the per-sentence FirstAudio ordering both hold — and returns
-// ctx.Err() once the turn is cancelled so the producer stops generating. A
-// dispatch failure is reported via the ErrorFunc but does not abort the turn
-// (one bad sentence must not silence the rest); a producer-level error is
-// likewise surfaced.
-func (r *Replier) dispatchStream(ctx context.Context, e voiceevent.AddressRouted) {
+// (B1), returning the turn-end reason if the turn failed of its own error (empty
+// on a clean turn or a ctx-cancel). It hands the producer a dispatch callback
+// that synthesizes one sentence at a time under ctx — serially, so the
+// [PlaybackPump]'s single-in-flight contract and the per-sentence FirstAudio
+// ordering both hold — and returns ctx.Err() once the turn is cancelled so the
+// producer stops generating. A dispatch failure is reported via the ErrorFunc but
+// does not abort the turn (one bad sentence must not silence the rest); a
+// producer-level error is likewise surfaced.
+func (r *Replier) dispatchStream(ctx context.Context, e voiceevent.AddressRouted) voiceevent.TurnEndReason {
+	var ttsFailed bool
 	dispatch := func(rep Reply) error {
 		if err := ctx.Err(); err != nil {
 			return err // barge-in cancelled the turn: stop the producer
@@ -371,10 +392,19 @@ func (r *Replier) dispatchStream(ctx context.Context, e voiceevent.AddressRouted
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			ttsFailed = true
 		}
 		return nil
 	}
-	if err := r.replyStream(ctx, e, dispatch); err != nil && ctx.Err() == nil && r.onError != nil {
-		r.onError(err)
+	if err := r.replyStream(ctx, e, dispatch); err != nil && ctx.Err() == nil {
+		if r.onError != nil {
+			r.onError(err)
+		}
+		// The producer (LLM round / tool loop) failed before the turn finished.
+		return voiceevent.TurnEndProviderError
 	}
+	if ttsFailed && ctx.Err() == nil {
+		return voiceevent.TurnEndTTSError
+	}
+	return ""
 }

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -293,9 +293,102 @@ func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 		}
 	}
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.TurnYielded) bool { return e.TurnID == "seg2" && e.Text == "and have you seen Gandalf" },
-		"turn.yielded for the coalesced seg2 carrying its dropped transcript",
+		func(e voiceevent.TurnEnded) bool {
+			return e.TurnID == "seg2" && e.Reason == voiceevent.TurnEndSupersedeCoalesced && e.Text == "and have you seen Gandalf"
+		},
+		"turn.ended (supersede_coalesced) for the coalesced seg2 carrying its dropped transcript",
 	)
+}
+
+// waitTurnEnded subscribes a channel to TurnEnded on bus so a test can block until
+// the async (floor goroutine) turn publishes its end signal — AssertEvent does not
+// poll, so a direct synchronization is needed for the goroutine-driven turns.
+func waitTurnEnded(t *testing.T, bus *voiceevent.Bus) <-chan voiceevent.TurnEnded {
+	t.Helper()
+	ch := make(chan voiceevent.TurnEnded, 4)
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.TurnEnded) { ch <- e }))
+	return ch
+}
+
+// TestReplier_FloorTurnPublishesTTSErrorEnded pins task #4's tts_error path: a
+// turn whose only sentence fails synthesis (no audio, ctx not cancelled) publishes
+// TurnEnded(tts_error) carrying the TurnID, so the metrics subscriber attributes
+// the death precisely instead of the coarse no-first-audio reap.
+func TestReplier_FloorTurnPublishesTTSErrorEnded(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
+	reply := func(_ context.Context, _ voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		return dispatch(orchestrator.Reply{Sentence: "boom"})
+	}
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(orchestrator.NewFloor())
+	ended := waitTurnEnded(t, h.Bus)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "terr"})
+
+	select {
+	case e := <-ended:
+		if e.TurnID != "terr" || e.Reason != voiceevent.TurnEndTTSError {
+			t.Fatalf("TurnEnded = %+v, want {terr tts_error}", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no TurnEnded(tts_error) published for a failed-synthesis turn")
+	}
+}
+
+// TestReplier_FloorTurnPublishesProviderErrorEnded pins task #4's provider_error
+// path: a producer (LLM/tool loop) that errors before any audio publishes
+// TurnEnded(provider_error).
+func TestReplier_FloorTurnPublishesProviderErrorEnded(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+	reply := func(_ context.Context, _ voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		return errors.New("gemini round failed")
+	}
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(orchestrator.NewFloor())
+	ended := waitTurnEnded(t, h.Bus)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "tperr"})
+
+	select {
+	case e := <-ended:
+		if e.TurnID != "tperr" || e.Reason != voiceevent.TurnEndProviderError {
+			t.Fatalf("TurnEnded = %+v, want {tperr provider_error}", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no TurnEnded(provider_error) published for a failed-producer turn")
+	}
+}
+
+// TestReplier_FloorCleanTurnPublishesNoTurnEnded proves a turn that produces audio
+// cleanly publishes no TurnEnded (the success path is silent; first audio is the
+// terminal signal). It synchronizes on the producer returning, then drains.
+func TestReplier_FloorCleanTurnPublishesNoTurnEnded(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{}) // all sentences succeed
+	done := make(chan struct{})
+	reply := func(_ context.Context, _ voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		defer close(done)
+		return dispatch(orchestrator.Reply{Sentence: "hello there"})
+	}
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(orchestrator.NewFloor())
+	ended := waitTurnEnded(t, h.Bus)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "tok"})
+
+	<-done // producer finished; the goroutine publishes TurnEnded (if any) before exiting
+	// The publish happens after dispatchAll returns, just after the producer; give
+	// that a beat, then assert nothing arrived.
+	select {
+	case e := <-ended:
+		t.Fatalf("clean turn must publish no TurnEnded, got %+v", e)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 // selectiveSynth is a [tts.Synthesizer] that fails Synthesize for sentences in

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
@@ -225,6 +226,57 @@ func TestReplier_BindCancelUnsubscribes(t *testing.T) {
 	h.Bus.Publish(voiceevent.AddressRouted{})
 
 	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+}
+
+// TestReplier_CoalescingFloorKeepsFirstSegmentTurn is the end-to-end proof of
+// root cause #2's fix: with a coalescing floor, two AddressRouted decisions from
+// one VAD-over-split utterance (two segments arriving back-to-back) must NOT
+// cancel each other. The first segment's turn keeps running; the second is
+// suppressed (coalesced) rather than superseding it mid-flight. Without the
+// coalesce window the second Floor.Take would cancel the first turn's ctx — the
+// self-cancel that produced no audio and no metric sample.
+func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	// A streaming reply that blocks until its turn ctx is cancelled, reporting
+	// which turn (by TurnID) saw a cancel. The first segment's producer should
+	// keep running (never cancelled by the second); the coalesced second should
+	// see an already-cancelled ctx immediately.
+	started := make(chan string, 4)
+	firstCancelled := make(chan struct{}, 1)
+	reply := func(ctx context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		started <- e.TurnID
+		if e.TurnID == "seg1" {
+			select {
+			case <-ctx.Done():
+				close(firstCancelled) // must NOT happen due to seg2
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
+		return nil
+	}
+
+	floor := orchestrator.NewFloorWithCoalesce(300 * time.Millisecond)
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	// Two segments of one utterance, back-to-back (well inside the window).
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg1"})
+	// Wait for seg1's producer to actually start and take the floor before seg2.
+	if got := <-started; got != "seg1" {
+		t.Fatalf("first producer started for %q, want seg1", got)
+	}
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg2"})
+
+	// seg1 must run to its natural end without being cancelled by seg2.
+	select {
+	case <-firstCancelled:
+		t.Fatal("the first segment's turn was cancelled by the second — the self-cancel the coalesce window must prevent")
+	case <-time.After(200 * time.Millisecond):
+		// seg1 still running uninterrupted: correct.
+	}
 }
 
 // selectiveSynth is a [tts.Synthesizer] that fails Synthesize for sentences in

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -232,25 +232,29 @@ func TestReplier_BindCancelUnsubscribes(t *testing.T) {
 // root cause #2's fix: with a coalescing floor, two AddressRouted decisions from
 // one VAD-over-split utterance (two segments arriving back-to-back) must NOT
 // cancel each other. The first segment's turn keeps running; the second is
-// suppressed (coalesced) rather than superseding it mid-flight. Without the
-// coalesce window the second Floor.Take would cancel the first turn's ctx — the
-// self-cancel that produced no audio and no metric sample.
+// coalesced — its producer never runs (the fragment is not spoken) and a
+// TurnYielded carrying its dropped transcript is published for the metrics
+// subscriber. Without the coalesce window the second Floor.Take would cancel the
+// first turn's ctx — the self-cancel that produced no audio and no metric sample.
 func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 	h := voicetest.New(t)
 	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
 
-	// A streaming reply that blocks until its turn ctx is cancelled, reporting
-	// which turn (by TurnID) saw a cancel. The first segment's producer should
-	// keep running (never cancelled by the second); the coalesced second should
-	// see an already-cancelled ctx immediately.
+	// A streaming reply that records which TurnIDs actually ran a producer, and
+	// blocks seg1 until its ctx is cancelled (which must NOT happen due to seg2).
+	var mu sync.Mutex
+	var ran []string
 	started := make(chan string, 4)
 	firstCancelled := make(chan struct{}, 1)
 	reply := func(ctx context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		mu.Lock()
+		ran = append(ran, e.TurnID)
+		mu.Unlock()
 		started <- e.TurnID
 		if e.TurnID == "seg1" {
 			select {
 			case <-ctx.Done():
-				close(firstCancelled) // must NOT happen due to seg2
+				close(firstCancelled)
 			case <-time.After(500 * time.Millisecond):
 			}
 		}
@@ -263,12 +267,12 @@ func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
 
 	// Two segments of one utterance, back-to-back (well inside the window).
-	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg1"})
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg1", Text: "Bart, what's a room"})
 	// Wait for seg1's producer to actually start and take the floor before seg2.
 	if got := <-started; got != "seg1" {
 		t.Fatalf("first producer started for %q, want seg1", got)
 	}
-	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg2"})
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg2", Text: "and have you seen Gandalf"})
 
 	// seg1 must run to its natural end without being cancelled by seg2.
 	select {
@@ -277,6 +281,21 @@ func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		// seg1 still running uninterrupted: correct.
 	}
+
+	// seg2 must have been coalesced: its producer never ran (the fragment is not
+	// spoken) and a TurnYielded carrying its transcript was published.
+	mu.Lock()
+	gotRan := append([]string(nil), ran...)
+	mu.Unlock()
+	for _, id := range gotRan {
+		if id == "seg2" {
+			t.Fatal("the coalesced segment's producer must not run (the fragment must not be spoken)")
+		}
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnYielded) bool { return e.TurnID == "seg2" && e.Text == "and have you seen Gandalf" },
+		"turn.yielded for the coalesced seg2 carrying its dropped transcript",
+	)
 }
 
 // selectiveSynth is a [tts.Synthesizer] that fails Synthesize for sentences in

--- a/pkg/voice/voicebench/README.md
+++ b/pkg/voice/voicebench/README.md
@@ -30,7 +30,7 @@ Each `Stage` maps 1:1 onto a prod `glyphoxa_voice_<stage>_seconds` histogram (a
 bench number == a Prometheus series). Boundaries are reconciled with
 `internal/observe`'s A3 subscriber:
 
-- `response_latency` (headline) = first `FirstAudio` per `TurnID` − `STTFinal.SpeechEndAt` — from the bus.
+- `response_latency` (headline) = first `FirstOpus` per `TurnID` − `STTFinal.SpeechEndAt` — from the bus. Audible-on-wire boundary (task #7); the rig's drain sink publishes `FirstOpus` on each sentence's first chunk since the bench has no codec/sender. `FirstAudio` still feeds `tts_ttfb` and the lifecycle success outcome.
 - `address_detect`, `llm_turn` — from bus event `At:` deltas.
 - `llm_round`, `vad_hangover`, `stt_request`, `tts_ttfb/total`, `codec_*` —
   from the `recorderTap` (these are `observe.StageRecorder` calls, not bus

--- a/pkg/voice/voicebench/bench_live_test.go
+++ b/pkg/voice/voicebench/bench_live_test.go
@@ -106,7 +106,7 @@ func runClipLive(t *testing.T, clip Clip, acc *Accumulator) {
 		Bus:      h.Bus,
 		VAD:      vadStage,
 		STT:      orchestrator.NewSTT(h.Bus, stteleven.New("")),
-		Persona:  agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper."},
+		Persona:  agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper.", Voice: benchVoice()},
 		Provider: gemini.New(""),
 		Synth:    ttseleven.New(""),
 		Detector: orchestrator.NewAddressDetector(alwaysRoute{target: target}),

--- a/pkg/voice/voicebench/bench_run_test.go
+++ b/pkg/voice/voicebench/bench_run_test.go
@@ -111,7 +111,7 @@ func runClipThroughRig(t *testing.T, clip Clip, acc *Accumulator) {
 		Bus:      h.Bus,
 		VAD:      vadStage,
 		STT:      orchestrator.NewSTT(h.Bus, stubRecognizer{text: "another ale, innkeeper"}),
-		Persona:  agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper."},
+		Persona:  agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper.", Voice: benchVoice()},
 		Provider: stubProvider{}, // default 3-sentence reply → exercises B1 per-sentence dispatch
 		Synth:    stubSynth{},
 		Detector: orchestrator.NewAddressDetector(alwaysRoute{target: target}),

--- a/pkg/voice/voicebench/recorder_tap.go
+++ b/pkg/voice/voicebench/recorder_tap.go
@@ -119,5 +119,9 @@ func (t *recorderTap) STTRequest(observe.Provider, time.Duration) {}
 func (t *recorderTap) TTSTotal(observe.Provider, time.Duration)   {}
 func (t *recorderTap) LLMTurn(observe.Provider, time.Duration)    {}
 
+// TurnOutcome is the turn-lifecycle counter; the bench measures latency on
+// surviving turns, not the outcome mix, so it is a no-op here.
+func (t *recorderTap) TurnOutcome(observe.TurnOutcome, observe.TurnReason) {}
+
 // compile-time assertion: the tap satisfies the recorder the orchestrator drives.
 var _ observe.StageRecorder = (*recorderTap)(nil)

--- a/pkg/voice/voicebench/rig.go
+++ b/pkg/voice/voicebench/rig.go
@@ -14,6 +14,7 @@ package voicebench
 
 import (
 	"context"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
@@ -51,8 +52,9 @@ type RigConfig struct {
 // BuildConversation wires the rig's Conversation: the agent reply loop over
 // Provider (dice tool granted, matching wirenpc's grant) feeding a Tee-wrapped
 // Synth that publishes FirstAudio on Bus. Returns the Conversation ready for
-// Register/Feed. The Tee's sink is a drain-only PlaybackSink — the bench measures
-// the FirstAudio boundary, not real playback.
+// Register/Feed. The Tee's sink is a drain-only PlaybackSink that also publishes
+// FirstOpus on each sentence's first chunk — the bench's audible-on-wire
+// boundary, where response_latency now ends (no real playback happens).
 func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 	rec := cfg.Recorder
 	if rec == nil {
@@ -73,10 +75,14 @@ func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 	})
 
 	// Tee the synth so the first AudioChunk per sentence publishes FirstAudio on
-	// the bus (A3 hook 1 — the headline SLO boundary). A drain-only sink stands
-	// in for the real PlaybackPump: the bench measures when audio reaches the
-	// pump boundary, not the audio itself.
-	tee := wire.NewTeeSynthesizer(cfg.Synth, drainSink{}, cfg.Bus)
+	// the bus (A3 hook 1 — tts_ttfb + the lifecycle success signal). The drain
+	// sink stands in for the real PlaybackPump AND for the wire boundary: it
+	// publishes FirstOpus on the first chunk per sentence the way prod's
+	// firstOpusSource does on the first frame the Discord sender pulls — the
+	// headline response_latency now ends there (task #7), so without it the
+	// bench records no response_latency samples at all. The bench has no codec
+	// /sender, so chunk-reaches-sink is its audible-on-wire moment.
+	tee := wire.NewTeeSynthesizer(cfg.Synth, drainSink{bus: cfg.Bus}, cfg.Bus)
 	ttsStage := orchestrator.NewTTS(cfg.Bus, tee)
 
 	// Install observe's StageSubscriber on the bus so the bus-derived headline
@@ -105,13 +111,25 @@ func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 	return orchestrator.NewConversation(cfg.Bus, cfg.VAD, cfg.STT, ttsStage, opts...)
 }
 
-// drainSink is a PlaybackSink that drains each sentence's chunks and drops them
-// — the bench needs the Tee→sink boundary to fire FirstAudio, not real audio.
-type drainSink struct{}
+// drainSink is a PlaybackSink that drains each sentence's chunks and drops them.
+// It publishes FirstOpus on the first chunk of each sentence (TurnID from the
+// per-turn ctx, mirroring prod's firstOpusSource; the subscriber dedupes to the
+// first per turn) — the bench's stand-in for the audible-on-wire boundary that
+// ends response_latency. A sentence cancelled before any chunk arrives publishes
+// nothing, matching prod.
+type drainSink struct{ bus *voiceevent.Bus }
 
-func (drainSink) HandleSentence(ctx context.Context, chunks <-chan tts.AudioChunk) {
+func (s drainSink) HandleSentence(ctx context.Context, chunks <-chan tts.AudioChunk) {
+	turnID := voiceevent.TurnIDFrom(ctx)
 	go func() {
+		first := true
 		for range chunks {
+			if first {
+				first = false
+				if s.bus != nil && turnID != "" {
+					s.bus.Publish(voiceevent.FirstOpus{At: time.Now(), TurnID: turnID})
+				}
+			}
 		}
 	}()
 }

--- a/pkg/voice/voicebench/rig.go
+++ b/pkg/voice/voicebench/rig.go
@@ -14,6 +14,8 @@ package voicebench
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
@@ -22,6 +24,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/wire"
 
@@ -109,6 +112,31 @@ func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 		opts = append(opts, orchestrator.WithDetector(cfg.Detector))
 	}
 	return orchestrator.NewConversation(cfg.Bus, cfg.VAD, cfg.STT, ttsStage, opts...)
+}
+
+// benchVoice mirrors wirenpc's npcVoice() (the prod NPC voice: ElevenLabs
+// "George" public preset, eleven_v3 defaults, pcm_48000) without importing the
+// pipeline's sole-owned internal/wirenpc. The live tier NEEDS it — a real
+// ElevenLabs Synthesize rejects an empty VoiceID, so a voiceless Persona makes
+// every live turn die silently with no audio (the exact 0-sample failure the
+// nightly hit on its first real run). The cassette tier's stub ignores the
+// VoiceID but the voice still shapes the system prompt via AudioMarkupPrompt,
+// so both tiers set it for prompt parity with prod.
+func benchVoice() tts.Voice {
+	settings := ttseleven.DefaultV3Settings()
+	settings.OutputFormat = "pcm_48000"
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		panic(fmt.Sprintf("voicebench.benchVoice: marshal voice settings: %v", err))
+	}
+	return tts.Voice{
+		ProviderID: ttseleven.ProviderID,
+		// ElevenLabs "George" public preset — same ID wirenpc pins for Bart.
+		VoiceID:  "JBFqnCBsd6RMkjVDRZzb",
+		Name:     "Bart",
+		Language: "en",
+		Settings: raw,
+	}
 }
 
 // drainSink is a PlaybackSink that drains each sentence's chunks and drops them.

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -143,25 +143,51 @@ type FirstAudio struct {
 // EventName implements [Event].
 func (FirstAudio) EventName() string { return "voice.first_audio" }
 
-// TurnYielded marks a turn that was coalesced away by the floor's same-utterance
-// grace window (see orchestrator.Floor): one spoken utterance VAD-split into two
-// segments opened two turns, and the LATE segment yielded to the turn already
-// holding the floor instead of superseding it. The late segment is therefore
-// never spoken — its turn ends here, before any TTS.
+// TurnEndReason is the bounded cause a turn ended without (or after) audio,
+// carried on [TurnEnded]. It is published by the seam that KNOWS the cause — the
+// only place the precise reason is available — so the metrics subscriber records
+// it instead of guessing. It is a log/exemplar value AND maps to the bounded
+// metric reason label (ADR-0032 §2.1): keep this set small.
+type TurnEndReason string
+
+const (
+	// TurnEndSupersedeCoalesced: the floor's same-utterance grace window folded a
+	// late VAD-split segment into the turn already speaking — the late segment is
+	// never spoken (latency investigation root cause #2). [TurnEnded.Text] carries
+	// its dropped transcript.
+	TurnEndSupersedeCoalesced TurnEndReason = "supersede_coalesced"
+	// TurnEndBarge: a confirmed human barge-in cancelled the turn (the floor was
+	// yielded while this turn held it).
+	TurnEndBarge TurnEndReason = "barge"
+	// TurnEndTTSError: the turn's TTS synthesis failed (a real provider/synth error,
+	// not a context cancel).
+	TurnEndTTSError TurnEndReason = "tts_error"
+	// TurnEndProviderError: the reply producer (LLM round/tool loop) failed before
+	// the turn could produce audio.
+	TurnEndProviderError TurnEndReason = "provider_error"
+)
+
+// TurnEnded marks a turn that ended for a known reason — distinct from a turn
+// that simply vanished (reaped by the metrics TTL sweep with no signal). It
+// carries the turn's TurnID and the precise [TurnEndReason] so the metrics
+// subscriber records WHY a turn died (barge vs supersede vs tts/provider error)
+// rather than the coarse "no first audio" catch-all. Text is the dropped
+// transcript, set only for [TurnEndSupersedeCoalesced]; empty otherwise.
 //
-// It carries the late segment's TurnID and transcript Text so the metrics
-// subscriber can record this turn's terminal outcome (yielded) without
-// double-counting it as abandoned, and log the dropped transcript — the known
-// residual until real utterance coalescing routes that text into the surviving
-// turn (latency investigation root cause #2, residual section).
-type TurnYielded struct {
+// Published by the seam that knows the cause: the [orchestrator.Replier]
+// (supersede-coalesced, tts/provider error) and the [orchestrator.BargeIn]
+// (barge). The subscriber treats first-audio as terminal, so a TurnEnded arriving
+// AFTER first audio (e.g. a barge mid-playback) is a normal interruption and does
+// not re-count the turn.
+type TurnEnded struct {
 	At     time.Time
 	TurnID string
+	Reason TurnEndReason
 	Text   string
 }
 
 // EventName implements [Event].
-func (TurnYielded) EventName() string { return "turn.yielded" }
+func (TurnEnded) EventName() string { return "turn.ended" }
 
 // BargeDetected marks a confirmed human barge-in: a participant reclaimed the
 // floor while an Agent was speaking, so the Agent's turn was torn down (ADR-0027).

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -126,15 +126,17 @@ type TTSInvoked struct {
 func (TTSInvoked) EventName() string { return "tts.invoked" }
 
 // FirstAudio marks the moment the first synthesized [tts.AudioChunk] of a
-// sentence crosses the TeeSynthesizer→PlaybackPump boundary — the headline SLO
-// boundary, "first audio handed to the pump" (A3 hook 1). It is published by the
-// wire tee, off its forward goroutine, so a metrics subscriber may receive it
-// concurrently with other turns and must lock its per-turn state.
+// sentence crosses the TeeSynthesizer→PlaybackPump boundary — "first audio handed
+// to the pump" (A3 hook 1). It is published by the wire tee, off its forward
+// goroutine, so a metrics subscriber may receive it concurrently with other turns
+// and must lock its per-turn state.
 //
-// There is no sentence index: the metrics subscriber keys on TurnID. The
-// headline response-latency uses the FIRST FirstAudio per TurnID; per-sentence
-// TTS time-to-first-byte pairs [TTSInvoked]↔FirstAudio within a TurnID by
-// arrival order (dispatch is sequential, so the interleave is clean).
+// It is NO LONGER the headline response-latency boundary — that is [FirstOpus],
+// the audible-on-wire moment. FirstAudio still owns two things: the per-sentence
+// tts_ttfb pairing ([TTSInvoked]↔FirstAudio by arrival order within a TurnID), and
+// the turn-lifecycle success signal ("this turn produced audio", which gates the
+// abandoned outcome). There is no sentence index: the metrics subscriber keys on
+// TurnID and uses the FIRST FirstAudio per turn for the success signal.
 type FirstAudio struct {
 	At     time.Time
 	TurnID string
@@ -142,6 +144,27 @@ type FirstAudio struct {
 
 // EventName implements [Event].
 func (FirstAudio) EventName() string { return "voice.first_audio" }
+
+// FirstOpus marks the moment the FIRST Opus packet of a turn is pulled from the
+// playback [voice.Source] by disgo's sender to be streamed to Discord — the
+// audible-on-wire boundary. It is the END of the headline response-latency SLO
+// per Luk's definition ("I stop talking until the first TTS opus packets are
+// streamed back to Discord"): strictly later than [FirstAudio] (handed-to-pump),
+// it includes the codec encode and the pump's real-time pacing that FirstAudio
+// excludes, so the span finally measures what the user experiences.
+//
+// Published once per turn by the wire playback path's Source decorator on the
+// first non-EOF frame it yields. It runs on disgo's sender goroutine, so a
+// metrics subscriber may receive it concurrently and must lock its per-turn
+// state. A turn whose audio is barge-cancelled before any frame reaches the wire
+// never emits it (correctly: nothing was audible).
+type FirstOpus struct {
+	At     time.Time
+	TurnID string
+}
+
+// EventName implements [Event].
+func (FirstOpus) EventName() string { return "voice.first_opus" }
 
 // TurnEndReason is the bounded cause a turn ended without (or after) audio,
 // carried on [TurnEnded]. It is published by the seam that KNOWS the cause — the

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -143,6 +143,26 @@ type FirstAudio struct {
 // EventName implements [Event].
 func (FirstAudio) EventName() string { return "voice.first_audio" }
 
+// TurnYielded marks a turn that was coalesced away by the floor's same-utterance
+// grace window (see orchestrator.Floor): one spoken utterance VAD-split into two
+// segments opened two turns, and the LATE segment yielded to the turn already
+// holding the floor instead of superseding it. The late segment is therefore
+// never spoken — its turn ends here, before any TTS.
+//
+// It carries the late segment's TurnID and transcript Text so the metrics
+// subscriber can record this turn's terminal outcome (yielded) without
+// double-counting it as abandoned, and log the dropped transcript — the known
+// residual until real utterance coalescing routes that text into the surviving
+// turn (latency investigation root cause #2, residual section).
+type TurnYielded struct {
+	At     time.Time
+	TurnID string
+	Text   string
+}
+
+// EventName implements [Event].
+func (TurnYielded) EventName() string { return "turn.yielded" }
+
 // BargeDetected marks a confirmed human barge-in: a participant reclaimed the
 // floor while an Agent was speaking, so the Agent's turn was torn down (ADR-0027).
 // It is the observability signal for a yield that actually cancelled an active

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -59,6 +59,15 @@ func TestFirstAudio_EventName(t *testing.T) {
 	}
 }
 
+func TestFirstOpus_EventName(t *testing.T) {
+	t.Parallel()
+
+	got := FirstOpus{}.EventName()
+	if got != "voice.first_opus" {
+		t.Errorf("EventName = %q, want %q", got, "voice.first_opus")
+	}
+}
+
 func TestTurnEnded_EventName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -59,6 +59,15 @@ func TestFirstAudio_EventName(t *testing.T) {
 	}
 }
 
+func TestTurnYielded_EventName(t *testing.T) {
+	t.Parallel()
+
+	got := TurnYielded{}.EventName()
+	if got != "turn.yielded" {
+		t.Errorf("EventName = %q, want %q", got, "turn.yielded")
+	}
+}
+
 func TestBus_PublishDeliversToSubscriber(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -59,12 +59,12 @@ func TestFirstAudio_EventName(t *testing.T) {
 	}
 }
 
-func TestTurnYielded_EventName(t *testing.T) {
+func TestTurnEnded_EventName(t *testing.T) {
 	t.Parallel()
 
-	got := TurnYielded{}.EventName()
-	if got != "turn.yielded" {
-		t.Errorf("EventName = %q, want %q", got, "turn.yielded")
+	got := TurnEnded{}.EventName()
+	if got != "turn.ended" {
+		t.Errorf("EventName = %q, want %q", got, "turn.ended")
 	}
 }
 

--- a/pkg/voice/wire/firstopus.go
+++ b/pkg/voice/wire/firstopus.go
@@ -1,0 +1,55 @@
+package wire
+
+import (
+	"context"
+	"time"
+
+	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// firstOpusSource decorates a playback [gxvoice.Source] to publish a single
+// [voiceevent.FirstOpus] the moment the first Opus frame of a turn is pulled to
+// be streamed to Discord — the audible-on-wire boundary that ends the headline
+// response-latency SLO (task #7 / Luk's definition). disgo's sender calls
+// NextFrame every 20ms on its own goroutine, so the publish happens off that
+// goroutine; the metrics subscriber locks its per-turn state.
+//
+// Only the FIRST non-EOF frame publishes: a turn's reply may be several
+// sentences (several Sources), but the SLO ends at the first packet on the wire,
+// and the per-turn dedupe lives in the subscriber (first FirstOpus per TurnID
+// wins) — so wrapping every sentence's Source is fine; the later ones are
+// no-ops at the metric. A Source that yields no frame (an immediately
+// barge-cancelled sentence) never publishes, which is correct: nothing was
+// audible.
+type firstOpusSource struct {
+	inner    gxvoice.Source
+	bus      *voiceevent.Bus
+	turnID   string
+	fired    bool
+	nowFn    func() time.Time
+}
+
+// newFirstOpusSource wraps inner so the first frame it yields publishes
+// [voiceevent.FirstOpus] for turnID on bus. If bus is nil or turnID is empty it
+// returns inner unwrapped — no signal to emit, no overhead (the keyless/test
+// path and any non-correlated playback).
+func newFirstOpusSource(inner gxvoice.Source, bus *voiceevent.Bus, turnID string) gxvoice.Source {
+	if bus == nil || turnID == "" {
+		return inner
+	}
+	return &firstOpusSource{inner: inner, bus: bus, turnID: turnID, nowFn: time.Now}
+}
+
+// NextFrame forwards to the inner Source and, on the first frame actually yielded
+// (no error), publishes FirstOpus exactly once. The publish is stamped and sent
+// before NextFrame returns, so the measured moment is when the frame was handed
+// to the sender, not when the next poll comes around.
+func (s *firstOpusSource) NextFrame(ctx context.Context) ([]byte, error) {
+	frame, err := s.inner.NextFrame(ctx)
+	if err == nil && !s.fired {
+		s.fired = true
+		s.bus.Publish(voiceevent.FirstOpus{At: s.nowFn(), TurnID: s.turnID})
+	}
+	return frame, err
+}

--- a/pkg/voice/wire/firstopus.go
+++ b/pkg/voice/wire/firstopus.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
@@ -23,11 +24,14 @@ import (
 // barge-cancelled sentence) never publishes, which is correct: nothing was
 // audible.
 type firstOpusSource struct {
-	inner    gxvoice.Source
-	bus      *voiceevent.Bus
-	turnID   string
-	fired    bool
-	nowFn    func() time.Time
+	inner  gxvoice.Source
+	bus    *voiceevent.Bus
+	turnID string
+	// fired guards the single publish. One disgo-sender goroutine pulls a Source
+	// serially today, so a plain bool would be safe — atomic.Bool future-proofs it
+	// against a pre-buffering pump that ever pulls one Source from two goroutines.
+	fired atomic.Bool
+	nowFn func() time.Time
 }
 
 // newFirstOpusSource wraps inner so the first frame it yields publishes
@@ -47,8 +51,7 @@ func newFirstOpusSource(inner gxvoice.Source, bus *voiceevent.Bus, turnID string
 // to the sender, not when the next poll comes around.
 func (s *firstOpusSource) NextFrame(ctx context.Context) ([]byte, error) {
 	frame, err := s.inner.NextFrame(ctx)
-	if err == nil && !s.fired {
-		s.fired = true
+	if err == nil && s.fired.CompareAndSwap(false, true) {
 		s.bus.Publish(voiceevent.FirstOpus{At: s.nowFn(), TurnID: s.turnID})
 	}
 	return frame, err

--- a/pkg/voice/wire/firstopus_test.go
+++ b/pkg/voice/wire/firstopus_test.go
@@ -1,0 +1,142 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// scriptedSource yields the queued frames in order, then io.EOF (or a queued
+// error). It records how many NextFrame calls it saw.
+type scriptedSource struct {
+	frames [][]byte
+	err    error // returned in place of the first frame when set
+	calls  int
+}
+
+func (s *scriptedSource) NextFrame(context.Context) ([]byte, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.frames) == 0 {
+		return nil, io.EOF
+	}
+	f := s.frames[0]
+	s.frames = s.frames[1:]
+	return f, nil
+}
+
+// collectFirstOpus subscribes a slice to FirstOpus on a fresh bus.
+func collectFirstOpus(bus *voiceevent.Bus) *[]voiceevent.FirstOpus {
+	var got []voiceevent.FirstOpus
+	voiceevent.On(bus, func(e voiceevent.FirstOpus) { got = append(got, e) })
+	return &got
+}
+
+// TestFirstOpusSource_PublishesOnFirstFrameOnly pins the audible-on-wire signal:
+// the wrapped Source publishes exactly one FirstOpus (for the right turn) on the
+// first frame it yields, and never again on later frames.
+func TestFirstOpusSource_PublishesOnFirstFrameOnly(t *testing.T) {
+	bus := voiceevent.NewBus()
+	got := collectFirstOpus(bus)
+	inner := &scriptedSource{frames: [][]byte{{0x01}, {0x02}, {0x03}}}
+
+	src := newFirstOpusSource(inner, bus, "T9")
+
+	for i := 0; i < 3; i++ {
+		if _, err := src.NextFrame(context.Background()); err != nil {
+			t.Fatalf("frame %d: unexpected err %v", i, err)
+		}
+	}
+	if _, err := src.NextFrame(context.Background()); !errors.Is(err, io.EOF) {
+		t.Fatalf("want EOF after the scripted frames, got %v", err)
+	}
+
+	if len(*got) != 1 {
+		t.Fatalf("FirstOpus fired %d times, want exactly 1 (first frame only)", len(*got))
+	}
+	if (*got)[0].TurnID != "T9" {
+		t.Errorf("FirstOpus TurnID = %q, want T9", (*got)[0].TurnID)
+	}
+}
+
+// TestFirstOpusSource_NoFrameNoPublish proves a Source that errors/EOFs before
+// yielding any frame publishes nothing — nothing reached the wire.
+func TestFirstOpusSource_NoFrameNoPublish(t *testing.T) {
+	bus := voiceevent.NewBus()
+	got := collectFirstOpus(bus)
+	inner := &scriptedSource{err: errors.New("cancelled before any frame")}
+
+	src := newFirstOpusSource(inner, bus, "T9")
+	if _, err := src.NextFrame(context.Background()); err == nil {
+		t.Fatal("expected the inner error to propagate")
+	}
+	if len(*got) != 0 {
+		t.Fatalf("FirstOpus fired %d times, want 0 (no frame reached the wire)", len(*got))
+	}
+}
+
+// TestFirstOpusSource_NoWrapWhenNilBusOrNoTurnID proves the decorator is a
+// transparent no-op (returns the inner Source unwrapped) when there is nothing to
+// publish — the keyless/test/non-correlated path pays no overhead.
+func TestFirstOpusSource_NoWrapWhenNilBusOrNoTurnID(t *testing.T) {
+	inner := &scriptedSource{frames: [][]byte{{0x01}}}
+
+	if got := newFirstOpusSource(inner, nil, "T9"); got != inner {
+		t.Error("nil bus must return the inner Source unwrapped")
+	}
+	bus := voiceevent.NewBus()
+	if got := newFirstOpusSource(inner, bus, ""); got != inner {
+		t.Error("empty turn id must return the inner Source unwrapped")
+	}
+}
+
+// pullingPlayer is a sessionPlayer that pulls the first frame from the Source it
+// is handed (modelling disgo's sender), so an end-to-end playSentenceBus test can
+// observe the FirstOpus the wrapped Source publishes.
+type pullingPlayer struct{ src gxvoice.Source }
+
+func (p *pullingPlayer) Play(ctx context.Context, src gxvoice.Source) (playback, error) {
+	p.src = src
+	_, _ = src.NextFrame(ctx) // pull one frame: the audible-on-wire moment
+	done := make(chan struct{})
+	close(done)
+	return &fakePlayback{done: done}, nil
+}
+
+// TestPlaySentenceBus_WrapsWithCtxTurnID is the integration pin: playSentenceBus
+// recovers the turn id from ctx and the first frame pulled to the wire publishes
+// FirstOpus for that turn.
+func TestPlaySentenceBus_WrapsWithCtxTurnID(t *testing.T) {
+	bus := voiceevent.NewBus()
+	got := collectFirstOpus(bus)
+
+	// fakeCodec.PlaybackSource returns a single-frame source so Play's pull yields.
+	codec := framingCodec{frames: [][]byte{{0x01}}}
+	ctx := voiceevent.WithTurnID(context.Background(), "Twire")
+	chunks := make(chan tts.AudioChunk)
+	close(chunks) // no chunks needed; the codec ignores them here
+
+	if err := playSentenceBus(ctx, &pullingPlayer{}, codec, chunks, bus); err != nil {
+		t.Fatalf("playSentenceBus: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].TurnID != "Twire" {
+		t.Fatalf("FirstOpus = %+v, want one for Twire", *got)
+	}
+}
+
+// framingCodec is a fakeCodec whose PlaybackSource yields scripted frames so the
+// pulling player's NextFrame returns a real frame (triggering FirstOpus).
+type framingCodec struct{ frames [][]byte }
+
+func (c framingCodec) DecodeInbound(gxvoice.Frame) ([]audio.Frame, error) { return nil, nil }
+func (c framingCodec) PlaybackSource(<-chan tts.AudioChunk) (gxvoice.Source, error) {
+	return &scriptedSource{frames: c.frames}, nil
+}

--- a/pkg/voice/wire/firstopus_test.go
+++ b/pkg/voice/wire/firstopus_test.go
@@ -132,6 +132,38 @@ func TestPlaySentenceBus_WrapsWithCtxTurnID(t *testing.T) {
 	}
 }
 
+// TestPlaySentenceBus_TwoSentencesPublishPerSource pins the multi-sentence shape:
+// a turn plays several sentences, each its OWN playSentenceBus call over its own
+// Source, so each sentence's first frame publishes its own FirstOpus (the
+// once-guard is per-Source). Two sentences ⇒ two FirstOpus, both for the same
+// turn. The headline-SLO once-per-turn dedup therefore lives in the subscriber
+// (latencyDone — see internal/observe TestStageSubscriberHeadlineExactlyOnce,
+// which feeds multiple FirstOpus and records exactly one sample), which is robust
+// to future pump refactors. This test guards the producer half of that contract.
+func TestPlaySentenceBus_TwoSentencesPublishPerSource(t *testing.T) {
+	bus := voiceevent.NewBus()
+	got := collectFirstOpus(bus)
+	codec := framingCodec{frames: [][]byte{{0x01}}}
+	ctx := voiceevent.WithTurnID(context.Background(), "Tmulti")
+
+	for i := 0; i < 2; i++ {
+		chunks := make(chan tts.AudioChunk)
+		close(chunks)
+		if err := playSentenceBus(ctx, &pullingPlayer{}, codec, chunks, bus); err != nil {
+			t.Fatalf("sentence %d: playSentenceBus: %v", i, err)
+		}
+	}
+
+	if len(*got) != 2 {
+		t.Fatalf("FirstOpus fired %d times, want 2 (one per sentence Source)", len(*got))
+	}
+	for i, e := range *got {
+		if e.TurnID != "Tmulti" {
+			t.Errorf("FirstOpus[%d].TurnID = %q, want Tmulti", i, e.TurnID)
+		}
+	}
+}
+
 // framingCodec is a fakeCodec whose PlaybackSource yields scripted frames so the
 // pulling player's NextFrame returns a real frame (triggering FirstOpus).
 type framingCodec struct{ frames [][]byte }

--- a/pkg/voice/wire/playback.go
+++ b/pkg/voice/wire/playback.go
@@ -7,6 +7,7 @@ import (
 
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 // playback and sessionPlayer are the seam over the concrete [gxvoice.Session]/
@@ -66,8 +67,19 @@ func PlaySentence(ctx context.Context, sess *gxvoice.Session, codec Codec, chunk
 
 // playSentence is the testable core: it depends on the sessionPlayer seam, not a
 // concrete Session, so the block-until-Done discipline can be exercised with a
-// fake player and no live connection.
+// fake player and no live connection. It publishes no FirstOpus (nil bus); the
+// live pump uses [playSentenceBus].
 func playSentence(ctx context.Context, p sessionPlayer, codec Codec, chunks <-chan tts.AudioChunk) error {
+	return playSentenceBus(ctx, p, codec, chunks, nil)
+}
+
+// playSentenceBus is playSentence with an optional bus: when non-nil, the
+// playback Source is wrapped so the first Opus frame pulled to the wire publishes
+// [voiceevent.FirstOpus] for the turn (task #7, the audible-on-wire SLO end). The
+// turn's correlation id is recovered from ctx ([voiceevent.TurnIDFrom]), which
+// the tee installs and threads through HandleSentence → the play job. A nil bus
+// or a ctx with no turn id leaves the Source unwrapped.
+func playSentenceBus(ctx context.Context, p sessionPlayer, codec Codec, chunks <-chan tts.AudioChunk, bus *voiceevent.Bus) error {
 	if chunks == nil {
 		return fmt.Errorf("wire.PlaySentence: chunks must not be nil")
 	}
@@ -81,6 +93,10 @@ func playSentence(ctx context.Context, p sessionPlayer, codec Codec, chunks <-ch
 		go drain(chunks)
 		return fmt.Errorf("wire.PlaySentence: build playback source: %w", err)
 	}
+
+	// Wrap so the first frame on the wire stamps FirstOpus for this turn (no-op
+	// when bus is nil or the ctx carries no turn id).
+	src = newFirstOpusSource(src, bus, voiceevent.TurnIDFrom(ctx))
 
 	pb, err := p.Play(ctx, src)
 	if err != nil {

--- a/pkg/voice/wire/pump.go
+++ b/pkg/voice/wire/pump.go
@@ -9,6 +9,7 @@ import (
 
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 // PlaybackPump is the outbound playback half of the live loop: a [PlaybackSink]
@@ -32,6 +33,7 @@ type PlaybackPump struct {
 	player sessionPlayer
 	codec  Codec
 	logger *slog.Logger
+	bus    *voiceevent.Bus // optional; when set, the playback Source publishes FirstOpus (task #7)
 
 	queue chan playJob
 	stop  chan struct{} // closed by Close to tell the worker to exit
@@ -47,17 +49,19 @@ type playJob struct {
 // NewPlaybackPump builds a pump speaking on sess via codec and starts its worker.
 // Call [PlaybackPump.Close] at teardown to stop the worker. sess and codec must
 // be non-nil. logger receives a warning per failed sentence playback (a mute
-// NPC must be diagnosable, not silent); nil discards them.
-func NewPlaybackPump(sess *gxvoice.Session, codec Codec, logger *slog.Logger) *PlaybackPump {
+// NPC must be diagnosable, not silent); nil discards them. bus is optional: when
+// non-nil, the first Opus frame of each turn publishes [voiceevent.FirstOpus] —
+// the audible-on-wire SLO boundary (task #7); nil disables it.
+func NewPlaybackPump(sess *gxvoice.Session, codec Codec, logger *slog.Logger, bus *voiceevent.Bus) *PlaybackPump {
 	if sess == nil {
 		panic("wire.NewPlaybackPump: session must not be nil")
 	}
-	return newPump(realPlayer{sess}, codec, logger)
+	return newPump(realPlayer{sess}, codec, logger, bus)
 }
 
 // newPump is the testable core over the sessionPlayer seam, so the cross-
 // sentence serialization can be exercised with a fake player and no live Session.
-func newPump(player sessionPlayer, codec Codec, logger *slog.Logger) *PlaybackPump {
+func newPump(player sessionPlayer, codec Codec, logger *slog.Logger, bus *voiceevent.Bus) *PlaybackPump {
 	if codec == nil {
 		panic("wire.NewPlaybackPump: codec must not be nil")
 	}
@@ -68,6 +72,7 @@ func newPump(player sessionPlayer, codec Codec, logger *slog.Logger) *PlaybackPu
 		player: player,
 		codec:  codec,
 		logger: logger,
+		bus:    bus,
 		// Cap 1 is provably sufficient: the orchestrator's TTS.Dispatch does not
 		// return (and so the Replier does not Dispatch the next sentence, which is
 		// what triggers the next HandleSentence) until the tee's forward goroutine
@@ -131,7 +136,7 @@ func (p *PlaybackPump) run() {
 			// but it must not be invisible either: a persistent failure here is
 			// "the NPC went mute", so warn on everything except the expected
 			// barge-in interrupt and ctx cancellation.
-			if err := playSentence(job.ctx, p.player, p.codec, job.chunks); err != nil &&
+			if err := playSentenceBus(job.ctx, p.player, p.codec, job.chunks, p.bus); err != nil &&
 				!errors.Is(err, gxvoice.ErrInterrupted) && !errors.Is(err, context.Canceled) {
 				p.logger.Warn("wire: sentence playback failed", "err", err)
 			}

--- a/pkg/voice/wire/pump_test.go
+++ b/pkg/voice/wire/pump_test.go
@@ -21,7 +21,7 @@ func openChunks() (chan tts.AudioChunk, <-chan tts.AudioChunk) {
 // off sentence one. Order must also hold.
 func TestPlaybackPump_SerializesSentences(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{}, nil)
+	pump := newPump(p, fakeCodec{}, nil, nil)
 	defer pump.Close()
 
 	c1, ro1 := openChunks()
@@ -67,7 +67,7 @@ func TestPlaybackPump_SerializesSentences(t *testing.T) {
 // sentence in flight beyond the playing one — see the cap-1 rationale).
 func TestPlaybackPump_HandleSentenceReturnsPromptly(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{}, nil)
+	pump := newPump(p, fakeCodec{}, nil, nil)
 	defer pump.Close()
 
 	_, ro1 := openChunks()
@@ -96,7 +96,7 @@ func TestPlaybackPump_HandleSentenceReturnsPromptly(t *testing.T) {
 // rather than blocking the (lockstep) producer.
 func TestPlaybackPump_CloseStopsWorker(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{}, nil)
+	pump := newPump(p, fakeCodec{}, nil, nil)
 
 	pump.Close()
 	pump.Close() // idempotent, must not panic or block
@@ -124,7 +124,7 @@ func TestPlaybackPump_CloseStopsWorker(t *testing.T) {
 // spoken into the teardown.
 func TestPlaybackPump_CloseDrainsQueuedJob(t *testing.T) {
 	p := newFakePlayer()
-	pump := newPump(p, fakeCodec{}, nil)
+	pump := newPump(p, fakeCodec{}, nil, nil)
 
 	// Worker busy on s1.
 	_, ro1 := openChunks()

--- a/pkg/voice/wire/tee.go
+++ b/pkg/voice/wire/tee.go
@@ -89,7 +89,10 @@ func NewTeeSynthesizer(inner tts.Synthesizer, sink PlaybackSink, bus *voiceevent
 // If the wrapped Synthesize fails to start, the error is returned directly and
 // no playback channel is opened (the sentence never speaks). The returned
 // channel closes when the wrapped stream ends or ctx is cancelled; the sink
-// channel closes at the same moment.
+// channel closes at the same moment. On a ctx-cancelled early exit the wrapped
+// stream may still be mid-send, so it is drained on a goroutine to release its
+// producer — the tee never wedges an inner Synthesizer goroutine, even one that
+// does not itself select on ctx when sending.
 func (t *TeeSynthesizer) Synthesize(ctx context.Context, req tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
 	src, err := t.inner.Synthesize(ctx, req)
 	if err != nil {
@@ -117,6 +120,7 @@ func (t *TeeSynthesizer) Synthesize(ctx context.Context, req tts.SynthesizeReque
 			select {
 			case out <- chunk:
 			case <-ctx.Done():
+				go drain(src) // src is not yet exhausted; release its producer
 				return
 			}
 			// First chunk crossing to the sink is the headline SLO boundary
@@ -133,6 +137,7 @@ func (t *TeeSynthesizer) Synthesize(ctx context.Context, req tts.SynthesizeReque
 			select {
 			case play <- chunk:
 			case <-ctx.Done():
+				go drain(src) // src is not yet exhausted; release its producer
 				return
 			}
 		}

--- a/pkg/voice/wire/tee_test.go
+++ b/pkg/voice/wire/tee_test.go
@@ -10,7 +10,67 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/wire"
+	"go.uber.org/goleak"
 )
+
+// ctxIgnoringSynth is a [tts.Synthesizer] whose stream goroutine does BARE sends
+// on the chunk channel — it does NOT select on ctx. The [tts.Synthesizer]
+// contract permits this (only the returned channel's close is specified, not the
+// producer's cancellation behaviour), so the tee must not rely on the inner
+// producer noticing ctx itself: it must drain src so a producer parked on a bare
+// send is released. It emits a bounded run of chunks then closes (a real synth
+// EOFs); the goroutine only terminates if every chunk is consumed. started closes
+// once the goroutine is live so a test can be sure there is a producer to leak.
+type ctxIgnoringSynth struct {
+	chunk   tts.AudioChunk
+	count   int
+	started chan struct{}
+}
+
+func (b *ctxIgnoringSynth) Synthesize(_ context.Context, _ tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	ch := make(chan tts.AudioChunk)
+	go func() {
+		defer close(ch)
+		close(b.started)
+		for i := 0; i < b.count; i++ {
+			ch <- b.chunk // bare blocking send: no ctx select, by design
+		}
+	}()
+	return ch, nil
+}
+
+func (b *ctxIgnoringSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestTee_DrainsInnerOnCancel proves the tee never wedges the wrapped
+// Synthesizer's producer goroutine when a turn is cancelled mid-stream (barge-in)
+// and the orchestrator stops draining the returned channel. The inner producer
+// here does bare blocking sends, so if the tee returned without draining src,
+// that goroutine would park forever on a send no one reads — goleak catches it.
+func TestTee_DrainsInnerOnCancel(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	inner := &ctxIgnoringSynth{chunk: chunk(1, 24000), count: 8, started: make(chan struct{})}
+	sink := wire.PlaybackSinkFunc(func(_ context.Context, chunks <-chan tts.AudioChunk) {
+		go drainAll(chunks)
+	})
+	tee := wire.NewTeeSynthesizer(inner, sink, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out, err := tee.Synthesize(ctx, tts.SynthesizeRequest{Sentence: "barge me"})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	<-inner.started // a producer goroutine now exists to potentially leak
+	// Read one chunk so the forward goroutine is past its first iteration, then
+	// cancel and stop reading: the orchestrator-side drain has gone away mid-turn.
+	<-out
+	cancel()
+
+	// Drain whatever is already buffered so the forward goroutine reaches its
+	// ctx-cancelled return; goleak (deferred) then asserts no goroutine survives.
+	go drainAll(out)
+}
 
 // fakeSynth is a minimal [tts.Synthesizer]: it streams a fixed list of chunks
 // (one per Synthesize call), or returns startErr without opening a stream. It


### PR DESCRIPTION
## Why

Live run 2026-06-10: a user waited **20+ seconds** for a voice reply while `glyphoxa_voice_response_latency_seconds` claimed ~2.3s. Root-cause analysis in `docs/latency-investigation/audio-process.md` (included).

The 20s and the 2.3s were different turns: the metric only sampled turns that produced audio, and the turns the user actually waited on were being **cancelled by the system itself** — invisibly.

## Root causes & fixes

1. **`WithBargeIn(0)` self-cancel (the 20s)** — a 0ms barge-in confirm window yielded Bart's floor the instant any inbound `speech_start` fired, including the addressing user's *own continued speech*, aborting the in-flight TTS POST. → confirm window now **250ms** (`bargeConfirmWindow`), pinned by a test that the wired window is non-zero. (`28441fe`)
2. **Per-segment turn supersession** — one utterance VAD-split into two STT segments opened two turns; the second `Floor.Take` cancelled the first mid-synthesis. → **coalesce window** (600ms live): a `Take` within the window of the previous one *yields to* the in-flight turn instead of killing it; zero window = unchanged legacy behavior. The yielded fragment is never spoken but is now visible (below). (`d2d3ac7`, `fb17979`)
3. **Survivorship-biased SLO** — cancelled/failed turns emitted no sample, so the incident was invisible. → new **`glyphoxa_voice_turn_total{outcome,reason}`** lifecycle counter (outcomes `first_audio|yielded|abandoned`; precise reasons `barge|supersede_coalesced|tts_error|provider_error` via a new `TurnEnded` bus event, `no_first_audio` only as TTL-reap fallback) + **one INFO log line per turn** with the timing spine. (`e1e9460`, `35f1bec`)
4. **Headline SLO measured the wrong end** — it stopped at handed-to-pump. → `response_latency` now ends at **`FirstOpus`**: the first opus frame the Discord sender actually pulls (audible-on-wire), per the product definition "I stop talking until the first opus packets are streamed back to Discord". `FirstAudio` keeps `tts_ttfb` pairing and the lifecycle success signal. (`1d36234`, `4a1fac2`)
5. **Baseline: unconditional `dice` tool grant** forced an empty Gemini tool round before prose on *every* turn. → grant is **gated on per-turn dice intent** (recall-biased matcher; false positive = the round we always paid, false negative would break the tool path — covered both ways). Plain turns are structurally single-round. (`82a9700`)

Also riding along:
- `f744942` — drop tag-only (`[laughs]`) sentences before TTS dispatch (they 400'd at ElevenLabs and killed replies).
- `6796549` — per-turn `TurnTimeout` deadline on the streaming reply path.
- `80fbc41` — `TeeSynthesizer` drains the inner synth stream on cancel (contract-level goroutine-leak fix, `goleak`-tested).
- `debebe0`, `1b5cce0` — zero-value `Floor{}` nil-clock guard; gofmt + `atomic.Bool` once-guard on `firstOpusSource`.

## Review & verification

Two-agent build: implementation (audio-process) cross-reviewed by an independent concurrency-focused pass (code-quality) — both review rounds **APPROVE**; findings (lock-held logging, zero-value Floor, fmt drift) fixed in-branch.

- `go test -race ./...` — 22 packages green
- `go vet ./...`, `gofmt -l .` — clean
- tagged build (`opus dave nolibopusfile`) compiles
- Known residual (documented in the doc): an over-split utterance answers the first fragment; the `yielded` metric/log now produces exactly the data needed to justify real segment coalescing later.

Next step after merge: paid live validation run with the new instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)