### PR TITLE
feat(voice/address): single-target cap + dynamic roster (#47)

### DIFF
--- a/pkg/voice/address/matcher.go
+++ b/pkg/voice/address/matcher.go
@@ -3,6 +3,7 @@ package address
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -60,6 +61,13 @@ type Config struct {
 	// AddressThreshold is the minimum total score an Agent needs to be
 	// addressed. Default 1.0.
 	AddressThreshold float64
+	// MaxTargets caps how many Agents one utterance may address, applied to the
+	// score-sorted hits before the decision set is built (so only the published
+	// Agents become the next turn's continuation context). Zero defaults to 1
+	// (single-target: naming two NPCs fires one turn on the top-scored). A
+	// positive N caps at N; a negative value lifts the cap entirely, restoring
+	// the full Ensemble Turn set (ADR-0025).
+	MaxTargets int
 	// RecencyWindow bounds how long mentioned words and interruptions stay
 	// "recent". Default 30s.
 	RecencyWindow time.Duration
@@ -111,15 +119,21 @@ func DefaultHeuristics() []Heuristic {
 // use; the bus delivers events synchronously but possibly from different
 // goroutines.
 type Matcher struct {
-	agents     []Agent
-	index      *fuzzyIndex
+	// index is read lock-free by TargetMatch and swapped wholesale by Add/Remove
+	// under m.mu, so a concurrent roster rebuild never tears a scoring pass.
+	index atomic.Pointer[fuzzyIndex]
+
+	nameMatch  NameMatchConfig // retained to rebuild the index on roster changes
+	enc        Encoder         // retained to rebuild the index on roster changes
 	heuristics []Heuristic
 	threshold  float64
+	maxTargets int // resolved cap: >0 caps at N, <0 is unlimited (0 never stored)
 	window     time.Duration
 	maxWords   int
 	clock      func() time.Time
 
 	mu            sync.Mutex
+	agents        []Agent
 	lastAddressed map[string]bool
 	interruptions map[string]time.Time
 	recentWords   []timedWord
@@ -163,28 +177,45 @@ func NewMatcher(cfg Config, agents ...Agent) *Matcher {
 	if clock == nil {
 		clock = time.Now
 	}
+	maxTargets := cfg.MaxTargets
+	if maxTargets == 0 {
+		maxTargets = 1
+	}
 
 	agents = append([]Agent(nil), agents...)
-	names := make([][]string, len(agents))
 	for i := range agents {
 		if agents[i].Target.AgentID == "" {
 			panic("address.NewMatcher: agent Target.AgentID must not be empty")
 		}
 		agents[i].index = i
-		names[i] = agents[i].matchableNames()
 	}
 
-	return &Matcher{
-		agents:        agents,
-		index:         newFuzzyIndex(cfg.NameMatch, enc, names),
+	m := &Matcher{
+		nameMatch:     cfg.NameMatch,
+		enc:           enc,
 		heuristics:    heuristics,
 		threshold:     threshold,
+		maxTargets:    maxTargets,
 		window:        window,
 		maxWords:      maxWords,
 		clock:         clock,
+		agents:        agents,
 		lastAddressed: map[string]bool{},
 		interruptions: map[string]time.Time{},
 	}
+	m.index.Store(m.buildIndex())
+	return m
+}
+
+// buildIndex rebuilds the fuzzy name index from the current m.agents. Callers
+// that mutate m.agents (the constructor and Add/Remove) hold m.mu; the
+// constructor is the sole exception, running before the Matcher is shared.
+func (m *Matcher) buildIndex() *fuzzyIndex {
+	names := make([][]string, len(m.agents))
+	for i := range m.agents {
+		names[i] = m.agents[i].matchableNames()
+	}
+	return newFuzzyIndex(m.nameMatch, m.enc, names)
 }
 
 // NoteInterruption records that the Agent with agentID was just interrupted
@@ -198,12 +229,87 @@ func (m *Matcher) NoteInterruption(agentID string) {
 	m.mu.Unlock()
 }
 
+// Add inserts agents into the live roster so they become addressable mid-Voice
+// Session (a Character NPC joining the scene). It rebuilds and atomically swaps
+// the fuzzy index so a concurrent [Matcher.TargetMatch] keeps scoring against a
+// consistent index throughout. It panics if any Agent has an empty
+// Target.AgentID or an AgentID already on the roster (or duplicated within the
+// same call): a roster that cannot uniquely name its targets is a wiring error,
+// matching [NewMatcher]'s contract. Adding nothing is a no-op.
+func (m *Matcher) Add(agents ...Agent) {
+	if len(agents) == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	seen := make(map[string]struct{}, len(m.agents)+len(agents))
+	for _, a := range m.agents {
+		seen[a.Target.AgentID] = struct{}{}
+	}
+	for _, a := range agents {
+		if a.Target.AgentID == "" {
+			panic("address.Matcher.Add: agent Target.AgentID must not be empty")
+		}
+		if _, dup := seen[a.Target.AgentID]; dup {
+			panic("address.Matcher.Add: duplicate agent AgentID " + a.Target.AgentID)
+		}
+		seen[a.Target.AgentID] = struct{}{}
+		m.agents = append(m.agents, a)
+	}
+	m.reindexLocked()
+}
+
+// Remove drops the Agents with agentIDs from the live roster (a Character NPC
+// leaving the scene) and prunes their continuation and interruption state so a
+// later turn never resurrects a departed Agent. Unknown agentIDs are ignored.
+// Removing every Agent is allowed: the matcher then routes to nobody. It
+// rebuilds and atomically swaps the fuzzy index like [Matcher.Add].
+func (m *Matcher) Remove(agentIDs ...string) {
+	if len(agentIDs) == 0 {
+		return
+	}
+	drop := make(map[string]struct{}, len(agentIDs))
+	for _, id := range agentIDs {
+		drop[id] = struct{}{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	kept := m.agents[:0]
+	for _, a := range m.agents {
+		if _, gone := drop[a.Target.AgentID]; gone {
+			continue
+		}
+		kept = append(kept, a)
+	}
+	m.agents = kept
+	for id := range drop {
+		delete(m.lastAddressed, id)
+		delete(m.interruptions, id)
+	}
+	m.reindexLocked()
+}
+
+// reindexLocked reassigns each Agent's index to its new slice position and swaps
+// in a freshly built fuzzy index. Caller holds m.mu. The index Store is atomic,
+// so TargetMatch's lock-free read always sees a whole index — the old one until
+// the swap, the new one after, never a half-built one.
+func (m *Matcher) reindexLocked() {
+	for i := range m.agents {
+		m.agents[i].index = i
+	}
+	m.index.Store(m.buildIndex())
+}
+
 // TargetMatch scores text against every Agent and returns the addressed set,
 // highest total first. It implements the orchestrator's TargetMatcher.
 func (m *Matcher) TargetMatch(text string) []voiceevent.AddressRouted {
 	now := m.clock()
 	words := tokenize(text)
-	nameScores := m.index.scoreAll(words)
+	// Read the index lock-free: Add/Remove swap it atomically, so this scoring
+	// pass sees one consistent index even across a concurrent rebuild.
+	nameScores := m.index.Load().scoreAll(words)
 
 	m.mu.Lock()
 
@@ -254,6 +360,13 @@ func (m *Matcher) TargetMatch(text string) []voiceevent.AddressRouted {
 
 	// Highest score wins; ties break by Agent order so the result is stable.
 	sort.SliceStable(hits, func(i, j int) bool { return hits[i].total > hits[j].total })
+
+	// Cap the published set before building it, so lastAddressed records only
+	// the Agents actually addressed: naming two NPCs under the single-target
+	// default fires one turn on the top-scored, not two.
+	if m.maxTargets >= 0 && len(hits) > m.maxTargets {
+		hits = hits[:m.maxTargets]
+	}
 
 	addressed := make(map[string]bool, len(hits))
 	out := make([]voiceevent.AddressRouted, 0, len(hits))

--- a/pkg/voice/address/matcher_test.go
+++ b/pkg/voice/address/matcher_test.go
@@ -1,6 +1,8 @@
 package address_test
 
 import (
+	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -24,6 +26,12 @@ var (
 	}
 	goblin = address.Agent{
 		Target: voiceevent.AddressTarget{AgentID: "npc-goblin", AgentRole: "character", Name: "Goblin"},
+	}
+	// dwarf is a spare Character NPC used to keep the lone-NPC fallback inert in
+	// roster tests, so an unnamed turn routing somewhere proves continuation
+	// rather than the single-NPC fallback.
+	dwarf = address.Agent{
+		Target: voiceevent.AddressTarget{AgentID: "npc-dwarf", AgentRole: "character", Name: "Durin"},
 	}
 )
 
@@ -174,10 +182,82 @@ func TestMatcher_EmptyHeuristicStackNeverAddresses(t *testing.T) {
 
 // TestMatcher_MultiTargetEnsemble covers the multi-target half of the contract:
 // one utterance naming two NPCs addresses both (an Ensemble Turn, ADR-0025).
+// MaxTargets: -1 lifts the single-target default cap so the full named set is
+// published — the proof that ensemble routing stays reachable.
 func TestMatcher_MultiTargetEnsemble(t *testing.T) {
-	m := address.NewMatcher(address.Config{Language: "en"}, butler, bart, goblin)
+	m := address.NewMatcher(address.Config{Language: "en", MaxTargets: -1}, butler, bart, goblin)
 	got := m.TargetMatch("Bart and the Goblin start arguing")
 	assertIDs(t, got, "npc-bart", "npc-goblin")
+}
+
+// TestMatcher_SingleTargetByDefault pins the default cap: naming two NPCs in one
+// utterance addresses only the top-scored one (ties break by Agent order), so a
+// default-config matcher fires a single turn rather than two.
+func TestMatcher_SingleTargetByDefault(t *testing.T) {
+	m := address.NewMatcher(address.Config{Language: "en"}, butler, bart, goblin)
+	assertIDs(t, m.TargetMatch("Bart and the Goblin start arguing"), "npc-bart")
+}
+
+// TestMatcher_MaxTargetsCap proves the cap is configurable: MaxTargets: 2 keeps
+// the top two of a larger named set, while MaxTargets: -1 keeps them all.
+func TestMatcher_MaxTargetsCap(t *testing.T) {
+	const utter = "Bart, the Goblin, and Glyphoxa all turn to look"
+
+	capped := address.NewMatcher(address.Config{Language: "en", MaxTargets: 2}, butler, bart, goblin)
+	if got := routedIDs(capped.TargetMatch(utter)); len(got) != 2 {
+		t.Fatalf("MaxTargets: 2 addressed %v, want 2", got)
+	}
+
+	unlimited := address.NewMatcher(address.Config{Language: "en", MaxTargets: -1}, butler, bart, goblin)
+	if got := routedIDs(unlimited.TargetMatch(utter)); len(got) != 3 {
+		t.Fatalf("MaxTargets: -1 addressed %v, want 3", got)
+	}
+}
+
+// TestMatcher_AddAgent proves an Agent added after construction is addressable:
+// before the Add naming the Goblin routes to nobody (two other NPCs keep the
+// lone-NPC fallback inert), after it the new NPC is reached by name.
+func TestMatcher_AddAgent(t *testing.T) {
+	m := address.NewMatcher(address.Config{Language: "en"}, butler, bart, dwarf)
+	assertIDs(t, m.TargetMatch("Goblin, what are you plotting?"))
+
+	m.Add(goblin)
+	assertIDs(t, m.TargetMatch("Goblin, what are you plotting?"), "npc-goblin")
+}
+
+// TestMatcher_RemoveAgent proves a removed Agent stops being addressed and that
+// its continuation state is pruned: after the Goblin holds the floor it is
+// removed, and the follow-up that would otherwise continue to it routes nowhere.
+// Bart and the Dwarf keep the lone-NPC fallback inert throughout, so the only
+// thing that could route an unnamed turn to the Goblin is stale continuation.
+func TestMatcher_RemoveAgent(t *testing.T) {
+	m := address.NewMatcher(address.Config{Language: "en"}, butler, bart, dwarf, goblin)
+
+	// The Goblin becomes the last addressee, so continuation would normally
+	// keep the floor on it.
+	assertIDs(t, m.TargetMatch("Goblin, hold the line."), "npc-goblin")
+
+	m.Remove("npc-goblin")
+
+	// Named again, the Goblin is gone, so nobody is addressed...
+	assertIDs(t, m.TargetMatch("Goblin, hold the line."))
+	// ...and the continuation state was pruned, so an unnamed follow-up does not
+	// resurrect it: it routes to nobody rather than continuing to the departed
+	// Goblin.
+	assertIDs(t, m.TargetMatch("anyway, carry on"))
+}
+
+// TestMatcher_Add_Panics pins Add's validation: an empty AgentID and a duplicate
+// AgentID are both wiring errors that must panic rather than corrupt the roster.
+func TestMatcher_Add_Panics(t *testing.T) {
+	assertPanics(t, "empty AgentID", func() {
+		m := address.NewMatcher(address.Config{Language: "en"}, butler, bart)
+		m.Add(address.Agent{Target: voiceevent.AddressTarget{AgentRole: "character", Name: "Nameless"}})
+	})
+	assertPanics(t, "duplicate AgentID", func() {
+		m := address.NewMatcher(address.Config{Language: "en"}, butler, bart)
+		m.Add(address.Agent{Target: voiceevent.AddressTarget{AgentID: "npc-bart", AgentRole: "character", Name: "Bartholomew"}})
+	})
 }
 
 // TestMatcher_TextEchoedVerbatim proves each decision carries the utterance text
@@ -245,15 +325,24 @@ func assertPanics(t *testing.T, desc string, fn func()) {
 }
 
 // TestMatcher_ConcurrentUse exercises the matcher's locking: many goroutines
-// route and feed interruptions at once. Run under `go test -race` it pins that
-// the shared conversational state is guarded.
+// route, feed interruptions, and churn the roster at once. Run under
+// `go test -race` it pins that the shared conversational state stays guarded and
+// that the lock-free index read sees a consistent index across a concurrent
+// rebuild.
 func TestMatcher_ConcurrentUse(t *testing.T) {
-	m := address.NewMatcher(address.Config{Language: "en"}, butler, bart, goblin)
+	m := address.NewMatcher(address.Config{Language: "en", MaxTargets: -1}, butler, bart)
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
-		wg.Add(2)
+		// Each iteration churns a uniquely-named NPC so concurrent Adds never
+		// collide on a duplicate AgentID (which is a panic), letting roster
+		// mutation race freely against routing and interruptions.
+		id := fmt.Sprintf("npc-extra-%d", i)
+		extra := address.Agent{Target: voiceevent.AddressTarget{AgentID: id, AgentRole: "character", Name: "Extra" + strconv.Itoa(i)}}
+		wg.Add(4)
 		go func() { defer wg.Done(); m.TargetMatch("Bart and the Goblin talk") }()
 		go func() { defer wg.Done(); m.NoteInterruption("npc-bart") }()
+		go func() { defer wg.Done(); m.Add(extra) }()
+		go func() { defer wg.Done(); m.Remove(id) }()
 	}
 	wg.Wait()
 }

--- a/pkg/voice/orchestrator/address_scoring_test.go
+++ b/pkg/voice/orchestrator/address_scoring_test.go
@@ -29,6 +29,14 @@ func newScoringDetector(agents ...address.Agent) *orchestrator.AddressDetector {
 	return orchestrator.NewAddressDetector(m)
 }
 
+// newEnsembleDetector is newScoringDetector with the single-target default cap
+// lifted (MaxTargets: -1), so a multi-NPC utterance yields the full Ensemble
+// Turn set the detector must forward verbatim.
+func newEnsembleDetector(agents ...address.Agent) *orchestrator.AddressDetector {
+	m := address.NewMatcher(address.Config{Language: "en", MaxTargets: -1}, agents...)
+	return orchestrator.NewAddressDetector(m)
+}
+
 // TestScoringMatcher_HelloTest_RoutesToButler is TB7 through the scoring
 // matcher: the hello-test clip ("Glyphoxa, roll a perception check for me")
 // names the Butler, so the cassette-replayed transcript must route there. It
@@ -97,12 +105,13 @@ func TestScoringMatcher_Mishearing_RoutesToNPC(t *testing.T) {
 }
 
 // TestScoringMatcher_Ensemble_PublishesEveryTarget proves the detector
-// publishes every decision the scoring matcher returns: an utterance naming two
-// NPCs yields two address.routed events (an Ensemble Turn, ADR-0025), not one.
+// publishes every decision the scoring matcher returns: with the single-target
+// cap lifted (an ensemble matcher), an utterance naming two NPCs yields two
+// address.routed events (an Ensemble Turn, ADR-0025), not one.
 func TestScoringMatcher_Ensemble_PublishesEveryTarget(t *testing.T) {
 	h := voicetest.New(t)
 	butlerAg, bartAg, goblinAg := scoringAgents()
-	d := newScoringDetector(butlerAg, bartAg, goblinAg)
+	d := newEnsembleDetector(butlerAg, bartAg, goblinAg)
 	t.Cleanup(d.Bind(t.Context(), h.Bus))
 
 	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart and the Goblin start arguing"})


### PR DESCRIPTION
## What

Stage 1 of the Multi-NPC voice epic, scoped to `pkg/voice/address/`.

- **Single-target cap.** `Config.MaxTargets` (`0 ⇒ 1` single-target default, `>0 ⇒ cap N`, `<0 ⇒ unlimited`). The score-sorted `hits` are truncated to the cap *before* the decision set is built, so `lastAddressed` records only the agent(s) actually published.
- **Race-safe index swap.** `index *fuzzyIndex` → `atomic.Pointer[fuzzyIndex]`. `TargetMatch` reads it lock-free; `Add`/`Remove` rebuild and `Store` it under `m.mu`. The `agents` slice stays guarded by `m.mu`.
- **Dynamic roster.** `Matcher.Add(agents ...Agent)` and `Matcher.Remove(agentIDs ...string)`: under `m.mu` they mutate `m.agents`, reindex, rebuild the fuzzy index, and (Remove) prune `lastAddressed`/`interruptions` for departed agents. `Add` validates AgentID (non-empty, no duplicates) and panics on violation; removing down to zero agents is allowed.

## Why

The matcher published *every* hit above threshold (naming two NPCs fired two turns) and was immutable after construction (no mid-session NPC join/leave, despite ADR-0024 referencing a never-implemented `Rebuild`). Default `NewMatcher(Config{Language:"en"}, …)` is now single-target; no changes required in `orchestrator`/`agent`.

Closes #47

## Tests added
- `TestMatcher_SingleTargetByDefault` — two named NPCs → only the top-scored under default config.
- `TestMatcher_MaxTargetsCap` — `MaxTargets: 2` keeps two; `-1` keeps the full set.
- `TestMatcher_AddAgent` — an agent added post-construction becomes addressable by name.
- `TestMatcher_RemoveAgent` — a removed agent stops being addressed and its continuation state is pruned (no resurrecting follow-up).
- `TestMatcher_Add_Panics` — empty + duplicate AgentID validation.
- `TestMatcher_ConcurrentUse` — extended to churn `Add`/`Remove` against `TargetMatch`/`NoteInterruption`.
- `TestMatcher_MultiTargetEnsemble` updated to `MaxTargets: -1` (proof ensemble stays reachable); orchestrator's `TestScoringMatcher_Ensemble_PublishesEveryTarget` likewise builds an ensemble-config detector.

`go test -race ./pkg/voice/...` green; `go build ./...`, `go vet`, `gofmt -l`, and `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)