### PR TITLE
fix(#138): Server.Wait() blocks until the graceful drain completes

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -269,6 +269,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		Root:   spa.Handler(),
 		Logger: log,
 	})
+	// An open SSE tail never goes idle on its own, so it would stall every
+	// graceful shutdown for the full 5s grace period (issue #138). Registering
+	// CloseStreams releases the relay's streams the moment Shutdown begins; the
+	// browser's EventSource reconnects into the restarted process.
+	srv.RegisterOnShutdown(relay.CloseStreams)
 
 	// Sessions are manager-driven (ADR-0039): the loop starts when the Session
 	// screen asks, not at boot. Run the web tier until SIGTERM, then stop any
@@ -345,10 +350,14 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 
 // runWebTier starts the web API server on ctx and blocks until it has fully shut
 // down — Start binds the listener, then Wait returns only after the ctx-triggered
-// graceful Shutdown has drained in-flight handlers, so the caller's deferred
-// pool.Close runs strictly after the drain. Factored out so the keyless
-// default-gate test can boot a fake-handler server and assert clean boot+shutdown
-// without Postgres or Discord credentials.
+// graceful Shutdown has returned (issue #138 pinned this: Serve returning is NOT
+// the end of the drain), so the caller's mgr.Shutdown and deferred pool.Close
+// run after the drain for every handler that finishes within the grace period.
+// The guarantee is bounded, not absolute: at the ShutdownGrace deadline the
+// drain is abandoned — net/http does not close active connections — so a
+// handler slower than the grace can still be running during teardown. Factored
+// out so the keyless default-gate test can boot a fake-handler server and assert
+// clean boot+shutdown without Postgres or Discord credentials.
 func runWebTier(ctx context.Context, srv *web.Server) error {
 	if err := srv.Start(ctx); err != nil {
 		return fmt.Errorf("web: start server: %w", err)

--- a/cmd/glyphoxa/main_test.go
+++ b/cmd/glyphoxa/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"log/slog"
@@ -9,10 +10,15 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/transcript"
 	"github.com/MrWong99/Glyphoxa/internal/web"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 // fakeCampaignService is a canned CampaignServiceHandler so runWebTier can be
@@ -80,5 +86,86 @@ func TestRunWebTierBootsAndShutsDown(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("runWebTier did not return after ctx cancel")
+	}
+}
+
+// staticSessions fakes the relay's Sessions read with a fixed active session, so
+// the SSE tail below attaches to a live id without a Manager or DB.
+type staticSessions struct{ id uuid.UUID }
+
+func (s staticSessions) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{ID: s.id}, true
+}
+
+// TestRunWebTierClosesSSEStreamsOnShutdown is the end-to-end half of the issue
+// #138 fix, wired exactly like runWeb: the transcript relay's SSE tail mounted
+// as a plain (non-APIMount) route and CloseStreams registered as the server's
+// shutdown hook. An open, never-idle SSE stream must not stall the graceful
+// drain: after ctx cancel, runWebTier (Start + Wait) must return promptly via
+// the released stream — far below observe.ShutdownGrace — not at grace expiry.
+func TestRunWebTierClosesSSEStreamsOnShutdown(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := voiceevent.NewBus()
+	sessions := staticSessions{id: uuid.New()}
+	relay := transcript.NewRelay(bus, sessions, nil, log)
+
+	srv := web.NewServer(web.Config{
+		Addr: "127.0.0.1:0",
+		// The SSE route is a plain mount in runWeb too (no auth here: the gate is
+		// orthogonal to shutdown behaviour and needs a DB-backed store).
+		Mounts: []web.Mount{{Path: "GET /api/v1/sessions/{id}/events", Handler: http.HandlerFunc(relay.ServeEvents)}},
+		Logger: log,
+	})
+	srv.RegisterOnShutdown(relay.CloseStreams)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- runWebTier(ctx, srv) }()
+
+	// Wait for the listener, then open the SSE tail and read until the first
+	// frame (the seeded "status: live") proves the stream is attached.
+	deadline := time.Now().Add(2 * time.Second)
+	var resp *http.Response
+	for {
+		if addr := srv.Addr(); addr != "127.0.0.1:0" {
+			bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "attach", TurnID: "t1"})
+			r, err := http.Get("http://" + addr + "/api/v1/sessions/" + sessions.id.String() + "/events")
+			if err == nil {
+				resp = r
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("web tier never served the SSE endpoint")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer resp.Body.Close()
+	sc := bufio.NewScanner(resp.Body)
+	streamAttached := false
+	for sc.Scan() {
+		if sc.Text() != "" {
+			streamAttached = true
+			break
+		}
+	}
+	if !streamAttached {
+		t.Fatal("SSE stream produced no frames before shutdown")
+	}
+
+	cancelled := time.Now()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runWebTier returned error: %v", err)
+		}
+		if elapsed := time.Since(cancelled); elapsed >= observe.ShutdownGrace/2 {
+			t.Fatalf("runWebTier took %v after cancel — the SSE stream stalled the drain to grace expiry", elapsed)
+		}
+	case <-time.After(observe.ShutdownGrace + 2*time.Second):
+		t.Fatal("runWebTier never returned after cancel with an open SSE stream")
 	}
 }

--- a/internal/observe/shutdown.go
+++ b/internal/observe/shutdown.go
@@ -17,18 +17,31 @@ const ShutdownGrace = 5 * time.Second
 // then gracefully shuts srv down within [ShutdownGrace], so a caller wires one
 // server's lifetime to a context without re-implementing the
 // "<-ctx.Done(); Shutdown(grace)" goroutine. It returns immediately; the
-// goroutine outlives the call and ends once the shutdown completes (or its grace
-// deadline expires). After cancel, srv.Serve / srv.ListenAndServe returns
-// [http.ErrServerClosed], which callers treat as a clean stop.
+// goroutine outlives the call. After cancel, srv.Serve / srv.ListenAndServe
+// returns [http.ErrServerClosed], which callers treat as a clean stop.
+//
+// The returned channel closes once srv.Shutdown has returned — i.e. after the
+// graceful drain of in-flight requests finished, or the grace deadline expired
+// and the drain was ABANDONED: net/http's Shutdown does not close active
+// connections at its deadline, so a handler slower than the grace keeps
+// running (until process exit) even after this channel closes. Serve returning
+// is NOT the drain either: Shutdown closes the listener first, which unblocks
+// Serve immediately, and drains afterwards (issue #138). A caller whose
+// teardown must wait for the drain gates on this channel; a caller that
+// doesn't care (the [MetricsServer]) ignores it. If ctx is never cancelled the
+// channel never closes.
 //
 // The Shutdown error is intentionally discarded: a graceful shutdown error
 // (deadline exceeded) is not actionable here — the listener is closing either
 // way — and the serve goroutine already logs the terminal Serve error.
-func ShutdownOnCancel(ctx context.Context, srv *http.Server) {
+func ShutdownOnCancel(ctx context.Context, srv *http.Server) <-chan struct{} {
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		<-ctx.Done()
 		shutCtx, cancel := context.WithTimeout(context.Background(), ShutdownGrace)
 		defer cancel()
 		_ = srv.Shutdown(shutCtx)
 	}()
+	return done
 }

--- a/internal/observe/shutdown_test.go
+++ b/internal/observe/shutdown_test.go
@@ -72,3 +72,68 @@ func TestShutdownOnCancelWaitsForCancel(t *testing.T) {
 		t.Fatal("Serve did not return after cancel")
 	}
 }
+
+// TestShutdownOnCancelSignalsDrainCompletion pins the completion signal (issue
+// #138): the returned channel must stay open while an in-flight request is still
+// draining — Serve returning is NOT the end of the drain — and close once
+// srv.Shutdown finishes, i.e. after the parked handler completes.
+func TestShutdownOnCancelSignalsDrainCompletion(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		close(handlerEntered)
+		<-releaseHandler
+	})
+
+	srv := &http.Server{Handler: mux}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	drained := ShutdownOnCancel(ctx, srv)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String() + "/slow")
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	select {
+	case <-handlerEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler never entered")
+	}
+
+	cancel()
+
+	// Serve returns as soon as Shutdown closes the listener; the drain is still
+	// in progress because the handler is parked, so the completion channel must
+	// still be open.
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Serve returned %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after cancel")
+	}
+	select {
+	case <-drained:
+		t.Fatal("completion channel closed while the in-flight handler was still draining")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("completion channel never closed after the drain finished")
+	}
+}

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -66,7 +66,8 @@ func (r *Relay) detach(s *subscriber) {
 
 // ServeEvents is the SSE live tail: GET /api/v1/sessions/{id}/events. It replays
 // the ring buffer after Last-Event-ID, then streams live frames until the client
-// disconnects or falls too far behind.
+// disconnects, falls too far behind, or the process begins its graceful shutdown
+// (CloseStreams — issue #138).
 func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -97,6 +98,8 @@ func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-r.closing:
 			return
 		case <-s.lagged:
 			return

--- a/internal/transcript/http_test.go
+++ b/internal/transcript/http_test.go
@@ -168,6 +168,59 @@ func TestSSE_ReplayThenLive(t *testing.T) {
 	}
 }
 
+// TestSSE_CloseStreamsEndsTail pins the shutdown hook (issue #138): CloseStreams
+// must make every open SSE tail return so the connections go idle and the web
+// tier's graceful drain completes promptly instead of waiting out the grace
+// period on never-idle streams. Idempotence matters because net/http runs
+// RegisterOnShutdown callbacks once per Shutdown call but tests and future
+// callers may close twice.
+func TestSSE_CloseStreamsEndsTail(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	relay := transcript.NewRelay(bus, fs, nil, nil)
+	srv := httptest.NewServer(mux(relay))
+	defer srv.Close()
+	id := fs.id.String()
+
+	// A live, idle tail: connected, replayed nothing new, now blocked streaming.
+	bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "hello", TurnID: "t1"})
+	ch, stop := connect(t, srv.URL, id, 0)
+	defer stop()
+	if l := nextLine(t, ch); l.Text != "hello" {
+		t.Fatalf("replayed line = %+v", l)
+	}
+
+	relay.CloseStreams()
+
+	// The handler returns → the response body ends → readFrames closes ch.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected the frame stream to end, got another frame")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE tail did not end after CloseStreams")
+	}
+
+	relay.CloseStreams() // idempotent: a second close must not panic
+
+	// A connection opened AFTER CloseStreams must not hang either: the tail
+	// returns immediately after the replay.
+	ch2, stop2 := connect(t, srv.URL, id, 0)
+	defer stop2()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch2:
+			if !ok {
+				return // stream ended, as required
+			}
+		case <-deadline:
+			t.Fatal("post-CloseStreams SSE connection did not end")
+		}
+	}
+}
+
 // TestSnapshotEndpoint returns the current lines + derived status as JSON.
 func TestSnapshotEndpoint(t *testing.T) {
 	bus := voiceevent.NewBus()

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -183,6 +183,14 @@ type Relay struct {
 	// blocking so the send drops on overflow, and Finalize sends a flush barrier.
 	// nil when persistence is disabled (store == nil).
 	writeCh chan writeOp
+
+	// closing is closed by CloseStreams when the process begins its graceful
+	// shutdown: every open SSE tail returns so the connections go idle and the
+	// web tier's drain completes promptly (issue #138) — an SSE stream never
+	// goes idle on its own and would otherwise stall shutdown for the full
+	// grace period, only to be abandoned (not closed) at its expiry.
+	closing   chan struct{}
+	closeOnce sync.Once
 }
 
 // NewRelay subscribes to the bus once and returns a Relay ready to serve. The
@@ -199,6 +207,7 @@ func NewRelay(bus *voiceevent.Bus, sessions Sessions, store LineStore, log *slog
 		log:      log,
 		turns:    map[string]*turn{},
 		subs:     map[*subscriber]struct{}{},
+		closing:  make(chan struct{}),
 	}
 	// One writer goroutine for the process drains the queue (#74). Only started
 	// when persistence is enabled, so the live-only relay keeps its single-state
@@ -287,6 +296,16 @@ func (r *Relay) project(e voiceevent.Event) {
 		r.turn(ev.TurnID).ended = true
 		r.setTyping(r.liveTyping())
 	}
+}
+
+// CloseStreams releases every open SSE tail — and makes any later ServeEvents
+// return right after its replay — so the connections go idle and the web tier's
+// graceful shutdown drains promptly (issue #138). Wired as the web server's
+// RegisterOnShutdown hook; net/http then closes the idled connections. The
+// browser's EventSource sees a clean stream end and reconnects into the
+// restarted process. Idempotent and safe from any goroutine.
+func (r *Relay) CloseStreams() {
+	r.closeOnce.Do(func() { close(r.closing) })
 }
 
 // currentSessionID returns the active session's id, or "" when idle.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -72,9 +72,13 @@ type Server struct {
 	srv *http.Server
 	log *slog.Logger
 
-	// done is closed once Serve returns (i.e. after the ctx-triggered graceful
-	// Shutdown has fully drained). [Server.Wait] blocks on it so callers can
-	// hold resources (e.g. the DB pool) open until in-flight handlers finish.
+	// done is closed once the server has fully stopped: after Serve returned
+	// AND — when the stop was the ctx-triggered graceful Shutdown — that
+	// Shutdown has returned (drain finished, or abandoned at the grace
+	// deadline). Serve alone returns the instant Shutdown closes the listener,
+	// BEFORE the drain (issue #138), so Serve returning must not signal done by
+	// itself. [Server.Wait] blocks on it so callers can hold resources (e.g.
+	// the DB pool) open until in-flight handlers finish.
 	done chan struct{}
 
 	mu   sync.Mutex // guards addr against the Start writer / Addr readers
@@ -137,23 +141,49 @@ func (s *Server) Start(ctx context.Context) error {
 	s.addr = ln.Addr().String()
 	s.mu.Unlock()
 
-	observe.ShutdownOnCancel(ctx, s.srv)
+	drained := observe.ShutdownOnCancel(ctx, s.srv)
 	go func() {
 		defer close(s.done)
 		s.log.Info("web server listening", "addr", s.addr)
 		if err := s.srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.log.Error("web server failed", "err", err)
 		}
+		// Serve returns the moment Shutdown closes the listener; the graceful
+		// drain of in-flight requests happens AFTERWARDS, inside Shutdown itself
+		// (issue #138). Hold done open until that drain completes, but only when
+		// a shutdown was actually triggered — a spontaneous Serve failure with a
+		// live ctx has no Shutdown to wait for, and blocking here would hang
+		// Wait forever.
+		select {
+		case <-ctx.Done():
+			<-drained
+		default:
+		}
 	}()
 	return nil
 }
 
+// RegisterOnShutdown registers f to run when the ctx-triggered graceful
+// Shutdown begins (net/http calls it before waiting out the drain). Long-lived
+// streaming handlers — the transcript SSE tail — never go idle on their own, so
+// without a release hook they stall every shutdown for the full grace period;
+// f is how their owner gets told to let go. Register before [Server.Start]:
+// net/http only guarantees callbacks registered before Shutdown is called, and
+// Start wires the cancel-to-Shutdown path.
+func (s *Server) RegisterOnShutdown(f func()) {
+	s.srv.RegisterOnShutdown(f)
+}
+
 // Wait blocks until the server has fully stopped — i.e. after the ctx passed to
-// [Server.Start] is cancelled and the graceful Shutdown has drained in-flight
-// requests and Serve has returned. Callers use it to keep dependencies (the DB
-// pool) alive until handlers finish, instead of racing teardown against drain.
-// Call it only after a successful [Server.Start]; on a bind failure Start
-// returns the error and Wait must not be called (done never closes).
+// [Server.Start] is cancelled, Serve has returned, and the graceful Shutdown
+// has returned. Callers use it to keep dependencies (the DB pool) alive until
+// handlers finish, instead of racing teardown against drain. The guarantee is
+// bounded by [observe.ShutdownGrace]: at the deadline Shutdown gives up and
+// returns WITHOUT closing active connections, so a handler slower than the
+// grace may still be running when Wait returns — teardown after Wait is safe
+// against drained handlers, not against ones that outlive the grace. Call it
+// only after a successful [Server.Start]; on a bind failure Start returns the
+// error and Wait must not be called (done never closes).
 func (s *Server) Wait() {
 	<-s.done
 }

--- a/internal/web/server_internal_test.go
+++ b/internal/web/server_internal_test.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestWaitReturnsOnSpontaneousServeFailure pins the non-shutdown exit path: when
+// Serve fails on its own — here forced by closing the http.Server directly, with
+// the Start ctx still live — Wait must still return instead of blocking forever
+// on a graceful shutdown that was never triggered. Internal test: only the
+// package can reach s.srv to kill it out-of-band.
+func TestWaitReturnsOnSpontaneousServeFailure(t *testing.T) {
+	srv := NewServer(Config{Addr: "127.0.0.1:0"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := srv.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Close (not Shutdown) makes Serve return http.ErrServerClosed while ctx is
+	// NOT cancelled — the shape of a spontaneous serve/listener failure as far
+	// as the done-signalling goroutine is concerned.
+	if err := srv.srv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	waitReturned := make(chan struct{})
+	go func() {
+		srv.Wait()
+		close(waitReturned)
+	}()
+
+	select {
+	case <-waitReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() blocked forever after a spontaneous Serve failure with no ctx cancel")
+	}
+}

--- a/internal/web/shutdown_test.go
+++ b/internal/web/shutdown_test.go
@@ -1,0 +1,174 @@
+package web_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/web"
+)
+
+// TestWaitBlocksUntilDrainCompletes pins the Wait contract (issue #138): a
+// request is parked inside a handler, the server ctx is cancelled, and Wait must
+// not return until the handler finishes draining. Every step is
+// channel-synchronized; the timeouts are generous upper bounds that fail instead
+// of deadlocking, and the handler is released well within observe.ShutdownGrace
+// so the test observes a genuine graceful drain — asserted by the in-flight
+// client receiving its full 200 response.
+func TestWaitBlocksUntilDrainCompletes(t *testing.T) {
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerFinished := make(chan struct{})
+
+	slow := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerEntered)
+		<-releaseHandler
+		fmt.Fprint(w, "drained-ok")
+		close(handlerFinished)
+	})
+
+	srv := web.NewServer(web.Config{
+		Addr:   "127.0.0.1:0",
+		Mounts: []web.Mount{{Path: "/slow", Handler: slow}},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := srv.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	type clientResult struct {
+		body string
+		code int
+		err  error
+	}
+	clientDone := make(chan clientResult, 1)
+	go func() {
+		resp, err := http.Get("http://" + srv.Addr() + "/slow")
+		if err != nil {
+			clientDone <- clientResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		clientDone <- clientResult{body: string(b), code: resp.StatusCode, err: err}
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler never entered")
+	}
+
+	cancel() // shutdown begins while the handler is still in flight
+
+	waitReturned := make(chan struct{})
+	go func() {
+		srv.Wait()
+		close(waitReturned)
+	}()
+
+	// releaseHandler has NOT been closed, so the handler is definitionally still
+	// in flight: Wait returning here is the #138 defect.
+	select {
+	case <-waitReturned:
+		t.Fatal("issue #138: Wait() returned before the in-flight handler finished draining")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(releaseHandler)
+
+	select {
+	case <-handlerFinished:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler never finished after release")
+	}
+	select {
+	case <-waitReturned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Wait() never returned after the drain completed")
+	}
+
+	select {
+	case res := <-clientDone:
+		if res.err != nil {
+			t.Fatalf("client error (drain was not graceful): %v", res.err)
+		}
+		if res.code != http.StatusOK || res.body != "drained-ok" {
+			t.Fatalf("unexpected response %d %q — drain was not graceful", res.code, res.body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("client never got a response")
+	}
+}
+
+// TestRegisterOnShutdownReleasesStreamingHandler pins the long-lived-stream
+// story (issue #138 fix follow-through): a never-idle streaming handler — the
+// shape of the transcript SSE tail — blocks on a channel that an OnShutdown
+// callback closes. Cancelling the server ctx must (a) run the callback, (b) let
+// the handler exit, and (c) let Wait return promptly, NOT by waiting out the
+// full observe.ShutdownGrace.
+func TestRegisterOnShutdownReleasesStreamingHandler(t *testing.T) {
+	streamEntered := make(chan struct{})
+	stopStreaming := make(chan struct{})
+
+	stream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		close(streamEntered)
+		<-stopStreaming // released only by the OnShutdown callback
+	})
+
+	srv := web.NewServer(web.Config{
+		Addr:   "127.0.0.1:0",
+		Mounts: []web.Mount{{Path: "/stream", Handler: stream}},
+	})
+	srv.RegisterOnShutdown(func() { close(stopStreaming) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := srv.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	go func() {
+		resp, err := http.Get("http://" + srv.Addr() + "/stream")
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}()
+
+	select {
+	case <-streamEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("streaming handler never entered")
+	}
+
+	cancelled := time.Now()
+	cancel()
+	waitReturned := make(chan struct{})
+	go func() {
+		srv.Wait()
+		close(waitReturned)
+	}()
+
+	// Wait must return via the released stream, well before the grace deadline
+	// would abandon the drain. The bound is deliberately far below ShutdownGrace
+	// so a grace-expiry exit cannot sneak through as a pass.
+	graceBound := observe.ShutdownGrace / 2
+	select {
+	case <-waitReturned:
+		if elapsed := time.Since(cancelled); elapsed >= graceBound {
+			t.Fatalf("Wait() took %v after cancel — the stream stalled the drain to grace expiry instead of being released on shutdown", elapsed)
+		}
+	case <-time.After(observe.ShutdownGrace + 2*time.Second):
+		t.Fatal("Wait() never returned")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #138.

Makes `web.Server.Wait()` actually block until the graceful shutdown has drained in-flight requests, and releases the transcript relay's SSE tails when shutdown begins so the corrected drain completes in milliseconds instead of stalling for the full 5s grace whenever the Session screen is open.

Three coordinated changes:

- **`observe.ShutdownOnCancel` now returns a completion channel**, closed when `srv.Shutdown` has returned. Previously the helper ran `Shutdown` fire-and-forget and nothing in the process could observe the end of the drain. The `MetricsServer` ignores the return value (unchanged behavior).
- **`web.Server`'s `done` gate waits on that channel** — but only when a shutdown was actually triggered. A spontaneous `Serve` failure with a live ctx still unblocks `Wait()` immediately (pinned by `TestWaitReturnsOnSpontaneousServeFailure`).
- **`transcript.Relay.CloseStreams`** (wired via the new `web.Server.RegisterOnShutdown` in `runWeb`) releases every open SSE tail the moment shutdown begins. An SSE stream never goes idle on its own, so without this the fixed `Wait()` would trade the old race for a guaranteed 5s shutdown stall. EventSource clients see a clean stream end and reconnect into the restarted process.

## Why is this change needed?

Per `net/http` semantics, `Shutdown` closes the listener first — which returns `Serve` with `http.ErrServerClosed` immediately — and drains in-flight requests *afterwards, inside `Shutdown`*. `Server.Wait()` was gated on `Serve` returning, so it unblocked ~0.1ms after SIGTERM while handlers were still draining, and `runWeb`'s teardown (`mgr.Shutdown()`, deferred `pool.Close()`) raced them. The doc comments promised the opposite ordering. Triage reproduced the defect deterministically (6/6 runs incl. `-race`); full analysis and agent brief on #138.

One honest limitation, now documented instead of overpromised: at the `ShutdownGrace` deadline the drain is **abandoned, not force-closed** — `net/http` leaves active connections running — so a handler slower than 5s can still be executing when `Wait()` returns. The fix narrows the teardown race from *every* in-flight handler to only those outliving the grace; nothing short of process exit stops those.

## How was this tested?

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

New tests, all channel-synchronized (no bare sleeps for correctness):

- `internal/web` — `TestWaitBlocksUntilDrainCompletes` (parks a handler, cancels ctx, asserts `Wait()` does not return until the handler drains and the in-flight client gets its full 200; fails on pre-fix code), `TestRegisterOnShutdownReleasesStreamingHandler` (never-idle stream must not stall `Wait()` to grace expiry), `TestWaitReturnsOnSpontaneousServeFailure` (internal test: `srv.Close()` without ctx cancel must not hang `Wait()`).
- `internal/observe` — `TestShutdownOnCancelSignalsDrainCompletion` (completion channel stays open while a handler drains — `Serve` returning is not the end of the drain — and closes after).
- `internal/transcript` — `TestSSE_CloseStreamsEndsTail` (open tail ends on `CloseStreams`; idempotent; post-close connections don't hang).
- `cmd/glyphoxa` — `TestRunWebTierClosesSSEStreamsOnShutdown` (end-to-end with the exact `runWeb` wiring: open SSE stream, cancel, `runWebTier` returns far below the grace).

`go test -race -count=5` stable on all four touched packages. An adversarial multi-agent review of the diff (4 lenses, every finding independently re-verified against the Go 1.26 stdlib source and throwaway repro programs) confirmed the synchronization sound — the select's happens-before, h2c stream draining, `RegisterOnShutdown` ordering, `CloseStreams` vs concurrent attach/detach — and caught one defect: earlier doc wording claimed force-close at the grace deadline; corrected to the abandoned-drain semantics described above.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- `observe.ShutdownOnCancel`'s signature change is source-compatible for its other caller (`MetricsServer` discards the return); its drain completion stays unobservable there by design — nothing gates teardown on the metrics port.
- Out of scope per the #138 agent brief: `session.Manager` closed flag (the millisecond `Start`-vs-`Shutdown` race) and boot-time reconciliation of stale `running` `voice_sessions` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)