### PR TITLE
docs(#115): .env.example + Discord-OAuth / operator-allowlist setup runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,68 @@
+# Glyphoxa v2 — environment template
+#
+# Copy to `.env`, fill in real values, then `source .env` before running the
+# binary (the repo's `.env` is shell-sourced: `export NAME='value'`).
+# `.env` and `.env.*` are gitignored; only THIS `.env.example` is tracked.
+#
+# EVERY value below is a PLACEHOLDER. Never commit a real secret. The web-tier
+# OAuth + operator setup is walked step by step in docs/configuration.md.
+#
+# Which vars each Mode needs:
+#   voice : GLYPHOXA_DATABASE_URL (or -hardcoded), DISCORD_BOT_TOKEN, provider keys
+#   web   : GLYPHOXA_DATABASE_URL, all three DISCORD_OAUTH_*, GLYPHOXA_OPERATOR_IDS
+#   all   : web + voice (drives the in-process voice loop too)
+
+# ── Database (ADR-0031) ──────────────────────────────────────────────────────
+# Postgres DSN. GLYPHOXA_DATABASE_URL wins; DATABASE_URL is the fallback.
+# Fatal at startup if BOTH are empty (voice/web/all all need the DB).
+export GLYPHOXA_DATABASE_URL='postgres://glyphoxa:CHANGE_ME@127.0.0.1:5432/glyphoxa?sslmode=disable'
+# export DATABASE_URL='postgres://glyphoxa:CHANGE_ME@127.0.0.1:5432/glyphoxa?sslmode=disable'
+
+# ── App secret / BYOK-at-rest (ADR-0004) ─────────────────────────────────────
+# Base64-encoded 32-byte AES-256 key: `openssl rand -base64 32`. Seals/opens the
+# encrypted provider credentials. Empty ⇒ cipher disabled: BYOK reads still work
+# but SAVING a provider key or Bot token fails (CodeFailedPrecondition).
+export GLYPHOXA_SECRET='CHANGE_ME_base64_32_bytes_from_openssl_rand'
+
+# ── Discord bot (voice loop) ─────────────────────────────────────────────────
+# Bot token for the Discord gateway/voice connection. REQUIRED in `voice` mode
+# (fatal if unset there); in web/all it is the deployment-shared fallback token.
+export DISCORD_BOT_TOKEN='your-discord-bot-token'
+
+# ── Discord OAuth + operator gate (ADR-0016 / ADR-0039 / ADR-0041) ───────────
+# Web-login OAuth app credentials. In web/all Mode, missing ANY of the three
+# below is FATAL at startup, naming the missing var. See docs/configuration.md
+# to register the OAuth app. REDIRECT_URL must EXACTLY equal the redirect
+# registered on the Discord app (scheme, host, port, path all match).
+export DISCORD_OAUTH_CLIENT_ID='your-discord-client-id'
+export DISCORD_OAUTH_CLIENT_SECRET='your-discord-client-secret'
+export DISCORD_OAUTH_REDIRECT_URL='http://127.0.0.1:8080/auth/discord/callback'
+# MANDATORY in web/all Mode (ADR-0041): the operator allowlist. Comma/whitespace
+# -separated Discord User snowflakes; only these may complete login. Empty ⇒
+# FATAL at startup. Single entry is the intended use; multiple is a documented
+# edge (each claims-or-creates its own Tenant). Find yours: Discord → Settings →
+# Advanced → Developer Mode ON, then right-click your user → Copy User ID.
+export GLYPHOXA_OPERATOR_IDS='000000000000000000'
+
+# ── Dev mode (ADR-0041) — NEVER set in production ────────────────────────────
+# Any non-empty value opts out of OAuth for LOCAL dev: auto-authenticates every
+# request as the seeded Operator, FORCES the listen address to 127.0.0.1
+# (overriding -web-addr), and logs a loud insecure-mode warning. The loopback
+# force makes production misuse structurally ineffective. Leave UNSET normally.
+# export GLYPHOXA_DEV_MODE='1'
+
+# ── Logging (ADR-0032) ───────────────────────────────────────────────────────
+# `text` or `json`. Empty ⇒ mode default.
+export GLYPHOXA_LOG_FORMAT='text'
+
+# ── Voice / ONNX (Silero VAD) ────────────────────────────────────────────────
+# Optional explicit path to the ONNX Runtime shared library for the VAD. Leave
+# unset to use the default lookup.
+# export GLYPHOXA_ONNX_LIB='/usr/local/lib/libonnxruntime.so'
+
+# ── Provider keys (BYOK, ADR-0004) — only the ones you actually use ───────────
+# Read at request time by the STT/TTS/LLM/S2S adapters; never compiled in.
+export GROQ_API_KEY='your-groq-api-key'
+export ELEVENLABS_API_KEY='your-elevenlabs-api-key'
+export GEMINI_API_KEY='your-gemini-api-key'
+export ANTHROPIC_API_KEY='your-anthropic-api-key'

--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,9 @@ export GLYPHOXA_DATABASE_URL='postgres://glyphoxa:CHANGE_ME@127.0.0.1:5432/glyph
 
 # ── App secret / BYOK-at-rest (ADR-0004) ─────────────────────────────────────
 # Base64-encoded 32-byte AES-256 key: `openssl rand -base64 32`. Seals/opens the
-# encrypted provider credentials. Empty ⇒ cipher disabled: BYOK reads still work
-# but SAVING a provider key or Bot token fails (CodeFailedPrecondition).
+# encrypted provider credentials. `glyphoxa seed` requires it; empty ⇒ cipher
+# disabled: BYOK reads still work but SAVING a provider key or Bot token fails
+# (CodeFailedPrecondition). The placeholder below is NOT valid base64 — replace it.
 export GLYPHOXA_SECRET='CHANGE_ME_base64_32_bytes_from_openssl_rand'
 
 # ── Discord bot (voice loop) ─────────────────────────────────────────────────
@@ -38,21 +39,24 @@ export DISCORD_OAUTH_CLIENT_ID='your-discord-client-id'
 export DISCORD_OAUTH_CLIENT_SECRET='your-discord-client-secret'
 export DISCORD_OAUTH_REDIRECT_URL='http://127.0.0.1:8080/auth/discord/callback'
 # MANDATORY in web/all Mode (ADR-0041): the operator allowlist. Comma/whitespace
-# -separated Discord User snowflakes; only these may complete login. Empty ⇒
-# FATAL at startup. Single entry is the intended use; multiple is a documented
-# edge (each claims-or-creates its own Tenant). Find yours: Discord → Settings →
+# -separated Discord User snowflakes (digits only); only these may complete
+# login. Empty, separators-only, or non-numeric entries ⇒ FATAL at startup.
+# Single entry is the intended use; multiple is a documented edge (each
+# claims-or-creates its own Tenant). Find yours: Discord → Settings →
 # Advanced → Developer Mode ON, then right-click your user → Copy User ID.
 export GLYPHOXA_OPERATOR_IDS='000000000000000000'
 
 # ── Dev mode (ADR-0041) — NEVER set in production ────────────────────────────
-# Any non-empty value opts out of OAuth for LOCAL dev: auto-authenticates every
-# request as the seeded Operator, FORCES the listen address to 127.0.0.1
-# (overriding -web-addr), and logs a loud insecure-mode warning. The loopback
-# force makes production misuse structurally ineffective. Leave UNSET normally.
+# Any non-empty value except 0/false/no/off opts out of OAuth for LOCAL dev:
+# auto-authenticates every request as the dev Operator, FORCES the listen
+# address to 127.0.0.1 (overriding -web-addr), rejects requests carrying proxy
+# headers (X-Forwarded-*/Forwarded), and logs a loud insecure-mode warning.
+# Point it at a THROWAWAY database — the dev Operator claims the seeded Tenant
+# (a later real OAuth login takes it over). Leave UNSET normally.
 # export GLYPHOXA_DEV_MODE='1'
 
 # ── Logging (ADR-0032) ───────────────────────────────────────────────────────
-# `text` or `json`. Empty ⇒ mode default.
+# `json`, or `text` (the default for any other value).
 export GLYPHOXA_LOG_FORMAT='text'
 
 # ── Voice / ONNX (Silero VAD) ────────────────────────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ coverage.html
 # Environment
 .env
 .env.*
+# ...but keep the committed placeholder template (see docs/configuration.md).
+!.env.example
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ make build
 ./bin/glyphoxa --config config.yaml
 ```
 
+For the **web tier** (Discord-OAuth operator login), copy `.env.example` to
+`.env`, fill it in, and follow the setup runbook in
+[docs/configuration.md](docs/configuration.md).
+
 ### Development
 
 ```bash
@@ -159,7 +163,7 @@ Comprehensive guides for developers and contributors — see the [full documenta
 |-------|-------------|
 | [Getting Started](docs/getting-started.md) | Prerequisites, build, first run |
 | [Architecture](docs/architecture.md) | System layers, data flow, key packages |
-| [Configuration](docs/configuration.md) | Complete config field reference |
+| [Configuration](docs/configuration.md) | Environment variables + Discord-OAuth / operator-allowlist setup runbook |
 | [Providers](docs/providers.md) | Provider system, adding new providers |
 | [NPC Agents](docs/npc-agents.md) | NPC definition, entities, campaigns |
 | [Memory](docs/memory.md) | 3-layer memory system |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,31 +23,69 @@ applies to **`web` and `all`** only; `voice` Mode is unaffected.
 
 ## 1. Prerequisites
 
-- **Postgres** reachable via a DSN. Set `GLYPHOXA_DATABASE_URL` (or the
-  `DATABASE_URL` fallback); both empty is fatal at startup. Example:
-  `postgres://glyphoxa:...@127.0.0.1:5432/glyphoxa?sslmode=disable`.
-- **App secret** for BYOK-at-rest (ADR-0004): `GLYPHOXA_SECRET`, a base64
-  32-byte key from `openssl rand -base64 32`. Optional to *boot* — without it
-  provider-key reads work but SAVES fail (`CodeFailedPrecondition`).
-- Apply the schema and seed the demo Tenant/Operator once:
+- **Go 1.26+** and a C toolchain — the build runs with `CGO_ENABLED=1`
+  (Makefile).
+- **Node.js 20+ and npm** — the operator console is a Vite/React bundle the Go
+  binary embeds; without it you get a blank placeholder page (see §3).
+- **[buf](https://buf.build/docs/installation)** — the Connect/protobuf stubs
+  under `gen/` are generated, not committed.
+- **Postgres with the [pgvector](https://github.com/pgvector/pgvector)
+  extension available** — the first migration runs
+  `CREATE EXTENSION IF NOT EXISTS vector` and fails on a stock Postgres without
+  the extension package. Easiest local path:
+  `docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=... pgvector/pgvector:pg17`.
+- `openssl` (or any source of 32 random bytes) for the app secret.
 
-  ```sh
-  ./glyphoxa migrate up
-  ./glyphoxa seed
-  ```
+No local toolchain? The container image (ADR-0034) ships everything prebuilt —
+see `deploy/`.
+
+## 2. Configure the environment
 
 Copy the committed template and fill it in — never edit a checked-in secret:
 
 ```sh
 cp .env.example .env
-$EDITOR .env
+$EDITOR .env       # set GLYPHOXA_DATABASE_URL; paste `openssl rand -base64 32` into GLYPHOXA_SECRET
 source .env        # the template is shell-sourced (export NAME='value')
 ```
 
-`.env` (and any `.env.*`) is gitignored; only `.env.example` — placeholders
-only — is tracked.
+- **Database DSN**: `GLYPHOXA_DATABASE_URL` (or the `DATABASE_URL` fallback);
+  both empty is fatal at startup. Example:
+  `postgres://glyphoxa:...@127.0.0.1:5432/glyphoxa?sslmode=disable`.
+- **App secret** for BYOK-at-rest (ADR-0004): `GLYPHOXA_SECRET`, a base64
+  32-byte key from `openssl rand -base64 32`. `glyphoxa seed` (§4) and every
+  credential **save** require it; without it the server still boots and
+  provider-key reads work, but saves fail (`CodeFailedPrecondition`). Set a
+  real one now — the template placeholder is not valid base64.
 
-## 2. Register a Discord OAuth application
+`.env` (and any `.env.*`) is gitignored; only `.env.example` — placeholders
+only — is tracked. The OAuth/allowlist values are filled in by §5–§6.
+
+## 3. Build
+
+```sh
+make proto                        # buf generate → gen/ (Go + TS stubs)
+(cd web && npm ci && npm run build)   # Vite bundle → internal/spa/dist (go:embed)
+make build                        # → bin/glyphoxa
+```
+
+Order matters: the Go build imports the generated `gen/` packages, and the web
+bundle must exist **before** `make build` embeds `internal/spa/dist`. Skipping
+the web step still compiles — the committed placeholder `index.html` satisfies
+the embed — but serves a **blank page** instead of the login screen.
+
+## 4. Apply the schema and seed
+
+With `.env` sourced (the seed needs the DSN **and** `GLYPHOXA_SECRET`):
+
+```sh
+./bin/glyphoxa migrate up
+./bin/glyphoxa seed
+```
+
+This seeds the demo Tenant/Campaign/NPC once, idempotently.
+
+## 5. Register a Discord OAuth application
 
 The web login is **Discord-only** OAuth (ADR-0016; Google/GitHub are "coming
 soon", disabled). Register one app:
@@ -62,14 +100,14 @@ soon", disabled). Register one app:
 5. Set `DISCORD_OAUTH_REDIRECT_URL` to the **exact same string** you registered
    (scheme, host, port, path all match) — a mismatch fails the OAuth exchange.
 
-## 3. Find your Discord snowflake and set the allowlist
+## 6. Find your Discord snowflake and set the allowlist
 
 The allowlist is the single gate (ADR-0041): only a listed Discord User can
 complete login. There is **no first-login/trust-on-first-use** claim (issue #107
 is wontfix), so you must list yourself up front.
 
 1. Discord → **Settings → Advanced → Developer Mode: ON**.
-2. Right-click your own user → **Copy User ID** (an 18–19 digit snowflake).
+2. Right-click your own user → **Copy User ID** (a 17–19 digit snowflake).
 3. Set `GLYPHOXA_OPERATOR_IDS` to it:
 
    ```sh
@@ -81,11 +119,11 @@ use.** Multiple is a documented edge (e.g. a second test account): each entry
 claims-or-creates its **own** isolated Tenant — the first to log in claims the
 seeded one, later ones get fresh empty Tenants. It is not shared-Tenant access.
 
-## 4. Run in `web`/`all` Mode and log in
+## 7. Run in `web`/`all` Mode and log in
 
 ```sh
 source .env
-./glyphoxa -mode web            # or -mode all to also drive the voice loop
+./bin/glyphoxa -mode web        # or -mode all to also drive the voice loop
 ```
 
 Open `http://127.0.0.1:8080`, click **Sign in with Discord**, approve the
@@ -93,31 +131,42 @@ consent screen. On success you land in the operator console. A Discord User
 **not** on `GLYPHOXA_OPERATOR_IDS` is rejected *before* any session or Tenant
 write and bounced back to the login screen with a `not_authorized` signal.
 
-## 5. Boot posture: loud fail, and the dev escape hatch
+## 8. Boot posture: loud fail, and the dev escape hatch
 
 In `web`/`all` Mode the process **refuses to boot** unless either all four gate
-variables are present or dev mode is set:
+variables are usable or dev mode is set:
 
 - Missing **any** of `DISCORD_OAUTH_CLIENT_ID` / `DISCORD_OAUTH_CLIENT_SECRET` /
-  `DISCORD_OAUTH_REDIRECT_URL`, **or** an empty `GLYPHOXA_OPERATOR_IDS` ⇒ a
-  **fatal startup error naming the missing variable(s)**. This is deliberate: a
-  deploy nobody can authorize into must fail loud, not look healthy (ADR-0041 —
-  the gate was already closed absent OAuth; this is the operability half).
+  `DISCORD_OAUTH_REDIRECT_URL`, **or** a `GLYPHOXA_OPERATOR_IDS` that yields no
+  usable allowlist (empty, separators only, or containing a non-numeric entry —
+  a pasted username can never match a snowflake) ⇒ a **fatal startup error
+  naming the missing variable(s) or bad entries**. This is deliberate: a deploy
+  nobody can authorize into must fail loud, not look healthy (ADR-0041 — the
+  gate was already closed absent OAuth; this is the operability half).
 - `voice` Mode is unaffected by all of the above.
 
-**Local dev opt-out — `GLYPHOXA_DEV_MODE`.** Set it to any non-empty value to
+**Local dev opt-out — `GLYPHOXA_DEV_MODE`.** Set it to `1` (any value other
+than blank or a falsy spelling — `0`, `false`, `no`, `off` — enables it) to
 boot without OAuth:
 
 ```sh
 export GLYPHOXA_DEV_MODE=1
-./glyphoxa -mode web
+./bin/glyphoxa -mode web
 ```
 
-Dev mode auto-authenticates every request as the seeded Operator, **forces the
+Dev mode auto-authenticates every request as the dev Operator, **forces the
 listen address to `127.0.0.1`** (overriding `-web-addr`), and logs a loud
-insecure-mode warning. The loopback force makes production misuse structurally
-ineffective — a container port-mapping cannot reach a loopback bind. **Never set
-`GLYPHOXA_DEV_MODE` in production.** (This replaces the old manual
+insecure-mode warning. A container port-mapping cannot reach the loopback bind,
+which blunts production misuse — but any **same-host** process still can (a
+reverse proxy pointed at `127.0.0.1`, a `kubectl port-forward`), so dev mode
+additionally **rejects (403) any request carrying proxy headers**
+(`X-Forwarded-For` / `X-Forwarded-Proto` / `Forwarded`). **Never set
+`GLYPHOXA_DEV_MODE` in production.**
+
+Point dev mode at a **throwaway database**: the dev Operator claims the seeded
+Tenant like a first login would. If you later switch the same database to real
+OAuth, your first real login takes that Tenant (with everything configured in
+dev mode) over from the dev Operator. (This replaces the old manual
 DB-session-insert dev flow; the superseded `GLYPHOXA_OPEN_TENANT_CREATION` flag
 from ADR-0016 plays no role here.)
 
@@ -131,14 +180,14 @@ used provider needs are required.
 |----------|----------|---------|
 | `GLYPHOXA_DATABASE_URL` | all Modes (DB path) | Postgres DSN. Fatal if this and `DATABASE_URL` are both empty. |
 | `DATABASE_URL` | fallback | Used only if `GLYPHOXA_DATABASE_URL` is empty. |
-| `GLYPHOXA_SECRET` | to save BYOK keys | base64 32-byte cipher key (`openssl rand -base64 32`). Empty ⇒ saves fail; reads still work. |
+| `GLYPHOXA_SECRET` | `seed` + saving BYOK keys | base64 32-byte cipher key (`openssl rand -base64 32`). Empty ⇒ `seed` fails and saves fail; reads still work. |
 | `DISCORD_BOT_TOKEN` | `voice` (fatal); web/all fallback | Discord gateway/voice bot token. |
 | `DISCORD_OAUTH_CLIENT_ID` | `web`/`all` | OAuth app client ID. |
 | `DISCORD_OAUTH_CLIENT_SECRET` | `web`/`all` | OAuth app client secret. |
 | `DISCORD_OAUTH_REDIRECT_URL` | `web`/`all` | Must equal the app's registered redirect exactly. |
-| `GLYPHOXA_OPERATOR_IDS` | `web`/`all` | Allowlisted Discord snowflakes (comma/whitespace-separated). Empty ⇒ fatal. |
-| `GLYPHOXA_DEV_MODE` | never in prod | Non-empty ⇒ OAuth-less local dev on `127.0.0.1` with auto-auth. |
-| `GLYPHOXA_LOG_FORMAT` | optional | `text` or `json` (empty ⇒ mode default). |
+| `GLYPHOXA_OPERATOR_IDS` | `web`/`all` | Allowlisted Discord snowflakes (comma/whitespace-separated, digits only). Empty, separators-only, or non-numeric entries ⇒ fatal. |
+| `GLYPHOXA_DEV_MODE` | never in prod | Non-empty (except `0`/`false`/`no`/`off`) ⇒ OAuth-less local dev on `127.0.0.1` with auto-auth. |
+| `GLYPHOXA_LOG_FORMAT` | optional | `json`, or `text` (the default for any other value). |
 | `GLYPHOXA_ONNX_LIB` | optional | Explicit path to the ONNX Runtime lib for the Silero VAD. |
 | `GROQ_API_KEY` | if Groq used | LLM provider key. |
 | `ELEVENLABS_API_KEY` | if ElevenLabs used | STT/TTS provider key. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,155 @@
+# Configuration & self-host setup
+
+This runbook takes a fresh checkout to a working **Operator** login for the
+single-operator web tier (ADR-0039), and lists every environment variable the
+`glyphoxa` binary reads. The access policy — a **mandatory Discord allowlist,
+no trust-on-first-use** — is decided by
+[ADR-0041](adr/0041-operator-allowlist-access-policy.md); read it for the *why*.
+For the `voice`-only live loop, see
+[docs/agents/live-npc-run.md](agents/live-npc-run.md).
+
+## Modes
+
+The binary runs one Mode at a time via `-mode` (ADR-0005):
+
+| Mode | Serves | Needs |
+|------|--------|-------|
+| `voice` | Discord voice loop only | DB (or `-hardcoded`), `DISCORD_BOT_TOKEN`, provider keys |
+| `web` | Web app + admin API | DB, all three `DISCORD_OAUTH_*`, `GLYPHOXA_OPERATOR_IDS` |
+| `all` | `web` + the in-process voice loop | everything for `web` and `voice` |
+
+The MVP binary defaults `-mode` to `voice`. The OAuth + allowlist gate below
+applies to **`web` and `all`** only; `voice` Mode is unaffected.
+
+## 1. Prerequisites
+
+- **Postgres** reachable via a DSN. Set `GLYPHOXA_DATABASE_URL` (or the
+  `DATABASE_URL` fallback); both empty is fatal at startup. Example:
+  `postgres://glyphoxa:...@127.0.0.1:5432/glyphoxa?sslmode=disable`.
+- **App secret** for BYOK-at-rest (ADR-0004): `GLYPHOXA_SECRET`, a base64
+  32-byte key from `openssl rand -base64 32`. Optional to *boot* — without it
+  provider-key reads work but SAVES fail (`CodeFailedPrecondition`).
+- Apply the schema and seed the demo Tenant/Operator once:
+
+  ```sh
+  ./glyphoxa migrate up
+  ./glyphoxa seed
+  ```
+
+Copy the committed template and fill it in — never edit a checked-in secret:
+
+```sh
+cp .env.example .env
+$EDITOR .env
+source .env        # the template is shell-sourced (export NAME='value')
+```
+
+`.env` (and any `.env.*`) is gitignored; only `.env.example` — placeholders
+only — is tracked.
+
+## 2. Register a Discord OAuth application
+
+The web login is **Discord-only** OAuth (ADR-0016; Google/GitHub are "coming
+soon", disabled). Register one app:
+
+1. Open the [Discord Developer Portal](https://discord.com/developers/applications)
+   → **New Application**.
+2. **OAuth2** tab → copy the **Client ID** → set `DISCORD_OAUTH_CLIENT_ID`.
+3. **Reset Secret** → copy it → set `DISCORD_OAUTH_CLIENT_SECRET`. (Shown once.)
+4. **OAuth2 → Redirects → Add Redirect**: enter the callback URL, e.g.
+   `http://127.0.0.1:8080/auth/discord/callback`, and **Save**. The path is
+   fixed at `/auth/discord/callback`; host/port match where you serve `-web-addr`.
+5. Set `DISCORD_OAUTH_REDIRECT_URL` to the **exact same string** you registered
+   (scheme, host, port, path all match) — a mismatch fails the OAuth exchange.
+
+## 3. Find your Discord snowflake and set the allowlist
+
+The allowlist is the single gate (ADR-0041): only a listed Discord User can
+complete login. There is **no first-login/trust-on-first-use** claim (issue #107
+is wontfix), so you must list yourself up front.
+
+1. Discord → **Settings → Advanced → Developer Mode: ON**.
+2. Right-click your own user → **Copy User ID** (an 18–19 digit snowflake).
+3. Set `GLYPHOXA_OPERATOR_IDS` to it:
+
+   ```sh
+   export GLYPHOXA_OPERATOR_IDS='000000000000000000'
+   ```
+
+Comma or whitespace separates multiple entries. **Single entry is the intended
+use.** Multiple is a documented edge (e.g. a second test account): each entry
+claims-or-creates its **own** isolated Tenant — the first to log in claims the
+seeded one, later ones get fresh empty Tenants. It is not shared-Tenant access.
+
+## 4. Run in `web`/`all` Mode and log in
+
+```sh
+source .env
+./glyphoxa -mode web            # or -mode all to also drive the voice loop
+```
+
+Open `http://127.0.0.1:8080`, click **Sign in with Discord**, approve the
+consent screen. On success you land in the operator console. A Discord User
+**not** on `GLYPHOXA_OPERATOR_IDS` is rejected *before* any session or Tenant
+write and bounced back to the login screen with a `not_authorized` signal.
+
+## 5. Boot posture: loud fail, and the dev escape hatch
+
+In `web`/`all` Mode the process **refuses to boot** unless either all four gate
+variables are present or dev mode is set:
+
+- Missing **any** of `DISCORD_OAUTH_CLIENT_ID` / `DISCORD_OAUTH_CLIENT_SECRET` /
+  `DISCORD_OAUTH_REDIRECT_URL`, **or** an empty `GLYPHOXA_OPERATOR_IDS` ⇒ a
+  **fatal startup error naming the missing variable(s)**. This is deliberate: a
+  deploy nobody can authorize into must fail loud, not look healthy (ADR-0041 —
+  the gate was already closed absent OAuth; this is the operability half).
+- `voice` Mode is unaffected by all of the above.
+
+**Local dev opt-out — `GLYPHOXA_DEV_MODE`.** Set it to any non-empty value to
+boot without OAuth:
+
+```sh
+export GLYPHOXA_DEV_MODE=1
+./glyphoxa -mode web
+```
+
+Dev mode auto-authenticates every request as the seeded Operator, **forces the
+listen address to `127.0.0.1`** (overriding `-web-addr`), and logs a loud
+insecure-mode warning. The loopback force makes production misuse structurally
+ineffective — a container port-mapping cannot reach a loopback bind. **Never set
+`GLYPHOXA_DEV_MODE` in production.** (This replaces the old manual
+DB-session-insert dev flow; the superseded `GLYPHOXA_OPEN_TENANT_CREATION` flag
+from ADR-0016 plays no role here.)
+
+## Environment variable reference
+
+Every variable the shipped binary reads. See `.env.example` for a copy-paste
+template with placeholders. Provider keys are BYOK (ADR-0004): only the ones a
+used provider needs are required.
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `GLYPHOXA_DATABASE_URL` | all Modes (DB path) | Postgres DSN. Fatal if this and `DATABASE_URL` are both empty. |
+| `DATABASE_URL` | fallback | Used only if `GLYPHOXA_DATABASE_URL` is empty. |
+| `GLYPHOXA_SECRET` | to save BYOK keys | base64 32-byte cipher key (`openssl rand -base64 32`). Empty ⇒ saves fail; reads still work. |
+| `DISCORD_BOT_TOKEN` | `voice` (fatal); web/all fallback | Discord gateway/voice bot token. |
+| `DISCORD_OAUTH_CLIENT_ID` | `web`/`all` | OAuth app client ID. |
+| `DISCORD_OAUTH_CLIENT_SECRET` | `web`/`all` | OAuth app client secret. |
+| `DISCORD_OAUTH_REDIRECT_URL` | `web`/`all` | Must equal the app's registered redirect exactly. |
+| `GLYPHOXA_OPERATOR_IDS` | `web`/`all` | Allowlisted Discord snowflakes (comma/whitespace-separated). Empty ⇒ fatal. |
+| `GLYPHOXA_DEV_MODE` | never in prod | Non-empty ⇒ OAuth-less local dev on `127.0.0.1` with auto-auth. |
+| `GLYPHOXA_LOG_FORMAT` | optional | `text` or `json` (empty ⇒ mode default). |
+| `GLYPHOXA_ONNX_LIB` | optional | Explicit path to the ONNX Runtime lib for the Silero VAD. |
+| `GROQ_API_KEY` | if Groq used | LLM provider key. |
+| `ELEVENLABS_API_KEY` | if ElevenLabs used | STT/TTS provider key. |
+| `GEMINI_API_KEY` | if Gemini used | LLM / S2S provider key. |
+| `ANTHROPIC_API_KEY` | if Anthropic used | LLM provider key. |
+
+## See also
+
+- [ADR-0041](adr/0041-operator-allowlist-access-policy.md) — operator allowlist, no trust-on-first-use, loud-fail/loopback posture (source of truth).
+- [ADR-0039](adr/0039-mvp-ui-backend-single-operator-web-tier.md) — single-operator web tier.
+- [ADR-0016](adr/0016-cookies-discord-only-oauth.md) — cookies + Discord-only OAuth.
+- [ADR-0004](adr/0004-byok-provider-key-matrix.md) — BYOK provider key matrix.
+- [ADR-0034](adr/0034-deployment-artifacts.md) — deployment artifacts (container/Helm).
+- [docs/agents/live-npc-run.md](agents/live-npc-run.md) — the `voice`-mode live NPC run guide.


### PR DESCRIPTION
Closes #115. Governed by [ADR-0041](../blob/main/docs/adr/0041-operator-allowlist-access-policy.md) (mandatory Discord operator allowlist, no trust-on-first-use, loud-fail + loopback dev opt-out).

## What changed (docs + env template only — zero product code)

- **`.env.example`** (new, tracked) — lists **every** env var the binary reads, grouped with comment headers, `export VAR='placeholder'` format matching the repo's shell-sourced `.env`. Placeholders only.
- **`.gitignore`** — add `!.env.example` un-ignore (it was caught by the existing `.env.*` rule).
- **`docs/configuration.md`** (new) — clean-checkout setup runbook.
- **`README.md`** — the dead `docs/configuration.md` link now resolves; added a web-tier setup pointer in Quick Start.

## Acceptance criteria

- [x] **Env template lists EVERY variable, placeholder + inline note, no real secrets** — `.env.example` covers `GLYPHOXA_DATABASE_URL`/`DATABASE_URL`, `GLYPHOXA_SECRET`, `DISCORD_BOT_TOKEN`, the three `DISCORD_OAUTH_*`, `GLYPHOXA_OPERATOR_IDS`, `GLYPHOXA_DEV_MODE`, `GLYPHOXA_LOG_FORMAT`, `GLYPHOXA_ONNX_LIB`, and provider keys (`GROQ`/`ELEVENLABS`/`GEMINI`/`ANTHROPIC`).
- [x] **Runbook: clean checkout → OAuth registration → redirect URL → allowlist → operator login** — `docs/configuration.md` §1–§4.
- [x] **Documents allowlist + first-login-lock fallback status + loud-fail/localhost opt-out** — §3 (allowlist mandatory, **no** trust-on-first-use, #107 wontfix) and §5 (fatal-naming-the-missing-var boot refusal; `GLYPHOXA_DEV_MODE` = auto-auth + forced `127.0.0.1` + loud warning).
- [x] **Secret-scan confirms placeholders only** — `git diff --cached` grepped for key/token shapes; only benign hits (`CHANGE_ME_...` placeholder + an ADR filename).
- [x] **Var names match the binary AND the ADR** — verified against `cmd/glyphoxa/{main,migrate,seed}.go` reads and ADR-0041 (`GLYPHOXA_OPERATOR_IDS`, `GLYPHOXA_DEV_MODE`).

## Scope corrections obeyed

- Added `GLYPHOXA_OPERATOR_IDS` (mandatory web/all) + `GLYPHOXA_DEV_MODE` (dev opt-out).
- **Dropped** any first-login-lock section (#107 wontfix); documented allowlist as mandatory + how to find a Discord snowflake (Developer Mode → Copy User ID).
- Boot posture documented: missing any `DISCORD_OAUTH_*` or empty `GLYPHOXA_OPERATOR_IDS` ⇒ FATAL naming the var; `GLYPHOXA_DEV_MODE` ⇒ `127.0.0.1` + loud warning; `voice` Mode unaffected.

## Notes

- `.gitignore` un-ignore: `git check-ignore .env.example` returns nothing ⇒ file is tracked.
- New vars' CODE lands concurrently via #103 (allowlist gate) / #112 (boot refusal + dev-mode); this PR touches only `.env.example`, `.gitignore`, `docs/`, `README.md` — no overlap.
- Docs/env-template change; all CI gates pass trivially (no markdown gate; `lint` = golangci-lint over Go; no gate parses `.env.example`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)