### PR TITLE
fix(#91): drive VAD endpointing with a continuous silence clock

### DIFF
--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -502,7 +502,16 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// Inbound (hear): the pipeline pumps Session.Inbound through the same Codec's
 	// DecodeInbound into the orchestrator. It tags its inbound counters (A2) with
 	// the guild and shares the run's MetricsRecorder.
-	pipe := wire.NewPipeline(conv, cdc, log, cfg.Guild, cfg.Metrics)
+	//
+	// WithSilenceClock drives VAD endpointing during the inbound packet gap a
+	// paused speaker leaves (issue #91): Discord sends a few Opus silence frames
+	// then stops sending entirely, so without a steady silence clock the VAD never
+	// sees the trailing silence and each line lands one utterance late. The clock
+	// runs at the VAD frame geometry (vadSampleRate/vadFrameMs) so silero endpoints
+	// ~vadMinSilenceFrames*vadFrameMs (= 384 ms) after the speaker stops — the
+	// natural cadence the bargeConfirm/floorCoalesce windows already account for.
+	pipe := wire.NewPipeline(conv, cdc, log, cfg.Guild, cfg.Metrics,
+		wire.WithSilenceClock(vadSampleRate, vadFrameMs))
 	return pipe.Run(cycleCtx, sess)
 }
 

--- a/pkg/voice/wire/silence_test.go
+++ b/pkg/voice/wire/silence_test.go
@@ -1,0 +1,294 @@
+package wire
+
+// White-box tests for the continuous silence clock that drives VAD endpointing
+// during inbound silence and packet gaps (issue #91). They live in `package
+// wire` so they can drive the unexported run loop with a test-owned inbound
+// channel and an injected, manually-fired silence clock — no Discord Session and
+// no wall-clock sleeps (the determinism requirement; see ADR-0019/0020).
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad/silero"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// VAD geometry the rig runs at: production's 16 kHz / 32 ms frames (512 samples,
+// internal/wirenpc/wirenpc.go). The hangover uses silero's DEFAULT 15-frame
+// threshold (the voicetest/vad_test default) rather than wirenpc's tuned 12: at 12
+// the hello-test clip splits at an internal pause into two utterances, which would
+// confound a single-utterance test. The exact production hangover (12) and its
+// natural ~384 ms endpointing are exercised by the live Discord test; these tests
+// pin the silence-clock MECHANISM, which is hangover-count agnostic.
+const (
+	testSampleRate    = 16000
+	testFrameMs       = 32
+	testHangoverTicks = 20 // > silero's default 15-frame hangover, so silence endpoints
+)
+
+// stubRecognizer returns a pinned transcript regardless of input, so a flushed
+// utterance produces a deterministic STTFinal with no STT provider or cassette.
+type stubRecognizer struct{ text string }
+
+func (s stubRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcript, error) {
+	return stt.Transcript{Text: s.text}, nil
+}
+
+// replayCodec is a fake [Codec] that replays a pre-framed clip: each
+// DecodeInbound call yields the next PCM frame, modelling the real Opus→PCM
+// transcoder one packet at a time. It records its call count so a test can pin
+// that Discord silence frames are NOT decoded.
+type replayCodec struct {
+	mu      sync.Mutex
+	frames  []audio.Frame
+	next    int
+	decodes int
+}
+
+func (c *replayCodec) DecodeInbound(gxvoice.Frame) ([]audio.Frame, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decodes++
+	if c.next >= len(c.frames) {
+		return nil, nil
+	}
+	f := c.frames[c.next]
+	c.next++
+	return []audio.Frame{f}, nil
+}
+
+func (c *replayCodec) PlaybackSource(<-chan tts.AudioChunk) (gxvoice.Source, error) {
+	return nil, nil
+}
+
+func (c *replayCodec) decodeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.decodes
+}
+
+// fakeSilenceClock is a [silenceClock] the test fires by hand: tick() pushes one
+// frame-cadence tick, and reset()/stop() are recorded so a test can assert real
+// audio resets the idle timer (so the production ticker never fires mid-speech).
+type fakeSilenceClock struct {
+	ch chan time.Time
+
+	mu      sync.Mutex
+	resets  int
+	stopped bool
+}
+
+func (c *fakeSilenceClock) ticks() <-chan time.Time { return c.ch }
+func (c *fakeSilenceClock) reset()                  { c.mu.Lock(); c.resets++; c.mu.Unlock() }
+func (c *fakeSilenceClock) stop()                   { c.mu.Lock(); c.stopped = true; c.mu.Unlock() }
+
+// tick fires one silence-clock tick and blocks until the run loop consumes it,
+// keeping the test deterministic (each tick is one synthesized silence frame).
+func (c *fakeSilenceClock) tick() { c.ch <- time.Now() }
+
+func (c *fakeSilenceClock) resetCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.resets
+}
+
+// newSilenceRig builds a Conversation around a REAL silero VAD (production
+// geometry + 12-frame hangover) and a stub recognizer, plus the "hello-test"
+// clip pre-framed at the VAD chunk size. The conversation publishes onto the
+// returned harness's bus; the silero session is closed at end of t.
+func newSilenceRig(t *testing.T, recText string) (*orchestrator.Conversation, *voicetest.Harness, []audio.Frame) {
+	t.Helper()
+
+	h := voicetest.New(t)
+
+	engine, err := silero.New()
+	if err != nil {
+		t.Fatalf("silero.New: %v", err)
+	}
+	sess, err := engine.NewSession(vad.Config{
+		SampleRate:       testSampleRate,
+		FrameSizeMs:      testFrameMs,
+		SpeechThreshold:  0.5,
+		SilenceThreshold: 0.35,
+	})
+	if err != nil {
+		t.Fatalf("engine.NewSession: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+
+	vadStage := orchestrator.NewVAD(h.Bus, sess)
+	sttStage := orchestrator.NewSTT(h.Bus, stubRecognizer{text: recText})
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil)
+
+	clip := voicetest.LoadClip(t, "hello-test")
+	chunk := testSampleRate * testFrameMs / 1000
+	frames, _ := clip.FramesOf(t, chunk)
+	return conv, h, frames
+}
+
+// feedSpeech sends one real inbound frame per pre-framed clip frame; each maps,
+// through the replayCodec, to one PCM frame fed into the VAD.
+func feedSpeech(inbound chan<- gxvoice.Frame, frames []audio.Frame) {
+	for range frames {
+		inbound <- gxvoice.Frame{}
+	}
+}
+
+// eventCounts tallies the speech_start / speech_end / stt.final events on the
+// harness. The hello-test clip VAD-splits into more than one utterance and leaves
+// the LAST one open (speech_start with no matching speech_end, because the clip
+// has little trailing silence) — exactly the live shape issue #91 is about. A
+// speech_end is emitted ONLY by the VAD on a real silence transition (a Flush
+// cannot fake one), so ends == starts is proof that every utterance, including the
+// trailing one, was endpointed by audible silence — i.e. by the silence clock.
+func eventCounts(h *voicetest.Harness) (starts, ends, finals int) {
+	for _, e := range h.Events() {
+		switch e.(type) {
+		case voiceevent.VADSpeechStart:
+			starts++
+		case voiceevent.VADSpeechEnd:
+			ends++
+		case voiceevent.STTFinal:
+			finals++
+		}
+	}
+	return starts, ends, finals
+}
+
+// TestPipeline_TrailingSilenceEndpointsTrailingUtterance is the tracer bullet
+// (acceptance #1): an utterance followed by trailing silence — driven ONLY by the
+// injected clock, with NO further inbound audio — endpoints within the hangover
+// window. The clip leaves its final utterance open; firing the silence clock past
+// the hangover must close it (speech_end == speech_start) and produce its STTFinal,
+// in speech order. Before the fix the trailing silence was dropped, the trailing
+// utterance never endpointed, and its line appeared only when the next utterance
+// arrived (issue #91).
+func TestPipeline_TrailingSilenceEndpointsTrailingUtterance(t *testing.T) {
+	conv, h, frames := newSilenceRig(t, "hello there")
+	codec := &replayCodec{frames: frames}
+	clk := &fakeSilenceClock{ch: make(chan time.Time)}
+	pipe := NewPipeline(conv, codec, nil, "guild", nil,
+		withSilenceClock(testSampleRate, testFrameMs, func() silenceClock { return clk }))
+
+	inbound := make(chan gxvoice.Frame)
+	done := make(chan error, 1)
+	go func() { done <- pipe.run(t.Context(), inbound) }()
+
+	feedSpeech(inbound, frames)
+	// Trailing silence: fire the clock past the hangover with NO more inbound
+	// audio. Silero must endpoint the open utterance here, not wait for a second.
+	for range testHangoverTicks {
+		clk.tick()
+	}
+	close(inbound)
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	starts, ends, finals := eventCounts(h)
+	if starts < 1 {
+		t.Fatalf("no speech detected: starts=%d", starts)
+	}
+	if ends != starts {
+		t.Errorf("trailing utterance not endpointed: speech_start=%d speech_end=%d (want equal); the silence clock must close the open utterance", starts, ends)
+	}
+	if finals != ends {
+		t.Errorf("STTFinal=%d, want %d (one per endpointed utterance)", finals, ends)
+	}
+	// The last thing that happened is the clock-driven endpoint and its transcript,
+	// in order — not a final waiting on a follow-up utterance.
+	voicetest.AssertOrder(t, h,
+		voicetest.MatchType[voiceevent.VADSpeechStart](),
+		voicetest.MatchType[voiceevent.VADSpeechEnd](),
+		voicetest.MatchType[voiceevent.STTFinal](),
+	)
+	if clk.stopped != true {
+		t.Errorf("silence clock not stopped on run exit")
+	}
+}
+
+// TestPipeline_ContinuousSpeechInjectsNoSilence is acceptance #2: while real
+// frames flow the silence clock must inject NOTHING (no premature mid-utterance
+// cut). The mechanism is an idle timer that every real frame resets, so the
+// production ticker never fires during speech — pinned here deterministically by
+// asserting every real inbound frame reset the clock and was decoded, with the
+// clock never fired by the test.
+func TestPipeline_ContinuousSpeechInjectsNoSilence(t *testing.T) {
+	conv, _, frames := newSilenceRig(t, "hello there")
+	codec := &replayCodec{frames: frames}
+	clk := &fakeSilenceClock{ch: make(chan time.Time)}
+	pipe := NewPipeline(conv, codec, nil, "guild", nil,
+		withSilenceClock(testSampleRate, testFrameMs, func() silenceClock { return clk }))
+
+	inbound := make(chan gxvoice.Frame)
+	done := make(chan error, 1)
+	go func() { done <- pipe.run(t.Context(), inbound) }()
+
+	feedSpeech(inbound, frames) // real audio only; never fire the clock
+	close(inbound)
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if got := clk.resetCount(); got != len(frames) {
+		t.Errorf("clock reset %d times, want one per real frame (%d): the production ticker must be reset by every real frame so it never fires during speech", got, len(frames))
+	}
+	if got := codec.decodeCount(); got != len(frames) {
+		t.Errorf("decoded %d frames, want %d (every real frame)", got, len(frames))
+	}
+}
+
+// TestPipeline_DiscordSilenceFramesDriveTheClock is acceptance #3: a Discord
+// "silence" frame must no longer be silently dropped. It is treated as "no real
+// audio" — NOT decoded and NOT a clock reset — so the silence clock keeps running
+// through the silence frames and the following packet gap, endpointing the open
+// utterance. Mirrors the live shape: speaker stops → a few silence frames → gap.
+func TestPipeline_DiscordSilenceFramesDriveTheClock(t *testing.T) {
+	conv, h, frames := newSilenceRig(t, "hello there")
+	codec := &replayCodec{frames: frames}
+	clk := &fakeSilenceClock{ch: make(chan time.Time)}
+	pipe := NewPipeline(conv, codec, nil, "guild", nil,
+		withSilenceClock(testSampleRate, testFrameMs, func() silenceClock { return clk }))
+
+	inbound := make(chan gxvoice.Frame)
+	done := make(chan error, 1)
+	go func() { done <- pipe.run(t.Context(), inbound) }()
+
+	feedSpeech(inbound, frames)
+	// Discord's ~5 Opus silence frames when the speaker stops.
+	const silenceFrames = 5
+	for range silenceFrames {
+		inbound <- gxvoice.Frame{Silence: true}
+	}
+	// Then the packet gap: the clock advances the VAD hangover.
+	for range testHangoverTicks {
+		clk.tick()
+	}
+	close(inbound)
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	starts, ends, _ := eventCounts(h)
+	if ends != starts {
+		t.Errorf("trailing utterance not endpointed through silence frames + gap: speech_start=%d speech_end=%d", starts, ends)
+	}
+	// Silence frames are "no real audio": not decoded and they do NOT reset the
+	// idle clock (so the production ticker keeps advancing the VAD through them).
+	if got := codec.decodeCount(); got != len(frames) {
+		t.Errorf("decoded %d frames, want %d: Discord silence frames must not be decoded", got, len(frames))
+	}
+	if got := clk.resetCount(); got != len(frames) {
+		t.Errorf("clock reset %d times, want %d: Discord silence frames must not reset the clock", got, len(frames))
+	}
+}

--- a/pkg/voice/wire/wire.go
+++ b/pkg/voice/wire/wire.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
@@ -83,6 +84,80 @@ type Pipeline struct {
 	log     *slog.Logger
 	metrics gxvoice.MetricsRecorder
 	guild   string
+
+	// silence is the synthesized PCM silence frame the silence clock feeds into
+	// the VAD during inbound gaps (issue #91); silenceOn gates the whole mechanism
+	// off when no [WithSilenceClock] was given (the pre-#91 behaviour). newClock
+	// builds the frame-cadence clock — a real time.Ticker in production, a fake in
+	// tests. See [WithSilenceClock] and [Pipeline.run].
+	silence   audio.Frame
+	silenceOn bool
+	newClock  func() silenceClock
+}
+
+// silenceClock paces synthesized PCM silence into the VAD so trailing silence
+// (Discord stops sending packets when a speaker pauses — see [Pipeline.run])
+// advances silero's end-of-speech hangover and the utterance endpoints naturally,
+// instead of hanging until the next utterance arrives (issue #91). It ticks once
+// per orchestrator frame interval while inbound audio is idle; every real inbound
+// frame calls reset, suppressing a tick for one interval so NO silence is injected
+// while speech flows. Production uses a [time.Ticker]; tests inject a fake whose
+// channel they fire by hand, so endpointing is deterministic with no wall-clock
+// (the precedent: address.Clock, reconnectPolicy.sleep).
+type silenceClock interface {
+	ticks() <-chan time.Time
+	reset()
+	stop()
+}
+
+// tickerClock is the production [silenceClock]: a [time.Ticker] at the frame
+// cadence. reset restarts the interval on every real inbound frame, so the ticker
+// only fires once audio has been idle for one full interval and keeps firing every
+// interval until audio resumes.
+type tickerClock struct {
+	t *time.Ticker
+	d time.Duration
+}
+
+func newTickerClock(d time.Duration) *tickerClock {
+	return &tickerClock{t: time.NewTicker(d), d: d}
+}
+
+func (c *tickerClock) ticks() <-chan time.Time { return c.t.C }
+func (c *tickerClock) reset()                  { c.t.Reset(c.d) }
+func (c *tickerClock) stop()                   { c.t.Stop() }
+
+// Option configures a [Pipeline] at construction.
+type Option func(*Pipeline)
+
+// WithSilenceClock enables the continuous silence clock (issue #91): during
+// inbound silence and packet gaps the pipeline feeds synthesized PCM silence into
+// the VAD at the orchestrator frame cadence, so a paused speaker's utterance
+// endpoints within the silero hangover window rather than coalescing with the next
+// utterance. sampleRate and frameMs are the orchestrator's frame geometry (the
+// VAD/STT rate, e.g. 16000 Hz / 32 ms): they shape the synthesized silence frame
+// AND set the tick interval. Without this option the pipeline keeps the pre-#91
+// behaviour, dropping inbound silence frames untouched.
+func WithSilenceClock(sampleRate, frameMs int) Option {
+	d := time.Duration(frameMs) * time.Millisecond
+	return withSilenceClock(sampleRate, frameMs, func() silenceClock { return newTickerClock(d) })
+}
+
+// withSilenceClock is the seam [WithSilenceClock] is built on, with the clock
+// factory injectable so tests drive a fake clock channel by hand. It derives the
+// silence frame from the supplied geometry (no magic 512/16000/32 in wire — the
+// shape matches whatever rate the pipeline runs at), panicking on an invalid
+// geometry since that is a wiring bug, not a runtime condition.
+func withSilenceClock(sampleRate, frameMs int, newClock func() silenceClock) Option {
+	return func(p *Pipeline) {
+		f, err := audio.NewFrame(make([]int16, sampleRate*frameMs/1000), sampleRate, frameMs)
+		if err != nil {
+			panic(fmt.Sprintf("wire.WithSilenceClock: invalid frame geometry %d Hz / %d ms: %v", sampleRate, frameMs, err))
+		}
+		p.silence = f
+		p.silenceOn = true
+		p.newClock = newClock
+	}
 }
 
 // NewPipeline wires the reactive Conversation to the Codec. conv is the fully
@@ -91,7 +166,7 @@ type Pipeline struct {
 // [UnavailableCodec] until the transcoder lands). guild is the Discord guild ID
 // the inbound counters are tagged with (A2); a nil logger discards logs and a
 // nil metrics recorder discards counters.
-func NewPipeline(conv *orchestrator.Conversation, codec Codec, log *slog.Logger, guild string, metrics gxvoice.MetricsRecorder) *Pipeline {
+func NewPipeline(conv *orchestrator.Conversation, codec Codec, log *slog.Logger, guild string, metrics gxvoice.MetricsRecorder, opts ...Option) *Pipeline {
 	if conv == nil {
 		panic("wire.NewPipeline: conv must not be nil")
 	}
@@ -104,7 +179,11 @@ func NewPipeline(conv *orchestrator.Conversation, codec Codec, log *slog.Logger,
 	if metrics == nil {
 		metrics = discardMetrics{}
 	}
-	return &Pipeline{conv: conv, codec: codec, log: log, guild: guild, metrics: metrics}
+	p := &Pipeline{conv: conv, codec: codec, log: log, guild: guild, metrics: metrics}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
 }
 
 // Run registers the conversation's reactors on its bus and pumps the Session's
@@ -121,6 +200,16 @@ func (p *Pipeline) Run(ctx context.Context, sess *gxvoice.Session) error {
 	if sess == nil {
 		return fmt.Errorf("wire.Run: session must not be nil")
 	}
+	return p.run(ctx, sess.Inbound())
+}
+
+// run is the inbound audio loop over an arbitrary frame channel: it registers the
+// conversation, pumps inbound frames through the [Codec] into the orchestrator,
+// and drives the silence clock that endpoints a paused speaker (issue #91). Run
+// supplies a live [gxvoice.Session]'s channel; the seam exists so the headless
+// tests drive the same loop with a synthetic inbound channel and an injected
+// silence clock — no Discord and no wall-clock waits (ADR-0019).
+func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error {
 	cancel := p.conv.Register(ctx)
 	defer cancel()
 	defer func() {
@@ -129,17 +218,50 @@ func (p *Pipeline) Run(ctx context.Context, sess *gxvoice.Session) error {
 		}
 	}()
 
-	inbound := sess.Inbound()
+	// Silence clock (#91): Discord sends a few Opus silence frames when a speaker
+	// stops, then STOPS sending packets entirely during the pause — so the inbound
+	// channel goes quiet and the VAD never sees the trailing silence that ends the
+	// utterance, leaving each line one utterance behind. While audio is idle this
+	// clock feeds synthesized PCM silence into the VAD at the frame cadence,
+	// advancing silero's end-of-speech hangover so the segment endpoints a few
+	// hundred ms after the speaker stops. Every real frame resets it, so NO silence
+	// is injected while speech flows (continuous speech must not endpoint). Disabled
+	// when no [WithSilenceClock] was given: the loop then just drops inbound silence
+	// frames, the pre-#91 behaviour.
+	var clk silenceClock
+	var clockTicks <-chan time.Time
+	if p.silenceOn {
+		clk = p.newClock()
+		defer clk.stop()
+		clockTicks = clk.ticks()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-clockTicks:
+			// Audio has been idle for one frame interval: advance the VAD with one
+			// frame of silence so a paused speaker's utterance endpoints.
+			if err := p.conv.Feed(p.silence); err != nil {
+				p.log.Debug("feed silence frame", "err", err)
+			}
 		case frame, ok := <-inbound:
 			if !ok {
 				return nil // session closed
 			}
 			if frame.Silence {
+				// A Discord Opus silence frame: the speaker has stopped. Do NOT decode
+				// it and do NOT reset the silence clock — let the clock keep advancing
+				// the VAD hangover through this frame and the packet gap that follows, so
+				// the utterance endpoints (issue #91). Pre-#91 this `continue` dropped the
+				// frame with nothing left to advance the VAD.
 				continue
+			}
+			// Real audio arrived: reset the idle clock so no synthesized silence is
+			// injected while frames keep flowing.
+			if clk != nil {
+				clk.reset()
 			}
 			pcm, err := p.codec.DecodeInbound(frame)
 			if err != nil {


### PR DESCRIPTION
## Issue #91 — voice STT "one utterance behind"

**Root cause:** Discord sends ~5 Opus *silence* frames when a speaker stops, then stops sending packets entirely during the pause. `wire.Pipeline.Run` dropped the silence frames (`if frame.Silence { continue }`) and no packets arrived in the gap, so silero's end-of-speech hangover counter never advanced. `VADSpeechEnd` (and therefore `STTFinal`) only fired when the **next** utterance arrived — each line landing one utterance late, or coalescing with the next.

## Fix

`wire.Pipeline` now drives a frame-cadence **silence clock** (new functional option `WithSilenceClock`):

- While inbound audio is idle, the clock feeds **synthesized PCM silence** into the VAD at the orchestrator frame cadence, advancing silero's hangover so the utterance endpoints ~384 ms (`vadMinSilenceFrames × vadFrameMs`) after the speaker stops — the natural cadence the existing `bargeConfirm`/`floorCoalesce` windows already account for.
- **Every real frame resets** the clock (idle-timer), so **nothing is injected while speech flows** — no premature mid-utterance cut.
- A Discord `frame.Silence` is now treated as "no real audio": **not decoded and not a clock reset**, so the clock keeps advancing the VAD through the silence frames and the following packet gap.
- Frame geometry is **supplied** to the Pipeline (no hardcoded 512/16000/32 in `wire`); the live caller passes `vadSampleRate`/`vadFrameMs`.

The clock is **injectable** (functional option, default = real `time.Ticker` at the frame cadence; `NewPipeline`'s 5-arg signature preserved via `opts ...Option`). Tests drive a hand-fired fake clock + synthetic inbound channel through the unexported `run` loop — **deterministic, no Discord, no wall-clock sleeps** (ADR-0019/0020).

## Tests (`pkg/voice/wire/silence_test.go`, real silero VAD + stub STT)

1. **Trailing silence endpoints the trailing utterance** — the hello-test clip VAD-splits and leaves its last utterance *open*; firing the clock past the hangover closes it (`speech_end == speech_start`) and produces its `STTFinal`. A `VADSpeechEnd` is emitted only by the VAD on a real silence transition (a Flush can't fake one), so this is proof the clock — not stream-end flush — endpointed it.
2. **Continuous speech injects nothing** — every real frame reset the clock and was decoded; the clock is never fired.
3. **Discord silence frames drive the clock** — silence frames + gap endpoint the open utterance; silence frames are not decoded and do not reset the clock.

## Caller updated

`internal/wirenpc/wirenpc.go` wires `wire.WithSilenceClock(vadSampleRate, vadFrameMs)`.

## Verification (local)

- `go test -race ./pkg/voice/wire/ ./pkg/voice/orchestrator/ ./pkg/voice/voicetest/ ./internal/wirenpc/` — green
- `go test ./pkg/voice/...` — green
- `golangci-lint run` (changed pkgs) — 0 issues; `go vet` clean
- `go build -tags "opus nolibopusfile" ./pkg/voice/wire/... ./internal/wirenpc/...` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)