### PR TITLE
feat(ci): end-to-end deploy smoke on k3d (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,73 @@ jobs:
             --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require' \
             | kubeconform -strict -summary -kubernetes-version 1.30.0
 
+  e2e:
+    name: deploy e2e (k3d smoke)
+    # Wait for the `image` job so its cache-to (mode=max) has populated the gha
+    # cache: this job's build is then a cache HIT (load layers, no recompile)
+    # rather than a second full native build of the slow whisper/libdave/CGO
+    # image. The serialization costs a little wall-time but halves the expensive
+    # build per run. The real cluster e2e is issue #37's gate — deliberately a
+    # SEPARATE job from the fast `test` suite (ADR-0033) so the heavy image build
+    # + cluster spin-up never slows unit feedback.
+    needs: [image]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Rebuild the single image (ADR-0034) from the warm gha cache and LOAD it
+      # into the local daemon so k3d can import it. cache-from only (no cache-to)
+      # — the `image` job owns the cache write, so the two never race on it.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: glyphoxa:e2e
+          cache-from: type=gha
+
+      # Helm >= 3.18 for platformHooks parity with the `helm` job (kept in step
+      # with the helm-unittest pin there).
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      # Pinned release binary, fetched without piping a script to a shell (same
+      # discipline as the kubeconform install in the `helm` job).
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d \
+            https://github.com/k3d-io/k3d/releases/download/v5.7.5/k3d-linux-amd64
+          sudo install -m 0755 /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Create k3d cluster
+        run: k3d cluster create glyphoxa-e2e --wait --timeout 120s
+
+      - name: Import image into k3d
+        run: k3d image import glyphoxa:e2e -c glyphoxa-e2e
+
+      # helm install (ordered hook chain: Postgres → migrate → seed → voice
+      # Available) + the /readyz assertion, then release teardown. No live Discord
+      # creds: the resilience fix (#44) keeps the pod serving the DB-backed
+      # /readyz so the Deployment reaches Available with a placeholder token.
+      - name: Deploy smoke test
+        run: ./scripts/e2e-deploy-smoke.sh
+        env:
+          RELEASE: glyphoxa-e2e
+          NAMESPACE: glyphoxa-e2e
+          IMAGE_REPO: glyphoxa
+          IMAGE_TAG: e2e
+          TIMEOUT: 300s
+
+      - name: Delete k3d cluster
+        if: always()
+        run: k3d cluster delete glyphoxa-e2e || true
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/scripts/e2e-deploy-smoke.sh
+++ b/scripts/e2e-deploy-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# e2e-deploy-smoke.sh — issue #37: prove the whole deploy chain converges on the
+# CURRENT kube context (an ephemeral k3d/kind cluster), WITHOUT live Discord
+# credentials. It helm-installs the chart and asserts, in order:
+#
+#   Postgres Ready → migrate Job Completed → seed Job Completed
+#     → voice Deployment Available → /readyz returns 200
+#
+# then tears the release down. The cluster lifecycle is the caller's concern (the
+# CI workflow creates/deletes the k3d cluster and imports the image); this script
+# owns the helm install + ordered assertions, so it is runnable locally too:
+#
+#   k3d cluster create gx-e2e
+#   docker build -t glyphoxa:e2e . && k3d image import glyphoxa:e2e -c gx-e2e
+#   ./scripts/e2e-deploy-smoke.sh
+#   k3d cluster delete gx-e2e
+#
+# No live credentials: a placeholder Discord token never joins a channel, but the
+# resilience fix (issue #44) keeps the pod serving /healthz + the DB-backed
+# /readyz, so the Deployment reaches Available regardless. The actual channel join
+# stays a manual check (slice 6). All knobs are env vars with defaults.
+set -euo pipefail
+
+RELEASE="${RELEASE:-glyphoxa-e2e}"
+NAMESPACE="${NAMESPACE:-glyphoxa-e2e}"
+CHART="${CHART:-deploy/charts/glyphoxa}"
+IMAGE_REPO="${IMAGE_REPO:-glyphoxa}"
+IMAGE_TAG="${IMAGE_TAG:-e2e}"
+# One timeout for the helm install and every wait. Generous so a cold image pull
+# (Postgres) or a slow runner does not flake the gate; a genuine non-convergence
+# still fails within it.
+TIMEOUT="${TIMEOUT:-300s}"
+# Local port the /readyz check forwards the metrics listener to.
+READYZ_LOCAL_PORT="${READYZ_LOCAL_PORT:-19090}"
+
+# Object names mirror the chart helpers: glyphoxa.<component>.fullname renders as
+# <release>-<component> (deploy/charts/glyphoxa/templates/_helpers.tpl).
+PG="${RELEASE}-postgres"
+MIGRATE="${RELEASE}-migrate"
+SEED="${RELEASE}-seed"
+VOICE="${RELEASE}-voice"
+
+VALUES_FILE="$(mktemp)"
+PF_PID=""
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+dump_diagnostics() {
+  log "DIAGNOSTICS (namespace ${NAMESPACE})"
+  kubectl -n "$NAMESPACE" get all,jobs -o wide 2>/dev/null || true
+  kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null | tail -40 || true
+  for c in postgres migrate seed voice; do
+    log "describe + logs: component=${c}"
+    kubectl -n "$NAMESPACE" describe pod -l "app.kubernetes.io/component=${c}" 2>/dev/null || true
+    kubectl -n "$NAMESPACE" logs -l "app.kubernetes.io/component=${c}" --all-containers --tail=80 2>/dev/null || true
+  done
+}
+
+cleanup() {
+  local rc=$?
+  [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null || true
+  if [ "$rc" -ne 0 ]; then dump_diagnostics; fi
+  # Best-effort release teardown. Helm leaves the chart's HOOK resources (the
+  # Postgres StatefulSet + PVC, the Secret, and the migrate/seed Jobs — all
+  # hook-delete-policy before-hook-creation) in place on uninstall; on a reused
+  # cluster they linger until the next install, while CI deletes the whole
+  # cluster (always()) which reclaims everything. No --wait: teardown readiness
+  # is not asserted and a wedged uninstall must not delay the real exit code.
+  log "helm uninstall ${RELEASE}"
+  helm uninstall "$RELEASE" -n "$NAMESPACE" --timeout 60s >/dev/null 2>&1 || true
+  rm -f "$VALUES_FILE"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+# Generate the install values. The provider keys + Discord token are obviously
+# fake (the bot never authenticates — that is the point); appSecret is a throwaway
+# credential-cipher key generated here (ADR-0004: real keys live in the OS keyring,
+# never the DB), so no secret is committed. image.pullPolicy=Never forces the pods
+# to use the k3d-imported image instead of pulling from a registry. The snowflakes
+# are quoted strings (a 64-bit ID loses precision as a YAML number).
+cat >"$VALUES_FILE" <<EOF
+image:
+  repository: "${IMAGE_REPO}"
+  tag: "${IMAGE_TAG}"
+  pullPolicy: Never
+appSecret: "$(openssl rand -base64 32)"
+discordBotToken: "ci-not-a-real-discord-token"
+elevenLabsApiKey: "ci-fake-elevenlabs-key"
+geminiApiKey: "ci-fake-gemini-key"
+groqApiKey: "ci-fake-groq-key"
+voice:
+  enabled: true
+  guild: "111111111111111111"
+  channel: "222222222222222222"
+EOF
+
+log "helm install ${RELEASE} (chart ${CHART}, image ${IMAGE_REPO}:${IMAGE_TAG})"
+# --wait blocks until the ORDERED pre-install hook chain succeeds — Postgres
+# (weight -10) up, migrate Job (-5) Completed, seed Job (-4) Completed — and then
+# the voice Deployment reaches Available. So a zero exit here already proves the
+# whole chain converged; the explicit asserts below name the exact link on a
+# regression and double as the issue-#37 acceptance checklist.
+helm install "$RELEASE" "$CHART" \
+  --namespace "$NAMESPACE" --create-namespace \
+  --values "$VALUES_FILE" \
+  --wait --timeout "$TIMEOUT"
+
+# The migrate/seed Jobs persist after success (hook-delete-policy
+# before-hook-creation), so they are still inspectable here.
+log "assert: Postgres StatefulSet Ready"
+kubectl -n "$NAMESPACE" rollout status "statefulset/${PG}" --timeout "$TIMEOUT"
+
+log "assert: migrate Job Completed (schema current)"
+kubectl -n "$NAMESPACE" wait --for=condition=Complete "job/${MIGRATE}" --timeout "$TIMEOUT"
+
+log "assert: seed Job Completed (NPC present)"
+kubectl -n "$NAMESPACE" wait --for=condition=Complete "job/${SEED}" --timeout "$TIMEOUT"
+
+log "assert: voice Deployment Available"
+kubectl -n "$NAMESPACE" wait --for=condition=Available "deployment/${VOICE}" --timeout "$TIMEOUT"
+
+log "assert: /readyz returns 200"
+# Port-forward the metrics listener and curl /readyz directly: the slim runtime
+# image ships no curl, but the runner has one. A 200 here is the same DB-backed
+# readiness the kubelet probe gates Available on, asserted end-to-end and without
+# live Discord. Retry briefly so a freshly established forward does not flake.
+kubectl -n "$NAMESPACE" port-forward "deployment/${VOICE}" "${READYZ_LOCAL_PORT}:9090" >/dev/null 2>&1 &
+PF_PID=$!
+ready=""
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${READYZ_LOCAL_PORT}/readyz" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [ -z "$ready" ]; then
+  echo "FAIL: /readyz did not return 200 within the window"
+  exit 1
+fi
+
+log "PASS: deploy chain converged — Postgres → migrate → seed → voice Available → /readyz 200"


### PR DESCRIPTION
Closes #37. Builds on the merged resilience fix (#44), which lets the voice pod reach `Available` without live Discord creds.

## What
An automated end-to-end test that proves the whole deploy chain on an ephemeral k3d cluster, on every PR (ADR-0033: its own job, off the fast unit path).

`scripts/e2e-deploy-smoke.sh` helm-installs the chart on the current kube context and asserts, **in order**:

`Postgres Ready → migrate Job Completed → seed Job Completed → voice Deployment Available → /readyz 200`

then tears the release down (EXIT trap, with pod describe/logs/events dumped on failure). No live Discord credentials — a placeholder token never joins a channel, but #44 keeps the pod serving the DB-backed `/readyz`, so the Deployment reaches `Available` regardless. The actual channel join stays the manual check (slice 6). All knobs are env vars, so it is runnable locally too.

## CI job
The new `e2e` job: pinned k3d (release binary, not `curl|bash`), build + `k3d image import` the single image, run the script, delete the cluster in `always()`. `needs: [image]` so the gha cache is warm (the build is a cache hit, not a second full native build). Helm pinned to v3.18.4 (parity with the `helm` job).

## Verification
Ran the full harness locally against a real k3d cluster end-to-end: the chain passes — **voice Deployment Available + /readyz 200** — with a placeholder token, confirming both the harness and #44's no-crashloop behavior in-cluster. This PR's own CI exercises the `e2e` job against the real production image on a clean runner.

## Acceptance criteria
- [x] CI spins up an ephemeral k3d cluster and `helm install`s the chart from the slice-1 image
- [x] Asserts the chain in order: Postgres Ready → migrate Completed → seed Completed → voice Deployment Available → `/readyz` 200
- [x] Tears the cluster down and fails the build if any step does not converge within a timeout
- [x] Runs as part of the e2e CI surface, off the fast default unit-test path (ADR-0033)

🤖 Generated with [Claude Code](https://claude.com/claude-code)