### PR TITLE
fix(#150): health probe — REST self-user check, concurrent probes, 60s server cache, active-session short-circuit

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -335,7 +335,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	// model allowlist, and the async provider-health signal — all via the
 	// decrypted tenant key (ADR-0004 credential bridge). Appended last so the
 	// existing mounts keep their order.
-	voicePath, voiceHandler := rpc.NewVoiceServer(store, cipher, log).Handler(stack.HandlerOptions()...)
+	voiceSrv := rpc.NewVoiceServer(store, cipher, log)
+	// While a session is live, the Discord health check short-circuits to
+	// healthy off the manager's Snapshot instead of touching Discord (#150).
+	voiceSrv.SetSessions(mgr)
+	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)
 
 	return []web.Mount{

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -329,16 +329,21 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 
 	campaignPath, campaignHandler := rpc.NewCampaignServer(store).Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
-	providerPath, providerHandler := rpc.NewProviderServer(store, cipher, log).Handler(stack.HandlerOptions()...)
 	// VoiceService (#70) serves the live provider data the Configuration +
 	// Campaign screens render — the ElevenLabs voice catalog + preview, the Groq
 	// model allowlist, and the async provider-health signal — all via the
-	// decrypted tenant key (ADR-0004 credential bridge). Appended last so the
-	// existing mounts keep their order.
+	// decrypted tenant key (ADR-0004 credential bridge). Its mount stays
+	// appended after provider's so the existing mount order is kept.
 	voiceSrv := rpc.NewVoiceServer(store, cipher, log)
 	// While a session is live, the Discord health check short-circuits to
 	// healthy off the manager's Snapshot instead of touching Discord (#150).
 	voiceSrv.SetSessions(mgr)
+	providerSrv := rpc.NewProviderServer(store, cipher, log)
+	// Saving a credential busts the tenant's cached health verdict so the next
+	// health call probes with the new key instead of serving a stale Degraded
+	// badge for up to the cache TTL (#150).
+	providerSrv.SetHealthInvalidator(voiceSrv.InvalidateHealth)
+	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)
 

--- a/internal/discordtag/discordtag.go
+++ b/internal/discordtag/discordtag.go
@@ -8,6 +8,10 @@
 // session's token could delay its reconnect and burn its budget; the REST read
 // costs neither.
 //
+// The call is a plain net/http GET, deliberately NOT disgo's rest.NewClient:
+// that client's rate limiter starts a cleanup goroutine (`for range ticker.C`)
+// its Close never stops, leaking one goroutine + ticker per probe.
+//
 // This is a LIVE network call. The RPC layer hides it behind a seam so unit
 // tests fake the resolver and never touch the network; [Resolve] against the
 // real API is exercised only by an operator run. Offline tests drive the
@@ -16,13 +20,23 @@ package discordtag
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"time"
 
 	"github.com/disgoorg/disgo/discord"
-	"github.com/disgoorg/disgo/rest"
 )
+
+// liveAPIBaseURL is Discord's REST API root, matching the version disgo pins.
+const liveAPIBaseURL = "https://discord.com/api/v10"
+
+// selfUserClient is shared across probes (http.Client is safe for concurrent
+// use); its Timeout is a belt on top of the caller's ctx deadline so a resolver
+// invoked without one still cannot hang.
+var selfUserClient = &http.Client{Timeout: 15 * time.Second}
 
 // Resolve reads the bot user via REST `GET /users/@me` with token and returns
 // its tag ("Username#Discriminator", or the bare username under Discord's new
@@ -44,19 +58,32 @@ func resolve(ctx context.Context, token, baseURL string, log *slog.Logger) (stri
 	if log == nil {
 		log = slog.Default()
 	}
-
-	opts := []rest.ClientConfigOpt{rest.WithLogger(log)}
-	if baseURL != "" {
-		opts = append(opts, rest.WithURL(baseURL))
+	if baseURL == "" {
+		baseURL = liveAPIBaseURL
 	}
-	client := rest.NewClient(token, opts...)
-	// Close on a fresh ctx so teardown still runs when the caller's ctx has
-	// already expired.
-	defer client.Close(context.WithoutCancel(ctx))
 
-	var user discord.OAuth2User
-	if err := client.Do(rest.GetCurrentUser.Compile(nil), nil, &user, rest.WithCtx(ctx)); err != nil {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/users/@me", nil)
+	if err != nil {
+		return "", fmt.Errorf("discordtag: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+token)
+	// Discord requires bots to identify with the DiscordBot User-Agent form.
+	req.Header.Set("User-Agent", "DiscordBot (https://github.com/MrWong99/Glyphoxa_v2, v2)")
+
+	resp, err := selfUserClient.Do(req)
+	if err != nil {
 		return "", fmt.Errorf("discordtag: GET /users/@me: %w", err)
 	}
-	return user.Tag(), nil
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("discordtag: GET /users/@me: HTTP %d", resp.StatusCode)
+	}
+
+	var user discord.OAuth2User
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return "", fmt.Errorf("discordtag: decode self user: %w", err)
+	}
+	tag := user.Tag()
+	log.Debug("resolved Discord bot tag via REST", "tag", tag)
+	return tag, nil
 }

--- a/internal/discordtag/discordtag.go
+++ b/internal/discordtag/discordtag.go
@@ -1,14 +1,17 @@
 // Package discordtag resolves a Discord bot's live tag (e.g. "Glyphoxa#4823")
-// by performing a SHORT-LIVED gateway login with a bot token and reading the
-// bot user off the gateway Ready event (#70). It is the real signal behind the
-// Configuration screen's Discord health badge: unlike a token-presence check, a
-// successful gateway login proves the token can actually identify with Discord.
+// by calling the REST `GET /users/@me` endpoint with the bot token (#70, #150).
+// It is the real signal behind the Configuration screen's Discord health badge:
+// unlike a token-presence check, a successful self-user read proves the token
+// authenticates with Discord — WITHOUT a gateway IDENTIFY. A gateway login
+// (the pre-#150 implementation) is serialized per token (~1 per 5s) and counts
+// toward Discord's daily session-start cap, so a health probe sharing the live
+// session's token could delay its reconnect and burn its budget; the REST read
+// costs neither.
 //
 // This is a LIVE network call. The RPC layer hides it behind a seam so unit
-// tests fake the resolver and never touch the network; [Resolve] itself is
-// exercised only under an integration/live build or a real operator run. The
-// only offline-safe path is the empty-token guard, which fails fast before any
-// dial.
+// tests fake the resolver and never touch the network; [Resolve] against the
+// real API is exercised only by an operator run. Offline tests drive the
+// package-private base-URL seam at a fake HTTP server.
 package discordtag
 
 import (
@@ -17,20 +20,24 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/disgoorg/disgo"
-	"github.com/disgoorg/disgo/bot"
-	"github.com/disgoorg/disgo/events"
-	"github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/rest"
 )
 
-// Resolve opens a short-lived Discord gateway session with token, waits for the
-// Ready event, and returns the bot user's tag ("Username#Discriminator", or the
-// bare username under Discord's new handle system). The session is always closed
-// before return.
+// Resolve reads the bot user via REST `GET /users/@me` with token and returns
+// its tag ("Username#Discriminator", or the bare username under Discord's new
+// handle system). No gateway connection is opened and no IDENTIFY happens.
 //
-// An empty token fails fast (no dial). A ctx deadline bounds the login: a hung
-// or unreachable gateway returns ctx.Err() rather than blocking. log may be nil.
+// An empty token fails fast (no dial). A ctx deadline bounds the call: a hung
+// or unreachable endpoint returns ctx.Err() rather than blocking. log may be
+// nil.
 func Resolve(ctx context.Context, token string, log *slog.Logger) (string, error) {
+	return resolve(ctx, token, "", log)
+}
+
+// resolve is Resolve with a base-URL seam: "" means the live Discord API,
+// tests point it at a fake HTTP server.
+func resolve(ctx context.Context, token, baseURL string, log *slog.Logger) (string, error) {
 	if token == "" {
 		return "", errors.New("discordtag: empty bot token")
 	}
@@ -38,38 +45,18 @@ func Resolve(ctx context.Context, token string, log *slog.Logger) (string, error
 		log = slog.Default()
 	}
 
-	// A buffered channel so the Ready listener never blocks even if Resolve has
-	// already returned on a ctx deadline.
-	tagCh := make(chan string, 1)
-
-	client, err := disgo.New(token,
-		bot.WithLogger(log),
-		bot.WithDefaultGateway(),
-		// Guilds is the minimal intent; Ready (and its bot user) is delivered on
-		// identify regardless, so this keeps the login cheap.
-		bot.WithGatewayConfigOpts(gateway.WithIntents(gateway.IntentGuilds)),
-		bot.WithEventListenerFunc(func(e *events.Ready) {
-			select {
-			case tagCh <- e.User.Tag():
-			default:
-			}
-		}),
-	)
-	if err != nil {
-		return "", fmt.Errorf("discordtag: build client: %w", err)
+	opts := []rest.ClientConfigOpt{rest.WithLogger(log)}
+	if baseURL != "" {
+		opts = append(opts, rest.WithURL(baseURL))
 	}
-	// Close the gateway on every exit path; a fresh ctx so teardown still runs
-	// when the caller's ctx has already expired.
-	defer client.Close(context.Background())
+	client := rest.NewClient(token, opts...)
+	// Close on a fresh ctx so teardown still runs when the caller's ctx has
+	// already expired.
+	defer client.Close(context.WithoutCancel(ctx))
 
-	if err := client.OpenGateway(ctx); err != nil {
-		return "", fmt.Errorf("discordtag: open gateway: %w", err)
+	var user discord.OAuth2User
+	if err := client.Do(rest.GetCurrentUser.Compile(nil), nil, &user, rest.WithCtx(ctx)); err != nil {
+		return "", fmt.Errorf("discordtag: GET /users/@me: %w", err)
 	}
-
-	select {
-	case tag := <-tagCh:
-		return tag, nil
-	case <-ctx.Done():
-		return "", fmt.Errorf("discordtag: timed out before Ready: %w", ctx.Err())
-	}
+	return user.Tag(), nil
 }

--- a/internal/discordtag/discordtag_test.go
+++ b/internal/discordtag/discordtag_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/discordtag"
 )
 
-// TestResolve_EmptyToken_FailsFastNoNetwork pins the only offline-deterministic
-// path: an empty token is rejected before any gateway dial, so the default
-// `go test` makes no live Discord call (ADR-0021). The live login itself is
-// exercised by an operator run / a live build, behind the RPC layer's seam.
+// TestResolve_EmptyToken_FailsFastNoNetwork pins the guard path: an empty token
+// is rejected before any REST call, so the default `go test` makes no live
+// Discord call (ADR-0021). The call against the real API is exercised by an
+// operator run, behind the RPC layer's seam.
 func TestResolve_EmptyToken_FailsFastNoNetwork(t *testing.T) {
 	t.Parallel()
 	_, err := discordtag.Resolve(context.Background(), "", nil)

--- a/internal/discordtag/discordtag_test.go
+++ b/internal/discordtag/discordtag_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -65,5 +66,41 @@ func TestResolve_RESTSelfUserNoGateway(t *testing.T) {
 	}
 	if want := "GET /users/@me Bot tok-abc"; reqs[0] != want {
 		t.Errorf("request = %q, want %q", reqs[0], want)
+	}
+}
+
+// TestResolve_NoGoroutineLeakPerCall pins the resolver's per-call footprint:
+// resolving must not leave a background goroutine behind. disgo's
+// rest.NewClient starts a rate-limiter cleanup goroutine (`for range ticker.C`)
+// that its Close never stops — one leaked goroutine + ticker per health probe,
+// forever. Not parallel: it counts process goroutines.
+func TestResolve_NoGoroutineLeakPerCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"123","username":"Glyphoxa","discriminator":"4823"}`))
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resolve := func() {
+		t.Helper()
+		if _, err := discordtag.ResolveAt(ctx, "tok", srv.URL, nil); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+	}
+
+	// One warm-up call so shared state (idle HTTP conns etc.) reaches steady state.
+	resolve()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	const calls = 25
+	for range calls {
+		resolve()
+	}
+	time.Sleep(100 * time.Millisecond) // let per-call teardown finish
+	if growth := runtime.NumGoroutine() - before; growth > 10 {
+		t.Errorf("goroutines grew by %d over %d resolves — a background goroutine leaks per call", growth, calls)
 	}
 }

--- a/internal/discordtag/discordtag_test.go
+++ b/internal/discordtag/discordtag_test.go
@@ -2,8 +2,12 @@ package discordtag_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/internal/discordtag"
 )
@@ -20,5 +24,46 @@ func TestResolve_EmptyToken_FailsFastNoNetwork(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty bot token") {
 		t.Errorf("error %q does not mention the empty token", err)
+	}
+}
+
+// TestResolve_RESTSelfUserNoGateway pins the #150 fix: the resolver proves the
+// token via a plain REST `GET /users/@me` (Bot auth) — no gateway dial, no
+// IDENTIFY, no session-start budget consumed. The fake HTTP server IS the whole
+// Discord surface the resolver may touch; a gateway login would try to dial a
+// websocket and fail this offline test.
+func TestResolve_RESTSelfUserNoGateway(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		reqs []string // "METHOD path AuthorizationHeader"
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		reqs = append(reqs, r.Method+" "+r.URL.Path+" "+r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"123","username":"Glyphoxa","discriminator":"4823"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tag, err := discordtag.ResolveAt(ctx, "tok-abc", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tag != "Glyphoxa#4823" {
+		t.Errorf("tag = %q, want Glyphoxa#4823", tag)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %v, want exactly one", reqs)
+	}
+	if want := "GET /users/@me Bot tok-abc"; reqs[0] != want {
+		t.Errorf("request = %q, want %q", reqs[0], want)
 	}
 }

--- a/internal/discordtag/export_test.go
+++ b/internal/discordtag/export_test.go
@@ -1,0 +1,5 @@
+package discordtag
+
+// ResolveAt exposes the base-URL seam so tests can point the resolver at a
+// fake Discord REST server instead of the live API.
+var ResolveAt = resolve

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -70,6 +70,11 @@ type ProviderServer struct {
 	store  providerStore
 	cipher *crypto.Cipher // nil when $GLYPHOXA_SECRET is unset: reads still work, saves fail loudly
 	log    *slog.Logger
+
+	// invalidateHealth busts the tenant's provider-health cache after a
+	// credential save (#150), so a cached Degraded badge cannot outlive the
+	// fixed key for up to a TTL. nil (not wired) skips.
+	invalidateHealth func(tenantID uuid.UUID)
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -82,6 +87,13 @@ func NewProviderServer(store providerStore, cipher *crypto.Cipher, log *slog.Log
 		log = slog.Default()
 	}
 	return &ProviderServer{store: store, cipher: cipher, log: log}
+}
+
+// SetHealthInvalidator wires the health-cache buster called after a successful
+// credential save (#150). Called once at boot, before the server serves, so no
+// lock is needed.
+func (s *ProviderServer) SetHealthInvalidator(fn func(tenantID uuid.UUID)) {
+	s.invalidateHealth = fn
 }
 
 // Handler builds the Connect HTTP handler for ProviderService and returns its
@@ -194,6 +206,12 @@ func (s *ProviderServer) SaveProviderConfig(
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
+	// The key changed: the cached health verdict (possibly Degraded from the
+	// old key) is stale — bust it so the next health call probes fresh (#150).
+	if s.invalidateHealth != nil {
+		s.invalidateHealth(tenantID)
+	}
+
 	return connect.NewResponse(&managementv1.SaveProviderConfigResponse{
 		Credential: providerCredential(string(slot.components[0]), slot.provider, saved[0]),
 	}), nil
@@ -239,6 +257,12 @@ func (s *ProviderServer) SaveDiscordSettings(
 	if err != nil {
 		s.log.Error("SaveDiscordSettings: save channels failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Discord config changed (token and/or IDs): bust the cached health
+	// verdict so the next health call probes with the new state (#150).
+	if s.invalidateHealth != nil {
+		s.invalidateHealth(tenantID)
 	}
 
 	return connect.NewResponse(&managementv1.SaveDiscordSettingsResponse{

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -82,6 +82,14 @@ type VoiceServer struct {
 	// now is the health cache's clock; tests advance it past the TTL.
 	now func() time.Time
 
+	// sessionActive reports whether a live voice session is running (#150):
+	// the Discord health check then short-circuits to healthy without touching
+	// Discord — the session on the same token IS the health signal, and a probe
+	// would race its reconnects for the per-token IDENTIFY budget. nil (not
+	// wired, e.g. web-only mode has no in-process loop to consult) means the
+	// probe always runs.
+	sessionActive func() bool
+
 	// healthMu guards healthCache: one TTL-cached GetProviderHealth result per
 	// tenant (#150). Each entry carries its own mutex, held across a probe, so
 	// concurrent RPCs on an expired entry serialize instead of stampeding the
@@ -116,6 +124,22 @@ func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *
 		botTag:      func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
 		now:         time.Now,
 		healthCache: map[uuid.UUID]*healthEntry{},
+	}
+}
+
+// activeSessionSource reports the live voice session, if any.
+// *session.Manager satisfies it; tests drive a fake.
+type activeSessionSource interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// SetSessions wires the live session source the Discord health check consults
+// (#150). Called once at boot, after the session manager exists and before the
+// server serves, so no lock is needed.
+func (s *VoiceServer) SetSessions(src activeSessionSource) {
+	s.sessionActive = func() bool {
+		_, active := src.Snapshot()
+		return active
 	}
 }
 
@@ -335,8 +359,16 @@ func (s *VoiceServer) healthTTS(ctx context.Context, tenantID uuid.UUID) *manage
 	return healthy("elevenlabs")
 }
 
-// healthDiscord performs a live gateway login and reports the resolved bot tag.
+// healthDiscord proves the Bot token via REST (GET /users/@me, no gateway
+// IDENTIFY — #150) and reports the resolved bot tag. While a voice session is
+// active the check short-circuits to healthy without touching Discord: the
+// live session runs on the same token, so it IS the health signal.
 func (s *VoiceServer) healthDiscord(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+	if s.sessionActive != nil && s.sessionActive() {
+		h := healthy("discord")
+		h.Detail = "live voice session active"
+		return h
+	}
 	token, err := s.resolveDiscordToken(ctx, tenantID)
 	if err != nil {
 		return degraded("discord", err)

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -42,10 +42,15 @@ const defaultPreviewText = "Hello! I'm your voice for this campaign. Roll for in
 // when shorter.
 const previewTimeout = 15 * time.Second
 
-// healthCheckTimeout bounds each provider's health test-call (the Discord
-// gateway login is the slowest), so a hung provider degrades that one badge
-// instead of stalling the whole health probe.
+// healthCheckTimeout bounds each provider's health test-call, so a hung
+// provider degrades that one badge instead of stalling the whole health probe.
+// The checks run concurrently (#150), so this also bounds the whole RPC.
 const healthCheckTimeout = 12 * time.Second
+
+// healthCacheTTL is how long a GetProviderHealth result is served from the
+// server-side cache (#150). The SPA refires the RPC on every window focus;
+// within the TTL those refetches cost zero vendor calls.
+const healthCacheTTL = 60 * time.Second
 
 // voiceStore is the narrow read surface VoiceServer needs to resolve the tenant
 // BYOK keys. *storage.Store satisfies it; tests drive a fake.
@@ -70,9 +75,26 @@ type VoiceServer struct {
 	// pingLLM is the Groq liveness test-call (a real key -> nil). Defaults to a
 	// GET against the Groq models endpoint.
 	pingLLM func(ctx context.Context, apiKey string) error
-	// botTag performs a live Discord gateway login and returns the bot tag.
-	// Defaults to discordtag.Resolve.
+	// botTag proves the Discord token via REST (GET /users/@me — no gateway
+	// IDENTIFY, #150) and returns the bot tag. Defaults to discordtag.Resolve.
 	botTag func(ctx context.Context, token string) (string, error)
+
+	// now is the health cache's clock; tests advance it past the TTL.
+	now func() time.Time
+
+	// healthMu guards healthCache: one TTL-cached GetProviderHealth result per
+	// tenant (#150). Each entry carries its own mutex, held across a probe, so
+	// concurrent RPCs on an expired entry serialize instead of stampeding the
+	// vendors — the waiters are then served the fresh cache.
+	healthMu    sync.Mutex
+	healthCache map[uuid.UUID]*healthEntry
+}
+
+// healthEntry is one tenant's cached provider-health result.
+type healthEntry struct {
+	mu        sync.Mutex
+	at        time.Time // zero until the first probe lands
+	providers []*managementv1.ProviderHealth
 }
 
 var _ managementv1connect.VoiceServiceHandler = (*VoiceServer)(nil)
@@ -85,13 +107,15 @@ func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *
 		log = slog.Default()
 	}
 	return &VoiceServer{
-		store:     store,
-		cipher:    cipher,
-		log:       log,
-		newLister: func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
-		newSynth:  func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
-		pingLLM:   livePingGroq,
-		botTag:    func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
+		store:       store,
+		cipher:      cipher,
+		log:         log,
+		newLister:   func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
+		newSynth:    func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
+		pingLLM:     livePingGroq,
+		botTag:      func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
+		now:         time.Now,
+		healthCache: map[uuid.UUID]*healthEntry{},
 	}
 }
 
@@ -217,6 +241,10 @@ func (s *VoiceServer) PreviewVoice(
 // tested status plus the resolved Discord bot tag. A provider with no resolvable
 // key (or a failing test-call) is reported degraded; the screen still renders
 // key-presence instantly and only upgrades the badge from this.
+//
+// The result is cached per tenant for healthCacheTTL (#150): the SPA refires
+// this RPC on every window focus, and within the TTL those refetches are
+// answered from cache without touching any vendor.
 func (s *VoiceServer) GetProviderHealth(
 	ctx context.Context,
 	_ *connect.Request[managementv1.GetProviderHealthRequest],
@@ -226,9 +254,35 @@ func (s *VoiceServer) GetProviderHealth(
 		return nil, err
 	}
 
-	return connect.NewResponse(&managementv1.GetProviderHealthResponse{
-		Providers: s.probeProviders(ctx, tenantID),
-	}), nil
+	e := s.healthEntry(tenantID)
+	// The entry lock is held across the probe: concurrent RPCs on a stale entry
+	// serialize, and the waiters are served the then-fresh cache below instead
+	// of stampeding the vendors.
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.at.IsZero() && s.now().Sub(e.at) < healthCacheTTL {
+		return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: e.providers}), nil
+	}
+
+	// Probe detached from the request's cancellation (values, e.g. the tenant,
+	// survive): a focus-refetch the browser aborts mid-probe must not poison the
+	// cache with cancellation errors. Each check still bounds itself with
+	// healthCheckTimeout.
+	e.providers = s.probeProviders(context.WithoutCancel(ctx), tenantID)
+	e.at = s.now()
+	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: e.providers}), nil
+}
+
+// healthEntry returns tenantID's cache slot, creating it on first use.
+func (s *VoiceServer) healthEntry(tenantID uuid.UUID) *healthEntry {
+	s.healthMu.Lock()
+	defer s.healthMu.Unlock()
+	e, ok := s.healthCache[tenantID]
+	if !ok {
+		e = &healthEntry{}
+		s.healthCache[tenantID] = e
+	}
+	return e
 }
 
 // probeProviders runs the three per-provider test-calls CONCURRENTLY (#150):

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -327,6 +327,18 @@ func (s *VoiceServer) GetProviderHealth(
 	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
 }
 
+// InvalidateHealth drops tenantID's cached health result (#150): called after
+// a credential save so a stale Degraded badge cannot outlive the fix for up to
+// a TTL — the next health call probes the vendors with the new key. The
+// last-known bot tag is dropped too (a new token may be a different bot). Safe
+// under concurrent RPCs: an in-flight probe writes into its own (now orphaned)
+// entry and the next call starts fresh.
+func (s *VoiceServer) InvalidateHealth(tenantID uuid.UUID) {
+	s.healthMu.Lock()
+	defer s.healthMu.Unlock()
+	delete(s.healthCache, tenantID)
+}
+
 // healthEntry returns tenantID's cache slot, creating it on first use.
 func (s *VoiceServer) healthEntry(tenantID uuid.UUID) *healthEntry {
 	s.healthMu.Lock()

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -100,14 +100,15 @@ type VoiceServer struct {
 	sessionActive func() bool
 
 	// healthMu guards healthCache: one TTL-cached GetProviderHealth result per
-	// tenant (#150). Each entry carries its own mutex, held across a probe, so
-	// concurrent RPCs on an expired entry serialize instead of stampeding the
-	// vendors — the waiters are then served the fresh cache.
+	// tenant (#150). Probes are singleflighted per entry: one leader probes,
+	// concurrent callers wait on that SAME probe (each with its own ctx
+	// bail-out) and are handed its result — never a probe of their own.
 	healthMu    sync.Mutex
 	healthCache map[uuid.UUID]*healthEntry
 }
 
-// healthEntry is one tenant's cached provider-health result.
+// healthEntry is one tenant's cached provider-health result. mu guards the
+// fields and is only held for state flips — never across a probe.
 type healthEntry struct {
 	mu        sync.Mutex
 	at        time.Time // zero until the first probe lands
@@ -117,6 +118,12 @@ type healthEntry struct {
 	// Discord) can keep reporting "Connected as X#NNNN" instead of blanking
 	// the row for the whole session.
 	botTag string
+	// inflight is non-nil while a leader's probe runs and is closed when it
+	// finishes; callers arriving meanwhile wait on it instead of probing.
+	inflight chan struct{}
+	// lastProbe is the most recent probe's result — set even when a timed-out
+	// probe is not cached, so waiters on that probe still get its answer.
+	lastProbe []*managementv1.ProviderHealth
 }
 
 var _ managementv1connect.VoiceServiceHandler = (*VoiceServer)(nil)
@@ -294,23 +301,53 @@ func (s *VoiceServer) GetProviderHealth(
 	}
 
 	e := s.healthEntry(tenantID)
-	// The entry lock is held across the probe: concurrent RPCs on a stale entry
-	// serialize, and the waiters are served the then-fresh cache below instead
-	// of stampeding the vendors.
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	if !e.at.IsZero() && s.now().Sub(e.at) < healthCacheTTL {
-		return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: e.providers}), nil
+		providers := e.providers
+		e.mu.Unlock()
+		return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
 	}
+
+	// Singleflight: if a probe is already in flight, wait on THAT probe (with
+	// this caller's own ctx bail-out) and take its result — never run a second
+	// probe for the same tenant concurrently or queue behind it for a fresh one.
+	if ch := e.inflight; ch != nil {
+		e.mu.Unlock()
+		select {
+		case <-ch:
+			e.mu.Lock()
+			providers := e.lastProbe
+			e.mu.Unlock()
+			return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
+		case <-ctx.Done():
+			return nil, ctxError(ctx)
+		}
+	}
+
+	// A caller that is already gone must not become a probe leader and burn a
+	// probeTimeout slot on vendors nobody will see.
+	if ctx.Err() != nil {
+		e.mu.Unlock()
+		return nil, ctxError(ctx)
+	}
+
+	// Become the leader: mark the flight, release the lock, probe.
+	ch := make(chan struct{})
+	e.inflight = ch
+	lastBotTag := e.botTag
+	e.mu.Unlock()
 
 	// Probe detached from the request's cancellation (values, e.g. the tenant,
 	// survive): a focus-refetch the browser aborts mid-probe must not poison the
-	// cache with cancellation errors. probeTimeout is the hard deadline on the
-	// whole probe — store reads included — so a hung dependency cannot hold the
-	// entry lock (and with it every later health call for the tenant) forever.
+	// cache with cancellation errors — and waiters on this flight still need the
+	// answer. probeTimeout is the hard deadline on the whole probe — store reads
+	// included — so a hung dependency cannot wedge the tenant's health path.
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.probeTimeout)
 	defer cancel()
-	providers, complete := s.probeProviders(pctx, tenantID, e.botTag)
+	providers, complete := s.probeProviders(pctx, tenantID, lastBotTag)
+
+	e.mu.Lock()
+	e.lastProbe = providers
 	if complete {
 		// Only a finished probe is cached: a timed-out one would pin
 		// "degraded: deadline exceeded" for the whole TTL, so the next call
@@ -324,7 +361,20 @@ func (s *VoiceServer) GetProviderHealth(
 			}
 		}
 	}
+	e.inflight = nil
+	e.mu.Unlock()
+	close(ch) // release the waiters onto lastProbe
+
 	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
+}
+
+// ctxError maps a done request context onto the matching Connect error.
+func ctxError(ctx context.Context) error {
+	code := connect.CodeCanceled
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		code = connect.CodeDeadlineExceeded
+	}
+	return connect.NewError(code, ctx.Err())
 }
 
 // InvalidateHealth drops tenantID's cached health result (#150): called after

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -112,6 +112,11 @@ type healthEntry struct {
 	mu        sync.Mutex
 	at        time.Time // zero until the first probe lands
 	providers []*managementv1.ProviderHealth
+	// botTag is the last tag a successful Discord probe resolved. It outlives
+	// the TTL so the active-session short-circuit (which does not touch
+	// Discord) can keep reporting "Connected as X#NNNN" instead of blanking
+	// the row for the whole session.
+	botTag string
 }
 
 var _ managementv1connect.VoiceServiceHandler = (*VoiceServer)(nil)
@@ -305,12 +310,19 @@ func (s *VoiceServer) GetProviderHealth(
 	// entry lock (and with it every later health call for the tenant) forever.
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.probeTimeout)
 	defer cancel()
-	providers, complete := s.probeProviders(pctx, tenantID)
+	providers, complete := s.probeProviders(pctx, tenantID, e.botTag)
 	if complete {
 		// Only a finished probe is cached: a timed-out one would pin
 		// "degraded: deadline exceeded" for the whole TTL, so the next call
 		// retries instead.
 		e.providers, e.at = providers, s.now()
+		// Remember the last successfully resolved bot tag for the
+		// active-session short-circuit; a degraded probe keeps the old one.
+		for _, p := range providers {
+			if p.GetProvider() == "discord" && p.GetBotTag() != "" {
+				e.botTag = p.GetBotTag()
+			}
+		}
 	}
 	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
 }
@@ -333,14 +345,16 @@ func (s *VoiceServer) healthEntry(tenantID uuid.UUID) *healthEntry {
 // with a degraded timeout result, the stuck goroutines are abandoned (their
 // sends land in the buffered channel and are dropped), and complete=false
 // tells the caller not to cache.
-func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID) (providers []*managementv1.ProviderHealth, complete bool) {
+func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID, lastBotTag string) (providers []*managementv1.ProviderHealth, complete bool) {
 	checks := []struct {
 		name string
 		run  func(context.Context, uuid.UUID) *managementv1.ProviderHealth
 	}{
 		{"groq", s.healthLLM},
 		{"elevenlabs", s.healthTTS},
-		{"discord", s.healthDiscord},
+		{"discord", func(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+			return s.healthDiscord(ctx, tenantID, lastBotTag)
+		}},
 	}
 
 	type slot struct {
@@ -412,11 +426,14 @@ func (s *VoiceServer) healthTTS(ctx context.Context, tenantID uuid.UUID) *manage
 
 // healthDiscord proves the Bot token via REST (GET /users/@me, no gateway
 // IDENTIFY — #150) and reports the resolved bot tag. While a voice session is
-// active the check short-circuits to healthy without touching Discord: the
-// live session runs on the same token, so it IS the health signal.
-func (s *VoiceServer) healthDiscord(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+// active the check short-circuits to healthy without touching Discord — the
+// live session runs on the same token, so it IS the health signal — carrying
+// lastBotTag (the tag of the last successful probe) so the screen's
+// "Connected as X#NNNN" row survives the session.
+func (s *VoiceServer) healthDiscord(ctx context.Context, tenantID uuid.UUID, lastBotTag string) *managementv1.ProviderHealth {
 	if s.sessionActive != nil && s.sessionActive() {
 		h := healthy("discord")
+		h.BotTag = lastBotTag
 		h.Detail = "live voice session active"
 		return h
 	}

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -225,12 +226,31 @@ func (s *VoiceServer) GetProviderHealth(
 		return nil, err
 	}
 
-	providers := []*managementv1.ProviderHealth{
-		s.healthLLM(ctx, tenantID),
-		s.healthTTS(ctx, tenantID),
-		s.healthDiscord(ctx, tenantID),
+	return connect.NewResponse(&managementv1.GetProviderHealthResponse{
+		Providers: s.probeProviders(ctx, tenantID),
+	}), nil
+}
+
+// probeProviders runs the three per-provider test-calls CONCURRENTLY (#150):
+// the worst case is the slowest single check (bounded by healthCheckTimeout),
+// not the sum of all three.
+func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID) []*managementv1.ProviderHealth {
+	checks := []func(context.Context, uuid.UUID) *managementv1.ProviderHealth{
+		s.healthLLM,
+		s.healthTTS,
+		s.healthDiscord,
 	}
-	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
+	providers := make([]*managementv1.ProviderHealth, len(checks))
+	var wg sync.WaitGroup
+	for i, check := range checks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			providers[i] = check(ctx, tenantID)
+		}()
+	}
+	wg.Wait()
+	return providers
 }
 
 // healthLLM pings Groq with the decrypted LLM key.

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -52,6 +52,12 @@ const healthCheckTimeout = 12 * time.Second
 // within the TTL those refetches cost zero vendor calls.
 const healthCacheTTL = 60 * time.Second
 
+// healthProbeTimeout is the hard deadline on the WHOLE health probe — store
+// reads included, which healthCheckTimeout does not cover. The probe runs
+// while the tenant's cache entry lock is held, so without this bound one hung
+// store read would wedge every later health call for the tenant.
+const healthProbeTimeout = healthCheckTimeout + 3*time.Second
+
 // voiceStore is the narrow read surface VoiceServer needs to resolve the tenant
 // BYOK keys. *storage.Store satisfies it; tests drive a fake.
 type voiceStore interface {
@@ -81,6 +87,9 @@ type VoiceServer struct {
 
 	// now is the health cache's clock; tests advance it past the TTL.
 	now func() time.Time
+	// probeTimeout is the whole-probe hard deadline (healthProbeTimeout in
+	// prod); tests shrink it to pin the hung-dependency path.
+	probeTimeout time.Duration
 
 	// sessionActive reports whether a live voice session is running (#150):
 	// the Discord health check then short-circuits to healthy without touching
@@ -115,15 +124,16 @@ func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *
 		log = slog.Default()
 	}
 	return &VoiceServer{
-		store:       store,
-		cipher:      cipher,
-		log:         log,
-		newLister:   func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
-		newSynth:    func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
-		pingLLM:     livePingGroq,
-		botTag:      func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
-		now:         time.Now,
-		healthCache: map[uuid.UUID]*healthEntry{},
+		store:        store,
+		cipher:       cipher,
+		log:          log,
+		newLister:    func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
+		newSynth:     func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
+		pingLLM:      livePingGroq,
+		botTag:       func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
+		now:          time.Now,
+		probeTimeout: healthProbeTimeout,
+		healthCache:  map[uuid.UUID]*healthEntry{},
 	}
 }
 
@@ -290,11 +300,19 @@ func (s *VoiceServer) GetProviderHealth(
 
 	// Probe detached from the request's cancellation (values, e.g. the tenant,
 	// survive): a focus-refetch the browser aborts mid-probe must not poison the
-	// cache with cancellation errors. Each check still bounds itself with
-	// healthCheckTimeout.
-	e.providers = s.probeProviders(context.WithoutCancel(ctx), tenantID)
-	e.at = s.now()
-	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: e.providers}), nil
+	// cache with cancellation errors. probeTimeout is the hard deadline on the
+	// whole probe — store reads included — so a hung dependency cannot hold the
+	// entry lock (and with it every later health call for the tenant) forever.
+	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.probeTimeout)
+	defer cancel()
+	providers, complete := s.probeProviders(pctx, tenantID)
+	if complete {
+		// Only a finished probe is cached: a timed-out one would pin
+		// "degraded: deadline exceeded" for the whole TTL, so the next call
+		// retries instead.
+		e.providers, e.at = providers, s.now()
+	}
+	return connect.NewResponse(&managementv1.GetProviderHealthResponse{Providers: providers}), nil
 }
 
 // healthEntry returns tenantID's cache slot, creating it on first use.
@@ -310,25 +328,58 @@ func (s *VoiceServer) healthEntry(tenantID uuid.UUID) *healthEntry {
 }
 
 // probeProviders runs the three per-provider test-calls CONCURRENTLY (#150):
-// the worst case is the slowest single check (bounded by healthCheckTimeout),
-// not the sum of all three.
-func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID) []*managementv1.ProviderHealth {
-	checks := []func(context.Context, uuid.UUID) *managementv1.ProviderHealth{
-		s.healthLLM,
-		s.healthTTS,
-		s.healthDiscord,
+// the worst case is the slowest single check, not the sum of all three. When
+// ctx expires before every check reports, the still-missing slots are filled
+// with a degraded timeout result, the stuck goroutines are abandoned (their
+// sends land in the buffered channel and are dropped), and complete=false
+// tells the caller not to cache.
+func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID) (providers []*managementv1.ProviderHealth, complete bool) {
+	checks := []struct {
+		name string
+		run  func(context.Context, uuid.UUID) *managementv1.ProviderHealth
+	}{
+		{"groq", s.healthLLM},
+		{"elevenlabs", s.healthTTS},
+		{"discord", s.healthDiscord},
 	}
-	providers := make([]*managementv1.ProviderHealth, len(checks))
-	var wg sync.WaitGroup
+
+	type slot struct {
+		i int
+		h *managementv1.ProviderHealth
+	}
+	results := make(chan slot, len(checks))
 	for i, check := range checks {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
-			providers[i] = check(ctx, tenantID)
+			results <- slot{i, check.run(ctx, tenantID)}
 		}()
 	}
-	wg.Wait()
-	return providers
+
+	providers = make([]*managementv1.ProviderHealth, len(checks))
+	for range checks {
+		select {
+		case r := <-results:
+			providers[r.i] = r.h
+		case <-ctx.Done():
+			// Drain checks that finished in the same instant, then mark the
+			// rest timed out.
+			for {
+				select {
+				case r := <-results:
+					providers[r.i] = r.h
+					continue
+				default:
+				}
+				break
+			}
+			for i, check := range checks {
+				if providers[i] == nil {
+					providers[i] = degraded(check.name, fmt.Errorf("health probe timed out: %w", ctx.Err()))
+				}
+			}
+			return providers, false
+		}
+	}
+	return providers, true
 }
 
 // healthLLM pings Groq with the decrypted LLM key.

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -564,3 +564,55 @@ func TestGetProviderHealth_HungStoreDoesNotWedgeTenant(t *testing.T) {
 		}
 	}
 }
+
+// TestGetProviderHealth_ActiveSessionKeepsLastKnownBotTag pins that the
+// active-session short-circuit does not blank the Configuration screen's
+// "Connected as X#NNNN" row: the tag from the last successful probe is
+// returned with the short-circuited healthy result.
+func TestGetProviderHealth_ActiveSessionKeepsLastKnownBotTag(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	srv := NewVoiceServer(healthyStore(t, cipher), cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+	sessions := &fakeSessions{}
+	srv.SetSessions(sessions)
+
+	now := time.Now()
+	srv.now = func() time.Time { return now }
+	ctx := tenantCtx()
+
+	discordOf := func(label string) *managementv1.ProviderHealth {
+		t.Helper()
+		resp, err := srv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+		if err != nil {
+			t.Fatalf("%s: GetProviderHealth: %v", label, err)
+		}
+		for _, p := range resp.Msg.GetProviders() {
+			if p.GetProvider() == "discord" {
+				return p
+			}
+		}
+		t.Fatalf("%s: no discord slot", label)
+		return nil
+	}
+
+	// No session yet: the probe runs and resolves the tag.
+	if got := discordOf("probe").GetBotTag(); got != "Glyphoxa#4823" {
+		t.Fatalf("probed tag = %q, want Glyphoxa#4823", got)
+	}
+
+	// Session starts; cache expires. The short-circuit must not blank the tag.
+	sessions.active = true
+	now = now.Add(healthCacheTTL + time.Second)
+	p := discordOf("short-circuit")
+	if p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_HEALTHY {
+		t.Errorf("discord should be healthy during an active session: %+v", p)
+	}
+	if got := p.GetBotTag(); got != "Glyphoxa#4823" {
+		t.Errorf("short-circuit tag = %q, want the last-known Glyphoxa#4823", got)
+	}
+	if got := seams.discord.Load(); got != 1 {
+		t.Errorf("discord probes = %d, want 1 (short-circuit must not touch Discord)", got)
+	}
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -483,3 +483,84 @@ func TestGetProviderHealth_ActiveSessionSkipsDiscordProbe(t *testing.T) {
 		t.Errorf("tts probes = %d, want 1", got)
 	}
 }
+
+// blockingVoiceStore blocks every read until release is closed, IGNORING ctx —
+// the worst-case wedged dependency. After release it delegates to inner.
+type blockingVoiceStore struct {
+	release chan struct{}
+	inner   *fakeVoiceStore
+}
+
+func (b *blockingVoiceStore) GetProviderConfigByComponent(ctx context.Context, id uuid.UUID, c storage.Component) (storage.ProviderConfig, error) {
+	<-b.release
+	return b.inner.GetProviderConfigByComponent(ctx, id, c)
+}
+
+func (b *blockingVoiceStore) GetDeploymentConfig(ctx context.Context, id uuid.UUID) (storage.DeploymentConfig, error) {
+	<-b.release
+	return b.inner.GetDeploymentConfig(ctx, id)
+}
+
+// TestGetProviderHealth_HungStoreDoesNotWedgeTenant pins the probe's hard
+// deadline: the WHOLE probe — store reads included — is bounded, the per-tenant
+// cache entry lock is released on timeout, and a timed-out probe is NOT cached
+// (the next call after the store recovers probes fresh and reports healthy).
+// Pre-fix a hung store read under context.WithoutCancel blocked the entry lock
+// forever, wedging every later health call for the tenant.
+func TestGetProviderHealth_HungStoreDoesNotWedgeTenant(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	bs := &blockingVoiceStore{release: make(chan struct{}), inner: healthyStore(t, cipher)}
+	srv := NewVoiceServer(bs, cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+	srv.probeTimeout = 50 * time.Millisecond
+
+	ctx := tenantCtx()
+	call := func(label string) *managementv1.GetProviderHealthResponse {
+		t.Helper()
+		done := make(chan *managementv1.GetProviderHealthResponse, 1)
+		go func() {
+			resp, err := srv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+			if err != nil {
+				t.Errorf("%s: GetProviderHealth: %v", label, err)
+				done <- nil
+				return
+			}
+			done <- resp.Msg
+		}()
+		select {
+		case msg := <-done:
+			return msg
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: GetProviderHealth wedged >2s on a hung store read", label)
+			return nil
+		}
+	}
+
+	first := call("first")
+	if first == nil {
+		return
+	}
+	for _, p := range first.GetProviders() {
+		if p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_DEGRADED {
+			t.Errorf("first call: %s should be degraded while the store hangs: %+v", p.GetProvider(), p)
+		}
+	}
+
+	// The entry lock must be free again: a second call also returns within bound.
+	call("second")
+
+	// A timed-out probe must not be cached: once the store recovers, the next
+	// call probes fresh and reports healthy.
+	close(bs.release)
+	third := call("third")
+	if third == nil {
+		return
+	}
+	for _, p := range third.GetProviders() {
+		if p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_HEALTHY {
+			t.Errorf("after store recovery %s should be healthy: %+v", p.GetProvider(), p)
+		}
+	}
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -489,14 +490,17 @@ func TestGetProviderHealth_ActiveSessionSkipsDiscordProbe(t *testing.T) {
 type blockingVoiceStore struct {
 	release chan struct{}
 	inner   *fakeVoiceStore
+	reads   atomic.Int64 // reads started, so a test can count launched probes
 }
 
 func (b *blockingVoiceStore) GetProviderConfigByComponent(ctx context.Context, id uuid.UUID, c storage.Component) (storage.ProviderConfig, error) {
+	b.reads.Add(1)
 	<-b.release
 	return b.inner.GetProviderConfigByComponent(ctx, id, c)
 }
 
 func (b *blockingVoiceStore) GetDeploymentConfig(ctx context.Context, id uuid.UUID) (storage.DeploymentConfig, error) {
+	b.reads.Add(1)
 	<-b.release
 	return b.inner.GetDeploymentConfig(ctx, id)
 }
@@ -703,3 +707,87 @@ func (stubProviderStore) SaveDiscordChannels(_ context.Context, _ uuid.UUID, gui
 
 // ptr returns a pointer to v, for proto3 optional scalar fields.
 func ptr[T any](v T) *T { return &v }
+
+// TestGetProviderHealth_CanceledCallersDoNotProbe pins the ctx-aware cache
+// entry: a caller whose request context is already canceled (browser closed
+// the focus-refetch) must return promptly with the ctx error — NOT queue on
+// the entry, become the next probe leader, and burn a full probeTimeout slot.
+// Pre-fix N canceled callers serialized at N x probeTimeout on a hung store.
+func TestGetProviderHealth_CanceledCallersDoNotProbe(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	bs := &blockingVoiceStore{release: make(chan struct{}), inner: healthyStore(t, cipher)}
+	srv := NewVoiceServer(bs, cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+	srv.probeTimeout = 200 * time.Millisecond
+
+	canceled, cancel := context.WithCancel(tenantCtx())
+	cancel()
+
+	const n = 5
+	errs := make([]error, n)
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = srv.GetProviderHealth(canceled, connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if elapsed >= 2*srv.probeTimeout {
+		t.Errorf("%d canceled callers took %v — they serialized full probe slots (probeTimeout %v)", n, elapsed, srv.probeTimeout)
+	}
+	for i, err := range errs {
+		if err == nil {
+			t.Errorf("call %d: canceled caller got nil error, want ctx error", i)
+		}
+	}
+}
+
+// TestGetProviderHealth_WaitersShareLeaderProbe pins true singleflight: calls
+// that arrive while a probe is in flight wait on THAT probe and are handed its
+// result — they never launch their own vendor probe. Pre-fix each waiter,
+// finding no fresh cache after the leader's timed-out probe, ran a fresh full
+// probe under the entry lock: N callers serialized at N x probeTimeout and the
+// store saw N probes' worth of reads.
+func TestGetProviderHealth_WaitersShareLeaderProbe(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	bs := &blockingVoiceStore{release: make(chan struct{}), inner: healthyStore(t, cipher)}
+	srv := NewVoiceServer(bs, cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+	srv.probeTimeout = 200 * time.Millisecond
+
+	ctx := tenantCtx()
+	const n = 5
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if i > 0 {
+				time.Sleep(50 * time.Millisecond) // join while the leader's probe is in flight
+			}
+			if _, err := srv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{})); err != nil {
+				t.Errorf("call %d: GetProviderHealth: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	if elapsed >= 2*srv.probeTimeout {
+		t.Errorf("%d concurrent callers took %v — waiters ran their own probes instead of sharing the leader's (probeTimeout %v)", n, elapsed, srv.probeTimeout)
+	}
+	// One probe = 3 store reads (LLM config, TTS config, deployment config).
+	if got := bs.reads.Load(); got != 3 {
+		t.Errorf("store reads = %d, want 3 (exactly one probe launched)", got)
+	}
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -301,5 +302,72 @@ func TestVoiceRPCs_RequireTenant(t *testing.T) {
 	srv := NewVoiceServer(&fakeVoiceStore{}, voiceTestCipher(t), nil)
 	if _, err := srv.ListVoices(context.Background(), connect.NewRequest(&managementv1.ListVoicesRequest{})); connect.CodeOf(err) != connect.CodeUnauthenticated {
 		t.Errorf("ListVoices without tenant code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}
+
+// healthyStore returns a fakeVoiceStore with a saved key for every component
+// plus a deployment bot token, so all three health checks reach their seams.
+func healthyStore(t *testing.T, cipher *crypto.Cipher) *fakeVoiceStore {
+	t.Helper()
+	return &fakeVoiceStore{
+		configs: map[storage.Component]storage.ProviderConfig{
+			storage.ComponentLLM: savedConfig(t, cipher, storage.ComponentLLM, "groq", "groq-key"),
+			storage.ComponentTTS: savedConfig(t, cipher, storage.ComponentTTS, "elevenlabs", "eleven-key"),
+		},
+		dep: &storage.DeploymentConfig{
+			DiscordBotTokenLast4: "tok9", DiscordBotTokenCiphertext: mustSeal(t, cipher, "bot-token"),
+		},
+	}
+}
+
+// TestGetProviderHealth_ChecksRunConcurrently pins #150: the three provider
+// checks run in parallel, so the RPC's worst case is the slowest single check
+// (~checkDelay), not the sum (~3×checkDelay). Sequential checks would take
+// ~360ms and fail the <300ms bound.
+func TestGetProviderHealth_ChecksRunConcurrently(t *testing.T) {
+	t.Parallel()
+	const checkDelay = 120 * time.Millisecond
+
+	cipher := voiceTestCipher(t)
+	srv := NewVoiceServer(healthyStore(t, cipher), cipher, nil)
+	srv.newLister = func(string) tts.VoiceLister { return &slowLister{delay: checkDelay} }
+	srv.pingLLM = func(ctx context.Context, _ string) error {
+		sleepCtx(ctx, checkDelay)
+		return nil
+	}
+	srv.botTag = func(ctx context.Context, _ string) (string, error) {
+		sleepCtx(ctx, checkDelay)
+		return "Glyphoxa#4823", nil
+	}
+
+	start := time.Now()
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	if got := len(resp.Msg.GetProviders()); got != 3 {
+		t.Fatalf("providers = %d, want 3", got)
+	}
+	if elapsed < checkDelay {
+		t.Errorf("elapsed %v < one check's delay %v — checks were skipped, not run", elapsed, checkDelay)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Errorf("elapsed %v suggests sequential checks; concurrent should be ~%v", elapsed, checkDelay)
+	}
+}
+
+// slowLister blocks ~delay before returning an empty healthy catalog.
+type slowLister struct{ delay time.Duration }
+
+func (s *slowLister) ListVoices(ctx context.Context) ([]tts.Voice, error) {
+	sleepCtx(ctx, s.delay)
+	return nil, nil
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
 	}
 }

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -659,7 +659,7 @@ func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
 
 	// Saving Discord settings busts it too.
 	if _, err := providerSrv.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		GuildId: "g1", VoiceChannelId: "c1",
+		GuildId: ptr("g1"), VoiceChannelId: ptr("c1"),
 	})); err != nil {
 		t.Fatalf("SaveDiscordSettings: %v", err)
 	}
@@ -700,3 +700,6 @@ func (stubProviderStore) SaveDiscordBotToken(context.Context, uuid.UUID, []byte,
 func (stubProviderStore) SaveDiscordChannels(_ context.Context, _ uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error) {
 	return storage.DeploymentConfig{GuildID: guildID, VoiceChannelID: voiceChannelID}, nil
 }
+
+// ptr returns a pointer to v, for proto3 optional scalar fields.
+func ptr[T any](v T) *T { return &v }

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -442,3 +442,44 @@ func TestGetProviderHealth_CachedWithinTTL(t *testing.T) {
 		t.Errorf("counts after TTL expiry = %v, want each vendor probed again (2)", got)
 	}
 }
+
+// fakeSessions is an activeSessionSource whose Snapshot reports a live voice
+// session iff active is true.
+type fakeSessions struct{ active bool }
+
+func (f *fakeSessions) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{}, f.active
+}
+
+// TestGetProviderHealth_ActiveSessionSkipsDiscordProbe pins #150: while a voice
+// session is active, the Discord check short-circuits to healthy WITHOUT
+// touching Discord — the live session (on the same token) IS the health signal,
+// and a probe would race its reconnects for the per-token IDENTIFY budget.
+func TestGetProviderHealth_ActiveSessionSkipsDiscordProbe(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	srv := NewVoiceServer(healthyStore(t, cipher), cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+	srv.SetSessions(&fakeSessions{active: true})
+
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	if got := seams.discord.Load(); got != 0 {
+		t.Errorf("discord probed %d times during an active session, want 0", got)
+	}
+	for _, p := range resp.Msg.GetProviders() {
+		if p.GetProvider() == "discord" && p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_HEALTHY {
+			t.Errorf("discord should report healthy during an active session: %+v", p)
+		}
+	}
+	// The other two providers are still probed for real.
+	if got := seams.llm.Load(); got != 1 {
+		t.Errorf("llm probes = %d, want 1", got)
+	}
+	if got := seams.lister.Load(); got != 1 {
+		t.Errorf("tts probes = %d, want 1", got)
+	}
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -369,5 +370,75 @@ func sleepCtx(ctx context.Context, d time.Duration) {
 	select {
 	case <-time.After(d):
 	case <-ctx.Done():
+	}
+}
+
+// countingHealthSeams wires all three provider seams to atomic counters so a
+// test can pin how often the vendors were actually touched.
+type countingHealthSeams struct {
+	lister, llm, discord atomic.Int64
+}
+
+func (c *countingHealthSeams) wire(srv *VoiceServer) {
+	srv.newLister = func(string) tts.VoiceLister {
+		c.lister.Add(1)
+		return &fakeLister{}
+	}
+	srv.pingLLM = func(context.Context, string) error {
+		c.llm.Add(1)
+		return nil
+	}
+	srv.botTag = func(context.Context, string) (string, error) {
+		c.discord.Add(1)
+		return "Glyphoxa#4823", nil
+	}
+}
+
+func (c *countingHealthSeams) counts() [3]int64 {
+	return [3]int64{c.lister.Load(), c.llm.Load(), c.discord.Load()}
+}
+
+// TestGetProviderHealth_CachedWithinTTL pins #150's server-side TTL cache: two
+// health calls within the TTL touch each vendor exactly once (the second is
+// served from cache), and after the TTL expires the vendors are probed again.
+func TestGetProviderHealth_CachedWithinTTL(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	srv := NewVoiceServer(healthyStore(t, cipher), cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(srv)
+
+	// A controllable clock so the test advances past the TTL without sleeping.
+	now := time.Now()
+	srv.now = func() time.Time { return now }
+
+	ctx := tenantCtx() // ONE tenant: the cache is keyed per tenant
+	req := func() *managementv1.GetProviderHealthResponse {
+		t.Helper()
+		resp, err := srv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+		if err != nil {
+			t.Fatalf("GetProviderHealth: %v", err)
+		}
+		return resp.Msg
+	}
+
+	first := req()
+	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+		t.Fatalf("counts after first call = %v, want each vendor touched once", got)
+	}
+
+	second := req()
+	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+		t.Errorf("counts after second call within TTL = %v, want still 1 each (served from cache)", got)
+	}
+	if len(second.GetProviders()) != len(first.GetProviders()) {
+		t.Errorf("cached response shape differs: %v vs %v", second, first)
+	}
+
+	// Advance past the TTL: the next call probes the vendors again.
+	now = now.Add(healthCacheTTL + time.Second)
+	req()
+	if got := seams.counts(); got != [3]int64{2, 2, 2} {
+		t.Errorf("counts after TTL expiry = %v, want each vendor probed again (2)", got)
 	}
 }

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -616,3 +616,87 @@ func TestGetProviderHealth_ActiveSessionKeepsLastKnownBotTag(t *testing.T) {
 		t.Errorf("discord probes = %d, want 1 (short-circuit must not touch Discord)", got)
 	}
 }
+
+// TestSaveCredentials_InvalidateHealthCache pins #150's cache-busting: after
+// the operator saves a new provider key or Discord settings, the next health
+// call probes the vendors fresh instead of serving a stale (possibly Degraded)
+// cached result for up to the TTL — which would imply the new key is also bad.
+func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	voiceSrv := NewVoiceServer(healthyStore(t, cipher), cipher, nil)
+	var seams countingHealthSeams
+	seams.wire(voiceSrv)
+	now := time.Now()
+	voiceSrv.now = func() time.Time { return now } // TTL never expires on its own
+
+	providerSrv := NewProviderServer(&stubProviderStore{}, cipher, nil)
+	providerSrv.SetHealthInvalidator(voiceSrv.InvalidateHealth)
+
+	ctx := tenantCtx() // same tenant drives saves and health calls
+	health := func(label string) {
+		t.Helper()
+		if _, err := voiceSrv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{})); err != nil {
+			t.Fatalf("%s: GetProviderHealth: %v", label, err)
+		}
+	}
+
+	health("initial")
+	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+		t.Fatalf("counts after initial call = %v, want 1 each", got)
+	}
+
+	// Saving a provider key busts the tenant's cache: the next call probes.
+	if _, err := providerSrv.SaveProviderConfig(ctx, connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "new-groq-key",
+	})); err != nil {
+		t.Fatalf("SaveProviderConfig: %v", err)
+	}
+	health("after key save")
+	if got := seams.counts(); got != [3]int64{2, 2, 2} {
+		t.Errorf("counts after key save = %v, want 2 each (cache busted)", got)
+	}
+
+	// Saving Discord settings busts it too.
+	if _, err := providerSrv.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		GuildId: "g1", VoiceChannelId: "c1",
+	})); err != nil {
+		t.Fatalf("SaveDiscordSettings: %v", err)
+	}
+	health("after discord save")
+	if got := seams.counts(); got != [3]int64{3, 3, 3} {
+		t.Errorf("counts after discord save = %v, want 3 each (cache busted)", got)
+	}
+}
+
+// stubProviderStore is the minimal providerStore for the invalidation test:
+// saves succeed with canned rows (provider_test.go's richer fake lives in the
+// external rpc_test package and is out of reach here).
+type stubProviderStore struct{}
+
+func (stubProviderStore) ListProviderConfigs(context.Context, uuid.UUID) ([]storage.ProviderConfig, error) {
+	return nil, nil
+}
+
+func (stubProviderStore) UpsertProviderConfigs(_ context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error) {
+	out := make([]storage.ProviderConfig, len(configs))
+	for i, n := range configs {
+		out[i] = storage.ProviderConfig{
+			Component: n.Component, Provider: n.Provider,
+			CredentialsCiphertext: n.CredentialsCiphertext, CredentialsLast4: n.CredentialsLast4,
+		}
+	}
+	return out, nil
+}
+
+func (stubProviderStore) GetDeploymentConfig(context.Context, uuid.UUID) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, storage.ErrNotFound
+}
+
+func (stubProviderStore) SaveDiscordBotToken(context.Context, uuid.UUID, []byte, string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, nil
+}
+
+func (stubProviderStore) SaveDiscordChannels(_ context.Context, _ uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{GuildID: guildID, VoiceChannelID: voiceChannelID}, nil
+}


### PR DESCRIPTION
## Defect

`GetProviderHealth` ran its three provider checks strictly sequentially (worst case 3 × 12 s = 36 s per request), and the Discord check was a **full gateway login** — disgo client build, IDENTIFY, wait-for-Ready — with the production bot token. The SPA refires the RPC on every window focus, so:

- the probe raced the live session's reconnect for the per-token IDENTIFY serialization (~1 per 5 s),
- an idle open tab accrued gateway logins toward Discord's daily session-start cap (exceeding it gets the token reset),
- a hung vendor pinned the RPC and a browser connection slot for up to 36 s.

## Fix

- **`internal/discordtag`**: `Resolve` rewritten from a gateway login to a REST `GET /users/@me` — proves the token authenticates without any IDENTIFY or session-start budget. Gateway code deleted; a package-private base-URL seam lets tests drive it offline. The call is a **plain net/http GET**, deliberately not disgo's `rest.NewClient`: that client's rate limiter starts a cleanup goroutine (`for range ticker.C`, `rest_rate_limiter.go:51,71-75` in disgo 0.19.6) that its `Close` never stops — one leaked goroutine + 10 s ticker per probe (test pinned exactly 25 leaked over 25 calls).
- **Concurrent checks**: `probeProviders` fans the LLM / TTS / Discord checks into goroutines; the RPC's worst case is now the slowest single check.
- **Whole-probe hard deadline**: `probeTimeout` (check timeout + 3 s) bounds everything under the cache entry lock, store reads included; on expiry the stuck checks are abandoned, missing slots report degraded-timeout, and the result is **not cached** — a hung store read can no longer wedge the tenant's health path forever.
- **Server-side TTL cache (60 s, per tenant)**: focus-refetches within the TTL are served from cache with zero vendor calls; after expiry the vendors are probed again. Probes are **true singleflight**: one leader probes per tenant, concurrent callers wait on that same flight (each with its own ctx bail-out) and take its result; a caller whose request context is already done returns `CodeCanceled`/`CodeDeadlineExceeded` without probing. The probe itself runs on `context.WithoutCancel` so an aborted refetch can't poison the cache.
- **Active-session short-circuit**: while a voice session is live, the Discord check reports healthy off `session.Manager.Snapshot` (wired via `VoiceServer.SetSessions` at boot) without touching Discord — carrying the **last-known bot tag** so the Configuration screen's "Connected as X#NNNN" row survives the session.
- **Cache busting on credential saves**: `SaveProviderConfig` / `SaveDiscordSettings` invalidate the tenant's cached verdict (wired via `SetHealthInvalidator` at boot), so a stale Degraded badge can't outlive a fixed key for up to a TTL.

## Tests (each red pre-fix)

- `TestResolve_RESTSelfUserNoGateway` — fake HTTP server is the entire Discord surface; pins exactly one `GET /users/@me` with `Bot` auth, no gateway dial possible.
- `TestResolve_NoGoroutineLeakPerCall` — 25 resolves grow goroutines by <10 (red: exactly +25 with disgo's rest client).
- `TestGetProviderHealth_ChecksRunConcurrently` — three 120 ms fakes complete in <300 ms (red at ~361 ms = sum).
- `TestGetProviderHealth_CachedWithinTTL` — two calls within the TTL touch each vendor once; injected clock advanced past the TTL probes again (red: 2 probes for 2 calls).
- `TestGetProviderHealth_HungStoreDoesNotWedgeTenant` — ctx-ignoring blocked store: all calls return within bound, entry lock released, timed-out result not cached, post-recovery call probes fresh to healthy (red: first call wedged >2 s).
- `TestGetProviderHealth_ActiveSessionSkipsDiscordProbe` — active fake session ⇒ zero Discord-seam calls, discord healthy, LLM/TTS still probed.
- `TestGetProviderHealth_ActiveSessionKeepsLastKnownBotTag` — probe once, start session, expire TTL ⇒ healthy + last-known tag, still one Discord call (red: tag blanked to `""`).
- `TestSaveCredentials_InvalidateHealthCache` — save key / Discord settings ⇒ next health call probes fresh despite live TTL (red: `SetHealthInvalidator` absent).
- `TestGetProviderHealth_CanceledCallersDoNotProbe` — 5 already-canceled callers return promptly with ctx errors (red: serialized at exactly 5 × 200 ms probeTimeout).
- `TestGetProviderHealth_WaitersShareLeaderProbe` — 5 concurrent live callers finish in ~1 probeTimeout with exactly one probe's worth of store reads (red: each waiter ran its own probe).

`go test -race ./...` clean, `golangci-lint run ./...` 0 issues.

## Out of scope

Client-side query tuning (staleTime / refetchOnWindowFocus) and Configuration-screen UI feedback (#154).

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
