### PR TITLE
feat(wirenpc): assemble N NPCs + programmatic Roster (#49)

### DIFF
--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -161,39 +161,48 @@ func SeedNPC(ctx context.Context, pool *pgxpool.Pool, cipher *crypto.Cipher, log
 	return nil
 }
 
-// loadSeededNPC reads the demo Campaign's single Character NPC from the DB and
-// maps it to the npcSpec the voice loop builds from. The auto-created Butler is
-// ignored (it is the slash-command Agent for #6, not voiced here); this slice
-// expects exactly one Character NPC in the Campaign.
+// loadSeededNPCs reads ALL the demo Campaign's Character NPCs from the DB and
+// maps each to the npcSpec the voice loop builds its Roster from. The
+// auto-created Butler is ignored (it is the slash-command Agent for #6, not
+// voiced here). This is the INITIAL roster membership; NPCs join and leave at
+// runtime via the programmatic [Roster] API (#49). The single-NPC default of the
+// demo seed yields a one-element slice — the pre-Roster behavior unchanged.
 //
-// AgentID is the Agent's DB UUID as a string — the stable identity Address
+// AgentID is each Agent's DB UUID as a string — the stable identity Address
 // Detection routes on (the in-code path used "bart"; the value only has to be
 // consistent between the matcher and the Persona, which it is).
-func loadSeededNPC(ctx context.Context, st *storage.Store) (npcSpec, error) {
+func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, error) {
 	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
 	if err != nil {
-		return npcSpec{}, fmt.Errorf("wirenpc: load NPC: find tenant: %w", err)
+		return nil, fmt.Errorf("wirenpc: load NPCs: find tenant: %w", err)
 	}
 
 	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
 	if err != nil {
-		return npcSpec{}, fmt.Errorf("wirenpc: load NPC: find campaign: %w", err)
+		return nil, fmt.Errorf("wirenpc: load NPCs: find campaign: %w", err)
 	}
 
 	chars, err := st.CharacterAgents(ctx, campaignID)
 	if err != nil {
-		return npcSpec{}, err
+		return nil, err
 	}
-	if len(chars) != 1 {
-		return npcSpec{}, fmt.Errorf("wirenpc: load NPC: expected exactly 1 Character NPC in %q, found %d",
-			SeedCampaignName, len(chars))
+	if len(chars) == 0 {
+		return nil, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
 	}
 
-	loaded, err := st.LoadAgent(ctx, chars[0].ID)
-	if err != nil {
-		return npcSpec{}, err
+	specs := make([]npcSpec, 0, len(chars))
+	for _, c := range chars {
+		loaded, err := st.LoadAgent(ctx, c.ID)
+		if err != nil {
+			return nil, err
+		}
+		spec, err := npcSpecFromAgent(loaded.Agent)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
 	}
-	return npcSpecFromAgent(loaded.Agent)
+	return specs, nil
 }
 
 // npcSpecFromAgent maps a storage.Agent (vendor-neutral) to the voice-domain

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 
 // These tests stand up a real Postgres (testcontainers) to exercise the seed →
-// DB → loadSeededNPC → buildConversation round-trip, so they are tag-isolated
+// DB → loadSeededNPCs → buildConversation round-trip, so they are tag-isolated
 // behind `integration` (ADR-0033): the default `go test ./...` stays Docker-free
 // per ADR-0021, and a dedicated `-tags=integration` CI job runs these with
 // Docker. The runtime t.Skip on a missing Postgres remains for local
@@ -116,10 +116,14 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 		t.Fatalf("SeedNPC: %v", err)
 	}
 
-	loaded, err := loadSeededNPC(ctx, storage.New(pool))
+	specs, err := loadSeededNPCs(ctx, storage.New(pool))
 	if err != nil {
-		t.Fatalf("loadSeededNPC: %v", err)
+		t.Fatalf("loadSeededNPCs: %v", err)
 	}
+	if len(specs) != 1 {
+		t.Fatalf("demo seed loaded %d Character NPCs, want 1", len(specs))
+	}
+	loaded := specs[0]
 	want := hardcodedNPC()
 
 	if loaded.name != want.name {
@@ -160,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), loaded, ttseleven.New(""), nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -168,13 +172,88 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	if conv == nil {
 		t.Fatal("buildConversation returned a nil Conversation")
 	}
+	if roster == nil {
+		t.Fatal("buildConversation returned a nil Roster")
+	}
 
-	routed := npcMatcher(loaded).TargetMatch("Bart, do you have a room?")
+	// The assembled Roster's Matcher must route a named utterance to the loaded
+	// Agent's identity (so the Persona the reply loop answers for and the Address
+	// Detection target agree — the chain that makes the NPC speak).
+	routed := roster.matcher.TargetMatch("Bart, do you have a room?")
 	if len(routed) == 0 {
 		t.Fatal("named utterance routed to nobody for the DB-loaded NPC")
 	}
 	if got := routed[0].Target.AgentID; got != loaded.agentID {
 		t.Errorf("routed AgentID = %q, want loaded agentID %q (matcher/Persona disagree)", got, loaded.agentID)
+	}
+}
+
+// TestLoadSeededNPCs_LoadsAllCharacterAgents pins the Stage-3 multi-NPC load
+// (issue #49): loadSeededNPCs returns EVERY Character NPC in the campaign, not
+// just one — the old loadSeededNPC hard-failed unless exactly one was present.
+// Seed the demo (one NPC), insert a second Character NPC into the same campaign,
+// and assert both come back and assemble into a Roster that routes each by name.
+func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+
+	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+
+	// A second Character NPC in the same campaign — a Voice Session can host ≥2.
+	if _, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  campaignID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        "Mira",
+		Persona:     "You are Mira, the wandering bard.",
+		AddressOnly: false,
+		Aliases:     []string{"bard"},
+	}); err != nil {
+		t.Fatalf("CreateAgent (Mira): %v", err)
+	}
+
+	specs, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("loadSeededNPCs returned %d NPCs, want 2 (Bart + Mira)", len(specs))
+	}
+
+	// The two NPCs must assemble into a Roster that routes each by name to its own
+	// identity — the end-to-end multi-NPC acceptance bar.
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil)
+	if err != nil {
+		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
+	}
+	defer cleanup()
+	if conv == nil {
+		t.Fatal("buildConversation returned a nil Conversation")
+	}
+
+	byName := map[string]string{} // display name -> agentID
+	for _, s := range specs {
+		byName[s.name] = s.agentID
+	}
+	for _, name := range []string{"Bart", "Mira"} {
+		routed := roster.matcher.TargetMatch(name + ", a word?")
+		if len(routed) == 0 {
+			t.Fatalf("naming %q routed to nobody", name)
+		}
+		if got := routed[0].Target.AgentID; got != byName[name] {
+			t.Errorf("naming %q routed to AgentID %q, want %q", name, got, byName[name])
+		}
 	}
 }
 
@@ -187,10 +266,10 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 // permanently deaf after the first Discord drop. Build → cleanup → build again
 // (mimicking one reconnect cycle) must both succeed. Real Silero, so integration.
 func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
-	npc := hardcodedNPC()
+	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npc, ttseleven.New(""), nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -199,7 +278,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npc, ttseleven.New(""), nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/ensurecurrent_integration_test.go
+++ b/internal/wirenpc/ensurecurrent_integration_test.go
@@ -96,7 +96,7 @@ func TestEnsureSchemaCurrent_CurrentSchemaPasses(t *testing.T) {
 // site: RunFromDB itself must fail fast on a stale schema, returning the
 // version-mismatch error WITHOUT proceeding to the NPC load (or Discord). The DB
 // here is stale AND empty of any seeded NPC, so if RunFromDB reached
-// loadSeededNPC it would surface a "find tenant" error instead — asserting the
+// loadSeededNPCs it would surface a "find tenant" error instead — asserting the
 // schema-out-of-date message proves the check runs first. No Discord token is
 // needed because the schema check precedes any gateway connection.
 func TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad(t *testing.T) {
@@ -110,6 +110,6 @@ func TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "schema out of date") {
 		t.Errorf("RunFromDB error %q is not the schema-out-of-date fail-fast error; "+
-			"the check must run before loadSeededNPC (which would error on the missing tenant)", err)
+			"the check must run before loadSeededNPCs (which would error on the missing tenant)", err)
 	}
 }

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -1,0 +1,128 @@
+package wirenpc
+
+import (
+	"log/slog"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Roster is the multi-NPC composition root: it ties one address [address.Matcher]
+// to one [agent.Cast] so a Voice Session can host several Character NPCs that
+// route and speak independently over one bus and one barge-in floor. It is THE
+// programmatic control surface for the scene's membership — [Roster.AddNPC] and
+// [Roster.RemoveNPC] add or drop an NPC from BOTH the matcher (so it is/ isn't
+// routed) and the Cast (so it does/doesn't speak), keeping the two halves of an
+// NPC's presence in lockstep (this slice has no Discord/HTTP trigger; the
+// programmatic API is the only seam — issue #49).
+//
+// "Roster" is a wiring construct, not a domain term: the glossary (CONTEXT.md)
+// names the parts it binds — the Voice Session's Agents, Address Detection, and
+// the Cast multiplexer — but has no word for "the live set of NPCs in a Session"
+// as one handle, so this is the composition-root name.
+//
+// The Matcher is built lazily on the first AddNPC because [address.NewMatcher]
+// requires at least one Agent; subsequent adds use [address.Matcher.Add]. A
+// Roster is built and mutated from the same goroutine that owns the voice loop;
+// the Matcher and Cast are each independently concurrency-safe for the bus's
+// dispatch.
+type Roster struct {
+	matcher *address.Matcher
+	cast    *agent.Cast
+
+	// replierFor builds the [agent.Replier] for one NPC. Production binds it to a
+	// shared tool-engine (so N NPCs share one Groq client); tests inject scripted
+	// engines through it. Always non-nil after [newRoster].
+	replierFor func(npcSpec) *agent.Replier
+}
+
+// rosterDeps carries what a [Roster] needs to assemble an NPC beyond the NPC's
+// own spec: the replier factory. It keeps [newRoster] callable from both the
+// production wiring (repliers over a shared Groq engine) and the tests (scripted
+// engines) through the one seam, rather than the Roster importing the engine.
+type rosterDeps struct {
+	// replierFor builds the Replier for one NPC; see [Roster.replierFor].
+	replierFor func(npcSpec) *agent.Replier
+}
+
+// newRoster builds an empty Roster wired to deps. It holds no NPCs yet — the
+// Matcher is created on the first [Roster.AddNPC] (address.NewMatcher needs one
+// Agent). deps.replierFor must be non-nil.
+func newRoster(deps rosterDeps) *Roster {
+	if deps.replierFor == nil {
+		panic("wirenpc.newRoster: replierFor must not be nil")
+	}
+	return &Roster{
+		cast:       agent.NewCast(),
+		replierFor: deps.replierFor,
+	}
+}
+
+// matcherAgent builds the address.Agent for one NPC: its routing target plus
+// aliases. A lone Character NPC is not AddressOnly, so it catches unaddressed
+// speech via the single-NPC fallback (CONTEXT.md "Address-Only").
+func matcherAgent(spec npcSpec) address.Agent {
+	return address.Agent{
+		Target: voiceevent.AddressTarget{
+			AgentID:   spec.agentID,
+			AgentRole: "character",
+			Name:      spec.name,
+		},
+		Aliases: spec.aliases,
+	}
+}
+
+// AddNPC brings one Character NPC into the scene: it registers the NPC's routing
+// Agent in the Matcher (so utterances naming it — or, for a lone NPC, any
+// unaddressed speech — route to it) and the NPC's Replier in the Cast (so the
+// route is answered in its Voice). The first AddNPC builds the Matcher; later
+// ones extend the live roster via [address.Matcher.Add]. Both halves move
+// together so an NPC is never routable-but-silent or speaking-but-unroutable.
+func (r *Roster) AddNPC(spec npcSpec) {
+	if r.matcher == nil {
+		// First NPC: build the Matcher around it. Single-target by default
+		// (Config.MaxTargets unset ⇒ 1): naming two NPCs fires one turn on the
+		// top-scored, the safe one-floor default (ADR-0025 deferred).
+		r.matcher = address.NewMatcher(address.Config{Language: "en"}, matcherAgent(spec))
+	} else {
+		r.matcher.Add(matcherAgent(spec))
+	}
+	r.cast.Add(r.replierFor(spec))
+}
+
+// RemoveNPC drops the NPC with agentID from the scene: it leaves the Matcher (so
+// nothing routes to it, and its last-addressed/interruption state is pruned so a
+// later unnamed continuation cannot resurrect it) and the Cast (so even a stray
+// route says nothing). Removing an unknown agentID is a no-op. Removing every
+// NPC leaves the Matcher routing to nobody — the voice loop simply stays quiet.
+func (r *Roster) RemoveNPC(agentID string) {
+	if r.matcher != nil {
+		r.matcher.Remove(agentID)
+	}
+	r.cast.Remove(agentID)
+}
+
+// rosterDepsForLive builds the production rosterDeps: every NPC's Replier is
+// constructed from the shared tool-engine, so N Character NPCs reuse one Groq
+// client and one synthesizer rather than each opening their own.
+func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger) rosterDeps {
+	return rosterDeps{
+		replierFor: func(spec npcSpec) *agent.Replier {
+			return agent.NewReplier(agent.Config{
+				Persona: agent.Persona{
+					AgentID:  spec.agentID,
+					Markdown: spec.persona,
+					Voice:    spec.voice,
+				},
+				Engine:       engine,
+				Synthesizer:  synth,
+				HistoryTurns: historyTurns,
+				OnError: func(err error) {
+					log.Warn("agent reply failed", "npc", spec.name, "err", err)
+				},
+			})
+		},
+	}
+}

--- a/internal/wirenpc/roster_test.go
+++ b/internal/wirenpc/roster_test.go
@@ -1,0 +1,288 @@
+package wirenpc
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// These tests pin the Stage-3 wiring: a Roster assembles N Character NPCs onto
+// one address Matcher + one agent Cast, the assembled pipeline routes a named
+// utterance to the named NPC (and an unnamed follow-up to whoever last spoke),
+// and the programmatic Add/RemoveNPC control surface makes an NPC addressable or
+// silent end-to-end. They run over the real Matcher and real Cast on a real bus
+// with a stub streaming engine — no LLM, STT, TTS, or Session (ADR-0019/0021).
+
+// scriptEngine is a stub [agent.StreamingEngine] that always speaks one fixed
+// line, so a dispatched sentence identifies which NPC's Replier produced it.
+type scriptEngine struct{ line string }
+
+func (e scriptEngine) Generate(context.Context, []llm.Message) (string, error) {
+	return e.line, nil
+}
+
+func (e scriptEngine) GenerateStream(_ context.Context, _ []llm.Message, onText func(string) error) (string, error) {
+	if onText != nil {
+		if err := onText(e.line); err != nil {
+			return e.line, err
+		}
+	}
+	return e.line, nil
+}
+
+// recordingSynth is a [tts.Synthesizer] that records every sentence dispatched
+// to it together with the Voice it was rendered in, so a test can attribute a
+// spoken sentence to its NPC (the Voice's VoiceID carries the agentID, stamped
+// by specFor). It returns an immediately-closed channel — no audio.
+type recordingSynth struct {
+	mu    sync.Mutex
+	spoke []spoken
+}
+
+type spoken struct {
+	sentence string
+	voiceID  string
+}
+
+func (s *recordingSynth) Synthesize(_ context.Context, req tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	s.mu.Lock()
+	s.spoke = append(s.spoke, spoken{sentence: req.Sentence, voiceID: req.Voice.VoiceID})
+	s.mu.Unlock()
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (s *recordingSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+func (s *recordingSynth) spokenBy(voiceID string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, sp := range s.spoke {
+		if sp.voiceID == voiceID {
+			out = append(out, sp.sentence)
+		}
+	}
+	return out
+}
+
+// specFor builds an npcSpec for a named NPC, stamping the agentID into the
+// Voice's VoiceID so the recordingSynth can attribute a sentence to its speaker.
+func specFor(agentID, name, line string) npcSpec {
+	return npcSpec{
+		agentID: agentID,
+		name:    name,
+		persona: "You are " + name + ".",
+		voice:   tts.Voice{ProviderID: "test", VoiceID: agentID, Name: name},
+		aliases: nil,
+	}
+}
+
+// replierFor builds the Replier the Roster would assemble for spec, over a
+// scripted engine that always says line — the test seam for replacing the live
+// Groq engine.
+func replierFor(spec npcSpec, line string, synth tts.Synthesizer) *agent.Replier {
+	return agent.NewReplier(agent.Config{
+		Persona: agent.Persona{
+			AgentID:  spec.agentID,
+			Markdown: spec.persona,
+			Voice:    spec.voice,
+		},
+		Engine:      scriptEngine{line: line},
+		Synthesizer: synth,
+	})
+}
+
+// testRoster assembles a Roster over the real Matcher + Cast on bus, with each
+// NPC backed by a scripted engine that speaks lines[spec.agentID]. It registers
+// the detector + cast reply stream on a Conversation and returns the Roster, a
+// publish helper that drives one utterance through the bus, and a teardown.
+func testRoster(t *testing.T, bus *voiceevent.Bus, synth *recordingSynth, specs []npcSpec, lines map[string]string) (*Roster, func(text string)) {
+	t.Helper()
+
+	repliers := make([]*agent.Replier, 0, len(specs))
+	for _, s := range specs {
+		repliers = append(repliers, replierFor(s, lines[s.agentID], synth))
+	}
+	roster := newRosterFor(specs, repliers, synth)
+
+	// Bind just the detector + streaming reply reactors on the bus: we drive the
+	// pipeline by publishing STTFinal directly (no audio), so the VAD/STT segmenter
+	// is not needed. The TTS stage records spoken sentences via the recordingSynth.
+	ttsStage := orchestrator.NewTTS(bus, synth)
+	detector := orchestrator.NewAddressDetector(roster.matcher)
+	replier := orchestrator.NewStreamReplier(ttsStage, roster.cast.ReplyStream(), nil)
+	cancel := orchestrator.Bind(context.Background(), bus, detector, replier)
+	t.Cleanup(cancel)
+
+	publish := func(text string) {
+		bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: text})
+		// The reply path dispatches synchronously on the bus goroutine (no floor),
+		// so the synth has recorded by the time Publish returns.
+	}
+	return roster, publish
+}
+
+// newRosterFor builds a Roster whose initial NPCs use the given pre-built
+// repliers (test seam) instead of the live Groq engine, but the same Matcher /
+// Cast assembly the production path uses. It mirrors the production constructor;
+// production builds its repliers from a shared engine.
+func newRosterFor(specs []npcSpec, repliers []*agent.Replier, synth tts.Synthesizer) *Roster {
+	r := newRoster(rosterDeps{replierFor: func(s npcSpec) *agent.Replier {
+		// Tests pre-build repliers; map agentID -> replier so a later AddNPC also
+		// resolves through the same scripted engines.
+		for i, sp := range specs {
+			if sp.agentID == s.agentID {
+				return repliers[i]
+			}
+		}
+		// Fall back to a silent replier so an unscripted AddNPC still assembles.
+		return replierFor(s, "(silent)", synth)
+	}})
+	for _, s := range specs {
+		r.AddNPC(s)
+	}
+	return r
+}
+
+// TestRoster_RoutesNamedUtterancesToEachNPC pins multi-NPC routing through the
+// assembled conversation: naming Aldra speaks Aldra; naming Bram speaks Bram.
+// Real Matcher + real Cast over the bus, single-target default.
+func TestRoster_RoutesNamedUtterancesToEachNPC(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{
+		specFor("aldra", "Aldra", ""),
+		specFor("bram", "Bram", ""),
+	}
+	lines := map[string]string{"aldra": "Aldra here.", "bram": "Bram here."}
+	_, publish := testRoster(t, bus, synth, specs, lines)
+
+	publish("Aldra, are you there?")
+	if got := synth.spokenBy("aldra"); len(got) != 1 || got[0] != "Aldra here." {
+		t.Fatalf("naming Aldra spoke %v, want [\"Aldra here.\"]", got)
+	}
+	if got := synth.spokenBy("bram"); len(got) != 0 {
+		t.Fatalf("naming Aldra also spoke Bram %v, want none (single-target)", got)
+	}
+
+	publish("Bram, your turn.")
+	if got := synth.spokenBy("bram"); len(got) != 1 || got[0] != "Bram here." {
+		t.Fatalf("naming Bram spoke %v, want [\"Bram here.\"]", got)
+	}
+}
+
+// TestRoster_UnnamedFollowUpContinuesLastAddressed pins the continuation
+// heuristic end-to-end: after naming Bram, an unnamed follow-up routes back to
+// Bram, not Aldra (last-addressed continuation over the real Matcher).
+func TestRoster_UnnamedFollowUpContinuesLastAddressed(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{
+		specFor("aldra", "Aldra", ""),
+		specFor("bram", "Bram", ""),
+	}
+	lines := map[string]string{"aldra": "Aldra here.", "bram": "Bram here."}
+	_, publish := testRoster(t, bus, synth, specs, lines)
+
+	publish("Bram, tell me a tale.")
+	publish("And then what happened?") // unnamed: continues Bram
+
+	if got := synth.spokenBy("bram"); len(got) != 2 {
+		t.Fatalf("Bram spoke %d times, want 2 (named + continuation): %v", len(got), got)
+	}
+	if got := synth.spokenBy("aldra"); len(got) != 0 {
+		t.Fatalf("Aldra spoke %v on a continuation that belonged to Bram, want none", got)
+	}
+}
+
+// TestRoster_AddNPC_BecomesAddressable pins the programmatic control surface: an
+// NPC added after assembly becomes addressable end-to-end through both the
+// Matcher (so it is routed) and the Cast (so it speaks).
+func TestRoster_AddNPC_BecomesAddressable(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("aldra", "Aldra", "")}
+	lines := map[string]string{"aldra": "Aldra here."}
+	roster, publish := testRoster(t, bus, synth, specs, lines)
+
+	// Before Add, naming Cyra routes to nobody the Cast holds (the lone NPC
+	// fallback may route to Aldra, but never to Cyra) — Cyra is silent.
+	publish("Cyra, are you about?")
+	if got := synth.spokenBy("cyra"); len(got) != 0 {
+		t.Fatalf("Cyra spoke %v before being added, want none", got)
+	}
+
+	roster.AddNPC(specFor("cyra", "Cyra", ""))
+
+	publish("Cyra, are you about?")
+	if got := synth.spokenBy("cyra"); len(got) != 1 {
+		t.Fatalf("Cyra spoke %d times after AddNPC, want 1: %v", len(got), got)
+	}
+}
+
+// TestRoster_RemoveNPC_GoesSilentAndStopsContinuations pins the other half of
+// the control surface: a removed NPC stops being routed (matcher) and stops
+// speaking (cast), AND stops catching unnamed continuations — its last-addressed
+// state must be pruned so a later unnamed utterance does not resurrect it.
+func TestRoster_RemoveNPC_GoesSilentAndStopsContinuations(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{
+		specFor("aldra", "Aldra", ""),
+		specFor("bram", "Bram", ""),
+	}
+	lines := map[string]string{"aldra": "Aldra here.", "bram": "Bram here."}
+	roster, publish := testRoster(t, bus, synth, specs, lines)
+
+	publish("Bram, stay a while.")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("Bram spoke %d times before removal, want 1", len(got))
+	}
+
+	roster.RemoveNPC("bram")
+
+	// Named: removed Bram says nothing.
+	publish("Bram, are you still here?")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("removed Bram spoke %d times total, want 1 (silent after removal)", len(got))
+	}
+	// Unnamed continuation must not resurrect Bram (his lastAddressed was pruned).
+	publish("Well, anyone?")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("removed Bram caught a continuation (%d total), want 1 — lastAddressed not pruned", len(got))
+	}
+}
+
+// TestRoster_SingleNPCBehaviorPreserved pins the Stage-2 acceptance bar: with a
+// Roster holding exactly one NPC, both a named utterance and an unnamed one route
+// to it (the lone-NPC fallback) — identical to the pre-Roster single-NPC loop.
+func TestRoster_SingleNPCBehaviorPreserved(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("bart", "Bart", "")}
+	lines := map[string]string{"bart": "What'll it be?"}
+	_, publish := testRoster(t, bus, synth, specs, lines)
+
+	publish("Bart, a room please.")
+	publish("Hello, is anyone here?") // unnamed: lone-NPC fallback
+
+	got := synth.spokenBy("bart")
+	if len(got) != 2 {
+		t.Fatalf("lone NPC spoke %d times (named + unnamed fallback), want 2: %v", len(got), got)
+	}
+	for _, s := range got {
+		if strings.TrimSpace(s) == "" {
+			t.Fatalf("lone NPC produced an empty sentence: %q", got)
+		}
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -29,7 +29,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
-	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agenttool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
@@ -223,9 +222,12 @@ type Config struct {
 	// nothing. The live binary injects the Prometheus adapter; the benchmark
 	// injects its own; the keyless default is the no-op recorder.
 	StageMetrics observe.StageRecorder
-	// npc is the Character NPC this loop voices. Run resolves it; RunFromDB
-	// loads it from storage, the env-only Run path uses the hardcoded NPC.
-	npc npcSpec
+	// npcs are the Character NPCs this loop voices. Run resolves them: RunFromDB
+	// loads all Character NPCs in the campaign from storage; the env-only Run path
+	// seeds the single hardcoded NPC when the slice is empty. The roster the loop
+	// assembles from these is the INITIAL membership; NPCs join and leave at
+	// runtime via the programmatic [Roster] API (issue #49).
+	npcs []npcSpec
 }
 
 // RunFromDB loads the seeded Character NPC from Postgres (via the task-#8
@@ -249,18 +251,20 @@ func RunFromDB(ctx context.Context, cfg Config, dsn string) error {
 	// serving Modes (voice) never auto-migrate, so a DB behind the embedded
 	// migrations must refuse to start with the actionable `migrate up` message
 	// rather than running queries against a schema the code no longer matches.
-	// This runs after the pool opens and before loadSeededNPC (the first query).
+	// This runs after the pool opens and before loadSeededNPCs (the first query).
 	if err := ensureSchemaCurrent(ctx, dsn); err != nil {
 		return err
 	}
 
-	npc, err := loadSeededNPC(ctx, storage.New(pool))
+	npcs, err := loadSeededNPCs(ctx, storage.New(pool))
 	if err != nil {
 		return err
 	}
-	log.Info("loaded NPC from DB", "npc", npc.name, "agentID", npc.agentID)
+	for _, npc := range npcs {
+		log.Info("loaded NPC from DB", "npc", npc.name, "agentID", npc.agentID)
+	}
 
-	cfg.npc = npc
+	cfg.npcs = npcs
 	return Run(ctx, cfg)
 }
 
@@ -297,8 +301,8 @@ func ensureSchemaCurrent(ctx context.Context, dsn string) error {
 // runnable and the wiring complete without the native dependency. Build with
 // -tags "opus dave nolibopusfile" for a hearing, speaking, encrypted NPC.
 func Run(ctx context.Context, cfg Config) error {
-	if cfg.npc.agentID == "" {
-		cfg.npc = hardcodedNPC()
+	if len(cfg.npcs) == 0 {
+		cfg.npcs = []npcSpec{hardcodedNPC()}
 	}
 
 	log := cfg.Logger
@@ -397,7 +401,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// a while and only later drops reconnects on the initial delay, not a delay
 	// grown by earlier connect failures (issue #44).
 	connected()
-	log.Info("joined voice channel", "guild", guild, "channel", channel, "npc", cfg.npc.name)
+	log.Info("joined voice channel", "guild", guild, "channel", channel, "npcs", npcNames(cfg.npcs))
 
 	// One Codec instance serves both directions: DecodeInbound (called from the
 	// single Pipeline.Run goroutine) and PlaybackSource (called from the playback
@@ -443,7 +447,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, cleanup, err := buildConversation(bus, log, cfg.npc, teeSynth, cfg.StageMetrics)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -459,25 +463,28 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	return pipe.Run(cycleCtx, sess)
 }
 
-// npcMatcher builds the Address Detection matcher for the NPC. This Campaign has
-// one Character NPC and no addressable Butler in this slice, so it uses the
-// scoring Matcher (ADR-0024): the NPC gets a name/alias match AND the single-NPC
-// fallback, so both a named utterance ("Bart, …") and an unnamed one route to
-// him — a non-Address-Only lone NPC catches unaddressed speech. The whole-word
-// matcher is deliberately not used: it requires a Butler as its unconditional
-// fallback, which this slice does not have, and would leave the NPC silent on
-// every unnamed utterance.
+// npcMatcher builds the Address Detection matcher for one NPC. With a single
+// non-Address-Only Character NPC and no addressable Butler it uses the scoring
+// Matcher (ADR-0024): the NPC gets a name/alias match AND the single-NPC
+// fallback, so both a named utterance ("Bart, …") and an unnamed one route to it.
+// The whole-word matcher is deliberately not used: it requires a Butler as its
+// unconditional fallback, which this slice does not have, and would leave the NPC
+// silent on every unnamed utterance.
+//
+// Multi-NPC wiring goes through [Roster.AddNPC] (the matcher's roster grows past
+// the first agent via [address.Matcher.Add]); this single-agent constructor is
+// retained as the unit-test seam for the one-NPC routing invariant.
 func npcMatcher(npc npcSpec) *address.Matcher {
-	return address.NewMatcher(address.Config{Language: "en"},
-		address.Agent{
-			Target: voiceevent.AddressTarget{
-				AgentID:   npc.agentID,
-				AgentRole: "character",
-				Name:      npc.name,
-			},
-			Aliases: npc.aliases,
-		},
-	)
+	return address.NewMatcher(address.Config{Language: "en"}, matcherAgent(npc))
+}
+
+// npcNames returns the NPCs' display names for a log line.
+func npcNames(npcs []npcSpec) []string {
+	names := make([]string, len(npcs))
+	for i, n := range npcs {
+		names[i] = n.name
+	}
+	return names
 }
 
 // npcVoice is the hardcoded NPC's TTS Voice (the [hardcodedNPC] seed source).
@@ -514,10 +521,18 @@ func npcVoice() tts.Voice {
 // Provider API keys are read by each adapter from its own env var at request
 // time (BYOK, ADR-0004), so construction here needs no secrets.
 //
-// npc supplies the addressable identity, Persona, and Voice (from the in-code
-// seed or, via [RunFromDB], the database). The `dice` Tool grant stays in code
-// (Tool Grants are a #6 table, not yet seeded). The LLM provider is Groq
-// (model llama-3.3-70b-versatile via the OpenAI-compat endpoint). The DB Agent's
+// npcs supplies the INITIAL Character NPCs the loop voices — their addressable
+// identity, Persona, and Voice (from the in-code seed or, via [RunFromDB], the
+// database). It assembles them into a [Roster] (one address Matcher + one Cast):
+// the detector routes against the Matcher and the reply stream multiplexes across
+// the Cast, so an utterance naming an NPC is answered in that NPC's Voice and a
+// lone NPC still catches unaddressed speech. The returned Roster is the
+// programmatic control surface for adding/removing NPCs at runtime (#49); the
+// caller owns it for the cycle's lifetime. npcs must be non-empty.
+//
+// All NPCs share ONE Groq tool-engine (one client, the `dice` grant in code —
+// Tool Grants are a #6 table, not yet seeded). The LLM provider is Groq (model
+// llama-3.3-70b-versatile via the OpenAI-compat endpoint). The DB Agent's
 // provider_config provider/model is recorded but adapter selection is not yet
 // driven by it; the wired adapter is Groq for any NPC in this tree. Keyless
 // cassette tests replay the Anthropic adapter behind the same llm.Provider
@@ -528,14 +543,17 @@ func npcVoice() tts.Voice {
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder) (*orchestrator.Conversation, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
+	}
+	if len(npcs) == 0 {
+		return nil, nil, nil, fmt.Errorf("wirenpc: buildConversation needs at least one NPC")
 	}
 
 	engine, err := silero.New(silero.WithMinSilenceFrames(vadMinSilenceFrames))
 	if err != nil {
-		return nil, nil, fmt.Errorf("init Silero VAD: %w", err)
+		return nil, nil, nil, fmt.Errorf("init Silero VAD: %w", err)
 	}
 	vadSession, err := engine.NewSession(vad.Config{
 		SampleRate:       vadSampleRate,
@@ -544,7 +562,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		SilenceThreshold: 0.35,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("open VAD session: %w", err)
+		return nil, nil, nil, fmt.Errorf("open VAD session: %w", err)
 	}
 	// cleanup releases ONLY the per-cycle VAD session (its ONNX inferencer), which
 	// a reconnect cycle (issue #44) would otherwise leak on every loop. It must
@@ -563,8 +581,6 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
 
-	detector := orchestrator.NewAddressDetector(npcMatcher(npc))
-
 	// The `dice` grant stays in code: Tool Grants are a #6 table, not yet
 	// seeded. With no grants the tool engine degrades to a single completion
 	// through the same path.
@@ -574,7 +590,8 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 	// before a live run (docs/agents/live-npc-run.md). There is no Anthropic key,
 	// so wiring the Anthropic adapter here would pass the keyless cassette tests
 	// (which replay Anthropic) but fail the live run — Groq is the only correct
-	// default for a runnable NPC.
+	// default for a runnable NPC. One engine is shared across every NPC in the
+	// Roster — they reuse one client rather than each opening their own.
 	provider := groq.New("")
 	reg := tool.NewRegistry()
 	reg.MustRegister(tool.NewDice())
@@ -585,27 +602,23 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 		// path silent; the live binary / benchmark inject a real one.
 		agenttool.WithMetrics(stageMetrics, observe.ProviderGroq))
 
-	replier := agent.NewReplier(agent.Config{
-		Persona: agent.Persona{
-			AgentID:  npc.agentID,
-			Markdown: npc.persona,
-			Voice:    npc.voice,
-		},
-		Engine:       toolEngine,
-		Synthesizer:  ttseleven.New(""),
-		HistoryTurns: 16,
-		OnError: func(err error) {
-			log.Warn("agent reply failed", "npc", npc.name, "err", err)
-		},
-	})
+	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
+	// in the Matcher and its Replier (over the shared engine) in the Cast. The
+	// Matcher is built from the first NPC and grown for the rest.
+	roster := newRoster(rosterDepsForLive(toolEngine, ttseleven.New(""), 16, log))
+	for _, npc := range npcs {
+		roster.AddNPC(npc)
+	}
+
+	detector := orchestrator.NewAddressDetector(roster.matcher)
 
 	conv := orchestrator.NewConversation(bus, vadStage, sttStage, ttsStage,
 		orchestrator.WithDetector(detector),
 		// B1: stream the reply sentence-by-sentence so first audio begins after the
 		// first sentence, not the whole completion. The agenttool Engine implements
-		// agent.StreamingEngine (it streams the final answer round), so ReplyStream
-		// dispatches each sentence as it lands.
-		orchestrator.WithReplyStream(replier.ReplyStream()),
+		// agent.StreamingEngine (it streams the final answer round), so the Cast's
+		// reply stream dispatches each sentence as it lands, to the addressed NPC.
+		orchestrator.WithReplyStream(roster.cast.ReplyStream()),
 		// Barge-in (ADR-0027): a human talking over Bart cancels his turn. The
 		// confirm window must be > 0 against a live mic — a zero window let the
 		// addressing user's own continued speech (single shared VAD session, no
@@ -620,5 +633,5 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npc npcSpec, synth
 			log.Warn("voice pipeline stage failed", "err", err)
 		}),
 	)
-	return conv, cleanup, nil
+	return conv, roster, cleanup, nil
 }


### PR DESCRIPTION
## What & why

Stage 3 of the Multi-NPC voice epic (parent #51). `internal/wirenpc` hardcoded ONE NPC at three points — `Config.npc` (singular), `npcMatcher(npc)`, and `loadSeededNPC`'s `!= 1` guard. Stages 1 (matcher `Add`/`Remove` + `MaxTargets`) and 2 (`agent.Cast`) shipped the leaf pieces; this stage **assembles** them and exposes the programmatic control surface.

Closes #49.

## Changes (scope: `internal/wirenpc/` only — no `pkg/voice/*` or reactor/floor changes)

- **New `Roster`** (`roster.go`) — composition root tying one `*address.Matcher` to one `*agent.Cast`:
  - `AddNPC(spec)` builds the matcher `Agent` + the `agent.Replier` and registers in BOTH; `RemoveNPC(agentID)` drops from both, so an NPC is never routable-but-silent or speaking-but-unroutable.
  - Single-target by default (`MaxTargets` unset ⇒ 1). **This is the only control surface this slice** — no Discord/HTTP trigger.
  - Matcher built lazily on the first `AddNPC` (`address.NewMatcher` needs ≥1 agent); later adds use `Matcher.Add`.
- **`buildConversation`** — builds N repliers over **one shared Groq tool-engine**, one matcher with all agents; wires `WithDetector(NewAddressDetector(roster.matcher))` + `WithReplyStream(roster.cast.ReplyStream())`. Floor/barge-in unchanged. Now returns the `*Roster` handle (4-value signature) for runtime Add/Remove.
- **`Config.npc npcSpec` → `npcs []npcSpec`**; `Run` seeds `{hardcodedNPC()}` when empty (single-NPC default preserved). `RunFromDB` loads the slice.
- **`loadSeededNPC` → `loadSeededNPCs`** — loads ALL Character NPCs in the campaign (dropped the `!= 1` guard). Initial roster from DB; runtime changes via the programmatic API.

## Tests (strict TDD: red → green)

- `TestRoster_RoutesNamedUtterancesToEachNPC` — naming A speaks A, naming B speaks B (real matcher + real cast over a real bus, stub streaming engine; vendor-free per ADR-0019/0021).
- `TestRoster_UnnamedFollowUpContinuesLastAddressed` — unnamed follow-up continues the last-addressed NPC.
- `TestRoster_AddNPC_BecomesAddressable` — added NPC becomes addressable end-to-end.
- `TestRoster_RemoveNPC_GoesSilentAndStopsContinuations` — removed NPC goes silent AND stops catching continuations (its `lastAddressed` is pruned).
- `TestRoster_SingleNPCBehaviorPreserved` — lone-NPC named + unnamed both route to it (pre-Roster behavior identical).
- `TestLoadSeededNPCs_LoadsAllCharacterAgents` (integration) — 2 Character NPCs load and route by name (verified against real Postgres).
- Existing `wirenpc_test.go` / `agentspec_test.go` updated for the `npcs` slice and the 4-return `buildConversation`.

## Glossary-naming note

`Roster` has **no `CONTEXT.md` glossary collision** — the glossary names the parts it binds (Agents, Address Detection, the Cast multiplexer) but has no handle for "the live set of NPCs in a Voice Session", so `Roster` is documented in-code as a wiring construct, not a domain term. `Cast` is already merged in `pkg/voice/agent` and is unchanged.

## Verification

- `go test ./...` green; `go test -race ./internal/wirenpc/...` green.
- Integration suite (`-tags integration`) green against real Postgres (Docker).
- `go build ./...`, `go vet ./internal/wirenpc/...`, `gofmt -l internal/wirenpc/` (empty), `golangci-lint run ./internal/wirenpc/...` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)