### PR TITLE
feat(#103): gate OAuth login on a mandatory Discord operator allowlist

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -320,7 +320,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 		ClientSecret: os.Getenv("DISCORD_OAUTH_CLIENT_SECRET"),
 		RedirectURL:  os.Getenv("DISCORD_OAUTH_REDIRECT_URL"),
 	})
-	oauth := auth.NewOAuth(store, discord, "/", log)
+	// GLYPHOXA_OPERATOR_IDS is the mandatory operator allowlist (ADR-0041): the
+	// single authorization gate at the OAuth callback. A Discord User whose
+	// snowflake is absent is denied a session before any Tenant write.
+	allowlist := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
+	oauth := auth.NewOAuth(store, discord, "/", allowlist, log)
 	authServer := auth.NewAuthServer(store, log)
 
 	// The store satisfies both Authenticator (AuthenticateSession) and

--- a/internal/auth/allowlist.go
+++ b/internal/auth/allowlist.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"strings"
+	"unicode"
+)
+
+// OperatorAllowlist is the parsed GLYPHOXA_OPERATOR_IDS gate (ADR-0041): the set
+// of Discord User snowflakes a self-host deployment grants web-tier access to.
+// It is the single authorization gate at the OAuth callback — a Discord User
+// whose snowflake is absent is rejected before any session or Tenant write.
+// The zero value denies every snowflake.
+type OperatorAllowlist struct {
+	ids map[string]struct{}
+}
+
+// ParseOperatorAllowlist parses a GLYPHOXA_OPERATOR_IDS value into an allowlist.
+// Snowflakes are separated by commas and/or whitespace; surrounding whitespace
+// is trimmed and empty entries are dropped. Exported and dependency-free so the
+// boot-refusal check (#112) can reuse it.
+func ParseOperatorAllowlist(s string) OperatorAllowlist {
+	sep := func(r rune) bool { return r == ',' || unicode.IsSpace(r) }
+	ids := make(map[string]struct{})
+	for _, f := range strings.FieldsFunc(s, sep) {
+		ids[f] = struct{}{}
+	}
+	return OperatorAllowlist{ids: ids}
+}
+
+// Contains reports whether the Discord User snowflake is on the allowlist.
+func (a OperatorAllowlist) Contains(id string) bool {
+	_, ok := a.ids[id]
+	return ok
+}
+
+// Len is the number of distinct snowflakes on the allowlist; zero means the gate
+// is unconfigured and every login is rejected.
+func (a OperatorAllowlist) Len() int { return len(a.ids) }

--- a/internal/auth/allowlist.go
+++ b/internal/auth/allowlist.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -36,3 +37,22 @@ func (a OperatorAllowlist) Contains(id string) bool {
 // Len is the number of distinct snowflakes on the allowlist; zero means the gate
 // is unconfigured and every login is rejected.
 func (a OperatorAllowlist) Len() int { return len(a.ids) }
+
+// Malformed returns the entries that cannot be Discord User snowflakes — a
+// snowflake is decimal digits only — sorted for stable error text. Such an
+// entry (a pasted username, a quoted value) can never match a real Discord
+// User, so it silently locks the operator out while still counting as a
+// "configured" allowlist; the boot preflight (#112) fails loud on it instead.
+func (a OperatorAllowlist) Malformed() []string {
+	var bad []string
+	for id := range a.ids {
+		for _, r := range id {
+			if r < '0' || r > '9' {
+				bad = append(bad, id)
+				break
+			}
+		}
+	}
+	slices.Sort(bad)
+	return bad
+}

--- a/internal/auth/allowlist_test.go
+++ b/internal/auth/allowlist_test.go
@@ -1,0 +1,46 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+func TestParseOperatorAllowlist(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want []string // snowflakes that MUST be Contains()==true
+		deny []string // snowflakes that MUST be Contains()==false
+		len  int
+	}{
+		{name: "empty", in: "", deny: []string{"", "77"}, len: 0},
+		{name: "single", in: "77", want: []string{"77"}, deny: []string{"78"}, len: 1},
+		{name: "comma", in: "77,88,99", want: []string{"77", "88", "99"}, len: 3},
+		{name: "whitespace", in: "77 88\t99", want: []string{"77", "88", "99"}, len: 3},
+		{name: "mixed comma+whitespace", in: "77, 88 ,99", want: []string{"77", "88", "99"}, len: 3},
+		{name: "surrounding whitespace", in: "  77  ", want: []string{"77"}, len: 1},
+		{name: "empty entries dropped", in: "77,,  ,88,", want: []string{"77", "88"}, deny: []string{""}, len: 2},
+		{name: "newlines", in: "77\n88\r\n99", want: []string{"77", "88", "99"}, len: 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := auth.ParseOperatorAllowlist(tc.in)
+			if a.Len() != tc.len {
+				t.Errorf("Len() = %d, want %d", a.Len(), tc.len)
+			}
+			for _, id := range tc.want {
+				if !a.Contains(id) {
+					t.Errorf("Contains(%q) = false, want true", id)
+				}
+			}
+			for _, id := range tc.deny {
+				if a.Contains(id) {
+					t.Errorf("Contains(%q) = true, want false", id)
+				}
+			}
+		})
+	}
+}

--- a/internal/auth/allowlist_test.go
+++ b/internal/auth/allowlist_test.go
@@ -1,6 +1,7 @@
 package auth_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/internal/auth"
@@ -40,6 +41,33 @@ func TestParseOperatorAllowlist(t *testing.T) {
 				if a.Contains(id) {
 					t.Errorf("Contains(%q) = true, want false", id)
 				}
+			}
+		})
+	}
+}
+
+// Malformed surfaces entries that can never match a Discord snowflake (digits
+// only), so the boot preflight (#112) can fail loud instead of letting a pasted
+// username silently lock the operator out.
+func TestOperatorAllowlistMalformed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "all numeric", in: "77, 88 99", want: nil},
+		{name: "pasted username", in: "MrWong99,770000000000000000", want: []string{"MrWong99"}},
+		{name: "quoted value", in: `"123",456`, want: []string{`"123"`}},
+		{name: "sorted output", in: "zz 123 abc", want: []string{"abc", "zz"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := auth.ParseOperatorAllowlist(tc.in).Malformed()
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Malformed() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/auth/auth_e2e_test.go
+++ b/internal/auth/auth_e2e_test.go
@@ -96,7 +96,9 @@ func TestAuthEndToEnd(t *testing.T) {
 	disc := &fakeDiscord{user: auth.DiscordUser{
 		ID: "555", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png",
 	}}
-	o := auth.NewOAuth(store, disc, "/", nil)
+	// The operator snowflake is on the mandatory allowlist (ADR-0041) so the
+	// callback issues a real session.
+	o := auth.NewOAuth(store, disc, "/", auth.ParseOperatorAllowlist("555"), nil)
 
 	// 1. OAuth callback issues a real session — capture the cookies.
 	cbReq := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=st", nil)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -35,15 +35,23 @@ const stateCookieTTL = 10 * time.Minute
 type OAuth struct {
 	store    OAuthStore
 	discord  DiscordOAuth
+	allow    OperatorAllowlist // the mandatory operator gate (ADR-0041)
 	ttl      time.Duration
 	redirect string // where the callback sends the browser after login
 	now      func() time.Time
 	log      *slog.Logger
 }
 
+// notAuthorizedRedirect is where the callback sends a Discord User who is not on
+// the operator allowlist: the login screen with a non-leaky not_authorized
+// signal (ADR-0041). This is the only redirect that carries an ?error= param —
+// bad-state/missing-code still fail with http.Error.
+const notAuthorizedRedirect = "/login?error=not_authorized"
+
 // NewOAuth builds the OAuth handlers. appRedirect is the post-login destination
-// (the SPA root, "/").
-func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, log *slog.Logger) *OAuth {
+// (the SPA root, "/"). allow is the mandatory operator allowlist (ADR-0041): a
+// Discord User whose snowflake is absent is denied a session at the callback.
+func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, allow OperatorAllowlist, log *slog.Logger) *OAuth {
 	if appRedirect == "" {
 		appRedirect = "/"
 	}
@@ -53,6 +61,7 @@ func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, log *s
 	return &OAuth{
 		store:    store,
 		discord:  discord,
+		allow:    allow,
 		ttl:      defaultSessionTTL,
 		redirect: appRedirect,
 		now:      time.Now,
@@ -107,6 +116,16 @@ func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
 		// The raw error can carry endpoint/status detail; log it, return generic.
 		o.log.Error("oauth callback: discord exchange", "err", err)
 		http.Error(w, "discord sign-in failed", http.StatusBadGateway)
+		return
+	}
+
+	// The mandatory operator allowlist is THE gate (ADR-0041). Reject a Discord
+	// User whose snowflake is absent BEFORE any UpsertUser / ResolveOperatorTenant
+	// / CreateSession — no session, no Tenant write, no auto-created Tenant — and
+	// bounce to the login screen with a non-leaky not_authorized signal.
+	if !o.allow.Contains(du.ID) {
+		o.log.Warn("oauth callback: rejected non-allowlisted Discord user", "discord_user_id", du.ID)
+		http.Redirect(w, r, notAuthorizedRedirect, http.StatusFound)
 		return
 	}
 

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -31,26 +31,33 @@ func (f *fakeDiscord) Exchange(_ context.Context, code string) (auth.DiscordUser
 	return f.user, nil
 }
 
-// fakeOAuthStore records the writes the callback performs.
+// fakeOAuthStore records the writes the callback performs, counting each call so
+// a rejected login can be asserted to have written NOTHING.
 type fakeOAuthStore struct {
-	upserted storage.UpsertUserParams
-	resolved uuid.UUID
-	created  storage.NewSession
-	userID   uuid.UUID
-	tenantID uuid.UUID
+	upserted    storage.UpsertUserParams
+	resolved    uuid.UUID
+	created     storage.NewSession
+	userID      uuid.UUID
+	tenantID    uuid.UUID
+	upsertCalls int
+	resolveN    int
+	createCalls int
 }
 
 func (f *fakeOAuthStore) UpsertUser(_ context.Context, p storage.UpsertUserParams) (storage.User, error) {
+	f.upsertCalls++
 	f.upserted = p
 	return storage.User{ID: f.userID, DiscordUserID: p.DiscordUserID, Name: p.Name, Avatar: p.Avatar, Role: "operator"}, nil
 }
 
 func (f *fakeOAuthStore) ResolveOperatorTenant(_ context.Context, userID uuid.UUID) (storage.Tenant, error) {
+	f.resolveN++
 	f.resolved = userID
 	return storage.Tenant{ID: f.tenantID, Name: "Glyphoxa"}, nil
 }
 
 func (f *fakeOAuthStore) CreateSession(_ context.Context, n storage.NewSession) (storage.Session, error) {
+	f.createCalls++
 	f.created = n
 	return storage.Session{ID: uuid.New(), UserID: n.UserID, Token: n.Token, ExpiresAt: n.ExpiresAt}, nil
 }
@@ -58,7 +65,7 @@ func (f *fakeOAuthStore) CreateSession(_ context.Context, n storage.NewSession) 
 func TestOAuthLogin_RedirectsAndSetsState(t *testing.T) {
 	t.Parallel()
 	disc := &fakeDiscord{authBase: "https://discord/authorize"}
-	o := auth.NewOAuth(&fakeOAuthStore{}, disc, "/", nil)
+	o := auth.NewOAuth(&fakeOAuthStore{}, disc, "/", auth.ParseOperatorAllowlist(""), nil)
 
 	rec := httptest.NewRecorder()
 	o.Login(rec, httptest.NewRequest(http.MethodGet, "/auth/discord/login", nil))
@@ -94,7 +101,8 @@ func TestOAuthCallback_IssuesSessionCookie(t *testing.T) {
 	t.Parallel()
 	disc := &fakeDiscord{user: auth.DiscordUser{ID: "77", Username: "sora", GlobalName: "Sora Vance", AvatarURL: "https://cdn/a.png"}}
 	store := &fakeOAuthStore{userID: uuid.New(), tenantID: uuid.New()}
-	o := auth.NewOAuth(store, disc, "/", nil)
+	// The fake user's snowflake IS on the allowlist (multi-value, whitespace-tolerant).
+	o := auth.NewOAuth(store, disc, "/", auth.ParseOperatorAllowlist("42, 77 99"), nil)
 
 	// A valid callback presents the state cookie matching the state param + a code.
 	form := url.Values{"code": {"the-code"}, "state": {"st-1"}}
@@ -150,7 +158,7 @@ func TestOAuthCallback_IssuesSessionCookie(t *testing.T) {
 func TestOAuthCallback_BadState_Rejected(t *testing.T) {
 	t.Parallel()
 	store := &fakeOAuthStore{}
-	o := auth.NewOAuth(store, &fakeDiscord{}, "/", nil)
+	o := auth.NewOAuth(store, &fakeDiscord{}, "/", auth.ParseOperatorAllowlist(""), nil)
 
 	// State cookie does not match the state param.
 	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?code=c&state=mismatch", nil)
@@ -164,5 +172,49 @@ func TestOAuthCallback_BadState_Rejected(t *testing.T) {
 	}
 	if store.created.Token != "" {
 		t.Error("session created despite state mismatch")
+	}
+}
+
+// A Discord User whose snowflake is NOT on the operator allowlist (ADR-0041) is
+// denied a session and a Tenant binding: the callback rejects BEFORE any store
+// write and bounces to /login?error=not_authorized. No session, no Tenant write,
+// no auto-created Tenant.
+func TestOAuthCallback_NotAllowlisted_Rejected(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{user: auth.DiscordUser{ID: "999", Username: "stranger", GlobalName: "Stranger"}}
+	store := &fakeOAuthStore{userID: uuid.New(), tenantID: uuid.New()}
+	// Allowlist holds other snowflakes; "999" is absent.
+	o := auth.NewOAuth(store, disc, "/", auth.ParseOperatorAllowlist("42, 77"), nil)
+
+	form := url.Values{"code": {"the-code"}, "state": {"st-1"}}
+	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?"+form.Encode(), nil)
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st-1"})
+
+	rec := httptest.NewRecorder()
+	o.Callback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/login?error=not_authorized" {
+		t.Errorf("Location = %q, want /login?error=not_authorized", loc)
+	}
+
+	// No session, no Tenant write, no user upsert — the gate ran first.
+	if store.upsertCalls != 0 {
+		t.Errorf("UpsertUser called %d times, want 0", store.upsertCalls)
+	}
+	if store.resolveN != 0 {
+		t.Errorf("ResolveOperatorTenant called %d times, want 0", store.resolveN)
+	}
+	if store.createCalls != 0 {
+		t.Errorf("CreateSession called %d times, want 0", store.createCalls)
+	}
+
+	// No session/csrf cookies were issued to the rejected user.
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_session" || c.Name == "glyphoxa_csrf" {
+			t.Errorf("issued %s cookie to a rejected user", c.Name)
+		}
 	}
 }

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
+
+import { routeTree } from "./router";
+
+// Pins the Go↔TS contract for the operator-allowlist denial signal (ADR-0041):
+// the OAuth callback redirects to the literal /login?error=not_authorized
+// (notAuthorizedRedirect in internal/auth/oauth.go), and the login route's
+// validateSearch must surface exactly that param name and value as the
+// not-authorized banner. Login.test.tsx covers the component prop; this covers
+// the URL→prop wiring, so a drift on either side of the contract fails a test.
+function renderAt(path: string) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(<RouterProvider router={router} />);
+}
+
+describe("loginRoute ?error=not_authorized contract", () => {
+  it("renders the allowlist banner for /login?error=not_authorized", async () => {
+    renderAt("/login?error=not_authorized");
+    expect(await screen.findByRole("alert")).toHaveTextContent(/allowlist/i);
+  });
+
+  it("renders no banner on a plain /login visit", async () => {
+    renderAt("/login");
+    await screen.findByRole("link", { name: /continue with discord/i });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders no banner for an unrecognized error value", async () => {
+    renderAt("/login?error=server_flu");
+    await screen.findByRole("link", { name: /continue with discord/i });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -27,11 +27,20 @@ const rootRoute = createRootRoute({
 });
 
 // /login — the Discord-only OAuth entry (ADR-0016). It lives OUTSIDE the tenant
-// shell so it never triggers the AuthGate (which would loop).
+// shell so it never triggers the AuthGate (which would loop). The OAuth callback
+// bounces an operator-allowlist rejection here with ?error=not_authorized
+// (ADR-0041); validateSearch surfaces it as a typed search param so the screen
+// can render the not-authorized banner.
 const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/login",
-  component: Login,
+  validateSearch: (search: Record<string, unknown>): { error?: string } => ({
+    error: typeof search.error === "string" ? search.error : undefined,
+  }),
+  component: function LoginScreen() {
+    const { error } = loginRoute.useSearch();
+    return <Login notAuthorized={error === "not_authorized"} />;
+  },
 });
 
 // "/" → the default tenant's Configuration (boot flow stand-in for this stage).

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -99,7 +99,9 @@ const screenRoute = createRoute({
   },
 });
 
-const routeTree = rootRoute.addChildren([
+// Exported so tests can mount the real tree on a memory history and pin the
+// Go↔TS ?error=not_authorized contract (see router.test.tsx).
+export const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
   tenantRoute.addChildren([tenantIndexRoute, screenRoute]),

--- a/web/src/screens/login/Login.test.tsx
+++ b/web/src/screens/login/Login.test.tsx
@@ -16,4 +16,17 @@ describe("Login", () => {
     expect(screen.getByRole("button", { name: /github/i })).toBeDisabled();
     expect(screen.getAllByText(/coming soon/i).length).toBeGreaterThanOrEqual(2);
   });
+
+  it("shows a friendly not-authorized banner when notAuthorized is set", () => {
+    render(<Login notAuthorized />);
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/allowlist/i);
+    // The Discord link stays available so the operator can retry with the right account.
+    expect(screen.getByRole("link", { name: /continue with discord/i })).toBeInTheDocument();
+  });
+
+  it("renders no banner on a normal first visit", () => {
+    render(<Login />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -9,7 +9,12 @@ import "./login.css";
 // Discord" link that starts the net/http OAuth carve-out (/auth/discord/login),
 // with Google/GitHub rendered DISABLED + "coming soon" (wired in v1.5+). It is a
 // full-page link, not a Connect call — OAuth is HTML redirects (ADR-0015).
-export function Login() {
+//
+// notAuthorized surfaces the operator-allowlist rejection (ADR-0041): the OAuth
+// callback bounces a Discord User who is not on GLYPHOXA_OPERATOR_IDS back here
+// with ?error=not_authorized. The banner is non-leaky — it never echoes the
+// rejected account's id. A normal first visit renders unchanged.
+export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
   return (
     <div className="gx-login">
       <div className="gx-login__card">
@@ -18,6 +23,12 @@ export function Login() {
         </span>
         <h1 className="gx-login__wordmark gx-gradient-text">Glyphoxa</h1>
         <p className="gx-login__lede">Sign in to run your table.</p>
+
+        {notAuthorized && (
+          <p className="gx-login__error" role="alert">
+            This Discord account isn&apos;t on the operator allowlist for this instance.
+          </p>
+        )}
 
         <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
           Continue with Discord

--- a/web/src/screens/login/login.css
+++ b/web/src/screens/login/login.css
@@ -41,6 +41,19 @@
   color: var(--text-subtle, #9a93a8);
 }
 
+/* Operator-allowlist rejection banner (ADR-0041, #103). Inline + role=alert —
+   the login screen is outside the Toaster host, so no sonner toast here. */
+.gx-login__error {
+  margin: 0;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--status-danger, #ff5c7a);
+  border-radius: var(--radius-sm, 8px);
+  color: var(--status-danger, #ff5c7a);
+  font-size: var(--body-sm, 0.875rem);
+  text-align: left;
+}
+
 .gx-login__soon {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #103. Implements the mandatory operator allowlist gate governed by **ADR-0041**.

## What
Discord OAuth authenticated but did not authorize — any Discord User completing the flow got a session + Tenant. This adds `GLYPHOXA_OPERATOR_IDS` as THE gate at the OAuth callback.

- **Gate placement**: right after `discord.Exchange` returns, BEFORE `UpsertUser` / `ResolveOperatorTenant` / `CreateSession`. A rejected user causes zero store writes and no auto-created Tenant.
- **Exported parser** `auth.ParseOperatorAllowlist(s) OperatorAllowlist` (+ `Contains`, `Len`): comma AND/OR whitespace separated, surrounding whitespace trimmed, empty entries dropped. Dependency-free so #112 (boot-refusal) can reuse it.
- **New redirect convention**: the denial 302s to `/login?error=not_authorized`. The existing `http.Error` bad-state / missing-code paths are unchanged (no `?error=` on those).
- **Tenant resolution untouched** — `storage.ResolveOperatorTenant` is not modified; each allowlisted Operator still claims-or-creates their own Tenant.
- **Login banner**: `Login.tsx` renders a non-leaky `role="alert"` banner ("This Discord account isn't on the operator allowlist for this instance.") only when `?error=not_authorized` is present; a normal first visit is unchanged. `router.tsx` `loginRoute` gains `validateSearch` to type the param.
- **main.go**: minimal wiring only — read + parse `GLYPHOXA_OPERATOR_IDS`, thread into `NewOAuth`. (Kept minimal to merge cleanly with #112 which edits the same file.)

## Acceptance criteria → test
| AC | Test |
|----|------|
| Allowlisted user gets a session + Tenant, unchanged | `TestOAuthCallback_IssuesSessionCookie` (allowlist contains the fake snowflake) |
| Non-allowlisted user denied — no session, no Tenant write, no auto-Tenant, rejection before any store call | `TestOAuthCallback_NotAllowlisted_Rejected` (asserts 0 UpsertUser/ResolveOperatorTenant/CreateSession calls, no cookies) |
| Rejected user lands on login with `not_authorized` in URL | same test asserts `Location == /login?error=not_authorized` |
| Login shows friendly not-authorized message; unchanged on normal visit | `Login.test.tsx`: banner shown with `notAuthorized`, absent otherwise |
| Multi-value, whitespace-tolerant allowlist parse | `TestParseOperatorAllowlist` (comma, whitespace, mixed, surrounding ws, empty entries, newlines) |
| e2e path stays green with allowlist set | `auth_e2e_test.go` allowlists the operator snowflake |

## Local verification
- `go test ./...` green; `go vet -tags integration ./internal/auth/` compiles; `golangci-lint run` 0 issues.
- `cd web && npm ci && npx vitest run` → 51 passed; `npm run build` (tsc + vite) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)