### PR TITLE
fix(#142): bot-token save no longer clobbers the stored guild/voice IDs

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -8,13 +8,3 @@ lint:
 breaking:
   use:
     - FILE
-  # #142: SaveDiscordSettingsRequest.guild_id/voice_channel_id gained proto3
-  # `optional` (explicit presence) so a token-only save can't clobber the stored
-  # IDs. Wire encoding is unchanged for string scalars; the flagged break is the
-  # presence semantics + the generated-API shape (string -> *string), and both
-  # consumers (Go server, web SPA) live in this repo and regenerate together.
-  # Narrowest exception: one rule, one file. Removable once this is on main —
-  # later runs compare against the already-optional fields.
-  ignore_only:
-    FIELD_SAME_CARDINALITY:
-      - proto/glyphoxa/management/v1/management.proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -8,3 +8,13 @@ lint:
 breaking:
   use:
     - FILE
+  # #142: SaveDiscordSettingsRequest.guild_id/voice_channel_id gained proto3
+  # `optional` (explicit presence) so a token-only save can't clobber the stored
+  # IDs. Wire encoding is unchanged for string scalars; the flagged break is the
+  # presence semantics + the generated-API shape (string -> *string), and both
+  # consumers (Go server, web SPA) live in this repo and regenerate together.
+  # Narrowest exception: one rule, one file. Removable once this is on main —
+  # later runs compare against the already-optional fields.
+  ignore_only:
+    FIELD_SAME_CARDINALITY:
+      - proto/glyphoxa/management/v1/management.proto

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -213,6 +213,16 @@ func (s *ProviderServer) SaveDiscordSettings(
 		return nil, err
 	}
 
+	// Validate the IDs before any write so a rejected request mutates nothing.
+	// Present-but-empty is REJECTED, not treated as a clear (mirrors bot_token's
+	// empty check): an empty ID only reaches the wire by accident — e.g. the form
+	// saving before the config load resolves — and clearing is unsupported (#142).
+	hasIDs := req.Msg.GuildId != nil || req.Msg.VoiceChannelId != nil
+	if hasIDs && (req.Msg.GetGuildId() == "" || req.Msg.GetVoiceChannelId() == "") {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("guild_id and voice_channel_id must both be non-empty when provided"))
+	}
+
 	var dep storage.DeploymentConfig
 
 	// Bot token first (when the client sent one), so the IDs upsert below returns
@@ -241,7 +251,7 @@ func (s *ProviderServer) SaveDiscordSettings(
 
 	// IDs only when present on the wire (mirrors the token's presence handling):
 	// a token-only save must never touch the stored IDs (#142).
-	if req.Msg.GuildId != nil || req.Msg.VoiceChannelId != nil {
+	if hasIDs {
 		dep, err = s.store.SaveDiscordChannels(ctx, tenantID, req.Msg.GetGuildId(), req.Msg.GetVoiceChannelId())
 		if err != nil {
 			s.log.Error("SaveDiscordSettings: save channels failed", "err", err)

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -200,8 +200,9 @@ func (s *ProviderServer) SaveProviderConfig(
 }
 
 // SaveDiscordSettings stores the Discord bot token (when present) and the
-// non-secret Guild / Voice channel IDs. An omitted bot_token leaves the stored
-// token untouched; the column-isolated upserts mean the token Save and the IDs
+// non-secret Guild / Voice channel IDs (when present). Every field has wire
+// presence: an omitted bot_token leaves the stored token untouched, and omitted
+// IDs leave the stored IDs untouched (#142) — so the token Save and the IDs
 // Save never clobber each other.
 func (s *ProviderServer) SaveDiscordSettings(
 	ctx context.Context,
@@ -211,6 +212,8 @@ func (s *ProviderServer) SaveDiscordSettings(
 	if err != nil {
 		return nil, err
 	}
+
+	var dep storage.DeploymentConfig
 
 	// Bot token first (when the client sent one), so the IDs upsert below returns
 	// the row with the freshly-saved token last4.
@@ -229,16 +232,21 @@ func (s *ProviderServer) SaveDiscordSettings(
 			s.log.Error("SaveDiscordSettings: seal failed", "err", err)
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
-		if _, err := s.store.SaveDiscordBotToken(ctx, tenantID, sealed, last4); err != nil {
+		dep, err = s.store.SaveDiscordBotToken(ctx, tenantID, sealed, last4)
+		if err != nil {
 			s.log.Error("SaveDiscordSettings: save token failed", "err", err)
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
 	}
 
-	dep, err := s.store.SaveDiscordChannels(ctx, tenantID, req.Msg.GetGuildId(), req.Msg.GetVoiceChannelId())
-	if err != nil {
-		s.log.Error("SaveDiscordSettings: save channels failed", "err", err)
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	// IDs only when present on the wire (mirrors the token's presence handling):
+	// a token-only save must never touch the stored IDs (#142).
+	if req.Msg.GuildId != nil || req.Msg.VoiceChannelId != nil {
+		dep, err = s.store.SaveDiscordChannels(ctx, tenantID, req.Msg.GetGuildId(), req.Msg.GetVoiceChannelId())
+		if err != nil {
+			s.log.Error("SaveDiscordSettings: save channels failed", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
 	}
 
 	return connect.NewResponse(&managementv1.SaveDiscordSettingsResponse{

--- a/internal/rpc/provider_integration_test.go
+++ b/internal/rpc/provider_integration_test.go
@@ -168,7 +168,7 @@ func TestProviderService_Integration(t *testing.T) {
 	// Discord settings: token sealed in deployment_config, IDs stored plain.
 	const botToken = "test-discord-bot-token-dddd"
 	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		BotToken: &[]string{botToken}[0], GuildId: "472093001100", VoiceChannelId: "472093774421",
+		BotToken: &[]string{botToken}[0], GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
 	})); err != nil {
 		t.Fatalf("SaveDiscordSettings: %v", err)
 	}

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -295,8 +295,8 @@ func TestProviderDiscordSettings_TokenAndChannels(t *testing.T) {
 	const token = "test-discord-bot-token-3333"
 	saveTok, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
 		BotToken:       &[]string{token}[0],
-		GuildId:        "472093001100",
-		VoiceChannelId: "472093774421",
+		GuildId:        strPtr("472093001100"),
+		VoiceChannelId: strPtr("472093774421"),
 	}))
 	if err != nil {
 		t.Fatalf("save discord: %v", err)
@@ -314,7 +314,7 @@ func TestProviderDiscordSettings_TokenAndChannels(t *testing.T) {
 
 	// IDs-only save (no bot_token) must not wipe the token.
 	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		GuildId: "999", VoiceChannelId: "888",
+		GuildId: strPtr("999"), VoiceChannelId: strPtr("888"),
 	})); err != nil {
 		t.Fatalf("save ids: %v", err)
 	}
@@ -327,6 +327,42 @@ func TestProviderDiscordSettings_TokenAndChannels(t *testing.T) {
 		t.Errorf("ids not updated: %q / %q", resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
 	}
 }
+
+// TestProviderDiscordSettings_TokenOnlySaveKeepsIDs pins #142: replacing the
+// bot token without sending the IDs must leave the stored Guild / Voice channel
+// IDs untouched — the exact clobber that wiped them when the client saved a
+// token while ListProviderConfigs was still loading.
+func TestProviderDiscordSettings_TokenOnlySaveKeepsIDs(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	client, _ := newProviderClient(t, store, testCipher(t))
+	ctx := context.Background()
+
+	// Operator has IDs saved.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	})); err != nil {
+		t.Fatalf("save ids: %v", err)
+	}
+
+	// Token-only save: no ID fields on the wire.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr("test-discord-bot-token-7777"),
+	})); err != nil {
+		t.Fatalf("save token: %v", err)
+	}
+
+	resp, err := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if resp.Msg.GetGuildId() != "472093001100" || resp.Msg.GetVoiceChannelId() != "472093774421" {
+		t.Errorf("token-only save clobbered ids: guild=%q voice=%q, want them untouched",
+			resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
+	}
+}
+
+func strPtr(s string) *string { return &s }
 
 // TestProviderList_EnvPlaceholderIsKeyNeeded asserts the ADR-0039 seam: a
 // provider_config still holding the seed's "env" placeholder reads as key-needed,

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -362,6 +362,45 @@ func TestProviderDiscordSettings_TokenOnlySaveKeepsIDs(t *testing.T) {
 	}
 }
 
+// TestProviderDiscordSettings_EmptyIDsRejected documents the #142 decision for
+// present-but-empty IDs: REJECT with InvalidArgument (mirroring bot_token's
+// "must not be empty when provided") rather than treating "" as an explicit
+// clear. Clearing the IDs is not a supported operation — an empty ID only ever
+// reaches the wire by accident (e.g. the form saving before the config load
+// resolves), and accepting it would reopen the silent-wipe this issue fixes.
+func TestProviderDiscordSettings_EmptyIDsRejected(t *testing.T) {
+	t.Parallel()
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	ctx := context.Background()
+
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	})); err != nil {
+		t.Fatalf("save ids: %v", err)
+	}
+
+	for name, req := range map[string]*managementv1.SaveDiscordSettingsRequest{
+		"both empty":  {GuildId: strPtr(""), VoiceChannelId: strPtr("")},
+		"empty guild": {GuildId: strPtr(""), VoiceChannelId: strPtr("472093774421")},
+		"empty voice": {GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("")},
+		"guild only":  {GuildId: strPtr("472093001100")}, // partial presence = the other ID is empty
+	} {
+		_, err := client.SaveDiscordSettings(ctx, connect.NewRequest(req))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("%s: code = %v, want InvalidArgument", name, connect.CodeOf(err))
+		}
+	}
+
+	// The rejected saves left the stored IDs untouched.
+	resp, err := client.ListProviderConfigs(ctx, connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if resp.Msg.GetGuildId() != "472093001100" || resp.Msg.GetVoiceChannelId() != "472093774421" {
+		t.Errorf("rejected save mutated ids: guild=%q voice=%q", resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
+	}
+}
+
 func strPtr(s string) *string { return &s }
 
 // TestProviderList_EnvPlaceholderIsKeyNeeded asserts the ADR-0039 seam: a

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -306,9 +306,12 @@ message SaveDiscordSettingsRequest {
   // stored token unchanged — lets the IDs be saved without re-entering the
   // secret. Write-only: never returned.
   optional string bot_token = 1;
-  // guild_id / voice_channel_id are the non-secret Discord IDs, stored as-is.
-  string guild_id = 2;
-  string voice_channel_id = 3;
+  // guild_id / voice_channel_id are the non-secret Discord IDs. Omit both (no
+  // presence) to leave the stored IDs unchanged — lets the token be replaced
+  // without clobbering the IDs (#142). When present they must be non-empty and
+  // sent together; a present-but-empty ID is rejected (mirrors bot_token).
+  optional string guild_id = 2;
+  optional string voice_channel_id = 3;
 }
 
 // SaveDiscordSettingsResponse returns the Bot token's masked metadata plus the

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -105,9 +105,18 @@ function mockBackend(
       saveDiscordSettings: (req) => {
         opts.discordSaves?.push(req);
         if (opts.discordSaveError) throw new ConnectError(opts.discordSaveError, Code.Internal);
-        if (req.botToken !== undefined) state.discord = req.botToken.slice(-4);
         // Presence semantics mirror the real server (#142): omitted IDs leave
-        // the stored ones untouched.
+        // the stored ones untouched, and present-but-empty is REJECTED exactly
+        // like internal/rpc/provider.go — so a client that regresses into
+        // sending blank IDs fails loudly here instead of silently diverging.
+        const hasIDs = req.guildId !== undefined || req.voiceChannelId !== undefined;
+        if (hasIDs && (!req.guildId || !req.voiceChannelId)) {
+          throw new ConnectError(
+            "guild_id and voice_channel_id must both be non-empty when provided",
+            Code.InvalidArgument,
+          );
+        }
+        if (req.botToken !== undefined) state.discord = req.botToken.slice(-4);
         if (req.guildId !== undefined) state.guildId = req.guildId;
         if (req.voiceChannelId !== undefined) state.voiceChannelId = req.voiceChannelId;
         return create(SaveDiscordSettingsResponseSchema, {

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -192,6 +192,22 @@ describe("Configuration", () => {
     expect(discordSaves[0].voiceChannelId).toBeUndefined();
   });
 
+  it("disables the IDs save until both IDs are non-empty (#142)", async () => {
+    renderScreen();
+
+    // Fresh install: guild pasted, voice still blank. The server rejects
+    // present-but-empty IDs, so the client must not offer the save at all —
+    // a click here used to fail invisibly and leave nothing stored.
+    const guild = await screen.findByLabelText("Guild ID");
+    fireEvent.change(guild, { target: { value: "472093001100" } });
+    const save = screen.getByRole("button", { name: /save discord settings/i });
+    expect(save).toBeDisabled();
+
+    // Both filled -> the save unlocks.
+    fireEvent.change(screen.getByLabelText("Voice channel ID"), { target: { value: "472093774421" } });
+    expect(save).toBeEnabled();
+  });
+
   it("renders the Groq model allowlist select (ListModels)", async () => {
     renderScreen();
     // The Groq row's model select defaults to the first allowlisted model.

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -18,6 +18,7 @@ import {
   ProviderHealthSchema,
   ListModelsResponseSchema,
   type ProviderHealth,
+  type SaveDiscordSettingsRequest,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -53,7 +54,15 @@ const GROQ_MODELS = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"];
 // refetch shows the saved credential — proving the write-only round-trip from
 // the screen's side (the RPC never returns a secret value). `opts` seeds already-
 // saved slots and the async health the GetProviderHealth RPC reports (#70).
-function mockBackend(opts: { saved?: Partial<Record<"groq" | "elevenlabs" | "discord", string>>; health?: ProviderHealth[] } = {}) {
+function mockBackend(
+  opts: {
+    saved?: Partial<Record<"groq" | "elevenlabs" | "discord", string>>;
+    health?: ProviderHealth[];
+    // discordSaves captures every SaveDiscordSettings request so tests can pin
+    // the wire shape (#142: a token-only save must omit the ID fields).
+    discordSaves?: SaveDiscordSettingsRequest[];
+  } = {},
+) {
   const state = {
     groq: opts.saved?.groq,
     elevenlabs: opts.saved?.elevenlabs,
@@ -91,9 +100,12 @@ function mockBackend(opts: { saved?: Partial<Record<"groq" | "elevenlabs" | "dis
         });
       },
       saveDiscordSettings: (req) => {
+        opts.discordSaves?.push(req);
         if (req.botToken !== undefined) state.discord = req.botToken.slice(-4);
-        state.guildId = req.guildId;
-        state.voiceChannelId = req.voiceChannelId;
+        // Presence semantics mirror the real server (#142): omitted IDs leave
+        // the stored ones untouched.
+        if (req.guildId !== undefined) state.guildId = req.guildId;
+        if (req.voiceChannelId !== undefined) state.voiceChannelId = req.voiceChannelId;
         return create(SaveDiscordSettingsResponseSchema, {
           credential: cred("discord", "discord", state.discord),
           guildId: state.guildId,
@@ -158,6 +170,26 @@ describe("Configuration", () => {
     // Values survive the invalidation refetch (round-tripped through the RPC).
     expect(await screen.findByDisplayValue("472093001100")).toBeInTheDocument();
     expect(screen.getByDisplayValue("472093774421")).toBeInTheDocument();
+  });
+
+  it("omits the guild/voice IDs from a token-only save (#142)", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    renderScreen(mockBackend({ discordSaves }));
+
+    // Operator only edits the bot token — the IDs inputs are untouched (still
+    // seeding from the in-flight config load).
+    const tokenInput = await screen.findByLabelText("Bot token key");
+    fireEvent.change(tokenInput, { target: { value: "test-discord-token-zzzz" } });
+    const botRow = tokenInput.closest(".gx-provider-row") as HTMLElement;
+    fireEvent.click(within(botRow).getByRole("button", { name: "Save" }));
+    expect(await within(botRow).findByText("••••••••")).toBeInTheDocument();
+
+    // The request carries the token and NOTHING else: no guild/voice fields on
+    // the wire, so a slow/failed config load can never clobber the stored IDs.
+    expect(discordSaves).toHaveLength(1);
+    expect(discordSaves[0].botToken).toBe("test-discord-token-zzzz");
+    expect(discordSaves[0].guildId).toBeUndefined();
+    expect(discordSaves[0].voiceChannelId).toBeUndefined();
   });
 
   it("renders the Groq model allowlist select (ListModels)", async () => {

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, within, fireEvent } from "@testing-library/react";
-import { createRouterTransport } from "@connectrpc/connect";
+import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -61,6 +61,9 @@ function mockBackend(
     // discordSaves captures every SaveDiscordSettings request so tests can pin
     // the wire shape (#142: a token-only save must omit the ID fields).
     discordSaves?: SaveDiscordSettingsRequest[];
+    // discordSaveError makes SaveDiscordSettings fail (simulates a server-side
+    // failure) so tests can pin that the screen surfaces the rejection.
+    discordSaveError?: string;
   } = {},
 ) {
   const state = {
@@ -101,6 +104,7 @@ function mockBackend(
       },
       saveDiscordSettings: (req) => {
         opts.discordSaves?.push(req);
+        if (opts.discordSaveError) throw new ConnectError(opts.discordSaveError, Code.Internal);
         if (req.botToken !== undefined) state.discord = req.botToken.slice(-4);
         // Presence semantics mirror the real server (#142): omitted IDs leave
         // the stored ones untouched.
@@ -206,6 +210,21 @@ describe("Configuration", () => {
     // Both filled -> the save unlocks.
     fireEvent.change(screen.getByLabelText("Voice channel ID"), { target: { value: "472093774421" } });
     expect(save).toBeEnabled();
+  });
+
+  it("surfaces a failed IDs save as a visible alert (#142)", async () => {
+    renderScreen(mockBackend({ discordSaveError: "database is down" }));
+
+    // Both IDs filled, save offered — but the RPC fails. The rejection must
+    // leave visible evidence: nothing was stored, and a silent failure here
+    // resurfaces later as an unrelated-looking session-start precondition error.
+    fireEvent.change(await screen.findByLabelText("Guild ID"), { target: { value: "472093001100" } });
+    fireEvent.change(screen.getByLabelText("Voice channel ID"), { target: { value: "472093774421" } });
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/couldn't save/i);
+    expect(alert).toHaveTextContent(/database is down/);
   });
 
   it("renders the Groq model allowlist select (ListModels)", async () => {

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -68,6 +68,9 @@ export function Configuration() {
 
   const saveProvider = useMutation(ProviderService.method.saveProviderConfig, { onSuccess: invalidateList });
   const saveDiscord = useMutation(ProviderService.method.saveDiscordSettings, { onSuccess: invalidateList });
+  // Separate mutation instance for the IDs form so its error/pending state is
+  // its own — a bot-token failure paints the SecretRow, not this form (#142).
+  const saveDiscordIds = useMutation(ProviderService.method.saveDiscordSettings, { onSuccess: invalidateList });
 
   // Guild / Voice channel IDs are controlled, seeded from the RPC. A `dirty` ref
   // guards the seed so a slow first load (or a post-save refetch) can never
@@ -186,14 +189,22 @@ export function Configuration() {
             <Button
               variant="primary"
               size="sm"
-              onClick={() => saveDiscord.mutate({ guildId, voiceChannelId })}
+              onClick={() => saveDiscordIds.mutate({ guildId, voiceChannelId })}
               // Locked until BOTH IDs are non-empty: the server rejects
               // present-but-empty IDs (#142), so a half-filled save must not be
               // offered — clicking it used to fail with no visible trace.
-              disabled={saveDiscord.isPending || !guildId || !voiceChannelId}
+              disabled={saveDiscordIds.isPending || !guildId || !voiceChannelId}
             >
               Save Discord settings
             </Button>
+            {/* Inline failure cue, mirroring the SecretRow save-error treatment:
+                a rejected save must leave visible evidence the IDs were NOT
+                stored, or it resurfaces as a session-start failure (#142). */}
+            {saveDiscordIds.isError && (
+              <span className="gx-discord__error" role="alert">
+                Couldn&apos;t save: {saveDiscordIds.error.message}
+              </span>
+            )}
           </div>
         </div>
       </Card>

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -187,7 +187,10 @@ export function Configuration() {
               variant="primary"
               size="sm"
               onClick={() => saveDiscord.mutate({ guildId, voiceChannelId })}
-              disabled={saveDiscord.isPending}
+              // Locked until BOTH IDs are non-empty: the server rejects
+              // present-but-empty IDs (#142), so a half-filled save must not be
+              // offered — clicking it used to fail with no visible trace.
+              disabled={saveDiscord.isPending || !guildId || !voiceChannelId}
             >
               Save Discord settings
             </Button>

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -161,9 +161,10 @@ export function Configuration() {
             placeholder="Paste the Discord bot token"
             credential={credentialFor(creds, "discord")}
             health={healthFor(health, "discord")}
-            onSave={(secret) =>
-              saveDiscord.mutateAsync({ botToken: secret, guildId, voiceChannelId })
-            }
+            // Token-only save: the ID fields stay OFF the wire (they have proto3
+            // presence), so replacing the token can never clobber the stored IDs —
+            // even while the config load is still resolving (#142).
+            onSave={(secret) => saveDiscord.mutateAsync({ botToken: secret })}
           />
           <div className="gx-discord__ids">
             <Input

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -51,6 +51,16 @@
 .gx-discord__save {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+/* Inline save-failure cue for the IDs form, mirroring the SecretRow error
+ * treatment (#142 / #154). */
+.gx-discord__error {
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--status-danger);
 }
 
 /* Resolved Discord bot tag from the live gateway login (#70), under the name. */


### PR DESCRIPTION
## Defect

A token-only `SaveDiscordSettings` wiped the stored Guild / Voice channel IDs. Three layers lined up (#142):

- **Proto**: `guild_id`/`voice_channel_id` were plain strings — no wire-level way to send a token without IDs.
- **Server** (`internal/rpc/provider.go`): unconditionally called `SaveDiscordChannels(req.GetGuildId(), req.GetVoiceChannelId())`, defeating the storage layer's column isolation.
- **Client** (`Configuration.tsx`): ID state seeds as `""` until `ListProviderConfigs` resolves, and the token save sent all three fields — so a token save during a slow/failed config load (or from a stale tab) wiped the IDs, surfacing later as a session-start `FailedPrecondition`.

## Fix

- **Proto**: `guild_id`/`voice_channel_id` are now `optional` (explicit presence) in `SaveDiscordSettingsRequest`.
- **Server**: `SaveDiscordChannels` runs only when the IDs are present on the wire, mirroring `bot_token`'s presence handling. Present-but-empty is **rejected** with `InvalidArgument` (decision documented in the test): mirroring `bot_token`'s empty check — an empty ID only reaches the wire by accident, and accepting it as a "clear" would reopen the silent wipe. Validation runs before the token seal so a rejected request mutates nothing.
- **Client** (defense in depth): the token SecretRow save sends `{ botToken }` only — the ID fields stay off the wire.

## buf breaking tradeoff

`buf breaking` flags the change: `FIELD_SAME_CARDINALITY` ("optional with implicit presence" → "optional with explicit presence") on both fields. The wire encoding of string scalars is unchanged; what changes is presence semantics and the generated API shape (`string` → `*string` in Go, `guildId?: string` in TS). Both consumers (Go server, web SPA) live in this repo and regenerate together, so the break is coordinated.

The escape hatch is the **`buf skip breaking` PR label** — bufbuild/buf-action's built-in one-shot skip (its breaking step's default condition is `github.event_name == 'pull_request' && !contains(labels, 'buf skip breaking')`). A `buf.yaml` `ignore_only` exception was considered and reverted: `management.proto` is the repo's only proto file, so it would have disabled `FIELD_SAME_CARDINALITY` for the entire API surface indefinitely. The label skips breaking for this PR only; the gate stays fully intact for every future change (verified in the CI job log: buf-action ran with `breaking: false`, `buf build`/`lint`/`format` still executed).

## Tests

- `TestProviderDiscordSettings_TokenOnlySaveKeepsIDs` — **red pre-fix** (`token-only save clobbered ids: guild="" voice=""`): stored IDs + token-only save → IDs untouched.
- `TestProviderDiscordSettings_EmptyIDsRejected` — **red pre-fix** (empty saves went through, `guild only` case mutated state): present-but-empty / partial presence → `InvalidArgument`, store untouched; documents the reject-over-clear decision.
- Existing `TestProviderDiscordSettings_TokenAndChannels` still proves a save with IDs present updates them (updated to presence pointers).
- Vitest `omits the guild/voice IDs from a token-only save (#142)` — **red pre-fix** (`guildId` arrived as `""`): captured request carries `botToken` and nothing else; mock backend now mirrors the server's presence semantics.

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
