### PR TITLE
Stage 7 — Campaign screen: edit Butler + CRUD NPCs (#71)

### DIFF
--- a/cmd/glyphoxa/main_test.go
+++ b/cmd/glyphoxa/main_test.go
@@ -18,8 +18,11 @@ import (
 // fakeCampaignService is a canned CampaignServiceHandler so runWebTier can be
 // exercised without Postgres: the keyless default gate (ADR-0021/0033) must
 // prove the web tier boots, serves the Connect API, and shuts down on ctx cancel
-// with no DB or Discord credentials in play.
-type fakeCampaignService struct{}
+// with no DB or Discord credentials in play. The embedded Unimplemented handler
+// supplies the roster + CRUD methods (#71) this test does not exercise.
+type fakeCampaignService struct {
+	managementv1connect.UnimplementedCampaignServiceHandler
+}
 
 func (fakeCampaignService) GetActiveCampaign(
 	context.Context,

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
@@ -20,23 +21,30 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// campaignReader is the read surface CampaignServer needs. *storage.Store
-// satisfies it via GetActiveCampaign, so handlers can be driven by a fake in
-// unit tests and the real store in integration tests.
-type campaignReader interface {
+// campaignStore is the narrow storage surface CampaignServer needs — the active
+// campaign read plus the roster reads and the agent CRUD writes (#71).
+// *storage.Store satisfies it, so handlers can be driven by a fake in unit tests
+// and the real store in integration tests.
+type campaignStore interface {
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
+	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
+	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
+	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
+	DeleteAgent(ctx context.Context, id uuid.UUID) error
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a
-// campaignReader.
+// campaignStore.
 type CampaignServer struct {
-	reader campaignReader
+	store campaignStore
 }
 
-// NewCampaignServer wraps a campaignReader (e.g. *storage.Store) in a
+// NewCampaignServer wraps a campaignStore (e.g. *storage.Store) in a
 // CampaignServer.
-func NewCampaignServer(r campaignReader) *CampaignServer {
-	return &CampaignServer{reader: r}
+func NewCampaignServer(s campaignStore) *CampaignServer {
+	return &CampaignServer{store: s}
 }
 
 // compile-time assertion that CampaignServer satisfies the generated handler.
@@ -49,7 +57,7 @@ func (s *CampaignServer) GetActiveCampaign(
 	ctx context.Context,
 	_ *connect.Request[managementv1.GetActiveCampaignRequest],
 ) (*connect.Response[managementv1.GetActiveCampaignResponse], error) {
-	c, err := s.reader.GetActiveCampaign(ctx)
+	c, err := s.store.GetActiveCampaign(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/campaign_crud.go
+++ b/internal/rpc/campaign_crud.go
@@ -1,0 +1,210 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Campaign-screen CRUD handlers (#71) on CampaignServer: the roster read plus
+// agent create/update/delete over the polymorphic agents table (ADR-0009).
+// Reads/writes resolve the single operator's active campaign server-side, the
+// same single-tenant pass-through GetActiveCampaign uses (ADR-0039); per-tenant
+// scoping fills in behind the X-Tenant-Id interceptor later.
+
+// GetCampaignRoster returns the active campaign with its ordered roster: the
+// Butler first, then the Character NPCs. No campaign yields CodeNotFound; a
+// missing Butler is an ADR-0009 invariant violation (logged, CodeInternal).
+func (s *CampaignServer) GetCampaignRoster(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetCampaignRosterRequest],
+) (*connect.Response[managementv1.GetCampaignRosterResponse], error) {
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("GetCampaignRoster: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	butler, err := s.store.GetButler(ctx, c.ID)
+	if err != nil {
+		// The Butler is auto-created with the campaign (ADR-0009); its absence is
+		// an invariant violation, not a client error. Log raw, return generic.
+		slog.Default().Error("GetCampaignRoster: get butler failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	chars, err := s.store.CharacterAgents(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("GetCampaignRoster: list character agents failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	roster := make([]*managementv1.Agent, 0, len(chars)+1)
+	roster = append(roster, toProtoAgent(butler))
+	for _, a := range chars {
+		roster = append(roster, toProtoAgent(a))
+	}
+
+	return connect.NewResponse(&managementv1.GetCampaignRosterResponse{
+		Campaign: toProtoCampaign(c),
+		Roster:   roster,
+	}), nil
+}
+
+// CreateAgent adds a Character NPC to the active campaign and returns it with its
+// server-assigned speaker-colour slot. The role is always 'character'.
+func (s *CampaignServer) CreateAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.CreateAgentRequest],
+) (*connect.Response[managementv1.CreateAgentResponse], error) {
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("CreateAgent: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	m := req.Msg
+	id, err := s.store.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  c.ID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        m.GetName(),
+		Title:       m.GetTitle(),
+		Persona:     m.GetPersona(),
+		Voice:       marshalVoice(m.GetVoice()),
+		AddressOnly: m.GetAddressOnly(),
+		Aliases:     m.GetAliases(),
+	})
+	if err != nil {
+		slog.Default().Error("CreateAgent: store create failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Read the row back so the response carries the assigned speaker-colour slot
+	// and the canonical persisted shape.
+	created, err := s.store.GetAgent(ctx, id)
+	if err != nil {
+		slog.Default().Error("CreateAgent: read-back failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.CreateAgentResponse{Agent: toProtoAgent(created)}), nil
+}
+
+// UpdateAgent saves an agent's editor fields and returns the updated agent. The
+// store force-keeps a Butler's role and Address-Only (ADR-0009 / ADR-0024). An
+// unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
+func (s *CampaignServer) UpdateAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateAgentRequest],
+) (*connect.Response[managementv1.UpdateAgentResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	m := req.Msg
+	updated, err := s.store.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          id,
+		Name:        m.GetName(),
+		Title:       m.GetTitle(),
+		Persona:     m.GetPersona(),
+		Voice:       marshalVoice(m.GetVoice()),
+		AddressOnly: m.GetAddressOnly(),
+		Aliases:     m.GetAliases(),
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("UpdateAgent: store update failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UpdateAgentResponse{Agent: toProtoAgent(updated)}), nil
+}
+
+// DeleteAgent removes a Character NPC. Deleting the Butler is CodeFailedPrecondition
+// (ADR-0009); an unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
+func (s *CampaignServer) DeleteAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteAgentRequest],
+) (*connect.Response[managementv1.DeleteAgentResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	switch err := s.store.DeleteAgent(ctx, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.DeleteAgentResponse{}), nil
+	case errors.Is(err, storage.ErrButlerUndeletable):
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the butler cannot be deleted"))
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+	default:
+		slog.Default().Error("DeleteAgent: store delete failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// toProtoAgent maps a storage.Agent onto its wire representation. The encrypted
+// provider bindings are intentionally not exposed (ADR-0004); voice is reduced
+// to its opaque voice id.
+func toProtoAgent(a storage.Agent) *managementv1.Agent {
+	return &managementv1.Agent{
+		Id:           a.ID.String(),
+		CampaignId:   a.CampaignID.String(),
+		Role:         string(a.Role),
+		Name:         a.Name,
+		Title:        a.Title,
+		Persona:      a.Persona,
+		Voice:        unmarshalVoice(a.Voice),
+		AddressOnly:  a.AddressOnly,
+		SpeakerColor: uint32(a.SpeakerColor),
+		Aliases:      a.Aliases,
+	}
+}
+
+// voiceBlob is the minimal shape of an Agent's voice JSONB this slice reads and
+// writes: a single voice id. The column is JSONB so the shape can grow without a
+// migration (ADR-0022/0023); the editor only selects a voice id today.
+type voiceBlob struct {
+	VoiceID string `json:"voice_id"`
+}
+
+// marshalVoice wraps a selected voice id into the voice JSONB. An empty id yields
+// the empty object the schema defaults to, so "no voice" round-trips cleanly.
+func marshalVoice(voiceID string) []byte {
+	if voiceID == "" {
+		return []byte(`{}`)
+	}
+	b, err := json.Marshal(voiceBlob{VoiceID: voiceID})
+	if err != nil { // a string field cannot fail to marshal; guard defensively
+		return []byte(`{}`)
+	}
+	return b
+}
+
+// unmarshalVoice extracts the voice id from an Agent's voice JSONB, returning ""
+// for an empty/unparsable blob.
+func unmarshalVoice(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v voiceBlob
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	return v.VoiceID
+}

--- a/internal/rpc/campaign_crud_integration_test.go
+++ b/internal/rpc/campaign_crud_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+// This drives the CampaignService CRUD + roster handlers end to end over
+// Connect-JSON against a real *storage.Store (testcontainers Postgres), proving
+// the wire → store → wire round-trip including the auto-Butler invariant
+// (ADR-0009). Tag-isolated behind `integration`; reuses startPostgres/seedStore
+// from campaign_integration_test.go.
+
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+)
+
+func TestCampaignCRUD_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, _ := seedStore(t, dsn) // seedStore inserts a campaign → auto-Butler fires
+
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
+	)
+	ctx := context.Background()
+
+	// Roster starts with the auto-Butler alone, Address-Only and first.
+	roster, err := client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (initial): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 1 {
+		t.Fatalf("initial roster len = %d, want 1 (butler only)", got)
+	}
+	butler := roster.Msg.GetRoster()[0]
+	if butler.GetRole() != "butler" || !butler.GetAddressOnly() {
+		t.Fatalf("roster[0] is not the Address-Only Butler: %+v", butler)
+	}
+	if roster.Msg.GetCampaign().GetName() != "Lost Mine" || roster.Msg.GetCampaign().GetSystem() != "dnd5e" {
+		t.Errorf("campaign title/system wrong: %+v", roster.Msg.GetCampaign())
+	}
+
+	// Add an NPC.
+	created, err := client.CreateAgent(ctx, connect.NewRequest(&managementv1.CreateAgentRequest{
+		Name: "Bart", Title: "Gruff innkeeper", Persona: "Grumbles.", Voice: "rachel",
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	bart := created.Msg.GetAgent()
+	if bart.GetRole() != "character" || bart.GetTitle() != "Gruff innkeeper" || bart.GetVoice() != "rachel" {
+		t.Errorf("created NPC fields wrong: %+v", bart)
+	}
+
+	// Edit every editor field, then reload the roster and assert it reloads
+	// identically (the acceptance round-trip).
+	if _, err := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{
+		Id: bart.GetId(), Name: "Bartholomew", Title: "Keeper of the Inn",
+		Persona: "Now grandiose.", Voice: "adam", AddressOnly: true, Aliases: []string{"Bart"},
+	})); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+
+	roster, err = client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (after update): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 2 {
+		t.Fatalf("roster len = %d, want 2 (butler + bart)", got)
+	}
+	reloaded := roster.Msg.GetRoster()[1]
+	if reloaded.GetName() != "Bartholomew" || reloaded.GetTitle() != "Keeper of the Inn" {
+		t.Errorf("update did not round-trip: %+v", reloaded)
+	}
+	if reloaded.GetVoice() != "adam" || !reloaded.GetAddressOnly() || len(reloaded.GetAliases()) != 1 {
+		t.Errorf("voice/address_only/aliases did not round-trip: %+v", reloaded)
+	}
+	if reloaded.GetSpeakerColor() != bart.GetSpeakerColor() {
+		t.Errorf("speaker_color flapped across update: %d → %d", bart.GetSpeakerColor(), reloaded.GetSpeakerColor())
+	}
+
+	// The Butler cannot be deleted (ADR-0009) — CodeFailedPrecondition.
+	_, err = client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: butler.GetId()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("DeleteAgent(butler) code = %v, want FailedPrecondition", got)
+	}
+
+	// The NPC deletes cleanly; the roster shrinks back to the Butler alone.
+	if _, err := client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: bart.GetId()})); err != nil {
+		t.Fatalf("DeleteAgent(bart): %v", err)
+	}
+	roster, err = client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (after delete): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 1 {
+		t.Fatalf("roster len after delete = %d, want 1 (butler only)", got)
+	}
+
+	// Deleting a missing agent is CodeNotFound.
+	_, err = client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: bart.GetId()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("DeleteAgent(already-gone) code = %v, want NotFound", got)
+	}
+
+	// Sanity: the Butler survived the rejected delete and is still Address-Only.
+	campaignID := uuid.MustParse(butler.GetCampaignId())
+	survivor, err := store.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("Butler missing after rejected delete: %v", err)
+	}
+	if !survivor.AddressOnly {
+		t.Error("Butler lost Address-Only after the rejected delete")
+	}
+}

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -1,0 +1,339 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeCampaignStore is a small in-memory campaignStore for the CRUD handlers'
+// keyless unit tests. Error hooks (campErr/butlerErr/…) force the failure paths;
+// the agents map backs GetAgent/Create/Update/Delete so happy paths round-trip
+// without a database.
+type fakeCampaignStore struct {
+	campaign  storage.Campaign
+	campErr   error
+	butler    storage.Agent
+	butlerErr error
+	chars     []storage.Agent
+	charsErr  error
+
+	agents    map[uuid.UUID]storage.Agent
+	createErr error
+	updateErr error
+	deleteErr error
+	nextColor int
+
+	created []storage.NewAgent
+}
+
+func newFakeStore() *fakeCampaignStore {
+	return &fakeCampaignStore{agents: map[uuid.UUID]storage.Agent{}}
+}
+
+func (f *fakeCampaignStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	return f.campaign, f.campErr
+}
+
+func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
+	return f.butler, f.butlerErr
+}
+
+func (f *fakeCampaignStore) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return f.chars, f.charsErr
+}
+
+func (f *fakeCampaignStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeCampaignStore) CreateAgent(_ context.Context, a storage.NewAgent) (uuid.UUID, error) {
+	if f.createErr != nil {
+		return uuid.Nil, f.createErr
+	}
+	f.created = append(f.created, a)
+	id := uuid.New()
+	f.agents[id] = storage.Agent{
+		ID:           id,
+		CampaignID:   a.CampaignID,
+		Role:         a.Role,
+		Name:         a.Name,
+		Title:        a.Title,
+		Persona:      a.Persona,
+		Voice:        a.Voice,
+		AddressOnly:  a.AddressOnly,
+		SpeakerColor: f.nextColor,
+		Aliases:      a.Aliases,
+	}
+	f.nextColor++
+	return id, nil
+}
+
+func (f *fakeCampaignStore) UpdateAgent(_ context.Context, u storage.AgentUpdate) (storage.Agent, error) {
+	if f.updateErr != nil {
+		return storage.Agent{}, f.updateErr
+	}
+	a, ok := f.agents[u.ID]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	a.Name = u.Name
+	a.Title = u.Title
+	a.Persona = u.Persona
+	a.Voice = u.Voice
+	a.AddressOnly = u.AddressOnly
+	a.Aliases = u.Aliases
+	f.agents[u.ID] = a
+	return a, nil
+}
+
+func (f *fakeCampaignStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	if _, ok := f.agents[id]; !ok {
+		return storage.ErrNotFound
+	}
+	delete(f.agents, id)
+	return nil
+}
+
+// crudClient stands up the full CampaignService handler over an httptest server
+// and returns a Connect-JSON client.
+func crudClient(t *testing.T, store *fakeCampaignStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
+	)
+}
+
+func TestGetCampaignRoster_Order(t *testing.T) {
+	t.Parallel()
+
+	campID := uuid.New()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine", System: "dnd5e", Language: "en"}
+	store.butler = storage.Agent{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleButler, Name: "Glyphoxa", AddressOnly: true, SpeakerColor: 0}
+	store.chars = []storage.Agent{
+		{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "Ana", Title: "Scout", SpeakerColor: 0},
+		{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "Borin", Title: "Smith", SpeakerColor: 1},
+	}
+
+	client := crudClient(t, store)
+	resp, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster: %v", err)
+	}
+	if got := resp.Msg.GetCampaign().GetName(); got != "Lost Mine" {
+		t.Errorf("campaign name = %q, want Lost Mine", got)
+	}
+	roster := resp.Msg.GetRoster()
+	if len(roster) != 3 {
+		t.Fatalf("roster len = %d, want 3 (butler + 2)", len(roster))
+	}
+	if roster[0].GetRole() != "butler" || !roster[0].GetAddressOnly() {
+		t.Errorf("roster[0] should be the Address-Only Butler: %+v", roster[0])
+	}
+	if roster[1].GetName() != "Ana" || roster[2].GetName() != "Borin" {
+		t.Errorf("character order not preserved: %q, %q", roster[1].GetName(), roster[2].GetName())
+	}
+	if roster[1].GetTitle() != "Scout" {
+		t.Errorf("title not mapped: %q", roster[1].GetTitle())
+	}
+	if roster[2].GetSpeakerColor() != 1 {
+		t.Errorf("speaker_color not mapped: %d", roster[2].GetSpeakerColor())
+	}
+}
+
+func TestGetCampaignRoster_NoCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestGetCampaignRoster_ButlerMissingIsInternal(t *testing.T) {
+	t.Parallel()
+	// A campaign with no Butler is an ADR-0009 invariant violation, not a client
+	// error: it maps to Internal, not NotFound.
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.butlerErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestCreateAgent_IsCharacterWithColor(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.nextColor = 2
+	client := crudClient(t, store)
+
+	resp, err := client.CreateAgent(context.Background(),
+		connect.NewRequest(&managementv1.CreateAgentRequest{
+			Name: "New NPC", Title: "Wanderer", Persona: "Mysterious.", Voice: "adam",
+		}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	agent := resp.Msg.GetAgent()
+	if agent.GetRole() != "character" {
+		t.Errorf("created role = %q, want character", agent.GetRole())
+	}
+	if agent.GetName() != "New NPC" || agent.GetTitle() != "Wanderer" {
+		t.Errorf("fields not mapped: %+v", agent)
+	}
+	if agent.GetVoice() != "adam" {
+		t.Errorf("voice did not round-trip: %q, want adam", agent.GetVoice())
+	}
+	if agent.GetSpeakerColor() != 2 {
+		t.Errorf("speaker_color = %d, want the assigned 2", agent.GetSpeakerColor())
+	}
+	// The handler must force role 'character' regardless of any client intent.
+	if len(store.created) != 1 || store.created[0].Role != storage.AgentRoleCharacter {
+		t.Errorf("store was not asked to create a character: %+v", store.created)
+	}
+}
+
+func TestCreateAgent_NoCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.CreateAgent(context.Background(),
+		connect.NewRequest(&managementv1.CreateAgentRequest{Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestUpdateAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: "not-a-uuid", Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: uuid.New().String(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestUpdateAgent_HappyPathRoundTrips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old", SpeakerColor: 3}
+	client := crudClient(t, store)
+
+	resp, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{
+			Id: id.String(), Name: "New", Title: "Renamed", Persona: "Changed.",
+			Voice: "rachel", AddressOnly: true, Aliases: []string{"alt"},
+		}))
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	a := resp.Msg.GetAgent()
+	if a.GetName() != "New" || a.GetTitle() != "Renamed" || a.GetPersona() != "Changed." {
+		t.Errorf("editor fields not applied: %+v", a)
+	}
+	if a.GetVoice() != "rachel" || !a.GetAddressOnly() || len(a.GetAliases()) != 1 {
+		t.Errorf("voice/address_only/aliases not applied: %+v", a)
+	}
+	if a.GetSpeakerColor() != 3 {
+		t.Errorf("speaker_color must be immutable across update: %d", a.GetSpeakerColor())
+	}
+}
+
+func TestDeleteAgent_ButlerIsFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.deleteErr = storage.ErrButlerUndeletable
+	client := crudClient(t, store)
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+}
+
+func TestDeleteAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestDeleteAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestDeleteAgent_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Doomed"}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if _, ok := store.agents[id]; ok {
+		t.Error("agent was not removed from the store")
+	}
+}

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -27,6 +27,28 @@ func (f fakeReader) GetActiveCampaign(context.Context) (storage.Campaign, error)
 	return f.campaign, f.err
 }
 
+// The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
+// tests; stub it so fakeReader still satisfies the widened interface. The CRUD
+// handlers have their own fake (campaign_crud_test.go).
+func (fakeReader) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return nil, nil
+}
+func (fakeReader) GetAgent(context.Context, uuid.UUID) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) CreateAgent(context.Context, storage.NewAgent) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+func (fakeReader) UpdateAgent(context.Context, storage.AgentUpdate) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) DeleteAgent(context.Context, uuid.UUID) error {
+	return nil
+}
+
 // newClient stands up the CampaignServer handler behind an httptest server and
 // returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on
 // the wire (the default is binary proto), so this also asserts the RPC is

--- a/internal/storage/agent_crud_test.go
+++ b/internal/storage/agent_crud_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestCreateUpdateDeleteCharacterAgent round-trips the editor CRUD (#71): create
+// a Character with a title, read it back, update its editable fields, then delete
+// it. Each step is verified through a fresh GetAgent so the assertions reflect
+// what actually landed in Postgres.
+func TestCreateUpdateDeleteCharacterAgent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	id, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  campaignID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        "Bart",
+		Title:       "Gruff innkeeper",
+		Persona:     "Wipes the bar and grumbles.",
+		Voice:       []byte(`{"voice_id":"rachel"}`),
+		AddressOnly: false,
+		Aliases:     []string{"Barty"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	got, err := st.GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgent after create: %v", err)
+	}
+	if got.Role != storage.AgentRoleCharacter {
+		t.Errorf("role = %q, want character", got.Role)
+	}
+	if got.Title != "Gruff innkeeper" {
+		t.Errorf("title = %q, want %q", got.Title, "Gruff innkeeper")
+	}
+	if got.Name != "Bart" || got.Persona != "Wipes the bar and grumbles." {
+		t.Errorf("name/persona not persisted: %+v", got)
+	}
+	// First Character in the campaign → slot 0 (round-robin index, see CreateAgent).
+	if got.SpeakerColor != 0 {
+		t.Errorf("speaker_color = %d, want 0 for the first character", got.SpeakerColor)
+	}
+
+	// Update the editable fields.
+	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          id,
+		Name:        "Bartholomew",
+		Title:       "Keeper of the Stonehill Inn",
+		Persona:     "Now eloquent and grandiose.",
+		Voice:       []byte(`{"voice_id":"adam"}`),
+		AddressOnly: true,
+		Aliases:     []string{"Bart", "the keeper"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	if updated.Name != "Bartholomew" || updated.Title != "Keeper of the Stonehill Inn" {
+		t.Errorf("update did not return new name/title: %+v", updated)
+	}
+	if !updated.AddressOnly {
+		t.Error("address_only did not persist true on a Character")
+	}
+	// speaker_color is immutable across an update.
+	if updated.SpeakerColor != 0 {
+		t.Errorf("speaker_color changed on update = %d, want 0", updated.SpeakerColor)
+	}
+
+	reloaded, err := st.GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgent after update: %v", err)
+	}
+	if reloaded.Name != "Bartholomew" || !reloaded.AddressOnly || len(reloaded.Aliases) != 2 {
+		t.Errorf("update did not round-trip to DB: %+v", reloaded)
+	}
+
+	// Delete it; it must then be gone.
+	if err := st.DeleteAgent(ctx, id); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if _, err := st.GetAgent(ctx, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetAgent after delete: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteButlerRejected asserts the Butler cannot be deleted (ADR-0009): the
+// auto-created Butler stays, and DeleteAgent returns the distinct
+// ErrButlerUndeletable (the RPC maps it to CodeFailedPrecondition).
+func TestDeleteButlerRejected(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	err = st.DeleteAgent(ctx, butler.ID)
+	if !errors.Is(err, storage.ErrButlerUndeletable) {
+		t.Fatalf("DeleteAgent(butler) = %v, want ErrButlerUndeletable", err)
+	}
+	// The Butler must still be there.
+	if _, err := st.GetButler(ctx, campaignID); err != nil {
+		t.Fatalf("Butler gone after a rejected delete: %v", err)
+	}
+}
+
+// TestUpdateButlerKeepsAddressOnly asserts editing the Butler can neither demote
+// its role nor turn off Address-Only (ADR-0009 / ADR-0024): even with
+// AddressOnly:false in the request, the stored Butler stays Address-Only and a
+// 'butler' role.
+func TestUpdateButlerKeepsAddressOnly(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          butler.ID,
+		Name:        "Glyphoxa the Wise",
+		Title:       "Game Master's Familiar",
+		Persona:     "A patient arcane butler.",
+		AddressOnly: false, // try to turn Address-Only OFF — must be ignored
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgent(butler): %v", err)
+	}
+	if !updated.AddressOnly {
+		t.Error("Butler address_only was turned off; it must stay true")
+	}
+	if updated.Role != storage.AgentRoleButler {
+		t.Errorf("Butler role changed to %q; it must stay butler", updated.Role)
+	}
+	if updated.Name != "Glyphoxa the Wise" || updated.Title != "Game Master's Familiar" {
+		t.Errorf("Butler editable fields did not persist: %+v", updated)
+	}
+
+	// And it remains the campaign's one Butler, still Address-Only on reload.
+	reloaded, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler after update: %v", err)
+	}
+	if !reloaded.AddressOnly || reloaded.Role != storage.AgentRoleButler {
+		t.Errorf("Butler invariant broke on reload: %+v", reloaded)
+	}
+}
+
+// TestCreateAgentAssignsStableSpeakerColors asserts Characters get distinct,
+// round-robin speaker-colour slots in creation order, and that the slot is
+// stable across reloads (#71).
+func TestCreateAgentAssignsStableSpeakerColors(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	names := []string{"Ana", "Borin", "Cora"}
+	ids := make([]uuid.UUID, len(names))
+	for i, n := range names {
+		id, err := st.CreateAgent(ctx, storage.NewAgent{
+			CampaignID: campaignID,
+			Role:       storage.AgentRoleCharacter,
+			Name:       n,
+		})
+		if err != nil {
+			t.Fatalf("CreateAgent(%s): %v", n, err)
+		}
+		ids[i] = id
+	}
+
+	for i, id := range ids {
+		a, err := st.GetAgent(ctx, id)
+		if err != nil {
+			t.Fatalf("GetAgent(%s): %v", names[i], err)
+		}
+		if a.SpeakerColor != i {
+			t.Errorf("%s speaker_color = %d, want %d (round-robin index)", names[i], a.SpeakerColor, i)
+		}
+	}
+}
+
+// TestDeleteAndUpdateAgentNotFound asserts a random id is ErrNotFound for both
+// mutating store ops (the RPC maps it to CodeNotFound).
+func TestDeleteAndUpdateAgentNotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := st.DeleteAgent(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("DeleteAgent(random) = %v, want ErrNotFound", err)
+	}
+	if _, err := st.UpdateAgent(ctx, storage.AgentUpdate{ID: uuid.New(), Name: "Nobody"}); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("UpdateAgent(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/migrations/00004_agent_editor_columns.sql
+++ b/internal/storage/migrations/00004_agent_editor_columns.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+
+-- Agent editor columns (#71, ADR-0009 / ADR-0039): the Campaign screen edits an
+-- Agent's role subtitle and renders each speaker in a stable colour. Both columns
+-- are ADDITIVE — existing rows take the defaults, the auto-Butler trigger
+-- (00002) and the one-Butler partial unique index (00001) are untouched.
+--
+--   title         — the role subtitle the editor shows under an Agent's name
+--                   (e.g. "Gruff innkeeper"); free text, defaults to ''.
+--   speaker_color — a server-assigned palette SLOT (not a colour value): a small
+--                   integer the web tier maps onto its speaker palette so each
+--                   roster member renders in a stable hue across reloads. Slots
+--                   are assigned round-robin per Campaign on Character insert
+--                   (see CreateAgent); the Butler keeps slot 0 (it renders in its
+--                   own reserved "Butler gold", ADR-0009).
+ALTER TABLE agents ADD COLUMN title         text     NOT NULL DEFAULT '';
+ALTER TABLE agents ADD COLUMN speaker_color smallint NOT NULL DEFAULT 0;
+
+-- Backfill: give pre-existing Character NPCs distinct, stable slots in roster
+-- order so an already-populated Campaign reads back with the same per-Agent hues
+-- new inserts get. The palette has 6 slots (matches the web speaker palette);
+-- the modulo wraps rosters larger than the palette. The Butler is excluded — it
+-- keeps slot 0.
+UPDATE agents a
+   SET speaker_color = n.slot
+  FROM (
+        SELECT id,
+               (row_number() OVER (PARTITION BY campaign_id
+                                       ORDER BY created_at, id) - 1) % 6 AS slot
+          FROM agents
+         WHERE agent_role = 'character'
+       ) n
+ WHERE a.id = n.id;
+
+-- +goose Down
+
+ALTER TABLE agents DROP COLUMN speaker_color;
+ALTER TABLE agents DROP COLUMN title;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -70,6 +70,9 @@ type Agent struct {
 	CampaignID uuid.UUID
 	Role       AgentRole
 	Name       string
+	// Title is the Agent's role subtitle shown in the editor (e.g. "Gruff
+	// innkeeper"); free text, may be empty.
+	Title string
 	// Persona: markdown personality/backstory/speech style.
 	Persona string
 	// Voice (ADR-0022/0023): TTS provider + voice-id config, stored as JSONB.
@@ -82,9 +85,14 @@ type Agent struct {
 	LLMProviderConfigID uuid.NullUUID
 	// AddressOnly: reachable only by explicit name/alias (ADR-0024). Butler true.
 	AddressOnly bool
-	Aliases     []string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// SpeakerColor is a server-assigned palette SLOT (not a colour value): the web
+	// tier maps it onto its speaker palette so each roster member renders in a
+	// stable hue across reloads (#71). Assigned round-robin per Campaign on
+	// Character insert; the Butler keeps slot 0.
+	SpeakerColor int
+	Aliases      []string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // User is a human operator authenticated via Discord OAuth (ADR-0016). The

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -98,16 +98,16 @@ func (s *Store) GetActiveCampaign(ctx context.Context) (Campaign, error) {
 }
 
 const agentColumns = `
-	id, campaign_id, agent_role, name, persona, voice,
+	id, campaign_id, agent_role, name, title, persona, voice,
 	voice_provider_config_id, llm_provider_config_id,
-	address_only, aliases, created_at, updated_at`
+	address_only, speaker_color, aliases, created_at, updated_at`
 
 func scanAgent(row pgx.Row) (Agent, error) {
 	var a Agent
 	err := row.Scan(
-		&a.ID, &a.CampaignID, &a.Role, &a.Name, &a.Persona, &a.Voice,
+		&a.ID, &a.CampaignID, &a.Role, &a.Name, &a.Title, &a.Persona, &a.Voice,
 		&a.VoiceProviderConfigID, &a.LLMProviderConfigID,
-		&a.AddressOnly, &a.Aliases, &a.CreatedAt, &a.UpdatedAt,
+		&a.AddressOnly, &a.SpeakerColor, &a.Aliases, &a.CreatedAt, &a.UpdatedAt,
 	)
 	return a, err
 }

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -77,12 +77,26 @@ func (s *Store) CreateProviderConfig(ctx context.Context, p NewProviderConfig) (
 	return id, nil
 }
 
+// speakerColorSlots is the size of the web speaker palette (#71). CreateAgent
+// assigns a Character a slot round-robin in [0, speakerColorSlots) per Campaign;
+// the web tier maps the slot onto its palette so each NPC renders in a stable
+// hue. Kept in sync with migration 00004's backfill modulo and the web palette.
+const speakerColorSlots = 6
+
+// ErrButlerUndeletable is returned by DeleteAgent when the target Agent is a
+// Butler. The Butler is an invariant of a Campaign's existence (ADR-0009): it is
+// auto-created and cannot be removed. The RPC layer maps this to Connect
+// CodeFailedPrecondition.
+var ErrButlerUndeletable = errors.New("storage: butler cannot be deleted")
+
 // NewAgent is the input to CreateAgent. Voice is the opaque JSONB blob the voice
 // domain serializes its tts.Voice into; storage keeps it vendor-neutral.
+// SpeakerColor is NOT an input — it is server-assigned on Character insert.
 type NewAgent struct {
 	CampaignID            uuid.UUID
 	Role                  AgentRole
 	Name                  string
+	Title                 string
 	Persona               string
 	Voice                 []byte // JSON; defaults to {} when nil
 	VoiceProviderConfigID uuid.NullUUID
@@ -92,7 +106,9 @@ type NewAgent struct {
 }
 
 // CreateAgent inserts an Agent and returns its generated ID. Inserting a second
-// Butler in a Campaign violates the partial-unique index (ADR-0009).
+// Butler in a Campaign violates the partial-unique index (ADR-0009). A Character
+// is assigned the next round-robin speaker-colour slot for its Campaign (stable
+// once stored); the Butler keeps slot 0.
 func (s *Store) CreateAgent(ctx context.Context, a NewAgent) (uuid.UUID, error) {
 	voice := a.Voice
 	if len(voice) == 0 {
@@ -103,17 +119,111 @@ func (s *Store) CreateAgent(ctx context.Context, a NewAgent) (uuid.UUID, error) 
 		aliases = []string{}
 	}
 	var id uuid.UUID
+	// $2 is cast to agent_role in BOTH uses so Postgres deduces one consistent
+	// type for the parameter. The speaker_color slot is the count of existing
+	// Characters in the Campaign (the new row's 0-based roster index) modulo the
+	// palette size; non-Characters take slot 0.
 	err := s.db.QueryRow(ctx,
 		`INSERT INTO agents
-		   (campaign_id, agent_role, name, persona, voice,
-		    voice_provider_config_id, llm_provider_config_id, address_only, aliases)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
-		a.CampaignID, a.Role, a.Name, a.Persona, voice,
-		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases).Scan(&id)
+		   (campaign_id, agent_role, name, title, persona, voice,
+		    voice_provider_config_id, llm_provider_config_id, address_only, aliases,
+		    speaker_color)
+		 VALUES ($1, $2::agent_role, $3, $4, $5, $6, $7, $8, $9, $10,
+		   CASE WHEN $2::agent_role = 'character'
+		        THEN ((SELECT count(*) FROM agents
+		                WHERE campaign_id = $1 AND agent_role = 'character') % $11)::smallint
+		        ELSE 0 END)
+		 RETURNING id`,
+		a.CampaignID, a.Role, a.Name, a.Title, a.Persona, voice,
+		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases,
+		speakerColorSlots).Scan(&id)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("storage: create agent: %w", err)
 	}
 	return id, nil
+}
+
+// AgentUpdate is the input to UpdateAgent. It carries the editor-editable fields
+// only — the Campaign screen edits name/title/persona/voice/address-only/aliases;
+// agent_role, campaign_id and speaker_color are immutable here. A Butler's
+// address_only is force-kept true regardless of AddressOnly (ADR-0009 / ADR-0024).
+type AgentUpdate struct {
+	ID                    uuid.UUID
+	Name                  string
+	Title                 string
+	Persona               string
+	Voice                 []byte // JSON; defaults to {} when nil
+	VoiceProviderConfigID uuid.NullUUID
+	LLMProviderConfigID   uuid.NullUUID
+	AddressOnly           bool
+	Aliases               []string
+}
+
+// UpdateAgent updates an Agent's editor fields and returns the updated row.
+// It never changes agent_role, and it force-keeps a Butler's address_only true
+// (the Butler always waits to be named, ADR-0024) — so editing the Butler can
+// neither demote it nor turn off Address-Only. A missing id yields ErrNotFound.
+func (s *Store) UpdateAgent(ctx context.Context, a AgentUpdate) (Agent, error) {
+	voice := a.Voice
+	if len(voice) == 0 {
+		voice = []byte(`{}`)
+	}
+	aliases := a.Aliases
+	if aliases == nil {
+		aliases = []string{}
+	}
+	row := s.db.QueryRow(ctx,
+		`UPDATE agents SET
+		    name = $2,
+		    title = $3,
+		    persona = $4,
+		    voice = $5,
+		    voice_provider_config_id = $6,
+		    llm_provider_config_id = $7,
+		    address_only = CASE WHEN agent_role = 'butler' THEN true ELSE $8 END,
+		    aliases = $9,
+		    updated_at = now()
+		  WHERE id = $1
+		 RETURNING `+agentColumns,
+		a.ID, a.Name, a.Title, a.Persona, voice,
+		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases)
+	updated, err := scanAgent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Agent{}, ErrNotFound
+	}
+	if err != nil {
+		return Agent{}, fmt.Errorf("storage: update agent %s: %w", a.ID, err)
+	}
+	return updated, nil
+}
+
+// DeleteAgent removes a Character NPC by id. Deleting a Butler is rejected with
+// ErrButlerUndeletable (ADR-0009): the guarded DELETE leaves a Butler row
+// untouched, and the wrapping CTE reports whether the id existed and whether it
+// was a Butler in one atomic round-trip — so a missing id yields ErrNotFound and
+// a Butler yields ErrButlerUndeletable, distinct from "deleted nothing".
+func (s *Store) DeleteAgent(ctx context.Context, id uuid.UUID) error {
+	var existed, isButler bool
+	err := s.db.QueryRow(ctx,
+		`WITH found AS (
+		     SELECT agent_role FROM agents WHERE id = $1
+		 ), del AS (
+		     DELETE FROM agents WHERE id = $1 AND agent_role <> 'butler' RETURNING 1
+		 )
+		 SELECT
+		     EXISTS (SELECT 1 FROM found),
+		     COALESCE((SELECT agent_role = 'butler' FROM found), false)`,
+		id).Scan(&existed, &isButler)
+	if err != nil {
+		return fmt.Errorf("storage: delete agent %s: %w", id, err)
+	}
+	if !existed {
+		return ErrNotFound
+	}
+	if isButler {
+		return ErrButlerUndeletable
+	}
+	return nil
 }
 
 // CharacterAgents returns the Campaign's Character NPC Agents (agent_role =

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -26,8 +26,11 @@ func TestMain(m *testing.M) {
 // fakeCampaignService is a keyless, deterministic CampaignServiceHandler. It
 // lets the web-server test prove routing of a Connect handler — success AND
 // error-code — without pulling in internal/rpc or internal/storage. The server
-// is decoupled from campaign specifics, so a canned handler is enough.
+// is decoupled from campaign specifics, so a canned handler is enough. The
+// embedded Unimplemented handler supplies the roster + CRUD methods (#71) the
+// routing test does not exercise.
 type fakeCampaignService struct {
+	managementv1connect.UnimplementedCampaignServiceHandler
 	campaign *managementv1.Campaign
 	err      error
 }

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -16,6 +16,30 @@ service CampaignService {
   // GetActiveCampaign returns the most-recently-created campaign for the
   // operator. It fails with CodeNotFound when no campaign exists.
   rpc GetActiveCampaign(GetActiveCampaignRequest) returns (GetActiveCampaignResponse);
+
+  // GetCampaignRoster returns the active campaign together with its ordered
+  // roster — the Butler first, then the Character NPCs — each carrying a stable
+  // speaker-colour slot (#71). It is a read (NO_SIDE_EFFECTS), so the CSRF check
+  // is exempt; it fails with CodeNotFound when no campaign exists.
+  rpc GetCampaignRoster(GetCampaignRosterRequest) returns (GetCampaignRosterResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // CreateAgent adds a Character NPC ("Add NPC") to the active campaign and
+  // returns the created agent, including its server-assigned speaker-colour slot.
+  // The role is always 'character'; the Butler is auto-created (ADR-0009).
+  rpc CreateAgent(CreateAgentRequest) returns (CreateAgentResponse);
+
+  // UpdateAgent saves an agent's editor fields (name, title, persona, voice,
+  // address-only, aliases) and returns the updated agent. Editing the Butler can
+  // neither change its role nor turn off Address-Only (ADR-0009 / ADR-0024). A
+  // missing id fails with CodeNotFound.
+  rpc UpdateAgent(UpdateAgentRequest) returns (UpdateAgentResponse);
+
+  // DeleteAgent removes a Character NPC. Deleting the Butler fails with
+  // CodeFailedPrecondition (it is undeletable, ADR-0009); a missing id fails with
+  // CodeNotFound.
+  rpc DeleteAgent(DeleteAgentRequest) returns (DeleteAgentResponse);
 }
 
 // Campaign is the wire representation of a campaign record.
@@ -92,3 +116,105 @@ message LogoutRequest {}
 
 // LogoutResponse is the (empty) response for Logout.
 message LogoutResponse {}
+
+// Agent is the wire representation of a roster member — the Butler or a Character
+// NPC (ADR-0009). It carries the editor-facing fields plus the server-assigned
+// speaker-colour slot; the encrypted provider bindings are not exposed here.
+message Agent {
+  // id is the agent's UUID.
+  string id = 1;
+  // campaign_id is the owning campaign's UUID.
+  string campaign_id = 2;
+  // role is the agent archetype: "butler" or "character" (ADR-0009).
+  string role = 3;
+  // name is the agent's display name (and primary address term).
+  string name = 4;
+  // title is the role subtitle shown under the name (e.g. "Gruff innkeeper").
+  string title = 5;
+  // persona is the markdown personality/backstory/speech style injected into the
+  // prompt.
+  string persona = 6;
+  // voice is the selected voice id (empty when unset). The encrypted TTS provider
+  // binding is not exposed.
+  string voice = 7;
+  // address_only: the agent waits to be named (ADR-0024). Always true for the
+  // Butler.
+  bool address_only = 8;
+  // speaker_color is the stable palette SLOT the web tier maps onto its speaker
+  // palette, so each roster member renders in a stable hue across reloads.
+  uint32 speaker_color = 9;
+  // aliases are extra name/aliases for Address Detection beyond name.
+  repeated string aliases = 10;
+}
+
+// GetCampaignRosterRequest is the (empty) request for GetCampaignRoster; the
+// active campaign is resolved server-side for the single operator.
+message GetCampaignRosterRequest {}
+
+// GetCampaignRosterResponse carries the active campaign and its ordered roster.
+message GetCampaignRosterResponse {
+  // campaign is the active campaign (title is its name; plus system/language).
+  Campaign campaign = 1;
+  // roster is the campaign's agents in stable order: the Butler first, then the
+  // Character NPCs.
+  repeated Agent roster = 2;
+}
+
+// CreateAgentRequest is the editor's "Add NPC" payload. The role is always
+// 'character' and the campaign is resolved server-side, so neither is carried.
+message CreateAgentRequest {
+  // name is the new NPC's display name (e.g. "New NPC").
+  string name = 1;
+  // title is the role subtitle.
+  string title = 2;
+  // persona is the markdown personality/backstory/speech style.
+  string persona = 3;
+  // voice is the selected voice id (empty when unset).
+  string voice = 4;
+  // address_only: the NPC waits to be named (ADR-0024).
+  bool address_only = 5;
+  // aliases are extra address terms beyond name.
+  repeated string aliases = 6;
+}
+
+// CreateAgentResponse carries the created Character NPC, including its
+// server-assigned speaker-colour slot.
+message CreateAgentResponse {
+  // agent is the newly created NPC.
+  Agent agent = 1;
+}
+
+// UpdateAgentRequest carries an agent's editor fields. address_only is ignored
+// for the Butler (kept true). Unknown id fails with CodeNotFound.
+message UpdateAgentRequest {
+  // id is the agent to update.
+  string id = 1;
+  // name is the agent's display name.
+  string name = 2;
+  // title is the role subtitle.
+  string title = 3;
+  // persona is the markdown personality/backstory/speech style.
+  string persona = 4;
+  // voice is the selected voice id (empty when unset).
+  string voice = 5;
+  // address_only: the agent waits to be named; ignored for the Butler (ADR-0024).
+  bool address_only = 6;
+  // aliases are extra address terms beyond name.
+  repeated string aliases = 7;
+}
+
+// UpdateAgentResponse carries the updated agent.
+message UpdateAgentResponse {
+  // agent is the updated agent.
+  Agent agent = 1;
+}
+
+// DeleteAgentRequest names the agent to delete. Deleting the Butler fails with
+// CodeFailedPrecondition (ADR-0009).
+message DeleteAgentRequest {
+  // id is the agent to delete.
+  string id = 1;
+}
+
+// DeleteAgentResponse is the (empty) response for DeleteAgent.
+message DeleteAgentResponse {}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -10,6 +10,7 @@ import { AppShell } from "@/components/AppShell";
 import { AuthGate } from "@/app/AuthGate";
 import { Login } from "@/screens/login/Login";
 import { Configuration } from "@/screens/configuration/Configuration";
+import { Campaign } from "@/screens/campaign/Campaign";
 import { Placeholder } from "@/screens/Placeholder";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
@@ -68,8 +69,8 @@ const tenantIndexRoute = createRoute({
   },
 });
 
-// /t/:tenantSlug/:screen — selects the active screen. Only Configuration is
-// live this stage; Campaign and Session render styled placeholders.
+// /t/:tenantSlug/:screen — selects the active screen. Configuration and Campaign
+// are live on their RPCs; Session renders a styled placeholder.
 const screenRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: "$screen",
@@ -79,7 +80,7 @@ const screenRoute = createRoute({
       case "configuration":
         return <Configuration />;
       case "campaign":
-        return <Placeholder title="Campaign" />;
+        return <Campaign />;
       case "session":
         return <Placeholder title="Session" />;
       default:

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  CampaignService,
+  AgentSchema,
+  CampaignSchema,
+  GetCampaignRosterResponseSchema,
+  CreateAgentResponseSchema,
+  UpdateAgentResponseSchema,
+  DeleteAgentResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { Campaign } from "./Campaign";
+
+// An in-memory campaign store served over a router transport (no network): the
+// roster mutates in this closure, so a Save → invalidate → refetch proves the
+// edit round-trips and reloads identically (the #71 acceptance), and the Butler
+// invariants are exercised against the same handlers the live screen calls.
+function mockTransport() {
+  const campaign = create(CampaignSchema, {
+    id: "c1",
+    name: "The Sunless Citadel",
+    system: "D&D 5e",
+    language: "en",
+  });
+  const butler = create(AgentSchema, {
+    id: "butler-1",
+    campaignId: "c1",
+    role: "butler",
+    name: "Glyphoxa",
+    title: "",
+    addressOnly: true,
+    speakerColor: 0,
+  });
+  const npcs = [
+    create(AgentSchema, {
+      id: "npc-1",
+      campaignId: "c1",
+      role: "character",
+      name: "Bart",
+      title: "Gruff innkeeper",
+      persona: "Grumbles.",
+      voice: "rachel",
+      addressOnly: false,
+      speakerColor: 0,
+    }),
+  ];
+  let nextId = 2;
+
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      getCampaignRoster: () =>
+        create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, ...npcs] }),
+      createAgent: (req) => {
+        const agent = create(AgentSchema, {
+          id: `npc-${nextId++}`,
+          campaignId: "c1",
+          role: "character",
+          name: req.name,
+          title: req.title,
+          persona: req.persona,
+          voice: req.voice,
+          addressOnly: req.addressOnly,
+          speakerColor: npcs.length % 6,
+        });
+        npcs.push(agent);
+        return create(CreateAgentResponseSchema, { agent });
+      },
+      updateAgent: (req) => {
+        const target = req.id === butler.id ? butler : npcs.find((n) => n.id === req.id);
+        if (!target) throw new Error("not found");
+        target.name = req.name;
+        target.title = req.title;
+        target.persona = req.persona;
+        target.voice = req.voice;
+        // The Butler stays Address-Only no matter what the client asks (server rule).
+        target.addressOnly = target.role === "butler" ? true : req.addressOnly;
+        return create(UpdateAgentResponseSchema, { agent: target });
+      },
+      deleteAgent: (req) => {
+        const i = npcs.findIndex((n) => n.id === req.id);
+        if (i >= 0) npcs.splice(i, 1);
+        return create(DeleteAgentResponseSchema, {});
+      },
+    });
+  });
+  return { transport, npcs };
+}
+
+function renderScreen() {
+  const { transport, npcs } = mockTransport();
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <Campaign />
+    </Providers>,
+  );
+  return { npcs };
+}
+
+describe("Campaign", () => {
+  it("renders the live campaign title and roster", async () => {
+    renderScreen();
+    expect(await screen.findByRole("heading", { name: "The Sunless Citadel" })).toBeInTheDocument();
+    // Both the Butler and the NPC appear in the roster.
+    expect(screen.getByText("Glyphoxa")).toBeInTheDocument();
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+  });
+
+  it("locks the Butler: Address-Only is forced on and its switch is disabled", async () => {
+    renderScreen();
+    // Select the Butler.
+    fireEvent.click(await screen.findByText("Glyphoxa"));
+    const sw = screen.getByLabelText(/address only/i);
+    expect(sw).toBeDisabled();
+    expect(sw).toBeChecked();
+    // The Butler is not deletable.
+    expect(screen.queryByRole("button", { name: /delete npc/i })).not.toBeInTheDocument();
+  });
+
+  it("round-trips an NPC edit to the store and reloads it identically", async () => {
+    const { npcs } = renderScreen();
+    // Select the NPC and rename it.
+    fireEvent.click(await screen.findByText("Bart"));
+    const name = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(name.value).toBe("Bart");
+    fireEvent.change(name, { target: { value: "Bartholomew" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    // The edit persisted to the store…
+    expect(await screen.findByText("Bartholomew")).toBeInTheDocument();
+    expect(npcs[0].name).toBe("Bartholomew");
+    // …and the old name is gone (the roster re-read the store).
+    expect(screen.queryByText("Bart")).not.toBeInTheDocument();
+  });
+
+  it("adds an NPC and deletes it, keeping the store in sync", async () => {
+    const { npcs } = renderScreen();
+    await screen.findByText("Bart");
+    expect(npcs).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /add npc/i }));
+    expect(await screen.findByText("New NPC")).toBeInTheDocument();
+    expect(npcs).toHaveLength(2);
+
+    // Delete the freshly added NPC (it is auto-selected after creation).
+    fireEvent.click(screen.getByRole("button", { name: /delete npc/i }));
+    // The new NPC leaves the roster once the store re-reads; the original stays.
+    await waitFor(() => expect(screen.queryByText("New NPC")).not.toBeInTheDocument());
+    expect(npcs).toHaveLength(1);
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -1,0 +1,295 @@
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Lock, Plus, Sparkles, Trash2 } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Avatar } from "@/components/ui/Avatar";
+import { Select } from "@/components/ui/Select";
+import { Input } from "@/components/ui/Input";
+import { Switch } from "@/components/ui/Switch";
+import { Button } from "@/components/ui/Button";
+
+import "./campaign.css";
+
+// The Campaign screen (#71) backs the design's Butler/NPC editor on the live
+// CampaignService roster + CRUD RPCs (ADR-0039). The Butler is required, role-
+// locked and undeletable (ADR-0009); its Address-Only switch is forced on and
+// disabled (ADR-0024). NPCs are added, edited and deleted; every edit round-trips
+// to the DB and the roster re-reads it back after each mutation invalidates the
+// query.
+
+// The voice dropdown is a static allowlist placeholder this slice — the live
+// ElevenLabs ListVoices wiring lands with the provider RPCs. The selected id is
+// persisted to the agent's voice field regardless, so edits round-trip.
+const VOICE_OPTIONS = ["rachel", "adam", "antoni", "bella", "elli", "domi"];
+
+// speakerVar maps a server-assigned palette slot onto the 6-colour speaker
+// palette (tokens.css --speaker-1..6). The slot is 0-based; the palette is 1-based.
+function speakerVar(slot: number): string {
+  return `var(--speaker-${(slot % 6) + 1})`;
+}
+
+function isButler(a: Agent): boolean {
+  return a.role === "butler";
+}
+
+export function Campaign() {
+  const queryClient = useQueryClient();
+  const { data, status, error } = useQuery(CampaignService.method.getCampaignRoster, {});
+  const roster = useMemo(() => data?.roster ?? [], [data]);
+
+  // Selection: the chosen agent, defaulting to the first roster member (the
+  // Butler) until the operator picks another. Falls back to the Butler when the
+  // selected NPC is deleted.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = roster.find((a) => a.id === selectedId) ?? roster[0];
+
+  const invalidateRoster = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.getCampaignRoster,
+        cardinality: "finite",
+      }),
+    });
+
+  const createAgent = useMutation(CampaignService.method.createAgent, {
+    onSuccess: (res) => {
+      void invalidateRoster();
+      if (res.agent) setSelectedId(res.agent.id);
+    },
+  });
+  const deleteAgent = useMutation(CampaignService.method.deleteAgent, {
+    onSuccess: () => {
+      setSelectedId(null); // fall back to the Butler
+      void invalidateRoster();
+    },
+  });
+
+  if (status === "pending") {
+    return (
+      <div className="gx-campaign-screen">
+        <h1>Campaign</h1>
+        <div className="gx-skeleton" data-testid="roster-loading" />
+      </div>
+    );
+  }
+  if (status === "error") {
+    return (
+      <div className="gx-campaign-screen">
+        <h1>Campaign</h1>
+        <p className="gx-campaign__error" role="alert">
+          Could not load the campaign: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  const campaign = data?.campaign;
+  const npcs = roster.filter((a) => !isButler(a));
+
+  return (
+    <div className="gx-campaign-screen">
+      <header className="gx-campaign-screen__header">
+        <h1>{campaign?.name ?? "Campaign"}</h1>
+        <div className="gx-campaign-screen__sub">
+          {campaign?.system && <span className="gx-campaign-screen__system">{campaign.system}</span>}
+          <span className="gx-campaign-screen__lede">
+            One Butler is required; add as many NPCs as your table needs.
+          </span>
+        </div>
+      </header>
+
+      <div className="gx-roster-layout">
+        {/* Roster list */}
+        <div className="gx-roster">
+          {roster.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="gx-roster__item"
+              data-active={selected?.id === a.id ? "true" : undefined}
+              data-role={a.role}
+              onClick={() => setSelectedId(a.id)}
+            >
+              {isButler(a) ? (
+                <Avatar name={a.name} size="sm" />
+              ) : (
+                <span
+                  className="gx-roster__dot"
+                  style={{ background: speakerVar(a.speakerColor) }}
+                  aria-hidden
+                />
+              )}
+              <span className="gx-roster__meta">
+                <span className="gx-roster__name">{a.name}</span>
+                {a.title && <span className="gx-roster__title">{a.title}</span>}
+              </span>
+              {isButler(a) ? (
+                <Badge variant="gold" size="sm" dot>
+                  <Lock size={11} /> Butler
+                </Badge>
+              ) : (
+                a.addressOnly && (
+                  <Badge variant="neutral" size="sm">
+                    Address only
+                  </Badge>
+                )
+              )}
+            </button>
+          ))}
+
+          <button
+            type="button"
+            className="gx-roster__add"
+            disabled={createAgent.isPending}
+            onClick={() =>
+              createAgent.mutate({ name: "New NPC", title: "", persona: "", voice: "", addressOnly: false })
+            }
+          >
+            <Plus size={15} /> Add NPC
+          </button>
+
+          {npcs.length === 0 && (
+            <p className="gx-roster__empty">
+              No NPCs yet. The Butler can run a session alone, or add your first NPC above.
+            </p>
+          )}
+        </div>
+
+        {/* Editor pane — keyed by the selected agent so its local form resets when
+            the selection changes. */}
+        {selected && (
+          <AgentEditor
+            key={selected.id}
+            agent={selected}
+            onSaved={() => void invalidateRoster()}
+            onDelete={
+              isButler(selected) ? undefined : () => deleteAgent.mutate({ id: selected.id })
+            }
+            deleting={deleteAgent.isPending}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// AgentEditor edits one roster member. It holds the editable fields in local
+// state (seeded from the agent) and saves them via UpdateAgent. For the Butler
+// the role is locked, it cannot be deleted, and Address-Only is forced on with a
+// disabled switch (ADR-0009 / ADR-0024).
+function AgentEditor({
+  agent,
+  onSaved,
+  onDelete,
+  deleting,
+}: {
+  agent: Agent;
+  onSaved: () => void;
+  onDelete?: () => void;
+  deleting: boolean;
+}) {
+  const butler = isButler(agent);
+  const [name, setName] = useState(agent.name);
+  const [title, setTitle] = useState(agent.title);
+  const [persona, setPersona] = useState(agent.persona);
+  const [voice, setVoice] = useState(agent.voice);
+  const [addressOnly, setAddressOnly] = useState(agent.addressOnly);
+
+  const update = useMutation(CampaignService.method.updateAgent, { onSuccess: onSaved });
+
+  const voiceOpts = useMemo(() => {
+    const set = new Set(VOICE_OPTIONS);
+    if (voice) set.add(voice);
+    return [...set];
+  }, [voice]);
+
+  const save = () =>
+    update.mutate({
+      id: agent.id,
+      name,
+      title,
+      persona,
+      voice,
+      // The Butler is always Address-Only; the server enforces this regardless.
+      addressOnly: butler ? true : addressOnly,
+      aliases: agent.aliases,
+    });
+
+  return (
+    <Card accent className="gx-editor">
+      <div className="gx-editor__head">
+        {butler ? <Avatar name={agent.name} size="lg" /> : <Avatar name={name || agent.name} size="lg" />}
+        <div className="gx-editor__head-meta">
+          {butler ? (
+            <Badge variant="gold" size="sm" dot>
+              <Sparkles size={11} /> Required
+            </Badge>
+          ) : (
+            <Badge variant="neutral" size="sm">
+              NPC
+            </Badge>
+          )}
+          <span className="gx-editor__role">{butler ? "Butler · role locked" : "Character NPC"}</span>
+        </div>
+      </div>
+
+      <div className="gx-editor__grid">
+        <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Input label="Title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Role subtitle" />
+      </div>
+
+      <div className="gx-field">
+        <label className="gx-field__label" htmlFor="gx-persona">
+          Persona
+        </label>
+        <textarea
+          id="gx-persona"
+          className="gx-input gx-textarea"
+          rows={4}
+          value={persona}
+          onChange={(e) => setPersona(e.target.value)}
+        />
+        <span className="gx-field__hint">
+          Personality, backstory and speech style — injected into the prompt.
+        </span>
+      </div>
+
+      <Select label="Voice" options={voiceOpts} value={voice || undefined} onValueChange={setVoice} placeholder="Pick a voice…" />
+
+      <div className="gx-editor__switch">
+        <Switch
+          label="Address only — waits to be named"
+          checked={butler ? true : addressOnly}
+          onCheckedChange={setAddressOnly}
+          disabled={butler}
+        />
+        <span className="gx-field__hint">
+          {butler
+            ? "The Butler always waits to be named; it never answers ambient table talk."
+            : "When on, this NPC only replies when addressed by name."}
+        </span>
+      </div>
+
+      <div className="gx-editor__actions">
+        <Button variant="primary" onClick={save} disabled={update.isPending}>
+          Save changes
+        </Button>
+        {onDelete && (
+          <Button
+            variant="danger"
+            iconStart={<Trash2 size={14} />}
+            onClick={onDelete}
+            disabled={deleting}
+          >
+            Delete NPC
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1,0 +1,189 @@
+/* Campaign screen — co-located CSS (ADR-0017). Shared gx- layout/component
+ * classes live in styles/components.css; only screen-local layout goes here.
+ */
+
+.gx-campaign-screen__header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.gx-campaign-screen__sub {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}
+
+.gx-campaign-screen__system {
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+  color: var(--rune);
+}
+
+.gx-campaign-screen__lede {
+  color: var(--text-muted);
+  font-size: var(--body-sm);
+}
+
+/* Two-column: roster list + editor pane. Collapses to one column when narrow. */
+.gx-roster-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+@media (max-width: 720px) {
+  .gx-roster-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gx-roster {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-roster__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-default);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.gx-roster__item:hover {
+  background: var(--surface-card-hover);
+}
+
+.gx-roster__item[data-active="true"] {
+  border-color: var(--border-strong);
+  box-shadow: var(--glow-arcane-soft);
+}
+
+.gx-roster__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-pill);
+  flex: 0 0 auto;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.gx-roster__meta {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.gx-roster__name {
+  font-weight: var(--weight-semibold);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-roster__title {
+  font-size: var(--body-xs);
+  color: var(--text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-roster__add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.gx-roster__add:hover:not(:disabled) {
+  color: var(--text-strong);
+  border-color: var(--border-strong);
+}
+
+.gx-roster__add:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.gx-roster__empty {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-md);
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+}
+
+/* Editor pane */
+.gx-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+}
+
+.gx-editor__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.gx-editor__head-meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  align-items: flex-start;
+}
+
+.gx-editor__role {
+  font-size: var(--body-xs);
+  color: var(--text-subtle);
+}
+
+.gx-editor__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 520px) {
+  .gx-editor__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gx-textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: inherit;
+  line-height: var(--body-line);
+}
+
+.gx-editor__switch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-editor__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}


### PR DESCRIPTION
## What

Backs the **Campaign screen** end to end (issue #71, ADR-0039): the operator edits the Butler and does full CRUD on Character NPCs, every edit round-tripping to Postgres.

- **Storage** — migration `00004_agent_editor_columns.sql` adds two **additive** columns: `agents.title` (role subtitle) and `agents.speaker_color` (a server-assigned palette SLOT, stable per agent, backfilled round-robin for existing Characters). New store ops `UpdateAgent` + `DeleteAgent` (only `CreateAgent` + reads existed before); `CreateAgent` now assigns the speaker-colour slot on Character insert.
- **proto** — appended to `CampaignService` (additive only): `GetCampaignRoster` (NO_SIDE_EFFECTS read → active campaign + ordered roster) and `CreateAgent` / `UpdateAgent` / `DeleteAgent`, plus the `Agent` message and request/response pairs.
- **rpc** — `internal/rpc/campaign_crud.go` extends `CampaignServer` over a narrowed `campaignStore` interface, **mounted behind #67's existing auth stack** (no `main.go` change — same `CampaignService` handler). Reads are CSRF-exempt; mutations keep default idempotency so auth + `X-CSRF-Token` gate them.
- **web** — real `src/screens/campaign/` screen on the live RPCs (connect-query): Butler card (Lock badge, role locked, not deletable, Address-only forced on + switch disabled), Add NPC, NPC list with Address-only badge, editor pane (name, title, persona, voice, Save changes). Each mutation invalidates the roster query → reloads identically.

## Why

Stage 7 of epic #64. Single-operator self-host web tier (ADR-0039) over the polymorphic `agents` table.

## Invariants / ADRs

- **ADR-0009 one-Butler** held: the `00002` auto-Butler trigger + one-Butler partial unique index are untouched. `DeleteAgent` rejects deleting a Butler with a distinct error → `CodeFailedPrecondition`. `UpdateAgent` never changes a Butler's `agent_role` and force-keeps `address_only = true` (ADR-0024).
- **Additive columns only** — defaults backfill existing rows; no renumber/removal in proto (append-only).
- **ADR-0039** — reads/writes resolve the single operator's active campaign server-side, same pass-through `GetActiveCampaign` uses; per-tenant scoping fills in behind the `X-Tenant-Id` interceptor later.

## Tests

- storage (integration): create/update/delete Characters, delete-Butler rejected, Butler stays Address-Only, stable speaker-colour assignment.
- rpc: keyless unit (error-code mapping + voice round-trip + force-character) and integration (create/update/delete/roster over Connect-JSON against a real store, incl. delete-Butler rejection).
- web (vitest): live roster render, Butler lock, NPC edit round-trip, add/delete store sync.

## Stacking / coordination

- **Stacks on #67** (`feat/67-auth`) — reuses `internal/auth`'s interceptor stack + tenant pass-through; do not merge before #67.
- **Migration number** — uses `00004`. Sibling PR #68 (config) is stacked on the same base and may also add `00004`; the final number may need a rebase depending on merge order.

## Local CI gates — all green

`buf generate` · `buf lint` · `go build ./...` · `go vet ./...` · `go vet -tags=record ./...` · `go test -race ./...` · `go test -race -tags=integration ./...` · `cd web && npm ci && npm run build && npm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)