### PR TITLE
fix(#144): a session that dies on its own becomes visible — terminal SSE idle frame + surfaced start/stop failures

### DIFF
--- a/internal/transcript/persist.go
+++ b/internal/transcript/persist.go
@@ -99,7 +99,15 @@ func (r *Relay) writeLoop() {
 // barrier rides the SAME queue as the line tees, so FIFO ordering guarantees every
 // line emitted before Finalize has been written when the count runs. Persistence
 // disabled (no store) returns 0.
+//
+// Finalize is also the relay's session-end signal (#144): the Manager calls it
+// at EVERY loop exit — Stop, self-exit (Discord outage, wirenpc error) and
+// Shutdown — so it pushes the terminal `status: idle` frame to the attached SSE
+// subscribers here, before the flush, independent of whether persistence is
+// enabled. Without it a self-terminated session leaves the open EventSource
+// silent and the screen "Live" forever.
 func (r *Relay) Finalize(ctx context.Context, id uuid.UUID) (int, error) {
+	r.endSession(id)
 	if r.writeCh == nil {
 		return 0, nil
 	}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -345,6 +345,23 @@ func (r *Relay) rollover(vs storage.VoiceSession) {
 	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "live", Typing: r.typing})})
 }
 
+// endSession emits the terminal `status: idle` frame when session id ends
+// (#144). Called from Finalize — the Manager's loop-exit hook — so attached SSE
+// subscribers learn the session died (self-exit included) instead of watching a
+// silent stream; the frame rides the ring too, so a reconnect replays it.
+func (r *Relay) endSession(id uuid.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id.String() != r.activeID {
+		// The relay never rolled over to this session (zero bus events) — there is
+		// no buffer to close, and emitting here would inject a spurious idle frame
+		// into the CURRENT session's stream.
+		return
+	}
+	r.typing = Typing{}
+	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "idle", Typing: Typing{}})})
+}
+
 // turn returns the coalescing state for a turn id, creating it on first sight.
 func (r *Relay) turn(id string) *turn {
 	t := r.turns[id]

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -1,6 +1,7 @@
 package transcript
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -320,6 +321,80 @@ func TestPublish_DoesNotBlockOnLaggedSubscriber(t *testing.T) {
 	case <-s.lagged:
 	case <-time.After(time.Second):
 		t.Fatal("a lagged subscriber was never signalled")
+	}
+}
+
+// TestFinalize_DeliversTerminalIdleFrame is issue #144: when the active session
+// ends (the Manager calls Finalize at every loop exit — Stop, self-exit,
+// Shutdown), an attached SSE subscriber receives a terminal `status: idle` frame
+// on the existing channel, and the frame lands in the ring so a reconnect
+// replays it. Without it the open EventSource just goes quiet and the screen
+// shows "Live" forever.
+func TestFinalize_DeliversTerminalIdleFrame(t *testing.T) {
+	bus, r, fs, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hello", TurnID: "t1"})
+
+	s, _ := r.attach(id, 0)
+	defer r.detach(s)
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	select {
+	case f := <-s.ch:
+		if f.Event != "status" {
+			t.Fatalf("terminal frame event = %q, want status", f.Event)
+		}
+		var st status
+		if err := json.Unmarshal(f.Data, &st); err != nil {
+			t.Fatalf("unmarshal terminal frame: %v", err)
+		}
+		if st.Status != "idle" || st.Typing.Active {
+			t.Fatalf("terminal frame = %+v, want idle with inactive typing", st)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no terminal frame delivered to the attached subscriber after Finalize")
+	}
+
+	// The frame is buffered too, so a reconnecting EventSource replays it.
+	frames := r.Frames(id, 0)
+	last := frames[len(frames)-1]
+	if last.Event != "status" || !json.Valid(last.Data) {
+		t.Fatalf("ring's last frame = %+v, want the terminal status frame", last)
+	}
+	var st status
+	if err := json.Unmarshal(last.Data, &st); err != nil {
+		t.Fatalf("unmarshal buffered terminal frame: %v", err)
+	}
+	if st.Status != "idle" {
+		t.Fatalf("buffered terminal frame status = %q, want idle", st.Status)
+	}
+}
+
+// TestFinalize_OtherSessionDoesNotPolluteBuffer (#144): a Finalize for a session
+// the relay never rolled over to (e.g. a session that produced zero bus events)
+// must NOT inject an idle frame into the CURRENT session's buffer — its
+// subscribers would see their live session spuriously flip idle.
+func TestFinalize_OtherSessionDoesNotPolluteBuffer(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hello", TurnID: "t1"})
+
+	s, _ := r.attach(id, 0)
+	defer r.detach(s)
+	before := len(r.Frames(id, 0))
+
+	if _, err := r.Finalize(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	select {
+	case f := <-s.ch:
+		t.Fatalf("live subscriber received a frame for another session's end: %+v", f)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := len(r.Frames(id, 0)); got != before {
+		t.Fatalf("buffer grew from %d to %d frames on another session's Finalize", before, got)
 	}
 }
 

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1,8 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import { createRouterTransport } from "@connectrpc/connect";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { toast } from "sonner";
+
+// The screen surfaces mutation failures as toasts (ADR-0017: sonner). Mock the
+// module so the tests assert the surface without the portal DOM.
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}));
 
 import {
   SessionService,
@@ -17,7 +25,7 @@ import {
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { MockEventSource } from "@/test/mockEventSource";
-import { Session, formatElapsed } from "./Session";
+import { Session, formatElapsed, sessionRefetchInterval, SESSION_REFETCH_MS } from "./Session";
 
 // An in-memory voice-session store served over a router transport (no network):
 // active/current/last mutate in this closure so Start → invalidate → refetch
@@ -82,6 +90,21 @@ describe("formatElapsed", () => {
     expect(formatElapsed(65)).toBe("00:01:05");
     expect(formatElapsed(3661)).toBe("01:01:01");
     expect(formatElapsed(-5)).toBe("00:00:00");
+  });
+});
+
+describe("sessionRefetchInterval (#144)", () => {
+  const query = (data?: { active: boolean }) => ({ state: { data } });
+
+  it("polls on a modest interval while a session is active", () => {
+    expect(sessionRefetchInterval(query({ active: true }))).toBe(SESSION_REFETCH_MS);
+    expect(SESSION_REFETCH_MS).toBeGreaterThanOrEqual(1000);
+    expect(SESSION_REFETCH_MS).toBeLessThanOrEqual(15000);
+  });
+
+  it("does not poll while idle or before the first read", () => {
+    expect(sessionRefetchInterval(query({ active: false }))).toBe(false);
+    expect(sessionRefetchInterval(query(undefined))).toBe(false);
   });
 });
 
@@ -197,6 +220,100 @@ describe("Session reload of an ended session (#74)", () => {
 
     // No live stream is opened for an ended session.
     expect(MockEventSource.last()).toBeUndefined();
+  });
+});
+
+// deadSessionTransport models issue #144's failure scenario: the loop died
+// server-side but the client's cached getSession still says active. Stop then
+// fails FailedPrecondition (no active session); the NEXT getSession returns the
+// ended truth. getSession calls are counted so invalidation is observable.
+function deadSessionTransport() {
+  const started = new Date(Date.now() - 90 * 60 * 1000);
+  const live = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "running",
+    startedAt: timestampFromDate(started),
+  });
+  const ended = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "ended",
+    startedAt: timestampFromDate(started),
+    endedAt: timestampFromDate(new Date()),
+    lineCount: 12,
+  });
+  let gets = 0;
+  const transport = createRouterTransport(({ service }) => {
+    service(SessionService, {
+      // First read: the stale "active" the screen cached; later reads: the truth.
+      getSession: () =>
+        create(GetSessionResponseSchema, gets++ === 0 ? { session: live, active: true } : { session: ended, active: false }),
+      startSession: () => {
+        throw new ConnectError("session: Discord guild/channel not configured", Code.FailedPrecondition);
+      },
+      stopSession: () => {
+        throw new ConnectError("session: no active voice session", Code.FailedPrecondition);
+      },
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+  return { transport, getSessionCalls: () => gets };
+}
+
+describe("Session mutation failures (#144)", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear();
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ lines: [], status: "live", typing: { active: true, label: "Listening to the table…" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+  });
+
+  it("a failing Stop surfaces the error and re-syncs the badge off Live", async () => {
+    const { transport } = deadSessionTransport();
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    // The stale cache says Live.
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+
+    // Stop hits ErrNoActiveSession (FailedPrecondition): the error surfaces and
+    // the invalidated query refetches the ended truth — the badge leaves Live.
+    fireEvent.click(screen.getByRole("button", { name: /stop session/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(String(vi.mocked(toast.error).mock.calls[0][0])).toMatch(/no active voice session/i);
+    expect(await screen.findByText("Idle")).toBeInTheDocument();
+  });
+
+  it("a failing Start surfaces the error and invalidates the session query", async () => {
+    const { transport, getSessionCalls } = deadSessionTransport();
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+
+    // Force the idle screen (second getSession read returns ended), then Start.
+    fireEvent.click(screen.getByRole("button", { name: /stop session/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /start session/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(toast.error).mock.calls.some(([m]) => /not configured/i.test(String(m)))).toBe(true),
+    );
+    // onError invalidated the session query: another getSession read happened
+    // after the failing Start (reads 1: mount, 2: post-Stop; >=3: post-Start).
+    await waitFor(() => expect(getSessionCalls()).toBeGreaterThanOrEqual(3));
   });
 });
 

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { Play, Square } from "lucide-react";
+import { toast } from "sonner";
 import { timestampMs } from "@bufbuild/protobuf/wkt";
 
 import { SessionService, CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
@@ -27,6 +28,18 @@ export function formatElapsed(totalSeconds: number): string {
   return [Math.floor(s / 3600), Math.floor((s % 3600) / 60), s % 60]
     .map((n) => String(n).padStart(2, "0"))
     .join(":");
+}
+
+// SESSION_REFETCH_MS is the getSession poll cadence while a session is live —
+// belt and suspenders for #144: even if the SSE terminal frame is missed, a
+// session that dies server-side flips the badge within one interval.
+export const SESSION_REFETCH_MS = 5000;
+
+// sessionRefetchInterval is the getSession refetchInterval policy: poll while
+// the last read said active, stop polling when idle. Exported so the config is
+// pinned by a unit test.
+export function sessionRefetchInterval(query: { state: { data?: { active?: boolean } } }): number | false {
+  return query.state.data?.active ? SESSION_REFETCH_MS : false;
 }
 
 // tsMs converts a protobuf Timestamp to epoch milliseconds, or null when unset.
@@ -71,7 +84,7 @@ function lastSummary(session: VoiceSession): string {
 
 export function Session() {
   const queryClient = useQueryClient();
-  const { data } = useQuery(SessionService.method.getSession, {});
+  const { data } = useQuery(SessionService.method.getSession, {}, { refetchInterval: sessionRefetchInterval });
   const campaignQ = useQuery(CampaignService.method.getActiveCampaign, {});
   const campaignName = campaignQ.data?.campaign?.name;
 
@@ -86,8 +99,21 @@ export function Session() {
       }),
     });
 
-  const start = useMutation(SessionService.method.startSession, { onSuccess: () => void invalidate() });
-  const stop = useMutation(SessionService.method.stopSession, { onSuccess: () => void invalidate() });
+  // A failing Start/Stop must not be swallowed (#144): surface it (ADR-0017:
+  // sonner) and invalidate — a Stop that hits "no active session" means the
+  // loop already died server-side, and the refetch snaps the badge off Live.
+  const onError = (verb: string) => (err: Error) => {
+    toast.error(`Couldn't ${verb} the session: ${err.message}`);
+    void invalidate();
+  };
+  const start = useMutation(SessionService.method.startSession, {
+    onSuccess: () => void invalidate(),
+    onError: onError("start"),
+  });
+  const stop = useMutation(SessionService.method.stopSession, {
+    onSuccess: () => void invalidate(),
+    onError: onError("stop"),
+  });
 
   // The timer runs only while live, counting up from the running session's start.
   const elapsed = useElapsed(active ? tsMs(session?.startedAt) : null);


### PR DESCRIPTION
## What does this PR do?

Closes #144.

**Defect:** server-side self-termination of the voice loop (Discord outage, wirenpc error) was observable nowhere in the client: once the manager went idle the relay's `project()` dropped every event and nothing else pushed to subscribers — the open EventSource just went quiet, `getSession` was fetched once with no refetch interval, and the start/stop mutations had `onSuccess` only. The operator kept a pulsing "Live" badge forever and a failing Stop (`ErrNoActiveSession` → FailedPrecondition) rendered nowhere.

**Fix:**

- **Relay (Go):** when the active session ends, attached SSE subscribers receive a terminal `status: idle` frame on the existing channel, and the frame lands in the ring so a Last-Event-ID reconnect replays it.
  - *How the relay learns the session ended:* no new signal was invented. The Manager already calls `Relay.Finalize` at **every** loop exit — Stop, self-exit, and Shutdown — before `EndVoiceSession` (`internal/session/manager.go` `runLoop`). That is a push from exactly where the session-end is already known, so the idle frame is emitted there: no interface widening, no manager change, no polling, and it works whether or not persistence is enabled. A Finalize for a session the relay never rolled over to (zero bus events) emits nothing, so it can't pollute the current session's buffer.
- **Client:** the start/stop mutations get `onError` — the error surfaces as a toast (ADR-0017: sonner, same pattern as Campaign) and the session query is invalidated, so a Stop that hits "no active session" snaps the badge off Live.
- **Client:** `getSession` refetches on a modest 5s interval while the last read said `active` (`sessionRefetchInterval`, exported + pinned) — belt and suspenders if the terminal frame is missed.

Out of scope, untouched: #148's strict-prefix lag + write-deadline mechanics, #149's single-snapshot rollover, #154 UI polish.

## Why is this change needed?

Severity high — the operator's primary status view lied indefinitely and the only way out was a manual reload.

## How was this tested?

All new tests were red before their fix (strict TDD):

- `TestFinalize_DeliversTerminalIdleFrame` (Go, red pre-fix: "no terminal frame delivered to the attached subscriber after Finalize") — session ends server-side → attached subscriber receives the idle status frame, and it is replayable from the ring.
- `TestFinalize_OtherSessionDoesNotPolluteBuffer` (Go, red pre-guard) — a foreign-session Finalize emits nothing into the live buffer.
- Vitest "a failing Stop surfaces the error and re-syncs the badge off Live" (red pre-fix) — toast surfaced + invalidated refetch flips the badge to Idle.
- Vitest "a failing Start surfaces the error and invalidates the session query" (red pre-fix).
- Vitest `sessionRefetchInterval` config pin (red pre-fix): 5s while active, no polling while idle.

Existing relay/SSE suites (#148 lag/deadline hardening, #149 rollover, #74 persistence) all stay green.

- [x] `make check` passes (fmt, vet, full `go test ./...`)
- [x] `go test -race ./internal/transcript/... ./internal/session/...`
- [x] `golangci-lint run ./internal/transcript/...` — 0 issues
- [x] web: `vitest run` 38 tests green, `npm run build` (tsc + vite) green
- [x] New/updated tests cover the change
- [ ] Manual testing (not applicable — behavior pinned by tests)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed (doc comments on `Finalize`/`endSession`)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

The alternative signals considered for the relay: widening `TranscriptFinalizer` with a dedicated `SessionEnded` method (bigger diff, second call site in `runLoop` for the same instant), or a periodic Snapshot poll in the relay (rejected: polling where a push already exists). `Finalize` is invoked at the exact loop-exit instant on every path, so reusing it keeps the diff minimal; its doc comment now names the session-end role explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)