### PR TITLE
feat(#70): live voices + Preview voice + Groq model list + async health

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -312,11 +312,18 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
 	providerPath, providerHandler := rpc.NewProviderServer(store, cipher, log).Handler(stack.HandlerOptions()...)
+	// VoiceService (#70) serves the live provider data the Configuration +
+	// Campaign screens render — the ElevenLabs voice catalog + preview, the Groq
+	// model allowlist, and the async provider-health signal — all via the
+	// decrypted tenant key (ADR-0004 credential bridge). Appended last so the
+	// existing mounts keep their order.
+	voicePath, voiceHandler := rpc.NewVoiceServer(store, cipher, log).Handler(stack.HandlerOptions()...)
 
 	return []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),
 		web.APIMount(authPath, authHandler),
 		web.APIMount(providerPath, providerHandler),
+		web.APIMount(voicePath, voiceHandler),
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/internal/discordtag/discordtag.go
+++ b/internal/discordtag/discordtag.go
@@ -1,0 +1,75 @@
+// Package discordtag resolves a Discord bot's live tag (e.g. "Glyphoxa#4823")
+// by performing a SHORT-LIVED gateway login with a bot token and reading the
+// bot user off the gateway Ready event (#70). It is the real signal behind the
+// Configuration screen's Discord health badge: unlike a token-presence check, a
+// successful gateway login proves the token can actually identify with Discord.
+//
+// This is a LIVE network call. The RPC layer hides it behind a seam so unit
+// tests fake the resolver and never touch the network; [Resolve] itself is
+// exercised only under an integration/live build or a real operator run. The
+// only offline-safe path is the empty-token guard, which fails fast before any
+// dial.
+package discordtag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/disgoorg/disgo"
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/gateway"
+)
+
+// Resolve opens a short-lived Discord gateway session with token, waits for the
+// Ready event, and returns the bot user's tag ("Username#Discriminator", or the
+// bare username under Discord's new handle system). The session is always closed
+// before return.
+//
+// An empty token fails fast (no dial). A ctx deadline bounds the login: a hung
+// or unreachable gateway returns ctx.Err() rather than blocking. log may be nil.
+func Resolve(ctx context.Context, token string, log *slog.Logger) (string, error) {
+	if token == "" {
+		return "", errors.New("discordtag: empty bot token")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+
+	// A buffered channel so the Ready listener never blocks even if Resolve has
+	// already returned on a ctx deadline.
+	tagCh := make(chan string, 1)
+
+	client, err := disgo.New(token,
+		bot.WithLogger(log),
+		bot.WithDefaultGateway(),
+		// Guilds is the minimal intent; Ready (and its bot user) is delivered on
+		// identify regardless, so this keeps the login cheap.
+		bot.WithGatewayConfigOpts(gateway.WithIntents(gateway.IntentGuilds)),
+		bot.WithEventListenerFunc(func(e *events.Ready) {
+			select {
+			case tagCh <- e.User.Tag():
+			default:
+			}
+		}),
+	)
+	if err != nil {
+		return "", fmt.Errorf("discordtag: build client: %w", err)
+	}
+	// Close the gateway on every exit path; a fresh ctx so teardown still runs
+	// when the caller's ctx has already expired.
+	defer client.Close(context.Background())
+
+	if err := client.OpenGateway(ctx); err != nil {
+		return "", fmt.Errorf("discordtag: open gateway: %w", err)
+	}
+
+	select {
+	case tag := <-tagCh:
+		return tag, nil
+	case <-ctx.Done():
+		return "", fmt.Errorf("discordtag: timed out before Ready: %w", ctx.Err())
+	}
+}

--- a/internal/discordtag/discordtag_test.go
+++ b/internal/discordtag/discordtag_test.go
@@ -1,0 +1,24 @@
+package discordtag_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/discordtag"
+)
+
+// TestResolve_EmptyToken_FailsFastNoNetwork pins the only offline-deterministic
+// path: an empty token is rejected before any gateway dial, so the default
+// `go test` makes no live Discord call (ADR-0021). The live login itself is
+// exercised by an operator run / a live build, behind the RPC layer's seam.
+func TestResolve_EmptyToken_FailsFastNoNetwork(t *testing.T) {
+	t.Parallel()
+	_, err := discordtag.Resolve(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("Resolve with empty token returned nil error")
+	}
+	if !strings.Contains(err.Error(), "empty bot token") {
+		t.Errorf("error %q does not mention the empty token", err)
+	}
+}

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -1,0 +1,434 @@
+package rpc
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/discordtag"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
+)
+
+// VoiceService (#70) serves the LIVE provider data the Configuration + Campaign
+// screens render: the ElevenLabs voice catalog, a short voice preview, the Groq
+// model allowlist, and the async provider-health signal. Every live call uses
+// the operator's decrypted BYOK key (ADR-0004 credential bridge, hybrid policy
+// ADR-0039 — a real saved key overrides ENV, the "env" placeholder falls back to
+// the adapter's own *_API_KEY). The live ElevenLabs / Groq / Discord seams are
+// function fields so unit tests fake them and the default `go test` makes no
+// network call (ADR-0021).
+
+// defaultPreviewText is spoken when PreviewVoice is called with empty text.
+const defaultPreviewText = "Hello! I'm your voice for this campaign. Roll for initiative."
+
+// previewTimeout bounds a single preview synthesis so a black-holed TTS endpoint
+// cannot hold the handler open; the request context's own deadline still wins
+// when shorter.
+const previewTimeout = 15 * time.Second
+
+// healthCheckTimeout bounds each provider's health test-call (the Discord
+// gateway login is the slowest), so a hung provider degrades that one badge
+// instead of stalling the whole health probe.
+const healthCheckTimeout = 12 * time.Second
+
+// voiceStore is the narrow read surface VoiceServer needs to resolve the tenant
+// BYOK keys. *storage.Store satisfies it; tests drive a fake.
+type voiceStore interface {
+	GetProviderConfigByComponent(ctx context.Context, tenantID uuid.UUID, component storage.Component) (storage.ProviderConfig, error)
+	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
+}
+
+// VoiceServer implements managementv1connect.VoiceServiceHandler. The live
+// adapter constructors and the Groq/Discord pings are seams (function fields)
+// defaulted by NewVoiceServer and overridden by unit tests.
+type VoiceServer struct {
+	store  voiceStore
+	cipher *crypto.Cipher
+	log    *slog.Logger
+
+	// newLister builds a TTS voice catalog client for an API key ("" -> the
+	// adapter's env fallback). Defaults to ElevenLabs.
+	newLister func(apiKey string) tts.VoiceLister
+	// newSynth builds a TTS synthesizer for an API key. Defaults to ElevenLabs.
+	newSynth func(apiKey string) tts.Synthesizer
+	// pingLLM is the Groq liveness test-call (a real key -> nil). Defaults to a
+	// GET against the Groq models endpoint.
+	pingLLM func(ctx context.Context, apiKey string) error
+	// botTag performs a live Discord gateway login and returns the bot tag.
+	// Defaults to discordtag.Resolve.
+	botTag func(ctx context.Context, token string) (string, error)
+}
+
+var _ managementv1connect.VoiceServiceHandler = (*VoiceServer)(nil)
+
+// NewVoiceServer wires a VoiceServer with the live ElevenLabs / Groq / Discord
+// seams. A nil cipher disables decrypting saved keys (the env-fallback path still
+// works); the live calls then surface the adapters' missing-key errors.
+func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *VoiceServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &VoiceServer{
+		store:     store,
+		cipher:    cipher,
+		log:       log,
+		newLister: func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
+		newSynth:  func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
+		pingLLM:   livePingGroq,
+		botTag:    func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
+	}
+}
+
+// Handler builds the Connect HTTP handler for VoiceService and returns its mount
+// path + handler, mirroring the other rpc servers.
+func (s *VoiceServer) Handler(opts ...connect.HandlerOption) (string, http.Handler) {
+	return managementv1connect.NewVoiceServiceHandler(s, opts...)
+}
+
+func (s *VoiceServer) tenant(ctx context.Context) (uuid.UUID, error) {
+	id, ok := auth.TenantID(ctx)
+	if !ok {
+		return uuid.Nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no tenant in context"))
+	}
+	return id, nil
+}
+
+// ListModels returns the static model allowlist for a provider. Groq exposes no
+// list-models call we surface, so its select is a curated allowlist (ADR-0039);
+// an unknown provider is a client error.
+func (s *VoiceServer) ListModels(
+	_ context.Context,
+	req *connect.Request[managementv1.ListModelsRequest],
+) (*connect.Response[managementv1.ListModelsResponse], error) {
+	switch req.Msg.GetProvider() {
+	case "groq":
+		return connect.NewResponse(&managementv1.ListModelsResponse{Models: groq.Models}), nil
+	default:
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("no model allowlist for provider %q", req.Msg.GetProvider()))
+	}
+}
+
+// ListVoices maps the ElevenLabs voice catalog onto the wire type for the voice
+// select, using the decrypted tenant TTS key. A live failure (bad/missing key)
+// is CodeUnavailable — the screen degrades to the persisted voice id.
+func (s *VoiceServer) ListVoices(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListVoicesRequest],
+) (*connect.Response[managementv1.ListVoicesResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentTTS)
+	if err != nil {
+		return nil, err
+	}
+
+	voices, err := s.newLister(key).ListVoices(ctx)
+	if err != nil {
+		s.log.Warn("ListVoices: live catalog failed", "err", err)
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("voice catalog is unavailable"))
+	}
+
+	out := make([]*managementv1.Voice, 0, len(voices))
+	for _, v := range voices {
+		out = append(out, toProtoVoice(v))
+	}
+	return connect.NewResponse(&managementv1.ListVoicesResponse{Voices: out}), nil
+}
+
+// PreviewVoice synthesizes a short sample for one voice and returns it as a WAV
+// blob the browser can play directly (wraps the existing Synthesize).
+func (s *VoiceServer) PreviewVoice(
+	ctx context.Context,
+	req *connect.Request[managementv1.PreviewVoiceRequest],
+) (*connect.Response[managementv1.PreviewVoiceResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	voiceID := req.Msg.GetVoiceId()
+	if voiceID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("voice_id is required"))
+	}
+	text := req.Msg.GetText()
+	if text == "" {
+		text = defaultPreviewText
+	}
+
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentTTS)
+	if err != nil {
+		return nil, err
+	}
+
+	synCtx, cancel := context.WithTimeout(ctx, previewTimeout)
+	defer cancel()
+
+	ch, err := s.newSynth(key).Synthesize(synCtx, tts.SynthesizeRequest{
+		Sentence: text,
+		Voice:    tts.Voice{ProviderID: elevenlabs.ProviderID, VoiceID: voiceID},
+	})
+	if err != nil {
+		s.log.Warn("PreviewVoice: synthesis failed to start", "err", err)
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("voice preview is unavailable"))
+	}
+
+	var (
+		pcm        []byte
+		sampleRate = 24000
+		channels   = 1
+	)
+	for chunk := range ch {
+		if len(pcm) == 0 && chunk.SampleRate > 0 {
+			sampleRate, channels = chunk.SampleRate, chunk.Channels
+		}
+		pcm = append(pcm, chunk.PCM...)
+	}
+	if channels == 0 {
+		channels = 1
+	}
+
+	return connect.NewResponse(&managementv1.PreviewVoiceResponse{
+		Audio:      encodeWAV(pcm, sampleRate, channels),
+		SampleRate: int32(sampleRate),
+		Channels:   int32(channels),
+		MimeType:   "audio/wav",
+	}), nil
+}
+
+// GetProviderHealth runs the per-provider test-calls and returns each slot's
+// tested status plus the resolved Discord bot tag. A provider with no resolvable
+// key (or a failing test-call) is reported degraded; the screen still renders
+// key-presence instantly and only upgrades the badge from this.
+func (s *VoiceServer) GetProviderHealth(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetProviderHealthRequest],
+) (*connect.Response[managementv1.GetProviderHealthResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := []*managementv1.ProviderHealth{
+		s.healthLLM(ctx, tenantID),
+		s.healthTTS(ctx, tenantID),
+		s.healthDiscord(ctx, tenantID),
+	}
+	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
+}
+
+// healthLLM pings Groq with the decrypted LLM key.
+func (s *VoiceServer) healthLLM(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentLLM)
+	if err != nil {
+		return degraded("groq", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	if err := s.pingLLM(cctx, key); err != nil {
+		return degraded("groq", err)
+	}
+	return healthy("groq")
+}
+
+// healthTTS reuses ListVoices as the ElevenLabs liveness probe (GET /v1/voices).
+func (s *VoiceServer) healthTTS(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentTTS)
+	if err != nil {
+		return degraded("elevenlabs", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	if _, err := s.newLister(key).ListVoices(cctx); err != nil {
+		return degraded("elevenlabs", err)
+	}
+	return healthy("elevenlabs")
+}
+
+// healthDiscord performs a live gateway login and reports the resolved bot tag.
+func (s *VoiceServer) healthDiscord(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+	token, err := s.resolveDiscordToken(ctx, tenantID)
+	if err != nil {
+		return degraded("discord", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	tag, err := s.botTag(cctx, token)
+	if err != nil {
+		return degraded("discord", err)
+	}
+	h := healthy("discord")
+	h.BotTag = tag
+	return h
+}
+
+func healthy(provider string) *managementv1.ProviderHealth {
+	return &managementv1.ProviderHealth{Provider: provider, Status: managementv1.HealthStatus_HEALTH_STATUS_HEALTHY}
+}
+
+func degraded(provider string, err error) *managementv1.ProviderHealth {
+	return &managementv1.ProviderHealth{
+		Provider: provider,
+		Status:   managementv1.HealthStatus_HEALTH_STATUS_DEGRADED,
+		Detail:   err.Error(),
+	}
+}
+
+// resolveComponentKey resolves a component's BYOK key under the hybrid policy:
+// no row / "env" placeholder -> "" (adapter env fallback); a real saved key ->
+// decrypted plaintext; a saved key with no cipher -> FailedPrecondition.
+func (s *VoiceServer) resolveComponentKey(ctx context.Context, tenantID uuid.UUID, component storage.Component) (string, error) {
+	cfg, err := s.store.GetProviderConfigByComponent(ctx, tenantID, component)
+	if errors.Is(err, storage.ErrNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		s.log.Error("resolveComponentKey: store read failed", "component", component, "err", err)
+		return "", connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return s.openKey(cfg.CredentialsLast4, cfg.CredentialsCiphertext)
+}
+
+// resolveDiscordToken resolves the deployment Bot token: no row / placeholder ->
+// "" (which the live login rejects fast), a saved token -> decrypted plaintext.
+func (s *VoiceServer) resolveDiscordToken(ctx context.Context, tenantID uuid.UUID) (string, error) {
+	dep, err := s.store.GetDeploymentConfig(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		s.log.Error("resolveDiscordToken: store read failed", "err", err)
+		return "", connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return s.openKey(dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext)
+}
+
+// openKey applies the hybrid decision to one (last4, ciphertext) pair.
+func (s *VoiceServer) openKey(last4 string, ciphertext []byte) (string, error) {
+	if !isSaved(last4) {
+		return "", nil
+	}
+	if s.cipher == nil {
+		return "", connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
+	}
+	plaintext, err := s.cipher.Open(ciphertext)
+	if err != nil {
+		s.log.Error("openKey: decrypt failed", "err", err)
+		return "", connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return string(plaintext), nil
+}
+
+// toProtoVoice maps a tts.Voice onto the wire Voice, building the "Provider ·
+// Name" display label the select renders.
+func toProtoVoice(v tts.Voice) *managementv1.Voice {
+	return &managementv1.Voice{
+		Provider: v.ProviderID,
+		VoiceId:  v.VoiceID,
+		Name:     v.Name,
+		Language: v.Language,
+		Label:    voiceLabel(v),
+	}
+}
+
+// voiceLabel renders the "ElevenLabs · Marcus" display string. ElevenLabs is the
+// only MVP TTS provider (ADR-0039); unknown providers fall back to their id.
+func voiceLabel(v tts.Voice) string {
+	name := v.Name
+	if name == "" {
+		name = v.VoiceID
+	}
+	provider := v.ProviderID
+	if provider == elevenlabs.ProviderID {
+		provider = "ElevenLabs"
+	}
+	if provider == "" {
+		return name
+	}
+	return provider + " · " + name
+}
+
+// encodeWAV wraps signed-16-bit little-endian PCM in a canonical 44-byte
+// RIFF/WAVE header so a browser <audio> element can play the preview without
+// decoding raw PCM.
+func encodeWAV(pcm []byte, sampleRate, channels int) []byte {
+	if sampleRate <= 0 {
+		sampleRate = 24000
+	}
+	if channels <= 0 {
+		channels = 1
+	}
+	const bitsPerSample = 16
+	byteRate := sampleRate * channels * bitsPerSample / 8
+	blockAlign := channels * bitsPerSample / 8
+	dataLen := len(pcm)
+
+	buf := make([]byte, 0, 44+dataLen)
+	buf = append(buf, "RIFF"...)
+	buf = appendU32(buf, uint32(36+dataLen)) // file size minus the 8-byte RIFF header
+	buf = append(buf, "WAVE"...)
+	// fmt subchunk (PCM).
+	buf = append(buf, "fmt "...)
+	buf = appendU32(buf, 16) // PCM fmt chunk size
+	buf = appendU16(buf, 1)  // audio format: 1 = PCM
+	buf = appendU16(buf, uint16(channels))
+	buf = appendU32(buf, uint32(sampleRate))
+	buf = appendU32(buf, uint32(byteRate))
+	buf = appendU16(buf, uint16(blockAlign))
+	buf = appendU16(buf, uint16(bitsPerSample))
+	// data subchunk.
+	buf = append(buf, "data"...)
+	buf = appendU32(buf, uint32(dataLen))
+	buf = append(buf, pcm...)
+	return buf
+}
+
+func appendU16(b []byte, v uint16) []byte { return binary.LittleEndian.AppendUint16(b, v) }
+func appendU32(b []byte, v uint32) []byte { return binary.LittleEndian.AppendUint32(b, v) }
+
+// groqPingClient bounds the Groq health probe so an unreachable endpoint fails
+// fast rather than hanging the whole health response.
+var groqPingClient = &http.Client{Timeout: healthCheckTimeout}
+
+// livePingGroq is the default Groq liveness test-call: a GET against the
+// OpenAI-compatible /models endpoint with the bearer key. A 2xx means the key
+// authenticates. An empty key falls back to GROQ_API_KEY (the hybrid env path).
+func livePingGroq(ctx context.Context, apiKey string) error {
+	if apiKey == "" {
+		apiKey = os.Getenv(groq.APIKeyEnv)
+	}
+	if apiKey == "" {
+		return fmt.Errorf("groq: missing API key (set %s)", groq.APIKeyEnv)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, groq.DefaultBaseURL+"/models", nil)
+	if err != nil {
+		return fmt.Errorf("groq ping: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := groqPingClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("groq ping: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("groq ping: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -1,0 +1,305 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+)
+
+// fakeVoiceStore is an in-memory voiceStore: it returns canned per-component
+// provider configs and a deployment config so the VoiceServer's key-resolution
+// is unit-tested keyless and offline.
+type fakeVoiceStore struct {
+	configs map[storage.Component]storage.ProviderConfig
+	dep     *storage.DeploymentConfig
+}
+
+func (f *fakeVoiceStore) GetProviderConfigByComponent(_ context.Context, _ uuid.UUID, c storage.Component) (storage.ProviderConfig, error) {
+	cfg, ok := f.configs[c]
+	if !ok {
+		return storage.ProviderConfig{}, storage.ErrNotFound
+	}
+	return cfg, nil
+}
+
+func (f *fakeVoiceStore) GetDeploymentConfig(_ context.Context, _ uuid.UUID) (storage.DeploymentConfig, error) {
+	if f.dep == nil {
+		return storage.DeploymentConfig{}, storage.ErrNotFound
+	}
+	return *f.dep, nil
+}
+
+// fakeLister is a tts.VoiceLister returning a canned catalog and recording the
+// api key it was built with, so a test can assert the resolved BYOK key flowed
+// through.
+type fakeLister struct {
+	voices []tts.Voice
+	err    error
+}
+
+func (f *fakeLister) ListVoices(context.Context) ([]tts.Voice, error) {
+	return f.voices, f.err
+}
+
+// fakeSynth is a tts.Synthesizer that streams canned PCM chunks.
+type fakeSynth struct {
+	chunks []tts.AudioChunk
+	err    error
+}
+
+func (f *fakeSynth) Synthesize(_ context.Context, _ tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	ch := make(chan tts.AudioChunk)
+	go func() {
+		defer close(ch)
+		for _, c := range f.chunks {
+			ch <- c
+		}
+	}()
+	return ch, nil
+}
+
+func (f *fakeSynth) AudioMarkupPrompt(tts.Voice) string { return "x" }
+
+func voiceTestCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	c, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}
+
+// savedConfig builds a provider_config holding a real saved key sealed under
+// cipher, so resolution decrypts it.
+func savedConfig(t *testing.T, cipher *crypto.Cipher, comp storage.Component, provider, secret string) storage.ProviderConfig {
+	t.Helper()
+	ct, err := cipher.Seal([]byte(secret))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return storage.ProviderConfig{
+		Component: comp, Provider: provider,
+		CredentialsCiphertext: ct, CredentialsLast4: crypto.Last4(secret),
+	}
+}
+
+func tenantCtx() context.Context {
+	return auth.WithTenant(context.Background(), uuid.New())
+}
+
+func TestListModels_GroqAllowlist(t *testing.T) {
+	t.Parallel()
+	srv := NewVoiceServer(&fakeVoiceStore{}, nil, nil)
+	resp, err := srv.ListModels(tenantCtx(), connect.NewRequest(&managementv1.ListModelsRequest{Provider: "groq"}))
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	got := resp.Msg.GetModels()
+	if len(got) != len(groq.Models) {
+		t.Fatalf("models = %v, want %v", got, groq.Models)
+	}
+	if got[0] != groq.DefaultModel {
+		t.Errorf("first model = %q, want default %q", got[0], groq.DefaultModel)
+	}
+}
+
+func TestListModels_UnknownProvider(t *testing.T) {
+	t.Parallel()
+	srv := NewVoiceServer(&fakeVoiceStore{}, nil, nil)
+	_, err := srv.ListModels(tenantCtx(), connect.NewRequest(&managementv1.ListModelsRequest{Provider: "openai"}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("unknown provider code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+}
+
+func TestListVoices_MapsAdapterVoicesWithDecryptedKey(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := &fakeVoiceStore{configs: map[storage.Component]storage.ProviderConfig{
+		storage.ComponentTTS: savedConfig(t, cipher, storage.ComponentTTS, "elevenlabs", "real-eleven-key"),
+	}}
+	srv := NewVoiceServer(store, cipher, nil)
+
+	var gotKey string
+	srv.newLister = func(apiKey string) tts.VoiceLister {
+		gotKey = apiKey
+		return &fakeLister{voices: []tts.Voice{
+			{ProviderID: "elevenlabs", VoiceID: "v-marcus", Name: "Marcus", Language: "en"},
+			{ProviderID: "elevenlabs", VoiceID: "v-aria", Name: "Aria"},
+		}}
+	}
+
+	resp, err := srv.ListVoices(tenantCtx(), connect.NewRequest(&managementv1.ListVoicesRequest{}))
+	if err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if gotKey != "real-eleven-key" {
+		t.Errorf("lister built with key %q, want decrypted real-eleven-key", gotKey)
+	}
+	voices := resp.Msg.GetVoices()
+	if len(voices) != 2 {
+		t.Fatalf("voices = %d, want 2", len(voices))
+	}
+	if voices[0].GetVoiceId() != "v-marcus" || voices[0].GetName() != "Marcus" {
+		t.Errorf("voice[0] = %+v", voices[0])
+	}
+	if voices[0].GetLabel() != "ElevenLabs · Marcus" {
+		t.Errorf("voice[0] label = %q, want 'ElevenLabs · Marcus'", voices[0].GetLabel())
+	}
+}
+
+func TestListVoices_EnvFallbackWhenNoSavedKey(t *testing.T) {
+	t.Parallel()
+	// Env-placeholder config -> "" key (the adapter reads its own env var).
+	store := &fakeVoiceStore{configs: map[storage.Component]storage.ProviderConfig{
+		storage.ComponentTTS: {Component: storage.ComponentTTS, Provider: "elevenlabs", CredentialsLast4: "env"},
+	}}
+	srv := NewVoiceServer(store, voiceTestCipher(t), nil)
+
+	var gotKey = "unset"
+	srv.newLister = func(apiKey string) tts.VoiceLister {
+		gotKey = apiKey
+		return &fakeLister{}
+	}
+	if _, err := srv.ListVoices(tenantCtx(), connect.NewRequest(&managementv1.ListVoicesRequest{})); err != nil {
+		t.Fatalf("ListVoices: %v", err)
+	}
+	if gotKey != "" {
+		t.Errorf("env-placeholder should resolve to empty key, got %q", gotKey)
+	}
+}
+
+func TestPreviewVoice_ReturnsPlayableWav(t *testing.T) {
+	t.Parallel()
+	store := &fakeVoiceStore{}
+	srv := NewVoiceServer(store, voiceTestCipher(t), nil)
+	srv.newSynth = func(string) tts.Synthesizer {
+		return &fakeSynth{chunks: []tts.AudioChunk{
+			{PCM: make([]byte, 480), SampleRate: 24000, Channels: 1},
+			{PCM: make([]byte, 480), SampleRate: 24000, Channels: 1},
+		}}
+	}
+
+	resp, err := srv.PreviewVoice(tenantCtx(), connect.NewRequest(&managementv1.PreviewVoiceRequest{VoiceId: "v-marcus"}))
+	if err != nil {
+		t.Fatalf("PreviewVoice: %v", err)
+	}
+	audio := resp.Msg.GetAudio()
+	if len(audio) < 44 || string(audio[0:4]) != "RIFF" || string(audio[8:12]) != "WAVE" {
+		t.Fatalf("audio is not a WAV container (len=%d)", len(audio))
+	}
+	// 44-byte header + 960 PCM bytes.
+	if len(audio) != 44+960 {
+		t.Errorf("wav length = %d, want %d", len(audio), 44+960)
+	}
+	if resp.Msg.GetMimeType() != "audio/wav" {
+		t.Errorf("mime = %q, want audio/wav", resp.Msg.GetMimeType())
+	}
+	if resp.Msg.GetSampleRate() != 24000 || resp.Msg.GetChannels() != 1 {
+		t.Errorf("rate/channels = %d/%d", resp.Msg.GetSampleRate(), resp.Msg.GetChannels())
+	}
+}
+
+func TestPreviewVoice_MissingVoiceID(t *testing.T) {
+	t.Parallel()
+	srv := NewVoiceServer(&fakeVoiceStore{}, voiceTestCipher(t), nil)
+	_, err := srv.PreviewVoice(tenantCtx(), connect.NewRequest(&managementv1.PreviewVoiceRequest{}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("missing voice_id code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+}
+
+func TestGetProviderHealth_AllHealthyResolvesBotTag(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := &fakeVoiceStore{
+		configs: map[storage.Component]storage.ProviderConfig{
+			storage.ComponentLLM: savedConfig(t, cipher, storage.ComponentLLM, "groq", "groq-key"),
+			storage.ComponentTTS: savedConfig(t, cipher, storage.ComponentTTS, "elevenlabs", "eleven-key"),
+		},
+		dep: &storage.DeploymentConfig{
+			DiscordBotTokenLast4: "tok9", DiscordBotTokenCiphertext: mustSeal(t, cipher, "bot-token"),
+		},
+	}
+	srv := NewVoiceServer(store, cipher, nil)
+	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{} }
+	srv.pingLLM = func(context.Context, string) error { return nil }
+	srv.botTag = func(context.Context, string) (string, error) { return "Glyphoxa#4823", nil }
+
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	byProvider := map[string]*managementv1.ProviderHealth{}
+	for _, p := range resp.Msg.GetProviders() {
+		byProvider[p.GetProvider()] = p
+	}
+	for _, prov := range []string{"groq", "elevenlabs", "discord"} {
+		p := byProvider[prov]
+		if p == nil || p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_HEALTHY {
+			t.Errorf("%s not healthy: %+v", prov, p)
+		}
+	}
+	if byProvider["discord"].GetBotTag() != "Glyphoxa#4823" {
+		t.Errorf("discord bot tag = %q, want Glyphoxa#4823", byProvider["discord"].GetBotTag())
+	}
+}
+
+func TestGetProviderHealth_DegradedOnFailures(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := &fakeVoiceStore{
+		configs: map[storage.Component]storage.ProviderConfig{
+			storage.ComponentLLM: savedConfig(t, cipher, storage.ComponentLLM, "groq", "groq-key"),
+			storage.ComponentTTS: savedConfig(t, cipher, storage.ComponentTTS, "elevenlabs", "eleven-key"),
+		},
+		dep: &storage.DeploymentConfig{
+			DiscordBotTokenLast4: "tok9", DiscordBotTokenCiphertext: mustSeal(t, cipher, "bot-token"),
+		},
+	}
+	srv := NewVoiceServer(store, cipher, nil)
+	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{err: errors.New("401 unauthorized")} }
+	srv.pingLLM = func(context.Context, string) error { return errors.New("groq down") }
+	srv.botTag = func(context.Context, string) (string, error) { return "", errors.New("bad token") }
+
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	for _, p := range resp.Msg.GetProviders() {
+		if p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_DEGRADED {
+			t.Errorf("%s should be degraded: %+v", p.GetProvider(), p)
+		}
+	}
+}
+
+func mustSeal(t *testing.T, c *crypto.Cipher, s string) []byte {
+	t.Helper()
+	ct, err := c.Seal([]byte(s))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return ct
+}
+
+// unauthenticated requests (no tenant in ctx) are rejected.
+func TestVoiceRPCs_RequireTenant(t *testing.T) {
+	t.Parallel()
+	srv := NewVoiceServer(&fakeVoiceStore{}, voiceTestCipher(t), nil)
+	if _, err := srv.ListVoices(context.Background(), connect.NewRequest(&managementv1.ListVoicesRequest{})); connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("ListVoices without tenant code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}

--- a/pkg/voice/llm/groq/groq.go
+++ b/pkg/voice/llm/groq/groq.go
@@ -49,6 +49,18 @@ const (
 	DefaultMaxTokens = 1024
 )
 
+// Models is the curated allowlist of Groq production models the Configuration
+// model select offers. Groq exposes no programmatic list-models call we surface
+// to the operator (ADR-0039), so the choice is a static, reviewed allowlist
+// rather than live data. [DefaultModel] is first so it is the default selection.
+// Extend this slice (not the UI) to offer another model.
+var Models = []string{
+	DefaultModel, // llama-3.3-70b-versatile
+	"llama-3.1-8b-instant",
+	"llama3-70b-8192",
+	"llama3-8b-8192",
+}
+
 // Client is the Groq LLM adapter: the shared [openaicompat.Client] preconfigured
 // by [New]. Construct with [New]; the zero value is not usable. Safe for
 // concurrent use across goroutines.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -319,3 +319,130 @@ message SaveDiscordSettingsResponse {
   string guild_id = 2;
   string voice_channel_id = 3;
 }
+
+// VoiceService backs the LIVE provider data the Configuration and Campaign
+// screens render (#70; ADR-0039 single-operator / ADR-0004 BYOK credential
+// bridge). It exposes the ElevenLabs voice catalog and a short voice preview for
+// the voice selects, the Groq model allowlist for the model select, and an async
+// provider-health signal that upgrades the Configuration badges from
+// key-presence to a real tested status. Every live call uses the operator's
+// decrypted tenant key; the read RPCs are NO_SIDE_EFFECTS so the SPA probes them
+// as queries that render after the page (CSRF-exempt).
+service VoiceService {
+  // ListVoices returns the ElevenLabs voice catalog (live ListVoices via the
+  // decrypted tenant key; cassette/fixture-deterministic in tests, ADR-0021).
+  // It feeds the Campaign voice select. Read (NO_SIDE_EFFECTS).
+  rpc ListVoices(ListVoicesRequest) returns (ListVoicesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // PreviewVoice synthesizes a short TTS sample for a chosen voice + sample text
+  // and returns playable audio (wraps the existing Synthesize). It spends
+  // provider quota, so unlike the reads it is auth + CSRF guarded like a
+  // mutation.
+  rpc PreviewVoice(PreviewVoiceRequest) returns (PreviewVoiceResponse);
+  // ListModels returns the static model allowlist for a provider — Groq exposes
+  // no list-models API, so its model select is a curated allowlist (ADR-0039).
+  // Read (NO_SIDE_EFFECTS).
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // GetProviderHealth runs the async test-calls — ElevenLabs /v1/voices, a Groq
+  // ping, and a live Discord gateway login that resolves the bot tag — and
+  // returns per-provider status plus that tag. The screen renders key-presence
+  // instantly, then upgrades from this. Read (NO_SIDE_EFFECTS).
+  rpc GetProviderHealth(GetProviderHealthRequest) returns (GetProviderHealthResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+// Voice is the wire view of one selectable TTS voice (ADR-0022/0023). It carries
+// the vendor voice id the agent persists plus a display label for the select.
+message Voice {
+  // provider is the owning TTS provider id (e.g. "elevenlabs").
+  string provider = 1;
+  // voice_id is the vendor-side voice identifier persisted on the agent.
+  string voice_id = 2;
+  // name is the human-readable voice name (e.g. "Marcus").
+  string name = 3;
+  // language is a BCP-47 hint (e.g. "en"); optional.
+  string language = 4;
+  // label is the display string for the select (e.g. "ElevenLabs · Marcus").
+  string label = 5;
+}
+
+// ListVoicesRequest is the (empty) request; the tenant key is resolved
+// server-side.
+message ListVoicesRequest {}
+
+// ListVoicesResponse carries the live voice catalog.
+message ListVoicesResponse {
+  // voices is the provider's voice catalog for the select.
+  repeated Voice voices = 1;
+}
+
+// PreviewVoiceRequest asks for a short spoken sample of one voice.
+message PreviewVoiceRequest {
+  // voice_id is the vendor voice to synthesize with.
+  string voice_id = 1;
+  // text is the sample line to speak; the server supplies a default when empty.
+  string text = 2;
+}
+
+// PreviewVoiceResponse carries the synthesized sample as a self-contained audio
+// blob the browser can play directly.
+message PreviewVoiceResponse {
+  // audio is the encoded sample (a WAV container around the PCM sample).
+  bytes audio = 1;
+  // sample_rate is the audio sample rate in Hz.
+  int32 sample_rate = 2;
+  // channels is the channel count (1 = mono).
+  int32 channels = 3;
+  // mime_type is the IANA media type of audio (e.g. "audio/wav").
+  string mime_type = 4;
+}
+
+// ListModelsRequest names the provider whose model allowlist to return.
+message ListModelsRequest {
+  // provider is the LLM provider slot (e.g. "groq").
+  string provider = 1;
+}
+
+// ListModelsResponse carries the static model allowlist.
+message ListModelsResponse {
+  // models is the curated list of selectable model ids (first is the default).
+  repeated string models = 1;
+}
+
+// HealthStatus is the tested liveness of a provider credential.
+enum HealthStatus {
+  // HEALTH_STATUS_UNSPECIFIED is the not-yet-tested / unknown state.
+  HEALTH_STATUS_UNSPECIFIED = 0;
+  // HEALTH_STATUS_HEALTHY means the test-call succeeded.
+  HEALTH_STATUS_HEALTHY = 1;
+  // HEALTH_STATUS_DEGRADED means the test-call failed (bad key, unreachable, …).
+  HEALTH_STATUS_DEGRADED = 2;
+}
+
+// ProviderHealth is one provider's tested status, upgrading the screen's badge
+// from key-presence to a real signal.
+message ProviderHealth {
+  // provider is the slot tested ("groq", "elevenlabs", "discord").
+  string provider = 1;
+  // status is the tested liveness.
+  HealthStatus status = 2;
+  // detail is a short human-readable note (an error summary when degraded).
+  string detail = 3;
+  // bot_tag is the resolved Discord bot tag from the live gateway login
+  // (e.g. "Glyphoxa#4823"); set only on the "discord" entry.
+  string bot_tag = 4;
+}
+
+// GetProviderHealthRequest is the (empty) request; the tenant is resolved
+// server-side.
+message GetProviderHealthRequest {}
+
+// GetProviderHealthResponse carries the per-provider tested health.
+message GetProviderHealthResponse {
+  // providers is the tested status for each credential slot.
+  repeated ProviderHealth providers = 1;
+}

--- a/web/src/lib/audio.ts
+++ b/web/src/lib/audio.ts
@@ -1,0 +1,20 @@
+// Browser audio playback for the Preview-voice affordance (#70). The VoiceService
+// PreviewVoice RPC returns a self-contained WAV blob; this wraps it in an object
+// URL and plays it through a transient <audio> element, revoking the URL when
+// playback ends. It is defensively no-op outside a real browser (e.g. jsdom under
+// test, where URL.createObjectURL is unimplemented) so callers can fire-and-forget.
+export function playAudioBlob(audio: Uint8Array, mimeType: string): HTMLAudioElement | null {
+  try {
+    if (typeof Audio === "undefined" || typeof URL?.createObjectURL !== "function") {
+      return null;
+    }
+    const blob = new Blob([audio as BlobPart], { type: mimeType || "audio/wav" });
+    const url = URL.createObjectURL(blob);
+    const el = new Audio(url);
+    el.addEventListener("ended", () => URL.revokeObjectURL(url));
+    void el.play();
+    return el;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -5,12 +5,16 @@ import { create } from "@bufbuild/protobuf";
 
 import {
   CampaignService,
+  VoiceService,
   AgentSchema,
   CampaignSchema,
   GetCampaignRosterResponseSchema,
   CreateAgentResponseSchema,
   UpdateAgentResponseSchema,
   DeleteAgentResponseSchema,
+  ListVoicesResponseSchema,
+  VoiceSchema,
+  PreviewVoiceResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -51,7 +55,28 @@ function mockTransport() {
   ];
   let nextId = 2;
 
+  // LIVE voice catalog the select renders (#70). It includes the NPC's persisted
+  // "rachel" id so the trigger shows its live label, proving the dropdown is fed
+  // by VoiceService rather than a static list.
+  const liveVoices = [
+    create(VoiceSchema, { provider: "elevenlabs", voiceId: "rachel", name: "Rachel", label: "ElevenLabs · Rachel" }),
+    create(VoiceSchema, { provider: "elevenlabs", voiceId: "marcus", name: "Marcus", label: "ElevenLabs · Marcus" }),
+  ];
+  const previewCalls: string[] = [];
+
   const transport = createRouterTransport(({ service }) => {
+    service(VoiceService, {
+      listVoices: () => create(ListVoicesResponseSchema, { voices: liveVoices }),
+      previewVoice: (req) => {
+        previewCalls.push(req.voiceId);
+        return create(PreviewVoiceResponseSchema, {
+          audio: new Uint8Array([1, 2, 3, 4]),
+          sampleRate: 24000,
+          channels: 1,
+          mimeType: "audio/wav",
+        });
+      },
+    });
     service(CampaignService, {
       getCampaignRoster: () =>
         create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, ...npcs] }),
@@ -88,17 +113,17 @@ function mockTransport() {
       },
     });
   });
-  return { transport, npcs };
+  return { transport, npcs, previewCalls };
 }
 
 function renderScreen() {
-  const { transport, npcs } = mockTransport();
+  const { transport, npcs, previewCalls } = mockTransport();
   render(
     <Providers transport={transport} queryClient={makeQueryClient()}>
       <Campaign />
     </Providers>,
   );
-  return { npcs };
+  return { npcs, previewCalls };
 }
 
 describe("Campaign", () => {
@@ -152,5 +177,23 @@ describe("Campaign", () => {
     await waitFor(() => expect(screen.queryByText("New NPC")).not.toBeInTheDocument());
     expect(npcs).toHaveLength(1);
     expect(screen.getByText("Bart")).toBeInTheDocument();
+  });
+
+  it("renders the voice select from the live ListVoices catalog", async () => {
+    renderScreen();
+    // Select Bart (persisted voice id "rachel"); the trigger shows the LIVE label
+    // resolved from the catalog, not the raw id — proving the dropdown is fed by
+    // VoiceService.ListVoices.
+    fireEvent.click(await screen.findByText("Bart"));
+    expect(await screen.findByText("ElevenLabs · Rachel")).toBeInTheDocument();
+  });
+
+  it("previews the selected voice via the PreviewVoice RPC", async () => {
+    const { previewCalls } = renderScreen();
+    fireEvent.click(await screen.findByText("Bart"));
+    fireEvent.click(screen.getByRole("button", { name: /preview voice/i }));
+    // The preview RPC fired for the selected voice (audio playback is a no-op in
+    // jsdom; the RPC call is the observable behaviour).
+    await waitFor(() => expect(previewCalls).toEqual(["rachel"]));
   });
 });

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { Lock, Plus, Sparkles, Trash2 } from "lucide-react";
+import { Lock, Plus, Sparkles, Trash2, Volume2 } from "lucide-react";
 
-import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
-import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
+import { CampaignService, VoiceService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent, Voice } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
@@ -12,6 +12,7 @@ import { Select } from "@/components/ui/Select";
 import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
+import { playAudioBlob } from "@/lib/audio";
 
 import "./campaign.css";
 
@@ -22,10 +23,9 @@ import "./campaign.css";
 // to the DB and the roster re-reads it back after each mutation invalidates the
 // query.
 
-// The voice dropdown is a static allowlist placeholder this slice — the live
-// ElevenLabs ListVoices wiring lands with the provider RPCs. The selected id is
-// persisted to the agent's voice field regardless, so edits round-trip.
-const VOICE_OPTIONS = ["rachel", "adam", "antoni", "bella", "elli", "domi"];
+// The voice dropdown is LIVE ElevenLabs ListVoices data (#70, VoiceService);
+// each option's value is the vendor voice id persisted on the agent and its
+// label is "ElevenLabs · Name". Preview voice synthesizes a short sample.
 
 // speakerVar maps a server-assigned palette slot onto the 6-colour speaker
 // palette (tokens.css --speaker-1..6). The slot is 0-based; the palette is 1-based.
@@ -41,6 +41,12 @@ export function Campaign() {
   const queryClient = useQueryClient();
   const { data, status, error } = useQuery(CampaignService.method.getCampaignRoster, {});
   const roster = useMemo(() => data?.roster ?? [], [data]);
+
+  // Live ElevenLabs voice catalog (#70). The query is non-blocking: a missing
+  // key / failed catalog leaves voices empty and the editor still renders the
+  // agent's persisted voice id, so the screen never breaks on a degraded TTS.
+  const voicesQuery = useQuery(VoiceService.method.listVoices, {});
+  const voices = useMemo(() => voicesQuery.data?.voices ?? [], [voicesQuery.data]);
 
   // Selection: the chosen agent, defaulting to the first roster member (the
   // Butler) until the operator picks another. Falls back to the Butler when the
@@ -166,6 +172,7 @@ export function Campaign() {
           <AgentEditor
             key={selected.id}
             agent={selected}
+            voices={voices}
             onSaved={() => void invalidateRoster()}
             onDelete={
               isButler(selected) ? undefined : () => deleteAgent.mutate({ id: selected.id })
@@ -184,11 +191,13 @@ export function Campaign() {
 // disabled switch (ADR-0009 / ADR-0024).
 function AgentEditor({
   agent,
+  voices,
   onSaved,
   onDelete,
   deleting,
 }: {
   agent: Agent;
+  voices: Voice[];
   onSaved: () => void;
   onDelete?: () => void;
   deleting: boolean;
@@ -201,12 +210,22 @@ function AgentEditor({
   const [addressOnly, setAddressOnly] = useState(agent.addressOnly);
 
   const update = useMutation(CampaignService.method.updateAgent, { onSuccess: onSaved });
+  const preview = useMutation(VoiceService.method.previewVoice);
 
+  // Options come from the live catalog: value = vendor voice id, label =
+  // "ElevenLabs · Name". The agent's persisted voice id is kept as a bare option
+  // even when the catalog is empty/stale, so the current selection always shows.
   const voiceOpts = useMemo(() => {
-    const set = new Set(VOICE_OPTIONS);
-    if (voice) set.add(voice);
-    return [...set];
-  }, [voice]);
+    const opts = voices.map((v) => ({ value: v.voiceId, label: v.label || v.name || v.voiceId }));
+    if (voice && !opts.some((o) => o.value === voice)) opts.unshift({ value: voice, label: voice });
+    return opts;
+  }, [voices, voice]);
+
+  const playPreview = async () => {
+    if (!voice) return;
+    const res = await preview.mutateAsync({ voiceId: voice, text: "" });
+    playAudioBlob(res.audio, res.mimeType);
+  };
 
   const save = () =>
     update.mutate({
@@ -259,7 +278,18 @@ function AgentEditor({
         </span>
       </div>
 
-      <Select label="Voice" options={voiceOpts} value={voice || undefined} onValueChange={setVoice} placeholder="Pick a voice…" />
+      <div className="gx-editor__voice">
+        <Select label="Voice" options={voiceOpts} value={voice || undefined} onValueChange={setVoice} placeholder="Pick a voice…" />
+        <Button
+          variant="secondary"
+          size="sm"
+          iconStart={<Volume2 size={14} />}
+          onClick={() => void playPreview()}
+          disabled={!voice || preview.isPending}
+        >
+          Preview voice
+        </Button>
+      </div>
 
       <div className="gx-editor__switch">
         <Switch

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -187,3 +187,14 @@
   gap: var(--spacing-sm);
   margin-top: var(--spacing-xs);
 }
+
+/* Voice select + Preview-voice button row (#70). */
+.gx-editor__voice {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.gx-editor__voice .gx-select-field {
+  flex: 1;
+}

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -6,12 +6,18 @@ import { create } from "@bufbuild/protobuf";
 import {
   CampaignService,
   ProviderService,
+  VoiceService,
+  HealthStatus,
   GetActiveCampaignResponseSchema,
   CampaignSchema,
   ListProviderConfigsResponseSchema,
   ProviderCredentialSchema,
   SaveProviderConfigResponseSchema,
   SaveDiscordSettingsResponseSchema,
+  GetProviderHealthResponseSchema,
+  ProviderHealthSchema,
+  ListModelsResponseSchema,
+  type ProviderHealth,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -36,18 +42,31 @@ function cred(component: string, provider: string, last4?: string) {
   });
 }
 
+// health builds a ProviderHealth entry the GetProviderHealth RPC returns.
+function health(provider: string, status: HealthStatus, botTag = ""): ProviderHealth {
+  return create(ProviderHealthSchema, { provider, status, botTag });
+}
+
+const GROQ_MODELS = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"];
+
 // stateful mock backend: List reflects what Save mutates, so an invalidation
 // refetch shows the saved credential — proving the write-only round-trip from
-// the screen's side (the RPC never returns a secret value).
-function mockBackend() {
+// the screen's side (the RPC never returns a secret value). `opts` seeds already-
+// saved slots and the async health the GetProviderHealth RPC reports (#70).
+function mockBackend(opts: { saved?: Partial<Record<"groq" | "elevenlabs" | "discord", string>>; health?: ProviderHealth[] } = {}) {
   const state = {
-    groq: undefined as string | undefined,
-    elevenlabs: undefined as string | undefined,
-    discord: undefined as string | undefined,
+    groq: opts.saved?.groq,
+    elevenlabs: opts.saved?.elevenlabs,
+    discord: opts.saved?.discord,
     guildId: "",
     voiceChannelId: "",
   };
   return createRouterTransport(({ service }) => {
+    service(VoiceService, {
+      getProviderHealth: () =>
+        create(GetProviderHealthResponseSchema, { providers: opts.health ?? [] }),
+      listModels: () => create(ListModelsResponseSchema, { models: GROQ_MODELS }),
+    });
     service(CampaignService, {
       getActiveCampaign: () =>
         create(GetActiveCampaignResponseSchema, { campaign: create(CampaignSchema, CAMPAIGN) }),
@@ -139,5 +158,36 @@ describe("Configuration", () => {
     // Values survive the invalidation refetch (round-tripped through the RPC).
     expect(await screen.findByDisplayValue("472093001100")).toBeInTheDocument();
     expect(screen.getByDisplayValue("472093774421")).toBeInTheDocument();
+  });
+
+  it("renders the Groq model allowlist select (ListModels)", async () => {
+    renderScreen();
+    // The Groq row's model select defaults to the first allowlisted model.
+    const groqModelSelect = await screen.findByLabelText("Groq model");
+    expect(within(groqModelSelect).getByText("llama-3.3-70b-versatile")).toBeInTheDocument();
+  });
+
+  it("upgrades a saved provider's badge to Degraded from the health RPC", async () => {
+    renderScreen(
+      mockBackend({
+        saved: { elevenlabs: "abcd" },
+        health: [health("elevenlabs", HealthStatus.DEGRADED)],
+      }),
+    );
+    // ElevenLabs is saved → renders presence-Healthy instantly, then the async
+    // health RPC downgrades it to Degraded.
+    const degraded = await screen.findByText(/degraded/i);
+    const row = degraded.closest(".gx-provider-row") as HTMLElement;
+    expect(within(row).getByText("ElevenLabs")).toBeInTheDocument();
+  });
+
+  it("shows the resolved Discord bot tag from the live login", async () => {
+    renderScreen(
+      mockBackend({
+        saved: { discord: "tok9" },
+        health: [health("discord", HealthStatus.HEALTHY, "Glyphoxa#4823")],
+      }),
+    );
+    expect(await screen.findByText(/Connected as Glyphoxa#4823/)).toBeInTheDocument();
   });
 });

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -6,12 +6,16 @@ import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-reac
 import {
   CampaignService,
   ProviderService,
+  VoiceService,
+  HealthStatus,
   type ProviderCredential,
+  type ProviderHealth,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
 import { Button } from "@/components/ui/Button";
 
 import "./configuration.css";
@@ -19,9 +23,10 @@ import "./configuration.css";
 // The Configuration screen (the design's "Providers" screen). The campaign
 // header reads LIVE GetActiveCampaign; the credential rows drive the write-only
 // BYOK flow (#68, ADR-0004/0039): each secret is sealed server-side and never
-// read back — the screen shows a masked value + Replace and a Healthy /
-// Key-needed badge derived purely from key-presence (the async test-call upgrade
-// is a later stage).
+// read back — the screen shows a masked value + Replace. The status badge starts
+// from key-presence and upgrades async (#70) from VoiceService.GetProviderHealth:
+// a real test-call (ElevenLabs /v1/voices, a Groq ping, a live Discord login that
+// resolves the bot tag) flips it Healthy → Degraded without blocking page load.
 
 // The three secret slots the screen holds, keyed by their wire `provider`. Each
 // renders a SecretRow; Groq/ElevenLabs save via SaveProviderConfig, the Discord
@@ -33,6 +38,10 @@ const BYOK_SLOTS = [
 
 function credentialFor(creds: ProviderCredential[], provider: string): ProviderCredential | undefined {
   return creds.find((c) => c.provider === provider);
+}
+
+function healthFor(health: ProviderHealth[], provider: string): ProviderHealth | undefined {
+  return health.find((h) => h.provider === provider);
 }
 
 export function Configuration() {
@@ -47,6 +56,15 @@ export function Configuration() {
 
   const config = useQuery(ProviderService.method.listProviderConfigs, {});
   const creds = config.data?.credentials ?? [];
+
+  // Async health upgrade (#70): runs the live test-calls off the page-load path.
+  // Until it resolves the badge stays on key-presence; then it flips per provider.
+  const healthQuery = useQuery(VoiceService.method.getProviderHealth, {});
+  const health = healthQuery.data?.providers ?? [];
+
+  // Groq model allowlist (static; Groq has no list-models API, ADR-0039).
+  const groqModels = useQuery(VoiceService.method.listModels, { provider: "groq" });
+  const models = groqModels.data?.models ?? [];
 
   const saveProvider = useMutation(ProviderService.method.saveProviderConfig, { onSuccess: invalidateList });
   const saveDiscord = useMutation(ProviderService.method.saveDiscordSettings, { onSuccess: invalidateList });
@@ -123,7 +141,11 @@ export function Configuration() {
             name={slot.label}
             placeholder={slot.placeholder}
             credential={credentialFor(creds, slot.provider)}
-            onSave={(secret) => saveProvider.mutateAsync({ provider: slot.provider, secret })}
+            health={healthFor(health, slot.provider)}
+            // Groq's model select is the static allowlist (#70); the chosen model
+            // rides along when the key is saved (SaveProviderConfig carries it).
+            models={slot.provider === "groq" ? models : undefined}
+            onSave={(secret, model) => saveProvider.mutateAsync({ provider: slot.provider, secret, model })}
           />
         ))}
       </div>
@@ -138,6 +160,7 @@ export function Configuration() {
             name="Bot token"
             placeholder="Paste the Discord bot token"
             credential={credentialFor(creds, "discord")}
+            health={healthFor(health, "discord")}
             onSave={(secret) =>
               saveDiscord.mutateAsync({ botToken: secret, guildId, voiceChannelId })
             }
@@ -182,17 +205,45 @@ export function Configuration() {
   );
 }
 
+// HealthBadge renders the status dot. An unsaved slot is "Key needed" (presence).
+// A saved slot shows "Healthy" instantly (presence) and downgrades to "Degraded"
+// only once GetProviderHealth reports a failed test-call (#70) — the page never
+// waits on the live call.
+function HealthBadge({ saved, health }: { saved: boolean; health?: ProviderHealth }) {
+  if (!saved) {
+    return (
+      <Badge variant="warning" dot size="sm">
+        Key needed
+      </Badge>
+    );
+  }
+  if (health?.status === HealthStatus.DEGRADED) {
+    return (
+      <Badge variant="danger" dot size="sm" title={health.detail || undefined}>
+        Degraded
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="success" dot size="sm">
+      Healthy
+    </Badge>
+  );
+}
+
 // SecretRow renders one write-only credential: an editable key field with Save
-// when unsaved (or being replaced), a masked value + Replace once saved, and a
-// Healthy / Key-needed badge from key-presence. onSave seals the secret
-// server-side and resolves once stored; the row then clears and re-reads as
-// masked from the invalidated list.
+// when unsaved (or being replaced), a masked value + Replace once saved, and the
+// status badge. When `models` is supplied (Groq) it also renders the static
+// model allowlist select; the chosen model is passed to onSave. A resolved
+// Discord bot tag (from the live login) is shown under the row.
 function SecretRow({
   icon,
   kind,
   name,
   placeholder,
   credential,
+  health,
+  models,
   onSave,
 }: {
   icon: ReactNode;
@@ -200,20 +251,26 @@ function SecretRow({
   name: string;
   placeholder: string;
   credential?: ProviderCredential;
-  onSave: (secret: string) => Promise<unknown>;
+  health?: ProviderHealth;
+  models?: string[];
+  onSave: (secret: string, model?: string) => Promise<unknown>;
 }) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState("");
   const [busy, setBusy] = useState(false);
+  const [model, setModel] = useState<string | undefined>(undefined);
 
   const saved = Boolean(credential?.showMasked);
   const masked = saved && !editing;
+  // The select shows the saved model, the operator's pick, or the allowlist
+  // default (first), in that order.
+  const selectedModel = model ?? (credential?.model || undefined) ?? models?.[0];
 
   async function handleSave() {
     if (!value || busy) return;
     setBusy(true);
     try {
-      await onSave(value);
+      await onSave(value, selectedModel);
       setValue("");
       setEditing(false);
     } finally {
@@ -228,7 +285,20 @@ function SecretRow({
         <div className="gx-provider-row__meta">
           <div className="gx-overline">{kind}</div>
           <div className="gx-provider-row__name">{name}</div>
+          {health?.botTag && (
+            <div className="gx-provider-row__tag">Connected as {health.botTag}</div>
+          )}
         </div>
+
+        {models && models.length > 0 && (
+          <Select
+            aria-label={`${name} model`}
+            options={models}
+            value={selectedModel}
+            onValueChange={setModel}
+            placeholder="Model…"
+          />
+        )}
 
         <div className="gx-secret">
           {masked ? (
@@ -276,15 +346,7 @@ function SecretRow({
           )}
         </div>
 
-        {saved ? (
-          <Badge variant="success" dot size="sm">
-            Healthy
-          </Badge>
-        ) : (
-          <Badge variant="warning" dot size="sm">
-            Key needed
-          </Badge>
-        )}
+        <HealthBadge saved={saved} health={health} />
       </div>
     </Card>
   );

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -49,3 +49,15 @@
   display: flex;
   justify-content: flex-end;
 }
+
+/* Resolved Discord bot tag from the live gateway login (#70), under the name. */
+.gx-provider-row__tag {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-subtle);
+  margin-top: 2px;
+}
+
+/* Groq model allowlist select sits between the row meta and the secret control. */
+.gx-provider-row .gx-select-field {
+  min-width: 12rem;
+}

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement HTMLMediaElement.play(); the Preview-voice helper
+// (src/lib/audio.ts) fires it fire-and-forget. Stub it so the noise stays out of
+// the test output — the observable behaviour under test is the PreviewVoice RPC
+// call, not real playback.
+if (typeof HTMLMediaElement !== "undefined") {
+  HTMLMediaElement.prototype.play = () => Promise.resolve();
+  HTMLMediaElement.prototype.pause = () => {};
+}


### PR DESCRIPTION
Closes #70.

Stage 6: replace the mock's hardcoded dropdowns with **live provider data**, all routed through the decrypted tenant BYOK key (ADR-0004 credential bridge / ADR-0039 hybrid policy).

## What landed
New `VoiceService` (appended at the END of `management.proto`, self-contained for a clean `make proto` rebase vs sibling #72):

- **`ListVoices`** — maps the existing ElevenLabs `ListVoices` adapter output onto the wire type; feeds the Campaign voice select (value = vendor voice id, label = `ElevenLabs · Name`).
- **`PreviewVoice`** — wraps the existing `Synthesize`, returns the sample wrapped in a WAV container the browser plays directly.
- **`ListModels`** — static Groq allowlist (`groq.Models`); Groq has no list-models API (ADR-0039).
- **`GetProviderHealth`** — async test-calls: ElevenLabs `/v1/voices`, a Groq `/models` ping, and a **live Discord gateway login** (`internal/discordtag`) that resolves the bot tag (`User.Tag()` → e.g. `Glyphoxa#4823`). Returns per-provider tested status + the tag.

### Web
- Campaign editor: voice select is live `ListVoices`; a **Preview voice** button synthesizes + plays a sample (`src/lib/audio.ts`, no-op under jsdom).
- Configuration: Groq **model select** from `ListModels` (chosen model rides along on save); status badge **upgrades async** key-presence → Healthy/Degraded from `GetProviderHealth`; the resolved Discord **bot tag** renders under the Bot token row. Badges render instantly, never blocking page load (ADR-0039).

## Determinism (ADR-0021)
The live ElevenLabs / Groq / Discord paths are **function-field seams** defaulted in `NewVoiceServer` and faked in unit tests, so default `go test ./...` makes **no** live network call. `discordtag.Resolve`'s only offline path (empty-token guard) is unit-tested; the real gateway login runs only on an operator run / live build.

## Acceptance criteria
- [x] `ListVoices` RPC maps adapter output (deterministic seam, ADR-0021); voice selects render live data.
- [x] Preview-voice returns playable audio (WAV) for a chosen voice + sample text.
- [x] Groq model allowlist served; health badge upgrades async presence → tested; real bot tag resolves from a live Discord login.

## Local gate status
- `buf lint` clean; `make proto` / `make proto-check` regenerate + compile (`gen/` is gitignored, produced in CI).
- `go build ./...`, `go vet ./...` (default + `-tags=record` + `-tags=integration`), `golangci-lint run ./...` — all clean.
- `go test -race ./...` green (backend seams faked, no live calls).
- `cd web && npm ci && npm run build && npm test` — 19 tests green, `tsc --noEmit` clean.

Built on the MERGED #69 (credential bridge) + #71 (campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)