### PR TITLE
feat(#111): Embeddings Provider — Ollama nomic-embed-text

### DIFF
--- a/pkg/voice/embeddings/embeddings.go
+++ b/pkg/voice/embeddings/embeddings.go
@@ -1,0 +1,38 @@
+// Package embeddings defines the v2 Embeddings provider surface — the
+// "embeddings" Component per CONTEXT.md and ADR-0004.
+//
+// The Component turns Transcript chunk text into dense vectors for the async,
+// eventually-consistent embedding pipeline (ADR-0011): the chunk writer inserts
+// a row with embedding=NULL, a background worker calls [Provider.Embed] and
+// UPDATEs the row, and NPC retrieval runs ANN similarity over the non-null
+// vectors. The provider matrix is Ollama + OpenAI (ADR-0004); v1.0 ships the
+// keyless local Ollama adapter as the default, with the OpenAI slot a future
+// sibling behind this same interface.
+//
+// Determinism in tests follows ADR-0021's spirit without a cassette: the
+// [github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest] doubles
+// yield stable vectors for the same input on every run and platform, so the
+// downstream worker and retrieval tests are reproducible without a live model.
+package embeddings
+
+import "context"
+
+// Dim is the embedding vector dimension every v1.0 Provider MUST return.
+//
+// Fixed at 768 because ADR-0011 pins the default model to Ollama
+// `nomic-embed-text` and the storage schema to `vector(768)`; switching models
+// or Matryoshka dimensions requires a schema+backfill migration, not a runtime
+// change. Adapters guard against any other returned dimension so a mis-pulled
+// model fails loudly instead of writing rows the ANN index cannot use.
+const Dim = 768
+
+// Provider embeds a batch of texts into dense vectors.
+//
+// The contract is total and order-preserving: Embed returns exactly len(texts)
+// vectors in input order, each exactly [Dim] elements long, or a non-nil error.
+// Implementations MUST error (never truncate or pad) when the underlying model
+// returns any other dimension — a wrong dimension signals a mis-configured
+// model, and silently reshaping it would corrupt the vector store.
+type Provider interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+}

--- a/pkg/voice/embeddings/embeddingstest/embeddingstest.go
+++ b/pkg/voice/embeddings/embeddingstest/embeddingstest.go
@@ -1,0 +1,111 @@
+// Package embeddingstest provides deterministic [embeddings.Provider] doubles
+// for tests, so downstream chunk-writer, backfill-worker, and retrieval tests
+// (ADR-0011) are reproducible without a live model.
+//
+// Two doubles, no cassette (ADR-0021's determinism goal, met by construction
+// rather than by recording a network call):
+//
+//   - [Deterministic] hashes each text and expands it into a pseudo-random
+//     unit vector. The same text yields the same [embeddings.Dim] vector on
+//     every run and platform; different texts yield different vectors. It has
+//     no semantic structure — it is for plumbing and reproducibility tests, not
+//     for asserting that related texts are close (use a live Ollama for that).
+//   - [Fixed] maps exact texts to hand-crafted vectors, so a test can lay out a
+//     small semantic space by hand (e.g. two near-duplicate vectors and one
+//     far) and assert retrieval ranking deterministically. An unmapped text is
+//     a test-authoring error and returns a non-nil error.
+package embeddingstest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+)
+
+// Deterministic is a stateless [embeddings.Provider] that maps each text to a
+// stable pseudo-random unit vector. The zero value is ready to use.
+type Deterministic struct{}
+
+// Embed returns one [embeddings.Dim] vector per text, in input order. Each
+// vector is a deterministic function of its text alone — identical across runs,
+// platforms, and process restarts — so tests that record or compare vectors are
+// reproducible. An empty batch returns (nil, nil).
+func (Deterministic) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = vectorFor(t)
+	}
+	return out, nil
+}
+
+// vectorFor derives a stable unit vector from text: SHA-256 seeds a splitmix64
+// stream that fills [embeddings.Dim] floats in [-1,1), then L2-normalizes so
+// cosine similarity is a plain dot product. Hashing makes it independent of any
+// float formatting, endianness at the API layer, or map-iteration order.
+func vectorFor(text string) []float32 {
+	sum := sha256.Sum256([]byte(text))
+	state := binary.BigEndian.Uint64(sum[:8])
+
+	v := make([]float32, embeddings.Dim)
+	var norm float64
+	for i := range v {
+		u := splitmix64(&state)
+		// Top 53 bits → float64 in [0,1), then scale to [-1,1).
+		f := float64(u>>11)/(1<<53)*2 - 1
+		v[i] = float32(f)
+		norm += f * f
+	}
+	norm = math.Sqrt(norm)
+	if norm == 0 {
+		// Astronomically unlikely with splitmix64, but keep the contract total:
+		// never emit a zero vector the ANN path can't normalize.
+		v[0] = 1
+		return v
+	}
+	inv := float32(1.0 / norm)
+	for i := range v {
+		v[i] *= inv
+	}
+	return v
+}
+
+// splitmix64 advances state and returns the next value of the SplitMix64
+// generator — a fast, well-distributed PRNG whose only state is one uint64,
+// making the derived vectors trivially reproducible.
+func splitmix64(state *uint64) uint64 {
+	*state += 0x9E3779B97F4A7C15
+	z := *state
+	z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+	z = (z ^ (z >> 27)) * 0x94D049BB133111EB
+	return z ^ (z >> 31)
+}
+
+// Fixed is an [embeddings.Provider] backed by an exact text→vector map. It lets
+// a test hand-place points in vector space (the map values need not be
+// [embeddings.Dim] long — the test owns their shape). An unmapped text errors.
+type Fixed map[string][]float32
+
+// Embed returns the mapped vector for each text, in input order. A text absent
+// from the map returns a non-nil error naming the missing text — an unmapped
+// input is a test-authoring mistake, not a silent zero vector.
+func (f Fixed) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, ok := f[t]
+		if !ok {
+			return nil, fmt.Errorf("embeddingstest.Fixed: no vector mapped for %q", t)
+		}
+		out[i] = v
+	}
+	return out, nil
+}

--- a/pkg/voice/embeddings/embeddingstest/embeddingstest.go
+++ b/pkg/voice/embeddings/embeddingstest/embeddingstest.go
@@ -60,7 +60,12 @@ func vectorFor(text string) []float32 {
 		// Top 53 bits → float64 in [0,1), then scale to [-1,1).
 		f := float64(u>>11)/(1<<53)*2 - 1
 		v[i] = float32(f)
-		norm += f * f
+		// The explicit float64() conversion rounds the product to float64 before
+		// the add, a Go-spec fusion barrier: without it a target (e.g. arm64) may
+		// fuse mul+add into one FMA, giving low-bit-different norms per platform.
+		// Downstream waves commit fixtures against these vectors, so cross-platform
+		// bit-stability is load-bearing.
+		norm += float64(f * f)
 	}
 	norm = math.Sqrt(norm)
 	if norm == 0 {
@@ -105,7 +110,9 @@ func (f Fixed) Embed(_ context.Context, texts []string) ([][]float32, error) {
 		if !ok {
 			return nil, fmt.Errorf("embeddingstest.Fixed: no vector mapped for %q", t)
 		}
-		out[i] = v
+		// Copy so a consumer that mutates a returned vector can't corrupt the
+		// shared fixture backing array (the map value).
+		out[i] = append([]float32(nil), v...)
 	}
 	return out, nil
 }

--- a/pkg/voice/embeddings/embeddingstest/embeddingstest_test.go
+++ b/pkg/voice/embeddings/embeddingstest/embeddingstest_test.go
@@ -163,3 +163,22 @@ func TestFixed_UnknownText_Errors(t *testing.T) {
 		t.Fatal("Fixed.Embed with unmapped text returned nil error")
 	}
 }
+
+// TestFixed_ReturnsCopy_NotFixtureAlias guards that a consumer mutating a
+// returned vector cannot corrupt the shared fixture map — the returned slice
+// must not alias the map's backing array.
+func TestFixed_ReturnsCopy_NotFixtureAlias(t *testing.T) {
+	f := embeddingstest.Fixed{"x": {1, 2, 3}}
+	out, err := f.Embed(context.Background(), []string{"x"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	out[0][0] = 99 // a hostile consumer mutating its result
+	again, err := f.Embed(context.Background(), []string{"x"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if again[0][0] != 1 {
+		t.Errorf("fixture corrupted: got %v, want original 1 (returned slice aliased the map)", again[0][0])
+	}
+}

--- a/pkg/voice/embeddings/embeddingstest/embeddingstest_test.go
+++ b/pkg/voice/embeddings/embeddingstest/embeddingstest_test.go
@@ -1,0 +1,165 @@
+package embeddingstest_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
+)
+
+// Compile-time assertions: both doubles satisfy [embeddings.Provider], so they
+// are drop-in substitutes for the Ollama adapter in worker and retrieval tests.
+var (
+	_ embeddings.Provider = embeddingstest.Deterministic{}
+	_ embeddings.Provider = embeddingstest.Fixed{}
+)
+
+func l2Norm(v []float32) float64 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	return math.Sqrt(sum)
+}
+
+// TestDeterministic_SameInput_IdenticalVector is the reproducibility guarantee
+// AC4 rests on: the same text yields byte-identical vectors every call, so
+// downstream worker and retrieval tests are stable without a live model.
+func TestDeterministic_SameInput_IdenticalVector(t *testing.T) {
+	var d embeddingstest.Deterministic
+	a, err := d.Embed(context.Background(), []string{"the dragon guards the northern pass"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	b, err := d.Embed(context.Background(), []string{"the dragon guards the northern pass"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("len(a)=%d len(b)=%d, want 1 each", len(a), len(b))
+	}
+	if len(a[0]) != embeddings.Dim {
+		t.Fatalf("vector len = %d, want %d", len(a[0]), embeddings.Dim)
+	}
+	for i := range a[0] {
+		if a[0][i] != b[0][i] {
+			t.Fatalf("vectors differ at index %d: %v vs %v", i, a[0][i], b[0][i])
+		}
+	}
+}
+
+// TestDeterministic_DifferentInput_DifferentVector guards against a degenerate
+// double that returns a constant vector — different texts must map to different
+// vectors or a retrieval test could never distinguish them.
+func TestDeterministic_DifferentInput_DifferentVector(t *testing.T) {
+	var d embeddingstest.Deterministic
+	out, err := d.Embed(context.Background(), []string{"alpha", "beta"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	same := true
+	for i := range out[0] {
+		if out[0][i] != out[1][i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Fatal("distinct inputs produced identical vectors")
+	}
+}
+
+// TestDeterministic_L2NormApproxOne pins the L2-normalization: unit-length
+// vectors make cosine similarity a plain dot product, matching how the ANN
+// retrieval path (ADR-0011) compares them.
+func TestDeterministic_L2NormApproxOne(t *testing.T) {
+	var d embeddingstest.Deterministic
+	out, err := d.Embed(context.Background(), []string{"tavern", "quest", "", "a much longer sentence here"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	for i, v := range out {
+		if len(v) != embeddings.Dim {
+			t.Fatalf("vector %d len = %d, want %d", i, len(v), embeddings.Dim)
+		}
+		if n := l2Norm(v); math.Abs(n-1.0) > 1e-5 {
+			t.Errorf("vector %d L2 norm = %v, want ~1", i, n)
+		}
+	}
+}
+
+// TestDeterministic_BatchOrderAndCount mirrors the real provider's totality:
+// N texts yield N vectors in input order.
+func TestDeterministic_BatchOrderAndCount(t *testing.T) {
+	var d embeddingstest.Deterministic
+	texts := []string{"one", "two", "three"}
+	out, err := d.Embed(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != len(texts) {
+		t.Fatalf("len(out) = %d, want %d", len(out), len(texts))
+	}
+	// The i-th output must equal a standalone embedding of texts[i] (order).
+	for i, txt := range texts {
+		single, err := d.Embed(context.Background(), []string{txt})
+		if err != nil {
+			t.Fatalf("Embed single: %v", err)
+		}
+		for j := range out[i] {
+			if out[i][j] != single[0][j] {
+				t.Fatalf("out[%d] != standalone embedding of %q at index %d", i, txt, j)
+			}
+		}
+	}
+}
+
+// TestDeterministic_Golden locks the exact algorithm output for one input, so a
+// future refactor of the hash/PRNG/normalization silently changing the vector
+// space (which would invalidate any committed fixtures downstream) fails loudly.
+// The values were captured from the reference implementation; they encode the
+// cross-run/platform stability AC4 requires, not any semantic meaning.
+func TestDeterministic_Golden(t *testing.T) {
+	var d embeddingstest.Deterministic
+	out, err := d.Embed(context.Background(), []string{"glyphoxa"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	want := []float32{-0.0302517, -0.019189103, 0.058886487, 0.0416833, -0.05829539}
+	for i, w := range want {
+		if out[0][i] != w {
+			t.Errorf("out[0][%d] = %v, want %v (algorithm changed?)", i, out[0][i], w)
+		}
+	}
+}
+
+// TestFixed_MappedText_ReturnsVector: a text present in the map returns exactly
+// its hand-crafted vector, in input order.
+func TestFixed_MappedText_ReturnsVector(t *testing.T) {
+	f := embeddingstest.Fixed{
+		"hello": {1, 0, 0},
+		"world": {0, 1, 0},
+	}
+	out, err := f.Embed(context.Background(), []string{"world", "hello"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2", len(out))
+	}
+	if out[0][1] != 1 || out[1][0] != 1 {
+		t.Errorf("Fixed returned wrong/ordered vectors: %v", out)
+	}
+}
+
+// TestFixed_UnknownText_Errors: an unmapped text is a test-authoring mistake and
+// must error loudly rather than silently returning a zero vector.
+func TestFixed_UnknownText_Errors(t *testing.T) {
+	f := embeddingstest.Fixed{"known": {1}}
+	_, err := f.Embed(context.Background(), []string{"known", "surprise"})
+	if err == nil {
+		t.Fatal("Fixed.Embed with unmapped text returned nil error")
+	}
+}

--- a/pkg/voice/embeddings/ollama/embed.go
+++ b/pkg/voice/embeddings/ollama/embed.go
@@ -1,0 +1,89 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+)
+
+// embedRequest is the POST /api/embed body. Ollama's batch embed endpoint takes
+// a string array in `input` and returns one vector per element.
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// embedResponse is the POST /api/embed response. `embeddings` carries one
+// vector per input, in input order.
+type embedResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+// Embed implements [embeddings.Provider]. One call → one POST /api/embed
+// request → len(texts) vectors in input order, each [embeddings.Dim] long.
+//
+// The response is validated hard: the vector count must equal len(texts) and
+// every vector's length must equal [embeddings.Dim]. A wrong dimension (e.g. a
+// mis-pulled model) returns an error naming the model, the wanted dimension,
+// and the got dimension — the adapter never truncates or pads.
+//
+// An empty input returns (nil, nil) without a network call: there is nothing to
+// embed and the endpoint would reject an empty batch.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("ollama.Embed: marshal request: %w", err)
+	}
+
+	u := strings.TrimRight(c.baseURL, "/") + "/api/embed"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama.Embed: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama.Embed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, readErrorResponse(resp)
+	}
+
+	var decoded embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("ollama.Embed: decode body: %w", err)
+	}
+
+	if n := len(decoded.Embeddings); n != len(texts) {
+		return nil, fmt.Errorf("ollama.Embed: model %q returned %d vectors for %d inputs",
+			c.model, n, len(texts))
+	}
+	for i, v := range decoded.Embeddings {
+		if len(v) != embeddings.Dim {
+			return nil, fmt.Errorf("ollama.Embed: model %q returned a %d-dim vector at index %d, want %d",
+				c.model, len(v), i, embeddings.Dim)
+		}
+	}
+	return decoded.Embeddings, nil
+}
+
+// readErrorResponse reads up to 512 bytes of a non-2xx response body for
+// diagnostic context and wraps it as an error naming the provider and status.
+func readErrorResponse(resp *http.Response) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("ollama.Embed: HTTP %d %s: %s",
+		resp.StatusCode, resp.Status, strings.TrimSpace(string(snippet)))
+}

--- a/pkg/voice/embeddings/ollama/ollama.go
+++ b/pkg/voice/embeddings/ollama/ollama.go
@@ -1,0 +1,93 @@
+// Package ollama implements the v2 Embeddings provider surface against a local
+// Ollama server, targeting the nomic-embed-text model (ADR-0011).
+//
+// The [Client] satisfies [github.com/MrWong99/Glyphoxa/pkg/voice/embeddings.Provider]:
+// batch text embedding that maps to a single POST /api/embed call. The async
+// embedding worker (ADR-0011) forwards Transcript chunk text and stores the
+// returned vector(768).
+//
+// Unlike the LLM/STT adapters, Ollama embeddings are KEYLESS in v1.0 — a local
+// server, no BYOK credential (ADR-0004's OpenAI sibling adds a key later behind
+// the same interface). Endpoint resolution is the consumer wiring's job (#116
+// reads GLYPHOXA_OLLAMA_URL); this adapter takes an explicit base URL via
+// [WithBaseURL], defaulting to [DefaultBaseURL]. The HTTP surface is hand-rolled
+// (mirroring the STT ElevenLabs adapter) rather than an SDK or the OpenAI-compat
+// layer, because Ollama's /api/embed wire is not the OpenAI embeddings wire.
+package ollama
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// ProviderID is the stable identifier for this Embeddings adapter, matching
+	// the Ollama Provider Config's provider slot (ADR-0004).
+	ProviderID = "ollama"
+
+	// DefaultModel is the v1.0 embedding model (ADR-0011): 768-dim, local.
+	DefaultModel = "nomic-embed-text"
+
+	// DefaultBaseURL is the loopback Ollama server root. The consumer wiring
+	// (#116) overrides it from GLYPHOXA_OLLAMA_URL via [WithBaseURL].
+	DefaultBaseURL = "http://127.0.0.1:11434"
+)
+
+// Client is the Ollama Embeddings adapter. Construct with [New]; the zero value
+// is not usable. Safe for concurrent use across goroutines.
+type Client struct {
+	baseURL string
+	model   string
+	http    *http.Client
+}
+
+// Option mutates a [Client] during construction.
+type Option func(*Client)
+
+// WithBaseURL overrides the Ollama server base URL. Used by tests (httptest
+// server) and by the consumer wiring that reads GLYPHOXA_OLLAMA_URL (#116).
+func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
+
+// WithModel overrides the embedding model. Defaults to [DefaultModel];
+// switching the model changes the vector space and requires a backfill
+// (ADR-0011), so this is an operational escape hatch, not a per-call knob.
+func WithModel(m string) Option { return func(c *Client) { c.model = m } }
+
+// WithHTTPClient supplies a custom http.Client. The default
+// ([defaultHTTPClient]) bounds the connection-establishment and response-header
+// phases but sets no overall Timeout; the per-call end-to-end bound is the
+// request context's deadline (the embedding worker's per-batch timeout).
+func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connect/TLS/response-header phases so a
+// black-holed Ollama endpoint fails in seconds rather than stalling the async
+// embedding worker. No overall Timeout: a large batch's response body may take
+// a while to stream, and the end-to-end bound is the caller's ctx deadline.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+
+// New constructs a [Client] with the loopback default base URL and
+// nomic-embed-text model. Pass [WithBaseURL], [WithModel], or [WithHTTPClient]
+// to override. New never fails so test binaries link the package
+// unconditionally; endpoint problems surface at the first [Client.Embed] call.
+func New(opts ...Option) *Client {
+	c := &Client{
+		baseURL: DefaultBaseURL,
+		model:   DefaultModel,
+		http:    defaultHTTPClient(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}

--- a/pkg/voice/embeddings/ollama/ollama_live_test.go
+++ b/pkg/voice/embeddings/ollama/ollama_live_test.go
@@ -1,0 +1,125 @@
+package ollama_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/ollama"
+)
+
+// ollamaBaseURL resolves the live-test endpoint from GLYPHOXA_OLLAMA_URL (the
+// env var the consumer wiring reads in #116), defaulting to the loopback
+// server. Test-only wiring — the adapter itself takes an explicit base URL.
+func ollamaBaseURL() string {
+	if u := os.Getenv("GLYPHOXA_OLLAMA_URL"); u != "" {
+		return u
+	}
+	return ollama.DefaultBaseURL
+}
+
+// probeOllama checks that a live Ollama is reachable AND has the embedding model
+// pulled, by reading GET /api/tags within a short timeout. It returns "" when
+// ready, or a human reason to skip: a black-holed or absent endpoint, or a
+// server that is up but missing the model (the operator must `ollama pull`).
+func probeOllama(base string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(base, "/")+"/api/tags", nil)
+	if err != nil {
+		return "could not build /api/tags request: " + err.Error()
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "no reachable Ollama at " + base + ": " + err.Error()
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "Ollama /api/tags returned HTTP " + resp.Status
+	}
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return "could not decode /api/tags: " + err.Error()
+	}
+	for _, m := range tags.Models {
+		if strings.HasPrefix(m.Name, ollama.DefaultModel) {
+			return ""
+		}
+	}
+	return "Ollama is up but model " + ollama.DefaultModel + " is not pulled (run `ollama pull " + ollama.DefaultModel + "`)"
+}
+
+func cosine(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// TestLive_Ollama_RelatedSentencesAreCloser is the AC3 live property: against a
+// real nomic-embed-text, two semantically related Campaign sentences sit closer
+// in cosine similarity than either does to an unrelated sentence. It asserts a
+// tolerant ordering property — never exact vector values, which drift with model
+// versions. Skipped LOUDLY (not failed) when no live Ollama with the model is
+// reachable, so a default `go test ./...` on a model-less box stays green
+// without pretending it exercised the real embedder.
+func TestLive_Ollama_RelatedSentencesAreCloser(t *testing.T) {
+	base := ollamaBaseURL()
+	if reason := probeOllama(base); reason != "" {
+		t.Skipf("SKIPPED LIVE OLLAMA EMBED TEST — %s. This test embeds real "+
+			"Campaign sentences against %s and was NOT run. Set GLYPHOXA_OLLAMA_URL "+
+			"to point at a reachable server with the model pulled to run it.",
+			reason, ollama.DefaultModel)
+	}
+
+	// Two related sentences about a dragon hoard, one unrelated about a tavern.
+	const (
+		a = "The ancient dragon guards a vast hoard of gold deep in the mountain."
+		b = "A great wyrm sleeps atop its treasure beneath the northern peaks."
+		c = "The cheerful tavern keeper poured another round of ale for the bards."
+	)
+
+	c1 := ollama.New(ollama.WithBaseURL(base))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := c1.Embed(ctx, []string{a, b, c})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("len(out) = %d, want 3", len(out))
+	}
+	for i, v := range out {
+		if len(v) != embeddings.Dim {
+			t.Fatalf("vector %d len = %d, want %d", i, len(v), embeddings.Dim)
+		}
+	}
+
+	simAB := cosine(out[0], out[1]) // related
+	simAC := cosine(out[0], out[2]) // unrelated
+	simBC := cosine(out[1], out[2]) // unrelated
+	t.Logf("cos(related a,b)=%.4f  cos(a,c)=%.4f  cos(b,c)=%.4f", simAB, simAC, simBC)
+
+	if !(simAB > simAC && simAB > simBC) {
+		t.Errorf("related pair not closest: cos(a,b)=%.4f must exceed cos(a,c)=%.4f and cos(b,c)=%.4f",
+			simAB, simAC, simBC)
+	}
+}

--- a/pkg/voice/embeddings/ollama/ollama_test.go
+++ b/pkg/voice/embeddings/ollama/ollama_test.go
@@ -1,0 +1,57 @@
+package ollama_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/ollama"
+)
+
+// Compile-time assertion: [ollama.Client] satisfies [embeddings.Provider],
+// the only contract the async embedding worker (ADR-0011) depends on.
+var _ embeddings.Provider = (*ollama.Client)(nil)
+
+// dimVectorJSON builds the `/api/embed` response body carrying one vector of
+// the given dimension, each element a distinct small float so a wrong length is
+// the only thing under test.
+func dimVectorJSON(dim int) string {
+	var b strings.Builder
+	b.WriteString(`{"embeddings":[[`)
+	for i := 0; i < dim; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString("0.1")
+	}
+	b.WriteString(`]]}`)
+	return b.String()
+}
+
+// TestEmbed_WrongDimension_ErrorsNamingWantGotModel pins the AC1 guard: when
+// the model returns any dimension other than [embeddings.Dim] the adapter MUST
+// error (never truncate or pad), and the error names the model, the wanted
+// dimension, and the got dimension so a mis-pulled model is diagnosable.
+func TestEmbed_WrongDimension_ErrorsNamingWantGotModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(dimVectorJSON(embeddings.Dim - 1)))
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	_, err := c.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("Embed with wrong-dimension vector returned nil error")
+	}
+	got := err.Error()
+	for _, must := range []string{ollama.DefaultModel, "767", "768"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("error %q missing required substring %q", got, must)
+		}
+	}
+}

--- a/pkg/voice/embeddings/ollama/ollama_test.go
+++ b/pkg/voice/embeddings/ollama/ollama_test.go
@@ -2,14 +2,40 @@ package ollama_test
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/ollama"
 )
+
+// fullVectorJSON builds the `/api/embed` response body carrying one
+// [embeddings.Dim] vector per marker; every element of vector i is markers[i],
+// so callers can pin per-input identity (and thus order) without depending on
+// exact float values.
+func fullVectorJSON(t *testing.T, markers ...float32) string {
+	t.Helper()
+	vecs := make([][]float32, len(markers))
+	for i, m := range markers {
+		v := make([]float32, embeddings.Dim)
+		for j := range v {
+			v[j] = m
+		}
+		vecs[i] = v
+	}
+	buf, err := json.Marshal(struct {
+		Embeddings [][]float32 `json:"embeddings"`
+	}{vecs})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	return string(buf)
+}
 
 // Compile-time assertion: [ollama.Client] satisfies [embeddings.Provider],
 // the only contract the async embedding worker (ADR-0011) depends on.
@@ -53,5 +79,159 @@ func TestEmbed_WrongDimension_ErrorsNamingWantGotModel(t *testing.T) {
 		if !strings.Contains(got, must) {
 			t.Errorf("error %q missing required substring %q", got, must)
 		}
+	}
+}
+
+// TestEmbed_Batch_ReturnsNVectorsInInputOrder pins AC2: N texts yield N vectors
+// in input order. The server also captures the request so the wire shape is
+// pinned in the same test — POST /api/embed with {"model":M,"input":[texts]} —
+// and echoes a per-input marker vector so a scrambled order would fail the
+// order assertion, not just the count.
+func TestEmbed_Batch_ReturnsNVectorsInInputOrder(t *testing.T) {
+	var sawMethod, sawPath, sawModel atomic.Value
+	var sawInput atomic.Value
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawMethod.Store(r.Method)
+		sawPath.Store(r.URL.Path)
+		raw, _ := io.ReadAll(r.Body)
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		sawModel.Store(req.Model)
+		sawInput.Store(strings.Join(req.Input, "|"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Marker vectors: 1.0, 2.0, 3.0 in input order.
+		_, _ = w.Write([]byte(fullVectorJSON(t, 1.0, 2.0, 3.0)))
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	texts := []string{"alpha", "beta", "gamma"}
+	out, err := c.Embed(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	if len(out) != len(texts) {
+		t.Fatalf("len(out) = %d, want %d", len(out), len(texts))
+	}
+	for i, want := range []float32{1.0, 2.0, 3.0} {
+		if len(out[i]) != embeddings.Dim {
+			t.Fatalf("out[%d] len = %d, want %d", i, len(out[i]), embeddings.Dim)
+		}
+		if out[i][0] != want {
+			t.Errorf("out[%d][0] = %v, want %v (order scrambled?)", i, out[i][0], want)
+		}
+	}
+
+	if got, _ := sawMethod.Load().(string); got != http.MethodPost {
+		t.Errorf("method = %q, want POST", got)
+	}
+	if got, _ := sawPath.Load().(string); got != "/api/embed" {
+		t.Errorf("path = %q, want /api/embed", got)
+	}
+	if got, _ := sawModel.Load().(string); got != ollama.DefaultModel {
+		t.Errorf("model = %q, want %q", got, ollama.DefaultModel)
+	}
+	if got, _ := sawInput.Load().(string); got != "alpha|beta|gamma" {
+		t.Errorf("input = %q, want %q", got, "alpha|beta|gamma")
+	}
+}
+
+// TestEmbed_CountMismatch_Errors pins the second half of AC2's totality: a
+// response with a different number of vectors than inputs is a protocol
+// violation and must error rather than return a short/over-long slice.
+func TestEmbed_CountMismatch_Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Two vectors for three inputs.
+		_, _ = w.Write([]byte(fullVectorJSON(t, 1.0, 2.0)))
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	_, err := c.Embed(context.Background(), []string{"a", "b", "c"})
+	if err == nil {
+		t.Fatal("Embed with 2 vectors for 3 inputs returned nil error")
+	}
+	for _, must := range []string{"2", "3", ollama.DefaultModel} {
+		if !strings.Contains(err.Error(), must) {
+			t.Errorf("error %q missing required substring %q", err.Error(), must)
+		}
+	}
+}
+
+// TestEmbed_Non2xx_WrapsProviderAndStatus pins the error surface: a non-2xx
+// response yields an error naming the provider op and the HTTP status, with a
+// body snippet for diagnostics — the shape on-call reviewers grep for.
+func TestEmbed_Non2xx_WrapsProviderAndStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"model 'nomic-embed-text' not found"}`))
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	_, err := c.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("Embed with 404 returned nil error")
+	}
+	for _, must := range []string{"ollama.Embed", "404", "not found"} {
+		if !strings.Contains(err.Error(), must) {
+			t.Errorf("error %q missing required substring %q", err.Error(), must)
+		}
+	}
+}
+
+// TestEmbed_MalformedJSON_WrapsDecodeError pins that a 200 with a non-JSON body
+// fails as a wrapped decode error naming the provider, not a panic or silent
+// empty result.
+func TestEmbed_MalformedJSON_WrapsDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embeddings": not-json`))
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	_, err := c.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("Embed with malformed JSON returned nil error")
+	}
+	if !strings.Contains(err.Error(), "ollama.Embed") {
+		t.Errorf("error %q does not name the provider op", err.Error())
+	}
+}
+
+// TestEmbed_EmptyInput_NoCallNoError pins the fast path: an empty batch returns
+// (nil, nil) without any network call, so the worker can flush a zero-length
+// batch harmlessly and a black-holed endpoint is never dialed for nothing.
+func TestEmbed_EmptyInput_NoCallNoError(t *testing.T) {
+	var called atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := ollama.New(ollama.WithBaseURL(srv.URL))
+	out, err := c.Embed(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Embed(nil): %v", err)
+	}
+	if out != nil {
+		t.Errorf("out = %v, want nil", out)
+	}
+	if called.Load() {
+		t.Error("Embed(nil) made a network call; want none")
 	}
 }


### PR DESCRIPTION
Closes #111

## What

The Embeddings Component (ADR-0004 matrix slot) with the keyless local **Ollama `nomic-embed-text`** adapter as the v1.0 default, feeding the async, eventually-consistent embedding pipeline (ADR-0011).

New, all under `pkg/voice/embeddings/**` (disjoint from parallel PRs — no `internal/**`, `cmd/**`, `pkg/voice/stt/**`, no new go.mod deps):

- `embeddings.go` — `Provider` interface + `Dim = 768`. Contract is total & order-preserving; adapters MUST error on any other dimension (never truncate/pad).
- `ollama/` — hand-rolled `net/http` adapter (mirrors the ElevenLabs STT adapter, **not** an SDK or the OpenAI-compat layer — Ollama's `/api/embed` wire is not the OpenAI wire). `New(...Option)` with `WithBaseURL`/`WithModel`/`WithHTTPClient`. Keyless: no API-key option in v1.0 (the OpenAI sibling adds one later behind the same interface).
- `embeddingstest/` — deterministic doubles, **no cassette**: `Deterministic` (SHA-256 → splitmix64 → 768 L2-normalized floats, stable per text across runs/platforms) and `Fixed` (exact text→vector map; unmapped text errors).

## Acceptance criteria

- **AC1 — 768-dim, clear dimension error:** `Provider.Dim = 768`; the adapter guards the vector count and each vector's length, erroring with model/want/got.
- **AC2 — N texts → N vectors in order:** pinned with per-input marker vectors + request-shape assertions (`POST /api/embed`, `{"model":M,"input":[texts]}`); count mismatch errors.
- **AC3 — live semantic property:** `ollama_live_test.go` probes `GET /api/tags` (2s) and skips loudly without a reachable endpoint + pulled model; otherwise asserts two related Campaign sentences are closer in cosine than an unrelated pair — tolerant property, no exact values. **Locally validated vs real `nomic-embed-text`:** `cos(related)=0.6291 > cos(unrelated)=0.4933 / 0.4514`.
- **AC4 — deterministic double:** same input → byte-identical vector every run (golden-locked); different inputs differ; L2-norm ≈ 1.
- **AC5 — selectable via Provider Config:** the `embeddings` Component enum already exists in `internal/storage/models.go`; `ProviderID`/`DefaultModel` are exported. **Resolution wiring (env `GLYPHOXA_OLLAMA_URL`) ships with the first consumer, #116** — this PR is the contract + adapter, Ollama as the default with the OpenAI slot left as a future sibling.

## ADR compliance

- **ADR-0011** — `nomic-embed-text` 768-dim → `vector(768)`; this is the embed step the async worker calls.
- **ADR-0004 (2026-07-03 amendment)** — Embeddings = OpenAI + Ollama; Ollama is keyless local, OpenAI sibling is future-additive behind `Provider`.
- **ADR-0021** — determinism goal met by construction (hash-seeded doubles), no cassette needed for embeddings (deterministic function of text, not a recorded network call).

## Tests

14 test functions + 3 compile-time `Provider` assertions across `ollama` and `embeddingstest`. `gofmt`, `go vet`, `golangci-lint` (scoped) all clean; live test skips cleanly in CI (no Ollama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
