### PR TITLE
fix(#149): transcript replay keeps insert-time seq; rollover takes one session snapshot

### DIFF
--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -45,14 +45,17 @@ func scanTranscriptLine(row pgx.Row) (TranscriptLine, error) {
 
 // UpsertTranscriptLine writes (or updates in place) one transcript Line. An Agent
 // reply coalesces across its sentences under one line_id, so a re-write of the
-// same (voice_session_id, line_id) updates the text/seq/ts rather than inserting
-// a new row — keeping COUNT(*) == distinct lines.
+// same (voice_session_id, line_id) updates the text/ts rather than inserting a
+// new row — keeping COUNT(*) == distinct lines. seq is deliberately NOT updated
+// on conflict (#149): it is the replay ordering key, fixed at insert time, so
+// ListTranscriptLines (ORDER BY seq) matches the live-view order even when an
+// interleaved line landed between a reply's sentences.
 func (s *Store) UpsertTranscriptLine(ctx context.Context, l TranscriptLine) error {
 	_, err := s.db.Exec(ctx,
 		`INSERT INTO transcript_line (`+transcriptLineColumns+`)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 ON CONFLICT (voice_session_id, line_id) DO UPDATE
-		    SET seq = EXCLUDED.seq, who = EXCLUDED.who, tag = EXCLUDED.tag,
+		    SET who = EXCLUDED.who, tag = EXCLUDED.tag,
 		        kind = EXCLUDED.kind, ts = EXCLUDED.ts, text = EXCLUDED.text,
 		        updated_at = now()`,
 		l.VoiceSessionID, l.CampaignID, l.LineID, l.Seq,

--- a/internal/storage/transcript_line_test.go
+++ b/internal/storage/transcript_line_test.go
@@ -77,6 +77,56 @@ func TestTranscriptLinePersistence(t *testing.T) {
 	}
 }
 
+// TestTranscriptLineUpsertKeepsInsertSeq is defect A of #149: a coalescing
+// re-upsert must NOT move the line's ordering key. An Agent reply inserted at
+// seq S keeps S across later upserts (which still update the text), so replay
+// (ORDER BY seq) matches the live-view/insertion order even when an interleaved
+// human line landed between the reply's sentences.
+func TestTranscriptLineUpsertKeepsInsertSeq(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	ts := func(sec int) time.Time { return time.Date(2026, 6, 27, 18, 0, sec, 0, time.UTC) }
+
+	// Agent reply starts at seq 10; a human backchannel lands at seq 12; the
+	// reply's next sentence re-upserts the SAME line_id at seq 14.
+	steps := []storage.TranscriptLine{
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "a:t1", Seq: 10, Who: "Bart", Tag: "NPC", Kind: "npc", TS: ts(1), Text: "Well met."},
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "u:5", Seq: 12, Who: "Player / DM", Kind: "player", TS: ts(2), Text: "mhm"},
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "a:t1", Seq: 14, Who: "Bart", Tag: "NPC", Kind: "npc", TS: ts(3), Text: "Well met. What'll it be?"},
+	}
+	for _, l := range steps {
+		if err := st.UpsertTranscriptLine(ctx, l); err != nil {
+			t.Fatalf("UpsertTranscriptLine %s seq %d: %v", l.LineID, l.Seq, err)
+		}
+	}
+
+	got, err := st.ListTranscriptLines(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("list len = %d, want 2: %+v", len(got), got)
+	}
+	// Replay order == insertion order: the reply stays FIRST at its insert seq.
+	if got[0].LineID != "a:t1" || got[0].Seq != 10 {
+		t.Errorf("line[0] = %s seq %d, want a:t1 at insert-time seq 10 (replay must match live order)", got[0].LineID, got[0].Seq)
+	}
+	if got[0].Text != "Well met. What'll it be?" {
+		t.Errorf("line[0] text = %q, want coalesced final text (non-seq updates still apply)", got[0].Text)
+	}
+	if got[1].LineID != "u:5" || got[1].Seq != 12 {
+		t.Errorf("line[1] = %s seq %d, want interjection u:5 at seq 12", got[1].LineID, got[1].Seq)
+	}
+}
+
 // TestTranscriptLineCascade: an unknown session counts zero, and deleting the
 // Voice Session cascades its lines (FK ON DELETE CASCADE).
 func TestTranscriptLineCascade(t *testing.T) {

--- a/internal/transcript/persist_test.go
+++ b/internal/transcript/persist_test.go
@@ -32,7 +32,11 @@ func (f *fakeLineStore) key(sid uuid.UUID, lid string) string { return sid.Strin
 func (f *fakeLineStore) UpsertTranscriptLine(_ context.Context, l storage.TranscriptLine) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.lines[f.key(l.VoiceSessionID, l.LineID)] = l
+	k := f.key(l.VoiceSessionID, l.LineID)
+	if prev, ok := f.lines[k]; ok {
+		l.Seq = prev.Seq // mirror the real UPSERT (#149): seq is fixed at insert time
+	}
+	f.lines[k] = l
 	return nil
 }
 
@@ -142,6 +146,75 @@ func TestSnapshot_EndedSessionReplaysFromDB(t *testing.T) {
 	}
 	if v.Lines[1].ID != "a:t1" || v.Lines[1].Kind != KindNPC || v.Lines[1].Tag != "NPC" || v.Lines[1].Text != "Well met. Sit." {
 		t.Errorf("line[1] = %+v, want coalesced NPC reply", v.Lines[1])
+	}
+}
+
+// funcSessions is a Sessions fake whose Snapshot answer the test scripts per
+// call — the tool for pinning interleavings where the session state changes
+// BETWEEN two Snapshot reads inside one projection.
+type funcSessions struct {
+	mu sync.Mutex
+	fn func() (storage.VoiceSession, bool)
+}
+
+func (f *funcSessions) set(fn func() (storage.VoiceSession, bool)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fn = fn
+}
+
+func (f *funcSessions) Snapshot() (storage.VoiceSession, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fn()
+}
+
+// TestPersist_RolloverTakesOneSnapshot is defect B of #149: the rollover must
+// use ONE sessions.Snapshot() for both the id comparison and the UUID/campaign
+// capture. Pinned interleaving: session A was live, session B replaces it, and
+// B ends between the event's projection (first Snapshot) and the rollover's
+// capture (the buggy second Snapshot). The triggering line must be attributed
+// to B — never to the previous session A and never to uuid.Nil.
+func TestPersist_RolloverTakesOneSnapshot(t *testing.T) {
+	bus := voiceevent.NewBus()
+	sessA := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	sessB := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	fs := &funcSessions{}
+	store := newFakeLineStore()
+	r := NewRelay(bus, fs, store, nil)
+	ctx := context.Background()
+
+	// Session A live: one human line lands under A.
+	fs.set(func() (storage.VoiceSession, bool) { return sessA, true })
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hi from A", TurnID: "t1"})
+
+	// A ended, B started. B ends again mid-projection: the FIRST Snapshot of the
+	// next event sees B active, any LATER Snapshot sees no active session.
+	calls := 0
+	fs.set(func() (storage.VoiceSession, bool) {
+		calls++
+		if calls == 1 {
+			return sessB, true
+		}
+		return storage.VoiceSession{}, false
+	})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "hi from B", TurnID: "t2"})
+
+	// Finalize's flush barrier rides the writer queue, so both lines are on disk.
+	if _, err := r.Finalize(ctx, sessB.ID); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	if nilLines, _ := store.ListTranscriptLines(ctx, uuid.Nil); len(nilLines) != 0 {
+		t.Errorf("line persisted under uuid.Nil: %+v", nilLines)
+	}
+	gotA, _ := store.ListTranscriptLines(ctx, sessA.ID)
+	if len(gotA) != 1 || gotA[0].Text != "hi from A" {
+		t.Errorf("session A lines = %+v, want exactly its own line (B's line must not leak into A's replay)", gotA)
+	}
+	gotB, _ := store.ListTranscriptLines(ctx, sessB.ID)
+	if len(gotB) != 1 || gotB[0].Text != "hi from B" || gotB[0].CampaignID != sessB.CampaignID {
+		t.Errorf("session B lines = %+v, want its line attributed to B's UUID + campaign", gotB)
 	}
 }
 

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -228,12 +228,16 @@ func (r *Relay) project(e voiceevent.Event) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	id := r.currentSessionID()
-	if id == "" {
+	// ONE Snapshot serves both the id comparison and the rollover's UUID/campaign
+	// capture (#149): the manager's mutex is independent of r.mu, so a second read
+	// could see the session already ended and leave the FKs pointing at the
+	// previous session (or uuid.Nil at process start).
+	vs, active := r.sessions.Snapshot()
+	if !active {
 		return // no active session — drop the event (ADR-0039)
 	}
-	if id != r.activeID {
-		r.rollover(id)
+	if vs.ID.String() != r.activeID {
+		r.rollover(vs)
 	}
 
 	switch ev := e.(type) {
@@ -317,17 +321,15 @@ func (r *Relay) currentSessionID() string {
 	return vs.ID.String()
 }
 
-// rollover starts a fresh buffer for a newly-active session id and seeds it with
-// the initial live/listening status frame, so a client connecting mid-session
-// replays a coherent state.
-func (r *Relay) rollover(id string) {
-	r.activeID = id
-	// Capture the typed session + campaign ids persistence needs as FKs (#74).
-	// During a rollover the snapshot is active, so this is the freshly-active row.
-	if vs, ok := r.sessions.Snapshot(); ok {
-		r.activeUUID = vs.ID
-		r.activeCampaignID = vs.CampaignID
-	}
+// rollover starts a fresh buffer for the newly-active session vs — the SAME
+// snapshot the caller compared ids against (#149), so the typed FKs persistence
+// needs can never belong to a different session than activeID — and seeds it
+// with the initial live/listening status frame, so a client connecting
+// mid-session replays a coherent state.
+func (r *Relay) rollover(vs storage.VoiceSession) {
+	r.activeID = vs.ID.String()
+	r.activeUUID = vs.ID
+	r.activeCampaignID = vs.CampaignID
 	r.buf = nil
 	r.lines = nil
 	r.turns = map[string]*turn{}


### PR DESCRIPTION
## Defects (#149, both from #93's transcript persistence)

**A — `SET seq = EXCLUDED.seq` reordered coalesced lines on replay.** A multi-sentence Agent reply's UPSERT moved its ordering key to the LAST sentence's seq, so `ListTranscriptLines` (`ORDER BY seq`) diverged from the live view: an interleaved human backchannel jumped *before* the reply it interrupted.

**B — rollover TOCTOU.** `project()` read `sessions.Snapshot()` once for the id comparison and `rollover` read it a *second* time for the UUID/campaign capture. The manager's mutex is independent of `r.mu`, so a session ending between the two reads left `activeUUID` pointing at the previous session (line persisted into the wrong replay history) or at `uuid.Nil` at process start (FK violation, line silently dropped).

## Fix

- `internal/storage/transcript_line.go` — the ON CONFLICT SET no longer updates `seq`: the replay ordering key is fixed at insert time; text/ts/who/tag/kind still coalesce.
- `internal/transcript/relay.go` — `project()` takes exactly ONE `Snapshot()` and passes the snapshot to `rollover(vs storage.VoiceSession)`, which captures `activeID`/`activeUUID`/`activeCampaignID` from that single consistent read.

## Tests (red before fix, green after)

- `TestTranscriptLineUpsertKeepsInsertSeq` (integration): reply at seq 10, interjection at seq 12, coalescing re-upsert at seq 14 → replay keeps the reply first at seq 10 with the final text. Red: `[u:5, a:t1]`.
- `TestPersist_RolloverTakesOneSnapshot` (unit, scripted `funcSessions`): session B ends between projection and capture → line lands under B, never under previous session A, never under `uuid.Nil`. Red: B's line overwrote A's `u:1`; B's history empty.
- `fakeLineStore` now mirrors the real UPSERT's insert-time-seq semantics.

Local gates: `go build ./...`, `go test -race` on both packages, storage integration suite vs local pgvector Postgres, gofmt, `golangci-lint run --build-tags integration` — clean.

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)