### PR TITLE
feat: Stage 3 — single-operator Discord OAuth + session cookie (#67)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
@@ -195,21 +197,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
 	}
 
-	// The web tier serves the Connect API under /api and the embedded SPA at /
-	// (ADR-0013/0039). The browser dials Connect at baseUrl "/api"
-	// (web/src/lib/transport.ts), so the generated handler — mounted on the mux
-	// at its own absolute path (mountPath, e.g.
-	// /glyphoxa.management.v1.CampaignService/) — is wrapped in
-	// http.StripPrefix("/api", …) and registered under "/api/". StripPrefix
-	// removes the /api segment before the Connect handler matches its method
-	// path, so /api/<service>/<method> resolves correctly. The SPA handler is the
-	// "/" catch-all; ServeMux's longest-prefix match keeps /api/ ahead of it, so
-	// only non-API paths (and client-side deep links) reach the SPA fallback.
-	mountPath, mountHandler := rpc.NewCampaignServer(store).Handler()
-	apiHandler := http.StripPrefix("/api", mountHandler)
+	// The web tier serves the auth-guarded Connect API under /api, the Discord
+	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /
+	// (ADR-0013/0039). The SPA handler is the "/" catch-all; ServeMux's
+	// longest-prefix match keeps /api/ and /auth/ ahead of it, so only non-API
+	// paths (and client-side deep links) reach the SPA fallback.
 	srv := web.NewServer(web.Config{
 		Addr:   webAddr,
-		Mounts: []web.Mount{{Path: "/api" + mountPath, Handler: apiHandler}},
+		Mounts: managementMounts(store, log),
 		Root:   spa.Handler(),
 		Logger: log,
 	})
@@ -258,6 +253,46 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // gating decision is unit-tested without Discord credentials.
 func voiceEnabled(token, guild, channel string) bool {
 	return token != "" && guild != "" && channel != ""
+}
+
+// managementMounts wires the auth tier and the management Connect services into
+// the web mux (ADR-0015/0016/0039): the interceptor-guarded Connect handlers
+// (CampaignService, AuthService) under /api, and the net/http Discord OAuth
+// redirect + callback under /auth. The single [auth.Stack] gates every Connect
+// service identically — auth (session cookie) → CSRF double-submit → tenant
+// pass-through — with AuthService.GetCurrentUser left reachable unauthenticated
+// so the SPA can probe the session at boot. Live Discord login requires the
+// operator's OAuth app credentials (DISCORD_OAUTH_CLIENT_ID / _SECRET /
+// _REDIRECT_URL) — a one-time setup, not code; absent them the gate still stands
+// and the API simply has no way in.
+func managementMounts(store *storage.Store, log *slog.Logger) []web.Mount {
+	clientID := os.Getenv("DISCORD_OAUTH_CLIENT_ID")
+	if clientID == "" {
+		log.Warn("Discord OAuth is not configured; login is disabled until " +
+			"DISCORD_OAUTH_CLIENT_ID, DISCORD_OAUTH_CLIENT_SECRET and " +
+			"DISCORD_OAUTH_REDIRECT_URL are set")
+	}
+	discord := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:     clientID,
+		ClientSecret: os.Getenv("DISCORD_OAUTH_CLIENT_SECRET"),
+		RedirectURL:  os.Getenv("DISCORD_OAUTH_REDIRECT_URL"),
+	})
+	oauth := auth.NewOAuth(store, discord, "/", log)
+	authServer := auth.NewAuthServer(store, log)
+
+	// The store satisfies both Authenticator (AuthenticateSession) and
+	// TenantResolver (TenantForUser); GetCurrentUser is the only public procedure.
+	stack := auth.NewStack(store, store, managementv1connect.AuthServiceGetCurrentUserProcedure)
+
+	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
+	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
+
+	return []web.Mount{
+		web.APIMount(campaignPath, campaignHandler),
+		web.APIMount(authPath, authHandler),
+		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
+		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
+	}
 }
 
 // runWebTier starts the web API server on ctx and blocks until it has fully shut

--- a/internal/auth/auth_e2e_test.go
+++ b/internal/auth/auth_e2e_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+// End-to-end auth over a real Postgres (testcontainers): the OAuth callback
+// issues a real session cookie, the Connect AuthService validates it through the
+// interceptor stack, and Logout deletes the session row. Tag-isolated behind
+// `integration` so the default `go test ./...` stays Docker-free (ADR-0021 /
+// ADR-0033). The Postgres harness is duplicated in miniature (storage's
+// harness_test.go is package-private).
+
+package auth_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?): %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+func migratedStore(t *testing.T) (*storage.Store, *pgxpool.Pool) {
+	t.Helper()
+	dsn := startPostgres(t)
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return storage.New(pool), pool
+}
+
+// cookieByName pulls one cookie out of a recorded response.
+func cookieByName(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestAuthEndToEnd drives the whole single-operator flow against a real DB:
+// OAuth callback → cookie issuance → GetCurrentUser validation → Logout deletes
+// the session row.
+func TestAuthEndToEnd(t *testing.T) {
+	store, pool := migratedStore(t)
+	ctx := context.Background()
+
+	disc := &fakeDiscord{user: auth.DiscordUser{
+		ID: "555", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png",
+	}}
+	o := auth.NewOAuth(store, disc, "/", nil)
+
+	// 1. OAuth callback issues a real session — capture the cookies.
+	cbReq := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=st", nil)
+	cbReq.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st"})
+	cbRec := httptest.NewRecorder()
+	o.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	sess := cookieByName(cbRec.Result().Cookies(), auth.SessionCookieName)
+	csrf := cookieByName(cbRec.Result().Cookies(), auth.CSRFCookieName)
+	if sess == nil || csrf == nil {
+		t.Fatal("callback did not set session/csrf cookies")
+	}
+
+	// The session row exists for the upserted operator.
+	var rowsBefore int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM sessions WHERE token = $1`, sess.Value).Scan(&rowsBefore); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if rowsBefore != 1 {
+		t.Fatalf("session rows = %d, want 1", rowsBefore)
+	}
+
+	// 2. AuthService over the real store + interceptor stack.
+	stack := auth.NewStack(store, store, managementv1connect.AuthServiceGetCurrentUserProcedure)
+	server := auth.NewAuthServer(store, nil)
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler(stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	cookieHeader := auth.SessionCookieName + "=" + sess.Value + "; " + auth.CSRFCookieName + "=" + csrf.Value
+
+	// 3. GetCurrentUser with the cookie resolves the real operator.
+	getReq := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	getReq.Header().Set("Cookie", cookieHeader)
+	getResp, err := client.GetCurrentUser(ctx, getReq)
+	if err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if got := getResp.Msg.GetUser(); got.GetName() != "Sora Vance" || got.GetAvatar() != "https://cdn/a.png" {
+		t.Errorf("user = %+v, want Sora Vance", got)
+	}
+
+	// Missing cookie → 401.
+	if _, err := client.GetCurrentUser(ctx, connect.NewRequest(&managementv1.GetCurrentUserRequest{})); connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("unauthenticated GetCurrentUser code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+
+	// 4. Logout (with CSRF double-submit) deletes the session row.
+	logoutReq := connect.NewRequest(&managementv1.LogoutRequest{})
+	logoutReq.Header().Set("Cookie", cookieHeader)
+	logoutReq.Header().Set("X-CSRF-Token", csrf.Value)
+	logoutResp, err := client.Logout(ctx, logoutReq)
+	if err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if !strings.Contains(strings.Join(logoutResp.Header().Values("Set-Cookie"), " "), auth.SessionCookieName) {
+		t.Error("Logout did not clear the session cookie")
+	}
+
+	var rowsAfter int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM sessions WHERE token = $1`, sess.Value).Scan(&rowsAfter); err != nil {
+		t.Fatalf("count sessions after logout: %v", err)
+	}
+	if rowsAfter != 0 {
+		t.Fatalf("session rows after logout = %d, want 0 (logout must delete the row)", rowsAfter)
+	}
+
+	// The now-deleted session no longer authenticates.
+	if _, err := store.AuthenticateSession(ctx, sess.Value); err == nil {
+		t.Error("session still authenticates after logout")
+	}
+}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,54 @@
+// Package auth is the single-operator authentication tier (ADR-0016 / ADR-0039):
+// the net/http Discord OAuth carve-out (ADR-0015), the opaque cookie session it
+// issues, and the Connect interceptor stack + context accessors that gate the
+// management RPCs. The stacked Configuration (#68) and Campaign (#71) PRs reuse
+// this package's exported seam: [NewStack] for the interceptor options and
+// [CurrentUser] / [TenantID] to read the resolved principal out of a handler's
+// context.
+package auth
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// ctxKey is the private context key type for the resolved principal, so no other
+// package can collide with or overwrite these context values.
+type ctxKey int
+
+const (
+	userKey ctxKey = iota
+	tenantKey
+)
+
+// WithUser returns a copy of ctx carrying the authenticated operator. The auth
+// interceptor calls it after validating the session cookie; tests use it to
+// inject a principal without standing up the interceptor.
+func WithUser(ctx context.Context, u storage.User) context.Context {
+	return context.WithValue(ctx, userKey, u)
+}
+
+// CurrentUser returns the authenticated operator carried in ctx, and false when
+// the request is unauthenticated. RPC handlers (e.g. AuthService.GetCurrentUser,
+// and #68/#71's mutations) use it to read the caller.
+func CurrentUser(ctx context.Context) (storage.User, bool) {
+	u, ok := ctx.Value(userKey).(storage.User)
+	return u, ok
+}
+
+// WithTenant returns a copy of ctx carrying the resolved tenant id. The tenant
+// interceptor calls it; the single-operator pass-through resolves the operator's
+// bound tenant (ADR-0039).
+func WithTenant(ctx context.Context, id uuid.UUID) context.Context {
+	return context.WithValue(ctx, tenantKey, id)
+}
+
+// TenantID returns the resolved tenant id carried in ctx, and false when none
+// was resolved (an unauthenticated request, or an operator with no bound tenant).
+func TenantID(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(tenantKey).(uuid.UUID)
+	return id, ok
+}

--- a/internal/auth/cookie.go
+++ b/internal/auth/cookie.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Cookie names (ADR-0016). The session cookie is HttpOnly so script can't read
+// the bearer; the CSRF cookie is deliberately NOT HttpOnly so the SPA can echo
+// it back in the X-CSRF-Token header (the double-submit pattern).
+const (
+	// SessionCookieName carries the opaque session token (HttpOnly).
+	SessionCookieName = "glyphoxa_session"
+	// CSRFCookieName carries the double-submit CSRF token (readable by script).
+	CSRFCookieName = "glyphoxa_csrf"
+	// stateCookieName carries the short-lived OAuth state nonce.
+	stateCookieName = "glyphoxa_oauth_state"
+)
+
+// newToken mints an opaque, high-entropy token from crypto/rand — the session
+// and CSRF secrets, and the OAuth state nonce. base64url so it is cookie-safe.
+// NOT a JWT: server-side sessions revoke with a row delete (ADR-0016).
+func newToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: read random token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// cookieValue reads a single cookie value out of a request/response header set,
+// returning "" when absent. It works for both a net/http request and a Connect
+// request's Header() (which carries the inbound Cookie header).
+func cookieValue(h http.Header, name string) string {
+	r := http.Request{Header: h}
+	c, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// headerSecure reports whether the request reached the reverse proxy over TLS,
+// per the X-Forwarded-Proto header. The self-host topology terminates TLS at the
+// proxy (ADR-0039), so the Go process sees cleartext but must still set Secure
+// cookies when the public edge is https.
+func headerSecure(h http.Header) bool {
+	return strings.EqualFold(h.Get("X-Forwarded-Proto"), "https")
+}
+
+// requestSecure reports whether to mark cookies Secure: the request is TLS
+// directly, or was forwarded as https. Local cleartext dev (http://localhost)
+// is correctly non-Secure so the browser still stores the login cookie.
+func requestSecure(r *http.Request) bool {
+	return r.TLS != nil || headerSecure(r.Header)
+}
+
+// sessionCookie builds the HttpOnly session cookie (ADR-0016: HttpOnly, Secure,
+// SameSite=Lax). Lax (not Strict) so the top-level redirect back from Discord
+// still presents the cookie.
+func sessionCookie(token string, secure bool, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// csrfCookie builds the double-submit CSRF cookie. It is NOT HttpOnly — the SPA
+// reads it and mirrors it into the X-CSRF-Token header that the CSRF interceptor
+// checks against this same cookie.
+func csrfCookie(token string, secure bool, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: false,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// clearCookie builds an immediately-expiring cookie that deletes name on the
+// client (logout, and clearing the one-shot OAuth state).
+func clearCookie(name string, httpOnly, secure bool) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: httpOnly,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/internal/auth/discord.go
+++ b/internal/auth/discord.go
@@ -1,0 +1,188 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Discord OAuth2 endpoints (ADR-0016: Discord-only). Overridable on
+// DiscordConfig so the token-exchange test points the client at an httptest
+// cassette instead of discord.com — no live Discord call in CI.
+const (
+	defaultAuthorizeURL = "https://discord.com/api/oauth2/authorize"
+	defaultTokenURL     = "https://discord.com/api/oauth2/token"
+	defaultUserURL      = "https://discord.com/api/users/@me"
+	// avatarCDN composes the user's avatar image URL from id + hash.
+	avatarCDN = "https://cdn.discordapp.com/avatars/%s/%s.png"
+)
+
+// DiscordUser is the authenticated Discord identity returned by Exchange — the
+// fields the operator record needs (ADR-0016).
+type DiscordUser struct {
+	ID         string
+	Username   string
+	GlobalName string
+	// AvatarURL is the composed CDN URL, or "" when the user has no avatar.
+	AvatarURL string
+}
+
+// DisplayName prefers the Discord global (display) name, falling back to the
+// legacy username.
+func (d DiscordUser) DisplayName() string {
+	if d.GlobalName != "" {
+		return d.GlobalName
+	}
+	return d.Username
+}
+
+// DiscordOAuth exchanges an OAuth authorization code for the authenticated
+// Discord user. The OAuth callback depends on this interface (not the concrete
+// client) so tests drive it with a fake — no live Discord call (ADR-0019 TDD).
+type DiscordOAuth interface {
+	// AuthCodeURL builds the Discord authorize redirect URL for the login start.
+	AuthCodeURL(state string) string
+	// Exchange swaps an authorization code for the authenticated Discord user.
+	Exchange(ctx context.Context, code string) (DiscordUser, error)
+}
+
+// DiscordConfig configures a [DiscordClient]. ClientID/ClientSecret/RedirectURL
+// are the operator's registered OAuth app credentials (a one-time setup, not
+// code). The *URL fields default to discord.com when empty.
+type DiscordConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+
+	AuthorizeURL string
+	TokenURL     string
+	UserURL      string
+
+	HTTPClient *http.Client
+}
+
+// DiscordClient is the live DiscordOAuth implementation.
+type DiscordClient struct {
+	cfg  DiscordConfig
+	http *http.Client
+}
+
+var _ DiscordOAuth = (*DiscordClient)(nil)
+
+// NewDiscordClient builds a DiscordClient, filling endpoint + HTTP-client
+// defaults.
+func NewDiscordClient(cfg DiscordConfig) *DiscordClient {
+	if cfg.AuthorizeURL == "" {
+		cfg.AuthorizeURL = defaultAuthorizeURL
+	}
+	if cfg.TokenURL == "" {
+		cfg.TokenURL = defaultTokenURL
+	}
+	if cfg.UserURL == "" {
+		cfg.UserURL = defaultUserURL
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &DiscordClient{cfg: cfg, http: hc}
+}
+
+// AuthCodeURL builds the authorize redirect URL: response_type=code, the
+// identify scope (enough for the @me identity), and the anti-forgery state.
+func (c *DiscordClient) AuthCodeURL(state string) string {
+	q := url.Values{}
+	q.Set("client_id", c.cfg.ClientID)
+	q.Set("redirect_uri", c.cfg.RedirectURL)
+	q.Set("response_type", "code")
+	q.Set("scope", "identify")
+	q.Set("state", state)
+	return c.cfg.AuthorizeURL + "?" + q.Encode()
+}
+
+// Exchange performs the OAuth code→token→user round trip and composes the
+// avatar URL. Errors carry no credential material.
+func (c *DiscordClient) Exchange(ctx context.Context, code string) (DiscordUser, error) {
+	token, err := c.exchangeCode(ctx, code)
+	if err != nil {
+		return DiscordUser{}, err
+	}
+	return c.fetchUser(ctx, token)
+}
+
+func (c *DiscordClient) exchangeCode(ctx context.Context, code string) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("client_secret", c.cfg.ClientSecret)
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", c.cfg.RedirectURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("auth: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("auth: token request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("auth: token endpoint status %d", resp.StatusCode)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tok); err != nil {
+		return "", fmt.Errorf("auth: decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return "", fmt.Errorf("auth: token endpoint returned no access_token")
+	}
+	return tok.AccessToken, nil
+}
+
+func (c *DiscordClient) fetchUser(ctx context.Context, accessToken string) (DiscordUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.UserURL, nil)
+	if err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: build userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo endpoint status %d", resp.StatusCode)
+	}
+	var raw struct {
+		ID         string `json:"id"`
+		Username   string `json:"username"`
+		GlobalName string `json:"global_name"`
+		Avatar     string `json:"avatar"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&raw); err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: decode userinfo response: %w", err)
+	}
+	if raw.ID == "" {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo returned no id")
+	}
+	u := DiscordUser{ID: raw.ID, Username: raw.Username, GlobalName: raw.GlobalName}
+	if raw.Avatar != "" {
+		u.AvatarURL = fmt.Sprintf(avatarCDN, raw.ID, raw.Avatar)
+	}
+	return u, nil
+}

--- a/internal/auth/discord_test.go
+++ b/internal/auth/discord_test.go
@@ -1,0 +1,86 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+// TestDiscordClient_Exchange covers the OAuth token exchange against an httptest
+// "cassette" standing in for discord.com — no live Discord call (issue #67
+// acceptance). It asserts the code→token→user round trip parses correctly and
+// composes the avatar CDN URL, and that the token request carried the code +
+// client credentials.
+func TestDiscordClient_Exchange(t *testing.T) {
+	t.Parallel()
+
+	var gotCode, gotClientID, gotGrant, gotBearer string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotCode = r.Form.Get("code")
+		gotClientID = r.Form.Get("client_id")
+		gotGrant = r.Form.Get("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at-123","token_type":"Bearer"}`))
+	})
+	mux.HandleFunc("/users/@me", func(w http.ResponseWriter, r *http.Request) {
+		gotBearer = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"99","username":"sora","global_name":"Sora Vance","avatar":"abc"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:     "client-1",
+		ClientSecret: "secret-1",
+		RedirectURL:  "https://app/auth/discord/callback",
+		TokenURL:     srv.URL + "/oauth2/token",
+		UserURL:      srv.URL + "/users/@me",
+		HTTPClient:   srv.Client(),
+	})
+
+	du, err := client.Exchange(context.Background(), "the-code")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if du.ID != "99" || du.Username != "sora" || du.GlobalName != "Sora Vance" {
+		t.Errorf("user = %+v", du)
+	}
+	if du.DisplayName() != "Sora Vance" {
+		t.Errorf("DisplayName = %q, want global name", du.DisplayName())
+	}
+	if du.AvatarURL != "https://cdn.discordapp.com/avatars/99/abc.png" {
+		t.Errorf("AvatarURL = %q", du.AvatarURL)
+	}
+	if gotCode != "the-code" || gotClientID != "client-1" || gotGrant != "authorization_code" {
+		t.Errorf("token request: code=%q client_id=%q grant=%q", gotCode, gotClientID, gotGrant)
+	}
+	if gotBearer != "Bearer at-123" {
+		t.Errorf("userinfo Authorization = %q, want Bearer at-123", gotBearer)
+	}
+}
+
+// TestDiscordClient_AuthCodeURL asserts the authorize redirect carries the
+// client id, redirect uri, response_type=code, identify scope, and the state.
+func TestDiscordClient_AuthCodeURL(t *testing.T) {
+	t.Parallel()
+	client := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:    "cid",
+		RedirectURL: "https://app/cb",
+	})
+	got := client.AuthCodeURL("state-xyz")
+	for _, want := range []string{
+		"client_id=cid", "response_type=code", "scope=identify", "state=state-xyz",
+		"redirect_uri=https%3A%2F%2Fapp%2Fcb",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthCodeURL missing %q in %q", want, got)
+		}
+	}
+}

--- a/internal/auth/interceptors.go
+++ b/internal/auth/interceptors.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Authenticator validates a session token and resolves the owning operator.
+// *storage.Store satisfies it via AuthenticateSession.
+type Authenticator interface {
+	AuthenticateSession(ctx context.Context, token string) (storage.User, error)
+}
+
+// TenantResolver resolves the tenant bound to an operator (ADR-0039 thin
+// pass-through). *storage.Store satisfies it via TenantForUser.
+type TenantResolver interface {
+	TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error)
+}
+
+// NewAuthInterceptor validates the glyphoxa_session cookie on every Connect call
+// and puts the resolved operator into the request context ([CurrentUser]).
+// Unauthenticated requests are rejected with CodeUnauthenticated — INCLUDING
+// reads, so the whole API is gated — EXCEPT procedures named in public, which
+// are allowed through unauthenticated so they can self-handle the missing
+// session (AuthService.GetCurrentUser returns CodeUnauthenticated itself, the
+// SPA's 401 → /login probe).
+func NewAuthInterceptor(a Authenticator, public ...string) connect.UnaryInterceptorFunc {
+	publicSet := make(map[string]struct{}, len(public))
+	for _, p := range public {
+		publicSet[p] = struct{}{}
+	}
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if token := cookieValue(req.Header(), SessionCookieName); token != "" {
+				if u, err := a.AuthenticateSession(ctx, token); err == nil {
+					return next(WithUser(ctx, u), req)
+				}
+			}
+			if _, ok := publicSet[req.Spec().Procedure]; ok {
+				return next(ctx, req)
+			}
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authentication required"))
+		}
+	}
+}
+
+// NewCSRFInterceptor enforces the double-submit CSRF check (ADR-0016) on
+// state-changing calls: the X-CSRF-Token header must match the glyphoxa_csrf
+// cookie, else CodePermissionDenied. Reads (NO_SIDE_EFFECTS, e.g.
+// GetActiveCampaign / GetCurrentUser) are exempt — they mutate nothing, and the
+// CSRF cookie is not guaranteed present before the first login.
+func NewCSRFInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if req.Spec().IdempotencyLevel == connect.IdempotencyNoSideEffects {
+				return next(ctx, req)
+			}
+			cookie := cookieValue(req.Header(), CSRFCookieName)
+			header := req.Header().Get("X-CSRF-Token")
+			if cookie == "" || header == "" ||
+				subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
+				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("CSRF token mismatch"))
+			}
+			return next(ctx, req)
+		}
+	}
+}
+
+// NewTenantInterceptor resolves the authenticated operator's bound tenant and
+// puts it in the context ([TenantID]). For the single operator this is the thin
+// X-Tenant-Id pass-through (ADR-0039): the tenant is resolved server-side from
+// the operator, not trusted from a client header, so the multi-tenant
+// membership check fills in here later without a rewrite. Unauthenticated reads
+// (no operator in ctx) pass through untouched; a resolve failure is logged and
+// the request proceeds without a tenant (handlers that need one fail on their
+// own terms).
+func NewTenantInterceptor(tr TenantResolver) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			u, ok := CurrentUser(ctx)
+			if !ok {
+				return next(ctx, req)
+			}
+			tenantID, err := tr.TenantForUser(ctx, u.ID)
+			if err != nil {
+				slog.Default().Warn("tenant interceptor: no tenant for operator",
+					"user_id", u.ID, "err", err)
+				return next(ctx, req)
+			}
+			return next(WithTenant(ctx, tenantID), req)
+		}
+	}
+}
+
+// Stack is the ordered Connect interceptor stack the web tier mounts on every
+// management handler: auth (who) → CSRF (anti-forgery) → tenant (which tenant).
+// Build it with [NewStack] and apply it with [Stack.HandlerOptions]. The stacked
+// #68/#71 PRs reuse the same Stack so the gate is identical across services.
+type Stack struct {
+	interceptors []connect.Interceptor
+}
+
+// NewStack assembles the interceptor stack. public lists the fully-qualified
+// procedures reachable without a valid session (the SPA's
+// AuthService.GetCurrentUser boot probe).
+func NewStack(a Authenticator, tr TenantResolver, public ...string) *Stack {
+	return &Stack{interceptors: []connect.Interceptor{
+		NewAuthInterceptor(a, public...),
+		NewCSRFInterceptor(),
+		NewTenantInterceptor(tr),
+	}}
+}
+
+// HandlerOptions returns the connect.HandlerOption that installs the stack on a
+// generated handler, e.g. authServer.Handler(stack.HandlerOptions()...).
+func (s *Stack) HandlerOptions() []connect.HandlerOption {
+	return []connect.HandlerOption{connect.WithInterceptors(s.interceptors...)}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// OAuthStore is the persistence the OAuth callback needs: refresh the operator
+// record, bind the single tenant, and create the session row. *storage.Store
+// satisfies it.
+type OAuthStore interface {
+	UpsertUser(ctx context.Context, p storage.UpsertUserParams) (storage.User, error)
+	ResolveOperatorTenant(ctx context.Context, userID uuid.UUID) (storage.Tenant, error)
+	CreateSession(ctx context.Context, n storage.NewSession) (storage.Session, error)
+}
+
+// defaultSessionTTL is how long a freshly issued session is valid.
+const defaultSessionTTL = 30 * 24 * time.Hour
+
+// stateCookieTTL bounds the OAuth round trip; the state nonce only has to
+// survive the redirect to Discord and back.
+const stateCookieTTL = 10 * time.Minute
+
+// OAuth serves the Discord OAuth carve-out (ADR-0015 — HTML redirects, NOT
+// Connect): GET /auth/discord/login starts the flow, GET /auth/discord/callback
+// finishes it by issuing the session + CSRF cookies (ADR-0016).
+type OAuth struct {
+	store    OAuthStore
+	discord  DiscordOAuth
+	ttl      time.Duration
+	redirect string // where the callback sends the browser after login
+	now      func() time.Time
+	log      *slog.Logger
+}
+
+// NewOAuth builds the OAuth handlers. appRedirect is the post-login destination
+// (the SPA root, "/").
+func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, log *slog.Logger) *OAuth {
+	if appRedirect == "" {
+		appRedirect = "/"
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &OAuth{
+		store:    store,
+		discord:  discord,
+		ttl:      defaultSessionTTL,
+		redirect: appRedirect,
+		now:      time.Now,
+		log:      log,
+	}
+}
+
+// Login starts the OAuth flow: mint an anti-forgery state nonce, stash it in a
+// short-lived cookie, and 302 to Discord's authorize URL.
+func (o *OAuth) Login(w http.ResponseWriter, r *http.Request) {
+	state, err := newToken()
+	if err != nil {
+		o.log.Error("oauth login: mint state", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	secure := requestSecure(r)
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    state,
+		Path:     "/",
+		Expires:  o.now().Add(stateCookieTTL),
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, o.discord.AuthCodeURL(state), http.StatusFound)
+}
+
+// Callback finishes the OAuth flow: verify the state nonce, exchange the code
+// for the Discord identity, upsert the operator, bind the tenant, create the
+// session, set the session + CSRF cookies, clear the state cookie, and 302 to
+// the SPA. The Discord exchange is behind the DiscordOAuth interface so CI uses
+// a fake — no live Discord call.
+func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
+	state := r.FormValue("state")
+	stateCookie, err := r.Cookie(stateCookieName)
+	if err != nil || state == "" ||
+		subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(state)) != 1 {
+		http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+		return
+	}
+	code := r.FormValue("code")
+	if code == "" {
+		http.Error(w, "missing OAuth code", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	du, err := o.discord.Exchange(ctx, code)
+	if err != nil {
+		// The raw error can carry endpoint/status detail; log it, return generic.
+		o.log.Error("oauth callback: discord exchange", "err", err)
+		http.Error(w, "discord sign-in failed", http.StatusBadGateway)
+		return
+	}
+
+	user, err := o.store.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: du.ID,
+		Name:          du.DisplayName(),
+		Avatar:        du.AvatarURL,
+	})
+	if err != nil {
+		o.log.Error("oauth callback: upsert user", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if _, err := o.store.ResolveOperatorTenant(ctx, user.ID); err != nil {
+		o.log.Error("oauth callback: bind tenant", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	sessionToken, err := newToken()
+	if err != nil {
+		o.log.Error("oauth callback: mint session token", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	csrfToken, err := newToken()
+	if err != nil {
+		o.log.Error("oauth callback: mint csrf token", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	expires := o.now().Add(o.ttl)
+	if _, err := o.store.CreateSession(ctx, storage.NewSession{
+		UserID:    user.ID,
+		Token:     sessionToken,
+		ExpiresAt: expires,
+		IP:        clientIP(r),
+		UA:        r.UserAgent(),
+	}); err != nil {
+		o.log.Error("oauth callback: create session", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	secure := requestSecure(r)
+	http.SetCookie(w, sessionCookie(sessionToken, secure, expires))
+	http.SetCookie(w, csrfCookie(csrfToken, secure, expires))
+	http.SetCookie(w, clearCookie(stateCookieName, true, secure))
+	http.Redirect(w, r, o.redirect, http.StatusFound)
+}
+
+// clientIP extracts the best-effort client IP for the session audit row,
+// preferring the proxy's X-Forwarded-For first hop.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		first, _, _ := strings.Cut(xff, ",")
+		return strings.TrimSpace(first)
+	}
+	return r.RemoteAddr
+}

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,0 +1,168 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeDiscord is a DiscordOAuth stand-in: AuthCodeURL echoes the state and
+// Exchange returns a canned user — no live Discord call.
+type fakeDiscord struct {
+	user     auth.DiscordUser
+	gotCode  string
+	authBase string
+}
+
+func (f *fakeDiscord) AuthCodeURL(state string) string {
+	return f.authBase + "?state=" + state
+}
+
+func (f *fakeDiscord) Exchange(_ context.Context, code string) (auth.DiscordUser, error) {
+	f.gotCode = code
+	return f.user, nil
+}
+
+// fakeOAuthStore records the writes the callback performs.
+type fakeOAuthStore struct {
+	upserted storage.UpsertUserParams
+	resolved uuid.UUID
+	created  storage.NewSession
+	userID   uuid.UUID
+	tenantID uuid.UUID
+}
+
+func (f *fakeOAuthStore) UpsertUser(_ context.Context, p storage.UpsertUserParams) (storage.User, error) {
+	f.upserted = p
+	return storage.User{ID: f.userID, DiscordUserID: p.DiscordUserID, Name: p.Name, Avatar: p.Avatar, Role: "operator"}, nil
+}
+
+func (f *fakeOAuthStore) ResolveOperatorTenant(_ context.Context, userID uuid.UUID) (storage.Tenant, error) {
+	f.resolved = userID
+	return storage.Tenant{ID: f.tenantID, Name: "Glyphoxa"}, nil
+}
+
+func (f *fakeOAuthStore) CreateSession(_ context.Context, n storage.NewSession) (storage.Session, error) {
+	f.created = n
+	return storage.Session{ID: uuid.New(), UserID: n.UserID, Token: n.Token, ExpiresAt: n.ExpiresAt}, nil
+}
+
+func TestOAuthLogin_RedirectsAndSetsState(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{authBase: "https://discord/authorize"}
+	o := auth.NewOAuth(&fakeOAuthStore{}, disc, "/", nil)
+
+	rec := httptest.NewRecorder()
+	o.Login(rec, httptest.NewRequest(http.MethodGet, "/auth/discord/login", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://discord/authorize?state=") {
+		t.Fatalf("Location = %q", loc)
+	}
+	state := strings.TrimPrefix(loc, "https://discord/authorize?state=")
+
+	// The state cookie is set and matches the state in the redirect URL.
+	var stateCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_oauth_state" {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("no state cookie set")
+	}
+	if stateCookie.Value != state {
+		t.Errorf("state cookie %q != redirect state %q", stateCookie.Value, state)
+	}
+	if !stateCookie.HttpOnly {
+		t.Error("state cookie must be HttpOnly")
+	}
+}
+
+func TestOAuthCallback_IssuesSessionCookie(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{user: auth.DiscordUser{ID: "77", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png"}}
+	store := &fakeOAuthStore{userID: uuid.New(), tenantID: uuid.New()}
+	o := auth.NewOAuth(store, disc, "/", nil)
+
+	// A valid callback presents the state cookie matching the state param + a code.
+	form := url.Values{"code": {"the-code"}, "state": {"st-1"}}
+	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?"+form.Encode(), nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st-1"})
+
+	rec := httptest.NewRecorder()
+	o.Callback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Errorf("Location = %q, want /", loc)
+	}
+
+	// The Discord identity was upserted (display name preferred) and the tenant bound.
+	if store.upserted.DiscordUserID != "77" || store.upserted.Name != "Sora Vance" || store.upserted.Avatar != "https://cdn/a.png" {
+		t.Errorf("upserted = %+v", store.upserted)
+	}
+	if store.resolved != store.userID {
+		t.Errorf("ResolveOperatorTenant got %s, want %s", store.resolved, store.userID)
+	}
+	if disc.gotCode != "the-code" {
+		t.Errorf("exchanged code = %q", disc.gotCode)
+	}
+
+	// The session + CSRF cookies are issued; the session cookie value matches the
+	// persisted session token; HttpOnly only on the session cookie.
+	cookies := map[string]*http.Cookie{}
+	for _, c := range rec.Result().Cookies() {
+		cookies[c.Name] = c
+	}
+	sess := cookies["glyphoxa_session"]
+	csrf := cookies["glyphoxa_csrf"]
+	if sess == nil || csrf == nil {
+		t.Fatalf("missing session/csrf cookies: %v", cookies)
+	}
+	if sess.Value != store.created.Token {
+		t.Errorf("session cookie %q != stored token %q", sess.Value, store.created.Token)
+	}
+	if !sess.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if csrf.HttpOnly {
+		t.Error("csrf cookie must NOT be HttpOnly (double-submit needs script access)")
+	}
+	if sess.SameSite != http.SameSiteLaxMode {
+		t.Error("session cookie must be SameSite=Lax")
+	}
+}
+
+func TestOAuthCallback_BadState_Rejected(t *testing.T) {
+	t.Parallel()
+	store := &fakeOAuthStore{}
+	o := auth.NewOAuth(store, &fakeDiscord{}, "/", nil)
+
+	// State cookie does not match the state param.
+	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=mismatch", nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "real-state"})
+
+	rec := httptest.NewRecorder()
+	o.Callback(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if store.created.Token != "" {
+		t.Error("session created despite state mismatch")
+	}
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+)
+
+// SessionDeleter revokes a session by token (logout). *storage.Store satisfies
+// it via DeleteSession.
+type SessionDeleter interface {
+	DeleteSession(ctx context.Context, token string) error
+}
+
+// AuthServer implements the Connect AuthService (ADR-0016 / ADR-0039): it reads
+// the operator the auth interceptor resolved into the context and tears the
+// session down on logout. The interceptor stack ([NewStack]) does the cookie
+// validation + CSRF; this handler is the thin policy layer over it.
+type AuthServer struct {
+	sessions SessionDeleter
+	log      *slog.Logger
+}
+
+var _ managementv1connect.AuthServiceHandler = (*AuthServer)(nil)
+
+// NewAuthServer builds an AuthServer over the session store.
+func NewAuthServer(sessions SessionDeleter, log *slog.Logger) *AuthServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &AuthServer{sessions: sessions, log: log}
+}
+
+// GetCurrentUser returns the signed-in operator's display identity. The auth
+// interceptor leaves this procedure reachable unauthenticated (it is in the
+// public set), so a missing/expired session reaches here with no operator in the
+// context and yields CodeUnauthenticated — the SPA's 401 → /login signal.
+func (s *AuthServer) GetCurrentUser(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetCurrentUserRequest],
+) (*connect.Response[managementv1.GetCurrentUserResponse], error) {
+	u, ok := CurrentUser(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	return connect.NewResponse(&managementv1.GetCurrentUserResponse{
+		User: &managementv1.User{
+			Name:   u.Name,
+			Role:   u.Role,
+			Avatar: u.Avatar,
+		},
+	}), nil
+}
+
+// Logout deletes the server-side session row and clears the session + CSRF
+// cookies. It is state-changing, so the auth + CSRF interceptors have already
+// proven a valid session and a matching CSRF token before it runs.
+func (s *AuthServer) Logout(
+	ctx context.Context,
+	req *connect.Request[managementv1.LogoutRequest],
+) (*connect.Response[managementv1.LogoutResponse], error) {
+	if token := cookieValue(req.Header(), SessionCookieName); token != "" {
+		if err := s.sessions.DeleteSession(ctx, token); err != nil {
+			s.log.Error("logout: delete session", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+	resp := connect.NewResponse(&managementv1.LogoutResponse{})
+	secure := headerSecure(req.Header())
+	resp.Header().Add("Set-Cookie", clearCookie(SessionCookieName, true, secure).String())
+	resp.Header().Add("Set-Cookie", clearCookie(CSRFCookieName, false, secure).String())
+	return resp, nil
+}
+
+// Handler builds the Connect HTTP handler for AuthService and returns the path +
+// handler, mirroring (*rpc.CampaignServer).Handler. Pass the auth interceptor
+// stack via opts (see [Stack.HandlerOptions]).
+func (s *AuthServer) Handler(opts ...connect.HandlerOption) (string, http.Handler) {
+	return managementv1connect.NewAuthServiceHandler(s, opts...)
+}

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,180 @@
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeAuthN is a keyless Authenticator: a token resolves to a user only if it is
+// in the map, else ErrNotFound (the "missing/expired" path).
+type fakeAuthN struct{ users map[string]storage.User }
+
+func (f fakeAuthN) AuthenticateSession(_ context.Context, token string) (storage.User, error) {
+	if u, ok := f.users[token]; ok {
+		return u, nil
+	}
+	return storage.User{}, storage.ErrNotFound
+}
+
+type fakeTenant struct {
+	id  uuid.UUID
+	err error
+}
+
+func (f fakeTenant) TenantForUser(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return f.id, f.err
+}
+
+type fakeDeleter struct{ deleted []string }
+
+func (f *fakeDeleter) DeleteSession(_ context.Context, token string) error {
+	f.deleted = append(f.deleted, token)
+	return nil
+}
+
+const (
+	validToken = "valid-session-token"
+	csrfValue  = "csrf-secret"
+)
+
+func operator() storage.User {
+	return storage.User{
+		ID: uuid.New(), DiscordUserID: "42",
+		Name: "Sora Vance", Role: "operator", Avatar: "https://cdn/x.png",
+	}
+}
+
+// newAuthClient stands up the AuthService handler behind the real interceptor
+// stack and an httptest server, with the given fakes. GetCurrentUser is the only
+// public (unauthenticated-reachable) procedure.
+func newAuthClient(t *testing.T, authn auth.Authenticator, del auth.SessionDeleter) managementv1connect.AuthServiceClient {
+	t.Helper()
+	stack := auth.NewStack(authn, fakeTenant{id: uuid.New()},
+		managementv1connect.AuthServiceGetCurrentUserProcedure)
+	server := auth.NewAuthServer(del, slog.Default())
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler(stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
+func TestGetCurrentUser_ValidCookie(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, &fakeDeleter{})
+
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken)
+
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetCurrentUser(valid): %v", err)
+	}
+	got := resp.Msg.GetUser()
+	if got.GetName() != op.Name || got.GetRole() != op.Role || got.GetAvatar() != op.Avatar {
+		t.Errorf("user = %+v, want name/role/avatar of %+v", got, op)
+	}
+}
+
+func TestGetCurrentUser_MissingCookie_401(t *testing.T) {
+	t.Parallel()
+	client := newAuthClient(t, fakeAuthN{}, &fakeDeleter{})
+
+	_, err := client.GetCurrentUser(context.Background(),
+		connect.NewRequest(&managementv1.GetCurrentUserRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+}
+
+func TestGetCurrentUser_ExpiredCookie_401(t *testing.T) {
+	t.Parallel()
+	// An empty user map means every token resolves to ErrNotFound — the
+	// expired/unknown path.
+	client := newAuthClient(t, fakeAuthN{}, &fakeDeleter{})
+
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"=expired-or-unknown")
+
+	_, err := client.GetCurrentUser(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+}
+
+func TestLogout_Unauthenticated_Rejected(t *testing.T) {
+	t.Parallel()
+	// Logout is state-changing and NOT public, so the auth interceptor rejects an
+	// unauthenticated call before any handler runs.
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{}, del)
+
+	_, err := client.Logout(context.Background(), connect.NewRequest(&managementv1.LogoutRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+	if len(del.deleted) != 0 {
+		t.Errorf("session deleted on a rejected logout: %v", del.deleted)
+	}
+}
+
+func TestLogout_MissingCSRF_Rejected(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, del)
+
+	// Valid session, but no X-CSRF-Token header → double-submit fails.
+	req := connect.NewRequest(&managementv1.LogoutRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken+"; "+auth.CSRFCookieName+"="+csrfValue)
+
+	_, err := client.Logout(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
+		t.Fatalf("code = %v, want CodePermissionDenied", got)
+	}
+	if len(del.deleted) != 0 {
+		t.Errorf("session deleted despite CSRF failure: %v", del.deleted)
+	}
+}
+
+func TestLogout_Authenticated_DeletesAndClears(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, del)
+
+	req := connect.NewRequest(&managementv1.LogoutRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken+"; "+auth.CSRFCookieName+"="+csrfValue)
+	req.Header().Set("X-CSRF-Token", csrfValue)
+
+	resp, err := client.Logout(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Logout(valid): %v", err)
+	}
+	if len(del.deleted) != 1 || del.deleted[0] != validToken {
+		t.Fatalf("deleted = %v, want [%s]", del.deleted, validToken)
+	}
+	// The session cookie is cleared on the response (Max-Age=0 from MaxAge=-1).
+	var cleared bool
+	for _, sc := range resp.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(sc, auth.SessionCookieName+"=") && strings.Contains(sc, "Max-Age=0") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Errorf("session cookie not cleared; Set-Cookie = %v", resp.Header().Values("Set-Cookie"))
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Auth control-plane persistence (ADR-0016 / ADR-0039): users, server-side
+// sessions, and the thin single-operator↔tenant binding. Reads and writes live
+// together here because they are one cohesive feature; the broader read/write
+// split in store.go / write.go predates it. The cookie token is an opaque
+// random secret minted by the auth tier (internal/auth) — this layer only
+// persists and validates it, never interprets it.
+
+const userColumns = `id, discord_user_id, name, avatar, role, created_at, updated_at`
+
+func scanUser(row pgx.Row) (User, error) {
+	var u User
+	err := row.Scan(
+		&u.ID, &u.DiscordUserID, &u.Name, &u.Avatar, &u.Role,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
+	return u, err
+}
+
+// UpsertUserParams is the input to UpsertUser: the Discord identity to insert or
+// refresh. Role is not an input — a new user defaults to 'operator' (the DB
+// default) and an existing user's role is left untouched on refresh.
+type UpsertUserParams struct {
+	DiscordUserID string
+	Name          string
+	Avatar        string
+}
+
+// UpsertUser inserts a user keyed by discord_user_id, or refreshes the display
+// name/avatar of the existing row (Discord is the source of truth for those on
+// every login). It returns the resulting user. The role is preserved on
+// conflict so an operator promotion is never clobbered by a login.
+func (s *Store) UpsertUser(ctx context.Context, p UpsertUserParams) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO users (discord_user_id, name, avatar)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (discord_user_id) DO UPDATE
+		   SET name = EXCLUDED.name, avatar = EXCLUDED.avatar, updated_at = now()
+		 RETURNING `+userColumns,
+		p.DiscordUserID, p.Name, p.Avatar)
+	u, err := scanUser(row)
+	if err != nil {
+		return User{}, fmt.Errorf("storage: upsert user %q: %w", p.DiscordUserID, err)
+	}
+	return u, nil
+}
+
+// GetUserByDiscordID loads a user by Discord snowflake, or ErrNotFound.
+func (s *Store) GetUserByDiscordID(ctx context.Context, discordUserID string) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+userColumns+` FROM users WHERE discord_user_id = $1`, discordUserID)
+	u, err := scanUser(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrNotFound
+	}
+	if err != nil {
+		return User{}, fmt.Errorf("storage: get user %q: %w", discordUserID, err)
+	}
+	return u, nil
+}
+
+// NewSession is the input to CreateSession. Token is the opaque random secret
+// the auth tier minted; ExpiresAt is the absolute expiry the validator enforces.
+type NewSession struct {
+	UserID    uuid.UUID
+	Token     string
+	ExpiresAt time.Time
+	IP        string
+	UA        string
+}
+
+// CreateSession inserts a session row and returns it.
+func (s *Store) CreateSession(ctx context.Context, n NewSession) (Session, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO sessions (user_id, token, expires_at, ip, ua)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING id, user_id, token, created_at, last_seen_at, expires_at, ip, ua`,
+		n.UserID, n.Token, n.ExpiresAt, n.IP, n.UA)
+	var sess Session
+	err := row.Scan(
+		&sess.ID, &sess.UserID, &sess.Token, &sess.CreatedAt,
+		&sess.LastSeenAt, &sess.ExpiresAt, &sess.IP, &sess.UA,
+	)
+	if err != nil {
+		return Session{}, fmt.Errorf("storage: create session: %w", err)
+	}
+	return sess, nil
+}
+
+// AuthenticateSession validates a session token and returns the owning user. It
+// bumps last_seen_at as a side effect of a successful, non-expired lookup, in a
+// single round trip. A missing or expired token yields ErrNotFound — the RPC
+// layer maps that to CodeUnauthenticated.
+func (s *Store) AuthenticateSession(ctx context.Context, token string) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`WITH s AS (
+		     UPDATE sessions SET last_seen_at = now()
+		      WHERE token = $1 AND expires_at > now()
+		      RETURNING user_id
+		 )
+		 SELECT u.id, u.discord_user_id, u.name, u.avatar, u.role,
+		        u.created_at, u.updated_at
+		   FROM users u JOIN s ON s.user_id = u.id`, token)
+	u, err := scanUser(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrNotFound
+	}
+	if err != nil {
+		return User{}, fmt.Errorf("storage: authenticate session: %w", err)
+	}
+	return u, nil
+}
+
+// DeleteSession removes a session row by token (logout / revocation). Deleting a
+// token that no longer exists is not an error — logout is idempotent.
+func (s *Store) DeleteSession(ctx context.Context, token string) error {
+	if _, err := s.db.Exec(ctx, `DELETE FROM sessions WHERE token = $1`, token); err != nil {
+		return fmt.Errorf("storage: delete session: %w", err)
+	}
+	return nil
+}
+
+// ResolveOperatorTenant binds the single seeded Tenant to the first operator and
+// returns it (ADR-0039). It is idempotent and atomic: if a tenant is already
+// bound to the user it is returned; otherwise the earliest unbound tenant (the
+// seed's) is claimed; otherwise — a fresh DB with no seed — a new 'Glyphoxa'
+// tenant is created bound to the user. Called once on OAuth login.
+func (s *Store) ResolveOperatorTenant(ctx context.Context, userID uuid.UUID) (Tenant, error) {
+	var t Tenant
+	err := s.InTx(ctx, func(tx *Store) error {
+		// Already bound to this operator?
+		row := tx.db.QueryRow(ctx,
+			`SELECT id, name, created_at, updated_at FROM tenant
+			  WHERE operator_user_id = $1 ORDER BY created_at, id LIMIT 1`, userID)
+		switch err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); {
+		case err == nil:
+			return nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return fmt.Errorf("storage: find bound tenant: %w", err)
+		}
+
+		// Claim the earliest unbound tenant (the seeded one), locking it so two
+		// concurrent first-logins can't both claim the same row.
+		row = tx.db.QueryRow(ctx,
+			`UPDATE tenant SET operator_user_id = $1, updated_at = now()
+			  WHERE id = (
+			      SELECT id FROM tenant WHERE operator_user_id IS NULL
+			       ORDER BY created_at, id LIMIT 1 FOR UPDATE SKIP LOCKED
+			  )
+			  RETURNING id, name, created_at, updated_at`, userID)
+		switch err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); {
+		case err == nil:
+			return nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return fmt.Errorf("storage: claim unbound tenant: %w", err)
+		}
+
+		// No tenant at all (unseeded DB): create one bound to the operator.
+		row = tx.db.QueryRow(ctx,
+			`INSERT INTO tenant (name, operator_user_id) VALUES ('Glyphoxa', $1)
+			 RETURNING id, name, created_at, updated_at`, userID)
+		if err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return fmt.Errorf("storage: seed operator tenant: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Tenant{}, err
+	}
+	return t, nil
+}
+
+// TenantForUser returns the id of the tenant bound to the operator, or
+// ErrNotFound when none is bound. The X-Tenant-Id interceptor uses it as the
+// thin single-operator pass-through (ADR-0039).
+func (s *Store) TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`SELECT id FROM tenant WHERE operator_user_id = $1 ORDER BY created_at, id LIMIT 1`,
+		userID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, ErrNotFound
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: tenant for user %s: %w", userID, err)
+	}
+	return id, nil
+}

--- a/internal/storage/auth_test.go
+++ b/internal/storage/auth_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// migrated stands up a freshly migrated DB and returns a Store over it.
+func migrated(t *testing.T) *storage.Store {
+	t.Helper()
+	dsn := startPostgres(t)
+	db := openSQL(t, dsn)
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	return storage.New(openPool(t, dsn))
+}
+
+func TestUpsertUserInsertThenRefresh(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: "1234567890", Name: "Sora Vance", Avatar: "https://cdn/x.png",
+	})
+	if err != nil {
+		t.Fatalf("UpsertUser insert: %v", err)
+	}
+	if u.ID == uuid.Nil || u.Name != "Sora Vance" || u.Role != "operator" {
+		t.Fatalf("insert user = %+v, want named operator with id", u)
+	}
+
+	// A second upsert for the same Discord id refreshes name/avatar in place — no
+	// duplicate row, same id, role preserved.
+	u2, err := st.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: "1234567890", Name: "Sora V.", Avatar: "https://cdn/y.png",
+	})
+	if err != nil {
+		t.Fatalf("UpsertUser refresh: %v", err)
+	}
+	if u2.ID != u.ID {
+		t.Errorf("refresh created a new row: id %s != %s", u2.ID, u.ID)
+	}
+	if u2.Name != "Sora V." || u2.Avatar != "https://cdn/y.png" {
+		t.Errorf("refresh did not update display fields: %+v", u2)
+	}
+
+	got, err := st.GetUserByDiscordID(ctx, "1234567890")
+	if err != nil || got.ID != u.ID {
+		t.Fatalf("GetUserByDiscordID = %+v, %v", got, err)
+	}
+	if _, err := st.GetUserByDiscordID(ctx, "nope"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetUserByDiscordID(unknown) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "u1", Name: "Op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	sess, err := st.CreateSession(ctx, storage.NewSession{
+		UserID: u.ID, Token: "opaque-token-1", ExpiresAt: time.Now().Add(time.Hour),
+		IP: "127.0.0.1", UA: "test-agent",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if sess.ID == uuid.Nil || sess.UserID != u.ID {
+		t.Fatalf("session = %+v", sess)
+	}
+
+	// Valid token resolves to the owning user.
+	got, err := st.AuthenticateSession(ctx, "opaque-token-1")
+	if err != nil {
+		t.Fatalf("AuthenticateSession(valid): %v", err)
+	}
+	if got.ID != u.ID {
+		t.Errorf("authenticated user = %s, want %s", got.ID, u.ID)
+	}
+
+	// Unknown token → ErrNotFound (→ 401 at the RPC layer).
+	if _, err := st.AuthenticateSession(ctx, "bogus"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession(unknown) = %v, want ErrNotFound", err)
+	}
+
+	// Expired token → ErrNotFound.
+	if _, err := st.CreateSession(ctx, storage.NewSession{
+		UserID: u.ID, Token: "expired-token", ExpiresAt: time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateSession(expired): %v", err)
+	}
+	if _, err := st.AuthenticateSession(ctx, "expired-token"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession(expired) = %v, want ErrNotFound", err)
+	}
+
+	// Delete revokes immediately; a re-delete is a no-op (idempotent logout).
+	if err := st.DeleteSession(ctx, "opaque-token-1"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, err := st.AuthenticateSession(ctx, "opaque-token-1"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession after delete = %v, want ErrNotFound", err)
+	}
+	if err := st.DeleteSession(ctx, "opaque-token-1"); err != nil {
+		t.Errorf("DeleteSession(already gone) = %v, want nil", err)
+	}
+}
+
+// TestResolveOperatorTenantClaimsSeeded asserts the first operator claims the
+// pre-existing (seeded) unbound tenant, and the resolution is idempotent.
+func TestResolveOperatorTenantClaimsSeeded(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	// A seeded, unbound tenant already exists (as `glyphoxa seed` writes).
+	seededID, err := st.CreateTenant(ctx, "Seeded Tenant")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "first-op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// No tenant is bound yet.
+	if _, err := st.TenantForUser(ctx, u.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("TenantForUser(unbound) = %v, want ErrNotFound", err)
+	}
+
+	bound, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant: %v", err)
+	}
+	if bound.ID != seededID {
+		t.Errorf("claimed tenant = %s, want the seeded %s", bound.ID, seededID)
+	}
+
+	// Idempotent: a second resolve returns the same already-bound tenant, no new row.
+	again, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant(again): %v", err)
+	}
+	if again.ID != seededID {
+		t.Errorf("re-resolve = %s, want %s", again.ID, seededID)
+	}
+
+	tid, err := st.TenantForUser(ctx, u.ID)
+	if err != nil || tid != seededID {
+		t.Fatalf("TenantForUser = %s, %v; want %s", tid, err, seededID)
+	}
+}
+
+// TestResolveOperatorTenantSeedsWhenEmpty asserts a fresh DB with no tenant at
+// all gets one created bound to the operator.
+func TestResolveOperatorTenantSeedsWhenEmpty(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "lonely-op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	bound, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant: %v", err)
+	}
+	if bound.ID == uuid.Nil || bound.Name != "Glyphoxa" {
+		t.Errorf("seeded tenant = %+v, want a 'Glyphoxa' tenant", bound)
+	}
+}

--- a/internal/storage/migrations/00003_auth.sql
+++ b/internal/storage/migrations/00003_auth.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+
+-- Single-operator auth control-plane (ADR-0016 / ADR-0039): the `users` and
+-- `sessions` tables the ADR-0016 cookie session needs, plus the thin binding of
+-- the single seeded Tenant to the first operator.
+--
+-- Scope is deliberately narrow (ADR-0039 single-operator fast-path): NO
+-- tenant_members roles, NO api_keys, NO onboarding. The multi-tenant surface
+-- fills in behind these without a rewrite — the operator↔tenant link is a single
+-- nullable column on `tenant`, not a membership table.
+
+-- ── users ────────────────────────────────────────────────────────────────────
+-- A human operator, authenticated via Discord OAuth (Discord-only, ADR-0016).
+-- discord_user_id is the Discord snowflake and the stable identity key; name and
+-- avatar are display-only and refreshed from Discord on every login.
+CREATE TABLE users (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    discord_user_id  text NOT NULL UNIQUE,
+    name             text NOT NULL DEFAULT '',
+    -- avatar is an absolute image URL (or empty); Discord's CDN URL is composed
+    -- at upsert time so the SPA renders it directly.
+    avatar           text NOT NULL DEFAULT '',
+    -- role is a free-text label for now (e.g. 'operator'); the tenant_members
+    -- role matrix (ADR-0018) is deferred (ADR-0039).
+    role             text NOT NULL DEFAULT 'operator',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- ── sessions ─────────────────────────────────────────────────────────────────
+-- Server-side session (ADR-0016): an opaque random token lives in the
+-- `glyphoxa_session` cookie; this row is the authority. Revocation is a row
+-- delete (the reason JWT was rejected). expires_at gates validity; last_seen_at
+-- is bumped on each authenticated request.
+CREATE TABLE sessions (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    -- token is the opaque, high-entropy secret in the cookie (crypto/rand, not a
+    -- JWT). Unique so a token resolves to exactly one session.
+    token        text NOT NULL UNIQUE,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    expires_at   timestamptz NOT NULL,
+    -- ip / ua are captured at issuance for audit; not used for validation.
+    ip           text NOT NULL DEFAULT '',
+    ua           text NOT NULL DEFAULT ''
+);
+
+CREATE INDEX sessions_user_idx ON sessions (user_id);
+
+-- ── tenant ↔ operator binding (ADR-0039 thin pass-through) ───────────────────
+-- The single seeded Tenant is bound to the first operator who logs in. A single
+-- nullable column (not a tenant_members table) keeps the binding thin; the
+-- X-Tenant-Id interceptor resolves the operator's tenant from it. ON DELETE SET
+-- NULL so removing a user unbinds rather than cascading away the campaign data.
+ALTER TABLE tenant
+    ADD COLUMN operator_user_id uuid REFERENCES users (id) ON DELETE SET NULL;
+
+-- +goose Down
+
+ALTER TABLE tenant DROP COLUMN IF EXISTS operator_user_id;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS users;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -87,6 +87,34 @@ type Agent struct {
 	UpdatedAt   time.Time
 }
 
+// User is a human operator authenticated via Discord OAuth (ADR-0016). The
+// Discord snowflake is the stable identity key; Name/Avatar are display-only and
+// refreshed from Discord on each login.
+type User struct {
+	ID            uuid.UUID
+	DiscordUserID string
+	Name          string
+	// Avatar is an absolute image URL (or empty).
+	Avatar    string
+	Role      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Session is a server-side login session (ADR-0016): the Token is the opaque
+// random secret carried in the glyphoxa_session cookie, and this row is the
+// authority. ExpiresAt gates validity; deleting the row revokes instantly.
+type Session struct {
+	ID         uuid.UUID
+	UserID     uuid.UUID
+	Token      string
+	CreatedAt  time.Time
+	LastSeenAt time.Time
+	ExpiresAt  time.Time
+	IP         string
+	UA         string
+}
+
 // LoadedAgent is an Agent with its bound Provider Configs resolved — the bundle
 // the orchestrator needs to bring an Agent to life (Persona, Voice, LLM/TTS
 // configs). Either config may be nil if the Agent has none bound.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -36,6 +36,18 @@ type Mount struct {
 	Handler http.Handler
 }
 
+// APIMount adapts a generated Connect handler pair — (mountPath, handler) as
+// returned by a service's Handler() method — into a [Mount] under the public
+// /api prefix. The browser dials Connect at baseUrl "/api"
+// (web/src/lib/transport.ts), so the handler is wrapped in
+// http.StripPrefix("/api", …) and registered at "/api"+mountPath; StripPrefix
+// removes the /api segment before the Connect handler matches its method path.
+// The stacked #68/#71 PRs reuse this to mount their services identically to
+// AuthService/CampaignService.
+func APIMount(mountPath string, handler http.Handler) Mount {
+	return Mount{Path: "/api" + mountPath, Handler: http.StripPrefix("/api", handler)}
+}
+
 // Config configures a [Server]. Logger defaults to slog.Default when nil. The
 // observability endpoints are NOT served here — they live on the separate
 // metrics port (see the package doc) — so this carries no recorder or probe.

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -73,7 +73,7 @@ func startServer(t *testing.T, mounts ...web.Mount) (base string, stop func()) {
 func mountFake(t *testing.T, svc fakeCampaignService) web.Mount {
 	t.Helper()
 	path, handler := managementv1connect.NewCampaignServiceHandler(svc)
-	return web.Mount{Path: "/api" + path, Handler: http.StripPrefix("/api", handler)}
+	return web.APIMount(path, handler)
 }
 
 func TestServerRoutesConnectThenShutsDown(t *testing.T) {

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -45,3 +45,50 @@ message GetActiveCampaignResponse {
   // campaign is the most-recently-created campaign for the operator.
   Campaign campaign = 1;
 }
+
+// AuthService exposes the operator's authenticated identity to the SPA boot
+// flow (ADR-0016 / ADR-0039). The session itself is issued by the net/http
+// Discord OAuth carve-out (ADR-0015); this Connect surface reads it back and
+// tears it down. The auth interceptor resolves the session cookie into the
+// request context, so GetCurrentUser fails with CodeUnauthenticated when no
+// valid session is present — the SPA's 401 → /login signal.
+service AuthService {
+  // GetCurrentUser returns the signed-in operator's display identity. It is a
+  // read (NO_SIDE_EFFECTS) and is reachable unauthenticated so the SPA can probe
+  // the session at boot: no/expired session fails with CodeUnauthenticated.
+  rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // Logout deletes the server-side session row and clears the session + CSRF
+  // cookies. It is state-changing, so the auth + CSRF interceptors guard it.
+  rpc Logout(LogoutRequest) returns (LogoutResponse);
+}
+
+// User is the signed-in operator's display identity (ADR-0016). It deliberately
+// omits the internal user id and Discord user id — the SPA only renders the
+// name, role, and avatar in the sidebar.
+message User {
+  // name is the operator's display name (Discord global name or username).
+  string name = 1;
+  // role is the operator's role label (e.g. "operator").
+  string role = 2;
+  // avatar is an absolute avatar image URL, or empty when none is set.
+  string avatar = 3;
+}
+
+// GetCurrentUserRequest is the (empty) request for GetCurrentUser; the operator
+// is resolved server-side from the session cookie.
+message GetCurrentUserRequest {}
+
+// GetCurrentUserResponse carries the signed-in operator's identity.
+message GetCurrentUserResponse {
+  // user is the signed-in operator.
+  User user = 1;
+}
+
+// LogoutRequest is the (empty) request for Logout; the session to delete is
+// resolved server-side from the session cookie.
+message LogoutRequest {}
+
+// LogoutResponse is the (empty) response for Logout.
+message LogoutResponse {}

--- a/web/src/app/AuthGate.test.tsx
+++ b/web/src/app/AuthGate.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AuthService,
+  GetCurrentUserResponseSchema,
+  UserSchema,
+  LogoutResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { AuthGate } from "./AuthGate";
+
+// useNavigate is mocked so the redirect is observable without a live router.
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigate }));
+
+beforeEach(() => navigate.mockClear());
+
+// authedTransport answers GetCurrentUser with a canned operator.
+function authedTransport() {
+  return createRouterTransport(({ service }) => {
+    service(AuthService, {
+      getCurrentUser: () =>
+        create(GetCurrentUserResponseSchema, {
+          user: create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" }),
+        }),
+      logout: () => create(LogoutResponseSchema, {}),
+    });
+  });
+}
+
+// unauthTransport fails GetCurrentUser with CodeUnauthenticated (no session).
+function unauthTransport() {
+  return createRouterTransport(({ service }) => {
+    service(AuthService, {
+      getCurrentUser: () => {
+        throw new ConnectError("no session", Code.Unauthenticated);
+      },
+      logout: () => create(LogoutResponseSchema, {}),
+    });
+  });
+}
+
+describe("AuthGate", () => {
+  it("redirects to /login when unauthenticated", async () => {
+    render(
+      <Providers transport={unauthTransport()} queryClient={makeQueryClient()}>
+        <AuthGate>{(user) => <div>{user.name}</div>}</AuthGate>
+      </Providers>,
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/login" }));
+  });
+
+  it("renders the shell with the real operator identity when authenticated", async () => {
+    render(
+      <Providers transport={authedTransport()} queryClient={makeQueryClient()}>
+        <AuthGate>{(user) => <div>shell for {user.name}</div>}</AuthGate>
+      </Providers>,
+    );
+    expect(await screen.findByText("shell for Sora Vance")).toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/AuthGate.tsx
+++ b/web/src/app/AuthGate.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { useQuery } from "@connectrpc/connect-query";
+import { useNavigate } from "@tanstack/react-router";
+import { ConnectError } from "@connectrpc/connect";
+
+import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+import { isUnauthenticated } from "@/lib/auth";
+
+// AuthGate is the SPA boot gate (ADR-0016 / ADR-0039): it probes
+// AuthService.GetCurrentUser and, on CodeUnauthenticated, redirects to /login.
+// On success it hands the resolved operator to its render-prop child (the app
+// shell), so the sidebar shows the real identity instead of a hardcoded one.
+// retry is off so a 401 redirects immediately rather than after react-query's
+// default backoff.
+export function AuthGate({ children }: { children: (user: User) => ReactNode }) {
+  const navigate = useNavigate();
+  const { data, status, error } = useQuery(
+    AuthService.method.getCurrentUser,
+    {},
+    { retry: false },
+  );
+
+  const unauthenticated = status === "error" && isUnauthenticated(error);
+
+  useEffect(() => {
+    if (unauthenticated) {
+      void navigate({ to: "/login" });
+    }
+  }, [unauthenticated, navigate]);
+
+  if (status === "success" && data.user) {
+    return <>{children(data.user)}</>;
+  }
+
+  // A non-401 error is a real failure (server down, etc.) — surface it rather
+  // than bouncing to /login, which would loop.
+  if (status === "error" && !unauthenticated) {
+    return (
+      <div className="gx-providers">
+        <p className="gx-campaign__error" role="alert">
+          Could not load your account: {ConnectError.from(error).message}
+        </p>
+      </div>
+    );
+  }
+
+  // Loading, or mid-redirect after a 401.
+  return <div className="gx-auth-boot" aria-busy="true" aria-label="Loading" />;
+}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -7,19 +7,29 @@ import {
 } from "@tanstack/react-router";
 
 import { AppShell } from "@/components/AppShell";
+import { AuthGate } from "@/app/AuthGate";
+import { Login } from "@/screens/login/Login";
 import { Configuration } from "@/screens/configuration/Configuration";
 import { Placeholder } from "@/screens/Placeholder";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
 // (/t/:tenantSlug/...) so URLs are bookmarkable; for the single-operator MVP
-// (ADR-0039) the slug is a thin pass-through. The boot flow's auth/onboarding
-// branches are deferred to later stages — this stage redirects the root to the
-// default tenant's Configuration screen.
+// (ADR-0039) the slug is a thin pass-through. The shell is wrapped in the
+// AuthGate (ADR-0016): it probes GetCurrentUser at boot and redirects to /login
+// on a 401, then hands the real operator identity to the shell.
 
 const DEFAULT_TENANT = "default";
 
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
+});
+
+// /login — the Discord-only OAuth entry (ADR-0016). It lives OUTSIDE the tenant
+// shell so it never triggers the AuthGate (which would loop).
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  component: Login,
 });
 
 // "/" → the default tenant's Configuration (boot flow stand-in for this stage).
@@ -34,13 +44,15 @@ const indexRoute = createRoute({
   },
 });
 
-// /t/:tenantSlug — the persistent shell hosting the screen Outlet.
+// /t/:tenantSlug — the persistent shell hosting the screen Outlet, gated by the
+// AuthGate so an unauthenticated visit redirects to /login and an authenticated
+// one renders the shell with the real operator identity.
 const tenantRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "t/$tenantSlug",
   component: function TenantLayout() {
     const { tenantSlug } = tenantRoute.useParams();
-    return <AppShell tenantSlug={tenantSlug} />;
+    return <AuthGate>{(user) => <AppShell tenantSlug={tenantSlug} user={user} />}</AuthGate>;
   },
 });
 
@@ -78,6 +90,7 @@ const screenRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  loginRoute,
   tenantRoute.addChildren([tenantIndexRoute, screenRoute]),
 ]);
 

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,16 +1,18 @@
 import type { ReactNode } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import { Dices, Settings, Swords, ScrollText, ChevronsUpDown } from "lucide-react";
+import { Dices, Settings, Swords, ScrollText } from "lucide-react";
 
-import { Avatar } from "./ui/Avatar";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+
+import { SidebarUser } from "./SidebarUser";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
 // ui_kits/glyphoxa-web/shell.jsx (its inline styles lifted onto .gx-shell* /
 // .gx-topbar* in styles/components.css) and driven by TanStack Router's active
 // route rather than page state (ADR-0018). The Tenant lives in the path
 // (/t/:tenantSlug/...); for the single-operator MVP (ADR-0039) it is a thin
-// pass-through slug, and the sidebar user footer is a static placeholder until
-// the auth/me RPC lands.
+// pass-through slug. The sidebar user footer now shows the real signed-in
+// operator (ADR-0016), passed in by the AuthGate that wraps the shell.
 
 type NavItem = { to: string; label: string; icon: ReactNode; title: string };
 
@@ -20,7 +22,7 @@ const NAV: NavItem[] = [
   { to: "session", label: "Session", icon: <ScrollText size={18} />, title: "Session" },
 ];
 
-export function AppShell({ tenantSlug }: { tenantSlug: string }) {
+export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User }) {
   const { screen } = useParams({ strict: false }) as { screen?: string };
   const active = NAV.find((n) => n.to === screen);
 
@@ -49,14 +51,7 @@ export function AppShell({ tenantSlug }: { tenantSlug: string }) {
           ))}
         </nav>
 
-        <div className="gx-sidebar__user">
-          <Avatar name="Operator" size="sm" status="live" />
-          <div className="gx-sidebar__user-meta">
-            <div className="gx-sidebar__user-name">Operator</div>
-            <div className="gx-sidebar__user-role">Self-host</div>
-          </div>
-          <ChevronsUpDown size={15} style={{ color: "var(--text-subtle)" }} />
-        </div>
+        <SidebarUser user={user} />
       </aside>
 
       <div className="gx-main">

--- a/web/src/components/SidebarUser.test.tsx
+++ b/web/src/components/SidebarUser.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AuthService,
+  UserSchema,
+  LogoutResponseSchema,
+  GetCurrentUserResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { SidebarUser } from "./SidebarUser";
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigate }));
+
+beforeEach(() => navigate.mockClear());
+
+describe("SidebarUser", () => {
+  it("renders the real operator identity", () => {
+    render(
+      <Providers transport={createRouterTransport(() => {})} queryClient={makeQueryClient()}>
+        <SidebarUser user={create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" })} />
+      </Providers>,
+    );
+    expect(screen.getByText("Sora Vance")).toBeInTheDocument();
+    expect(screen.getByText("operator")).toBeInTheDocument();
+  });
+
+  it("logs out — calls Logout and redirects to /login", async () => {
+    let loggedOut = false;
+    const transport = createRouterTransport(({ service }) => {
+      service(AuthService, {
+        getCurrentUser: () =>
+          create(GetCurrentUserResponseSchema, { user: create(UserSchema, {}) }),
+        logout: () => {
+          loggedOut = true;
+          return create(LogoutResponseSchema, {});
+        },
+      });
+    });
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <SidebarUser user={create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" })} />
+      </Providers>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /log out/i }));
+
+    await waitFor(() => expect(loggedOut).toBe(true));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/login" }));
+  });
+});

--- a/web/src/components/SidebarUser.tsx
+++ b/web/src/components/SidebarUser.tsx
@@ -1,0 +1,52 @@
+import { useMutation } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { LogOut } from "lucide-react";
+
+import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+
+import { Avatar } from "./ui/Avatar";
+
+// SidebarUser is the app-shell footer identity (ADR-0016 / ADR-0039): it renders
+// the real signed-in operator (name / role / avatar) the AuthGate resolved,
+// replacing the design's hardcoded "Operator / Sora Vance". The logout button
+// calls AuthService.Logout, which deletes the server-side session row and clears
+// the cookies; on success it drops the cached queries and routes to /login.
+export function SidebarUser({ user }: { user: User }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const logout = useMutation(AuthService.method.logout, {
+    onSuccess: () => {
+      queryClient.clear();
+      void navigate({ to: "/login" });
+    },
+  });
+
+  return (
+    <div className="gx-sidebar__user">
+      <Avatar name={user.name} src={user.avatar || null} size="sm" status="live" />
+      <div className="gx-sidebar__user-meta">
+        <div className="gx-sidebar__user-name">{user.name}</div>
+        <div className="gx-sidebar__user-role">{user.role}</div>
+      </div>
+      <button
+        type="button"
+        className="gx-sidebar__logout"
+        aria-label="Log out"
+        onClick={() => logout.mutate({})}
+        disabled={logout.isPending}
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--text-subtle)",
+          cursor: "pointer",
+          padding: 4,
+        }}
+      >
+        <LogOut size={15} />
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,10 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
+// isUnauthenticated reports whether an error from a Connect call is the
+// server's CodeUnauthenticated — the SPA's "no/expired session" signal that
+// drives the boot redirect to /login (ADR-0016). ConnectError.from normalizes
+// any thrown value; a non-Connect error resolves to Code.Unknown, not
+// Unauthenticated, so only a real 401 triggers the redirect.
+export function isUnauthenticated(error: unknown): boolean {
+  return ConnectError.from(error).code === Code.Unauthenticated;
+}

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -1,9 +1,33 @@
 import { createConnectTransport } from "@connectrpc/connect-web";
+import type { Interceptor } from "@connectrpc/connect";
 
 // The browser dials Connect-JSON at /api (ADR-0015 — JSON keeps the network tab
 // human-readable). In dev, Vite proxies /api → the Go web tier (vite.config.ts);
 // in prod the Go binary serves the SPA and mounts the Connect handler under /api
-// on the same origin, so a relative baseUrl is correct in both modes.
+// on the same origin, so a relative baseUrl is correct in both modes. The
+// session cookie rides along automatically (same-origin); the CSRF interceptor
+// adds the double-submit header.
+
+// readCookie returns a cookie value by name, or null. Used to mirror the
+// non-HttpOnly glyphoxa_csrf cookie into the request header.
+function readCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+// csrf is the double-submit CSRF interceptor (ADR-0016): it echoes the
+// glyphoxa_csrf cookie into the X-CSRF-Token header that the server's CSRF
+// interceptor checks on state-changing calls. Harmless on reads (the server
+// exempts NO_SIDE_EFFECTS RPCs); required on mutations like Logout.
+const csrf: Interceptor = (next) => (req) => {
+  const token = readCookie("glyphoxa_csrf");
+  if (token) {
+    req.header.set("X-CSRF-Token", token);
+  }
+  return next(req);
+};
+
 export const transport = createConnectTransport({
   baseUrl: "/api",
+  interceptors: [csrf],
 });

--- a/web/src/screens/login/Login.test.tsx
+++ b/web/src/screens/login/Login.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Login } from "./Login";
+
+describe("Login", () => {
+  it("offers Continue with Discord pointing at the OAuth start", () => {
+    render(<Login />);
+    const link = screen.getByRole("link", { name: /continue with discord/i });
+    expect(link).toHaveAttribute("href", "/auth/discord/login");
+  });
+
+  it("renders Google and GitHub as disabled coming-soon slots", () => {
+    render(<Login />);
+    expect(screen.getByRole("button", { name: /google/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /github/i })).toBeDisabled();
+    expect(screen.getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -1,0 +1,37 @@
+import { Dices } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+
+import "./login.css";
+
+// The Login screen (ADR-0016: Discord-only OAuth). No design handoff exists for
+// it, so this is the minimal gate the self-host operator needs: a "Continue with
+// Discord" link that starts the net/http OAuth carve-out (/auth/discord/login),
+// with Google/GitHub rendered DISABLED + "coming soon" (wired in v1.5+). It is a
+// full-page link, not a Connect call — OAuth is HTML redirects (ADR-0015).
+export function Login() {
+  return (
+    <div className="gx-login">
+      <div className="gx-login__card">
+        <span className="gx-login__sigil">
+          <Dices size={24} />
+        </span>
+        <h1 className="gx-login__wordmark gx-gradient-text">Glyphoxa</h1>
+        <p className="gx-login__lede">Sign in to run your table.</p>
+
+        <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
+          Continue with Discord
+        </a>
+
+        <div className="gx-login__soon">
+          <Button variant="secondary" block disabled>
+            Continue with Google · coming soon
+          </Button>
+          <Button variant="secondary" block disabled>
+            Continue with GitHub · coming soon
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/login/login.css
+++ b/web/src/screens/login/login.css
@@ -1,0 +1,50 @@
+/* Login screen — the minimal Discord-only auth gate (ADR-0016). Centered arcane
+   card on the app surface; reuses the gx- token vocabulary. */
+.gx-login {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.gx-login__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  max-width: 360px;
+  padding: 32px 28px;
+  background: var(--surface-card, #16131f);
+  border: 1px solid var(--border-subtle, #2a2535);
+  border-radius: 16px;
+  text-align: center;
+}
+
+.gx-login__sigil {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  color: #fff;
+  background: linear-gradient(135deg, #9059ff, #00ddff);
+}
+
+.gx-login__wordmark {
+  margin: 4px 0 0;
+  font-size: 26px;
+}
+
+.gx-login__lede {
+  margin: 0 0 8px;
+  color: var(--text-subtle, #9a93a8);
+}
+
+.gx-login__soon {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+}


### PR DESCRIPTION
Closes #67. Gates the app behind Discord OAuth for a single operator (ADR-0016 / ADR-0039), end to end: migration → storage → net/http OAuth carve-out → Connect interceptor stack + `AuthService` → SPA boot gate. This is the bottom of the stack #68 (config) and #71 (campaign) build on.

## What & why
- **Schema (`00003_auth.sql`)** — `users` (`discord_user_id` unique, name/avatar/role) + server-side `sessions` (opaque `crypto/rand` token, `expires_at`, ip/ua) per ADR-0016. The single-operator↔tenant link is one thin nullable column `tenant.operator_user_id` (ADR-0039 — **not** a `tenant_members` table/roles/switcher). Additive, with a Down.
- **Storage** — `UpsertUser`, `GetUserByDiscordID`, `CreateSession`, `AuthenticateSession` (expiry-gated, bumps `last_seen_at`), `DeleteSession` (idempotent), `ResolveOperatorTenant` (atomic resolve-or-seed+bind the first operator), `TenantForUser`. The cookie token is opaque random, never a JWT.
- **OAuth (net/http, ADR-0015 carve-out)** — `/auth/discord/login` (state nonce → authorize redirect) and `/auth/discord/callback` (exchange → upsert → bind tenant → issue `glyphoxa_session` HttpOnly/Secure/SameSite=Lax + `glyphoxa_csrf`). The Discord token exchange + userinfo sit behind the `DiscordOAuth` interface; CI uses a **fake/cassette** — no live Discord call.
- **`AuthService` (Connect)** — `GetCurrentUser` → `{name, role, avatar}`, `CodeUnauthenticated` on no/expired session; `Logout` deletes the session row + clears the cookies.
- **Frontend** — `/login` (Continue with Discord; Google/GitHub disabled "coming soon"); `AuthGate` probes `GetCurrentUser` at boot → `/login` on 401, else renders the shell with the real sidebar identity (replaces hardcoded "Operator/Sora Vance"); logout deletes the session row. Transport mirrors the CSRF cookie into `X-CSRF-Token`.

## Reusable seam for #68 / #71
- `auth.NewStack(authn, tenantResolver, public...)` → `stack.HandlerOptions()` installs **auth → CSRF double-submit → X-Tenant-Id pass-through** on any generated Connect handler. `*storage.Store` satisfies both `Authenticator` (`AuthenticateSession`) and `TenantResolver` (`TenantForUser`); `managementv1connect.AuthServiceGetCurrentUserProcedure` is the one public procedure.
- ctx accessors `auth.CurrentUser(ctx)` / `auth.TenantID(ctx)` (and `auth.WithUser` / `auth.WithTenant`).
- `web.APIMount(mountPath, handler)` — the `StripPrefix("/api", …)` mount helper, used for both services in `runWeb`.

CSRF/auth classification keys on the proto `idempotency_level`: reads (`NO_SIDE_EFFECTS`) skip CSRF and let `GetCurrentUser` self-handle the 401; everything else requires a valid session, and state-changing calls require a matching CSRF token.

## Test coverage (issue acceptance)
- Cookie issuance + server-side validation: valid → user; missing/expired → 401 (`internal/auth` unit + e2e; `internal/storage` session lifecycle).
- Auth interceptor rejects unauthenticated state-changing RPCs; CSRF double-submit enforced (`internal/auth`).
- OAuth token exchange via cassette/fake — no live Discord (`discord_test.go`, `oauth_test.go`).
- SPA: unauth → `/login`; auth → shell real identity; logout (`web` vitest).
- E2E (`//go:build integration`, real Postgres): callback issues cookie → `GetCurrentUser` validates → `Logout` deletes the session row.

## Local CI — all green
`buf generate` · `buf lint` · `go build ./...` · `go vet ./...` · `go vet -tags=record ./...` · `go test -race ./...` · `go test -race -tags=integration ./...` · `cd web && npm ci && npm run build && npm run test` (8 tests).

> Live end-to-end login needs an operator-registered Discord OAuth app (`DISCORD_OAUTH_CLIENT_ID` / `_SECRET` / `_REDIRECT_URL`) — a one-time setup, not code. Absent it the gate stands and `runWeb` logs a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)