### PR TITLE
fix(#148): SSE hardening — lossless lagged replay + per-write deadline

### DIFF
--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -5,7 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 )
+
+// defaultWriteTimeout bounds each SSE frame write/flush (#148 Defect B). Big
+// enough for any live client on a bad link to drain one frame; small enough
+// that a stalled reader releases its handler well within an operator's
+// patience and does not pin the graceful shutdown drain.
+const defaultWriteTimeout = 5 * time.Second
 
 // subscriber is one live SSE connection's fan-out channel. id is the session it
 // subscribed to: only frames for the matching active session are delivered, so a
@@ -75,11 +82,11 @@ func (r *Relay) detach(s *subscriber) {
 // disconnects, falls too far behind, or the process begins its graceful shutdown
 // (CloseStreams — issue #138).
 func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	if _, ok := w.(http.Flusher); !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return
 	}
+	fw := r.newFrameWriter(w)
 	id := req.PathValue("id")
 
 	h := w.Header()
@@ -90,15 +97,18 @@ func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 	// frames flush promptly.
 	h.Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	if err := fw.flush(); err != nil {
+		return
+	}
 
 	s, replay := r.attach(id, lastEventID(req))
 	defer r.detach(s)
 
 	for _, f := range replay {
-		writeFrame(w, f)
+		if err := fw.write(f); err != nil {
+			return
+		}
 	}
-	flusher.Flush()
 
 	ctx := req.Context()
 	for {
@@ -110,8 +120,9 @@ func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 		case <-s.lagged:
 			return
 		case f := <-s.ch:
-			writeFrame(w, f)
-			flusher.Flush()
+			if err := fw.write(f); err != nil {
+				return
+			}
 		}
 	}
 }
@@ -130,11 +141,70 @@ func (r *Relay) ServeSnapshot(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// writeFrame serializes one SSE frame: an id/event/data triple terminated by a
-// blank line. Data is single-line JSON (json.Marshal never emits a raw newline),
-// so no multi-line data folding is needed.
-func writeFrame(w http.ResponseWriter, f Frame) {
-	fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", f.Seq, f.Event, f.Data)
+// frameWriter writes SSE frames bounded by a per-write deadline (#148 Defect
+// B): each write/flush is armed with writeTimeout via
+// http.ResponseController.SetWriteDeadline, so a client that stops reading
+// (laptop sleep, TCP zero-window, exhausted h2c flow-control window) makes the
+// blocked write fail — the handler exits and its subscriber is cleaned up —
+// instead of parking the goroutine in Write forever, where the lagged escape
+// can never fire. Both production paths honor the deadline (HTTP/1.1 conn
+// deadline; the bundled HTTP/2 server's per-stream write deadline under the
+// web tier's h2c Protocols setup — pinned by the h2c hardening test).
+type frameWriter struct {
+	w         http.ResponseWriter
+	rc        *http.ResponseController
+	timeout   time.Duration
+	deadlines bool // writer supports SetWriteDeadline
+}
+
+// newFrameWriter probes deadline support once so an exotic wrapped writer
+// degrades LOUDLY (a warning, unbounded writes) rather than silently killing
+// the stream on its first frame.
+func (r *Relay) newFrameWriter(w http.ResponseWriter) *frameWriter {
+	fw := &frameWriter{w: w, rc: http.NewResponseController(w), timeout: r.writeTimeout, deadlines: true}
+	if err := fw.rc.SetWriteDeadline(time.Time{}); err != nil {
+		fw.deadlines = false
+		r.log.Warn("transcript: response writer does not support write deadlines; stalled-client protection disabled", "err", err)
+	}
+	return fw
+}
+
+// write serializes one SSE frame — an id/event/data triple terminated by a
+// blank line — and flushes it, all under one armed write deadline. Data is
+// single-line JSON (json.Marshal never emits a raw newline), so no multi-line
+// data folding is needed. The deadline is disarmed after a successful flush:
+// the tail can sit idle between frames indefinitely, and under h2c an armed
+// deadline is a stream-reset timer that fires even with no write pending.
+func (fw *frameWriter) write(f Frame) error {
+	if err := fw.arm(time.Now().Add(fw.timeout)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(fw.w, "id: %d\nevent: %s\ndata: %s\n\n", f.Seq, f.Event, f.Data); err != nil {
+		return err
+	}
+	if err := fw.rc.Flush(); err != nil {
+		return err
+	}
+	return fw.arm(time.Time{})
+}
+
+// flush pushes buffered bytes (the response headers) under a write deadline.
+func (fw *frameWriter) flush() error {
+	if err := fw.arm(time.Now().Add(fw.timeout)); err != nil {
+		return err
+	}
+	if err := fw.rc.Flush(); err != nil {
+		return err
+	}
+	return fw.arm(time.Time{})
+}
+
+// arm sets (or clears, for the zero time) the write deadline when supported.
+func (fw *frameWriter) arm(t time.Time) error {
+	if !fw.deadlines {
+		return nil
+	}
+	return fw.rc.SetWriteDeadline(t)
 }
 
 // lastEventID reads the browser's resume cursor from the Last-Event-ID header

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -17,23 +17,29 @@ type subscriber struct {
 }
 
 // push fans a frame out to every subscriber on the active session. A full
-// channel means a slow reader: it is signalled lagged (once) and skipped — its
-// EventSource reconnects with Last-Event-ID and replays from the ring. Caller
-// holds r.mu, and the bus contract forbids blocking, so the send is
-// non-blocking.
+// channel means a slow reader: it is signalled lagged (once) and from then on
+// receives NOTHING more (#148 Defect A) — delivering any frame past the
+// dropped one would let the client reconnect with a Last-Event-ID beyond the
+// hole and skip it forever. The connection sees a strict prefix of the
+// sequence, so its EventSource reconnect replays the dropped frame from the
+// ring losslessly. Caller holds r.mu, and the bus contract forbids blocking,
+// so the send is non-blocking.
 func (r *Relay) push(f Frame) {
 	for s := range r.subs {
 		if s.id != r.activeID {
 			continue
 		}
 		select {
+		case <-s.lagged:
+			// Already dropped a frame: never send another. Only push closes
+			// lagged, always under r.mu, so this check-then-close is race-free.
+			continue
+		default:
+		}
+		select {
 		case s.ch <- f:
 		default:
-			select {
-			case <-s.lagged:
-			default:
-				close(s.lagged)
-			}
+			close(s.lagged)
 		}
 	}
 }

--- a/internal/transcript/http_hardening_test.go
+++ b/internal/transcript/http_hardening_test.go
@@ -1,0 +1,84 @@
+package transcript
+
+// SSE hardening tests (#148): Defect A — once a subscription has dropped a
+// frame, no later frame may be delivered on it, so Last-Event-ID replay is
+// genuinely lossless. Defect B — a stalled reader must not park the handler in
+// a write forever (per-write deadline).
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestLaggedDrop_StrictPrefixAndLosslessReplay (#148 Defect A): after frame X
+// is dropped for a slow subscriber, the connection must deliver a strict
+// prefix of the sequence — never a frame past X — so the reconnect replay from
+// the last delivered seq contains X instead of skipping the hole forever.
+//
+// Choreography of the bug: the reader stalls long enough to overflow its
+// channel (X dropped, lagged signalled), then briefly resumes — freeing
+// channel capacity — while new frames keep arriving. The buggy push slips
+// frames > X into the freed capacity and the handler writes them to the wire
+// before it notices the lag, so the browser reconnects with Last-Event-ID > X.
+func TestLaggedDrop_StrictPrefixAndLosslessReplay(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	// Warm publish sets the active session (frames: status seq 1, line seq 2).
+	bus.Publish(voiceevent.STTFinal{At: at(0), Text: "warm", TurnID: "w"})
+
+	s, _ := r.attach(id, 0)
+	defer r.detach(s)
+
+	// Stalled reader: subBuffer line frames fill s.ch, one more overflows — the
+	// dropped frame X — and the subscription is signalled lagged.
+	for i := 0; i <= subBuffer; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: "flood", TurnID: fmt.Sprintf("f%d", i)})
+	}
+	select {
+	case <-s.lagged:
+	default:
+		t.Fatal("expected the overflowing subscriber to be signalled lagged")
+	}
+	dropped := r.nextSeq // seq of frame X: the last emitted frame overflowed
+
+	// Reader briefly resumes: drain a little capacity, then more frames arrive.
+	last := uint64(2) // the warm frames (seq 1, 2) predate attach; live starts at 3
+	for i := 0; i < 8; i++ {
+		last = (<-s.ch).Seq
+	}
+	for i := 0; i < 8; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: "after-drop", TurnID: fmt.Sprintf("g%d", i)})
+	}
+
+	// Drain everything this connection would deliver: it must be a strict
+	// prefix — contiguous seqs, none past the dropped frame X.
+	for {
+		select {
+		case f := <-s.ch:
+			if f.Seq != last+1 {
+				t.Fatalf("delivered seq %d after %d: not a strict prefix", f.Seq, last)
+			}
+			if f.Seq >= dropped {
+				t.Fatalf("delivered frame seq %d on a lagged connection; nothing >= dropped frame %d may be delivered", f.Seq, dropped)
+			}
+			last = f.Seq
+		default:
+			// Channel drained.
+			if last >= dropped {
+				t.Fatalf("last delivered seq %d, dropped frame was %d", last, dropped)
+			}
+			// Reconnect replay from the last delivered seq must contain X, gap-free.
+			replay := r.Frames(id, last)
+			if len(replay) == 0 || replay[0].Seq != last+1 {
+				t.Fatalf("replay after seq %d starts at %+v; want contiguous from %d", last, replay, last+1)
+			}
+			for _, f := range replay {
+				if f.Seq == dropped {
+					return // lossless: the hole is replayed
+				}
+			}
+			t.Fatalf("replay after seq %d does not contain the dropped frame %d", last, dropped)
+		}
+	}
+}

--- a/internal/transcript/http_hardening_test.go
+++ b/internal/transcript/http_hardening_test.go
@@ -6,6 +6,7 @@ package transcript
 // a write forever (per-write deadline).
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/web"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
@@ -155,5 +157,54 @@ func TestServeEvents_StalledClientReleasedWithinWriteDeadline(t *testing.T) {
 
 	waitFor(t, 5*time.Second,
 		"stalled client still holds its subscriber: frame write never timed out",
+		func() bool { return r.subscriberCount() == 0 })
+}
+
+// TestServeEvents_StalledH2CClientReleasedWithinWriteDeadline pins the #148
+// Defect B caveat: SetWriteDeadline must be honored under the web tier's h2c
+// setup (internal/web.NewServer, http.Protocols SetUnencryptedHTTP2), not just
+// on a plain HTTP/1.1 conn. An h2 client that never reads the response body
+// stops replenishing its flow-control window, so the server's DATA writes
+// block on flow control — the bundled HTTP/2 server's per-stream write
+// deadline must fail that write and release the handler.
+func TestServeEvents_StalledH2CClientReleasedWithinWriteDeadline(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	r.writeTimeout = 250 * time.Millisecond
+
+	srv := web.NewServer(web.Config{
+		Addr:   "127.0.0.1:0",
+		Mounts: []web.Mount{{Path: "/api/v1/sessions/", Handler: eventsMux(r)}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := srv.Start(ctx); err != nil {
+		t.Fatalf("start web server: %v", err)
+	}
+	t.Cleanup(func() { cancel(); srv.Wait() })
+
+	bus.Publish(voiceevent.STTFinal{At: at(0), Text: "warm", TurnID: "w"})
+
+	// Prior-knowledge h2c client, mirroring the gRPC lane of the web tier.
+	protos := new(http.Protocols)
+	protos.SetUnencryptedHTTP2(true)
+	client := &http.Client{Transport: &http.Transport{Protocols: protos}}
+	resp, err := client.Get("http://" + srv.Addr() + "/api/v1/sessions/" + id + "/events")
+	if err != nil {
+		t.Fatalf("h2c get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.ProtoMajor != 2 {
+		t.Fatalf("want HTTP/2 (h2c), got %s", resp.Proto)
+	}
+	// Deliberately never read resp.Body: the stream's flow-control window is
+	// never replenished and the server's writes block once it is exhausted.
+
+	waitFor(t, 2*time.Second, "SSE handler never attached over h2c", func() bool {
+		return r.subscriberCount() == 1
+	})
+
+	floodBigFrames(bus)
+
+	waitFor(t, 5*time.Second,
+		"stalled h2c client still holds its subscriber: SetWriteDeadline not honored under h2c",
 		func() bool { return r.subscriberCount() == 0 })
 }

--- a/internal/transcript/http_hardening_test.go
+++ b/internal/transcript/http_hardening_test.go
@@ -7,10 +7,53 @@ package transcript
 
 import (
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
+
+// subscriberCount is a test-only probe for the live subscriber set.
+func (r *Relay) subscriberCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.subs)
+}
+
+// waitFor polls cond until it holds or the bound expires.
+func waitFor(t *testing.T, bound time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(bound)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// eventsMux mounts ServeEvents the way production does (cmd/glyphoxa/main.go).
+func eventsMux(r *Relay) *http.ServeMux {
+	m := http.NewServeMux()
+	m.HandleFunc("GET /api/v1/sessions/{id}/events", r.ServeEvents)
+	return m
+}
+
+// floodBigFrames publishes enough oversized line frames to overrun any socket
+// buffer between the handler and a non-reading client, guaranteeing the
+// handler ends up parked inside a frame write. ~19MB total, far past loopback
+// send+receive buffering.
+func floodBigFrames(bus *voiceevent.Bus) {
+	big := strings.Repeat("x", 64<<10)
+	for i := 0; i < 300; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: big, TurnID: fmt.Sprintf("t%d", i)})
+	}
+}
 
 // TestLaggedDrop_StrictPrefixAndLosslessReplay (#148 Defect A): after frame X
 // is dropped for a slow subscriber, the connection must deliver a strict
@@ -81,4 +124,36 @@ func TestLaggedDrop_StrictPrefixAndLosslessReplay(t *testing.T) {
 			t.Fatalf("replay after seq %d does not contain the dropped frame %d", last, dropped)
 		}
 	}
+}
+
+// TestServeEvents_StalledClientReleasedWithinWriteDeadline (#148 Defect B):
+// a client that stops reading (laptop sleep, TCP zero-window) must not park
+// the SSE handler inside a write forever. With a per-write deadline the
+// blocked write fails, the handler exits and its subscriber entry is cleaned
+// up within a bounded time. Real server + raw TCP client that never reads.
+func TestServeEvents_StalledClientReleasedWithinWriteDeadline(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	r.writeTimeout = 250 * time.Millisecond
+	srv := httptest.NewServer(eventsMux(r))
+	defer srv.Close()
+
+	bus.Publish(voiceevent.STTFinal{At: at(0), Text: "warm", TurnID: "w"})
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "GET /api/v1/sessions/%s/events HTTP/1.1\r\nHost: stalled\r\n\r\n", id)
+	// Deliberately never read from conn: OS buffers fill, server writes block.
+
+	waitFor(t, 2*time.Second, "SSE handler never attached", func() bool {
+		return r.subscriberCount() == 1
+	})
+
+	floodBigFrames(bus)
+
+	waitFor(t, 5*time.Second,
+		"stalled client still holds its subscriber: frame write never timed out",
+		func() bool { return r.subscriberCount() == 0 })
 }

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -184,6 +184,11 @@ type Relay struct {
 	// nil when persistence is disabled (store == nil).
 	writeCh chan writeOp
 
+	// writeTimeout bounds each SSE frame write/flush (#148 Defect B): a client
+	// that stops reading makes the blocked write fail instead of parking the
+	// handler forever. Defaults to defaultWriteTimeout; tests shrink it.
+	writeTimeout time.Duration
+
 	// closing is closed by CloseStreams when the process begins its graceful
 	// shutdown: every open SSE tail returns so the connections go idle and the
 	// web tier's drain completes promptly (issue #138) — an SSE stream never
@@ -202,12 +207,13 @@ func NewRelay(bus *voiceevent.Bus, sessions Sessions, store LineStore, log *slog
 		log = slog.Default()
 	}
 	r := &Relay{
-		sessions: sessions,
-		store:    store,
-		log:      log,
-		turns:    map[string]*turn{},
-		subs:     map[*subscriber]struct{}{},
-		closing:  make(chan struct{}),
+		sessions:     sessions,
+		store:        store,
+		log:          log,
+		turns:        map[string]*turn{},
+		subs:         map[*subscriber]struct{}{},
+		writeTimeout: defaultWriteTimeout,
+		closing:      make(chan struct{}),
 	}
 	// One writer goroutine for the process drains the queue (#74). Only started
 	// when persistence is enabled, so the live-only relay keeps its single-state


### PR DESCRIPTION
## Defects (both `internal/transcript/http.go`, introduced by #90)

**A — "replay is lossless" invariant was false.** After a slow subscriber dropped frame X (channel overflow → `lagged` closed), `push` kept sending newer frames into freed channel capacity and the handler wrote X+1, X+2… to the wire before noticing the lag. The client reconnected with `Last-Event-ID > X` and the replay skipped the hole **forever**.

**B — no write deadline.** Frame writes/flushes ran against a bare `ResponseWriter` (the server intentionally has no global `WriteTimeout` — it would kill SSE). A client that stops reading parked the handler inside `Write`, where the `lagged` escape can never fire: goroutine + subscriber entry leaked indefinitely, and every deploy burned the full shutdown grace on it.

## Fix

- **A:** `push` delivers nothing once `lagged` is closed — the connection sees a strict prefix of the sequence, so the `Last-Event-ID` replay from the ring contains the dropped frame. Race-free: only `push` closes `lagged`, always under `r.mu`.
- **B:** `ServeEvents` writes through a `frameWriter` that arms `http.ResponseController.SetWriteDeadline(writeTimeout=5s)` around every write+flush and **disarms it after success** (an armed h2 deadline is a stream-reset timer even while idle). A blocked write fails at the deadline → handler exits → subscriber detached. Deadline support is probed once per connection; an unsupported exotic wrapper degrades loudly (warning log, unbounded) instead of killing the stream on frame one.

**h2c caveat verified:** `SetWriteDeadline` IS honored under the repo's h2c setup (`web.NewServer`, `http.Protocols` `SetUnencryptedHTTP2`) — pinned by a test using a prior-knowledge HTTP/2 client that never reads the body, blocking the server on the exhausted flow-control window. No fallback needed.

## Tests (`internal/transcript/http_hardening_test.go`, all red before fix)

- `TestLaggedDrop_StrictPrefixAndLosslessReplay` — pins the bug's choreography: overflow drops X, reader briefly resumes freeing capacity, more frames arrive; asserts contiguous seqs, nothing ≥ X delivered, gap-free replay containing X.
- `TestServeEvents_StalledClientReleasedWithinWriteDeadline` — real HTTP/1.1 server + raw TCP client that never reads; flood past socket buffering; subscriber count returns to 0 within the bound.
- `TestServeEvents_StalledH2CClientReleasedWithinWriteDeadline` — same over the web tier's real h2c stack (flow-control stall).
- Mutation-checked: with deadlines disabled, both stall tests hang red.
- Existing SSE tests untouched and green; `go test -race` clean; `golangci-lint` 0 issues.

Out of scope per the brief: terminal idle frame (#144), heartbeats, persistence (#149) — `relay.go` changes are limited to the `writeTimeout` field + default.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)