### PR TITLE
fix(voice): make TTS start-errors observable (#20)

### DIFF
--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -68,11 +68,11 @@ type turnState struct {
 	// blocks on TTS.Dispatch, which drains the synthesis before the next sentence
 	// — orchestrator tts.go), so the order is strictly TTSInvoked_i ≺ FirstAudio_i
 	// ≺ TTSInvoked_{i+1}. A TTSInvoked left unmatched when the next one arrives was
-	// a zero-chunk synthesis (TTSInvoked is published unconditionally, FirstAudio
-	// only on a chunk) that will never get a FirstAudio — so the correct match for
-	// any FirstAudio is always the latest invoke, and FIFO-front would mispair it
-	// against the stale zero-chunk one. (Revisit if Ensemble Turns make dispatch
-	// concurrent — tts.go:69 anticipates that.)
+	// a zero-chunk or start-errored synthesis (TTSInvoked is published per dispatch
+	// attempt, FirstAudio only on a chunk) that will never get a FirstAudio — so the
+	// correct match for any FirstAudio is always the latest invoke, and FIFO-front
+	// would mispair it against the stale unmatched one. (Revisit if Ensemble Turns
+	// make dispatch concurrent — tts.go anticipates that.)
 	pendingTTS time.Time
 
 	lastSeen time.Time

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -302,9 +302,15 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		ctx := voiceevent.WithTurnID(ctx, e.TurnID)
 
 		// Default (no floor): dispatch synchronously on the bus goroutine — the
-		// behaviour every non-barge-in caller relies on.
+		// behaviour every non-barge-in caller relies on. Announce a turn that died of
+		// its own error (a real TTS/provider failure) before producing audio so the
+		// metrics subscriber records the precise reason, not the coarse no-first-audio
+		// TTL reap (#20) — mirroring the floor branch below. The sync path has no
+		// barge/supersede, so a non-cancelled ctx is the only guard needed.
 		if r.floor == nil {
-			r.dispatchAll(ctx, e)
+			if reason := r.dispatchAll(ctx, e); reason != "" && ctx.Err() == nil {
+				bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: reason})
+			}
 			return
 		}
 		// Barge-in: take the floor and run the turn on its own goroutine so the

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -337,6 +337,34 @@ func TestReplier_FloorTurnPublishesTTSErrorEnded(t *testing.T) {
 	}
 }
 
+// TestReplier_SyncTurnPublishesTTSErrorEnded pins #20's sync-path gap: a no-floor
+// replier (the voicebench rig's config — WithReplyStream, no barge-in) whose only
+// sentence start-errors must publish TurnEnded(tts_error) carrying the TurnID, so
+// the metrics subscriber records abandoned/tts_error instead of the coarse
+// no-first-audio TTL reap. The floor path already does this
+// (TestReplier_FloorTurnPublishesTTSErrorEnded); the sync path discarded the
+// reason, so a start-error there was completely silent.
+func TestReplier_SyncTurnPublishesTTSErrorEnded(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"boom": true}})
+	reply := func(_ context.Context, _ voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		return dispatch(orchestrator.Reply{Sentence: "boom"})
+	}
+	// No SetFloor: the synchronous (no-barge-in) dispatch path runs on the bus
+	// goroutine, so the TurnEnded is published before Publish returns.
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "tsync"})
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool {
+			return e.TurnID == "tsync" && e.Reason == voiceevent.TurnEndTTSError
+		},
+		"turn.ended (tts_error) for a sync-path failed-synthesis turn",
+	)
+}
+
 // TestReplier_FloorTurnPublishesProviderErrorEnded pins task #4's provider_error
 // path: a producer (LLM/tool loop) that errors before any audio publishes
 // TurnEnded(provider_error).
@@ -426,8 +454,14 @@ func TestReplier_DispatchErrorReportedAndDoesNotStopRemaining(t *testing.T) {
 	if len(errs) != 1 {
 		t.Fatalf("ErrorFunc saw %d errors, want 1", len(errs))
 	}
-	// The first reply failed (no event); the second still dispatched.
-	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	// Both sentences are announced: TTSInvoked is the dispatch attempt (#20), so
+	// the start-errored sentence is visible as invoked-but-never-spoke AND the
+	// reply after it still dispatched.
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 2)
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TTSInvoked) bool { return e.Sentence == "boom" },
+		"tts.invoked for the start-errored sentence (invoked-but-never-spoke)",
+	)
 	voicetest.AssertEvent(t, h,
 		func(e voiceevent.TTSInvoked) bool { return e.Sentence == "ok" },
 		"tts.invoked for the reply after the failed one",
@@ -446,7 +480,9 @@ func TestReplier_NilErrorFuncDropsErrorWithoutPanic(t *testing.T) {
 
 	h.Bus.Publish(voiceevent.AddressRouted{}) // must not panic on the dropped error
 
-	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	// Both sentences are announced (TTSInvoked = dispatch attempt, #20); the
+	// failed one's error is dropped silently and the next reply still dispatched.
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 2)
 }
 
 // TestSegmenter_ConcurrentFeedAndFlush is a -race probe: an audio loop feeding

--- a/pkg/voice/orchestrator/tts.go
+++ b/pkg/voice/orchestrator/tts.go
@@ -41,11 +41,18 @@ func NewTTS(bus *voiceevent.Bus, synthesizer tts.Synthesizer) *TTS {
 // [voiceevent.TTSInvoked] event identifying the sentence and its 0-based
 // position in the turn.
 //
+// TTSInvoked is published BEFORE the [tts.Synthesizer.Synthesize] call — it
+// announces the dispatch attempt, not a success. A sentence whose Synthesize
+// start-errors (empty VoiceID, auth failure, bad request) therefore still emits
+// TTSInvoked, so the failed sentence is visible as invoked-but-never-spoke rather
+// than vanishing with no per-sentence signal (#20); the start error is then
+// wrapped and returned. (A FirstAudio for the sentence is what marks it actually
+// spoken — see [voiceevent.FirstAudio].)
+//
 // Per ADR-0022 callers must drain the returned audio channel to release the
 // implementation's goroutines; this stage drains and discards the chunks
 // itself (per ADR-0021's TTS cassette policy the audio is not observable to
-// tests). Errors from the synthesizer are wrapped and returned without
-// publishing, and do not advance the per-turn index.
+// tests).
 //
 // Forward-looking shape — when the playback pipeline lands, the drain loop
 // becomes a forward into the resampler/aligner that feeds the Opus encoder
@@ -59,17 +66,11 @@ func NewTTS(bus *voiceevent.Bus, synthesizer tts.Synthesizer) *TTS {
 // bullet) will scope a fresh TTS per Agent reply rather than reset this one
 // in place.
 func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) error {
-	ch, err := s.synthesizer.Synthesize(ctx, tts.SynthesizeRequest{
-		Sentence: sentence,
-		Voice:    voice,
-	})
-	if err != nil {
-		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
-	}
 	// Assign the per-turn index under the lock so concurrent dispatches (an
 	// Ensemble Turn or a barge-in canceller, both anticipated below) get
-	// distinct, monotonically increasing indices. Only a successful synthesis
-	// consumes an index — the error path above returns before this.
+	// distinct, monotonically increasing indices. The index counts dispatch
+	// attempts within the turn, assigned before Synthesize so a start-errored
+	// sentence still consumes its slot and stays visible.
 	s.mu.Lock()
 	index := s.nextIndex
 	s.nextIndex++
@@ -81,6 +82,14 @@ func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) er
 		Index:    index,
 		TurnID:   voiceevent.TurnIDFrom(ctx),
 	})
+
+	ch, err := s.synthesizer.Synthesize(ctx, tts.SynthesizeRequest{
+		Sentence: sentence,
+		Voice:    voice,
+	})
+	if err != nil {
+		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
+	}
 	for range ch {
 	}
 	return nil

--- a/pkg/voice/orchestrator/tts_test.go
+++ b/pkg/voice/orchestrator/tts_test.go
@@ -2,6 +2,7 @@ package orchestrator_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -25,6 +26,36 @@ func (closedChanSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-cha
 }
 
 func (closedChanSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// startErrSynth is a [tts.Synthesizer] whose Synthesize always start-errors (nil
+// channel, non-nil error), standing in for an empty VoiceID / auth failure / bad
+// request — the start-error the #20 visibility fix is about.
+type startErrSynth struct{}
+
+func (startErrSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	return nil, errors.New("synth start error")
+}
+
+func (startErrSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestTTS_DispatchPublishesInvokedOnStartError pins #20's per-sentence visibility:
+// a sentence whose Synthesize start-errors must still publish TTSInvoked — the
+// invoked-but-never-spoke signal — and return the error, rather than vanishing
+// before any event. The event announces the dispatch ATTEMPT, not a success.
+func TestTTS_DispatchPublishesInvokedOnStartError(t *testing.T) {
+	h := voicetest.New(t)
+	stage := orchestrator.NewTTS(h.Bus, startErrSynth{})
+
+	const sentence = "this will fail to synthesize"
+	if err := stage.Dispatch(context.Background(), sentence, voicetest.LiveElevenLabsVoice()); err == nil {
+		t.Fatal("Dispatch: expected the synth start error to propagate")
+	}
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TTSInvoked) bool { return e.Sentence == sentence && e.Index == 0 },
+		"tts.invoked published for a start-errored sentence",
+	)
+}
 
 // TestTTS_HelloTest_DispatchesSentence is TB6: the first TTS tracer bullet,
 // per ADR-0021's TTS cassette policy.

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -106,13 +106,16 @@ func (AddressRouted) EventName() string { return "address.routed" }
 // TTSInvoked marks the dispatch of one sentence to the TTS stage.
 //
 // Per ADR-0021's TTS cassette policy the observable contract for TTS is "the
-// provider was invoked with sentence N" — synthesized audio is not fed back
-// to tests. The orchestrator publishes this event once the underlying
-// [tts.Synthesizer] has accepted the sentence (Synthesize returned without
-// error); whether audio chunks subsequently arrived is not observable here.
+// provider was invoked with sentence N" — synthesized audio is not fed back to
+// tests. The orchestrator publishes this event when it hands the sentence to the
+// underlying [tts.Synthesizer], BEFORE the Synthesize call returns — so a sentence
+// whose Synthesize start-errors (empty VoiceID, auth failure) still emits
+// TTSInvoked, the invoked-but-never-spoke signal (#20). It announces the dispatch
+// attempt, not a success: whether the sentence was actually spoken is signalled by
+// [FirstAudio], not here.
 //
-// Index is 0-based within the current turn and increments per successful
-// dispatch on the same stage.
+// Index is 0-based within the current turn and increments per dispatch attempt on
+// the same stage.
 type TTSInvoked struct {
 	At       time.Time
 	Sentence string


### PR DESCRIPTION
## What

Closes #20.

A `tts.Synthesizer.Synthesize` **start-error** (immediate non-nil error — empty `VoiceID`, auth failure, bad request) died invisibly:

- `TTS.Dispatch` returned **before** publishing `TTSInvoked`, so no per-sentence signal existed in **any** path.
- The **sync** replier path (`r.floor == nil`, the `voicebench` rig's config — the exact path from the incident in the issue) **discarded** `dispatchAll`'s `reason`, so the turn was completely silent and only surfaced via the TTL reap as `turn_total{abandoned, no_first_audio}` with no cause.

The floor/streaming **production** path already mapped `tts_error` after `6b917ca` (post-dates the issue), but still emitted no `TTSInvoked` for the failed sentence.

## Changes

- **`orchestrator/tts.go`** — `Dispatch` publishes `TTSInvoked` **before** `Synthesize`. It now announces the *dispatch attempt*, so a start-errored sentence is visible as **invoked-but-never-spoke**; the per-turn `Index` counts dispatch attempts. The start error is still wrapped and returned. `FirstAudio` remains the "actually spoken" signal.
- **`orchestrator/reactor.go`** — the sync replier branch now publishes `TurnEnded{reason}` (mirroring the floor branch), so a start-error in the no-floor/bench path yields `turn_total{abandoned, tts_error}` instead of the coarse `no_first_audio`.
- **`voiceevent/event.go`**, **`observe/subscriber.go`** — doc comments updated to the dispatch-attempt `TTSInvoked` contract (the subscriber's `tts_ttfb` pairing already tolerated an unmatched invoke, now noted explicitly).

## Tests (TDD)

- `TestTTS_DispatchPublishesInvokedOnStartError` — a start-erroring synth still emits `TTSInvoked` and returns the error.
- `TestReplier_SyncTurnPublishesTTSErrorEnded` — the no-floor replier publishes `TurnEnded{tts_error}` carrying the `TurnID`.
- Existing `TestReplier_FloorTurnPublishesTTSErrorEnded` stays green; the two dispatch-error tests are updated to the dispatch-attempt contract (the failed sentence now also emits `TTSInvoked`).
- Subscriber mapping `tts_error → abandoned/tts_error` is already covered by `TestStageSubscriberTurnEndedReasons`.

Full suite + `-race` + `golangci-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)