### PR TITLE
feat(#87): session reads the saved Discord bot token (drop DISCORD_BOT_TOKEN requirement)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -223,12 +223,13 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	}
 
 	// Base voice config for manager-driven sessions (ADR-0039): the Session screen
-	// starts/stops the live loop in-process via the SessionManager. The Discord
-	// token comes from the environment (the deployment-shared Bot); the guild and
-	// voice channel are sourced per-session from the saved deployment config, not
-	// these flags (#72). The credential-bridge keys (#69) are resolved inside
-	// RunFromDB. enabled = withVoice: only `all` mode drives the loop — a web-only
-	// replica answers GetSession (idle) but rejects Start.
+	// starts/stops the live loop in-process via the SessionManager. The base
+	// Discord token is the env fallback (the deployment-shared Bot); a saved
+	// deployment token (decrypted via cipher) overrides it per-session (#87). The
+	// guild and voice channel are sourced per-session from the saved deployment
+	// config, not these flags (#72). The credential-bridge keys (#69) are resolved
+	// inside RunFromDB. enabled = withVoice: only `all` mode drives the loop — a
+	// web-only replica answers GetSession (idle) but rejects Start.
 	cfg.Token = os.Getenv("DISCORD_BOT_TOKEN")
 	cfg.Logger = log
 	cfg.Metrics = metrics
@@ -236,7 +237,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	runner := func(rctx context.Context, c wirenpc.Config) error {
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
-	mgr := session.NewManager(store, runner, cfg, log, withVoice)
+	mgr := session.NewManager(store, runner, cfg, cipher, log, withVoice)
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -146,6 +146,12 @@ func (s *SessionServer) startError(err error) error {
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("the Discord guild/voice channel are not configured"))
 	case errors.Is(err, session.ErrDiscordTokenMissing):
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("no Discord bot token is configured"))
+	case errors.Is(err, session.ErrDiscordTokenUndecryptable):
+		// The full decrypt detail stays in the manager/server log; the client gets a
+		// static, actionable hint (no underlying error echoed).
+		s.log.Error("StartSession: saved Discord bot token could not be decrypted", "err", err)
+		return connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("the saved Discord bot token could not be decrypted; ensure the server $GLYPHOXA_SECRET is set correctly (ADR-0004)"))
 	case errors.Is(err, session.ErrVoiceUnavailable):
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("voice is not available in this mode"))
 	default:

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -144,6 +144,8 @@ func (s *SessionServer) startError(err error) error {
 		return connect.NewError(connect.CodeAlreadyExists, errors.New("a voice session is already active"))
 	case errors.Is(err, session.ErrDiscordNotConfigured):
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("the Discord guild/voice channel are not configured"))
+	case errors.Is(err, session.ErrDiscordTokenMissing):
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("no Discord bot token is configured"))
 	case errors.Is(err, session.ErrVoiceUnavailable):
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("voice is not available in this mode"))
 	default:

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -186,6 +186,19 @@ func TestSessionStartDiscordUnconfigured(t *testing.T) {
 	}
 }
 
+// TestSessionStartTokenMissing maps the #87 no-token precondition to
+// FailedPrecondition (mirrors the guild/channel-unconfigured mapping).
+func TestSessionStartTokenMissing(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{startErr: session.ErrDiscordTokenMissing}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("token-missing code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
 // TestSessionStartNoCampaign fails with FailedPrecondition when there is no
 // active campaign to run a session for.
 func TestSessionStartNoCampaign(t *testing.T) {

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -199,6 +199,20 @@ func TestSessionStartTokenMissing(t *testing.T) {
 	}
 }
 
+// TestSessionStartTokenUndecryptable maps the #87 undecryptable-token
+// precondition to FailedPrecondition (the boot-without-$GLYPHOXA_SECRET misconfig
+// must be actionable, not an opaque Internal).
+func TestSessionStartTokenUndecryptable(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{startErr: session.ErrDiscordTokenUndecryptable}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("token-undecryptable code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
 // TestSessionStartNoCampaign fails with FailedPrecondition when there is no
 // active campaign to run a session for.
 func TestSessionStartNoCampaign(t *testing.T) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -44,6 +44,12 @@ var (
 	// Bot token nor a DISCORD_BOT_TOKEN env token is available (#87). Mapped to
 	// CodeFailedPrecondition, mirroring ErrDiscordNotConfigured.
 	ErrDiscordTokenMissing = errors.New("session: no Discord bot token configured")
+	// ErrDiscordTokenUndecryptable is returned by Start when a real saved Bot token
+	// cannot be decrypted — booted without $GLYPHOXA_SECRET (nil cipher) or a
+	// ciphertext the cipher won't open (#87). The underlying actionable detail is
+	// wrapped in the chain. Mapped to CodeFailedPrecondition (a self-host
+	// misconfig), not an opaque Internal.
+	ErrDiscordTokenUndecryptable = errors.New("session: saved Discord bot token could not be decrypted")
 )
 
 // Store is the narrow storage surface the Manager needs: the saved Discord
@@ -91,7 +97,8 @@ type Manager struct {
 // overlays the saved guild/channel onto a copy and resolves the Bot token (the
 // saved deployment token decrypted via cipher, else the base env token — #87).
 // cipher may be nil (boot without $GLYPHOXA_SECRET): the env-fallback path still
-// works, but a real saved token then fails Start clearly. enabled is false in
+// works, but a real saved token then fails Start with a clear precondition
+// (ErrDiscordTokenUndecryptable). enabled is false in
 // web-only mode, where the process does not drive voice (Start fails
 // ErrVoiceUnavailable).
 func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto.Cipher, log *slog.Logger, enabled bool) *Manager {
@@ -131,7 +138,9 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 	// mirroring the guild/channel precondition above.
 	token, err := wirenpc.ResolveDiscordToken(m.cipher, dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext, m.base.Token)
 	if err != nil {
-		return storage.VoiceSession{}, fmt.Errorf("session: resolve Discord token: %w", err)
+		// A real saved token that won't decrypt: surface ErrDiscordTokenUndecryptable
+		// (errors.Is at the RPC layer) while keeping the actionable detail in the chain.
+		return storage.VoiceSession{}, fmt.Errorf("%w: %w", ErrDiscordTokenUndecryptable, err)
 	}
 	if token == "" {
 		return storage.VoiceSession{}, ErrDiscordTokenMissing

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
 
@@ -39,6 +40,10 @@ var (
 	// ErrVoiceUnavailable is returned by Start when this process does not drive
 	// voice (web-only mode, ADR-0039). Mapped to CodeFailedPrecondition.
 	ErrVoiceUnavailable = errors.New("session: voice is not available in this mode")
+	// ErrDiscordTokenMissing is returned by Start when neither a saved deployment
+	// Bot token nor a DISCORD_BOT_TOKEN env token is available (#87). Mapped to
+	// CodeFailedPrecondition, mirroring ErrDiscordNotConfigured.
+	ErrDiscordTokenMissing = errors.New("session: no Discord bot token configured")
 )
 
 // Store is the narrow storage surface the Manager needs: the saved Discord
@@ -72,7 +77,8 @@ type activeSession struct {
 type Manager struct {
 	store   Store
 	run     LoopRunner
-	base    wirenpc.Config // Token/Logger/Metrics template; Guild/Channel come from saved config
+	base    wirenpc.Config // Token (env fallback)/Logger/Metrics template; Guild/Channel come from saved config
+	cipher  *crypto.Cipher // decrypts the saved deployment Bot token (#87); nil without $GLYPHOXA_SECRET
 	log     *slog.Logger
 	enabled bool // false in web-only mode: Start is rejected (ADR-0039)
 
@@ -81,14 +87,18 @@ type Manager struct {
 }
 
 // NewManager wraps the store, loop runner and base config in a Manager. base
-// carries the Discord token, logger and metrics recorders; Start overlays the
-// saved guild/channel onto a copy. enabled is false in web-only mode, where the
-// process does not drive voice (Start then fails ErrVoiceUnavailable).
-func NewManager(store Store, run LoopRunner, base wirenpc.Config, log *slog.Logger, enabled bool) *Manager {
+// carries the env-fallback Discord token, logger and metrics recorders; Start
+// overlays the saved guild/channel onto a copy and resolves the Bot token (the
+// saved deployment token decrypted via cipher, else the base env token — #87).
+// cipher may be nil (boot without $GLYPHOXA_SECRET): the env-fallback path still
+// works, but a real saved token then fails Start clearly. enabled is false in
+// web-only mode, where the process does not drive voice (Start fails
+// ErrVoiceUnavailable).
+func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto.Cipher, log *slog.Logger, enabled bool) *Manager {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Manager{store: store, run: run, base: base, log: log, enabled: enabled}
+	return &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled}
 }
 
 // Start launches the live voice loop for a campaign and records a running
@@ -115,12 +125,25 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		return storage.VoiceSession{}, ErrDiscordNotConfigured
 	}
 
+	// Resolve the Bot token under the hybrid policy (#87): a real saved deployment
+	// token (decrypted via cipher) overrides ENV, else the base env token. Resolve
+	// before writing the row so a missing/undecryptable token leaves no stuck row,
+	// mirroring the guild/channel precondition above.
+	token, err := wirenpc.ResolveDiscordToken(m.cipher, dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext, m.base.Token)
+	if err != nil {
+		return storage.VoiceSession{}, fmt.Errorf("session: resolve Discord token: %w", err)
+	}
+	if token == "" {
+		return storage.VoiceSession{}, ErrDiscordTokenMissing
+	}
+
 	vs, err := m.store.CreateVoiceSession(ctx, campaignID)
 	if err != nil {
 		return storage.VoiceSession{}, fmt.Errorf("session: create voice session: %w", err)
 	}
 
 	cfg := m.base
+	cfg.Token = token
 	cfg.Guild = dep.GuildID
 	cfg.Channel = dep.VoiceChannelID
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"log/slog"
 	"sync"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
 
@@ -128,8 +130,24 @@ func (r *blockingRunner) wasCancelled() bool {
 
 func newManager(t *testing.T, store session.Store, run session.LoopRunner, enabled bool) *session.Manager {
 	t.Helper()
-	return session.NewManager(store, run, wirenpc.Config{Token: "test-token"},
+	return session.NewManager(store, run, wirenpc.Config{Token: "test-token"}, nil,
 		slog.New(slog.DiscardHandler), enabled)
+}
+
+// newCipher builds a Cipher on a fresh random AES-256 key for the #87 saved-token
+// path — keyless and Docker-free, so the resolution logic is proven in the
+// default suite.
+func newCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	c, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
 }
 
 // TestStartStopLifecycle is AC1: Start → status running + row written + the loop
@@ -221,6 +239,80 @@ func TestStartRequiresDiscordConfig(t *testing.T) {
 	}
 	if created, _ := store.counts(); created != 0 {
 		t.Errorf("created rows = %d, want 0", created)
+	}
+}
+
+// TestStartUsesSavedToken is issue #87 AC1: a real Bot token saved in the
+// deployment config is DECRYPTED with the cipher and handed to the loop in
+// cfg.Token — DISCORD_BOT_TOKEN is not required (the base token here is empty).
+func TestStartUsesSavedToken(t *testing.T) {
+	const savedToken = "MT999.saved.bot.token"
+	cipher := newCipher(t)
+	sealed, err := cipher.Seal([]byte(savedToken))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	store := newFakeStore()
+	store.dep.DiscordBotTokenCiphertext = sealed
+	store.dep.DiscordBotTokenLast4 = crypto.Last4(savedToken)
+
+	runner := newBlockingRunner()
+	mgr := session.NewManager(store, runner.run, wirenpc.Config{}, cipher,
+		slog.New(slog.DiscardHandler), true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _, _ = mgr.Stop(context.Background()) })
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+	if got := runner.cfg().Token; got != savedToken {
+		t.Errorf("loop cfg token = %q, want decrypted saved token %q", got, savedToken)
+	}
+}
+
+// TestStartFallsBackToEnvToken is issue #87 AC2: with no real saved token (the
+// "env" placeholder), Start uses the base DISCORD_BOT_TOKEN — the
+// voice-mode/dev/CI path is preserved.
+func TestStartFallsBackToEnvToken(t *testing.T) {
+	store := newFakeStore()
+	store.dep.DiscordBotTokenLast4 = "env" // seeded placeholder: no real token in the DB
+	runner := newBlockingRunner()
+	mgr := session.NewManager(store, runner.run, wirenpc.Config{Token: "env-bot-token"}, nil,
+		slog.New(slog.DiscardHandler), true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _, _ = mgr.Stop(context.Background()) })
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+	if got := runner.cfg().Token; got != "env-bot-token" {
+		t.Errorf("loop cfg token = %q, want env fallback %q", got, "env-bot-token")
+	}
+}
+
+// TestStartMissingToken is issue #87 AC3: neither a saved token nor an env token
+// -> a clear precondition (ErrDiscordTokenMissing) and NO voice_sessions row.
+func TestStartMissingToken(t *testing.T) {
+	store := newFakeStore() // guild/channel set, no token saved
+	mgr := session.NewManager(store, newBlockingRunner().run, wirenpc.Config{}, nil,
+		slog.New(slog.DiscardHandler), true)
+
+	_, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrDiscordTokenMissing) {
+		t.Errorf("Start with no token = %v, want ErrDiscordTokenMissing", err)
+	}
+	if created, _ := store.counts(); created != 0 {
+		t.Errorf("created rows = %d, want 0 (missing token must not write)", created)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -316,6 +316,34 @@ func TestStartMissingToken(t *testing.T) {
 	}
 }
 
+// TestStartUndecryptableToken is issue #87 polish: a REAL saved token the manager
+// cannot decrypt (here: no cipher, the boot-without-$GLYPHOXA_SECRET misconfig)
+// fails Start with the ErrDiscordTokenUndecryptable precondition (not an opaque
+// internal error) and writes NO voice_sessions row.
+func TestStartUndecryptableToken(t *testing.T) {
+	const savedToken = "MT999.saved.bot.token"
+	cipher := newCipher(t)
+	sealed, err := cipher.Seal([]byte(savedToken))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	store := newFakeStore()
+	store.dep.DiscordBotTokenCiphertext = sealed
+	store.dep.DiscordBotTokenLast4 = crypto.Last4(savedToken)
+
+	// nil cipher: a real saved token can no longer be opened.
+	mgr := session.NewManager(store, newBlockingRunner().run, wirenpc.Config{}, nil,
+		slog.New(slog.DiscardHandler), true)
+
+	_, err = mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrDiscordTokenUndecryptable) {
+		t.Errorf("Start with undecryptable token = %v, want ErrDiscordTokenUndecryptable", err)
+	}
+	if created, _ := store.counts(); created != 0 {
+		t.Errorf("created rows = %d, want 0 (undecryptable token must not write)", created)
+	}
+}
+
 // TestStopWithoutActiveSession returns ErrNoActiveSession.
 func TestStopWithoutActiveSession(t *testing.T) {
 	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, true)

--- a/internal/wirenpc/credentials.go
+++ b/internal/wirenpc/credentials.go
@@ -54,6 +54,34 @@ func resolveKey(cipher *crypto.Cipher, cfg *storage.ProviderConfig, component st
 	return string(plaintext), nil
 }
 
+// ResolveDiscordToken resolves the Discord bot token a UI-started session drives
+// (issue #87), under the SAME hybrid policy as [resolveKey] (ADR-0039):
+//
+//   - last4 == "" or the "env" placeholder: no real token in the DB -> the
+//     envToken (DISCORD_BOT_TOKEN), preserving the voice-mode / dev / CI path.
+//   - a real saved token (last4 != "env") but no cipher: a CLEAR error, never a
+//     silent env fall-through (AC3) — boot without $GLYPHOXA_SECRET cannot quietly
+//     ignore a saved token and degrade to ENV.
+//   - a real saved token the cipher cannot open: a CLEAR error wrapping crypto's.
+//   - otherwise: the decrypted plaintext token.
+//
+// Unlike the provider keys (where "" means "adapter env fallback"), the caller
+// treats an empty result as a missing token precondition — the env token is
+// already folded in here.
+func ResolveDiscordToken(cipher *crypto.Cipher, last4 string, ciphertext []byte, envToken string) (string, error) {
+	if last4 == "" || last4 == credPlaceholderLast4 {
+		return envToken, nil
+	}
+	if cipher == nil {
+		return "", fmt.Errorf("wirenpc: Discord bot token needs decryption but the credential cipher is unavailable; set $GLYPHOXA_SECRET (ADR-0004)")
+	}
+	plaintext, err := cipher.Open(ciphertext)
+	if err != nil {
+		return "", fmt.Errorf("wirenpc: decrypt Discord bot token: %w", err)
+	}
+	return string(plaintext), nil
+}
+
 // resolveProviderKeys resolves all three components a voice session needs.
 // Any single component's decryption failure fails the whole resolution (AC2):
 // a misconfigured key surfaces at boot, never as a half-configured session that

--- a/internal/wirenpc/credentials_test.go
+++ b/internal/wirenpc/credentials_test.go
@@ -93,6 +93,62 @@ func TestResolveKey(t *testing.T) {
 	}
 }
 
+// TestResolveDiscordToken is issue #87: a UI-started session resolves the saved
+// deployment Bot token under the same hybrid policy as the provider keys. A real
+// saved token (last4 != "env") is DECRYPTED and overrides ENV; an unset or "env"
+// placeholder token falls back to the ENV token (the voice-mode/dev/CI path); and
+// a real saved token the cipher cannot open (or a missing cipher) is a CLEAR
+// error, never a silent fall-through to ENV.
+func TestResolveDiscordToken(t *testing.T) {
+	cipher := newUnitCipher(t)
+	wrong := newUnitCipher(t) // a different key -> cannot open cipher's blobs
+
+	const realToken = "MT234.real.bot.token"
+	const envToken = "env.bot.token"
+	sealed, err := cipher.Seal([]byte(realToken))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		cipher     *crypto.Cipher
+		last4      string
+		ciphertext []byte
+		wantToken  string
+		wantErr    string // substring; "" means no error expected
+	}{
+		{name: "empty last4 -> env fallback", cipher: cipher, last4: "", wantToken: envToken},
+		{name: "env placeholder -> env fallback", cipher: cipher, last4: credPlaceholderLast4, wantToken: envToken},
+		{name: "saved token + cipher -> decrypted", cipher: cipher, last4: crypto.Last4(realToken), ciphertext: sealed, wantToken: realToken},
+		{name: "saved token + nil cipher -> clear error", cipher: nil, last4: crypto.Last4(realToken), ciphertext: sealed, wantErr: "cipher"},
+		{name: "saved token + wrong cipher -> clear error", cipher: wrong, last4: crypto.Last4(realToken), ciphertext: sealed, wantErr: "decrypt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveDiscordToken(tt.cipher, tt.last4, tt.ciphertext, envToken)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveDiscordToken() error = nil, want error containing %q — a real saved token must never resolve to a silent env fall-through (AC3)", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ResolveDiscordToken() error = %q, want substring %q", err, tt.wantErr)
+				}
+				if got != "" {
+					t.Errorf("ResolveDiscordToken() token = %q on error, want empty", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveDiscordToken() unexpected error: %v", err)
+			}
+			if got != tt.wantToken {
+				t.Errorf("ResolveDiscordToken() = %q, want %q", got, tt.wantToken)
+			}
+		})
+	}
+}
+
 // TestResolveProviderKeys pins the per-component aggregation: each component
 // resolves independently (real keys decrypted, an unbound component -> ""), and
 // a single undecryptable component fails the WHOLE resolution clearly (AC2) so a


### PR DESCRIPTION
## What

A UI-started voice session now resolves the Discord bot token from the **saved `deployment_config`** (decrypted via the #69 credential cipher), falling back to `DISCORD_BOT_TOKEN` only when no real token is saved. A web-configured operator no longer needs the env var.

## Why

Closes #87. Today `StartSession` reads the bot token only from the `DISCORD_BOT_TOKEN` process env, even though the Configuration UI already saves it (sealed) into `deployment_config` (and #70's `GetProviderHealth` already reads that saved token). This closes the gap so a UI-configured operator drives the session with the saved token — the same hybrid BYOK policy the provider keys already use. Honors ADR-0004 (BYOK encrypted config) and ADR-0039 (DB-as-source end-state, hybrid).

## How

- **`wirenpc.ResolveDiscordToken`** — a pure, unit-testable resolver mirroring the existing `resolveKey` hybrid policy: a real saved token (`last4 != ""`/`"env"`) decrypts via the cipher and overrides ENV; the `"env"`/empty placeholder falls back to the env token; a saved token with a missing or wrong cipher is a **clear error**, never a silent degrade to ENV. Reuses the existing `credPlaceholderLast4` const (no duplicated `"env"` literal).
- **`session.Manager`** holds the `*crypto.Cipher` and resolves the token in `Start` — right after the guild/channel precondition and **before** the `voice_sessions` row write, so a missing/undecryptable token leaves no stuck row. New `ErrDiscordTokenMissing` sentinel when neither a saved nor an env token is available.
- **`rpc.StartSession`** maps `ErrDiscordTokenMissing` -> `CodeFailedPrecondition`, alongside the existing guild/channel precondition.
- **`cmd/glyphoxa/main.go`** `runWeb` passes the app cipher into `NewManager` (minimal edit).

## Acceptance criteria

- [x] `StartSession` uses the saved `deployment_config` bot token (decrypted via the cipher) when a real one is saved; `DISCORD_BOT_TOKEN` is no longer required for a UI-configured operator.
- [x] Falls back to `DISCORD_BOT_TOKEN` env when no token is saved (`last4` empty/`"env"`), preserving the voice-mode / dev / CI path.
- [x] A clear `CodeFailedPrecondition` when neither a saved token nor an env token is available (mirrors the existing guild/channel precondition).
- [x] Tests: the session resolves the saved token (faked store + cipher) and the env-fallback path — no live Discord call in unit tests.

## How tested

- `go test -race ./...` (CI `test` gate equivalent) — green.
- `go test -tags=integration -run='^$' ./...` — integration test binaries still compile against the new `NewManager` signature.
- `golangci-lint run` (v2.12.2, the CI pin) on the changed packages — 0 issues.
- `go vet` + `go build ./...` — clean.
- New unit tests: `TestResolveDiscordToken` (saved / env / cipher-missing / wrong-cipher), `TestStartUsesSavedToken`, `TestStartFallsBackToEnvToken`, `TestStartMissingToken`, `TestSessionStartTokenMissing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)