### PR TITLE
fix(#147): silence clock keys on Discord's speaker-stop signal, not packet arrival

### DIFF
--- a/pkg/voice/wire/silence_test.go
+++ b/pkg/voice/wire/silence_test.go
@@ -171,13 +171,14 @@ func eventCounts(h *voicetest.Harness) (starts, ends, finals int) {
 }
 
 // TestPipeline_TrailingSilenceEndpointsTrailingUtterance is the tracer bullet
-// (acceptance #1): an utterance followed by trailing silence — driven ONLY by the
-// injected clock, with NO further inbound audio — endpoints within the hangover
-// window. The clip leaves its final utterance open; firing the silence clock past
-// the hangover must close it (speech_end == speech_start) and produce its STTFinal,
-// in speech order. Before the fix the trailing silence was dropped, the trailing
-// utterance never endpointed, and its line appeared only when the next utterance
-// arrived (issue #91).
+// (acceptance #1): an utterance followed by a genuine speaker stop — Discord's
+// explicit silence frames, then NO further packets, the silence driven ONLY by
+// the injected clock — endpoints within the hangover window. The clip leaves its
+// final utterance open; the silence frames arm the clock (#147) and firing it
+// past the hangover must close the utterance (speech_end == speech_start) and
+// produce its STTFinal, in speech order. Before the #91 fix the trailing silence
+// was dropped, the trailing utterance never endpointed, and its line appeared
+// only when the next utterance arrived.
 func TestPipeline_TrailingSilenceEndpointsTrailingUtterance(t *testing.T) {
 	conv, h, frames := newSilenceRig(t, "hello there")
 	codec := &replayCodec{frames: frames}
@@ -190,8 +191,13 @@ func TestPipeline_TrailingSilenceEndpointsTrailingUtterance(t *testing.T) {
 	go func() { done <- pipe.run(t.Context(), inbound) }()
 
 	feedSpeech(inbound, frames)
-	// Trailing silence: fire the clock past the hangover with NO more inbound
-	// audio. Silero must endpoint the open utterance here, not wait for a second.
+	// The speaker stops: Discord's explicit silence frames (the speaker-stop
+	// signal that arms the clock), then a packet gap — fire the clock past the
+	// hangover with NO more inbound audio. Silero must endpoint the open
+	// utterance here, not wait for a second one.
+	for range discordStopSilenceFrames {
+		inbound <- gxvoice.Frame{Silence: true}
+	}
 	for range testHangoverTicks {
 		clk.tick()
 	}

--- a/pkg/voice/wire/silence_test.go
+++ b/pkg/voice/wire/silence_test.go
@@ -34,6 +34,11 @@ const (
 	testSampleRate    = 16000
 	testFrameMs       = 32
 	testHangoverTicks = 20 // > silero's default 15-frame hangover, so silence endpoints
+
+	// discordStopSilenceFrames is the ~5 explicit Opus silence frames a Discord
+	// sender emits when the speaker stops, before it stops sending packets — the
+	// speaker-stop signal on the wire (disgo's own sender does the same).
+	discordStopSilenceFrames = 5
 )
 
 // stubRecognizer returns a pinned transcript regardless of input, so a flushed
@@ -245,6 +250,73 @@ func TestPipeline_ContinuousSpeechInjectsNoSilence(t *testing.T) {
 	}
 	if got := codec.decodeCount(); got != len(frames) {
 		t.Errorf("decoded %d frames, want %d (every real frame)", got, len(frames))
+	}
+}
+
+// TestPipeline_ArrivalGapMidUtteranceDoesNotEndpoint is issue #147: a transport
+// jitter gap ≥ the VAD hangover in the MIDDLE of a continuous utterance — packet
+// ARRIVAL pauses, but stream time is continuous (contiguous PTS) and Discord sent
+// NO silence frames, so the speaker did not stop — must not endpoint the turn.
+// The silence clock keys on wall-clock arrival, so pre-fix the gap ticks inject
+// ≥ hangover silence frames, silero fires speech_end mid-word, and the resumed
+// speech becomes a second turn (starts=2). Post-fix the clock is armed only by
+// Discord's explicit silence frames (the speaker-stop signal), so the gap injects
+// nothing and the utterance stays ONE turn, endpointed once at the genuine stop.
+func TestPipeline_ArrivalGapMidUtteranceDoesNotEndpoint(t *testing.T) {
+	conv, h, all := newSilenceRig(t, "hello there")
+	// The hello-test clip VAD-splits at an internal pause; slice to its second,
+	// single utterance (speech from ~frame 61 to the clip end, left open) so "one
+	// turn" is unambiguous. Probed with silero at this exact rig geometry.
+	frames := all[46:]
+	gapAt := 85 - 46 // mid-speech: well after speech-start (~61), well before clip end
+	codec := &replayCodec{frames: frames}
+	clk := &fakeSilenceClock{ch: make(chan time.Time)}
+	pipe := NewPipeline(conv, codec, nil, "guild", nil,
+		withSilenceClock(testSampleRate, testFrameMs, func() silenceClock { return clk }))
+
+	inbound := make(chan gxvoice.Frame)
+	done := make(chan error, 1)
+	go func() { done <- pipe.run(t.Context(), inbound) }()
+
+	// pts models Discord's 20 ms packet cadence: contiguous across the arrival
+	// gap (the packets were delayed, not part of a speaker stop).
+	pts := func(i int) time.Duration { return time.Duration(i) * 20 * time.Millisecond }
+	for i := range frames[:gapAt] {
+		inbound <- gxvoice.Frame{PTS: pts(i), Sequence: uint32(i)}
+	}
+	// The jitter gap: no packets ARRIVE for ≥ the hangover, but no Discord
+	// silence frames were seen — the speaker did not stop. The clock must not
+	// advance the VAD here.
+	for range testHangoverTicks {
+		clk.tick()
+	}
+	// Speech resumes: stream time contiguous with the pre-gap frames.
+	for i := range frames[gapAt:] {
+		j := gapAt + i
+		inbound <- gxvoice.Frame{PTS: pts(j), Sequence: uint32(j)}
+	}
+	// The genuine stop: Discord's explicit silence frames, then the packet gap
+	// the clock endpoints through (the #91 shape).
+	for range discordStopSilenceFrames {
+		inbound <- gxvoice.Frame{Silence: true}
+	}
+	for range testHangoverTicks {
+		clk.tick()
+	}
+	close(inbound)
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	starts, ends, finals := eventCounts(h)
+	if starts != 1 {
+		t.Errorf("speech_start=%d, want 1: a mid-utterance arrival gap with continuous PTS and no Discord silence frames must not split the turn", starts)
+	}
+	if ends != 1 {
+		t.Errorf("speech_end=%d, want 1: exactly one endpoint, at the genuine speaker stop", ends)
+	}
+	if finals != 1 {
+		t.Errorf("STTFinal=%d, want 1: the utterance must reach STT as one turn", finals)
 	}
 }
 

--- a/pkg/voice/wire/wire.go
+++ b/pkg/voice/wire/wire.go
@@ -130,11 +130,14 @@ func (c *tickerClock) stop()                   { c.t.Stop() }
 // Option configures a [Pipeline] at construction.
 type Option func(*Pipeline)
 
-// WithSilenceClock enables the continuous silence clock (issue #91): during
-// inbound silence and packet gaps the pipeline feeds synthesized PCM silence into
-// the VAD at the orchestrator frame cadence, so a paused speaker's utterance
-// endpoints within the silero hangover window rather than coalescing with the next
-// utterance. sampleRate and frameMs are the orchestrator's frame geometry (the
+// WithSilenceClock enables the continuous silence clock (issue #91): once a
+// speaker stop is signalled by Discord's explicit Opus silence frames, the
+// pipeline feeds synthesized PCM silence into the VAD at the orchestrator frame
+// cadence through the packet gap that follows, so a paused speaker's utterance
+// endpoints within the silero hangover window rather than coalescing with the
+// next utterance. A packet-arrival gap WITHOUT that signal — transport jitter
+// mid-utterance — injects nothing, so it cannot falsely split a turn (issue
+// #147). sampleRate and frameMs are the orchestrator's frame geometry (the
 // VAD/STT rate, e.g. 16000 Hz / 32 ms): they shape the synthesized silence frame
 // AND set the tick interval. Without this option the pipeline keeps the pre-#91
 // behaviour, dropping inbound silence frames untouched.
@@ -228,8 +231,20 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 	// is injected while speech flows (continuous speech must not endpoint). Disabled
 	// when no [WithSilenceClock] was given: the loop then just drops inbound silence
 	// frames, the pre-#91 behaviour.
+	//
+	// The clock injects only while ARMED (#147): a wall-clock arrival gap alone is
+	// NOT evidence the speaker stopped — a ≥ hangover transport jitter burst
+	// mid-utterance would otherwise be endpointed as if the speaker had paused,
+	// splitting one turn in two and losing half of it. The speaker-stop signal on
+	// the wire is Discord's explicit Opus silence frames (a sender emits ~5 before
+	// it stops transmitting; the frame's PTS stream time carries no gap during
+	// arrival jitter), so a silence frame arms the clock and every real frame
+	// disarms it. If all stop-silence frames are lost, the utterance endpoints at
+	// the next arming signal or the shutdown Flush — the pre-#91 worst case —
+	// instead of risking a false mid-utterance split.
 	var clk silenceClock
 	var clockTicks <-chan time.Time
+	armed := false
 	if p.silenceOn {
 		clk = p.newClock()
 		defer clk.stop()
@@ -241,8 +256,13 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-clockTicks:
-			// Audio has been idle for one frame interval: advance the VAD with one
-			// frame of silence so a paused speaker's utterance endpoints.
+			if !armed {
+				// Packets stopped ARRIVING but no Discord silence frame said the
+				// speaker stopped: an unarmed tick is transport jitter, not a pause.
+				continue
+			}
+			// The speaker stopped and audio has been idle for one frame interval:
+			// advance the VAD with one frame of silence so the utterance endpoints.
 			if err := p.conv.Feed(p.silence); err != nil {
 				p.log.Debug("feed silence frame", "err", err)
 			}
@@ -251,15 +271,18 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 				return nil // session closed
 			}
 			if frame.Silence {
-				// A Discord Opus silence frame: the speaker has stopped. Do NOT decode
-				// it and do NOT reset the silence clock — let the clock keep advancing
-				// the VAD hangover through this frame and the packet gap that follows, so
-				// the utterance endpoints (issue #91). Pre-#91 this `continue` dropped the
-				// frame with nothing left to advance the VAD.
+				// A Discord Opus silence frame: the speaker has stopped. Arm the
+				// clock, but do NOT decode the frame and do NOT reset the clock — let
+				// it keep advancing the VAD hangover through this frame and the packet
+				// gap that follows, so the utterance endpoints (issue #91). Pre-#91
+				// this `continue` dropped the frame with nothing left to advance the VAD.
+				armed = true
 				continue
 			}
-			// Real audio arrived: reset the idle clock so no synthesized silence is
-			// injected while frames keep flowing.
+			// Real audio arrived: the speaker is talking again. Disarm and reset the
+			// idle clock so no synthesized silence is injected while frames keep
+			// flowing — not even through an arrival gap (#147).
+			armed = false
 			if clk != nil {
 				clk.reset()
 			}


### PR DESCRIPTION
## Defect

The wire-layer silence clock (`pkg/voice/wire/wire.go`, introduced by #92 for #91) injected synthesized silence into the VAD whenever no frame had **arrived** for one 32 ms interval — wall-clock arrival, not stream time. A ≥ hangover (384 ms) transport jitter gap mid-utterance (UDP loss/wifi hiccup, no Discord silence frames) was indistinguishable from the speaker stopping: silero fired `VADSpeechEnd`, the half-utterance flushed to STT as turn A, and the resumed speech became turn B — coalesced away (transcript discarded) or superseding A's reply mid-synthesis. Issue #147.

## Mechanism + evidence

**Chosen: gate the clock's injection on Discord's explicit silence frames (the speaker-stop signal).** A silence frame arms the clock; every real frame disarms it; an unarmed tick injects nothing.

Evidence the signal is reliable in this pipeline:

- Discord voice senders emit ~5 explicit Opus silence frames (`0xF8 0xFF 0xFE`) before they stop transmitting; disgo's own sender does exactly this (`disgo/voice/audio_sender.go:109` writes `SilenceAudioFrame` on send breaks).
- This repo already detects them per-packet: `pkg/voice/inbound.go:81` sets `Frame.Silence` via `bytes.Equal(packet.Opus, voice.SilenceAudioFrame)`.
- The signal survives DAVE E2EE: disgo decrypts (transport, then DAVE, `disgo/voice/udp_conn.go:364,387`) before handing `packet.Opus` to our `ReceiveOpusFrame`, so the comparison sees plaintext.
- The live-validated #92 work documented the shape ("Discord sends a few Opus silence frames when a speaker stops, then STOPS sending packets") and pinned it in `TestPipeline_DiscordSilenceFramesDriveTheClock` ("mirrors the live shape").

PTS backfill was not needed: PTS can only distinguish jitter from a stop *after* speech resumes, which is too late to un-fire a VAD event — the silence-frame gate is the smallest mechanism that decides correctly *during* the gap. (The new test still models contiguous PTS to document the scenario.)

**Latency unchanged:** silence frames never reset the ticker (same as before), so injection still starts one frame interval after the last real frame — the first stop-silence frame (~20 ms after the last real packet) arms the clock before the first tick (~32 ms).

**Degradation if all ~5 stop-silence frames are lost (rare, UDP):** the utterance endpoints at the next arming signal or the shutdown `Flush` — the pre-#91 worst case — instead of risking a false mid-utterance split.

## Tests

- **New (red pre-fix):** `TestPipeline_ArrivalGapMidUtteranceDoesNotEndpoint` — continuous utterance, ≥ hangover ARRIVAL gap mid-speech (contiguous PTS, no silence frames), then genuine stop. Pre-fix: `speech_start=2 speech_end=2 STTFinal=2` (turn split). Post-fix: `1/1/1` — one turn, endpointed once at the genuine stop. Committed red first (`31db7c8`), fix on top.
- **Updated:** `TestPipeline_TrailingSilenceEndpointsTrailingUtterance` now feeds Discord's ~5 stop-silence frames before the clock ticks — the wire-accurate speaker-stop shape. Its old shape (packets stop arriving, NO silence frames) is by #147's definition exactly the jitter gap that must NOT endpoint, so the two were mutually exclusive; the test's intent (trailing utterance endpoints via the clock alone, no further audio) is preserved.
- **Untouched, green:** `TestPipeline_DiscordSilenceFramesDriveTheClock` (the #91 live-shape regression test) and `TestPipeline_ContinuousSpeechInjectsNoSilence`.

Local gates: `go build ./...`, `go test -race ./pkg/voice/wire/...`, full `go test ./...`, `gofmt`, `golangci-lint` (0 issues), `-tags opus` build — all clean.

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)