### PR TITLE
feat(build): multi-stage container image for the single Glyphoxa binary (#31)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,17 @@ examples/
 LICENSE
 CONTRIBUTING.md
 SECURITY.md
+
+# Test fixtures: audio clips + recorded cassettes are not needed to compile the
+# binary (the production assets — Silero model, SQL migrations — are go:embed'd
+# from pkg/ and internal/, not from tests/). Keeping them out trims the build
+# context the daemon has to ship.
+tests/
+
+# Agent worktrees and local Claude state never belong in the image context.
+.claude/
+
+# The Dockerfile itself and the smoke-test harness aren't build inputs.
+Dockerfile
+.dockerignore
+scripts/container-smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,38 @@ jobs:
       - name: Cassette latency benchmark (regression gate)
         run: go test -race -tags "bench opus nolibopusfile" -run '^TestBench_CassetteRegression$' ./pkg/voice/voicebench/
 
+  image:
+    name: container image (build + smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # buildx + layer caching keeps the slow native build (whisper.cpp +
+      # libopus + libdave + CGO) off the critical path on warm caches. This is a
+      # SEPARATE job from the fast `test` gate (ADR-0033): the heavy image build
+      # must not slow an unrelated PR's unit feedback.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the single image (ADR-0034) and LOAD it into the local daemon so
+      # the smoke test can `docker run` it. No push on PRs — publishing happens
+      # only on release (release-image.yml).
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: glyphoxa:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # The executable acceptance spec for issue #31: migrate --help exits 0;
+      # ldd resolves every native lib (libopus, libdave, libonnxruntime — no
+      # "not found"); the bundled ONNX runtime exists at $GLYPHOXA_ONNX_LIB; and
+      # the process runs as a non-root uid.
+      - name: Container smoke test
+        run: ./scripts/container-smoke.sh glyphoxa:smoke
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,69 @@
+name: release-image
+
+# Publishes the single Glyphoxa OCI image (ADR-0034) to GitHub Container
+# Registry on a release tag. The image tags match the goreleaser footer
+# (.goreleaser.yml: `docker pull ghcr.io/mrwong99/glyphoxa:v{{ .Version }}`) and
+# the issue-#31 requirement that the published image carry version + git SHA.
+#
+# Triggered by the same `v*` tags goreleaser releases on, so the binary archives
+# (goreleaser) and the container image are cut from one tag. The `zhi-*` tags
+# goreleaser ignores are excluded here too, for parity.
+on:
+  push:
+    tags:
+      - "v*"
+      - "!zhi-*"
+
+# Pushing to ghcr needs `packages: write`; `contents: read` to check out.
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: build + push image to ghcr
+    runs-on: ubuntu-latest
+    # Don't attempt to publish from forks (no package write, no intent).
+    if: github.repository == 'MrWong99/Glyphoxa_v2'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # docker/metadata-action derives the tag set from the git ref:
+      #   - type=ref,event=tag → the literal tag, e.g. v1.2.3 (matches the
+      #     goreleaser footer's ghcr.io/mrwong99/glyphoxa:v1.2.3).
+      #   - type=sha,prefix= → the short git SHA, e.g. a1b2c3d (the "+ git SHA"
+      #     half of issue #31's "version + git SHA").
+      #   - latest only on a non-prerelease tag.
+      # The repo is lowercased by the action, so MrWong99 → mrwong99 to match the
+      # goreleaser footer's ghcr.io/mrwong99/glyphoxa.
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/glyphoxa
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # The PR `image` job (ci.yml) primes this gha cache, so the release
+          # build reuses the slow native layers when the source matches.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,175 @@
+# syntax=docker/dockerfile:1
+#
+# Glyphoxa — single multi-stage OCI image for the one binary (ADR-0005, ADR-0034).
+#
+# There is ONE image. `mode` and all config (Postgres URL, provider keys, guild/
+# channel, etc.) are supplied at RUNTIME via args/env — there are no per-mode
+# images. The build stage compiles the live binary with the production CGO tags
+# (`opus dave nolibopusfile`) after building the whisper.cpp static lib and
+# installing libopus + libdave, exactly as the Makefile / CI do. The runtime
+# stage is a slim glibc base (distroless deferred — the CGO deps need glibc,
+# ADR-0034) carrying the binary plus the native libs it needs: libopus + libdave
+# (link-time deps, via pkg-config) and a bundled libonnxruntime (the version the
+# Silero VAD pins in pkg/voice/vad/silero/runtime.go — dlopen'd at runtime, not
+# linked). GLYPHOXA_ONNX_LIB points at that bundled lib so the VAD never
+# downloads a runtime at container start.
+#
+# The embedded Silero model (pkg/voice/vad/silero/data/silero_vad.onnx) and the
+# SQL migrations (internal/storage/migrations/*.sql) are go:embed'd into the
+# binary — they need no separate runtime files.
+
+# ---------------------------------------------------------------------------
+# Build args — pinned versions live here so a bump is one obvious edit.
+# ONNX_VERSION MUST match onnxRuntimeVersion in pkg/voice/vad/silero/runtime.go;
+# the smoke test fails loudly if the bundled lib is missing, but it cannot tell
+# you the version drifted, so keep these in lockstep.
+# ---------------------------------------------------------------------------
+ARG GO_VERSION=1.26
+ARG ONNX_VERSION=1.25.1
+ARG DAVE_VERSION=v1.1.0
+
+# ===========================================================================
+# Stage: build — compile the live binary + gather the native runtime deps.
+# Debian trixie (glibc 2.41) so the CGO toolchain and the runtime base agree on
+# libc. trixie — NOT the older bookworm — because the prebuilt libdave asset is
+# linked against GLIBC_2.38 / GLIBCXX_3.4.32 (it's built on a newer toolchain,
+# the same Ubuntu-24.04 glibc the CI audio job links it against); bookworm's
+# glibc 2.36 / older libstdc++ can't satisfy those symbols at link time.
+# ===========================================================================
+FROM golang:${GO_VERSION}-trixie AS build
+ARG ONNX_VERSION
+ARG DAVE_VERSION
+
+# A fixed HOME so the libdave install script (which targets $HOME/.local) lands
+# its lib/include/pkgconfig at a path we control and can replicate verbatim in
+# the runtime stage — the generated dave.pc bakes `-Wl,-rpath,$HOME/.local/lib`
+# into the binary, so the runtime stage recreates that exact directory too.
+ENV HOME=/opt/build
+ENV CGO_ENABLED=1
+
+# Build/runtime native deps:
+#   - cmake/git/build-essential: build whisper.cpp (static) and (fallback) libdave.
+#   - pkg-config + libopus-dev: the opus codec links libopus via pkg-config opus.
+#   - curl/unzip: fetch the libdave prebuilt + the ONNX runtime tarball.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		git \
+		cmake \
+		build-essential \
+		pkg-config \
+		libopus-dev \
+		curl \
+		unzip \
+	&& rm -rf /var/lib/apt/lists/*
+
+# --- whisper.cpp static library (mirrors Makefile `whisper-libs`) ----------
+# Static (BUILD_SHARED_LIBS=OFF) so the .a is linked into the binary; nothing
+# from whisper needs to ship in the runtime image. GGML_NATIVE=OFF here (unlike
+# the Makefile's ON): the image must run on hosts other than the builder, so we
+# must NOT bake in -march=native instructions the runtime CPU may lack.
+ARG WHISPER_DEST=/tmp/whisper-install
+RUN git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git /tmp/whisper-src \
+	&& cmake -B /tmp/whisper-src/build -S /tmp/whisper-src \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DGGML_NATIVE=OFF \
+		-DWHISPER_BUILD_TESTS=OFF \
+		-DWHISPER_BUILD_SERVER=OFF \
+	&& cmake --build /tmp/whisper-src/build --config Release -j"$(nproc)" \
+	&& mkdir -p "${WHISPER_DEST}/include" "${WHISPER_DEST}/lib" \
+	&& cp /tmp/whisper-src/include/whisper.h "${WHISPER_DEST}/include/" \
+	&& cp -r /tmp/whisper-src/ggml/include/* "${WHISPER_DEST}/include/" \
+	&& find /tmp/whisper-src/build -name '*.a' -exec cp {} "${WHISPER_DEST}/lib/" \;
+
+# --- libdave (mirrors Makefile `dave-libs`) --------------------------------
+# Installs libdave.so → $HOME/.local/lib, dave.h → $HOME/.local/include, and
+# generates $HOME/.local/lib/pkgconfig/dave.pc. NON_INTERACTIVE so the script's
+# shell-profile prompt is skipped. Prefers the prebuilt asset, builds from
+# source otherwise.
+#
+# SHELL must be set: the script's final (cosmetic) update_shell_profile step
+# reads $SHELL, which is unset under `sh -c` in a Docker RUN, and the script's
+# `set -u` would abort with exit 2 — AFTER it has already installed the lib and
+# written dave.pc, but still failing the layer. Setting SHELL lets it finish.
+RUN git clone --depth 1 https://github.com/disgoorg/godave.git /tmp/godave \
+	&& SHELL=/bin/sh NON_INTERACTIVE=1 sh /tmp/godave/scripts/libdave_install.sh "${DAVE_VERSION}"
+
+# --- ONNX Runtime (the exact version the Silero VAD pins) ------------------
+# Bundled so GLYPHOXA_ONNX_LIB can point at it and the VAD never reaches the
+# network at container start (ADR-0034). Pulled from the same Microsoft release
+# pkg/voice/vad/silero/runtime.go resolves; we keep just the lib/ payload.
+RUN curl -fsSL \
+		"https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-x64-${ONNX_VERSION}.tgz" \
+		-o /tmp/onnxruntime.tgz \
+	&& mkdir -p /opt/onnxruntime/lib \
+	&& tar -xzf /tmp/onnxruntime.tgz -C /tmp \
+	&& cp -P /tmp/onnxruntime-linux-x64-${ONNX_VERSION}/lib/libonnxruntime.so* /opt/onnxruntime/lib/ \
+	&& rm /tmp/onnxruntime.tgz
+
+WORKDIR /src
+
+# Warm the module cache on the manifests alone so a code-only change doesn't
+# re-download every dependency.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Compile the live binary with the production CGO tags and the whisper/dave/opus
+# env the Makefile + .goreleaser.yml use. PKG_CONFIG_PATH carries both the
+# system libopus (.pc shipped by libopus-dev) and the libdave .pc the script
+# wrote under $HOME/.local. ldflags `-s -w` strip debug info, matching goreleaser.
+ENV C_INCLUDE_PATH=${WHISPER_DEST}/include
+ENV LIBRARY_PATH=${WHISPER_DEST}/lib
+ENV PKG_CONFIG_PATH=/opt/build/.local/lib/pkgconfig
+RUN go build -tags "opus dave nolibopusfile" -ldflags "-s -w" \
+		-o /out/glyphoxa ./cmd/glyphoxa
+
+# ===========================================================================
+# Stage: runtime — slim glibc base carrying the binary + its native deps.
+# trixie-slim matches the build stage's glibc/libstdc++ (the prebuilt libdave
+# needs GLIBC_2.38 / GLIBCXX_3.4.32 at load time, not just link time).
+# ===========================================================================
+FROM debian:trixie-slim AS runtime
+ARG ONNX_VERSION
+
+# Runtime-only system deps: libopus shared lib (the codec links it) and the
+# loader bits. ca-certificates so outbound TLS to the providers works. No build
+# tooling, no -dev packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		libopus0 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# libdave: copied to /usr/local/lib (a default ldconfig search path) AND to the
+# exact $HOME/.local/lib the build stage used, because the binary's baked rpath
+# (from dave.pc) names that path. Either resolver then finds it.
+COPY --from=build /opt/build/.local/lib/libdave.so /usr/local/lib/libdave.so
+RUN mkdir -p /opt/build/.local/lib \
+	&& ln -s /usr/local/lib/libdave.so /opt/build/.local/lib/libdave.so
+
+# Bundled ONNX runtime (lib + its versioned soname symlinks).
+COPY --from=build /opt/onnxruntime/lib/ /usr/local/lib/
+
+# Refresh the dynamic linker cache so /usr/local/lib libs resolve without
+# LD_LIBRARY_PATH. The smoke test's `ldd` assertion verifies this worked.
+RUN ldconfig
+
+# The binary itself. On $PATH so `glyphoxa <mode>` / `glyphoxa migrate` just work.
+COPY --from=build /out/glyphoxa /usr/local/bin/glyphoxa
+
+# Point the Silero VAD at the bundled runtime so it never downloads one at start
+# (ADR-0034). ensureRuntime() short-circuits on this env var.
+ENV GLYPHOXA_ONNX_LIB=/usr/local/lib/libonnxruntime.so
+
+# Run as a non-root user (uid/gid 65532, the conventional "nonroot" id). The app
+# needs no write access to its own files at runtime; config comes from env.
+RUN groupadd --gid 65532 glyphoxa \
+	&& useradd --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin glyphoxa
+USER 65532:65532
+
+# Entry is the binary; `mode` and config are args/env at runtime (ADR-0034).
+# Default to `all` mode per ADR-0005 (the self-host default); override with e.g.
+# `docker run … glyphoxa -mode voice -guild … -channel …` or `glyphoxa migrate up`.
+ENTRYPOINT ["glyphoxa"]
+CMD ["-mode", "all"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint
+.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke
 
 # Build voice engine
 build:
@@ -133,3 +133,18 @@ proto-lint:
 # Clean build artifacts
 clean:
 	rm -rf bin/ coverage.out
+
+# --- Container image (ADR-0034) --------------------------------------------
+# One multi-stage image for the single binary; `mode`/config are runtime args.
+# The native build (whisper.cpp + libopus + libdave + CGO) is SLOW on a cold
+# layer cache — expect several minutes on first build.
+DOCKER_IMAGE ?= glyphoxa:smoke
+
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .
+
+# Run the container smoke test (issue #31) against $(DOCKER_IMAGE). Asserts the
+# CLI works, ldd resolves every native dep, the bundled ONNX runtime exists, and
+# the process is non-root. Build the image first (make docker-build).
+docker-smoke:
+	./scripts/container-smoke.sh $(DOCKER_IMAGE)

--- a/cmd/glyphoxa/migrate.go
+++ b/cmd/glyphoxa/migrate.go
@@ -35,6 +35,16 @@ func RunMigrate(ctx context.Context, args []string) error {
 		return fmt.Errorf("migrate: missing subcommand")
 	}
 
+	// Help is a pure documentation path: it must succeed with no database and
+	// no network (e.g. `docker run … glyphoxa migrate --help` in a fresh image),
+	// so it short-circuits before the DSN check. Usage goes to stdout — it's the
+	// requested output here, not an error diagnostic.
+	switch args[0] {
+	case "-h", "--help", "help":
+		fmt.Println(migrateUsage)
+		return nil
+	}
+
 	dsn := os.Getenv("GLYPHOXA_DATABASE_URL")
 	if dsn == "" {
 		dsn = os.Getenv("DATABASE_URL")

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# container-smoke.sh — the executable acceptance spec for the Glyphoxa OCI image
+# (issue #31, ADR-0034). Runs against an already-built image and asserts the
+# image is actually runnable: the CLI works, every native dependency the live
+# build links is resolvable inside the container, the bundled ONNX runtime is
+# present (so the Silero VAD never reaches the network at start, ADR-0034), and
+# the process is a non-root user.
+#
+# Usage: scripts/container-smoke.sh [IMAGE]
+#   IMAGE defaults to "glyphoxa:smoke" (what `make docker-build` tags).
+#
+# Exit status is 0 only if every assertion passes; the first failure aborts.
+set -euo pipefail
+
+IMAGE="${1:-glyphoxa:smoke}"
+
+# Resolve the binary path and onnx-lib path once from the image's own config so
+# the assertions don't hard-code a layout the Dockerfile might change later.
+BIN_PATH="/usr/local/bin/glyphoxa"
+
+pass=0
+fail=0
+note() { printf '  -> %s\n' "$*"; }
+ok() { printf 'PASS: %s\n' "$1"; pass=$((pass + 1)); }
+bad() {
+	printf 'FAIL: %s\n' "$1" >&2
+	fail=$((fail + 1))
+}
+
+# run_in_image runs a command inside a throwaway container of $IMAGE, overriding
+# the entrypoint so we can invoke arbitrary shell assertions. Returns the
+# command's own exit status.
+run_in_image() {
+	docker run --rm --network none --entrypoint /bin/sh "$IMAGE" -c "$*"
+}
+
+printf '== Glyphoxa container smoke test ==\n'
+printf 'image: %s\n\n' "$IMAGE"
+
+# Fail fast with a clear message if the image was never built.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+	printf 'FAIL: image %q does not exist — build it first (make docker-build / docker build -t %q .)\n' "$IMAGE" "$IMAGE" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. `glyphoxa migrate --help` exits 0 (issue #31 acceptance criterion).
+#    The entrypoint is the binary, so we invoke the subcommand via run args, and
+#    --network none proves the help path needs no network. RunMigrate
+#    (cmd/glyphoxa/migrate.go) short-circuits --help BEFORE its $GLYPHOXA_DATABASE_URL
+#    check, so this succeeds in a fresh DB-less container.
+# ---------------------------------------------------------------------------
+printf '[1] glyphoxa migrate --help exits 0\n'
+if docker run --rm --network none "$IMAGE" migrate --help >/dev/null 2>&1; then
+	ok 'migrate --help exited 0'
+else
+	bad "migrate --help did not exit 0 (got $?)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. ldd on the binary resolves EVERY shared lib — no "not found".
+#    libopus and libdave are LINK-time deps (pkg-config opus / dave), so they
+#    must appear in the binary's ldd and resolve. libonnxruntime is deliberately
+#    NOT here: the Silero VAD dlopen()s it at runtime via
+#    ort.SetSharedLibraryPath($GLYPHOXA_ONNX_LIB) — it is never link-time linked,
+#    so it correctly does not appear in `ldd glyphoxa`. Its resolvability is
+#    asserted separately in step 3 (ldd on the .so itself), which is the check
+#    that actually predicts whether the runtime dlopen will succeed.
+# ---------------------------------------------------------------------------
+printf '[2] ldd on the binary resolves every linked library (no "not found")\n'
+ldd_out="$(run_in_image "ldd $BIN_PATH" 2>&1)" || true
+note "ldd output:"
+printf '%s\n' "$ldd_out" | sed 's/^/      /'
+if printf '%s\n' "$ldd_out" | grep -qi 'not found'; then
+	bad 'ldd reported an unresolved shared library ("not found")'
+else
+	ok 'ldd reported no "not found" entries'
+fi
+for lib in libopus libdave; do
+	if printf '%s\n' "$ldd_out" | grep -q "$lib"; then
+		ok "ldd links $lib"
+	else
+		bad "ldd output does not mention $lib (expected a link-time dependency)"
+	fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. The bundled ONNX runtime: $GLYPHOXA_ONNX_LIB is set in the image config (so
+#    the VAD short-circuits its download path — ADR-0034: no network fetch at
+#    container start), the file exists, AND its OWN shared-lib deps all resolve
+#    so the runtime dlopen() won't fail with "not found".
+# ---------------------------------------------------------------------------
+printf '[3] bundled ONNX runtime is set, present, and itself fully resolvable\n'
+onnx_lib="$(run_in_image 'printf "%s" "$GLYPHOXA_ONNX_LIB"')" || true
+if [ -z "$onnx_lib" ]; then
+	bad 'GLYPHOXA_ONNX_LIB is not set in the image config'
+else
+	note "GLYPHOXA_ONNX_LIB=$onnx_lib"
+	if run_in_image "test -e \"\$GLYPHOXA_ONNX_LIB\""; then
+		ok "ONNX runtime exists at \$GLYPHOXA_ONNX_LIB"
+	else
+		bad "no file at \$GLYPHOXA_ONNX_LIB ($onnx_lib)"
+	fi
+	onnx_ldd="$(run_in_image 'ldd "$GLYPHOXA_ONNX_LIB"' 2>&1)" || true
+	note "ldd \$GLYPHOXA_ONNX_LIB:"
+	printf '%s\n' "$onnx_ldd" | sed 's/^/      /'
+	if printf '%s\n' "$onnx_ldd" | grep -qi 'not found'; then
+		bad 'the bundled libonnxruntime has an unresolved dependency ("not found")'
+	else
+		ok 'libonnxruntime resolves all its own shared libs'
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The process runs as a non-root uid.
+# ---------------------------------------------------------------------------
+printf '[4] process runs as a non-root uid\n'
+uid="$(run_in_image 'id -u')" || true
+note "container uid: ${uid:-<unknown>}"
+if [ -n "${uid:-}" ] && [ "$uid" -ne 0 ]; then
+	ok "runs as non-root uid ($uid)"
+else
+	bad "runs as root (uid=$uid) — expected a non-root user"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+printf '\n== summary: %d passed, %d failed ==\n' "$pass" "$fail"
+if [ "$fail" -ne 0 ]; then
+	exit 1
+fi
+printf 'all container smoke assertions passed\n'


### PR DESCRIPTION
## What does this PR do?

Adds the single multi-stage OCI image for the one Glyphoxa binary (ADR-0005, ADR-0034). `mode` and all config are supplied at **runtime** via args/env — there are no per-mode images.

Closes #31.

- **`Dockerfile`** (new): two stages.
  - *Build* (`golang:1.26-trixie`): builds the whisper.cpp static lib, installs libopus + libdave (via the godave `libdave_install.sh`, mirroring Makefile `dave-libs`), bundles the pinned ONNX runtime (`1.25.1` — the version `pkg/voice/vad/silero/runtime.go` resolves), then `go build -tags "opus dave nolibopusfile" -ldflags "-s -w"` with the whisper/dave/opus env the Makefile + `.goreleaser.yml` use.
  - *Runtime* (`debian:trixie-slim`, glibc — distroless deferred per ADR-0034): carries the binary, libopus + libdave, the bundled `libonnxruntime`, a non-root user (uid 65532), and `GLYPHOXA_ONNX_LIB` pointing at the bundled lib so the Silero VAD never downloads a runtime at start. The Silero model + SQL migrations are already `go:embed`'d into the binary.
- **`scripts/container-smoke.sh`** (new): the executable acceptance spec (red→green). Asserts `migrate --help` exits 0, `ldd` resolution, the bundled ONNX lib, and non-root uid.
- **`cmd/glyphoxa/migrate.go`**: small CLI fix folded in (see below) — `migrate --help` now exits 0.
- **`.github/workflows/ci.yml`**: a **separate** `image` job (buildx + gha cache) builds the image and runs the smoke test on every PR — off the fast unit path per ADR-0033.
- **`.github/workflows/release-image.yml`** (new): publishes to `ghcr.io/mrwong99/glyphoxa` on a `v*` tag, tagged with the version (matching the `.goreleaser.yml` footer) **and** the git SHA.
- **`Makefile`**: `docker-build` / `docker-smoke` targets.
- **`.dockerignore`**: trims the build context.

## Why is this change needed?

ADR-0034 commits to one OCI image with `mode` as a runtime parameter; nothing built it yet, and `.goreleaser.yml` already advertises `docker pull ghcr.io/mrwong99/glyphoxa:vX.Y.Z` in its release footer. This wires the image and its publish path, and adds a per-PR smoke gate so the live CGO surface (whisper/opus/dave/ONNX) can't silently break.

## How was this tested?

`docker build` **succeeded locally** and the smoke test **passed (7/7)** against it. Final image size: **222 MB**. Rebased on current `main` (post-#32).

Local-build caveat: this sandbox's default Docker bridge has no DNS, so the build was run with `--network=host` (a host-network workaround for the sandbox only — CI runners have working DNS and need no such flag; the Dockerfile is unchanged). Bundled ONNX runtime version: **1.25.1** (linux/amd64), matching `runtime.go`.

Smoke assertions (`--network none` on every run, proving no network at start):
- [x] `glyphoxa migrate --help` exits 0 (verified in-container and via the rebuilt binary directly).
- [x] `ldd` on the binary: no "not found"; libopus + libdave present (libonnxruntime is `dlopen`'d at runtime via `ort.SetSharedLibraryPath`, not linked, so it's verified separately).
- [x] bundled ONNX lib exists at `$GLYPHOXA_ONNX_LIB` **and** resolves all its own shared libs.
- [x] process runs as non-root uid (65532).

**`migrate --help` fix (folded in):** the acceptance criterion needs `migrate --help` to exit 0, but `RunMigrate` ran the `$GLYPHOXA_DATABASE_URL` check before any help handling, so it exited 1 in a DB-less container. `cmd/glyphoxa/migrate.go` now short-circuits `--help`/`-h`/`help` to print usage on stdout and return nil, before the DSN check. `migrate` with no args / unknown subcommand still errors (exit 1) as before. This `cmd/` change was originally #32's territory; that issue merged (#39), so the fix lands here to keep #31 self-contained and the smoke assertion literal.

- [x] Manual testing: local `docker build` + `scripts/container-smoke.sh` (above); `go vet ./cmd/glyphoxa/` clean; help-path exit codes verified for `--help`/`-h`/`help`/no-args.

## Type of Change

- [x] Build / CI / tooling

## Additional Notes

- **trixie, not bookworm:** the prebuilt libdave asset links against `GLIBC_2.38` / `GLIBCXX_3.4.32`; bookworm's glibc 2.36 can't satisfy those, so both stages use Debian trixie (matching the Ubuntu-24.04 glibc the CI `audio` job links libdave against).
- **libdave install fix:** the install script's cosmetic `update_shell_profile` reads `$SHELL` under `set -u`; unset in a `RUN`, it aborted exit 2 *after* installing the lib. The Dockerfile sets `SHELL=/bin/sh` for that step.
- `whisper.cpp` is built with `GGML_NATIVE=OFF` (the Makefile uses `ON`) so the image isn't pinned to the builder's `-march=native`.
- Not in scope (separate ADR-0034 follow-ups): `compose.yml`, the Helm chart, the systemd unit.
- Could not trigger the GitHub Actions runs from here; both changed workflows are `actionlint`-clean and YAML-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)