### PR TITLE
UI polish: spacing, voice-picker filter, save feedback, responsive (#88)

### DIFF
--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { UserSchema } from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+
+// The shell is driven by TanStack Router; mock the bits AppShell + SidebarUser
+// touch so it renders without a live router (mirrors AuthGate.test.tsx).
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  Outlet: () => null,
+  useParams: () => ({ screen: "campaign" }),
+  useNavigate: () => vi.fn(),
+}));
+
+import { AppShell } from "./AppShell";
+
+const user = create(UserSchema, { name: "Sora Vance", role: "operator", avatar: "" });
+
+function renderShell() {
+  return render(
+    <Providers transport={createRouterTransport(() => {})} queryClient={makeQueryClient()}>
+      <AppShell tenantSlug="acme" user={user} />
+    </Providers>,
+  );
+}
+
+describe("AppShell", () => {
+  it("toggles the sidebar collapsed state from the topbar control", () => {
+    const { container } = renderShell();
+    const shell = container.querySelector(".gx-shell") as HTMLElement;
+    const toggle = screen.getByRole("button", { name: /toggle sidebar/i });
+
+    // Sidebar starts expanded.
+    expect(shell).not.toHaveAttribute("data-collapsed", "true");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // Clicking collapses it.
+    fireEvent.click(toggle);
+    expect(shell).toHaveAttribute("data-collapsed", "true");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Clicking again restores it.
+    fireEvent.click(toggle);
+    expect(shell).not.toHaveAttribute("data-collapsed", "true");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
 import { Toaster } from "sonner";
-import { Dices, Settings, Swords, ScrollText } from "lucide-react";
+import { Dices, PanelLeft, Settings, Swords, ScrollText } from "lucide-react";
 
 import type { User } from "@gen/glyphoxa/management/v1/management_pb";
 
+import { Button } from "./ui/Button";
 import { SidebarUser } from "./SidebarUser";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
@@ -27,8 +28,25 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
   const { screen } = useParams({ strict: false }) as { screen?: string };
   const active = NAV.find((n) => n.to === screen);
 
+  // Sidebar collapse (#88 slice 4). On narrow viewports the sidebar is an
+  // off-canvas drawer the topbar toggle opens; on wide viewports the toggle hides
+  // it for focus. State lives on data-collapsed so the CSS breakpoints (and the
+  // unit test) read it without media-query support. It starts collapsed on a
+  // small viewport so mobile loads with the drawer shut (matchMedia is absent in
+  // jsdom → the shell defaults to expanded under test).
+  const [collapsed, setCollapsed] = useState(
+    () => typeof window !== "undefined" && (window.matchMedia?.("(max-width: 880px)").matches ?? false),
+  );
+
   return (
-    <div className="gx-shell">
+    <div className="gx-shell" data-collapsed={collapsed ? "true" : undefined}>
+      <button
+        type="button"
+        className="gx-shell__scrim"
+        aria-hidden="true"
+        tabIndex={-1}
+        onClick={() => setCollapsed(true)}
+      />
       <aside className="gx-sidebar">
         <div className="gx-sidebar__brand">
           <span className="gx-sidebar__sigil">
@@ -57,6 +75,17 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
 
       <div className="gx-main">
         <header className="gx-topbar">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gx-topbar__toggle"
+            aria-label="Toggle sidebar"
+            aria-expanded={!collapsed}
+            title="Toggle sidebar"
+            onClick={() => setCollapsed((c) => !c)}
+            iconStart={<PanelLeft size={18} />}
+          />
+          <div className="gx-topbar__divider" />
           <div className="gx-topbar__titles">
             <div className="gx-topbar__title">{active?.title ?? "Glyphoxa"}</div>
           </div>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
+import { Toaster } from "sonner";
 import { Dices, Settings, Swords, ScrollText } from "lucide-react";
 
 import type { User } from "@gen/glyphoxa/management/v1/management_pb";
@@ -65,6 +66,11 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
           <Outlet />
         </main>
       </div>
+
+      {/* Single toast host for the whole app (ADR-0017: sonner). Mounted here, not
+          in Providers, so the screen unit tests that render without the shell get a
+          clean DOM and their deterministic inline cues instead of toast portals. */}
+      <Toaster theme="dark" position="bottom-right" richColors />
     </div>
   );
 }

--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+import { Combobox } from "./Combobox";
+
+const OPTS = [
+  { value: "r", label: "Rachel" },
+  { value: "m", label: "Marcus" },
+  { value: "a", label: "Aria" },
+];
+
+describe("Combobox", () => {
+  it("filters the options as you type", () => {
+    render(<Combobox label="Voice" options={OPTS} value="" onValueChange={() => {}} />);
+    // Open the popover.
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+    // All options visible before filtering.
+    expect(screen.getByRole("option", { name: /rachel/i })).toBeInTheDocument();
+    // Type to narrow: only the matching voice survives the filter.
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "marcus" } });
+    expect(screen.getByRole("option", { name: /marcus/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /rachel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /aria/i })).not.toBeInTheDocument();
+  });
+
+  it("fires onValueChange on pick and shows the chosen label on the trigger", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Combobox label="Voice" options={OPTS} value="" onValueChange={onChange} placeholder="Pick…" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+    fireEvent.click(screen.getByRole("option", { name: /marcus/i }));
+    // The picked option's value (not its label) is reported to the parent.
+    expect(onChange).toHaveBeenCalledWith("m");
+
+    // The parent persists the new value; the trigger now reads its live label.
+    rerender(
+      <Combobox label="Voice" options={OPTS} value="m" onValueChange={onChange} placeholder="Pick…" />,
+    );
+    const trigger = screen.getByRole("button", { name: "Voice" });
+    expect(within(trigger).getByText("Marcus")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Command } from "cmdk";
+import { ChevronDown, Check, Search } from "lucide-react";
+
+// Combobox — a filterable, height-bounded picker for large/growing option lists
+// (the live ElevenLabs voice catalog, #88 slice 2). The plain Radix Select can't
+// filter, so this pairs cmdk (the ADR-0017 combobox library) with a lightweight
+// popover. It reuses the gx-select* trigger vocabulary so it reads as the same
+// control, and adds gx-combobox* classes for the filterable popover.
+//
+// cmdk filters on each item's `value`; we set that to the human-readable label so
+// typeahead matches what the operator sees, and recover the real option value from
+// a closure on select. The selected option's label renders on the trigger.
+
+type Option = { value: string; label: string };
+
+export function Combobox({
+  label = null,
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+  placeholder = "Select…",
+  searchPlaceholder = "Search…",
+  emptyText = "No matches",
+  id,
+  "aria-label": ariaLabel,
+}: {
+  label?: string | null;
+  options: Option[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  id?: string;
+  "aria-label"?: string;
+}) {
+  const generatedId = useId();
+  const fid = id || generatedId;
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  // Close on outside click / Escape so the popover behaves like a native select.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const pick = (optValue: string) => {
+    onValueChange?.(optValue);
+    setOpen(false);
+    setSearch("");
+  };
+
+  return (
+    <div className="gx-select-field gx-combobox" ref={wrapRef}>
+      {label && (
+        <label className="gx-select-field__label" htmlFor={fid}>
+          {label}
+        </label>
+      )}
+      <div className="gx-combobox__anchor">
+        <button
+          type="button"
+          id={fid}
+          className="gx-select gx-combobox__trigger"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-label={ariaLabel || label || undefined}
+          disabled={disabled}
+          data-state={open ? "open" : "closed"}
+          onClick={() => setOpen((o) => !o)}
+        >
+          <span className={selected ? "gx-combobox__value" : "gx-combobox__placeholder"}>
+            {selected ? selected.label : placeholder}
+          </span>
+          <ChevronDown size={14} className="gx-select-chevron" />
+        </button>
+
+        {open && (
+          <div className="gx-select__content gx-combobox__content">
+            <Command className="gx-combobox__command" label={ariaLabel || label || "Options"}>
+              <div className="gx-combobox__search">
+                <Search size={14} className="gx-combobox__search-icon" />
+                <Command.Input
+                  className="gx-combobox__input"
+                  placeholder={searchPlaceholder}
+                  value={search}
+                  onValueChange={setSearch}
+                  autoFocus
+                />
+              </div>
+              <Command.List className="gx-combobox__list">
+                <Command.Empty className="gx-combobox__empty">{emptyText}</Command.Empty>
+                {options.map((o) => (
+                  <Command.Item
+                    key={o.value}
+                    value={o.label}
+                    className="gx-select__item gx-combobox__item"
+                    onSelect={() => pick(o.value)}
+                  >
+                    <span>{o.label}</span>
+                    {o.value === value && <Check size={13} />}
+                  </Command.Item>
+                ))}
+              </Command.List>
+            </Command>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -179,6 +179,76 @@ describe("Campaign", () => {
     expect(screen.getByText("Bart")).toBeInTheDocument();
   });
 
+  it("shows a success cue after Save changes succeeds", async () => {
+    renderScreen();
+    fireEvent.click(await screen.findByText("Bart"));
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    // A live status region confirms the persist landed.
+    expect(await screen.findByText(/^saved$/i)).toBeInTheDocument();
+  });
+
+  it("surfaces an error cue when Save changes fails", async () => {
+    // A transport whose UpdateAgent rejects, so the editor must show an error.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+        updateAgent: () => {
+          throw new Error("boom");
+        },
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't save/i);
+  });
+
+  it("disables Save while in flight and cannot be double-submitted", async () => {
+    // A deferred UpdateAgent holds the mutation pending until we resolve it.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+    let resolveUpdate: () => void = () => {};
+    let updateCalls = 0;
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+        updateAgent: async () => {
+          updateCalls += 1;
+          await new Promise<void>((r) => (resolveUpdate = r));
+          return create(UpdateAgentResponseSchema, { agent: npc });
+        },
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    const saveBtn = screen.getByRole("button", { name: /save changes/i });
+    fireEvent.click(saveBtn);
+
+    // In flight: the button reads "Saving…" and is disabled.
+    const pending = await screen.findByRole("button", { name: /saving/i });
+    expect(pending).toBeDisabled();
+    // A second click while pending is a no-op (disabled → no extra RPC).
+    fireEvent.click(pending);
+    expect(updateCalls).toBe(1);
+
+    resolveUpdate();
+    expect(await screen.findByText(/^saved$/i)).toBeInTheDocument();
+  });
+
   it("renders the voice select from the live ListVoices catalog", async () => {
     renderScreen();
     // Select Bart (persisted voice id "rachel"); the trigger shows the LIVE label

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Lock, Plus, Sparkles, Trash2, Volume2 } from "lucide-react";
 
 import { CampaignService, VoiceService } from "@gen/glyphoxa/management/v1/management_pb";
@@ -209,7 +210,13 @@ function AgentEditor({
   const [voice, setVoice] = useState(agent.voice);
   const [addressOnly, setAddressOnly] = useState(agent.addressOnly);
 
-  const update = useMutation(CampaignService.method.updateAgent, { onSuccess: onSaved });
+  const update = useMutation(CampaignService.method.updateAgent, {
+    onSuccess: () => {
+      onSaved();
+      toast.success(`Saved ${name || agent.name}`);
+    },
+    onError: (err) => toast.error(`Couldn't save: ${err.message}`),
+  });
   const preview = useMutation(VoiceService.method.previewVoice);
 
   // Options come from the live catalog: value = vendor voice id, label =
@@ -307,7 +314,7 @@ function AgentEditor({
 
       <div className="gx-editor__actions">
         <Button variant="primary" onClick={save} disabled={update.isPending}>
-          Save changes
+          {update.isPending ? "Saving…" : "Save changes"}
         </Button>
         {onDelete && (
           <Button
@@ -319,6 +326,19 @@ function AgentEditor({
             Delete NPC
           </Button>
         )}
+        {/* Deterministic, accessible save cue — independent of the toast portal so
+            the screen test (rendered without the shell's <Toaster>) can assert it. */}
+        <span className="gx-editor__status" aria-live="polite">
+          {update.isError ? (
+            <span className="gx-editor__status--error" role="alert">
+              Couldn't save: {update.error.message}
+            </span>
+          ) : update.isSuccess ? (
+            "Saved"
+          ) : (
+            ""
+          )}
+        </span>
       </div>
     </Card>
   );

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -9,7 +9,7 @@ import type { Agent, Voice } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
-import { Select } from "@/components/ui/Select";
+import { Combobox } from "@/components/ui/Combobox";
 import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
@@ -286,7 +286,15 @@ function AgentEditor({
       </div>
 
       <div className="gx-editor__voice">
-        <Select label="Voice" options={voiceOpts} value={voice || undefined} onValueChange={setVoice} placeholder="Pick a voice…" />
+        <Combobox
+          label="Voice"
+          options={voiceOpts}
+          value={voice || undefined}
+          onValueChange={setVoice}
+          placeholder="Pick a voice…"
+          searchPlaceholder="Search voices…"
+          emptyText="No matching voices"
+        />
         <Button
           variant="secondary"
           size="sm"

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -184,8 +184,22 @@
 
 .gx-editor__actions {
   display: flex;
+  align-items: center;
   gap: var(--spacing-sm);
   margin-top: var(--spacing-xs);
+  padding-top: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+/* Inline save cue beside the action buttons. */
+.gx-editor__status {
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--status-success);
+}
+
+.gx-editor__status--error {
+  color: var(--status-danger);
 }
 
 /* Voice select + Preview-voice button row (#70). */

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -2,6 +2,15 @@
  * classes live in styles/components.css; only screen-local layout goes here.
  */
 
+/* Page gutter (#88 slice 1): the screen root had no padding, so the content sat
+ * flush against the topbar and the content edges. Mirror the Configuration
+ * screen's centered, padded container. */
+.gx-campaign-screen {
+  padding: var(--spacing-xl);
+  max-width: var(--content-xl);
+  margin: 0 auto;
+}
+
 .gx-campaign-screen__header {
   margin-bottom: var(--spacing-lg);
 }

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -32,11 +32,14 @@
   font-family: var(--font-mono, monospace);
 }
 
-/* Discord connection card: the Bot token row above the two ID inputs. */
+/* Discord connection card: the Bot token row above the two ID inputs.
+ * (#88 slice 1) The card carried no inner padding — its rows were flush to the
+ * card edges, unlike the padded provider rows / defaults body. */
 .gx-discord {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  padding: var(--spacing-md);
 }
 
 .gx-discord__ids {

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -2,6 +2,14 @@
  * classes live in styles/components.css; only screen-local tweaks go here.
  */
 
+/* Page gutter (#88 slice 1): the screen root had no padding, so the content sat
+ * flush against the topbar and the content edges. */
+.gx-session {
+  padding: var(--spacing-xl);
+  max-width: var(--content-lg);
+  margin: 0 auto;
+}
+
 .gx-session__header {
   margin-bottom: var(--spacing-lg);
 }
@@ -10,13 +18,16 @@
   margin: 0;
 }
 
-/* Control row: status badge + elapsed timer on the left, Start/Stop on the right. */
+/* Control row: status badge + elapsed timer on the left, Start/Stop on the right.
+ * (#88 slice 1) The control Card carried no inner padding — its badge/timer/
+ * buttons sat flush against the card edges. */
 .gx-session__control {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-lg);
   flex-wrap: wrap;
+  padding: var(--spacing-md) var(--spacing-lg);
 }
 
 .gx-session__status {
@@ -52,6 +63,12 @@
 
 .gx-session__transcript {
   margin-top: var(--spacing-xl);
+}
+
+/* (#88 slice 1) The transcript Card had no inner padding, so its lines / empty
+ * state were flush to the card edges. */
+.gx-session__transcript .gx-card {
+  padding: var(--spacing-md) var(--spacing-lg);
 }
 
 .gx-session__transcript-empty {

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -835,7 +835,7 @@ textarea.gx-input {
 .gx-providers__list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-md);
 }
 .gx-provider-row {
   padding: 16px;

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -656,6 +656,23 @@ textarea.gx-input {
   min-height: 0;
   background: var(--surface-base);
 }
+/* Collapsed (#88 slice 4): the topbar toggle hides the sidebar. On wide
+ * viewports this is a focus mode; on narrow ones the sidebar is an off-canvas
+ * drawer (see the breakpoint block below), shut by default. */
+.gx-shell[data-collapsed="true"] > .gx-sidebar {
+  display: none;
+}
+/* Scrim behind the open mobile drawer; inert (and hidden) until the breakpoint
+ * block reveals it. */
+.gx-shell__scrim {
+  display: none;
+  border: none;
+  padding: 0;
+}
+.gx-topbar__toggle {
+  flex: 0 0 auto;
+  margin-left: calc(var(--spacing-xs) * -1);
+}
 .gx-sidebar {
   width: 248px;
   flex: 0 0 248px;
@@ -937,5 +954,63 @@ textarea.gx-input {
   }
   100% {
     background-position: -200% 0;
+  }
+}
+
+/* ===================== Responsive (#88 slice 4) =========================
+ * The shell + screens assumed desktop width. Below the tablet breakpoint the
+ * sidebar becomes an off-canvas drawer the topbar toggle opens, and the multi-
+ * column rows/grids collapse so nothing overflows horizontally.
+ */
+@media (max-width: 880px) {
+  /* Off-canvas drawer: fixed, above the content, shut by default (the shell
+   * starts data-collapsed on small viewports). The toggle slides it in. */
+  .gx-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 60;
+    box-shadow: var(--shadow-lg);
+  }
+  /* When open, a full-bleed scrim sits behind the drawer; clicking it shuts. */
+  .gx-shell:not([data-collapsed="true"]) > .gx-shell__scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 55;
+    background: rgba(0, 0, 0, 0.55);
+    cursor: pointer;
+  }
+
+  /* Provider key rows reflow instead of running off the edge. */
+  .gx-provider-row {
+    flex-wrap: wrap;
+  }
+  .gx-provider-row .gx-select-field,
+  .gx-provider-row__select {
+    min-width: 0;
+    max-width: none;
+    flex: 1 1 100%;
+  }
+  .gx-secret {
+    margin-left: 0;
+    flex: 1 1 100%;
+  }
+  .gx-secret__edit,
+  .gx-secret__saved {
+    flex-wrap: wrap;
+  }
+
+  /* Two-up grids drop to a single column. */
+  .gx-discord__ids,
+  .gx-defaults__grid,
+  .gx-editor__grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Tighter screen gutters on small viewports. */
+  .gx-providers {
+    padding: var(--spacing-md);
   }
 }

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -502,6 +502,87 @@ textarea.gx-input {
   color: var(--text-strong);
 }
 
+/* ===================== Combobox (components/ui/Combobox.tsx) =============
+ * A filterable, height-bounded picker (cmdk) for large/growing option lists —
+ * the live ElevenLabs voice catalog (#88 slice 2). Reuses the .gx-select trigger
+ * + .gx-select__content popover vocabulary; adds the filter input + bounded list.
+ */
+.gx-combobox__anchor {
+  position: relative;
+}
+.gx-combobox__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding-right: var(--spacing-md);
+}
+.gx-combobox__trigger .gx-select-chevron {
+  position: static;
+  flex: 0 0 auto;
+}
+.gx-combobox__value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gx-combobox__placeholder {
+  color: var(--text-subtle);
+}
+.gx-combobox__content {
+  position: absolute;
+  top: calc(100% + var(--spacing-xs));
+  left: 0;
+  right: 0;
+  min-width: 100%;
+  padding: 0;
+}
+.gx-combobox__search {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.gx-combobox__search-icon {
+  color: var(--text-muted);
+  flex: 0 0 auto;
+}
+.gx-combobox__input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-strong);
+  font-family: var(--font-base);
+  font-size: var(--body-sm);
+}
+.gx-combobox__input::placeholder {
+  color: var(--text-subtle);
+}
+/* Bound the list so a 28+ catalog scrolls instead of running off-screen. */
+.gx-combobox__list {
+  max-height: calc(var(--layout-2xl) + var(--layout-xl));
+  overflow-y: auto;
+  padding: var(--spacing-xs);
+}
+.gx-combobox__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+.gx-combobox__item[data-selected="true"] {
+  background: rgba(144, 89, 255, 0.18);
+  color: var(--text-strong);
+}
+.gx-combobox__empty {
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+}
+
 /* ===================== Switch (components/forms/Switch.jsx) =============
  * Ported onto a Radix Switch wrapper (ADR-0017): the Radix root carries
  * .gx-switch__track, the thumb .gx-switch__thumb; [data-state=checked] replaces

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -12,6 +12,21 @@ if (typeof HTMLMediaElement !== "undefined") {
   HTMLMediaElement.prototype.pause = () => {};
 }
 
+// jsdom implements neither ResizeObserver nor Element.scrollIntoView; cmdk (the
+// Voice Combobox, #88 slice 2) uses both. Stub them so the filterable popover
+// mounts and highlights items under test — the observable behaviour is the
+// filtering/selection, not layout measurement.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 // jsdom has no EventSource; the Session screen opens one for the live transcript
 // (#73). Install the mock globally so every test renders without crashing, and a
 // transcript test can drive frames via MockEventSource.last().


### PR DESCRIPTION
Closes #88. Cross-cutting UI polish on the three MVP web screens. Pure web tier — no proto/backend changes. Four independent TDD slices, each its own commit.

## Slices

1. **Spacing / margins** — Campaign and Session screen roots had no page gutter (content flush to the topbar/edges); the Session control card, Session transcript card and Configuration Discord card had no inner padding. Restored with existing spacing tokens; tokenized the off-scale provider-list gap. CSS-only, validated visually.
2. **Voice picker overflow + filtering** — new `cmdk`-backed `Combobox` (`gx-combobox*`) for the Voice field: typeahead filter, token-bounded scrollable popover, value-on-pick, persisted voice label on the trigger. `Select` stays for the Groq model field. Added jsdom `ResizeObserver`/`scrollIntoView` shims cmdk needs.
3. **Save-changes feedback** — Save button drives off the `UpdateAgent` mutation: `isPending` → disabled + "Saving…" (no double-submit); success/error → an accessible inline live-region cue plus a `sonner` toast. One `<Toaster>` mounted in `AppShell`.
4. **Responsive / mobile** — topbar ghost toggle flips the shell `data-collapsed`; below the tablet breakpoint the sidebar becomes an off-canvas drawer (shut by default, scrim) and the provider rows / two-up grids / editor grid collapse to one column. State on `data-collapsed` + `aria-expanded` so it's testable without media queries.

## ADR-0017 honored
Plain CSS + existing tokens (no hardcoded px in new spacing); `cmdk` combobox, `sonner` toast, `lucide-react` icons; stable `gx-` class vocabulary. Butler invariants (ADR-0009/0024) and the existing `Campaign.test.tsx` assertions untouched.

## Checks
`npm test` 32 passed (8 files), `npm run typecheck` clean, `npm run build` green. New tests: Combobox filter + select, AppShell sidebar toggle, three Campaign save-feedback tests (success / error / in-flight no-double-submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)