### PR TITLE
Record LLM cassettes against Groq Llama instead of Anthropic

### DIFF
--- a/.github/workflows/record-live.yml
+++ b/.github/workflows/record-live.yml
@@ -1,8 +1,9 @@
 name: record-live
 
-# Nightly smoke test of the -tags=record path against the real ElevenLabs API,
-# per ADR-0021's "live (nightly)" cadence. Catches vendor drift between
-# cassette refreshes — voice removed, schema change, eleven_v3 deprecated, etc.
+# Nightly smoke test of the -tags=record path against the real vendor APIs, per
+# ADR-0021's "live (nightly)" cadence. Catches vendor drift between cassette
+# refreshes — ElevenLabs voice removed / schema change / eleven_v3 deprecated,
+# or the Groq LLM endpoint / Llama 3.3 70B model id (ADR-0036) shifting.
 #
 # Also runnable on demand via the Actions UI ("Run workflow") when a reviewer
 # wants to re-record cassettes from a feature branch.
@@ -62,6 +63,30 @@ jobs:
       # recorder writing a cassette the replay path can't read.
       - name: Replay rewritten cassette
         run: go test -run='^TestTTS_HelloTest_DispatchesSentence$' ./pkg/voice/orchestrator/
+
+      # Live LLM record run — drives the real Groq API (Llama 3.3 70B, ADR-0036)
+      # and rewrites the agent-loop greeting cassette in-place. Like the TTS leg,
+      # the diff is not committed back; this verifies the -tags=record LLM path
+      # still works end-to-end against the live vendor and catches Groq endpoint
+      # or model-id drift. Only the greeting cassette is recorded here — its
+      # replay test asserts on response shape (non-empty text, no tool calls),
+      # so a live refresh stays green regardless of the exact wording Llama
+      # returns. The tool-dice cassette stays a hand-authored fixture: it pins an
+      # exact final string and a provider-specific tool_call id, which a live
+      # recording would not reproduce verbatim.
+      - name: Record LLM cassette against live Groq API
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: |
+          if [ -z "$GROQ_API_KEY" ]; then
+            echo "GROQ_API_KEY secret is not set — add it under repo Settings → Secrets and variables → Actions." >&2
+            exit 1
+          fi
+          go test -tags=record -run='^TestLoadLLM_AgentLoop_ReplaysGreeting$' ./pkg/voice/voicecassette/
+
+      # Confirm the rewritten LLM cassette replays clean.
+      - name: Replay rewritten LLM cassette
+        run: go test -run='^TestLoadLLM_AgentLoop_ReplaysGreeting$' ./pkg/voice/voicecassette/
 
       # Surface the cassette diff in the run log so a human can spot
       # unexpected drift (sentence changed, schema shifted, etc.).

--- a/pkg/voice/voicecassette/llm_record.go
+++ b/pkg/voice/voicecassette/llm_record.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
-	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/anthropic"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"gopkg.in/yaml.v3"
 )
 
 // LoadLLM in -tags=record builds returns an [LLMRecorder] that proxies every
-// Complete call to a live Anthropic client, captures the request hash and the
-// streamed response (text, tool_calls, stop reason), and rewrites
-// tests/voice-cassettes/<name>.yaml at test cleanup. The ANTHROPIC_API_KEY
+// Complete call to a live Groq client (Llama 3.3 70B, ADR-0036), captures the
+// request hash and the streamed response (text, tool_calls, stop reason), and
+// rewrites tests/voice-cassettes/<name>.yaml at test cleanup. The GROQ_API_KEY
 // environment variable supplies credentials.
 //
 // Because the cassette is hashed per prompt, the tool-use loop records one
@@ -31,7 +31,7 @@ func LoadLLM(t *testing.T, name string) llm.Provider {
 	existing, _ := loadLLMCassetteFromDisk(t, name, false)
 	r := &LLMRecorder{
 		name:     name,
-		client:   anthropic.New(""),
+		client:   groq.New(""),
 		existing: existing,
 	}
 	t.Cleanup(func() {
@@ -43,12 +43,12 @@ func LoadLLM(t *testing.T, name string) llm.Provider {
 }
 
 // LLMRecorder is the -tags=record counterpart to [LLMProvider]: it forwards
-// every Complete call to a live [anthropic.Client], drains the stream while
+// every Complete call to a live [groq.Client], drains the stream while
 // capturing the response, and appends a keyed [LLMExchange] so the cassette can
 // be rewritten at cleanup.
 type LLMRecorder struct {
 	name     string
-	client   *anthropic.Client
+	client   *groq.Client
 	existing LLMCassette
 
 	mu        sync.Mutex
@@ -105,7 +105,7 @@ func (r *LLMRecorder) write() error {
 	}
 	out := LLMCassette{
 		Exchanges: r.exchanges,
-		Notes:     appendProvenance(r.existing.Notes, "Anthropic", "claude"),
+		Notes:     appendProvenance(r.existing.Notes, "Groq", "llama-3.3-70b-versatile"),
 	}
 	body, err := yaml.Marshal(out)
 	if err != nil {

--- a/pkg/voice/voicecassette/llm_test.go
+++ b/pkg/voice/voicecassette/llm_test.go
@@ -34,7 +34,7 @@ func drain(t *testing.T, ch <-chan llm.StreamEvent) (text string, calls []llm.To
 // llm-agent-greet cassette pins.
 func agentLoopRequest() llm.Request {
 	return llm.Request{
-		Model:     "claude-opus-4-8",
+		Model:     "llama-3.3-70b-versatile",
 		MaxTokens: 256,
 		Messages: []llm.Message{
 			{Role: llm.RoleSystem, Text: "You are Bart, the innkeeper.\n\nSpeak plainly."},
@@ -81,7 +81,7 @@ func TestLoadLLM_ToolUseLoop_ReplaysDiceRoundTrip(t *testing.T) {
 	reg.MustRegister(tool.NewDiceWithRand(rand.New(rand.NewPCG(42, 99)))) // same seed as the fixture
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
 
-	eng := agenttool.NewEngine(prov, grants, "claude-opus-4-8", 256, 0)
+	eng := agenttool.NewEngine(prov, grants, "llama-3.3-70b-versatile", 256, 0)
 	got, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart, the innkeeper.\n\nSpeak plainly."},
 		{Role: llm.RoleUser, Text: "Roll a d20 for my luck."},
@@ -101,7 +101,7 @@ func TestLoadLLM_ToolUseLoop_ReplaysDiceRoundTrip(t *testing.T) {
 func TestLoadLLM_MissingHash_FailsWithRerecordHint(t *testing.T) {
 	prov := voicecassette.LoadLLM(t, "llm-agent-greet")
 	_, err := prov.Complete(context.Background(), llm.Request{
-		Model:    "claude-opus-4-8",
+		Model:    "llama-3.3-70b-versatile",
 		Messages: []llm.Message{{Role: llm.RoleUser, Text: "a prompt never recorded"}},
 	})
 	if err == nil {

--- a/pkg/voice/voicecassette/record_notes.go
+++ b/pkg/voice/voicecassette/record_notes.go
@@ -13,8 +13,8 @@ import (
 // appendProvenance returns notes with a dated "Re-recorded against <vendor>
 // <model> on <date>." line appended for reviewer context. The vendor is passed
 // explicitly because the three recorders hit different APIs — ElevenLabs for
-// STT/TTS, Anthropic for the LLM cassettes (ADR-0021's Anthropic/Ollama BYOK
-// matrix) — and the stamp must name the one that produced the bytes. The append
+// STT/TTS, Groq for the LLM cassettes (Llama 3.3 70B per ADR-0036) — and the
+// stamp must name the one that produced the bytes. The append
 // is idempotent within a day: re-running -tags=record twice on the same date
 // (the recorder loads the existing notes, which on the second run already carry
 // the line) must not accrete duplicate stamps. Re-records on a later date still

--- a/tests/voice-cassettes/llm-agent-greet.yaml
+++ b/tests/voice-cassettes/llm-agent-greet.yaml
@@ -4,9 +4,11 @@
 # loop assembles for Persona "Bart, the innkeeper" + audio-markup "Speak
 # plainly." + the user utterance "Hello, innkeeper." The exchange is keyed by
 # prompt_hash (sha256 of model+system+messages+tools); a prompt change misses
-# and fails the test. Re-record against a live LLM with `-tags=record`.
+# and fails the test. The hash pins model "llama-3.3-70b-versatile" (Groq, the
+# production LLM per ADR-0036). Re-record against the live Groq API with
+# `-tags=record` (GROQ_API_KEY supplies credentials).
 exchanges:
-  - prompt_hash: 6ca5a6fcface92d62b3c92f752c920cbe79192fb8bfe8ba669ae80bfd50ff38f
+  - prompt_hash: dce2b29a032e3e951940a2f3336a397ece486da052836591468819028b5f7139
     text: "Welcome, traveler. A warm bed and a hot meal await — what'll it be?"
     stop_reason: end_turn
-notes: Hand-authored fixture for the agent-loop replay test (no live recording).
+notes: Hand-authored fixture for the agent-loop replay test (no live recording); prompt_hash pins model llama-3.3-70b-versatile (Groq).

--- a/tests/voice-cassettes/llm-tool-dice.yaml
+++ b/tests/voice-cassettes/llm-tool-dice.yaml
@@ -9,16 +9,18 @@
 #
 # Each is keyed by prompt_hash. The second hash depends on the first exchange's
 # tool_call id ("toolu_roll1") and args AND on the live dice result, so those
-# must replay verbatim — change any and exchange 2 misses. Re-record against a
-# live LLM with `-tags=record` (the dice seed stays fixed in the test).
+# must replay verbatim — change any and exchange 2 misses. Both hashes pin model
+# "llama-3.3-70b-versatile" (Groq, the production LLM per ADR-0036). Re-record
+# against the live Groq API with `-tags=record` (GROQ_API_KEY supplies
+# credentials; the dice seed stays fixed in the test).
 exchanges:
-  - prompt_hash: 5056cd6d46898b2739ef3d972d378a67d37e7e4010436bba0a537792da26c76d
+  - prompt_hash: 94d0e3189c69ee6b6fe388161f54ceab89eb6bbfa2871cbbfb806c02580244e1
     tool_calls:
       - id: toolu_roll1
         name: dice
         input: '{"count":1,"sides":20}'
     stop_reason: tool_use
-  - prompt_hash: 7ebd62378001b170acfe4ac2070a0ccd3dc98c828cdd2b274f15963617a3b747
+  - prompt_hash: 42ee6314e058ae5b1b559a3c22eee6ee8984ceedb1833c7976a85d7012362c92
     text: "The bones favor you tonight, traveler."
     stop_reason: end_turn
-notes: Hand-authored fixture for the tool-use-loop replay test; dice rng seeded PCG(42,99), first draw.
+notes: Hand-authored fixture for the tool-use-loop replay test; prompt_hashes pin model llama-3.3-70b-versatile (Groq); dice rng seeded PCG(42,99), first draw.


### PR DESCRIPTION
## What

Switches the `-tags=record` LLM cassette recorder from the Anthropic Messages API to **Groq's Llama 3.3 70B** (`llama-3.3-70b-versatile`, per ADR-0036), so the live-recording smoke path uses the same provider production runs on. `GROQ_API_KEY` is already configured as a repo Actions secret.

## Changes

- **`voicecassette.LoadLLM` (record build)** now proxies every `Complete` call to `groq.New("")` instead of `anthropic.New("")`. Cassette provenance is stamped `Groq llama-3.3-70b-versatile`; credentials come from `GROQ_API_KEY`. Package/recorder docs updated accordingly.
- **Replay tests + agenttool engine** now request `llama-3.3-70b-versatile`. The cassette key is a sha256 over `model + system + messages + tools`, so the model swap changes every hash — the committed `prompt_hash` values in `llm-agent-greet.yaml` and `llm-tool-dice.yaml` are recomputed for the new model (response text/tool-call ids are unchanged hand-authored fixtures).
- **`record-live.yml`** gains a live LLM leg: record the agent-loop greeting cassette against the real Groq API, then replay it. Only the greeting is recorded live — its replay test asserts on response *shape* (non-empty text, no tool calls), so a refresh stays green regardless of Llama's exact wording. The tool-dice cassette stays a hand-authored fixture because it pins an exact final string and a provider-specific `tool_call` id that a live recording wouldn't reproduce verbatim.

## Verification

- `go test ./pkg/voice/voicecassette/...` — green (replay).
- `go vet -tags=record ./pkg/voice/voicecassette/` — clean (recorder compiles against the Groq client).
- `go build ./...` — clean.

The only remaining `voice/llm/anthropic` reference is the Anthropic provider's own package test; the provider itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MGJCwXQ61StdyQYACwwH6)_