### PR TITLE
feat(deploy): voice-mode Deployment for k3s (#36)

### DIFF
--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -15,6 +15,14 @@ What this release stands up (ADR-0034):
     the demo Tenant/Campaign/NPC with `glyphoxa seed`. The seed is idempotent, so
     it re-runs harmlessly on `helm upgrade`.
 {{- end }}
+{{- if .Values.voice.enabled }}
+  - A voice-mode Deployment (single replica) running
+      glyphoxa -mode voice -guild {{ .Values.voice.guild }} -channel {{ .Values.voice.channel }}
+    that joins the configured Discord voice channel and gives the seeded NPC a
+    live voice loop. It serves /healthz, /readyz, /metrics on port
+    {{ .Values.voice.metricsPort }}. It never migrates: if the schema is behind
+    it fails fast (EnsureCurrent) rather than serving.
+{{- end }}
 
 Verify the schema is current:
 
@@ -23,5 +31,15 @@ Verify the schema is current:
     --env GLYPHOXA_DATABASE_URL="$(kubectl -n {{ .Release.Namespace }} get secret {{ include "glyphoxa.secretName" . }} -o jsonpath='{.data.database-url}' | base64 -d)" \
     -- migrate status
 
-The voice Deployment is not part of this slice; it lands in a later issue (#36)
-and assumes this schema is current and the demo NPC seeded.
+{{- if .Values.voice.enabled }}
+
+Manual verification of the voice loop (cannot be automated — needs a live
+Discord gateway): with a REAL DISCORD_BOT_TOKEN and a guild/channel the bot can
+join, the voice pod becomes Available and joins the channel; speak to the NPC
+and it responds. With a placeholder token, the pod still reaches /readyz=200
+(DB connected, schema current) but then exits when the Discord join fails and
+the Deployment crashloops — that is expected without live credentials.
+
+  kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.voice.fullname" . }}
+  kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "glyphoxa.voice.fullname" . }} -f
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -60,6 +60,31 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-seed" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.voice.fullname" -}}
+{{- printf "%s-voice" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Render a Discord snowflake ID (guild/channel) as an exact string, rejecting any
+non-string value with an actionable error.
+
+Snowflakes are 64-bit IDs whose magnitude exceeds float64's 53-bit integer
+precision, so a value parsed as a NUMBER is already truncated before any
+template logic runs — `111111111111111111` becomes `111111111111111104`. That
+happens at the YAML/`--set` boundary (a bare `--set voice.guild=111...`, or
+Helm's --reuse-values re-serializing through JSON), where int64 coercion can no
+longer recover the lost digits. So rather than silently deploy a pod with a
+wrong ID that fails confusingly at runtime, fail the render and tell the operator
+to quote it (a YAML string, or `--set-string`).
+*/}}
+{{- define "glyphoxa.voice.snowflake" -}}
+{{- if kindIs "string" . -}}
+{{- . -}}
+{{- else -}}
+{{- fail (printf "Discord snowflake ID %v must be a quoted string, not a number — a 64-bit ID loses precision as a float. Set it as a YAML string (guild: \"111...\") or use --set-string." .) -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 The single Glyphoxa image reference (ADR-0034). tag falls back to the chart
 appVersion so an unset tag still pins a matching image.
@@ -75,18 +100,30 @@ appVersion so an unset tag still pins a matching image.
 {{- end }}
 
 {{/*
+The voice Deployment's image. It defaults to the shared [glyphoxa.image] (one
+image, ADR-0034) but lets voice.image.repository/tag override either field
+independently — handy for pinning the voice pod to a build with the native opus/
+ONNX tags without moving the migrate/seed Jobs.
+*/}}
+{{- define "glyphoxa.voice.image" -}}
+{{- $repo := .Values.voice.image.repository | default .Values.image.repository -}}
+{{- $tag := .Values.voice.image.tag | default .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end }}
+
+{{/*
 Hook ordering weights. The DB resources (Secret, Service, StatefulSet) come up
-first, then the migrate Job, then the seed Job, then (later) the serving
-workloads. All are pre-install/pre-upgrade hooks EXCEPT the voice Deployment
-(#36), which is a plain resource applied after every hook — so the migration and
-seed always precede it. Weights sort ascending; lower runs first; Helm waits for
-each weight's hook Jobs to complete before the next, so the seed only starts
-once the migration has finished and the schema is current.
+first, then the migrate Job, then the seed Job, then the serving workloads. All
+are pre-install/pre-upgrade hooks EXCEPT the voice Deployment (#36), which is a
+plain resource applied after every hook — so the migration and seed always
+precede it. Weights sort ascending; lower runs first; Helm waits for each
+weight's hook Jobs to complete before the next, so the seed only starts once the
+migration has finished and the schema is current.
 
   -10  DB Secret + Postgres Service + StatefulSet
    -5  migrate Job
    -4  seed Job
-    0  (voice Deployment, #36 — not in this slice)
+    0  voice Deployment (#36 — a plain resource, applied after every hook)
 */}}
 {{- define "glyphoxa.dbHookWeight" -}}-10{{- end }}
 

--- a/deploy/charts/glyphoxa/templates/secret.yaml
+++ b/deploy/charts/glyphoxa/templates/secret.yaml
@@ -1,10 +1,19 @@
 {{/*
 App Secret. Holds the Postgres password, the assembled (or operator-supplied)
-GLYPHOXA_DATABASE_URL, and the GLYPHOXA_SECRET credential-cipher key (ADR-0004).
-Postgres reads `password`; the migrate Job reads `database-url`; the seed Job
-(#35) reads both `database-url` and `app-secret`. Keeping them in one Secret
-means the URL, the role password, and the cipher key can never drift apart and
+GLYPHOXA_DATABASE_URL, the GLYPHOXA_SECRET credential-cipher key (ADR-0004), and
+— when the voice Deployment is enabled — the runtime Discord token and the three
+provider keys the voice pod reads (DISCORD_BOT_TOKEN, ELEVENLABS_API_KEY,
+GEMINI_API_KEY, GROQ_API_KEY). Postgres reads `password`; the migrate Job reads
+`database-url`; the seed Job (#35) reads `database-url` and `app-secret`; the
+voice Deployment (#36) reads `database-url` and the four credential keys (NOT
+`app-secret` — it never decrypts the sealed placeholders). Keeping them in one
+Secret means the URL, the role password, and the keys can never drift apart and
 the demo app's secrets stay in one place.
+
+The voice credential keys are only emitted when voice.enabled, and each is
+`required` then, so a voice deploy can never start with an empty Discord token or
+provider key; a migrate/seed-only install (voice.enabled=false) needs none of
+them and renders without them.
 
 stringData (kubelet base64-encodes it) over data so the values stay reviewable
 in `helm template` output and assertable in helm-unittest.
@@ -32,3 +41,9 @@ stringData:
   password: {{ .Values.database.password | quote }}
   database: {{ .Values.database.name | quote }}
   app-secret: {{ required "appSecret is required: a base64-encoded 32-byte credential-cipher key (ADR-0004) the seed Job uses to seal placeholder provider credentials. Generate one with `openssl rand -base64 32`." .Values.appSecret | quote }}
+  {{- if .Values.voice.enabled }}
+  discord-bot-token: {{ required "discordBotToken is required when voice.enabled: the Discord bot token the voice pod joins the gateway with." .Values.discordBotToken | quote }}
+  elevenlabs-api-key: {{ required "elevenLabsApiKey is required when voice.enabled: the ElevenLabs API key the STT/TTS adapters read." .Values.elevenLabsApiKey | quote }}
+  gemini-api-key: {{ required "geminiApiKey is required when voice.enabled: the Gemini API key." .Values.geminiApiKey | quote }}
+  groq-api-key: {{ required "groqApiKey is required when voice.enabled: the Groq API key the LLM adapter reads." .Values.groqApiKey | quote }}
+  {{- end }}

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -1,0 +1,151 @@
+{{/*
+Voice-mode Deployment (#36) — the serving workload of the chart.
+
+It runs the single image as `glyphoxa -mode voice -guild <id> -channel <id>`,
+joining one Discord guild+channel and giving the seeded NPC a live voice loop.
+
+- ONE replica, by intent: voice is stateful per channel (one Discord gateway
+  connection, one channel join), so two replicas would fight over the same
+  channel. The replica count is fixed here rather than surfaced as a tunable.
+- NOT a Helm hook: a plain resource applies after every pre-install/pre-upgrade
+  hook, so the migrate (-5) and seed (-4) hooks have completed — the schema is
+  current and the demo NPC seeded — before this pod starts.
+- It NEVER migrates: no `migrate` arg and no migrate initContainer. The migrate
+  hook owns the schema; EnsureCurrent (#32) inside RunFromDB fails the pod fast
+  with the actionable `migrate up` message if the schema is behind, rather than
+  auto-migrating under a serving process.
+- Credentials come from the app Secret (ADR-0034): DISCORD_BOT_TOKEN plus the
+  three provider keys each adapter reads at request time (BYOK, ADR-0004). It
+  does NOT read GLYPHOXA_SECRET — loadSeededNPC takes no cipher and never
+  decrypts the sealed placeholder credentials; keeping the cipher key off this
+  long-lived pod keeps its blast radius small.
+- Health/metrics (#33, ADR-0032): the metrics-only listener serves /metrics for
+  scraping plus the /healthz liveness and /readyz readiness probes on the metrics
+  port. Liveness targets /healthz (process-up; it ignores DB health so a DB blip
+  can't get the pod killed); readiness targets /readyz (a DB ping — 200 only when
+  the schema is current and reachable). The port is advertised for Prometheus via
+  prometheus.io/* pod annotations (annotation-based discovery; no operator CRD).
+- GLYPHOXA_ONNX_LIB is set by the image (#31 Dockerfile points it at the bundled
+  libonnxruntime), so the pod relies on that by default and only overrides it
+  when voice.onnxLib is set.
+*/}}
+{{- if .Values.voice.enabled }}
+{{- $metricsAddr := printf ":%d" (int .Values.voice.metricsPort) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glyphoxa.voice.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: voice
+spec:
+  # Voice is stateful per channel — a single replica by intent (see the header).
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: voice
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: voice
+      annotations:
+        # Advertise the metrics-only listener for annotation-based Prometheus
+        # scrape discovery (ADR-0032). No operator CRD (ServiceMonitor) required.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.voice.metricsPort | quote }}
+        prometheus.io/path: /metrics
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: voice
+          image: {{ include "glyphoxa.voice.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -mode
+            - voice
+            - -guild
+            - {{ include "glyphoxa.voice.snowflake" (required "voice.guild is required when voice.enabled: the Discord guild (server) snowflake ID the bot joins." .Values.voice.guild) | quote }}
+            - -channel
+            - {{ include "glyphoxa.voice.snowflake" (required "voice.channel is required when voice.enabled: the Discord voice channel snowflake ID the bot joins." .Values.voice.channel) | quote }}
+            - -metrics-addr
+            - {{ $metricsAddr | quote }}
+          env:
+            # The in-cluster Postgres Service URL: RunFromDB loads the seeded NPC
+            # from it and /readyz pings through it. Same key the migrate/seed
+            # hooks used, so the host can never drift.
+            - name: GLYPHOXA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database-url
+            # Required by runVoice to open the Discord gateway.
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: discord-bot-token
+            # Provider keys each adapter reads from its own env var at request
+            # time (BYOK, ADR-0004): ElevenLabs (STT + TTS), Gemini, Groq (LLM).
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: elevenlabs-api-key
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: gemini-api-key
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: groq-api-key
+            # JSON logs for cluster log aggregation (ADR-0032).
+            - name: GLYPHOXA_LOG_FORMAT
+              value: json
+            {{- with .Values.voice.onnxLib }}
+            # Override the image's bundled libonnxruntime path only when set.
+            - name: GLYPHOXA_ONNX_LIB
+              value: {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.voice.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: {{ .Values.voice.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.voice.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.voice.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.voice.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: {{ .Values.voice.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.voice.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.voice.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.voice.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.voice.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -41,6 +41,18 @@ metadata:
 spec:
   # Voice is stateful per channel — a single replica by intent (see the header).
   replicas: 1
+  # Recreate, NOT the default RollingUpdate: on a `helm upgrade` (e.g. an image
+  # bump) RollingUpdate would surge a second voice pod and keep the old one until
+  # the new is Ready. But /readyz only pings the DB — the Discord gateway is
+  # opened later in Run(), after the readiness server is already serving — so the
+  # new pod reports Ready on DB alone while the old pod still holds the gateway
+  # session. For the surge window TWO pods would mgr.Open the SAME guild+channel
+  # with the SAME token, the single-replica-per-channel violation this chart
+  # exists to prevent. Recreate tears the old pod down before the new one starts,
+  # so at most one pod ever holds the channel (at the cost of a brief gap on
+  # upgrade, which is correct for a single-session voice workload).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
@@ -65,6 +77,13 @@ spec:
         - name: voice
           image: {{ include "glyphoxa.voice.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.voice.securityContext }}
+          # Hardened by default (overridable). The image runs as USER 65532 (#31)
+          # and GLYPHOXA_ONNX_LIB points at the bundled lib so the VAD never
+          # downloads/writes a runtime at boot — so a locked-down context holds.
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - -mode
             - voice

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -8,11 +8,18 @@ templates:
   - templates/secret.yaml
 # appSecret has no default (an unset value fails the render so a deploy can never
 # silently run on a weak key); supply a placeholder for every render here. The
-# fixture is deliberately plain low-entropy ASCII, NOT a base64 32-byte key — the
-# template stores it verbatim in stringData, and a random-base64 blob here only
-# trips secret scanners. Production still requires a real key (see values.yaml).
+# voice credential keys (DISCORD_BOT_TOKEN + the three provider keys) are
+# likewise required when voice.enabled — on by default — so supply placeholders
+# for them too. Every fixture is deliberately plain low-entropy ASCII, NOT a
+# base64 32-byte key or a real token — the template stores them verbatim in
+# stringData, and a random blob here only trips secret scanners. Production still
+# requires real values (see values.yaml).
 set:
   appSecret: unit-test-placeholder-not-a-real-secret
+  discordBotToken: unit-test-discord-token-placeholder
+  elevenLabsApiKey: unit-test-elevenlabs-placeholder
+  geminiApiKey: unit-test-gemini-placeholder
+  groqApiKey: unit-test-groq-placeholder
 tests:
   - it: renders an Opaque Secret named for the release
     asserts:
@@ -70,3 +77,34 @@ tests:
       - equal:
           path: stringData["app-secret"]
           value: unit-test-placeholder-not-a-real-secret
+
+  - it: carries the voice credential keys when voice is enabled
+    # The voice Deployment (#36) reads DISCORD_BOT_TOKEN + the three provider
+    # keys from this Secret; they are only emitted when voice.enabled (on by
+    # default) and each is required then.
+    asserts:
+      - isNotNullOrEmpty:
+          path: stringData["discord-bot-token"]
+      - isNotNullOrEmpty:
+          path: stringData["elevenlabs-api-key"]
+      - isNotNullOrEmpty:
+          path: stringData["gemini-api-key"]
+      - isNotNullOrEmpty:
+          path: stringData["groq-api-key"]
+
+  - it: omits the voice credential keys for a migrate/seed-only install
+    # With voice.enabled=false the DB-only install needs no Discord/provider
+    # keys, so they are left out of the Secret entirely (and not required).
+    set:
+      voice:
+        enabled: false
+    asserts:
+      - notExists:
+          path: stringData["discord-bot-token"]
+      - notExists:
+          path: stringData["groq-api-key"]
+      # The DB + cipher keys still render — they are not gated on voice.
+      - isNotNullOrEmpty:
+          path: stringData["database-url"]
+      - isNotNullOrEmpty:
+          path: stringData["app-secret"]

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -49,6 +49,16 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: uses the Recreate strategy so an upgrade never runs two pods on one channel
+    # The default RollingUpdate would surge a second voice pod that reports Ready
+    # on the DB-only /readyz while the old pod still holds the Discord gateway —
+    # two pods on the same guild+channel with the same token. Recreate tears the
+    # old pod down first, keeping at most one session-holder.
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
   - it: is NOT a Helm hook so it applies after the migrate and seed hooks
     # The migrate (-5) and seed (-4) hooks complete before any non-hook resource;
     # leaving the Deployment hook-free puts it at the implicit weight 0, after the
@@ -287,6 +297,43 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.cpu
       - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.limits.memory
+
+  - it: hardens the voice container's securityContext by default
+    # The image runs as USER 65532 (#31); the container locks down further —
+    # non-root, no privilege escalation, a read-only rootfs (the k3d e2e proved
+    # the pod boots to /readyz=200 without a writable rootfs), all capabilities
+    # dropped, the runtime default seccomp profile. Overridable via
+    # voice.securityContext.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: lets the operator override the container securityContext
+    # The block is rendered from voice.securityContext, so an operator can loosen
+    # it (here: opt out of the read-only rootfs). Setting it to {} in a values
+    # file drops the block entirely.
+    set:
+      voice:
+        securityContext:
+          readOnlyRootFilesystem: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false
 
   - it: does NOT run migrations
     # The migrate hook owns the schema; EnsureCurrent (#32) fails the pod fast if

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -1,0 +1,312 @@
+suite: voice-mode Deployment
+# The voice Deployment runs the single image in `voice` mode: one replica (voice
+# is stateful per channel), joining the configured Discord guild+channel and
+# giving the seeded NPC a live voice loop (#36). It consumes the four
+# provider/runtime keys + GLYPHOXA_DATABASE_URL from the app Secret, takes
+# guild/channel from values, and exposes /healthz, /readyz, /metrics on the
+# metrics port. It is NOT a Helm hook: it applies after the migrate+seed hooks,
+# and it NEVER runs migrations — EnsureCurrent (#32) fails the pod fast if the
+# schema is behind.
+templates:
+  - templates/voice-deployment.yaml
+# Voice requires guild/channel + a Discord token + the three provider keys to
+# render (each is `required` when voice.enabled). guild/channel are quoted
+# strings (a snowflake loses precision as a number). The credential values are
+# deliberately plain low-entropy ASCII placeholders, NOT real tokens or random
+# base64 — a random blob here only trips secret scanners. Production supplies
+# real keys.
+set:
+  voice:
+    guild: "111111111111111111"
+    channel: "222222222222222222"
+  discordBotToken: unit-test-discord-token-placeholder
+  elevenLabsApiKey: unit-test-elevenlabs-placeholder
+  geminiApiKey: unit-test-gemini-placeholder
+  groqApiKey: unit-test-groq-placeholder
+tests:
+  - it: renders a Deployment named for the release
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-voice
+
+  - it: is disabled when voice.enabled is false
+    set:
+      voice:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: runs exactly one replica
+    # Voice is stateful per channel (one gateway connection / one channel join),
+    # so the workload is pinned to a single replica — scaling out would have two
+    # bots fighting over the same voice channel.
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: is NOT a Helm hook so it applies after the migrate and seed hooks
+    # The migrate (-5) and seed (-4) hooks complete before any non-hook resource;
+    # leaving the Deployment hook-free puts it at the implicit weight 0, after the
+    # schema is current and the NPC seeded.
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: runs `glyphoxa` in voice mode with the configured guild, channel, and metrics address
+    # The whole arg vector, in order: mode/guild/channel from values plus the
+    # -metrics-addr that must match the exposed container port (asserted below).
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -mode
+            - voice
+            - -guild
+            - "111111111111111111"
+            - -channel
+            - "222222222222222222"
+            - -metrics-addr
+            - ":9090"
+
+  - it: rejects a numeric guild rather than deploying a truncated snowflake
+    # A snowflake passed as a NUMBER is already truncated by float64 before the
+    # template runs (111111111111111111 -> 111111111111111104), and int64 can't
+    # recover the lost digits. So the render fails with an actionable message
+    # instead of silently shipping a wrong ID that fails confusingly at runtime.
+    set:
+      voice:
+        guild: 111111111111111111
+    asserts:
+      - failedTemplate:
+          errorPattern: "must be a quoted string, not a number"
+
+  - it: runs the configured image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mrwong99/glyphoxa:0.1.0
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: honours an overridden image repository and tag
+    set:
+      image:
+        repository: ghcr.io/example/glyphoxa
+        tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa:v9.9.9
+
+  - it: lets the voice block override the image independently of the shared image
+    set:
+      voice:
+        image:
+          repository: ghcr.io/example/glyphoxa-voice
+          tag: voice-1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa-voice:voice-1.2.3
+
+  - it: sources GLYPHOXA_DATABASE_URL from the DB connection Secret
+    # Same in-cluster Postgres Service the migrate/seed hooks used; the pod's
+    # /readyz pings through it, and RunFromDB loads the seeded NPC from it.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+
+  - it: sources DISCORD_BOT_TOKEN from the Secret
+    # runVoice requires DISCORD_BOT_TOKEN; it must come from a Secret, never be
+    # baked into the image or the template.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: discord-bot-token
+
+  - it: sources the three provider keys from the Secret
+    # ElevenLabs (STT/TTS), Gemini, and Groq (LLM) — each adapter reads its own
+    # env var at request time (BYOK, ADR-0004); all ride in the app Secret.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELEVENLABS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: elevenlabs-api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEMINI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: gemini-api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GROQ_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: groq-api-key
+
+  - it: emits JSON logs in the cluster
+    # GLYPHOXA_LOG_FORMAT=json so the structured logs are machine-parseable for
+    # cluster log aggregation (ADR-0032).
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_LOG_FORMAT
+            value: json
+
+  - it: does NOT carry GLYPHOXA_SECRET
+    # Voice never decrypts the sealed provider_config: loadSeededNPC takes no
+    # cipher and the adapters read real keys from their own env vars. The cipher
+    # key stays on the seed Job; leaking it into the long-lived serving pod would
+    # widen its blast radius for no reason.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: app-secret
+
+  - it: relies on the image's bundled GLYPHOXA_ONNX_LIB by default
+    # The image already sets GLYPHOXA_ONNX_LIB to its bundled libonnxruntime path
+    # (#31 Dockerfile), so the chart does not override it by default.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_ONNX_LIB
+
+  - it: lets the operator override GLYPHOXA_ONNX_LIB when needed
+    set:
+      voice:
+        onnxLib: /custom/lib/libonnxruntime.so
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_ONNX_LIB
+            value: /custom/lib/libonnxruntime.so
+
+  - it: exposes the metrics port as a named container port
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 9090
+            protocol: TCP
+
+  - it: derives the metrics address and container port from voice.metricsPort together
+    # A custom port must flow to BOTH the -metrics-addr flag and the container
+    # port, or the probes/scrape would target a port the process isn't serving.
+    set:
+      voice:
+        metricsPort: 9999
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: ":9999"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9999
+
+  - it: probes liveness against /healthz on the metrics port
+    # Liveness ignores DB health (a failing DB must not get the pod killed); it
+    # targets /healthz, which is 200 while the process serves.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: metrics
+
+  - it: probes readiness against /readyz on the metrics port
+    # /readyz pings the DB (200 only when the schema is current and reachable),
+    # which is the real "ready to serve" bar for the automated e2e.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
+
+  - it: annotates the pod for Prometheus scraping on the metrics port
+    # ADR-0032: voice opens a minimal metrics-only listener scraped at /metrics.
+    # Pod annotations are the operator-CRD-free way to advertise that to a
+    # Prometheus configured for annotation-based discovery.
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9090"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: /metrics
+
+  - it: sets resource requests and limits
+    # A long-lived serving pod must declare requests+limits so the scheduler can
+    # place it and the kubelet can cap it (the ONNX VAD + audio path are not free).
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.requests.memory
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.limits.memory
+
+  - it: does NOT run migrations
+    # The migrate hook owns the schema; EnsureCurrent (#32) fails the pod fast if
+    # it is behind. The pod must never carry a `migrate` arg or a migrate
+    # initContainer that would auto-migrate under it.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: migrate
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: selects its pods with the standard selector labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: glyphoxa
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: voice

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -91,9 +91,11 @@ seed:
 # It never migrates: EnsureCurrent (#32) fails the pod fast if the schema is
 # behind, rather than auto-migrating under a serving process.
 voice:
-  # Enable/disable the voice Deployment. Off by default: a bare `helm install`
-  # stands up the DB + schema + seed without needing live Discord/provider keys.
-  # Set true (and supply guild/channel + the credential values above) to serve.
+  # Enable/disable the voice Deployment. ON by default, so a bare `helm install`
+  # serves the NPC — which means it requires guild/channel plus the four
+  # credential values above, or the render fails fast with an actionable message
+  # (a voice pod can't run without them). For the DB-prep path only (migrate +
+  # seed, no live Discord/provider keys), set this false.
   enabled: true
 
   # Discord guild (server) and voice channel snowflake IDs the bot joins. Both
@@ -139,6 +141,23 @@ voice:
     limits:
       cpu: "1"
       memory: 1Gi
+
+  # Container securityContext for the voice container, hardened by default and
+  # overridable. The image runs as USER 65532 (#31) and the bundled ONNX runtime
+  # means the VAD never writes at boot, so the locked-down defaults hold —
+  # readOnlyRootFilesystem included: the k3d e2e confirmed the pod boots to
+  # /readyz=200 with a read-only rootfs (no boot-time write to /tmp or elsewhere).
+  # Set to {} (in a values file) to disable, or override individual fields for a
+  # cluster with a stricter or looser policy.
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   # Probe tuning. Liveness targets /healthz (process-up, ignores DB health so a
   # DB blip can't get the pod killed); readiness targets /readyz (DB ping — 200

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -1,6 +1,6 @@
-# Glyphoxa Helm values — slice 1 (ADR-0034): pgvector Postgres + migrate hook +
-# seed Job. The voice Deployment (#36) adds its own keys under this same file
-# when it lands.
+# Glyphoxa Helm values — pgvector Postgres + migrate hook + seed Job (ADR-0034)
+# and the voice-mode Deployment (#36) that serves the seeded NPC in a Discord
+# voice channel.
 
 # The single Glyphoxa image (ADR-0034). `tag` defaults to the chart appVersion
 # when left empty so a chart bump pins a matching image.
@@ -10,13 +10,27 @@ image:
   pullPolicy: IfNotPresent
 
 # The single app secret (ADR-0004): a base64-encoded 32-byte credential-cipher
-# key. The seed Job (and later the voice workload) reads it as GLYPHOXA_SECRET to
-# seal/open the placeholder provider credentials it writes to the DB (the real
-# provider keys live in the OS keyring, NOT the DB). There is no default: an
-# unset value fails the render so a deploy can never silently run on a weak or
-# shared key. Generate one with `openssl rand -base64 32`. For real deploys,
-# prefer templating it from an external Secret over committing it to values.
+# key. The seed Job reads it as GLYPHOXA_SECRET to seal the placeholder provider
+# credentials it writes to the DB (the real provider keys live in env/the OS
+# keyring, NOT the DB). The voice Deployment does NOT read it — it never decrypts
+# those placeholders. There is no default: an unset value fails the render so a
+# deploy can never silently run on a weak or shared key. Generate one with
+# `openssl rand -base64 32`. For real deploys, prefer templating it from an
+# external Secret over committing it to values.
 appSecret: ""
+
+# Runtime credentials the voice Deployment (#36) reads from the app Secret. The
+# voice pod reads DISCORD_BOT_TOKEN to join the gateway and the three provider
+# keys at request time (BYOK, ADR-0004): ELEVENLABS_API_KEY (STT + TTS),
+# GEMINI_API_KEY, and GROQ_API_KEY (LLM). They are stored in the Secret, never
+# baked into the image (ADR-0034). Defaults are empty: voice mode fails without a
+# real Discord token, and a migrate/seed-only install (voice.enabled=false) needs
+# none of them. For real deploys, prefer templating them from an external Secret
+# over committing them to values.
+discordBotToken: ""
+elevenLabsApiKey: ""
+geminiApiKey: ""
+groqApiKey: ""
 
 # DB connection. By default the chart stands up its own in-cluster Postgres and
 # assembles the connection URL against that Service. Set `database.url` to point
@@ -69,6 +83,78 @@ seed:
   # yet still ahead of the non-hook serving workloads at weight 0.
   hookWeight: -4
   resources: {}
+
+# Voice-mode Deployment (#36): the single image run as `glyphoxa -mode voice`,
+# joining one Discord guild+channel and giving the seeded NPC a live voice loop.
+# It is a plain (non-hook) workload, so it applies after the migrate (-5) and
+# seed (-4) hooks — the schema is current and the NPC seeded before it starts.
+# It never migrates: EnsureCurrent (#32) fails the pod fast if the schema is
+# behind, rather than auto-migrating under a serving process.
+voice:
+  # Enable/disable the voice Deployment. Off by default: a bare `helm install`
+  # stands up the DB + schema + seed without needing live Discord/provider keys.
+  # Set true (and supply guild/channel + the credential values above) to serve.
+  enabled: true
+
+  # Discord guild (server) and voice channel snowflake IDs the bot joins. Both
+  # are required when voice.enabled; the render fails if either is empty so a
+  # voice pod can never start with the `-guild`/`-channel` flags unset.
+  #
+  # QUOTE THEM. A snowflake is a 64-bit ID that loses precision as a float, so a
+  # bare number (`--set voice.guild=111...`, or a YAML value without quotes) is
+  # silently truncated. The render rejects a non-string value with an actionable
+  # error; supply a quoted YAML string (guild: "111...") or use `--set-string`.
+  guild: ""
+  channel: ""
+
+  # Single replica, by intent: voice is stateful per channel (one gateway
+  # connection and one channel join), so two replicas would fight over the same
+  # voice channel. Not surfaced as a tunable — scaling out is a design change,
+  # not a value.
+
+  # Optional per-workload image override. When repository/tag are set here they
+  # win over the shared top-level `image`; otherwise the voice pod runs the same
+  # image as the migrate/seed Jobs (the common case — one image, ADR-0034).
+  image:
+    repository: ""
+    tag: ""
+
+  # Override the image's bundled GLYPHOXA_ONNX_LIB only if the libonnxruntime
+  # path differs from the #31 image default (/usr/local/lib/libonnxruntime.so).
+  # Empty leaves the image's own ENV in force.
+  onnxLib: ""
+
+  # The voice node's metrics-only HTTP listener (ADR-0032): /metrics for scraping
+  # plus the /healthz liveness and /readyz readiness probes (#33). The port is
+  # named `metrics` on the container and advertised via prometheus.io/* pod
+  # annotations for annotation-based scrape discovery (no operator CRD required).
+  metricsPort: 9090
+
+  # Resource requests/limits for the long-lived serving pod. The ONNX VAD and the
+  # audio path are not free, so both are set; tune for your cluster.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  # Probe tuning. Liveness targets /healthz (process-up, ignores DB health so a
+  # DB blip can't get the pod killed); readiness targets /readyz (DB ping — 200
+  # only when the schema is current and reachable). initialDelaySeconds gives the
+  # boot path (pool open → EnsureCurrent → NPC load → Discord join) room before
+  # the first probe.
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
 
 # Pod-level knobs shared by the workloads this chart renders.
 podSecurityContext: {}


### PR DESCRIPTION
## What does this PR do?

Closes #36.

Adds a Helm-templated **voice-mode Deployment** that runs the single image as
`glyphoxa -mode voice -guild <id> -channel <id>`, joining one Discord guild and
channel to give the seeded NPC a live voice loop. Scope stays entirely within
`deploy/charts/glyphoxa/**` (no Go, Dockerfile, or CI changes).

New/changed:
- `templates/voice-deployment.yaml` (new) — single-replica Deployment.
- `tests/voice_deployment_test.yaml` (new) — 24-test helm-unittest suite.
- `templates/secret.yaml` — adds `discord-bot-token` + the three provider keys, emitted and `required` only when `voice.enabled`.
- `tests/secret_test.yaml` — covers the new keys (present when voice on, absent for a migrate/seed-only install).
- `values.yaml` — runtime credential values + a `voice:` block (enabled, image override, metricsPort, resources, probe tuning).
- `templates/_helpers.tpl` — `glyphoxa.voice.fullname`, `glyphoxa.voice.image` (independent override falling back to the shared image), `glyphoxa.voice.snowflake` (rejects a non-string guild/channel).
- `templates/NOTES.txt` — documents the manual live-Discord step and the no-live-creds crashloop.

Key decisions:
- **One replica, by intent** — voice is stateful per channel (one gateway connection, one channel join).
- **Not a Helm hook** — a plain resource applies after the migrate (-5) and seed (-4) hooks, so the schema is current and the NPC seeded before it starts. It **never migrates**: EnsureCurrent (#32) fails the pod fast if the schema is behind.
- **`GLYPHOXA_SECRET` omitted** — voice never decrypts the sealed placeholder credentials (`loadSeededNPC` takes no cipher); the cipher key stays on the seed Job to keep the long-lived pod's blast radius small.
- **`GLYPHOXA_ONNX_LIB`** relies on the image default (#31 Dockerfile sets `/usr/local/lib/libonnxruntime.so`); only overridden when `voice.onnxLib` is set.
- Health/metrics (#33, ADR-0032): liveness → `/healthz`, readiness → `/readyz`, scrape `/metrics` on the named `metrics` port advertised via `prometheus.io/*` pod annotations. The `-metrics-addr` flag and container port both derive from `voice.metricsPort`.
- **Snowflake safety**: a 64-bit guild/channel ID loses precision as a float, so a bare number (`--set voice.guild=111...`) is silently truncated. The render rejects a non-string value with an actionable message; supply a quoted string or `--set-string`.

## Why is this change needed?

It is the serving workload of the deploy chart: the migrate hook (#34) brings the
schema current and the seed hook (#35) loads the demo NPC, but nothing yet runs
the NPC. This Deployment consumes that prepared cluster state and serves the
live voice loop.

## How was this tested?

- `helm unittest` — **5 suites, 61 tests pass**: the new voice suite (24 tests) plus the extended secret suite, with the migrate/postgres/seed (#34/#35) suites still green.
- `helm lint` — clean (only the pre-existing "icon is recommended" INFO).
- `kubeconform -strict` — valid on both the in-cluster path (6 resources) and the external-DB / voice-off path (3 resources).
- **e2e on k3d (no live Discord)**: installed the full chart against a real in-cluster Postgres. The migrate and seed hook Jobs completed; the voice pod booted; **`/healthz` and `/readyz` both returned HTTP 200** (DB connected, schema current, health wiring correct) — this is the automated readiness bar.
- **Stale-schema fail-fast**: rolling back one migration made the voice pod exit with `storage: schema out of date (db at version 1, want 2); run \`glyphoxa migrate up\`` instead of serving.
- **Automated bar vs. manual**: the automated e2e bar is **/readyz 200 + the stale-schema fail-fast**. Reaching steady k8s **Available** and **actually joining the channel** require a real Discord token + guild + channel (live creds) and **stay a manual runbook step** — without a live gateway the pod reaches `/readyz`=200, then exits when the Discord join fails and the Deployment crashloops (documented in NOTES.txt). No Go change was made to alter that.

- [ ] `make check` passes — N/A (chart-only change; verified via `helm unittest` + `helm lint` + `kubeconform`)
- [x] New/updated tests cover the change
- [x] Manual testing (k3d e2e above)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build / CI / tooling

## Additional Notes

Fixtures are GitGuardian-safe: every committed secret value is low-entropy plain
ASCII (`unit-test-*-placeholder`), no base64 blobs. The base64-shaped fake
Discord token used to widen the e2e probe window was only ever passed on the
command line, never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)