### PR TITLE
fix(#155): Groq TTFT probe stops recording mid-stream failures as latency samples

### DIFF
--- a/pkg/voice/llm/groq/latency_drain_test.go
+++ b/pkg/voice/llm/groq/latency_drain_test.go
@@ -10,6 +10,7 @@ package groq_test
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,26 @@ func failureKind(err error) string {
 	default:
 		return "call-failed"
 	}
+}
+
+// failSummary formats a per-tier failure count for the summary, kinds sorted
+// for a stable log line: "n=3 (provider-error=2 truncated=1)".
+func failSummary(byKind map[string]int) string {
+	var n int
+	kinds := make([]string, 0, len(byKind))
+	for k, c := range byKind {
+		n += c
+		kinds = append(kinds, k)
+	}
+	if n == 0 {
+		return "n=0"
+	}
+	sort.Strings(kinds)
+	parts := make([]string, len(kinds))
+	for i, k := range kinds {
+		parts[i] = fmt.Sprintf("%s=%d", k, byKind[k])
+	}
+	return fmt.Sprintf("n=%d (%s)", n, strings.Join(parts, " "))
 }
 
 // drainStream consumes one completion stream and classifies the outcome. It
@@ -166,5 +187,18 @@ func TestFailureKind_BucketsByCause(t *testing.T) {
 		if got := failureKind(tc.err); got != tc.want {
 			t.Errorf("failureKind(%v): want %q, got %q", tc.err, tc.want, got)
 		}
+	}
+}
+
+// The summary reports failures separately from the latency distribution:
+// total count plus a deterministic per-kind breakdown.
+func TestFailSummary_CountsByKind(t *testing.T) {
+	if got := failSummary(nil); got != "n=0" {
+		t.Errorf("no failures: want %q, got %q", "n=0", got)
+	}
+	got := failSummary(map[string]int{"truncated": 1, "provider-error": 2})
+	want := "n=3 (provider-error=2 truncated=1)"
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
 	}
 }

--- a/pkg/voice/llm/groq/latency_drain_test.go
+++ b/pkg/voice/llm/groq/latency_drain_test.go
@@ -1,0 +1,170 @@
+// Unit tests + implementation for the live TTFT probe's per-call drain and
+// classification logic (issue #155). Deliberately NOT behind the `live` build
+// tag: the drain loop is pure channel-consumption over [llm.StreamEvent], so
+// its failure classification (provider EventError vs. truncation vs. success)
+// is pinned here against fake event streams in the default keyless suite
+// (ADR-0033). The live-tagged probe (latency_live_test.go) reuses drainStream
+// for the real Groq calls.
+package groq_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// errTruncated marks a stream whose channel closed with neither an
+// [llm.EventDone] nor an [llm.EventError] — per the [llm.Provider] contract
+// that stream was cancelled and its text must not count as a complete reply.
+var errTruncated = errors.New("stream truncated: closed without EventDone or EventError")
+
+// errProvider marks a mid-stream [llm.EventError]; the vendor's detail is
+// wrapped around it so errors.Is classification and the log line both work.
+var errProvider = errors.New("provider stream error")
+
+// failureKind buckets a failed call for the summary: "provider-error" (the
+// vendor emitted a mid-stream EventError), "truncated" (channel closed with
+// no terminal event, e.g. ctx timeout), or "call-failed" (Complete never
+// returned a stream — bad key, non-2xx, ...).
+func failureKind(err error) string {
+	switch {
+	case errors.Is(err, errProvider):
+		return "provider-error"
+	case errors.Is(err, errTruncated):
+		return "truncated"
+	default:
+		return "call-failed"
+	}
+}
+
+// drainStream consumes one completion stream and classifies the outcome. It
+// returns the time from start to the first non-empty content token, the total
+// wall time, and the accumulated text. A sample is successful (err == nil)
+// only if the stream delivered a terminal completion; a mid-stream
+// [llm.EventError] fails it with the provider's detail.
+func drainStream(start time.Time, ch <-chan llm.StreamEvent) (first, total time.Duration, text string, err error) {
+	var sawFirst, done, failed bool
+	var provErr string
+	for ev := range ch {
+		switch ev.Type {
+		case llm.EventText:
+			if ev.Text == "" {
+				continue
+			}
+			if !sawFirst {
+				first = time.Since(start)
+				sawFirst = true
+			}
+			text += ev.Text
+		case llm.EventDone:
+			done = true
+		case llm.EventError:
+			failed = true
+			provErr = ev.Err
+		}
+	}
+	total = time.Since(start)
+	if !sawFirst {
+		first = total
+	}
+	if failed {
+		return first, total, text, fmt.Errorf("%w: %s", errProvider, provErr)
+	}
+	if !done {
+		return first, total, text, errTruncated
+	}
+	return first, total, text, nil
+}
+
+// feed returns a closed channel pre-loaded with the given events — a fake
+// provider stream per the [llm.Provider] contract.
+func feed(events ...llm.StreamEvent) <-chan llm.StreamEvent {
+	ch := make(chan llm.StreamEvent, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+// A mid-stream provider failure (llm.EventError) must fail the sample with
+// the provider's error detail — before #155 the drain loop swallowed it and
+// recorded the call as a successful latency sample.
+func TestDrainStream_MidStreamProviderError_FailsSample(t *testing.T) {
+	ch := feed(
+		llm.StreamEvent{Type: llm.EventText, Text: "Ein Bier"},
+		llm.StreamEvent{Type: llm.EventError, Err: "rate limited by vendor"},
+	)
+	_, _, _, err := drainStream(time.Now(), ch)
+	if err == nil {
+		t.Fatal("mid-stream EventError must fail the sample, got err == nil")
+	}
+	if !strings.Contains(err.Error(), "rate limited by vendor") {
+		t.Fatalf("error must carry the provider's detail, got: %v", err)
+	}
+}
+
+// A channel that closes with neither EventDone nor EventError was cancelled
+// (e.g. the probe's 60s ctx timeout): the accumulated text is truncated, so
+// the sample must fail as a truncation — before #155 it was recorded as a
+// successful sample with first == total when no token had arrived.
+func TestDrainStream_CloseWithoutTerminalEvent_FailsAsTruncation(t *testing.T) {
+	ch := feed(
+		llm.StreamEvent{Type: llm.EventText, Text: "Ein halbes"},
+	)
+	_, _, _, err := drainStream(time.Now(), ch)
+	if err == nil {
+		t.Fatal("close without terminal event must fail the sample, got err == nil")
+	}
+	if !errors.Is(err, errTruncated) {
+		t.Fatalf("want errTruncated, got: %v", err)
+	}
+}
+
+// A stream that ends in EventDone is a successful sample and measures exactly
+// what the probe measured before #155: first-token time stamped at the first
+// NON-EMPTY EventText, total at channel close, text accumulated across chunks.
+func TestDrainStream_TerminalDone_SucceedsWithLatencySample(t *testing.T) {
+	ch := feed(
+		llm.StreamEvent{Type: llm.EventText, Text: ""}, // empty delta: not a content token
+		llm.StreamEvent{Type: llm.EventText, Text: "Ein "},
+		llm.StreamEvent{Type: llm.EventText, Text: "Bier."},
+		llm.StreamEvent{Type: llm.EventDone, StopReason: "stop"},
+	)
+	first, total, text, err := drainStream(time.Now(), ch)
+	if err != nil {
+		t.Fatalf("terminal EventDone must succeed, got: %v", err)
+	}
+	if text != "Ein Bier." {
+		t.Fatalf("accumulated text: want %q, got %q", "Ein Bier.", text)
+	}
+	if first <= 0 || total < first {
+		t.Fatalf("want 0 < first <= total, got first=%v total=%v", first, total)
+	}
+}
+
+// failureKind buckets each failed call for the summary so the probe reports
+// WHAT failed (provider error vs. truncation vs. call never started), not
+// just how many — that attribution is the probe's purpose per #28.
+func TestFailureKind_BucketsByCause(t *testing.T) {
+	_, _, _, provErr := drainStream(time.Now(), feed(
+		llm.StreamEvent{Type: llm.EventError, Err: "boom"},
+	))
+	_, _, _, truncErr := drainStream(time.Now(), feed())
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{provErr, "provider-error"},
+		{truncErr, "truncated"},
+		{errors.New("401 unauthorized"), "call-failed"},
+	} {
+		if got := failureKind(tc.err); got != tc.want {
+			t.Errorf("failureKind(%v): want %q, got %q", tc.err, tc.want, got)
+		}
+	}
+}

--- a/pkg/voice/llm/groq/latency_live_test.go
+++ b/pkg/voice/llm/groq/latency_live_test.go
@@ -95,9 +95,12 @@ func TestLive_GroqLlama_TTFT(t *testing.T) {
 	// llama-3.3-70b-versatile, no reasoning_effort (Llama does not think).
 	client := groq.New("")
 
-	// samples bucketed by tier name → the per-tier distribution.
+	// samples bucketed by tier name → the per-tier distribution; failed calls
+	// (provider EventError, truncation, call never started) are counted per
+	// kind instead of polluting the latency samples (#155).
 	ttft := map[string][]float64{}
 	total := map[string][]float64{}
+	fails := map[string]map[string]int{}
 
 	var calls int
 	for _, p := range ttftPrompts {
@@ -106,9 +109,13 @@ func TestLive_GroqLlama_TTFT(t *testing.T) {
 				time.Sleep(delay)
 			}
 			calls++
-			first, tot, text, err := timeOne(t, client, p.system, p.user)
+			first, tot, text, err := timeOne(client, p.system, p.user)
 			if err != nil {
-				t.Logf("[%s #%d] %v", p.name, i, err)
+				t.Logf("[%s #%d] FAILED (%s): %v", p.name, i, failureKind(err), err)
+				if fails[p.name] == nil {
+					fails[p.name] = map[string]int{}
+				}
+				fails[p.name][failureKind(err)]++
 				continue
 			}
 			ttft[p.name] = append(ttft[p.name], first)
@@ -123,10 +130,11 @@ func TestLive_GroqLlama_TTFT(t *testing.T) {
 	for _, p := range ttftPrompts {
 		t.Logf("[%s] ttft_ms  %s", p.name, dist(ttft[p.name]))
 		t.Logf("[%s] total_ms %s", p.name, dist(total[p.name]))
+		t.Logf("[%s] failed   %s", p.name, failSummary(fails[p.name]))
 		any = any || len(ttft[p.name]) > 0
 	}
 	if !any {
-		t.Fatal("no successful samples on any tier — check key/quota")
+		t.Fatal("no successful samples on any tier — check key/quota (and the per-kind failure counts above)")
 	}
 }
 
@@ -134,7 +142,12 @@ func TestLive_GroqLlama_TTFT(t *testing.T) {
 // and the accumulated text. Tools are intentionally omitted: this isolates the
 // LLM-stage TTFT from tool-loop rounds (ADR-0028); the bait prompt still
 // exercises a reasoning-shaped input without adding a second round-trip.
-func timeOne(t *testing.T, c *groq.Client, system, user string) (firstMs, totalMs float64, text string, err error) {
+//
+// Drain/classification lives in drainStream (latency_drain_test.go, no live
+// tag) so the failure modes — mid-stream EventError, truncation — are pinned
+// by keyless unit tests (#155). A non-nil err means the sample must NOT be
+// recorded: only streams that delivered a terminal completion count.
+func timeOne(c *groq.Client, system, user string) (firstMs, totalMs float64, text string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -148,22 +161,8 @@ func timeOne(t *testing.T, c *groq.Client, system, user string) (firstMs, totalM
 	if err != nil {
 		return 0, 0, "", err
 	}
-	var first time.Duration
-	var sawFirst bool
-	for ev := range ch {
-		if ev.Type == llm.EventText && ev.Text != "" {
-			if !sawFirst {
-				first = time.Since(start)
-				sawFirst = true
-			}
-			text += ev.Text
-		}
-	}
-	tot := time.Since(start)
-	if !sawFirst {
-		first = tot
-	}
-	return ms(first), ms(tot), text, nil
+	first, tot, text, err := drainStream(start, ch)
+	return ms(first), ms(tot), text, err
 }
 
 func ms(d time.Duration) float64 { return float64(d.Microseconds()) / 1000.0 }


### PR DESCRIPTION
## What does this PR do?

Fixes #155.

The Groq TTFT live probe's per-call drain loop (`timeOne`) handled only `llm.EventText` and returned success unconditionally when the stream channel closed. Mid-stream vendor failures (`llm.EventError`) and truncations (the 60s ctx timeout closing the channel with no terminal event) were silently recorded as **successful latency samples** — with `first == total` when no token arrived at all. So the `no successful samples` gate could never trip and the probe printed a green-but-skewed p50/p95/p99 exactly when it was supposed to attribute a bench-live SLO breach to Groq itself vs. the pipeline (#28).

**Fix**

- The drain/classification logic moves to `drainStream` in a new **non-live-tagged** test file (`pkg/voice/llm/groq/latency_drain_test.go`), so it is unit-tested against fake event channels in the default keyless suite (ADR-0033) — no live Groq needed.
- A sample is successful **only** if the stream delivered a terminal completion (`EventDone`). `EventError` fails the sample with the provider's detail; channel-close-without-terminal-event fails it as truncation (per the `llm.Provider` contract, such a stream was cancelled).
- The live probe counts failed calls per tier and per kind (`provider-error` / `truncated` / `call-failed`) and prints them in the summary **next to — not inside —** the latency distribution:
  ```
  [trivial] ttft_ms  n=6 p50=… p95=… p99=… max=…
  [trivial] total_ms n=6 p50=… p95=… p99=… max=…
  [trivial] failed   n=2 (provider-error=1 truncated=1)
  ```
- The existing `no successful samples` gate now trips when every call fails, because failures no longer masquerade as samples.
- Successful streams measure exactly what they measured before: first-token time stamped at the first non-empty `EventText`, total at channel close.

## Why is this change needed?

The probe (`llm-ttft-live.yml`, #28) exists to attribute latency SLO breaches to the provider; with provider errors swallowed into the percentiles, that attribution was unreliable exactly when it mattered (e.g. Groq rate-limiting mid-response during a run).

## How was this tested?

New keyless unit tests (red before fix — `drainStream` extracted TDD-style, one failing test per cycle):

- `TestDrainStream_MidStreamProviderError_FailsSample` — mid-stream `EventError` fails the sample and carries the vendor detail.
- `TestDrainStream_CloseWithoutTerminalEvent_FailsAsTruncation` — close without `EventDone`/`EventError` fails as `errTruncated`.
- `TestDrainStream_TerminalDone_SucceedsWithLatencySample` — success path pins pre-fix latency semantics (empty deltas ignored, text accumulated, `0 < first <= total`).
- `TestFailureKind_BucketsByCause` — provider-error / truncated / call-failed bucketing.
- `TestFailSummary_CountsByKind` — deterministic per-kind summary line.

Local gates: `make check` (fmt+vet+test), `go build ./...`, `go test -race ./pkg/voice/llm/groq/...`, `go vet -tags live ./pkg/voice/llm/groq/...` and `go test -tags live -run NoSuchTest ./pkg/voice/llm/groq/...` (live probe still compiles; no live Groq calls made), `golangci-lint run` (0 issues).

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (not applicable — live probe run needs the deployment key; workflow unchanged)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

`llm-ttft-live.yml` is untouched: the workflow compiles and runs the same test; only the summary output is richer. Probe cadence, prompts, and SLO thresholds are out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)