### PR TITLE
fix(voice): bound STT/TTS vendor calls so a hang can't silence the NPC; make bench-live measure real latency

### DIFF
--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -405,7 +405,8 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 	}
 	vadStage := orchestrator.NewVAD(bus, vadSession)
 
-	sttStage := orchestrator.NewSTT(bus, stteleven.New(""))
+	sttStage := orchestrator.NewSTT(bus, stteleven.New(""),
+		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
 
 	detector := orchestrator.NewAddressDetector(npcMatcher(npc))

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -20,17 +21,79 @@ import (
 type STT struct {
 	bus        *voiceevent.Bus
 	recognizer stt.Recognizer
+
+	// rec/provider carry the A3 instrumentation: one stt_request span per
+	// [stt.Recognizer.Transcribe] (the provider POST round-trip), the SAME seam
+	// the agenttool adapter records llm_round on. Both default to no-ops
+	// (observe.Discard, empty provider label) so the keyless path and any caller
+	// that did not opt in stay silent. This is the STT half of the response_latency
+	// span — speechEnd→STTFinal — and the live bench's latency localisation showed
+	// it is the dominant fixed cost (~0.7s) inside the headline, so making it a
+	// real series lets prod alert on a scribe slowdown, not just the nightly.
+	rec      observe.StageRecorder
+	provider observe.Provider
+
+	// timeout bounds ONE [stt.Recognizer.Transcribe] call. It is the STT analogue
+	// of the Replier's per-turn LLM deadline (agent.DefaultTurnTimeout): the single
+	// serial transcription worker (orchestrator.Segmenter) runs Transcribe under the
+	// CONVERSATION-lifetime context, which has no per-request deadline — so a hung
+	// recognizer POST (e.g. a black-holed ElevenLabs scribe call) would block the
+	// worker forever, and every later utterance would queue behind it and never be
+	// transcribed: the NPC goes permanently silent (observed live). Bounding each
+	// call means a hung provider degrades ONE turn and the worker recovers, instead
+	// of wedging the whole pipeline. A barge/supersede cancels only the per-TURN
+	// context, never this one, so without this bound nothing interrupts the POST.
+	// Zero disables the bound (defaults to [defaultSTTRequestTimeout]).
+	timeout time.Duration
+}
+
+// defaultSTTRequestTimeout bounds one recognizer call when [WithSTTTimeout] is
+// not set. Generous against a real call (scribe transcribes a VAD-segmented
+// utterance in ~1–2s) yet tight enough that a hung provider recovers in seconds
+// rather than wedging the serial worker until session shutdown.
+const defaultSTTRequestTimeout = 15 * time.Second
+
+// STTOption configures an [STT] at construction: [WithSTTMetrics] opts the
+// stt_request instrumentation in, [WithSTTTimeout] overrides the per-request
+// deadline.
+type STTOption func(*STT)
+
+// WithSTTTimeout overrides the per-[stt.Recognizer.Transcribe] deadline (see
+// [STT.timeout]). A non-positive value disables the bound; the default is
+// [defaultSTTRequestTimeout]. Tests use a short value to exercise the hung-
+// recognizer recovery without waiting the full default.
+func WithSTTTimeout(d time.Duration) STTOption {
+	return func(s *STT) { s.timeout = d }
+}
+
+// WithSTTMetrics injects the stt_request instrumentation: rec receives one
+// [observe.StageRecorder.STTRequest] span per [stt.Recognizer.Transcribe],
+// labelled with provider (the bounded provider enum for the wired recognizer). A
+// nil rec leaves the no-op default in place.
+func WithSTTMetrics(rec observe.StageRecorder, provider observe.Provider) STTOption {
+	return func(s *STT) {
+		if rec != nil {
+			s.rec = rec
+		}
+		s.provider = provider
+	}
 }
 
 // NewSTT wires recognizer into bus. Both must be non-nil; passing nil panics.
-func NewSTT(bus *voiceevent.Bus, recognizer stt.Recognizer) *STT {
+// Pass [WithSTTMetrics] to record the stt_request POST round-trip; without it
+// the stage records nothing (the keyless default).
+func NewSTT(bus *voiceevent.Bus, recognizer stt.Recognizer, opts ...STTOption) *STT {
 	if bus == nil {
 		panic("orchestrator.NewSTT: bus must not be nil")
 	}
 	if recognizer == nil {
 		panic("orchestrator.NewSTT: recognizer must not be nil")
 	}
-	return &STT{bus: bus, recognizer: recognizer}
+	s := &STT{bus: bus, recognizer: recognizer, rec: observe.Discard{}, timeout: defaultSTTRequestTimeout}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 // Transcribe forwards frames to the recognizer and, on success, publishes
@@ -42,7 +105,23 @@ func NewSTT(bus *voiceevent.Bus, recognizer stt.Recognizer) *STT {
 // signal; the orchestrator's job is to faithfully relay whatever the
 // recognizer authoritatively returns.
 func (s *STT) Transcribe(ctx context.Context, frames []audio.Frame) error {
+	// Bound the recognizer call so a hung provider cannot wedge the serial
+	// transcription worker forever (see [STT.timeout]). context.WithTimeout honours
+	// any earlier parent deadline, so this only ever tightens the bound. The
+	// recognizer's request ctx is cancelled when the deadline fires, aborting the
+	// in-flight POST and freeing the worker for the next utterance.
+	if s.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
 	t, err := s.recognizer.Transcribe(ctx, frames)
+	// Record the POST round-trip whether it succeeded or failed — both consumed
+	// real wall-clock inside the response_latency span, and a failed/slow scribe
+	// call is exactly what this series exists to surface.
+	s.rec.STTRequest(s.provider, time.Since(start))
 	if err != nil {
 		return fmt.Errorf("orchestrator.STT.Transcribe: %w", err)
 	}

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -2,6 +2,7 @@ package orchestrator_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -27,6 +28,50 @@ type stubRecognizer struct {
 
 func (s stubRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcript, error) {
 	return s.transcript, nil
+}
+
+// hangingRecognizer is a [stt.Recognizer] that never returns on its own — it
+// blocks until its context is cancelled, then returns ctx.Err(). It stands in for
+// a black-holed provider POST (the live wedge: a hung ElevenLabs scribe call that
+// the conversation-lifetime context never cancels).
+type hangingRecognizer struct{}
+
+func (hangingRecognizer) Transcribe(ctx context.Context, _ []audio.Frame) (stt.Transcript, error) {
+	<-ctx.Done()
+	return stt.Transcript{}, ctx.Err()
+}
+
+// TestSTT_Transcribe_BoundsHungRecognizer pins the wedge fix: a recognizer call
+// that would otherwise block forever is bounded by the stage's per-request
+// timeout ([orchestrator.WithSTTTimeout]). Without the bound, the single serial
+// transcription worker stalls on the hung POST and every later utterance starves
+// — the NPC goes permanently silent (observed live). With it, the call returns a
+// deadline error promptly so the worker recovers, and no STTFinal is published
+// for the failed turn.
+func TestSTT_Transcribe_BoundsHungRecognizer(t *testing.T) {
+	h := voicetest.New(t)
+
+	var finals int
+	voiceevent.On(h.Bus, func(voiceevent.STTFinal) { finals++ }) // sync bus: runs on Publish's goroutine
+
+	stage := orchestrator.NewSTT(h.Bus, hangingRecognizer{}, orchestrator.WithSTTTimeout(50*time.Millisecond))
+
+	start := time.Now()
+	err := stage.Transcribe(context.Background(), []audio.Frame{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Transcribe returned nil on a hung recognizer; want a deadline error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v; want context.DeadlineExceeded (the per-request timeout firing)", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Transcribe blocked %v on a 50ms timeout; the per-request bound did not fire", elapsed)
+	}
+	if finals != 0 {
+		t.Fatalf("published %d STTFinal for a timed-out transcription; want 0 (no transcript to relay)", finals)
+	}
 }
 
 // TestSTT_HelloTest_EmitsFinal is TB5: the first cassette-backed tracer

--- a/pkg/voice/stt/elevenlabs/elevenlabs.go
+++ b/pkg/voice/stt/elevenlabs/elevenlabs.go
@@ -14,8 +14,10 @@
 package elevenlabs
 
 import (
+	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -48,9 +50,38 @@ type Option func(*Client)
 // and self-hosted ElevenLabs deployments.
 func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
 
-// WithHTTPClient supplies a custom http.Client. The default has no overall
-// timeout; per-call deadlines must come from the request context.
+// WithHTTPClient supplies a custom http.Client. The default ([defaultHTTPClient])
+// bounds the connection-establishment and response-header phases but sets no
+// overall Timeout; the per-call end-to-end bound is the request context's
+// deadline (the orchestrator STT stage's per-request timeout).
 func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connection-establishment and response-header
+// phases so a black-holed scribe endpoint fails in seconds instead of hanging
+// the single serial transcription worker (and, behind it, the whole voice loop)
+// until session shutdown. No overall Timeout: a Scribe POST uploads the utterance
+// audio first, and an http.Client.Timeout would cap that upload as well as the
+// transcription — the end-to-end bound is the caller's ctx deadline (the
+// orchestrator STT stage's per-request timeout, default 15s).
+//
+// Scribe's response is a single JSON blob (non-streaming), so ResponseHeaderTimeout
+// bounds the WHOLE transcription once the body is sent — the exact "connected but
+// never answers" hang the live wedge hit. We expect a response well under 2s
+// (stt_request p95 ~1.4s), so 10s gives generous headroom for a long utterance on
+// a slow day while still failing a hang in 10s. Dial/TLS are voice-tight (5s) —
+// a healthy connect is sub-second; these only delay failure on a cold connect to
+// a dead endpoint.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
 
 // New constructs a [Client]. If apiKey is empty it falls back to the
 // ELEVENLABS_API_KEY environment variable; if that is also empty, the
@@ -63,7 +94,7 @@ func New(apiKey string, opts ...Option) *Client {
 	c := &Client{
 		apiKey:  apiKey,
 		baseURL: DefaultBaseURL,
-		http:    &http.Client{},
+		http:    defaultHTTPClient(),
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/voice/stt/elevenlabs/transcribe.go
+++ b/pkg/voice/stt/elevenlabs/transcribe.go
@@ -49,6 +49,22 @@ func (c *Client) Transcribe(ctx context.Context, frames []audio.Frame) (stt.Tran
 	if err := mw.WriteField("file_format", FileFormatPCMS16LE16); err != nil {
 		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write file_format: %w", err)
 	}
+	// Turn off the server-side work we never consume — we read only Transcript.Text,
+	// so both of these shrink the scribe POST's latency (the dominant fixed cost
+	// inside response_latency) without changing the text we act on. diarize defaults
+	// off and language stays auto-detected, since the user may speak EN or DE.
+	//
+	// timestamps_granularity=none skips word/character forced-alignment, a
+	// non-trivial server cost the orchestrator has no use for (it carries no
+	// per-word timing).
+	if err := mw.WriteField("timestamps_granularity", "none"); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write timestamps_granularity: %w", err)
+	}
+	// tag_audio_events=false skips non-speech event detection ([laughter], etc.),
+	// keeping the transcript to the spoken words the LLM and address matcher want.
+	if err := mw.WriteField("tag_audio_events", "false"); err != nil {
+		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: write tag_audio_events: %w", err)
+	}
 	filePart, err := mw.CreateFormFile("file", "utterance.pcm")
 	if err != nil {
 		return stt.Transcript{}, fmt.Errorf("elevenlabs.Transcribe: create file part: %w", err)

--- a/pkg/voice/tts/elevenlabs/elevenlabs.go
+++ b/pkg/voice/tts/elevenlabs/elevenlabs.go
@@ -13,8 +13,10 @@
 package elevenlabs
 
 import (
+	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -46,10 +48,34 @@ type Option func(*Client)
 // and self-hosted ElevenLabs deployments.
 func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
 
-// WithHTTPClient supplies a custom http.Client. The default has no overall
-// timeout because streaming syntheses are long-lived; per-call deadlines must
-// come from the request context.
+// WithHTTPClient supplies a custom http.Client. The default ([defaultHTTPClient])
+// bounds the connection-establishment and time-to-first-audio-byte phases but
+// sets no overall Timeout (a synthesis streams for the length of the reply); the
+// per-call end-to-end bound is the request context's deadline (the per-turn floor
+// context, cancelled on barge-in).
 func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connection-establishment and response-header
+// phases so a black-holed synthesis endpoint fails fast instead of holding the
+// reply goroutine open. It mirrors the STT adapter and the LLM clients, but with
+// voice-tight values: a synthesis must start emitting audio in well under a
+// second (first-audio TTFB is ~0.25–0.45s in practice), so ResponseHeaderTimeout
+// is 5s — ~10× the observed max, enough headroom to never trip on a real reply
+// yet failing a hung connection in 5s rather than tens of seconds. It bounds
+// time-to-first-RESPONSE-byte only, NOT the streamed audio that follows, so a
+// long multi-sentence reply is never clipped. No overall Timeout, for the same
+// reason. The barge/per-turn ctx is still the end-to-end cancel.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
 
 // New constructs a [Client]. If apiKey is empty it falls back to the
 // ELEVENLABS_API_KEY environment variable; if that is also empty, the
@@ -63,7 +89,7 @@ func New(apiKey string, opts ...Option) *Client {
 	c := &Client{
 		apiKey:  apiKey,
 		baseURL: DefaultBaseURL,
-		http:    &http.Client{},
+		http:    defaultHTTPClient(),
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/voice/voicebench/bench_live_test.go
+++ b/pkg/voice/voicebench/bench_live_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	stteleven "github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
@@ -102,9 +103,12 @@ func runClipLive(t *testing.T, clip Clip, acc *Accumulator) {
 	tap := newRecorderTap()
 	target := voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"}
 	conv := BuildConversation(RigConfig{
-		Bus:      h.Bus,
-		VAD:      vadStage,
-		STT:      orchestrator.NewSTT(h.Bus, stteleven.New("")),
+		Bus: h.Bus,
+		VAD: vadStage,
+		// Record stt_request through the SAME prod seam wirenpc uses (the STT stage's
+		// injected recorder), so the live report decomposes response_latency into its
+		// STT half — the dominant fixed cost — via the real emit path, not a bench wrapper.
+		STT:      orchestrator.NewSTT(h.Bus, stteleven.New(""), orchestrator.WithSTTMetrics(tap, observe.ProviderElevenLabs)),
 		Persona:  benchPersona(),
 		Provider: groq.New(""),
 		Synth:    ttseleven.New(""),
@@ -114,6 +118,7 @@ func runClipLive(t *testing.T, clip Clip, acc *Accumulator) {
 
 	silence := silenceLike(t, frames)
 	d := NewDriver(conv, h, tap, acc, silence, 20)
+	d.realtime = true // live tier: feed at wall-clock so per-turn latency isn't a fast-feed serialization artifact
 	if err := d.RunClip(context.Background(), frames); err != nil {
 		t.Fatalf("clip %q: %v", clip.Dir, err)
 	}

--- a/pkg/voice/voicebench/driver.go
+++ b/pkg/voice/voicebench/driver.go
@@ -31,6 +31,22 @@ type Driver struct {
 	// §5). silenceFrames is how many to append (must exceed minSilenceFrames).
 	silence       audio.Frame
 	silenceFrames int
+
+	// realtime paces Feed at each frame's wall-clock duration instead of feeding
+	// the whole clip as fast as the CPU allows. It is the live-tier fidelity fix:
+	// the corpus clips are continuous monologues the VAD splits into several
+	// utterances, and fast-feeding stamps every VADSpeechEnd within the same few
+	// milliseconds (clip-start). Because the reply runs synchronously on the single
+	// transcription worker (the bench wires no floor), utterance N's turn then
+	// waits behind every prior turn — so its response_latency (firstOpus −
+	// speechEndAt) accrues all of their wall-clock, a pure fast-feed artifact that
+	// inflated the live p95 to ~10s while the REAL per-turn latency (~STT + first
+	// sentence + tts ≈ 1.2s) is well inside budget. Pacing at real time spaces the
+	// utterances by their true durations, so the worker drains each turn before the
+	// next utterance's speech-end fires — measuring the user-facing per-turn latency
+	// rather than a serialization queue. The cassette tier leaves it false (its
+	// canned replay has no real per-turn cost to serialize).
+	realtime bool
 }
 
 // NewDriver builds a Driver. tap may be nil on a tier that takes no recorder
@@ -52,7 +68,13 @@ func NewDriver(conv *orchestrator.Conversation, h *voicetest.Harness, tap *recor
 // never produces audio at all (a wedged provider/tee), where a hard error — a
 // clip that yields no headline metric is exactly the silent-drop the bench
 // exists to catch — beats hanging the run forever.
-const headlineTimeout = 5 * time.Second
+//
+// It must comfortably outlast the SLOWEST legitimate turn: a rambling live reply
+// can take ~9 s of LLM generation + serial TTS drain, and the dice clip runs two
+// LLM rounds before first audio. At 5 s the guard fired on a valid-but-slow turn
+// and aborted the WHOLE run (losing every sample) — the opposite of a hang guard.
+// 30 s only trips on a genuinely wedged provider/tee, never on a slow-but-live one.
+const headlineTimeout = 30 * time.Second
 
 // RunClip feeds one clip's frames through the conversation, appends trailing
 // silence to provoke a natural speech-end, flushes any utterance still buffered,
@@ -76,12 +98,30 @@ func (d *Driver) RunClip(ctx context.Context, frames []audio.Frame) error {
 	cancel := d.conv.Register(ctx)
 	defer cancel()
 
+	// pace returns how long to sleep before feeding the i-th frame of the run so
+	// the whole sequence is fed at wall-clock speed (zero on the fast cassette
+	// path). It schedules against a fixed start so per-frame sleep jitter does not
+	// accumulate into drift.
+	start := time.Now()
+	var elapsed time.Duration
+	pace := func(f audio.Frame) {
+		if !d.realtime {
+			return
+		}
+		elapsed += frameDuration(f)
+		if wait := elapsed - time.Since(start); wait > 0 {
+			time.Sleep(wait)
+		}
+	}
+
 	for _, f := range frames {
+		pace(f)
 		if err := d.conv.Feed(f); err != nil {
 			return err
 		}
 	}
 	for i := 0; i < d.silenceFrames; i++ {
+		pace(d.silence)
 		if err := d.conv.Feed(d.silence); err != nil {
 			return err
 		}
@@ -126,6 +166,17 @@ func (d *Driver) waitHeadlines(ctx context.Context) (int, error) {
 		case <-time.After(5 * time.Millisecond):
 		}
 	}
+}
+
+// frameDuration is a frame's wall-clock duration (samples ÷ sample-rate). A
+// zero-sample or zero-rate frame is zero, so an unsized frame never blocks the
+// paced feed. Used by [Driver.RunClip] to feed the live tier at real time.
+func frameDuration(f audio.Frame) time.Duration {
+	n, rate := len(f.Samples()), f.SampleRate()
+	if n == 0 || rate <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Second / time.Duration(rate)
 }
 
 // eligibleTurns counts the turns in an event log that the subscriber records a

--- a/pkg/voice/voicebench/recorder_tap.go
+++ b/pkg/voice/voicebench/recorder_tap.go
@@ -81,10 +81,11 @@ func (t *recorderTap) drain() map[Stage][]time.Duration {
 // the captured numbers are definitionally the Prometheus series (bench == series)
 // with no re-derivation and no double-count.
 //
-// vad_hangover / stt_request / tts_total / codec_* / llm_turn are interface-
-// present but UNWIRED (no caller anywhere yet — carry-over #11); they would land
-// here if/when their emit site records onto the injected recorder, but the bench
-// must not assert non-zero on them until then.
+// stt_request is now wired (the STT stage records it via WithSTTMetrics — see
+// below). vad_hangover / tts_total / codec_* / llm_turn remain interface-present
+// but UNWIRED (no caller anywhere yet — carry-over #11); they would land here
+// if/when their emit site records onto the injected recorder, but the bench must
+// not assert non-zero on them until then.
 func (t *recorderTap) LLMRound(_ observe.Provider, _ int, _ bool, d time.Duration) {
 	t.add(StageLLMRound, d)
 }
@@ -112,12 +113,18 @@ func (t *recorderTap) TTSTimeToFirstByte(_ observe.Provider, d time.Duration) {
 
 // Unwired (carry-over #11): no caller records these yet. No-ops so the tap
 // satisfies the interface; the bench must not assert non-zero on them.
-func (t *recorderTap) VADHangover(time.Duration)                  {}
-func (t *recorderTap) CodecDecode(time.Duration)                  {}
-func (t *recorderTap) CodecEncode(time.Duration)                  {}
-func (t *recorderTap) STTRequest(observe.Provider, time.Duration) {}
-func (t *recorderTap) TTSTotal(observe.Provider, time.Duration)   {}
-func (t *recorderTap) LLMTurn(observe.Provider, time.Duration)    {}
+func (t *recorderTap) VADHangover(time.Duration)                {}
+func (t *recorderTap) CodecDecode(time.Duration)                {}
+func (t *recorderTap) CodecEncode(time.Duration)                {}
+func (t *recorderTap) TTSTotal(observe.Provider, time.Duration) {}
+func (t *recorderTap) LLMTurn(observe.Provider, time.Duration)  {}
+
+// STTRequest IS wired: the orchestrator's STT stage records the recognizer POST
+// round-trip onto the injected recorder (this tap, via WithSTTMetrics) — the SAME
+// prod seam wirenpc uses — so the live report decomposes response_latency into
+// its STT half (the dominant fixed cost). The cassette tier replays a stub
+// recognizer with metrics off, so it stays absent there.
+func (t *recorderTap) STTRequest(_ observe.Provider, d time.Duration) { t.add(StageSTTRequest, d) }
 
 // TurnOutcome is the turn-lifecycle counter; the bench measures latency on
 // surviving turns, not the outcome mix, so it is a no-op here.

--- a/pkg/voice/voicebench/recorder_tap_test.go
+++ b/pkg/voice/voicebench/recorder_tap_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 // TestRecorderTap_CapturesWiredStages pins what the tap, driven through the REAL
-// observe.StageRecorder interface, captures. Two emit paths record onto it with
-// no overlap: the agenttool adapter (llm_round — the B2 signal) and observe's
+// observe.StageRecorder interface, captures. Three emit paths record onto it with
+// no overlap: the agenttool adapter (llm_round — the B2 signal), the orchestrator
+// STT stage (stt_request — the POST round-trip, via WithSTTMetrics), and observe's
 // StageSubscriber (the bus-derived response_latency/address_detect/tts_ttfb,
-// installed on the bus by the rig). Both are the single emitter for their span,
-// so a captured sample is the same value the Prometheus adapter observes — no
-// double-count. The genuinely-unwired stages (vad_hangover/stt_request/…,
+// installed on the bus by the rig). Each is the single emitter for its span, so a
+// captured sample is the same value the Prometheus adapter observes — no
+// double-count. The genuinely-unwired stages (vad_hangover/codec_*/llm_turn/…,
 // carry-over #11) have no caller yet and remain no-ops.
 func TestRecorderTap_CapturesWiredStages(t *testing.T) {
 	var rec observe.StageRecorder = newRecorderTap()
@@ -22,16 +23,18 @@ func TestRecorderTap_CapturesWiredStages(t *testing.T) {
 	// Adapter span (owned by the tap): two LLM rounds in one turn (H2 tool-loop).
 	rec.LLMRound(observe.ProviderGemini, 0, false, 420*time.Millisecond)
 	rec.LLMRound(observe.ProviderGemini, 1, true, 380*time.Millisecond)
+	// STT stage span (owned by the tap via WithSTTMetrics): the POST round-trip.
+	rec.STTRequest(observe.ProviderElevenLabs, 300*time.Millisecond)
 	// Bus-derived spans the subscriber records onto this tap (single emitter each).
 	rec.ResponseLatency(observe.RoleCharacter, 900*time.Millisecond)
 	rec.AddressDetect(60 * time.Millisecond)
 	rec.TTSTimeToFirstByte(observe.ProviderElevenLabs, 120*time.Millisecond)
 	// Unwired stages: still no-ops (no emitter records them yet, #11).
 	rec.VADHangover(256 * time.Millisecond)
-	rec.STTRequest(observe.ProviderElevenLabs, 300*time.Millisecond)
 
 	for stage, want := range map[Stage]int{
 		StageLLMRound:        2,
+		StageSTTRequest:      1,
 		StageResponseLatency: 1,
 		StageAddressDetect:   1,
 		StageTTSTTFB:         1,
@@ -40,7 +43,7 @@ func TestRecorderTap_CapturesWiredStages(t *testing.T) {
 			t.Errorf("tap %q samples = %d, want %d", stage, got, want)
 		}
 	}
-	for _, unwired := range []Stage{StageVADHangover, StageSTTRequest} {
+	for _, unwired := range []Stage{StageVADHangover, StageLLMTurn} {
 		if got := tap.samples(unwired); len(got) != 0 {
 			t.Errorf("tap captured unwired %q (%d samples); it has no emitter yet (#11)", unwired, len(got))
 		}

--- a/tests/voice-cassettes/stt-bart-test.yaml
+++ b/tests/voice-cassettes/stt-bart-test.yaml
@@ -20,3 +20,5 @@ notes: |-
     Re-recorded against ElevenLabs scribe_v2 on 2026-05-21.
 
     Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-06-18.

--- a/tests/voice-cassettes/stt-hello-test.yaml
+++ b/tests/voice-cassettes/stt-hello-test.yaml
@@ -19,3 +19,5 @@ notes: |-
     Re-recorded against ElevenLabs scribe_v2 on 2026-05-21.
 
     Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-06-18.

--- a/tests/voice-cassettes/stt-ttrpg-intro-de.yaml
+++ b/tests/voice-cassettes/stt-ttrpg-intro-de.yaml
@@ -5,4 +5,7 @@ segments:
       transcript: Hey, Glyphoxer Butler, wiederhol doch einfach einmal bitte, was letzte Session so passiert ist. Äh, was, mach 'ne kurze Zusammenfassung und
     - audio_sha256: 8739a0ff8af000e0cb7af4c570ccb306ce985d04de3256ebe269d4defff61af8
       transcript: Ja, wo sind wir am Ende bei rausgekommen?
-notes: Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+notes: |-
+    Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-06-18.

--- a/tests/voice-cassettes/stt-ttrpg-intro-en.yaml
+++ b/tests/voice-cassettes/stt-ttrpg-intro-en.yaml
@@ -5,4 +5,7 @@ segments:
       transcript: Okay. Glyphox or Butler, can you s- give us a quick
     - audio_sha256: a8278255e2d04ab1197884aacc507cda1816b7e6a26f6e76ed70bf40fb8d0d15
       transcript: Intro, what happened last session and what did we do? Where did we leave the session? What's the current status?
-notes: Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+notes: |-
+    Re-recorded against ElevenLabs scribe_v2 on 2026-05-27.
+
+    Re-recorded against ElevenLabs scribe_v2 on 2026-06-18.

--- a/tests/voice-cassettes/tts-hello-test.yaml
+++ b/tests/voice-cassettes/tts-hello-test.yaml
@@ -19,3 +19,5 @@ notes: |-
     Re-recorded against ElevenLabs eleven_v3 on 2026-05-21.
 
     Re-recorded against ElevenLabs eleven_v3 on 2026-05-27.
+
+    Re-recorded against ElevenLabs eleven_v3 on 2026-06-18.

--- a/tests/voice-cassettes/tts-ttrpg-intro-de.yaml
+++ b/tests/voice-cassettes/tts-ttrpg-intro-de.yaml
@@ -1,3 +1,6 @@
 sentences:
     - Ja natürlich, letztes mal habt ihr alles umgehauen!
-notes: Re-recorded against ElevenLabs eleven_v3 on 2026-05-27.
+notes: |-
+    Re-recorded against ElevenLabs eleven_v3 on 2026-05-27.
+
+    Re-recorded against ElevenLabs eleven_v3 on 2026-06-18.

--- a/tests/voice-cassettes/tts-ttrpg-intro-en.yaml
+++ b/tests/voice-cassettes/tts-ttrpg-intro-en.yaml
@@ -1,3 +1,6 @@
 sentences:
     - Yes of course. Last time you mowed down everything!
-notes: Re-recorded against ElevenLabs eleven_v3 on 2026-05-27.
+notes: |-
+    Re-recorded against ElevenLabs eleven_v3 on 2026-05-27.
+
+    Re-recorded against ElevenLabs eleven_v3 on 2026-06-18.


### PR DESCRIPTION
## Why

A live Discord run surfaced two distinct things:

1. **Production bug** — after a few good turns, a barge left the NPC **permanently silent** until Ctrl+C.
2. **Test soundness** — the nightly `bench-live` reported `response_latency` p95 ~10s, but the real per-turn latency was always fine (~1.2s). The bench was measuring an artifact.

## 1. Production wedge (the real bug)

The Segmenter runs **one serial transcription worker**, calling ElevenLabs STT under the **conversation-lifetime context with no per-request deadline**, against an `http.Client{}` with **no timeout**. A single hung/slow scribe POST blocked the worker forever → every later utterance queued and was never transcribed → silence. A barge/supersede cancels only the *per-turn* context, never the STT call's lifetime ctx, so nothing interrupted the POST (the Ctrl+C `STT.Transcribe ... context canceled` was that stuck POST finally aborting).

Confirmed by a multi-agent code trace; the playback and bus paths were ruled out (they unwind cleanly on cancel).

**Fix**
- `orchestrator.STT`: per-request timeout (`WithSTTTimeout`, default 15s) — provider-agnostic, bounds *any* recognizer, only ever tightens an earlier parent deadline. A hung provider now degrades one turn and the worker recovers.
- ElevenLabs **STT + TTS** clients: bounded transport (dial/TLS/response-header) instead of the bare `http.Client{}`. Values matched to expected voice latency, **not** the 30s the streaming LLM clients use:
  - TTS (streaming): `ResponseHeaderTimeout` **5s** — bounds time-to-first-audio-byte (~0.45s max observed, ~10× headroom), **not** stream length, so a long reply is never clipped.
  - STT (non-streaming): `ResponseHeaderTimeout` **10s** — bounds the whole transcription (~1.4s p95), with the 15s orchestrator ctx as backstop.
- Regression test `TestSTT_Transcribe_BoundsHungRecognizer`: a hung recognizer must return a deadline error, not wedge.

## 2. bench-live now measures real latency

The driver fed each clip faster than real-time, bunching every `VADSpeechEnd` at clip-start; the serial worker then ran each turn synchronously, so utterance N's `response_latency` accrued *all prior turns'* wall-clock.

**Fix**
- Feed the live tier at **wall-clock pace** (`Driver.realtime`) → utterances spaced by their true durations → each turn drains before the next speech-end. `response_latency` p95 drops ~10s → **~2.2–2.7s**.
- Promote **`stt_request`** to a real production metric (`WithSTTMetrics` → `wirenpc`) — the dominant real cost inside `response_latency`, previously invisible. The live report now decomposes the headline (`stt_request` / `llm_round` / `tts_ttfb`) so a sub-stage regression can't hide.
- Raise the bench headline hang-guard 5s → 30s (it had aborted valid slow turns and lost all samples).

## 3. STT POST perf

`timestamps_granularity=none` + `tag_audio_events=false` — we read only `Transcript.Text`, so skip word forced-alignment and non-speech event detection. Language stays auto-detected (EN/DE).

## Validation

- Full keyless suite green; all build-tag combos compile; `gofmt` clean.
- Live `bench-live`: all turns clean, `response_latency` p95 ≈ 2.2–2.7s (under the 5s goal). TTS `tts_ttfb` max 429ms and STT max 1170ms confirm the tightened timeouts never false-trip.
- Production app confirmed `first_audio` 1.0–1.6s.

## Note

The bench's hardcoded `EngineeringSLO` (1.2s p50 / 2.5s p95) is still marginally exceeded by the real **STT-bound** latency — a separate calibration decision (recalibrate vs. pursue streaming STT), not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)