### PR TITLE
feat(#72): Start/Stop a session from the UI (SessionManager + voice_sessions)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -15,12 +15,12 @@ import (
 	"syscall"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
@@ -179,11 +179,12 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 // metrics + k8s probes (/metrics, /healthz, /readyz) on the separate internal
 // metricsAddr — so the actuator endpoints stay off the public API surface.
 //
-// When withVoice is set (-mode=all) AND the Discord credentials are present
-// (DISCORD_BOT_TOKEN + -guild + -channel), the existing env-cred voice loop runs
-// concurrently under the same context, so SIGTERM stops both. Missing creds
-// degrade to web-only with a warning rather than failing (matches the #44
-// resilience posture); the single Prometheus recorder feeds both halves.
+// When withVoice is set (-mode=all) the process drives the voice loop in-process
+// via the SessionManager (ADR-0039): the Session screen starts/stops it, the
+// loop is not run at boot, and SIGTERM stops both the web tier and any active
+// session. A web-only run (withVoice false) still serves SessionService but
+// rejects Start — it does not drive the loop. The single Prometheus recorder
+// feeds both halves.
 func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRecorder, webAddr, metricsAddr string, withVoice bool) error {
 	dsn := databaseURL()
 	if dsn == "" {
@@ -221,6 +222,22 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
 	}
 
+	// Base voice config for manager-driven sessions (ADR-0039): the Session screen
+	// starts/stops the live loop in-process via the SessionManager. The Discord
+	// token comes from the environment (the deployment-shared Bot); the guild and
+	// voice channel are sourced per-session from the saved deployment config, not
+	// these flags (#72). The credential-bridge keys (#69) are resolved inside
+	// RunFromDB. enabled = withVoice: only `all` mode drives the loop — a web-only
+	// replica answers GetSession (idle) but rejects Start.
+	cfg.Token = os.Getenv("DISCORD_BOT_TOKEN")
+	cfg.Logger = log
+	cfg.Metrics = metrics
+	cfg.StageMetrics = metrics
+	runner := func(rctx context.Context, c wirenpc.Config) error {
+		return wirenpc.RunFromDB(rctx, c, pool, cipher)
+	}
+	mgr := session.NewManager(store, runner, cfg, log, withVoice)
+
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /
 	// (ADR-0013/0039). The SPA handler is the "/" catch-all; ServeMux's
@@ -228,55 +245,18 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// paths (and client-side deep links) reach the SPA fallback.
 	srv := web.NewServer(web.Config{
 		Addr:   webAddr,
-		Mounts: managementMounts(store, cipher, log),
+		Mounts: managementMounts(store, cipher, log, mgr),
 		Root:   spa.Handler(),
 		Logger: log,
 	})
 
-	// Without the voice half, runWebTier blocks on the web server alone.
-	if !withVoice {
-		return runWebTier(ctx, srv)
-	}
-
-	// all-mode: the voice loop only joins when the Discord credentials are
-	// present. Resolving the token here (not in wirenpc) keeps the no-creds
-	// fallback a local decision: web-only is a healthy all-mode run, not an error.
-	cfg.Token = os.Getenv("DISCORD_BOT_TOKEN")
-	if !voiceEnabled(cfg.Token, cfg.Guild, cfg.Channel) {
-		log.Warn("voice disabled: set DISCORD_BOT_TOKEN, -guild, -channel to enable")
-		return runWebTier(ctx, srv)
-	}
-
-	cfg.Logger = log
-	cfg.Metrics = metrics
-	cfg.StageMetrics = metrics
-
-	// errgroup ties the two halves to one context so SIGTERM (via ctx) stops both.
-	// The web tier is the only fatal half: if it fails, gctx cancels and the voice
-	// loop unwinds. The voice half is best-effort (below) and always returns nil,
-	// so the process exits non-zero only on a web-tier error.
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error { return runWebTier(gctx, srv) })
-	g.Go(func() error {
-		// Voice is best-effort in all-mode: a voice startup/runtime failure must
-		// NOT tear down the web tier (the #44 resilience posture — the pod keeps
-		// serving /readyz). Log and degrade to web-only by returning nil; the
-		// gctx.Err() guard suppresses the benign cancellation log when SIGTERM is
-		// already stopping both halves.
-		if err := wirenpc.RunFromDB(gctx, cfg, pool, cipher); err != nil && gctx.Err() == nil {
-			log.Error("voice loop exited; continuing web-only", "err", err)
-		}
-		return nil
-	})
-	return g.Wait()
-}
-
-// voiceEnabled reports whether the all-mode voice loop should join: it needs the
-// Discord bot token plus a target guild and channel. Missing any of the three is
-// a healthy web-only all-mode run (ADR-0039), not an error — factored out so the
-// gating decision is unit-tested without Discord credentials.
-func voiceEnabled(token, guild, channel string) bool {
-	return token != "" && guild != "" && channel != ""
+	// Sessions are manager-driven (ADR-0039): the loop starts when the Session
+	// screen asks, not at boot. Run the web tier until SIGTERM, then stop any
+	// active session BEFORE the deferred pool.Close, so a row never stays stuck
+	// 'running' and the loop's ended_at write never races a closing pool.
+	err = runWebTier(ctx, srv)
+	mgr.Shutdown()
+	return err
 }
 
 // managementMounts wires the auth tier and the management Connect services into
@@ -290,7 +270,8 @@ func voiceEnabled(token, guild, channel string) bool {
 // _SECRET / _REDIRECT_URL) — a one-time setup, not code; absent them the gate
 // still stands and the API simply has no way in. cipher seals BYOK provider
 // keys (ADR-0004); it may be nil (saving keys then fails CodeFailedPrecondition).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger) []web.Mount {
+// mgr drives the in-process voice loop for SessionService (#72, ADR-0039).
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager) []web.Mount {
 	clientID := os.Getenv("DISCORD_OAUTH_CLIENT_ID")
 	if clientID == "" {
 		log.Warn("Discord OAuth is not configured; login is disabled until " +
@@ -312,11 +293,13 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
 	providerPath, providerHandler := rpc.NewProviderServer(store, cipher, log).Handler(stack.HandlerOptions()...)
+	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)
 
 	return []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),
 		web.APIMount(authPath, authHandler),
 		web.APIMount(providerPath, providerHandler),
+		web.APIMount(sessionPath, sessionHandler),
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -1,0 +1,191 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// SessionManager is the in-process voice-loop control surface SessionServer
+// drives (ADR-0039). *session.Manager satisfies it; tests use a fake so the
+// handler is exercised without Discord.
+type SessionManager interface {
+	Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error)
+	Stop(ctx context.Context) (storage.VoiceSession, error)
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// SessionStore is the narrow storage surface SessionServer needs: the active
+// campaign to scope a session, and the latest ended session for the idle
+// last-session summary (#72).
+type SessionStore interface {
+	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
+	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
+}
+
+// SessionServer implements the Connect SessionService over a SessionManager +
+// SessionStore: Start/Stop drive the in-process loop, GetSession reports the live
+// or last session.
+type SessionServer struct {
+	mgr   SessionManager
+	store SessionStore
+	log   *slog.Logger
+}
+
+var _ managementv1connect.SessionServiceHandler = (*SessionServer)(nil)
+
+// NewSessionServer wraps the manager + store in a SessionServer.
+func NewSessionServer(mgr SessionManager, store SessionStore, log *slog.Logger) *SessionServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &SessionServer{mgr: mgr, store: store, log: log}
+}
+
+// Handler builds the Connect HTTP handler for SessionService and returns its
+// mount path + handler, mirroring the other servers.
+func (s *SessionServer) Handler(opts ...connect.HandlerOption) (string, http.Handler) {
+	return managementv1connect.NewSessionServiceHandler(s, opts...)
+}
+
+// tenant resolves the operator's tenant from the auth interceptor's context.
+func (s *SessionServer) tenant(ctx context.Context) (uuid.UUID, error) {
+	id, ok := auth.TenantID(ctx)
+	if !ok {
+		return uuid.Nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no tenant in context"))
+	}
+	return id, nil
+}
+
+// GetSession returns the running session when one is live, otherwise the most
+// recent ended session for the active campaign (the screen's last-session
+// summary), and whether voice is active. A read (NO_SIDE_EFFECTS).
+func (s *SessionServer) GetSession(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetSessionRequest],
+) (*connect.Response[managementv1.GetSessionResponse], error) {
+	if vs, active := s.mgr.Snapshot(); active {
+		return connect.NewResponse(&managementv1.GetSessionResponse{
+			Session: toProtoVoiceSession(vs),
+			Active:  true,
+		}), nil
+	}
+
+	// Idle: surface the last session for the active campaign, if any. A missing
+	// campaign or no prior session is the never-run state, not an error.
+	campaign, err := s.store.GetActiveCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return connect.NewResponse(&managementv1.GetSessionResponse{Active: false}), nil
+	}
+	if err != nil {
+		s.log.Error("GetSession: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	latest, err := s.store.GetLatestVoiceSession(ctx, campaign.ID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return connect.NewResponse(&managementv1.GetSessionResponse{Active: false}), nil
+	}
+	if err != nil {
+		s.log.Error("GetSession: get latest voice session failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.GetSessionResponse{
+		Session: toProtoVoiceSession(latest),
+		Active:  false,
+	}), nil
+}
+
+// StartSession launches the voice loop for the active campaign and returns the
+// created running session.
+func (s *SessionServer) StartSession(
+	ctx context.Context,
+	_ *connect.Request[managementv1.StartSessionRequest],
+) (*connect.Response[managementv1.StartSessionResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	campaign, err := s.store.GetActiveCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active campaign to start a session for"))
+	}
+	if err != nil {
+		s.log.Error("StartSession: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	vs, err := s.mgr.Start(ctx, tenantID, campaign.ID)
+	if err != nil {
+		return nil, s.startError(err)
+	}
+	return connect.NewResponse(&managementv1.StartSessionResponse{
+		Session: toProtoVoiceSession(vs),
+	}), nil
+}
+
+// startError maps a manager Start failure onto a Connect status code: the
+// single-active guard is AlreadyExists, the configuration/mode preconditions are
+// FailedPrecondition, anything else is a logged Internal.
+func (s *SessionServer) startError(err error) error {
+	switch {
+	case errors.Is(err, session.ErrSessionActive):
+		return connect.NewError(connect.CodeAlreadyExists, errors.New("a voice session is already active"))
+	case errors.Is(err, session.ErrDiscordNotConfigured):
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("the Discord guild/voice channel are not configured"))
+	case errors.Is(err, session.ErrVoiceUnavailable):
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("voice is not available in this mode"))
+	default:
+		s.log.Error("StartSession: manager start failed", "err", err)
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// StopSession cancels the active voice loop and returns the ended session.
+func (s *SessionServer) StopSession(
+	ctx context.Context,
+	_ *connect.Request[managementv1.StopSessionRequest],
+) (*connect.Response[managementv1.StopSessionResponse], error) {
+	vs, err := s.mgr.Stop(ctx)
+	if errors.Is(err, session.ErrNoActiveSession) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
+	}
+	if err != nil {
+		s.log.Error("StopSession: manager stop failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.StopSessionResponse{
+		Session: toProtoVoiceSession(vs),
+	}), nil
+}
+
+// toProtoVoiceSession maps a storage.VoiceSession onto its wire view. A zero
+// value (no session) maps to nil so the screen renders the never-run state;
+// ended_at is set only once the session has ended.
+func toProtoVoiceSession(v storage.VoiceSession) *managementv1.VoiceSession {
+	if v.ID == uuid.Nil {
+		return nil
+	}
+	pb := &managementv1.VoiceSession{
+		Id:         v.ID.String(),
+		CampaignId: v.CampaignID.String(),
+		Status:     string(v.Status),
+		StartedAt:  timestamppb.New(v.StartedAt),
+		LineCount:  uint32(v.LineCount), //nolint:gosec // line_count is a small non-negative count
+	}
+	if v.EndedAt != nil {
+		pb.EndedAt = timestamppb.New(*v.EndedAt)
+	}
+	return pb
+}

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -1,0 +1,242 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeSessionManager mimics the SessionManager's single-active lifecycle so the
+// handler's error mapping + snapshot wiring can be unit-tested without Discord.
+type fakeSessionManager struct {
+	mu         sync.Mutex
+	active     bool
+	current    storage.VoiceSession
+	startErr   error
+	stopErr    error
+	startCalls int
+}
+
+func (f *fakeSessionManager) Start(_ context.Context, _, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCalls++
+	if f.startErr != nil {
+		return storage.VoiceSession{}, f.startErr
+	}
+	if f.active {
+		return storage.VoiceSession{}, session.ErrSessionActive
+	}
+	f.current = storage.VoiceSession{
+		ID:         uuid.New(),
+		CampaignID: campaignID,
+		Status:     storage.VoiceSessionRunning,
+		StartedAt:  time.Date(2026, 6, 27, 18, 0, 0, 0, time.UTC),
+	}
+	f.active = true
+	return f.current, nil
+}
+
+func (f *fakeSessionManager) Stop(_ context.Context) (storage.VoiceSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.stopErr != nil {
+		return storage.VoiceSession{}, f.stopErr
+	}
+	if !f.active {
+		return storage.VoiceSession{}, session.ErrNoActiveSession
+	}
+	end := time.Date(2026, 6, 27, 19, 0, 0, 0, time.UTC)
+	f.current.EndedAt = &end
+	f.current.Status = storage.VoiceSessionEnded
+	f.active = false
+	return f.current, nil
+}
+
+func (f *fakeSessionManager) Snapshot() (storage.VoiceSession, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.current, f.active
+}
+
+// fakeSessionStore serves the active campaign and the latest ended session.
+type fakeSessionStore struct {
+	campaign    storage.Campaign
+	campaignErr error
+	latest      storage.VoiceSession
+	latestErr   error
+}
+
+func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	if f.campaignErr != nil {
+		return storage.Campaign{}, f.campaignErr
+	}
+	return f.campaign, nil
+}
+
+func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (storage.VoiceSession, error) {
+	if f.latestErr != nil {
+		return storage.VoiceSession{}, f.latestErr
+	}
+	return f.latest, nil
+}
+
+func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
+	t.Helper()
+	tenantID := uuid.New()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(auth.WithTenant(ctx, tenantID), req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(mgr, store, nil).Handler(connect.WithInterceptors(inject)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
+func activeStore() *fakeSessionStore {
+	return &fakeSessionStore{
+		campaign:  storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Sunless Citadel"},
+		latestErr: storage.ErrNotFound,
+	}
+}
+
+// TestSessionStartStopReflectsSnapshot is AC4's server half: GetSession reports
+// idle, StartSession flips it to active/running, GetSession reflects Live, and
+// StopSession returns the ended session with an ended_at.
+func TestSessionStartStopReflectsSnapshot(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{}
+	client := newSessionClient(t, mgr, activeStore())
+	ctx := context.Background()
+
+	// Idle: no session has ever run.
+	get, err := client.GetSession(ctx, connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession idle: %v", err)
+	}
+	if get.Msg.GetActive() || get.Msg.GetSession() != nil {
+		t.Errorf("idle GetSession = active %v session %v, want inactive/nil", get.Msg.GetActive(), get.Msg.GetSession())
+	}
+
+	// Start → running + active.
+	start, err := client.StartSession(ctx, connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if start.Msg.GetSession().GetStatus() != "running" {
+		t.Errorf("started status = %q, want running", start.Msg.GetSession().GetStatus())
+	}
+
+	// GetSession now reflects Live.
+	live, err := client.GetSession(ctx, connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession live: %v", err)
+	}
+	if !live.Msg.GetActive() || live.Msg.GetSession().GetId() != start.Msg.GetSession().GetId() {
+		t.Errorf("live GetSession = %+v, want active session %s", live.Msg, start.Msg.GetSession().GetId())
+	}
+
+	// Stop → ended with ended_at.
+	stop, err := client.StopSession(ctx, connect.NewRequest(&managementv1.StopSessionRequest{}))
+	if err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+	if stop.Msg.GetSession().GetStatus() != "ended" || stop.Msg.GetSession().GetEndedAt() == nil {
+		t.Errorf("stopped session = %+v, want ended with ended_at", stop.Msg.GetSession())
+	}
+}
+
+// TestSessionStartAlreadyActive maps the single-active guard to CodeAlreadyExists.
+func TestSessionStartAlreadyActive(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{startErr: session.ErrSessionActive}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeAlreadyExists {
+		t.Errorf("already-active code = %v, want AlreadyExists", connect.CodeOf(err))
+	}
+}
+
+// TestSessionStartDiscordUnconfigured maps the precondition to FailedPrecondition.
+func TestSessionStartDiscordUnconfigured(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{startErr: session.ErrDiscordNotConfigured}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("unconfigured code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestSessionStartNoCampaign fails with FailedPrecondition when there is no
+// active campaign to run a session for.
+func TestSessionStartNoCampaign(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{}
+	store := &fakeSessionStore{campaignErr: storage.ErrNotFound}
+	client := newSessionClient(t, mgr, store)
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("no-campaign code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+	if mgr.startCalls != 0 {
+		t.Errorf("manager.Start called %d times, want 0 when no campaign", mgr.startCalls)
+	}
+}
+
+// TestSessionStopNoActive maps ErrNoActiveSession to FailedPrecondition.
+func TestSessionStopNoActive(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{stopErr: session.ErrNoActiveSession}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StopSession(context.Background(), connect.NewRequest(&managementv1.StopSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("stop-no-active code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestSessionGetIdleReturnsLastSession returns the most recent ended session when
+// idle (the screen's last-session summary), with active=false.
+func TestSessionGetIdleReturnsLastSession(t *testing.T) {
+	t.Parallel()
+	end := time.Date(2026, 6, 27, 17, 0, 0, 0, time.UTC)
+	store := &fakeSessionStore{
+		campaign: storage.Campaign{ID: uuid.New(), Name: "Sunless Citadel"},
+		latest: storage.VoiceSession{
+			ID: uuid.New(), Status: storage.VoiceSessionEnded, EndedAt: &end, LineCount: 12,
+		},
+	}
+	client := newSessionClient(t, &fakeSessionManager{}, store)
+
+	resp, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if resp.Msg.GetActive() {
+		t.Error("active = true, want false when idle")
+	}
+	got := resp.Msg.GetSession()
+	if got == nil || got.GetStatus() != "ended" || got.GetLineCount() != 12 {
+		t.Errorf("idle session = %+v, want ended with 12 lines", got)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1,0 +1,216 @@
+// Package session holds the in-process SessionManager that drives the live voice
+// loop from the web tier (ADR-0039): the Session screen's Start/Stop call into a
+// Manager that launches the wirenpc loop, holds its cancel func, and records the
+// run in the voice_sessions table. A single-active-session guard prevents
+// overlap. There is no loopback RPC or multi-replica backplane — `all` mode runs
+// the loop in the same process (ADR-0005/0039); the deferred voice.v1 control
+// service is explicitly NOT built here.
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// endTimeout bounds the ended_at write after the loop exits, so a Stop / shutdown
+// can't hang on a slow DB while the run context is already cancelled.
+const endTimeout = 5 * time.Second
+
+// Sentinel errors the RPC layer maps onto Connect status codes.
+var (
+	// ErrSessionActive is returned by Start when a session is already running —
+	// the single-active-session guard (AC2). Mapped to CodeAlreadyExists.
+	ErrSessionActive = errors.New("session: a voice session is already active")
+	// ErrNoActiveSession is returned by Stop when nothing is running. Mapped to
+	// CodeFailedPrecondition.
+	ErrNoActiveSession = errors.New("session: no active voice session")
+	// ErrDiscordNotConfigured is returned by Start when the saved deployment
+	// config has no guild/voice channel (#72). Mapped to CodeFailedPrecondition.
+	ErrDiscordNotConfigured = errors.New("session: Discord guild/channel not configured")
+	// ErrVoiceUnavailable is returned by Start when this process does not drive
+	// voice (web-only mode, ADR-0039). Mapped to CodeFailedPrecondition.
+	ErrVoiceUnavailable = errors.New("session: voice is not available in this mode")
+)
+
+// Store is the narrow storage surface the Manager needs: the saved Discord
+// guild/channel (deployment config) and the voice_sessions lifecycle writes.
+// *storage.Store satisfies it; tests use a fake.
+type Store interface {
+	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
+	CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
+	EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error)
+}
+
+// LoopRunner runs the live voice loop until ctx is cancelled. Production wraps
+// wirenpc.RunFromDB (which loads the campaign roster and resolves the
+// credential-bridge keys, #69) bound to the app pool + cipher; tests inject a
+// fake so no Discord/Postgres is touched. The Manager builds the cfg, sourcing
+// guild/channel from the saved deployment config (#72).
+type LoopRunner func(ctx context.Context, cfg wirenpc.Config) error
+
+// activeSession is the Manager's record of the one running session: the cancel
+// func that unwinds its loop, the voice_sessions row, and a done channel closed
+// once the loop has exited and the ended_at write has landed.
+type activeSession struct {
+	campaignID uuid.UUID
+	session    storage.VoiceSession
+	cancel     context.CancelFunc
+	done       chan struct{}
+}
+
+// Manager owns at most one live voice session at a time (the single-active
+// guard). It is safe for concurrent use.
+type Manager struct {
+	store   Store
+	run     LoopRunner
+	base    wirenpc.Config // Token/Logger/Metrics template; Guild/Channel come from saved config
+	log     *slog.Logger
+	enabled bool // false in web-only mode: Start is rejected (ADR-0039)
+
+	mu     sync.Mutex
+	active *activeSession
+}
+
+// NewManager wraps the store, loop runner and base config in a Manager. base
+// carries the Discord token, logger and metrics recorders; Start overlays the
+// saved guild/channel onto a copy. enabled is false in web-only mode, where the
+// process does not drive voice (Start then fails ErrVoiceUnavailable).
+func NewManager(store Store, run LoopRunner, base wirenpc.Config, log *slog.Logger, enabled bool) *Manager {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Manager{store: store, run: run, base: base, log: log, enabled: enabled}
+}
+
+// Start launches the live voice loop for a campaign and records a running
+// voice_sessions row. It sources the Discord guild/channel from the saved
+// deployment config (#72), rejects a second concurrent start (ErrSessionActive),
+// and returns the created row. The loop runs on a background context the Manager
+// cancels on Stop / Shutdown — it deliberately outlives the request ctx.
+func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	if !m.enabled {
+		return storage.VoiceSession{}, ErrVoiceUnavailable
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active != nil {
+		return storage.VoiceSession{}, ErrSessionActive
+	}
+
+	dep, err := m.store.GetDeploymentConfig(ctx, tenantID)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, fmt.Errorf("session: load deployment config: %w", err)
+	}
+	if dep.GuildID == "" || dep.VoiceChannelID == "" {
+		return storage.VoiceSession{}, ErrDiscordNotConfigured
+	}
+
+	vs, err := m.store.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		return storage.VoiceSession{}, fmt.Errorf("session: create voice session: %w", err)
+	}
+
+	cfg := m.base
+	cfg.Guild = dep.GuildID
+	cfg.Channel = dep.VoiceChannelID
+
+	// A background context so the loop survives the HTTP request that started it;
+	// the Manager holds cancel and reaps it on Stop / Shutdown.
+	runCtx, cancel := context.WithCancel(context.Background())
+	as := &activeSession{
+		campaignID: campaignID,
+		session:    vs,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+	}
+	m.active = as
+	go m.runLoop(runCtx, as, cfg)
+	return vs, nil
+}
+
+// runLoop runs the voice loop to completion (cancel or self-exit), then writes
+// the ended_at/status row and clears the active slot. close(done) runs last, so
+// a Stop waiting on done observes both the updated session and the freed guard.
+func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Config) {
+	defer close(as.done)
+
+	if err := m.run(ctx, cfg); err != nil && ctx.Err() == nil {
+		// A real loop error (not the expected cancellation) — log it; the session
+		// still ends cleanly below so the row never stays stuck 'running'.
+		m.log.Error("voice session loop exited with error", "err", err, "voice_session", as.session.ID)
+	}
+
+	// The run ctx is cancelled on a Stop, so end the row on a detached, bounded
+	// context — otherwise the ended_at write would itself be cancelled.
+	endCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), endTimeout)
+	defer cancel()
+	ended, err := m.store.EndVoiceSession(endCtx, as.session.ID, as.session.LineCount)
+
+	m.mu.Lock()
+	if err != nil {
+		m.log.Error("end voice session", "err", err, "voice_session", as.session.ID)
+	} else {
+		as.session = ended
+	}
+	if m.active == as {
+		m.active = nil
+	}
+	m.mu.Unlock()
+}
+
+// Stop cancels the active session's loop and waits for it to end, returning the
+// ended voice_sessions row. ErrNoActiveSession when nothing is running. If ctx is
+// cancelled while waiting, it returns ctx.Err() — the loop still unwinds in the
+// background.
+func (m *Manager) Stop(ctx context.Context) (storage.VoiceSession, error) {
+	m.mu.Lock()
+	as := m.active
+	m.mu.Unlock()
+	if as == nil {
+		return storage.VoiceSession{}, ErrNoActiveSession
+	}
+
+	as.cancel()
+	select {
+	case <-as.done:
+		// done closes after runLoop set as.session to the ended row; safe to read.
+		return as.session, nil
+	case <-ctx.Done():
+		return storage.VoiceSession{}, ctx.Err()
+	}
+}
+
+// Snapshot returns the active session and true, or the zero value and false when
+// idle — the in-process read backing GetSession (the screen's live status).
+func (m *Manager) Snapshot() (storage.VoiceSession, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil {
+		return storage.VoiceSession{}, false
+	}
+	return m.active.session, true
+}
+
+// Shutdown cancels any active session and waits for its loop to end and the
+// ended_at write to land. The web tier calls it on process shutdown, before the
+// DB pool closes, so a SIGTERM never leaves a row stuck 'running'.
+func (m *Manager) Shutdown() {
+	m.mu.Lock()
+	as := m.active
+	m.mu.Unlock()
+	if as == nil {
+		return
+	}
+	as.cancel()
+	<-as.done
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,0 +1,268 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// fakeStore is an in-memory session.Store: it serves a canned deployment config
+// (guild/channel source, #72) and records the voice_sessions Create/End calls so
+// the lifecycle can be asserted without Postgres.
+type fakeStore struct {
+	mu       sync.Mutex
+	dep      storage.DeploymentConfig
+	depErr   error
+	sessions map[uuid.UUID]storage.VoiceSession
+	created  int
+	ended    int
+	tick     int
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		dep: storage.DeploymentConfig{
+			GuildID:        "111222333",
+			VoiceChannelID: "444555666",
+		},
+		sessions: map[uuid.UUID]storage.VoiceSession{},
+	}
+}
+
+func (f *fakeStore) now() time.Time {
+	f.tick++
+	return time.Date(2026, 6, 27, 12, 0, f.tick, 0, time.UTC)
+}
+
+func (f *fakeStore) GetDeploymentConfig(_ context.Context, _ uuid.UUID) (storage.DeploymentConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.depErr != nil {
+		return storage.DeploymentConfig{}, f.depErr
+	}
+	return f.dep, nil
+}
+
+func (f *fakeStore) CreateVoiceSession(_ context.Context, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.created++
+	vs := storage.VoiceSession{
+		ID:         uuid.New(),
+		CampaignID: campaignID,
+		StartedAt:  f.now(),
+		Status:     storage.VoiceSessionRunning,
+	}
+	f.sessions[vs.ID] = vs
+	return vs, nil
+}
+
+func (f *fakeStore) EndVoiceSession(_ context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ended++
+	vs, ok := f.sessions[id]
+	if !ok {
+		return storage.VoiceSession{}, storage.ErrNotFound
+	}
+	end := f.now()
+	vs.EndedAt = &end
+	vs.Status = storage.VoiceSessionEnded
+	vs.LineCount = lineCount
+	f.sessions[id] = vs
+	return vs, nil
+}
+
+func (f *fakeStore) counts() (created, ended int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.created, f.ended
+}
+
+// blockingRunner is a fake loop runner that records the cfg it ran with and the
+// fact it was cancelled, then unblocks on ctx cancellation — a stand-in for the
+// real wirenpc loop so no Discord/Postgres is touched.
+type blockingRunner struct {
+	mu        sync.Mutex
+	started   chan struct{} // closed once the runner is executing
+	gotCfg    wirenpc.Config
+	cancelled bool
+}
+
+func newBlockingRunner() *blockingRunner {
+	return &blockingRunner{started: make(chan struct{})}
+}
+
+func (r *blockingRunner) run(ctx context.Context, cfg wirenpc.Config) error {
+	r.mu.Lock()
+	r.gotCfg = cfg
+	r.mu.Unlock()
+	close(r.started)
+	<-ctx.Done()
+	r.mu.Lock()
+	r.cancelled = true
+	r.mu.Unlock()
+	return ctx.Err()
+}
+
+func (r *blockingRunner) cfg() wirenpc.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gotCfg
+}
+
+func (r *blockingRunner) wasCancelled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cancelled
+}
+
+func newManager(t *testing.T, store session.Store, run session.LoopRunner, enabled bool) *session.Manager {
+	t.Helper()
+	return session.NewManager(store, run, wirenpc.Config{Token: "test-token"},
+		slog.New(slog.DiscardHandler), enabled)
+}
+
+// TestStartStopLifecycle is AC1: Start → status running + row written + the loop
+// runs; Stop → ended_at + status ended, and the cancellation propagates to the
+// loop (the runner observes ctx.Done).
+func TestStartStopLifecycle(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	vs, err := mgr.Start(context.Background(), tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if vs.Status != storage.VoiceSessionRunning {
+		t.Errorf("started status = %q, want running", vs.Status)
+	}
+	if created, _ := store.counts(); created != 1 {
+		t.Errorf("created rows = %d, want 1", created)
+	}
+
+	// The loop is running and was handed the saved guild/channel (#72: sourced
+	// from the deployment config, not CLI flags).
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+	if got := runner.cfg(); got.Guild != "111222333" || got.Channel != "444555666" {
+		t.Errorf("loop cfg guild/channel = %q/%q, want saved 111222333/444555666", got.Guild, got.Channel)
+	}
+
+	// Snapshot reflects the active session.
+	if snap, active := mgr.Snapshot(); !active || snap.ID != vs.ID {
+		t.Errorf("Snapshot = %+v active=%v, want active %s", snap, active, vs.ID)
+	}
+
+	ended, err := mgr.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded || ended.EndedAt == nil {
+		t.Errorf("stopped session = %+v, want ended with ended_at", ended)
+	}
+	if _, e := store.counts(); e != 1 {
+		t.Errorf("ended rows = %d, want 1", e)
+	}
+	if !runner.wasCancelled() {
+		t.Error("cancellation did not propagate to the loop")
+	}
+	if _, active := mgr.Snapshot(); active {
+		t.Error("Snapshot still active after Stop")
+	}
+}
+
+// TestSecondStartRejected is AC2: a second Start while one is active is rejected
+// (single-active-session guard), and no second row is written.
+func TestSecondStartRejected(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	if _, err := mgr.Start(context.Background(), tenantID, campaignID); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	t.Cleanup(func() { _, _ = mgr.Stop(context.Background()) })
+
+	_, err := mgr.Start(context.Background(), tenantID, campaignID)
+	if !errors.Is(err, session.ErrSessionActive) {
+		t.Errorf("second Start = %v, want ErrSessionActive", err)
+	}
+	if created, _ := store.counts(); created != 1 {
+		t.Errorf("created rows = %d, want 1 (second Start must not write)", created)
+	}
+}
+
+// TestStartRequiresDiscordConfig is the #72 precondition: an unset guild/channel
+// fails Start with ErrDiscordNotConfigured and writes no row.
+func TestStartRequiresDiscordConfig(t *testing.T) {
+	store := newFakeStore()
+	store.dep = storage.DeploymentConfig{} // no guild/channel
+	mgr := newManager(t, store, newBlockingRunner().run, true)
+
+	_, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrDiscordNotConfigured) {
+		t.Errorf("Start with no guild/channel = %v, want ErrDiscordNotConfigured", err)
+	}
+	if created, _ := store.counts(); created != 0 {
+		t.Errorf("created rows = %d, want 0", created)
+	}
+}
+
+// TestStopWithoutActiveSession returns ErrNoActiveSession.
+func TestStopWithoutActiveSession(t *testing.T) {
+	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, true)
+	if _, err := mgr.Stop(context.Background()); !errors.Is(err, session.ErrNoActiveSession) {
+		t.Errorf("Stop with no session = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestStartDisabledMode rejects Start when voice is not enabled for the mode
+// (web-only, ADR-0039: all-mode drives sessions in-process).
+func TestStartDisabledMode(t *testing.T) {
+	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, false)
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); !errors.Is(err, session.ErrVoiceUnavailable) {
+		t.Errorf("Start in disabled mode = %v, want ErrVoiceUnavailable", err)
+	}
+}
+
+// TestLoopExitClearsActive asserts a loop that exits on its own (not via Stop)
+// still ends the session and clears the active slot, so the guard frees up.
+func TestLoopExitClearsActive(t *testing.T) {
+	store := newFakeStore()
+	// A runner that returns immediately (loop ended by itself).
+	mgr := newManager(t, store, func(_ context.Context, _ wirenpc.Config) error { return nil }, true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Wait for the self-exiting loop to End the session and clear active.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, active := mgr.Snapshot(); !active {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("active session not cleared after the loop exited")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, ended := store.counts(); ended != 1 {
+		t.Errorf("ended rows = %d, want 1 after self-exit", ended)
+	}
+}

--- a/internal/storage/migrations/00006_voice_sessions.sql
+++ b/internal/storage/migrations/00006_voice_sessions.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+
+-- voice_sessions backs the Session screen's Start/Stop loop (#72, ADR-0039): one
+-- row per Voice Session — the Bot's presence in one Discord voice channel, bound
+-- to a Campaign (CONTEXT.md). A session is INSERTed status='running' on Start and
+-- UPDATEd ended_at=now()/status='ended' on Stop. line_count records how many
+-- transcript lines the session produced (0 for this stage; the live transcript
+-- feed is #73/SSE).
+CREATE TABLE voice_sessions (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id  uuid NOT NULL REFERENCES campaign (id) ON DELETE CASCADE,
+    started_at   timestamptz NOT NULL DEFAULT now(),
+    -- NULL while the session is running; set to now() on Stop / loop exit.
+    ended_at     timestamptz,
+    -- Lifecycle: 'running' then 'ended'. Plain text (no enum) keeps the stage's
+    -- migration additive; the manager writes the two values it owns.
+    status       text NOT NULL,
+    line_count   int NOT NULL DEFAULT 0
+);
+
+CREATE INDEX voice_sessions_campaign_idx ON voice_sessions (campaign_id);
+
+-- Wire up the transcript_chunk SEAM (#6): the voice_session_id column already
+-- exists (00001_init) as a nullable uuid placeholder. Add the FK additively now
+-- that the target table exists, but keep the column NULLABLE — transcript writes
+-- do not set it yet (#73), so NOT NULL stays deferred. ON DELETE SET NULL: losing
+-- a session must not delete its transcript chunks.
+ALTER TABLE transcript_chunk
+    ADD CONSTRAINT transcript_chunk_voice_session_id_fkey
+    FOREIGN KEY (voice_session_id) REFERENCES voice_sessions (id) ON DELETE SET NULL;
+
+-- +goose Down
+
+ALTER TABLE transcript_chunk
+    DROP CONSTRAINT IF EXISTS transcript_chunk_voice_session_id_fkey;
+DROP TABLE IF EXISTS voice_sessions;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -81,6 +81,28 @@ type DeploymentConfig struct {
 	UpdatedAt                 time.Time
 }
 
+// VoiceSessionStatus is a Voice Session's lifecycle state (#72). A session is
+// 'running' from Start until Stop (or loop exit), then 'ended'.
+type VoiceSessionStatus string
+
+const (
+	VoiceSessionRunning VoiceSessionStatus = "running"
+	VoiceSessionEnded   VoiceSessionStatus = "ended"
+)
+
+// VoiceSession is one run of the live voice loop — the Bot's presence in one
+// Discord voice channel, bound to a Campaign (CONTEXT.md "Voice Session", #72).
+// EndedAt is nil while running; LineCount records transcript lines produced (0
+// for this stage — the live feed is #73).
+type VoiceSession struct {
+	ID         uuid.UUID
+	CampaignID uuid.UUID
+	StartedAt  time.Time
+	EndedAt    *time.Time
+	Status     VoiceSessionStatus
+	LineCount  int
+}
+
 // Agent is an AI-controlled persona — Butler or Character NPC (ADR-0009).
 type Agent struct {
 	ID         uuid.UUID

--- a/internal/storage/voice_session.go
+++ b/internal/storage/voice_session.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Voice-session persistence (#72, ADR-0039): the SessionManager INSERTs a row on
+// Start (status='running'), UPDATEs it on Stop / loop exit (ended_at + status),
+// and the Session screen reads the active or last session back. The queries are
+// thin and domain-neutral, mirroring the rest of the storage layer.
+
+const voiceSessionColumns = `
+	id, campaign_id, started_at, ended_at, status, line_count`
+
+func scanVoiceSession(row pgx.Row) (VoiceSession, error) {
+	var v VoiceSession
+	err := row.Scan(
+		&v.ID, &v.CampaignID, &v.StartedAt, &v.EndedAt, &v.Status, &v.LineCount,
+	)
+	return v, err
+}
+
+// CreateVoiceSession opens a Voice Session for a Campaign: it INSERTs a row with
+// status='running' and started_at=now() and returns it. The SessionManager holds
+// the returned id to End the session on Stop.
+func (s *Store) CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (VoiceSession, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO voice_sessions (campaign_id, status)
+		 VALUES ($1, $2)
+		 RETURNING `+voiceSessionColumns,
+		campaignID, VoiceSessionRunning)
+	v, err := scanVoiceSession(row)
+	if err != nil {
+		return VoiceSession{}, fmt.Errorf("storage: create voice session for campaign %s: %w", campaignID, err)
+	}
+	return v, nil
+}
+
+// EndVoiceSession closes a running Voice Session: it sets ended_at=now(),
+// status='ended' and the final line_count, returning the updated row. A missing
+// id yields ErrNotFound.
+func (s *Store) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (VoiceSession, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_sessions
+		    SET ended_at = now(), status = $2, line_count = $3
+		  WHERE id = $1
+		 RETURNING `+voiceSessionColumns,
+		id, VoiceSessionEnded, lineCount)
+	v, err := scanVoiceSession(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSession{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSession{}, fmt.Errorf("storage: end voice session %s: %w", id, err)
+	}
+	return v, nil
+}
+
+// GetVoiceSession loads one Voice Session by id, or ErrNotFound.
+func (s *Store) GetVoiceSession(ctx context.Context, id uuid.UUID) (VoiceSession, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+voiceSessionColumns+` FROM voice_sessions WHERE id = $1`, id)
+	v, err := scanVoiceSession(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSession{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSession{}, fmt.Errorf("storage: get voice session %s: %w", id, err)
+	}
+	return v, nil
+}
+
+// GetLatestVoiceSession returns a Campaign's most-recently-started Voice Session,
+// or ErrNotFound when none has ever run. It backs the Session screen's idle
+// last-session summary (#72): when no session is active, the screen shows when
+// the prior session ended and its line count.
+func (s *Store) GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (VoiceSession, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+voiceSessionColumns+`
+		   FROM voice_sessions
+		  WHERE campaign_id = $1
+		  ORDER BY started_at DESC, id DESC
+		  LIMIT 1`, campaignID)
+	v, err := scanVoiceSession(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSession{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSession{}, fmt.Errorf("storage: get latest voice session for campaign %s: %w", campaignID, err)
+	}
+	return v, nil
+}

--- a/internal/storage/voice_session_test.go
+++ b/internal/storage/voice_session_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestVoiceSessionLifecycle round-trips the #72 Voice Session lifecycle against a
+// real Postgres: Create writes a running row, End sets ended_at + status='ended'
+// + line_count, and the reads (Get / GetLatest) reflect each state. It also
+// proves the 00006 migration's transcript_chunk FK seam: a transcript chunk can
+// point at the session, and dropping is additive (the migration up+down is
+// exercised by MigrateUp inside seedCampaign).
+func TestVoiceSessionLifecycle(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// No session yet → GetLatest is ErrNotFound (the idle, never-run state).
+	if _, err := st.GetLatestVoiceSession(ctx, campaignID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetLatestVoiceSession on empty = %v, want ErrNotFound", err)
+	}
+
+	// Start: a running row with no ended_at.
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	if vs.Status != storage.VoiceSessionRunning {
+		t.Errorf("status = %q, want running", vs.Status)
+	}
+	if vs.EndedAt != nil {
+		t.Errorf("ended_at = %v, want nil while running", vs.EndedAt)
+	}
+	if vs.CampaignID != campaignID {
+		t.Errorf("campaign_id = %s, want %s", vs.CampaignID, campaignID)
+	}
+
+	// While running, it is the latest session and reads back identically.
+	got, err := st.GetVoiceSession(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("GetVoiceSession: %v", err)
+	}
+	if got.ID != vs.ID || got.Status != storage.VoiceSessionRunning {
+		t.Errorf("GetVoiceSession = %+v, want running %s", got, vs.ID)
+	}
+
+	// The transcript_chunk SEAM FK (00006): a chunk may reference the session.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO transcript_chunk (campaign_id, voice_session_id, content)
+		 VALUES ($1, $2, 'hello')`, campaignID, vs.ID); err != nil {
+		t.Fatalf("insert transcript chunk referencing session: %v", err)
+	}
+
+	// Stop: ended_at set, status ended, line_count recorded.
+	ended, err := st.EndVoiceSession(ctx, vs.ID, 7)
+	if err != nil {
+		t.Fatalf("EndVoiceSession: %v", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded {
+		t.Errorf("ended status = %q, want ended", ended.Status)
+	}
+	if ended.EndedAt == nil {
+		t.Fatal("ended_at is nil after End")
+	}
+	if ended.LineCount != 7 {
+		t.Errorf("line_count = %d, want 7", ended.LineCount)
+	}
+
+	// GetLatest now returns the ended session (the idle summary source).
+	latest, err := st.GetLatestVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetLatestVoiceSession after end: %v", err)
+	}
+	if latest.ID != vs.ID || latest.Status != storage.VoiceSessionEnded || latest.LineCount != 7 {
+		t.Errorf("GetLatestVoiceSession = %+v, want ended %s with 7 lines", latest, vs.ID)
+	}
+}
+
+// TestEndVoiceSessionNotFound asserts ending an unknown id is ErrNotFound (the
+// RPC maps it accordingly).
+func TestEndVoiceSessionNotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.EndVoiceSession(ctx, uuid.New(), 0); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("EndVoiceSession(random) = %v, want ErrNotFound", err)
+	}
+	if _, err := st.GetVoiceSession(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetVoiceSession(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -319,3 +319,77 @@ message SaveDiscordSettingsResponse {
   string guild_id = 2;
   string voice_channel_id = 3;
 }
+
+// SessionService drives the live Voice Session from the Session screen (#72,
+// ADR-0039): an in-process SessionManager starts/stops the voice loop in `all`
+// mode — the control RPC is defined, not looped through a backplane (ADR-0005).
+// The Bot's guild/voice channel come from the saved deployment config, not CLI
+// flags; the credential-bridge keys (#69) drive the loop.
+service SessionService {
+  // GetSession returns the current Voice Session for the active campaign — the
+  // running session when one is live, otherwise the most recent ended one (for
+  // the screen's last-session summary) — and whether voice is active. It is a
+  // read (NO_SIDE_EFFECTS), so the CSRF check is skipped.
+  rpc GetSession(GetSessionRequest) returns (GetSessionResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // StartSession launches the voice loop for the active campaign and returns the
+  // created running session. It fails with CodeFailedPrecondition when the
+  // Discord guild/channel are unconfigured, and CodeAlreadyExists when a session
+  // is already active. State-changing: auth + CSRF guard it.
+  rpc StartSession(StartSessionRequest) returns (StartSessionResponse);
+  // StopSession cancels the active voice loop and returns the ended session. It
+  // fails with CodeFailedPrecondition when no session is active. State-changing.
+  rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
+}
+
+// VoiceSession is the wire view of a voice_sessions row (#72): the Bot's
+// presence in one Discord voice channel, bound to a campaign.
+message VoiceSession {
+  // id is the voice session's UUID.
+  string id = 1;
+  // campaign_id is the campaign the session runs for.
+  string campaign_id = 2;
+  // status is the lifecycle state: "running" or "ended".
+  string status = 3;
+  // started_at is when the session started.
+  google.protobuf.Timestamp started_at = 4;
+  // ended_at is when the session ended; unset while running.
+  google.protobuf.Timestamp ended_at = 5;
+  // line_count is how many transcript lines the session produced (0 this stage;
+  // the live transcript feed is #73).
+  uint32 line_count = 6;
+}
+
+// GetSessionRequest is the (empty) request; the active campaign and the
+// in-process session are resolved server-side for the single operator.
+message GetSessionRequest {}
+
+// GetSessionResponse carries the current session and whether voice is active.
+message GetSessionResponse {
+  // session is the running session, or the most recent ended one; unset when no
+  // session has ever run for the active campaign.
+  VoiceSession session = 1;
+  // active is true exactly when a voice loop is running in this process.
+  bool active = 2;
+}
+
+// StartSessionRequest is the (empty) request; the active campaign is resolved
+// server-side for the single operator.
+message StartSessionRequest {}
+
+// StartSessionResponse carries the created running session.
+message StartSessionResponse {
+  // session is the newly started running session.
+  VoiceSession session = 1;
+}
+
+// StopSessionRequest is the (empty) request; the active session is resolved from
+// the in-process manager.
+message StopSessionRequest {}
+
+// StopSessionResponse carries the ended session.
+message StopSessionResponse {
+  // session is the session that was just ended.
+  VoiceSession session = 1;
+}

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -11,6 +11,7 @@ import { AuthGate } from "@/app/AuthGate";
 import { Login } from "@/screens/login/Login";
 import { Configuration } from "@/screens/configuration/Configuration";
 import { Campaign } from "@/screens/campaign/Campaign";
+import { Session } from "@/screens/session/Session";
 import { Placeholder } from "@/screens/Placeholder";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
@@ -82,7 +83,7 @@ const screenRoute = createRoute({
       case "campaign":
         return <Campaign />;
       case "session":
-        return <Placeholder title="Session" />;
+        return <Session />;
       default:
         return <Placeholder title="Not found" />;
     }

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import {
+  SessionService,
+  CampaignService,
+  VoiceSessionSchema,
+  GetSessionResponseSchema,
+  StartSessionResponseSchema,
+  StopSessionResponseSchema,
+  GetActiveCampaignResponseSchema,
+  CampaignSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { Session, formatElapsed } from "./Session";
+
+// An in-memory voice-session store served over a router transport (no network):
+// active/current/last mutate in this closure so Start → invalidate → refetch
+// flips the screen to Live and Stop flips it back to Idle with a last-session
+// summary — the #72 acceptance (Idle → Live → Idle + elapsed timer).
+function mockTransport() {
+  let active = false;
+  let current: ReturnType<typeof create<typeof VoiceSessionSchema>> | undefined;
+  let last: ReturnType<typeof create<typeof VoiceSessionSchema>> | undefined;
+
+  const transport = createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () =>
+        create(GetSessionResponseSchema, { session: active ? current : last, active }),
+      startSession: () => {
+        current = create(VoiceSessionSchema, {
+          id: "vs1",
+          campaignId: "c1",
+          status: "running",
+          startedAt: timestampFromDate(new Date()),
+        });
+        active = true;
+        return create(StartSessionResponseSchema, { session: current });
+      },
+      stopSession: () => {
+        const started = new Date(Date.now() - 90 * 60 * 1000); // 1h30m ago
+        const ended = create(VoiceSessionSchema, {
+          id: "vs1",
+          campaignId: "c1",
+          status: "ended",
+          startedAt: timestampFromDate(started),
+          endedAt: timestampFromDate(new Date()),
+          lineCount: 12,
+        });
+        last = ended;
+        active = false;
+        current = undefined;
+        return create(StopSessionResponseSchema, { session: ended });
+      },
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+  return transport;
+}
+
+function renderScreen() {
+  render(
+    <Providers transport={mockTransport()} queryClient={makeQueryClient()}>
+      <Session />
+    </Providers>,
+  );
+}
+
+describe("formatElapsed", () => {
+  it("formats seconds as zero-padded HH:MM:SS", () => {
+    expect(formatElapsed(0)).toBe("00:00:00");
+    expect(formatElapsed(65)).toBe("00:01:05");
+    expect(formatElapsed(3661)).toBe("01:01:01");
+    expect(formatElapsed(-5)).toBe("00:00:00");
+  });
+});
+
+describe("Session", () => {
+  it("renders idle with a zeroed timer and a Start button", async () => {
+    renderScreen();
+    expect(await screen.findByText("Idle")).toBeInTheDocument();
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("00:00:00");
+    expect(screen.getByRole("button", { name: /start session/i })).toBeInTheDocument();
+    // The campaign name renders in the header (subtle); it loads on its own query.
+    expect(await screen.findByText("The Sunless Citadel")).toBeInTheDocument();
+  });
+
+  it("reflects Idle → Live → Idle and resets the timer + shows the last summary", async () => {
+    renderScreen();
+
+    // Idle → Live: Start flips the badge and swaps in the Stop button.
+    fireEvent.click(await screen.findByRole("button", { name: /start session/i }));
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /stop session/i })).toBeInTheDocument();
+
+    // Live → Idle: Stop resets to Idle, the timer zeroes, and the last-session
+    // summary appears with the transcribed line count.
+    fireEvent.click(screen.getByRole("button", { name: /stop session/i }));
+    expect(await screen.findByText("Idle")).toBeInTheDocument();
+    expect(screen.getByTestId("elapsed")).toHaveTextContent("00:00:00");
+    await waitFor(() =>
+      expect(screen.getByText(/12 lines transcribed/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /start session/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Play, Square } from "lucide-react";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+
+import { SessionService, CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { VoiceSession } from "@gen/glyphoxa/management/v1/management_pb";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+
+import "./session.css";
+
+// The Session screen (#72) drives the live Voice Session from the UI on the live
+// SessionService (ADR-0039): Start/Stop call the in-process SessionManager, the
+// status badge + elapsed timer reflect the running session, and an idle screen
+// shows a summary of the last session that ended. The live transcript feed itself
+// is a separate issue (#73/SSE) — the timer is client-side from started_at and
+// the status comes from GetSession.
+
+// formatElapsed renders a non-negative second count as zero-padded HH:MM:SS
+// (the design's exact format). Exported so the format is unit-tested directly.
+export function formatElapsed(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  return [Math.floor(s / 3600), Math.floor((s % 3600) / 60), s % 60]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":");
+}
+
+// tsMs converts a protobuf Timestamp to epoch milliseconds, or null when unset.
+function tsMs(ts: VoiceSession["startedAt"] | undefined): number | null {
+  return ts ? Number(timestampMs(ts)) : null;
+}
+
+// useElapsed ticks a once-per-second elapsed-seconds counter from a start instant
+// (epoch ms), resetting to 0 when idle (start === null).
+function useElapsed(startMs: number | null): number {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (startMs == null) {
+      setElapsed(0);
+      return;
+    }
+    const tick = () => setElapsed(Math.floor((Date.now() - startMs) / 1000));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startMs]);
+  return elapsed;
+}
+
+// lastSummary renders the idle "Last session ended …" line from an ended session.
+function lastSummary(session: VoiceSession): string {
+  const endedMs = tsMs(session.endedAt);
+  const startedMs = tsMs(session.startedAt);
+  const ended = endedMs != null ? new Date(endedMs) : null;
+
+  const when = ended
+    ? `${String(ended.getHours()).padStart(2, "0")}:${String(ended.getMinutes()).padStart(2, "0")}`
+    : "—";
+
+  let duration = "0h 0m";
+  if (endedMs != null && startedMs != null) {
+    const minutes = Math.max(0, Math.round((endedMs - startedMs) / 60000));
+    duration = `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+  }
+  return `Last session ended ${when} · ${duration} · ${session.lineCount} lines transcribed.`;
+}
+
+export function Session() {
+  const queryClient = useQueryClient();
+  const { data } = useQuery(SessionService.method.getSession, {});
+  const campaignQ = useQuery(CampaignService.method.getActiveCampaign, {});
+  const campaignName = campaignQ.data?.campaign?.name;
+
+  const active = data?.active ?? false;
+  const session = data?.session;
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: SessionService.method.getSession,
+        cardinality: "finite",
+      }),
+    });
+
+  const start = useMutation(SessionService.method.startSession, { onSuccess: () => void invalidate() });
+  const stop = useMutation(SessionService.method.stopSession, { onSuccess: () => void invalidate() });
+
+  // The timer runs only while live, counting up from the running session's start.
+  const elapsed = useElapsed(active ? tsMs(session?.startedAt) : null);
+
+  return (
+    <div className="gx-session">
+      <header className="gx-session__header">
+        {campaignName && <span className="gx-overline">{campaignName}</span>}
+        <h1>Voice session</h1>
+      </header>
+
+      <Card accent className="gx-session__control">
+        <div className="gx-session__status">
+          {active ? (
+            <Badge variant="live" dot pulse>
+              Live
+            </Badge>
+          ) : (
+            <Badge variant="neutral" dot>
+              Idle
+            </Badge>
+          )}
+          <span className="gx-session__timer" data-testid="elapsed">
+            {formatElapsed(elapsed)}
+          </span>
+        </div>
+
+        <div className="gx-session__actions">
+          {active ? (
+            <Button
+              variant="danger"
+              iconStart={<Square size={15} />}
+              onClick={() => stop.mutate({})}
+              disabled={stop.isPending}
+            >
+              Stop session
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              iconStart={<Play size={15} />}
+              onClick={() => start.mutate({})}
+              disabled={start.isPending}
+            >
+              Start session
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {!active && session && session.status === "ended" && (
+        <div className="gx-session__last">{lastSummary(session)}</div>
+      )}
+
+      <section className="gx-session__transcript">
+        <h2 className="gx-section-title">{active ? "Live transcript" : "Session transcript"}</h2>
+        <Card>
+          <p className="gx-session__transcript-empty">
+            {active
+              ? "Listening… transcript lines will appear here."
+              : "Start a session to capture the table's voice transcript."}
+          </p>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -1,0 +1,60 @@
+/* Session screen — co-located CSS (ADR-0017). Shared gx- layout/component
+ * classes live in styles/components.css; only screen-local tweaks go here.
+ */
+
+.gx-session__header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.gx-session__header h1 {
+  margin: 0;
+}
+
+/* Control row: status badge + elapsed timer on the left, Start/Stop on the right. */
+.gx-session__control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.gx-session__status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+/* Large monospace count-up, HH:MM:SS. */
+.gx-session__timer {
+  font-family: var(--font-mono, monospace);
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.gx-session__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* Subtle inset summary of the prior session, shown only while idle. */
+.gx-session__last {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+  color: var(--text-subtle);
+  font-size: 0.875rem;
+}
+
+.gx-session__transcript {
+  margin-top: var(--spacing-xl);
+}
+
+.gx-session__transcript-empty {
+  margin: 0;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
Closes #72 — Stage 8: drive the voice loop from the Session screen.

## What
- **`voice_sessions` table** (migration `00006`): `{id, campaign_id, started_at, ended_at, status, line_count}`, and the `transcript_chunk.voice_session_id` SEAM (#6) FK is wired additively (column stays nullable; `ON DELETE SET NULL`). Storage queries `CreateVoiceSession` / `EndVoiceSession` / `GetVoiceSession` / `GetLatestVoiceSession` + `VoiceSession` model.
- **In-process `SessionManager`** (`internal/session`, ADR-0039): `Start(tenantID, campaignID)` launches the `wirenpc` loop on a background context and writes a running row, sourcing the Discord **guild/channel from the saved deployment config** (not CLI flags); `Stop` cancels the loop and writes `ended_at`/`status`; a **single-active-session guard** rejects overlap; `Snapshot` is the in-memory read. The loop runner is injected, so the lifecycle is unit-tested without Discord/Postgres. Production wraps `wirenpc.RunFromDB(pool, cipher)` — so a started session **inherits the credential-bridge keys (#69) and the campaign roster** for free.
- **`SessionService` RPC** (proto appended at end, non-breaking): `GetSession` (NO_SIDE_EFFECTS) / `StartSession` / `StopSession` + `VoiceSession` message. Handler maps the manager's guards onto Connect codes (AlreadyExists / FailedPrecondition). Wired into `runWeb` + `managementMounts`; in `all` mode the loop is now manager-driven (started from the UI, not at boot) and `Shutdown` reaps any active session before the pool closes. Web-only rejects Start.
- **Session screen** (`web/src/screens/session`): Live/Idle status badge (pulse while live), client-side `HH:MM:SS` elapsed timer (counts up from `started_at`, zeroes when idle), Start/Stop button, and an idle last-session summary.

## Acceptance criteria
- [x] SessionManager lifecycle: Start → running + row written; Stop → `ended_at` + status; cancellation propagates to the loop.
- [x] A second Start on an already-active campaign is rejected.
- [x] A started session uses the credential-bridge keys + campaign roster (production runner wraps `RunFromDB`; manager test asserts guild/channel sourced from saved config).
- [x] The Session screen reflects Idle → Live → Idle and the elapsed timer.

## Tests
- Go: storage integration round-trip (running→ended + transcript FK seam), SessionManager unit (run / cancel-propagation / self-exit / single-active guard / precondition / disabled-mode), RPC handler unit (Connect error mapping + snapshot wiring).
- Web: vitest Idle→Live→Idle + timer reset + last-session summary, plus a `formatElapsed` unit test.
- Local green: `go build/vet/test -race ./...`, `golangci-lint run ./...` (0 issues), `buf lint` + `buf breaking`, migration up/down + voice-session integration against real Postgres, `tsc --noEmit`, `vitest` (17), `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)