### PR TITLE
feat(deploy): Helm chart — pgvector Postgres + migrate pre-install hook Job (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,57 @@ jobs:
       - name: Container smoke test
         run: ./scripts/container-smoke.sh glyphoxa:smoke
 
+  helm:
+    name: helm chart (lint + unittest + kubeconform)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # The fast, cluster-free gate for the deploy chart (ADR-0034, issue #34):
+      # template-time correctness only. The real cluster e2e (helm install →
+      # Postgres Ready → migrate Job Completed) is issue #37's job and is NOT run
+      # here, so an unrelated PR's chart feedback stays seconds, not minutes.
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      # helm-unittest renders the templates and asserts the hook ordering,
+      # images, and Secret wiring (deploy/charts/glyphoxa/tests/*). Pinned (not
+      # @latest) so a plugin release can't silently change what CI enforces.
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
+
+      # kubeconform validates the rendered manifests against the upstream
+      # Kubernetes JSON schemas — the structural gate `helm lint`/unittest don't
+      # provide. Pinned release binary, fetched without piping a script to a shell.
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform
+          sudo install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Helm lint
+        run: helm lint deploy/charts/glyphoxa
+
+      - name: Helm unittest
+        run: helm unittest deploy/charts/glyphoxa
+
+      # Render every value path the chart supports and schema-validate each.
+      # -strict rejects unknown fields; the in-cluster path (4 docs) and the
+      # external-DB path (postgres disabled, 2 docs) are both checked so neither
+      # render branch can regress into an invalid manifest.
+      - name: Render + kubeconform
+        run: |
+          helm template glyphoxa deploy/charts/glyphoxa \
+            | kubeconform -strict -summary -kubernetes-version 1.30.0
+          helm template glyphoxa deploy/charts/glyphoxa \
+            --set postgres.enabled=false \
+            --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require' \
+            | kubeconform -strict -summary -kubernetes-version 1.30.0
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,13 @@ jobs:
       # template-time correctness only. The real cluster e2e (helm install →
       # Postgres Ready → migrate Job Completed) is issue #37's job and is NOT run
       # here, so an unrelated PR's chart feedback stays seconds, not minutes.
+      # Helm >= 3.18 is required: helm-unittest v1.1.1's plugin.yaml uses the
+      # `platformHooks` field, which older Helm (<= 3.17) refuses to parse,
+      # leaving the plugin installed-but-unusable. Keep these two pins in step.
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.16.3
+          version: v3.18.4
 
       # helm-unittest renders the templates and asserts the hook ordering,
       # images, and Secret wiring (deploy/charts/glyphoxa/tests/*). Pinned (not

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke
+.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke helm-lint helm-test helm-validate
 
 # Build voice engine
 build:
@@ -148,3 +148,26 @@ docker-build:
 # the process is non-root. Build the image first (make docker-build).
 docker-smoke:
 	./scripts/container-smoke.sh $(DOCKER_IMAGE)
+
+# --- Helm chart (ADR-0034, issue #34) --------------------------------------
+# The deploy chart stands up a pgvector Postgres and applies the schema via a
+# migrate pre-install hook Job. These targets mirror the fast `helm` CI job:
+# template-time correctness only, no cluster (the cluster e2e is issue #37).
+# Requires: helm, the helm-unittest plugin
+# (helm plugin install https://github.com/helm-unittest/helm-unittest), and
+# kubeconform (https://github.com/yannh/kubeconform).
+HELM_CHART ?= deploy/charts/glyphoxa
+
+helm-lint:
+	helm lint $(HELM_CHART)
+
+helm-test:
+	helm unittest $(HELM_CHART)
+
+# Render both value paths (in-cluster Postgres and external DB) and schema-check
+# each against the upstream Kubernetes schemas.
+helm-validate:
+	helm template glyphoxa $(HELM_CHART) | kubeconform -strict -summary -kubernetes-version 1.30.0
+	helm template glyphoxa $(HELM_CHART) --set postgres.enabled=false \
+		--set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require' \
+		| kubeconform -strict -summary -kubernetes-version 1.30.0

--- a/deploy/charts/glyphoxa/.helmignore
+++ b/deploy/charts/glyphoxa/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+.vscode/
+.idea/
+# helm-unittest specs are dev-only; they must not ship in the packaged chart.
+tests/

--- a/deploy/charts/glyphoxa/Chart.yaml
+++ b/deploy/charts/glyphoxa/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: glyphoxa
+description: |
+  Glyphoxa on Kubernetes — a pgvector Postgres plus a migrate Job that applies
+  the embedded schema as a Helm pre-install/pre-upgrade hook (ADR-0034).
+  This is the first deploy slice: it stands up the database and brings the
+  schema current. The serving workloads (seed Job, voice Deployment) slot in
+  later behind their own templates.
+type: application
+
+# Chart version is the packaging version; appVersion tracks the Glyphoxa image
+# the chart deploys (ADR-0034: one image, mode/config via args+env). When no
+# image.tag is set in values, templates fall back to appVersion.
+version: 0.1.0
+appVersion: "0.1.0"
+
+kubeVersion: ">=1.27.0-0"
+
+keywords:
+  - glyphoxa
+  - postgres
+  - pgvector
+  - migrations
+
+sources:
+  - https://github.com/MrWong99/Glyphoxa_v2

--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -1,0 +1,22 @@
+Glyphoxa slice 1 installed: {{ .Release.Name }} (namespace {{ .Release.Namespace }}).
+
+What this release stands up (ADR-0034):
+{{- if .Values.postgres.enabled }}
+  - A pgvector Postgres StatefulSet reachable in-cluster at:
+      {{ include "glyphoxa.postgres.fullname" . }}:{{ .Values.postgres.service.port }}
+{{- else }}
+  - No in-cluster Postgres (postgres.enabled=false); using the external
+    database.url you supplied.
+{{- end }}
+  - A migrate Job run as a pre-install/pre-upgrade hook that applied the schema
+    with `glyphoxa migrate up` before this release became ready.
+
+Verify the schema is current:
+
+  kubectl -n {{ .Release.Namespace }} run glyphoxa-migrate-check --rm -it --restart=Never \
+    --image={{ include "glyphoxa.image" . }} \
+    --env GLYPHOXA_DATABASE_URL="$(kubectl -n {{ .Release.Namespace }} get secret {{ include "glyphoxa.secretName" . }} -o jsonpath='{.data.database-url}' | base64 -d)" \
+    -- migrate status
+
+The serving workloads (seed Job, voice Deployment) are not part of this slice;
+they land in later issues and assume this schema is already current.

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -1,0 +1,99 @@
+{{/*
+Naming + label helpers shared by every template in the chart.
+
+The names here are load-bearing: the Postgres Service name is what both the
+assembled connection URL and the migrate Job's pg_isready wait target resolve
+by DNS, so they all flow from one helper.
+*/}}
+
+{{/* Base name, honouring nameOverride / fullnameOverride like the Helm starter. */}}
+{{- define "glyphoxa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "glyphoxa.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "glyphoxa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels stamped on every object. */}}
+{{- define "glyphoxa.labels" -}}
+helm.sh/chart: {{ include "glyphoxa.chart" . }}
+{{ include "glyphoxa.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "glyphoxa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "glyphoxa.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Object names derived from the release. */}}
+{{- define "glyphoxa.postgres.fullname" -}}
+{{- printf "%s-postgres" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "glyphoxa.secretName" -}}
+{{- printf "%s-db" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "glyphoxa.migrate.fullname" -}}
+{{- printf "%s-migrate" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The single Glyphoxa image reference (ADR-0034). tag falls back to the chart
+appVersion so an unset tag still pins a matching image.
+*/}}
+{{- define "glyphoxa.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/* The pgvector Postgres image reference. */}}
+{{- define "glyphoxa.postgres.image" -}}
+{{- printf "%s:%s" .Values.postgres.image.repository .Values.postgres.image.tag -}}
+{{- end }}
+
+{{/*
+Hook ordering weights. The DB resources (Secret, Service, StatefulSet) come up
+first, then the migrate Job, then (later) the serving workloads. All are
+pre-install/pre-upgrade hooks EXCEPT the serving workloads (#35/#36), which are
+plain resources applied after every hook — so the migration always precedes
+them. Weights sort ascending; lower runs first.
+
+  -10  DB Secret + Postgres Service + StatefulSet
+   -5  migrate Job
+    0  (serving workloads, not in this slice)
+*/}}
+{{- define "glyphoxa.dbHookWeight" -}}-10{{- end }}
+
+{{/*
+The DB connection URL. When the operator sets database.url it wins verbatim
+(external Postgres); otherwise the chart assembles a DSN against the in-cluster
+Postgres Service so the host can never drift from the Service name.
+*/}}
+{{- define "glyphoxa.databaseURL" -}}
+{{- if .Values.database.url -}}
+{{- .Values.database.url -}}
+{{- else -}}
+{{- $host := include "glyphoxa.postgres.fullname" . -}}
+{{- $port := .Values.postgres.service.port | int -}}
+{{- printf "postgres://%s:%s@%s:%d/%s?sslmode=%s" .Values.database.user .Values.database.password $host $port .Values.database.name .Values.database.sslmode -}}
+{{- end -}}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/migrate-job.yaml
+++ b/deploy/charts/glyphoxa/templates/migrate-job.yaml
@@ -1,0 +1,86 @@
+{{/*
+Migrate hook Job — the heart of slice 1 (ADR-0034, ADR-0031).
+
+It runs `glyphoxa migrate up` (advisory-locked inside the binary) ONCE per
+install/upgrade as a Helm pre-install/pre-upgrade hook, BEFORE any serving
+workload, rather than as an init-container on every replica. The single hook is
+what makes the migration run once and observably; the advisory lock is what
+makes a concurrent run safe (ADR-0031).
+
+- hook + hook-weight: pre-install,pre-upgrade at a negative weight so it applies
+  ahead of the (non-hook, weight-0) serving workloads added in #35/#36.
+- hook-delete-policy before-hook-creation: the prior run's Job is cleared before
+  re-running on upgrade, so a leftover completed Job never blocks the new one
+  and its logs stay around until the next upgrade for inspection.
+- initContainer: hook Jobs can start before Postgres accepts connections, so an
+  initContainer blocks on pg_isready against the Postgres Service before the
+  migrate container runs. The migrate path also retries, but waiting here keeps
+  the run deterministic and the Job logs clean.
+- GLYPHOXA_DATABASE_URL comes from the DB Secret, pointed at the in-cluster
+  Postgres Service DNS.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "glyphoxa.migrate.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ .Values.migrate.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.postgres.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ include "glyphoxa.postgres.image" . }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              until pg_isready -h {{ include "glyphoxa.postgres.fullname" . }} -p {{ .Values.postgres.service.port }} -U {{ .Values.database.user | quote }};
+              do echo "waiting for postgres at {{ include "glyphoxa.postgres.fullname" . }}:{{ .Values.postgres.service.port }}"; sleep 2; done
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ include "glyphoxa.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - migrate
+            - up
+          env:
+            - name: GLYPHOXA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database-url
+          {{- with .Values.migrate.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/glyphoxa/templates/postgres-service.yaml
+++ b/deploy/charts/glyphoxa/templates/postgres-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.postgres.enabled }}
+{{/*
+Headless Service (clusterIP: None) giving the Postgres StatefulSet stable
+per-pod DNS. Its name is the host both the assembled connection URL and the
+migrate Job's pg_isready wait target resolve — that single name is the contract
+between the database and everything that connects to it.
+
+A pre-install/pre-upgrade hook (weight -10) so its DNS is resolvable before the
+migrate hook (weight -5) connects through it.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glyphoxa.postgres.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ include "glyphoxa.dbHookWeight" . | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  clusterIP: None
+  selector:
+    {{- include "glyphoxa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/postgres-statefulset.yaml
+++ b/deploy/charts/glyphoxa/templates/postgres-statefulset.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.postgres.enabled }}
+{{/*
+pgvector Postgres as a plain StatefulSet (ADR-0034 scopes the CNPG operator out
+of slice 1). A volumeClaimTemplate gives the single replica durable storage; the
+headless Service (postgres-service.yaml) gives it stable DNS. The migrate hook
+Job and (later) the serving workloads connect through that Service.
+
+Credentials come from the DB Secret so they cannot drift from the assembled
+connection URL. PGDATA points at a subdirectory of the mount because the
+pgvector/postgres image refuses to initialise into a volume root that carries a
+lost+found directory (a common PVC backing-store artifact).
+
+It is a pre-install/pre-upgrade hook (weight -10) so the database is up before
+the migrate hook (weight -5) and any serving workload. Helm does not wait for
+non-Job hooks to become Ready — it only waits for them to be created — so the
+migrate Job's own pg_isready initContainer is what blocks until Postgres
+actually accepts connections.
+
+before-hook-creation means an upgrade deletes and recreates this StatefulSet.
+The data survives: a StatefulSet delete does NOT garbage-collect the PVCs its
+volumeClaimTemplate created, so the recreated pod reattaches the same volume.
+The cost is a brief Postgres restart per upgrade, acceptable for the single
+in-cluster instance this slice ships (operators wanting zero-downtime point
+database.url at an externally managed Postgres and set postgres.enabled=false).
+*/}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "glyphoxa.postgres.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ include "glyphoxa.dbHookWeight" . | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  replicas: 1
+  serviceName: {{ include "glyphoxa.postgres.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ include "glyphoxa.postgres.image" . }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- with .Values.postgres.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.postgres.persistence.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/secret.yaml
+++ b/deploy/charts/glyphoxa/templates/secret.yaml
@@ -1,0 +1,30 @@
+{{/*
+DB connection Secret. Holds the Postgres password and the assembled (or
+operator-supplied) GLYPHOXA_DATABASE_URL. Postgres reads `password`; the migrate
+Job reads `database-url`. Keeping both in one Secret means the URL and the role
+password can never drift apart.
+
+stringData (kubelet base64-encodes it) over data so the values stay reviewable
+in `helm template` output and assertable in helm-unittest.
+
+It is a pre-install/pre-upgrade hook (weight -10) like the Postgres it backs, so
+it exists before the migrate hook (weight -5) reads `database-url` from it. The
+migrate hook runs before any serving workload, and a pre-install hook resource
+is created before those serving (non-hook) resources too, so they also find it.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "glyphoxa.secretName" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ include "glyphoxa.dbHookWeight" . | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+type: Opaque
+stringData:
+  database-url: {{ include "glyphoxa.databaseURL" . | quote }}
+  username: {{ .Values.database.user | quote }}
+  password: {{ .Values.database.password | quote }}
+  database: {{ .Values.database.name | quote }}

--- a/deploy/charts/glyphoxa/tests/migrate_job_test.yaml
+++ b/deploy/charts/glyphoxa/tests/migrate_job_test.yaml
@@ -1,0 +1,86 @@
+suite: migrate hook Job
+# The migrate Job is the heart of slice 1 (ADR-0034): it runs `glyphoxa migrate
+# up` from the single image as a Helm pre-install/pre-upgrade hook, ordered to
+# run before any serving workload, and reads its connection string from the DB
+# Secret pointed at the in-cluster Postgres Service.
+templates:
+  - templates/migrate-job.yaml
+tests:
+  - it: renders a Job
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-migrate
+
+  - it: is a pre-install AND pre-upgrade Helm hook
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+
+  - it: carries a hook-weight that orders it before serving workloads
+    # Serving workloads (#35 seed Job, #36 voice Deployment) are NOT hooks and
+    # so apply at weight 0 / after hooks; a negative weight guarantees the
+    # migration runs first. We pin the exact value the templates use.
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-5"
+
+  - it: cleans up the prior hook Job before re-running on upgrade
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: runs `glyphoxa migrate up` from the configured image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mrwong99/glyphoxa:0.1.0
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - migrate
+            - up
+
+  - it: honours an overridden image repository and tag
+    set:
+      image:
+        repository: ghcr.io/example/glyphoxa
+        tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa:v9.9.9
+
+  - it: sources GLYPHOXA_DATABASE_URL from the DB connection Secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+
+  - it: waits for Postgres to accept connections before migrating
+    # Hook Jobs can start before Postgres is reachable; an initContainer that
+    # blocks on pg_isready against the Postgres Service makes the migrate run
+    # deterministic rather than relying solely on the Job backoff.
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: pgvector/pgvector:pg17
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[-1]
+          pattern: pg_isready.*RELEASE-NAME-glyphoxa-postgres
+
+  - it: never restarts a completed migrate pod
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never

--- a/deploy/charts/glyphoxa/tests/postgres_test.yaml
+++ b/deploy/charts/glyphoxa/tests/postgres_test.yaml
@@ -1,0 +1,101 @@
+suite: pgvector Postgres
+# ADR-0034 scopes slice 1 to a plain StatefulSet pgvector Postgres (NOT the CNPG
+# operator) with a PVC and a Service whose DNS the migrate Job targets.
+templates:
+  - templates/postgres-statefulset.yaml
+  - templates/postgres-service.yaml
+tests:
+  - it: runs the pgvector/pgvector:pg17 image
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: pgvector/pgvector:pg17
+
+  - it: comes up as a hook ahead of the migrate Job
+    # weight -10 < the migrate Job's -5, so the database exists before the
+    # migration connects; same hook events as the migrate Job.
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+
+  - it: is omitted entirely when an external database is used
+    template: templates/postgres-statefulset.yaml
+    set:
+      postgres:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: persists data on a PVC volume claim template
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 8Gi
+      - contains:
+          path: spec.volumeClaimTemplates[0].spec.accessModes
+          content: ReadWriteOnce
+
+  - it: binds to the headless Service so the StatefulSet has stable DNS
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-glyphoxa-postgres
+
+  - it: sources its credentials and database name from the DB Secret
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: password
+
+  - it: declares a readiness probe via pg_isready
+    template: templates/postgres-statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[-1]
+          pattern: pg_isready
+
+  - it: exposes a Service the migrate Job and serving workloads resolve by DNS
+    template: templates/postgres-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-postgres
+      - equal:
+          path: spec.ports[0].port
+          value: 5432
+
+  - it: is a headless Service for stable per-pod DNS
+    template: templates/postgres-service.yaml
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: comes up as a hook ahead of the migrate Job
+    template: templates/postgres-service.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -1,0 +1,54 @@
+suite: DB connection Secret
+# A single Secret holds the Postgres credentials and the assembled
+# GLYPHOXA_DATABASE_URL. Both Postgres (its POSTGRES_PASSWORD) and the migrate
+# Job (its GLYPHOXA_DATABASE_URL) read from it, so the URL and the password can
+# never drift apart. The template writes stringData (kubelet encodes it), which
+# also keeps the rendered value assertable here.
+templates:
+  - templates/secret.yaml
+tests:
+  - it: renders an Opaque Secret named for the release
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-db
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: comes up as a hook ahead of the migrate Job
+    # weight -10 < the migrate Job's -5, so the Secret exists before the migrate
+    # hook reads database-url from it.
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+
+  - it: carries the database-url key keyed as the migrate Job references it
+    asserts:
+      - isNotNullOrEmpty:
+          path: stringData["database-url"]
+      - isNotNullOrEmpty:
+          path: stringData.password
+
+  - it: assembles the url against the in-cluster Postgres Service DNS
+    # The migrate Job's GLYPHOXA_DATABASE_URL comes from this key; it MUST target
+    # the Postgres Service name (not localhost) so the hook Pod reaches the DB.
+    asserts:
+      - matchRegex:
+          path: stringData["database-url"]
+          pattern: ^postgres://glyphoxa:.+@RELEASE-NAME-glyphoxa-postgres:5432/glyphoxa
+
+  - it: lets the operator supply an external database url verbatim
+    set:
+      database:
+        url: postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require
+    asserts:
+      - equal:
+          path: stringData["database-url"]
+          value: postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -1,0 +1,55 @@
+# Glyphoxa Helm values — slice 1 (ADR-0034): pgvector Postgres + migrate hook.
+# The serving workloads (#35 seed Job, #36 voice Deployment) add their own keys
+# under this same file when they land.
+
+# The single Glyphoxa image (ADR-0034). `tag` defaults to the chart appVersion
+# when left empty so a chart bump pins a matching image.
+image:
+  repository: ghcr.io/mrwong99/glyphoxa
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# DB connection. By default the chart stands up its own in-cluster Postgres and
+# assembles the connection URL against that Service. Set `database.url` to point
+# the migrate Job (and later the serving workloads) at an external Postgres
+# instead; when set, the bundled Postgres can be disabled via `postgres.enabled`.
+database:
+  # Full DSN. Leave empty to have the chart assemble one from the values below
+  # against the in-cluster Postgres Service.
+  url: ""
+  name: glyphoxa
+  user: glyphoxa
+  # Password for the in-cluster Postgres role and the assembled URL. CHANGE THIS
+  # for any real deploy — or better, template it from an external Secret. A
+  # static default keeps `helm install` zero-ceremony for local/dev clusters.
+  password: glyphoxa
+  sslmode: disable
+
+# In-cluster pgvector Postgres (a plain StatefulSet, NOT the CNPG operator —
+# ADR-0034 scopes the operator out of slice 1).
+postgres:
+  enabled: true
+  image:
+    repository: pgvector/pgvector
+    tag: pg17
+    pullPolicy: IfNotPresent
+  service:
+    port: 5432
+  persistence:
+    size: 8Gi
+    # storageClassName: ""  # use the cluster default when unset
+  resources: {}
+
+# Migrate hook Job (ADR-0031: `glyphoxa migrate up`, advisory-locked). Runs as a
+# Helm pre-install/pre-upgrade hook before any serving workload.
+migrate:
+  # Negative hook-weight orders the migration ahead of the non-hook serving
+  # workloads (which apply at weight 0 / after hooks).
+  hookWeight: -5
+  resources: {}
+
+# Pod-level knobs shared by the workloads this chart renders.
+podSecurityContext: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## What does this PR do?

Adds the first "Glyphoxa schema lives in k3s" deploy slice (ADR-0034): a new Helm chart at `deploy/charts/glyphoxa` that, on `helm install`, stands up a pgvector Postgres and applies the embedded schema with `glyphoxa migrate up` run as a Helm **pre-install/pre-upgrade hook Job** before any serving workload.

Files added:
- `deploy/charts/glyphoxa/` — `Chart.yaml`, `values.yaml`, `.helmignore`, `templates/` (`_helpers.tpl`, `secret.yaml`, `postgres-service.yaml`, `postgres-statefulset.yaml`, `migrate-job.yaml`, `NOTES.txt`), and `tests/` (helm-unittest specs).
- `.github/workflows/ci.yml` — a fast `helm` job (lint + unittest + kubeconform; no cluster).
- `Makefile` — `helm-lint` / `helm-test` / `helm-validate` targets mirroring the CI job.

Design (ADR-0034, ADR-0031):
- **Postgres:** a plain StatefulSet (NOT the CNPG operator — out of scope) running `pgvector/pgvector:pg17`, with a retained PVC and a **headless Service** whose DNS is the single host the connection URL and the migrate wait-target both resolve.
- **migrate Job:** `pre-install,pre-upgrade` hook at weight `-5`, runs `glyphoxa migrate up` from the single image (ADR-0005), `GLYPHOXA_DATABASE_URL` sourced from the DB Secret. The advisory lock (ADR-0031) makes it safe; the single hook makes it run once and observably. An initContainer blocks on `pg_isready` so the hook never races Postgres accepting connections.
- **DB resources as hooks:** the Secret, Postgres Service, and StatefulSet are themselves `pre-install,pre-upgrade` hooks at weight `-10` so the in-cluster database exists **before** the migrate hook connects. This is the one non-obvious decision — see *Additional Notes*.
- **Serving workloads** (seed Job #35, voice Deployment #36) are NOT in this slice; the chart leaves room for them and the migration always precedes them.

## Why is this change needed?

ADR-0034 commits the Kubernetes path to a Helm chart that runs migrations once as a pre-deploy hook (not an init-container on every replica). This PR delivers the first vertical slice of that: database + schema. Later issues add the seed Job and the voice Deployment on top of a schema this chart guarantees is current.

## How was this tested?

Merge gates (all cluster-free, all run in the new `helm` CI job):
- `helm lint deploy/charts/glyphoxa` — clean (only the cosmetic "icon is recommended" INFO).
- `helm unittest deploy/charts/glyphoxa` — **24 tests, 3 suites, all pass** (written red→green). They assert: the migrate Job's `pre-install,pre-upgrade` hook + `-5` weight + `before-hook-creation` policy; that it runs `migrate up` from the configured image and honours overrides; that `GLYPHOXA_DATABASE_URL` comes from the DB Secret; the `pg_isready` initContainer wait; Postgres renders `pgvector/pgvector:pg17` + PVC + headless Service at `-10`; the Secret's assembled URL targets the Postgres Service DNS and accepts an external URL verbatim; and that the StatefulSet vanishes when `postgres.enabled=false`.
- `kubeconform -strict -kubernetes-version 1.30.0` over both render paths (in-cluster Postgres = 4 docs; external DB / `postgres.enabled=false` = 2 docs) — all valid.
- `actionlint` on the edited workflow — clean.

**Cluster e2e (RAN, not deferred)** against a local k3d (v1.30) cluster, with the slice-1 image (`docker build` from this repo's Dockerfile) imported via `k3d image import`:
- `helm install --wait` → STATUS deployed.
- Postgres StatefulSet `1/1 ready`; migrate Job condition `Complete`, `succeeded=1`.
- Migrate pod logs show the initContainer's `pg_isready` loop waiting until "accepting connections", then `migrate: up complete`.
- In-DB assertions: `pg_extension` shows `vector 0.8.3` and `pgcrypto 1.3` present (the `CREATE EXTENSION vector` acceptance criterion); `goose_db_version` max = `2` (both embedded migrations applied); 6 tables in `public`.
- `helm upgrade --wait` → REVISION 2; migrate Job re-ran and succeeded (idempotent); the **same PVC stayed Bound** and schema/`vector` survived — confirming `before-hook-creation` does not lose data.

The existing testcontainer migrate round-trip test is untouched Go; `go build ./...` still passes.

- [ ] `make check` passes — n/a, this PR adds no Go; `make helm-lint`/`helm-test`/`helm-validate` all pass.
- [x] New/updated tests cover the change (24 helm-unittest assertions)
- [x] Manual testing (full k3d cluster e2e, described above)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build / CI / tooling

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass (helm unittest 24/24; cluster e2e green)
- [x] I have updated documentation if needed (chart `NOTES.txt`; inline template comments)
- [x] My commits are focused and have clear messages

## Additional Notes

**Why the DB resources are hooks too (the one non-obvious decision):** a Helm `pre-install` hook runs before *any* regular resource is applied. With Postgres as a regular resource, the migrate hook's `pg_isready` initContainer waited forever for a Service that did not yet exist — a fresh-install deadlock (caught in e2e). Making the Secret/Service/StatefulSet `pre-install,pre-upgrade` hooks at weight `-10` (the migrate Job is `-5`) brings the database up first. Helm does not wait for non-Job hooks to be *Ready*, only created, so the migrate Job's own `pg_isready` initContainer remains the thing that blocks until Postgres accepts connections.

**Upgrade tradeoff:** `before-hook-creation` recreates the Postgres StatefulSet on each `helm upgrade` (a brief restart of the single instance). The `volumeClaimTemplate` PVC is **not** garbage-collected on StatefulSet delete, so data persists — verified by the round-trip upgrade above. Operators wanting zero-downtime point `database.url` at an externally managed Postgres and set `postgres.enabled=false`.

The cluster e2e is also covered by issue #37; the hard merge gates here are lint + unittest + kubeconform, all in the cluster-free `helm` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)