### PR TITLE
fix(#169): SSE events route 404s non-UUID session ids

### DIFF
--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -83,13 +83,21 @@ func (r *Relay) detach(s *subscriber) {
 // the ring buffer after Last-Event-ID, then streams live frames until the client
 // disconnects, falls too far behind, or the process begins its graceful shutdown
 // (CloseStreams — issue #138).
+//
+// An id that does not parse as a UUID is 404 (#169), same as ServeSnapshot (see
+// its doc comment for the id-class argument): answering 200 would pin a
+// subscriber slot + handler goroutine forever on a stream no session can feed.
 func (r *Relay) ServeEvents(w http.ResponseWriter, req *http.Request) {
 	if _, ok := w.(http.Flusher); !ok {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return
 	}
-	fw := r.newFrameWriter(w)
 	id := req.PathValue("id")
+	if _, err := uuid.Parse(id); err != nil {
+		http.NotFound(w, req)
+		return
+	}
+	fw := r.newFrameWriter(w)
 
 	h := w.Header()
 	h.Set("Content-Type", "text/event-stream")

--- a/internal/transcript/http_test.go
+++ b/internal/transcript/http_test.go
@@ -273,6 +273,29 @@ func TestSnapshotRejectsUnparseableID(t *testing.T) {
 	}
 }
 
+// TestEventsRejectsUnparseableID pins the events half of the same id class
+// (#169): a non-UUID {id} can never name a session, so the SSE route must 404
+// like the snapshot route does — not answer 200 text/event-stream and hold a
+// subscriber slot + goroutine forever for a stream no session will ever feed.
+func TestEventsRejectsUnparseableID(t *testing.T) {
+	bus := voiceevent.NewBus()
+	relay := transcript.NewRelay(bus, &fakeSessions{id: uuid.New(), active: true}, nil, nil)
+	srv := httptest.NewServer(mux(relay))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/sessions/not-a-uuid/events")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("events for unparseable id: status=%d Content-Type=%q, want 404", resp.StatusCode, resp.Header.Get("Content-Type"))
+	}
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("events for unparseable id: Content-Type=%q, want no event stream", ct)
+	}
+}
+
 // TestSnapshotIdle returns idle when no session is active.
 func TestSnapshotIdle(t *testing.T) {
 	bus := voiceevent.NewBus()


### PR DESCRIPTION
> *This was generated by AI during triage.*

Fixes #169

## Defect

`GET /api/v1/sessions/<non-UUID>/events` answered `200 text/event-stream` and streamed forever: `ServeEvents` attached a subscriber without validating that `{id}` parses as a UUID. Any junk id (curl typo, malformed EventSource URL path-cleaned by ServeMux) pinned a subscriber slot + handler goroutine + h2c stream on a session that can never exist — while the sibling snapshot route has 404'd the same id class since PR #160.

## Fix

Mirror the `ServeSnapshot` guard: `uuid.Parse` the path id **before** writing the SSE headers/200; `http.NotFound` on failure. Doc comment points at ServeSnapshot's id-class argument (#153) for the full reasoning.

## Test

`TestEventsRejectsUnparseableID` (mirrors `TestSnapshotRejectsUnparseableID`): `GET /api/v1/sessions/not-a-uuid/events` must be 404 and not `text/event-stream`. Red on the old code (got `200 text/event-stream`), green with the guard. Full `internal/transcript` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)