### PR TITLE
feat(deploy): seed Job — load the demo NPC into the cluster DB (#35)

### DIFF
--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -10,6 +10,11 @@ What this release stands up (ADR-0034):
 {{- end }}
   - A migrate Job run as a pre-install/pre-upgrade hook that applied the schema
     with `glyphoxa migrate up` before this release became ready.
+{{- if .Values.seed.enabled }}
+  - A seed Job run as a pre-install/pre-upgrade hook (after migrate) that loaded
+    the demo Tenant/Campaign/NPC with `glyphoxa seed`. The seed is idempotent, so
+    it re-runs harmlessly on `helm upgrade`.
+{{- end }}
 
 Verify the schema is current:
 
@@ -18,5 +23,5 @@ Verify the schema is current:
     --env GLYPHOXA_DATABASE_URL="$(kubectl -n {{ .Release.Namespace }} get secret {{ include "glyphoxa.secretName" . }} -o jsonpath='{.data.database-url}' | base64 -d)" \
     -- migrate status
 
-The serving workloads (seed Job, voice Deployment) are not part of this slice;
-they land in later issues and assume this schema is already current.
+The voice Deployment is not part of this slice; it lands in a later issue (#36)
+and assumes this schema is current and the demo NPC seeded.

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -56,6 +56,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-migrate" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.seed.fullname" -}}
+{{- printf "%s-seed" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 The single Glyphoxa image reference (ADR-0034). tag falls back to the chart
 appVersion so an unset tag still pins a matching image.
@@ -72,14 +76,17 @@ appVersion so an unset tag still pins a matching image.
 
 {{/*
 Hook ordering weights. The DB resources (Secret, Service, StatefulSet) come up
-first, then the migrate Job, then (later) the serving workloads. All are
-pre-install/pre-upgrade hooks EXCEPT the serving workloads (#35/#36), which are
-plain resources applied after every hook — so the migration always precedes
-them. Weights sort ascending; lower runs first.
+first, then the migrate Job, then the seed Job, then (later) the serving
+workloads. All are pre-install/pre-upgrade hooks EXCEPT the voice Deployment
+(#36), which is a plain resource applied after every hook — so the migration and
+seed always precede it. Weights sort ascending; lower runs first; Helm waits for
+each weight's hook Jobs to complete before the next, so the seed only starts
+once the migration has finished and the schema is current.
 
   -10  DB Secret + Postgres Service + StatefulSet
    -5  migrate Job
-    0  (serving workloads, not in this slice)
+   -4  seed Job
+    0  (voice Deployment, #36 — not in this slice)
 */}}
 {{- define "glyphoxa.dbHookWeight" -}}-10{{- end }}
 

--- a/deploy/charts/glyphoxa/templates/secret.yaml
+++ b/deploy/charts/glyphoxa/templates/secret.yaml
@@ -1,16 +1,19 @@
 {{/*
-DB connection Secret. Holds the Postgres password and the assembled (or
-operator-supplied) GLYPHOXA_DATABASE_URL. Postgres reads `password`; the migrate
-Job reads `database-url`. Keeping both in one Secret means the URL and the role
-password can never drift apart.
+App Secret. Holds the Postgres password, the assembled (or operator-supplied)
+GLYPHOXA_DATABASE_URL, and the GLYPHOXA_SECRET credential-cipher key (ADR-0004).
+Postgres reads `password`; the migrate Job reads `database-url`; the seed Job
+(#35) reads both `database-url` and `app-secret`. Keeping them in one Secret
+means the URL, the role password, and the cipher key can never drift apart and
+the demo app's secrets stay in one place.
 
 stringData (kubelet base64-encodes it) over data so the values stay reviewable
 in `helm template` output and assertable in helm-unittest.
 
 It is a pre-install/pre-upgrade hook (weight -10) like the Postgres it backs, so
-it exists before the migrate hook (weight -5) reads `database-url` from it. The
-migrate hook runs before any serving workload, and a pre-install hook resource
-is created before those serving (non-hook) resources too, so they also find it.
+it exists before the migrate hook (weight -5) and seed hook (weight -4) read
+from it. The hooks run before any serving workload, and a pre-install hook
+resource is created before those serving (non-hook) resources too, so they also
+find it.
 */}}
 apiVersion: v1
 kind: Secret
@@ -28,3 +31,4 @@ stringData:
   username: {{ .Values.database.user | quote }}
   password: {{ .Values.database.password | quote }}
   database: {{ .Values.database.name | quote }}
+  app-secret: {{ required "appSecret is required: a base64-encoded 32-byte credential-cipher key (ADR-0004) the seed Job uses to seal placeholder provider credentials. Generate one with `openssl rand -base64 32`." .Values.appSecret | quote }}

--- a/deploy/charts/glyphoxa/templates/seed-job.yaml
+++ b/deploy/charts/glyphoxa/templates/seed-job.yaml
@@ -1,0 +1,97 @@
+{{/*
+Seed hook Job — loads the demo NPC into the cluster DB (#35).
+
+It runs `glyphoxa seed` ONCE per install/upgrade as a Helm
+pre-install/pre-upgrade hook, after the migrate hook and before any serving
+workload, so the in-cluster DB holds the demo Tenant/Campaign/NPC (+
+provider_configs) that voice mode (#36) loads by default — without it the voice
+pod has no NPC and crashloops. The seed is idempotent on the demo Tenant name
+(it skips when the Tenant already exists), so the pre-upgrade run neither errors
+nor duplicates data on a chart bump.
+
+- hook + hook-weight: pre-install,pre-upgrade at weight -4 — after the migrate
+  Job (-5), so the schema is current before seeding, yet still ahead of the
+  non-hook serving workloads at weight 0. Helm waits for each weight's hook Jobs
+  to complete before the next, so the migration has finished when the seed runs.
+- hook-delete-policy before-hook-creation: the prior run's Job is cleared before
+  re-running on upgrade, so a leftover completed Job never blocks the new one and
+  its logs stay around until the next upgrade for inspection.
+- initContainer: like the migrate hook, the seed Pod can start before Postgres
+  accepts connections, so an initContainer blocks on pg_isready against the
+  Postgres Service before the seed container runs.
+- GLYPHOXA_DATABASE_URL comes from the DB Secret, pointed at the in-cluster
+  Postgres Service DNS; GLYPHOXA_SECRET (ADR-0004) comes from the same Secret and
+  is the credential-cipher key the seed uses to seal placeholder provider
+  credentials (the real keys live in the OS keyring, not the DB).
+*/}}
+{{- if .Values.seed.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "glyphoxa.seed.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: seed
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ .Values.seed.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: seed
+    spec:
+      restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.postgres.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ include "glyphoxa.postgres.image" . }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              until pg_isready -h {{ include "glyphoxa.postgres.fullname" . }} -p {{ .Values.postgres.service.port }} -U {{ .Values.database.user | quote }};
+              do echo "waiting for postgres at {{ include "glyphoxa.postgres.fullname" . }}:{{ .Values.postgres.service.port }}"; sleep 2; done
+      {{- end }}
+      containers:
+        - name: seed
+          image: {{ include "glyphoxa.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - seed
+          env:
+            - name: GLYPHOXA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database-url
+            - name: GLYPHOXA_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: app-secret
+          {{- with .Values.seed.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -6,6 +6,13 @@ suite: DB connection Secret
 # also keeps the rendered value assertable here.
 templates:
   - templates/secret.yaml
+# appSecret has no default (an unset value fails the render so a deploy can never
+# silently run on a weak key); supply a placeholder for every render here. The
+# fixture is deliberately plain low-entropy ASCII, NOT a base64 32-byte key — the
+# template stores it verbatim in stringData, and a random-base64 blob here only
+# trips secret scanners. Production still requires a real key (see values.yaml).
+set:
+  appSecret: unit-test-placeholder-not-a-real-secret
 tests:
   - it: renders an Opaque Secret named for the release
     asserts:
@@ -52,3 +59,14 @@ tests:
       - equal:
           path: stringData["database-url"]
           value: postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require
+
+  - it: carries the app-secret key the seed Job reads as GLYPHOXA_SECRET
+    # The credential-cipher key (ADR-0004) the seed uses to seal placeholder
+    # provider credentials. It rides in the same Secret as the DB URL so the
+    # demo app's two secrets stay in one place.
+    set:
+      appSecret: unit-test-placeholder-not-a-real-secret
+    asserts:
+      - equal:
+          path: stringData["app-secret"]
+          value: unit-test-placeholder-not-a-real-secret

--- a/deploy/charts/glyphoxa/tests/seed_job_test.yaml
+++ b/deploy/charts/glyphoxa/tests/seed_job_test.yaml
@@ -1,0 +1,103 @@
+suite: seed hook Job
+# The seed Job loads the demo Tenant/Campaign/NPC (+ provider_configs) the voice
+# mode (#36) loads by default — without it the voice pod has no NPC and
+# crashloops. It runs `glyphoxa seed` from the single image as a Helm
+# pre-install/pre-upgrade hook, ordered AFTER the migrate hook (so the schema is
+# current) and before the serving workloads. It reads GLYPHOXA_DATABASE_URL from
+# the DB Secret and GLYPHOXA_SECRET (the ADR-0004 credential cipher key) from the
+# same Secret. The seed code is idempotent on the demo Tenant name, so re-running
+# on upgrade is safe.
+templates:
+  - templates/seed-job.yaml
+tests:
+  - it: renders a Job
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-seed
+
+  - it: is a pre-install AND pre-upgrade Helm hook
+    # pre-upgrade matters: re-seeding on upgrade is safe (idempotent) and keeps
+    # the demo NPC present after a chart bump.
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+
+  - it: runs AFTER the migrate hook but before serving workloads
+    # migrate is weight -5; the seed at -4 sorts after it (so the schema exists
+    # before seeding) yet still ahead of the non-hook serving workloads at
+    # weight 0. We pin the exact value the template uses.
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-4"
+
+  - it: cleans up the prior hook Job before re-running on upgrade
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: runs `glyphoxa seed` from the configured image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mrwong99/glyphoxa:0.1.0
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - seed
+
+  - it: honours an overridden image repository and tag
+    set:
+      image:
+        repository: ghcr.io/example/glyphoxa
+        tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa:v9.9.9
+
+  - it: sources GLYPHOXA_DATABASE_URL from the DB connection Secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+
+  - it: sources GLYPHOXA_SECRET (the credential cipher key) from the Secret
+    # The seed seals placeholder provider credentials with this key (ADR-0004);
+    # it must come from a Secret, never be baked into the template.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: app-secret
+
+  - it: waits for Postgres to accept connections before seeding
+    # Like the migrate hook, the seed Pod can start before Postgres is reachable;
+    # an initContainer blocking on pg_isready keeps the run deterministic.
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: pgvector/pgvector:pg17
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[-1]
+          pattern: pg_isready.*RELEASE-NAME-glyphoxa-postgres
+
+  - it: never restarts a completed seed pod
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -1,6 +1,6 @@
-# Glyphoxa Helm values — slice 1 (ADR-0034): pgvector Postgres + migrate hook.
-# The serving workloads (#35 seed Job, #36 voice Deployment) add their own keys
-# under this same file when they land.
+# Glyphoxa Helm values — slice 1 (ADR-0034): pgvector Postgres + migrate hook +
+# seed Job. The voice Deployment (#36) adds its own keys under this same file
+# when it lands.
 
 # The single Glyphoxa image (ADR-0034). `tag` defaults to the chart appVersion
 # when left empty so a chart bump pins a matching image.
@@ -8,6 +8,15 @@ image:
   repository: ghcr.io/mrwong99/glyphoxa
   tag: ""
   pullPolicy: IfNotPresent
+
+# The single app secret (ADR-0004): a base64-encoded 32-byte credential-cipher
+# key. The seed Job (and later the voice workload) reads it as GLYPHOXA_SECRET to
+# seal/open the placeholder provider credentials it writes to the DB (the real
+# provider keys live in the OS keyring, NOT the DB). There is no default: an
+# unset value fails the render so a deploy can never silently run on a weak or
+# shared key. Generate one with `openssl rand -base64 32`. For real deploys,
+# prefer templating it from an external Secret over committing it to values.
+appSecret: ""
 
 # DB connection. By default the chart stands up its own in-cluster Postgres and
 # assembles the connection URL against that Service. Set `database.url` to point
@@ -46,6 +55,19 @@ migrate:
   # Negative hook-weight orders the migration ahead of the non-hook serving
   # workloads (which apply at weight 0 / after hooks).
   hookWeight: -5
+  resources: {}
+
+# Seed hook Job: `glyphoxa seed` loads the demo Tenant/Campaign/NPC (+
+# provider_configs) the voice mode (#36) loads by default. Runs as a Helm
+# pre-install/pre-upgrade hook. The seed is idempotent on the demo Tenant name,
+# so re-running on upgrade neither errors nor duplicates data.
+seed:
+  # Enable/disable the seed Job. On by default so the demo NPC is present for the
+  # voice workload; set false for clusters that load NPCs by other means.
+  enabled: true
+  # -4 sorts AFTER the migrate Job (-5), so the schema is current before seeding,
+  # yet still ahead of the non-hook serving workloads at weight 0.
+  hookWeight: -4
   resources: {}
 
 # Pod-level knobs shared by the workloads this chart renders.


### PR DESCRIPTION
## What does this PR do?

Closes #35.

Extends the slice-1 Helm chart (`deploy/charts/glyphoxa/`) with a seed Job that
runs `glyphoxa seed` as a Helm pre-install/pre-upgrade hook, loading the demo
Tenant / Campaign / Character NPC (+ provider_configs) into the in-cluster DB.

- New `templates/seed-job.yaml`: pre-install,pre-upgrade hook at hook-weight
  **-4** (after the migrate Job at -5, before the non-hook serving workloads at
  0), `hook-delete-policy: before-hook-creation`, `restartPolicy: Never`, image
  from the shared `glyphoxa.image` helper, command `glyphoxa seed`. It waits on
  `pg_isready` via an initContainer (when the bundled Postgres is enabled) and
  reads `GLYPHOXA_DATABASE_URL` + `GLYPHOXA_SECRET` from the app Secret.
- `GLYPHOXA_SECRET` plumbing (ADR-0004): the chart Secret gains an `app-secret`
  key, fed by a new `appSecret` value. `appSecret` is **required with no
  default** — an unset value fails the render so a deploy can never silently run
  on a weak or shared cipher key — and must be a base64-encoded 32-byte key
  (`openssl rand -base64 32`). It is a placeholder demo cipher key only; real
  provider keys live in the OS keyring, not the DB.
- `seed.enabled` (default true) and `seed.hookWeight` (-4) values; `NOTES.txt`
  and the hook-weight ladder comment updated.

No serving workloads (the voice Deployment is #36). No Go / Dockerfile / CI
changes.

## Why is this change needed?

Voice mode (#36) loads its NPC from the DB on boot; without a seeded NPC the
voice pod has no Character to load and crashloops. The seed must run after the
migrate hook (schema current) and before any serving workload, and must be safe
to re-run on upgrade.

## How was this tested?

- [x] `helm unittest` (red→green): new `tests/seed_job_test.yaml` (10 cases) +
  one added `secret_test.yaml` case. Full suite **35/35** across 4 suites — the
  #34 migrate / postgres / secret suites still pass.
- [x] `helm lint` clean (and correctly warns when `appSecret` is unset).
- [x] `helm template | kubeconform -strict` valid: in-cluster path (5
  resources), external-DB path (`postgres.enabled=false`, 3 resources),
  `seed.enabled=false` (no seed objects rendered).
- [x] **e2e on k3d**: built the slice-1 image, imported it, `helm install
  --wait` with a generated base64 32-byte `GLYPHOXA_SECRET`. Verified migrate
  Job Complete → seed Job Complete (seed started at migrate's completionTime),
  seed log "created NPC … Bart", and DB rows present: `tenant`=1
  (Glyphoxa Demo), `campaign`=1, `provider_config`=3 (groq LLM, elevenlabs
  STT/TTS), `agents`=2 (Character "Bart" wired to its LLM+voice configs + the
  auto-Butler "Glyphoxa" from the ADR-0009 trigger). Then `helm upgrade --wait`:
  seed re-ran, logged "tenant already present, skipping", and row counts were
  identical — no error, no duplicates.
- [x] Existing Go seed integration tests untouched and green:
  `go test -tags=integration ./internal/wirenpc/ -run TestSeed` →
  `TestSeedThenLoadEquivalence` + `TestSeedIdempotent` PASS. `go build ./...` OK.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build / CI / tooling

## Additional Notes

`appSecret` has no default by design (mirrors the seed binary's own refusal to
run without `GLYPHOXA_SECRET`). Operators must supply a base64 32-byte key;
prefer templating it from an external Secret over committing it to values.

Cluster e2e here was a one-off local run; the recurring k3d e2e job is #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)