### PR TITLE
chore: stage-1 review cleanups (shared shutdown helper, pool reuse) + re-enable buf breaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,6 @@ jobs:
         with:
           token: ${{ secrets.BUF_REGISTRY_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # BOOTSTRAP CARVE-OUT (#65): breaking-change detection compares against
-          # the PR base (main), which has NO .proto files yet — this is the first
-          # PR to add proto/glyphoxa/management/v1. `buf breaking` against an empty
-          # baseline errors ("had no .proto files") and would fail the job. Once
-          # this lands and main carries the module, remove this line to re-enable
-          # breaking against main (or set breaking_against_registry: true after the
-          # first push-to-main publishes buf.build/glyphoxa/glyphoxa).
-          breaking: false
 
   # Generate the protobuf/Connect/ES stubs exactly ONCE per push, in an
   # authenticated job, and fan them out as an artifact (ADR-0039 codegen).

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -16,11 +15,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
-
-	// pgx stdlib driver: the /readyz probe pings through a database/sql handle
-	// (issue #33). Registered here as well as in migrate.go so this file's use of
-	// sql.Open("pgx", …) is self-documenting; the blank import is idempotent.
-	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
@@ -132,40 +126,34 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Resolve the DB DSN once: it both gates the load path below and, when
-	// present, backs the /readyz probe (issue #33). -hardcoded runs with no DB,
-	// so its readiness probe is nil (always-ready — see observe.ReadinessProbe).
-	dsn := ""
-	if !hardcoded {
-		dsn = databaseURL()
-		if dsn == "" {
-			return fmt.Errorf("voice mode loads the NPC from the DB by default; set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL), or pass -hardcoded to use the in-code NPC")
-		}
-	}
-
-	if metricsAddr != "" {
-		var ready observe.ReadinessProbe
-		if dsn != "" {
-			// The live pgxpool is opened later inside wirenpc.RunFromDB and isn't
-			// reachable here, so /readyz pings through a small standalone
-			// database/sql handle (pgx stdlib driver, already a dep — see
-			// migrate.go). It lives for the metrics server's lifetime alongside the
-			// voice loop. NOTE: this ping-handle may later be consolidated with the
-			// schema-check handle from the wirenpc boot path (#32) once both merge.
-			db, err := sql.Open("pgx", dsn)
-			if err != nil {
-				return fmt.Errorf("voice: open readiness-probe db handle: %w", err)
-			}
-			defer db.Close()
-			ready = db.PingContext
-		}
-		observe.NewMetricsServer(metricsAddr, metrics, ready, log).Start(ctx)
-	}
-
+	// -hardcoded runs with no DB: no pool, and the readiness probe is nil
+	// (always-ready — see observe.ReadinessProbe). The default path resolves the
+	// DSN and opens ONE pgxpool that serves BOTH the /readyz probe (pool.Ping) and
+	// the NPC load inside RunFromDB — the voice node no longer opens a separate
+	// standalone readiness handle alongside RunFromDB's own pool (issue #77).
 	if hardcoded {
+		if metricsAddr != "" {
+			observe.NewMetricsServer(metricsAddr, metrics, nil, log).Start(ctx)
+		}
 		return wirenpc.Run(ctx, cfg)
 	}
-	return wirenpc.RunFromDB(ctx, cfg, dsn)
+
+	dsn := databaseURL()
+	if dsn == "" {
+		return fmt.Errorf("voice mode loads the NPC from the DB by default; set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL), or pass -hardcoded to use the in-code NPC")
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("voice: open db pool: %w", err)
+	}
+	defer pool.Close()
+
+	if metricsAddr != "" {
+		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
+	}
+
+	return wirenpc.RunFromDB(ctx, cfg, pool)
 }
 
 // runWeb is the web/all-mode entrypoint (ADR-0039). It resolves the required DB
@@ -243,7 +231,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		// serving /readyz). Log and degrade to web-only by returning nil; the
 		// gctx.Err() guard suppresses the benign cancellation log when SIGTERM is
 		// already stopping both halves.
-		if err := wirenpc.RunFromDB(gctx, cfg, dsn); err != nil && gctx.Err() == nil {
+		if err := wirenpc.RunFromDB(gctx, cfg, pool); err != nil && gctx.Err() == nil {
 			log.Error("voice loop exited; continuing web-only", "err", err)
 		}
 		return nil

--- a/internal/observe/server.go
+++ b/internal/observe/server.go
@@ -98,12 +98,7 @@ func newMux(rec *PrometheusRecorder, ready ReadinessProbe) *http.ServeMux {
 // a missing metrics endpoint is operationally visible but must not crash the
 // voice node.
 func (m *MetricsServer) Start(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = m.srv.Shutdown(shutCtx)
-	}()
+	ShutdownOnCancel(ctx, m.srv)
 	go func() {
 		m.log.Info("metrics server listening", "addr", m.srv.Addr, "path", "/metrics")
 		if err := m.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/internal/observe/shutdown.go
+++ b/internal/observe/shutdown.go
@@ -1,0 +1,34 @@
+package observe
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// ShutdownGrace is the deadline a graceful HTTP shutdown gets to drain in-flight
+// requests before the listener is force-closed. It lives here so every server
+// that calls [ShutdownOnCancel] — the standalone voice [MetricsServer] and the
+// web-tier server (ADR-0039) — uses the SAME grace period and they stay in
+// lockstep when it changes.
+const ShutdownGrace = 5 * time.Second
+
+// ShutdownOnCancel spawns a goroutine that waits for ctx to be cancelled and
+// then gracefully shuts srv down within [ShutdownGrace], so a caller wires one
+// server's lifetime to a context without re-implementing the
+// "<-ctx.Done(); Shutdown(grace)" goroutine. It returns immediately; the
+// goroutine outlives the call and ends once the shutdown completes (or its grace
+// deadline expires). After cancel, srv.Serve / srv.ListenAndServe returns
+// [http.ErrServerClosed], which callers treat as a clean stop.
+//
+// The Shutdown error is intentionally discarded: a graceful shutdown error
+// (deadline exceeded) is not actionable here — the listener is closing either
+// way — and the serve goroutine already logs the terminal Serve error.
+func ShutdownOnCancel(ctx context.Context, srv *http.Server) {
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), ShutdownGrace)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+}

--- a/internal/observe/shutdown_test.go
+++ b/internal/observe/shutdown_test.go
@@ -1,0 +1,74 @@
+package observe
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestShutdownOnCancelStopsServe is the core contract: once the wired context is
+// cancelled, the helper's goroutine calls srv.Shutdown and the blocking
+// srv.Serve returns the clean http.ErrServerClosed within the grace window — the
+// behaviour both the MetricsServer and the web server depend on.
+func TestShutdownOnCancelStopsServe(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &http.Server{Handler: http.NewServeMux()}
+	ctx, cancel := context.WithCancel(context.Background())
+	ShutdownOnCancel(ctx, srv)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Cancelling triggers the helper's graceful Shutdown; Serve must then return
+	// the clean ErrServerClosed well inside the grace period.
+	cancel()
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Serve returned %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(ShutdownGrace + time.Second):
+		t.Fatalf("Serve did not return within %v after cancel", ShutdownGrace+time.Second)
+	}
+}
+
+// TestShutdownOnCancelWaitsForCancel pins the other half: the helper does NOT
+// shut the server down until the context is actually cancelled, so a running
+// server keeps serving for its context's lifetime.
+func TestShutdownOnCancelWaitsForCancel(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	srv := &http.Server{Handler: http.NewServeMux()}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ShutdownOnCancel(ctx, srv)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Without a cancel, Serve must stay blocked (no premature shutdown).
+	select {
+	case err := <-serveErr:
+		t.Fatalf("Serve returned %v before context cancel; helper shut down early", err)
+	case <-time.After(150 * time.Millisecond):
+		// still serving, as required
+	}
+
+	cancel()
+	select {
+	case <-serveErr:
+	case <-time.After(ShutdownGrace + time.Second):
+		t.Fatal("Serve did not return after cancel")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 )
 
 // Mount is one path-prefixed handler to register on the server's mux — e.g. the
@@ -109,12 +111,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.addr = ln.Addr().String()
 	s.mu.Unlock()
 
-	go func() {
-		<-ctx.Done()
-		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.srv.Shutdown(shutCtx)
-	}()
+	observe.ShutdownOnCancel(ctx, s.srv)
 	go func() {
 		defer close(s.done)
 		s.log.Info("web server listening", "addr", s.addr)

--- a/internal/wirenpc/ensurecurrent_integration_test.go
+++ b/internal/wirenpc/ensurecurrent_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -31,6 +32,18 @@ func openSQL(t *testing.T, dsn string) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	return db
+}
+
+// openPool opens a pgxpool the way the production callers (cmd/glyphoxa) do, so
+// the RunFromDB seam is exercised against a real pool, not a dsn string.
+func openPool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
 }
 
 // migrateToHead applies every embedded migration so the DB schema is current.
@@ -104,7 +117,7 @@ func TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad(t *testing.T) {
 	migrateToHead(t, dsn)
 	rollBackOne(t, dsn)
 
-	err := RunFromDB(context.Background(), Config{}, dsn)
+	err := RunFromDB(context.Background(), Config{}, openPool(t, dsn))
 	if err == nil {
 		t.Fatal("RunFromDB returned nil on a stale schema; serving must fail fast before any other DB query")
 	}

--- a/internal/wirenpc/poolthread_test.go
+++ b/internal/wirenpc/poolthread_test.go
@@ -1,0 +1,31 @@
+package wirenpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestRunFromDB_DerivesSchemaCheckDSNFromPool is the Docker-free unit guard for
+// the #77 pool-threading seam: RunFromDB no longer takes a dsn string and opens
+// its own pool — it takes the caller's already-open *pgxpool.Pool and recovers
+// the goose schema-check dsn from pool.Config().ConnString(). pgxpool.New is lazy
+// (it parses the dsn without dialing), and ConnString() round-trips the dsn
+// verbatim, so this test pins the contract the production callers rely on:
+// whatever dsn the single shared pool was built from is exactly what backs the
+// schema check, with no second connection string threaded through.
+func TestRunFromDB_DerivesSchemaCheckDSNFromPool(t *testing.T) {
+	const dsn = "postgres://u:p@127.0.0.1:5999/glyphoxa?sslmode=disable"
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if got := pool.Config().ConnString(); got != dsn {
+		t.Fatalf("pool.Config().ConnString() = %q, want %q — RunFromDB feeds this to "+
+			"ensureSchemaCurrent, so a drift here would point the schema check at the wrong DB", got, dsn)
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -230,29 +230,29 @@ type Config struct {
 	npcs []npcSpec
 }
 
-// RunFromDB loads the seeded Character NPC from Postgres (via the task-#8
-// storage layer) and runs the live voice loop with it, instead of the in-code
-// NPC. dsn is the Postgres connection string. This is the task-#5 DB-load path:
-// the only thing it changes versus [Run] is the *source* of the NPC's Persona/
-// Voice/identity — the assembled pipeline is identical.
-func RunFromDB(ctx context.Context, cfg Config, dsn string) error {
+// RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
+// storage layer) and runs the live voice loop with them, instead of the in-code
+// NPC. pool is an already-open pgxpool the caller owns (and closes) — voice mode
+// opens exactly one pool that ALSO backs the /readyz probe, and all/web mode
+// hands in its existing request pool, so the voice path never opens a second
+// duplicate handle. This is the task-#5 DB-load path: the only thing it changes
+// versus [Run] is the *source* of the NPC's Persona/Voice/identity — the
+// assembled pipeline is identical.
+func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool) error {
 	log := cfg.Logger
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
 
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		return fmt.Errorf("wirenpc: open DB pool: %w", err)
-	}
-	defer pool.Close()
-
 	// Fail fast on a stale schema BEFORE any other DB interaction (ADR-0031):
 	// serving Modes (voice) never auto-migrate, so a DB behind the embedded
 	// migrations must refuse to start with the actionable `migrate up` message
 	// rather than running queries against a schema the code no longer matches.
-	// This runs after the pool opens and before loadSeededNPCs (the first query).
-	if err := ensureSchemaCurrent(ctx, dsn); err != nil {
+	// This runs before loadSeededNPCs (the first query). The schema check needs a
+	// database/sql handle (goose's API), which the pgxpool can't provide, so the
+	// dsn is recovered from the pool's own config — no second connection string
+	// threaded through the callers.
+	if err := ensureSchemaCurrent(ctx, pool.Config().ConnString()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Closes #77 and #76. Parent epic: #64.

Three small, independent stage-1 cleanups surfaced by the PR #75 review, plus the buf-breaking re-enable that was blocked on #75 merging.

## #77 — Stage-1 review cleanups

### Item 1 — shared graceful-shutdown helper (`refactor(observe): share graceful-shutdown helper`)
`internal/web` `Server.Start` and `internal/observe` `MetricsServer.Start` each carried a copy of the `go func(){ <-ctx.Done(); Shutdown(5s) }()` goroutine. Extracted into one `observe.ShutdownOnCancel(ctx, *http.Server)` helper with the grace period as a single `observe.ShutdownGrace` const, so both servers stay in lockstep when it changes. `web -> observe` is the existing import direction; `observe` does not import `web` (no cycle — verified with `go list -deps`). New observe test asserts cancelling the context makes `srv.Serve` return `http.ErrServerClosed` within the grace window, and that it does NOT shut down before cancel.

### Item 2 — reuse the pgxpool in the voice path (`refactor(wirenpc): reuse pgxpool in voice path`)
`wirenpc.RunFromDB` now takes the caller's already-open `*pgxpool.Pool` instead of a dsn string + opening its own pool. The goose schema-check still needs a `database/sql` handle, so its dsn is recovered from `pool.Config().ConnString()` rather than threaded separately.

- `cmd/glyphoxa` `runVoice` opens **one** pgxpool from the resolved dsn and uses it for BOTH `/readyz` (`observe.ReadinessProbe(pool.Ping)`) AND the NPC load (`RunFromDB`), removing the standalone `sql.Open` readiness handle and resolving its consolidation NOTE.
- all/web `runWeb` passes its existing request pool to `RunFromDB` — no second pool.
- The `-hardcoded` no-DB path (`wirenpc.Run`) is untouched: no pool, nil readiness probe.
- Dropped the now-unused `database/sql` + blank pgx-stdlib imports from `main.go` (`migrate.go` still registers the driver for goose).

Pool-threading seam covered by a Docker-free unit test (ConnString round-trips the dsn the schema check sees); the `//go:build integration` tests open a real pool and stay green.

### Item 3 — testcontainers harness extraction: **DEFERRED**
The issue says extract `startPostgres`/seed into `internal/testsupport/pg` only on a **3rd** consumer of the duplicated harness. The two named consumers (`internal/storage/harness_test.go`, `internal/rpc/campaign_integration_test.go`) remain; no third consumer exists in this PR, so per the issue's own gate the extraction is deliberately left for the PR that adds the third. Not done here on purpose.

## #76 — re-enable buf breaking-change detection (`ci(buf): re-enable breaking-change detection`)
PR #75 landed the first proto on `main`, so the bootstrap carve-out is obsolete. Removed the `breaking: false` line and its `BOOTSTRAP CARVE-OUT (#65)` comment from the `buf` job in `.github/workflows/ci.yml`, so `bufbuild/buf-action` runs breaking detection against the PR base (`main`) by default. `breaking_against_registry` is intentionally NOT set (registry publish is separate).

**Local verification (recorded for the reviewer):**
- `buf breaking proto --against '.git#ref=main,subdir=proto'` exits **0** for the current proto — no false positive against the now-populated `main` baseline.
- A scratch edit deleting `Campaign.name` (field 3) made the same command report `Previously present field "3" with name "name" on message "Campaign" was deleted.` and exit **100** — confirming a real breaking change reds the check. The scratch edit was fully reverted (working tree clean, breaking back to exit 0).

## Verification
All green locally: `buf generate`; `gofmt -l .` (empty); `go build ./...`; `go vet ./...`; `go vet -tags=record ./...`; `go test -race ./...`; `go test -race -tags=integration ./...` (Docker / testcontainers, ran); `golangci-lint run ./...` (0 issues); `buf lint`; `buf breaking`.

## Note on rebase
May need a rebase after the sibling SPA PR (#66) merges — both touch `cmd/glyphoxa/main.go` `runWeb` and `internal/web/server.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)