### PR TITLE
fix(#141): reconnect backoff resets only after a healthy serve duration, not on join

### DIFF
--- a/internal/wirenpc/reconnect_test.go
+++ b/internal/wirenpc/reconnect_test.go
@@ -104,6 +104,40 @@ func TestRunWithReconnect_ResetsBackoffOnConnect(t *testing.T) {
 	}
 }
 
+// TestRunWithReconnect_ImmediatePostJoinFailureKeepsBackoffGrowing pins the
+// issue-#141 fix: a cycle that JOINS successfully (connected() fires) but then
+// fails immediately — the codec-less build's ErrCodecUnavailable, a persistent
+// VAD/ONNX init failure — must count as a connect failure, NOT a healthy
+// session. The delays must keep growing exponentially to the cap; a reset here
+// would hammer Discord's voice join at 1 Hz forever (the exact failure mode
+// the #45 backoff was written to prevent). Uses the production
+// defaultReconnectPolicy (real clock: an immediate failure serves ~0s, far
+// under any healthy threshold) with only the sleep seam faked.
+func TestRunWithReconnect_ImmediatePostJoinFailureKeepsBackoffGrowing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 7, cancel: cancel}
+	p := defaultReconnectPolicy() // initial 1s, max 30s, factor 2
+	p.sleep = fs.sleep
+
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			connected() // voice join succeeded...
+			return errors.New("wire: opus codec unavailable")
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil on ctx-cancel", err)
+	}
+	want := []time.Duration{
+		time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+		16 * time.Second, 30 * time.Second, 30 * time.Second,
+	}
+	if !equalDelays(fs.delays, want) {
+		t.Errorf("backoff delays = %v, want %v (join-then-immediate-fail must keep growing, never reset to initial)", fs.delays, want)
+	}
+}
+
 // TestRunWithReconnect_StopsCleanOnCtxCancelInAttempt models SIGTERM landing
 // mid-serve: attempt cancels ctx and then returns an error. The loop must NOT
 // treat that as a transient failure to back off from — it must see the cancelled

--- a/internal/wirenpc/reconnect_test.go
+++ b/internal/wirenpc/reconnect_test.go
@@ -35,6 +35,15 @@ func (f *fakeSleep) sleep(ctx context.Context, d time.Duration) error {
 	return nil
 }
 
+// fakeClock is the injected reconnectPolicy.now: tests advance it manually to
+// fake a session serving for minutes without wall-clock waits. connected() and
+// Advance both run on runWithReconnect's goroutine (attempt calls the callback
+// synchronously), so no locking.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.t }
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
 // TestRunWithReconnect_RetriesWithGrowingBackoff pins the core issue-#44
 // invariant: when Discord never connects (attempt always errors), the loop does
 // not exit — it retries on a capped-exponential schedule. With initial=1s
@@ -66,28 +75,36 @@ func TestRunWithReconnect_RetriesWithGrowingBackoff(t *testing.T) {
 	}
 }
 
-// TestRunWithReconnect_ResetsBackoffOnConnect pins the reset contract AND that
-// the schedule re-grows from the reset baseline: a connection that succeeds
-// (calls connected()) and only later drops must reconnect on the INITIAL delay,
-// not inherit the grown backoff from earlier failures — and if reconnection then
-// keeps failing it must back off again 1s, 2s, 4s. attempt errors twice without
-// connecting (delays 1s, 2s), the 3rd call connects-then-drops (reset → 1s), and
-// calls 4–5 fail again, so delays[2:5] must be 1s, 2s, 4s. This catches both a
-// missing reset and a reset that fails to re-advance.
-func TestRunWithReconnect_ResetsBackoffOnConnect(t *testing.T) {
+// TestRunWithReconnect_ResetsBackoffAfterHealthySession pins the reset contract
+// AND that the schedule re-grows from the reset baseline: a session that serves
+// at least the healthy threshold and only later drops must reconnect on the
+// INITIAL delay, not inherit the grown backoff from earlier failures — and if
+// reconnection then keeps failing it must back off again 1s, 2s, 4s. attempt
+// errors twice without connecting (delays 1s, 2s), the 3rd call connects and
+// serves past healthyAfter before dropping (reset → 1s), and calls 4–5 fail
+// again, so delays[2:5] must be 1s, 2s, 4s. This catches both a missing reset
+// and a reset that fails to re-advance. Adjusted for issue #141: the reset used
+// to key on connected() alone (the buggy reset point); it now requires the
+// healthy serve duration, faked here by advancing the injected clock.
+func TestRunWithReconnect_ResetsBackoffAfterHealthySession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	fs := &fakeSleep{cancelAt: 6, cancel: cancel}
-	p := reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: fs.sleep}
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	p := defaultReconnectPolicy() // healthyAfter = healthySessionDuration
+	p.sleep = fs.sleep
+	p.now = clk.Now
 
 	calls := 0
 	err := runWithReconnect(ctx, discardLogger(), p,
 		func(ctx context.Context, connected func()) error {
 			calls++
 			if calls == 3 {
-				connected() // session established, then drops
+				connected()                            // session established...
+				clk.Advance(healthySessionDuration)    // ...serves the full healthy threshold...
+				return errors.New("gateway went away") // ...then drops
 			}
-			return errors.New("connection dropped")
+			return errors.New("connection refused")
 		})
 
 	if err != nil {
@@ -96,11 +113,11 @@ func TestRunWithReconnect_ResetsBackoffOnConnect(t *testing.T) {
 	if len(fs.delays) < 5 {
 		t.Fatalf("recorded %d delays, want >= 5", len(fs.delays))
 	}
-	// delays[2] is the backoff AFTER the connected 3rd attempt — the initial delay
+	// delays[2] is the backoff AFTER the healthy 3rd attempt — the initial delay
 	// (reset fired). delays[3], delays[4] prove the schedule re-grows from there.
 	wantAfterReset := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
 	if !equalDelays(fs.delays[2:5], wantAfterReset) {
-		t.Errorf("backoff after a connected attempt = %v, want %v (reset on connect, then re-grow)", fs.delays[2:5], wantAfterReset)
+		t.Errorf("backoff after a healthy session = %v, want %v (reset after healthy serve, then re-grow)", fs.delays[2:5], wantAfterReset)
 	}
 }
 
@@ -135,6 +152,37 @@ func TestRunWithReconnect_ImmediatePostJoinFailureKeepsBackoffGrowing(t *testing
 	}
 	if !equalDelays(fs.delays, want) {
 		t.Errorf("backoff delays = %v, want %v (join-then-immediate-fail must keep growing, never reset to initial)", fs.delays, want)
+	}
+}
+
+// TestRunWithReconnect_SubThresholdSessionKeepsBackoffGrowing pins the
+// boundary: a session that joins and serves for a while — but less than the
+// healthy threshold — before dropping is still a connect failure, not a healthy
+// session. Serving healthyAfter-1s each cycle must never reset the delay.
+// Distinct from the immediate-failure test: some serving happened, just not
+// enough to forgive past failures.
+func TestRunWithReconnect_SubThresholdSessionKeepsBackoffGrowing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fs := &fakeSleep{cancelAt: 4, cancel: cancel}
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	p := defaultReconnectPolicy()
+	p.sleep = fs.sleep
+	p.now = clk.Now
+
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			connected()                                       // join succeeded...
+			clk.Advance(healthySessionDuration - time.Second) // ...serves, but one second short...
+			return errors.New("gateway went away")            // ...then drops
+		})
+
+	if err != nil {
+		t.Fatalf("runWithReconnect returned %v, want nil on ctx-cancel", err)
+	}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second}
+	if !equalDelays(fs.delays, want) {
+		t.Errorf("backoff delays = %v, want %v (sub-threshold sessions must not reset the backoff)", fs.delays, want)
 	}
 }
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -411,8 +411,10 @@ func Run(ctx context.Context, cfg Config) error {
 // connectAndServe runs ONE connect-and-serve cycle: build the Discord client,
 // open the gateway, join the channel, assemble the pipeline, and pump audio
 // until ctx is cancelled or the connection drops. It calls connected() once the
-// join succeeds, which resets the caller's backoff so a long-lived session that
-// later drops reconnects promptly. Any error — or a clean return (a dropped
+// join succeeds, marking when serving began; the caller resets its backoff only
+// if the cycle then survives the healthy threshold (issue #141), so a
+// long-lived session that later drops reconnects promptly while a
+// join-then-immediate-fail cycle keeps backing off. Any error — or a clean return (a dropped
 // gateway often reports none) — flows back to runWithReconnect, which decides
 // whether to retry; only a cancelled ctx ends the loop.
 func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func()) error {
@@ -467,9 +469,10 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 		return fmt.Errorf("wirenpc: join voice channel: %w", err)
 	}
 	defer sess.Close()
-	// The join succeeded: reset the reconnect backoff so a session that runs for
-	// a while and only later drops reconnects on the initial delay, not a delay
-	// grown by earlier connect failures (issue #44).
+	// The join succeeded: mark when serving began. runWithReconnect resets the
+	// backoff only if this cycle survives the healthy threshold (issue #141), so
+	// a session that serves for a while and later drops reconnects on the initial
+	// delay (issue #44) while a join-then-immediate-fail keeps backing off.
 	connected()
 	log.Info("joined voice channel", "guild", guild, "channel", channel, "npcs", npcNames(cfg.npcs))
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -108,13 +108,36 @@ type reconnectPolicy struct {
 	initial time.Duration
 	max     time.Duration
 	factor  float64
+	// healthyAfter is how long a cycle must serve after connected() fires before
+	// it counts as a healthy session and resets the backoff to initial. A cycle
+	// that joins but fails sooner (codec-less build, broken ONNX init — issue
+	// #141) is a connect failure: the delay keeps growing to its cap instead of
+	// retrying the Discord voice join at 1 Hz forever. Zero means reset on join.
+	healthyAfter time.Duration
 	// sleep blocks for d or until ctx is cancelled (returns ctx.Err() if
 	// cancelled first). Injected so tests drive the backoff without real waits.
 	sleep func(ctx context.Context, d time.Duration) error
+	// now reports the current time for the healthyAfter measurement. Injected so
+	// tests fake a long-serving session in milliseconds; nil means time.Now.
+	now func() time.Time
 }
 
+// healthySessionDuration is how long a session must serve post-join before the
+// reconnect backoff forgives past failures and resets to the initial delay.
+// Sized to the backoff cap: a session must outlive the maximum backoff before
+// the loop trusts it, so a persistent join-then-fail cycle (issue #141) settles
+// at cap cadence instead of resetting to 1 Hz.
+const healthySessionDuration = 30 * time.Second
+
 func defaultReconnectPolicy() reconnectPolicy {
-	return reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: sleepCtx}
+	return reconnectPolicy{
+		initial:      time.Second,
+		max:          30 * time.Second,
+		factor:       2,
+		healthyAfter: healthySessionDuration,
+		sleep:        sleepCtx,
+		now:          time.Now,
+	}
 }
 
 // sleepCtx blocks for d or until ctx is cancelled, returning ctx.Err() on
@@ -143,14 +166,28 @@ func nextDelay(d time.Duration, p reconnectPolicy) time.Duration {
 // when ctx is cancelled; every other return from attempt — an error OR a clean
 // session-close (nil) — is a lost connection and triggers a backed-off
 // reconnect. attempt is handed a connected callback it calls once the join
-// succeeds, which resets the backoff so a long-lived session that later drops
-// reconnects promptly instead of inheriting a grown delay.
+// succeeds; the backoff resets to initial only if the cycle then serves for at
+// least p.healthyAfter (issue #141), so a long-lived session that later drops
+// reconnects promptly while a join-then-immediate-fail cycle keeps growing its
+// delay instead of hammering the Discord voice join at 1 Hz.
 func runWithReconnect(ctx context.Context, log *slog.Logger, p reconnectPolicy, attempt func(ctx context.Context, connected func()) error) error {
+	now := p.now
+	if now == nil {
+		now = time.Now
+	}
 	delay := p.initial
 	for {
-		err := attempt(ctx, func() { delay = p.initial })
+		// connectedAt is written by the callback inside attempt and read after
+		// attempt returns — connectAndServe invokes it synchronously, same
+		// goroutine, so no lock. The delay is only consumed post-return, so
+		// deciding the reset here is equivalent to arming a timer on connect.
+		var connectedAt time.Time
+		err := attempt(ctx, func() { connectedAt = now() })
 		if ctx.Err() != nil {
 			return nil // shutdown requested — stop retrying, exit clean (fixes SIGTERM->exit1)
+		}
+		if !connectedAt.IsZero() && now().Sub(connectedAt) >= p.healthyAfter {
+			delay = p.initial // served healthily — forgive past failures (issue #44)
 		}
 		if err != nil {
 			log.Warn("voice connection failed; reconnecting", "err", err, "backoff", delay)


### PR DESCRIPTION
## Defect

`runWithReconnect` handed `connectAndServe` a `connected()` callback that reset the backoff delay to initial the moment the Discord voice join succeeded — before `buildConversation` or `pipe.Run` served anything. Any persistent post-join failure (codec-less build returning `ErrCodecUnavailable` on the first frame, broken ONNX/VAD init) therefore looped join → reset to 1s → fail → sleep 1s → full client rebuild, hammering Discord's gateway/voice-join at 1 Hz indefinitely — the exact failure mode the #45 backoff was written to prevent.

## Fix

The reset now keys on "served healthily", not "joined":

- `connected()` only records when serving began (`connectedAt` via the injected `now` clock).
- After `attempt` returns, `runWithReconnect` resets the delay only if the cycle survived at least `reconnectPolicy.healthyAfter`; shorter cycles count as connect failures and the delay keeps growing to its cap.
- New package constant `healthySessionDuration = 30s` (sized to the backoff cap: a session must outlive the max backoff before the loop forgives past failures) wired into `defaultReconnectPolicy()`.
- `now func() time.Time` is an injectable policy field (nil → `time.Now`) so tests fake long serves in milliseconds.

Reconnect loop structure and backoff constants unchanged; fatal-vs-transient classification stays out of scope (#123).

## Tests

- `TestRunWithReconnect_ImmediatePostJoinFailureKeepsBackoffGrowing` — **red pre-fix**: observed delays `[1s 1s 1s 1s 1s 1s 1s]` (the 1 Hz hammer); now pins capped-exponential `[1s 2s 4s 8s 16s 30s 30s]` on join-then-immediate-fail.
- `TestRunWithReconnect_ResetsBackoffAfterHealthySession` — rewrite of `ResetsBackoffOnConnect` (it encoded the buggy reset-on-join point): 3rd attempt serves the full healthy threshold on a fake clock, then drops → next delay is initial and the schedule re-grows 1s, 2s, 4s.
- `TestRunWithReconnect_SubThresholdSessionKeepsBackoffGrowing` — boundary: serving `healthyAfter − 1s` each cycle never resets.
- All other reconnect/backoff tests unchanged and green; `go test -race ./internal/wirenpc/...` and full `go test ./...` clean.

Fixes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)