### PR TITLE
fix(#146): target-aware floor coalescing — cross-NPC address within the window supersedes instead of vanishing

### DIFF
--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -17,7 +17,7 @@ func TestBargeIn_InstantYieldsActiveFloor(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	parent := voiceevent.WithTurnID(context.Background(), "T1")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
@@ -42,7 +42,7 @@ func TestBargeIn_PublishesTurnEndedWithTurnID(t *testing.T) {
 	floor := orchestrator.NewFloor()
 	// The turn holds the floor with its TurnID in ctx, as the reply reactor wires it.
 	parent := voiceevent.WithTurnID(context.Background(), "T42")
-	_, release, _ := floor.Take(parent)
+	_, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
@@ -68,7 +68,7 @@ func TestBargeIn_NoBargeWhileHolderNotYetSpeaking(t *testing.T) {
 	floor := orchestrator.NewFloor()
 	// The turn holds the floor (Take at AddressRouted) but no FirstOpus yet.
 	parent := voiceevent.WithTurnID(context.Background(), "T1")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	// Confirm window 0 would yield instantly on a merely-held floor (the old bug);
@@ -89,7 +89,7 @@ func TestBargeIn_BargesOnceHolderIsSpeaking(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	parent := voiceevent.WithTurnID(context.Background(), "T2")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
@@ -114,7 +114,7 @@ func TestBargeIn_SpeakingSignalForStaleTurnIgnored(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	parent := voiceevent.WithTurnID(context.Background(), "T3")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
@@ -147,7 +147,7 @@ func TestBargeIn_SoftOverlapDoesNotCancel(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	parent := voiceevent.WithTurnID(context.Background(), "T1")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 200*time.Millisecond).Bind(t.Context(), h.Bus))
@@ -167,7 +167,7 @@ func TestBargeIn_ConfirmWindowCrossingCancels(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	parent := voiceevent.WithTurnID(context.Background(), "T1")
-	turnCtx, release, _ := floor.Take(parent)
+	turnCtx, release, _ := floor.Take(parent, "")
 	defer release()
 
 	t.Cleanup(orchestrator.NewBargeIn(floor, 20*time.Millisecond).Bind(t.Context(), h.Bus))

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -89,10 +89,12 @@ func WithBargeIn(confirmWindow time.Duration) Option {
 
 // WithBargeInCoalesce is [WithBargeIn] plus a floor coalesce window (root cause
 // #2 of the latency investigation): a per-turn [Floor.Take] arriving within
-// coalesceWindow of the previous one is treated as the SAME utterance continuing
-// and yields to the in-flight turn instead of superseding it (see [Floor]). This
-// stops a VAD over-split of one utterance from self-cancelling its own first
-// turn mid-synthesis. A zero coalesceWindow is identical to [WithBargeIn].
+// coalesceWindow of the previous one AND routed to the same target agent is
+// treated as the SAME utterance continuing and yields to the in-flight turn
+// instead of superseding it (see [Floor]). This stops a VAD over-split of one
+// utterance from self-cancelling its own first turn mid-synthesis; a take for a
+// different agent inside the window supersedes as normal (#146). A zero
+// coalesceWindow is identical to [WithBargeIn].
 func WithBargeInCoalesce(confirmWindow, coalesceWindow time.Duration) Option {
 	return func(c *Conversation) {
 		c.bargeConfirm = confirmWindow

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -25,18 +25,22 @@ import (
 // second Take's supersession cancels the first segment's turn mid-synthesis (a
 // self-cancel with no barge involved). When a coalesce window is configured
 // ([NewFloorWithCoalesce]) a Take arriving within that window of the previous one
-// is treated as the SAME utterance continuing: it does not supersede the
-// in-flight turn but yields to it — the new turn's context comes back already
-// cancelled so its reply is suppressed and the turn already speaking keeps the
-// floor. One utterance then maps to one turn even when VAD over-splits it. A zero
-// window (the [NewFloor] default) keeps the plain always-supersede behaviour the
-// barge path and the tracer-bullet tests rely on.
+// AND routed to the same target agent is treated as the SAME utterance
+// continuing: it does not supersede the in-flight turn but yields to it — the
+// new turn's context comes back already cancelled so its reply is suppressed and
+// the turn already speaking keeps the floor. One utterance then maps to one turn
+// even when VAD over-splits it. A take for a DIFFERENT agent inside the window
+// is not the same utterance continuing — the matcher routed it to someone else
+// ("Bart, hold the door. Greta, run!", #146) — so it supersedes as normal. A
+// zero window (the [NewFloor] default) keeps the plain always-supersede
+// behaviour the barge path and the tracer-bullet tests rely on.
 type Floor struct {
 	mu         sync.Mutex
 	cancel     context.CancelFunc // non-nil while a turn holds the floor
 	gen        uint64             // increments per Take; guards stale releases
-	lastTake   time.Time          // when the current holder took the floor (coalesce anchor)
-	holderTurn string             // TurnID of the turn currently holding the floor (for Yield → barge attribution)
+	lastTake    time.Time          // when the current holder took the floor (coalesce anchor)
+	holderTurn  string             // TurnID of the turn currently holding the floor (for Yield → barge attribution)
+	holderAgent string             // target AgentID of the current holder's route (coalesce is same-target only, #146)
 	// speaking is true once the current holder has produced its first audible
 	// frame — the barge gate (ADR-0027). A held-but-silent turn (the pre-audio
 	// LLM "thinking" phase) is NOT speaking, so a human speech_start in that
@@ -66,9 +70,9 @@ func (f *Floor) clock() time.Time {
 func NewFloor() *Floor { return &Floor{now: time.Now} }
 
 // NewFloorWithCoalesce returns an unheld floor whose [Floor.Take] coalesces a
-// re-take arriving within window of the previous take into the turn already
-// holding the floor, rather than superseding it (see [Floor] — root cause #2).
-// A non-positive window behaves like [NewFloor].
+// same-target re-take arriving within window of the previous take into the turn
+// already holding the floor, rather than superseding it (see [Floor] — root
+// cause #2). A non-positive window behaves like [NewFloor].
 func NewFloorWithCoalesce(window time.Duration) *Floor {
 	if window < 0 {
 		window = 0
@@ -77,33 +81,40 @@ func NewFloorWithCoalesce(window time.Duration) *Floor {
 }
 
 // Take derives a per-turn context from parent and installs it as the held floor,
-// returning that context and a release function. A new Take supersedes any turn
+// returning that context and a release function. agentID is the target agent of
+// the route this turn answers ([voiceevent.AddressTarget.AgentID]); it decides
+// whom a coalesce window may fold this take into. A new Take supersedes any turn
 // still holding the floor — its context is cancelled — so two turns never speak
 // at once. release clears the floor (only if this turn still holds it) and
 // cancels the turn's context; it is idempotent and must be called when the turn
 // ends, conventionally via defer.
 //
 // With a coalesce window ([NewFloorWithCoalesce]) a Take landing within that
-// window of the previous one is a split-utterance continuation: it does NOT
-// cancel the in-flight turn. The returned context comes back already cancelled,
-// the returned release is a no-op on the floor, and coalesced is true — so the
-// caller can see this Take yielded (rather than took) the floor and react (e.g.
-// publish [voiceevent.TurnEnded] for the dropped segment) instead of speaking
-// it, while the turn already holding the floor keeps it. On a normal take
+// window of the previous one AND addressing the holder's agent is a
+// split-utterance continuation: it does NOT cancel the in-flight turn. The
+// returned context comes back already cancelled, the returned release is a
+// no-op on the floor, and coalesced is true — so the caller can see this Take
+// yielded (rather than took) the floor and react (e.g. publish
+// [voiceevent.TurnEnded] for the dropped segment) instead of speaking it, while
+// the turn already holding the floor keeps it. A take for a DIFFERENT agent
+// inside the window supersedes as normal (#146): "same utterance continuing" is
+// provably false once the matcher routed the segment to another agent, and
+// coalescing it away would silently drop a direct address. On a normal take
 // coalesced is false.
 //
 // The turn's TurnID is recovered from parent ([voiceevent.TurnIDFrom]) and held
 // so [Floor.Yield] can attribute a barge to the turn it cancelled.
-func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(), coalesced bool) {
+func (f *Floor) Take(parent context.Context, agentID string) (ctx context.Context, release func(), coalesced bool) {
 	ctx, cancel := context.WithCancel(parent)
 
 	f.mu.Lock()
-	if f.cancel != nil && f.coalesce > 0 && f.clock().Sub(f.lastTake) < f.coalesce {
-		// Same-utterance re-take inside the coalesce window: yield to the turn
-		// already holding the floor instead of superseding it. Cancel only THIS
-		// (the late segment's) context and leave the holder untouched. Refresh the
-		// anchor so a run of closely-spaced splits keeps coalescing (each segment
-		// is within the window of the previous one, not just the first).
+	if f.cancel != nil && f.coalesce > 0 && agentID == f.holderAgent && f.clock().Sub(f.lastTake) < f.coalesce {
+		// Same-utterance re-take inside the coalesce window, addressed to the same
+		// agent: yield to the turn already holding the floor instead of superseding
+		// it. Cancel only THIS (the late segment's) context and leave the holder
+		// untouched. Refresh the anchor so a run of closely-spaced splits keeps
+		// coalescing (each segment is within the window of the previous one, not
+		// just the first).
 		f.lastTake = f.clock()
 		f.mu.Unlock()
 		cancel()
@@ -117,6 +128,7 @@ func (f *Floor) Take(parent context.Context) (ctx context.Context, release func(
 	f.cancel = cancel
 	f.lastTake = f.clock()
 	f.holderTurn = voiceevent.TurnIDFrom(parent)
+	f.holderAgent = agentID
 	f.speaking = false // a fresh holder starts silent until it produces audio
 	f.mu.Unlock()
 
@@ -146,6 +158,7 @@ func (f *Floor) Yield() (turnID string, yielded bool) {
 	turnID = f.holderTurn
 	f.cancel = nil
 	f.holderTurn = ""
+	f.holderAgent = ""
 	f.speaking = false
 	f.mu.Unlock()
 	if c == nil {

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -35,9 +35,9 @@ import (
 // zero window (the [NewFloor] default) keeps the plain always-supersede
 // behaviour the barge path and the tracer-bullet tests rely on.
 type Floor struct {
-	mu         sync.Mutex
-	cancel     context.CancelFunc // non-nil while a turn holds the floor
-	gen        uint64             // increments per Take; guards stale releases
+	mu          sync.Mutex
+	cancel      context.CancelFunc // non-nil while a turn holds the floor
+	gen         uint64             // increments per Take; guards stale releases
 	lastTake    time.Time          // when the current holder took the floor (coalesce anchor)
 	holderTurn  string             // TurnID of the turn currently holding the floor (for Yield → barge attribution)
 	holderAgent string             // target AgentID of the current holder's route (coalesce is same-target only, #146)

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -15,7 +15,7 @@ import (
 // usable zero-valued too.
 func TestFloor_ZeroValueUsable(t *testing.T) {
 	var f orchestrator.Floor // zero value, now == nil
-	ctx, release, coalesced := f.Take(context.Background())
+	ctx, release, coalesced := f.Take(context.Background(), "")
 	defer release()
 	if coalesced {
 		t.Fatal("a zero-value floor has no coalesce window; Take must not coalesce")
@@ -33,7 +33,7 @@ func TestFloor_TakeActiveReleaseInactive(t *testing.T) {
 	if f.Active() {
 		t.Fatal("a fresh floor must be inactive")
 	}
-	ctx, release, _ := f.Take(context.Background())
+	ctx, release, _ := f.Take(context.Background(), "")
 	if !f.Active() {
 		t.Fatal("floor must be active after Take")
 	}
@@ -54,7 +54,7 @@ func TestFloor_YieldCancelsHeldTurnAndReportsTrue(t *testing.T) {
 	// The turn carries its TurnID in the parent ctx (as the production reply
 	// reactor does) so Yield can attribute the barge to the cut turn.
 	parent := voiceevent.WithTurnID(context.Background(), "T7")
-	ctx, release, _ := f.Take(parent)
+	ctx, release, _ := f.Take(parent, "")
 	defer release()
 
 	turnID, yielded := f.Yield()
@@ -81,10 +81,10 @@ func TestFloor_YieldOnFreeFloorReportsFalse(t *testing.T) {
 
 func TestFloor_TakeSupersedesPreviousTurn(t *testing.T) {
 	f := orchestrator.NewFloor()
-	ctx1, release1, _ := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background(), "")
 	defer release1()
 
-	ctx2, release2, coalesced := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background(), "")
 	defer release2()
 
 	if coalesced {
@@ -111,7 +111,7 @@ func TestFloor_CoalesceWindowKeepsInFlightTurn(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1, c1 := f.Take(context.Background())
+	ctx1, release1, c1 := f.Take(context.Background(), "bart")
 	defer release1()
 	if c1 {
 		t.Fatal("the first Take must not coalesce (nothing is holding the floor)")
@@ -119,7 +119,7 @@ func TestFloor_CoalesceWindowKeepsInFlightTurn(t *testing.T) {
 
 	// Second segment arrives 100ms later — inside the 500ms window.
 	now = now.Add(100 * time.Millisecond)
-	ctx2, release2, c2 := f.Take(context.Background())
+	ctx2, release2, c2 := f.Take(context.Background(), "bart")
 	defer release2()
 
 	if !c2 {
@@ -145,6 +145,39 @@ func TestFloor_CoalesceWindowKeepsInFlightTurn(t *testing.T) {
 	}
 }
 
+// TestFloor_CoalesceWindowCrossTargetSupersedes pins #146: the coalesce window
+// folds takes into the in-flight turn only when they address the SAME target
+// agent. A take routed to a DIFFERENT agent inside the window is not "the same
+// utterance continuing" — the matcher routed it elsewhere ("Bart, hold the
+// door. Greta, run!") — so it must supersede the holder as a normal take, not
+// be silently coalesced away.
+func TestFloor_CoalesceWindowCrossTargetSupersedes(t *testing.T) {
+	now := time.Unix(0, 0)
+	f := orchestrator.NewFloorWithCoalesce(600 * time.Millisecond)
+	f.SetClock(func() time.Time { return now })
+
+	ctx1, release1, _ := f.Take(context.Background(), "bart")
+	defer release1()
+
+	// Greta's take lands 100ms later — inside the window, but for another agent.
+	now = now.Add(100 * time.Millisecond)
+	ctx2, release2, coalesced := f.Take(context.Background(), "greta")
+	defer release2()
+
+	if coalesced {
+		t.Fatal("a cross-target take inside the coalesce window must supersede, not coalesce")
+	}
+	if ctx1.Err() == nil {
+		t.Fatal("a cross-target take must cancel the prior holder's ctx (supersede)")
+	}
+	if ctx2.Err() != nil {
+		t.Fatalf("the cross-target turn's ctx must be live so its reply is spoken: %v", ctx2.Err())
+	}
+	if !f.Active() {
+		t.Fatal("the cross-target turn must hold the floor")
+	}
+}
+
 // TestFloor_CoalesceWindowExpiresToSupersession proves the window is bounded: a
 // re-Take after the window elapses is a genuine new utterance and supersedes the
 // prior turn as normal.
@@ -153,12 +186,12 @@ func TestFloor_CoalesceWindowExpiresToSupersession(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(500 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1, _ := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background(), "bart")
 	defer release1()
 
 	// Real conversational gap: past the window.
 	now = now.Add(800 * time.Millisecond)
-	ctx2, release2, coalesced := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background(), "bart")
 	defer release2()
 
 	if coalesced {
@@ -184,16 +217,16 @@ func TestFloor_CoalesceChainKeepsCoalescing(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(300 * time.Millisecond)
 	f.SetClock(func() time.Time { return now })
 
-	ctx1, release1, _ := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background(), "bart")
 	defer release1()
 
 	// Segment 2 at +200ms (inside window of seg1), segment 3 at +400ms (outside
 	// window of seg1 but inside window of seg2 — anchor refreshed).
 	now = now.Add(200 * time.Millisecond)
-	_, r2, c2 := f.Take(context.Background())
+	_, r2, c2 := f.Take(context.Background(), "bart")
 	defer r2()
 	now = now.Add(200 * time.Millisecond)
-	_, r3, c3 := f.Take(context.Background())
+	_, r3, c3 := f.Take(context.Background(), "bart")
 	defer r3()
 
 	if !c2 || !c3 {
@@ -212,9 +245,9 @@ func TestFloor_CoalesceChainKeepsCoalescing(t *testing.T) {
 // the tracer-bullet tests depend on, even on a back-to-back re-take.
 func TestFloor_ZeroCoalesceIsPlainSupersession(t *testing.T) {
 	f := orchestrator.NewFloorWithCoalesce(0)
-	ctx1, release1, _ := f.Take(context.Background())
+	ctx1, release1, _ := f.Take(context.Background(), "")
 	defer release1()
-	ctx2, release2, coalesced := f.Take(context.Background())
+	ctx2, release2, coalesced := f.Take(context.Background(), "")
 	defer release2()
 
 	if coalesced {
@@ -230,8 +263,8 @@ func TestFloor_ZeroCoalesceIsPlainSupersession(t *testing.T) {
 
 func TestFloor_StaleReleaseDoesNotClearNewerTurn(t *testing.T) {
 	f := orchestrator.NewFloor()
-	_, release1, _ := f.Take(context.Background())
-	_, release2, _ := f.Take(context.Background())
+	_, release1, _ := f.Take(context.Background(), "")
+	_, release2, _ := f.Take(context.Background(), "")
 	defer release2()
 
 	// Releasing the first (already-superseded) turn must not wipe the second

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -415,14 +415,19 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		// Barge-in: take the floor and run the turn on its own goroutine so the
 		// inbound loop keeps feeding VAD during playback. A barge cancels turnCtx,
 		// which unwinds TTS synthesis and playback and breaks the dispatch loop.
-		turnCtx, release, coalesced := r.floor.Take(ctx, "")
+		// The take carries the route's target agent so the floor's coalesce window
+		// only folds same-target re-takes (#146): a segment routed to a DIFFERENT
+		// agent inside the window ("Bart, hold the door. Greta, run!") supersedes
+		// instead of vanishing.
+		turnCtx, release, coalesced := r.floor.Take(ctx, e.Target.AgentID)
 		if coalesced {
-			// The floor's same-utterance grace window folded this late segment into
-			// the turn already speaking (one utterance VAD-split into two). The
-			// segment is NOT spoken; announce it so the metrics subscriber records a
-			// distinct `yielded` outcome (not `abandoned`) and logs the dropped
-			// transcript — the known residual until real utterance coalescing routes
-			// this text into the surviving turn. No goroutine is spawned.
+			// The floor's same-utterance grace window folded this late same-target
+			// segment into the turn already speaking (one utterance VAD-split in
+			// two). The segment is NOT spoken; announce it so the metrics subscriber
+			// records a distinct `yielded` outcome (not `abandoned`) and logs the
+			// dropped transcript — the known residual until real utterance
+			// coalescing routes this text into the surviving turn. No goroutine is
+			// spawned.
 			release() // no-op on the floor, but keeps the take/release pairing honest
 			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSupersedeCoalesced, Text: e.Text})
 			return

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -415,7 +415,7 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		// Barge-in: take the floor and run the turn on its own goroutine so the
 		// inbound loop keeps feeding VAD during playback. A barge cancels turnCtx,
 		// which unwinds TTS synthesis and playback and breaks the dispatch loop.
-		turnCtx, release, coalesced := r.floor.Take(ctx)
+		turnCtx, release, coalesced := r.floor.Take(ctx, "")
 		if coalesced {
 			// The floor's same-utterance grace window folded this late segment into
 			// the turn already speaking (one utterance VAD-split into two). The

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -389,6 +389,78 @@ func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 	)
 }
 
+// TestReplier_CrossTargetAddressWithinWindowSupersedes pins #146 end-to-end:
+// "Bart, hold the door. Greta, run!" — VAD splits at the internal pause and the
+// address detector routes segment 1 → Bart, segment 2 → Greta, with Greta's
+// take landing inside the floor's coalesce window. The window's "same utterance
+// continuing" inference is provably false across targets, so Greta's
+// directly-addressed turn must be DISPATCHED (her producer runs under a live
+// ctx, superseding Bart's turn) — not silently dropped as supersede_coalesced,
+// which left nobody answering a direct, named address.
+func TestReplier_CrossTargetAddressWithinWindowSupersedes(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	started := make(chan string, 4)
+	bartCancelled := make(chan struct{})
+	gretaRan := make(chan struct{})
+	reply := func(ctx context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		started <- e.TurnID
+		switch e.TurnID {
+		case "seg-bart":
+			// Bart's turn is mid-generation when Greta's address arrives; a
+			// cross-target supersede must cancel it.
+			select {
+			case <-ctx.Done():
+				close(bartCancelled)
+			case <-time.After(2 * time.Second):
+			}
+		case "seg-greta":
+			if ctx.Err() == nil {
+				close(gretaRan)
+			}
+		}
+		return nil
+	}
+
+	floor := orchestrator.NewFloorWithCoalesce(600 * time.Millisecond)
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "seg-bart", Text: "Bart, hold the door",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	// Bart's producer must hold the floor before Greta's segment lands.
+	if got := <-started; got != "seg-bart" {
+		t.Fatalf("first producer started for %q, want seg-bart", got)
+	}
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "seg-greta", Text: "Greta, run",
+		Target: voiceevent.AddressTarget{AgentID: "greta", AgentRole: "character", Name: "Greta"},
+	})
+
+	// Greta's turn is dispatched: the addressed agent's producer sees the route.
+	select {
+	case <-gretaRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Greta's directly-addressed turn was never dispatched — coalesced away by a target-blind floor (#146)")
+	}
+	// Bart's turn was superseded, not left speaking over Greta's.
+	select {
+	case <-bartCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Bart's in-flight turn must be cancelled by Greta's cross-target supersede")
+	}
+	// The cross-target segment must not be announced as a coalesced drop.
+	for _, ev := range h.Events() {
+		if e, ok := ev.(voiceevent.TurnEnded); ok && e.TurnID == "seg-greta" && e.Reason == voiceevent.TurnEndSupersedeCoalesced {
+			t.Fatal("seg-greta was published as supersede_coalesced — a cross-target address must supersede, not coalesce")
+		}
+	}
+}
+
 // waitTurnEnded subscribes a channel to TurnEnded on bus so a test can block until
 // the async (floor goroutine) turn publishes its end signal — AssertEvent does not
 // poll, so a direct synchronization is needed for the goroutine-driven turns.

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -355,13 +355,15 @@ func TestReplier_CoalescingFloorKeepsFirstSegmentTurn(t *testing.T) {
 	replier.SetFloor(floor)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
 
-	// Two segments of one utterance, back-to-back (well inside the window).
-	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg1", Text: "Bart, what's a room"})
+	// Two segments of one utterance, back-to-back (well inside the window), both
+	// routed to the SAME agent — coalescing is same-target only (#146).
+	bart := voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"}
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg1", Text: "Bart, what's a room", Target: bart})
 	// Wait for seg1's producer to actually start and take the floor before seg2.
 	if got := <-started; got != "seg1" {
 		t.Fatalf("first producer started for %q, want seg1", got)
 	}
-	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg2", Text: "and have you seen Gandalf"})
+	h.Bus.Publish(voiceevent.AddressRouted{TurnID: "seg2", Text: "and have you seen Gandalf", Target: bart})
 
 	// seg1 must run to its natural end without being cancelled by seg2.
 	select {

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -179,8 +179,10 @@ type TurnEndReason string
 const (
 	// TurnEndSupersedeCoalesced: the floor's same-utterance grace window folded a
 	// late VAD-split segment into the turn already speaking — the late segment is
-	// never spoken (latency investigation root cause #2). [TurnEnded.Text] carries
-	// its dropped transcript.
+	// never spoken (latency investigation root cause #2). Coalescing is
+	// same-target only: a segment routed to a different agent inside the window
+	// supersedes instead (#146), so this reason never marks a cross-target
+	// address. [TurnEnded.Text] carries its dropped transcript.
 	TurnEndSupersedeCoalesced TurnEndReason = "supersede_coalesced"
 	// TurnEndBarge: a confirmed human barge-in cancelled the turn (the floor was
 	// yielded while this turn held it).


### PR DESCRIPTION
## Defect

`Floor.Take` coalesced ANY take within the 600 ms window of the previous one as "the same utterance continuing", without comparing the new route's `Target.AgentID` to the holder's. Correct for one NPC; provably wrong across NPCs: "Bart, hold the door. Greta, run!" — VAD splits at the pause, segment 2 routes to Greta, and if her take lands within 600 ms of Bart's it came back pre-cancelled, the reactor published `TurnEnded(supersede_coalesced)`, and **nobody answered a direct, named address**.

## Fix

- `Floor.Take(parent, agentID)` now carries the route's target agent (`pkg/voice/orchestrator/floor.go`). The coalesce branch adds one condition: `agentID == f.holderAgent`. Same-target takes within the window coalesce exactly as before; a cross-target take supersedes via the existing normal path (cancel holder, dispatch new turn). `holderAgent` is set on take and cleared on `Yield`.
- The `Replier` passes `e.Target.AgentID` into the take (`pkg/voice/orchestrator/reactor.go`).

## Event taxonomy (ADR-0020)

No new `TurnEndReason`. A cross-target supersede uses the plain supersede path, which (as before, e.g. past-window supersedes) publishes no `TurnEnded` — the superseded turn is covered by the metrics subscriber's first-audio/TTL guards. `supersede_coalesced` now means strictly "same-target split-utterance folded"; its doc comment says so.

## Tests (TDD, red first)

- `TestFloor_CoalesceWindowCrossTargetSupersedes` (floor unit): bart then greta 100 ms apart inside a 600 ms window → not coalesced, bart's ctx cancelled, greta's live. Red pre-fix (drove the signature + condition).
- `TestReplier_CrossTargetAddressWithinWindowSupersedes` (reactor, end-to-end): the Bart/Greta scenario over the bus — red pre-fix with exactly the defect's symptom (`Greta's directly-addressed turn was never dispatched`); green once the reactor threads the real target. Asserts Greta's producer runs under a live ctx, Bart's turn is cancelled, and no `supersede_coalesced` is published for her segment.
- Same-target still coalesces: `TestFloor_CoalesceWindowKeepsInFlightTurn` / `TestFloor_CoalesceChainKeepsCoalescing` now use a real same agent id, and `TestReplier_CoalescingFloorKeepsFirstSegmentTurn` routes both segments to the same Target.
- All existing floor/barge/reactor tests green; `go test -race ./pkg/voice/orchestrator/...` and full `go test ./...` clean; `golangci-lint` clean.

Out of scope per the brief: silence-clock endpointing (#147), window size, barge-in semantics (ADR-0027).

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)