### PR TITLE
feat(#118): Web Instance Deployment + Service in the Helm chart

### DIFF
--- a/deploy/charts/glyphoxa/ci/ci-values.yaml
+++ b/deploy/charts/glyphoxa/ci/ci-values.yaml
@@ -1,9 +1,9 @@
 # Values for the CI schema-validation render ONLY (scripts/helm-validate.sh).
 # The chart has `required` values with no defaults (appSecret + the voice
-# credentials/IDs), so a bare `helm template` fails by design; this file
-# supplies syntactically valid placeholders so the render succeeds and
-# kubeconform has manifests to validate. Nothing here is a real credential and
-# nothing here is ever deployed.
+# credentials/IDs + the web OAuth credentials/operator allowlist), so a bare
+# `helm template` fails by design; this file supplies syntactically valid
+# placeholders so the render succeeds and kubeconform has manifests to validate.
+# Nothing here is a real credential and nothing here is ever deployed.
 appSecret: "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHg=" # base64 of 32 dummy bytes
 discordBotToken: "ci-dummy-discord-bot-token"
 elevenLabsApiKey: "ci-dummy-elevenlabs-api-key"
@@ -14,3 +14,11 @@ voice:
   # glyphoxa.voice.snowflake helper rejects non-string values.
   guild: "111111111111111111"
   channel: "222222222222222222"
+web:
+  # The Web Instance (#118) is on by default, so a render needs its required
+  # OAuth credentials + a non-empty operator allowlist (ADR-0041) or it fails.
+  oauth:
+    clientId: "ci-dummy-oauth-client-id"
+    clientSecret: "ci-dummy-oauth-client-secret"
+    redirectUrl: "http://localhost:8080/auth/discord/callback"
+  operatorIds: "111111111111111111"

--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -23,6 +23,21 @@ What this release stands up (ADR-0034):
     {{ .Values.voice.metricsPort }}. It never migrates: if the schema is behind
     it fails fast (EnsureCurrent) rather than serving.
 {{- end }}
+{{- if .Values.web.enabled }}
+  - A web-mode Deployment (single replica) + Service running
+      glyphoxa -mode {{ .Values.web.mode }}
+    serving the operator console + the Connect API behind a Discord-OAuth login
+    with a mandatory operator allowlist (ADR-0041). Reach it in-cluster at:
+      {{ include "glyphoxa.web.fullname" . }}:{{ .Values.web.service.port }}
+    The /healthz, /readyz, /metrics endpoints stay on the internal metrics port
+    {{ .Values.web.metricsPort }}, never the public API port. It never migrates:
+    if the schema is behind it fails fast (EnsureCurrent) rather than serving.
+
+    NOTE (ADR-0039): Mode `all` drives voice sessions IN-PROCESS in this single
+    pod. Cross-pod session control across a SEPARATE Voice Instance is DEFERRED —
+    the control-RPC transport is not built — so the web tier is a single pod for
+    v1.0 (replicas are not a tunable).
+{{- end }}
 
 Verify the schema is current:
 
@@ -44,4 +59,14 @@ crashlooping. The channel join itself is the manual, live-credential check.
 
   kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.voice.fullname" . }}
   kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "glyphoxa.voice.fullname" . }} -f
+{{- end }}
+{{- if .Values.web.enabled }}
+
+Reach the operator console: port-forward the web Service and open the root in a
+browser (the SPA), then complete the Discord OAuth login. A Discord User must be
+on GLYPHOXA_OPERATOR_IDS to obtain a session (ADR-0041).
+
+  kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.web.fullname" . }}
+  kubectl -n {{ .Release.Namespace }} port-forward service/{{ include "glyphoxa.web.fullname" . }} 8080:{{ .Values.web.service.port }}
+  # then open http://127.0.0.1:8080/
 {{- end }}

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -64,6 +64,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-voice" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.web.fullname" -}}
+{{- printf "%s-web" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Validate the Web Instance Mode (ADR-0005). `web` serves the operator console +
+Connect API only; `all` additionally drives the voice loop in-process for
+single-pod sessions (ADR-0039). Any other value would deploy a pod that exits(2)
+at runtime ("unknown mode"), so reject it at render time with an actionable
+message instead — mirroring the snowflake guard's fail-fast philosophy.
+*/}}
+{{- define "glyphoxa.web.mode" -}}
+{{- if or (eq . "web") (eq . "all") -}}
+{{- . -}}
+{{- else -}}
+{{- fail (printf "web.mode must be \"web\" or \"all\", got %q — \"web\" serves the console + Connect API only; \"all\" additionally drives the in-process voice loop (ADR-0039, single-pod)." .) -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 Render a Discord snowflake ID (guild/channel) as an exact string, rejecting any
 non-string value with an actionable error.
@@ -112,18 +131,30 @@ ONNX tags without moving the migrate/seed Jobs.
 {{- end }}
 
 {{/*
+The web Deployment's image. Like [glyphoxa.voice.image] it defaults to the
+shared [glyphoxa.image] (one image, ADR-0034) but lets web.image.repository/tag
+override either field independently.
+*/}}
+{{- define "glyphoxa.web.image" -}}
+{{- $repo := .Values.web.image.repository | default .Values.image.repository -}}
+{{- $tag := .Values.web.image.tag | default .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end }}
+
+{{/*
 Hook ordering weights. The DB resources (Secret, Service, StatefulSet) come up
 first, then the migrate Job, then the seed Job, then the serving workloads. All
-are pre-install/pre-upgrade hooks EXCEPT the voice Deployment (#36), which is a
-plain resource applied after every hook — so the migration and seed always
-precede it. Weights sort ascending; lower runs first; Helm waits for each
+are pre-install/pre-upgrade hooks EXCEPT the voice + web Deployments, which are
+plain resources applied after every hook — so the migration and seed always
+precede them. Weights sort ascending; lower runs first; Helm waits for each
 weight's hook Jobs to complete before the next, so the seed only starts once the
 migration has finished and the schema is current.
 
   -10  DB Secret + Postgres Service + StatefulSet
    -5  migrate Job
    -4  seed Job
-    0  voice Deployment (#36 — a plain resource, applied after every hook)
+    0  voice Deployment (#36) + web Deployment/Service (#118) — plain resources,
+       applied after every hook
 */}}
 {{- define "glyphoxa.dbHookWeight" -}}-10{{- end }}
 

--- a/deploy/charts/glyphoxa/templates/secret.yaml
+++ b/deploy/charts/glyphoxa/templates/secret.yaml
@@ -1,19 +1,24 @@
 {{/*
 App Secret. Holds the Postgres password, the assembled (or operator-supplied)
-GLYPHOXA_DATABASE_URL, the GLYPHOXA_SECRET credential-cipher key (ADR-0004), and
-— when the voice Deployment is enabled — the runtime Discord token and the three
-provider keys the voice pod reads (DISCORD_BOT_TOKEN, ELEVENLABS_API_KEY,
-GEMINI_API_KEY, GROQ_API_KEY). Postgres reads `password`; the migrate Job reads
-`database-url`; the seed Job (#35) reads `database-url` and `app-secret`; the
-voice Deployment (#36) reads `database-url` and the four credential keys (NOT
-`app-secret` — it never decrypts the sealed placeholders). Keeping them in one
-Secret means the URL, the role password, and the keys can never drift apart and
-the demo app's secrets stay in one place.
+GLYPHOXA_DATABASE_URL, the GLYPHOXA_SECRET credential-cipher key (ADR-0004), the
+shared runtime Discord token + three provider keys (DISCORD_BOT_TOKEN,
+ELEVENLABS_API_KEY, GEMINI_API_KEY, GROQ_API_KEY) the voice/web pods read, and —
+when the web Deployment is enabled — the three Discord OAuth credentials + the
+operator allowlist (discord-oauth-client-id/-secret/-redirect-url, operator-ids)
+the Web Instance boots with (ADR-0041). Postgres reads `password`; the migrate
+Job reads `database-url`; the seed Job (#35) reads `database-url` and
+`app-secret`; the voice Deployment (#36) reads `database-url` and the four shared
+credential keys (NOT `app-secret` — it never decrypts the sealed placeholders);
+the web Deployment (#118) reads `database-url`, `app-secret` (its RPC layer DOES
+decrypt BYOK credentials), the four shared keys, and the four web keys. Keeping
+them in one Secret means the URL, the role password, and the keys can never
+drift apart and the app's secrets stay in one place.
 
-The voice credential keys are only emitted when voice.enabled, and each is
-`required` then, so a voice deploy can never start with an empty Discord token or
-provider key; a migrate/seed-only install (voice.enabled=false) needs none of
-them and renders without them.
+The shared credential keys are emitted when EITHER voice.enabled or web.enabled,
+and the web keys when web.enabled; each is `required` under its gate, so a deploy
+can never start with an empty Discord token, provider key, OAuth credential, or
+an empty operator allowlist. A migrate/seed-only install (both disabled) needs
+none of them and renders without them.
 
 stringData (kubelet base64-encodes it) over data so the values stay reviewable
 in `helm template` output and assertable in helm-unittest.
@@ -41,9 +46,15 @@ stringData:
   password: {{ .Values.database.password | quote }}
   database: {{ .Values.database.name | quote }}
   app-secret: {{ required "appSecret is required: a base64-encoded 32-byte credential-cipher key (ADR-0004) the seed Job uses to seal placeholder provider credentials. Generate one with `openssl rand -base64 32`." .Values.appSecret | quote }}
-  {{- if .Values.voice.enabled }}
-  discord-bot-token: {{ required "discordBotToken is required when voice.enabled: the Discord bot token the voice pod joins the gateway with." .Values.discordBotToken | quote }}
-  elevenlabs-api-key: {{ required "elevenLabsApiKey is required when voice.enabled: the ElevenLabs API key the STT/TTS adapters read." .Values.elevenLabsApiKey | quote }}
-  gemini-api-key: {{ required "geminiApiKey is required when voice.enabled: the Gemini API key." .Values.geminiApiKey | quote }}
-  groq-api-key: {{ required "groqApiKey is required when voice.enabled: the Groq API key the LLM adapter reads." .Values.groqApiKey | quote }}
+  {{- if or .Values.voice.enabled .Values.web.enabled }}
+  discord-bot-token: {{ required "discordBotToken is required when voice.enabled or web.enabled: the Discord bot token the voice pod joins the gateway with (and the web tier's base session bot)." .Values.discordBotToken | quote }}
+  elevenlabs-api-key: {{ required "elevenLabsApiKey is required when voice.enabled or web.enabled: the ElevenLabs API key the STT/TTS adapters read." .Values.elevenLabsApiKey | quote }}
+  gemini-api-key: {{ required "geminiApiKey is required when voice.enabled or web.enabled: the Gemini API key." .Values.geminiApiKey | quote }}
+  groq-api-key: {{ required "groqApiKey is required when voice.enabled or web.enabled: the Groq API key the LLM adapter reads." .Values.groqApiKey | quote }}
+  {{- end }}
+  {{- if .Values.web.enabled }}
+  discord-oauth-client-id: {{ required "web.oauth.clientId is required when web.enabled: the Discord OAuth application's Client ID (ADR-0016/0039). A Web Instance refuses to boot without a usable login (ADR-0041)." .Values.web.oauth.clientId | quote }}
+  discord-oauth-client-secret: {{ required "web.oauth.clientSecret is required when web.enabled: the Discord OAuth application's Client Secret." .Values.web.oauth.clientSecret | quote }}
+  discord-oauth-redirect-url: {{ required "web.oauth.redirectUrl is required when web.enabled: the Discord OAuth redirect URL registered on the application." .Values.web.oauth.redirectUrl | quote }}
+  operator-ids: {{ required "web.operatorIds is required when web.enabled: a comma/whitespace-separated list of Discord User snowflakes (the operator allowlist, ADR-0041). A Web Instance refuses to boot without at least one." .Values.web.operatorIds | quote }}
   {{- end }}

--- a/deploy/charts/glyphoxa/templates/web-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/web-deployment.yaml
@@ -8,10 +8,15 @@ mandatory operator allowlist (ADR-0041).
 - ONE replica, by intent: the self-host web tier holds sessions in-process and
   cross-pod session control is deferred (ADR-0039), so scaling out is a design
   change (a session backplane), not a value.
-- RollingUpdate (the k8s default), NOT Recreate like voice: web holds no hard
-  single-instance external resource — voice must be Recreate because two pods
-  would fight over one Discord gateway/channel — so a brief upgrade surge is
-  harmless and keeps the console available across an image bump.
+- Update strategy depends on Mode. `web` Mode holds no in-process session loop,
+  so it uses RollingUpdate (the k8s default) — a brief upgrade surge is harmless
+  and keeps the console available across an image bump. `all` Mode drives voice
+  sessions in-process, so it uses Recreate like voice: a RollingUpdate surge
+  would (a) run a second loop on the same DISCORD_BOT_TOKEN and (b) let the new
+  pod's boot-time ReconcileOrphans (#143) close the OLD pod's still-live session
+  row — its "no loop is live at boot" invariant is violated during the surge,
+  corrupting the old pod's transcript finalization on Stop. Recreate tears the
+  old pod down first, so at most one loop ever runs.
 - NOT a Helm hook: a plain resource applies after every pre-install/pre-upgrade
   hook, so the migrate (-5) and seed (-4) hooks have completed before this pod
   starts.
@@ -46,10 +51,18 @@ spec:
   # Single pod for v1.0 — the web tier holds sessions in-process and cross-pod
   # session control is deferred (see the header).
   replicas: 1
-  # RollingUpdate (default), unlike voice's Recreate: no single-instance external
-  # resource to serialize on, so a surge on upgrade is harmless.
+  {{- if eq .Values.web.mode "all" }}
+  # `all` Mode drives voice sessions in-process — Recreate (like voice) so an
+  # upgrade never runs two loops on one Discord token and never lets a surged
+  # pod's boot-time ReconcileOrphans close the old pod's live session (see header).
+  strategy:
+    type: Recreate
+  {{- else }}
+  # web-only Mode has no in-process loop to serialize on, so RollingUpdate
+  # (default) is safe and keeps the console available across an image bump.
   strategy:
     type: RollingUpdate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "glyphoxa.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/glyphoxa/templates/web-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/web-deployment.yaml
@@ -1,0 +1,194 @@
+{{/*
+Web-mode Deployment (#118, ADR-0039) — the operator console + Connect API tier.
+
+It runs the single image as `glyphoxa -mode web` (or `all`), serving the SPA and
+the auth-gated Connect API behind a Discord-OAuth login (ADR-0016) with a
+mandatory operator allowlist (ADR-0041).
+
+- ONE replica, by intent: the self-host web tier holds sessions in-process and
+  cross-pod session control is deferred (ADR-0039), so scaling out is a design
+  change (a session backplane), not a value.
+- RollingUpdate (the k8s default), NOT Recreate like voice: web holds no hard
+  single-instance external resource — voice must be Recreate because two pods
+  would fight over one Discord gateway/channel — so a brief upgrade surge is
+  harmless and keeps the console available across an image bump.
+- NOT a Helm hook: a plain resource applies after every pre-install/pre-upgrade
+  hook, so the migrate (-5) and seed (-4) hooks have completed before this pod
+  starts.
+- It NEVER migrates: no `migrate` arg, no migrate initContainer. EnsureCurrent
+  (#32) fails the pod fast if the schema is behind, rather than auto-migrating
+  under a serving process.
+- Credentials come from the app Secret (ADR-0034): GLYPHOXA_SECRET (the cipher
+  key — the web RPC layer DECRYPTS BYOK provider credentials for Provider Config
+  CRUD, ADR-0004; voice deliberately does NOT read this), DISCORD_BOT_TOKEN (the
+  base session bot), the three provider keys (BYOK env fallback), the three
+  Discord OAuth credentials, and GLYPHOXA_OPERATOR_IDS (the mandatory allowlist,
+  ADR-0041). Without the OAuth trio + a non-empty allowlist the process refuses
+  to boot; those Secret keys are `required` when web.enabled (see secret.yaml).
+- Two container ports: the PUBLIC `http` port (the Connect API + console, the
+  Service targets it) and the INTERNAL `metrics` port. Health/metrics (#33,
+  ADR-0032) — /metrics, /healthz, /readyz — are served on the metrics port ONLY,
+  kept off the public API port; liveness targets /healthz (process-up), readiness
+  targets /readyz (a DB ping). The metrics port is advertised for Prometheus via
+  prometheus.io/* pod annotations.
+*/}}
+{{- if .Values.web.enabled }}
+{{- $webAddr := printf ":%d" (int .Values.web.port) }}
+{{- $metricsAddr := printf ":%d" (int .Values.web.metricsPort) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glyphoxa.web.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  # Single pod for v1.0 — the web tier holds sessions in-process and cross-pod
+  # session control is deferred (see the header).
+  replicas: 1
+  # RollingUpdate (default), unlike voice's Recreate: no single-instance external
+  # resource to serialize on, so a surge on upgrade is harmless.
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+      annotations:
+        # Advertise the metrics-only listener for annotation-based Prometheus
+        # scrape discovery (ADR-0032). The public `http` port is never scraped.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.web.metricsPort | quote }}
+        prometheus.io/path: /metrics
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: {{ include "glyphoxa.web.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.web.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - -mode
+            - {{ include "glyphoxa.web.mode" .Values.web.mode }}
+            - -web-addr
+            - {{ $webAddr | quote }}
+            - -metrics-addr
+            - {{ $metricsAddr | quote }}
+          env:
+            # The DB the Connect handlers read/write and /readyz pings. Same key
+            # the migrate/seed hooks used, so the host can never drift.
+            - name: GLYPHOXA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database-url
+            # The credential cipher (ADR-0004): the web RPC layer decrypts saved
+            # BYOK provider credentials with it. Voice never reads this key.
+            - name: GLYPHOXA_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: app-secret
+            # The base session bot token; a saved per-deployment token (decrypted
+            # via GLYPHOXA_SECRET) overrides it per session (#87).
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: discord-bot-token
+            # Provider keys the adapters read as the BYOK env fallback (ADR-0004).
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: elevenlabs-api-key
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: gemini-api-key
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: groq-api-key
+            # Discord OAuth application credentials (ADR-0016/0039): the login the
+            # SPA sends the operator through. All three are `required` when
+            # web.enabled — the process refuses to boot without them (ADR-0041).
+            - name: DISCORD_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: discord-oauth-client-id
+            - name: DISCORD_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: discord-oauth-client-secret
+            - name: DISCORD_OAUTH_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: discord-oauth-redirect-url
+            # The mandatory operator allowlist (ADR-0041): the single
+            # authorization gate at the OAuth callback and the boot-time session
+            # sweep. Non-empty is `required` when web.enabled.
+            - name: GLYPHOXA_OPERATOR_IDS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: operator-ids
+            # JSON logs for cluster log aggregation (ADR-0032).
+            - name: GLYPHOXA_LOG_FORMAT
+              value: json
+          ports:
+            # The PUBLIC Connect API + console port (the Service targets it).
+            - name: http
+              containerPort: {{ .Values.web.port }}
+              protocol: TCP
+            # The INTERNAL metrics/probe port (never Service-exposed).
+            - name: metrics
+              containerPort: {{ .Values.web.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/web-service.yaml
+++ b/deploy/charts/glyphoxa/templates/web-service.yaml
@@ -1,0 +1,32 @@
+{{/*
+Web Service (#118) — exposes the Web Instance's PUBLIC Connect API + console
+`http` port in-cluster.
+
+- It targets the container's NAMED `http` port, so a change to web.port follows
+  the name without also editing the Service.
+- It exposes ONLY the public port. The internal metrics/probe port (/metrics,
+  /healthz, /readyz) stays off the Service (ADR-0032): only the kubelet and
+  Prometheus reach it, via the pod directly.
+- ClusterIP by default — Ingress/TLS is a separate slice (#121). It is a plain
+  (non-hook) resource applied after the migrate/seed hooks, and is gated on
+  web.enabled together with the Deployment.
+*/}}
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glyphoxa.web.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.web.service.type }}
+  selector:
+    {{- include "glyphoxa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -8,18 +8,25 @@ templates:
   - templates/secret.yaml
 # appSecret has no default (an unset value fails the render so a deploy can never
 # silently run on a weak key); supply a placeholder for every render here. The
-# voice credential keys (DISCORD_BOT_TOKEN + the three provider keys) are
-# likewise required when voice.enabled — on by default — so supply placeholders
-# for them too. Every fixture is deliberately plain low-entropy ASCII, NOT a
-# base64 32-byte key or a real token — the template stores them verbatim in
-# stringData, and a random blob here only trips secret scanners. Production still
-# requires real values (see values.yaml).
+# shared credential keys (DISCORD_BOT_TOKEN + the three provider keys) are
+# required when EITHER voice.enabled or web.enabled — both on by default — and the
+# web keys (the three Discord OAuth credentials + the operator allowlist) are
+# required when web.enabled, so supply placeholders for them too. Every fixture is
+# deliberately plain low-entropy ASCII, NOT a base64 32-byte key or a real token —
+# the template stores them verbatim in stringData, and a random blob here only
+# trips secret scanners. Production still requires real values (see values.yaml).
 set:
   appSecret: unit-test-placeholder-not-a-real-secret
   discordBotToken: unit-test-discord-token-placeholder
   elevenLabsApiKey: unit-test-elevenlabs-placeholder
   geminiApiKey: unit-test-gemini-placeholder
   groqApiKey: unit-test-groq-placeholder
+  web:
+    oauth:
+      clientId: unit-test-oauth-client-id
+      clientSecret: unit-test-oauth-client-secret
+      redirectUrl: http://localhost:8080/auth/discord/callback
+    operatorIds: "111111111111111111"
 tests:
   - it: renders an Opaque Secret named for the release
     asserts:
@@ -78,10 +85,10 @@ tests:
           path: stringData["app-secret"]
           value: unit-test-placeholder-not-a-real-secret
 
-  - it: carries the voice credential keys when voice is enabled
-    # The voice Deployment (#36) reads DISCORD_BOT_TOKEN + the three provider
-    # keys from this Secret; they are only emitted when voice.enabled (on by
-    # default) and each is required then.
+  - it: carries the shared credential keys when voice is enabled
+    # The DISCORD_BOT_TOKEN + the three provider keys are shared by the voice
+    # Deployment (#36) and the web Deployment (#118); they are emitted when
+    # EITHER is enabled and each is required then.
     asserts:
       - isNotNullOrEmpty:
           path: stringData["discord-bot-token"]
@@ -92,18 +99,69 @@ tests:
       - isNotNullOrEmpty:
           path: stringData["groq-api-key"]
 
-  - it: omits the voice credential keys for a migrate/seed-only install
-    # With voice.enabled=false the DB-only install needs no Discord/provider
-    # keys, so they are left out of the Secret entirely (and not required).
+  - it: carries the shared credential keys when only web is enabled
+    # Web reads the same bot token + provider keys (BYOK env fallback), so
+    # disabling voice does not drop them while web is on.
     set:
       voice:
+        enabled: false
+    asserts:
+      - isNotNullOrEmpty:
+          path: stringData["discord-bot-token"]
+      - isNotNullOrEmpty:
+          path: stringData["groq-api-key"]
+
+  - it: carries the web keys — the three OAuth credentials + the operator allowlist — when web is enabled
+    # The web Deployment (#118) reads the Discord OAuth trio + GLYPHOXA_OPERATOR_IDS
+    # from this Secret; they are only emitted when web.enabled (on by default) and
+    # each is required then (a Web Instance refuses to boot without a login,
+    # ADR-0041). Asserted by exact value (not isNotNullOrEmpty, which passes on a
+    # missing path) so an absent key is a real failure.
+    asserts:
+      - equal:
+          path: stringData["discord-oauth-client-id"]
+          value: unit-test-oauth-client-id
+      - equal:
+          path: stringData["discord-oauth-client-secret"]
+          value: unit-test-oauth-client-secret
+      - equal:
+          path: stringData["discord-oauth-redirect-url"]
+          value: http://localhost:8080/auth/discord/callback
+      - equal:
+          path: stringData["operator-ids"]
+          value: "111111111111111111"
+
+  - it: omits the web keys when web is disabled
+    # A voice-only install needs no OAuth/allowlist, so those keys are left out
+    # of the Secret entirely (and not required).
+    set:
+      web:
+        enabled: false
+    asserts:
+      - notExists:
+          path: stringData["discord-oauth-client-id"]
+      - notExists:
+          path: stringData["operator-ids"]
+
+  - it: omits every runtime credential key for a migrate/seed-only install
+    # With BOTH voice.enabled=false and web.enabled=false the DB-only install
+    # needs no Discord/provider/OAuth keys, so they are all left out of the Secret
+    # (and not required).
+    set:
+      voice:
+        enabled: false
+      web:
         enabled: false
     asserts:
       - notExists:
           path: stringData["discord-bot-token"]
       - notExists:
           path: stringData["groq-api-key"]
-      # The DB + cipher keys still render — they are not gated on voice.
+      - notExists:
+          path: stringData["discord-oauth-client-id"]
+      - notExists:
+          path: stringData["operator-ids"]
+      # The DB + cipher keys still render — they are not gated on voice or web.
       - isNotNullOrEmpty:
           path: stringData["database-url"]
       - isNotNullOrEmpty:

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -143,6 +143,25 @@ tests:
       - notExists:
           path: stringData["operator-ids"]
 
+  - it: keeps the shared credential keys for a voice-only install (web disabled)
+    # The voice-only branch of the `or voice web` gate: with web off but voice on,
+    # the bot token + the three provider keys must STILL render. Asserted with
+    # `exists` (not isNotNullOrEmpty, which passes on a missing path) so a mutant
+    # dropping voice from the OR — which would break every real voice-only
+    # install — is a real failure here.
+    set:
+      web:
+        enabled: false
+    asserts:
+      - exists:
+          path: stringData["discord-bot-token"]
+      - exists:
+          path: stringData["elevenlabs-api-key"]
+      - exists:
+          path: stringData["gemini-api-key"]
+      - exists:
+          path: stringData["groq-api-key"]
+
   - it: omits every runtime credential key for a migrate/seed-only install
     # With BOTH voice.enabled=false and web.enabled=false the DB-only install
     # needs no Discord/provider/OAuth keys, so they are all left out of the Secret

--- a/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
@@ -1,0 +1,363 @@
+suite: web-mode Deployment
+# The web Deployment runs the single image in `web` (or `all`) Mode: the operator
+# console (SPA) + the Connect API behind a Discord-OAuth gate (#118, ADR-0039). It
+# consumes GLYPHOXA_DATABASE_URL, GLYPHOXA_SECRET (it decrypts BYOK provider
+# credentials — unlike voice), the Discord bot token, the three provider keys, and
+# the three Discord OAuth credentials + the operator allowlist from the app Secret.
+# It exposes a public `http` port (the Connect API) AND an internal `metrics` port,
+# and serves /healthz, /readyz, /metrics on the metrics port only — never the
+# public API port (ADR-0032). It is NOT a Helm hook: it applies after the
+# migrate+seed hooks, and NEVER runs migrations.
+templates:
+  - templates/web-deployment.yaml
+tests:
+  - it: renders a Deployment named for the release
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-web
+
+  - it: is disabled when web.enabled is false
+    set:
+      web:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: runs exactly one replica for the single-pod web tier
+    # The self-host web tier holds sessions in-process and cross-pod session
+    # control is deferred (ADR-0039), so the workload is pinned to a single pod.
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: uses the default RollingUpdate strategy (not Recreate like voice)
+    # Web holds no hard single-instance external resource (voice holds one Discord
+    # gateway per channel and must be Recreate), so a brief upgrade surge is
+    # harmless; RollingUpdate keeps the console available across an image bump.
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: is NOT a Helm hook so it applies after the migrate and seed hooks
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: runs `glyphoxa` in web mode with the public API + metrics addresses
+    # The whole arg vector, in order: -mode from web.mode, -web-addr from web.port
+    # (the public Connect API), -metrics-addr from web.metricsPort (the internal
+    # actuator port, kept off the public API surface).
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -mode
+            - web
+            - -web-addr
+            - ":8080"
+            - -metrics-addr
+            - ":9090"
+
+  - it: runs `all` Mode when web.mode is all
+    # `all` drives the voice loop in-process for single-pod sessions (ADR-0039).
+    set:
+      web:
+        mode: all
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: all
+
+  - it: rejects an invalid Mode rather than deploying a pod that exits at runtime
+    # An unknown -mode makes the binary exit(2); the render fails fast instead.
+    set:
+      web:
+        mode: voice
+    asserts:
+      - failedTemplate:
+          errorPattern: 'web.mode must be "web" or "all"'
+
+  - it: runs the configured image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/mrwong99/glyphoxa:0.1.0
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: honours an overridden top-level image repository and tag
+    set:
+      image:
+        repository: ghcr.io/example/glyphoxa
+        tag: v9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa:v9.9.9
+
+  - it: lets the web block override the image independently of the shared image
+    set:
+      web:
+        image:
+          repository: ghcr.io/example/glyphoxa-web
+          tag: web-1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/example/glyphoxa-web:web-1.2.3
+
+  - it: sources GLYPHOXA_DATABASE_URL from the DB connection Secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+
+  - it: sources GLYPHOXA_SECRET (the credential cipher) from the Secret
+    # Unlike voice, the web tier DECRYPTS BYOK provider credentials for Provider
+    # Config CRUD (ADR-0004), so it reads the app-secret cipher key.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: app-secret
+
+  - it: sources DISCORD_BOT_TOKEN and the three provider keys from the Secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_BOT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: discord-bot-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELEVENLABS_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: elevenlabs-api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEMINI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: gemini-api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GROQ_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: groq-api-key
+
+  - it: sources the three Discord OAuth credentials from the Secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: discord-oauth-client-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: discord-oauth-client-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_OAUTH_REDIRECT_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: discord-oauth-redirect-url
+
+  - it: sources the mandatory operator allowlist from the Secret
+    # GLYPHOXA_OPERATOR_IDS is the single authorization gate (ADR-0041); without
+    # it the Web Instance refuses to boot.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_OPERATOR_IDS
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: operator-ids
+
+  - it: emits JSON logs in the cluster
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_LOG_FORMAT
+            value: json
+
+  - it: exposes the public http port and the internal metrics port as named ports
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8080
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 9090
+            protocol: TCP
+
+  - it: derives the public web address and http container port from web.port together
+    # A custom port must flow to BOTH the -web-addr flag and the http container
+    # port, or the Service would target a port the process isn't serving.
+    set:
+      web:
+        port: 8888
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: ":8888"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8888
+            protocol: TCP
+
+  - it: derives the metrics address and container port from web.metricsPort together
+    set:
+      web:
+        metricsPort: 9999
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: ":9999"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 9999
+            protocol: TCP
+
+  - it: probes liveness against /healthz on the internal metrics port, never the public API port
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: metrics
+
+  - it: probes readiness against /readyz on the internal metrics port, never the public API port
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
+
+  - it: annotates the pod for Prometheus scraping on the metrics port
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9090"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: /metrics
+
+  - it: sets resource requests and limits
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.requests.memory
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+      - isNotNullOrEmpty:
+          path: spec.template.spec.containers[0].resources.limits.memory
+
+  - it: hardens the web container's securityContext by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: lets the operator override the container securityContext
+    set:
+      web:
+        securityContext:
+          readOnlyRootFilesystem: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false
+
+  - it: does NOT run migrations
+    # The migrate hook owns the schema; EnsureCurrent fails the pod fast if it is
+    # behind. The pod must never carry a `migrate` arg or a migrate initContainer.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: migrate
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: selects its pods with the standard selector labels plus the web component
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: glyphoxa
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: web
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: web

--- a/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
@@ -35,14 +35,27 @@ tests:
           path: spec.replicas
           value: 1
 
-  - it: uses the default RollingUpdate strategy (not Recreate like voice)
-    # Web holds no hard single-instance external resource (voice holds one Discord
-    # gateway per channel and must be Recreate), so a brief upgrade surge is
-    # harmless; RollingUpdate keeps the console available across an image bump.
+  - it: uses RollingUpdate in web Mode (no in-process session loop to serialize on)
+    # web-only Mode holds no in-process loop, so a brief upgrade surge is harmless;
+    # RollingUpdate keeps the console available across an image bump.
     asserts:
       - equal:
           path: spec.strategy.type
           value: RollingUpdate
+
+  - it: uses Recreate in all Mode so an upgrade never runs two in-process session loops
+    # `all` Mode drives voice sessions in-process. A RollingUpdate surge would (a)
+    # run a second loop on the same DISCORD_BOT_TOKEN and (b) let the surged pod's
+    # boot-time ReconcileOrphans (#143) close the OLD pod's still-live session row
+    # (its "no loop is live at boot" invariant is violated during the surge).
+    # Recreate tears the old pod down first, like voice-deployment.yaml.
+    set:
+      web:
+        mode: all
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
 
   - it: is NOT a Helm hook so it applies after the migrate and seed hooks
     asserts:

--- a/deploy/charts/glyphoxa/tests/web_service_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_service_test.yaml
@@ -1,0 +1,94 @@
+suite: web Service
+# The web Service exposes the Web Instance's PUBLIC Connect API + console `http`
+# port in-cluster (#118). It targets the container's named `http` port (never the
+# internal metrics/probe port, ADR-0032) and selects the web pods by the standard
+# selector labels + the web component. ClusterIP by default — Ingress/TLS is a
+# separate slice (#121). It is disabled together with the Deployment when
+# web.enabled is false.
+templates:
+  - templates/web-service.yaml
+tests:
+  - it: renders a Service named for the release
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-web
+
+  - it: is disabled when web.enabled is false
+    set:
+      web:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is NOT a Helm hook so it applies after the migrate and seed hooks
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+
+  - it: is a ClusterIP Service by default
+    # Ingress/TLS is issue #121; this slice exposes the API in-cluster only.
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: honours an overridden service type
+    set:
+      web:
+        service:
+          type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: exposes the public http port and targets the container's named http port
+    # The Service port is web.service.port (80 by default); it targets the
+    # container's NAMED `http` port, so a change to web.port follows the name
+    # without also editing the Service.
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+
+  - it: does NOT expose the internal metrics/probe port
+    # /metrics, /healthz, /readyz stay off the public Service (ADR-0032): only the
+    # kubelet + Prometheus reach them, via the pod's metrics port.
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: selects the web pods by the standard selector labels plus the web component
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: glyphoxa
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: web
+
+  - it: carries the standard chart labels plus the web component
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: web
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -175,6 +175,119 @@ voice:
     timeoutSeconds: 3
     failureThreshold: 3
 
+# Web Instance (#118, ADR-0039): the single image run as `glyphoxa -mode web`
+# (or `all`), serving the operator console (SPA) + the Connect API behind a
+# Discord-OAuth gate. Like voice it is a plain (non-hook) workload, so it applies
+# after the migrate (-5) and seed (-4) hooks — the schema is current and the demo
+# data seeded before it starts — and it NEVER migrates (EnsureCurrent fails the
+# pod fast if the schema is behind). Unlike voice it also gets a Service (it is
+# k8s-reachable) and reads GLYPHOXA_SECRET (its RPC layer decrypts BYOK provider
+# credentials for Provider Config CRUD, ADR-0004) — which voice never does.
+web:
+  # Enable/disable the Web Instance (Deployment + Service). ON by default so a
+  # bare `helm install` serves the operator console — which means it requires the
+  # three Discord OAuth credentials AND a non-empty operator allowlist below
+  # (ADR-0041): a Web Instance REFUSES TO BOOT without a usable login, so those
+  # four values are `required` when web.enabled and the render fails fast with an
+  # actionable message if any is empty (mirroring voice's required guild/channel).
+  # For a DB-prep-only or voice-only install, set this false.
+  enabled: true
+
+  # Process Mode (ADR-0005). `web` serves the console + Connect API only; `all`
+  # ADDITIONALLY drives the voice loop in-process so the Session screen can
+  # start/stop a live NPC in the same pod (ADR-0039). Cross-pod session control
+  # across a SEPARATE Voice Instance is DEFERRED — the control-RPC transport is
+  # not built — so `all` is a single-pod arrangement, not a multi-replica
+  # backplane. Must be `web` or `all`; any other value fails the render.
+  mode: web
+
+  # Discord OAuth application credentials (ADR-0016/0039) and the mandatory
+  # operator allowlist (ADR-0041). All four are REQUIRED when web.enabled — a Web
+  # Instance refuses to boot without a usable login, so the render fails fast if
+  # any is empty. `operatorIds` is a comma/whitespace-separated list of Discord
+  # User snowflakes (Developer Mode → Copy ID); a Discord User whose snowflake is
+  # absent is rejected before any session is issued or Tenant written. Intended
+  # use is a single entry; multiple entries are a documented edge (e.g. a second
+  # test account). For real deploys, prefer templating these from an external
+  # Secret over committing them to values.
+  oauth:
+    clientId: ""
+    clientSecret: ""
+    redirectUrl: ""
+  operatorIds: ""
+
+  # Single replica for v1.0 (ADR-0039): the self-host web tier holds sessions
+  # in-process, and cross-pod session control is deferred, so this is pinned to
+  # one pod. Unlike voice (Recreate — one gateway per channel), web uses the
+  # default RollingUpdate: it holds no hard single-instance external resource, so
+  # a brief upgrade surge is harmless. Scaling out is a design change (a session
+  # backplane), not a value.
+
+  # Optional per-workload image override. When repository/tag are set here they
+  # win over the shared top-level `image`; otherwise the web pod runs the same
+  # image as the migrate/seed Jobs and the voice pod (one image, ADR-0034).
+  image:
+    repository: ""
+    tag: ""
+
+  # The public Connect API + console port the container serves on (-web-addr) and
+  # the Service targets. Named `http` on the container to keep it distinct from
+  # the internal `metrics` port.
+  port: 8080
+
+  # The Service that exposes the public `http` port in-cluster. ClusterIP by
+  # default (Ingress/TLS is issue #121); `port` is the Service's own port, which
+  # targets the container's named `http` port.
+  service:
+    type: ClusterIP
+    port: 80
+
+  # The metrics-only HTTP listener (ADR-0032): /metrics for scraping plus the
+  # /healthz liveness and /readyz readiness probes (-metrics-addr). Kept OFF the
+  # public API port — the probes and scrape target this internal port, never the
+  # externally-reachable `http` port. Named `metrics` and advertised via
+  # prometheus.io/* pod annotations for annotation-based scrape discovery.
+  metricsPort: 9090
+
+  # Resource requests/limits for the serving pod. Lighter than voice by default
+  # (no ONNX VAD / audio path in web-only Mode); tune up for `all` Mode, which
+  # runs the voice loop in-process.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+  # Container securityContext, hardened by default and overridable. The image
+  # runs as USER 65532 (#31); the web tier writes nothing to its rootfs at boot,
+  # so a read-only rootfs holds. Set to {} in a values file to drop the block.
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Probe tuning. Liveness targets /healthz (process-up, ignores DB health so a
+  # DB blip can't get the pod killed); readiness targets /readyz (DB ping — 200
+  # only when the schema is current and reachable). Both hit the internal metrics
+  # port, never the public API port (ADR-0032).
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
 # Pod-level knobs shared by the workloads this chart renders.
 podSecurityContext: {}
 nodeSelector: {}

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -218,9 +218,11 @@ web:
 
   # Single replica for v1.0 (ADR-0039): the self-host web tier holds sessions
   # in-process, and cross-pod session control is deferred, so this is pinned to
-  # one pod. Unlike voice (Recreate — one gateway per channel), web uses the
-  # default RollingUpdate: it holds no hard single-instance external resource, so
-  # a brief upgrade surge is harmless. Scaling out is a design change (a session
+  # one pod. The update strategy tracks the Mode: `web` uses RollingUpdate (no
+  # in-process loop, so an upgrade surge is harmless), while `all` uses Recreate
+  # like voice — it drives a session loop in-process, so two pods would run two
+  # loops on one Discord token AND a surged pod's boot-time orphan sweep would
+  # close the old pod's live session. Scaling out is a design change (a session
   # backplane), not a value.
 
   # Optional per-workload image override. When repository/tag are set here they

--- a/scripts/e2e-deploy-smoke.sh
+++ b/scripts/e2e-deploy-smoke.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# e2e-deploy-smoke.sh — issue #37: prove the whole deploy chain converges on the
-# CURRENT kube context (an ephemeral k3d/kind cluster), WITHOUT live Discord
-# credentials. It helm-installs the chart and asserts, in order:
+# e2e-deploy-smoke.sh — issue #37 (extended by #118): prove the whole deploy chain
+# converges on the CURRENT kube context (an ephemeral k3d/kind cluster), WITHOUT
+# live Discord credentials. It helm-installs the chart and asserts, in order:
 #
 #   Postgres Ready → migrate Job Completed → seed Job Completed
 #     → voice Deployment Available → /readyz returns 200
+#     → web Deployment Available → the web Service serves the console root (200)
 #
 # then tears the release down. The cluster lifecycle is the caller's concern (the
 # CI workflow creates/deletes the k3d cluster and imports the image); this script
@@ -32,6 +33,8 @@ IMAGE_TAG="${IMAGE_TAG:-e2e}"
 TIMEOUT="${TIMEOUT:-300s}"
 # Local port the /readyz check forwards the metrics listener to.
 READYZ_LOCAL_PORT="${READYZ_LOCAL_PORT:-19090}"
+# Local port the console-root check forwards the web Service to.
+WEB_LOCAL_PORT="${WEB_LOCAL_PORT:-18080}"
 
 # Object names mirror the chart helpers: glyphoxa.<component>.fullname renders as
 # <release>-<component> (deploy/charts/glyphoxa/templates/_helpers.tpl).
@@ -39,6 +42,7 @@ PG="${RELEASE}-postgres"
 MIGRATE="${RELEASE}-migrate"
 SEED="${RELEASE}-seed"
 VOICE="${RELEASE}-voice"
+WEB="${RELEASE}-web"
 
 VALUES_FILE="$(mktemp)"
 PF_PID=""
@@ -49,7 +53,7 @@ dump_diagnostics() {
   log "DIAGNOSTICS (namespace ${NAMESPACE})"
   kubectl -n "$NAMESPACE" get all,jobs -o wide 2>/dev/null || true
   kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>/dev/null | tail -40 || true
-  for c in postgres migrate seed voice; do
+  for c in postgres migrate seed voice web; do
     log "describe + logs: component=${c}"
     kubectl -n "$NAMESPACE" describe pod -l "app.kubernetes.io/component=${c}" 2>/dev/null || true
     kubectl -n "$NAMESPACE" logs -l "app.kubernetes.io/component=${c}" --all-containers --tail=80 2>/dev/null || true
@@ -93,14 +97,27 @@ voice:
   enabled: true
   guild: "111111111111111111"
   channel: "222222222222222222"
+web:
+  enabled: true
+  # Dummy-but-syntactically-valid OAuth credentials + a numeric operator snowflake.
+  # requireWebEnv (ADR-0041, #112) only checks they are present + parseable, not
+  # that Discord accepts them — OAuth is exercised on an actual login, which this
+  # unattended smoke never performs — so the Web Instance boots to /readyz=200 on
+  # the DB-backed readiness alone, exactly like the voice pod with a placeholder
+  # token. A live OAuth login round-trip is issue #128's smoke.
+  oauth:
+    clientId: "ci-not-a-real-oauth-client-id"
+    clientSecret: "ci-not-a-real-oauth-client-secret"
+    redirectUrl: "http://localhost:8080/auth/discord/callback"
+  operatorIds: "111111111111111111"
 EOF
 
 log "helm install ${RELEASE} (chart ${CHART}, image ${IMAGE_REPO}:${IMAGE_TAG})"
 # --wait blocks until the ORDERED pre-install hook chain succeeds — Postgres
 # (weight -10) up, migrate Job (-5) Completed, seed Job (-4) Completed — and then
-# the voice Deployment reaches Available. So a zero exit here already proves the
-# whole chain converged; the explicit asserts below name the exact link on a
-# regression and double as the issue-#37 acceptance checklist.
+# BOTH the voice and web Deployments reach Available. So a zero exit here already
+# proves the whole chain converged; the explicit asserts below name the exact
+# link on a regression and double as the #37/#118 acceptance checklist.
 helm install "$RELEASE" "$CHART" \
   --namespace "$NAMESPACE" --create-namespace \
   --values "$VALUES_FILE" \
@@ -139,5 +156,35 @@ if [ -z "$ready" ]; then
   echo "FAIL: /readyz did not return 200 within the window"
   exit 1
 fi
+kill "$PF_PID" 2>/dev/null || true
+PF_PID=""
 
-log "PASS: deploy chain converged — Postgres → migrate → seed → voice Available → /readyz 200"
+log "assert: web Deployment Available"
+# The Web Instance (#118) boots with the dummy OAuth creds + operator snowflake
+# above; requireWebEnv (ADR-0041) is satisfied by their presence, and readiness
+# is the same DB-backed /readyz on the internal metrics port, so it reaches
+# Available without a live Discord login.
+kubectl -n "$NAMESPACE" wait --for=condition=Available "deployment/${WEB}" --timeout "$TIMEOUT"
+
+log "assert: the web Service serves the console root (200)"
+# Port-forward the web SERVICE (not the pod) so the Service's selector + the
+# named http targetPort are exercised end to end, then curl the console root: the
+# SPA handler returns index.html (200) for GET /. This proves the public Connect
+# API port is reachable through the Service. The authenticated RPC surface + a
+# live OAuth round-trip are issue #128's smoke.
+kubectl -n "$NAMESPACE" port-forward "service/${WEB}" "${WEB_LOCAL_PORT}:80" >/dev/null 2>&1 &
+PF_PID=$!
+served=""
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${WEB_LOCAL_PORT}/" >/dev/null 2>&1; then
+    served=1
+    break
+  fi
+  sleep 1
+done
+if [ -z "$served" ]; then
+  echo "FAIL: the web Service did not serve the console root (200) within the window"
+  exit 1
+fi
+
+log "PASS: deploy chain converged — Postgres → migrate → seed → voice Available → /readyz 200 → web Available → console root 200"

--- a/scripts/e2e-deploy-smoke.sh
+++ b/scripts/e2e-deploy-smoke.sh
@@ -170,8 +170,8 @@ log "assert: the web Service serves the console root (200)"
 # Port-forward the web SERVICE (not the pod) so the Service's selector + the
 # named http targetPort are exercised end to end, then curl the console root: the
 # SPA handler returns index.html (200) for GET /. This proves the public Connect
-# API port is reachable through the Service. The authenticated RPC surface + a
-# live OAuth round-trip are issue #128's smoke.
+# API port is reachable through the Service. A live OAuth login round-trip is
+# issue #128's smoke.
 kubectl -n "$NAMESPACE" port-forward "service/${WEB}" "${WEB_LOCAL_PORT}:80" >/dev/null 2>&1 &
 PF_PID=$!
 served=""
@@ -187,4 +187,25 @@ if [ -z "$served" ]; then
   exit 1
 fi
 
-log "PASS: deploy chain converged — Postgres → migrate → seed → voice Available → /readyz 200 → web Available → console root 200"
+log "assert: unauthenticated GetCurrentUser returns 401 (the auth gate stands)"
+# The corrected #118 AC: the console's current-user probe must be REJECTED for a
+# request with no session. AuthServer.GetCurrentUser is reachable unauthenticated
+# (it is in the public set) but returns Connect CodeUnauthenticated, which the
+# Connect protocol maps to HTTP 401 — the SPA's "-> /login" signal. A regression
+# that exposed it as 200 would be an auth-bypass smell; assert the 401 explicitly
+# so the smoke catches it. POST an empty Connect (JSON) request through the same
+# Service port-forward; retry briefly for a freshly re-checked forward.
+code=""
+for _ in $(seq 1 30); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' --data '{}' \
+    "http://127.0.0.1:${WEB_LOCAL_PORT}/api/glyphoxa.management.v1.AuthService/GetCurrentUser" 2>/dev/null || true)"
+  [ -n "$code" ] && [ "$code" != "000" ] && break
+  sleep 1
+done
+if [ "$code" != "401" ]; then
+  echo "FAIL: unauthenticated GetCurrentUser returned ${code:-<none>}, want 401 (auth gate)"
+  exit 1
+fi
+
+log "PASS: deploy chain converged — Postgres → migrate → seed → voice Available → /readyz 200 → web Available → console root 200 → GetCurrentUser 401"

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -103,11 +103,17 @@ PY
 
 # The two render branches the chart supports: in-cluster Postgres (default)
 # and external DB (postgres disabled) — same paths the gate checked before #42
-# broke it.
+# broke it. Both render the Web Instance (#118, enabled by default) + the voice
+# Deployment, so the new web Deployment + Service are schema-validated on both.
 validate_path in-cluster-postgres
 validate_path external-db \
   --set postgres.enabled=false \
   --set database.url='postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require'
+
+# The Web-Instance-disabled render path (#118 AC): the chart must still render
+# (and validate) with web.enabled=false — a voice-only / DB-prep install that
+# needs none of the web OAuth credentials.
+validate_path web-disabled --set web.enabled=false
 
 # Reserved-character credentials (issue #151): the same raw values feed
 # POSTGRES_USER/POSTGRES_PASSWORD, so the assembled DSN must percent-encode


### PR DESCRIPTION
## What does this PR do?

Adds the **Web Instance** to the Helm chart (epic #106, E2): a web-Mode
`Deployment` (the operator console + Connect API) and a ClusterIP `Service`
exposing its public `http` port, mirroring the voice Deployment's conventions
(ADR-0034).

- **Deployment** (`templates/web-deployment.yaml`): runs `glyphoxa -mode web`
  (or `all`), single replica, RollingUpdate (not voice's Recreate — no
  single-instance external resource to serialize on). Wires the app Secret for
  `GLYPHOXA_DATABASE_URL`, `GLYPHOXA_SECRET` (the cipher — the web RPC layer
  decrypts BYOK credentials, which voice deliberately does **not**),
  `DISCORD_BOT_TOKEN`, the three provider keys, the three Discord OAuth
  credentials, and `GLYPHOXA_OPERATOR_IDS`. Two container ports: public `http`
  (Service-exposed) + internal `metrics`. `/healthz` liveness + `/readyz`
  readiness probe the **metrics port only**, never the public API port
  (ADR-0032).
- **Service** (`templates/web-service.yaml`): ClusterIP, targets the container's
  named `http` port (Ingress/TLS is #121).
- **Mandatory operator allowlist (ADR-0041):** the OAuth trio + a non-empty
  `operatorIds` are `required` when `web.enabled`, so a login-less Web Instance
  fails the render fast (mirrors voice's required guild/channel). The shared
  bot/provider Secret keys are now gated on `voice OR web`.
- **Mode is a chart value** (`web.mode`, validated `web|all`); `values.yaml` +
  `NOTES.txt` document that cross-pod session control is **deferred** (ADR-0039,
  single pod for v1.0).
- Helpers `glyphoxa.web.fullname` / `glyphoxa.web.image` / `glyphoxa.web.mode`.

`web.enabled` defaults **true** (mirrors `voice.enabled`) so a bare
`helm install` serves the console — which, like voice, means the operator must
supply the required credentials.

## Why is this change needed?

Epic #106 ("make the web tier actually deployable"). The web/all Mode
entrypoint, OAuth gate, and app Secret already exist (#74/#87/#112); this slice
gives them a Deployment + Service so the console is reachable in-cluster.

## How was this tested?

- **helm-unittest** (`tests/web_deployment_test.yaml`, `web_service_test.yaml`,
  extended `secret_test.yaml`): 104 tests pass (was 64). Covers the disabled
  render path, the Mode value + its validation, the full env/port/probe wiring,
  and the new Secret keys across web-enabled / voice-only / DB-only.
- **helm lint** + **scripts/helm-validate.sh**: the new resources are
  schema-validated (kubeconform) on the in-cluster **and** external-DB paths,
  plus a new **web-disabled** render path. `helm-validate-test.sh` self-test
  still green. `ci/ci-values.yaml` supplies the new required fields.
- **k3d e2e** (`scripts/e2e-deploy-smoke.sh`): enables web with dummy-but-valid
  OAuth creds, asserts the web Deployment reaches **Available**, and curls the
  console root (**200**) through the Service.

- [x] Helm gates pass locally (`helm unittest` / `helm lint` / `helm-validate.sh`)
- [x] New/updated tests cover the change
- [ ] Manual testing — k3d e2e runs in CI

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Build / CI / tooling

## Additional Notes

**AC discrepancy flagged for review:** AC #5 says the Service should answer "the
unauthenticated current-user probe with **200**". The shipped
`AuthServer.GetCurrentUser` returns Connect `CodeUnauthenticated` (**HTTP 401**)
when no session is present — that 401 is the SPA's "→ /login" signal, by design.
So the e2e asserts the unambiguous half (console root 200 through the Service +
Deployment Available); the authenticated RPC surface and a live OAuth login
round-trip are #128's (deploy smoke web+OAuth) territory. Naming is kept close to
the voice convention so #121 (Ingress) and #128 can depend on
`<release>-web` / `web.*` values predictably.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)