### PR TITLE
fix(#140): helm-validate gate fails on failed, empty, or invalid renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,18 +332,20 @@ jobs:
       - name: Helm unittest
         run: helm unittest deploy/charts/glyphoxa
 
-      # Render every value path the chart supports and schema-validate each.
-      # -strict rejects unknown fields; the in-cluster path (4 docs) and the
-      # external-DB path (postgres disabled, 2 docs) are both checked so neither
-      # render branch can regress into an invalid manifest.
+      # Render every value path the chart supports — with the CI dummy values
+      # (deploy/charts/glyphoxa/ci/ci-values.yaml): the chart has `required`
+      # values, so a bare render fails by design — and schema-validate each.
+      # scripts/helm-validate.sh renders to a file (a render error fails the
+      # gate directly) and requires a non-zero validated-resource count. The
+      # former inline pipes had no pipefail and kubeconform exits 0 on empty
+      # stdin, so this gate had validated zero manifests since #42 (#140).
       - name: Render + kubeconform
-        run: |
-          helm template glyphoxa deploy/charts/glyphoxa \
-            | kubeconform -strict -summary -kubernetes-version 1.30.0
-          helm template glyphoxa deploy/charts/glyphoxa \
-            --set postgres.enabled=false \
-            --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require' \
-            | kubeconform -strict -summary -kubernetes-version 1.30.0
+        run: scripts/helm-validate.sh
+
+      # The gate must itself be trusted: assert it fails on a failing render
+      # and on an empty render — the two silent-pass modes of #140.
+      - name: helm-validate self-test
+        run: scripts/helm-validate-test.sh
 
   e2e:
     name: deploy e2e (k3d smoke)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke helm-lint helm-test helm-validate
+.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke helm-lint helm-test helm-validate helm-validate-test
 
 # Build voice engine
 build:
@@ -166,10 +166,14 @@ helm-lint:
 helm-test:
 	helm unittest $(HELM_CHART)
 
-# Render both value paths (in-cluster Postgres and external DB) and schema-check
-# each against the upstream Kubernetes schemas.
+# Render both value paths (in-cluster Postgres and external DB) with the CI
+# dummy values and schema-check each against the upstream Kubernetes schemas.
+# Delegates to scripts/helm-validate.sh, which fails on a render error and on
+# an empty render — the two modes the former inline pipes silently passed (#140).
 helm-validate:
-	helm template glyphoxa $(HELM_CHART) | kubeconform -strict -summary -kubernetes-version 1.30.0
-	helm template glyphoxa $(HELM_CHART) --set postgres.enabled=false \
-		--set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require' \
-		| kubeconform -strict -summary -kubernetes-version 1.30.0
+	HELM_VALIDATE_CHART=$(HELM_CHART) scripts/helm-validate.sh
+
+# Self-test for the gate above: asserts helm-validate actually fails when the
+# render fails or is empty.
+helm-validate-test:
+	scripts/helm-validate-test.sh

--- a/deploy/charts/glyphoxa/ci/ci-values.yaml
+++ b/deploy/charts/glyphoxa/ci/ci-values.yaml
@@ -1,0 +1,16 @@
+# Values for the CI schema-validation render ONLY (scripts/helm-validate.sh).
+# The chart has `required` values with no defaults (appSecret + the voice
+# credentials/IDs), so a bare `helm template` fails by design; this file
+# supplies syntactically valid placeholders so the render succeeds and
+# kubeconform has manifests to validate. Nothing here is a real credential and
+# nothing here is ever deployed.
+appSecret: "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=" # base64 of 32 dummy bytes
+discordBotToken: "ci-dummy-discord-bot-token"
+elevenLabsApiKey: "ci-dummy-elevenlabs-api-key"
+geminiApiKey: "ci-dummy-gemini-api-key"
+groqApiKey: "ci-dummy-groq-api-key"
+voice:
+  # Quoted strings, not numbers — snowflakes exceed float64 precision and the
+  # glyphoxa.voice.snowflake helper rejects non-string values.
+  guild: "111111111111111111"
+  channel: "222222222222222222"

--- a/scripts/helm-validate-test.sh
+++ b/scripts/helm-validate-test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Self-test for scripts/helm-validate.sh (issue #140): the gate must actually
+# gate. The pre-#140 pipeline (`helm template | kubeconform`, no pipefail) had
+# been green while validating zero manifests since #42, because a failed render
+# left only kubeconform's exit status and kubeconform exits 0 on empty stdin.
+# Each case here pins one property whose loss re-opens that hole.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "helm-validate-test: [1/3] gate passes on the real chart with the CI values"
+scripts/helm-validate.sh
+
+echo "helm-validate-test: [2/3] gate fails when the render fails (missing required values)"
+if HELM_VALIDATE_VALUES=/dev/null scripts/helm-validate.sh >/dev/null 2>&1; then
+  echo "helm-validate-test: FAIL — gate exited 0 although the render errored" >&2
+  exit 1
+fi
+
+echo "helm-validate-test: [3/3] gate fails when the render is empty (0 resources)"
+if HELM_VALIDATE_CHART=scripts/testdata/empty-chart HELM_VALIDATE_VALUES=/dev/null \
+  scripts/helm-validate.sh >/dev/null 2>&1; then
+  echo "helm-validate-test: FAIL — gate exited 0 although kubeconform saw no resources" >&2
+  exit 1
+fi
+
+echo "helm-validate-test: OK"

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Schema-validation gate for the deploy chart (issue #140): render every value
+# path the chart supports and kubeconform-validate each against the upstream
+# Kubernetes schemas. Shared by `make helm-validate` and ci.yml's helm job.
+#
+# This replaces the former `helm template | kubeconform` pipelines, which had
+# been a dead gate since #42: without pipefail a failed render (missing
+# `required` values) left only kubeconform's exit status, and kubeconform exits
+# 0 on empty stdin — so the step passed while validating zero manifests. Here
+# the render goes to a file first (a render error fails the gate directly) and
+# the gate additionally requires a non-zero validated-resource count, so an
+# empty render can never pass again. scripts/helm-validate-test.sh pins both
+# properties.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CHART="${HELM_VALIDATE_CHART:-deploy/charts/glyphoxa}"
+# The render needs the chart's `required` values; CI dummies live next to the
+# chart. Overridable so the self-test can force a failing render.
+VALUES="${HELM_VALIDATE_VALUES:-${CHART}/ci/ci-values.yaml}"
+KUBERNETES_VERSION="1.30.0"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+# validate_path <label> [extra helm args...] — render one value path of the
+# chart and schema-validate the result, failing on a render error, an invalid
+# manifest, or an empty render.
+validate_path() {
+  local label="$1"
+  shift
+  local rendered="${workdir}/${label}.yaml"
+
+  echo "helm-validate: rendering '${label}'"
+  helm template glyphoxa "${CHART}" --values "${VALUES}" "$@" >"${rendered}"
+
+  local summary
+  if ! summary="$(kubeconform -strict -summary -kubernetes-version "${KUBERNETES_VERSION}" "${rendered}")"; then
+    echo "${summary}" >&2
+    echo "helm-validate: FAIL (${label}): kubeconform rejected the render" >&2
+    exit 1
+  fi
+  echo "helm-validate: ${label}: ${summary}"
+
+  # kubeconform exits 0 when it parsed nothing, so a successful-but-empty
+  # render must be rejected here.
+  local valid
+  valid="$(sed -n 's/.*Valid: \([0-9][0-9]*\).*/\1/p' <<<"${summary}")"
+  if [[ -z "${valid}" || "${valid}" -eq 0 ]]; then
+    echo "helm-validate: FAIL (${label}): kubeconform validated 0 resources — empty or unparsed render" >&2
+    exit 1
+  fi
+}
+
+# The two render branches the chart supports: in-cluster Postgres (default)
+# and external DB (postgres disabled) — same paths the gate checked before #42
+# broke it.
+validate_path in-cluster-postgres
+validate_path external-db \
+  --set postgres.enabled=false \
+  --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require'
+
+echo "helm-validate: OK"

--- a/scripts/testdata/empty-chart/Chart.yaml
+++ b/scripts/testdata/empty-chart/Chart.yaml
@@ -1,0 +1,6 @@
+# Fixture for scripts/helm-validate-test.sh: a chart with no templates renders
+# successfully but produces zero manifests — the case kubeconform exits 0 on,
+# which the gate's resource-count guard must catch (issue #140).
+apiVersion: v2
+name: empty-chart
+version: 0.0.0


### PR DESCRIPTION
> *This was generated by AI during triage.*

Fixes #140.

## Problem

Reproduced locally (helm v4.2.2 + kubeconform v0.7.0), exactly as reported: since #42 the chart has `required` values with no defaults, so the bare `helm template | kubeconform` in ci.yml's "Render + kubeconform" step and `make helm-validate` exits 1 on the render — but with no pipefail the step's status is kubeconform's, and kubeconform exits 0 on empty stdin (`Summary: 0 resource found`). A dead CI gate reading green: any schema-invalid manifest merges. `helm lint` can't back-stop it (demotes `required` failures to INFO, verified).

## Fix (TDD)

1. **Red** — `scripts/helm-validate-test.sh` + an empty fixture chart, pinning the gate's three properties: passes on the real chart with CI values, **fails when the render fails** (the no-pipefail hole), **fails when the render is empty** (the kubeconform-exits-0 hole).
2. **Green** — `scripts/helm-validate.sh`, shared by `make helm-validate` and the CI step:
   - renders each value path (in-cluster Postgres, external DB) **to a file** — a render error fails the gate directly, no pipe subtlety;
   - supplies the 7 required values from checked-in dummies (`deploy/charts/glyphoxa/ci/ci-values.yaml`, snowflakes quoted per the `glyphoxa.voice.snowflake` helper);
   - requires a **non-zero validated-resource count**, so an empty render can never pass again;
   - surfaces kubeconform's per-resource diagnostics on rejection.

   ci.yml's helm job now runs the gate *and* the self-test, so the gate can't go dead silently again.

## Verification

- `make helm-validate`: `Valid: 6` (in-cluster) + `Valid: 4` (external-DB) — the old gate saw 0.
- `make helm-validate-test`: all three cases pass.
- Teeth check (manual, not committed): corrupted a copy of the chart (`replicas` → `replicaz`) → gate exits 1 naming `Deployment glyphoxa-voice is invalid … additional properties 'replicaz' not allowed`.
- `helm lint` (unchanged INFO only) and `helm unittest` (64/64) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)