### PR TITLE
[E2] Embed the real operator console in the released image (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,11 @@ jobs:
   # Build the Vite + React SPA and run its vitest suite (ADR-0013/0039). Depends
   # on `proto` because the SPA's typed Connect client imports the generated
   # gen/ts/* stubs (gen/ is gitignored, produced once by `proto` and fanned out
-  # as the `gen` artifact — same pattern as the Go `test` job). The Go `test`/
-  # `image`/`e2e` jobs keep compiling without a node step because the committed
-  # placeholder internal/spa/dist/index.html satisfies the //go:embed; shipping
-  # the REAL built SPA inside the container image is a follow-up.
+  # as the `gen` artifact — same pattern as the Go `test` job). The Go `test` job
+  # keeps compiling without a node step because the committed placeholder
+  # internal/spa/dist/index.html satisfies the //go:embed; the `image`/`e2e`
+  # docker builds instead download the `spa-dist` artifact this job uploads, so
+  # the shipped image embeds the REAL console (#114, ADR-0034).
   web:
     name: web (vite build + vitest)
     needs: [proto]
@@ -111,9 +112,24 @@ jobs:
         run: npm ci
         working-directory: web
 
+      # vite.config.ts builds into ../internal/spa/dist (build.outDir), so the
+      # real bundle lands where Go's //go:embed picks it up. That directory is
+      # the artifact the docker-build jobs consume (#114, ADR-0034 amendment).
       - name: Build SPA
         run: npm run build
         working-directory: web
+
+      # Fan the real built bundle out so the `image`/`e2e` docker builds embed
+      # the console instead of the committed placeholder index.html — exactly the
+      # `gen` artifact pattern above, but for the SPA. Uploading internal/spa/dist
+      # (not just dist/) keeps the download landing back at the same path.
+      - name: Upload spa-dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spa-dist
+          path: internal/spa/dist
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Test
         run: npm run test
@@ -250,7 +266,10 @@ jobs:
 
   image:
     name: container image (build + smoke)
-    needs: [proto]
+    # `web` is added so its `spa-dist` artifact (the real built console) exists
+    # to download into the build context before the docker build — otherwise the
+    # image embeds the committed placeholder index.html (#114, ADR-0034).
+    needs: [proto, web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -264,6 +283,16 @@ jobs:
         with:
           name: gen
           path: gen
+
+      # Same story for the SPA bundle: the real Vite build is context-fed, not
+      # built in the image (ADR-0034 amendment). Restore the `web` job's
+      # `spa-dist` into internal/spa/dist so `COPY . .` + //go:embed ship the
+      # real console; .dockerignore does not exclude internal/spa/dist.
+      - name: Download spa-dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: spa-dist
+          path: internal/spa/dist
 
       # buildx + layer caching keeps the slow native build (whisper.cpp +
       # libopus + libdave + CGO) off the critical path on warm caches. This is a
@@ -290,6 +319,13 @@ jobs:
       # the process runs as a non-root uid.
       - name: Container smoke test
         run: ./scripts/container-smoke.sh glyphoxa:smoke
+
+      # The smoke test's embedded-console check must itself be trusted (the same
+      # #140 lesson the helm-validate self-test enforces): assert it FAILS on a
+      # placeholder-only image and PASSES only on a real build, so the gate can't
+      # silently no-op if the artifact wiring above ever regresses.
+      - name: Container smoke self-test
+        run: ./scripts/container-smoke-test.sh
 
   helm:
     name: helm chart (lint + unittest + kubeconform)
@@ -357,8 +393,10 @@ jobs:
     # SEPARATE job from the fast `test` suite (ADR-0033) so the heavy image build
     # + cluster spin-up never slows unit feedback.
     # `image` stays for cache ordering; `proto` is added because this job runs
-    # its OWN docker build and so needs gen/ in its build context too.
-    needs: [image, proto]
+    # its OWN docker build and so needs gen/ in its build context too. `web` is
+    # added for the same reason with the SPA: this job's build must embed the
+    # real console, so it downloads the `spa-dist` artifact too (#114).
+    needs: [image, proto, web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -370,6 +408,15 @@ jobs:
         with:
           name: gen
           path: gen
+
+      # Restore the real SPA bundle into the build context too (context-fed, not
+      # built in the image — ADR-0034) so this job's docker build embeds the
+      # console, not the placeholder.
+      - name: Download spa-dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: spa-dist
+          path: internal/spa/dist
 
       # Rebuild the single image (ADR-0034) from the warm gha cache and LOAD it
       # into the local daemon so k3d can import it. cache-from only (no cache-to)

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -47,6 +47,28 @@ jobs:
         env:
           BUF_TOKEN: ${{ secrets.BUF_REGISTRY_TOKEN }}
 
+      # The SPA bundle is context-fed, not built in the image (ADR-0034
+      # amendment, #114). ci.yml's docker-build jobs download the `spa-dist`
+      # artifact ci.yml's `web` job uploads, but artifacts don't cross workflows
+      # (same reason this workflow self-generates gen/ above), so publish builds
+      # the SPA itself: Vite emits into internal/spa/dist (build.outDir), which
+      # `COPY . .` then embeds. The build imports the generated gen/ts stubs, so
+      # it must run AFTER `buf generate`.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web deps
+        run: npm ci
+        working-directory: web
+
+      - name: Build SPA
+        run: npm run build
+        working-directory: web
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint docker-build docker-smoke helm-lint helm-test helm-validate helm-validate-test
+.PHONY: build test lint vet fmt check clean whisper-libs dave-libs refresh-silero-model install-lint proto proto-check proto-lint spa docker-build docker-smoke docker-smoke-test helm-lint helm-test helm-validate helm-validate-test
 
 # Build voice engine
 build:
@@ -142,14 +142,32 @@ DOCKER_IMAGE ?= glyphoxa:smoke
 # Depends on `proto`: gen/ is gitignored and NOT generated inside the image
 # (buf/node stay out of the builder), so it must exist in the build context on
 # the host before `docker build` ships it. `make proto` runs `buf generate` first.
+#
+# The SPA bundle is context-fed too (ADR-0034 amendment, #114): a node-free
+# `make docker-build` embeds the committed placeholder index.html, so run
+# `make spa` first to build the real console into internal/spa/dist and ship it
+# (CI feeds this via the `web` job's `spa-dist` artifact instead).
 docker-build: proto
 	docker build -t $(DOCKER_IMAGE) .
 
+# Build the real Vite + React console into internal/spa/dist (vite.config.ts
+# build.outDir) so a following `make docker-build` embeds the console rather than
+# the placeholder fallback (#114). Requires Node; the pure-Go build path does not.
+spa:
+	cd web && npm ci && npm run build
+
 # Run the container smoke test (issue #31) against $(DOCKER_IMAGE). Asserts the
-# CLI works, ldd resolves every native dep, the bundled ONNX runtime exists, and
-# the process is non-root. Build the image first (make docker-build).
+# CLI works, ldd resolves every native dep, the bundled ONNX runtime exists, the
+# process is non-root, and the embedded web root is the real console (#114).
+# Build the image first (make docker-build).
 docker-smoke:
 	./scripts/container-smoke.sh $(DOCKER_IMAGE)
+
+# Self-test for the embedded-console gate above: proves container-smoke.sh FAILS
+# on a placeholder-only image and PASSES only on a real build, so the gate can't
+# silently no-op (the #140 discipline, mirrored for #114). Needs only Docker.
+docker-smoke-test:
+	./scripts/container-smoke-test.sh
 
 # --- Helm chart (ADR-0034, issue #34) --------------------------------------
 # The deploy chart stands up a pgvector Postgres and applies the schema via a

--- a/internal/ci/workflows_test.go
+++ b/internal/ci/workflows_test.go
@@ -38,6 +38,49 @@ type step struct {
 // because the broken job (release-image.yml's publish) only runs on a release
 // tag. That is exactly how #75 shipped the regression reported in #139.
 func TestDockerBuildJobsProvisionGeneratedStubs(t *testing.T) {
+	eachDockerBuildJob(t, func(t *testing.T, file, jobName string, steps []step, build int) {
+		if !provisionsGen(steps[:build]) {
+			t.Errorf(
+				"%s: job %q runs docker/build-push-action (step %d) without an earlier step providing gen/ "+
+					"(`buf generate` or download-artifact `gen`); the Dockerfile's `COPY . .` + `go build` "+
+					"cannot compile without the gitignored stubs in the context",
+				file, jobName, build,
+			)
+		}
+	})
+}
+
+// TestDockerBuildJobsEmbedRealSPA enforces the build-context contract the #114
+// ADR-0034 amendment adds ("The SPA bundle is context-fed, not built in the
+// image"): every workflow job that runs a docker build of this repo must, in an
+// earlier step of the same job, provision the REAL built SPA bundle into
+// internal/spa/dist — either by downloading the `spa-dist` artifact (ci.yml's
+// `web` job builds and uploads it) or by building it in-job (release-image.yml's
+// publish can't cross-workflow the artifact, so it runs `npm run build` itself,
+// exactly as it self-generates gen/).
+//
+// Like the gen invariant, this is cross-file and latent: without it a docker
+// build silently embeds the committed placeholder index.html instead of the
+// console, and the release path only runs on a v* tag — long after the PR that
+// broke it merged.
+func TestDockerBuildJobsEmbedRealSPA(t *testing.T) {
+	eachDockerBuildJob(t, func(t *testing.T, file, jobName string, steps []step, build int) {
+		if !provisionsRealSPA(steps[:build]) {
+			t.Errorf(
+				"%s: job %q runs docker/build-push-action (step %d) without an earlier step providing the real "+
+					"SPA bundle (download-artifact `spa-dist` or `npm run build`); the Dockerfile's `COPY . .` "+
+					"would then embed the committed placeholder internal/spa/dist/index.html, not the console",
+				file, jobName, build,
+			)
+		}
+	})
+}
+
+// eachDockerBuildJob parses every workflow file and invokes fn for each job that
+// runs a docker/build-push-action step, passing that step's index so callers can
+// assert on the steps that precede it.
+func eachDockerBuildJob(t *testing.T, fn func(t *testing.T, file, jobName string, steps []step, build int)) {
+	t.Helper()
 	files, err := filepath.Glob(filepath.Join("..", "..", ".github", "workflows", "*.yml"))
 	if err != nil {
 		t.Fatal(err)
@@ -66,14 +109,7 @@ func TestDockerBuildJobsProvisionGeneratedStubs(t *testing.T) {
 			if build < 0 {
 				continue
 			}
-			if !provisionsGen(job.Steps[:build]) {
-				t.Errorf(
-					"%s: job %q runs docker/build-push-action (step %d) without an earlier step providing gen/ "+
-						"(`buf generate` or download-artifact `gen`); the Dockerfile's `COPY . .` + `go build` "+
-						"cannot compile without the gitignored stubs in the context",
-					filepath.Base(file), jobName, build,
-				)
-			}
+			fn(t, filepath.Base(file), jobName, job.Steps, build)
 		}
 	}
 }
@@ -98,6 +134,24 @@ func provisionsGen(steps []step) bool {
 		}
 		if strings.HasPrefix(s.Uses, "actions/download-artifact") {
 			if name, ok := s.With["name"].(string); ok && name == "gen" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// provisionsRealSPA reports whether any of the given steps puts the real built
+// SPA bundle into the working tree (internal/spa/dist): building it in-job with
+// `npm run build`, or restoring the `spa-dist` artifact uploaded by ci.yml's
+// `web` job.
+func provisionsRealSPA(steps []step) bool {
+	for _, s := range steps {
+		if strings.Contains(s.Run, "npm run build") {
+			return true
+		}
+		if strings.HasPrefix(s.Uses, "actions/download-artifact") {
+			if name, ok := s.With["name"].(string); ok && name == "spa-dist" {
 				return true
 			}
 		}

--- a/scripts/container-smoke-test.sh
+++ b/scripts/container-smoke-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Self-test for the embedded-console gate in scripts/container-smoke.sh (#114):
+# the gate must actually gate. It has to FAIL when an image's embedded web root
+# is the committed placeholder index.html and PASS only when it is a real Vite
+# build. This is the same "prove the gate isn't a silent no-op" discipline the
+# helm-validate self-test enforces after #140.
+#
+# The real gate greps the binary for the bytes a Vite build bakes in, so we
+# exercise it against two tiny throwaway images whose only payload is a fake
+# /usr/local/bin/glyphoxa carrying the distinguishing bytes — no multi-minute
+# native image build needed. SMOKE_ONLY=spa runs only the embedded-console
+# assertion against them.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PLACEHOLDER_IMG="glyphoxa-smoke-selftest-placeholder"
+REAL_IMG="glyphoxa-smoke-selftest-real"
+
+cleanup() {
+	docker rmi -f "$PLACEHOLDER_IMG" "$REAL_IMG" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# build_fixture TAG CONTENT builds an image whose /usr/local/bin/glyphoxa is a
+# fake "binary" holding exactly CONTENT. `docker build -` takes the Dockerfile
+# from stdin with an empty context (no repo files shipped), so this is fast.
+build_fixture() {
+	local tag="$1" content="$2"
+	docker build -q -t "$tag" - >/dev/null <<DOCKERFILE
+FROM busybox
+RUN mkdir -p /usr/local/bin && printf '%s' '${content}' > /usr/local/bin/glyphoxa
+DOCKERFILE
+}
+
+# The committed placeholder index.html, verbatim (internal/spa/dist/index.html).
+PLACEHOLDER='<!doctype html><html><body><div id="root"></div></body></html>'
+# A representative slice of a real Vite index.html: a content-hashed bundle ref.
+REAL='<script type="module" crossorigin src="/assets/index-a1b2c3d4.js"></script>'
+
+echo "container-smoke-test: [1/2] gate FAILS on a placeholder-only embedded web root"
+build_fixture "$PLACEHOLDER_IMG" "$PLACEHOLDER"
+if SMOKE_ONLY=spa ./scripts/container-smoke.sh "$PLACEHOLDER_IMG" >/dev/null 2>&1; then
+	echo "container-smoke-test: FAIL — the SPA gate passed on the placeholder image" >&2
+	exit 1
+fi
+
+echo "container-smoke-test: [2/2] gate PASSES on a real Vite-built embedded web root"
+build_fixture "$REAL_IMG" "$REAL"
+if ! SMOKE_ONLY=spa ./scripts/container-smoke.sh "$REAL_IMG" >/dev/null 2>&1; then
+	echo "container-smoke-test: FAIL — the SPA gate failed on a real console image" >&2
+	exit 1
+fi
+
+echo "container-smoke-test: OK"

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -35,6 +35,41 @@ run_in_image() {
 	docker run --rm --network none --entrypoint /bin/sh "$IMAGE" -c "$*"
 }
 
+# assert_spa is the embedded-console gate (#114, ADR-0034 amendment "the SPA
+# bundle is context-fed"). The image must serve the REAL Vite build at the web
+# root, not the committed placeholder index.html. The SPA is go:embed'd INTO the
+# binary (internal/spa/dist), so it is not a file on disk to stat — instead we
+# grep the binary for the distinguishing bytes:
+#   - a real build overwrites index.html to reference a content-hashed bundle
+#     (/assets/index-<hash>.js|css), and go:embed bakes those bytes in;
+#   - the placeholder is a single <div id="root"> line with NO /assets/.
+# The check is two-sided: a hashed asset reference must be PRESENT and the exact
+# placeholder one-liner must be ABSENT, so a bundle embedded alongside a stale
+# placeholder fails as loudly as a missing one.
+assert_spa() {
+	printf '[5] embedded web root is the real console, not the placeholder\n'
+	if run_in_image "grep -aEq '/assets/index-[A-Za-z0-9_-]+\.js' $BIN_PATH"; then
+		ok 'binary embeds a hashed /assets/index-*.js reference (real console)'
+	else
+		bad 'no hashed /assets/ reference in the binary — embedded web root is the placeholder, not a real console build'
+	fi
+	if run_in_image "grep -aqF '<!doctype html><html><body><div id=\"root\"></div></body></html>' $BIN_PATH"; then
+		bad 'binary still contains the committed placeholder index.html one-liner (a real build must overwrite it)'
+	else
+		ok 'committed placeholder index.html one-liner is absent'
+	fi
+}
+
+# summary prints the pass/fail tally and exits: non-zero if any assertion failed.
+summary() {
+	printf '\n== summary: %d passed, %d failed ==\n' "$pass" "$fail"
+	if [ "$fail" -ne 0 ]; then
+		exit 1
+	fi
+	printf 'all container smoke assertions passed\n'
+	exit 0
+}
+
 printf '== Glyphoxa container smoke test ==\n'
 printf 'image: %s\n\n' "$IMAGE"
 
@@ -42,6 +77,14 @@ printf 'image: %s\n\n' "$IMAGE"
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
 	printf 'FAIL: image %q does not exist — build it first (make docker-build / docker build -t %q .)\n' "$IMAGE" "$IMAGE" >&2
 	exit 1
+fi
+
+# SMOKE_ONLY=spa runs ONLY the embedded-console gate and exits. scripts/
+# container-smoke-test.sh uses this to point the gate at tiny placeholder/real
+# fixture images without the full native runtime the other checks assert.
+if [ "${SMOKE_ONLY:-}" = "spa" ]; then
+	assert_spa
+	summary
 fi
 
 # ---------------------------------------------------------------------------
@@ -125,10 +168,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 5. The embedded web root is the REAL console build, not the placeholder (#114).
+# ---------------------------------------------------------------------------
+assert_spa
+
+# ---------------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------------
-printf '\n== summary: %d passed, %d failed ==\n' "$pass" "$fail"
-if [ "$fail" -ne 0 ]; then
-	exit 1
-fi
-printf 'all container smoke assertions passed\n'
+summary


### PR DESCRIPTION
## What

The released container image now serves the **real** operator console at the web root instead of the committed placeholder `internal/spa/dist/index.html`.

The SPA bundle is **context-fed, not built in the image** (ADR-0034 amendment, 2026-07-04 — a node stage in the Dockerfile was explicitly rejected). The gap was CI-only: each GitHub Actions job is an isolated checkout, so the docker-build jobs only had the committed placeholder on disk; the real gitignored Vite bundle was built by the `web` job and thrown away.

## Changes

- **ci.yml `web`**: upload the built `internal/spa/dist` as the `spa-dist` artifact (mirrors the `gen` artifact pattern).
- **ci.yml `image` / `e2e`**: add `web` to `needs` and download `spa-dist` into `internal/spa/dist` before the docker build.
- **release-image.yml `publish`**: self-build the SPA (`npm ci` + `npm run build`) after `buf generate` — artifacts don't cross workflows, same reasoning as its self-generated `gen/`.
- **`scripts/container-smoke.sh`**: new two-sided embedded-console gate (check `[5]`) — the binary must embed a hashed `/assets/index-*.js` reference **and** must NOT contain the placeholder one-liner. `SMOKE_ONLY=spa` runs only this check.
- **`scripts/container-smoke-test.sh`** (new): self-test proving the gate FAILS on a placeholder image and PASSES on a real build (the #140 "gate must gate" discipline). Wired as a step in the `image` job.
- **`internal/ci/workflows_test.go`**: new invariant `TestDockerBuildJobsEmbedRealSPA` — every docker-build job must provision the real SPA (`spa-dist` download or `npm run build`), guarding the latent release path exactly like the existing `gen` invariant.
- **Makefile**: `spa` (local console build into `internal/spa/dist`) + `docker-smoke-test` targets.

## Acceptance criteria

- [x] Clean local + CI image builds serve the real console at web root (hashed asset refs resolve) — `image`/`e2e` download `spa-dist`; local via `make spa && make docker-build`.
- [x] Build strategy recorded in an ADR note — already in `docs/adr/0034-deployment-artifacts.md` (2026-07-04 amendment); this PR does not contradict it.
- [x] Release publish path produces an image whose embedded console is the real build — `release-image.yml` self-builds the SPA.
- [x] Smoke check fails on placeholder, passes only on the real app — `container-smoke.sh` `[5]` + `container-smoke-test.sh` self-test.
- [x] Pure-Go build with no node step still compiles via the placeholder fallback — unchanged `test` job + existing `internal/spa` tests.

## Verification

- Confirmed real Vite output references `/assets/index-<hash>.js` (placeholder has no `/assets/`).
- Proved the grep-vs-`go:embed` assumption on a standalone `go:embed all:dist` binary: real bundle → asset ref found + placeholder absent; placeholder → ref missing + placeholder present. (The real `spa.go` consumes the embedded FS, so the linker retains the bytes.)
- `container-smoke-test.sh` green (fails on placeholder fixture, passes on real fixture).
- `go build/vet/test ./internal/ci ./internal/spa`, `gofmt`, `golangci-lint ./internal/ci`, workflow YAML parse, and `shellcheck` (no new findings) all clean.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)