### PR TITLE
fix(#184): boot-time sweep revokes sessions outside the operator allowlist (ADR-0041 amendment)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -217,6 +217,25 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	defer pool.Close()
 	store := storage.New(pool)
 
+	// Boot-time session sweep (ADR-0041 amendment, issue #184): the allowlist
+	// gates only NEW logins at the OAuth callback, so sessions issued before the
+	// gate existed — or before a snowflake was removed — would stay valid for up
+	// to 30 days. The allowlist is parsed at boot, so a restart is exactly when
+	// a grant change takes effect: revoke every session whose owner is no longer
+	// allowlisted (including leftover GLYPHOXA_DEV_MODE sessions). Dev mode has
+	// no allowlist and skips the sweep.
+	if !dev {
+		allow := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
+		revoked, err := store.RevokeSessionsOutsideAllowlist(ctx, allow.IDs())
+		if err != nil {
+			return fmt.Errorf("web: revoke sessions outside the operator allowlist: %w", err)
+		}
+		if revoked > 0 {
+			log.Warn("revoked sessions of users not on the operator allowlist (ADR-0041)",
+				"count", revoked)
+		}
+	}
+
 	// The BYOK credential cipher (ADR-0004) is best-effort at boot: without
 	// $GLYPHOXA_SECRET the web tier still serves (Configuration reads work), but
 	// saving a provider key / Bot token fails loudly (CodeFailedPrecondition) —

--- a/cmd/glyphoxa/runweb_preflight_test.go
+++ b/cmd/glyphoxa/runweb_preflight_test.go
@@ -52,3 +52,42 @@ func TestRunWebPreflightWiring(t *testing.T) {
 		t.Errorf("dev-mode error = %q, want the missing-database error (preflight must be skipped)", err)
 	}
 }
+
+// TestRunWebSessionSweepWiring pins the #184 boot-time revocation sweep into
+// runWeb: with a fully-configured gate and an unreachable database, the boot
+// must fail INSIDE the sweep (it is the first DB touch — the pool dials
+// lazily), proving the wiring exists; deleting the sweep block would surface a
+// different error. Dev mode must skip the sweep entirely (its first DB touch is
+// the dev-session seed instead). DB-free: the DSN points at a closed loopback
+// port.
+func TestRunWebSessionSweepWiring(t *testing.T) {
+	t.Setenv("DISCORD_OAUTH_CLIENT_ID", "cid")
+	t.Setenv("DISCORD_OAUTH_CLIENT_SECRET", "secret")
+	t.Setenv("DISCORD_OAUTH_REDIRECT_URL", "https://x/cb")
+	t.Setenv("GLYPHOXA_OPERATOR_IDS", "770000000000000000")
+	t.Setenv("GLYPHOXA_DEV_MODE", "")
+	t.Setenv("GLYPHOXA_DATABASE_URL", "postgres://glyphoxa:x@127.0.0.1:1/glyphoxa?sslmode=disable&connect_timeout=1")
+	t.Setenv("DATABASE_URL", "")
+
+	log := slog.New(slog.DiscardHandler)
+	metrics := observe.NewPrometheusRecorder()
+
+	err := runWeb(log, wirenpc.Config{}, metrics, "127.0.0.1:0", "", false)
+	if err == nil {
+		t.Fatal("runWeb with an unreachable DB returned nil, want the sweep error")
+	}
+	if !strings.Contains(err.Error(), "revoke sessions outside the operator allowlist") {
+		t.Errorf("boot error = %q, want it to fail inside the #184 session sweep", err)
+	}
+
+	// Dev mode has no allowlist: the sweep is skipped and the first DB touch is
+	// the dev-session seed.
+	t.Setenv("GLYPHOXA_DEV_MODE", "1")
+	err = runWeb(log, wirenpc.Config{}, metrics, "127.0.0.1:0", "", false)
+	if err == nil {
+		t.Fatal("runWeb (dev mode) with an unreachable DB returned nil, want an error")
+	}
+	if strings.Contains(err.Error(), "allowlist") {
+		t.Errorf("dev-mode boot error = %q, must not come from the allowlist sweep", err)
+	}
+}

--- a/docs/adr/0041-operator-allowlist-access-policy.md
+++ b/docs/adr/0041-operator-allowlist-access-policy.md
@@ -2,6 +2,15 @@
 
 The shipped Discord OAuth login (ADR-0016/0039) authenticates but does not authorize: any Discord User completing the flow is upserted, claims-or-creates a Tenant, and receives a 30-day session (`internal/auth/oauth.go`). This ADR closes that gap with a **mandatory operator allowlist** as the single gate.
 
+## Amendment: boot-time session revocation sweep (2026-07-04, #184)
+
+The allowlist as shipped gated only **new** logins: `storage.AuthenticateSession` never re-checks the owning user against the allowlist, so sessions issued before the gate existed (the pre-gate stranger hole this ADR closes) — or before a snowflake was removed — stayed valid for their full 30-day TTL with no revocation path.
+
+**Decided: revocation is a boot-time sweep.** Every non-dev `web`/`all` boot deletes all sessions whose owner's `discord_user_id` is not on the parsed allowlist (`storage.RevokeSessionsOutsideAllowlist`), immediately after the pool opens. Rationale: the allowlist is parsed at boot, so a restart is already the moment any grant change takes effect — a sweep at that moment makes the restart apply the change *fully*. Side benefit: leftover `GLYPHOXA_DEV_MODE` sessions (the synthetic dev operator is never allowlisted) are flushed by the first real boot. Dev mode skips the sweep (it has no allowlist; an empty list would revoke everything — storage refuses it defensively).
+
+- **Per-request re-check** (Contains() after AuthenticateSession) — rejected *for now*: the only session-minting paths are the gated callback and the loopback-only dev seed, so it adds wiring (allowlist threaded through the interceptor stack + RequireSession, dev-mode carve-out) without closing a real hole. **It becomes mandatory the day the allowlist is runtime-editable** (config UI) — revisit then.
+- **Upgrade note**: instances that ran pre-gate builds with OAuth configured should also audit `tenant` for stranger-claimed rows — those are data, not sessions; the sweep does not touch them.
+
 ## What this decides
 
 - **`GLYPHOXA_OPERATOR_IDS` is the gate.** A comma/whitespace-separated list of Discord User snowflakes, checked at the OAuth callback. A Discord User not on the list is rejected *before* any session issuance or Tenant write and redirected to the login screen with a `not_authorized` signal.

--- a/internal/auth/allowlist.go
+++ b/internal/auth/allowlist.go
@@ -56,3 +56,15 @@ func (a OperatorAllowlist) Malformed() []string {
 	slices.Sort(bad)
 	return bad
 }
+
+// IDs returns the allowlisted snowflakes, sorted for determinism. The boot-time
+// session sweep (#184) hands them to storage, which cannot import this package
+// (auth already depends on storage).
+func (a OperatorAllowlist) IDs() []string {
+	ids := make([]string, 0, len(a.ids))
+	for id := range a.ids {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/auth/allowlist_test.go
+++ b/internal/auth/allowlist_test.go
@@ -72,3 +72,16 @@ func TestOperatorAllowlistMalformed(t *testing.T) {
 		})
 	}
 }
+
+// IDs feeds the boot-time session sweep (#184): all entries, sorted, and empty
+// for the zero-value gate.
+func TestOperatorAllowlistIDs(t *testing.T) {
+	t.Parallel()
+	if got := auth.ParseOperatorAllowlist("").IDs(); len(got) != 0 {
+		t.Errorf("IDs() on an empty allowlist = %q, want none", got)
+	}
+	got := auth.ParseOperatorAllowlist("99, 77 88,77").IDs()
+	if want := []string{"77", "88", "99"}; !slices.Equal(got, want) {
+		t.Errorf("IDs() = %q, want %q (sorted, deduped)", got, want)
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -139,6 +139,29 @@ func (s *Store) DeleteSession(ctx context.Context, token string) error {
 	return nil
 }
 
+// RevokeSessionsOutsideAllowlist deletes every session whose owning user's
+// discord_user_id is not on the operator allowlist (ADR-0041 amendment, issue
+// #184). The allowlist gates only NEW logins at the OAuth callback; this sweep
+// is the revocation half, run at every non-dev web/all boot — which is exactly
+// when a grant change takes effect, since the env var is parsed at boot. It
+// also clears leftover GLYPHOXA_DEV_MODE sessions ([DevOperatorDiscordID] is
+// never allowlisted). An empty allowlist is refused defensively: it would
+// revoke every session, and the boot preflight guarantees a non-empty list at
+// the only call site.
+func (s *Store) RevokeSessionsOutsideAllowlist(ctx context.Context, discordUserIDs []string) (int64, error) {
+	if len(discordUserIDs) == 0 {
+		return 0, errors.New("storage: refusing to revoke sessions against an empty allowlist")
+	}
+	tag, err := s.db.Exec(ctx,
+		`DELETE FROM sessions USING users
+		  WHERE sessions.user_id = users.id
+		    AND users.discord_user_id <> ALL($1)`, discordUserIDs)
+	if err != nil {
+		return 0, fmt.Errorf("storage: revoke sessions outside allowlist: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // ResolveOperatorTenant binds the single seeded Tenant to the first operator and
 // returns it (ADR-0039). It is idempotent and atomic: if a tenant is already
 // bound to the user it is returned; otherwise the earliest claimable tenant —

--- a/internal/storage/auth_test.go
+++ b/internal/storage/auth_test.go
@@ -238,3 +238,68 @@ func TestResolveOperatorTenantTakesOverDevTenant(t *testing.T) {
 		t.Errorf("TenantForUser(real) after dev re-resolve = %s, %v; want %s", tid, err, seededID)
 	}
 }
+
+// TestRevokeSessionsOutsideAllowlist is the boot-time revocation sweep (#184,
+// ADR-0041 amendment): sessions of users NOT on the operator allowlist —
+// pre-gate strangers, removed snowflakes, the synthetic dev operator — are
+// deleted; allowlisted users' sessions survive. An empty allowlist is refused
+// (it would revoke everything).
+func TestRevokeSessionsOutsideAllowlist(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	mkSession := func(userID uuid.UUID, token string) {
+		t.Helper()
+		if _, err := st.CreateSession(ctx, storage.NewSession{
+			UserID: userID, Token: token, ExpiresAt: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("CreateSession(%s): %v", token, err)
+		}
+	}
+
+	keeper, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "777000000000000000"})
+	if err != nil {
+		t.Fatalf("upsert keeper: %v", err)
+	}
+	stranger, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "666000000000000000"})
+	if err != nil {
+		t.Fatalf("upsert stranger: %v", err)
+	}
+	dev, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: storage.DevOperatorDiscordID})
+	if err != nil {
+		t.Fatalf("upsert dev operator: %v", err)
+	}
+	mkSession(keeper.ID, "keeper-tok")
+	mkSession(stranger.ID, "stranger-tok-1")
+	mkSession(stranger.ID, "stranger-tok-2")
+	mkSession(dev.ID, "dev-tok")
+
+	// Empty allowlist is a bug at the call site, not a revoke-the-world request.
+	if _, err := st.RevokeSessionsOutsideAllowlist(ctx, nil); err == nil {
+		t.Fatal("RevokeSessionsOutsideAllowlist(empty) = nil, want a refusal error")
+	}
+
+	revoked, err := st.RevokeSessionsOutsideAllowlist(ctx, []string{"777000000000000000"})
+	if err != nil {
+		t.Fatalf("RevokeSessionsOutsideAllowlist: %v", err)
+	}
+	if revoked != 3 {
+		t.Errorf("revoked = %d sessions, want 3 (2 stranger + 1 dev)", revoked)
+	}
+
+	// The allowlisted operator stays logged in; everyone else is out.
+	if _, err := st.AuthenticateSession(ctx, "keeper-tok"); err != nil {
+		t.Errorf("keeper session was revoked: %v", err)
+	}
+	for _, tok := range []string{"stranger-tok-1", "stranger-tok-2", "dev-tok"} {
+		if _, err := st.AuthenticateSession(ctx, tok); !errors.Is(err, storage.ErrNotFound) {
+			t.Errorf("AuthenticateSession(%s) = %v, want ErrNotFound", tok, err)
+		}
+	}
+
+	// Idempotent: a second sweep finds nothing left to revoke.
+	again, err := st.RevokeSessionsOutsideAllowlist(ctx, []string{"777000000000000000"})
+	if err != nil || again != 0 {
+		t.Errorf("second sweep = (%d, %v), want (0, nil)", again, err)
+	}
+}


### PR DESCRIPTION
Closes #184. Implements the **boot-time sweep** semantic decided 2026-07-04 (recorded as an ADR-0041 amendment in this PR).

## Why
The allowlist (#103) gates only NEW logins at the OAuth callback. `AuthenticateSession` never re-checks the owner, so sessions from before the gate existed — or from snowflakes later removed from `GLYPHOXA_OPERATOR_IDS` — stayed valid up to 30 days with no revocation path.

## What
- `storage.RevokeSessionsOutsideAllowlist(ctx, ids)` — one `DELETE ... USING users` statement; returns the revoked count; **refuses an empty allowlist** (it would revoke everything; the #112 preflight guarantees non-empty at the call site).
- `auth.OperatorAllowlist.IDs()` — sorted snowflakes for storage (which can't import auth).
- `runWeb`: sweep runs right after the pool opens on **non-dev** `web`/`all` boots, WARNs the count when > 0. A restart is already when a grant change takes effect (env parsed at boot) — the sweep makes the restart apply it *fully*. Leftover `GLYPHOXA_DEV_MODE` sessions are flushed too (the synthetic dev operator is never allowlisted); dev mode itself skips the sweep.
- ADR-0041 amendment records the decision, the rejected-for-now per-request re-check (mandatory if the allowlist ever becomes runtime-editable), and the upgrade note (audit `tenant` for stranger-claimed rows — data, not sessions).

## Tests
- Postgres integration: stranger×2 + dev sessions revoked (count=3), allowlisted keeper survives, idempotent second sweep, empty-list refusal.
- DB-free wiring pin: the sweep is the first DB touch, so a closed-port DSN must fail *inside the sweep* on a non-dev boot — and must NOT mention the allowlist in dev mode (sweep skipped). Deleting the wiring block fails the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)