### PR TITLE
fix(#139): release-image generates gen/ stubs before the docker build

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -28,6 +28,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The Dockerfile does `COPY . .` then `go build` — gen/ is gitignored and
+      # NOT generated inside the image (no buf/node in the builder), so it must
+      # be present in the build CONTEXT. ci.yml's jobs restore it from the
+      # `proto` job's artifact, but artifacts don't cross workflows, so this
+      # workflow generates the stubs itself with the same pinned buf. Guarded by
+      # internal/ci's workflow-invariant test (#139).
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1.50.0
+        with:
+          version: 1.66.0
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The remote BSR plugins in buf.gen.yaml are rate-limited for anonymous
+      # callers; BUF_TOKEN lifts that, exactly as in ci.yml's proto job.
+      - name: Generate stubs
+        run: buf generate
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_REGISTRY_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/internal/ci/workflows_test.go
+++ b/internal/ci/workflows_test.go
@@ -1,0 +1,106 @@
+// Package ci holds repository-level invariant tests for the GitHub Actions
+// workflows — cross-file contracts that no single workflow's own run can
+// enforce, because the violating workflow only executes long after the PR that
+// broke it is merged (e.g. release-image.yml runs on the first v* tag).
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// workflow mirrors just enough of the GitHub Actions schema to inspect steps.
+type workflow struct {
+	Jobs map[string]struct {
+		Steps []step `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+type step struct {
+	Name string         `yaml:"name"`
+	Uses string         `yaml:"uses"`
+	Run  string         `yaml:"run"`
+	With map[string]any `yaml:"with"`
+}
+
+// TestDockerBuildJobsProvisionGeneratedStubs enforces the build-context
+// contract stated in Dockerfile ("The generated protobuf/Connect stubs (gen/,
+// gitignored, ADR-0039) are expected to ALREADY exist in the build context"):
+// every workflow job that runs a docker build of this repo must, in an earlier
+// step of the same job, either run `buf generate` or download the `gen`
+// artifact produced by ci.yml's proto job.
+//
+// The invariant is cross-file and latent — CI stays green when it breaks,
+// because the broken job (release-image.yml's publish) only runs on a release
+// tag. That is exactly how #75 shipped the regression reported in #139.
+func TestDockerBuildJobsProvisionGeneratedStubs(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	yamls, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files = append(files, yamls...)
+	if len(files) == 0 {
+		t.Fatal("no workflow files found — glob path wrong?")
+	}
+
+	for _, file := range files {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var wf workflow
+		if err := yaml.Unmarshal(raw, &wf); err != nil {
+			t.Fatalf("%s: %v", file, err)
+		}
+
+		for jobName, job := range wf.Jobs {
+			build := dockerBuildIndex(job.Steps)
+			if build < 0 {
+				continue
+			}
+			if !provisionsGen(job.Steps[:build]) {
+				t.Errorf(
+					"%s: job %q runs docker/build-push-action (step %d) without an earlier step providing gen/ "+
+						"(`buf generate` or download-artifact `gen`); the Dockerfile's `COPY . .` + `go build` "+
+						"cannot compile without the gitignored stubs in the context",
+					filepath.Base(file), jobName, build,
+				)
+			}
+		}
+	}
+}
+
+// dockerBuildIndex returns the index of the first docker build step, -1 if none.
+func dockerBuildIndex(steps []step) int {
+	for i, s := range steps {
+		if strings.HasPrefix(s.Uses, "docker/build-push-action") {
+			return i
+		}
+	}
+	return -1
+}
+
+// provisionsGen reports whether any of the given steps puts the generated
+// stubs into the working tree: running buf generate, or restoring the `gen`
+// artifact uploaded by ci.yml's proto job.
+func provisionsGen(steps []step) bool {
+	for _, s := range steps {
+		if strings.Contains(s.Run, "buf generate") {
+			return true
+		}
+		if strings.HasPrefix(s.Uses, "actions/download-artifact") {
+			if name, ok := s.With["name"].(string); ok && name == "gen" {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
> *This was generated by AI during triage.*

Fixes #139.

## Problem

`release-image.yml` checks out the repo and runs `docker/build-push-action` directly. Since #75 the binary imports the gitignored Connect stubs (`gen/`), which the Dockerfile expects to **already exist in the build context** (Dockerfile:116-122 — buf/node deliberately stay out of the builder). ci.yml's `image`/`e2e` jobs restore the `gen` artifact before their builds; the release workflow was never updated. First `v*` tag → `RUN go build` fails on a missing package → no image published. Invisible until then because CI stays green.

## Fix (TDD)

1. **Red** — `internal/ci/workflows_test.go`: a workflow-invariant test that parses `.github/workflows/*.yml` and requires every job running `docker/build-push-action` to have an earlier step providing `gen/` (a `buf generate` run or a `download-artifact: gen`). Failed on exactly `release-image.yml`'s `publish` job; ci.yml's two docker-build jobs already passed. This encodes the cross-file contract #75 broke — latent by nature, since the violating workflow only executes on a release tag.
2. **Green** — mirror ci.yml's `proto` job in the publish job before the build: pinned `bufbuild/buf-setup-action@v1.50.0` with buf `1.66.0`, then `buf generate` authenticated via `BUF_REGISTRY_TOKEN` (artifacts don't cross workflows, so the release workflow generates its own stubs). Secrets are available on same-repo tag pushes and the job is already gated to this repo.

## Verification

- `go test ./internal/ci/` red before the workflow change (publish job flagged), green after.
- `go build ./...`, `go vet`, `gofmt` clean; test-only package compiles fine under `go test ./...`.
- The added steps are byte-for-byte the pins/env of ci.yml's proven `proto` job.

Not in scope: #114 (embedding the operator console in the release image) touches this workflow next; nothing here conflicts with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)