### PR TITLE
chore(ci): make bench-live manual-only

### DIFF
--- a/.github/workflows/bench-live.yml
+++ b/.github/workflows/bench-live.yml
@@ -7,8 +7,6 @@ name: bench-live
 # regression" signal; it NEVER gates a PR (the every-PR cassette gate in ci.yml
 # is the relative-regression tripwire). The cadence mirrors record-live.yml.
 on:
-  schedule:
-    - cron: "30 6 * * *" # 06:30 UTC daily (after the weekly record-live at 06:00).
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary
- Removes the daily `schedule` cron trigger from `bench-live.yml`
- The live latency benchmark now only runs on `workflow_dispatch` (manual trigger)
- `workflow_dispatch` inputs are unchanged — ref can still be overridden

## Test plan
- [ ] Confirm CI (regular `ci.yml`) passes on this PR
- [ ] Verify no schedule trigger appears in Actions after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)