### PR TITLE
feat(voice): wire EnsureCurrent into serving startup — fail fast on stale schema (#32)

### DIFF
--- a/internal/wirenpc/ensurecurrent_integration_test.go
+++ b/internal/wirenpc/ensurecurrent_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+// These tests stand up a real Postgres (testcontainers) to exercise the
+// fail-fast-on-stale-schema contract ADR-0031 mandates for serving modes, so
+// they are tag-isolated behind `integration` (ADR-0033): the default
+// `go test ./...` stays Docker-free per ADR-0021, and a dedicated
+// `-tags=integration` CI job runs these with Docker. The runtime t.Skip on a
+// missing Postgres (via dsnFromEnvOrContainer) remains for local convenience.
+//
+// The shared container harness (pgImage, dsnFromEnvOrContainer) lives in
+// agentspec_test.go in this package.
+package wirenpc
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// openSQL opens a database/sql handle on the pgx stdlib driver (for goose).
+func openSQL(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// migrateToHead applies every embedded migration so the DB schema is current.
+func migrateToHead(t *testing.T, dsn string) {
+	t.Helper()
+	db := openSQL(t, dsn)
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+}
+
+// rollBackOne rolls back the most recently applied migration, leaving the DB
+// one version behind head — a deliberately stale schema.
+func rollBackOne(t *testing.T, dsn string) {
+	t.Helper()
+	db := openSQL(t, dsn)
+	if err := storage.MigrateDown(context.Background(), db); err != nil {
+		t.Fatalf("migrate down: %v", err)
+	}
+}
+
+// TestEnsureSchemaCurrent_StaleSchemaFailsFast is the red→green core of #32:
+// serving startup must verify the DB is at the latest embedded schema BEFORE any
+// other DB interaction and refuse to start if the DB is behind (ADR-0031). We
+// migrate to head, then roll back one migration so the DB version < embedded
+// latest, and assert the schema-check seam RunFromDB calls returns the existing
+// actionable version-mismatch error.
+func TestEnsureSchemaCurrent_StaleSchemaFailsFast(t *testing.T) {
+	dsn := dsnFromEnvOrContainer(t)
+	migrateToHead(t, dsn)
+	rollBackOne(t, dsn)
+
+	err := ensureSchemaCurrent(context.Background(), dsn)
+	if err == nil {
+		t.Fatal("ensureSchemaCurrent returned nil on a stale schema; serving must fail fast (ADR-0031)")
+	}
+	// Assert the EXISTING actionable message is surfaced verbatim, including the
+	// remediation hint — operators key on it, and #32 must not reword it.
+	const wantSubstr = "schema out of date"
+	const wantHint = "run `glyphoxa migrate up`"
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Errorf("error %q does not contain %q (version-mismatch message changed)", err, wantSubstr)
+	}
+	if !strings.Contains(err.Error(), wantHint) {
+		t.Errorf("error %q does not contain the remediation hint %q", err, wantHint)
+	}
+}
+
+// TestEnsureSchemaCurrent_CurrentSchemaPasses is the green half: with the schema
+// fully migrated, the same check the serving boot path runs returns nil so boot
+// proceeds to load the NPC. This pins that the fail-fast check does not block a
+// correctly-migrated serving process.
+func TestEnsureSchemaCurrent_CurrentSchemaPasses(t *testing.T) {
+	dsn := dsnFromEnvOrContainer(t)
+	migrateToHead(t, dsn)
+
+	if err := ensureSchemaCurrent(context.Background(), dsn); err != nil {
+		t.Fatalf("ensureSchemaCurrent on a current schema = %v, want nil (boot must proceed)", err)
+	}
+}
+
+// TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad asserts the PRODUCTION call
+// site: RunFromDB itself must fail fast on a stale schema, returning the
+// version-mismatch error WITHOUT proceeding to the NPC load (or Discord). The DB
+// here is stale AND empty of any seeded NPC, so if RunFromDB reached
+// loadSeededNPC it would surface a "find tenant" error instead — asserting the
+// schema-out-of-date message proves the check runs first. No Discord token is
+// needed because the schema check precedes any gateway connection.
+func TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad(t *testing.T) {
+	dsn := dsnFromEnvOrContainer(t)
+	migrateToHead(t, dsn)
+	rollBackOne(t, dsn)
+
+	err := RunFromDB(context.Background(), Config{}, dsn)
+	if err == nil {
+		t.Fatal("RunFromDB returned nil on a stale schema; serving must fail fast before any other DB query")
+	}
+	if !strings.Contains(err.Error(), "schema out of date") {
+		t.Errorf("RunFromDB error %q is not the schema-out-of-date fail-fast error; "+
+			"the check must run before loadSeededNPC (which would error on the missing tenant)", err)
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -11,6 +11,7 @@ package wirenpc
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -21,6 +22,7 @@ import (
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib" // registers the database/sql "pgx" driver for the goose-backed schema check
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -177,6 +179,15 @@ func RunFromDB(ctx context.Context, cfg Config, dsn string) error {
 	}
 	defer pool.Close()
 
+	// Fail fast on a stale schema BEFORE any other DB interaction (ADR-0031):
+	// serving Modes (voice) never auto-migrate, so a DB behind the embedded
+	// migrations must refuse to start with the actionable `migrate up` message
+	// rather than running queries against a schema the code no longer matches.
+	// This runs after the pool opens and before loadSeededNPC (the first query).
+	if err := ensureSchemaCurrent(ctx, dsn); err != nil {
+		return err
+	}
+
 	npc, err := loadSeededNPC(ctx, storage.New(pool))
 	if err != nil {
 		return err
@@ -185,6 +196,26 @@ func RunFromDB(ctx context.Context, cfg Config, dsn string) error {
 
 	cfg.npc = npc
 	return Run(ctx, cfg)
+}
+
+// ensureSchemaCurrent verifies the DB at dsn is migrated to the latest embedded
+// schema version, returning the storage layer's actionable version-mismatch
+// error (verbatim) if it is behind. This is the ADR-0031 fail-fast guard for
+// serving Modes: [RunFromDB] calls it once at startup, after the pool opens and
+// before any other query, so a process can never serve against a stale schema.
+//
+// [storage.EnsureCurrent] needs a database/sql handle on the pgx stdlib driver
+// (goose's API; the app's own queries use the pgxpool). That handle exists only
+// for this check, so it is opened from the same dsn and closed immediately —
+// keeping the seam free of the live voice loop and Discord, so it is testable on
+// its own against a real Postgres.
+func ensureSchemaCurrent(ctx context.Context, dsn string) error {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("wirenpc: open schema-check handle: %w", err)
+	}
+	defer db.Close()
+	return storage.EnsureCurrent(ctx, db)
 }
 
 // Run builds and runs the live NPC voice loop until ctx is cancelled. It joins


### PR DESCRIPTION
## What does this PR do?

Wires `storage.EnsureCurrent` into the serving boot path so every serving
process (today: `voice` mode) verifies the DB schema is at the latest embedded
version **before any other DB interaction** and refuses to start if the DB is
behind. `RunFromDB` now calls a small `ensureSchemaCurrent(ctx, dsn)` seam right
after the `pgxpool` opens and before `loadSeededNPC` (the first NPC query). On a
stale schema it returns the existing actionable message verbatim
(``schema out of date (db at version N, want M); run `glyphoxa migrate up` ``),
so the process exits non-zero without proceeding to the NPC load or Discord.

Closes #32.

## Why is this change needed?

ADR-0031's fail-fast contract: `web`/`voice` Modes never auto-migrate — they
assume a current schema and must fail fast if it is behind. `storage.EnsureCurrent`
already existed and was unit-tested but had **no production caller**, so a stale
schema would not have been caught at serving startup. This wires the guard into
the real boot path.

## How was this tested?

- `make check` (= `gofmt` + `go vet` + `go test -race ./...`): passes. The
  default suite stays Docker-free (~3s) — the new test is tag-isolated behind
  `//go:build integration`.
- `go vet -tags integration ./internal/wirenpc/... ./internal/storage/...`: clean.
- `golangci-lint run ./internal/wirenpc/...`: 0 issues.
- Integration suite (real Postgres via testcontainers, Docker):
  `go test -tags integration ./internal/wirenpc/... ./internal/storage/...` — all
  green, including the pre-existing `TestMigrateUpDown` round-trip and
  `TestSeedThenLoadEquivalence`.

New tests (`internal/wirenpc/ensurecurrent_integration_test.go`):
- `TestEnsureSchemaCurrent_StaleSchemaFailsFast` — migrate to head, roll back one
  migration, assert the seam returns an error containing `schema out of date` and
  the remediation hint ``run `glyphoxa migrate up` ``.
- `TestEnsureSchemaCurrent_CurrentSchemaPasses` — fully migrated → check returns
  nil (boot proceeds).
- `TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad` — the **production call site**:
  with a stale *and* un-seeded DB, `RunFromDB` returns the `schema out of date`
  error; if it had reached `loadSeededNPC` it would have surfaced a "find tenant"
  error instead, so this proves the check runs first (no Discord token needed —
  the schema check precedes any gateway connection).

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (covered by the integration suite against a real Postgres)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] All exported symbols have Godoc comments (no new *exported* symbols;
      `ensureSchemaCurrent` is unexported and documented)
- [x] My commits are focused and have clear messages

## Additional Notes

**Seam decision:** `RunFromDB` delegates to `Run`, which joins Discord, so the
full function is not end-to-end unit-testable without credentials. I extracted a
tiny unexported `ensureSchemaCurrent(ctx, dsn)` helper that opens a `database/sql`
handle on the pgx stdlib driver (goose's API; the app's own queries use the
pgxpool), runs `storage.EnsureCurrent`, and closes the handle — it exists only
for the check. The production call site in `RunFromDB` is real and is exercised
end-to-end by the stale-schema test (which fails before Discord is touched).

**Scope:** No behavior change for `all`-Mode auto-migration (`storage.MigrateUp`)
or for `-hardcoded` (no-DB) runs, which call `Run` not `RunFromDB`. Changes are
confined to `internal/wirenpc` (+ read-only use of `internal/storage`);
`cmd/glyphoxa/main.go`, `internal/observe/*`, and CI/Dockerfiles are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
