### PR TITLE
feat(#68): Configuration — write-only BYOK key save (masked)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/web"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
@@ -187,6 +188,17 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	defer pool.Close()
 	store := storage.New(pool)
 
+	// The BYOK credential cipher (ADR-0004) is best-effort at boot: without
+	// $GLYPHOXA_SECRET the web tier still serves (Configuration reads work), but
+	// saving a provider key / Bot token fails loudly (CodeFailedPrecondition) —
+	// the #44 keyless-degradation posture, not a hard boot failure.
+	cipher, err := appCipher()
+	if err != nil {
+		log.Warn("provider credential encryption is disabled; saving keys in "+
+			"Configuration will fail until $GLYPHOXA_SECRET is set", "err", err)
+		cipher = nil
+	}
+
 	// Metrics + k8s probes (/metrics, /healthz, /readyz) listen on their OWN port
 	// (metricsAddr), separate from the public web API — so they are scrapeable by
 	// Prometheus and the kubelet but never exposed on the external API surface.
@@ -204,7 +216,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// paths (and client-side deep links) reach the SPA fallback.
 	srv := web.NewServer(web.Config{
 		Addr:   webAddr,
-		Mounts: managementMounts(store, log),
+		Mounts: managementMounts(store, cipher, log),
 		Root:   spa.Handler(),
 		Logger: log,
 	})
@@ -257,15 +269,16 @@ func voiceEnabled(token, guild, channel string) bool {
 
 // managementMounts wires the auth tier and the management Connect services into
 // the web mux (ADR-0015/0016/0039): the interceptor-guarded Connect handlers
-// (CampaignService, AuthService) under /api, and the net/http Discord OAuth
-// redirect + callback under /auth. The single [auth.Stack] gates every Connect
-// service identically — auth (session cookie) → CSRF double-submit → tenant
-// pass-through — with AuthService.GetCurrentUser left reachable unauthenticated
-// so the SPA can probe the session at boot. Live Discord login requires the
-// operator's OAuth app credentials (DISCORD_OAUTH_CLIENT_ID / _SECRET /
-// _REDIRECT_URL) — a one-time setup, not code; absent them the gate still stands
-// and the API simply has no way in.
-func managementMounts(store *storage.Store, log *slog.Logger) []web.Mount {
+// (CampaignService, AuthService, ProviderService) under /api, and the net/http
+// Discord OAuth redirect + callback under /auth. The single [auth.Stack] gates
+// every Connect service identically — auth (session cookie) → CSRF double-submit
+// → tenant pass-through — with AuthService.GetCurrentUser left reachable
+// unauthenticated so the SPA can probe the session at boot. Live Discord login
+// requires the operator's OAuth app credentials (DISCORD_OAUTH_CLIENT_ID /
+// _SECRET / _REDIRECT_URL) — a one-time setup, not code; absent them the gate
+// still stands and the API simply has no way in. cipher seals BYOK provider
+// keys (ADR-0004); it may be nil (saving keys then fails CodeFailedPrecondition).
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger) []web.Mount {
 	clientID := os.Getenv("DISCORD_OAUTH_CLIENT_ID")
 	if clientID == "" {
 		log.Warn("Discord OAuth is not configured; login is disabled until " +
@@ -286,10 +299,12 @@ func managementMounts(store *storage.Store, log *slog.Logger) []web.Mount {
 
 	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
+	providerPath, providerHandler := rpc.NewProviderServer(store, cipher, log).Handler(stack.HandlerOptions()...)
 
 	return []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),
 		web.APIMount(authPath, authHandler),
+		web.APIMount(providerPath, providerHandler),
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -17,6 +17,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
@@ -195,21 +197,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
 	}
 
-	// The web tier serves the Connect API under /api and the embedded SPA at /
-	// (ADR-0013/0039). The browser dials Connect at baseUrl "/api"
-	// (web/src/lib/transport.ts), so the generated handler — mounted on the mux
-	// at its own absolute path (mountPath, e.g.
-	// /glyphoxa.management.v1.CampaignService/) — is wrapped in
-	// http.StripPrefix("/api", …) and registered under "/api/". StripPrefix
-	// removes the /api segment before the Connect handler matches its method
-	// path, so /api/<service>/<method> resolves correctly. The SPA handler is the
-	// "/" catch-all; ServeMux's longest-prefix match keeps /api/ ahead of it, so
-	// only non-API paths (and client-side deep links) reach the SPA fallback.
-	mountPath, mountHandler := rpc.NewCampaignServer(store).Handler()
-	apiHandler := http.StripPrefix("/api", mountHandler)
+	// The web tier serves the auth-guarded Connect API under /api, the Discord
+	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /
+	// (ADR-0013/0039). The SPA handler is the "/" catch-all; ServeMux's
+	// longest-prefix match keeps /api/ and /auth/ ahead of it, so only non-API
+	// paths (and client-side deep links) reach the SPA fallback.
 	srv := web.NewServer(web.Config{
 		Addr:   webAddr,
-		Mounts: []web.Mount{{Path: "/api" + mountPath, Handler: apiHandler}},
+		Mounts: managementMounts(store, log),
 		Root:   spa.Handler(),
 		Logger: log,
 	})
@@ -258,6 +253,46 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // gating decision is unit-tested without Discord credentials.
 func voiceEnabled(token, guild, channel string) bool {
 	return token != "" && guild != "" && channel != ""
+}
+
+// managementMounts wires the auth tier and the management Connect services into
+// the web mux (ADR-0015/0016/0039): the interceptor-guarded Connect handlers
+// (CampaignService, AuthService) under /api, and the net/http Discord OAuth
+// redirect + callback under /auth. The single [auth.Stack] gates every Connect
+// service identically — auth (session cookie) → CSRF double-submit → tenant
+// pass-through — with AuthService.GetCurrentUser left reachable unauthenticated
+// so the SPA can probe the session at boot. Live Discord login requires the
+// operator's OAuth app credentials (DISCORD_OAUTH_CLIENT_ID / _SECRET /
+// _REDIRECT_URL) — a one-time setup, not code; absent them the gate still stands
+// and the API simply has no way in.
+func managementMounts(store *storage.Store, log *slog.Logger) []web.Mount {
+	clientID := os.Getenv("DISCORD_OAUTH_CLIENT_ID")
+	if clientID == "" {
+		log.Warn("Discord OAuth is not configured; login is disabled until " +
+			"DISCORD_OAUTH_CLIENT_ID, DISCORD_OAUTH_CLIENT_SECRET and " +
+			"DISCORD_OAUTH_REDIRECT_URL are set")
+	}
+	discord := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:     clientID,
+		ClientSecret: os.Getenv("DISCORD_OAUTH_CLIENT_SECRET"),
+		RedirectURL:  os.Getenv("DISCORD_OAUTH_REDIRECT_URL"),
+	})
+	oauth := auth.NewOAuth(store, discord, "/", log)
+	authServer := auth.NewAuthServer(store, log)
+
+	// The store satisfies both Authenticator (AuthenticateSession) and
+	// TenantResolver (TenantForUser); GetCurrentUser is the only public procedure.
+	stack := auth.NewStack(store, store, managementv1connect.AuthServiceGetCurrentUserProcedure)
+
+	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
+	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
+
+	return []web.Mount{
+		web.APIMount(campaignPath, campaignHandler),
+		web.APIMount(authPath, authHandler),
+		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
+		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
+	}
 }
 
 // runWebTier starts the web API server on ctx and blocks until it has fully shut

--- a/cmd/glyphoxa/main_test.go
+++ b/cmd/glyphoxa/main_test.go
@@ -18,8 +18,11 @@ import (
 // fakeCampaignService is a canned CampaignServiceHandler so runWebTier can be
 // exercised without Postgres: the keyless default gate (ADR-0021/0033) must
 // prove the web tier boots, serves the Connect API, and shuts down on ctx cancel
-// with no DB or Discord credentials in play.
-type fakeCampaignService struct{}
+// with no DB or Discord credentials in play. The embedded Unimplemented handler
+// supplies the roster + CRUD methods (#71) this test does not exercise.
+type fakeCampaignService struct {
+	managementv1connect.UnimplementedCampaignServiceHandler
+}
 
 func (fakeCampaignService) GetActiveCampaign(
 	context.Context,

--- a/internal/auth/auth_e2e_test.go
+++ b/internal/auth/auth_e2e_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+// End-to-end auth over a real Postgres (testcontainers): the OAuth callback
+// issues a real session cookie, the Connect AuthService validates it through the
+// interceptor stack, and Logout deletes the session row. Tag-isolated behind
+// `integration` so the default `go test ./...` stays Docker-free (ADR-0021 /
+// ADR-0033). The Postgres harness is duplicated in miniature (storage's
+// harness_test.go is package-private).
+
+package auth_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?): %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+func migratedStore(t *testing.T) (*storage.Store, *pgxpool.Pool) {
+	t.Helper()
+	dsn := startPostgres(t)
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return storage.New(pool), pool
+}
+
+// cookieByName pulls one cookie out of a recorded response.
+func cookieByName(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestAuthEndToEnd drives the whole single-operator flow against a real DB:
+// OAuth callback → cookie issuance → GetCurrentUser validation → Logout deletes
+// the session row.
+func TestAuthEndToEnd(t *testing.T) {
+	store, pool := migratedStore(t)
+	ctx := context.Background()
+
+	disc := &fakeDiscord{user: auth.DiscordUser{
+		ID: "555", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png",
+	}}
+	o := auth.NewOAuth(store, disc, "/", nil)
+
+	// 1. OAuth callback issues a real session — capture the cookies.
+	cbReq := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=st", nil)
+	cbReq.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st"})
+	cbRec := httptest.NewRecorder()
+	o.Callback(cbRec, cbReq)
+	if cbRec.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	sess := cookieByName(cbRec.Result().Cookies(), auth.SessionCookieName)
+	csrf := cookieByName(cbRec.Result().Cookies(), auth.CSRFCookieName)
+	if sess == nil || csrf == nil {
+		t.Fatal("callback did not set session/csrf cookies")
+	}
+
+	// The session row exists for the upserted operator.
+	var rowsBefore int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM sessions WHERE token = $1`, sess.Value).Scan(&rowsBefore); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if rowsBefore != 1 {
+		t.Fatalf("session rows = %d, want 1", rowsBefore)
+	}
+
+	// 2. AuthService over the real store + interceptor stack.
+	stack := auth.NewStack(store, store, managementv1connect.AuthServiceGetCurrentUserProcedure)
+	server := auth.NewAuthServer(store, nil)
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler(stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	cookieHeader := auth.SessionCookieName + "=" + sess.Value + "; " + auth.CSRFCookieName + "=" + csrf.Value
+
+	// 3. GetCurrentUser with the cookie resolves the real operator.
+	getReq := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	getReq.Header().Set("Cookie", cookieHeader)
+	getResp, err := client.GetCurrentUser(ctx, getReq)
+	if err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if got := getResp.Msg.GetUser(); got.GetName() != "Sora Vance" || got.GetAvatar() != "https://cdn/a.png" {
+		t.Errorf("user = %+v, want Sora Vance", got)
+	}
+
+	// Missing cookie → 401.
+	if _, err := client.GetCurrentUser(ctx, connect.NewRequest(&managementv1.GetCurrentUserRequest{})); connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("unauthenticated GetCurrentUser code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+
+	// 4. Logout (with CSRF double-submit) deletes the session row.
+	logoutReq := connect.NewRequest(&managementv1.LogoutRequest{})
+	logoutReq.Header().Set("Cookie", cookieHeader)
+	logoutReq.Header().Set("X-CSRF-Token", csrf.Value)
+	logoutResp, err := client.Logout(ctx, logoutReq)
+	if err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if !strings.Contains(strings.Join(logoutResp.Header().Values("Set-Cookie"), " "), auth.SessionCookieName) {
+		t.Error("Logout did not clear the session cookie")
+	}
+
+	var rowsAfter int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM sessions WHERE token = $1`, sess.Value).Scan(&rowsAfter); err != nil {
+		t.Fatalf("count sessions after logout: %v", err)
+	}
+	if rowsAfter != 0 {
+		t.Fatalf("session rows after logout = %d, want 0 (logout must delete the row)", rowsAfter)
+	}
+
+	// The now-deleted session no longer authenticates.
+	if _, err := store.AuthenticateSession(ctx, sess.Value); err == nil {
+		t.Error("session still authenticates after logout")
+	}
+}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,54 @@
+// Package auth is the single-operator authentication tier (ADR-0016 / ADR-0039):
+// the net/http Discord OAuth carve-out (ADR-0015), the opaque cookie session it
+// issues, and the Connect interceptor stack + context accessors that gate the
+// management RPCs. The stacked Configuration (#68) and Campaign (#71) PRs reuse
+// this package's exported seam: [NewStack] for the interceptor options and
+// [CurrentUser] / [TenantID] to read the resolved principal out of a handler's
+// context.
+package auth
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// ctxKey is the private context key type for the resolved principal, so no other
+// package can collide with or overwrite these context values.
+type ctxKey int
+
+const (
+	userKey ctxKey = iota
+	tenantKey
+)
+
+// WithUser returns a copy of ctx carrying the authenticated operator. The auth
+// interceptor calls it after validating the session cookie; tests use it to
+// inject a principal without standing up the interceptor.
+func WithUser(ctx context.Context, u storage.User) context.Context {
+	return context.WithValue(ctx, userKey, u)
+}
+
+// CurrentUser returns the authenticated operator carried in ctx, and false when
+// the request is unauthenticated. RPC handlers (e.g. AuthService.GetCurrentUser,
+// and #68/#71's mutations) use it to read the caller.
+func CurrentUser(ctx context.Context) (storage.User, bool) {
+	u, ok := ctx.Value(userKey).(storage.User)
+	return u, ok
+}
+
+// WithTenant returns a copy of ctx carrying the resolved tenant id. The tenant
+// interceptor calls it; the single-operator pass-through resolves the operator's
+// bound tenant (ADR-0039).
+func WithTenant(ctx context.Context, id uuid.UUID) context.Context {
+	return context.WithValue(ctx, tenantKey, id)
+}
+
+// TenantID returns the resolved tenant id carried in ctx, and false when none
+// was resolved (an unauthenticated request, or an operator with no bound tenant).
+func TenantID(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(tenantKey).(uuid.UUID)
+	return id, ok
+}

--- a/internal/auth/cookie.go
+++ b/internal/auth/cookie.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Cookie names (ADR-0016). The session cookie is HttpOnly so script can't read
+// the bearer; the CSRF cookie is deliberately NOT HttpOnly so the SPA can echo
+// it back in the X-CSRF-Token header (the double-submit pattern).
+const (
+	// SessionCookieName carries the opaque session token (HttpOnly).
+	SessionCookieName = "glyphoxa_session"
+	// CSRFCookieName carries the double-submit CSRF token (readable by script).
+	CSRFCookieName = "glyphoxa_csrf"
+	// stateCookieName carries the short-lived OAuth state nonce.
+	stateCookieName = "glyphoxa_oauth_state"
+)
+
+// newToken mints an opaque, high-entropy token from crypto/rand — the session
+// and CSRF secrets, and the OAuth state nonce. base64url so it is cookie-safe.
+// NOT a JWT: server-side sessions revoke with a row delete (ADR-0016).
+func newToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: read random token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// cookieValue reads a single cookie value out of a request/response header set,
+// returning "" when absent. It works for both a net/http request and a Connect
+// request's Header() (which carries the inbound Cookie header).
+func cookieValue(h http.Header, name string) string {
+	r := http.Request{Header: h}
+	c, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// headerSecure reports whether the request reached the reverse proxy over TLS,
+// per the X-Forwarded-Proto header. The self-host topology terminates TLS at the
+// proxy (ADR-0039), so the Go process sees cleartext but must still set Secure
+// cookies when the public edge is https.
+func headerSecure(h http.Header) bool {
+	return strings.EqualFold(h.Get("X-Forwarded-Proto"), "https")
+}
+
+// requestSecure reports whether to mark cookies Secure: the request is TLS
+// directly, or was forwarded as https. Local cleartext dev (http://localhost)
+// is correctly non-Secure so the browser still stores the login cookie.
+func requestSecure(r *http.Request) bool {
+	return r.TLS != nil || headerSecure(r.Header)
+}
+
+// sessionCookie builds the HttpOnly session cookie (ADR-0016: HttpOnly, Secure,
+// SameSite=Lax). Lax (not Strict) so the top-level redirect back from Discord
+// still presents the cookie.
+func sessionCookie(token string, secure bool, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// csrfCookie builds the double-submit CSRF cookie. It is NOT HttpOnly — the SPA
+// reads it and mirrors it into the X-CSRF-Token header that the CSRF interceptor
+// checks against this same cookie.
+func csrfCookie(token string, secure bool, expires time.Time) *http.Cookie {
+	return &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: false,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}
+
+// clearCookie builds an immediately-expiring cookie that deletes name on the
+// client (logout, and clearing the one-shot OAuth state).
+func clearCookie(name string, httpOnly, secure bool) *http.Cookie {
+	return &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: httpOnly,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	}
+}

--- a/internal/auth/discord.go
+++ b/internal/auth/discord.go
@@ -1,0 +1,188 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Discord OAuth2 endpoints (ADR-0016: Discord-only). Overridable on
+// DiscordConfig so the token-exchange test points the client at an httptest
+// cassette instead of discord.com — no live Discord call in CI.
+const (
+	defaultAuthorizeURL = "https://discord.com/api/oauth2/authorize"
+	defaultTokenURL     = "https://discord.com/api/oauth2/token"
+	defaultUserURL      = "https://discord.com/api/users/@me"
+	// avatarCDN composes the user's avatar image URL from id + hash.
+	avatarCDN = "https://cdn.discordapp.com/avatars/%s/%s.png"
+)
+
+// DiscordUser is the authenticated Discord identity returned by Exchange — the
+// fields the operator record needs (ADR-0016).
+type DiscordUser struct {
+	ID         string
+	Username   string
+	GlobalName string
+	// AvatarURL is the composed CDN URL, or "" when the user has no avatar.
+	AvatarURL string
+}
+
+// DisplayName prefers the Discord global (display) name, falling back to the
+// legacy username.
+func (d DiscordUser) DisplayName() string {
+	if d.GlobalName != "" {
+		return d.GlobalName
+	}
+	return d.Username
+}
+
+// DiscordOAuth exchanges an OAuth authorization code for the authenticated
+// Discord user. The OAuth callback depends on this interface (not the concrete
+// client) so tests drive it with a fake — no live Discord call (ADR-0019 TDD).
+type DiscordOAuth interface {
+	// AuthCodeURL builds the Discord authorize redirect URL for the login start.
+	AuthCodeURL(state string) string
+	// Exchange swaps an authorization code for the authenticated Discord user.
+	Exchange(ctx context.Context, code string) (DiscordUser, error)
+}
+
+// DiscordConfig configures a [DiscordClient]. ClientID/ClientSecret/RedirectURL
+// are the operator's registered OAuth app credentials (a one-time setup, not
+// code). The *URL fields default to discord.com when empty.
+type DiscordConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+
+	AuthorizeURL string
+	TokenURL     string
+	UserURL      string
+
+	HTTPClient *http.Client
+}
+
+// DiscordClient is the live DiscordOAuth implementation.
+type DiscordClient struct {
+	cfg  DiscordConfig
+	http *http.Client
+}
+
+var _ DiscordOAuth = (*DiscordClient)(nil)
+
+// NewDiscordClient builds a DiscordClient, filling endpoint + HTTP-client
+// defaults.
+func NewDiscordClient(cfg DiscordConfig) *DiscordClient {
+	if cfg.AuthorizeURL == "" {
+		cfg.AuthorizeURL = defaultAuthorizeURL
+	}
+	if cfg.TokenURL == "" {
+		cfg.TokenURL = defaultTokenURL
+	}
+	if cfg.UserURL == "" {
+		cfg.UserURL = defaultUserURL
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &DiscordClient{cfg: cfg, http: hc}
+}
+
+// AuthCodeURL builds the authorize redirect URL: response_type=code, the
+// identify scope (enough for the @me identity), and the anti-forgery state.
+func (c *DiscordClient) AuthCodeURL(state string) string {
+	q := url.Values{}
+	q.Set("client_id", c.cfg.ClientID)
+	q.Set("redirect_uri", c.cfg.RedirectURL)
+	q.Set("response_type", "code")
+	q.Set("scope", "identify")
+	q.Set("state", state)
+	return c.cfg.AuthorizeURL + "?" + q.Encode()
+}
+
+// Exchange performs the OAuth code→token→user round trip and composes the
+// avatar URL. Errors carry no credential material.
+func (c *DiscordClient) Exchange(ctx context.Context, code string) (DiscordUser, error) {
+	token, err := c.exchangeCode(ctx, code)
+	if err != nil {
+		return DiscordUser{}, err
+	}
+	return c.fetchUser(ctx, token)
+}
+
+func (c *DiscordClient) exchangeCode(ctx context.Context, code string) (string, error) {
+	form := url.Values{}
+	form.Set("client_id", c.cfg.ClientID)
+	form.Set("client_secret", c.cfg.ClientSecret)
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", c.cfg.RedirectURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("auth: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("auth: token request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("auth: token endpoint status %d", resp.StatusCode)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tok); err != nil {
+		return "", fmt.Errorf("auth: decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return "", fmt.Errorf("auth: token endpoint returned no access_token")
+	}
+	return tok.AccessToken, nil
+}
+
+func (c *DiscordClient) fetchUser(ctx context.Context, accessToken string) (DiscordUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.UserURL, nil)
+	if err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: build userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo endpoint status %d", resp.StatusCode)
+	}
+	var raw struct {
+		ID         string `json:"id"`
+		Username   string `json:"username"`
+		GlobalName string `json:"global_name"`
+		Avatar     string `json:"avatar"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&raw); err != nil {
+		return DiscordUser{}, fmt.Errorf("auth: decode userinfo response: %w", err)
+	}
+	if raw.ID == "" {
+		return DiscordUser{}, fmt.Errorf("auth: userinfo returned no id")
+	}
+	u := DiscordUser{ID: raw.ID, Username: raw.Username, GlobalName: raw.GlobalName}
+	if raw.Avatar != "" {
+		u.AvatarURL = fmt.Sprintf(avatarCDN, raw.ID, raw.Avatar)
+	}
+	return u, nil
+}

--- a/internal/auth/discord_test.go
+++ b/internal/auth/discord_test.go
@@ -1,0 +1,86 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+// TestDiscordClient_Exchange covers the OAuth token exchange against an httptest
+// "cassette" standing in for discord.com — no live Discord call (issue #67
+// acceptance). It asserts the code→token→user round trip parses correctly and
+// composes the avatar CDN URL, and that the token request carried the code +
+// client credentials.
+func TestDiscordClient_Exchange(t *testing.T) {
+	t.Parallel()
+
+	var gotCode, gotClientID, gotGrant, gotBearer string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotCode = r.Form.Get("code")
+		gotClientID = r.Form.Get("client_id")
+		gotGrant = r.Form.Get("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at-123","token_type":"Bearer"}`))
+	})
+	mux.HandleFunc("/users/@me", func(w http.ResponseWriter, r *http.Request) {
+		gotBearer = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"99","username":"sora","global_name":"Sora Vance","avatar":"abc"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:     "client-1",
+		ClientSecret: "secret-1",
+		RedirectURL:  "https://app/auth/discord/callback",
+		TokenURL:     srv.URL + "/oauth2/token",
+		UserURL:      srv.URL + "/users/@me",
+		HTTPClient:   srv.Client(),
+	})
+
+	du, err := client.Exchange(context.Background(), "the-code")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if du.ID != "99" || du.Username != "sora" || du.GlobalName != "Sora Vance" {
+		t.Errorf("user = %+v", du)
+	}
+	if du.DisplayName() != "Sora Vance" {
+		t.Errorf("DisplayName = %q, want global name", du.DisplayName())
+	}
+	if du.AvatarURL != "https://cdn.discordapp.com/avatars/99/abc.png" {
+		t.Errorf("AvatarURL = %q", du.AvatarURL)
+	}
+	if gotCode != "the-code" || gotClientID != "client-1" || gotGrant != "authorization_code" {
+		t.Errorf("token request: code=%q client_id=%q grant=%q", gotCode, gotClientID, gotGrant)
+	}
+	if gotBearer != "Bearer at-123" {
+		t.Errorf("userinfo Authorization = %q, want Bearer at-123", gotBearer)
+	}
+}
+
+// TestDiscordClient_AuthCodeURL asserts the authorize redirect carries the
+// client id, redirect uri, response_type=code, identify scope, and the state.
+func TestDiscordClient_AuthCodeURL(t *testing.T) {
+	t.Parallel()
+	client := auth.NewDiscordClient(auth.DiscordConfig{
+		ClientID:    "cid",
+		RedirectURL: "https://app/cb",
+	})
+	got := client.AuthCodeURL("state-xyz")
+	for _, want := range []string{
+		"client_id=cid", "response_type=code", "scope=identify", "state=state-xyz",
+		"redirect_uri=https%3A%2F%2Fapp%2Fcb",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthCodeURL missing %q in %q", want, got)
+		}
+	}
+}

--- a/internal/auth/interceptors.go
+++ b/internal/auth/interceptors.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Authenticator validates a session token and resolves the owning operator.
+// *storage.Store satisfies it via AuthenticateSession.
+type Authenticator interface {
+	AuthenticateSession(ctx context.Context, token string) (storage.User, error)
+}
+
+// TenantResolver resolves the tenant bound to an operator (ADR-0039 thin
+// pass-through). *storage.Store satisfies it via TenantForUser.
+type TenantResolver interface {
+	TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error)
+}
+
+// NewAuthInterceptor validates the glyphoxa_session cookie on every Connect call
+// and puts the resolved operator into the request context ([CurrentUser]).
+// Unauthenticated requests are rejected with CodeUnauthenticated — INCLUDING
+// reads, so the whole API is gated — EXCEPT procedures named in public, which
+// are allowed through unauthenticated so they can self-handle the missing
+// session (AuthService.GetCurrentUser returns CodeUnauthenticated itself, the
+// SPA's 401 → /login probe).
+func NewAuthInterceptor(a Authenticator, public ...string) connect.UnaryInterceptorFunc {
+	publicSet := make(map[string]struct{}, len(public))
+	for _, p := range public {
+		publicSet[p] = struct{}{}
+	}
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if token := cookieValue(req.Header(), SessionCookieName); token != "" {
+				if u, err := a.AuthenticateSession(ctx, token); err == nil {
+					return next(WithUser(ctx, u), req)
+				}
+			}
+			if _, ok := publicSet[req.Spec().Procedure]; ok {
+				return next(ctx, req)
+			}
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authentication required"))
+		}
+	}
+}
+
+// NewCSRFInterceptor enforces the double-submit CSRF check (ADR-0016) on
+// state-changing calls: the X-CSRF-Token header must match the glyphoxa_csrf
+// cookie, else CodePermissionDenied. Reads (NO_SIDE_EFFECTS, e.g.
+// GetActiveCampaign / GetCurrentUser) are exempt — they mutate nothing, and the
+// CSRF cookie is not guaranteed present before the first login.
+func NewCSRFInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if req.Spec().IdempotencyLevel == connect.IdempotencyNoSideEffects {
+				return next(ctx, req)
+			}
+			cookie := cookieValue(req.Header(), CSRFCookieName)
+			header := req.Header().Get("X-CSRF-Token")
+			if cookie == "" || header == "" ||
+				subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
+				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("CSRF token mismatch"))
+			}
+			return next(ctx, req)
+		}
+	}
+}
+
+// NewTenantInterceptor resolves the authenticated operator's bound tenant and
+// puts it in the context ([TenantID]). For the single operator this is the thin
+// X-Tenant-Id pass-through (ADR-0039): the tenant is resolved server-side from
+// the operator, not trusted from a client header, so the multi-tenant
+// membership check fills in here later without a rewrite. Unauthenticated reads
+// (no operator in ctx) pass through untouched; a resolve failure is logged and
+// the request proceeds without a tenant (handlers that need one fail on their
+// own terms).
+func NewTenantInterceptor(tr TenantResolver) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			u, ok := CurrentUser(ctx)
+			if !ok {
+				return next(ctx, req)
+			}
+			tenantID, err := tr.TenantForUser(ctx, u.ID)
+			if err != nil {
+				slog.Default().Warn("tenant interceptor: no tenant for operator",
+					"user_id", u.ID, "err", err)
+				return next(ctx, req)
+			}
+			return next(WithTenant(ctx, tenantID), req)
+		}
+	}
+}
+
+// Stack is the ordered Connect interceptor stack the web tier mounts on every
+// management handler: auth (who) → CSRF (anti-forgery) → tenant (which tenant).
+// Build it with [NewStack] and apply it with [Stack.HandlerOptions]. The stacked
+// #68/#71 PRs reuse the same Stack so the gate is identical across services.
+type Stack struct {
+	interceptors []connect.Interceptor
+}
+
+// NewStack assembles the interceptor stack. public lists the fully-qualified
+// procedures reachable without a valid session (the SPA's
+// AuthService.GetCurrentUser boot probe).
+func NewStack(a Authenticator, tr TenantResolver, public ...string) *Stack {
+	return &Stack{interceptors: []connect.Interceptor{
+		NewAuthInterceptor(a, public...),
+		NewCSRFInterceptor(),
+		NewTenantInterceptor(tr),
+	}}
+}
+
+// HandlerOptions returns the connect.HandlerOption that installs the stack on a
+// generated handler, e.g. authServer.Handler(stack.HandlerOptions()...).
+func (s *Stack) HandlerOptions() []connect.HandlerOption {
+	return []connect.HandlerOption{connect.WithInterceptors(s.interceptors...)}
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// OAuthStore is the persistence the OAuth callback needs: refresh the operator
+// record, bind the single tenant, and create the session row. *storage.Store
+// satisfies it.
+type OAuthStore interface {
+	UpsertUser(ctx context.Context, p storage.UpsertUserParams) (storage.User, error)
+	ResolveOperatorTenant(ctx context.Context, userID uuid.UUID) (storage.Tenant, error)
+	CreateSession(ctx context.Context, n storage.NewSession) (storage.Session, error)
+}
+
+// defaultSessionTTL is how long a freshly issued session is valid.
+const defaultSessionTTL = 30 * 24 * time.Hour
+
+// stateCookieTTL bounds the OAuth round trip; the state nonce only has to
+// survive the redirect to Discord and back.
+const stateCookieTTL = 10 * time.Minute
+
+// OAuth serves the Discord OAuth carve-out (ADR-0015 — HTML redirects, NOT
+// Connect): GET /auth/discord/login starts the flow, GET /auth/discord/callback
+// finishes it by issuing the session + CSRF cookies (ADR-0016).
+type OAuth struct {
+	store    OAuthStore
+	discord  DiscordOAuth
+	ttl      time.Duration
+	redirect string // where the callback sends the browser after login
+	now      func() time.Time
+	log      *slog.Logger
+}
+
+// NewOAuth builds the OAuth handlers. appRedirect is the post-login destination
+// (the SPA root, "/").
+func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, log *slog.Logger) *OAuth {
+	if appRedirect == "" {
+		appRedirect = "/"
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &OAuth{
+		store:    store,
+		discord:  discord,
+		ttl:      defaultSessionTTL,
+		redirect: appRedirect,
+		now:      time.Now,
+		log:      log,
+	}
+}
+
+// Login starts the OAuth flow: mint an anti-forgery state nonce, stash it in a
+// short-lived cookie, and 302 to Discord's authorize URL.
+func (o *OAuth) Login(w http.ResponseWriter, r *http.Request) {
+	state, err := newToken()
+	if err != nil {
+		o.log.Error("oauth login: mint state", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	secure := requestSecure(r)
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    state,
+		Path:     "/",
+		Expires:  o.now().Add(stateCookieTTL),
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, o.discord.AuthCodeURL(state), http.StatusFound)
+}
+
+// Callback finishes the OAuth flow: verify the state nonce, exchange the code
+// for the Discord identity, upsert the operator, bind the tenant, create the
+// session, set the session + CSRF cookies, clear the state cookie, and 302 to
+// the SPA. The Discord exchange is behind the DiscordOAuth interface so CI uses
+// a fake — no live Discord call.
+func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
+	state := r.FormValue("state")
+	stateCookie, err := r.Cookie(stateCookieName)
+	if err != nil || state == "" ||
+		subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(state)) != 1 {
+		http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+		return
+	}
+	code := r.FormValue("code")
+	if code == "" {
+		http.Error(w, "missing OAuth code", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	du, err := o.discord.Exchange(ctx, code)
+	if err != nil {
+		// The raw error can carry endpoint/status detail; log it, return generic.
+		o.log.Error("oauth callback: discord exchange", "err", err)
+		http.Error(w, "discord sign-in failed", http.StatusBadGateway)
+		return
+	}
+
+	user, err := o.store.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: du.ID,
+		Name:          du.DisplayName(),
+		Avatar:        du.AvatarURL,
+	})
+	if err != nil {
+		o.log.Error("oauth callback: upsert user", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if _, err := o.store.ResolveOperatorTenant(ctx, user.ID); err != nil {
+		o.log.Error("oauth callback: bind tenant", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	sessionToken, err := newToken()
+	if err != nil {
+		o.log.Error("oauth callback: mint session token", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	csrfToken, err := newToken()
+	if err != nil {
+		o.log.Error("oauth callback: mint csrf token", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	expires := o.now().Add(o.ttl)
+	if _, err := o.store.CreateSession(ctx, storage.NewSession{
+		UserID:    user.ID,
+		Token:     sessionToken,
+		ExpiresAt: expires,
+		IP:        clientIP(r),
+		UA:        r.UserAgent(),
+	}); err != nil {
+		o.log.Error("oauth callback: create session", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	secure := requestSecure(r)
+	http.SetCookie(w, sessionCookie(sessionToken, secure, expires))
+	http.SetCookie(w, csrfCookie(csrfToken, secure, expires))
+	http.SetCookie(w, clearCookie(stateCookieName, true, secure))
+	http.Redirect(w, r, o.redirect, http.StatusFound)
+}
+
+// clientIP extracts the best-effort client IP for the session audit row,
+// preferring the proxy's X-Forwarded-For first hop.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		first, _, _ := strings.Cut(xff, ",")
+		return strings.TrimSpace(first)
+	}
+	return r.RemoteAddr
+}

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,0 +1,168 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeDiscord is a DiscordOAuth stand-in: AuthCodeURL echoes the state and
+// Exchange returns a canned user — no live Discord call.
+type fakeDiscord struct {
+	user     auth.DiscordUser
+	gotCode  string
+	authBase string
+}
+
+func (f *fakeDiscord) AuthCodeURL(state string) string {
+	return f.authBase + "?state=" + state
+}
+
+func (f *fakeDiscord) Exchange(_ context.Context, code string) (auth.DiscordUser, error) {
+	f.gotCode = code
+	return f.user, nil
+}
+
+// fakeOAuthStore records the writes the callback performs.
+type fakeOAuthStore struct {
+	upserted storage.UpsertUserParams
+	resolved uuid.UUID
+	created  storage.NewSession
+	userID   uuid.UUID
+	tenantID uuid.UUID
+}
+
+func (f *fakeOAuthStore) UpsertUser(_ context.Context, p storage.UpsertUserParams) (storage.User, error) {
+	f.upserted = p
+	return storage.User{ID: f.userID, DiscordUserID: p.DiscordUserID, Name: p.Name, Avatar: p.Avatar, Role: "operator"}, nil
+}
+
+func (f *fakeOAuthStore) ResolveOperatorTenant(_ context.Context, userID uuid.UUID) (storage.Tenant, error) {
+	f.resolved = userID
+	return storage.Tenant{ID: f.tenantID, Name: "Glyphoxa"}, nil
+}
+
+func (f *fakeOAuthStore) CreateSession(_ context.Context, n storage.NewSession) (storage.Session, error) {
+	f.created = n
+	return storage.Session{ID: uuid.New(), UserID: n.UserID, Token: n.Token, ExpiresAt: n.ExpiresAt}, nil
+}
+
+func TestOAuthLogin_RedirectsAndSetsState(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{authBase: "https://discord/authorize"}
+	o := auth.NewOAuth(&fakeOAuthStore{}, disc, "/", nil)
+
+	rec := httptest.NewRecorder()
+	o.Login(rec, httptest.NewRequest(http.MethodGet, "/auth/discord/login", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://discord/authorize?state=") {
+		t.Fatalf("Location = %q", loc)
+	}
+	state := strings.TrimPrefix(loc, "https://discord/authorize?state=")
+
+	// The state cookie is set and matches the state in the redirect URL.
+	var stateCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_oauth_state" {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("no state cookie set")
+	}
+	if stateCookie.Value != state {
+		t.Errorf("state cookie %q != redirect state %q", stateCookie.Value, state)
+	}
+	if !stateCookie.HttpOnly {
+		t.Error("state cookie must be HttpOnly")
+	}
+}
+
+func TestOAuthCallback_IssuesSessionCookie(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{user: auth.DiscordUser{ID: "77", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png"}}
+	store := &fakeOAuthStore{userID: uuid.New(), tenantID: uuid.New()}
+	o := auth.NewOAuth(store, disc, "/", nil)
+
+	// A valid callback presents the state cookie matching the state param + a code.
+	form := url.Values{"code": {"the-code"}, "state": {"st-1"}}
+	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?"+form.Encode(), nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st-1"})
+
+	rec := httptest.NewRecorder()
+	o.Callback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Errorf("Location = %q, want /", loc)
+	}
+
+	// The Discord identity was upserted (display name preferred) and the tenant bound.
+	if store.upserted.DiscordUserID != "77" || store.upserted.Name != "Sora Vance" || store.upserted.Avatar != "https://cdn/a.png" {
+		t.Errorf("upserted = %+v", store.upserted)
+	}
+	if store.resolved != store.userID {
+		t.Errorf("ResolveOperatorTenant got %s, want %s", store.resolved, store.userID)
+	}
+	if disc.gotCode != "the-code" {
+		t.Errorf("exchanged code = %q", disc.gotCode)
+	}
+
+	// The session + CSRF cookies are issued; the session cookie value matches the
+	// persisted session token; HttpOnly only on the session cookie.
+	cookies := map[string]*http.Cookie{}
+	for _, c := range rec.Result().Cookies() {
+		cookies[c.Name] = c
+	}
+	sess := cookies["glyphoxa_session"]
+	csrf := cookies["glyphoxa_csrf"]
+	if sess == nil || csrf == nil {
+		t.Fatalf("missing session/csrf cookies: %v", cookies)
+	}
+	if sess.Value != store.created.Token {
+		t.Errorf("session cookie %q != stored token %q", sess.Value, store.created.Token)
+	}
+	if !sess.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if csrf.HttpOnly {
+		t.Error("csrf cookie must NOT be HttpOnly (double-submit needs script access)")
+	}
+	if sess.SameSite != http.SameSiteLaxMode {
+		t.Error("session cookie must be SameSite=Lax")
+	}
+}
+
+func TestOAuthCallback_BadState_Rejected(t *testing.T) {
+	t.Parallel()
+	store := &fakeOAuthStore{}
+	o := auth.NewOAuth(store, &fakeDiscord{}, "/", nil)
+
+	// State cookie does not match the state param.
+	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=mismatch", nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "real-state"})
+
+	rec := httptest.NewRecorder()
+	o.Callback(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if store.created.Token != "" {
+		t.Error("session created despite state mismatch")
+	}
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+)
+
+// SessionDeleter revokes a session by token (logout). *storage.Store satisfies
+// it via DeleteSession.
+type SessionDeleter interface {
+	DeleteSession(ctx context.Context, token string) error
+}
+
+// AuthServer implements the Connect AuthService (ADR-0016 / ADR-0039): it reads
+// the operator the auth interceptor resolved into the context and tears the
+// session down on logout. The interceptor stack ([NewStack]) does the cookie
+// validation + CSRF; this handler is the thin policy layer over it.
+type AuthServer struct {
+	sessions SessionDeleter
+	log      *slog.Logger
+}
+
+var _ managementv1connect.AuthServiceHandler = (*AuthServer)(nil)
+
+// NewAuthServer builds an AuthServer over the session store.
+func NewAuthServer(sessions SessionDeleter, log *slog.Logger) *AuthServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &AuthServer{sessions: sessions, log: log}
+}
+
+// GetCurrentUser returns the signed-in operator's display identity. The auth
+// interceptor leaves this procedure reachable unauthenticated (it is in the
+// public set), so a missing/expired session reaches here with no operator in the
+// context and yields CodeUnauthenticated — the SPA's 401 → /login signal.
+func (s *AuthServer) GetCurrentUser(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetCurrentUserRequest],
+) (*connect.Response[managementv1.GetCurrentUserResponse], error) {
+	u, ok := CurrentUser(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	return connect.NewResponse(&managementv1.GetCurrentUserResponse{
+		User: &managementv1.User{
+			Name:   u.Name,
+			Role:   u.Role,
+			Avatar: u.Avatar,
+		},
+	}), nil
+}
+
+// Logout deletes the server-side session row and clears the session + CSRF
+// cookies. It is state-changing, so the auth + CSRF interceptors have already
+// proven a valid session and a matching CSRF token before it runs.
+func (s *AuthServer) Logout(
+	ctx context.Context,
+	req *connect.Request[managementv1.LogoutRequest],
+) (*connect.Response[managementv1.LogoutResponse], error) {
+	if token := cookieValue(req.Header(), SessionCookieName); token != "" {
+		if err := s.sessions.DeleteSession(ctx, token); err != nil {
+			s.log.Error("logout: delete session", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+	resp := connect.NewResponse(&managementv1.LogoutResponse{})
+	secure := headerSecure(req.Header())
+	resp.Header().Add("Set-Cookie", clearCookie(SessionCookieName, true, secure).String())
+	resp.Header().Add("Set-Cookie", clearCookie(CSRFCookieName, false, secure).String())
+	return resp, nil
+}
+
+// Handler builds the Connect HTTP handler for AuthService and returns the path +
+// handler, mirroring (*rpc.CampaignServer).Handler. Pass the auth interceptor
+// stack via opts (see [Stack.HandlerOptions]).
+func (s *AuthServer) Handler(opts ...connect.HandlerOption) (string, http.Handler) {
+	return managementv1connect.NewAuthServiceHandler(s, opts...)
+}

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,180 @@
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeAuthN is a keyless Authenticator: a token resolves to a user only if it is
+// in the map, else ErrNotFound (the "missing/expired" path).
+type fakeAuthN struct{ users map[string]storage.User }
+
+func (f fakeAuthN) AuthenticateSession(_ context.Context, token string) (storage.User, error) {
+	if u, ok := f.users[token]; ok {
+		return u, nil
+	}
+	return storage.User{}, storage.ErrNotFound
+}
+
+type fakeTenant struct {
+	id  uuid.UUID
+	err error
+}
+
+func (f fakeTenant) TenantForUser(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return f.id, f.err
+}
+
+type fakeDeleter struct{ deleted []string }
+
+func (f *fakeDeleter) DeleteSession(_ context.Context, token string) error {
+	f.deleted = append(f.deleted, token)
+	return nil
+}
+
+const (
+	validToken = "valid-session-token"
+	csrfValue  = "csrf-secret"
+)
+
+func operator() storage.User {
+	return storage.User{
+		ID: uuid.New(), DiscordUserID: "42",
+		Name: "Sora Vance", Role: "operator", Avatar: "https://cdn/x.png",
+	}
+}
+
+// newAuthClient stands up the AuthService handler behind the real interceptor
+// stack and an httptest server, with the given fakes. GetCurrentUser is the only
+// public (unauthenticated-reachable) procedure.
+func newAuthClient(t *testing.T, authn auth.Authenticator, del auth.SessionDeleter) managementv1connect.AuthServiceClient {
+	t.Helper()
+	stack := auth.NewStack(authn, fakeTenant{id: uuid.New()},
+		managementv1connect.AuthServiceGetCurrentUserProcedure)
+	server := auth.NewAuthServer(del, slog.Default())
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler(stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
+func TestGetCurrentUser_ValidCookie(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, &fakeDeleter{})
+
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken)
+
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetCurrentUser(valid): %v", err)
+	}
+	got := resp.Msg.GetUser()
+	if got.GetName() != op.Name || got.GetRole() != op.Role || got.GetAvatar() != op.Avatar {
+		t.Errorf("user = %+v, want name/role/avatar of %+v", got, op)
+	}
+}
+
+func TestGetCurrentUser_MissingCookie_401(t *testing.T) {
+	t.Parallel()
+	client := newAuthClient(t, fakeAuthN{}, &fakeDeleter{})
+
+	_, err := client.GetCurrentUser(context.Background(),
+		connect.NewRequest(&managementv1.GetCurrentUserRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+}
+
+func TestGetCurrentUser_ExpiredCookie_401(t *testing.T) {
+	t.Parallel()
+	// An empty user map means every token resolves to ErrNotFound — the
+	// expired/unknown path.
+	client := newAuthClient(t, fakeAuthN{}, &fakeDeleter{})
+
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"=expired-or-unknown")
+
+	_, err := client.GetCurrentUser(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+}
+
+func TestLogout_Unauthenticated_Rejected(t *testing.T) {
+	t.Parallel()
+	// Logout is state-changing and NOT public, so the auth interceptor rejects an
+	// unauthenticated call before any handler runs.
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{}, del)
+
+	_, err := client.Logout(context.Background(), connect.NewRequest(&managementv1.LogoutRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v, want CodeUnauthenticated", got)
+	}
+	if len(del.deleted) != 0 {
+		t.Errorf("session deleted on a rejected logout: %v", del.deleted)
+	}
+}
+
+func TestLogout_MissingCSRF_Rejected(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, del)
+
+	// Valid session, but no X-CSRF-Token header → double-submit fails.
+	req := connect.NewRequest(&managementv1.LogoutRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken+"; "+auth.CSRFCookieName+"="+csrfValue)
+
+	_, err := client.Logout(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
+		t.Fatalf("code = %v, want CodePermissionDenied", got)
+	}
+	if len(del.deleted) != 0 {
+		t.Errorf("session deleted despite CSRF failure: %v", del.deleted)
+	}
+}
+
+func TestLogout_Authenticated_DeletesAndClears(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	del := &fakeDeleter{}
+	client := newAuthClient(t, fakeAuthN{users: map[string]storage.User{validToken: op}}, del)
+
+	req := connect.NewRequest(&managementv1.LogoutRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken+"; "+auth.CSRFCookieName+"="+csrfValue)
+	req.Header().Set("X-CSRF-Token", csrfValue)
+
+	resp, err := client.Logout(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Logout(valid): %v", err)
+	}
+	if len(del.deleted) != 1 || del.deleted[0] != validToken {
+		t.Fatalf("deleted = %v, want [%s]", del.deleted, validToken)
+	}
+	// The session cookie is cleared on the response (Max-Age=0 from MaxAge=-1).
+	var cleared bool
+	for _, sc := range resp.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(sc, auth.SessionCookieName+"=") && strings.Contains(sc, "Max-Age=0") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Errorf("session cookie not cleared; Set-Cookie = %v", resp.Header().Values("Set-Cookie"))
+	}
+}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
@@ -20,23 +21,30 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// campaignReader is the read surface CampaignServer needs. *storage.Store
-// satisfies it via GetActiveCampaign, so handlers can be driven by a fake in
-// unit tests and the real store in integration tests.
-type campaignReader interface {
+// campaignStore is the narrow storage surface CampaignServer needs — the active
+// campaign read plus the roster reads and the agent CRUD writes (#71).
+// *storage.Store satisfies it, so handlers can be driven by a fake in unit tests
+// and the real store in integration tests.
+type campaignStore interface {
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
+	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
+	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
+	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
+	DeleteAgent(ctx context.Context, id uuid.UUID) error
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a
-// campaignReader.
+// campaignStore.
 type CampaignServer struct {
-	reader campaignReader
+	store campaignStore
 }
 
-// NewCampaignServer wraps a campaignReader (e.g. *storage.Store) in a
+// NewCampaignServer wraps a campaignStore (e.g. *storage.Store) in a
 // CampaignServer.
-func NewCampaignServer(r campaignReader) *CampaignServer {
-	return &CampaignServer{reader: r}
+func NewCampaignServer(s campaignStore) *CampaignServer {
+	return &CampaignServer{store: s}
 }
 
 // compile-time assertion that CampaignServer satisfies the generated handler.
@@ -49,7 +57,7 @@ func (s *CampaignServer) GetActiveCampaign(
 	ctx context.Context,
 	_ *connect.Request[managementv1.GetActiveCampaignRequest],
 ) (*connect.Response[managementv1.GetActiveCampaignResponse], error) {
-	c, err := s.reader.GetActiveCampaign(ctx)
+	c, err := s.store.GetActiveCampaign(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/campaign_crud.go
+++ b/internal/rpc/campaign_crud.go
@@ -1,0 +1,210 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Campaign-screen CRUD handlers (#71) on CampaignServer: the roster read plus
+// agent create/update/delete over the polymorphic agents table (ADR-0009).
+// Reads/writes resolve the single operator's active campaign server-side, the
+// same single-tenant pass-through GetActiveCampaign uses (ADR-0039); per-tenant
+// scoping fills in behind the X-Tenant-Id interceptor later.
+
+// GetCampaignRoster returns the active campaign with its ordered roster: the
+// Butler first, then the Character NPCs. No campaign yields CodeNotFound; a
+// missing Butler is an ADR-0009 invariant violation (logged, CodeInternal).
+func (s *CampaignServer) GetCampaignRoster(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetCampaignRosterRequest],
+) (*connect.Response[managementv1.GetCampaignRosterResponse], error) {
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("GetCampaignRoster: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	butler, err := s.store.GetButler(ctx, c.ID)
+	if err != nil {
+		// The Butler is auto-created with the campaign (ADR-0009); its absence is
+		// an invariant violation, not a client error. Log raw, return generic.
+		slog.Default().Error("GetCampaignRoster: get butler failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	chars, err := s.store.CharacterAgents(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("GetCampaignRoster: list character agents failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	roster := make([]*managementv1.Agent, 0, len(chars)+1)
+	roster = append(roster, toProtoAgent(butler))
+	for _, a := range chars {
+		roster = append(roster, toProtoAgent(a))
+	}
+
+	return connect.NewResponse(&managementv1.GetCampaignRosterResponse{
+		Campaign: toProtoCampaign(c),
+		Roster:   roster,
+	}), nil
+}
+
+// CreateAgent adds a Character NPC to the active campaign and returns it with its
+// server-assigned speaker-colour slot. The role is always 'character'.
+func (s *CampaignServer) CreateAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.CreateAgentRequest],
+) (*connect.Response[managementv1.CreateAgentResponse], error) {
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("CreateAgent: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	m := req.Msg
+	id, err := s.store.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  c.ID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        m.GetName(),
+		Title:       m.GetTitle(),
+		Persona:     m.GetPersona(),
+		Voice:       marshalVoice(m.GetVoice()),
+		AddressOnly: m.GetAddressOnly(),
+		Aliases:     m.GetAliases(),
+	})
+	if err != nil {
+		slog.Default().Error("CreateAgent: store create failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Read the row back so the response carries the assigned speaker-colour slot
+	// and the canonical persisted shape.
+	created, err := s.store.GetAgent(ctx, id)
+	if err != nil {
+		slog.Default().Error("CreateAgent: read-back failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.CreateAgentResponse{Agent: toProtoAgent(created)}), nil
+}
+
+// UpdateAgent saves an agent's editor fields and returns the updated agent. The
+// store force-keeps a Butler's role and Address-Only (ADR-0009 / ADR-0024). An
+// unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
+func (s *CampaignServer) UpdateAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateAgentRequest],
+) (*connect.Response[managementv1.UpdateAgentResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	m := req.Msg
+	updated, err := s.store.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          id,
+		Name:        m.GetName(),
+		Title:       m.GetTitle(),
+		Persona:     m.GetPersona(),
+		Voice:       marshalVoice(m.GetVoice()),
+		AddressOnly: m.GetAddressOnly(),
+		Aliases:     m.GetAliases(),
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("UpdateAgent: store update failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UpdateAgentResponse{Agent: toProtoAgent(updated)}), nil
+}
+
+// DeleteAgent removes a Character NPC. Deleting the Butler is CodeFailedPrecondition
+// (ADR-0009); an unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
+func (s *CampaignServer) DeleteAgent(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteAgentRequest],
+) (*connect.Response[managementv1.DeleteAgentResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	switch err := s.store.DeleteAgent(ctx, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.DeleteAgentResponse{}), nil
+	case errors.Is(err, storage.ErrButlerUndeletable):
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the butler cannot be deleted"))
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+	default:
+		slog.Default().Error("DeleteAgent: store delete failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// toProtoAgent maps a storage.Agent onto its wire representation. The encrypted
+// provider bindings are intentionally not exposed (ADR-0004); voice is reduced
+// to its opaque voice id.
+func toProtoAgent(a storage.Agent) *managementv1.Agent {
+	return &managementv1.Agent{
+		Id:           a.ID.String(),
+		CampaignId:   a.CampaignID.String(),
+		Role:         string(a.Role),
+		Name:         a.Name,
+		Title:        a.Title,
+		Persona:      a.Persona,
+		Voice:        unmarshalVoice(a.Voice),
+		AddressOnly:  a.AddressOnly,
+		SpeakerColor: uint32(a.SpeakerColor),
+		Aliases:      a.Aliases,
+	}
+}
+
+// voiceBlob is the minimal shape of an Agent's voice JSONB this slice reads and
+// writes: a single voice id. The column is JSONB so the shape can grow without a
+// migration (ADR-0022/0023); the editor only selects a voice id today.
+type voiceBlob struct {
+	VoiceID string `json:"voice_id"`
+}
+
+// marshalVoice wraps a selected voice id into the voice JSONB. An empty id yields
+// the empty object the schema defaults to, so "no voice" round-trips cleanly.
+func marshalVoice(voiceID string) []byte {
+	if voiceID == "" {
+		return []byte(`{}`)
+	}
+	b, err := json.Marshal(voiceBlob{VoiceID: voiceID})
+	if err != nil { // a string field cannot fail to marshal; guard defensively
+		return []byte(`{}`)
+	}
+	return b
+}
+
+// unmarshalVoice extracts the voice id from an Agent's voice JSONB, returning ""
+// for an empty/unparsable blob.
+func unmarshalVoice(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v voiceBlob
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	return v.VoiceID
+}

--- a/internal/rpc/campaign_crud_integration_test.go
+++ b/internal/rpc/campaign_crud_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+// This drives the CampaignService CRUD + roster handlers end to end over
+// Connect-JSON against a real *storage.Store (testcontainers Postgres), proving
+// the wire → store → wire round-trip including the auto-Butler invariant
+// (ADR-0009). Tag-isolated behind `integration`; reuses startPostgres/seedStore
+// from campaign_integration_test.go.
+
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+)
+
+func TestCampaignCRUD_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, _ := seedStore(t, dsn) // seedStore inserts a campaign → auto-Butler fires
+
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
+	)
+	ctx := context.Background()
+
+	// Roster starts with the auto-Butler alone, Address-Only and first.
+	roster, err := client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (initial): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 1 {
+		t.Fatalf("initial roster len = %d, want 1 (butler only)", got)
+	}
+	butler := roster.Msg.GetRoster()[0]
+	if butler.GetRole() != "butler" || !butler.GetAddressOnly() {
+		t.Fatalf("roster[0] is not the Address-Only Butler: %+v", butler)
+	}
+	if roster.Msg.GetCampaign().GetName() != "Lost Mine" || roster.Msg.GetCampaign().GetSystem() != "dnd5e" {
+		t.Errorf("campaign title/system wrong: %+v", roster.Msg.GetCampaign())
+	}
+
+	// Add an NPC.
+	created, err := client.CreateAgent(ctx, connect.NewRequest(&managementv1.CreateAgentRequest{
+		Name: "Bart", Title: "Gruff innkeeper", Persona: "Grumbles.", Voice: "rachel",
+	}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	bart := created.Msg.GetAgent()
+	if bart.GetRole() != "character" || bart.GetTitle() != "Gruff innkeeper" || bart.GetVoice() != "rachel" {
+		t.Errorf("created NPC fields wrong: %+v", bart)
+	}
+
+	// Edit every editor field, then reload the roster and assert it reloads
+	// identically (the acceptance round-trip).
+	if _, err := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{
+		Id: bart.GetId(), Name: "Bartholomew", Title: "Keeper of the Inn",
+		Persona: "Now grandiose.", Voice: "adam", AddressOnly: true, Aliases: []string{"Bart"},
+	})); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+
+	roster, err = client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (after update): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 2 {
+		t.Fatalf("roster len = %d, want 2 (butler + bart)", got)
+	}
+	reloaded := roster.Msg.GetRoster()[1]
+	if reloaded.GetName() != "Bartholomew" || reloaded.GetTitle() != "Keeper of the Inn" {
+		t.Errorf("update did not round-trip: %+v", reloaded)
+	}
+	if reloaded.GetVoice() != "adam" || !reloaded.GetAddressOnly() || len(reloaded.GetAliases()) != 1 {
+		t.Errorf("voice/address_only/aliases did not round-trip: %+v", reloaded)
+	}
+	if reloaded.GetSpeakerColor() != bart.GetSpeakerColor() {
+		t.Errorf("speaker_color flapped across update: %d → %d", bart.GetSpeakerColor(), reloaded.GetSpeakerColor())
+	}
+
+	// The Butler cannot be deleted (ADR-0009) — CodeFailedPrecondition.
+	_, err = client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: butler.GetId()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("DeleteAgent(butler) code = %v, want FailedPrecondition", got)
+	}
+
+	// The NPC deletes cleanly; the roster shrinks back to the Butler alone.
+	if _, err := client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: bart.GetId()})); err != nil {
+		t.Fatalf("DeleteAgent(bart): %v", err)
+	}
+	roster, err = client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster (after delete): %v", err)
+	}
+	if got := len(roster.Msg.GetRoster()); got != 1 {
+		t.Fatalf("roster len after delete = %d, want 1 (butler only)", got)
+	}
+
+	// Deleting a missing agent is CodeNotFound.
+	_, err = client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: bart.GetId()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("DeleteAgent(already-gone) code = %v, want NotFound", got)
+	}
+
+	// Sanity: the Butler survived the rejected delete and is still Address-Only.
+	campaignID := uuid.MustParse(butler.GetCampaignId())
+	survivor, err := store.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("Butler missing after rejected delete: %v", err)
+	}
+	if !survivor.AddressOnly {
+		t.Error("Butler lost Address-Only after the rejected delete")
+	}
+}

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -1,0 +1,339 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeCampaignStore is a small in-memory campaignStore for the CRUD handlers'
+// keyless unit tests. Error hooks (campErr/butlerErr/…) force the failure paths;
+// the agents map backs GetAgent/Create/Update/Delete so happy paths round-trip
+// without a database.
+type fakeCampaignStore struct {
+	campaign  storage.Campaign
+	campErr   error
+	butler    storage.Agent
+	butlerErr error
+	chars     []storage.Agent
+	charsErr  error
+
+	agents    map[uuid.UUID]storage.Agent
+	createErr error
+	updateErr error
+	deleteErr error
+	nextColor int
+
+	created []storage.NewAgent
+}
+
+func newFakeStore() *fakeCampaignStore {
+	return &fakeCampaignStore{agents: map[uuid.UUID]storage.Agent{}}
+}
+
+func (f *fakeCampaignStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	return f.campaign, f.campErr
+}
+
+func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
+	return f.butler, f.butlerErr
+}
+
+func (f *fakeCampaignStore) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return f.chars, f.charsErr
+}
+
+func (f *fakeCampaignStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeCampaignStore) CreateAgent(_ context.Context, a storage.NewAgent) (uuid.UUID, error) {
+	if f.createErr != nil {
+		return uuid.Nil, f.createErr
+	}
+	f.created = append(f.created, a)
+	id := uuid.New()
+	f.agents[id] = storage.Agent{
+		ID:           id,
+		CampaignID:   a.CampaignID,
+		Role:         a.Role,
+		Name:         a.Name,
+		Title:        a.Title,
+		Persona:      a.Persona,
+		Voice:        a.Voice,
+		AddressOnly:  a.AddressOnly,
+		SpeakerColor: f.nextColor,
+		Aliases:      a.Aliases,
+	}
+	f.nextColor++
+	return id, nil
+}
+
+func (f *fakeCampaignStore) UpdateAgent(_ context.Context, u storage.AgentUpdate) (storage.Agent, error) {
+	if f.updateErr != nil {
+		return storage.Agent{}, f.updateErr
+	}
+	a, ok := f.agents[u.ID]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	a.Name = u.Name
+	a.Title = u.Title
+	a.Persona = u.Persona
+	a.Voice = u.Voice
+	a.AddressOnly = u.AddressOnly
+	a.Aliases = u.Aliases
+	f.agents[u.ID] = a
+	return a, nil
+}
+
+func (f *fakeCampaignStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	if _, ok := f.agents[id]; !ok {
+		return storage.ErrNotFound
+	}
+	delete(f.agents, id)
+	return nil
+}
+
+// crudClient stands up the full CampaignService handler over an httptest server
+// and returns a Connect-JSON client.
+func crudClient(t *testing.T, store *fakeCampaignStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
+	)
+}
+
+func TestGetCampaignRoster_Order(t *testing.T) {
+	t.Parallel()
+
+	campID := uuid.New()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine", System: "dnd5e", Language: "en"}
+	store.butler = storage.Agent{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleButler, Name: "Glyphoxa", AddressOnly: true, SpeakerColor: 0}
+	store.chars = []storage.Agent{
+		{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "Ana", Title: "Scout", SpeakerColor: 0},
+		{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "Borin", Title: "Smith", SpeakerColor: 1},
+	}
+
+	client := crudClient(t, store)
+	resp, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster: %v", err)
+	}
+	if got := resp.Msg.GetCampaign().GetName(); got != "Lost Mine" {
+		t.Errorf("campaign name = %q, want Lost Mine", got)
+	}
+	roster := resp.Msg.GetRoster()
+	if len(roster) != 3 {
+		t.Fatalf("roster len = %d, want 3 (butler + 2)", len(roster))
+	}
+	if roster[0].GetRole() != "butler" || !roster[0].GetAddressOnly() {
+		t.Errorf("roster[0] should be the Address-Only Butler: %+v", roster[0])
+	}
+	if roster[1].GetName() != "Ana" || roster[2].GetName() != "Borin" {
+		t.Errorf("character order not preserved: %q, %q", roster[1].GetName(), roster[2].GetName())
+	}
+	if roster[1].GetTitle() != "Scout" {
+		t.Errorf("title not mapped: %q", roster[1].GetTitle())
+	}
+	if roster[2].GetSpeakerColor() != 1 {
+		t.Errorf("speaker_color not mapped: %d", roster[2].GetSpeakerColor())
+	}
+}
+
+func TestGetCampaignRoster_NoCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestGetCampaignRoster_ButlerMissingIsInternal(t *testing.T) {
+	t.Parallel()
+	// A campaign with no Butler is an ADR-0009 invariant violation, not a client
+	// error: it maps to Internal, not NotFound.
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.butlerErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.GetCampaignRoster(context.Background(),
+		connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestCreateAgent_IsCharacterWithColor(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.nextColor = 2
+	client := crudClient(t, store)
+
+	resp, err := client.CreateAgent(context.Background(),
+		connect.NewRequest(&managementv1.CreateAgentRequest{
+			Name: "New NPC", Title: "Wanderer", Persona: "Mysterious.", Voice: "adam",
+		}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	agent := resp.Msg.GetAgent()
+	if agent.GetRole() != "character" {
+		t.Errorf("created role = %q, want character", agent.GetRole())
+	}
+	if agent.GetName() != "New NPC" || agent.GetTitle() != "Wanderer" {
+		t.Errorf("fields not mapped: %+v", agent)
+	}
+	if agent.GetVoice() != "adam" {
+		t.Errorf("voice did not round-trip: %q, want adam", agent.GetVoice())
+	}
+	if agent.GetSpeakerColor() != 2 {
+		t.Errorf("speaker_color = %d, want the assigned 2", agent.GetSpeakerColor())
+	}
+	// The handler must force role 'character' regardless of any client intent.
+	if len(store.created) != 1 || store.created[0].Role != storage.AgentRoleCharacter {
+		t.Errorf("store was not asked to create a character: %+v", store.created)
+	}
+}
+
+func TestCreateAgent_NoCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.CreateAgent(context.Background(),
+		connect.NewRequest(&managementv1.CreateAgentRequest{Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestUpdateAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: "not-a-uuid", Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: uuid.New().String(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestUpdateAgent_HappyPathRoundTrips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old", SpeakerColor: 3}
+	client := crudClient(t, store)
+
+	resp, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{
+			Id: id.String(), Name: "New", Title: "Renamed", Persona: "Changed.",
+			Voice: "rachel", AddressOnly: true, Aliases: []string{"alt"},
+		}))
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	a := resp.Msg.GetAgent()
+	if a.GetName() != "New" || a.GetTitle() != "Renamed" || a.GetPersona() != "Changed." {
+		t.Errorf("editor fields not applied: %+v", a)
+	}
+	if a.GetVoice() != "rachel" || !a.GetAddressOnly() || len(a.GetAliases()) != 1 {
+		t.Errorf("voice/address_only/aliases not applied: %+v", a)
+	}
+	if a.GetSpeakerColor() != 3 {
+		t.Errorf("speaker_color must be immutable across update: %d", a.GetSpeakerColor())
+	}
+}
+
+func TestDeleteAgent_ButlerIsFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.deleteErr = storage.ErrButlerUndeletable
+	client := crudClient(t, store)
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+}
+
+func TestDeleteAgent_NotFound(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestDeleteAgent_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestDeleteAgent_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Doomed"}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if _, ok := store.agents[id]; ok {
+		t.Error("agent was not removed from the store")
+	}
+}

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -27,6 +27,28 @@ func (f fakeReader) GetActiveCampaign(context.Context) (storage.Campaign, error)
 	return f.campaign, f.err
 }
 
+// The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
+// tests; stub it so fakeReader still satisfies the widened interface. The CRUD
+// handlers have their own fake (campaign_crud_test.go).
+func (fakeReader) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return nil, nil
+}
+func (fakeReader) GetAgent(context.Context, uuid.UUID) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) CreateAgent(context.Context, storage.NewAgent) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+func (fakeReader) UpdateAgent(context.Context, storage.AgentUpdate) (storage.Agent, error) {
+	return storage.Agent{}, storage.ErrNotFound
+}
+func (fakeReader) DeleteAgent(context.Context, uuid.UUID) error {
+	return nil
+}
+
 // newClient stands up the CampaignServer handler behind an httptest server and
 // returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on
 // the wire (the default is binary proto), so this also asserts the RPC is

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -1,0 +1,300 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// envPlaceholderLast4 is the credentials_last4 the seed writes for a
+// provider_config whose real key lives in ENV/the keyring, not the DB (ADR-0039;
+// matches wirenpc's credPlaceholderLast4). A slot still holding it has no real
+// saved key, so the Configuration screen renders it as "Key needed".
+const envPlaceholderLast4 = "env"
+
+// providerStore is the narrow Configuration surface ProviderServer needs;
+// *storage.Store satisfies it. Handlers depend on this interface (not the
+// concrete store) so they unit-test keyless with a fake.
+type providerStore interface {
+	ListProviderConfigs(ctx context.Context, tenantID uuid.UUID) ([]storage.ProviderConfig, error)
+	UpsertProviderConfigs(ctx context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error)
+	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
+	SaveDiscordBotToken(ctx context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (storage.DeploymentConfig, error)
+	SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error)
+}
+
+// byokSlot is one Bring-Your-Own-Key provider the Configuration screen saves. A
+// provider can back several Components — ElevenLabs powers STT + TTS from one
+// key (ADR-0004) — so saving it upserts every listed Component; the first is the
+// display Component on the wire.
+type byokSlot struct {
+	provider   string
+	components []storage.Component
+}
+
+// byokSlots is the MVP provider matrix (ADR-0039): Groq (LLM) + ElevenLabs
+// (STT + TTS). The Discord bot token is NOT here — it is the deployment-shared
+// Bot (CONTEXT.md), stored in deployment_config, not a per-Component
+// provider_config.
+var byokSlots = []byokSlot{
+	{provider: "groq", components: []storage.Component{storage.ComponentLLM}},
+	{provider: "elevenlabs", components: []storage.Component{storage.ComponentTTS, storage.ComponentSTT}},
+}
+
+func slotFor(provider string) (byokSlot, bool) {
+	for _, s := range byokSlots {
+		if s.provider == provider {
+			return s, true
+		}
+	}
+	return byokSlot{}, false
+}
+
+// ProviderServer implements the Connect ProviderService over a providerStore and
+// the app cipher (ADR-0004 / ADR-0039). It enforces the write-only contract: a
+// saved secret's plaintext is sealed on the way in and never read back out — RPC
+// responses carry only last4 + metadata.
+type ProviderServer struct {
+	store  providerStore
+	cipher *crypto.Cipher // nil when $GLYPHOXA_SECRET is unset: reads still work, saves fail loudly
+	log    *slog.Logger
+}
+
+var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
+
+// NewProviderServer wraps a providerStore + cipher in a ProviderServer. A nil
+// cipher disables secret saves (CodeFailedPrecondition) while keeping reads
+// available, matching the keyless-degradation posture of the web tier.
+func NewProviderServer(store providerStore, cipher *crypto.Cipher, log *slog.Logger) *ProviderServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ProviderServer{store: store, cipher: cipher, log: log}
+}
+
+// Handler builds the Connect HTTP handler for ProviderService and returns its
+// mount path + handler, mirroring (*CampaignServer).Handler.
+func (s *ProviderServer) Handler(opts ...connect.HandlerOption) (string, http.Handler) {
+	return managementv1connect.NewProviderServiceHandler(s, opts...)
+}
+
+// tenant resolves the operator's tenant the auth interceptor stack put in the
+// context (ADR-0039 thin pass-through). Behind the stack this is always present;
+// a missing tenant is treated as unauthenticated.
+func (s *ProviderServer) tenant(ctx context.Context) (uuid.UUID, error) {
+	id, ok := auth.TenantID(ctx)
+	if !ok {
+		return uuid.Nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no tenant in context"))
+	}
+	return id, nil
+}
+
+// ListProviderConfigs returns the three write-only credential slots (Discord,
+// Groq, ElevenLabs) plus the non-secret Discord IDs. No secret value is read.
+func (s *ProviderServer) ListProviderConfigs(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListProviderConfigsRequest],
+) (*connect.Response[managementv1.ListProviderConfigsResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, err := s.store.ListProviderConfigs(ctx, tenantID)
+	if err != nil {
+		s.log.Error("ListProviderConfigs: list provider_config failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	// Index by provider, keeping the most-recently-updated row (ElevenLabs has
+	// two rows — stt + tts — sharing one key; either represents the slot).
+	byProvider := make(map[string]storage.ProviderConfig, len(configs))
+	for _, c := range configs {
+		if cur, ok := byProvider[c.Provider]; !ok || c.UpdatedAt.After(cur.UpdatedAt) {
+			byProvider[c.Provider] = c
+		}
+	}
+
+	dep, err := s.store.GetDeploymentConfig(ctx, tenantID)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		s.log.Error("ListProviderConfigs: get deployment_config failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	// ErrNotFound → zero DeploymentConfig (all empty): the unsaved, key-needed state.
+
+	creds := []*managementv1.ProviderCredential{discordCredential(dep)}
+	for _, slot := range byokSlots {
+		creds = append(creds, providerCredential(string(slot.components[0]), slot.provider, byProvider[slot.provider]))
+	}
+
+	return connect.NewResponse(&managementv1.ListProviderConfigsResponse{
+		Credentials:    creds,
+		GuildId:        dep.GuildID,
+		VoiceChannelId: dep.VoiceChannelID,
+	}), nil
+}
+
+// SaveProviderConfig seals a BYOK provider key and upserts every Component the
+// provider backs, returning only the saved key's masked metadata.
+func (s *ProviderServer) SaveProviderConfig(
+	ctx context.Context,
+	req *connect.Request[managementv1.SaveProviderConfigRequest],
+) (*connect.Response[managementv1.SaveProviderConfigResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.cipher == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
+	}
+
+	slot, ok := slotFor(req.Msg.GetProvider())
+	if !ok {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("unknown provider %q", req.Msg.GetProvider()))
+	}
+	secret := req.Msg.GetSecret()
+	if secret == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("secret is required"))
+	}
+
+	sealed, last4, err := s.seal(secret)
+	if err != nil {
+		s.log.Error("SaveProviderConfig: seal failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	model := req.Msg.GetModel()
+	batch := make([]storage.NewProviderConfig, 0, len(slot.components))
+	for _, comp := range slot.components {
+		batch = append(batch, storage.NewProviderConfig{
+			TenantID:              tenantID,
+			Component:             comp,
+			Provider:              slot.provider,
+			Model:                 model,
+			CredentialsCiphertext: sealed,
+			CredentialsLast4:      last4,
+		})
+	}
+	saved, err := s.store.UpsertProviderConfigs(ctx, batch)
+	if err != nil {
+		s.log.Error("SaveProviderConfig: upsert failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	return connect.NewResponse(&managementv1.SaveProviderConfigResponse{
+		Credential: providerCredential(string(slot.components[0]), slot.provider, saved[0]),
+	}), nil
+}
+
+// SaveDiscordSettings stores the Discord bot token (when present) and the
+// non-secret Guild / Voice channel IDs. An omitted bot_token leaves the stored
+// token untouched; the column-isolated upserts mean the token Save and the IDs
+// Save never clobber each other.
+func (s *ProviderServer) SaveDiscordSettings(
+	ctx context.Context,
+	req *connect.Request[managementv1.SaveDiscordSettingsRequest],
+) (*connect.Response[managementv1.SaveDiscordSettingsResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bot token first (when the client sent one), so the IDs upsert below returns
+	// the row with the freshly-saved token last4.
+	if req.Msg.BotToken != nil {
+		if s.cipher == nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition,
+				errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
+		}
+		token := req.Msg.GetBotToken()
+		if token == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument,
+				errors.New("bot_token must not be empty when provided"))
+		}
+		sealed, last4, err := s.seal(token)
+		if err != nil {
+			s.log.Error("SaveDiscordSettings: seal failed", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		if _, err := s.store.SaveDiscordBotToken(ctx, tenantID, sealed, last4); err != nil {
+			s.log.Error("SaveDiscordSettings: save token failed", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	dep, err := s.store.SaveDiscordChannels(ctx, tenantID, req.Msg.GetGuildId(), req.Msg.GetVoiceChannelId())
+	if err != nil {
+		s.log.Error("SaveDiscordSettings: save channels failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	return connect.NewResponse(&managementv1.SaveDiscordSettingsResponse{
+		Credential:     discordCredential(dep),
+		GuildId:        dep.GuildID,
+		VoiceChannelId: dep.VoiceChannelID,
+	}), nil
+}
+
+// seal encrypts a plaintext secret and returns the ciphertext + its last4. The
+// caller guards s.cipher != nil before calling.
+func (s *ProviderServer) seal(secret string) (ciphertext []byte, last4 string, err error) {
+	sealed, err := s.cipher.Seal([]byte(secret))
+	if err != nil {
+		return nil, "", err
+	}
+	return sealed, crypto.Last4(secret), nil
+}
+
+// providerCredential maps a stored provider_config onto its write-only wire
+// view. A zero-value config (no row) or one still holding the ENV placeholder is
+// reported as never-saved.
+func providerCredential(component, provider string, c storage.ProviderConfig) *managementv1.ProviderCredential {
+	saved := isSaved(c.CredentialsLast4)
+	cred := &managementv1.ProviderCredential{
+		Component:  component,
+		Provider:   provider,
+		EverSaved:  saved,
+		ShowMasked: saved,
+		Model:      c.Model,
+	}
+	if saved {
+		cred.Last4 = c.CredentialsLast4
+		cred.UpdatedAt = timestamppb.New(c.UpdatedAt)
+	}
+	return cred
+}
+
+// discordCredential maps the deployment Bot token onto its write-only wire view.
+func discordCredential(d storage.DeploymentConfig) *managementv1.ProviderCredential {
+	saved := isSaved(d.DiscordBotTokenLast4)
+	cred := &managementv1.ProviderCredential{
+		Component:  "discord",
+		Provider:   "discord",
+		EverSaved:  saved,
+		ShowMasked: saved,
+	}
+	if saved {
+		cred.Last4 = d.DiscordBotTokenLast4
+		cred.UpdatedAt = timestamppb.New(d.UpdatedAt)
+	}
+	return cred
+}
+
+// isSaved reports whether a last4 marks a real saved key: non-empty and not the
+// seed's ENV placeholder.
+func isSaved(last4 string) bool {
+	return last4 != "" && last4 != envPlaceholderLast4
+}

--- a/internal/rpc/provider_integration_test.go
+++ b/internal/rpc/provider_integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+// Drives ProviderService against a real *storage.Store (testcontainers Postgres)
+// end to end over Connect-JSON, with the app cipher, proving the write-only BYOK
+// contract at the storage boundary: a saved secret is sealed at rest and never
+// returned. Tag-isolated behind `integration` (ADR-0021 / ADR-0033). The
+// Postgres harness (startPostgres) is shared with campaign_integration_test.go.
+
+package rpc_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// seedTenant migrates the schema and inserts one tenant, returning a Store over
+// the DB, the pool (for direct assertions), and the tenant id.
+func seedTenant(t *testing.T, dsn string) (*storage.Store, *pgxpool.Pool, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var tenantID uuid.UUID
+	if err := pool.QueryRow(ctx, `INSERT INTO tenant (name) VALUES ('Acme TTRPG') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	return storage.New(pool), pool, tenantID
+}
+
+func providerClient(t *testing.T, store *storage.Store, cipher *crypto.Cipher, tenantID uuid.UUID) managementv1connect.ProviderServiceClient {
+	t.Helper()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(auth.WithTenant(ctx, tenantID), req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewProviderServer(store, cipher, nil).Handler(connect.WithInterceptors(inject)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewProviderServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
+func TestProviderService_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, pool, tenantID := seedTenant(t, dsn)
+	cipher, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	client := providerClient(t, store, cipher, tenantID)
+	ctx := context.Background()
+
+	const secret = "test-groq-secret-aaaa"
+
+	// Save a Groq key.
+	saveResp, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: secret, Model: "llama-3.3-70b-versatile",
+	}))
+	if err != nil {
+		t.Fatalf("SaveProviderConfig: %v", err)
+	}
+	if got := saveResp.Msg.GetCredential().GetLast4(); got != crypto.Last4(secret) {
+		t.Errorf("last4 = %q, want %q", got, crypto.Last4(secret))
+	}
+	if strings.Contains(saveResp.Msg.GetCredential().String(), secret) {
+		t.Fatal("response leaked the plaintext secret")
+	}
+
+	// At rest the DB holds ciphertext (sealed), never the plaintext, and it opens
+	// back to the original — the write-only round-trip.
+	var ciphertext []byte
+	var last4 string
+	if err := pool.QueryRow(ctx,
+		`SELECT credentials_ciphertext, credentials_last4 FROM provider_config
+		  WHERE tenant_id = $1 AND component = 'llm' AND provider = 'groq'`, tenantID).
+		Scan(&ciphertext, &last4); err != nil {
+		t.Fatalf("read stored row: %v", err)
+	}
+	if strings.Contains(string(ciphertext), secret) {
+		t.Fatal("stored ciphertext contains the plaintext")
+	}
+	opened, err := cipher.Open(ciphertext)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if string(opened) != secret {
+		t.Errorf("round-trip = %q, want %q", opened, secret)
+	}
+	if last4 != crypto.Last4(secret) {
+		t.Errorf("stored last4 = %q, want %q", last4, crypto.Last4(secret))
+	}
+
+	// Reload shows masked metadata, no value.
+	list, err := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	groq := credByProvider(list.Msg.GetCredentials(), "groq")
+	if groq == nil || !groq.GetShowMasked() || groq.GetLast4() != crypto.Last4(secret) {
+		t.Errorf("reload groq = %+v, want masked with last4", groq)
+	}
+	if groq.GetUpdatedAt() == nil {
+		t.Error("reload groq missing updated_at")
+	}
+
+	// Replace updates last4 + timestamp.
+	const secret2 = "test-groq-secret-rotated-bbbb"
+	replaceResp, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: secret2,
+	}))
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if replaceResp.Msg.GetCredential().GetLast4() != crypto.Last4(secret2) {
+		t.Errorf("replace last4 = %q, want %q", replaceResp.Msg.GetCredential().GetLast4(), crypto.Last4(secret2))
+	}
+	if !replaceResp.Msg.GetCredential().GetUpdatedAt().AsTime().After(groq.GetUpdatedAt().AsTime()) {
+		t.Error("replace did not advance updated_at")
+	}
+
+	// ElevenLabs save writes both stt + tts rows from one key.
+	if _, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "elevenlabs", Secret: "test-elevenlabs-secret-cccc",
+	})); err != nil {
+		t.Fatalf("elevenlabs save: %v", err)
+	}
+	var elevenRows int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM provider_config WHERE tenant_id = $1 AND provider = 'elevenlabs'`, tenantID).
+		Scan(&elevenRows); err != nil {
+		t.Fatalf("count elevenlabs: %v", err)
+	}
+	if elevenRows != 2 {
+		t.Errorf("elevenlabs rows = %d, want 2 (stt + tts)", elevenRows)
+	}
+
+	// Discord settings: token sealed in deployment_config, IDs stored plain.
+	const botToken = "test-discord-bot-token-dddd"
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: &[]string{botToken}[0], GuildId: "472093001100", VoiceChannelId: "472093774421",
+	})); err != nil {
+		t.Fatalf("SaveDiscordSettings: %v", err)
+	}
+	var depCiphertext []byte
+	var depLast4, guildID, voiceID string
+	if err := pool.QueryRow(ctx,
+		`SELECT discord_bot_token_ciphertext, discord_bot_token_last4, guild_id, voice_channel_id
+		   FROM deployment_config WHERE tenant_id = $1`, tenantID).
+		Scan(&depCiphertext, &depLast4, &guildID, &voiceID); err != nil {
+		t.Fatalf("read deployment_config: %v", err)
+	}
+	if strings.Contains(string(depCiphertext), botToken) {
+		t.Fatal("deployment_config stores the plaintext bot token")
+	}
+	if depLast4 != crypto.Last4(botToken) || guildID != "472093001100" || voiceID != "472093774421" {
+		t.Errorf("deployment row = last4 %q guild %q voice %q", depLast4, guildID, voiceID)
+	}
+
+	final, _ := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if final.Msg.GetGuildId() != "472093001100" || final.Msg.GetVoiceChannelId() != "472093774421" {
+		t.Errorf("list ids = %q / %q", final.Msg.GetGuildId(), final.Msg.GetVoiceChannelId())
+	}
+	if d := credByProvider(final.Msg.GetCredentials(), "discord"); d == nil || !d.GetEverSaved() {
+		t.Errorf("discord slot not saved: %+v", d)
+	}
+}

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -1,0 +1,348 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// fakeProviderStore is an in-memory providerStore: it mimics the (tenant,
+// component, provider) upsert and the column-isolated deployment_config saves so
+// the handler can be unit-tested keyless.
+type fakeProviderStore struct {
+	configs map[string]storage.ProviderConfig // key: component|provider
+	dep     *storage.DeploymentConfig
+	tick    int
+}
+
+func newFakeProviderStore() *fakeProviderStore {
+	return &fakeProviderStore{configs: map[string]storage.ProviderConfig{}}
+}
+
+// now returns a strictly-increasing timestamp so updated_at advances on replace.
+func (f *fakeProviderStore) now() time.Time {
+	f.tick++
+	return time.Date(2026, 6, 25, 12, 0, f.tick, 0, time.UTC)
+}
+
+func (f *fakeProviderStore) ListProviderConfigs(_ context.Context, _ uuid.UUID) ([]storage.ProviderConfig, error) {
+	out := make([]storage.ProviderConfig, 0, len(f.configs))
+	for _, c := range f.configs {
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func (f *fakeProviderStore) UpsertProviderConfigs(_ context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error) {
+	out := make([]storage.ProviderConfig, 0, len(configs))
+	for _, n := range configs {
+		key := string(n.Component) + "|" + n.Provider
+		row, ok := f.configs[key]
+		if !ok {
+			row = storage.ProviderConfig{ID: uuid.New(), TenantID: n.TenantID, Component: n.Component, Provider: n.Provider, CreatedAt: f.now()}
+		}
+		row.Model = n.Model
+		row.CredentialsCiphertext = n.CredentialsCiphertext
+		row.CredentialsLast4 = n.CredentialsLast4
+		row.UpdatedAt = f.now()
+		f.configs[key] = row
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+func (f *fakeProviderStore) GetDeploymentConfig(_ context.Context, _ uuid.UUID) (storage.DeploymentConfig, error) {
+	if f.dep == nil {
+		return storage.DeploymentConfig{}, storage.ErrNotFound
+	}
+	return *f.dep, nil
+}
+
+func (f *fakeProviderStore) SaveDiscordBotToken(_ context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (storage.DeploymentConfig, error) {
+	if f.dep == nil {
+		f.dep = &storage.DeploymentConfig{TenantID: tenantID, CreatedAt: f.now()}
+	}
+	f.dep.DiscordBotTokenCiphertext = ciphertext
+	f.dep.DiscordBotTokenLast4 = last4
+	f.dep.UpdatedAt = f.now()
+	return *f.dep, nil
+}
+
+func (f *fakeProviderStore) SaveDiscordChannels(_ context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error) {
+	if f.dep == nil {
+		f.dep = &storage.DeploymentConfig{TenantID: tenantID, CreatedAt: f.now()}
+	}
+	f.dep.GuildID = guildID
+	f.dep.VoiceChannelID = voiceChannelID
+	f.dep.UpdatedAt = f.now()
+	return *f.dep, nil
+}
+
+func testCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	c, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}
+
+// newProviderClient mounts a ProviderServer behind a server-side interceptor
+// that injects a fixed tenant (the auth stack's job, faked here), and returns a
+// Connect-JSON client. WithProtoJSON also asserts the RPCs work over JSON.
+func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Cipher) (managementv1connect.ProviderServiceClient, uuid.UUID) {
+	t.Helper()
+	tenantID := uuid.New()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(auth.WithTenant(ctx, tenantID), req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewProviderServer(store, cipher, nil).Handler(connect.WithInterceptors(inject)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewProviderServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON()), tenantID
+}
+
+// credByProvider finds a credential in a list by its provider slot.
+func credByProvider(creds []*managementv1.ProviderCredential, provider string) *managementv1.ProviderCredential {
+	for _, c := range creds {
+		if c.GetProvider() == provider {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestProviderList_EmptyShowsKeyNeeded(t *testing.T) {
+	t.Parallel()
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+
+	resp, err := client.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	creds := resp.Msg.GetCredentials()
+	if len(creds) != 3 {
+		t.Fatalf("credentials = %d, want 3 (discord, groq, elevenlabs)", len(creds))
+	}
+	for _, want := range []string{"discord", "groq", "elevenlabs"} {
+		c := credByProvider(creds, want)
+		if c == nil {
+			t.Fatalf("missing credential slot %q", want)
+		}
+		if c.GetEverSaved() || c.GetShowMasked() || c.GetLast4() != "" {
+			t.Errorf("%s should be key-needed on an empty store: %+v", want, c)
+		}
+	}
+	if resp.Msg.GetGuildId() != "" || resp.Msg.GetVoiceChannelId() != "" {
+		t.Errorf("guild/voice should be empty: %q / %q", resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
+	}
+}
+
+func TestProviderSave_SealStoreLast4_WriteOnly(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	cipher := testCipher(t)
+	client, _ := newProviderClient(t, store, cipher)
+
+	const secret = "test-groq-secret-value-1111"
+	resp, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq",
+		Secret:   secret,
+		Model:    "llama-3.3-70b-versatile",
+	}))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cred := resp.Msg.GetCredential()
+	if !cred.GetEverSaved() || !cred.GetShowMasked() {
+		t.Errorf("saved credential should be ever_saved + show_masked: %+v", cred)
+	}
+	if cred.GetComponent() != "llm" || cred.GetProvider() != "groq" {
+		t.Errorf("component/provider = %q/%q, want llm/groq", cred.GetComponent(), cred.GetProvider())
+	}
+	if cred.GetLast4() != crypto.Last4(secret) {
+		t.Errorf("last4 = %q, want %q", cred.GetLast4(), crypto.Last4(secret))
+	}
+
+	// Write-only contract: the plaintext must not appear anywhere in the response.
+	if strings.Contains(cred.String(), secret) {
+		t.Fatal("response leaked the plaintext secret")
+	}
+
+	// Seal → store round-trip: the stored ciphertext opens back to the plaintext,
+	// proving the handler sealed it (and stored ciphertext, never plaintext).
+	stored := store.configs["llm|groq"]
+	if string(stored.CredentialsCiphertext) == secret {
+		t.Fatal("stored ciphertext is the raw plaintext")
+	}
+	opened, err := cipher.Open(stored.CredentialsCiphertext)
+	if err != nil {
+		t.Fatalf("open stored ciphertext: %v", err)
+	}
+	if string(opened) != secret {
+		t.Errorf("round-trip = %q, want %q", opened, secret)
+	}
+}
+
+func TestProviderSave_ElevenLabsUpsertsSttAndTts(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	cipher := testCipher(t)
+	client, _ := newProviderClient(t, store, cipher)
+
+	const secret = "test-elevenlabs-secret-2222"
+	if _, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "elevenlabs", Secret: secret,
+	})); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// One save wrote both Components, sharing the ciphertext + last4.
+	for _, comp := range []string{"tts|elevenlabs", "stt|elevenlabs"} {
+		row, ok := store.configs[comp]
+		if !ok {
+			t.Fatalf("missing upserted row %q", comp)
+		}
+		if row.CredentialsLast4 != crypto.Last4(secret) {
+			t.Errorf("%s last4 = %q, want %q", comp, row.CredentialsLast4, crypto.Last4(secret))
+		}
+	}
+
+	// List collapses the two rows into one ElevenLabs slot.
+	resp, _ := client.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	c := credByProvider(resp.Msg.GetCredentials(), "elevenlabs")
+	if c == nil || !c.GetEverSaved() || c.GetComponent() != "tts" {
+		t.Errorf("elevenlabs slot = %+v, want one saved tts-labelled credential", c)
+	}
+}
+
+func TestProviderSave_ReplaceUpdatesLast4AndTimestamp(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	client, _ := newProviderClient(t, store, testCipher(t))
+	ctx := context.Background()
+
+	first, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{Provider: "groq", Secret: "first_keyAAAA"}))
+	if err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	second, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{Provider: "groq", Secret: "second_keyBBBB"}))
+	if err != nil {
+		t.Fatalf("replace save: %v", err)
+	}
+
+	if first.Msg.GetCredential().GetLast4() == second.Msg.GetCredential().GetLast4() {
+		t.Errorf("replace did not change last4 (%q)", second.Msg.GetCredential().GetLast4())
+	}
+	if !second.Msg.GetCredential().GetUpdatedAt().AsTime().After(first.Msg.GetCredential().GetUpdatedAt().AsTime()) {
+		t.Errorf("replace did not advance updated_at: %v !> %v",
+			second.Msg.GetCredential().GetUpdatedAt().AsTime(), first.Msg.GetCredential().GetUpdatedAt().AsTime())
+	}
+}
+
+func TestProviderSave_UnknownProviderAndEmptySecret(t *testing.T) {
+	t.Parallel()
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	ctx := context.Background()
+
+	_, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{Provider: "openai", Secret: "x"}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("unknown provider code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	_, err = client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{Provider: "groq", Secret: ""}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("empty secret code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+}
+
+func TestProviderSave_NoCipherFailsPrecondition(t *testing.T) {
+	t.Parallel()
+	client, _ := newProviderClient(t, newFakeProviderStore(), nil) // nil cipher
+	ctx := context.Background()
+
+	_, err := client.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{Provider: "groq", Secret: "x"}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("save without cipher code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+	// Reads still work without a cipher.
+	if _, err := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{})); err != nil {
+		t.Errorf("List without cipher: %v", err)
+	}
+}
+
+func TestProviderDiscordSettings_TokenAndChannels(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	client, _ := newProviderClient(t, store, testCipher(t))
+	ctx := context.Background()
+
+	const token = "test-discord-bot-token-3333"
+	saveTok, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken:       &[]string{token}[0],
+		GuildId:        "472093001100",
+		VoiceChannelId: "472093774421",
+	}))
+	if err != nil {
+		t.Fatalf("save discord: %v", err)
+	}
+	cred := saveTok.Msg.GetCredential()
+	if !cred.GetEverSaved() || cred.GetProvider() != "discord" || cred.GetLast4() != crypto.Last4(token) {
+		t.Errorf("discord credential = %+v, want saved/discord/last4=%q", cred, crypto.Last4(token))
+	}
+	if strings.Contains(cred.String(), token) {
+		t.Fatal("discord response leaked the bot token")
+	}
+	if saveTok.Msg.GetGuildId() != "472093001100" || saveTok.Msg.GetVoiceChannelId() != "472093774421" {
+		t.Errorf("ids not stored: %q / %q", saveTok.Msg.GetGuildId(), saveTok.Msg.GetVoiceChannelId())
+	}
+
+	// IDs-only save (no bot_token) must not wipe the token.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		GuildId: "999", VoiceChannelId: "888",
+	})); err != nil {
+		t.Fatalf("save ids: %v", err)
+	}
+	resp, _ := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	discord := credByProvider(resp.Msg.GetCredentials(), "discord")
+	if discord == nil || !discord.GetEverSaved() || discord.GetLast4() != crypto.Last4(token) {
+		t.Errorf("token wiped by ids-only save: %+v", discord)
+	}
+	if resp.Msg.GetGuildId() != "999" || resp.Msg.GetVoiceChannelId() != "888" {
+		t.Errorf("ids not updated: %q / %q", resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
+	}
+}
+
+// TestProviderList_EnvPlaceholderIsKeyNeeded asserts the ADR-0039 seam: a
+// provider_config still holding the seed's "env" placeholder reads as key-needed,
+// not as a saved key.
+func TestProviderList_EnvPlaceholderIsKeyNeeded(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	store.configs["llm|groq"] = storage.ProviderConfig{
+		ID: uuid.New(), Component: storage.ComponentLLM, Provider: "groq",
+		CredentialsLast4: "env", UpdatedAt: time.Now(),
+	}
+	client, _ := newProviderClient(t, store, testCipher(t))
+
+	resp, _ := client.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	groq := credByProvider(resp.Msg.GetCredentials(), "groq")
+	if groq.GetEverSaved() {
+		t.Errorf("env-placeholder groq should be key-needed, got ever_saved=true: %+v", groq)
+	}
+}

--- a/internal/storage/agent_crud_test.go
+++ b/internal/storage/agent_crud_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestCreateUpdateDeleteCharacterAgent round-trips the editor CRUD (#71): create
+// a Character with a title, read it back, update its editable fields, then delete
+// it. Each step is verified through a fresh GetAgent so the assertions reflect
+// what actually landed in Postgres.
+func TestCreateUpdateDeleteCharacterAgent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	id, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  campaignID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        "Bart",
+		Title:       "Gruff innkeeper",
+		Persona:     "Wipes the bar and grumbles.",
+		Voice:       []byte(`{"voice_id":"rachel"}`),
+		AddressOnly: false,
+		Aliases:     []string{"Barty"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	got, err := st.GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgent after create: %v", err)
+	}
+	if got.Role != storage.AgentRoleCharacter {
+		t.Errorf("role = %q, want character", got.Role)
+	}
+	if got.Title != "Gruff innkeeper" {
+		t.Errorf("title = %q, want %q", got.Title, "Gruff innkeeper")
+	}
+	if got.Name != "Bart" || got.Persona != "Wipes the bar and grumbles." {
+		t.Errorf("name/persona not persisted: %+v", got)
+	}
+	// First Character in the campaign → slot 0 (round-robin index, see CreateAgent).
+	if got.SpeakerColor != 0 {
+		t.Errorf("speaker_color = %d, want 0 for the first character", got.SpeakerColor)
+	}
+
+	// Update the editable fields.
+	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          id,
+		Name:        "Bartholomew",
+		Title:       "Keeper of the Stonehill Inn",
+		Persona:     "Now eloquent and grandiose.",
+		Voice:       []byte(`{"voice_id":"adam"}`),
+		AddressOnly: true,
+		Aliases:     []string{"Bart", "the keeper"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	if updated.Name != "Bartholomew" || updated.Title != "Keeper of the Stonehill Inn" {
+		t.Errorf("update did not return new name/title: %+v", updated)
+	}
+	if !updated.AddressOnly {
+		t.Error("address_only did not persist true on a Character")
+	}
+	// speaker_color is immutable across an update.
+	if updated.SpeakerColor != 0 {
+		t.Errorf("speaker_color changed on update = %d, want 0", updated.SpeakerColor)
+	}
+
+	reloaded, err := st.GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgent after update: %v", err)
+	}
+	if reloaded.Name != "Bartholomew" || !reloaded.AddressOnly || len(reloaded.Aliases) != 2 {
+		t.Errorf("update did not round-trip to DB: %+v", reloaded)
+	}
+
+	// Delete it; it must then be gone.
+	if err := st.DeleteAgent(ctx, id); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if _, err := st.GetAgent(ctx, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetAgent after delete: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteButlerRejected asserts the Butler cannot be deleted (ADR-0009): the
+// auto-created Butler stays, and DeleteAgent returns the distinct
+// ErrButlerUndeletable (the RPC maps it to CodeFailedPrecondition).
+func TestDeleteButlerRejected(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	err = st.DeleteAgent(ctx, butler.ID)
+	if !errors.Is(err, storage.ErrButlerUndeletable) {
+		t.Fatalf("DeleteAgent(butler) = %v, want ErrButlerUndeletable", err)
+	}
+	// The Butler must still be there.
+	if _, err := st.GetButler(ctx, campaignID); err != nil {
+		t.Fatalf("Butler gone after a rejected delete: %v", err)
+	}
+}
+
+// TestUpdateButlerKeepsAddressOnly asserts editing the Butler can neither demote
+// its role nor turn off Address-Only (ADR-0009 / ADR-0024): even with
+// AddressOnly:false in the request, the stored Butler stays Address-Only and a
+// 'butler' role.
+func TestUpdateButlerKeepsAddressOnly(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:          butler.ID,
+		Name:        "Glyphoxa the Wise",
+		Title:       "Game Master's Familiar",
+		Persona:     "A patient arcane butler.",
+		AddressOnly: false, // try to turn Address-Only OFF — must be ignored
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgent(butler): %v", err)
+	}
+	if !updated.AddressOnly {
+		t.Error("Butler address_only was turned off; it must stay true")
+	}
+	if updated.Role != storage.AgentRoleButler {
+		t.Errorf("Butler role changed to %q; it must stay butler", updated.Role)
+	}
+	if updated.Name != "Glyphoxa the Wise" || updated.Title != "Game Master's Familiar" {
+		t.Errorf("Butler editable fields did not persist: %+v", updated)
+	}
+
+	// And it remains the campaign's one Butler, still Address-Only on reload.
+	reloaded, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler after update: %v", err)
+	}
+	if !reloaded.AddressOnly || reloaded.Role != storage.AgentRoleButler {
+		t.Errorf("Butler invariant broke on reload: %+v", reloaded)
+	}
+}
+
+// TestCreateAgentAssignsStableSpeakerColors asserts Characters get distinct,
+// round-robin speaker-colour slots in creation order, and that the slot is
+// stable across reloads (#71).
+func TestCreateAgentAssignsStableSpeakerColors(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	names := []string{"Ana", "Borin", "Cora"}
+	ids := make([]uuid.UUID, len(names))
+	for i, n := range names {
+		id, err := st.CreateAgent(ctx, storage.NewAgent{
+			CampaignID: campaignID,
+			Role:       storage.AgentRoleCharacter,
+			Name:       n,
+		})
+		if err != nil {
+			t.Fatalf("CreateAgent(%s): %v", n, err)
+		}
+		ids[i] = id
+	}
+
+	for i, id := range ids {
+		a, err := st.GetAgent(ctx, id)
+		if err != nil {
+			t.Fatalf("GetAgent(%s): %v", names[i], err)
+		}
+		if a.SpeakerColor != i {
+			t.Errorf("%s speaker_color = %d, want %d (round-robin index)", names[i], a.SpeakerColor, i)
+		}
+	}
+}
+
+// TestDeleteAndUpdateAgentNotFound asserts a random id is ErrNotFound for both
+// mutating store ops (the RPC maps it to CodeNotFound).
+func TestDeleteAndUpdateAgentNotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := st.DeleteAgent(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("DeleteAgent(random) = %v, want ErrNotFound", err)
+	}
+	if _, err := st.UpdateAgent(ctx, storage.AgentUpdate{ID: uuid.New(), Name: "Nobody"}); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("UpdateAgent(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Auth control-plane persistence (ADR-0016 / ADR-0039): users, server-side
+// sessions, and the thin single-operator↔tenant binding. Reads and writes live
+// together here because they are one cohesive feature; the broader read/write
+// split in store.go / write.go predates it. The cookie token is an opaque
+// random secret minted by the auth tier (internal/auth) — this layer only
+// persists and validates it, never interprets it.
+
+const userColumns = `id, discord_user_id, name, avatar, role, created_at, updated_at`
+
+func scanUser(row pgx.Row) (User, error) {
+	var u User
+	err := row.Scan(
+		&u.ID, &u.DiscordUserID, &u.Name, &u.Avatar, &u.Role,
+		&u.CreatedAt, &u.UpdatedAt,
+	)
+	return u, err
+}
+
+// UpsertUserParams is the input to UpsertUser: the Discord identity to insert or
+// refresh. Role is not an input — a new user defaults to 'operator' (the DB
+// default) and an existing user's role is left untouched on refresh.
+type UpsertUserParams struct {
+	DiscordUserID string
+	Name          string
+	Avatar        string
+}
+
+// UpsertUser inserts a user keyed by discord_user_id, or refreshes the display
+// name/avatar of the existing row (Discord is the source of truth for those on
+// every login). It returns the resulting user. The role is preserved on
+// conflict so an operator promotion is never clobbered by a login.
+func (s *Store) UpsertUser(ctx context.Context, p UpsertUserParams) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO users (discord_user_id, name, avatar)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (discord_user_id) DO UPDATE
+		   SET name = EXCLUDED.name, avatar = EXCLUDED.avatar, updated_at = now()
+		 RETURNING `+userColumns,
+		p.DiscordUserID, p.Name, p.Avatar)
+	u, err := scanUser(row)
+	if err != nil {
+		return User{}, fmt.Errorf("storage: upsert user %q: %w", p.DiscordUserID, err)
+	}
+	return u, nil
+}
+
+// GetUserByDiscordID loads a user by Discord snowflake, or ErrNotFound.
+func (s *Store) GetUserByDiscordID(ctx context.Context, discordUserID string) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+userColumns+` FROM users WHERE discord_user_id = $1`, discordUserID)
+	u, err := scanUser(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrNotFound
+	}
+	if err != nil {
+		return User{}, fmt.Errorf("storage: get user %q: %w", discordUserID, err)
+	}
+	return u, nil
+}
+
+// NewSession is the input to CreateSession. Token is the opaque random secret
+// the auth tier minted; ExpiresAt is the absolute expiry the validator enforces.
+type NewSession struct {
+	UserID    uuid.UUID
+	Token     string
+	ExpiresAt time.Time
+	IP        string
+	UA        string
+}
+
+// CreateSession inserts a session row and returns it.
+func (s *Store) CreateSession(ctx context.Context, n NewSession) (Session, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO sessions (user_id, token, expires_at, ip, ua)
+		 VALUES ($1, $2, $3, $4, $5)
+		 RETURNING id, user_id, token, created_at, last_seen_at, expires_at, ip, ua`,
+		n.UserID, n.Token, n.ExpiresAt, n.IP, n.UA)
+	var sess Session
+	err := row.Scan(
+		&sess.ID, &sess.UserID, &sess.Token, &sess.CreatedAt,
+		&sess.LastSeenAt, &sess.ExpiresAt, &sess.IP, &sess.UA,
+	)
+	if err != nil {
+		return Session{}, fmt.Errorf("storage: create session: %w", err)
+	}
+	return sess, nil
+}
+
+// AuthenticateSession validates a session token and returns the owning user. It
+// bumps last_seen_at as a side effect of a successful, non-expired lookup, in a
+// single round trip. A missing or expired token yields ErrNotFound — the RPC
+// layer maps that to CodeUnauthenticated.
+func (s *Store) AuthenticateSession(ctx context.Context, token string) (User, error) {
+	row := s.db.QueryRow(ctx,
+		`WITH s AS (
+		     UPDATE sessions SET last_seen_at = now()
+		      WHERE token = $1 AND expires_at > now()
+		      RETURNING user_id
+		 )
+		 SELECT u.id, u.discord_user_id, u.name, u.avatar, u.role,
+		        u.created_at, u.updated_at
+		   FROM users u JOIN s ON s.user_id = u.id`, token)
+	u, err := scanUser(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrNotFound
+	}
+	if err != nil {
+		return User{}, fmt.Errorf("storage: authenticate session: %w", err)
+	}
+	return u, nil
+}
+
+// DeleteSession removes a session row by token (logout / revocation). Deleting a
+// token that no longer exists is not an error — logout is idempotent.
+func (s *Store) DeleteSession(ctx context.Context, token string) error {
+	if _, err := s.db.Exec(ctx, `DELETE FROM sessions WHERE token = $1`, token); err != nil {
+		return fmt.Errorf("storage: delete session: %w", err)
+	}
+	return nil
+}
+
+// ResolveOperatorTenant binds the single seeded Tenant to the first operator and
+// returns it (ADR-0039). It is idempotent and atomic: if a tenant is already
+// bound to the user it is returned; otherwise the earliest unbound tenant (the
+// seed's) is claimed; otherwise — a fresh DB with no seed — a new 'Glyphoxa'
+// tenant is created bound to the user. Called once on OAuth login.
+func (s *Store) ResolveOperatorTenant(ctx context.Context, userID uuid.UUID) (Tenant, error) {
+	var t Tenant
+	err := s.InTx(ctx, func(tx *Store) error {
+		// Already bound to this operator?
+		row := tx.db.QueryRow(ctx,
+			`SELECT id, name, created_at, updated_at FROM tenant
+			  WHERE operator_user_id = $1 ORDER BY created_at, id LIMIT 1`, userID)
+		switch err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); {
+		case err == nil:
+			return nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return fmt.Errorf("storage: find bound tenant: %w", err)
+		}
+
+		// Claim the earliest unbound tenant (the seeded one), locking it so two
+		// concurrent first-logins can't both claim the same row.
+		row = tx.db.QueryRow(ctx,
+			`UPDATE tenant SET operator_user_id = $1, updated_at = now()
+			  WHERE id = (
+			      SELECT id FROM tenant WHERE operator_user_id IS NULL
+			       ORDER BY created_at, id LIMIT 1 FOR UPDATE SKIP LOCKED
+			  )
+			  RETURNING id, name, created_at, updated_at`, userID)
+		switch err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); {
+		case err == nil:
+			return nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return fmt.Errorf("storage: claim unbound tenant: %w", err)
+		}
+
+		// No tenant at all (unseeded DB): create one bound to the operator.
+		row = tx.db.QueryRow(ctx,
+			`INSERT INTO tenant (name, operator_user_id) VALUES ('Glyphoxa', $1)
+			 RETURNING id, name, created_at, updated_at`, userID)
+		if err := row.Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return fmt.Errorf("storage: seed operator tenant: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Tenant{}, err
+	}
+	return t, nil
+}
+
+// TenantForUser returns the id of the tenant bound to the operator, or
+// ErrNotFound when none is bound. The X-Tenant-Id interceptor uses it as the
+// thin single-operator pass-through (ADR-0039).
+func (s *Store) TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`SELECT id FROM tenant WHERE operator_user_id = $1 ORDER BY created_at, id LIMIT 1`,
+		userID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, ErrNotFound
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: tenant for user %s: %w", userID, err)
+	}
+	return id, nil
+}

--- a/internal/storage/auth_test.go
+++ b/internal/storage/auth_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// migrated stands up a freshly migrated DB and returns a Store over it.
+func migrated(t *testing.T) *storage.Store {
+	t.Helper()
+	dsn := startPostgres(t)
+	db := openSQL(t, dsn)
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	return storage.New(openPool(t, dsn))
+}
+
+func TestUpsertUserInsertThenRefresh(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: "1234567890", Name: "Sora Vance", Avatar: "https://cdn/x.png",
+	})
+	if err != nil {
+		t.Fatalf("UpsertUser insert: %v", err)
+	}
+	if u.ID == uuid.Nil || u.Name != "Sora Vance" || u.Role != "operator" {
+		t.Fatalf("insert user = %+v, want named operator with id", u)
+	}
+
+	// A second upsert for the same Discord id refreshes name/avatar in place — no
+	// duplicate row, same id, role preserved.
+	u2, err := st.UpsertUser(ctx, storage.UpsertUserParams{
+		DiscordUserID: "1234567890", Name: "Sora V.", Avatar: "https://cdn/y.png",
+	})
+	if err != nil {
+		t.Fatalf("UpsertUser refresh: %v", err)
+	}
+	if u2.ID != u.ID {
+		t.Errorf("refresh created a new row: id %s != %s", u2.ID, u.ID)
+	}
+	if u2.Name != "Sora V." || u2.Avatar != "https://cdn/y.png" {
+		t.Errorf("refresh did not update display fields: %+v", u2)
+	}
+
+	got, err := st.GetUserByDiscordID(ctx, "1234567890")
+	if err != nil || got.ID != u.ID {
+		t.Fatalf("GetUserByDiscordID = %+v, %v", got, err)
+	}
+	if _, err := st.GetUserByDiscordID(ctx, "nope"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetUserByDiscordID(unknown) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "u1", Name: "Op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	sess, err := st.CreateSession(ctx, storage.NewSession{
+		UserID: u.ID, Token: "opaque-token-1", ExpiresAt: time.Now().Add(time.Hour),
+		IP: "127.0.0.1", UA: "test-agent",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if sess.ID == uuid.Nil || sess.UserID != u.ID {
+		t.Fatalf("session = %+v", sess)
+	}
+
+	// Valid token resolves to the owning user.
+	got, err := st.AuthenticateSession(ctx, "opaque-token-1")
+	if err != nil {
+		t.Fatalf("AuthenticateSession(valid): %v", err)
+	}
+	if got.ID != u.ID {
+		t.Errorf("authenticated user = %s, want %s", got.ID, u.ID)
+	}
+
+	// Unknown token → ErrNotFound (→ 401 at the RPC layer).
+	if _, err := st.AuthenticateSession(ctx, "bogus"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession(unknown) = %v, want ErrNotFound", err)
+	}
+
+	// Expired token → ErrNotFound.
+	if _, err := st.CreateSession(ctx, storage.NewSession{
+		UserID: u.ID, Token: "expired-token", ExpiresAt: time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("CreateSession(expired): %v", err)
+	}
+	if _, err := st.AuthenticateSession(ctx, "expired-token"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession(expired) = %v, want ErrNotFound", err)
+	}
+
+	// Delete revokes immediately; a re-delete is a no-op (idempotent logout).
+	if err := st.DeleteSession(ctx, "opaque-token-1"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, err := st.AuthenticateSession(ctx, "opaque-token-1"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("AuthenticateSession after delete = %v, want ErrNotFound", err)
+	}
+	if err := st.DeleteSession(ctx, "opaque-token-1"); err != nil {
+		t.Errorf("DeleteSession(already gone) = %v, want nil", err)
+	}
+}
+
+// TestResolveOperatorTenantClaimsSeeded asserts the first operator claims the
+// pre-existing (seeded) unbound tenant, and the resolution is idempotent.
+func TestResolveOperatorTenantClaimsSeeded(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	// A seeded, unbound tenant already exists (as `glyphoxa seed` writes).
+	seededID, err := st.CreateTenant(ctx, "Seeded Tenant")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "first-op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// No tenant is bound yet.
+	if _, err := st.TenantForUser(ctx, u.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("TenantForUser(unbound) = %v, want ErrNotFound", err)
+	}
+
+	bound, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant: %v", err)
+	}
+	if bound.ID != seededID {
+		t.Errorf("claimed tenant = %s, want the seeded %s", bound.ID, seededID)
+	}
+
+	// Idempotent: a second resolve returns the same already-bound tenant, no new row.
+	again, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant(again): %v", err)
+	}
+	if again.ID != seededID {
+		t.Errorf("re-resolve = %s, want %s", again.ID, seededID)
+	}
+
+	tid, err := st.TenantForUser(ctx, u.ID)
+	if err != nil || tid != seededID {
+		t.Fatalf("TenantForUser = %s, %v; want %s", tid, err, seededID)
+	}
+}
+
+// TestResolveOperatorTenantSeedsWhenEmpty asserts a fresh DB with no tenant at
+// all gets one created bound to the operator.
+func TestResolveOperatorTenantSeedsWhenEmpty(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	u, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "lonely-op"})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	bound, err := st.ResolveOperatorTenant(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant: %v", err)
+	}
+	if bound.ID == uuid.Nil || bound.Name != "Glyphoxa" {
+		t.Errorf("seeded tenant = %+v, want a 'Glyphoxa' tenant", bound)
+	}
+}

--- a/internal/storage/configuration_test.go
+++ b/internal/storage/configuration_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestUpsertProviderConfigsInsertThenReplace asserts the (tenant, component,
+// provider) upsert: a first save inserts, a second save with the same key
+// replaces the credential + last4 + model in place (no duplicate row), and the
+// updated_at advances — the Configuration "Replace" flow at the storage layer.
+func TestUpsertProviderConfigsInsertThenReplace(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	first, err := st.UpsertProviderConfigs(ctx, []storage.NewProviderConfig{{
+		TenantID:              tenantID,
+		Component:             storage.ComponentLLM,
+		Provider:              "groq",
+		Model:                 "llama-3.3-70b-versatile",
+		CredentialsCiphertext: []byte{0x01, 0xAA},
+		CredentialsLast4:      "aaaa",
+	}})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if len(first) != 1 || first[0].CredentialsLast4 != "aaaa" {
+		t.Fatalf("first upsert = %+v, want one row last4=aaaa", first)
+	}
+
+	second, err := st.UpsertProviderConfigs(ctx, []storage.NewProviderConfig{{
+		TenantID:              tenantID,
+		Component:             storage.ComponentLLM,
+		Provider:              "groq",
+		Model:                 "llama-3.1-8b-instant",
+		CredentialsCiphertext: []byte{0x02, 0xBB},
+		CredentialsLast4:      "bbbb",
+	}})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if second[0].ID != first[0].ID {
+		t.Errorf("replace created a new row (id %s != %s); want in-place upsert", second[0].ID, first[0].ID)
+	}
+	if second[0].CredentialsLast4 != "bbbb" || second[0].Model != "llama-3.1-8b-instant" {
+		t.Errorf("replace did not update last4/model: %+v", second[0])
+	}
+	if !second[0].UpdatedAt.After(first[0].UpdatedAt) {
+		t.Errorf("updated_at did not advance on replace: %v !> %v", second[0].UpdatedAt, first[0].UpdatedAt)
+	}
+
+	// Exactly one row for (tenant, llm, groq) — the replace did not duplicate.
+	all, err := st.ListProviderConfigs(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	groqRows := 0
+	for _, c := range all {
+		if c.Component == storage.ComponentLLM && c.Provider == "groq" {
+			groqRows++
+		}
+	}
+	if groqRows != 1 {
+		t.Fatalf("groq rows = %d, want 1 (upsert must not duplicate)", groqRows)
+	}
+}
+
+// TestUpsertProviderConfigsBatchAtomic asserts the ElevenLabs case: one save
+// upserts the stt + tts rows together so a per-Component read resolves the same
+// key for both (ADR-0004 shared key).
+func TestUpsertProviderConfigsBatchAtomic(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	sealed := []byte{0x01, 0xDE, 0xAD}
+	rows, err := st.UpsertProviderConfigs(ctx, []storage.NewProviderConfig{
+		{TenantID: tenantID, Component: storage.ComponentTTS, Provider: "elevenlabs", CredentialsCiphertext: sealed, CredentialsLast4: "9zZ8"},
+		{TenantID: tenantID, Component: storage.ComponentSTT, Provider: "elevenlabs", CredentialsCiphertext: sealed, CredentialsLast4: "9zZ8"},
+	})
+	if err != nil {
+		t.Fatalf("batch upsert: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+
+	for _, comp := range []storage.Component{storage.ComponentTTS, storage.ComponentSTT} {
+		got, err := st.GetProviderConfigByComponent(ctx, tenantID, comp)
+		if err != nil {
+			t.Fatalf("get by component %s: %v", comp, err)
+		}
+		if got.Provider != "elevenlabs" || got.CredentialsLast4 != "9zZ8" {
+			t.Errorf("component %s resolved to %+v, want elevenlabs/9zZ8", comp, got)
+		}
+	}
+}
+
+// TestGetProviderConfigByComponentNotFound asserts the empty case maps to
+// ErrNotFound (the RPC layer renders that slot as key-needed).
+func TestGetProviderConfigByComponentNotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	st := storage.New(pool)
+	if _, err := st.GetProviderConfigByComponent(context.Background(), tenantID, storage.ComponentEmbeddings); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeploymentConfigTokenAndChannels asserts the deployment_config upserts are
+// column-isolated: saving the Bot token leaves the IDs untouched and vice versa,
+// so the screen's separate Save buttons never clobber each other.
+func TestDeploymentConfigTokenAndChannels(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// No row yet → ErrNotFound.
+	if _, err := st.GetDeploymentConfig(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("get empty: got %v, want ErrNotFound", err)
+	}
+
+	// Save the IDs first.
+	if _, err := st.SaveDiscordChannels(ctx, tenantID, "472093001100", "472093774421"); err != nil {
+		t.Fatalf("save channels: %v", err)
+	}
+	// Then the token — must not wipe the IDs.
+	tokRow, err := st.SaveDiscordBotToken(ctx, tenantID, []byte{0x01, 0x99}, "tok9")
+	if err != nil {
+		t.Fatalf("save token: %v", err)
+	}
+	if tokRow.GuildID != "472093001100" || tokRow.VoiceChannelID != "472093774421" {
+		t.Errorf("token save clobbered IDs: %+v", tokRow)
+	}
+	if tokRow.DiscordBotTokenLast4 != "tok9" {
+		t.Errorf("token last4 = %q, want tok9", tokRow.DiscordBotTokenLast4)
+	}
+
+	// Re-saving the IDs must not wipe the token.
+	idRow, err := st.SaveDiscordChannels(ctx, tenantID, "999", "888")
+	if err != nil {
+		t.Fatalf("re-save channels: %v", err)
+	}
+	if idRow.DiscordBotTokenLast4 != "tok9" {
+		t.Errorf("channels save clobbered token: last4 = %q, want tok9", idRow.DiscordBotTokenLast4)
+	}
+	if idRow.GuildID != "999" || idRow.VoiceChannelID != "888" {
+		t.Errorf("channels not updated: %+v", idRow)
+	}
+}
+
+// TestDeploymentConfigCascade asserts the tenant FK cascade so a deleted tenant
+// takes its deployment_config with it (no orphan secret rows).
+func TestDeploymentConfigCascade(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.SaveDiscordBotToken(ctx, tenantID, []byte{0x01}, "x"); err != nil {
+		t.Fatalf("save token: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM tenant WHERE id = $1`, tenantID); err != nil {
+		t.Fatalf("delete tenant: %v", err)
+	}
+	if _, err := st.GetDeploymentConfig(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("deployment_config survived tenant delete: %v", err)
+	}
+}

--- a/internal/storage/deployment.go
+++ b/internal/storage/deployment.go
@@ -1,0 +1,85 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Deployment-config persistence (#68, ADR-0039): the single-operator Discord
+// integration the Configuration screen edits — the deployment Bot token (a
+// write-only secret) plus the non-secret Guild / Voice channel IDs. Reads and
+// writes live together because they are one cohesive feature; the secret token
+// is sealed by the caller (the RPC layer) before it reaches here, so this layer
+// only persists ciphertext + last4 and never interprets the secret.
+
+const deploymentConfigColumns = `
+	tenant_id, discord_bot_token_ciphertext, discord_bot_token_last4,
+	guild_id, voice_channel_id, created_at, updated_at`
+
+func scanDeploymentConfig(row pgx.Row) (DeploymentConfig, error) {
+	var d DeploymentConfig
+	err := row.Scan(
+		&d.TenantID, &d.DiscordBotTokenCiphertext, &d.DiscordBotTokenLast4,
+		&d.GuildID, &d.VoiceChannelID, &d.CreatedAt, &d.UpdatedAt,
+	)
+	return d, err
+}
+
+// GetDeploymentConfig loads a Tenant's deployment config, or ErrNotFound when
+// nothing has been saved yet (the Configuration screen treats that as the empty,
+// key-needed state).
+func (s *Store) GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (DeploymentConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+deploymentConfigColumns+` FROM deployment_config WHERE tenant_id = $1`, tenantID)
+	d, err := scanDeploymentConfig(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return DeploymentConfig{}, ErrNotFound
+	}
+	if err != nil {
+		return DeploymentConfig{}, fmt.Errorf("storage: get deployment_config for tenant %s: %w", tenantID, err)
+	}
+	return d, nil
+}
+
+// SaveDiscordBotToken upserts only the deployment Bot token columns (sealed
+// ciphertext + last4), leaving the Guild / Voice channel IDs untouched. It
+// returns the resulting row. The ciphertext is the caller-sealed secret.
+func (s *Store) SaveDiscordBotToken(ctx context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (DeploymentConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO deployment_config (tenant_id, discord_bot_token_ciphertext, discord_bot_token_last4)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		   SET discord_bot_token_ciphertext = EXCLUDED.discord_bot_token_ciphertext,
+		       discord_bot_token_last4 = EXCLUDED.discord_bot_token_last4,
+		       updated_at = now()
+		 RETURNING `+deploymentConfigColumns,
+		tenantID, ciphertext, last4)
+	d, err := scanDeploymentConfig(row)
+	if err != nil {
+		return DeploymentConfig{}, fmt.Errorf("storage: save discord bot token for tenant %s: %w", tenantID, err)
+	}
+	return d, nil
+}
+
+// SaveDiscordChannels upserts only the non-secret Guild / Voice channel IDs,
+// leaving the Bot token untouched, and returns the resulting row.
+func (s *Store) SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (DeploymentConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO deployment_config (tenant_id, guild_id, voice_channel_id)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (tenant_id) DO UPDATE
+		   SET guild_id = EXCLUDED.guild_id,
+		       voice_channel_id = EXCLUDED.voice_channel_id,
+		       updated_at = now()
+		 RETURNING `+deploymentConfigColumns,
+		tenantID, guildID, voiceChannelID)
+	d, err := scanDeploymentConfig(row)
+	if err != nil {
+		return DeploymentConfig{}, fmt.Errorf("storage: save discord channels for tenant %s: %w", tenantID, err)
+	}
+	return d, nil
+}

--- a/internal/storage/migrations/00003_auth.sql
+++ b/internal/storage/migrations/00003_auth.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+
+-- Single-operator auth control-plane (ADR-0016 / ADR-0039): the `users` and
+-- `sessions` tables the ADR-0016 cookie session needs, plus the thin binding of
+-- the single seeded Tenant to the first operator.
+--
+-- Scope is deliberately narrow (ADR-0039 single-operator fast-path): NO
+-- tenant_members roles, NO api_keys, NO onboarding. The multi-tenant surface
+-- fills in behind these without a rewrite — the operator↔tenant link is a single
+-- nullable column on `tenant`, not a membership table.
+
+-- ── users ────────────────────────────────────────────────────────────────────
+-- A human operator, authenticated via Discord OAuth (Discord-only, ADR-0016).
+-- discord_user_id is the Discord snowflake and the stable identity key; name and
+-- avatar are display-only and refreshed from Discord on every login.
+CREATE TABLE users (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    discord_user_id  text NOT NULL UNIQUE,
+    name             text NOT NULL DEFAULT '',
+    -- avatar is an absolute image URL (or empty); Discord's CDN URL is composed
+    -- at upsert time so the SPA renders it directly.
+    avatar           text NOT NULL DEFAULT '',
+    -- role is a free-text label for now (e.g. 'operator'); the tenant_members
+    -- role matrix (ADR-0018) is deferred (ADR-0039).
+    role             text NOT NULL DEFAULT 'operator',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- ── sessions ─────────────────────────────────────────────────────────────────
+-- Server-side session (ADR-0016): an opaque random token lives in the
+-- `glyphoxa_session` cookie; this row is the authority. Revocation is a row
+-- delete (the reason JWT was rejected). expires_at gates validity; last_seen_at
+-- is bumped on each authenticated request.
+CREATE TABLE sessions (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    -- token is the opaque, high-entropy secret in the cookie (crypto/rand, not a
+    -- JWT). Unique so a token resolves to exactly one session.
+    token        text NOT NULL UNIQUE,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    expires_at   timestamptz NOT NULL,
+    -- ip / ua are captured at issuance for audit; not used for validation.
+    ip           text NOT NULL DEFAULT '',
+    ua           text NOT NULL DEFAULT ''
+);
+
+CREATE INDEX sessions_user_idx ON sessions (user_id);
+
+-- ── tenant ↔ operator binding (ADR-0039 thin pass-through) ───────────────────
+-- The single seeded Tenant is bound to the first operator who logs in. A single
+-- nullable column (not a tenant_members table) keeps the binding thin; the
+-- X-Tenant-Id interceptor resolves the operator's tenant from it. ON DELETE SET
+-- NULL so removing a user unbinds rather than cascading away the campaign data.
+ALTER TABLE tenant
+    ADD COLUMN operator_user_id uuid REFERENCES users (id) ON DELETE SET NULL;
+
+-- +goose Down
+
+ALTER TABLE tenant DROP COLUMN IF EXISTS operator_user_id;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS users;

--- a/internal/storage/migrations/00004_agent_editor_columns.sql
+++ b/internal/storage/migrations/00004_agent_editor_columns.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+
+-- Agent editor columns (#71, ADR-0009 / ADR-0039): the Campaign screen edits an
+-- Agent's role subtitle and renders each speaker in a stable colour. Both columns
+-- are ADDITIVE — existing rows take the defaults, the auto-Butler trigger
+-- (00002) and the one-Butler partial unique index (00001) are untouched.
+--
+--   title         — the role subtitle the editor shows under an Agent's name
+--                   (e.g. "Gruff innkeeper"); free text, defaults to ''.
+--   speaker_color — a server-assigned palette SLOT (not a colour value): a small
+--                   integer the web tier maps onto its speaker palette so each
+--                   roster member renders in a stable hue across reloads. Slots
+--                   are assigned round-robin per Campaign on Character insert
+--                   (see CreateAgent); the Butler keeps slot 0 (it renders in its
+--                   own reserved "Butler gold", ADR-0009).
+ALTER TABLE agents ADD COLUMN title         text     NOT NULL DEFAULT '';
+ALTER TABLE agents ADD COLUMN speaker_color smallint NOT NULL DEFAULT 0;
+
+-- Backfill: give pre-existing Character NPCs distinct, stable slots in roster
+-- order so an already-populated Campaign reads back with the same per-Agent hues
+-- new inserts get. The palette has 6 slots (matches the web speaker palette);
+-- the modulo wraps rosters larger than the palette. The Butler is excluded — it
+-- keeps slot 0.
+UPDATE agents a
+   SET speaker_color = n.slot
+  FROM (
+        SELECT id,
+               (row_number() OVER (PARTITION BY campaign_id
+                                       ORDER BY created_at, id) - 1) % 6 AS slot
+          FROM agents
+         WHERE agent_role = 'character'
+       ) n
+ WHERE a.id = n.id;
+
+-- +goose Down
+
+ALTER TABLE agents DROP COLUMN speaker_color;
+ALTER TABLE agents DROP COLUMN title;

--- a/internal/storage/migrations/00005_configuration.sql
+++ b/internal/storage/migrations/00005_configuration.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+
+-- Backs the Configuration screen's save/mask/Replace flow (#68; ADR-0004 BYOK /
+-- ADR-0039 single-operator). Two additive changes:
+--
+--   1. A UNIQUE key on provider_config (tenant_id, component, provider) so saving
+--      a BYOK key UPSERTs the matching row — the operator replacing a key, or the
+--      first real key overwriting the seed's "env" placeholder — instead of
+--      inserting duplicates. The seed's three rows ((llm,groq), (tts,elevenlabs),
+--      (stt,elevenlabs)) are already distinct on this key, so it is safe to add.
+--
+--   2. deployment_config: the Discord integration the screen also holds — the
+--      single deployment Bot token (a write-only secret, sealed at rest with the
+--      same app secret as provider_config) plus the non-secret Guild / Voice
+--      channel IDs. The Bot is deployment-shared (one token regardless of Tenant —
+--      CONTEXT.md), so it is NOT a Provider Config (ADR-0004 is per-Component,
+--      Tenant-scoped). It is keyed by tenant_id for the single operator now and
+--      de-tenants when multi-deploy lands (ADR-0039 thin pass-through).
+
+CREATE UNIQUE INDEX provider_config_tenant_component_provider_key
+    ON provider_config (tenant_id, component, provider);
+
+CREATE TABLE deployment_config (
+    tenant_id  uuid PRIMARY KEY REFERENCES tenant (id) ON DELETE CASCADE,
+    -- Discord Bot token, write-only after save: AES-GCM ciphertext (empty until
+    -- saved); last4 is the only plaintext kept for display (ADR-0004).
+    discord_bot_token_ciphertext  bytea NOT NULL DEFAULT '',
+    discord_bot_token_last4       text  NOT NULL DEFAULT '',
+    -- Non-secret Discord IDs the screen edits as plain text.
+    guild_id          text NOT NULL DEFAULT '',
+    voice_channel_id  text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS deployment_config;
+DROP INDEX IF EXISTS provider_config_tenant_component_provider_key;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -64,6 +64,23 @@ type ProviderConfig struct {
 	UpdatedAt             time.Time
 }
 
+// DeploymentConfig is the single-operator Discord integration the Configuration
+// screen edits (#68): the deployment Bot token — a write-only secret, sealed at
+// rest like a Provider Config — plus the non-secret Guild / Voice channel IDs.
+// The Bot is deployment-shared (one token regardless of Tenant, CONTEXT.md), so
+// this is distinct from the per-Component, Tenant-scoped provider_config
+// (ADR-0004); it is keyed by tenant_id only for the MVP single operator
+// (ADR-0039). DiscordBotTokenCiphertext is empty until a token is saved.
+type DeploymentConfig struct {
+	TenantID                  uuid.UUID
+	DiscordBotTokenCiphertext []byte
+	DiscordBotTokenLast4      string
+	GuildID                   string
+	VoiceChannelID            string
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+}
+
 // Agent is an AI-controlled persona — Butler or Character NPC (ADR-0009).
 type Agent struct {
 	ID         uuid.UUID

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -87,6 +87,34 @@ type Agent struct {
 	UpdatedAt   time.Time
 }
 
+// User is a human operator authenticated via Discord OAuth (ADR-0016). The
+// Discord snowflake is the stable identity key; Name/Avatar are display-only and
+// refreshed from Discord on each login.
+type User struct {
+	ID            uuid.UUID
+	DiscordUserID string
+	Name          string
+	// Avatar is an absolute image URL (or empty).
+	Avatar    string
+	Role      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Session is a server-side login session (ADR-0016): the Token is the opaque
+// random secret carried in the glyphoxa_session cookie, and this row is the
+// authority. ExpiresAt gates validity; deleting the row revokes instantly.
+type Session struct {
+	ID         uuid.UUID
+	UserID     uuid.UUID
+	Token      string
+	CreatedAt  time.Time
+	LastSeenAt time.Time
+	ExpiresAt  time.Time
+	IP         string
+	UA         string
+}
+
 // LoadedAgent is an Agent with its bound Provider Configs resolved — the bundle
 // the orchestrator needs to bring an Agent to life (Persona, Voice, LLM/TTS
 // configs). Either config may be nil if the Agent has none bound.

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -70,6 +70,9 @@ type Agent struct {
 	CampaignID uuid.UUID
 	Role       AgentRole
 	Name       string
+	// Title is the Agent's role subtitle shown in the editor (e.g. "Gruff
+	// innkeeper"); free text, may be empty.
+	Title string
 	// Persona: markdown personality/backstory/speech style.
 	Persona string
 	// Voice (ADR-0022/0023): TTS provider + voice-id config, stored as JSONB.
@@ -82,9 +85,14 @@ type Agent struct {
 	LLMProviderConfigID uuid.NullUUID
 	// AddressOnly: reachable only by explicit name/alias (ADR-0024). Butler true.
 	AddressOnly bool
-	Aliases     []string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// SpeakerColor is a server-assigned palette SLOT (not a colour value): the web
+	// tier maps it onto its speaker palette so each roster member renders in a
+	// stable hue across reloads (#71). Assigned round-robin per Campaign on
+	// Character insert; the Butler keeps slot 0.
+	SpeakerColor int
+	Aliases      []string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // User is a human operator authenticated via Discord OAuth (ADR-0016). The

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -98,16 +98,16 @@ func (s *Store) GetActiveCampaign(ctx context.Context) (Campaign, error) {
 }
 
 const agentColumns = `
-	id, campaign_id, agent_role, name, persona, voice,
+	id, campaign_id, agent_role, name, title, persona, voice,
 	voice_provider_config_id, llm_provider_config_id,
-	address_only, aliases, created_at, updated_at`
+	address_only, speaker_color, aliases, created_at, updated_at`
 
 func scanAgent(row pgx.Row) (Agent, error) {
 	var a Agent
 	err := row.Scan(
-		&a.ID, &a.CampaignID, &a.Role, &a.Name, &a.Persona, &a.Voice,
+		&a.ID, &a.CampaignID, &a.Role, &a.Name, &a.Title, &a.Persona, &a.Voice,
 		&a.VoiceProviderConfigID, &a.LLMProviderConfigID,
-		&a.AddressOnly, &a.Aliases, &a.CreatedAt, &a.UpdatedAt,
+		&a.AddressOnly, &a.SpeakerColor, &a.Aliases, &a.CreatedAt, &a.UpdatedAt,
 	)
 	return a, err
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -195,6 +195,55 @@ func (s *Store) GetProviderConfig(ctx context.Context, id uuid.UUID) (ProviderCo
 	return p, nil
 }
 
+// ListProviderConfigs returns all of a Tenant's Provider Configs, ordered by
+// Component then Provider (deterministic for the Configuration screen, #68). An
+// empty result is not an error.
+func (s *Store) ListProviderConfigs(ctx context.Context, tenantID uuid.UUID) ([]ProviderConfig, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+providerConfigColumns+`
+		   FROM provider_config
+		  WHERE tenant_id = $1
+		  ORDER BY component, provider`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list provider_config for tenant %s: %w", tenantID, err)
+	}
+	defer rows.Close()
+
+	var out []ProviderConfig
+	for rows.Next() {
+		p, err := scanProviderConfig(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan provider_config: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list provider_config for tenant %s: %w", tenantID, err)
+	}
+	return out, nil
+}
+
+// GetProviderConfigByComponent returns the Tenant's most-recently-updated
+// Provider Config for a Component, or ErrNotFound when none is bound. A Component
+// can have more than one Provider in the matrix (ADR-0004); this resolves the one
+// the operator last saved.
+func (s *Store) GetProviderConfigByComponent(ctx context.Context, tenantID uuid.UUID, component Component) (ProviderConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+providerConfigColumns+`
+		   FROM provider_config
+		  WHERE tenant_id = $1 AND component = $2
+		  ORDER BY updated_at DESC, id DESC
+		  LIMIT 1`, tenantID, component)
+	p, err := scanProviderConfig(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ProviderConfig{}, ErrNotFound
+	}
+	if err != nil {
+		return ProviderConfig{}, fmt.Errorf("storage: get provider_config (tenant %s, component %s): %w", tenantID, component, err)
+	}
+	return p, nil
+}
+
 // LoadAgent loads an Agent together with its bound LLM and TTS Provider Configs
 // — the Persona/Voice/provider bundle the orchestrator needs (the core read
 // this task exists to enable). Missing or unbound configs yield nil, not an

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -89,6 +89,44 @@ const speakerColorSlots = 6
 // CodeFailedPrecondition.
 var ErrButlerUndeletable = errors.New("storage: butler cannot be deleted")
 
+// UpsertProviderConfigs inserts-or-replaces a batch of Provider Configs in one
+// transaction, keyed by (tenant_id, component, provider): a matching row has its
+// model + sealed credential + last4 refreshed (the operator replacing a key, or
+// the first real key overwriting the seed's "env" placeholder), otherwise a new
+// row is inserted. The batch is atomic so a multi-Component provider (ElevenLabs
+// → stt + tts share one key, ADR-0004) lands all-or-nothing. Returns the
+// resulting rows in input order. Requires the UNIQUE (tenant_id, component,
+// provider) key from migration 00005.
+func (s *Store) UpsertProviderConfigs(ctx context.Context, configs []NewProviderConfig) ([]ProviderConfig, error) {
+	out := make([]ProviderConfig, 0, len(configs))
+	err := s.InTx(ctx, func(tx *Store) error {
+		for _, c := range configs {
+			row := tx.db.QueryRow(ctx,
+				`INSERT INTO provider_config
+				   (tenant_id, component, provider, model, credentials_ciphertext, credentials_last4)
+				 VALUES ($1, $2, $3, $4, $5, $6)
+				 ON CONFLICT (tenant_id, component, provider) DO UPDATE
+				   SET model = EXCLUDED.model,
+				       credentials_ciphertext = EXCLUDED.credentials_ciphertext,
+				       credentials_last4 = EXCLUDED.credentials_last4,
+				       updated_at = now()
+				 RETURNING `+providerConfigColumns,
+				c.TenantID, c.Component, c.Provider, c.Model,
+				c.CredentialsCiphertext, c.CredentialsLast4)
+			pc, err := scanProviderConfig(row)
+			if err != nil {
+				return fmt.Errorf("storage: upsert provider_config (%s/%s): %w", c.Component, c.Provider, err)
+			}
+			out = append(out, pc)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // NewAgent is the input to CreateAgent. Voice is the opaque JSONB blob the voice
 // domain serializes its tts.Voice into; storage keeps it vendor-neutral.
 // SpeakerColor is NOT an input — it is server-assigned on Character insert.

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -77,12 +77,26 @@ func (s *Store) CreateProviderConfig(ctx context.Context, p NewProviderConfig) (
 	return id, nil
 }
 
+// speakerColorSlots is the size of the web speaker palette (#71). CreateAgent
+// assigns a Character a slot round-robin in [0, speakerColorSlots) per Campaign;
+// the web tier maps the slot onto its palette so each NPC renders in a stable
+// hue. Kept in sync with migration 00004's backfill modulo and the web palette.
+const speakerColorSlots = 6
+
+// ErrButlerUndeletable is returned by DeleteAgent when the target Agent is a
+// Butler. The Butler is an invariant of a Campaign's existence (ADR-0009): it is
+// auto-created and cannot be removed. The RPC layer maps this to Connect
+// CodeFailedPrecondition.
+var ErrButlerUndeletable = errors.New("storage: butler cannot be deleted")
+
 // NewAgent is the input to CreateAgent. Voice is the opaque JSONB blob the voice
 // domain serializes its tts.Voice into; storage keeps it vendor-neutral.
+// SpeakerColor is NOT an input — it is server-assigned on Character insert.
 type NewAgent struct {
 	CampaignID            uuid.UUID
 	Role                  AgentRole
 	Name                  string
+	Title                 string
 	Persona               string
 	Voice                 []byte // JSON; defaults to {} when nil
 	VoiceProviderConfigID uuid.NullUUID
@@ -92,7 +106,9 @@ type NewAgent struct {
 }
 
 // CreateAgent inserts an Agent and returns its generated ID. Inserting a second
-// Butler in a Campaign violates the partial-unique index (ADR-0009).
+// Butler in a Campaign violates the partial-unique index (ADR-0009). A Character
+// is assigned the next round-robin speaker-colour slot for its Campaign (stable
+// once stored); the Butler keeps slot 0.
 func (s *Store) CreateAgent(ctx context.Context, a NewAgent) (uuid.UUID, error) {
 	voice := a.Voice
 	if len(voice) == 0 {
@@ -103,17 +119,111 @@ func (s *Store) CreateAgent(ctx context.Context, a NewAgent) (uuid.UUID, error) 
 		aliases = []string{}
 	}
 	var id uuid.UUID
+	// $2 is cast to agent_role in BOTH uses so Postgres deduces one consistent
+	// type for the parameter. The speaker_color slot is the count of existing
+	// Characters in the Campaign (the new row's 0-based roster index) modulo the
+	// palette size; non-Characters take slot 0.
 	err := s.db.QueryRow(ctx,
 		`INSERT INTO agents
-		   (campaign_id, agent_role, name, persona, voice,
-		    voice_provider_config_id, llm_provider_config_id, address_only, aliases)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
-		a.CampaignID, a.Role, a.Name, a.Persona, voice,
-		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases).Scan(&id)
+		   (campaign_id, agent_role, name, title, persona, voice,
+		    voice_provider_config_id, llm_provider_config_id, address_only, aliases,
+		    speaker_color)
+		 VALUES ($1, $2::agent_role, $3, $4, $5, $6, $7, $8, $9, $10,
+		   CASE WHEN $2::agent_role = 'character'
+		        THEN ((SELECT count(*) FROM agents
+		                WHERE campaign_id = $1 AND agent_role = 'character') % $11)::smallint
+		        ELSE 0 END)
+		 RETURNING id`,
+		a.CampaignID, a.Role, a.Name, a.Title, a.Persona, voice,
+		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases,
+		speakerColorSlots).Scan(&id)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("storage: create agent: %w", err)
 	}
 	return id, nil
+}
+
+// AgentUpdate is the input to UpdateAgent. It carries the editor-editable fields
+// only — the Campaign screen edits name/title/persona/voice/address-only/aliases;
+// agent_role, campaign_id and speaker_color are immutable here. A Butler's
+// address_only is force-kept true regardless of AddressOnly (ADR-0009 / ADR-0024).
+type AgentUpdate struct {
+	ID                    uuid.UUID
+	Name                  string
+	Title                 string
+	Persona               string
+	Voice                 []byte // JSON; defaults to {} when nil
+	VoiceProviderConfigID uuid.NullUUID
+	LLMProviderConfigID   uuid.NullUUID
+	AddressOnly           bool
+	Aliases               []string
+}
+
+// UpdateAgent updates an Agent's editor fields and returns the updated row.
+// It never changes agent_role, and it force-keeps a Butler's address_only true
+// (the Butler always waits to be named, ADR-0024) — so editing the Butler can
+// neither demote it nor turn off Address-Only. A missing id yields ErrNotFound.
+func (s *Store) UpdateAgent(ctx context.Context, a AgentUpdate) (Agent, error) {
+	voice := a.Voice
+	if len(voice) == 0 {
+		voice = []byte(`{}`)
+	}
+	aliases := a.Aliases
+	if aliases == nil {
+		aliases = []string{}
+	}
+	row := s.db.QueryRow(ctx,
+		`UPDATE agents SET
+		    name = $2,
+		    title = $3,
+		    persona = $4,
+		    voice = $5,
+		    voice_provider_config_id = $6,
+		    llm_provider_config_id = $7,
+		    address_only = CASE WHEN agent_role = 'butler' THEN true ELSE $8 END,
+		    aliases = $9,
+		    updated_at = now()
+		  WHERE id = $1
+		 RETURNING `+agentColumns,
+		a.ID, a.Name, a.Title, a.Persona, voice,
+		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases)
+	updated, err := scanAgent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Agent{}, ErrNotFound
+	}
+	if err != nil {
+		return Agent{}, fmt.Errorf("storage: update agent %s: %w", a.ID, err)
+	}
+	return updated, nil
+}
+
+// DeleteAgent removes a Character NPC by id. Deleting a Butler is rejected with
+// ErrButlerUndeletable (ADR-0009): the guarded DELETE leaves a Butler row
+// untouched, and the wrapping CTE reports whether the id existed and whether it
+// was a Butler in one atomic round-trip — so a missing id yields ErrNotFound and
+// a Butler yields ErrButlerUndeletable, distinct from "deleted nothing".
+func (s *Store) DeleteAgent(ctx context.Context, id uuid.UUID) error {
+	var existed, isButler bool
+	err := s.db.QueryRow(ctx,
+		`WITH found AS (
+		     SELECT agent_role FROM agents WHERE id = $1
+		 ), del AS (
+		     DELETE FROM agents WHERE id = $1 AND agent_role <> 'butler' RETURNING 1
+		 )
+		 SELECT
+		     EXISTS (SELECT 1 FROM found),
+		     COALESCE((SELECT agent_role = 'butler' FROM found), false)`,
+		id).Scan(&existed, &isButler)
+	if err != nil {
+		return fmt.Errorf("storage: delete agent %s: %w", id, err)
+	}
+	if !existed {
+		return ErrNotFound
+	}
+	if isButler {
+		return ErrButlerUndeletable
+	}
+	return nil
 }
 
 // CharacterAgents returns the Campaign's Character NPC Agents (agent_role =

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -36,6 +36,18 @@ type Mount struct {
 	Handler http.Handler
 }
 
+// APIMount adapts a generated Connect handler pair — (mountPath, handler) as
+// returned by a service's Handler() method — into a [Mount] under the public
+// /api prefix. The browser dials Connect at baseUrl "/api"
+// (web/src/lib/transport.ts), so the handler is wrapped in
+// http.StripPrefix("/api", …) and registered at "/api"+mountPath; StripPrefix
+// removes the /api segment before the Connect handler matches its method path.
+// The stacked #68/#71 PRs reuse this to mount their services identically to
+// AuthService/CampaignService.
+func APIMount(mountPath string, handler http.Handler) Mount {
+	return Mount{Path: "/api" + mountPath, Handler: http.StripPrefix("/api", handler)}
+}
+
 // Config configures a [Server]. Logger defaults to slog.Default when nil. The
 // observability endpoints are NOT served here — they live on the separate
 // metrics port (see the package doc) — so this carries no recorder or probe.

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -73,7 +73,7 @@ func startServer(t *testing.T, mounts ...web.Mount) (base string, stop func()) {
 func mountFake(t *testing.T, svc fakeCampaignService) web.Mount {
 	t.Helper()
 	path, handler := managementv1connect.NewCampaignServiceHandler(svc)
-	return web.Mount{Path: "/api" + path, Handler: http.StripPrefix("/api", handler)}
+	return web.APIMount(path, handler)
 }
 
 func TestServerRoutesConnectThenShutsDown(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -26,8 +26,11 @@ func TestMain(m *testing.M) {
 // fakeCampaignService is a keyless, deterministic CampaignServiceHandler. It
 // lets the web-server test prove routing of a Connect handler — success AND
 // error-code — without pulling in internal/rpc or internal/storage. The server
-// is decoupled from campaign specifics, so a canned handler is enough.
+// is decoupled from campaign specifics, so a canned handler is enough. The
+// embedded Unimplemented handler supplies the roster + CRUD methods (#71) the
+// routing test does not exercise.
 type fakeCampaignService struct {
+	managementv1connect.UnimplementedCampaignServiceHandler
 	campaign *managementv1.Campaign
 	err      error
 }

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -45,3 +45,50 @@ message GetActiveCampaignResponse {
   // campaign is the most-recently-created campaign for the operator.
   Campaign campaign = 1;
 }
+
+// AuthService exposes the operator's authenticated identity to the SPA boot
+// flow (ADR-0016 / ADR-0039). The session itself is issued by the net/http
+// Discord OAuth carve-out (ADR-0015); this Connect surface reads it back and
+// tears it down. The auth interceptor resolves the session cookie into the
+// request context, so GetCurrentUser fails with CodeUnauthenticated when no
+// valid session is present — the SPA's 401 → /login signal.
+service AuthService {
+  // GetCurrentUser returns the signed-in operator's display identity. It is a
+  // read (NO_SIDE_EFFECTS) and is reachable unauthenticated so the SPA can probe
+  // the session at boot: no/expired session fails with CodeUnauthenticated.
+  rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // Logout deletes the server-side session row and clears the session + CSRF
+  // cookies. It is state-changing, so the auth + CSRF interceptors guard it.
+  rpc Logout(LogoutRequest) returns (LogoutResponse);
+}
+
+// User is the signed-in operator's display identity (ADR-0016). It deliberately
+// omits the internal user id and Discord user id — the SPA only renders the
+// name, role, and avatar in the sidebar.
+message User {
+  // name is the operator's display name (Discord global name or username).
+  string name = 1;
+  // role is the operator's role label (e.g. "operator").
+  string role = 2;
+  // avatar is an absolute avatar image URL, or empty when none is set.
+  string avatar = 3;
+}
+
+// GetCurrentUserRequest is the (empty) request for GetCurrentUser; the operator
+// is resolved server-side from the session cookie.
+message GetCurrentUserRequest {}
+
+// GetCurrentUserResponse carries the signed-in operator's identity.
+message GetCurrentUserResponse {
+  // user is the signed-in operator.
+  User user = 1;
+}
+
+// LogoutRequest is the (empty) request for Logout; the session to delete is
+// resolved server-side from the session cookie.
+message LogoutRequest {}
+
+// LogoutResponse is the (empty) response for Logout.
+message LogoutResponse {}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -218,3 +218,104 @@ message DeleteAgentRequest {
 
 // DeleteAgentResponse is the (empty) response for DeleteAgent.
 message DeleteAgentResponse {}
+
+// ProviderService backs the Configuration screen (#68; ADR-0004 BYOK /
+// ADR-0039 single-operator). Credentials are WRITE-ONLY after save: a saved
+// secret's plaintext is NEVER returned over any RPC — responses carry only the
+// last 4 characters (last4) plus metadata, so the screen renders a masked value
+// and a "last updated" without ever reading a secret back.
+service ProviderService {
+  // ListProviderConfigs returns the operator's saved Configuration: the three
+  // write-only credentials (Discord bot token, Groq, ElevenLabs) as masked
+  // metadata, plus the non-secret Discord Guild / Voice channel IDs. It is a
+  // read (NO_SIDE_EFFECTS), so the CSRF check is skipped.
+  rpc ListProviderConfigs(ListProviderConfigsRequest) returns (ListProviderConfigsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // SaveProviderConfig seals and stores one BYOK provider key (Groq or
+  // ElevenLabs) and returns only its masked metadata. Replacing an existing key
+  // updates its last4 + updated_at. State-changing: auth + CSRF guard it.
+  rpc SaveProviderConfig(SaveProviderConfigRequest) returns (SaveProviderConfigResponse);
+  // SaveDiscordSettings stores the Discord deployment integration: the Bot token
+  // (a write-only secret, sealed at rest) and the non-secret Guild / Voice
+  // channel IDs. An omitted bot_token leaves the stored token unchanged, so the
+  // IDs can be saved without re-entering the secret. State-changing.
+  rpc SaveDiscordSettings(SaveDiscordSettingsRequest) returns (SaveDiscordSettingsResponse);
+}
+
+// ProviderCredential is the WRITE-ONLY view of a saved secret: never its value,
+// only the last 4 characters and whether/when it was saved (ADR-0004). The
+// Configuration screen renders a masked field, a "last updated", and a Healthy /
+// Key-needed badge from these fields alone.
+message ProviderCredential {
+  // component is the credential's primary Component label ("llm", "tts") or
+  // "discord" for the Bot token. Display/identity only — not the storage enum.
+  string component = 1;
+  // provider identifies the credential slot ("groq", "elevenlabs", "discord").
+  string provider = 2;
+  // ever_saved is true once a real key has been stored. An unsaved slot, or one
+  // still holding the seed's ENV placeholder, is false → the screen shows
+  // "Key needed".
+  bool ever_saved = 3;
+  // show_masked tells the screen to render the masked value + Replace button
+  // (true exactly when ever_saved).
+  bool show_masked = 4;
+  // last4 is the last 4 characters of the saved secret — the only plaintext
+  // kept (empty when never saved).
+  string last4 = 5;
+  // model is the selected model/voice id for the provider (empty for Discord).
+  string model = 6;
+  // updated_at is when the credential was last saved (unset when never saved).
+  google.protobuf.Timestamp updated_at = 7;
+}
+
+// ListProviderConfigsRequest is the (empty) request; the tenant is resolved
+// server-side from the session.
+message ListProviderConfigsRequest {}
+
+// ListProviderConfigsResponse carries the three write-only credentials plus the
+// non-secret Discord IDs the screen edits.
+message ListProviderConfigsResponse {
+  // credentials are the Discord bot token, Groq, and ElevenLabs slots.
+  repeated ProviderCredential credentials = 1;
+  // guild_id is the Discord server the Bot serves (non-secret; may be empty).
+  string guild_id = 2;
+  // voice_channel_id is the channel sessions join (non-secret; may be empty).
+  string voice_channel_id = 3;
+}
+
+// SaveProviderConfigRequest seals one BYOK provider key.
+message SaveProviderConfigRequest {
+  // provider is the BYOK slot to save: "groq" or "elevenlabs".
+  string provider = 1;
+  // secret is the plaintext API key to seal. Write-only: never returned.
+  string secret = 2;
+  // model is the selected model/voice id (optional).
+  string model = 3;
+}
+
+// SaveProviderConfigResponse returns the saved key's masked metadata.
+message SaveProviderConfigResponse {
+  // credential is the saved key's write-only view (never its value).
+  ProviderCredential credential = 1;
+}
+
+// SaveDiscordSettingsRequest stores the Discord deployment integration.
+message SaveDiscordSettingsRequest {
+  // bot_token is the Discord Bot token to seal. Omit (no presence) to leave the
+  // stored token unchanged — lets the IDs be saved without re-entering the
+  // secret. Write-only: never returned.
+  optional string bot_token = 1;
+  // guild_id / voice_channel_id are the non-secret Discord IDs, stored as-is.
+  string guild_id = 2;
+  string voice_channel_id = 3;
+}
+
+// SaveDiscordSettingsResponse returns the Bot token's masked metadata plus the
+// stored IDs after the save.
+message SaveDiscordSettingsResponse {
+  // credential is the Bot token's write-only view after the save.
+  ProviderCredential credential = 1;
+  string guild_id = 2;
+  string voice_channel_id = 3;
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -16,6 +16,30 @@ service CampaignService {
   // GetActiveCampaign returns the most-recently-created campaign for the
   // operator. It fails with CodeNotFound when no campaign exists.
   rpc GetActiveCampaign(GetActiveCampaignRequest) returns (GetActiveCampaignResponse);
+
+  // GetCampaignRoster returns the active campaign together with its ordered
+  // roster — the Butler first, then the Character NPCs — each carrying a stable
+  // speaker-colour slot (#71). It is a read (NO_SIDE_EFFECTS), so the CSRF check
+  // is exempt; it fails with CodeNotFound when no campaign exists.
+  rpc GetCampaignRoster(GetCampaignRosterRequest) returns (GetCampaignRosterResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // CreateAgent adds a Character NPC ("Add NPC") to the active campaign and
+  // returns the created agent, including its server-assigned speaker-colour slot.
+  // The role is always 'character'; the Butler is auto-created (ADR-0009).
+  rpc CreateAgent(CreateAgentRequest) returns (CreateAgentResponse);
+
+  // UpdateAgent saves an agent's editor fields (name, title, persona, voice,
+  // address-only, aliases) and returns the updated agent. Editing the Butler can
+  // neither change its role nor turn off Address-Only (ADR-0009 / ADR-0024). A
+  // missing id fails with CodeNotFound.
+  rpc UpdateAgent(UpdateAgentRequest) returns (UpdateAgentResponse);
+
+  // DeleteAgent removes a Character NPC. Deleting the Butler fails with
+  // CodeFailedPrecondition (it is undeletable, ADR-0009); a missing id fails with
+  // CodeNotFound.
+  rpc DeleteAgent(DeleteAgentRequest) returns (DeleteAgentResponse);
 }
 
 // Campaign is the wire representation of a campaign record.
@@ -92,3 +116,105 @@ message LogoutRequest {}
 
 // LogoutResponse is the (empty) response for Logout.
 message LogoutResponse {}
+
+// Agent is the wire representation of a roster member — the Butler or a Character
+// NPC (ADR-0009). It carries the editor-facing fields plus the server-assigned
+// speaker-colour slot; the encrypted provider bindings are not exposed here.
+message Agent {
+  // id is the agent's UUID.
+  string id = 1;
+  // campaign_id is the owning campaign's UUID.
+  string campaign_id = 2;
+  // role is the agent archetype: "butler" or "character" (ADR-0009).
+  string role = 3;
+  // name is the agent's display name (and primary address term).
+  string name = 4;
+  // title is the role subtitle shown under the name (e.g. "Gruff innkeeper").
+  string title = 5;
+  // persona is the markdown personality/backstory/speech style injected into the
+  // prompt.
+  string persona = 6;
+  // voice is the selected voice id (empty when unset). The encrypted TTS provider
+  // binding is not exposed.
+  string voice = 7;
+  // address_only: the agent waits to be named (ADR-0024). Always true for the
+  // Butler.
+  bool address_only = 8;
+  // speaker_color is the stable palette SLOT the web tier maps onto its speaker
+  // palette, so each roster member renders in a stable hue across reloads.
+  uint32 speaker_color = 9;
+  // aliases are extra name/aliases for Address Detection beyond name.
+  repeated string aliases = 10;
+}
+
+// GetCampaignRosterRequest is the (empty) request for GetCampaignRoster; the
+// active campaign is resolved server-side for the single operator.
+message GetCampaignRosterRequest {}
+
+// GetCampaignRosterResponse carries the active campaign and its ordered roster.
+message GetCampaignRosterResponse {
+  // campaign is the active campaign (title is its name; plus system/language).
+  Campaign campaign = 1;
+  // roster is the campaign's agents in stable order: the Butler first, then the
+  // Character NPCs.
+  repeated Agent roster = 2;
+}
+
+// CreateAgentRequest is the editor's "Add NPC" payload. The role is always
+// 'character' and the campaign is resolved server-side, so neither is carried.
+message CreateAgentRequest {
+  // name is the new NPC's display name (e.g. "New NPC").
+  string name = 1;
+  // title is the role subtitle.
+  string title = 2;
+  // persona is the markdown personality/backstory/speech style.
+  string persona = 3;
+  // voice is the selected voice id (empty when unset).
+  string voice = 4;
+  // address_only: the NPC waits to be named (ADR-0024).
+  bool address_only = 5;
+  // aliases are extra address terms beyond name.
+  repeated string aliases = 6;
+}
+
+// CreateAgentResponse carries the created Character NPC, including its
+// server-assigned speaker-colour slot.
+message CreateAgentResponse {
+  // agent is the newly created NPC.
+  Agent agent = 1;
+}
+
+// UpdateAgentRequest carries an agent's editor fields. address_only is ignored
+// for the Butler (kept true). Unknown id fails with CodeNotFound.
+message UpdateAgentRequest {
+  // id is the agent to update.
+  string id = 1;
+  // name is the agent's display name.
+  string name = 2;
+  // title is the role subtitle.
+  string title = 3;
+  // persona is the markdown personality/backstory/speech style.
+  string persona = 4;
+  // voice is the selected voice id (empty when unset).
+  string voice = 5;
+  // address_only: the agent waits to be named; ignored for the Butler (ADR-0024).
+  bool address_only = 6;
+  // aliases are extra address terms beyond name.
+  repeated string aliases = 7;
+}
+
+// UpdateAgentResponse carries the updated agent.
+message UpdateAgentResponse {
+  // agent is the updated agent.
+  Agent agent = 1;
+}
+
+// DeleteAgentRequest names the agent to delete. Deleting the Butler fails with
+// CodeFailedPrecondition (ADR-0009).
+message DeleteAgentRequest {
+  // id is the agent to delete.
+  string id = 1;
+}
+
+// DeleteAgentResponse is the (empty) response for DeleteAgent.
+message DeleteAgentResponse {}

--- a/web/src/app/AuthGate.test.tsx
+++ b/web/src/app/AuthGate.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AuthService,
+  GetCurrentUserResponseSchema,
+  UserSchema,
+  LogoutResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { AuthGate } from "./AuthGate";
+
+// useNavigate is mocked so the redirect is observable without a live router.
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigate }));
+
+beforeEach(() => navigate.mockClear());
+
+// authedTransport answers GetCurrentUser with a canned operator.
+function authedTransport() {
+  return createRouterTransport(({ service }) => {
+    service(AuthService, {
+      getCurrentUser: () =>
+        create(GetCurrentUserResponseSchema, {
+          user: create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" }),
+        }),
+      logout: () => create(LogoutResponseSchema, {}),
+    });
+  });
+}
+
+// unauthTransport fails GetCurrentUser with CodeUnauthenticated (no session).
+function unauthTransport() {
+  return createRouterTransport(({ service }) => {
+    service(AuthService, {
+      getCurrentUser: () => {
+        throw new ConnectError("no session", Code.Unauthenticated);
+      },
+      logout: () => create(LogoutResponseSchema, {}),
+    });
+  });
+}
+
+describe("AuthGate", () => {
+  it("redirects to /login when unauthenticated", async () => {
+    render(
+      <Providers transport={unauthTransport()} queryClient={makeQueryClient()}>
+        <AuthGate>{(user) => <div>{user.name}</div>}</AuthGate>
+      </Providers>,
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/login" }));
+  });
+
+  it("renders the shell with the real operator identity when authenticated", async () => {
+    render(
+      <Providers transport={authedTransport()} queryClient={makeQueryClient()}>
+        <AuthGate>{(user) => <div>shell for {user.name}</div>}</AuthGate>
+      </Providers>,
+    );
+    expect(await screen.findByText("shell for Sora Vance")).toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/AuthGate.tsx
+++ b/web/src/app/AuthGate.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { useQuery } from "@connectrpc/connect-query";
+import { useNavigate } from "@tanstack/react-router";
+import { ConnectError } from "@connectrpc/connect";
+
+import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+import { isUnauthenticated } from "@/lib/auth";
+
+// AuthGate is the SPA boot gate (ADR-0016 / ADR-0039): it probes
+// AuthService.GetCurrentUser and, on CodeUnauthenticated, redirects to /login.
+// On success it hands the resolved operator to its render-prop child (the app
+// shell), so the sidebar shows the real identity instead of a hardcoded one.
+// retry is off so a 401 redirects immediately rather than after react-query's
+// default backoff.
+export function AuthGate({ children }: { children: (user: User) => ReactNode }) {
+  const navigate = useNavigate();
+  const { data, status, error } = useQuery(
+    AuthService.method.getCurrentUser,
+    {},
+    { retry: false },
+  );
+
+  const unauthenticated = status === "error" && isUnauthenticated(error);
+
+  useEffect(() => {
+    if (unauthenticated) {
+      void navigate({ to: "/login" });
+    }
+  }, [unauthenticated, navigate]);
+
+  if (status === "success" && data.user) {
+    return <>{children(data.user)}</>;
+  }
+
+  // A non-401 error is a real failure (server down, etc.) — surface it rather
+  // than bouncing to /login, which would loop.
+  if (status === "error" && !unauthenticated) {
+    return (
+      <div className="gx-providers">
+        <p className="gx-campaign__error" role="alert">
+          Could not load your account: {ConnectError.from(error).message}
+        </p>
+      </div>
+    );
+  }
+
+  // Loading, or mid-redirect after a 401.
+  return <div className="gx-auth-boot" aria-busy="true" aria-label="Loading" />;
+}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -7,19 +7,29 @@ import {
 } from "@tanstack/react-router";
 
 import { AppShell } from "@/components/AppShell";
+import { AuthGate } from "@/app/AuthGate";
+import { Login } from "@/screens/login/Login";
 import { Configuration } from "@/screens/configuration/Configuration";
 import { Placeholder } from "@/screens/Placeholder";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
 // (/t/:tenantSlug/...) so URLs are bookmarkable; for the single-operator MVP
-// (ADR-0039) the slug is a thin pass-through. The boot flow's auth/onboarding
-// branches are deferred to later stages — this stage redirects the root to the
-// default tenant's Configuration screen.
+// (ADR-0039) the slug is a thin pass-through. The shell is wrapped in the
+// AuthGate (ADR-0016): it probes GetCurrentUser at boot and redirects to /login
+// on a 401, then hands the real operator identity to the shell.
 
 const DEFAULT_TENANT = "default";
 
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
+});
+
+// /login — the Discord-only OAuth entry (ADR-0016). It lives OUTSIDE the tenant
+// shell so it never triggers the AuthGate (which would loop).
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  component: Login,
 });
 
 // "/" → the default tenant's Configuration (boot flow stand-in for this stage).
@@ -34,13 +44,15 @@ const indexRoute = createRoute({
   },
 });
 
-// /t/:tenantSlug — the persistent shell hosting the screen Outlet.
+// /t/:tenantSlug — the persistent shell hosting the screen Outlet, gated by the
+// AuthGate so an unauthenticated visit redirects to /login and an authenticated
+// one renders the shell with the real operator identity.
 const tenantRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "t/$tenantSlug",
   component: function TenantLayout() {
     const { tenantSlug } = tenantRoute.useParams();
-    return <AppShell tenantSlug={tenantSlug} />;
+    return <AuthGate>{(user) => <AppShell tenantSlug={tenantSlug} user={user} />}</AuthGate>;
   },
 });
 
@@ -78,6 +90,7 @@ const screenRoute = createRoute({
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  loginRoute,
   tenantRoute.addChildren([tenantIndexRoute, screenRoute]),
 ]);
 

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -10,6 +10,7 @@ import { AppShell } from "@/components/AppShell";
 import { AuthGate } from "@/app/AuthGate";
 import { Login } from "@/screens/login/Login";
 import { Configuration } from "@/screens/configuration/Configuration";
+import { Campaign } from "@/screens/campaign/Campaign";
 import { Placeholder } from "@/screens/Placeholder";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
@@ -68,8 +69,8 @@ const tenantIndexRoute = createRoute({
   },
 });
 
-// /t/:tenantSlug/:screen — selects the active screen. Only Configuration is
-// live this stage; Campaign and Session render styled placeholders.
+// /t/:tenantSlug/:screen — selects the active screen. Configuration and Campaign
+// are live on their RPCs; Session renders a styled placeholder.
 const screenRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: "$screen",
@@ -79,7 +80,7 @@ const screenRoute = createRoute({
       case "configuration":
         return <Configuration />;
       case "campaign":
-        return <Placeholder title="Campaign" />;
+        return <Campaign />;
       case "session":
         return <Placeholder title="Session" />;
       default:

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,16 +1,18 @@
 import type { ReactNode } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
-import { Dices, Settings, Swords, ScrollText, ChevronsUpDown } from "lucide-react";
+import { Dices, Settings, Swords, ScrollText } from "lucide-react";
 
-import { Avatar } from "./ui/Avatar";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+
+import { SidebarUser } from "./SidebarUser";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
 // ui_kits/glyphoxa-web/shell.jsx (its inline styles lifted onto .gx-shell* /
 // .gx-topbar* in styles/components.css) and driven by TanStack Router's active
 // route rather than page state (ADR-0018). The Tenant lives in the path
 // (/t/:tenantSlug/...); for the single-operator MVP (ADR-0039) it is a thin
-// pass-through slug, and the sidebar user footer is a static placeholder until
-// the auth/me RPC lands.
+// pass-through slug. The sidebar user footer now shows the real signed-in
+// operator (ADR-0016), passed in by the AuthGate that wraps the shell.
 
 type NavItem = { to: string; label: string; icon: ReactNode; title: string };
 
@@ -20,7 +22,7 @@ const NAV: NavItem[] = [
   { to: "session", label: "Session", icon: <ScrollText size={18} />, title: "Session" },
 ];
 
-export function AppShell({ tenantSlug }: { tenantSlug: string }) {
+export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User }) {
   const { screen } = useParams({ strict: false }) as { screen?: string };
   const active = NAV.find((n) => n.to === screen);
 
@@ -49,14 +51,7 @@ export function AppShell({ tenantSlug }: { tenantSlug: string }) {
           ))}
         </nav>
 
-        <div className="gx-sidebar__user">
-          <Avatar name="Operator" size="sm" status="live" />
-          <div className="gx-sidebar__user-meta">
-            <div className="gx-sidebar__user-name">Operator</div>
-            <div className="gx-sidebar__user-role">Self-host</div>
-          </div>
-          <ChevronsUpDown size={15} style={{ color: "var(--text-subtle)" }} />
-        </div>
+        <SidebarUser user={user} />
       </aside>
 
       <div className="gx-main">

--- a/web/src/components/SidebarUser.test.tsx
+++ b/web/src/components/SidebarUser.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AuthService,
+  UserSchema,
+  LogoutResponseSchema,
+  GetCurrentUserResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { SidebarUser } from "./SidebarUser";
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => navigate }));
+
+beforeEach(() => navigate.mockClear());
+
+describe("SidebarUser", () => {
+  it("renders the real operator identity", () => {
+    render(
+      <Providers transport={createRouterTransport(() => {})} queryClient={makeQueryClient()}>
+        <SidebarUser user={create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" })} />
+      </Providers>,
+    );
+    expect(screen.getByText("Sora Vance")).toBeInTheDocument();
+    expect(screen.getByText("operator")).toBeInTheDocument();
+  });
+
+  it("logs out — calls Logout and redirects to /login", async () => {
+    let loggedOut = false;
+    const transport = createRouterTransport(({ service }) => {
+      service(AuthService, {
+        getCurrentUser: () =>
+          create(GetCurrentUserResponseSchema, { user: create(UserSchema, {}) }),
+        logout: () => {
+          loggedOut = true;
+          return create(LogoutResponseSchema, {});
+        },
+      });
+    });
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <SidebarUser user={create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" })} />
+      </Providers>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /log out/i }));
+
+    await waitFor(() => expect(loggedOut).toBe(true));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/login" }));
+  });
+});

--- a/web/src/components/SidebarUser.tsx
+++ b/web/src/components/SidebarUser.tsx
@@ -1,0 +1,52 @@
+import { useMutation } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { LogOut } from "lucide-react";
+
+import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { User } from "@gen/glyphoxa/management/v1/management_pb";
+
+import { Avatar } from "./ui/Avatar";
+
+// SidebarUser is the app-shell footer identity (ADR-0016 / ADR-0039): it renders
+// the real signed-in operator (name / role / avatar) the AuthGate resolved,
+// replacing the design's hardcoded "Operator / Sora Vance". The logout button
+// calls AuthService.Logout, which deletes the server-side session row and clears
+// the cookies; on success it drops the cached queries and routes to /login.
+export function SidebarUser({ user }: { user: User }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const logout = useMutation(AuthService.method.logout, {
+    onSuccess: () => {
+      queryClient.clear();
+      void navigate({ to: "/login" });
+    },
+  });
+
+  return (
+    <div className="gx-sidebar__user">
+      <Avatar name={user.name} src={user.avatar || null} size="sm" status="live" />
+      <div className="gx-sidebar__user-meta">
+        <div className="gx-sidebar__user-name">{user.name}</div>
+        <div className="gx-sidebar__user-role">{user.role}</div>
+      </div>
+      <button
+        type="button"
+        className="gx-sidebar__logout"
+        aria-label="Log out"
+        onClick={() => logout.mutate({})}
+        disabled={logout.isPending}
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--text-subtle)",
+          cursor: "pointer",
+          padding: 4,
+        }}
+      >
+        <LogOut size={15} />
+      </button>
+    </div>
+  );
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,10 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
+// isUnauthenticated reports whether an error from a Connect call is the
+// server's CodeUnauthenticated — the SPA's "no/expired session" signal that
+// drives the boot redirect to /login (ADR-0016). ConnectError.from normalizes
+// any thrown value; a non-Connect error resolves to Code.Unknown, not
+// Unauthenticated, so only a real 401 triggers the redirect.
+export function isUnauthenticated(error: unknown): boolean {
+  return ConnectError.from(error).code === Code.Unauthenticated;
+}

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -1,9 +1,33 @@
 import { createConnectTransport } from "@connectrpc/connect-web";
+import type { Interceptor } from "@connectrpc/connect";
 
 // The browser dials Connect-JSON at /api (ADR-0015 — JSON keeps the network tab
 // human-readable). In dev, Vite proxies /api → the Go web tier (vite.config.ts);
 // in prod the Go binary serves the SPA and mounts the Connect handler under /api
-// on the same origin, so a relative baseUrl is correct in both modes.
+// on the same origin, so a relative baseUrl is correct in both modes. The
+// session cookie rides along automatically (same-origin); the CSRF interceptor
+// adds the double-submit header.
+
+// readCookie returns a cookie value by name, or null. Used to mirror the
+// non-HttpOnly glyphoxa_csrf cookie into the request header.
+function readCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+// csrf is the double-submit CSRF interceptor (ADR-0016): it echoes the
+// glyphoxa_csrf cookie into the X-CSRF-Token header that the server's CSRF
+// interceptor checks on state-changing calls. Harmless on reads (the server
+// exempts NO_SIDE_EFFECTS RPCs); required on mutations like Logout.
+const csrf: Interceptor = (next) => (req) => {
+  const token = readCookie("glyphoxa_csrf");
+  if (token) {
+    req.header.set("X-CSRF-Token", token);
+  }
+  return next(req);
+};
+
 export const transport = createConnectTransport({
   baseUrl: "/api",
+  interceptors: [csrf],
 });

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  CampaignService,
+  AgentSchema,
+  CampaignSchema,
+  GetCampaignRosterResponseSchema,
+  CreateAgentResponseSchema,
+  UpdateAgentResponseSchema,
+  DeleteAgentResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { Campaign } from "./Campaign";
+
+// An in-memory campaign store served over a router transport (no network): the
+// roster mutates in this closure, so a Save → invalidate → refetch proves the
+// edit round-trips and reloads identically (the #71 acceptance), and the Butler
+// invariants are exercised against the same handlers the live screen calls.
+function mockTransport() {
+  const campaign = create(CampaignSchema, {
+    id: "c1",
+    name: "The Sunless Citadel",
+    system: "D&D 5e",
+    language: "en",
+  });
+  const butler = create(AgentSchema, {
+    id: "butler-1",
+    campaignId: "c1",
+    role: "butler",
+    name: "Glyphoxa",
+    title: "",
+    addressOnly: true,
+    speakerColor: 0,
+  });
+  const npcs = [
+    create(AgentSchema, {
+      id: "npc-1",
+      campaignId: "c1",
+      role: "character",
+      name: "Bart",
+      title: "Gruff innkeeper",
+      persona: "Grumbles.",
+      voice: "rachel",
+      addressOnly: false,
+      speakerColor: 0,
+    }),
+  ];
+  let nextId = 2;
+
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      getCampaignRoster: () =>
+        create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, ...npcs] }),
+      createAgent: (req) => {
+        const agent = create(AgentSchema, {
+          id: `npc-${nextId++}`,
+          campaignId: "c1",
+          role: "character",
+          name: req.name,
+          title: req.title,
+          persona: req.persona,
+          voice: req.voice,
+          addressOnly: req.addressOnly,
+          speakerColor: npcs.length % 6,
+        });
+        npcs.push(agent);
+        return create(CreateAgentResponseSchema, { agent });
+      },
+      updateAgent: (req) => {
+        const target = req.id === butler.id ? butler : npcs.find((n) => n.id === req.id);
+        if (!target) throw new Error("not found");
+        target.name = req.name;
+        target.title = req.title;
+        target.persona = req.persona;
+        target.voice = req.voice;
+        // The Butler stays Address-Only no matter what the client asks (server rule).
+        target.addressOnly = target.role === "butler" ? true : req.addressOnly;
+        return create(UpdateAgentResponseSchema, { agent: target });
+      },
+      deleteAgent: (req) => {
+        const i = npcs.findIndex((n) => n.id === req.id);
+        if (i >= 0) npcs.splice(i, 1);
+        return create(DeleteAgentResponseSchema, {});
+      },
+    });
+  });
+  return { transport, npcs };
+}
+
+function renderScreen() {
+  const { transport, npcs } = mockTransport();
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <Campaign />
+    </Providers>,
+  );
+  return { npcs };
+}
+
+describe("Campaign", () => {
+  it("renders the live campaign title and roster", async () => {
+    renderScreen();
+    expect(await screen.findByRole("heading", { name: "The Sunless Citadel" })).toBeInTheDocument();
+    // Both the Butler and the NPC appear in the roster.
+    expect(screen.getByText("Glyphoxa")).toBeInTheDocument();
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+  });
+
+  it("locks the Butler: Address-Only is forced on and its switch is disabled", async () => {
+    renderScreen();
+    // Select the Butler.
+    fireEvent.click(await screen.findByText("Glyphoxa"));
+    const sw = screen.getByLabelText(/address only/i);
+    expect(sw).toBeDisabled();
+    expect(sw).toBeChecked();
+    // The Butler is not deletable.
+    expect(screen.queryByRole("button", { name: /delete npc/i })).not.toBeInTheDocument();
+  });
+
+  it("round-trips an NPC edit to the store and reloads it identically", async () => {
+    const { npcs } = renderScreen();
+    // Select the NPC and rename it.
+    fireEvent.click(await screen.findByText("Bart"));
+    const name = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(name.value).toBe("Bart");
+    fireEvent.change(name, { target: { value: "Bartholomew" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    // The edit persisted to the store…
+    expect(await screen.findByText("Bartholomew")).toBeInTheDocument();
+    expect(npcs[0].name).toBe("Bartholomew");
+    // …and the old name is gone (the roster re-read the store).
+    expect(screen.queryByText("Bart")).not.toBeInTheDocument();
+  });
+
+  it("adds an NPC and deletes it, keeping the store in sync", async () => {
+    const { npcs } = renderScreen();
+    await screen.findByText("Bart");
+    expect(npcs).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /add npc/i }));
+    expect(await screen.findByText("New NPC")).toBeInTheDocument();
+    expect(npcs).toHaveLength(2);
+
+    // Delete the freshly added NPC (it is auto-selected after creation).
+    fireEvent.click(screen.getByRole("button", { name: /delete npc/i }));
+    // The new NPC leaves the roster once the store re-reads; the original stays.
+    await waitFor(() => expect(screen.queryByText("New NPC")).not.toBeInTheDocument());
+    expect(npcs).toHaveLength(1);
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -1,0 +1,295 @@
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Lock, Plus, Sparkles, Trash2 } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Avatar } from "@/components/ui/Avatar";
+import { Select } from "@/components/ui/Select";
+import { Input } from "@/components/ui/Input";
+import { Switch } from "@/components/ui/Switch";
+import { Button } from "@/components/ui/Button";
+
+import "./campaign.css";
+
+// The Campaign screen (#71) backs the design's Butler/NPC editor on the live
+// CampaignService roster + CRUD RPCs (ADR-0039). The Butler is required, role-
+// locked and undeletable (ADR-0009); its Address-Only switch is forced on and
+// disabled (ADR-0024). NPCs are added, edited and deleted; every edit round-trips
+// to the DB and the roster re-reads it back after each mutation invalidates the
+// query.
+
+// The voice dropdown is a static allowlist placeholder this slice — the live
+// ElevenLabs ListVoices wiring lands with the provider RPCs. The selected id is
+// persisted to the agent's voice field regardless, so edits round-trip.
+const VOICE_OPTIONS = ["rachel", "adam", "antoni", "bella", "elli", "domi"];
+
+// speakerVar maps a server-assigned palette slot onto the 6-colour speaker
+// palette (tokens.css --speaker-1..6). The slot is 0-based; the palette is 1-based.
+function speakerVar(slot: number): string {
+  return `var(--speaker-${(slot % 6) + 1})`;
+}
+
+function isButler(a: Agent): boolean {
+  return a.role === "butler";
+}
+
+export function Campaign() {
+  const queryClient = useQueryClient();
+  const { data, status, error } = useQuery(CampaignService.method.getCampaignRoster, {});
+  const roster = useMemo(() => data?.roster ?? [], [data]);
+
+  // Selection: the chosen agent, defaulting to the first roster member (the
+  // Butler) until the operator picks another. Falls back to the Butler when the
+  // selected NPC is deleted.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = roster.find((a) => a.id === selectedId) ?? roster[0];
+
+  const invalidateRoster = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.getCampaignRoster,
+        cardinality: "finite",
+      }),
+    });
+
+  const createAgent = useMutation(CampaignService.method.createAgent, {
+    onSuccess: (res) => {
+      void invalidateRoster();
+      if (res.agent) setSelectedId(res.agent.id);
+    },
+  });
+  const deleteAgent = useMutation(CampaignService.method.deleteAgent, {
+    onSuccess: () => {
+      setSelectedId(null); // fall back to the Butler
+      void invalidateRoster();
+    },
+  });
+
+  if (status === "pending") {
+    return (
+      <div className="gx-campaign-screen">
+        <h1>Campaign</h1>
+        <div className="gx-skeleton" data-testid="roster-loading" />
+      </div>
+    );
+  }
+  if (status === "error") {
+    return (
+      <div className="gx-campaign-screen">
+        <h1>Campaign</h1>
+        <p className="gx-campaign__error" role="alert">
+          Could not load the campaign: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  const campaign = data?.campaign;
+  const npcs = roster.filter((a) => !isButler(a));
+
+  return (
+    <div className="gx-campaign-screen">
+      <header className="gx-campaign-screen__header">
+        <h1>{campaign?.name ?? "Campaign"}</h1>
+        <div className="gx-campaign-screen__sub">
+          {campaign?.system && <span className="gx-campaign-screen__system">{campaign.system}</span>}
+          <span className="gx-campaign-screen__lede">
+            One Butler is required; add as many NPCs as your table needs.
+          </span>
+        </div>
+      </header>
+
+      <div className="gx-roster-layout">
+        {/* Roster list */}
+        <div className="gx-roster">
+          {roster.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className="gx-roster__item"
+              data-active={selected?.id === a.id ? "true" : undefined}
+              data-role={a.role}
+              onClick={() => setSelectedId(a.id)}
+            >
+              {isButler(a) ? (
+                <Avatar name={a.name} size="sm" />
+              ) : (
+                <span
+                  className="gx-roster__dot"
+                  style={{ background: speakerVar(a.speakerColor) }}
+                  aria-hidden
+                />
+              )}
+              <span className="gx-roster__meta">
+                <span className="gx-roster__name">{a.name}</span>
+                {a.title && <span className="gx-roster__title">{a.title}</span>}
+              </span>
+              {isButler(a) ? (
+                <Badge variant="gold" size="sm" dot>
+                  <Lock size={11} /> Butler
+                </Badge>
+              ) : (
+                a.addressOnly && (
+                  <Badge variant="neutral" size="sm">
+                    Address only
+                  </Badge>
+                )
+              )}
+            </button>
+          ))}
+
+          <button
+            type="button"
+            className="gx-roster__add"
+            disabled={createAgent.isPending}
+            onClick={() =>
+              createAgent.mutate({ name: "New NPC", title: "", persona: "", voice: "", addressOnly: false })
+            }
+          >
+            <Plus size={15} /> Add NPC
+          </button>
+
+          {npcs.length === 0 && (
+            <p className="gx-roster__empty">
+              No NPCs yet. The Butler can run a session alone, or add your first NPC above.
+            </p>
+          )}
+        </div>
+
+        {/* Editor pane — keyed by the selected agent so its local form resets when
+            the selection changes. */}
+        {selected && (
+          <AgentEditor
+            key={selected.id}
+            agent={selected}
+            onSaved={() => void invalidateRoster()}
+            onDelete={
+              isButler(selected) ? undefined : () => deleteAgent.mutate({ id: selected.id })
+            }
+            deleting={deleteAgent.isPending}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// AgentEditor edits one roster member. It holds the editable fields in local
+// state (seeded from the agent) and saves them via UpdateAgent. For the Butler
+// the role is locked, it cannot be deleted, and Address-Only is forced on with a
+// disabled switch (ADR-0009 / ADR-0024).
+function AgentEditor({
+  agent,
+  onSaved,
+  onDelete,
+  deleting,
+}: {
+  agent: Agent;
+  onSaved: () => void;
+  onDelete?: () => void;
+  deleting: boolean;
+}) {
+  const butler = isButler(agent);
+  const [name, setName] = useState(agent.name);
+  const [title, setTitle] = useState(agent.title);
+  const [persona, setPersona] = useState(agent.persona);
+  const [voice, setVoice] = useState(agent.voice);
+  const [addressOnly, setAddressOnly] = useState(agent.addressOnly);
+
+  const update = useMutation(CampaignService.method.updateAgent, { onSuccess: onSaved });
+
+  const voiceOpts = useMemo(() => {
+    const set = new Set(VOICE_OPTIONS);
+    if (voice) set.add(voice);
+    return [...set];
+  }, [voice]);
+
+  const save = () =>
+    update.mutate({
+      id: agent.id,
+      name,
+      title,
+      persona,
+      voice,
+      // The Butler is always Address-Only; the server enforces this regardless.
+      addressOnly: butler ? true : addressOnly,
+      aliases: agent.aliases,
+    });
+
+  return (
+    <Card accent className="gx-editor">
+      <div className="gx-editor__head">
+        {butler ? <Avatar name={agent.name} size="lg" /> : <Avatar name={name || agent.name} size="lg" />}
+        <div className="gx-editor__head-meta">
+          {butler ? (
+            <Badge variant="gold" size="sm" dot>
+              <Sparkles size={11} /> Required
+            </Badge>
+          ) : (
+            <Badge variant="neutral" size="sm">
+              NPC
+            </Badge>
+          )}
+          <span className="gx-editor__role">{butler ? "Butler · role locked" : "Character NPC"}</span>
+        </div>
+      </div>
+
+      <div className="gx-editor__grid">
+        <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Input label="Title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Role subtitle" />
+      </div>
+
+      <div className="gx-field">
+        <label className="gx-field__label" htmlFor="gx-persona">
+          Persona
+        </label>
+        <textarea
+          id="gx-persona"
+          className="gx-input gx-textarea"
+          rows={4}
+          value={persona}
+          onChange={(e) => setPersona(e.target.value)}
+        />
+        <span className="gx-field__hint">
+          Personality, backstory and speech style — injected into the prompt.
+        </span>
+      </div>
+
+      <Select label="Voice" options={voiceOpts} value={voice || undefined} onValueChange={setVoice} placeholder="Pick a voice…" />
+
+      <div className="gx-editor__switch">
+        <Switch
+          label="Address only — waits to be named"
+          checked={butler ? true : addressOnly}
+          onCheckedChange={setAddressOnly}
+          disabled={butler}
+        />
+        <span className="gx-field__hint">
+          {butler
+            ? "The Butler always waits to be named; it never answers ambient table talk."
+            : "When on, this NPC only replies when addressed by name."}
+        </span>
+      </div>
+
+      <div className="gx-editor__actions">
+        <Button variant="primary" onClick={save} disabled={update.isPending}>
+          Save changes
+        </Button>
+        {onDelete && (
+          <Button
+            variant="danger"
+            iconStart={<Trash2 size={14} />}
+            onClick={onDelete}
+            disabled={deleting}
+          >
+            Delete NPC
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1,0 +1,189 @@
+/* Campaign screen — co-located CSS (ADR-0017). Shared gx- layout/component
+ * classes live in styles/components.css; only screen-local layout goes here.
+ */
+
+.gx-campaign-screen__header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.gx-campaign-screen__sub {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}
+
+.gx-campaign-screen__system {
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+  color: var(--rune);
+}
+
+.gx-campaign-screen__lede {
+  color: var(--text-muted);
+  font-size: var(--body-sm);
+}
+
+/* Two-column: roster list + editor pane. Collapses to one column when narrow. */
+.gx-roster-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+@media (max-width: 720px) {
+  .gx-roster-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gx-roster {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-roster__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-default);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.gx-roster__item:hover {
+  background: var(--surface-card-hover);
+}
+
+.gx-roster__item[data-active="true"] {
+  border-color: var(--border-strong);
+  box-shadow: var(--glow-arcane-soft);
+}
+
+.gx-roster__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-pill);
+  flex: 0 0 auto;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.gx-roster__meta {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.gx-roster__name {
+  font-weight: var(--weight-semibold);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-roster__title {
+  font-size: var(--body-xs);
+  color: var(--text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-roster__add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.gx-roster__add:hover:not(:disabled) {
+  color: var(--text-strong);
+  border-color: var(--border-strong);
+}
+
+.gx-roster__add:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.gx-roster__empty {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-md);
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+}
+
+/* Editor pane */
+.gx-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+}
+
+.gx-editor__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.gx-editor__head-meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  align-items: flex-start;
+}
+
+.gx-editor__role {
+  font-size: var(--body-xs);
+  color: var(--text-subtle);
+}
+
+.gx-editor__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 520px) {
+  .gx-editor__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gx-textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: inherit;
+  line-height: var(--body-line);
+}
+
+.gx-editor__switch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-editor__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -1,22 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
 import {
   CampaignService,
+  ProviderService,
   GetActiveCampaignResponseSchema,
   CampaignSchema,
+  ListProviderConfigsResponseSchema,
+  ProviderCredentialSchema,
+  SaveProviderConfigResponseSchema,
+  SaveDiscordSettingsResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { Configuration } from "./Configuration";
 
-// Mount the Configuration screen against a MOCKED connect client (no network):
-// createRouterTransport serves a canned GetActiveCampaign in-memory, so the test
-// proves the screen renders LIVE RPC data (name / system / language) rather than
-// the design mock's hardcoded values.
-const CANNED = {
+const CAMPAIGN = {
   id: "11111111-1111-1111-1111-111111111111",
   tenantId: "22222222-2222-2222-2222-222222222222",
   name: "The Sunless Citadel",
@@ -24,43 +25,119 @@ const CANNED = {
   language: "en",
 };
 
-function mockTransport() {
+// cred builds a ProviderCredential the List RPC returns. saved => masked + last4.
+function cred(component: string, provider: string, last4?: string) {
+  return create(ProviderCredentialSchema, {
+    component,
+    provider,
+    everSaved: Boolean(last4),
+    showMasked: Boolean(last4),
+    last4: last4 ?? "",
+  });
+}
+
+// stateful mock backend: List reflects what Save mutates, so an invalidation
+// refetch shows the saved credential — proving the write-only round-trip from
+// the screen's side (the RPC never returns a secret value).
+function mockBackend() {
+  const state = {
+    groq: undefined as string | undefined,
+    elevenlabs: undefined as string | undefined,
+    discord: undefined as string | undefined,
+    guildId: "",
+    voiceChannelId: "",
+  };
   return createRouterTransport(({ service }) => {
     service(CampaignService, {
       getActiveCampaign: () =>
-        create(GetActiveCampaignResponseSchema, {
-          campaign: create(CampaignSchema, CANNED),
+        create(GetActiveCampaignResponseSchema, { campaign: create(CampaignSchema, CAMPAIGN) }),
+    });
+    service(ProviderService, {
+      listProviderConfigs: () =>
+        create(ListProviderConfigsResponseSchema, {
+          credentials: [
+            cred("discord", "discord", state.discord),
+            cred("llm", "groq", state.groq),
+            cred("tts", "elevenlabs", state.elevenlabs),
+          ],
+          guildId: state.guildId,
+          voiceChannelId: state.voiceChannelId,
         }),
+      saveProviderConfig: (req) => {
+        const last4 = req.secret.slice(-4);
+        if (req.provider === "groq") state.groq = last4;
+        if (req.provider === "elevenlabs") state.elevenlabs = last4;
+        return create(SaveProviderConfigResponseSchema, {
+          credential: cred(req.provider === "groq" ? "llm" : "tts", req.provider, last4),
+        });
+      },
+      saveDiscordSettings: (req) => {
+        if (req.botToken !== undefined) state.discord = req.botToken.slice(-4);
+        state.guildId = req.guildId;
+        state.voiceChannelId = req.voiceChannelId;
+        return create(SaveDiscordSettingsResponseSchema, {
+          credential: cred("discord", "discord", state.discord),
+          guildId: state.guildId,
+          voiceChannelId: state.voiceChannelId,
+        });
+      },
     });
   });
 }
 
+function renderScreen(transport = mockBackend()) {
+  return render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <Configuration />
+    </Providers>,
+  );
+}
+
 describe("Configuration", () => {
   it("renders the active campaign from the RPC", async () => {
-    render(
-      <Providers transport={mockTransport()} queryClient={makeQueryClient()}>
-        <Configuration />
-      </Providers>,
-    );
-
-    // The campaign name / system / language come from the mocked RPC response.
-    expect(await screen.findByText(CANNED.name)).toBeInTheDocument();
-    expect(screen.getByText(CANNED.system)).toBeInTheDocument();
-    expect(screen.getByText(CANNED.language)).toBeInTheDocument();
+    renderScreen();
+    expect(await screen.findByText(CAMPAIGN.name)).toBeInTheDocument();
+    expect(screen.getByText(CAMPAIGN.system)).toBeInTheDocument();
+    expect(screen.getByText(CAMPAIGN.language)).toBeInTheDocument();
   });
 
-  it("marks the not-yet-wired sections as coming soon", async () => {
-    render(
-      <Providers transport={mockTransport()} queryClient={makeQueryClient()}>
-        <Configuration />
-      </Providers>,
-    );
+  it("shows a Key-needed badge for each unsaved credential", async () => {
+    renderScreen();
+    // Three secret slots start unsaved → three Key-needed badges.
+    expect(await screen.findAllByText(/key needed/i)).toHaveLength(3);
+    expect(screen.queryByText(/healthy/i)).not.toBeInTheDocument();
+  });
 
-    await screen.findByText(CANNED.name);
-    // The provider rows + Session-defaults render as disabled "coming soon"
-    // placeholders (no Stage-2 backend); the live campaign header is the only
-    // wired data. Case-insensitive: the badges say "coming soon", the
-    // Session-defaults label "Coming soon".
-    expect(screen.getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(2);
+  it("saves a provider key write-only: the row masks and the badge turns Healthy", async () => {
+    renderScreen();
+
+    const groqInput = await screen.findByLabelText("Groq key");
+    fireEvent.change(groqInput, { target: { value: "test-groq-secret-eeee" } });
+
+    // The Save button in the Groq row.
+    const groqRow = groqInput.closest(".gx-provider-row") as HTMLElement;
+    fireEvent.click(within(groqRow).getByRole("button", { name: "Save" }));
+
+    // After the invalidated list refetches, the row shows a masked value +
+    // Replace and a Healthy badge — derived from key-presence, never the secret.
+    expect(await within(groqRow).findByText("••••••••")).toBeInTheDocument();
+    expect(within(groqRow).getByRole("button", { name: /replace/i })).toBeInTheDocument();
+    expect(within(groqRow).getByText(/healthy/i)).toBeInTheDocument();
+    // The plaintext key never appears in the DOM.
+    expect(screen.queryByText(/test-groq-secret-eeee/)).not.toBeInTheDocument();
+  });
+
+  it("persists Guild ID and Voice channel ID", async () => {
+    renderScreen();
+
+    const guild = await screen.findByLabelText("Guild ID");
+    const voice = screen.getByLabelText("Voice channel ID");
+    fireEvent.change(guild, { target: { value: "472093001100" } });
+    fireEvent.change(voice, { target: { value: "472093774421" } });
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+
+    // Values survive the invalidation refetch (round-tripped through the RPC).
+    expect(await screen.findByDisplayValue("472093001100")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("472093774421")).toBeInTheDocument();
   });
 });

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -1,36 +1,77 @@
-import { useQuery } from "@connectrpc/connect-query";
-import { Ear, BrainCircuit, AudioLines, Network } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-react";
 
-import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import {
+  CampaignService,
+  ProviderService,
+  type ProviderCredential,
+} from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
-import { Select } from "@/components/ui/Select";
 import { Input } from "@/components/ui/Input";
-import { Switch } from "@/components/ui/Switch";
+import { Button } from "@/components/ui/Button";
 
 import "./configuration.css";
 
-// The Configuration screen (the design's "Providers" screen — ported from the
-// handoff ui_kits/glyphoxa-web/settings.jsx). The campaign header reads LIVE
-// GetActiveCampaign via connect-query (ADR-0018/0039) — real RPC data, not the
-// mock's hardcoded arrays. The provider rows + Session-defaults render as inert
-// DISABLED placeholders clearly marked "coming soon": their backend (Provider/
-// voice/health RPCs) lands in later stages.
+// The Configuration screen (the design's "Providers" screen). The campaign
+// header reads LIVE GetActiveCampaign; the credential rows drive the write-only
+// BYOK flow (#68, ADR-0004/0039): each secret is sealed server-side and never
+// read back — the screen shows a masked value + Replace and a Healthy /
+// Key-needed badge derived purely from key-presence (the async test-call upgrade
+// is a later stage).
 
-// The 4 provider rows mirror the design's shape. The MVP provider matrix
-// (ADR-0039) is Groq (LLM) + ElevenLabs (STT + TTS); these rows are inert until
-// ProviderService is wired, so the option lists are illustrative placeholders.
-const PROVIDERS = [
-  { kind: "STT", name: "ElevenLabs", icon: <Ear size={19} />, opts: ["ElevenLabs", "Deepgram", "whisper.cpp (local)"] },
-  { kind: "LLM", name: "Groq", icon: <BrainCircuit size={19} />, opts: ["Groq", "Anthropic", "OpenAI"] },
-  { kind: "TTS", name: "ElevenLabs", icon: <AudioLines size={19} />, opts: ["ElevenLabs", "OpenAI"] },
-  { kind: "Embeddings", name: "OpenAI", icon: <Network size={19} />, opts: ["OpenAI", "Ollama (local)"] },
-];
+// The three secret slots the screen holds, keyed by their wire `provider`. Each
+// renders a SecretRow; Groq/ElevenLabs save via SaveProviderConfig, the Discord
+// bot token via SaveDiscordSettings.
+const BYOK_SLOTS = [
+  { provider: "groq", label: "Groq", kind: "LLM", icon: <BrainCircuit size={19} />, placeholder: "Paste your Groq API key" },
+  { provider: "elevenlabs", label: "ElevenLabs", kind: "Speech", icon: <AudioLines size={19} />, placeholder: "Paste your ElevenLabs API key" },
+] as const;
+
+function credentialFor(creds: ProviderCredential[], provider: string): ProviderCredential | undefined {
+  return creds.find((c) => c.provider === provider);
+}
 
 export function Configuration() {
   const { data, status, error } = useQuery(CampaignService.method.getActiveCampaign, {});
   const campaign = data?.campaign;
+
+  const queryClient = useQueryClient();
+  const invalidateList = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({ schema: ProviderService.method.listProviderConfigs, cardinality: "finite" }),
+    });
+
+  const config = useQuery(ProviderService.method.listProviderConfigs, {});
+  const creds = config.data?.credentials ?? [];
+
+  const saveProvider = useMutation(ProviderService.method.saveProviderConfig, { onSuccess: invalidateList });
+  const saveDiscord = useMutation(ProviderService.method.saveDiscordSettings, { onSuccess: invalidateList });
+
+  // Guild / Voice channel IDs are controlled, seeded from the RPC. A `dirty` ref
+  // guards the seed so a slow first load (or a post-save refetch) can never
+  // clobber what the operator is typing — once edited, the field is the source
+  // of truth.
+  const [guildId, setGuildId] = useState("");
+  const [voiceChannelId, setVoiceChannelId] = useState("");
+  const idsDirty = useRef(false);
+  useEffect(() => {
+    if (config.data && !idsDirty.current) {
+      setGuildId(config.data.guildId);
+      setVoiceChannelId(config.data.voiceChannelId);
+    }
+  }, [config.data]);
+  const editGuildId = (v: string) => {
+    idsDirty.current = true;
+    setGuildId(v);
+  };
+  const editVoiceChannelId = (v: string) => {
+    idsDirty.current = true;
+    setVoiceChannelId(v);
+  };
 
   return (
     <div className="gx-providers">
@@ -71,40 +112,180 @@ export function Configuration() {
         </div>
       </Card>
 
-      {/* Provider rows — inert placeholders ("coming soon") */}
+      {/* Provider keys — write-only BYOK (ADR-0004) */}
+      <h2 className="gx-section-title">Provider keys</h2>
       <div className="gx-providers__list">
-        {PROVIDERS.map((p) => (
-          <Card key={p.kind}>
-            <div className="gx-provider-row">
-              <span className="gx-provider-row__icon">{p.icon}</span>
-              <div className="gx-provider-row__meta">
-                <div className="gx-overline">{p.kind}</div>
-                <div className="gx-provider-row__name">{p.name}</div>
-              </div>
-              <div className="gx-provider-row__select">
-                <Select options={p.opts} defaultValue={p.name} aria-label={p.kind + " provider"} disabled />
-              </div>
-              <Badge variant="neutral" dot size="sm">
-                coming soon
-              </Badge>
-            </div>
-          </Card>
+        {BYOK_SLOTS.map((slot) => (
+          <SecretRow
+            key={slot.provider}
+            icon={slot.icon}
+            kind={slot.kind}
+            name={slot.label}
+            placeholder={slot.placeholder}
+            credential={credentialFor(creds, slot.provider)}
+            onSave={(secret) => saveProvider.mutateAsync({ provider: slot.provider, secret })}
+          />
         ))}
       </div>
+
+      {/* Discord connection — Bot token (secret) + non-secret Guild / Voice IDs */}
+      <h2 className="gx-section-title">Discord connection</h2>
+      <Card>
+        <div className="gx-discord">
+          <SecretRow
+            icon={<MessagesSquare size={19} />}
+            kind="Bot"
+            name="Bot token"
+            placeholder="Paste the Discord bot token"
+            credential={credentialFor(creds, "discord")}
+            onSave={(secret) =>
+              saveDiscord.mutateAsync({ botToken: secret, guildId, voiceChannelId })
+            }
+          />
+          <div className="gx-discord__ids">
+            <Input
+              label="Guild ID"
+              placeholder="e.g. 472093001100"
+              hint="The Discord server the bot serves."
+              value={guildId}
+              onChange={(e) => editGuildId(e.target.value)}
+            />
+            <Input
+              label="Voice channel ID"
+              placeholder="472093774421"
+              hint="The channel sessions join."
+              value={voiceChannelId}
+              onChange={(e) => editVoiceChannelId(e.target.value)}
+            />
+          </div>
+          <div className="gx-discord__save">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => saveDiscord.mutate({ guildId, voiceChannelId })}
+              disabled={saveDiscord.isPending}
+            >
+              Save Discord settings
+            </Button>
+          </div>
+        </div>
+      </Card>
 
       {/* Session defaults — inert placeholders ("coming soon") */}
       <h2 className="gx-section-title">Session defaults</h2>
       <Card>
         <div className="gx-defaults__body">
           <span className="gx-coming-soon">Coming soon</span>
-          <div className="gx-defaults__grid">
-            <Input label="Latency budget (ms)" defaultValue="1200" disabled />
-            <Select label="Default engine" options={["Cascaded", "S2S — Gemini", "S2S — OpenAI"]} disabled />
-          </div>
-          <Switch label="Continuous live transcription" defaultChecked disabled />
-          <Switch label="Speculative sentence cascade (experimental)" disabled />
         </div>
       </Card>
     </div>
+  );
+}
+
+// SecretRow renders one write-only credential: an editable key field with Save
+// when unsaved (or being replaced), a masked value + Replace once saved, and a
+// Healthy / Key-needed badge from key-presence. onSave seals the secret
+// server-side and resolves once stored; the row then clears and re-reads as
+// masked from the invalidated list.
+function SecretRow({
+  icon,
+  kind,
+  name,
+  placeholder,
+  credential,
+  onSave,
+}: {
+  icon: ReactNode;
+  kind: string;
+  name: string;
+  placeholder: string;
+  credential?: ProviderCredential;
+  onSave: (secret: string) => Promise<unknown>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const saved = Boolean(credential?.showMasked);
+  const masked = saved && !editing;
+
+  async function handleSave() {
+    if (!value || busy) return;
+    setBusy(true);
+    try {
+      await onSave(value);
+      setValue("");
+      setEditing(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <div className="gx-provider-row">
+        <span className="gx-provider-row__icon">{icon}</span>
+        <div className="gx-provider-row__meta">
+          <div className="gx-overline">{kind}</div>
+          <div className="gx-provider-row__name">{name}</div>
+        </div>
+
+        <div className="gx-secret">
+          {masked ? (
+            <div className="gx-secret__saved">
+              <span className="gx-secret__mask" aria-label={`${name} saved`}>
+                ••••••••
+              </span>
+              <Button
+                variant="secondary"
+                size="sm"
+                iconStart={<RefreshCw size={13} />}
+                onClick={() => {
+                  setEditing(true);
+                  setValue("");
+                }}
+              >
+                Replace
+              </Button>
+            </div>
+          ) : (
+            <div className="gx-secret__edit">
+              <Input
+                type="password"
+                placeholder={placeholder}
+                aria-label={`${name} key`}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
+              <Button variant="primary" size="sm" onClick={handleSave} disabled={!value || busy}>
+                Save
+              </Button>
+              {editing && saved && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setEditing(false);
+                    setValue("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {saved ? (
+          <Badge variant="success" dot size="sm">
+            Healthy
+          </Badge>
+        ) : (
+          <Badge variant="warning" dot size="sm">
+            Key needed
+          </Badge>
+        )}
+      </div>
+    </Card>
   );
 }

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -7,3 +7,45 @@
 .gx-providers__campaign {
   margin-bottom: var(--spacing-lg);
 }
+
+/* Secret credential control (key field / masked + Replace), right-aligned in the
+ * provider row before the status badge. */
+.gx-secret {
+  margin-left: auto;
+  min-width: 0;
+}
+
+.gx-secret__edit,
+.gx-secret__saved {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.gx-secret__edit .gx-field {
+  margin: 0;
+}
+
+.gx-secret__mask {
+  letter-spacing: 0.18em;
+  color: var(--text-subtle);
+  font-family: var(--font-mono, monospace);
+}
+
+/* Discord connection card: the Bot token row above the two ID inputs. */
+.gx-discord {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.gx-discord__ids {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+}
+
+.gx-discord__save {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/web/src/screens/login/Login.test.tsx
+++ b/web/src/screens/login/Login.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Login } from "./Login";
+
+describe("Login", () => {
+  it("offers Continue with Discord pointing at the OAuth start", () => {
+    render(<Login />);
+    const link = screen.getByRole("link", { name: /continue with discord/i });
+    expect(link).toHaveAttribute("href", "/auth/discord/login");
+  });
+
+  it("renders Google and GitHub as disabled coming-soon slots", () => {
+    render(<Login />);
+    expect(screen.getByRole("button", { name: /google/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /github/i })).toBeDisabled();
+    expect(screen.getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -1,0 +1,37 @@
+import { Dices } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+
+import "./login.css";
+
+// The Login screen (ADR-0016: Discord-only OAuth). No design handoff exists for
+// it, so this is the minimal gate the self-host operator needs: a "Continue with
+// Discord" link that starts the net/http OAuth carve-out (/auth/discord/login),
+// with Google/GitHub rendered DISABLED + "coming soon" (wired in v1.5+). It is a
+// full-page link, not a Connect call — OAuth is HTML redirects (ADR-0015).
+export function Login() {
+  return (
+    <div className="gx-login">
+      <div className="gx-login__card">
+        <span className="gx-login__sigil">
+          <Dices size={24} />
+        </span>
+        <h1 className="gx-login__wordmark gx-gradient-text">Glyphoxa</h1>
+        <p className="gx-login__lede">Sign in to run your table.</p>
+
+        <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
+          Continue with Discord
+        </a>
+
+        <div className="gx-login__soon">
+          <Button variant="secondary" block disabled>
+            Continue with Google · coming soon
+          </Button>
+          <Button variant="secondary" block disabled>
+            Continue with GitHub · coming soon
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/login/login.css
+++ b/web/src/screens/login/login.css
@@ -1,0 +1,50 @@
+/* Login screen — the minimal Discord-only auth gate (ADR-0016). Centered arcane
+   card on the app surface; reuses the gx- token vocabulary. */
+.gx-login {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.gx-login__card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  max-width: 360px;
+  padding: 32px 28px;
+  background: var(--surface-card, #16131f);
+  border: 1px solid var(--border-subtle, #2a2535);
+  border-radius: 16px;
+  text-align: center;
+}
+
+.gx-login__sigil {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  color: #fff;
+  background: linear-gradient(135deg, #9059ff, #00ddff);
+}
+
+.gx-login__wordmark {
+  margin: 4px 0 0;
+  font-size: 26px;
+}
+
+.gx-login__lede {
+  margin: 0 0 8px;
+  color: var(--text-subtle, #9a93a8);
+}
+
+.gx-login__soon {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## What & why

Backs the Configuration screen's save / mask / Replace flow (issue #68, Stage 4 of epic #64). Operators paste their Discord bot token, Groq, and ElevenLabs keys plus the Discord Guild / Voice channel IDs; secrets are sealed at rest and **never returned** — only `last4` + metadata.

**Stacks on #67** (base `feat/67-auth`): reuses that PR's `internal/auth` interceptor stack (auth → CSRF → tenant pass-through) and `auth.TenantID(ctx)` / `auth.WithTenant` seam. No auth code rebuilt.

## Write-only contract (ADR-0004)

A saved secret's plaintext is sealed via `crypto.Cipher.Seal` and stored as AES-GCM ciphertext; only `crypto.Last4(plaintext)` is kept in plaintext. No RPC response carries a secret value — `ProviderCredential` is structurally `{component, provider, ever_saved, show_masked, last4, model, updated_at}`. Reads need no cipher; saves without `$GLYPHOXA_SECRET` fail `CodeFailedPrecondition` (keyless-degradation, #44 posture) rather than crashing boot.

## Data model (ADRs honored)

- **Groq + ElevenLabs → `provider_config`** (BYOK, ADR-0004), now upsertable by a new UNIQUE `(tenant_id, component, provider)`. ElevenLabs writes both `stt` + `tts` rows from one key (matches the seed convention); the upsert replaces the seed's `last4="env"` placeholder, flipping the DB authoritative (ADR-0039 hybrid). `"env"` reads as **key-needed**.
- **Discord bot token + Guild/Voice IDs → new `deployment_config` table.** The **Bot is deployment-shared** (one token regardless of Tenant — `CONTEXT.md`), and **Component** is a closed enum (`llm/stt/tts/embeddings/s2s`), so the bot token is deliberately **not** a Provider Config and `discord` is **not** forced into the Component enum. Token sealed; Guild/Voice IDs plain. Keyed by `tenant_id` for the MVP single operator, de-tenants later. Additive migration `00004` with Down.

## New proto (appended after AuthService; additive — buf breaking safe)

`ProviderService`:
- `ListProviderConfigs` (`NO_SIDE_EFFECTS`) → `{repeated ProviderCredential, guild_id, voice_channel_id}`
- `SaveProviderConfig` (`{provider, secret, model}` → masked `ProviderCredential`)
- `SaveDiscordSettings` (`{optional bot_token, guild_id, voice_channel_id}` → masked credential + IDs)

New messages: `ProviderCredential`, `ListProviderConfigs{Request,Response}`, `SaveProviderConfig{Request,Response}`, `SaveDiscordSettings{Request,Response}`.

## Tests

- **Storage (integration):** insert→replace upsert (in-place, `updated_at` advances, no duplicate); ElevenLabs stt+tts batch; column-isolated deployment saves (token / IDs never clobber); tenant FK cascade.
- **rpc (unit + integration):** write-only contract (plaintext never in response / DB; ciphertext `Open`s back to plaintext; `last4` round-trip); Replace updates `last4` + timestamp; unknown provider → `InvalidArgument`; nil cipher → `FailedPrecondition` (reads still work); `env` placeholder → key-needed; Discord token + IDs over Connect-JSON.
- **web (vitest):** Key-needed badges; write-only save (row masks → Replace, badge → Healthy, plaintext never in DOM); Guild/Voice persistence.

## CI gates (all green locally; Docker present)

`buf generate` · `buf lint` · `go build ./...` · `go vet ./...` · `go vet -tags=record ./...` · `go test -race ./...` · `go test -race -tags=integration ./...` · `cd web && npm ci && npm run build && npm run test`

## Deviation from the brief

The brief sketched `ProviderService` as "List + Save". Shipped **three** RPCs — `SaveProviderConfig` (BYOK keys) is kept separate from `SaveDiscordSettings` (deployment Bot token + non-secret IDs) because they target two distinct storage homes (`provider_config` vs `deployment_config`) and two domain concepts; one fat ambiguous Save was rejected for clarity. Each RPC is small and cohesive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)