### PR TITLE
feat(observe): add /healthz and /readyz endpoints for k8s probes (#33)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -6,12 +6,18 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+
+	// pgx stdlib driver: the /readyz probe pings through a database/sql handle
+	// (issue #33). Registered here as well as in migrate.go so this file's use of
+	// sql.Open("pgx", …) is self-documenting; the blank import is idempotent.
+	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
@@ -107,16 +113,38 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Resolve the DB DSN once: it both gates the load path below and, when
+	// present, backs the /readyz probe (issue #33). -hardcoded runs with no DB,
+	// so its readiness probe is nil (always-ready — see observe.ReadinessProbe).
+	dsn := ""
+	if !hardcoded {
+		dsn = databaseURL()
+		if dsn == "" {
+			return fmt.Errorf("voice mode loads the NPC from the DB by default; set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL), or pass -hardcoded to use the in-code NPC")
+		}
+	}
+
 	if metricsAddr != "" {
-		observe.NewMetricsServer(metricsAddr, metrics, log).Start(ctx)
+		var ready observe.ReadinessProbe
+		if dsn != "" {
+			// The live pgxpool is opened later inside wirenpc.RunFromDB and isn't
+			// reachable here, so /readyz pings through a small standalone
+			// database/sql handle (pgx stdlib driver, already a dep — see
+			// migrate.go). It lives for the metrics server's lifetime alongside the
+			// voice loop. NOTE: this ping-handle may later be consolidated with the
+			// schema-check handle from the wirenpc boot path (#32) once both merge.
+			db, err := sql.Open("pgx", dsn)
+			if err != nil {
+				return fmt.Errorf("voice: open readiness-probe db handle: %w", err)
+			}
+			defer db.Close()
+			ready = db.PingContext
+		}
+		observe.NewMetricsServer(metricsAddr, metrics, ready, log).Start(ctx)
 	}
 
 	if hardcoded {
 		return wirenpc.Run(ctx, cfg)
-	}
-	dsn := databaseURL()
-	if dsn == "" {
-		return fmt.Errorf("voice mode loads the NPC from the DB by default; set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL), or pass -hardcoded to use the in-code NPC")
 	}
 	return wirenpc.RunFromDB(ctx, cfg, dsn)
 }

--- a/internal/observe/server.go
+++ b/internal/observe/server.go
@@ -3,37 +3,79 @@ package observe
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
 )
 
+// ReadinessProbe reports whether the voice node's external dependencies are
+// healthy enough to serve traffic — in practice a DB ping (issue #33). It backs
+// /readyz: a nil error means ready (200), any error means not-ready (503). A nil
+// ReadinessProbe means "no dependency to gate on" and /readyz is always 200,
+// which is the correct answer for a -hardcoded no-DB run.
+type ReadinessProbe func(context.Context) error
+
 // MetricsServer is the minimal metrics-only HTTP listener for voice mode
 // (ADR-0032 §2.3): no SPA, no SSE, just /metrics so a Prometheus can scrape a
-// headless voice node. In web/all mode the adapter's [PrometheusRecorder.Handler]
-// is mounted on the existing server instead (control-plane, issue #6) — this
-// type is only for the standalone voice node.
+// headless voice node — plus the /healthz and /readyz k8s probes (issue #33). In
+// web/all mode the adapter's [PrometheusRecorder.Handler] is mounted on the
+// existing server instead (control-plane, issue #6) — this type is only for the
+// standalone voice node.
 type MetricsServer struct {
 	srv *http.Server
 	log *slog.Logger
 }
 
 // NewMetricsServer builds a metrics-only server serving rec's registry at
-// /metrics on addr (e.g. ":9090"). It does not listen until [MetricsServer.Start].
-func NewMetricsServer(addr string, rec *PrometheusRecorder, log *slog.Logger) *MetricsServer {
+// /metrics on addr (e.g. ":9090"), plus the /healthz liveness and /readyz
+// readiness probes for Kubernetes (issue #33). ready gates /readyz; pass nil for
+// a no-DB run (see [ReadinessProbe]). It does not listen until
+// [MetricsServer.Start].
+func NewMetricsServer(addr string, rec *PrometheusRecorder, ready ReadinessProbe, log *slog.Logger) *MetricsServer {
 	if log == nil {
 		log = slog.Default()
 	}
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", rec.Handler())
 	return &MetricsServer{
 		srv: &http.Server{
 			Addr:              addr,
-			Handler:           mux,
+			Handler:           newMux(rec, ready),
 			ReadHeaderTimeout: 5 * time.Second,
 		},
 		log: log,
 	}
+}
+
+// newMux wires the voice-node endpoints onto a fresh mux: /metrics (rec's
+// registry), /healthz (liveness — always 200 while the process serves), and
+// /readyz (readiness — 200 when ready returns nil, 503 otherwise; always 200 if
+// ready is nil). Factored out so the handlers are testable without a real
+// listener.
+func newMux(rec *PrometheusRecorder, ready ReadinessProbe) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", rec.Handler())
+	// Liveness: the process is up and able to serve a request. It deliberately
+	// ignores dependency health — a failing DB must not make k8s kill the pod
+	// (that's readiness's job).
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	// Readiness: gate traffic on the dependency probe (a DB ping).
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if ready == nil {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "ok")
+			return
+		}
+		if err := ready(r.Context()); err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	return mux
 }
 
 // Start serves in a background goroutine and shuts the listener down when ctx is

--- a/internal/observe/server_test.go
+++ b/internal/observe/server_test.go
@@ -2,9 +2,11 @@ package observe
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +25,7 @@ func TestMetricsServerServesAndShutsDown(t *testing.T) {
 
 	rec := NewPrometheusRecorder()
 	rec.SessionOpened("g")
-	srv := NewMetricsServer(addr, rec, nil)
+	srv := NewMetricsServer(addr, rec, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	srv.Start(ctx)
@@ -59,5 +61,76 @@ func TestMetricsServerServesAndShutsDown(t *testing.T) {
 			t.Fatal("metrics server did not shut down on context cancel")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestHealthzAlwaysOK pins the liveness contract: /healthz is 200 as long as the
+// process can serve a request — it never consults the readiness probe.
+func TestHealthzAlwaysOK(t *testing.T) {
+	// Even with a probe that always fails, liveness stays 200.
+	srv := httptest.NewServer(newMux(NewPrometheusRecorder(), func(context.Context) error {
+		return errors.New("db down")
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestReadyzProbeOK is the happy-path readiness gate: a probe returning nil means
+// the dependency (a DB ping) is healthy, so /readyz is 200.
+func TestReadyzProbeOK(t *testing.T) {
+	srv := httptest.NewServer(newMux(NewPrometheusRecorder(), func(context.Context) error {
+		return nil
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/readyz = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestReadyzProbeDown is the DB-down readiness case: a probe returning an error
+// means the dependency is unreachable, so /readyz is 503 and k8s holds traffic.
+func TestReadyzProbeDown(t *testing.T) {
+	srv := httptest.NewServer(newMux(NewPrometheusRecorder(), func(context.Context) error {
+		return errors.New("dial tcp: connection refused")
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("/readyz = %d, want 503", resp.StatusCode)
+	}
+}
+
+// TestReadyzNilProbeOK pins the -hardcoded / no-DB contract: a nil probe means
+// there is no dependency to gate on, so /readyz is unconditionally 200.
+func TestReadyzNilProbeOK(t *testing.T) {
+	srv := httptest.NewServer(newMux(NewPrometheusRecorder(), nil))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/readyz (nil probe) = %d, want 200", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Adds Kubernetes liveness/readiness HTTP endpoints to the voice-mode metrics listener (`MetricsServer`, ADR-0032 §2.3), mounted alongside the existing `/metrics`.

- **`/healthz`** — liveness. Always `200` while the process can serve a request. It deliberately ignores dependency health: a failing DB must not make k8s kill the pod (that is readiness's job).
- **`/readyz`** — readiness. Gated on an injectable `observe.ReadinessProbe` (`func(context.Context) error`): `nil` error → `200`, any error → `503`. A `nil` probe means "no dependency to gate on" → always `200`, the correct answer for a `-hardcoded` no-DB run.

Closes #33.

## Why is this change needed?

Kubernetes needs liveness/readiness probes to manage a serving voice pod: liveness to restart a wedged process, readiness to hold traffic from a pod whose DB is unreachable. The voice node already runs a minimal metrics-only listener (ADR-0032), so the probes ride on it rather than standing up a second server.

## How was this tested?

`make check` (gofmt + `go vet ./...` + `go test -race -count=1 ./...`) passes; all packages green. New httptest coverage written test-first (red → green):

- `TestHealthzAlwaysOK` — `/healthz` is `200` even when the readiness probe fails.
- `TestReadyzProbeOK` — `/readyz` is `200` when the probe returns `nil`.
- `TestReadyzProbeDown` — `/readyz` is `503` when the probe returns an error (the DB-down case).
- `TestReadyzNilProbeOK` — `/readyz` is `200` with a `nil` probe (the `-hardcoded` no-DB contract).

The existing `TestMetricsServerServesAndShutsDown` still passes, confirming `/metrics` coexistence and the listener-error / shutdown contract.

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (covered by httptest; no live k8s probe exercised)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [ ] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

**Readiness-probe wiring choice (pragmatic, flagged for follow-up):** in `runVoice` the live `pgxpool` is opened later inside `wirenpc.RunFromDB` and isn't reachable where the metrics server starts. So when a DSN is present, `/readyz` pings through a small standalone `database/sql` handle (pgx stdlib driver, already a dependency — same pattern as `migrate.go`), opened for the metrics server's lifetime. In `-hardcoded` mode the probe is `nil`. The DSN is resolved once via the existing `databaseURL()`, and the existing `-hardcoded` / empty-`-metrics-addr` behaviors are preserved. This ping-handle may later be consolidated with #32's schema-check handle once both merge (noted in a code comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)