### PR TITLE
feat(#73): Live transcript streams to the browser (SSE relay)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -24,8 +24,10 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/spa"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/internal/transcript"
 	"github.com/MrWong99/Glyphoxa/internal/web"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 func main() {
@@ -233,10 +235,21 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	cfg.Logger = log
 	cfg.Metrics = metrics
 	cfg.StageMetrics = metrics
+	// ONE process-wide event bus (issue #73, ADR-0014): set on the base config
+	// BEFORE the Manager copies it, so the bus pointer flows through every
+	// manager-started session (Manager.base → RunFromDB → connectAndServe) and
+	// the SSE relay can subscribe once and observe events across reconnect cycles
+	// and sessions. Created here so the same instance feeds both halves.
+	eventBus := voiceevent.NewBus()
+	cfg.Bus = eventBus
 	runner := func(rctx context.Context, c wirenpc.Config) error {
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
 	mgr := session.NewManager(store, runner, cfg, log, withVoice)
+
+	// The SSE transcript relay (issue #73, ADR-0014 Hop-B) subscribes to the
+	// process bus once and reads the active session from the manager (Snapshot).
+	relay := transcript.NewRelay(eventBus, mgr, log)
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /
@@ -245,7 +258,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// paths (and client-side deep links) reach the SPA fallback.
 	srv := web.NewServer(web.Config{
 		Addr:   webAddr,
-		Mounts: managementMounts(store, cipher, log, mgr),
+		Mounts: managementMounts(store, cipher, log, mgr, relay),
 		Root:   spa.Handler(),
 		Logger: log,
 	})
@@ -271,7 +284,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // still stands and the API simply has no way in. cipher seals BYOK provider
 // keys (ADR-0004); it may be nil (saving keys then fails CodeFailedPrecondition).
 // mgr drives the in-process voice loop for SessionService (#72, ADR-0039).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager) []web.Mount {
+// relay serves the live transcript over SSE + a JSON snapshot (#73, ADR-0014):
+// its two plain net/http reads mount OUTSIDE the Connect /api prefix at
+// /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
+// Connect interceptor chain does not cover them).
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay) []web.Mount {
 	clientID := os.Getenv("DISCORD_OAUTH_CLIENT_ID")
 	if clientID == "" {
 		log.Warn("Discord OAuth is not configured; login is disabled until " +
@@ -307,6 +324,13 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 		web.APIMount(providerPath, providerHandler),
 		web.APIMount(voicePath, voiceHandler),
 		web.APIMount(sessionPath, sessionHandler),
+		// The SSE relay + snapshot are PLAIN mounts (not web.APIMount): they want
+		// the full /api/v1/... path, not the /api-stripped Connect method path.
+		// Go 1.22 method+wildcard patterns keep them off the Connect mounts
+		// (/api/glyphoxa.management.v1.*) and the SPA root. auth.RequireSession
+		// validates the glyphoxa_session cookie the EventSource/fetch send.
+		{Path: "GET /api/v1/sessions/{id}/events", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeEvents))},
+		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,28 @@
+package auth
+
+import "net/http"
+
+// RequireSession is the net/http guard for the plain (non-Connect) read
+// endpoints — the SSE transcript relay and its snapshot (ADR-0014 Hop-B). Those
+// handlers live OUTSIDE the Connect interceptor chain ([NewAuthInterceptor]), so
+// they would be unauthenticated without this. It mirrors the interceptor's gate:
+// the glyphoxa_session cookie must resolve to an operator via [Authenticator],
+// else the request is rejected 401.
+//
+// EventSource and same-origin fetch send the cookie automatically, so no custom
+// header is needed; both are GET reads, so there is no CSRF check (ADR-0016
+// exempts NO_SIDE_EFFECTS reads).
+func RequireSession(a Authenticator, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := cookieValue(r.Header, SessionCookieName)
+		if token == "" {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		if _, err := a.AuthenticateSession(r.Context(), token); err != nil {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,73 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// guarded wraps a 200-OK handler in RequireSession backed by a one-token authN.
+func guarded() http.Handler {
+	authN := fakeAuthN{users: map[string]storage.User{
+		validToken: {ID: uuid.New(), Name: "op", Role: "operator"},
+	}}
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("served"))
+	})
+	return auth.RequireSession(authN, ok)
+}
+
+func TestRequireSession_ValidCookiePasses(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc/events", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: validToken})
+
+	guarded().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "served" {
+		t.Fatalf("valid cookie: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireSession_MissingCookie401(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc/events", nil)
+
+	guarded().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing cookie: code=%d, want 401", rec.Code)
+	}
+}
+
+func TestRequireSession_InvalidCookie401(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc/events", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: "nope"})
+
+	guarded().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid cookie: code=%d, want 401", rec.Code)
+	}
+}
+
+// guard against an accidentally-blocking next call: ensure the downstream
+// handler is never invoked without auth.
+func TestRequireSession_DoesNotCallNextUnauthed(t *testing.T) {
+	called := false
+	h := auth.RequireSession(
+		fakeAuthN{users: map[string]storage.User{}},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }),
+	)
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	if called {
+		t.Fatal("next handler ran without a valid session")
+	}
+}

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -78,8 +78,10 @@ func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 	h := w.Header()
 	h.Set("Content-Type", "text/event-stream")
 	h.Set("Cache-Control", "no-cache")
-	h.Set("Connection", "keep-alive")
-	h.Set("X-Accel-Buffering", "no") // disable proxy buffering so frames flush promptly
+	// No "Connection: keep-alive": it is a hop-by-hop header the web tier's h2c
+	// listener rejects, and SSE needs no help from it. Disable proxy buffering so
+	// frames flush promptly.
+	h.Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -1,0 +1,140 @@
+package transcript
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// subscriber is one live SSE connection's fan-out channel. id is the session it
+// subscribed to: only frames for the matching active session are delivered, so a
+// stale connection from a previous session never receives the next one's frames.
+type subscriber struct {
+	id     string
+	ch     chan Frame
+	lagged chan struct{} // closed when ch overflows; the handler then exits → reconnect
+}
+
+// push fans a frame out to every subscriber on the active session. A full
+// channel means a slow reader: it is signalled lagged (once) and skipped — its
+// EventSource reconnects with Last-Event-ID and replays from the ring. Caller
+// holds r.mu, and the bus contract forbids blocking, so the send is
+// non-blocking.
+func (r *Relay) push(f Frame) {
+	for s := range r.subs {
+		if s.id != r.activeID {
+			continue
+		}
+		select {
+		case s.ch <- f:
+		default:
+			select {
+			case <-s.lagged:
+			default:
+				close(s.lagged)
+			}
+		}
+	}
+}
+
+// attach registers a subscriber and atomically returns the replay frames after
+// lastID, all under one lock so no frame is lost or duplicated across the
+// snapshot/subscribe boundary.
+func (r *Relay) attach(id string, lastID uint64) (*subscriber, []Frame) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var replay []Frame
+	if id == r.activeID {
+		for _, f := range r.buf {
+			if f.Seq > lastID {
+				replay = append(replay, f)
+			}
+		}
+	}
+	s := &subscriber{id: id, ch: make(chan Frame, subBuffer), lagged: make(chan struct{})}
+	r.subs[s] = struct{}{}
+	return s, replay
+}
+
+// detach removes a subscriber when its connection closes.
+func (r *Relay) detach(s *subscriber) {
+	r.mu.Lock()
+	delete(r.subs, s)
+	r.mu.Unlock()
+}
+
+// ServeEvents is the SSE live tail: GET /api/v1/sessions/{id}/events. It replays
+// the ring buffer after Last-Event-ID, then streams live frames until the client
+// disconnects or falls too far behind.
+func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	id := req.PathValue("id")
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no") // disable proxy buffering so frames flush promptly
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	s, replay := r.attach(id, lastEventID(req))
+	defer r.detach(s)
+
+	for _, f := range replay {
+		writeFrame(w, f)
+	}
+	flusher.Flush()
+
+	ctx := req.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.lagged:
+			return
+		case f := <-s.ch:
+			writeFrame(w, f)
+			flusher.Flush()
+		}
+	}
+}
+
+// ServeSnapshot is the initial-state read: GET /api/v1/sessions/{id}. It returns
+// the current transcript lines plus the derived status/typing as JSON.
+func (r *Relay) ServeSnapshot(w http.ResponseWriter, req *http.Request) {
+	view := r.View(req.PathValue("id"))
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache")
+	if err := json.NewEncoder(w).Encode(view); err != nil {
+		r.log.Warn("transcript: encode snapshot", "err", err)
+	}
+}
+
+// writeFrame serializes one SSE frame: an id/event/data triple terminated by a
+// blank line. Data is single-line JSON (json.Marshal never emits a raw newline),
+// so no multi-line data folding is needed.
+func writeFrame(w http.ResponseWriter, f Frame) {
+	fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", f.Seq, f.Event, f.Data)
+}
+
+// lastEventID reads the browser's resume cursor from the Last-Event-ID header
+// (sent automatically on EventSource reconnect), falling back to the
+// last_event_id query param for manual replay. 0 (or unparseable) replays the
+// whole buffer.
+func lastEventID(req *http.Request) uint64 {
+	v := req.Header.Get("Last-Event-ID")
+	if v == "" {
+		v = req.URL.Query().Get("last_event_id")
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/transcript/http_test.go
+++ b/internal/transcript/http_test.go
@@ -1,0 +1,219 @@
+package transcript_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/transcript"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+type fakeSessions struct {
+	id     uuid.UUID
+	active bool
+}
+
+func (f *fakeSessions) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{ID: f.id}, f.active
+}
+
+// sseFrame is one parsed SSE frame from the response stream.
+type sseFrame struct {
+	id    uint64
+	event string
+	data  string
+}
+
+// readFrames parses SSE frames off body into a channel until the body closes.
+func readFrames(body io.Reader) <-chan sseFrame {
+	out := make(chan sseFrame)
+	go func() {
+		defer close(out)
+		sc := bufio.NewScanner(body)
+		var cur sseFrame
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case line == "":
+				if cur.event != "" {
+					out <- cur
+				}
+				cur = sseFrame{}
+			case strings.HasPrefix(line, "id: "):
+				cur.id, _ = strconv.ParseUint(strings.TrimPrefix(line, "id: "), 10, 64)
+			case strings.HasPrefix(line, "event: "):
+				cur.event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				cur.data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+	}()
+	return out
+}
+
+func nextFrame(t *testing.T, ch <-chan sseFrame) sseFrame {
+	t.Helper()
+	select {
+	case f, ok := <-ch:
+		if !ok {
+			t.Fatal("frame stream closed early")
+		}
+		return f
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SSE frame")
+		return sseFrame{}
+	}
+}
+
+// nextLine reads frames until a "line" frame and returns its decoded line.
+func nextLine(t *testing.T, ch <-chan sseFrame) transcript.Line {
+	t.Helper()
+	for {
+		f := nextFrame(t, ch)
+		if f.event != "line" {
+			continue
+		}
+		var l transcript.Line
+		if err := json.Unmarshal([]byte(f.data), &l); err != nil {
+			t.Fatalf("unmarshal line: %v", err)
+		}
+		return l
+	}
+}
+
+func mux(r *transcript.Relay) http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("GET /api/v1/sessions/{id}/events", r.ServeEvents)
+	m.HandleFunc("GET /api/v1/sessions/{id}", r.ServeSnapshot)
+	return m
+}
+
+// connect opens the SSE stream for id (optionally resuming from lastID) and
+// returns the frame channel + a cancel that closes the connection.
+func connect(t *testing.T, base, id string, lastID uint64) (<-chan sseFrame, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/v1/sessions/"+id+"/events", nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("new request: %v", err)
+	}
+	if lastID > 0 {
+		req.Header.Set("Last-Event-ID", strconv.FormatUint(lastID, 10))
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("connect: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		cancel()
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		cancel()
+		t.Fatalf("content-type %q", ct)
+	}
+	ch := readFrames(resp.Body)
+	return ch, func() { cancel(); resp.Body.Close() }
+}
+
+// TestSSE_ReplayThenLive: buffered frames replay on connect, then a fresh event
+// streams live; a reconnect with Last-Event-ID skips already-seen frames.
+func TestSSE_ReplayThenLive(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	relay := transcript.NewRelay(bus, fs, nil)
+	srv := httptest.NewServer(mux(relay))
+	defer srv.Close()
+	id := fs.id.String()
+
+	// Buffered before any client connects.
+	bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "first", TurnID: "t1"})
+
+	ch, stop := connect(t, srv.URL, id, 0)
+	// Replay delivers the buffered human line.
+	if l := nextLine(t, ch); l.Text != "first" || l.Kind != transcript.KindPlayer {
+		t.Fatalf("replayed line = %+v", l)
+	}
+
+	// A new event streams live.
+	bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "second", TurnID: "t2"})
+	live := nextLine(t, ch)
+	if live.Text != "second" {
+		t.Fatalf("live line = %+v", live)
+	}
+	seenSeq := relay.Frames(id, 0)
+	stop()
+
+	// Reconnect resuming after the live "second" line's seq: no replay of it.
+	lastID := seenSeq[len(seenSeq)-1].Seq
+	bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "third", TurnID: "t3"})
+	ch2, stop2 := connect(t, srv.URL, id, lastID)
+	defer stop2()
+	got := nextLine(t, ch2)
+	if got.Text != "third" {
+		t.Fatalf("after reconnect want 'third' first, got %+v", got)
+	}
+}
+
+// TestSnapshotEndpoint returns the current lines + derived status as JSON.
+func TestSnapshotEndpoint(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	relay := transcript.NewRelay(bus, fs, nil)
+	srv := httptest.NewServer(mux(relay))
+	defer srv.Close()
+	id := fs.id.String()
+
+	bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "snap me", TurnID: "t1"})
+
+	resp, err := http.Get(srv.URL + "/api/v1/sessions/" + id)
+	if err != nil {
+		t.Fatalf("get snapshot: %v", err)
+	}
+	defer resp.Body.Close()
+	var v transcript.View
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v.Status != "live" || !v.Typing.Active {
+		t.Fatalf("snapshot status=%q typing=%+v", v.Status, v.Typing)
+	}
+	if len(v.Lines) != 1 || v.Lines[0].Text != "snap me" {
+		t.Fatalf("snapshot lines = %+v", v.Lines)
+	}
+}
+
+// TestSnapshotIdle returns idle when no session is active.
+func TestSnapshotIdle(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: false}
+	relay := transcript.NewRelay(bus, fs, nil)
+	srv := httptest.NewServer(mux(relay))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/sessions/" + fs.id.String())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	var v transcript.View
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v.Status != "idle" || len(v.Lines) != 0 {
+		t.Fatalf("idle snapshot = %+v", v)
+	}
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -196,6 +196,13 @@ func (r *Relay) project(e voiceevent.Event) {
 	}
 
 	switch ev := e.(type) {
+	case voiceevent.VADSpeechStart:
+		// A human opened their mouth: clear any stale "<NPC> is speaking…" the
+		// moment speech starts (it fires BEFORE STTFinal), instead of waiting for
+		// the next finalized line. Live-validated — a clean turn emits no
+		// TurnEnded, so without this the last agent line keeps the label through
+		// the following silence. Also correct for a barge (human over the Agent).
+		r.setTyping(r.liveTyping())
 	case voiceevent.STTFinal:
 		// A human utterance — one line per STTFinal in the anonymous lane
 		// (ADR-0039: raw STT carries no speaker id).

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -1,0 +1,358 @@
+// Package transcript is the SSE relay (ADR-0014 Hop-B): it bridges the
+// in-process voiceevent.Bus to the browser's live Session screen. It subscribes
+// to the bus ONCE at startup, projects the voice pipeline's events into
+// human-readable transcript lines (ADR-0020 taxonomy, ADR-0039 anonymous human
+// lane), keeps a per-session ~500-event ring buffer for Last-Event-ID replay,
+// and serves two endpoints: a Server-Sent-Events live tail and a JSON snapshot.
+//
+// There is no DB write here: line persistence is issue #74. The buffer is the
+// only state, scoped to the single active session (ADR-0039 single-operator) —
+// a fresh buffer starts when the active session id changes.
+package transcript
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+const (
+	// ringCap bounds the per-session replay buffer (ADR-0014: ~500 events). A
+	// reconnecting browser replays the frames after its Last-Event-ID; older
+	// frames are dropped, so a very stale reconnect re-syncs from the snapshot.
+	ringCap = 500
+	// subBuffer sizes each live subscriber's channel. It is >= ringCap so a
+	// reader keeping any reasonable pace never overflows; a reader that stalls is
+	// dropped (lagged) and its EventSource reconnects + replays from the ring.
+	subBuffer = 512
+
+	// listenLabel is the typing label while a session is live but no Agent is
+	// mid-reply (the design's "Listening to the table…").
+	listenLabel = "Listening to the table…"
+)
+
+// Kind classifies a transcript line's speaker. Per ADR-0039 the live projection
+// only ever emits player/npc/butler — raw STT has no speaker id, so all humans
+// share the anonymous "player" lane; gm is reserved for future SpeakerID work.
+type Kind string
+
+const (
+	KindGM     Kind = "gm"
+	KindPlayer Kind = "player"
+	KindNPC    Kind = "npc"
+	KindButler Kind = "butler"
+)
+
+// kindFor maps a speaker role to its transcript Kind. role is the
+// AddressTarget.AgentRole ("butler"/"character") for an Agent reply, or one of
+// the human pseudo-roles "gm"/"player" for human STT. The live projection only
+// passes "player" for humans (ADR-0039); "gm" is reserved for future SpeakerID
+// work, so an explicit gm input still maps to gm.
+func kindFor(role string) Kind {
+	switch role {
+	case "butler":
+		return KindButler
+	case "gm":
+		return KindGM
+	case "player":
+		return KindPlayer
+	default: // "character" and any other Agent role
+		return KindNPC
+	}
+}
+
+// tagFor is the tiny uppercase pill the SPA renders beside an Agent's name —
+// none for a human line.
+func tagFor(k Kind) string {
+	switch k {
+	case KindButler:
+		return "Butler"
+	case KindNPC:
+		return "NPC"
+	default:
+		return ""
+	}
+}
+
+// Line is one rendered transcript line. ID is stable so the SPA upserts a turn's
+// coalescing Agent reply in place; ts is the line's instant (RFC3339 on the
+// wire).
+type Line struct {
+	ID   string    `json:"id"`
+	Who  string    `json:"who"`
+	Tag  string    `json:"tag,omitempty"`
+	Kind Kind      `json:"kind"`
+	TS   time.Time `json:"ts"`
+	Text string    `json:"text"`
+}
+
+// Typing is the "is speaking" / "listening" indicator the SPA renders as the
+// blinking dots + label. Derived server-side so it is unit-testable (ADR-0019).
+type Typing struct {
+	Active bool   `json:"active"`
+	Label  string `json:"label"`
+}
+
+// status is the payload of a "status" frame and the status half of a snapshot:
+// the live/idle session state plus the typing indicator.
+type status struct {
+	Status string `json:"status"` // "live" | "idle"
+	Typing Typing `json:"typing"`
+}
+
+// View is the snapshot the JSON endpoint returns and the unit tests assert on:
+// the current coalesced lines plus the derived status/typing.
+type View struct {
+	Lines  []Line `json:"lines"`
+	Status string `json:"status"`
+	Typing Typing `json:"typing"`
+}
+
+// Frame is one buffered SSE frame. Seq is the monotonic `id:` field a browser
+// echoes back as Last-Event-ID; Event is the `event:` name; Data is the JSON
+// `data:` payload (a Line or a status).
+type Frame struct {
+	Seq   uint64
+	Event string
+	Data  []byte
+}
+
+// Sessions is the narrow read the relay needs from the SessionManager: which
+// voice session (if any) is currently active. *session.Manager satisfies it via
+// Snapshot; tests fake it.
+type Sessions interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// turn holds the per-turn coalescing state: the routed target and the Agent's
+// reply line whose text accumulates across the turn's TTSInvoked sentences.
+type turn struct {
+	target voiceevent.AddressTarget
+	line   *Line
+}
+
+// Relay projects bus events into transcript lines and serves them over SSE +
+// JSON. Safe for concurrent use: the bus callback, the HTTP handlers and View
+// all take the same lock.
+type Relay struct {
+	sessions Sessions
+	log      *slog.Logger
+
+	mu       sync.Mutex
+	activeID string // current session id; "" when idle
+	buf      []Frame
+	lines    []Line
+	typing   Typing
+	turns    map[string]*turn
+	nextSeq  uint64
+	humanSeq uint64
+	subs     map[*subscriber]struct{}
+}
+
+// NewRelay subscribes to the bus once and returns a Relay ready to serve. The
+// subscription lives for the process: the same bus persists across reconnect
+// cycles AND across sessions (single active session, ADR-0039), so the relay
+// sees every event without re-subscribing.
+func NewRelay(bus *voiceevent.Bus, sessions Sessions, log *slog.Logger) *Relay {
+	if log == nil {
+		log = slog.Default()
+	}
+	r := &Relay{
+		sessions: sessions,
+		log:      log,
+		turns:    map[string]*turn{},
+		subs:     map[*subscriber]struct{}{},
+	}
+	bus.Subscribe(r.project)
+	return r
+}
+
+// project is the bus callback: it attributes the event to the active session,
+// rolling the buffer over on a session change, and folds the event into the
+// transcript. It must not block (the bus delivers synchronously): all sends to
+// live subscribers are non-blocking.
+func (r *Relay) project(e voiceevent.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	id := r.currentSessionID()
+	if id == "" {
+		return // no active session — drop the event (ADR-0039)
+	}
+	if id != r.activeID {
+		r.rollover(id)
+	}
+
+	switch ev := e.(type) {
+	case voiceevent.STTFinal:
+		// A human utterance — one line per STTFinal in the anonymous lane
+		// (ADR-0039: raw STT carries no speaker id).
+		r.humanSeq++
+		r.emitLine(Line{
+			ID:   "u:" + strconv.FormatUint(r.humanSeq, 10),
+			Who:  "Player / DM",
+			Kind: KindPlayer,
+			TS:   ev.At,
+			Text: ev.Text,
+		})
+	case voiceevent.AddressRouted:
+		// Records WHO answers this turn; no line yet (no text).
+		t := r.turn(ev.TurnID)
+		t.target = ev.Target
+	case voiceevent.TTSInvoked:
+		// One sentence of the Agent's reply — coalesced into the turn's line.
+		t := r.turn(ev.TurnID)
+		if t.line == nil {
+			k := kindFor(t.target.AgentRole)
+			t.line = &Line{
+				ID:   "a:" + ev.TurnID,
+				Who:  nameOr(t.target.Name, "NPC"),
+				Tag:  tagFor(k),
+				Kind: k,
+				TS:   ev.At,
+				Text: ev.Sentence,
+			}
+		} else if ev.Sentence != "" {
+			t.line.Text += " " + ev.Sentence
+		}
+		r.emitLine(*t.line)
+		r.setTyping(Typing{Active: true, Label: nameOr(t.target.Name, "NPC") + " is speaking…"})
+	case voiceevent.TurnEnded:
+		// The turn's reply is finalized; back to listening.
+		delete(r.turns, ev.TurnID)
+		r.setTyping(r.liveTyping())
+	}
+}
+
+// currentSessionID returns the active session's id, or "" when idle.
+func (r *Relay) currentSessionID() string {
+	vs, active := r.sessions.Snapshot()
+	if !active {
+		return ""
+	}
+	return vs.ID.String()
+}
+
+// rollover starts a fresh buffer for a newly-active session id and seeds it with
+// the initial live/listening status frame, so a client connecting mid-session
+// replays a coherent state.
+func (r *Relay) rollover(id string) {
+	r.activeID = id
+	r.buf = nil
+	r.lines = nil
+	r.turns = map[string]*turn{}
+	r.nextSeq = 0
+	r.humanSeq = 0
+	r.typing = r.liveTyping()
+	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "live", Typing: r.typing})})
+}
+
+// turn returns the coalescing state for a turn id, creating it on first sight.
+func (r *Relay) turn(id string) *turn {
+	t := r.turns[id]
+	if t == nil {
+		t = &turn{}
+		r.turns[id] = t
+	}
+	return t
+}
+
+// liveTyping is the indicator while a session is live but no Agent is mid-reply.
+func (r *Relay) liveTyping() Typing {
+	return Typing{Active: true, Label: listenLabel}
+}
+
+// emitLine upserts the line into the current display state (replacing a turn's
+// coalescing reply in place) and emits a "line" frame.
+func (r *Relay) emitLine(l Line) {
+	replaced := false
+	for i := range r.lines {
+		if r.lines[i].ID == l.ID {
+			r.lines[i] = l
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		r.lines = append(r.lines, l)
+	}
+	r.emit(Frame{Event: "line", Data: mustJSON(l)})
+}
+
+// setTyping emits a "status" frame only when the typing indicator changes, so an
+// idle session does not churn the stream.
+func (r *Relay) setTyping(t Typing) {
+	if t == r.typing {
+		return
+	}
+	r.typing = t
+	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "live", Typing: t})})
+}
+
+// emit assigns the next seq, appends to the ring (dropping the oldest past cap)
+// and fans the frame out to live subscribers. Caller holds r.mu.
+func (r *Relay) emit(f Frame) {
+	r.nextSeq++
+	f.Seq = r.nextSeq
+	r.buf = append(r.buf, f)
+	if len(r.buf) > ringCap {
+		r.buf = append([]Frame(nil), r.buf[len(r.buf)-ringCap:]...)
+	}
+	r.push(f)
+}
+
+// View returns the current snapshot for id: the coalesced lines plus the derived
+// status/typing. status is recomputed from the live manager state, so it reads
+// idle the moment the session ends even though the buffer's last frame said live.
+func (r *Relay) View(id string) View {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.currentSessionID() != id || id != r.activeID {
+		return View{Lines: []Line{}, Status: "idle", Typing: Typing{}}
+	}
+	return View{
+		Lines:  append([]Line(nil), r.lines...),
+		Status: "live",
+		Typing: r.typing,
+	}
+}
+
+// Frames returns the buffered frames for id with Seq > afterSeq — the
+// Last-Event-ID replay set. Empty when id is not the active session.
+func (r *Relay) Frames(id string, afterSeq uint64) []Frame {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id != r.activeID {
+		return nil
+	}
+	var out []Frame
+	for _, f := range r.buf {
+		if f.Seq > afterSeq {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// nameOr returns name, or def when name is empty.
+func nameOr(name, def string) string {
+	if name == "" {
+		return def
+	}
+	return name
+}
+
+// mustJSON marshals v, panicking on a programming error (the relay's own fixed
+// structs are always marshalable).
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("transcript: marshal frame: " + err.Error())
+	}
+	return b
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -26,10 +26,13 @@ const (
 	// reconnecting browser replays the frames after its Last-Event-ID; older
 	// frames are dropped, so a very stale reconnect re-syncs from the snapshot.
 	ringCap = 500
-	// subBuffer sizes each live subscriber's channel. It is >= ringCap so a
-	// reader keeping any reasonable pace never overflows; a reader that stalls is
-	// dropped (lagged) and its EventSource reconnects + replays from the ring.
-	subBuffer = 512
+	// subBuffer sizes each live subscriber's channel. It MUST be <= ringCap so the
+	// replay is lossless across a lagged drop: when a stalled reader's channel
+	// overflows (subBuffer unsent frames) and is dropped, every frame it missed is
+	// still within the ring's last ringCap, so its EventSource reconnect replays
+	// them from Last-Event-ID with no gap. A reader keeping any reasonable pace
+	// never overflows; an unbounded gap re-syncs from the snapshot.
+	subBuffer = 256
 
 	// listenLabel is the typing label while a session is live but no Agent is
 	// mid-reply (the design's "Listening to the table…").
@@ -131,9 +134,13 @@ type Sessions interface {
 
 // turn holds the per-turn coalescing state: the routed target and the Agent's
 // reply line whose text accumulates across the turn's TTSInvoked sentences.
+// ended marks a finalized turn (TurnEnded seen) so a late TTSInvoked — which a
+// barge can deliver AFTER the end — does not recreate the entry with a zero
+// target and clobber the completed coalesced reply.
 type turn struct {
 	target voiceevent.AddressTarget
 	line   *Line
+	ended  bool
 }
 
 // Relay projects bus events into transcript lines and serves them over SSE +
@@ -207,6 +214,11 @@ func (r *Relay) project(e voiceevent.Event) {
 	case voiceevent.TTSInvoked:
 		// One sentence of the Agent's reply — coalesced into the turn's line.
 		t := r.turn(ev.TurnID)
+		if t.ended {
+			// A barge can deliver a sentence after TurnEnded; ignore it so the
+			// finalized reply is not clobbered (FIX 2). typing already cleared.
+			return
+		}
 		if t.line == nil {
 			k := kindFor(t.target.AgentRole)
 			t.line = &Line{
@@ -218,13 +230,22 @@ func (r *Relay) project(e voiceevent.Event) {
 				Text: ev.Sentence,
 			}
 		} else if ev.Sentence != "" {
-			t.line.Text += " " + ev.Sentence
+			// Only separate with a space when there is preceding text — an empty
+			// first sentence then a non-empty one must not leave a leading space.
+			if t.line.Text != "" {
+				t.line.Text += " "
+			}
+			t.line.Text += ev.Sentence
 		}
+		// emitLine derives typing from the line's kind (FIX 1), so a clean turn
+		// (which emits NO TurnEnded) still shows "speaking" and a later human line
+		// returns to listening — no standalone setTyping here.
 		r.emitLine(*t.line)
-		r.setTyping(Typing{Active: true, Label: nameOr(t.target.Name, "NPC") + " is speaking…"})
 	case voiceevent.TurnEnded:
-		// The turn's reply is finalized; back to listening.
-		delete(r.turns, ev.TurnID)
+		// Mark the turn finalized (keep the entry so a late sentence is dropped,
+		// FIX 2) and fall back to listening — correct for a barge that cut the
+		// Agent off mid-reply.
+		r.turn(ev.TurnID).ended = true
 		r.setTyping(r.liveTyping())
 	}
 }
@@ -268,7 +289,12 @@ func (r *Relay) liveTyping() Typing {
 }
 
 // emitLine upserts the line into the current display state (replacing a turn's
-// coalescing reply in place) and emits a "line" frame.
+// coalescing reply in place), emits a "line" frame, and derives the typing
+// indicator from the line's kind (FIX 1). Deriving it from the LAST emitted line
+// — Agent line => "<who> is speaking…", human line => listening — matches the
+// design rule and is robust to a CLEAN turn, which emits no TurnEnded: without
+// this the label would stick on "speaking" through the following silence and
+// human turns.
 func (r *Relay) emitLine(l Line) {
 	replaced := false
 	for i := range r.lines {
@@ -282,6 +308,13 @@ func (r *Relay) emitLine(l Line) {
 		r.lines = append(r.lines, l)
 	}
 	r.emit(Frame{Event: "line", Data: mustJSON(l)})
+
+	switch l.Kind {
+	case KindNPC, KindButler:
+		r.setTyping(Typing{Active: true, Label: l.Who + " is speaking…"})
+	default: // KindPlayer / KindGM — a human line means we are back to listening
+		r.setTyping(r.liveTyping())
+	}
 }
 
 // setTyping emits a "status" frame only when the typing indicator changes, so an

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -223,6 +223,26 @@ func TestTyping_ClearsAfterCleanTurn(t *testing.T) {
 	}
 }
 
+// TestTyping_ClearsOnSpeechStart (round 3, live-validated): the stale
+// "<NPC> is speaking…" label clears the moment a human starts talking
+// (VADSpeechStart fires before STTFinal), not only on the next finalized line.
+func TestTyping_ClearsOnSpeechStart(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Aye.", TurnID: "t1"})
+	if v := r.View(id); v.Typing.Label != "Bart is speaking…" {
+		t.Fatalf("pre-speech typing=%+v", v.Typing)
+	}
+	// Clean turn (no TurnEnded); the human opens their mouth.
+	bus.Publish(voiceevent.VADSpeechStart{At: at(3)})
+	if v := r.View(id); !v.Typing.Active || v.Typing.Label != listenLabel {
+		t.Fatalf("typing not cleared on speech start: %+v", v.Typing)
+	}
+}
+
 // TestLateTTSInvoked_DoesNotClobber (FIX 2): a barge can deliver a sentence
 // after TurnEnded; it must not recreate the turn with a zero target and overwrite
 // the finalized coalesced reply.

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -2,6 +2,7 @@ package transcript
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -197,6 +198,108 @@ func TestRolloverOnSessionChange(t *testing.T) {
 	v := r.View(id2)
 	if len(v.Lines) != 1 || v.Lines[0].Text != "new" {
 		t.Errorf("session 2 view = %+v", v)
+	}
+}
+
+// TestTyping_ClearsAfterCleanTurn is the headline regression (FIX 1): a CLEAN
+// turn emits NO TurnEnded, so typing must NOT stay stuck on "<NPC> is speaking…"
+// — a following human utterance returns it to listening.
+func TestTyping_ClearsAfterCleanTurn(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hi", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Aye.", TurnID: "t1"})
+	// No TurnEnded — a clean (successful) turn reports nothing.
+	if v := r.View(id); v.Typing.Label != "Bart is speaking…" {
+		t.Fatalf("mid-reply typing=%+v", v.Typing)
+	}
+	// A new human turn must clear the stuck speaking label.
+	bus.Publish(voiceevent.STTFinal{At: at(4), Text: "again", TurnID: "t2"})
+	if v := r.View(id); !v.Typing.Active || v.Typing.Label != listenLabel {
+		t.Fatalf("typing did not return to listening after clean turn: %+v", v.Typing)
+	}
+}
+
+// TestLateTTSInvoked_DoesNotClobber (FIX 2): a barge can deliver a sentence
+// after TurnEnded; it must not recreate the turn with a zero target and overwrite
+// the finalized coalesced reply.
+func TestLateTTSInvoked_DoesNotClobber(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hello", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Sit.", TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+	before := r.View(id)
+
+	bus.Publish(voiceevent.TTSInvoked{At: at(6), Sentence: "LATE", TurnID: "t1"})
+	after := r.View(id)
+
+	if len(after.Lines) != len(before.Lines) {
+		t.Fatalf("late TTS changed line count: before %d after %d", len(before.Lines), len(after.Lines))
+	}
+	agent := after.Lines[1]
+	if agent.Who != "Bart" || agent.Text != "Well met. Sit." {
+		t.Fatalf("late TTS clobbered the finalized reply: %+v", agent)
+	}
+	if after.Typing.Label != listenLabel {
+		t.Fatalf("typing changed after a dropped late sentence: %+v", after.Typing)
+	}
+}
+
+// TestRingEviction_Lossless (FIX 3): subBuffer <= ringCap guarantees a lagged
+// drop is replayable from the ring. Emitting past the cap keeps a contiguous
+// suffix (no gap) so a reconnect resumes losslessly within the retained window.
+func TestRingEviction_Lossless(t *testing.T) {
+	if subBuffer > ringCap {
+		t.Fatalf("subBuffer(%d) must be <= ringCap(%d) for lossless lagged replay", subBuffer, ringCap)
+	}
+	bus, r, _, id := liveRelay(t)
+	for i := 0; i < ringCap+100; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: fmt.Sprintf("%d", i), TurnID: fmt.Sprintf("t%d", i)})
+	}
+	all := r.Frames(id, 0)
+	if len(all) != ringCap {
+		t.Fatalf("ring kept %d frames, want %d", len(all), ringCap)
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i].Seq != all[i-1].Seq+1 {
+			t.Fatalf("gap in retained ring at %d: %d then %d", i, all[i-1].Seq, all[i].Seq)
+		}
+	}
+}
+
+// TestPublish_DoesNotBlockOnLaggedSubscriber (FIX 5): the synchronous bus must
+// never stall on a slow SSE client — flooding a never-read subscriber past
+// subBuffer signals it lagged and Publish returns promptly.
+func TestPublish_DoesNotBlockOnLaggedSubscriber(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(0), Text: "warm", TurnID: "w"}) // sets activeID
+	s, _ := r.attach(id, 0)                                                // never read s.ch
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < subBuffer+50; i++ {
+			bus.Publish(voiceevent.STTFinal{At: at(i), Text: "x", TurnID: fmt.Sprintf("f%d", i)})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on a lagged (never-read) subscriber")
+	}
+	select {
+	case <-s.lagged:
+	case <-time.After(time.Second):
+		t.Fatal("a lagged subscriber was never signalled")
 	}
 }
 

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -1,0 +1,212 @@
+package transcript
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// fakeSessions is a settable Snapshot source: the relay attributes events and
+// derives status from whatever active session it reports.
+type fakeSessions struct {
+	id     uuid.UUID
+	active bool
+}
+
+func (f *fakeSessions) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{ID: f.id}, f.active
+}
+
+func at(sec int) time.Time {
+	return time.Date(2026, 6, 27, 18, 0, sec, 0, time.UTC)
+}
+
+// liveRelay returns a relay wired to a bus with one active session.
+func liveRelay(t *testing.T) (*voiceevent.Bus, *Relay, *fakeSessions, string) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	r := NewRelay(bus, fs, nil)
+	return bus, r, fs, fs.id.String()
+}
+
+func TestKindFor(t *testing.T) {
+	cases := map[string]Kind{
+		"gm":        KindGM,
+		"player":    KindPlayer,
+		"butler":    KindButler,
+		"character": KindNPC,
+		"":          KindNPC, // any other Agent role
+	}
+	for role, want := range cases {
+		if got := kindFor(role); got != want {
+			t.Errorf("kindFor(%q) = %q, want %q", role, got, want)
+		}
+	}
+}
+
+// TestProjection_LinesAndOrder feeds one turn (human → routed → two reply
+// sentences → end) and asserts the projected lines: an anonymous human lane and
+// a coalesced NPC reply, in order.
+func TestProjection_LinesAndOrder(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hello Bart", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), Text: "Hello Bart", TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", Index: 0, TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "What'll it be?", Index: 1, TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+
+	v := r.View(id)
+	if len(v.Lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %+v", len(v.Lines), v.Lines)
+	}
+	human := v.Lines[0]
+	if human.Who != "Player / DM" || human.Kind != KindPlayer || human.Tag != "" || human.Text != "Hello Bart" {
+		t.Errorf("human line = %+v", human)
+	}
+	npc := v.Lines[1]
+	if npc.Who != "Bart" || npc.Kind != KindNPC || npc.Tag != "NPC" {
+		t.Errorf("npc line meta = %+v", npc)
+	}
+	if npc.Text != "Well met. What'll it be?" {
+		t.Errorf("npc coalesced text = %q, want %q", npc.Text, "Well met. What'll it be?")
+	}
+}
+
+// TestProjection_ButlerKind checks the butler role maps to the butler kind + tag.
+func TestProjection_ButlerKind(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "butler", AgentRole: "butler", Name: "Butler"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "At your service.", TurnID: "t1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(v.Lines))
+	}
+	if l := v.Lines[0]; l.Kind != KindButler || l.Tag != "Butler" || l.Who != "Butler" {
+		t.Errorf("butler line = %+v", l)
+	}
+}
+
+// TestTypingAndStatus asserts the server-side typing/status derivation: live +
+// listening while idle-between-turns, "<Name> is speaking…" mid-reply, back to
+// listening on turn end, and idle once the session stops.
+func TestTypingAndStatus(t *testing.T) {
+	bus, r, fs, id := liveRelay(t)
+
+	// First event opens the session → live + listening.
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hi", TurnID: "t1"})
+	if v := r.View(id); v.Status != "live" || !v.Typing.Active || v.Typing.Label != listenLabel {
+		t.Fatalf("after STT: status=%q typing=%+v", v.Status, v.Typing)
+	}
+
+	// Mid-reply → "<Name> is speaking…".
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Aye.", TurnID: "t1"})
+	if v := r.View(id); !v.Typing.Active || v.Typing.Label != "Bart is speaking…" {
+		t.Fatalf("mid-reply typing=%+v", v.Typing)
+	}
+
+	// Turn end → back to listening.
+	bus.Publish(voiceevent.TurnEnded{At: at(4), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+	if v := r.View(id); v.Typing.Label != listenLabel {
+		t.Fatalf("post-turn typing=%+v", v.Typing)
+	}
+
+	// Session stops → idle, inactive typing, no lines.
+	fs.active = false
+	if v := r.View(id); v.Status != "idle" || v.Typing.Active || len(v.Lines) != 0 {
+		t.Fatalf("idle view=%+v", v)
+	}
+}
+
+// TestReplayAfterLastEventID checks the ring buffer replays only frames after a
+// cursor, in monotonic seq order — the Last-Event-ID reconnect contract.
+func TestReplayAfterLastEventID(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "one", TurnID: "t1"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "two", TurnID: "t2"})
+
+	all := r.Frames(id, 0)
+	if len(all) < 3 { // status(open) + 2 lines
+		t.Fatalf("got %d frames, want >=3: %+v", len(all), all)
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i].Seq <= all[i-1].Seq {
+			t.Fatalf("frames not monotonic: %d then %d", all[i-1].Seq, all[i].Seq)
+		}
+	}
+
+	// Replay after the first frame returns the strict suffix.
+	cursor := all[0].Seq
+	after := r.Frames(id, cursor)
+	if len(after) != len(all)-1 {
+		t.Fatalf("replay after %d returned %d frames, want %d", cursor, len(after), len(all)-1)
+	}
+	for _, f := range after {
+		if f.Seq <= cursor {
+			t.Errorf("replay leaked frame seq %d <= cursor %d", f.Seq, cursor)
+		}
+	}
+
+	// Last frame is the "two" line.
+	last := all[len(all)-1]
+	if last.Event != "line" {
+		t.Fatalf("last frame event = %q", last.Event)
+	}
+	var l Line
+	if err := json.Unmarshal(last.Data, &l); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if l.Text != "two" {
+		t.Errorf("last line text = %q, want two", l.Text)
+	}
+}
+
+// TestRolloverOnSessionChange checks a new active session id starts a fresh
+// buffer (old frames gone, seq reset).
+func TestRolloverOnSessionChange(t *testing.T) {
+	bus, r, fs, id1 := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "old", TurnID: "t1"})
+	if len(r.Frames(id1, 0)) == 0 {
+		t.Fatal("session 1 buffered nothing")
+	}
+
+	fs.id = uuid.New()
+	id2 := fs.id.String()
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "new", TurnID: "t2"})
+
+	if got := r.Frames(id1, 0); got != nil {
+		t.Errorf("old session still buffered %d frames", len(got))
+	}
+	v := r.View(id2)
+	if len(v.Lines) != 1 || v.Lines[0].Text != "new" {
+		t.Errorf("session 2 view = %+v", v)
+	}
+}
+
+// TestDropWhenIdle checks events with no active session are dropped.
+func TestDropWhenIdle(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: false}
+	r := NewRelay(bus, fs, nil)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "ignored", TurnID: "t1"})
+	if got := r.Frames(fs.id.String(), 0); got != nil {
+		t.Errorf("idle relay buffered %d frames", len(got))
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -224,6 +224,13 @@ type Config struct {
 	// nothing. The live binary injects the Prometheus adapter; the benchmark
 	// injects its own; the keyless default is the no-op recorder.
 	StageMetrics observe.StageRecorder
+	// Bus, when non-nil, is the process-wide voiceevent.Bus the orchestrator
+	// publishes onto INSTEAD of a fresh per-cycle bus (issue #73, ADR-0014).
+	// The web tier injects ONE bus so the SSE transcript relay can subscribe
+	// once and keep seeing events across reconnect cycles AND across sessions
+	// (single active session, ADR-0039). nil (the env-only voice/bench paths)
+	// keeps today's behavior: connectAndServe makes its own per-cycle bus.
+	Bus *voiceevent.Bus
 	// npcs are the Character NPCs this loop voices. Run resolves them: RunFromDB
 	// loads all Character NPCs in the campaign from storage; the env-only Run path
 	// seeds the single hardcoded NPC when the slice is empty. The roster the loop
@@ -456,7 +463,15 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// tee can publish FirstAudio (A3 hook 1) and the pump can publish FirstOpus
 	// (task #7, the audible-on-wire SLO end) onto the same bus the conversation's
 	// stages publish on and the metrics subscriber reads.
-	bus := voiceevent.NewBus()
+	//
+	// The web tier injects ONE process-wide bus (cfg.Bus, issue #73) so the SSE
+	// transcript relay subscribes once and keeps observing events across reconnect
+	// cycles and sessions; the env-only voice/bench paths leave it nil and get a
+	// fresh per-cycle bus (today's behavior, unchanged).
+	bus := cfg.Bus
+	if bus == nil {
+		bus = voiceevent.NewBus()
+	}
 
 	pump := wire.NewPlaybackPump(sess, cdc, log, bus)
 	defer pump.Close()

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
@@ -16,6 +16,7 @@ import {
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
+import { MockEventSource } from "@/test/mockEventSource";
 import { Session, formatElapsed } from "./Session";
 
 // An in-memory voice-session store served over a router transport (no network):
@@ -111,5 +112,77 @@ describe("Session", () => {
       expect(screen.getByText(/12 lines transcribed/i)).toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: /start session/i })).toBeInTheDocument();
+  });
+});
+
+// liveTransport reports an already-running session so the transcript hook is
+// enabled immediately (no Start click needed for the SSE assertions).
+function liveTransport() {
+  const current = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "running",
+    startedAt: timestampFromDate(new Date()),
+  });
+  return createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () => create(GetSessionResponseSchema, { session: current, active: true }),
+      startSession: () => create(StartSessionResponseSchema, { session: current }),
+      stopSession: () => create(StopSessionResponseSchema, { session: current }),
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+}
+
+describe("Session live transcript (#73)", () => {
+  it("seeds from the snapshot then renders streamed lines + typing dots", async () => {
+    // Snapshot: live + listening, no lines yet.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ lines: [], status: "live", typing: { active: true, label: "Listening to the table…" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    // Live badge + the listening indicator (3 dots + label) from the snapshot.
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+    expect(await screen.findByText("Listening to the table…")).toBeInTheDocument();
+    expect(screen.getByTestId("typing")).toBeInTheDocument();
+
+    // The screen opened the live stream; drive a coalesced NPC line + a
+    // "speaking" status frame and assert they render.
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("EventSource not opened yet");
+      return inst;
+    });
+    expect(es.url).toContain("/api/v1/sessions/vs1/events");
+
+    act(() => {
+      es.emit("line", {
+        id: "a:t1",
+        who: "Bart",
+        tag: "NPC",
+        kind: "npc",
+        ts: new Date().toISOString(),
+        text: "Well met, traveller.",
+      });
+      es.emit("status", { status: "live", typing: { active: true, label: "Bart is speaking…" } });
+    });
+
+    expect(await screen.findByText("Well met, traveller.")).toBeInTheDocument();
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+    expect(screen.getByText("NPC")).toBeInTheDocument();
+    expect(await screen.findByText("Bart is speaking…")).toBeInTheDocument();
   });
 });

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
@@ -184,5 +184,79 @@ describe("Session live transcript (#73)", () => {
     expect(screen.getByText("Bart")).toBeInTheDocument();
     expect(screen.getByText("NPC")).toBeInTheDocument();
     expect(await screen.findByText("Bart is speaking…")).toBeInTheDocument();
+  });
+
+  it("does not open the stream until the snapshot resolves (FIX 4)", async () => {
+    // A snapshot that never resolves until we say so.
+    let resolveSnap!: (r: Response) => void;
+    globalThis.fetch = (() =>
+      new Promise<Response>((res) => {
+        resolveSnap = res;
+      })) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    // Session is live, but the snapshot is still pending.
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+
+    // The stream must NOT be open yet — so an SSE line can never race ahead of a
+    // late snapshot that would clobber it.
+    expect(MockEventSource.last()).toBeUndefined();
+
+    // Resolve the snapshot → the stream opens → a streamed line renders.
+    act(() => {
+      resolveSnap(
+        new Response(JSON.stringify({ lines: [], status: "live", typing: { active: false, label: "" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("stream not opened after snapshot resolved");
+      return inst;
+    });
+    act(() => {
+      es.emit("line", {
+        id: "u:1",
+        who: "Player / DM",
+        kind: "player",
+        ts: new Date().toISOString(),
+        text: "hello there",
+      });
+    });
+    expect(await screen.findByText("hello there")).toBeInTheDocument();
+  });
+
+  it("re-syncs the snapshot on EventSource reconnect (FIX 3)", async () => {
+    const snap = { lines: [], status: "live", typing: { active: false, label: "" } };
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify(snap), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    await screen.findByText("Live");
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("EventSource not opened yet");
+      return inst;
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1)); // initial snapshot
+
+    // First open = initial connect (no refetch); a SECOND open = reconnect, which
+    // re-fetches the authoritative snapshot.
+    act(() => es.emit("open", null));
+    act(() => es.emit("open", null));
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
   });
 });

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -9,6 +9,7 @@ import type { VoiceSession } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { useSessionEvents, formatClock } from "./useSessionEvents";
 
 import "./session.css";
 
@@ -91,6 +92,11 @@ export function Session() {
   // The timer runs only while live, counting up from the running session's start.
   const elapsed = useElapsed(active ? tsMs(session?.startedAt) : null);
 
+  // Live transcript: snapshot + SSE tail into the query cache (#73).
+  const transcript = useSessionEvents(session?.id, active);
+  const hasLines = transcript.lines.length > 0;
+  const showTyping = active && transcript.typing.active;
+
   return (
     <div className="gx-session">
       <header className="gx-session__header">
@@ -144,11 +150,40 @@ export function Session() {
       <section className="gx-session__transcript">
         <h2 className="gx-section-title">{active ? "Live transcript" : "Session transcript"}</h2>
         <Card>
-          <p className="gx-session__transcript-empty">
-            {active
-              ? "Listening… transcript lines will appear here."
-              : "Start a session to capture the table's voice transcript."}
-          </p>
+          {!hasLines && !showTyping ? (
+            <p className="gx-session__transcript-empty">
+              {active
+                ? "Listening… transcript lines will appear here."
+                : "Start a session to capture the table's voice transcript."}
+            </p>
+          ) : (
+            <ol className="gx-transcript">
+              {transcript.lines.map((line) => (
+                <li key={line.id} className="gx-line">
+                  <span className="gx-line__who" data-kind={line.kind}>
+                    {line.who}
+                  </span>
+                  {line.tag && (
+                    <span className="gx-line__tag" data-kind={line.kind}>
+                      {line.tag}
+                    </span>
+                  )}
+                  <time className="gx-line__ts">{formatClock(line.ts)}</time>
+                  <span className="gx-line__text">{line.text}</span>
+                </li>
+              ))}
+              {showTyping && (
+                <li className="gx-typing" aria-live="polite" data-testid="typing">
+                  <span className="gx-typing__dots" aria-hidden="true">
+                    <i />
+                    <i />
+                    <i />
+                  </span>
+                  <span className="gx-typing__label">{transcript.typing.label}</span>
+                </li>
+              )}
+            </ol>
+          )}
         </Card>
       </section>
     </div>

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -58,3 +58,113 @@
   margin: 0;
   color: var(--text-muted);
 }
+
+/* Live transcript list: one row per line — speaker name, optional tag pill,
+ * timestamp, then the utterance text. */
+.gx-transcript {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.gx-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  line-height: 1.5;
+}
+
+/* Speaker name, bold in the kind's color (design tokens). */
+.gx-line__who {
+  font-weight: 700;
+  color: var(--text-default);
+}
+.gx-line__who[data-kind="gm"] {
+  color: var(--text-strong);
+}
+.gx-line__who[data-kind="player"] {
+  color: var(--rune);
+}
+.gx-line__who[data-kind="butler"] {
+  color: var(--gold);
+}
+.gx-line__who[data-kind="npc"] {
+  color: var(--text-default);
+}
+
+/* Tiny uppercase pill beside an Agent's name: gold for the Butler, subtle for
+ * a Character NPC. */
+.gx-line__tag {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border-subtle, var(--text-muted));
+  color: var(--text-subtle);
+}
+.gx-line__tag[data-kind="butler"] {
+  border-color: var(--gold);
+  color: var(--gold);
+}
+
+.gx-line__ts {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.gx-line__text {
+  color: var(--text-default);
+}
+
+/* Typing / "is speaking" indicator: three blinking dots + a mono label. */
+.gx-typing {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs, 4px);
+}
+
+.gx-typing__dots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.gx-typing__dots i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--rune);
+  display: inline-block;
+  animation: gx-blink 1.2s infinite ease-in-out both;
+}
+.gx-typing__dots i:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.gx-typing__dots i:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+.gx-typing__label {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8125rem;
+  color: var(--text-subtle);
+}
+
+@keyframes gx-blink {
+  0%,
+  80%,
+  100% {
+    opacity: 0.25;
+  }
+  40% {
+    opacity: 1;
+  }
+}

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -57,7 +57,7 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
 
   // Snapshot seed: the initial state the live stream then tails. staleTime is
   // Infinity because the EventSource — not refetching — keeps it current.
-  const { data } = useQuery<Transcript>({
+  const { data, isSuccess } = useQuery<Transcript>({
     queryKey: transcriptKey(sessionId ?? ""),
     enabled,
     staleTime: Infinity,
@@ -70,9 +70,24 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
   });
 
   useEffect(() => {
-    if (!enabled || !sessionId) return;
+    // Gate the stream on snapshot success (FIX 4): if the snapshot resolved AFTER
+    // an SSE line write it would clobber the cache and drop that line. Opening
+    // only once the snapshot has landed makes that ordering impossible; the
+    // first-connect ring replay (idempotent upsert) re-covers the small window
+    // between the snapshot capture and the stream opening.
+    if (!enabled || !sessionId || !isSuccess) return;
     const key = transcriptKey(sessionId);
     const es = new EventSource(`/api/v1/sessions/${sessionId}/events`);
+
+    // Re-sync the authoritative snapshot on a RECONNECT (any "open" after the
+    // first, FIX 3): the Last-Event-ID ring replay covers bounded lag, this
+    // covers an unbounded gap. upsert-by-id makes the refetch + replay overlap
+    // idempotent.
+    let everConnected = false;
+    es.addEventListener("open", () => {
+      if (everConnected) void queryClient.invalidateQueries({ queryKey: key });
+      everConnected = true;
+    });
 
     es.addEventListener("line", (e) => {
       const line = JSON.parse((e as MessageEvent).data) as TranscriptLine;
@@ -84,7 +99,7 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
     });
 
     return () => es.close();
-  }, [enabled, sessionId, queryClient]);
+  }, [enabled, sessionId, isSuccess, queryClient]);
 
   return data ?? EMPTY;
 }

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -1,0 +1,100 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+// useSessionEvents is the SSE transcript client (#73, ADR-0014 Hop-B). When a
+// voice session is live it seeds a TanStack query from the JSON snapshot
+// (GET /api/v1/sessions/:id) then keeps it fresh by amending the SAME cache
+// entry from an EventSource (ADR-0018: no parallel React state tree). The
+// EventSource closes on unmount / when the session ends.
+
+export type LineKind = "gm" | "player" | "npc" | "butler";
+
+// TranscriptLine mirrors the relay's Line JSON. id is stable so a turn's
+// coalescing NPC reply upserts in place; ts is RFC3339.
+export interface TranscriptLine {
+  id: string;
+  who: string;
+  tag?: string;
+  kind: LineKind;
+  ts: string;
+  text: string;
+}
+
+// TypingState is the relay's derived "is speaking" / "listening" indicator.
+export interface TypingState {
+  active: boolean;
+  label: string;
+}
+
+// Transcript is the cached view the screen renders: the lines plus status/typing.
+export interface Transcript {
+  lines: TranscriptLine[];
+  status: "live" | "idle";
+  typing: TypingState;
+}
+
+const EMPTY: Transcript = { lines: [], status: "idle", typing: { active: false, label: "" } };
+
+// transcriptKey is the cache key for one session's live transcript.
+export function transcriptKey(id: string) {
+  return ["sessionTranscript", id] as const;
+}
+
+// upsertLine replaces a line with the same id (the turn's coalescing reply) or
+// appends a new one, preserving arrival order.
+function upsertLine(prev: Transcript | undefined, line: TranscriptLine): Transcript {
+  const base = prev ?? EMPTY;
+  const lines = base.lines.slice();
+  const i = lines.findIndex((l) => l.id === line.id);
+  if (i >= 0) lines[i] = line;
+  else lines.push(line);
+  return { ...base, lines };
+}
+
+export function useSessionEvents(sessionId: string | undefined, active: boolean): Transcript {
+  const queryClient = useQueryClient();
+  const enabled = active && !!sessionId;
+
+  // Snapshot seed: the initial state the live stream then tails. staleTime is
+  // Infinity because the EventSource — not refetching — keeps it current.
+  const { data } = useQuery<Transcript>({
+    queryKey: transcriptKey(sessionId ?? ""),
+    enabled,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const res = await fetch(`/api/v1/sessions/${sessionId}`, { credentials: "same-origin" });
+      if (!res.ok) throw new Error(`session snapshot failed: ${res.status}`);
+      return (await res.json()) as Transcript;
+    },
+  });
+
+  useEffect(() => {
+    if (!enabled || !sessionId) return;
+    const key = transcriptKey(sessionId);
+    const es = new EventSource(`/api/v1/sessions/${sessionId}/events`);
+
+    es.addEventListener("line", (e) => {
+      const line = JSON.parse((e as MessageEvent).data) as TranscriptLine;
+      queryClient.setQueryData<Transcript>(key, (prev) => upsertLine(prev, line));
+    });
+    es.addEventListener("status", (e) => {
+      const s = JSON.parse((e as MessageEvent).data) as { status: "live" | "idle"; typing: TypingState };
+      queryClient.setQueryData<Transcript>(key, (prev) => ({ ...(prev ?? EMPTY), status: s.status, typing: s.typing }));
+    });
+
+    return () => es.close();
+  }, [enabled, sessionId, queryClient]);
+
+  return data ?? EMPTY;
+}
+
+// formatClock renders an RFC3339 instant as zero-padded HH:MM:SS (the design's
+// per-line timestamp), or "" when unparseable.
+export function formatClock(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return [d.getHours(), d.getMinutes(), d.getSeconds()]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":");
+}

--- a/web/src/test/mockEventSource.ts
+++ b/web/src/test/mockEventSource.ts
@@ -1,0 +1,48 @@
+// MockEventSource is a minimal jsdom-less EventSource stand-in for vitest:
+// jsdom ships none, and the Session screen opens one for the live transcript
+// (#73). Registered as the global EventSource in vitest.setup.ts; a test grabs
+// the constructed instance via MockEventSource.last() and drives frames with
+// emit().
+
+type Listener = (e: MessageEvent) => void;
+
+export class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  /** Clear the registry between tests (called from a global beforeEach). */
+  static reset() {
+    MockEventSource.instances = [];
+  }
+
+  /** The most recently constructed instance (the screen's open stream). */
+  static last(): MockEventSource | undefined {
+    return MockEventSource.instances[MockEventSource.instances.length - 1];
+  }
+
+  url: string;
+  closed = false;
+  private listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: Listener) {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  removeEventListener(type: string, cb: Listener) {
+    this.listeners[type] = (this.listeners[type] || []).filter((l) => l !== cb);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  /** Dispatch a named SSE event carrying JSON-encoded data, like the relay. */
+  emit(type: string, data: unknown) {
+    const e = { data: JSON.stringify(data) } as MessageEvent;
+    (this.listeners[type] || []).forEach((cb) => cb(e));
+  }
+}

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,4 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { beforeEach } from "vitest";
+
+import { MockEventSource } from "./src/test/mockEventSource";
 
 // jsdom does not implement HTMLMediaElement.play(); the Preview-voice helper
 // (src/lib/audio.ts) fires it fire-and-forget. Stub it so the noise stays out of
@@ -8,3 +11,19 @@ if (typeof HTMLMediaElement !== "undefined") {
   HTMLMediaElement.prototype.play = () => Promise.resolve();
   HTMLMediaElement.prototype.pause = () => {};
 }
+
+// jsdom has no EventSource; the Session screen opens one for the live transcript
+// (#73). Install the mock globally so every test renders without crashing, and a
+// transcript test can drive frames via MockEventSource.last().
+globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+// Default snapshot fetch: a benign empty-but-live transcript so a session-active
+// render never hits the network. Transcript tests override globalThis.fetch.
+beforeEach(() => {
+  MockEventSource.reset();
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ lines: [], status: "live", typing: { active: false, label: "" } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+});


### PR DESCRIPTION
Closes #73. Stage 9 — ADR-0014 Hop-B: bridge the in-process `voiceevent.Bus` to the browser's Session screen over Server-Sent Events.

## What & why
The voice pipeline already emits a rich event taxonomy onto an in-process bus (ADR-0020); the Session screen had a placeholder transcript. This wires the two together so a live session shows the table's conversation streaming in, with a server-derived "is speaking" / "listening" indicator.

### Backend (`internal/transcript`)
- **Projection** bus events → transcript lines `{who, tag, ts, text, kind ∈ {gm,player,npc,butler}}`:
  - human `STTFinal` → one anonymous **"Player / DM"** lane (`player`) — raw STT has no speaker id (ADR-0039).
  - `AddressRouted` + `TTSInvoked` → an Agent reply named from `AddressTarget.Name`, `kind=butler` for the Butler else `npc`, **coalesced per turn** into one line, finalized on `TurnEnded`.
- **Typing / status derived server-side** (so it is Go-unit-testable): `live` while a session is active; `"<Name> is speaking…"` mid-reply, else `"Listening to the table…"`, else idle.
- **Per-session ~500-frame ring buffer** with a monotonic `id:` seq for **`Last-Event-ID` replay**; a fresh buffer starts when the active session id changes (single active session, ADR-0039).
- Endpoints (plain `net/http`, Go 1.22 method+wildcard patterns):
  - `GET /api/v1/sessions/{id}/events` — `text/event-stream`, replay-after-`Last-Event-ID` then live tail.
  - `GET /api/v1/sessions/{id}` — JSON snapshot (lines + status/typing).
- **`auth.RequireSession`** net/http middleware guards both reads (they sit outside the Connect interceptor chain); the `glyphoxa_session` cookie rides along automatically on EventSource/fetch.
- **One process bus**: `wirenpc.Config.Bus` injects a single bus from `runWeb`, set on the base config before the `SessionManager` copies it, so the pointer flows through every manager-started session and the relay sees events across reconnect cycles + sessions. `nil` keeps the env-only voice/bench path's per-cycle bus unchanged. No proto changes; no DB writes (persistence is #74).

### SPA (Console layout only — per operator scope decision)
- `useSessionEvents` hook: seed a TanStack query from the snapshot, then amend the **same cache entry** from an `EventSource` (ADR-0018, no parallel state tree) — `line` frames upsert lines, `status` frames set status/typing; closes on unmount/session end.
- `Session.tsx`: renders lines (name colored by kind, optional Butler/NPC pill, `HH:MM:SS`, text) + 3 blinking typing dots with the derived label; status badge + timer unchanged.

## Acceptance criteria
- [x] Relay unit test: bus events in → ordered SSE frames out; `Last-Event-ID` replays the buffer.
- [x] kind-mapping test covers gm / player / npc / butler; humans share the anonymous lane.
- [x] The typing indicator + status derive correctly from turn/sentence events.
- [x] The SPA shows streaming lines + typing dots during a live session.

## How tested
- `go test ./...` (incl. `-race` on the relay) + `go vet ./...` + `golangci-lint` (0 issues) green.
- `internal/transcript`: white-box projection/kind/typing/replay/rollover tests + black-box `httptest` SSE end-to-end (replay → live → reconnect-with-`Last-Event-ID`) + snapshot.
- `internal/auth`: `RequireSession` pass / missing-cookie 401 / invalid-cookie 401.
- web: `npm run test` (23 pass, incl. a live-session transcript test driving a mock `EventSource`), `typecheck`, `build` green.

## Round 2 — adversarial-review fixes (commits 801c074 + 525418a)
- **FIX 1** typing no longer sticks on "&lt;NPC&gt; is speaking…" — a clean turn emits no `TurnEnded`, so typing is now derived from the last emitted line's kind (a human line returns it to "Listening to the table…").
- **FIX 2** a barge can deliver `TTSInvoked` after `TurnEnded`; the turn is marked `ended` (entry kept, not deleted) and late sentences are dropped so the finalized coalesced reply is not clobbered.
- **FIX 3** `subBuffer` 512→256 (≤ `ringCap`) makes a lagged drop losslessly replayable from the ring; the SPA also re-syncs the snapshot on EventSource reconnect (covers an unbounded gap, idempotent upsert-by-id).
- **FIX 4** the SPA opens the stream only after the snapshot query succeeds, so a late-resolving snapshot can never clobber an already-landed SSE line.
- **FIX 5** added a flood test pinning the "synchronous bus must not block on a lagged SSE client" invariant.
- **NIT** no leading space when an empty first TTS sentence precedes a non-empty one.
- A regression test was added for each fix.

## Round 3 — live-validated refinement (commit b874c30)
- Typing clears on `VADSpeechStart` (live-validated): the stale "&lt;NPC&gt; is speaking…" left by a clean turn now clears the moment the human starts talking, instead of lingering through the following silence. Full turn-complete signal is deferred to a voice-pipeline follow-up.

## Out of scope / deferred
- **Stage / Scroll layout variants + the Console/Stage/Scroll segmented toggle** — deferred follow-up (operator decision: Console layout only).
- DB-backed transcript persistence (`voice_sessions.line_count`) — issue #74.
- **Unbounded `r.lines` growth** across a long session (cap/window or rely on #74 persistence) — follow-up.
- **Terminal idle/`ended` SSE frame** on session end (today the SPA closes the stream off the existing `GetSession` poll) — follow-up.
- **SSE heartbeat / keepalive** comment frames for idle-connection liveness — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
