### PR TITLE
fix(voice): retry Discord join with backoff instead of crashlooping (#44)

### DIFF
--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -36,9 +36,11 @@ Verify the schema is current:
 Manual verification of the voice loop (cannot be automated — needs a live
 Discord gateway): with a REAL DISCORD_BOT_TOKEN and a guild/channel the bot can
 join, the voice pod becomes Available and joins the channel; speak to the NPC
-and it responds. With a placeholder token, the pod still reaches /readyz=200
-(DB connected, schema current) but then exits when the Discord join fails and
-the Deployment crashloops — that is expected without live credentials.
+and it responds. With a placeholder token, the pod still becomes Available and
+serves /readyz=200 (DB connected, schema current) but cannot join Discord: it
+keeps the process up and retries the join with backoff (issue #44), logging
+repeated "voice connection failed; reconnecting" warnings rather than
+crashlooping. The channel join itself is the manual, live-credential check.
 
   kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.voice.fullname" . }}
   kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "glyphoxa.voice.fullname" . }} -f

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -160,10 +160,11 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), loaded, ttseleven.New(""), nil)
+	conv, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), loaded, ttseleven.New(""), nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
+	defer cleanup()
 	if conv == nil {
 		t.Fatal("buildConversation returned a nil Conversation")
 	}
@@ -175,6 +176,37 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	if got := routed[0].Target.AgentID; got != loaded.agentID {
 		t.Errorf("routed AgentID = %q, want loaded agentID %q (matcher/Persona disagree)", got, loaded.agentID)
 	}
+}
+
+// TestBuildConversation_CleanupDoesNotDestroyEngine guards issue #44's reconnect
+// loop against a regression that destroys the process-global Silero/ONNX
+// environment. cleanup() must release only the per-cycle VAD session, NEVER the
+// shared engine: silero.Engine wraps an ONNX environment initialised once and
+// never re-initialised, so closing it would tear ONNX down for the whole process
+// and every later reconnect's NewSession would fail — the NPC would go
+// permanently deaf after the first Discord drop. Build → cleanup → build again
+// (mimicking one reconnect cycle) must both succeed. Real Silero, so integration.
+func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
+	npc := hardcodedNPC()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	conv1, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npc, ttseleven.New(""), nil)
+	if err != nil {
+		t.Fatalf("first buildConversation: %v", err)
+	}
+	if conv1 == nil {
+		t.Fatal("first buildConversation returned a nil Conversation")
+	}
+	cleanup1() // end of reconnect cycle 1
+
+	conv2, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npc, ttseleven.New(""), nil)
+	if err != nil {
+		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
+	}
+	if conv2 == nil {
+		t.Fatal("second buildConversation returned a nil Conversation")
+	}
+	cleanup2()
 }
 
 // TestSeedIdempotent asserts a second SeedNPC is a no-op (the slice re-seeds on

--- a/internal/wirenpc/reconnect_test.go
+++ b/internal/wirenpc/reconnect_test.go
@@ -1,0 +1,246 @@
+package wirenpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSleep records the backoff delays runWithReconnect asks it to wait and
+// cancels ctx after a fixed number of calls, so a reconnect loop that would
+// otherwise spin forever terminates deterministically with no real waiting. It
+// is the injected reconnectPolicy.sleep — the seam that lets these tests drive
+// the backoff schedule (issue #44) without Discord or wall-clock time.
+type fakeSleep struct {
+	delays    []time.Duration
+	cancelAt  int
+	cancel    context.CancelFunc
+	callCount int
+}
+
+func (f *fakeSleep) sleep(ctx context.Context, d time.Duration) error {
+	f.callCount++
+	f.delays = append(f.delays, d)
+	if f.callCount >= f.cancelAt {
+		f.cancel()
+	}
+	// Honor a ctx that is (now) cancelled, mirroring the real sleepCtx contract:
+	// a backoff sleep on a cancelled ctx returns the ctx error so the loop exits.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return nil
+}
+
+// TestRunWithReconnect_RetriesWithGrowingBackoff pins the core issue-#44
+// invariant: when Discord never connects (attempt always errors), the loop does
+// not exit — it retries on a capped-exponential schedule. With initial=1s
+// factor=2 the first three backoffs are 1s, 2s, 4s, and a SIGTERM-style ctx
+// cancel (here driven by the fake sleep after 3 waits) returns a clean nil so
+// the pod exits 0 rather than crashlooping.
+func TestRunWithReconnect_RetriesWithGrowingBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 3, cancel: cancel}
+	p := reconnectPolicy{initial: time.Second, max: 8 * time.Second, factor: 2, sleep: fs.sleep}
+
+	calls := 0
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			calls++
+			return errors.New("dial tcp: connection refused")
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil on ctx-cancel (clean exit, no crashloop)", err)
+	}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+	if !equalDelays(fs.delays, want) {
+		t.Errorf("backoff delays = %v, want %v (capped exponential)", fs.delays, want)
+	}
+	if calls != 3 {
+		t.Errorf("attempt called %d times, want 3", calls)
+	}
+}
+
+// TestRunWithReconnect_ResetsBackoffOnConnect pins the reset contract AND that
+// the schedule re-grows from the reset baseline: a connection that succeeds
+// (calls connected()) and only later drops must reconnect on the INITIAL delay,
+// not inherit the grown backoff from earlier failures — and if reconnection then
+// keeps failing it must back off again 1s, 2s, 4s. attempt errors twice without
+// connecting (delays 1s, 2s), the 3rd call connects-then-drops (reset → 1s), and
+// calls 4–5 fail again, so delays[2:5] must be 1s, 2s, 4s. This catches both a
+// missing reset and a reset that fails to re-advance.
+func TestRunWithReconnect_ResetsBackoffOnConnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 6, cancel: cancel}
+	p := reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: fs.sleep}
+
+	calls := 0
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			calls++
+			if calls == 3 {
+				connected() // session established, then drops
+			}
+			return errors.New("connection dropped")
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil", err)
+	}
+	if len(fs.delays) < 5 {
+		t.Fatalf("recorded %d delays, want >= 5", len(fs.delays))
+	}
+	// delays[2] is the backoff AFTER the connected 3rd attempt — the initial delay
+	// (reset fired). delays[3], delays[4] prove the schedule re-grows from there.
+	wantAfterReset := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
+	if !equalDelays(fs.delays[2:5], wantAfterReset) {
+		t.Errorf("backoff after a connected attempt = %v, want %v (reset on connect, then re-grow)", fs.delays[2:5], wantAfterReset)
+	}
+}
+
+// TestRunWithReconnect_StopsCleanOnCtxCancelInAttempt models SIGTERM landing
+// mid-serve: attempt cancels ctx and then returns an error. The loop must NOT
+// treat that as a transient failure to back off from — it must see the cancelled
+// ctx, skip the sleep entirely, and exit clean (nil). This is the fix for the
+// shutdown path exiting 1.
+func TestRunWithReconnect_StopsCleanOnCtxCancelInAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 1, cancel: cancel}
+	p := reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: fs.sleep}
+
+	calls := 0
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			calls++
+			cancel() // SIGTERM during serve
+			return errors.New("serve interrupted")
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil on shutdown", err)
+	}
+	if fs.callCount != 0 {
+		t.Errorf("sleep called %d times, want 0 (no backoff after a shutdown cancel)", fs.callCount)
+	}
+	if calls != 1 {
+		t.Errorf("attempt called %d times, want 1", calls)
+	}
+}
+
+// TestRunWithReconnect_CleanSessionCloseReconnects pins that a clean
+// session-close (attempt returns nil) with ctx still alive is a LOST connection,
+// not a successful shutdown: the loop must back off and reconnect, not exit. A
+// dropped Discord gateway often returns no error, so a nil from attempt while
+// ctx lives must still reconnect.
+func TestRunWithReconnect_CleanSessionCloseReconnects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 1, cancel: cancel}
+	p := reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: fs.sleep}
+
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			return nil // session closed cleanly, ctx still alive
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil", err)
+	}
+	if fs.callCount != 1 {
+		t.Errorf("sleep called %d times, want 1 (a clean session close reconnects, it is not a shutdown)", fs.callCount)
+	}
+}
+
+// TestNextDelay_CappedExponential pins the schedule arithmetic: the delay
+// doubles each step until it hits the cap, then stays there, and a value already
+// past a clean power of two still clamps to max rather than overshooting.
+func TestNextDelay_CappedExponential(t *testing.T) {
+	p := reconnectPolicy{initial: time.Second, max: 8 * time.Second, factor: 2}
+
+	steps := []struct{ in, want time.Duration }{
+		{1 * time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 8 * time.Second}, // capped, stays
+		{6 * time.Second, 8 * time.Second}, // 6*2=12 > 8 -> cap, no overshoot
+	}
+	for _, s := range steps {
+		if got := nextDelay(s.in, p); got != s.want {
+			t.Errorf("nextDelay(%v) = %v, want %v", s.in, got, s.want)
+		}
+	}
+}
+
+// TestSleepCtx_ReturnsPromptlyOnCancel pins that an already-cancelled ctx makes
+// sleepCtx return its error immediately rather than waiting the full duration —
+// the property that lets a SIGTERM during backoff exit fast instead of stalling
+// shutdown for up to the max backoff.
+func TestSleepCtx_ReturnsPromptlyOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	start := time.Now()
+	err := sleepCtx(ctx, time.Hour)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("sleepCtx err = %v, want context.Canceled", err)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("sleepCtx took %v on a cancelled ctx, want < 100ms (must not wait the full duration)", elapsed)
+	}
+}
+
+// TestSleepCtx_CompletesAfterDuration pins the happy path: with a live ctx,
+// sleepCtx waits out the duration and returns nil (the timer fired, not a
+// cancel), so a normal backoff actually delays.
+func TestSleepCtx_CompletesAfterDuration(t *testing.T) {
+	if err := sleepCtx(context.Background(), time.Millisecond); err != nil {
+		t.Errorf("sleepCtx returned %v, want nil after the duration elapsed", err)
+	}
+}
+
+// TestRun_BadGuildID_FatalNoRetry pins that config validation stays FATAL and
+// happens BEFORE the reconnect loop: a guild ID that can never parse is a
+// permanent error, so Run must return it promptly (mentioning the guild) instead
+// of retrying forever. The parse failure short-circuits before any Discord
+// dial, so the test needs no token, no network, and cannot hang.
+func TestRun_BadGuildID_FatalNoRetry(t *testing.T) {
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(context.Background(), Config{Guild: "not-a-snowflake", Channel: "123"})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil for a bad guild ID, want a fatal parse error")
+		}
+		if !strings.Contains(err.Error(), "guild") {
+			t.Errorf("Run error = %q, want it to mention the guild", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return promptly on a bad guild ID; it must fail at parse before any retry loop")
+	}
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+func equalDelays(a, b []time.Duration) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -97,6 +97,72 @@ const (
 	floorCoalesceWindow = 600 * time.Millisecond
 )
 
+// reconnectPolicy bounds how the live voice loop backs off between failed or
+// dropped Discord connections (issue #44). A serving voice pod must not
+// crashloop because Discord is briefly unreachable: Run keeps serving /healthz
+// and /readyz (DB-backed) and retries on this schedule instead of exiting.
+// Capped exponential, no jitter — one pod reconnecting to one gateway has no
+// thundering herd to spread.
+type reconnectPolicy struct {
+	initial time.Duration
+	max     time.Duration
+	factor  float64
+	// sleep blocks for d or until ctx is cancelled (returns ctx.Err() if
+	// cancelled first). Injected so tests drive the backoff without real waits.
+	sleep func(ctx context.Context, d time.Duration) error
+}
+
+func defaultReconnectPolicy() reconnectPolicy {
+	return reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: sleepCtx}
+}
+
+// sleepCtx blocks for d or until ctx is cancelled, returning ctx.Err() on
+// cancel. A timer (not time.Sleep) so a cancelled ctx returns immediately.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+func nextDelay(d time.Duration, p reconnectPolicy) time.Duration {
+	next := time.Duration(float64(d) * p.factor)
+	if next > p.max {
+		return p.max
+	}
+	return next
+}
+
+// runWithReconnect calls attempt repeatedly, keeping the process alive across
+// failed or dropped Discord connections. It returns nil (clean shutdown) ONLY
+// when ctx is cancelled; every other return from attempt — an error OR a clean
+// session-close (nil) — is a lost connection and triggers a backed-off
+// reconnect. attempt is handed a connected callback it calls once the join
+// succeeds, which resets the backoff so a long-lived session that later drops
+// reconnects promptly instead of inheriting a grown delay.
+func runWithReconnect(ctx context.Context, log *slog.Logger, p reconnectPolicy, attempt func(ctx context.Context, connected func()) error) error {
+	delay := p.initial
+	for {
+		err := attempt(ctx, func() { delay = p.initial })
+		if ctx.Err() != nil {
+			return nil // shutdown requested — stop retrying, exit clean (fixes SIGTERM->exit1)
+		}
+		if err != nil {
+			log.Warn("voice connection failed; reconnecting", "err", err, "backoff", delay)
+		} else {
+			log.Info("voice session ended; reconnecting", "backoff", delay)
+		}
+		if serr := p.sleep(ctx, delay); serr != nil {
+			return nil // ctx cancelled during backoff — clean shutdown
+		}
+		delay = nextDelay(delay, p)
+	}
+}
+
 // BartPersona is the Character NPC Persona (CONTEXT.md "Persona") for the MVP
 // slice. Exported so the `seed` command writes the same Persona text the in-code
 // NPC used, and the DB-load equivalence test can compare against it.
@@ -240,6 +306,9 @@ func Run(ctx context.Context, cfg Config) error {
 		log = slog.New(slog.DiscardHandler)
 	}
 
+	// Config validation is fatal: a bad guild/channel ID can never succeed, so
+	// retrying would crashloop slowly. Parse before the reconnect loop so only
+	// genuinely transient connection failures are retried.
 	guild, err := snowflake.Parse(cfg.Guild)
 	if err != nil {
 		return fmt.Errorf("wirenpc: parse guild ID %q: %w", cfg.Guild, err)
@@ -248,6 +317,41 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("wirenpc: parse channel ID %q: %w", cfg.Channel, err)
 	}
+
+	// Keep serving across a briefly unreachable or dropped Discord instead of
+	// exiting (issue #44): cmd/glyphoxa's metrics server (which carries /healthz
+	// and the DB-backed /readyz) lives for ctx independently of this loop, so a
+	// reconnecting voice loop lets the Deployment reach Available without live
+	// Discord creds. Each cycle is one connectAndServe; runWithReconnect backs
+	// off between cycles and returns clean only when ctx is cancelled.
+	//
+	// Note: disgo runs its own bounded reconnect during OpenGateway, so this
+	// policy governs the inter-cycle gap and post-join drops (a session that joins
+	// then later disconnects), not the initial dial retries disgo already handles.
+	return runWithReconnect(ctx, log, defaultReconnectPolicy(),
+		func(ctx context.Context, connected func()) error {
+			return connectAndServe(ctx, cfg, guild, channel, log, connected)
+		})
+}
+
+// connectAndServe runs ONE connect-and-serve cycle: build the Discord client,
+// open the gateway, join the channel, assemble the pipeline, and pump audio
+// until ctx is cancelled or the connection drops. It calls connected() once the
+// join succeeds, which resets the caller's backoff so a long-lived session that
+// later drops reconnects promptly. Any error — or a clean return (a dropped
+// gateway often reports none) — flows back to runWithReconnect, which decides
+// whether to retry; only a cancelled ctx ends the loop.
+func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func()) error {
+	// Per-cycle context: everything this cycle spawns — the stage subscriber's
+	// TTL-sweep goroutine (stageSub.Start), the Discord gateway, and the audio
+	// loop — is bound to cycleCtx, so the deferred cancel reaps it at cycle end.
+	// Without this a flapping Discord (issue #44) would leak one sweeper goroutine
+	// per reconnect: the outer ctx only ends at process shutdown. cycleCtx is a
+	// child of ctx, so a cancelled process still unwinds promptly (pipe.Run et al.
+	// observe the cancellation), and runWithReconnect checks the OUTER ctx to
+	// decide shutdown vs reconnect.
+	cycleCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// Discord client: DAVE/MLS is wired at construction (it cannot be enabled
 	// after disgo builds its VoiceManager). DaveOption() is a no-op stub unless
@@ -273,7 +377,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	defer client.Close(context.Background())
 
-	if err := client.OpenGateway(ctx); err != nil {
+	if err := client.OpenGateway(cycleCtx); err != nil {
 		return fmt.Errorf("wirenpc: open gateway: %w", err)
 	}
 
@@ -284,11 +388,15 @@ func Run(ctx context.Context, cfg Config) error {
 	)
 	defer mgr.Close()
 
-	sess, err := mgr.Open(ctx, guild, channel)
+	sess, err := mgr.Open(cycleCtx, guild, channel)
 	if err != nil {
 		return fmt.Errorf("wirenpc: join voice channel: %w", err)
 	}
 	defer sess.Close()
+	// The join succeeded: reset the reconnect backoff so a session that runs for
+	// a while and only later drops reconnects on the initial delay, not a delay
+	// grown by earlier connect failures (issue #44).
+	connected()
 	log.Info("joined voice channel", "guild", guild, "channel", channel, "npc", cfg.npc.name)
 
 	// One Codec instance serves both directions: DecodeInbound (called from the
@@ -333,18 +441,22 @@ func Run(ctx context.Context, cfg Config) error {
 	// StageMetrics (keyless) makes the subscriber a no-op via observe.Discard.
 	stageSub := observe.NewStageSubscriber(cfg.StageMetrics, observe.WithTurnLog(log))
 	defer stageSub.Subscribe(bus)()
-	stageSub.Start(ctx)
+	stageSub.Start(cycleCtx)
 
-	conv, err := buildConversation(bus, log, cfg.npc, teeSynth, cfg.StageMetrics)
+	conv, cleanup, err := buildConversation(bus, log, cfg.npc, teeSynth, cfg.StageMetrics)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
+	// cleanup closes the per-cycle VAD session (not the shared Silero engine — see
+	// buildConversation). Without it each reconnect cycle (issue #44) would leak a
+	// Silero session that nothing ever closed.
+	defer cleanup()
 
 	// Inbound (hear): the pipeline pumps Session.Inbound through the same Codec's
 	// DecodeInbound into the orchestrator. It tags its inbound counters (A2) with
 	// the guild and shares the run's MetricsRecorder.
 	pipe := wire.NewPipeline(conv, cdc, log, cfg.Guild, cfg.Metrics)
-	return pipe.Run(ctx, sess)
+	return pipe.Run(cycleCtx, sess)
 }
 
 // npcMatcher builds the Address Detection matcher for the NPC. This Campaign has
@@ -416,14 +528,14 @@ func npcVoice() tts.Voice {
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder) (*orchestrator.Conversation, error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder) (*orchestrator.Conversation, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
 
 	engine, err := silero.New(silero.WithMinSilenceFrames(vadMinSilenceFrames))
 	if err != nil {
-		return nil, fmt.Errorf("init Silero VAD: %w", err)
+		return nil, nil, fmt.Errorf("init Silero VAD: %w", err)
 	}
 	vadSession, err := engine.NewSession(vad.Config{
 		SampleRate:       vadSampleRate,
@@ -432,7 +544,18 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		SilenceThreshold: 0.35,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("open VAD session: %w", err)
+		return nil, nil, fmt.Errorf("open VAD session: %w", err)
+	}
+	// cleanup releases ONLY the per-cycle VAD session (its ONNX inferencer), which
+	// a reconnect cycle (issue #44) would otherwise leak on every loop. It must
+	// NOT close the engine: silero.Engine wraps the process-global ONNX
+	// environment (initialised once via sync.Once and never re-initialised), so
+	// engine.Close() → DestroyEnvironment would tear ONNX down for the whole
+	// process — the next cycle's NewSession would fail and the NPC would go
+	// permanently deaf after the first Discord drop. The engine is a singleton: it
+	// lives for the process and is never closed here. session.Close is idempotent.
+	cleanup := func() {
+		_ = vadSession.Close()
 	}
 	vadStage := orchestrator.NewVAD(bus, vadSession)
 
@@ -497,5 +620,5 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 			log.Warn("voice pipeline stage failed", "err", err)
 		}),
 	)
-	return conv, nil
+	return conv, cleanup, nil
 }


### PR DESCRIPTION
Closes #44. Prereq for #37 (unblocks an honest `Deployment Available → /readyz 200` without live Discord creds).

## Problem
`wirenpc.Run` exited non-zero when it could not reach Discord (`OpenGateway` / `mgr.Open`), so the k8s voice pod **CrashLoopBackOff**'d whenever Discord was unreachable — and the crashloop made #37's acceptance unassertable in CI without live credentials. A long-lived serving process should not die because an external dependency is briefly unreachable.

## Change
- `Run` parses the guild/channel snowflakes **once up front** (config errors stay fatal) and then loops `connectAndServe` through a new `runWithReconnect`: a **capped exponential backoff** (1s→30s, reset on a successful join) that keeps the process — and `cmd/glyphoxa`'s DB-backed `/readyz` — alive across failed or dropped connections. Only a cancelled context ends the loop, which also fixes clean **SIGTERM exiting non-zero**.
- `/readyz` stays a **DB ping** (a transient remote must not yank the pod from k8s endpoints). `RunFromDB`'s stale-schema check stays **fatal** (ADR-0031). This is the Discord join only.

## Built TDD via an agent workflow; adversarial review caught two real bugs
- `connectAndServe` now derives a **per-cycle context** so the stage-subscriber sweeper goroutine is reaped each cycle — a flapping Discord no longer leaks goroutines.
- `buildConversation` cleanup closes **only the per-cycle VAD session**, never the process-global Silero/ONNX engine (`engine.Close()`→`DestroyEnvironment` would make the NPC permanently deaf after the first reconnect). Guarded by an integration test that builds → cleans up → builds again.

## Tests
- Keyless unit tests (default `go test` path, ADR-0033): backoff schedule, reset-on-connect **then re-grow**, clean shutdown, clean-session-close reconnect, fatal config.
- Integration regression for the engine-singleton invariant (real Silero).
- `go build ./...`, `go vet ./...` (+ `-tags=integration`), `go test -race ./...` all green; `helm lint` clean.

`NOTES.txt` updated: a placeholder token now keeps the pod Available and retries, no longer crashloops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)