### PR TITLE
feat(voice/agent): Cast reply multiplexer (#48)

### DIFF
--- a/pkg/voice/agent/cast.go
+++ b/pkg/voice/agent/cast.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Cast multiplexes one reply strategy across several [Replier]s, keyed by the
+// Agent they answer for. It is the single reply strategy [orchestrator.Conversation]
+// wires when more than one NPC shares the conversation: each [voiceevent.AddressRouted]
+// is delegated to the one Replier whose [Persona.AgentID] matches the route's
+// [voiceevent.AddressTarget.AgentID], so N independent Agents speak on one bus and
+// one barge-in floor.
+//
+// Why one strategy and not N bound repliers: the reply reactor takes the barge-in
+// floor on every AddressRouted (reactor.go), so binding several independent
+// repliers on one shared floor would corrupt floor state — they would each take
+// and release the floor for the same turn. Routing a single addressed turn to a
+// single Replier keeps the floor's one-turn-at-a-time invariant intact, which is
+// why single-target is the safe default and the speculative fan-out / multiple
+// floors of an Ensemble Turn (ADR-0025) is deferred.
+//
+// A route whose AgentID names no current member dispatches nothing and yields nil
+// — the right answer when the matcher selected an Agent the Cast does not hold, or
+// one that was removed mid-conversation. Members may be added and removed at
+// runtime ([Cast.Add], [Cast.Remove]); the RWMutex guards the roster against a
+// concurrent dispatch and the race detector.
+type Cast struct {
+	mu       sync.RWMutex
+	repliers map[string]*Replier // AgentID -> Replier
+}
+
+// NewCast builds a Cast from the given repliers, keyed by each one's
+// [Persona.AgentID]. When two repliers share an AgentID the last one wins (a
+// wiring error the caller is responsible for avoiding). A Cast with no members is
+// valid — every route says nothing until one is added.
+func NewCast(repliers ...*Replier) *Cast {
+	c := &Cast{repliers: make(map[string]*Replier, len(repliers))}
+	for _, r := range repliers {
+		c.Add(r)
+	}
+	return c
+}
+
+// Add registers r under its [Persona.AgentID], so subsequent routes for that
+// Agent are delegated to it. Re-adding an AgentID replaces the prior member. A nil
+// Replier is ignored.
+func (c *Cast) Add(r *Replier) {
+	if r == nil {
+		return
+	}
+	c.mu.Lock()
+	c.repliers[r.cfg.Persona.AgentID] = r
+	c.mu.Unlock()
+}
+
+// Remove drops the Agent with the given AgentID from the Cast; subsequent routes
+// for it say nothing. Removing an absent AgentID is a no-op.
+func (c *Cast) Remove(agentID string) {
+	c.mu.Lock()
+	delete(c.repliers, agentID)
+	c.mu.Unlock()
+}
+
+// lookup returns the Replier registered for agentID, or nil. It takes the read
+// lock so dispatch never reads the roster concurrently with [Cast.Add] /
+// [Cast.Remove]. The returned *Replier is itself concurrency-safe for its own turn.
+func (c *Cast) lookup(agentID string) *Replier {
+	c.mu.RLock()
+	r := c.repliers[agentID]
+	c.mu.RUnlock()
+	return r
+}
+
+// ReplyStream returns the [orchestrator.StreamReplyFunc] that multiplexes the
+// streaming reply path across the Cast: it looks up the Replier for
+// e.Target.AgentID and delegates to that Replier's streaming turn. A route for an
+// unknown (or removed) Agent dispatches nothing and returns nil. Install it with
+// [orchestrator.WithReplyStream] — it is the production strategy for a multi-NPC
+// conversation.
+func (c *Cast) ReplyStream() orchestrator.StreamReplyFunc {
+	return func(ctx context.Context, e voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		r := c.lookup(e.Target.AgentID)
+		if r == nil {
+			return nil // no Agent answers for this route
+		}
+		return r.ReplyStream()(ctx, e, dispatch)
+	}
+}
+
+// Reply returns the batch [orchestrator.ReplyFunc] twin of [Cast.ReplyStream]: it
+// delegates the route to the addressed Replier's batch turn, or returns nil for an
+// unknown Agent. Provided for symmetry with [Replier.Reply]; production wires the
+// streaming path.
+func (c *Cast) Reply() orchestrator.ReplyFunc {
+	return func(ctx context.Context, e voiceevent.AddressRouted) []orchestrator.Reply {
+		r := c.lookup(e.Target.AgentID)
+		if r == nil {
+			return nil // no Agent answers for this route
+		}
+		return r.Reply()(ctx, e)
+	}
+}

--- a/pkg/voice/agent/cast_test.go
+++ b/pkg/voice/agent/cast_test.go
@@ -1,0 +1,221 @@
+package agent_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+)
+
+// castReplier builds a Replier for a named Agent over a streaming engine, so a
+// Cast can be assembled from several distinguishable repliers. The Voice carries
+// the AgentID in its identifying fields so a dispatched Reply can be attributed to
+// its speaker.
+func castReplier(agentID string, eng agent.Engine) *agent.Replier {
+	return agent.NewReplier(agent.Config{
+		Persona: agent.Persona{
+			AgentID:  agentID,
+			Markdown: "You are " + agentID + ".",
+			Voice:    voiceNamed(agentID),
+		},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+	})
+}
+
+// voiceNamed is testVoice with the speaker's id stamped into its identifying
+// fields so a dispatched Reply's Voice tells which Agent spoke it.
+func voiceNamed(agentID string) tts.Voice {
+	v := testVoice()
+	v.VoiceID = agentID
+	v.Name = agentID
+	return v
+}
+
+// TestCast_RoutesToAddressedAgent pins the multiplexer core: a route for agent B
+// drives B's reply (and only B's). The dispatched Reply's Voice attributes the
+// sentence to its speaker, so a route for "b" must be spoken in b's voice.
+func TestCast_RoutesToAddressedAgent(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"I am A."}})
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"I am B."}})
+	cast := agent.NewCast(a, b)
+
+	var got []orchestrator.Reply
+	err := cast.ReplyStream()(context.Background(), routed("b", "who are you?"), func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ReplyStream: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("dispatched %d replies, want 1 (only B speaks)", len(got))
+	}
+	if got[0].Sentence != "I am B." {
+		t.Errorf("sentence = %q, want B's reply", got[0].Sentence)
+	}
+	if got[0].Voice.VoiceID != "b" {
+		t.Errorf("voice = %q, want B's voice (A must not have spoken)", got[0].Voice.VoiceID)
+	}
+}
+
+// TestCast_UnknownAgentSaysNothing pins the unknown-target contract: a route for
+// an AgentID no replier in the Cast answers for dispatches nothing and returns
+// nil — the safe default when the matcher selected an Agent the Cast does not (or
+// no longer) holds.
+func TestCast_UnknownAgentSaysNothing(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"I am A."}})
+	cast := agent.NewCast(a)
+
+	var dispatched int
+	err := cast.ReplyStream()(context.Background(), routed("ghost", "hello?"), func(orchestrator.Reply) error {
+		dispatched++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("ReplyStream for unknown agent = %v, want nil", err)
+	}
+	if dispatched != 0 {
+		t.Errorf("dispatched %d replies for unknown agent, want 0", dispatched)
+	}
+}
+
+// TestCast_AddNPC pins runtime registration: an Agent added after construction
+// replies when addressed, so a Cast can grow as NPCs enter the scene.
+func TestCast_AddNPC(t *testing.T) {
+	cast := agent.NewCast()
+
+	// Before Add, the target is unknown — nothing is said.
+	var before int
+	_ = cast.ReplyStream()(context.Background(), routed("c", "hi"), func(orchestrator.Reply) error {
+		before++
+		return nil
+	})
+	if before != 0 {
+		t.Fatalf("dispatched %d before Add, want 0", before)
+	}
+
+	cast.Add(castReplier("c", &fakeStreamEngine{deltas: []string{"I am C."}}))
+
+	var got []orchestrator.Reply
+	if err := cast.ReplyStream()(context.Background(), routed("c", "hi"), func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	}); err != nil {
+		t.Fatalf("ReplyStream after Add: %v", err)
+	}
+	if len(got) != 1 || got[0].Sentence != "I am C." {
+		t.Errorf("after Add dispatched %+v, want C's single reply", got)
+	}
+}
+
+// TestCast_RemoveNPC pins runtime removal: an Agent removed from the Cast goes
+// silent — a route for it dispatches nothing, as if it had never been registered.
+func TestCast_RemoveNPC(t *testing.T) {
+	d := castReplier("d", &fakeStreamEngine{deltas: []string{"I am D."}})
+	cast := agent.NewCast(d)
+
+	cast.Remove("d")
+
+	var dispatched int
+	if err := cast.ReplyStream()(context.Background(), routed("d", "still there?"), func(orchestrator.Reply) error {
+		dispatched++
+		return nil
+	}); err != nil {
+		t.Fatalf("ReplyStream after Remove: %v", err)
+	}
+	if dispatched != 0 {
+		t.Errorf("removed agent dispatched %d replies, want 0 (gone silent)", dispatched)
+	}
+}
+
+// TestCast_Reply_RoutesToAddressedAgent pins the batch [orchestrator.ReplyFunc]
+// twin of the streaming multiplexer: Reply() looks up the addressed agent and
+// returns its turn, nothing for the others.
+func TestCast_Reply_RoutesToAddressedAgent(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"I am A."}})
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"I am B."}})
+	cast := agent.NewCast(a, b)
+
+	got := cast.Reply()(context.Background(), routed("a", "who?"))
+	if len(got) != 1 || got[0].Sentence != "I am A." {
+		t.Fatalf("Reply for a = %+v, want A's single reply", got)
+	}
+	if got[0].Voice.VoiceID != "a" {
+		t.Errorf("voice = %q, want A's voice", got[0].Voice.VoiceID)
+	}
+
+	if unknown := cast.Reply()(context.Background(), routed("ghost", "?")); unknown != nil {
+		t.Errorf("Reply for unknown agent = %+v, want nil", unknown)
+	}
+}
+
+// TestCast_ConcurrentAddRemoveDispatch races Add/Remove against reply dispatch to
+// pin the RWMutex guard: under -race, runtime roster mutation must not corrupt the
+// lookup nor data-race the dispatch path. Correctness of any single dispatch is
+// not asserted (the roster is changing under it) — only that no race fires and no
+// dispatch panics.
+func TestCast_ConcurrentAddRemoveDispatch(t *testing.T) {
+	cast := agent.NewCast()
+	const n = 8
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = string(rune('a' + i))
+		cast.Add(castReplier(ids[i], &fakeStreamEngine{deltas: []string{"hi"}}))
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Mutator: churn the roster.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for _, id := range ids {
+				cast.Remove(id)
+				cast.Add(castReplier(id, &fakeStreamEngine{deltas: []string{"hi"}}))
+			}
+		}
+	}()
+
+	// Dispatchers: keep routing while the roster churns.
+	dispatch := func(orchestrator.Reply) error { return nil }
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, id := range ids {
+					_ = cast.ReplyStream()(context.Background(), routed(id, "go"), dispatch)
+					_ = cast.Reply()(context.Background(), routed(id, "go"))
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// Compile-time assertions: a Cast's strategies are drop-in for the orchestrator
+// reply seams without an adapter.
+var (
+	_ orchestrator.StreamReplyFunc = agent.NewCast().ReplyStream()
+	_ orchestrator.ReplyFunc       = agent.NewCast().Reply()
+)


### PR DESCRIPTION
## What
`Cast` — one reply strategy that multiplexes each `voiceevent.AddressRouted` to the single `Replier` whose `Persona.AgentID` matches `e.Target.AgentID`. Construct with `NewCast(...*Replier)`; mutate at runtime with `Add(*Replier)` / `Remove(agentID string)` under a `sync.RWMutex`.

- `Cast.ReplyStream()` is a drop-in `orchestrator.StreamReplyFunc` (the production path).
- `Cast.Reply()` is the batch `orchestrator.ReplyFunc` twin, for symmetry.
- A route for an unknown/removed Agent dispatches nothing and returns nil.

## Why
`Replier` already self-filters by `AgentID`, but the reply reactor takes the barge-in floor on **every** `AddressRouted` (`reactor.go`), so binding N independent repliers on one shared floor would corrupt floor state. Routing a single addressed turn to a single Replier keeps the floor's one-turn-at-a-time invariant intact — single-target is the safe default; ensemble fan-out (ADR-0025) stays deferred. Barge-in behavior is unchanged for single-target.

Closes #48

## Tests (TDD: red → green)
- `TestCast_RoutesToAddressedAgent` — route for B drives B's reply (and Voice), not A's.
- `TestCast_UnknownAgentSaysNothing` — unregistered AgentID dispatches nothing, returns nil.
- `TestCast_AddNPC` — Agent added at runtime replies when addressed.
- `TestCast_RemoveNPC` — removed Agent goes silent.
- `TestCast_Reply_RoutesToAddressedAgent` — batch `ReplyFunc` twin.
- `TestCast_ConcurrentAddRemoveDispatch` — Add/Remove churned against streaming + batch dispatch.

Vendor-free per ADR-0019/0021 — fakes/stubs for `Engine` + `Synthesizer`, no live providers.

`go test -race ./pkg/voice/agent/...` green. `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)