### PR TITLE
fix(#143,#157): session end path — fresh end-write budget, surfaced end failures, boot reconciliation, Manager closed state

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -247,6 +247,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
 	mgr := session.NewManager(store, runner, cfg, cipher, log, withVoice)
+	// Boot-time reconciliation (#143): close voice_sessions rows a previous run
+	// left 'running' (crash / failed end-write). No loop is live yet, so every
+	// such row is an orphan; done before the web tier serves so GetSession never
+	// reports a dead session as live. Web-only mode skips inside (it owns no
+	// rows). A failure here is a broken DB — fail the boot loudly.
+	if err := mgr.ReconcileOrphans(ctx); err != nil {
+		return fmt.Errorf("web: %w", err)
+	}
 
 	// The SSE transcript relay (issue #73, ADR-0014 Hop-B) subscribes to the
 	// process bus once and reads the active session from the manager (Snapshot).

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -154,6 +154,10 @@ func (s *SessionServer) startError(err error) error {
 			errors.New("the saved Discord bot token could not be decrypted; ensure the server $GLYPHOXA_SECRET is set correctly (ADR-0004)"))
 	case errors.Is(err, session.ErrVoiceUnavailable):
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("voice is not available in this mode"))
+	case errors.Is(err, session.ErrManagerClosed):
+		// The manager is in its terminal closed state (#157): the process is
+		// shutting down. Unavailable, so the client retries the restarted process.
+		return connect.NewError(connect.CodeUnavailable, errors.New("the server is shutting down; try again shortly"))
 	default:
 		s.log.Error("StartSession: manager start failed", "err", err)
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -213,6 +213,20 @@ func TestSessionStartTokenUndecryptable(t *testing.T) {
 	}
 }
 
+// TestSessionStartManagerClosed is #157: a Start refused by the manager's
+// terminal closed state (process shutting down) surfaces CodeUnavailable, not an
+// opaque Internal — the client should retry against the restarted process.
+func TestSessionStartManagerClosed(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{startErr: session.ErrManagerClosed}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeUnavailable {
+		t.Errorf("manager-closed code = %v, want Unavailable", connect.CodeOf(err))
+	}
+}
+
 // TestSessionStartNoCampaign fails with FailedPrecondition when there is no
 // active campaign to run a session for.
 func TestSessionStartNoCampaign(t *testing.T) {

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -1,0 +1,10 @@
+package session
+
+import "time"
+
+// SetEndTimeoutForTest shrinks the per-step end budget (Finalize / end-write)
+// so the #143 budget-separation tests run in milliseconds instead of the
+// production 5s. Test-only; called before any session starts.
+func (m *Manager) SetEndTimeoutForTest(d time.Duration) {
+	m.endTimeout = d
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -44,6 +44,10 @@ var (
 	// Bot token nor a DISCORD_BOT_TOKEN env token is available (#87). Mapped to
 	// CodeFailedPrecondition, mirroring ErrDiscordNotConfigured.
 	ErrDiscordTokenMissing = errors.New("session: no Discord bot token configured")
+	// ErrManagerClosed is returned by Start after Shutdown: the Manager is in its
+	// terminal closed state and refuses new work (#157) — no store write, no loop.
+	// Mapped to CodeUnavailable.
+	ErrManagerClosed = errors.New("session: the session manager is shut down")
 	// ErrDiscordTokenUndecryptable is returned by Start when a real saved Bot token
 	// cannot be decrypted — booted without $GLYPHOXA_SECRET (nil cipher) or a
 	// ciphertext the cipher won't open (#87). The underlying actionable detail is
@@ -102,6 +106,7 @@ type Manager struct {
 
 	mu     sync.Mutex
 	active *activeSession
+	closed bool // terminal: set by Shutdown; Start refuses with ErrManagerClosed (#157)
 }
 
 // NewManager wraps the store, loop runner and base config in a Manager. base
@@ -141,6 +146,12 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// The closed check lives under the same lock Shutdown takes, so a Start that
+	// wins the lock after Shutdown returned can never insert a row or spawn a
+	// loop nothing will cancel (#157).
+	if m.closed {
+		return storage.VoiceSession{}, ErrManagerClosed
+	}
 	if m.active != nil {
 		return storage.VoiceSession{}, ErrSessionActive
 	}
@@ -268,11 +279,14 @@ func (m *Manager) Snapshot() (storage.VoiceSession, bool) {
 	return m.active.session, true
 }
 
-// Shutdown cancels any active session and waits for its loop to end and the
-// ended_at write to land. The web tier calls it on process shutdown, before the
-// DB pool closes, so a SIGTERM never leaves a row stuck 'running'.
+// Shutdown moves the Manager to its terminal closed state (any later Start
+// fails ErrManagerClosed, #157), then cancels any active session and waits for
+// its loop to end and the ended_at write to land. The web tier calls it on
+// process shutdown, before the DB pool closes, so a SIGTERM never leaves a row
+// stuck 'running'. Idempotent: a second call finds no active session.
 func (m *Manager) Shutdown() {
 	m.mu.Lock()
+	m.closed = true
 	as := m.active
 	m.mu.Unlock()
 	if as == nil {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -102,7 +102,8 @@ type Manager struct {
 	cipher     *crypto.Cipher      // decrypts the saved deployment Bot token (#87); nil without $GLYPHOXA_SECRET
 	transcript TranscriptFinalizer // finalizes persisted lines on Stop (#74); nil keeps line_count at 0
 	log        *slog.Logger
-	enabled    bool // false in web-only mode: Start is rejected (ADR-0039)
+	enabled    bool          // false in web-only mode: Start is rejected (ADR-0039)
+	endTimeout time.Duration // per-step end budget (Finalize, end-write); endTimeout in prod, shrunk in tests
 
 	mu     sync.Mutex
 	active *activeSession
@@ -122,7 +123,7 @@ func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled}
+	return &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled, endTimeout: endTimeout}
 }
 
 // SetTranscript wires the transcript finalizer the Manager calls on Stop / loop
@@ -214,24 +215,32 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		m.log.Error("voice session loop exited with error", "err", err, "voice_session", as.session.ID)
 	}
 
-	// The run ctx is cancelled on a Stop, so end the row on a detached, bounded
-	// context — otherwise the ended_at write would itself be cancelled.
-	endCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), endTimeout)
-	defer cancel()
+	// The run ctx is cancelled on a Stop, so both end steps run on detached,
+	// bounded contexts — otherwise the writes would themselves be cancelled.
+	base := context.WithoutCancel(ctx)
 
 	// Drain the live transcript's writer queue and read the authoritative count
 	// BEFORE ending the row, so line_count matches the persisted rows (#74). A
 	// finalize failure logs and falls back to the in-memory count rather than
-	// blocking the session from ending.
+	// blocking the session from ending. Finalize gets its OWN budget: its flush
+	// barrier can queue behind slow line UPSERTs and eat the whole deadline
+	// (#143 Defect B), and the end-write below must not inherit that.
 	lineCount := as.session.LineCount
 	if m.transcript != nil {
-		if n, ferr := m.transcript.Finalize(endCtx, as.session.ID); ferr != nil {
+		finCtx, finCancel := context.WithTimeout(base, m.endTimeout)
+		n, ferr := m.transcript.Finalize(finCtx, as.session.ID)
+		finCancel()
+		if ferr != nil {
 			m.log.Error("finalize transcript before end", "err", ferr, "voice_session", as.session.ID)
 		} else {
 			lineCount = n
 		}
 	}
 
+	// A FRESH deadline for the ended_at write, regardless of what Finalize
+	// consumed (#143): the row landing 'ended' is the invariant that matters.
+	endCtx, cancel := context.WithTimeout(base, m.endTimeout)
+	defer cancel()
 	ended, err := m.store.EndVoiceSession(endCtx, as.session.ID, lineCount)
 
 	m.mu.Lock()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -57,12 +57,14 @@ var (
 )
 
 // Store is the narrow storage surface the Manager needs: the saved Discord
-// guild/channel (deployment config) and the voice_sessions lifecycle writes.
-// *storage.Store satisfies it; tests use a fake.
+// guild/channel (deployment config), the voice_sessions lifecycle writes, and
+// the boot-time orphan reconciliation (#143). *storage.Store satisfies it;
+// tests use a fake.
 type Store interface {
 	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
 	CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
 	EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error)
+	ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, error)
 }
 
 // TranscriptFinalizer drains the live transcript's writer queue for a session and
@@ -137,6 +139,27 @@ func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto
 // needed.
 func (m *Manager) SetTranscript(t TranscriptFinalizer) {
 	m.transcript = t
+}
+
+// ReconcileOrphans closes voice_sessions rows still marked 'running' that no
+// live loop owns (#143). Called once at boot, before any session can start: at
+// that point NO loop is live, so every 'running' row is an orphan — stranded by
+// a crash (kill -9 / OOM) or a failed end-write — and is marked ended with the
+// distinguishing storage.VoiceSessionReasonOrphaned. A web-only Manager
+// (enabled=false) never owns rows and skips: another process may be driving
+// voice against the same DB.
+func (m *Manager) ReconcileOrphans(ctx context.Context) error {
+	if !m.enabled {
+		return nil
+	}
+	n, err := m.store.ReconcileOrphanedVoiceSessions(ctx)
+	if err != nil {
+		return fmt.Errorf("session: reconcile orphaned voice sessions: %w", err)
+	}
+	if n > 0 {
+		m.log.Warn("closed orphaned voice sessions left 'running' by a previous run", "count", n)
+	}
+	return nil
 }
 
 // Start launches the live voice loop for a campaign and records a running

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -85,10 +85,14 @@ type LoopRunner func(ctx context.Context, cfg wirenpc.Config) error
 
 // activeSession is the Manager's record of the one running session: the cancel
 // func that unwinds its loop, the voice_sessions row, and a done channel closed
-// once the loop has exited and the ended_at write has landed.
+// once the loop has exited and the ended_at write has landed (or failed —
+// endErr carries that failure so Stop reports it instead of a stale success,
+// #143 Defect A). session/endErr are written before close(done) and read only
+// after <-done, so done is the synchronization point.
 type activeSession struct {
 	campaignID uuid.UUID
 	session    storage.VoiceSession
+	endErr     error
 	cancel     context.CancelFunc
 	done       chan struct{}
 }
@@ -245,6 +249,10 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 
 	m.mu.Lock()
 	if err != nil {
+		// The row is still 'running' in the DB. Remember the failure so a waiting
+		// Stop surfaces it (#143 Defect A); the startup reconciliation repairs the
+		// row on the next boot. Still clear the active slot — the loop is gone.
+		as.endErr = fmt.Errorf("session: end voice session %s: %w", as.session.ID, err)
 		m.log.Error("end voice session", "err", err, "voice_session", as.session.ID)
 	} else {
 		as.session = ended
@@ -256,9 +264,11 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 }
 
 // Stop cancels the active session's loop and waits for it to end, returning the
-// ended voice_sessions row. ErrNoActiveSession when nothing is running. If ctx is
-// cancelled while waiting, it returns ctx.Err() — the loop still unwinds in the
-// background.
+// ended voice_sessions row. ErrNoActiveSession when nothing is running. If the
+// ended_at write failed, Stop returns the row's true (still-'running') state
+// WITH the failure — never a plain success carrying status='running' (#143). If
+// ctx is cancelled while waiting, it returns ctx.Err() — the loop still unwinds
+// in the background.
 func (m *Manager) Stop(ctx context.Context) (storage.VoiceSession, error) {
 	m.mu.Lock()
 	as := m.active
@@ -270,8 +280,8 @@ func (m *Manager) Stop(ctx context.Context) (storage.VoiceSession, error) {
 	as.cancel()
 	select {
 	case <-as.done:
-		// done closes after runLoop set as.session to the ended row; safe to read.
-		return as.session, nil
+		// done closes after runLoop set as.session/as.endErr; safe to read.
+		return as.session, as.endErr
 	case <-ctx.Done():
 		return storage.VoiceSession{}, ctx.Err()
 	}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -21,15 +21,16 @@ import (
 // (guild/channel source, #72) and records the voice_sessions Create/End calls so
 // the lifecycle can be asserted without Postgres.
 type fakeStore struct {
-	mu       sync.Mutex
-	dep      storage.DeploymentConfig
-	depErr   error
-	sessions map[uuid.UUID]storage.VoiceSession
-	created  int
-	ended    int
-	depReads int
-	tick     int
-	endErr   error // injected EndVoiceSession failure (#143 Defect A)
+	mu         sync.Mutex
+	dep        storage.DeploymentConfig
+	depErr     error
+	sessions   map[uuid.UUID]storage.VoiceSession
+	created    int
+	ended      int
+	depReads   int
+	reconciles int
+	tick       int
+	endErr     error // injected EndVoiceSession failure (#143 Defect A)
 }
 
 func newFakeStore() *fakeStore {
@@ -93,6 +94,31 @@ func (f *fakeStore) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount
 	vs.LineCount = lineCount
 	f.sessions[id] = vs
 	return vs, nil
+}
+
+// ReconcileOrphanedVoiceSessions mirrors the real store's boot reconciliation
+// (#143): every 'running' row flips to 'ended' with the orphaned end reason.
+func (f *fakeStore) ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reconciles++
+	var n int64
+	for id, vs := range f.sessions {
+		if vs.Status != storage.VoiceSessionRunning {
+			continue
+		}
+		end := f.now()
+		reason := storage.VoiceSessionReasonOrphaned
+		vs.EndedAt = &end
+		vs.Status = storage.VoiceSessionEnded
+		vs.EndReason = &reason
+		f.sessions[id] = vs
+		n++
+	}
+	return n, nil
 }
 
 func (f *fakeStore) counts() (created, ended int) {
@@ -529,6 +555,55 @@ func TestStartAfterShutdownRefused(t *testing.T) {
 	case <-runner.started:
 		t.Error("loop spawned after Shutdown")
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestReconcileOrphansAtStartup is #143's reconciliation: a row still 'running'
+// from a crashed process (kill -9 / OOM — no live loop owns it) is closed at
+// Manager startup, marked ended with the distinguishing orphaned reason, so
+// GetLatestVoiceSession stops mislabeling a dead session as live.
+func TestReconcileOrphansAtStartup(t *testing.T) {
+	store := newFakeStore()
+	orphan := storage.VoiceSession{
+		ID:         uuid.New(),
+		CampaignID: uuid.New(),
+		StartedAt:  time.Date(2026, 6, 27, 11, 0, 0, 0, time.UTC),
+		Status:     storage.VoiceSessionRunning,
+	}
+	store.mu.Lock()
+	store.sessions[orphan.ID] = orphan
+	store.mu.Unlock()
+
+	mgr := newManager(t, store, newBlockingRunner().run, true)
+	if err := mgr.ReconcileOrphans(context.Background()); err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+
+	store.mu.Lock()
+	row := store.sessions[orphan.ID]
+	store.mu.Unlock()
+	if row.Status != storage.VoiceSessionEnded || row.EndedAt == nil {
+		t.Errorf("orphaned row = %+v, want ended with ended_at", row)
+	}
+	if row.EndReason == nil || *row.EndReason != storage.VoiceSessionReasonOrphaned {
+		t.Errorf("orphaned row end_reason = %v, want %q", row.EndReason, storage.VoiceSessionReasonOrphaned)
+	}
+}
+
+// TestReconcileOrphansWebOnlySkips: a web-only Manager (enabled=false) never
+// created rows and must not touch ones another process may own — reconciliation
+// is a no-op there.
+func TestReconcileOrphansWebOnlySkips(t *testing.T) {
+	store := newFakeStore()
+	mgr := newManager(t, store, newBlockingRunner().run, false)
+	if err := mgr.ReconcileOrphans(context.Background()); err != nil {
+		t.Fatalf("ReconcileOrphans (web-only): %v", err)
+	}
+	store.mu.Lock()
+	reconciles := store.reconciles
+	store.mu.Unlock()
+	if reconciles != 0 {
+		t.Errorf("web-only reconciles = %d, want 0", reconciles)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -70,7 +70,12 @@ func (f *fakeStore) CreateVoiceSession(_ context.Context, campaignID uuid.UUID) 
 	return vs, nil
 }
 
-func (f *fakeStore) EndVoiceSession(_ context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error) {
+func (f *fakeStore) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error) {
+	// A real EndVoiceSession fails on an expired context (#143 Defect B pins
+	// exactly that), so the fake honours ctx like pgx would.
+	if err := ctx.Err(); err != nil {
+		return storage.VoiceSession{}, err
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ended++
@@ -398,6 +403,51 @@ func TestStopFinalizesTranscriptCount(t *testing.T) {
 	}
 	if id, called := fin.seen(); called != 1 || id != vs.ID {
 		t.Errorf("finalize seen id=%s called=%d, want id=%s called=1", id, called, vs.ID)
+	}
+}
+
+// slowFinalizer is a TranscriptFinalizer that consumes its ENTIRE context
+// budget (a flush barrier stuck behind slow line UPSERTs, #143 Defect B) and
+// returns the context error, like the relay would.
+type slowFinalizer struct{}
+
+func (slowFinalizer) Finalize(ctx context.Context, _ uuid.UUID) (int, error) {
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+// TestSlowFinalizeStillEndsRow is #143 Defect B: a Finalize that exhausts the
+// whole end budget must NOT hand EndVoiceSession an already-expired context —
+// the end-write gets its own fresh deadline, so the row still lands 'ended'.
+func TestSlowFinalizeStillEndsRow(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+	mgr.SetEndTimeoutForTest(50 * time.Millisecond)
+	mgr.SetTranscript(slowFinalizer{})
+
+	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	ended, err := mgr.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded || ended.EndedAt == nil {
+		t.Errorf("stopped session = %+v, want ended with ended_at", ended)
+	}
+	store.mu.Lock()
+	row := store.sessions[vs.ID]
+	store.mu.Unlock()
+	if row.Status != storage.VoiceSessionEnded {
+		t.Errorf("stored row status = %q, want ended (end-write must get a fresh deadline)", row.Status)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -29,6 +29,7 @@ type fakeStore struct {
 	ended    int
 	depReads int
 	tick     int
+	endErr   error // injected EndVoiceSession failure (#143 Defect A)
 }
 
 func newFakeStore() *fakeStore {
@@ -78,6 +79,9 @@ func (f *fakeStore) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.endErr != nil {
+		return storage.VoiceSession{}, f.endErr
+	}
 	f.ended++
 	vs, ok := f.sessions[id]
 	if !ok {
@@ -448,6 +452,37 @@ func TestSlowFinalizeStillEndsRow(t *testing.T) {
 	store.mu.Unlock()
 	if row.Status != storage.VoiceSessionEnded {
 		t.Errorf("stored row status = %q, want ended (end-write must get a fresh deadline)", row.Status)
+	}
+}
+
+// TestStopSurfacesEndWriteFailure is #143 Defect A: when the EndVoiceSession
+// write fails, Stop must NOT report plain success carrying the stale 'running'
+// row — the caller sees the failure (previously it was log-only and StopSession
+// answered success with status='running').
+func TestStopSurfacesEndWriteFailure(t *testing.T) {
+	store := newFakeStore()
+	endErr := errors.New("db down at stop time")
+	store.mu.Lock()
+	store.endErr = endErr
+	store.mu.Unlock()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	got, err := mgr.Stop(context.Background())
+	if err == nil {
+		t.Fatalf("Stop = %+v with nil error, want the end-write failure surfaced", got)
+	}
+	if !errors.Is(err, endErr) {
+		t.Errorf("Stop error = %v, want the underlying end-write failure in the chain", err)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -27,6 +27,7 @@ type fakeStore struct {
 	sessions map[uuid.UUID]storage.VoiceSession
 	created  int
 	ended    int
+	depReads int
 	tick     int
 }
 
@@ -48,6 +49,7 @@ func (f *fakeStore) now() time.Time {
 func (f *fakeStore) GetDeploymentConfig(_ context.Context, _ uuid.UUID) (storage.DeploymentConfig, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.depReads++
 	if f.depErr != nil {
 		return storage.DeploymentConfig{}, f.depErr
 	}
@@ -413,6 +415,66 @@ func TestStartDisabledMode(t *testing.T) {
 	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, false)
 	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); !errors.Is(err, session.ErrVoiceUnavailable) {
 		t.Errorf("Start in disabled mode = %v, want ErrVoiceUnavailable", err)
+	}
+}
+
+// TestStartAfterShutdownRefused is #157: Shutdown moves the Manager to a
+// terminal closed state, so a Start that acquires the lock after Shutdown has
+// returned fails fast with ErrManagerClosed — it must not touch the store (no
+// config read, no running row INSERT) and must not spawn a loop nothing will
+// ever cancel.
+func TestStartAfterShutdownRefused(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	mgr.Shutdown()
+
+	_, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrManagerClosed) {
+		t.Errorf("Start after Shutdown = %v, want ErrManagerClosed", err)
+	}
+	store.mu.Lock()
+	depReads, created := store.depReads, store.created
+	store.mu.Unlock()
+	if depReads != 0 || created != 0 {
+		t.Errorf("store touched after Shutdown: depReads=%d created=%d, want 0/0", depReads, created)
+	}
+	select {
+	case <-runner.started:
+		t.Error("loop spawned after Shutdown")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestShutdownIdempotentStopSafe is #157's tail: Shutdown of an active session
+// ends it; a second Shutdown is an idempotent no-op; Stop after Shutdown stays
+// well-defined (ErrNoActiveSession, no panic).
+func TestShutdownIdempotentStopSafe(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	mgr.Shutdown()
+	if _, ended := store.counts(); ended != 1 {
+		t.Errorf("ended rows after Shutdown = %d, want 1", ended)
+	}
+	mgr.Shutdown() // idempotent: no second end write, no hang
+
+	if _, err := mgr.Stop(context.Background()); !errors.Is(err, session.ErrNoActiveSession) {
+		t.Errorf("Stop after Shutdown = %v, want ErrNoActiveSession", err)
+	}
+	if _, ended := store.counts(); ended != 1 {
+		t.Errorf("ended rows after second Shutdown = %d, want still 1", ended)
 	}
 }
 

--- a/internal/storage/migrations/00008_voice_session_end_reason.sql
+++ b/internal/storage/migrations/00008_voice_session_end_reason.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+-- end_reason distinguishes HOW a Voice Session ended (#143). NULL is the normal
+-- Stop / loop-exit path; the boot-time reconciliation stamps 'orphaned:
+-- reconciled at startup' when it closes a row still 'running' with no live loop
+-- (crash / kill -9 / a failed ended_at write). Additive and nullable, so the
+-- migration is safe over existing rows.
+ALTER TABLE voice_sessions
+    ADD COLUMN end_reason text;
+
+-- +goose Down
+
+ALTER TABLE voice_sessions
+    DROP COLUMN IF EXISTS end_reason;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -90,10 +90,17 @@ const (
 	VoiceSessionEnded   VoiceSessionStatus = "ended"
 )
 
+// VoiceSessionReasonOrphaned is the end_reason stamped by the boot-time
+// reconciliation (#143): the row was still 'running' but no live loop owned it
+// (crash / kill -9 / a failed end-write), so startup closed it. A NULL
+// end_reason means the session ended through the normal Stop / loop-exit path.
+const VoiceSessionReasonOrphaned = "orphaned: reconciled at startup"
+
 // VoiceSession is one run of the live voice loop — the Bot's presence in one
 // Discord voice channel, bound to a Campaign (CONTEXT.md "Voice Session", #72).
 // EndedAt is nil while running; LineCount records transcript lines produced (0
-// for this stage — the live feed is #73).
+// for this stage — the live feed is #73). EndReason is nil for a clean end and
+// set when the boot reconciliation closed an orphaned row (#143).
 type VoiceSession struct {
 	ID         uuid.UUID
 	CampaignID uuid.UUID
@@ -101,6 +108,7 @@ type VoiceSession struct {
 	EndedAt    *time.Time
 	Status     VoiceSessionStatus
 	LineCount  int
+	EndReason  *string
 }
 
 // Agent is an AI-controlled persona — Butler or Character NPC (ADR-0009).

--- a/internal/storage/voice_session.go
+++ b/internal/storage/voice_session.go
@@ -15,12 +15,12 @@ import (
 // thin and domain-neutral, mirroring the rest of the storage layer.
 
 const voiceSessionColumns = `
-	id, campaign_id, started_at, ended_at, status, line_count`
+	id, campaign_id, started_at, ended_at, status, line_count, end_reason`
 
 func scanVoiceSession(row pgx.Row) (VoiceSession, error) {
 	var v VoiceSession
 	err := row.Scan(
-		&v.ID, &v.CampaignID, &v.StartedAt, &v.EndedAt, &v.Status, &v.LineCount,
+		&v.ID, &v.CampaignID, &v.StartedAt, &v.EndedAt, &v.Status, &v.LineCount, &v.EndReason,
 	)
 	return v, err
 }
@@ -59,6 +59,24 @@ func (s *Store) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int
 		return VoiceSession{}, fmt.Errorf("storage: end voice session %s: %w", id, err)
 	}
 	return v, nil
+}
+
+// ReconcileOrphanedVoiceSessions closes every Voice Session row still marked
+// 'running' — at startup no live loop exists, so any such row is an orphan from
+// a crash or a failed end-write (#143). Each is stamped ended_at=now(),
+// status='ended' and the distinguishing VoiceSessionReasonOrphaned end_reason
+// (a clean end leaves end_reason NULL). Returns how many rows were closed.
+// Called by the SessionManager at boot, before any session can start.
+func (s *Store) ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_sessions
+		    SET ended_at = now(), status = $1, end_reason = $2
+		  WHERE status = $3`,
+		VoiceSessionEnded, VoiceSessionReasonOrphaned, VoiceSessionRunning)
+	if err != nil {
+		return 0, fmt.Errorf("storage: reconcile orphaned voice sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
 }
 
 // GetVoiceSession loads one Voice Session by id, or ErrNotFound.

--- a/internal/storage/voice_session_test.go
+++ b/internal/storage/voice_session_test.go
@@ -85,6 +85,65 @@ func TestVoiceSessionLifecycle(t *testing.T) {
 	}
 }
 
+// TestReconcileOrphanedVoiceSessions is #143's boot reconciliation against a
+// real Postgres: a row stranded 'running' (crash / failed end-write) is closed
+// with ended_at + the distinguishing end_reason; a cleanly ended row keeps its
+// NULL end_reason; a second reconcile finds nothing (idempotent).
+func TestReconcileOrphanedVoiceSessions(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A cleanly ended session: reconciliation must not touch it.
+	clean, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession (clean): %v", err)
+	}
+	if _, err := st.EndVoiceSession(ctx, clean.ID, 3); err != nil {
+		t.Fatalf("EndVoiceSession (clean): %v", err)
+	}
+
+	// The orphan: still 'running', no live loop (this "process" just booted).
+	orphan, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession (orphan): %v", err)
+	}
+
+	n, err := st.ReconcileOrphanedVoiceSessions(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOrphanedVoiceSessions: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reconciled = %d, want 1", n)
+	}
+
+	got, err := st.GetVoiceSession(ctx, orphan.ID)
+	if err != nil {
+		t.Fatalf("GetVoiceSession (orphan): %v", err)
+	}
+	if got.Status != storage.VoiceSessionEnded || got.EndedAt == nil {
+		t.Errorf("orphan after reconcile = %+v, want ended with ended_at", got)
+	}
+	if got.EndReason == nil || *got.EndReason != storage.VoiceSessionReasonOrphaned {
+		t.Errorf("orphan end_reason = %v, want %q", got.EndReason, storage.VoiceSessionReasonOrphaned)
+	}
+
+	// The clean end stays distinguishable: end_reason NULL.
+	cleanGot, err := st.GetVoiceSession(ctx, clean.ID)
+	if err != nil {
+		t.Fatalf("GetVoiceSession (clean): %v", err)
+	}
+	if cleanGot.EndReason != nil {
+		t.Errorf("clean end_reason = %q, want NULL", *cleanGot.EndReason)
+	}
+
+	// Idempotent: nothing left to close.
+	if n, err := st.ReconcileOrphanedVoiceSessions(ctx); err != nil || n != 0 {
+		t.Errorf("second reconcile = %d, %v; want 0, nil", n, err)
+	}
+}
+
 // TestEndVoiceSessionNotFound asserts ending an unknown id is ErrNotFound (the
 // RPC maps it accordingly).
 func TestEndVoiceSessionNotFound(t *testing.T) {


### PR DESCRIPTION
## Defects

**#143 — voice_sessions rows strand as 'running' forever.**
- *Defect B:* `runLoop` shared one 5s `endCtx` between `transcript.Finalize` and `EndVoiceSession`; a Finalize stuck behind slow line UPSERTs exhausted the budget and the end-write ran with an already-expired context → row stuck `running`.
- *Defect A:* an end-write failure was log-only; `Stop`/StopSession answered **success** carrying `status='running'`, and nothing ever repaired the row (no reaper, no boot reconciliation) — a `kill -9`/OOM stranded rows permanently.

**#157 — `Manager.Start` succeeds after `Shutdown`.** Shutdown recorded no terminal state, so a StartSession handler outliving the drain grace could INSERT a `running` row and spawn a loop on a context nothing would ever cancel, during process exit.

## Fix

- `runLoop` gives Finalize and the `EndVoiceSession` write **separate** `endTimeout` budgets off the detached base context — the end-write always gets a fresh deadline.
- The end-write failure is recorded on the active session; `Stop` returns the row's true state **with** the error (StopSession maps it to `Internal` instead of lying with success).
- New `Store.ReconcileOrphanedVoiceSessions` + migration `00008` (nullable `end_reason` column): at boot the Manager closes every row still `'running'` (no loop is live yet, so all are orphans) with the distinguishing reason `orphaned: reconciled at startup`; clean ends keep `end_reason` NULL. Web-only managers skip (they own no rows). Wired in `main.go` before the web tier serves.
- `Shutdown` sets a terminal `closed` flag under `m.mu`; `Start` after `Shutdown` fails fast with the new `ErrManagerClosed` sentinel — zero store reads/writes, no loop spawned. StartSession maps it to `CodeUnavailable`. Shutdown stays idempotent; `Stop` after `Shutdown` remains `ErrNoActiveSession`, no panic.

## Tests (all red before the fix, green after; `-race` clean)

- `TestSlowFinalizeStillEndsRow` — Finalize exhausts its whole budget; row still lands `ended` (fake store now honours ctx expiry like pgx; `export_test` seam shrinks the budget to ms).
- `TestStopSurfacesEndWriteFailure` — injected end-write failure; Stop no longer returns nil-error + `running`.
- `TestReconcileOrphansAtStartup` / `TestReconcileOrphansWebOnlySkips` — fake-store reconciliation + web-only guard.
- `TestReconcileOrphanedVoiceSessions` (integration, real Postgres) — orphan closed with reason, clean end keeps NULL `end_reason`, idempotent second pass.
- `TestStartAfterShutdownRefused` — Shutdown→Start: `ErrManagerClosed`, zero store touches, no loop.
- `TestSessionStartManagerClosed` — RPC maps the sentinel to `CodeUnavailable`.
- `TestShutdownIdempotentStopSafe` — double Shutdown + Stop-after-Shutdown pinned.

Out of scope (per the briefs): UI visibility (#144), SSE relay (#148), a periodic reaper, and PR #156's drain semantics.

Fixes #143
Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)