### PR TITLE
feat(#69): credential bridge — saved BYOK keys drive the session (hybrid)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -158,7 +158,19 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
 	}
 
-	return wirenpc.RunFromDB(ctx, cfg, pool)
+	// The BYOK credential cipher (ADR-0004) is best-effort, mirroring runWeb: a
+	// self-host voice node with no $GLYPHOXA_SECRET still runs on the seeded "env"
+	// placeholder configs (which resolve to the adapters' env vars — today's
+	// behavior). A real saved key WITH no cipher is the only failure, and
+	// RunFromDB surfaces it clearly (issue #69) rather than silently using ENV.
+	cipher, err := appCipher()
+	if err != nil {
+		log.Warn("provider credential decryption is disabled; the voice loop will "+
+			"use env-var API keys unless a saved BYOK key requires $GLYPHOXA_SECRET", "err", err)
+		cipher = nil
+	}
+
+	return wirenpc.RunFromDB(ctx, cfg, pool, cipher)
 }
 
 // runWeb is the web/all-mode entrypoint (ADR-0039). It resolves the required DB
@@ -251,7 +263,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		// serving /readyz). Log and degrade to web-only by returning nil; the
 		// gctx.Err() guard suppresses the benign cancellation log when SIGTERM is
 		// already stopping both halves.
-		if err := wirenpc.RunFromDB(gctx, cfg, pool); err != nil && gctx.Err() == nil {
+		if err := wirenpc.RunFromDB(gctx, cfg, pool, cipher); err != nil && gctx.Err() == nil {
 			log.Error("voice loop exited; continuing web-only", "err", err)
 		}
 		return nil

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -171,38 +171,50 @@ func SeedNPC(ctx context.Context, pool *pgxpool.Pool, cipher *crypto.Cipher, log
 // AgentID is each Agent's DB UUID as a string — the stable identity Address
 // Detection routes on (the in-code path used "bart"; the value only has to be
 // consistent between the matcher and the Persona, which it is).
-func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, error) {
+//
+// It also surfaces the owning tenant ID and the PRIMARY (first) Character's
+// LoadedAgent — the bits the credential bridge (issue #69) resolves the session
+// BYOK keys from. The primary's LoadedAgent already carries its LLM/TTS provider
+// configs (LoadAgent joins them), so this returns them rather than re-querying.
+// A single set of keys backs the whole session (one shared Groq client + one
+// ElevenLabs synth across the Roster — see buildConversation), so the primary
+// agent is the representative; per-NPC adapter selection is a later concern.
+func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.LoadedAgent, uuid.UUID, error) {
 	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
 	if err != nil {
-		return nil, fmt.Errorf("wirenpc: load NPCs: find tenant: %w", err)
+		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: find tenant: %w", err)
 	}
 
 	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
 	if err != nil {
-		return nil, fmt.Errorf("wirenpc: load NPCs: find campaign: %w", err)
+		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: find campaign: %w", err)
 	}
 
 	chars, err := st.CharacterAgents(ctx, campaignID)
 	if err != nil {
-		return nil, err
+		return nil, storage.LoadedAgent{}, uuid.Nil, err
 	}
 	if len(chars) == 0 {
-		return nil, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
+		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
 	}
 
 	specs := make([]npcSpec, 0, len(chars))
-	for _, c := range chars {
+	var primary storage.LoadedAgent
+	for i, c := range chars {
 		loaded, err := st.LoadAgent(ctx, c.ID)
 		if err != nil {
-			return nil, err
+			return nil, storage.LoadedAgent{}, uuid.Nil, err
+		}
+		if i == 0 {
+			primary = loaded
 		}
 		spec, err := npcSpecFromAgent(loaded.Agent)
 		if err != nil {
-			return nil, err
+			return nil, storage.LoadedAgent{}, uuid.Nil, err
 		}
 		specs = append(specs, spec)
 	}
-	return specs, nil
+	return specs, primary, tenant.ID, nil
 }
 
 // npcSpecFromAgent maps a storage.Agent (vendor-neutral) to the voice-domain

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -116,7 +116,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 		t.Fatalf("SeedNPC: %v", err)
 	}
 
-	specs, err := loadSeededNPCs(ctx, storage.New(pool))
+	specs, _, _, err := loadSeededNPCs(ctx, storage.New(pool))
 	if err != nil {
 		t.Fatalf("loadSeededNPCs: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{})
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 		t.Fatalf("CreateAgent (Mira): %v", err)
 	}
 
-	specs, err := loadSeededNPCs(ctx, st)
+	specs, _, _, err := loadSeededNPCs(ctx, st)
 	if err != nil {
 		t.Fatalf("loadSeededNPCs: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{})
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{})
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{})
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials.go
+++ b/internal/wirenpc/credentials.go
@@ -1,0 +1,95 @@
+package wirenpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// This file is the issue-#69 credential bridge: it turns the UI-saved BYOK keys
+// in provider_config (ADR-0004) into the per-component API keys the live voice
+// loop hands its adapters, under the hybrid policy (ADR-0039). A real saved key
+// is decrypted and overrides ENV; the seeded "env" placeholder resolves to the
+// empty string, which the adapters read as "fall back to your *_API_KEY env var"
+// — so the self-host ENV path stays untouched while the web-app BYOK path drives
+// the session.
+
+// providerKeys holds the resolved per-component BYOK API keys for one session.
+// An empty string means "no DB key for this component — let the adapter fall
+// back to its own *_API_KEY env var" (the hybrid policy, ADR-0039). The adapters
+// (groq, stt/elevenlabs, tts/elevenlabs) all treat an empty apiKey as exactly
+// that, so a zero-value providerKeys reproduces today's ENV-only behavior.
+type providerKeys struct {
+	llm, tts, stt string
+}
+
+// resolveKey resolves ONE component's API key under the hybrid BYOK policy
+// (ADR-0039):
+//
+//   - cfg == nil, or cfg.CredentialsLast4 == "env" (the seeded placeholder):
+//     no real key in the DB -> "" so the adapter falls back to its env var.
+//   - a real saved key (last4 != "env") but no cipher: a CLEAR error, never a
+//     silent empty key (AC2) — boot without $GLYPHOXA_SECRET cannot quietly
+//     ignore a configured key and degrade to ENV.
+//   - a real saved key the cipher cannot open: a CLEAR error wrapping crypto's.
+//   - otherwise: the decrypted plaintext key.
+//
+// component only labels the error so an operator knows which key failed.
+func resolveKey(cipher *crypto.Cipher, cfg *storage.ProviderConfig, component storage.Component) (string, error) {
+	if cfg == nil || cfg.CredentialsLast4 == credPlaceholderLast4 {
+		return "", nil
+	}
+	if cipher == nil {
+		return "", fmt.Errorf("wirenpc: %s key needs decryption but the credential cipher is unavailable; set $GLYPHOXA_SECRET (ADR-0004)", component)
+	}
+	plaintext, err := cipher.Open(cfg.CredentialsCiphertext)
+	if err != nil {
+		return "", fmt.Errorf("wirenpc: decrypt %s key: %w", component, err)
+	}
+	return string(plaintext), nil
+}
+
+// resolveProviderKeys resolves all three components a voice session needs.
+// Any single component's decryption failure fails the whole resolution (AC2):
+// a misconfigured key surfaces at boot, never as a half-configured session that
+// silently falls back to ENV for the broken half.
+func resolveProviderKeys(cipher *crypto.Cipher, llmCfg, ttsCfg, sttCfg *storage.ProviderConfig) (providerKeys, error) {
+	llm, err := resolveKey(cipher, llmCfg, storage.ComponentLLM)
+	if err != nil {
+		return providerKeys{}, err
+	}
+	tts, err := resolveKey(cipher, ttsCfg, storage.ComponentTTS)
+	if err != nil {
+		return providerKeys{}, err
+	}
+	stt, err := resolveKey(cipher, sttCfg, storage.ComponentSTT)
+	if err != nil {
+		return providerKeys{}, err
+	}
+	return providerKeys{llm: llm, tts: tts, stt: stt}, nil
+}
+
+// resolveSessionKeys is the DB-side seam [RunFromDB] drives: it reads the
+// Tenant's STT Provider Config by Component (STT is not Agent-joined, unlike the
+// LLM/TTS configs the primary agent's LoadedAgent already carries) and resolves
+// all three keys against cipher. A missing STT config is treated as an env
+// fallback, not an error. ElevenLabs STT shares the TTS key in the demo seed,
+// but the bind is read per-Component for correctness.
+func resolveSessionKeys(ctx context.Context, st *storage.Store, tenantID uuid.UUID, primary storage.LoadedAgent, cipher *crypto.Cipher) (providerKeys, error) {
+	var sttCfg *storage.ProviderConfig
+	pc, err := st.GetProviderConfigByComponent(ctx, tenantID, storage.ComponentSTT)
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		// No STT config bound -> the adapter reads ELEVENLABS_API_KEY (env).
+	case err != nil:
+		return providerKeys{}, fmt.Errorf("wirenpc: load STT provider config: %w", err)
+	default:
+		sttCfg = &pc
+	}
+	return resolveProviderKeys(cipher, primary.LLMConfig, primary.TTSConfig, sttCfg)
+}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// This test guards the issue-#69 credential fan-out — the final hop the resolver
+// value-tests cannot see: buildConversation handing each resolved BYOK key to
+// its OWN adapter. It needs a real Silero VAD (like the other buildConversation
+// tests), so it is tag-isolated behind `integration` (ADR-0033); no Postgres is
+// used. The keyless resolver logic lives in credentials_test.go.
+package wirenpc
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+	stteleven "github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestBuildConversation_RoutesEachKeyToItsAdapter is the AC1 fan-out guard. The
+// resolver output is value-tested elsewhere; this covers the untested final hop
+// (keys.llm -> groq, keys.stt -> stt/elevenlabs, keys.tts -> tts/elevenlabs).
+// A slot swap or a dropped `cfg.keys = keys` would silently revert the feature to
+// ENV while the rest of the suite (every call passes providerKeys{}) stayed
+// green. The adapters expose no key getter, so we spy on the package-var
+// constructors with three DISTINCT non-empty keys and assert each reached its
+// own adapter (catches both a swap and an empty-from-dropped-assignment).
+func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
+	origLLM, origSTT, origTTS := newLLM, newSTT, newTTS
+	t.Cleanup(func() { newLLM, newSTT, newTTS = origLLM, origSTT, origTTS })
+
+	var gotLLM, gotSTT, gotTTS string
+	newLLM = func(apiKey string, opts ...groq.Option) *groq.Client {
+		gotLLM = apiKey
+		return origLLM(apiKey, opts...)
+	}
+	newSTT = func(apiKey string, opts ...stteleven.Option) *stteleven.Client {
+		gotSTT = apiKey
+		return origSTT(apiKey, opts...)
+	}
+	newTTS = func(apiKey string, opts ...ttseleven.Option) *ttseleven.Client {
+		gotTTS = apiKey
+		return origTTS(apiKey, opts...)
+	}
+
+	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
+		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys)
+	if err != nil {
+		t.Fatalf("buildConversation: %v", err)
+	}
+	defer cleanup()
+
+	if gotLLM != keys.llm {
+		t.Errorf("groq adapter got apiKey %q, want %q — keys.llm must reach the LLM adapter, not another slot or ENV", gotLLM, keys.llm)
+	}
+	if gotSTT != keys.stt {
+		t.Errorf("stt adapter got apiKey %q, want %q — keys.stt must reach the STT adapter", gotSTT, keys.stt)
+	}
+	if gotTTS != keys.tts {
+		t.Errorf("tts adapter got apiKey %q, want %q — keys.tts must reach the TTS adapter", gotTTS, keys.tts)
+	}
+}

--- a/internal/wirenpc/credentials_integration_test.go
+++ b/internal/wirenpc/credentials_integration_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+// These tests exercise the issue-#69 credential bridge end-to-end against a real
+// Postgres (testcontainers): a saved BYOK key in provider_config is read back,
+// decrypted, and turned into the per-component session keys — and a key that
+// cannot be decrypted fails RunFromDB clearly, before any Discord connection.
+// Tag-isolated behind `integration` (ADR-0033) like the rest of this package's
+// DB tests; the keyless resolver logic lives in credentials_test.go. The shared
+// container harness (startDB, dsnFromEnvOrContainer, testCipher) lives in
+// agentspec_test.go.
+package wirenpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// seedRealKeyNPC seeds the demo Tenant/Campaign with provider_config rows whose
+// credentials are REAL sealed keys (last4 != "env" — the web-app BYOK path),
+// bound to one Character NPC, so loadSeededNPCs/RunFromDB read them back. It uses
+// the demo names loadSeededNPCs looks up. Returns the tenant ID and the three
+// plaintext keys the bridge must reproduce.
+func seedRealKeyNPC(t *testing.T, ctx context.Context, st *storage.Store, cipher *crypto.Cipher) (uuid.UUID, providerKeys) {
+	t.Helper()
+	want := providerKeys{
+		llm: "sk-llm-REALsecret-0001",
+		tts: "sk-tts-REALsecret-0002",
+		stt: "sk-stt-REALsecret-0003",
+	}
+
+	tenantID, err := st.CreateTenant(ctx, SeedTenantName)
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	campaignID, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID,
+		Name:     SeedCampaignName,
+		System:   "dnd5e",
+		Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+
+	sealCfg := func(component storage.Component, provider, model, key string) uuid.UUID {
+		ct, err := cipher.Seal([]byte(key))
+		if err != nil {
+			t.Fatalf("seal %s: %v", component, err)
+		}
+		id, err := st.CreateProviderConfig(ctx, storage.NewProviderConfig{
+			TenantID:              tenantID,
+			Component:             component,
+			Provider:              provider,
+			Model:                 model,
+			CredentialsCiphertext: ct,
+			CredentialsLast4:      crypto.Last4(key),
+		})
+		if err != nil {
+			t.Fatalf("CreateProviderConfig %s: %v", component, err)
+		}
+		return id
+	}
+
+	llmCfgID := sealCfg(storage.ComponentLLM, llmProvider, llmModel, want.llm)
+	ttsCfgID := sealCfg(storage.ComponentTTS, "elevenlabs", ttsModel, want.tts)
+	sealCfg(storage.ComponentSTT, "elevenlabs", sttModel, want.stt)
+
+	if _, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:            campaignID,
+		Role:                  storage.AgentRoleCharacter,
+		Name:                  "Bart",
+		Persona:               BartPersona,
+		VoiceProviderConfigID: uuid.NullUUID{UUID: ttsCfgID, Valid: true},
+		LLMProviderConfigID:   uuid.NullUUID{UUID: llmCfgID, Valid: true},
+		AddressOnly:           false,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return tenantID, want
+}
+
+// TestRunFromDB_DecryptsSavedKeys is the AC1 proof against a real DB: a saved
+// BYOK key (last4 != "env") is read back from provider_config and reaches the
+// session DECRYPTED. We assert via the exact seam RunFromDB drives
+// (loadSeededNPCs -> resolveSessionKeys) rather than running the Discord loop, so
+// no credential getter is exposed on the public adapters.
+func TestRunFromDB_DecryptsSavedKeys(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+	cipher := testCipher(t)
+
+	tenantID, want := seedRealKeyNPC(t, ctx, st, cipher)
+
+	_, primary, gotTenant, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if gotTenant != tenantID {
+		t.Fatalf("loadSeededNPCs tenant = %s, want %s", gotTenant, tenantID)
+	}
+
+	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher)
+	if err != nil {
+		t.Fatalf("resolveSessionKeys: %v", err)
+	}
+	if keys.llm != want.llm {
+		t.Errorf("llm key = %q, want decrypted %q", keys.llm, want.llm)
+	}
+	if keys.tts != want.tts {
+		t.Errorf("tts key = %q, want decrypted %q", keys.tts, want.tts)
+	}
+	if keys.stt != want.stt {
+		t.Errorf("stt key = %q, want decrypted %q (resolved per-Component)", keys.stt, want.stt)
+	}
+}
+
+// TestRunFromDB_EnvPlaceholderFallsBack is the AC1/AC3 env-path proof: the demo
+// seed writes "env" placeholders (real keys live in the OS keyring), and the
+// bridge must resolve them to "" so every adapter reads its own env var — the
+// pre-#69 behavior, unchanged. No cipher is even needed.
+func TestRunFromDB_EnvPlaceholderFallsBack(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+
+	_, primary, tenantID, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+
+	// A nil cipher is deliberate: the env-placeholder path must not need one.
+	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, nil)
+	if err != nil {
+		t.Fatalf("resolveSessionKeys on env placeholders: %v (must fall back to ENV, not error)", err)
+	}
+	if keys != (providerKeys{}) {
+		t.Errorf("env-placeholder keys = %+v, want all empty (adapter ENV fallback)", keys)
+	}
+}
+
+// TestRunFromDB_DecryptFailureSurfacesClearError is the AC2 proof at the PRODUCTION
+// call site: a real saved key the configured cipher cannot open makes RunFromDB
+// return a CLEAR error BEFORE any Discord connection — never a silent empty key
+// that degrades the NPC to the wrong (env) credential. The schema is current and
+// an NPC is seeded, so RunFromDB gets past the fail-fast + load and fails AT key
+// resolution; a wrong cipher (different key) cannot decrypt the sealed blob.
+func TestRunFromDB_DecryptFailureSurfacesClearError(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	seedRealKeyNPC(t, ctx, st, testCipher(t)) // sealed with one cipher...
+	wrong := testCipher(t)                    // ...opened with another -> fails
+
+	err := RunFromDB(ctx, Config{}, pool, wrong)
+	if err == nil {
+		t.Fatal("RunFromDB returned nil with an undecryptable saved key; a broken key must fail clearly, not silently fall back to ENV (AC2)")
+	}
+	if !strings.Contains(err.Error(), "decrypt") {
+		t.Errorf("RunFromDB error = %q, want a clear decrypt failure (AC2)", err)
+	}
+}

--- a/internal/wirenpc/credentials_test.go
+++ b/internal/wirenpc/credentials_test.go
@@ -1,0 +1,124 @@
+package wirenpc
+
+import (
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// newUnitCipher builds a Cipher on a fresh random AES-256 key. Keyless and
+// Docker-free, so the credential-bridge resolution logic is proven in the
+// default suite (the DB round-trip lives in credentials_integration_test.go).
+func newUnitCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	c, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}
+
+// sealedConfig builds a ProviderConfig holding a real (non-placeholder) key
+// sealed with cipher — the BYOK web-app path (last4 is the key's, not "env").
+func sealedConfig(t *testing.T, cipher *crypto.Cipher, key string) *storage.ProviderConfig {
+	t.Helper()
+	ct, err := cipher.Seal([]byte(key))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return &storage.ProviderConfig{
+		CredentialsCiphertext: ct,
+		CredentialsLast4:      crypto.Last4(key),
+	}
+}
+
+// TestResolveKey is the core AC1+AC2 proof: a real saved key reaches the caller
+// DECRYPTED; the "env" placeholder (and an unbound config) falls back to "" so
+// the adapter reads ENV; and a real key that cannot be decrypted surfaces a
+// CLEAR error rather than a silent empty string.
+func TestResolveKey(t *testing.T) {
+	cipher := newUnitCipher(t)
+	wrong := newUnitCipher(t) // a different key -> cannot open cipher's blobs
+
+	const realKey = "sk-real-secret-key-1234"
+	sealed := sealedConfig(t, cipher, realKey)
+
+	// An env-placeholder row: it carries a (sealed) placeholder blob but its
+	// last4 is the "env" marker, so the real key lives outside the DB.
+	placeholder := sealedConfig(t, cipher, "placeholder: real key in keyring")
+	placeholder.CredentialsLast4 = credPlaceholderLast4
+
+	tests := []struct {
+		name    string
+		cipher  *crypto.Cipher
+		cfg     *storage.ProviderConfig
+		wantKey string
+		wantErr string // substring; "" means no error expected
+	}{
+		{name: "nil config -> env fallback", cipher: cipher, cfg: nil, wantKey: ""},
+		{name: "env placeholder -> env fallback", cipher: cipher, cfg: placeholder, wantKey: ""},
+		{name: "real key + cipher -> decrypted", cipher: cipher, cfg: sealed, wantKey: realKey},
+		{name: "real key + nil cipher -> clear error", cipher: nil, cfg: sealed, wantErr: "cipher"},
+		{name: "real key + wrong cipher -> clear error", cipher: wrong, cfg: sealed, wantErr: "decrypt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveKey(tt.cipher, tt.cfg, storage.ComponentLLM)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("resolveKey() error = nil, want error containing %q — a real saved key must never resolve to a silent empty key (AC2)", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("resolveKey() error = %q, want substring %q", err, tt.wantErr)
+				}
+				if got != "" {
+					t.Errorf("resolveKey() key = %q on error, want empty", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveKey() unexpected error: %v", err)
+			}
+			if got != tt.wantKey {
+				t.Errorf("resolveKey() = %q, want %q", got, tt.wantKey)
+			}
+		})
+	}
+}
+
+// TestResolveProviderKeys pins the per-component aggregation: each component
+// resolves independently (real keys decrypted, an unbound component -> ""), and
+// a single undecryptable component fails the WHOLE resolution clearly (AC2) so a
+// broken key can never silently fall through to a half-configured session.
+func TestResolveProviderKeys(t *testing.T) {
+	cipher := newUnitCipher(t)
+	llm := sealedConfig(t, cipher, "llm-key-aaaa")
+	tts := sealedConfig(t, cipher, "tts-key-bbbb")
+
+	// STT unbound -> env fallback ("") while LLM/TTS decrypt — the hybrid mix.
+	keys, err := resolveProviderKeys(cipher, llm, tts, nil)
+	if err != nil {
+		t.Fatalf("resolveProviderKeys: %v", err)
+	}
+	if keys.llm != "llm-key-aaaa" {
+		t.Errorf("keys.llm = %q, want decrypted %q", keys.llm, "llm-key-aaaa")
+	}
+	if keys.tts != "tts-key-bbbb" {
+		t.Errorf("keys.tts = %q, want decrypted %q", keys.tts, "tts-key-bbbb")
+	}
+	if keys.stt != "" {
+		t.Errorf("keys.stt = %q, want \"\" (unbound -> adapter ENV fallback)", keys.stt)
+	}
+
+	// A real key the cipher cannot open fails the whole resolution (AC2).
+	if _, err := resolveProviderKeys(nil, llm, tts, nil); err == nil {
+		t.Fatal("resolveProviderKeys(nil cipher, real keys) = nil error, want a clear failure (AC2)")
+	}
+}

--- a/internal/wirenpc/ensurecurrent_integration_test.go
+++ b/internal/wirenpc/ensurecurrent_integration_test.go
@@ -117,7 +117,7 @@ func TestRunFromDB_StaleSchemaFailsFastBeforeNPCLoad(t *testing.T) {
 	migrateToHead(t, dsn)
 	rollBackOne(t, dsn)
 
-	err := RunFromDB(context.Background(), Config{}, openPool(t, dsn))
+	err := RunFromDB(context.Background(), Config{}, openPool(t, dsn), nil)
 	if err == nil {
 		t.Fatal("RunFromDB returned nil on a stale schema; serving must fail fast before any other DB query")
 	}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -5,8 +5,9 @@
 //
 // "Hardcoded" means the NPC's Persona, Voice, and provider selection live in
 // code here (no DB); task #5 swaps this for a DB-loaded Agent. Credentials are
-// runtime-only — the Discord token and provider API keys come from the
-// environment, never compiled in.
+// runtime-only and never compiled in: the Discord token and provider API keys
+// come from the environment or, on the DB-load path, from the decrypted saved
+// provider_config (BYOK, ADR-0004/0039, issue #69).
 package wirenpc
 
 import (
@@ -462,7 +463,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 
 	// cfg.keys.tts is the resolved BYOK TTS key (issue #69): the decrypted saved
 	// key when one is configured, or "" to fall back to ELEVENLABS_API_KEY.
-	teeSynth := wire.NewTeeSynthesizer(ttseleven.New(cfg.keys.tts), pump, bus)
+	teeSynth := wire.NewTeeSynthesizer(newTTS(cfg.keys.tts), pump, bus)
 
 	// Attach the orchestrator-sibling latency subscriber (A2/#10): it derives the
 	// SLO histograms (response_latency, address_detect, per-sentence tts_ttfb) from
@@ -542,6 +543,18 @@ func npcVoice() tts.Voice {
 	}
 }
 
+// Provider-adapter constructors, injected as package vars so a test can spy on
+// the apiKey each component receives (issue #69). The adapters expose no key
+// getter, so this is the seam that pins the resolved BYOK key reaching its OWN
+// adapter — a slot swap (e.g. groq.New(keys.stt)) or a dropped `cfg.keys = keys`
+// would otherwise revert the feature to ENV while every providerKeys{} test
+// stayed green. Production always uses the real constructors.
+var (
+	newLLM = groq.New
+	newSTT = stteleven.New
+	newTTS = ttseleven.New
+)
+
 // buildConversation assembles the orchestrator reactive pipeline: VAD (Silero)
 // → STT (ElevenLabs) → Address Detection → production Reply (the Agent loop over
 // Groq, with the dice Tool granted via the tool-use loop) → TTS (synth).
@@ -609,7 +622,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	}
 	vadStage := orchestrator.NewVAD(bus, vadSession)
 
-	sttStage := orchestrator.NewSTT(bus, stteleven.New(keys.stt),
+	sttStage := orchestrator.NewSTT(bus, newSTT(keys.stt),
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
 
@@ -626,7 +639,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// Anthropic) but fail the live run — Groq is the only correct default for a
 	// runnable NPC. One engine is shared across every NPC in the Roster — they
 	// reuse one client rather than each opening their own.
-	provider := groq.New(keys.llm)
+	provider := newLLM(keys.llm)
 	reg := tool.NewRegistry()
 	reg.MustRegister(tool.NewDice())
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
@@ -639,7 +652,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over the shared engine) in the Cast. The
 	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, ttseleven.New(keys.tts), 16, log))
+	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
@@ -228,6 +229,12 @@ type Config struct {
 	// assembles from these is the INITIAL membership; NPCs join and leave at
 	// runtime via the programmatic [Roster] API (issue #49).
 	npcs []npcSpec
+	// keys are the resolved per-component BYOK API keys (issue #69): RunFromDB
+	// decrypts the saved provider_config credentials into them under the hybrid
+	// policy (ADR-0039), and connectAndServe/buildConversation hand them to the
+	// adapters. An empty key means "adapter ENV fallback", so the zero value (the
+	// env-only Run path) reproduces today's behavior untouched.
+	keys providerKeys
 }
 
 // RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
@@ -238,7 +245,14 @@ type Config struct {
 // duplicate handle. This is the task-#5 DB-load path: the only thing it changes
 // versus [Run] is the *source* of the NPC's Persona/Voice/identity — the
 // assembled pipeline is identical.
-func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool) error {
+//
+// cipher decrypts the saved BYOK provider credentials (issue #69, ADR-0004): a
+// real saved key (last4 != "env") drives the session decrypted, while the seeded
+// "env" placeholder falls back to the adapter's own env var (the hybrid policy,
+// ADR-0039). A nil cipher is fine when every config is the env placeholder — the
+// no-$GLYPHOXA_SECRET self-host path — but a real saved key with no cipher is a
+// clear startup error, never a silent fall back to ENV.
+func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *crypto.Cipher) error {
 	log := cfg.Logger
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
@@ -256,7 +270,8 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool) error {
 		return err
 	}
 
-	npcs, err := loadSeededNPCs(ctx, storage.New(pool))
+	st := storage.New(pool)
+	npcs, primary, tenantID, err := loadSeededNPCs(ctx, st)
 	if err != nil {
 		return err
 	}
@@ -264,7 +279,17 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool) error {
 		log.Info("loaded NPC from DB", "npc", npc.name, "agentID", npc.agentID)
 	}
 
+	// Resolve the session's BYOK keys from the saved provider_config (issue #69).
+	// A decryption failure (e.g. a real saved key with the wrong/absent cipher)
+	// is fatal here, before any Discord connection — the operator sees a clear
+	// error instead of an NPC that silently ran on the wrong (env) key.
+	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher)
+	if err != nil {
+		return err
+	}
+
 	cfg.npcs = npcs
+	cfg.keys = keys
 	return Run(ctx, cfg)
 }
 
@@ -435,7 +460,9 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	pump := wire.NewPlaybackPump(sess, cdc, log, bus)
 	defer pump.Close()
 
-	teeSynth := wire.NewTeeSynthesizer(ttseleven.New(""), pump, bus)
+	// cfg.keys.tts is the resolved BYOK TTS key (issue #69): the decrypted saved
+	// key when one is configured, or "" to fall back to ELEVENLABS_API_KEY.
+	teeSynth := wire.NewTeeSynthesizer(ttseleven.New(cfg.keys.tts), pump, bus)
 
 	// Attach the orchestrator-sibling latency subscriber (A2/#10): it derives the
 	// SLO histograms (response_latency, address_detect, per-sentence tts_ttfb) from
@@ -447,7 +474,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -518,8 +545,13 @@ func npcVoice() tts.Voice {
 // buildConversation assembles the orchestrator reactive pipeline: VAD (Silero)
 // → STT (ElevenLabs) → Address Detection → production Reply (the Agent loop over
 // Groq, with the dice Tool granted via the tool-use loop) → TTS (synth).
-// Provider API keys are read by each adapter from its own env var at request
-// time (BYOK, ADR-0004), so construction here needs no secrets.
+//
+// keys are the resolved BYOK provider keys (issue #69, hybrid policy ADR-0039):
+// each adapter is constructed with its component's key, which OVERRIDES that
+// adapter's *_API_KEY env var — except an empty key (the env placeholder, or the
+// env-only [Run] path) keeps today's behavior, where the adapter reads its env
+// var at request time (ADR-0004). So a saved key drives the session and an
+// unconfigured component falls back to ENV.
 //
 // npcs supplies the INITIAL Character NPCs the loop voices — their addressable
 // identity, Persona, and Voice (from the in-code seed or, via [RunFromDB], the
@@ -543,7 +575,7 @@ func npcVoice() tts.Voice {
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -577,7 +609,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	}
 	vadStage := orchestrator.NewVAD(bus, vadSession)
 
-	sttStage := orchestrator.NewSTT(bus, stteleven.New(""),
+	sttStage := orchestrator.NewSTT(bus, stteleven.New(keys.stt),
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
 
@@ -585,14 +617,16 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// seeded. With no grants the tool engine degrades to a single completion
 	// through the same path.
 	//
-	// Groq is the live LLM provider (see the function doc): it reads
-	// GROQ_API_KEY at request time (BYOK, ADR-0004); export it from the keyring
-	// before a live run (docs/agents/live-npc-run.md). There is no Anthropic key,
-	// so wiring the Anthropic adapter here would pass the keyless cassette tests
-	// (which replay Anthropic) but fail the live run — Groq is the only correct
-	// default for a runnable NPC. One engine is shared across every NPC in the
-	// Roster — they reuse one client rather than each opening their own.
-	provider := groq.New("")
+	// Groq is the live LLM provider (see the function doc). Its key is keys.llm:
+	// the decrypted saved BYOK key (issue #69) when one is configured, otherwise
+	// "" so the adapter falls back to GROQ_API_KEY at request time (BYOK,
+	// ADR-0004) — export it from the keyring before an env-only live run
+	// (docs/agents/live-npc-run.md). There is no Anthropic key, so wiring the
+	// Anthropic adapter here would pass the keyless cassette tests (which replay
+	// Anthropic) but fail the live run — Groq is the only correct default for a
+	// runnable NPC. One engine is shared across every NPC in the Roster — they
+	// reuse one client rather than each opening their own.
+	provider := groq.New(keys.llm)
 	reg := tool.NewRegistry()
 	reg.MustRegister(tool.NewDice())
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
@@ -605,7 +639,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over the shared engine) in the Cast. The
 	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, ttseleven.New(""), 16, log))
+	roster := newRoster(rosterDepsForLive(toolEngine, ttseleven.New(keys.tts), 16, log))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}


### PR DESCRIPTION
## What

Make the live voice loop use UI-saved BYOK keys (decrypted from `provider_config`) instead of always reading ENV. Saved keys now drive the session under the hybrid policy.

Closes #69.

## Why / hybrid policy (ADR-0039, ADR-0004)

Stage 4 (#68) lets the operator save BYOK keys (write-only, AES-GCM at rest). This stage wires them into the running NPC:

- `credentials_last4 != "env"` (a real saved key) -> the key is DECRYPTED and handed to the adapter, OVERRIDING its env var.
- `credentials_last4 == "env"` (the seeded placeholder) or no bound config -> resolve to `""`, which every adapter (`groq`, `stt/elevenlabs`, `tts/elevenlabs`) reads as "fall back to my own `*_API_KEY` env var".

So the web-app BYOK path drives the session while the self-host ENV path stays intact.

## How

- New resolver seam `internal/wirenpc/credentials.go`: `providerKeys`, `resolveKey`, `resolveProviderKeys`, `resolveSessionKeys`. A real saved key that can't be decrypted (nil cipher / wrong cipher) is a CLEAR error, never a silent empty key.
- **Per-Component resolution / STT note:** LLM+TTS configs ride on the primary agent's `LoadedAgent` (LoadAgent joins them); STT is NOT agent-joined, so it is read via `GetProviderConfigByComponent(tenant, ComponentSTT)` (ElevenLabs STT shares the TTS key in the demo seed, but the bind is resolved per-Component for correctness). Missing STT config -> env fallback, not an error.
- `RunFromDB` gains a `*crypto.Cipher` param; it resolves the session keys BEFORE any Discord connection (a decrypt failure fails fast). `buildConversation`/`connectAndServe` pass the keys to the adapters.
- `main.go`: `runVoice` builds the cipher best-effort (mirrors `runWeb`'s `appCipher()` pattern — no `$GLYPHOXA_SECRET` => nil cipher => env-placeholder configs resolve to `""` => today's behavior). All-mode threads the existing `cipher`. `-hardcoded` still calls `wirenpc.Run` (env-only, untouched).
- `loadSeededNPCs` now also surfaces the tenant ID + primary `LoadedAgent`, so key resolution adds ONE query (STT-by-component) rather than re-querying tenant/campaign/agent.

## Acceptance criteria -> tests

| AC | Test |
|----|------|
| 1. Real saved key (`last4 != "env"`) reaches adapter DECRYPTED; placeholder (`last4 == "env"`) falls back to ENV | `TestResolveKey`, `TestResolveProviderKeys` (unit, keyless); `TestRunFromDB_DecryptsSavedKeys`, `TestRunFromDB_EnvPlaceholderFallsBack` (integration, real DB round-trip via the exact `loadSeededNPCs`->`resolveSessionKeys` seam RunFromDB drives) |
| 2. Decryption failure surfaces a CLEAR error, not a silent empty key | `TestResolveKey` (nil cipher -> "...cipher..."; wrong cipher -> "...decrypt..."); `TestResolveProviderKeys`; `TestRunFromDB_DecryptFailureSurfacesClearError` (production call site: RunFromDB returns the clear error before Discord) |
| 3. `-hardcoded` + existing voice-mode ENV path UNCHANGED | `-hardcoded` calls `wirenpc.Run` (no cipher, `cfg.keys` zero -> all "" -> env). Env path through `buildConversation` is the `providerKeys{}` regression covered by the existing `TestBuildConversation_CleanupDoesNotDestroyEngine` + `TestSeedThenLoadEquivalence` (now passing `providerKeys{}`) |

No credential getter is exposed on the public adapter — resolution is asserted at the unexported seam.

## Deviation from design

None of substance. `resolveKey`'s `component` param is typed `storage.Component` (not bare `string`) for type-safe call sites; it formats identically in the error message.

## CI gates (run locally from the worktree, Docker present)

- `buf generate` — clean, no proto change (exit 0)
- `go build ./...` — ok
- `go vet ./...` — ok
- `go vet -tags=record ./...` — ok
- `go test -race ./...` — ok
- `go test -race -tags=integration ./...` — ok (all packages, testcontainers Postgres)
- web — UNCHANGED (not touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)