### PR TITLE
fix(#151): percent-encode DB user/password in the assembled Helm databaseURL

### DIFF
--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -131,6 +131,13 @@ migration has finished and the schema is current.
 The DB connection URL. When the operator sets database.url it wins verbatim
 (external Postgres); otherwise the chart assembles a DSN against the in-cluster
 Postgres Service so the host can never drift from the Service name.
+
+User and password are percent-encoded (#151): the raw values also feed
+POSTGRES_USER/POSTGRES_PASSWORD, so any URL-reserved character Postgres happily
+accepts would otherwise make the DSN unparseable (or parse to the wrong
+credential) for the migrate hook and the app. urlquery leaves alphanumerics
+untouched, so default-style credentials render exactly as before. Host and DB
+name come from the chart, not operator free-text, and stay unescaped.
 */}}
 {{- define "glyphoxa.databaseURL" -}}
 {{- if .Values.database.url -}}
@@ -138,6 +145,6 @@ Postgres Service so the host can never drift from the Service name.
 {{- else -}}
 {{- $host := include "glyphoxa.postgres.fullname" . -}}
 {{- $port := .Values.postgres.service.port | int -}}
-{{- printf "postgres://%s:%s@%s:%d/%s?sslmode=%s" .Values.database.user .Values.database.password $host $port .Values.database.name .Values.database.sslmode -}}
+{{- printf "postgres://%s:%s@%s:%d/%s?sslmode=%s" (.Values.database.user | urlquery) (.Values.database.password | urlquery) $host $port .Values.database.name .Values.database.sslmode -}}
 {{- end -}}
 {{- end }}

--- a/scripts/helm-validate-test.sh
+++ b/scripts/helm-validate-test.sh
@@ -8,19 +8,26 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-echo "helm-validate-test: [1/3] gate passes on the real chart with the CI values"
+echo "helm-validate-test: [1/4] gate passes on the real chart with the CI values"
 scripts/helm-validate.sh
 
-echo "helm-validate-test: [2/3] gate fails when the render fails (missing required values)"
+echo "helm-validate-test: [2/4] gate fails when the render fails (missing required values)"
 if HELM_VALIDATE_VALUES=/dev/null scripts/helm-validate.sh >/dev/null 2>&1; then
   echo "helm-validate-test: FAIL — gate exited 0 although the render errored" >&2
   exit 1
 fi
 
-echo "helm-validate-test: [3/3] gate fails when the render is empty (0 resources)"
+echo "helm-validate-test: [3/4] gate fails when the render is empty (0 resources)"
 if HELM_VALIDATE_CHART=scripts/testdata/empty-chart HELM_VALIDATE_VALUES=/dev/null \
   scripts/helm-validate.sh >/dev/null 2>&1; then
   echo "helm-validate-test: FAIL — gate exited 0 although kubeconform saw no resources" >&2
+  exit 1
+fi
+
+echo "helm-validate-test: [4/4] gate fails when the DSN interpolates credentials without URL-escaping (#151)"
+if HELM_VALIDATE_CHART=scripts/testdata/unescaped-dsn-chart HELM_VALIDATE_VALUES=/dev/null \
+  scripts/helm-validate.sh >/dev/null 2>&1; then
+  echo "helm-validate-test: FAIL — gate exited 0 although the DSN does not round-trip a reserved-character password" >&2
   exit 1
 fi
 

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -53,6 +53,47 @@ validate_path() {
   fi
 }
 
+# check_dsn_roundtrip <rendered> <user> <password> — the assembled DSN must
+# round-trip the exact credentials Postgres is initialized with (issue #151):
+# extract the Secret's database-url from the render, URL-parse it the way pgx
+# (Go net/url) does, and compare the decoded userinfo to the originals. Raw
+# printf interpolation of a reserved-character password fails here.
+check_dsn_roundtrip() {
+  local rendered="$1" user="$2" password="$3"
+  if ! python3 - "${rendered}" "${user}" "${password}" <<'PY'; then
+import re, sys, urllib.parse
+
+rendered, want_user, want_password = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(rendered, encoding="utf-8") as f:
+    text = f.read()
+
+m = re.search(r'^\s*database-url:\s*"([^"]*)"\s*$', text, re.M)
+if not m:
+    sys.exit("no database-url found in the render")
+dsn = m.group(1)
+
+try:
+    url = urllib.parse.urlsplit(dsn)
+    # net/url unescapes %XX in userinfo but leaves '+' literal — mirror that
+    # (unquote, NOT unquote_plus) so the check matches the real consumer.
+    got_user = urllib.parse.unquote(url.username or "")
+    got_password = urllib.parse.unquote(url.password or "")
+except ValueError as err:
+    sys.exit(f"DSN does not URL-parse: {dsn!r}: {err}")
+
+if (got_user, got_password) != (want_user, want_password):
+    sys.exit(
+        f"DSN does not round-trip the credentials: {dsn!r} "
+        f"parses to user={got_user!r} password={got_password!r}, "
+        f"want user={want_user!r} password={want_password!r}"
+    )
+PY
+    echo "helm-validate: FAIL (dsn-roundtrip): see above" >&2
+    exit 1
+  fi
+  echo "helm-validate: dsn-roundtrip: DSN round-trips reserved-character credentials"
+}
+
 # The two render branches the chart supports: in-cluster Postgres (default)
 # and external DB (postgres disabled) — same paths the gate checked before #42
 # broke it.
@@ -60,5 +101,16 @@ validate_path in-cluster-postgres
 validate_path external-db \
   --set postgres.enabled=false \
   --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require'
+
+# Reserved-character credentials (issue #151): the same raw values feed
+# POSTGRES_USER/POSTGRES_PASSWORD, so the assembled DSN must percent-encode
+# them or the migrate hook and the app parse a different credential than the
+# one Postgres was initialized with.
+DSN_USER='us@r/n:me?'
+DSN_PASSWORD='p@ss/w:rd?'
+validate_path dsn-roundtrip \
+  --set-string database.user="${DSN_USER}" \
+  --set-string database.password="${DSN_PASSWORD}"
+check_dsn_roundtrip "${workdir}/dsn-roundtrip.yaml" "${DSN_USER}" "${DSN_PASSWORD}"
 
 echo "helm-validate: OK"

--- a/scripts/testdata/unescaped-dsn-chart/Chart.yaml
+++ b/scripts/testdata/unescaped-dsn-chart/Chart.yaml
@@ -1,0 +1,8 @@
+# Fixture for scripts/helm-validate-test.sh (issue #151): a chart whose Secret
+# interpolates database.user/password into the DSN raw — the pre-#151 defect.
+# The validate gate's dsn-roundtrip case must fail on it.
+apiVersion: v2
+name: unescaped-dsn-chart
+description: helm-validate self-test fixture — DSN built without URL-escaping
+type: application
+version: 0.1.0

--- a/scripts/testdata/unescaped-dsn-chart/templates/secret.yaml
+++ b/scripts/testdata/unescaped-dsn-chart/templates/secret.yaml
@@ -1,0 +1,9 @@
+# The defect under test: raw printf interpolation of user/password into the
+# DSN (no urlquery) — exactly what deploy/charts/glyphoxa had before #151.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unescaped-dsn
+type: Opaque
+stringData:
+  database-url: {{ printf "postgres://%s:%s@db:5432/%s?sslmode=%s" .Values.database.user .Values.database.password .Values.database.name .Values.database.sslmode | quote }}

--- a/scripts/testdata/unescaped-dsn-chart/values.yaml
+++ b/scripts/testdata/unescaped-dsn-chart/values.yaml
@@ -1,0 +1,7 @@
+# Defaults so the gate's in-cluster/external render paths succeed; the
+# dsn-roundtrip path overrides user/password with reserved characters.
+database:
+  user: glyphoxa
+  password: glyphoxa
+  name: glyphoxa
+  sslmode: disable


### PR DESCRIPTION
## Defect

`glyphoxa.databaseURL` (`deploy/charts/glyphoxa/templates/_helpers.tpl`) built the DSN by raw `printf` interpolation of `database.user`/`database.password`, while handing the same raw values to Postgres as `POSTGRES_USER`/`POSTGRES_PASSWORD`. Any URL-reserved character in the password (values.yaml explicitly tells the operator to change it) made the two representations diverge: Postgres initialized fine, but the migrate pre-install hook and the app parsed a different (or unparseable) credential and crashlooped with a DB-looking error.

Example (before): `database.password: "p@ss/w:rd?"` rendered `postgres://glyphoxa:p@ss/w:rd?@glyphoxa-postgres:5432/...` — URL-parses to user `glyphoxa` password `p`, host `ss`.

## Fix

Pipe user and password through sprig's `urlquery` in the helper. After: `postgres://glyphoxa:p%40ss%2Fw%3Ard%3F@glyphoxa-postgres:5432/glyphoxa?sslmode=disable` — parses back to the exact original credential. Host/DB name stay unescaped (chart-derived, out of scope per the issue).

TDD: the gate case landed first (commit 1, red against the raw template), the template fix second (commit 2, green).

## Gate extension (scripts/helm-validate.sh)

New `dsn-roundtrip` case: renders the chart with reserved-character user (`us@r/n:me?`) and password (`p@ss/w:rd?`), kubeconform-validates the render, extracts the Secret's `database-url`, URL-parses it the way pgx (Go `net/url`) does (percent-decode userinfo, literal `+`), and requires the decoded user/password to equal the originals.

Self-test case [4/4] pins the gate itself: a fixture chart (`scripts/testdata/unescaped-dsn-chart`) reproducing the raw-printf defect must keep failing the gate.

## Validation

- `scripts/helm-validate.sh` — green (in-cluster-postgres, external-db, dsn-roundtrip); red before the template fix with `parses to user='us' password=''`.
- `scripts/helm-validate-test.sh` — 4/4 green (incl. new unescaped-DSN fixture case).
- Byte-identical default renders: `helm template` with `ci/ci-values.yaml` (both the default and the `postgres.enabled=false` external-db path) diffed before vs. after the template change — zero differences, so alphanumeric/default installs see no churn.
- `helm lint` clean, `helm unittest` 64/64 pass.

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)