### PR TITLE
fix(#154): Configuration & Campaign defect roundup — voice picker identity, rendered errors, URL leak, stale search

### DIFF
--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -23,6 +23,25 @@ describe("Combobox", () => {
     expect(screen.queryByRole("option", { name: /aria/i })).not.toBeInTheDocument();
   });
 
+  it("distinguishes options with identical labels: selecting the second dispatches its value", () => {
+    // ElevenLabs voice names are not unique — two "Rachel"s must stay separate
+    // cmdk identities so keyboard selection lands on the one the operator chose.
+    const dupes = [
+      { value: "voice-rachel-1", label: "Rachel" },
+      { value: "voice-rachel-2", label: "Rachel" },
+    ];
+    const onChange = vi.fn();
+    render(<Combobox label="Voice" options={dupes} value="" onValueChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+
+    // Arrow from the first Rachel to the second, then confirm with Enter.
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith("voice-rachel-2");
+  });
+
   it("fires onValueChange on pick and shows the chosen label on the trigger", () => {
     const onChange = vi.fn();
     const { rerender } = render(

--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -23,6 +23,22 @@ describe("Combobox", () => {
     expect(screen.queryByRole("option", { name: /aria/i })).not.toBeInTheDocument();
   });
 
+  it("clears the search when dismissed without picking, so reopen shows the full list", () => {
+    render(<Combobox label="Voice" options={OPTS} value="" onValueChange={() => {}} />);
+    // Open, filter down to Marcus, then dismiss with Escape (no pick).
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "marcus" } });
+    expect(screen.queryByRole("option", { name: /rachel/i })).not.toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // Reopen: the input is empty and the list is unfiltered.
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+    expect(screen.getByPlaceholderText(/search/i)).toHaveValue("");
+    expect(screen.getByRole("option", { name: /rachel/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /marcus/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /aria/i })).toBeInTheDocument();
+  });
+
   it("distinguishes options with identical labels: selecting the second dispatches its value", () => {
     // ElevenLabs voice names are not unique — two "Rachel"s must stay separate
     // cmdk identities so keyboard selection lands on the one the operator chose.

--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -23,6 +23,32 @@ describe("Combobox", () => {
     expect(screen.queryByRole("option", { name: /aria/i })).not.toBeInTheDocument();
   });
 
+  it("filters on the label only — an opaque voice id never matches typeahead", () => {
+    // Real ElevenLabs ids are 20-char base62 blobs; with cmdk's default filter
+    // the item value joins the search haystack, so an id subsequence ("wam" ⊂
+    // 21m00Tcm4TlvDq8ikWAM) keeps "Rachel" visible though nothing the operator
+    // can see matches. Filtering must score the label alone.
+    const opts = [
+      { value: "21m00Tcm4TlvDq8ikWAM", label: "Rachel" },
+      { value: "AZnzlk1XvdvUeBnXmlld", label: "Domi" },
+    ];
+    render(
+      <Combobox label="Voice" options={opts} value="" onValueChange={() => {}} emptyText="No matches" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Voice" }));
+
+    // A label substring still filters correctly.
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "rach" } });
+    expect(screen.getByRole("option", { name: /rachel/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /domi/i })).not.toBeInTheDocument();
+
+    // An id-only match must show nothing.
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "wam" } });
+    expect(screen.queryByRole("option", { name: /rachel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /domi/i })).not.toBeInTheDocument();
+    expect(screen.getByText("No matches")).toBeInTheDocument();
+  });
+
   it("clears the search when dismissed without picking, so reopen shows the full list", () => {
     render(<Combobox label="Voice" options={OPTS} value="" onValueChange={() => {}} />);
     // Open, filter down to Marcus, then dismiss with Escape (no pick).

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -8,9 +8,11 @@ import { ChevronDown, Check, Search } from "lucide-react";
 // popover. It reuses the gx-select* trigger vocabulary so it reads as the same
 // control, and adds gx-combobox* classes for the filterable popover.
 //
-// cmdk filters on each item's `value`; we set that to the human-readable label so
-// typeahead matches what the operator sees, and recover the real option value from
-// a closure on select. The selected option's label renders on the trigger.
+// cmdk keys selection/active state on each item's `value`; we set that to the
+// UNIQUE option value (labels can collide — ElevenLabs voice names are not
+// unique, #154) and pass the human-readable label as `keywords` so typeahead
+// still matches what the operator sees. The selected option's label renders on
+// the trigger.
 
 type Option = { value: string; label: string };
 
@@ -111,7 +113,8 @@ export function Combobox({
                 {options.map((o) => (
                   <Command.Item
                     key={o.value}
-                    value={o.label}
+                    value={o.value}
+                    keywords={[o.label]}
                     className="gx-select__item gx-combobox__item"
                     onSelect={() => pick(o.value)}
                   >

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -48,8 +48,13 @@ export function Combobox({
   const selected = options.find((o) => o.value === value);
 
   // Close on outside click / Escape so the popover behaves like a native select.
+  // Whenever the popover is closed — pick, Escape or outside click — the search
+  // resets so the next open shows the full, unfiltered list (#154).
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setSearch("");
+      return;
+    }
     const onDown = (e: MouseEvent) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
     };
@@ -66,8 +71,7 @@ export function Combobox({
 
   const pick = (optValue: string) => {
     onValueChange?.(optValue);
-    setOpen(false);
-    setSearch("");
+    setOpen(false); // the close effect clears the search
   };
 
   return (

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
-import { Command } from "cmdk";
+import { Command, defaultFilter } from "cmdk";
 import { ChevronDown, Check, Search } from "lucide-react";
 
 // Combobox — a filterable, height-bounded picker for large/growing option lists
@@ -10,11 +10,18 @@ import { ChevronDown, Check, Search } from "lucide-react";
 //
 // cmdk keys selection/active state on each item's `value`; we set that to the
 // UNIQUE option value (labels can collide — ElevenLabs voice names are not
-// unique, #154) and pass the human-readable label as `keywords` so typeahead
-// still matches what the operator sees. The selected option's label renders on
-// the trigger.
+// unique, #154) and pass the human-readable label as `keywords`. A custom
+// label-only filter keeps typeahead matching what the operator sees (never the
+// opaque id). The selected option's label renders on the trigger.
 
 type Option = { value: string; label: string };
+
+// cmdk's default filter scores `value + " " + keywords.join(" ")`, so an opaque
+// vendor id (e.g. an ElevenLabs voice id like 21m00Tcm4TlvDq8ikWAM) would join
+// the typeahead haystack and match searches nothing visible matches. Score the
+// human-readable keywords (the label) alone; the value stays pure identity.
+const labelOnlyFilter = (value: string, search: string, keywords?: string[]) =>
+  defaultFilter(keywords?.length ? keywords.join(" ") : value, search);
 
 export function Combobox({
   label = null,
@@ -101,7 +108,11 @@ export function Combobox({
 
         {open && (
           <div className="gx-select__content gx-combobox__content">
-            <Command className="gx-combobox__command" label={ariaLabel || label || "Options"}>
+            <Command
+              className="gx-combobox__command"
+              label={ariaLabel || label || "Options"}
+              filter={labelOnlyFilter}
+            >
               <div className="gx-combobox__search">
                 <Search size={14} className="gx-combobox__search-icon" />
                 <Command.Input

--- a/web/src/lib/audio.test.ts
+++ b/web/src/lib/audio.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { playAudioBlob } from "./audio";
+
+// jsdom has no real media pipeline: Audio.play is unimplemented and
+// URL.createObjectURL doesn't exist. These stubs stand in so the tests can
+// observe the object-URL lifecycle (#154 item 3: a failed preview must revoke
+// its URL and surface the play() rejection instead of leaking silently).
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+  static playImpl: () => Promise<void> = () => Promise.resolve();
+  src: string;
+  private listeners = new Map<string, Array<() => void>>();
+  constructor(src: string) {
+    this.src = src;
+    FakeAudio.instances.push(this);
+  }
+  addEventListener(type: string, fn: () => void) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), fn]);
+  }
+  dispatch(type: string) {
+    for (const fn of this.listeners.get(type) ?? []) fn();
+  }
+  play() {
+    return FakeAudio.playImpl();
+  }
+}
+
+const createObjectURL = vi.fn(() => "blob:preview");
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  FakeAudio.instances = [];
+  FakeAudio.playImpl = () => Promise.resolve();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  vi.stubGlobal("Audio", FakeAudio);
+  (URL as unknown as Record<string, unknown>).createObjectURL = createObjectURL;
+  (URL as unknown as Record<string, unknown>).revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (URL as unknown as Record<string, unknown>).createObjectURL;
+  delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+});
+
+describe("playAudioBlob", () => {
+  it("rejects and revokes the object URL when play() fails", async () => {
+    FakeAudio.playImpl = () => Promise.reject(new Error("autoplay blocked"));
+
+    await expect(playAudioBlob(new Uint8Array([1, 2]), "audio/wav")).rejects.toThrow(
+      /autoplay blocked/,
+    );
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+  });
+
+  it("still revokes the object URL when playback reaches ended", async () => {
+    await playAudioBlob(new Uint8Array([1, 2]), "audio/wav");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    FakeAudio.instances[0].dispatch("ended");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+  });
+
+  it("revokes the object URL when the media element errors", async () => {
+    await playAudioBlob(new Uint8Array([1, 2]), "audio/wav");
+
+    FakeAudio.instances[0].dispatch("error");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+  });
+});

--- a/web/src/lib/audio.test.ts
+++ b/web/src/lib/audio.test.ts
@@ -3,35 +3,31 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { playAudioBlob } from "./audio";
 
 // jsdom has no real media pipeline: Audio.play is unimplemented and
-// URL.createObjectURL doesn't exist. These stubs stand in so the tests can
-// observe the object-URL lifecycle (#154 item 3: a failed preview must revoke
-// its URL and surface the play() rejection instead of leaking silently).
-class FakeAudio {
-  static instances: FakeAudio[] = [];
-  static playImpl: () => Promise<void> = () => Promise.resolve();
-  src: string;
-  private listeners = new Map<string, Array<() => void>>();
-  constructor(src: string) {
-    this.src = src;
-    FakeAudio.instances.push(this);
-  }
-  addEventListener(type: string, fn: () => void) {
-    this.listeners.set(type, [...(this.listeners.get(type) ?? []), fn]);
-  }
-  dispatch(type: string) {
-    for (const fn of this.listeners.get(type) ?? []) fn();
-  }
-  play() {
-    return FakeAudio.playImpl();
-  }
+// URL.createObjectURL doesn't exist. The stub below stands in a REAL <audio>
+// DOM node (so attachment is observable) with a controllable play().
+//
+// Lifecycle contract under test (#154): Chrome interrupts detached media
+// elements ("The play() request was interrupted because the media was removed
+// from the document"), so the element must live in the document for the whole
+// playback, and both the element and its object URL must be released on
+// ended / error / play() rejection.
+const instances: HTMLAudioElement[] = [];
+let playImpl: () => Promise<void>;
+
+function FakeAudio(src: string): HTMLAudioElement {
+  const el = document.createElement("audio");
+  el.src = src;
+  Object.defineProperty(el, "play", { value: () => playImpl(), configurable: true });
+  instances.push(el);
+  return el;
 }
 
 const createObjectURL = vi.fn(() => "blob:preview");
 const revokeObjectURL = vi.fn();
 
 beforeEach(() => {
-  FakeAudio.instances = [];
-  FakeAudio.playImpl = () => Promise.resolve();
+  instances.length = 0;
+  playImpl = () => Promise.resolve();
   createObjectURL.mockClear();
   revokeObjectURL.mockClear();
   vi.stubGlobal("Audio", FakeAudio);
@@ -43,30 +39,43 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete (URL as unknown as Record<string, unknown>).createObjectURL;
   delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  document.body.innerHTML = "";
 });
 
 describe("playAudioBlob", () => {
-  it("rejects and revokes the object URL when play() fails", async () => {
-    FakeAudio.playImpl = () => Promise.reject(new Error("autoplay blocked"));
+  it("keeps the element attached (hidden) to the document while playing", async () => {
+    await playAudioBlob(new Uint8Array([1, 2]), "audio/wav");
+
+    // Detached media gets interrupted by Chrome — the element must be in the
+    // document for the playback duration, invisible to the operator.
+    expect(instances[0].isConnected).toBe(true);
+    expect(instances[0].style.display).toBe("none");
+  });
+
+  it("rejects, revokes the object URL and detaches when play() fails", async () => {
+    playImpl = () => Promise.reject(new Error("autoplay blocked"));
 
     await expect(playAudioBlob(new Uint8Array([1, 2]), "audio/wav")).rejects.toThrow(
       /autoplay blocked/,
     );
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+    expect(instances[0].isConnected).toBe(false);
   });
 
-  it("still revokes the object URL when playback reaches ended", async () => {
+  it("revokes the object URL and detaches when playback reaches ended", async () => {
     await playAudioBlob(new Uint8Array([1, 2]), "audio/wav");
     expect(revokeObjectURL).not.toHaveBeenCalled();
 
-    FakeAudio.instances[0].dispatch("ended");
+    instances[0].dispatchEvent(new Event("ended"));
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+    expect(instances[0].isConnected).toBe(false);
   });
 
-  it("revokes the object URL when the media element errors", async () => {
+  it("revokes the object URL and detaches when the media element errors", async () => {
     await playAudioBlob(new Uint8Array([1, 2]), "audio/wav");
 
-    FakeAudio.instances[0].dispatch("error");
+    instances[0].dispatchEvent(new Event("error"));
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+    expect(instances[0].isConnected).toBe(false);
   });
 });

--- a/web/src/lib/audio.ts
+++ b/web/src/lib/audio.ts
@@ -1,20 +1,29 @@
 // Browser audio playback for the Preview-voice affordance (#70). The VoiceService
 // PreviewVoice RPC returns a self-contained WAV blob; this wraps it in an object
-// URL and plays it through a transient <audio> element, revoking the URL when
-// playback ends. It is defensively no-op outside a real browser (e.g. jsdom under
-// test, where URL.createObjectURL is unimplemented) so callers can fire-and-forget.
-export function playAudioBlob(audio: Uint8Array, mimeType: string): HTMLAudioElement | null {
+// URL and plays it through a transient <audio> element. The URL is revoked when
+// playback ends, when the media element errors, or when play() rejects (e.g. an
+// autoplay-policy block) — otherwise a failed preview leaks the blob for the
+// document lifetime (#154). The play() rejection is surfaced to the caller so a
+// blocked preview is distinguishable from silence. It is defensively no-op
+// outside a real browser (e.g. jsdom under test, where URL.createObjectURL is
+// unimplemented) so callers can fire-and-forget.
+export function playAudioBlob(audio: Uint8Array, mimeType: string): Promise<void> {
+  let url: string;
+  let el: HTMLAudioElement;
   try {
     if (typeof Audio === "undefined" || typeof URL?.createObjectURL !== "function") {
-      return null;
+      return Promise.resolve();
     }
     const blob = new Blob([audio as BlobPart], { type: mimeType || "audio/wav" });
-    const url = URL.createObjectURL(blob);
-    const el = new Audio(url);
-    el.addEventListener("ended", () => URL.revokeObjectURL(url));
-    void el.play();
-    return el;
+    url = URL.createObjectURL(blob);
+    el = new Audio(url);
+    el.addEventListener("ended", () => URL.revokeObjectURL(url), { once: true });
+    el.addEventListener("error", () => URL.revokeObjectURL(url), { once: true });
   } catch {
-    return null;
+    return Promise.resolve();
   }
+  return Promise.resolve(el.play()).catch((err: unknown) => {
+    URL.revokeObjectURL(url);
+    throw err;
+  });
 }

--- a/web/src/lib/audio.ts
+++ b/web/src/lib/audio.ts
@@ -2,16 +2,17 @@
 // PreviewVoice RPC returns a self-contained WAV blob; this wraps it in an object
 // URL and plays it through a transient <audio> element.
 //
-// The element is appended to the document (hidden) for the playback duration:
-// Chrome interrupts detached media elements and rejects play() with "The play()
-// request was interrupted because the media was removed from the document", so
-// a bare `new Audio(url)` never audibly plays (#154). Element and object URL are
-// both released when playback ends, when the media element errors, or when
-// play() rejects (e.g. an autoplay-policy block) — otherwise a failed preview
-// leaks the blob for the document lifetime. The play() rejection is surfaced to
-// the caller so a blocked preview is distinguishable from silence. It is
-// defensively no-op outside a real browser (e.g. jsdom under test, where
-// URL.createObjectURL is unimplemented) so callers can fire-and-forget.
+// Lifecycle hardening (#154): the element is appended to the document (hidden)
+// until playback finishes, pinning a strong reference so nothing — GC pressure
+// or page tooling that manipulates detached media — can interrupt it with "The
+// play() request was interrupted because the media was removed from the
+// document". Element and object URL are both released when playback ends, when
+// the media element errors, or when play() rejects (e.g. an autoplay-policy
+// block) — otherwise a failed preview leaks the blob for the document lifetime.
+// The play() rejection is surfaced to the caller so a blocked preview is
+// distinguishable from silence. It is defensively no-op outside a real browser
+// (e.g. jsdom under test, where URL.createObjectURL is unimplemented) so
+// callers can fire-and-forget.
 export function playAudioBlob(audio: Uint8Array, mimeType: string): Promise<void> {
   let el: HTMLAudioElement;
   let cleanup: () => void;

--- a/web/src/lib/audio.ts
+++ b/web/src/lib/audio.ts
@@ -1,29 +1,43 @@
 // Browser audio playback for the Preview-voice affordance (#70). The VoiceService
 // PreviewVoice RPC returns a self-contained WAV blob; this wraps it in an object
-// URL and plays it through a transient <audio> element. The URL is revoked when
-// playback ends, when the media element errors, or when play() rejects (e.g. an
-// autoplay-policy block) — otherwise a failed preview leaks the blob for the
-// document lifetime (#154). The play() rejection is surfaced to the caller so a
-// blocked preview is distinguishable from silence. It is defensively no-op
-// outside a real browser (e.g. jsdom under test, where URL.createObjectURL is
-// unimplemented) so callers can fire-and-forget.
+// URL and plays it through a transient <audio> element.
+//
+// The element is appended to the document (hidden) for the playback duration:
+// Chrome interrupts detached media elements and rejects play() with "The play()
+// request was interrupted because the media was removed from the document", so
+// a bare `new Audio(url)` never audibly plays (#154). Element and object URL are
+// both released when playback ends, when the media element errors, or when
+// play() rejects (e.g. an autoplay-policy block) — otherwise a failed preview
+// leaks the blob for the document lifetime. The play() rejection is surfaced to
+// the caller so a blocked preview is distinguishable from silence. It is
+// defensively no-op outside a real browser (e.g. jsdom under test, where
+// URL.createObjectURL is unimplemented) so callers can fire-and-forget.
 export function playAudioBlob(audio: Uint8Array, mimeType: string): Promise<void> {
-  let url: string;
   let el: HTMLAudioElement;
+  let cleanup: () => void;
   try {
     if (typeof Audio === "undefined" || typeof URL?.createObjectURL !== "function") {
       return Promise.resolve();
     }
     const blob = new Blob([audio as BlobPart], { type: mimeType || "audio/wav" });
-    url = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(blob);
     el = new Audio(url);
-    el.addEventListener("ended", () => URL.revokeObjectURL(url), { once: true });
-    el.addEventListener("error", () => URL.revokeObjectURL(url), { once: true });
+    let done = false;
+    cleanup = () => {
+      if (done) return;
+      done = true;
+      URL.revokeObjectURL(url);
+      el.remove();
+    };
+    el.addEventListener("ended", cleanup, { once: true });
+    el.addEventListener("error", cleanup, { once: true });
+    el.style.display = "none";
+    document.body.appendChild(el);
   } catch {
     return Promise.resolve();
   }
   return Promise.resolve(el.play()).catch((err: unknown) => {
-    URL.revokeObjectURL(url);
+    cleanup();
     throw err;
   });
 }

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -258,6 +258,32 @@ describe("Campaign", () => {
     expect(await screen.findByText("ElevenLabs · Rachel")).toBeInTheDocument();
   });
 
+  it("surfaces an error cue when the voice preview fails", async () => {
+    // A degraded TTS (PreviewVoice rejects) must render, not just stop the spinner.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, {
+        listVoices: () => create(ListVoicesResponseSchema, { voices: [] }),
+        previewVoice: () => {
+          throw new Error("tts unavailable");
+        },
+      });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    fireEvent.click(screen.getByRole("button", { name: /preview voice/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't preview/i);
+  });
+
   it("previews the selected voice via the PreviewVoice RPC", async () => {
     const { previewCalls } = renderScreen();
     fireEvent.click(await screen.findByText("Bart"));

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -228,10 +228,19 @@ function AgentEditor({
     return opts;
   }, [voices, voice]);
 
+  // Preview failures — a degraded-TTS RPC rejection or a blocked/failed
+  // play() — render an inline cue instead of vanishing (#154, mirrors the
+  // save status treatment from #94).
+  const [previewError, setPreviewError] = useState<string | null>(null);
   const playPreview = async () => {
     if (!voice) return;
-    const res = await preview.mutateAsync({ voiceId: voice, text: "" });
-    playAudioBlob(res.audio, res.mimeType);
+    setPreviewError(null);
+    try {
+      const res = await preview.mutateAsync({ voiceId: voice, text: "" });
+      await playAudioBlob(res.audio, res.mimeType);
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : String(err));
+    }
   };
 
   const save = () =>
@@ -304,6 +313,11 @@ function AgentEditor({
         >
           Preview voice
         </Button>
+        {previewError && (
+          <span className="gx-editor__status gx-editor__status--error" role="alert">
+            Couldn't preview: {previewError}
+          </span>
+        )}
       </div>
 
       <div className="gx-editor__switch">

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -211,11 +211,13 @@
   color: var(--status-danger);
 }
 
-/* Voice select + Preview-voice button row (#70). */
+/* Voice select + Preview-voice button row (#70). Wraps so the inline preview
+ * failure cue (#154) can spill to its own line. */
 .gx-editor__voice {
   display: flex;
   align-items: flex-end;
   gap: var(--spacing-sm);
+  flex-wrap: wrap;
 }
 
 .gx-editor__voice .gx-select-field {

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -210,6 +210,46 @@ describe("Configuration", () => {
     expect(within(groqRow).getByText(/key needed/i)).toBeInTheDocument();
   });
 
+  it("clears the save error when the Replace edit is cancelled", async () => {
+    // Replace on a SAVED key → failing save → Cancel returns the row to the
+    // masked+Healthy state; a stale "Couldn't save" alert must not linger there.
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, {
+        getProviderHealth: () => create(GetProviderHealthResponseSchema, { providers: [] }),
+        listModels: () => create(ListModelsResponseSchema, { models: GROQ_MODELS }),
+      });
+      service(CampaignService, {
+        getActiveCampaign: () =>
+          create(GetActiveCampaignResponseSchema, { campaign: create(CampaignSchema, CAMPAIGN) }),
+      });
+      service(ProviderService, {
+        listProviderConfigs: () =>
+          create(ListProviderConfigsResponseSchema, {
+            credentials: [cred("discord", "discord"), cred("llm", "groq", "eeee"), cred("tts", "elevenlabs")],
+          }),
+        saveProviderConfig: () => {
+          throw new Error("secret sealing unavailable");
+        },
+      });
+    });
+    renderScreen(transport);
+
+    // The Groq key is saved → masked with a Replace affordance.
+    const mask = await screen.findByLabelText("Groq saved");
+    const groqRow = mask.closest(".gx-provider-row") as HTMLElement;
+    fireEvent.click(within(groqRow).getByRole("button", { name: /replace/i }));
+
+    // Replacement attempt fails → alert renders.
+    fireEvent.change(within(groqRow).getByLabelText("Groq key"), { target: { value: "sk-new" } });
+    fireEvent.click(within(groqRow).getByRole("button", { name: "Save" }));
+    expect(await within(groqRow).findByRole("alert")).toHaveTextContent(/couldn't save/i);
+
+    // Cancel returns to the masked view — the stale alert goes with it.
+    fireEvent.click(within(groqRow).getByRole("button", { name: /cancel/i }));
+    expect(within(groqRow).getByLabelText("Groq saved")).toBeInTheDocument();
+    expect(within(groqRow).queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("persists Guild ID and Voice channel ID", async () => {
     renderScreen();
 

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -146,6 +146,45 @@ describe("Configuration", () => {
     expect(screen.queryByText(/test-groq-secret-eeee/)).not.toBeInTheDocument();
   });
 
+  it("renders an error in the row when saving a provider key fails", async () => {
+    // A backend whose Save rejects (e.g. FailedPrecondition when the sealing
+    // secret is unset) must leave visible evidence, not just un-busy the button.
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, {
+        getProviderHealth: () => create(GetProviderHealthResponseSchema, { providers: [] }),
+        listModels: () => create(ListModelsResponseSchema, { models: GROQ_MODELS }),
+      });
+      service(CampaignService, {
+        getActiveCampaign: () =>
+          create(GetActiveCampaignResponseSchema, { campaign: create(CampaignSchema, CAMPAIGN) }),
+      });
+      service(ProviderService, {
+        listProviderConfigs: () =>
+          create(ListProviderConfigsResponseSchema, {
+            credentials: [cred("discord", "discord"), cred("llm", "groq"), cred("tts", "elevenlabs")],
+            guildId: "",
+            voiceChannelId: "",
+          }),
+        saveProviderConfig: () => {
+          throw new Error("secret sealing unavailable");
+        },
+      });
+    });
+    renderScreen(transport);
+
+    const groqInput = await screen.findByLabelText("Groq key");
+    fireEvent.change(groqInput, { target: { value: "sk-will-fail" } });
+    const groqRow = groqInput.closest(".gx-provider-row") as HTMLElement;
+    fireEvent.click(within(groqRow).getByRole("button", { name: "Save" }));
+
+    // The failure renders in the row…
+    const alert = await within(groqRow).findByRole("alert");
+    expect(alert).toHaveTextContent(/couldn't save/i);
+    // …and the key field stays editable for a retry, badge still unsaved.
+    expect(within(groqRow).getByLabelText("Groq key")).toBeInTheDocument();
+    expect(within(groqRow).getByText(/key needed/i)).toBeInTheDocument();
+  });
+
   it("persists Guild ID and Voice channel ID", async () => {
     renderScreen();
 

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -334,6 +334,7 @@ function SecretRow({
                 onClick={() => {
                   setEditing(true);
                   setValue("");
+                  setSaveError(null); // fresh edit starts without a stale cue
                 }}
               >
                 Replace
@@ -358,6 +359,9 @@ function SecretRow({
                   onClick={() => {
                     setEditing(false);
                     setValue("");
+                    // Back to masked+Healthy — a stale "Couldn't save" alert
+                    // would contradict that state (#154).
+                    setSaveError(null);
                   }}
                 >
                   Cancel

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -258,6 +258,7 @@ function SecretRow({
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState("");
   const [busy, setBusy] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [model, setModel] = useState<string | undefined>(undefined);
 
   const saved = Boolean(credential?.showMasked);
@@ -269,10 +270,15 @@ function SecretRow({
   async function handleSave() {
     if (!value || busy) return;
     setBusy(true);
+    setSaveError(null);
     try {
       await onSave(value, selectedModel);
       setValue("");
       setEditing(false);
+    } catch (err) {
+      // A rejected save (e.g. FailedPrecondition when the sealing secret is
+      // unset) must leave visible evidence — the key was NOT stored (#154).
+      setSaveError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
     }
@@ -343,6 +349,12 @@ function SecretRow({
                 </Button>
               )}
             </div>
+          )}
+          {/* Inline failure cue, mirroring the agent editor's save status (#94). */}
+          {saveError && (
+            <span className="gx-secret__error" role="alert">
+              Couldn't save: {saveError}
+            </span>
           )}
         </div>
 

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -26,6 +26,16 @@
   margin: 0;
 }
 
+/* Inline save-failure cue under the key field, mirroring the agent editor's
+ * status treatment (#94 / #154). */
+.gx-secret__error {
+  display: block;
+  margin-top: var(--spacing-xs);
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--status-danger);
+}
+
 .gx-secret__mask {
   letter-spacing: 0.18em;
   color: var(--text-subtle);


### PR DESCRIPTION
Four small frontend fixes in the Configuration/Campaign screens, one TDD cycle each (test red pre-fix, then the fix).

## 1. Voice picker keyed cmdk identity by the human label
Two ElevenLabs voices named "Rachel" were one cmdk identity: Enter dispatched the first match's `voiceId` regardless of which the operator arrowed to — wrong data persisted.
**Fix:** `Command.Item` uses `value={o.value}` (unique voice id) + `keywords={[o.label]}` so typeahead still filters on the visible name.
**Test (red pre-fix):** two options with identical labels, distinct values — ArrowDown+Enter on the second dispatched the *first's* value (`Combobox.test.tsx`).

## 2. Swallowed errors rendered (mirrors #94's agent-editor treatment)
- SecretRow's `handleSave` awaited in try/`finally` with no catch: a rejected `SaveProviderConfig` un-busied the button with zero evidence the key was never stored. Now catches and renders an inline `role=alert` cue in the row; field stays editable for retry.
- Campaign's preview was fired as `void playPreview()`: a degraded-TTS rejection just stopped the spinner. Now catches (RPC rejection *and* failed `play()`) into an inline `role=alert` cue beside the Preview button.
**Tests (red pre-fix):** failing Groq save rendered no alert (`Configuration.test.tsx`); rejecting PreviewVoice rendered no alert (`Campaign.test.tsx`) — both escaped as unhandled rejections.

## 3. Preview object-URL leak
`playAudioBlob` revoked its object URL only on `ended`; no `error` listener, and the `play()` rejection was discarded — a blocked/failed preview leaked the WAV blob for the document lifetime and looked like silent success.
**Fix:** revoke on `error` and on `play()` rejection too; return the `play()` promise so callers can surface the failure.
**Tests:** new `audio.test.ts` — failure rejects *and* revokes (red pre-fix: unhandled rejection, URL never revoked); success still revokes on `ended`; media `error` revokes.

## 4. Stale combobox search after dismissal
Escape/outside-click kept the old query, so the next open showed a pre-filtered (possibly empty) list.
**Fix:** the close effect clears the search on any `open`→false transition (pick's own reset became redundant and was removed).
**Test (red pre-fix):** dismiss with Escape after typing, reopen → list still filtered.

**Out of scope:** the token-save clobber (#142, separate PR); any visual redesign.

## Review/validation addenda

- **Label-only typeahead** (`bdac60d`): keying items by the unique voice id had put the opaque id into cmdk's default filter haystack (an id subsequence like "wam" matched "Rachel"). A custom `filter` on the Command root scores the label (`keywords`) alone; the id stays pure identity.
- **Audio element lifecycle hardening** (`7d2d1cb`, reframed in `f5eb716`): the preview `<audio>` is now appended hidden to the document until playback finishes and removed wherever the URL is revoked (ended/error/play() rejection). Live-validation initially attributed a "media was removed from the document" play() interruption to this; deeper instrumentation showed that error was induced by the browser-automation extension, not the app — the change stays as a defensive attached-until-ended contract, pinned by jsdom lifecycle tests, not as a bug fix.
- **SecretRow Cancel clears the error cue** (`f5eb716`): Replace → failing Save → Cancel previously returned the row to masked+Healthy while the stale "Couldn't save" alert kept rendering; Cancel and Replace now reset it (red pre-fix test).
- Merged `origin/main` (incl. #173's Configuration.tsx changes); regenerated proto stubs.

Local gates: vitest 49/49, `tsc --noEmit` + vite build, `go build ./...`.

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
