### PR TITLE
feat(#104): Transcript Chunk writer + live embedding-backlog gauge

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -299,6 +299,24 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// relay needs the manager (Snapshot), so the manager is built first.
 	mgr.SetTranscript(relay)
 
+	// The Transcript Chunk writer (#104, ADR-0011) subscribes to the SAME process
+	// bus and folds utterances into 3–6-utterance chunks written with embedding
+	// NULL (the async embedding pipeline, #116, fills them later); it refreshes the
+	// embedding-backlog gauge from the DB after each write. The manager closes its
+	// open chunk on Stop / loop exit. This CHUNK grain is independent of the relay's
+	// line grain (ADR-0040). Voice-standalone mode does not chunk (same posture as
+	// line persistence).
+	chunker := transcript.NewChunker(eventBus, mgr, store, metrics, log, transcript.ChunkerConfig{})
+	mgr.SetChunkFlusher(chunker)
+	// Seed the backlog gauge from the DB at boot so it reads the true count before
+	// the first chunk is written (idempotent Set-from-COUNT, ADR-0032). A read
+	// failure logs and leaves the gauge at 0 rather than failing the boot.
+	if n, err := store.CountUnembeddedChunks(ctx); err != nil {
+		log.Warn("seed embedding-backlog gauge", "err", err)
+	} else {
+		metrics.SetEmbeddingBacklog(n)
+	}
+
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /
 	// (ADR-0013/0039). The SPA handler is the "/" catch-all; ServeMux's

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -63,9 +63,10 @@ type PrometheusRecorder struct {
 	// response_latency — every turn records one terminal outcome.
 	turnTotal *prometheus.CounterVec // outcome, reason
 
-	// embedding backlog: spec-complete stub (ADR-0032). The persistence/embedding
-	// layer isn't coded yet, so nothing Sets this — registered so the /metrics
-	// surface matches ADR-0032 and a reviewer diffing the two sees no gap.
+	// embedding backlog (ADR-0032): chunks awaiting embedding. The chunk writer
+	// (#104) Sets it from CountUnembeddedChunks after each write; the future
+	// backfill worker (#116) Sets it too. Always Set-from-COUNT, never Inc/Dec, so
+	// it stays idempotent across writers and restarts.
 	embeddingBacklog prometheus.Gauge
 }
 
@@ -139,7 +140,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 	r.embeddingBacklog = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace, // process-level, not a voice subsystem metric (ADR-0032)
 		Name:      "embedding_backlog",
-		Help:      "Transcript chunks awaiting embedding (embedding IS NULL). Stub until the embedding layer lands.",
+		Help:      "Transcript chunks awaiting embedding (embedding IS NULL).",
 	})
 
 	reg.MustRegister(
@@ -217,6 +218,15 @@ func (r *PrometheusRecorder) ProviderError(s Stage, p Provider) {
 }
 func (r *PrometheusRecorder) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
 	r.turnTotal.WithLabelValues(string(outcome), string(reason)).Inc()
+}
+
+// SetEmbeddingBacklog publishes the current count of transcript chunks awaiting an
+// embedding (#104, ADR-0032). Callers Set from a COUNT(*) — never Inc/Dec — so the
+// gauge is idempotent across the chunk writer, the future backfill worker (#116)
+// and process restarts: whoever last counted wins, and a restart re-seeds it from
+// the DB rather than resuming a drifted in-memory delta.
+func (r *PrometheusRecorder) SetEmbeddingBacklog(n int) {
+	r.embeddingBacklog.Set(float64(n))
 }
 
 // Static assertions that the one adapter satisfies both contracts. The

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -78,6 +78,16 @@ type TranscriptFinalizer interface {
 	Finalize(ctx context.Context, id uuid.UUID) (int, error)
 }
 
+// ChunkFinalizer closes a session's open Transcript Chunk on Stop / loop exit
+// (#104, ADR-0011): a lone trailing utterance is flushed ONLY here, at session
+// end. *transcript.Chunker satisfies it; defined here (not imported) so the
+// manager does NOT depend on the transcript package — the chunker already depends
+// on the manager via Sessions, and the reverse import would cycle (mirrors
+// TranscriptFinalizer). nil (no chunking / voice-standalone) is a no-op.
+type ChunkFinalizer interface {
+	FlushSession(ctx context.Context, sessionID uuid.UUID) error
+}
+
 // LoopRunner runs the live voice loop until ctx is cancelled. Production wraps
 // wirenpc.RunFromDB (which loads the campaign roster and resolves the
 // credential-bridge keys, #69) bound to the app pool + cipher; tests inject a
@@ -107,6 +117,7 @@ type Manager struct {
 	base       wirenpc.Config      // Token (env fallback)/Logger/Metrics template; Guild/Channel come from saved config
 	cipher     *crypto.Cipher      // decrypts the saved deployment Bot token (#87); nil without $GLYPHOXA_SECRET
 	transcript TranscriptFinalizer // finalizes persisted lines on Stop (#74); nil keeps line_count at 0
+	chunker    ChunkFinalizer      // closes the open Transcript Chunk on Stop (#104); nil = no chunking
 	log        *slog.Logger
 	enabled    bool          // false in web-only mode: Start is rejected (ADR-0039)
 	endTimeout time.Duration // per-step end budget (Finalize, end-write); endTimeout in prod, shrunk in tests
@@ -139,6 +150,15 @@ func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto
 // needed.
 func (m *Manager) SetTranscript(t TranscriptFinalizer) {
 	m.transcript = t
+}
+
+// SetChunkFlusher wires the chunk finalizer the Manager calls on Stop / loop exit
+// (#104). Like SetTranscript it is set once at boot, after the chunker is built
+// (the chunker needs the Manager via Sessions), before any session can start, so
+// no lock is needed. nil leaves chunking off (voice-standalone, same posture as
+// line persistence).
+func (m *Manager) SetChunkFlusher(f ChunkFinalizer) {
+	m.chunker = f
 }
 
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no
@@ -262,6 +282,19 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		} else {
 			lineCount = n
 		}
+	}
+
+	// Close the session's open Transcript Chunk (#104, ADR-0011): a lone trailing
+	// utterance is flushed ONLY here, at session end. Best-effort with its OWN
+	// budget (like Finalize) — a flush failure logs and never blocks the row from
+	// ending. Distinct from the line grain above (ADR-0040): the two persist
+	// independently.
+	if m.chunker != nil {
+		chunkCtx, chunkCancel := context.WithTimeout(base, m.endTimeout)
+		if err := m.chunker.FlushSession(chunkCtx, as.session.ID); err != nil {
+			m.log.Warn("flush transcript chunk before end", "err", err, "voice_session", as.session.ID)
+		}
+		chunkCancel()
 	}
 
 	// A FRESH deadline for the ended_at write, regardless of what Finalize

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -663,3 +663,91 @@ func TestLoopExitClearsActive(t *testing.T) {
 		t.Errorf("ended rows = %d, want 1 after self-exit", ended)
 	}
 }
+
+// fakeChunkFinalizer is a stand-in ChunkFinalizer (#104): it records the id it was
+// flushed for, the store's ended-count AT flush time (to prove the flush ran
+// BEFORE EndVoiceSession), and can inject an error to prove a flush failure does
+// not fail Stop.
+type fakeChunkFinalizer struct {
+	mu           sync.Mutex
+	store        *fakeStore
+	id           uuid.UUID
+	called       int
+	endedAtFlush int
+	err          error
+}
+
+func (f *fakeChunkFinalizer) FlushSession(_ context.Context, id uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called++
+	f.id = id
+	created, ended := f.store.counts()
+	_ = created
+	f.endedAtFlush = ended
+	return f.err
+}
+
+func (f *fakeChunkFinalizer) seen() (uuid.UUID, int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.id, f.called, f.endedAtFlush
+}
+
+// TestStopFlushesChunkBeforeEnd is #104: on Stop / loop exit the Manager flushes
+// the active session's open Transcript Chunk BEFORE ending the row.
+func TestStopFlushesChunkBeforeEnd(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+	flusher := &fakeChunkFinalizer{store: store}
+	mgr.SetChunkFlusher(flusher)
+
+	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	id, called, endedAtFlush := flusher.seen()
+	if called != 1 || id != vs.ID {
+		t.Errorf("chunk flush seen id=%s called=%d, want id=%s called=1", id, called, vs.ID)
+	}
+	if endedAtFlush != 0 {
+		t.Errorf("EndVoiceSession ran (ended=%d) before the chunk flush; want flush first", endedAtFlush)
+	}
+}
+
+// TestStopSucceedsDespiteChunkFlushError is #104: a chunk-flush failure logs and
+// never fails Stop — the row still ends cleanly.
+func TestStopSucceedsDespiteChunkFlushError(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+	mgr.SetChunkFlusher(&fakeChunkFinalizer{store: store, err: errors.New("chunk writer wedged")})
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	ended, err := mgr.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("Stop returned %v, want nil (a chunk-flush error must not fail Stop)", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded {
+		t.Errorf("stopped session status = %q, want ended despite the flush error", ended.Status)
+	}
+}

--- a/internal/storage/transcript_chunk.go
+++ b/internal/storage/transcript_chunk.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Transcript-chunk persistence (#104, ADR-0011): the chunk writer inserts one row
+// per closed chunk (3–6 utterances) with embedding NULL; a background worker
+// (#116) fills the embedding later and retrieval filters WHERE embedding IS NOT
+// NULL. This CHUNK grain — the retrieval/embedding unit for NPC Hot Context — is
+// distinct from the per-line transcript_line grain (ADR-0040): the two are
+// independent records of the same speech and do not share rows.
+
+// TranscriptChunk is one persisted Transcript Chunk. embedding is always NULL at
+// insert (the async embedding pipeline, ADR-0011); EmbeddingModel is deferred to
+// #116 (no column yet), so it is neither written nor read here and scans "".
+type TranscriptChunk struct {
+	ID                    uuid.UUID
+	CampaignID            uuid.UUID
+	VoiceSessionID        uuid.UUID   // column nullable; the writer always sets it
+	Content               string      // the chunk's utterances joined "\n"
+	SpeakerDiscordUserIDs []string    // empty in v1.0: anonymous STT lane (ADR-0039)
+	ParticipatedAgentIDs  []uuid.UUID // Agents that spoke in the chunk (NPC-knowledge filter)
+	EmbeddingModel        string      // deferred to #116; not persisted here
+	StartedAt             time.Time
+	CreatedAt             time.Time
+}
+
+// InsertTranscriptChunk writes one closed chunk and returns its generated id. The
+// embedding is left NULL — the async pipeline fills it later (ADR-0011) — and the
+// arrays default to empty (never NULL). embedding_model is deferred (#116), so it
+// is not written here.
+func (s *Store) InsertTranscriptChunk(ctx context.Context, c TranscriptChunk) (uuid.UUID, error) {
+	speakers := c.SpeakerDiscordUserIDs
+	if speakers == nil {
+		speakers = []string{}
+	}
+	agents := c.ParticipatedAgentIDs
+	if agents == nil {
+		agents = []uuid.UUID{}
+	}
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO transcript_chunk
+		   (campaign_id, voice_session_id, content,
+		    speaker_discord_user_ids, participated_agent_ids, started_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING id`,
+		c.CampaignID, c.VoiceSessionID, c.Content, speakers, agents, c.StartedAt).Scan(&id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: insert transcript chunk: %w", err)
+	}
+	return id, nil
+}
+
+// CountUnembeddedChunks returns the number of Transcript Chunks still awaiting an
+// embedding (embedding IS NULL) — the embedding-backlog gauge value (#104). It is
+// process-wide (no tenant/campaign filter): ADR-0032 keeps that cardinality off
+// the metric, so the gauge is a single global number.
+func (s *Store) CountUnembeddedChunks(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRow(ctx,
+		`SELECT count(*) FROM transcript_chunk WHERE embedding IS NULL`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("storage: count unembedded transcript chunks: %w", err)
+	}
+	return n, nil
+}

--- a/internal/storage/transcript_chunk_test.go
+++ b/internal/storage/transcript_chunk_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestTranscriptChunkPersistence is #104 AC1 + the ADR-0011 grain: a chunk is
+// inserted with embedding NULL (the async pipeline fills it later), its fts column
+// is generated non-null, and the text[]/uuid[] arrays round-trip. The
+// NULL-embedding COUNT (the backlog gauge value) counts only un-embedded rows, and
+// the same Voice Session carries transcript_line rows too — proving the chunk and
+// line grains coexist as independent records of the same speech (ADR-0040).
+func TestTranscriptChunkPersistence(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	agentA, agentB := uuid.New(), uuid.New()
+	startedAt := time.Date(2026, 7, 5, 18, 0, 1, 0, time.UTC)
+
+	id, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID:            campaignID,
+		VoiceSessionID:        vs.ID,
+		Content:               "Player / DM: Hello Bart\nBart: Well met. Sit.",
+		SpeakerDiscordUserIDs: []string{}, // anonymous STT lane (ADR-0039)
+		ParticipatedAgentIDs:  []uuid.UUID{agentA, agentB},
+		StartedAt:             startedAt,
+	})
+	if err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+	if id == uuid.Nil {
+		t.Fatal("insert returned a nil id")
+	}
+
+	// Read back the row's derived state directly: embedding NULL, fts generated
+	// non-null, and the arrays scan back into their Go slice types.
+	var (
+		embNull    bool
+		ftsNotNull bool
+		content    string
+		speakers   []string
+		agents     []uuid.UUID
+		gotVSID    uuid.UUID
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT embedding IS NULL, fts IS NOT NULL, content,
+		        speaker_discord_user_ids, participated_agent_ids, voice_session_id
+		   FROM transcript_chunk WHERE id = $1`, id).
+		Scan(&embNull, &ftsNotNull, &content, &speakers, &agents, &gotVSID); err != nil {
+		t.Fatalf("read back chunk: %v", err)
+	}
+	if !embNull {
+		t.Error("embedding is not NULL — the writer must insert with NULL embedding (ADR-0011)")
+	}
+	if !ftsNotNull {
+		t.Error("fts generated column is NULL — expected a non-null tsvector over content")
+	}
+	if content != "Player / DM: Hello Bart\nBart: Well met. Sit." {
+		t.Errorf("content = %q", content)
+	}
+	if len(speakers) != 0 {
+		t.Errorf("speakers = %v, want empty", speakers)
+	}
+	if len(agents) != 2 || agents[0] != agentA || agents[1] != agentB {
+		t.Errorf("participated_agent_ids = %v, want [%s %s] in order", agents, agentA, agentB)
+	}
+	if gotVSID != vs.ID {
+		t.Errorf("voice_session_id = %s, want %s", gotVSID, vs.ID)
+	}
+
+	// CountUnembeddedChunks counts NULL-embedding rows only. Insert a second chunk,
+	// then embed the FIRST (manually) and confirm the count drops to just the
+	// still-unembedded one.
+	if n, err := st.CountUnembeddedChunks(ctx); err != nil || n != 1 {
+		t.Fatalf("CountUnembeddedChunks = %d, %v; want 1", n, err)
+	}
+	if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: campaignID, VoiceSessionID: vs.ID, Content: "Player / DM: second", StartedAt: startedAt,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk (second): %v", err)
+	}
+	if n, err := st.CountUnembeddedChunks(ctx); err != nil || n != 2 {
+		t.Fatalf("CountUnembeddedChunks after second insert = %d, %v; want 2", n, err)
+	}
+	// Give the first chunk an embedding: the count must exclude it (only NULLs).
+	if _, err := pool.Exec(ctx,
+		`UPDATE transcript_chunk SET embedding = array_fill(0::real, ARRAY[768])::vector WHERE id = $1`, id); err != nil {
+		t.Fatalf("embed first chunk: %v", err)
+	}
+	if n, err := st.CountUnembeddedChunks(ctx); err != nil || n != 1 {
+		t.Fatalf("CountUnembeddedChunks after embedding one = %d, %v; want 1 (NULL only)", n, err)
+	}
+
+	// The two grains coexist: the SAME Voice Session also has transcript_line rows.
+	if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "u:1", Seq: 1,
+		Who: "Player / DM", Kind: "player", TS: startedAt, Text: "Hello Bart",
+	}); err != nil {
+		t.Fatalf("UpsertTranscriptLine: %v", err)
+	}
+	if n, err := st.CountTranscriptLines(ctx, vs.ID); err != nil || n != 1 {
+		t.Fatalf("CountTranscriptLines = %d, %v; want 1 (line grain independent of chunk grain)", n, err)
+	}
+	var chunkRows int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM transcript_chunk WHERE voice_session_id = $1`, vs.ID).Scan(&chunkRows); err != nil {
+		t.Fatalf("count chunk rows: %v", err)
+	}
+	if chunkRows != 2 {
+		t.Errorf("chunk rows for session = %d, want 2 (both grains persist under one session)", chunkRows)
+	}
+}

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -234,15 +234,26 @@ func (c *Chunker) appendHuman(ev voiceevent.STTFinal) {
 
 // bufferAgentSentence records one DISPATCHED sentence. TTSInvoked is a dispatch
 // attempt, not delivery (ADR-0012 / event.go), so nothing enters the chunk here:
-// the sentence is buffered FIFO and committed only when its FirstAudio confirms it
-// reached the room. Every dispatch is buffered (empty sentences included) so
-// pending stays 1:1 with dispatch attempts and the FirstAudio pairing holds. A
-// sentence for a turn already ended (barge / tts_error) is dropped + logged.
+// the sentence is buffered and committed only when its FirstAudio confirms it
+// reached the room. A sentence for a turn already ended (barge / tts_error) is
+// dropped + logged.
+//
+// Dispatch is serial single-in-flight and FirstAudio(sN) is published inline
+// before Dispatch(sN) returns (orchestrator.dispatchStream + wire/tee), so
+// FirstAudio(sN) always precedes TTSInvoked(sN+1) on the bus. A sentence still
+// pending when the NEXT dispatch arrives therefore start-errored and was never
+// delivered — purge it (never commit unheard text, ADR-0012), else a mid-turn
+// start-error the turn recovers from would commit the lost sentence AND shift the
+// FirstAudio pairing of every later sentence by one.
 func (c *Chunker) bufferAgentSentence(ev voiceevent.TTSInvoked) {
 	t := c.turn(ev.TurnID)
 	if t.ended {
 		c.log.Warn("transcript: chunk sentence after turn ended, dropping", "turn", ev.TurnID)
 		return
+	}
+	if n := len(t.pending); n > 0 {
+		c.log.Warn("transcript: undelivered dispatched sentence superseded, dropping", "turn", ev.TurnID, "dropped", n)
+		t.pending = t.pending[:0]
 	}
 	t.pending = append(t.pending, ev.Sentence)
 }

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -16,7 +16,11 @@ import (
 // Transcript chunk writer (#104, ADR-0011). The chunker subscribes to the process
 // voiceevent.Bus, folds the pipeline's events into a per-session open chunk of
 // 3–6 utterances, and closes the chunk on whichever-first of five utterances,
-// the window elapsing (with ≥2 utterances), or session end. A closed chunk is
+// the window elapsing (with ≥2 utterances), or session end. An Agent utterance
+// counts only DELIVERED speech (ADR-0012): a sentence enters the chunk on its
+// FirstAudio (audio handed to the room), not on TTSInvoked (a dispatch attempt),
+// so the undelivered tail of a barged / errored turn never reaches the transcript
+// and a zero-delivered turn logs nothing. A closed chunk is
 // written with embedding NULL — the async embedding pipeline fills it later — and
 // the NULL-embedding backlog gauge is refreshed from the store's COUNT after each
 // write. This CHUNK grain (retrieval/Hot Context) is distinct from the per-line
@@ -68,14 +72,17 @@ type ChunkerConfig struct {
 }
 
 // chunkTurn is the per-turn coalescing state: the routed target (name + agent id
-// from AddressRouted) and, once the turn's first TTSInvoked opens its utterance,
-// the open-chunk line whose text later sentences append to. closed marks a turn
-// whose line was flushed into a now-closed chunk, so a late sentence is dropped
-// (mirrors the relay's post-TurnEnded drop).
+// from AddressRouted); pending, the sentences DISPATCHED (TTSInvoked) but not yet
+// delivered, held FIFO and paired with FirstAudio by arrival order within the
+// TurnID (event.go); line, the open-chunk utterance once the turn's first
+// delivered sentence has opened it, which later delivered sentences append to; and
+// ended (TurnEnded seen), after which a late TTSInvoked is dropped and the
+// undelivered pending tail never commits (ADR-0012).
 type chunkTurn struct {
-	target voiceevent.AddressTarget
-	line   *chunkLine
-	closed bool
+	target  voiceevent.AddressTarget
+	line    *chunkLine
+	pending []string
+	ended   bool
 }
 
 // chunkLine is one rendered utterance line ("Who: text") in an open chunk. It is a
@@ -91,7 +98,7 @@ type openChunk struct {
 	openedWall time.Time    // wall clock at open — the window-elapsed reference
 	count      int          // utterance count (human STTFinal, or one per Agent turn)
 	entries    []*chunkLine // rendered lines, in order
-	turnIDs    []string     // Agent turns whose line lives in this chunk (for close-drop)
+	turnIDs    []string     // Agent turns whose line lives in this chunk (detached on close)
 	agents     []uuid.UUID  // participated Agent ids, first-seen order
 	agentSeen  map[uuid.UUID]struct{}
 	timer      *time.Timer
@@ -189,7 +196,15 @@ func (c *Chunker) project(e voiceevent.Event) {
 	case voiceevent.AddressRouted:
 		c.turn(ev.TurnID).target = ev.Target
 	case voiceevent.TTSInvoked:
-		c.appendAgentSentence(ev)
+		c.bufferAgentSentence(ev)
+	case voiceevent.FirstAudio:
+		c.commitDelivered(ev)
+	case voiceevent.TurnEnded:
+		// The turn is finalized: drop its undelivered tail (ADR-0012 — the room
+		// never heard those sentences) and refuse late dispatches.
+		t := c.turn(ev.TurnID)
+		t.ended = true
+		t.pending = nil
 	}
 }
 
@@ -217,19 +232,42 @@ func (c *Chunker) appendHuman(ev voiceevent.STTFinal) {
 	c.afterAppend(oc)
 }
 
-// appendAgentSentence folds one TTS sentence into its turn's utterance: the first
-// sentence of a turn opens a new utterance line (and records the Agent), later
-// sentences append to that same line without bumping the utterance count. A
-// sentence for a turn already flushed into a closed chunk is dropped + logged.
-func (c *Chunker) appendAgentSentence(ev voiceevent.TTSInvoked) {
+// bufferAgentSentence records one DISPATCHED sentence. TTSInvoked is a dispatch
+// attempt, not delivery (ADR-0012 / event.go), so nothing enters the chunk here:
+// the sentence is buffered FIFO and committed only when its FirstAudio confirms it
+// reached the room. Every dispatch is buffered (empty sentences included) so
+// pending stays 1:1 with dispatch attempts and the FirstAudio pairing holds. A
+// sentence for a turn already ended (barge / tts_error) is dropped + logged.
+func (c *Chunker) bufferAgentSentence(ev voiceevent.TTSInvoked) {
 	t := c.turn(ev.TurnID)
-	if t.closed {
-		c.log.Warn("transcript: chunk sentence for a closed chunk, dropping", "turn", ev.TurnID)
+	if t.ended {
+		c.log.Warn("transcript: chunk sentence after turn ended, dropping", "turn", ev.TurnID)
 		return
 	}
+	t.pending = append(t.pending, ev.Sentence)
+}
+
+// commitDelivered commits the next dispatched sentence now that its FirstAudio
+// confirms it was delivered (ADR-0012: transcripts reflect what listeners actually
+// heard). FirstAudio pairs FIFO with TTSInvoked by arrival order within the TurnID
+// (event.go), so it pops pending's head. The first delivered sentence OPENS the
+// turn's utterance (one utterance per Agent turn, records the Agent, bumps the
+// count); later delivered sentences append to that same line. A FirstAudio with
+// nothing pending — a straggler after TurnEnded cleared the buffer — is a no-op.
+func (c *Chunker) commitDelivered(ev voiceevent.FirstAudio) {
+	t := c.turn(ev.TurnID)
+	if len(t.pending) == 0 {
+		c.log.Debug("transcript: first audio with no pending sentence, ignoring", "turn", ev.TurnID)
+		return
+	}
+	s := t.pending[0]
+	t.pending = t.pending[1:]
 	if t.line == nil {
+		// First delivered sentence of this turn's current utterance: open it. After
+		// a chunk close detached the line, this re-opens a CONTINUATION in the next
+		// chunk (started_at = this delivery's time, Agent in the new chunk's set).
 		oc := c.ensureOpen(ev.At)
-		t.line = &chunkLine{text: nameOr(t.target.Name, "NPC") + ": " + ev.Sentence}
+		t.line = &chunkLine{text: nameOr(t.target.Name, "NPC") + ": " + s}
 		oc.entries = append(oc.entries, t.line)
 		oc.turnIDs = append(oc.turnIDs, ev.TurnID)
 		c.recordAgent(oc, t.target)
@@ -237,13 +275,13 @@ func (c *Chunker) appendAgentSentence(ev voiceevent.TTSInvoked) {
 		c.afterAppend(oc)
 		return
 	}
-	if ev.Sentence == "" {
+	if s == "" {
 		return
 	}
 	if t.line.text != "" {
 		t.line.text += " "
 	}
-	t.line.text += ev.Sentence
+	t.line.text += s
 }
 
 // recordAgent adds the turn's Agent to the chunk's participated set (deduped,
@@ -308,11 +346,12 @@ func (c *Chunker) onTimer(oc *openChunk) {
 	}
 }
 
-// closeChunk finalizes oc: it stops the timer, clears it as the open chunk, marks
-// its Agent turns closed (so a late sentence drops), and tees the built chunk onto
-// the writer queue. Idempotent-safe: a count-0 chunk (never happens in practice,
-// as a chunk only opens on an utterance) is dropped without a write. Caller holds
-// c.mu.
+// closeChunk finalizes oc: it stops the timer, clears it as the open chunk,
+// DETACHES its Agent turns (line = nil) so a not-ended turn's next delivered
+// sentence opens a continuation utterance in the next chunk, and tees the built
+// chunk onto the writer queue. A count-0 chunk (a chunk only opens on a delivered
+// or human utterance, so this is defensive) is dropped without a write. Caller
+// holds c.mu.
 func (c *Chunker) closeChunk(oc *openChunk) {
 	if oc.timer != nil {
 		oc.timer.Stop()
@@ -322,7 +361,6 @@ func (c *Chunker) closeChunk(oc *openChunk) {
 	}
 	for _, id := range oc.turnIDs {
 		if t := c.turns[id]; t != nil {
-			t.closed = true
 			t.line = nil
 		}
 	}

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -1,0 +1,426 @@
+package transcript
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Transcript chunk writer (#104, ADR-0011). The chunker subscribes to the process
+// voiceevent.Bus, folds the pipeline's events into a per-session open chunk of
+// 3–6 utterances, and closes the chunk on whichever-first of five utterances,
+// the window elapsing (with ≥2 utterances), or session end. A closed chunk is
+// written with embedding NULL — the async embedding pipeline fills it later — and
+// the NULL-embedding backlog gauge is refreshed from the store's COUNT after each
+// write. This CHUNK grain (retrieval/Hot Context) is distinct from the per-line
+// transcript_line grain (ADR-0040): the two are independent records of the same
+// speech.
+//
+// Concurrency mirrors the relay (#74): the bus delivers project SYNCHRONOUSLY and
+// must not block, so a closed chunk is teed onto a bounded queue drained by ONE
+// writer goroutine, and an overflow drops + logs rather than ever calling the DB
+// inline. FlushSession (the Manager's loop-exit hook) closes the open chunk and
+// rides a flush barrier through the SAME queue, so FIFO guarantees every prior
+// insert has landed when it returns.
+
+const (
+	// chunkQueue bounds the writer's backlog. Closes past this are dropped (logged)
+	// rather than blocking the bus; a healthy DB drains far faster than a session
+	// closes chunks.
+	chunkQueue = 64
+	// chunkWriteTimeout bounds one Insert+Count so a stalled DB can't wedge the
+	// single writer goroutine indefinitely.
+	chunkWriteTimeout = 5 * time.Second
+
+	// defaultWindow / defaultMaxUtterances are the chunk-close thresholds (ADR-0011):
+	// close at five utterances or sixty seconds, whichever first.
+	defaultWindow        = 60 * time.Second
+	defaultMaxUtterances = 5
+)
+
+// ChunkStore is the narrow persistence surface the chunker needs (#104):
+// insert-with-NULL-embedding and the global NULL-embedding COUNT for the gauge.
+// *storage.Store satisfies it; tests fake it.
+type ChunkStore interface {
+	InsertTranscriptChunk(ctx context.Context, c storage.TranscriptChunk) (uuid.UUID, error)
+	CountUnembeddedChunks(ctx context.Context) (int, error)
+}
+
+// BacklogGauge receives the current NULL-embedding backlog after each write
+// (Set-from-COUNT, never Inc/Dec — ADR-0032). *observe.PrometheusRecorder
+// satisfies it; nil disables the gauge update.
+type BacklogGauge interface {
+	SetEmbeddingBacklog(n int)
+}
+
+// ChunkerConfig tunes the chunk-close thresholds. Zero values fall back to the
+// ADR-0011 defaults (60s window, 5 utterances); tests shrink the window.
+type ChunkerConfig struct {
+	Window        time.Duration
+	MaxUtterances int
+}
+
+// chunkTurn is the per-turn coalescing state: the routed target (name + agent id
+// from AddressRouted) and, once the turn's first TTSInvoked opens its utterance,
+// the open-chunk line whose text later sentences append to. closed marks a turn
+// whose line was flushed into a now-closed chunk, so a late sentence is dropped
+// (mirrors the relay's post-TurnEnded drop).
+type chunkTurn struct {
+	target voiceevent.AddressTarget
+	line   *chunkLine
+	closed bool
+}
+
+// chunkLine is one rendered utterance line ("Who: text") in an open chunk. It is a
+// pointer so an Agent turn's later sentences append to the same line in place.
+type chunkLine struct {
+	text string
+}
+
+// openChunk accumulates the current session's utterances until a close condition
+// fires.
+type openChunk struct {
+	startedAt  time.Time    // first utterance's event time — the row's started_at
+	openedWall time.Time    // wall clock at open — the window-elapsed reference
+	count      int          // utterance count (human STTFinal, or one per Agent turn)
+	entries    []*chunkLine // rendered lines, in order
+	turnIDs    []string     // Agent turns whose line lives in this chunk (for close-drop)
+	agents     []uuid.UUID  // participated Agent ids, first-seen order
+	agentSeen  map[uuid.UUID]struct{}
+	timer      *time.Timer
+}
+
+// Chunker projects bus events into Transcript Chunks and writes them async. Safe
+// for concurrent use: the bus callback, the window timer and FlushSession all take
+// the same lock.
+type Chunker struct {
+	sessions Sessions
+	store    ChunkStore
+	gauge    BacklogGauge
+	log      *slog.Logger
+	window   time.Duration
+	maxUtt   int
+
+	mu               sync.Mutex
+	activeID         string // current session id; "" at process start
+	activeUUID       uuid.UUID
+	activeCampaignID uuid.UUID
+	open             *openChunk
+	turns            map[string]*chunkTurn // per-session, reset on rollover
+
+	// writeCh is the non-blocking queue draining into the single writer goroutine;
+	// nil when persistence is disabled (store == nil).
+	writeCh chan chunkOp
+}
+
+// chunkOp is one item on the writer queue: a chunk to insert, or a flush barrier.
+type chunkOp struct {
+	chunk *storage.TranscriptChunk
+	flush *chunkFlush
+}
+
+// chunkFlush is the FlushSession barrier: the writer replies on result once every
+// insert enqueued before it has landed (FIFO).
+type chunkFlush struct {
+	result chan error
+}
+
+// NewChunker subscribes to the bus once and returns a Chunker ready to fold
+// events. The subscription lives for the process (single active session across
+// reconnects/sessions, ADR-0039). A nil store disables writes (no writer
+// goroutine); a nil gauge disables the backlog update.
+func NewChunker(bus *voiceevent.Bus, sessions Sessions, store ChunkStore, gauge BacklogGauge, log *slog.Logger, cfg ChunkerConfig) *Chunker {
+	if log == nil {
+		log = slog.Default()
+	}
+	window := cfg.Window
+	if window <= 0 {
+		window = defaultWindow
+	}
+	maxUtt := cfg.MaxUtterances
+	if maxUtt <= 0 {
+		maxUtt = defaultMaxUtterances
+	}
+	c := &Chunker{
+		sessions: sessions,
+		store:    store,
+		gauge:    gauge,
+		log:      log,
+		window:   window,
+		maxUtt:   maxUtt,
+		turns:    map[string]*chunkTurn{},
+	}
+	if store != nil {
+		c.writeCh = make(chan chunkOp, chunkQueue)
+		go c.writeLoop()
+	}
+	if bus != nil {
+		bus.Subscribe(c.project)
+	}
+	return c
+}
+
+// project is the bus callback: it attributes the event to the active session
+// (rolling over on a session change, one Snapshot per event like the relay) and
+// folds it into the open chunk. It must not block (the bus delivers
+// synchronously): the only outward call, closeChunk's enqueue, is non-blocking.
+func (c *Chunker) project(e voiceevent.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	vs, active := c.sessions.Snapshot()
+	if !active {
+		return // no active session — drop the event (ADR-0039)
+	}
+	if vs.ID.String() != c.activeID {
+		c.rollover(vs)
+	}
+
+	switch ev := e.(type) {
+	case voiceevent.STTFinal:
+		c.appendHuman(ev)
+	case voiceevent.AddressRouted:
+		c.turn(ev.TurnID).target = ev.Target
+	case voiceevent.TTSInvoked:
+		c.appendAgentSentence(ev)
+	}
+}
+
+// rollover switches to the newly-active session vs. Any stale open chunk from the
+// previous session is enqueue-flushed as a safety net (a session that ended
+// without a FlushSession still persists its last chunk), BEFORE the active FKs are
+// repointed so the flushed chunk keeps the OLD session's ids.
+func (c *Chunker) rollover(vs storage.VoiceSession) {
+	if c.open != nil {
+		c.closeChunk(c.open)
+	}
+	c.activeID = vs.ID.String()
+	c.activeUUID = vs.ID
+	c.activeCampaignID = vs.CampaignID
+	c.open = nil
+	c.turns = map[string]*chunkTurn{}
+}
+
+// appendHuman folds one human utterance (one STTFinal, anonymous lane ADR-0039)
+// into the open chunk and re-checks the close conditions.
+func (c *Chunker) appendHuman(ev voiceevent.STTFinal) {
+	oc := c.ensureOpen(ev.At)
+	oc.entries = append(oc.entries, &chunkLine{text: "Player / DM: " + ev.Text})
+	oc.count++
+	c.afterAppend(oc)
+}
+
+// appendAgentSentence folds one TTS sentence into its turn's utterance: the first
+// sentence of a turn opens a new utterance line (and records the Agent), later
+// sentences append to that same line without bumping the utterance count. A
+// sentence for a turn already flushed into a closed chunk is dropped + logged.
+func (c *Chunker) appendAgentSentence(ev voiceevent.TTSInvoked) {
+	t := c.turn(ev.TurnID)
+	if t.closed {
+		c.log.Warn("transcript: chunk sentence for a closed chunk, dropping", "turn", ev.TurnID)
+		return
+	}
+	if t.line == nil {
+		oc := c.ensureOpen(ev.At)
+		t.line = &chunkLine{text: nameOr(t.target.Name, "NPC") + ": " + ev.Sentence}
+		oc.entries = append(oc.entries, t.line)
+		oc.turnIDs = append(oc.turnIDs, ev.TurnID)
+		c.recordAgent(oc, t.target)
+		oc.count++
+		c.afterAppend(oc)
+		return
+	}
+	if ev.Sentence == "" {
+		return
+	}
+	if t.line.text != "" {
+		t.line.text += " "
+	}
+	t.line.text += ev.Sentence
+}
+
+// recordAgent adds the turn's Agent to the chunk's participated set (deduped,
+// first-seen order). AddressTarget.AgentID IS the DB UUID for a Character NPC
+// (wirenpc/agentspec.go); the well-known "butler" route and any other non-UUID id
+// is logged and skipped — a chunk with only such replies is left with no
+// participants, which is the correct hard-filter behaviour for NPC-knowledge
+// retrieval (ADR-0011).
+func (c *Chunker) recordAgent(oc *openChunk, target voiceevent.AddressTarget) {
+	id, err := uuid.Parse(target.AgentID)
+	if err != nil {
+		c.log.Warn("transcript: unparsable agent id on chunk turn, skipping participation", "agent_id", target.AgentID)
+		return
+	}
+	if _, ok := oc.agentSeen[id]; ok {
+		return
+	}
+	oc.agentSeen[id] = struct{}{}
+	oc.agents = append(oc.agents, id)
+}
+
+// ensureOpen returns the open chunk, creating one (armed with the window timer)
+// on first utterance. at is the utterance's event time, kept as the row's
+// started_at; the wall clock at open is the window-elapsed reference.
+func (c *Chunker) ensureOpen(at time.Time) *openChunk {
+	if c.open == nil {
+		oc := &openChunk{
+			startedAt:  at,
+			openedWall: time.Now(),
+			agentSeen:  map[uuid.UUID]struct{}{},
+		}
+		oc.timer = time.AfterFunc(c.window, func() { c.onTimer(oc) })
+		c.open = oc
+	}
+	return c.open
+}
+
+// afterAppend closes the open chunk when a count threshold is met: at MaxUtterances
+// unconditionally, or once the window has elapsed with ≥2 utterances (a late
+// utterance arriving after the timer already fired closes here immediately).
+func (c *Chunker) afterAppend(oc *openChunk) {
+	if oc.count >= c.maxUtt {
+		c.closeChunk(oc)
+		return
+	}
+	if oc.count >= 2 && time.Since(oc.openedWall) >= c.window {
+		c.closeChunk(oc)
+	}
+}
+
+// onTimer fires when the window elapses. With ≥2 utterances it closes the chunk;
+// with a lone utterance it leaves the chunk open (the ONLY flush of a lone
+// utterance is session end), so the next append re-checks and closes immediately.
+func (c *Chunker) onTimer(oc *openChunk) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.open != oc {
+		return // already closed / superseded
+	}
+	if oc.count >= 2 {
+		c.closeChunk(oc)
+	}
+}
+
+// closeChunk finalizes oc: it stops the timer, clears it as the open chunk, marks
+// its Agent turns closed (so a late sentence drops), and tees the built chunk onto
+// the writer queue. Idempotent-safe: a count-0 chunk (never happens in practice,
+// as a chunk only opens on an utterance) is dropped without a write. Caller holds
+// c.mu.
+func (c *Chunker) closeChunk(oc *openChunk) {
+	if oc.timer != nil {
+		oc.timer.Stop()
+	}
+	if c.open == oc {
+		c.open = nil
+	}
+	for _, id := range oc.turnIDs {
+		if t := c.turns[id]; t != nil {
+			t.closed = true
+			t.line = nil
+		}
+	}
+	if oc.count == 0 {
+		return
+	}
+	texts := make([]string, len(oc.entries))
+	for i, e := range oc.entries {
+		texts[i] = e.text
+	}
+	chunk := storage.TranscriptChunk{
+		CampaignID:            c.activeCampaignID,
+		VoiceSessionID:        c.activeUUID,
+		Content:               strings.Join(texts, "\n"),
+		SpeakerDiscordUserIDs: []string{},
+		ParticipatedAgentIDs:  oc.agents,
+		StartedAt:             oc.startedAt,
+	}
+	c.enqueue(chunkOp{chunk: &chunk})
+}
+
+// enqueue tees an op onto the writer queue with a non-blocking send — the bus must
+// not block, so an overflow drops + logs. No-op when persistence is disabled.
+func (c *Chunker) enqueue(op chunkOp) {
+	if c.writeCh == nil {
+		return
+	}
+	select {
+	case c.writeCh <- op:
+	default:
+		c.log.Warn("transcript: chunk queue full, dropping chunk")
+	}
+}
+
+// turn returns the coalescing state for a turn id, creating it on first sight.
+func (c *Chunker) turn(id string) *chunkTurn {
+	t := c.turns[id]
+	if t == nil {
+		t = &chunkTurn{}
+		c.turns[id] = t
+	}
+	return t
+}
+
+// writeLoop is the single writer goroutine: it serially inserts closed chunks and
+// refreshes the backlog gauge, and services flush barriers. An insert/count
+// failure is logged but does not stop the loop — durability is best-effort.
+func (c *Chunker) writeLoop() {
+	for op := range c.writeCh {
+		switch {
+		case op.chunk != nil:
+			ctx, cancel := context.WithTimeout(context.Background(), chunkWriteTimeout)
+			if _, err := c.store.InsertTranscriptChunk(ctx, *op.chunk); err != nil {
+				c.log.Warn("transcript: insert chunk", "err", err)
+				cancel()
+				continue
+			}
+			n, err := c.store.CountUnembeddedChunks(ctx)
+			cancel()
+			if err != nil {
+				c.log.Warn("transcript: count unembedded chunks", "err", err)
+				continue
+			}
+			if c.gauge != nil {
+				c.gauge.SetEmbeddingBacklog(n)
+			}
+		case op.flush != nil:
+			op.flush.result <- nil // FIFO: every prior insert has landed
+		}
+	}
+}
+
+// FlushSession closes the session's open chunk (even a lone utterance — the ONLY
+// place ADR-0011 flushes one) and drains the writer queue via a flush barrier,
+// returning once every enqueued insert has landed (#104). The Manager calls it at
+// every loop exit. It satisfies session.ChunkFinalizer. Persistence disabled (no
+// store) or a mismatched session id is a no-op.
+func (c *Chunker) FlushSession(ctx context.Context, sessionID uuid.UUID) error {
+	c.mu.Lock()
+	if c.open != nil && c.activeUUID == sessionID {
+		c.closeChunk(c.open)
+	}
+	ch := c.writeCh
+	c.mu.Unlock()
+
+	if ch == nil {
+		return nil
+	}
+	res := make(chan error, 1)
+	select {
+	case ch <- chunkOp{flush: &chunkFlush{result: res}}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case err := <-res:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/transcript/chunker_test.go
+++ b/internal/transcript/chunker_test.go
@@ -102,6 +102,26 @@ func newChunker(t *testing.T, store ChunkStore, gauge BacklogGauge, cfg ChunkerC
 	return bus, fs, c
 }
 
+// liveChunker wires a chunker to a bus with one active session that carries a
+// campaign id (fakeSessions reports uuid.Nil for the campaign; the funcSessions
+// script here lets a test assert campaign_id / voice_session_id on the row).
+func liveChunker(t *testing.T, store ChunkStore, gauge BacklogGauge, cfg ChunkerConfig, vs storage.VoiceSession) (*voiceevent.Bus, *Chunker) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	fs := &funcSessions{}
+	fs.set(func() (storage.VoiceSession, bool) { return vs, true })
+	c := NewChunker(bus, fs, store, gauge, slog.New(slog.DiscardHandler), cfg)
+	return bus, c
+}
+
+// agentReply is the event sequence for one DELIVERED Agent sentence: dispatch
+// (TTSInvoked) immediately followed by delivery (FirstAudio). The chunk grain
+// commits only on delivery (ADR-0012).
+func agentReply(bus *voiceevent.Bus, turnID, sentence string, at time.Time) {
+	bus.Publish(voiceevent.TTSInvoked{At: at, Sentence: sentence, TurnID: turnID})
+	bus.Publish(voiceevent.FirstAudio{At: at, TurnID: turnID})
+}
+
 // eventually polls fn until it returns true or the deadline passes.
 func eventually(t *testing.T, within time.Duration, fn func() bool) bool {
 	t.Helper()
@@ -116,26 +136,25 @@ func eventually(t *testing.T, within time.Duration, fn func() bool) bool {
 }
 
 // TestChunker_FiveUtterancesOneInsert is #104 rule CLOSE: a chunk closes at the
-// fifth utterance into ONE insert whose content is the five lines in order — not
-// one insert per utterance — and the embedding is never set on the write path.
+// fifth utterance into ONE insert whose content is the five lines in order — and
+// the write happens on the auto-close path WITHOUT any FlushSession draining it.
+// It also pins started_at = the first utterance's event time and the row's
+// campaign/session FKs.
 func TestChunker_FiveUtterancesOneInsert(t *testing.T) {
 	store := &fakeChunkStore{}
-	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	bus, _ := liveChunker(t, store, nil, ChunkerConfig{}, vs)
 
 	for i := 1; i <= 5; i++ {
 		bus.Publish(voiceevent.STTFinal{At: at(i), Text: "line" + string(rune('0'+i)), TurnID: "t"})
 	}
 
-	// Drain the async writer via the flush barrier (the auto-close at 5 already
-	// enqueued the insert; FlushSession only adds the barrier here).
-	if err := c.FlushSession(context.Background(), fs.id); err != nil {
-		t.Fatalf("FlushSession: %v", err)
+	// The fifth utterance auto-closes the chunk and the async writer inserts it —
+	// no FlushSession barrier involved.
+	if !eventually(t, 2*time.Second, func() bool { return store.count() == 1 }) {
+		t.Fatalf("five utterances did not auto-close into one insert: inserts = %d", store.count())
 	}
-
 	got := store.all()
-	if len(got) != 1 {
-		t.Fatalf("inserts = %d, want 1 (five utterances = one chunk)", len(got))
-	}
 	want := "Player / DM: line1\nPlayer / DM: line2\nPlayer / DM: line3\nPlayer / DM: line4\nPlayer / DM: line5"
 	if got[0].Content != want {
 		t.Errorf("content = %q,\nwant %q", got[0].Content, want)
@@ -145,6 +164,13 @@ func TestChunker_FiveUtterancesOneInsert(t *testing.T) {
 	}
 	if len(got[0].SpeakerDiscordUserIDs) != 0 {
 		t.Errorf("speakers = %v, want empty (anonymous STT lane)", got[0].SpeakerDiscordUserIDs)
+	}
+	if !got[0].StartedAt.Equal(at(1)) {
+		t.Errorf("started_at = %s, want the first utterance's event time %s", got[0].StartedAt, at(1))
+	}
+	if got[0].CampaignID != vs.CampaignID || got[0].VoiceSessionID != vs.ID {
+		t.Errorf("row FKs = campaign %s / session %s, want %s / %s",
+			got[0].CampaignID, got[0].VoiceSessionID, vs.CampaignID, vs.ID)
 	}
 }
 
@@ -212,8 +238,9 @@ func TestChunker_SecondUtteranceAfterWindowClosesImmediately(t *testing.T) {
 }
 
 // TestChunker_AgentReplyCoalesces is #104 rule UTTERANCES: an Agent turn is ONE
-// utterance no matter how many TTS sentences it spans (they append to one line),
-// and participated_agent_ids carries exactly that Agent's DB UUID.
+// utterance no matter how many DELIVERED sentences it spans (each delivered on its
+// FirstAudio, appended to one line), and participated_agent_ids carries exactly
+// that Agent's DB UUID.
 func TestChunker_AgentReplyCoalesces(t *testing.T) {
 	store := &fakeChunkStore{}
 	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
@@ -224,9 +251,10 @@ func TestChunker_AgentReplyCoalesces(t *testing.T) {
 		At: at(2), TurnID: "t1",
 		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
 	})
-	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", Index: 0, TurnID: "t1"})
-	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Sit down.", Index: 1, TurnID: "t1"})
-	bus.Publish(voiceevent.TTSInvoked{At: at(5), Sentence: "What'll it be?", Index: 2, TurnID: "t1"})
+	// Each sentence dispatched then delivered (TTSInvoked + FirstAudio interleaved).
+	agentReply(bus, "t1", "Well met.", at(3))
+	agentReply(bus, "t1", "Sit down.", at(4))
+	agentReply(bus, "t1", "What'll it be?", at(5))
 	bus.Publish(voiceevent.STTFinal{At: at(6), Text: "An ale", TurnID: "t2"})
 
 	if err := c.FlushSession(context.Background(), fs.id); err != nil {
@@ -243,6 +271,216 @@ func TestChunker_AgentReplyCoalesces(t *testing.T) {
 	}
 	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
 		t.Errorf("participated = %v, want exactly [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+}
+
+// TestChunker_DispatchedButNotDeliveredIsIgnored is #104 + ADR-0012: TTSInvoked is
+// a dispatch attempt, not delivery. A sentence dispatched but never delivered (no
+// FirstAudio — e.g. a Synthesize start-error) leaves the chunk unchanged and the
+// Agent out of participated_agent_ids.
+func TestChunker_DispatchedButNotDeliveredIsIgnored(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "hi", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	// Dispatched, but no FirstAudio ever follows: the room never heard it.
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "unheard", TurnID: "t1"})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || got[0].Content != "Player / DM: hi" {
+		t.Fatalf("content = %+v, want only the human line (undelivered agent sentence excluded)", got)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 0 {
+		t.Errorf("participated = %v, want empty (agent produced no audio)", got[0].ParticipatedAgentIDs)
+	}
+}
+
+// TestChunker_UndeliveredTailDroppedOnBarge is #104 + ADR-0012: on a barge the
+// turn ends carrying only its delivered sentences; the dispatched-but-undelivered
+// tail is dropped, a late TTSInvoked after TurnEnded is dropped + logged, and a
+// late FirstAudio after the buffer cleared is a no-op.
+func TestChunker_UndeliveredTailDroppedOnBarge(t *testing.T) {
+	store := &fakeChunkStore{}
+	cap := &capHandler{}
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	c := NewChunker(bus, fs, store, nil, slog.New(cap), ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	agentReply(bus, "t1", "Well met.", at(2))                                        // delivered
+	agentReply(bus, "t1", "Sit.", at(3))                                             // delivered
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Have a—", TurnID: "t1"}) // dispatched, not delivered
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+	bus.Publish(voiceevent.TTSInvoked{At: at(6), Sentence: "late", TurnID: "t1"}) // after end: dropped + logged
+	bus.Publish(voiceevent.FirstAudio{At: at(7), TurnID: "t1"})                   // straggler: no pending -> no-op
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || got[0].Content != "Bart: Well met. Sit." {
+		t.Fatalf("content = %+v, want only the two delivered sentences", got)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("participated = %v, want [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+	if !cap.has("after turn ended") {
+		t.Errorf("late dispatch after TurnEnded was not logged")
+	}
+}
+
+// TestChunker_ZeroDeliveredTurnLogsNothing is #104 + ADR-0012: a turn interrupted
+// before its first sentence is delivered (no FirstAudio at all) contributes no
+// utterance — a chunk never even opens for it.
+func TestChunker_ZeroDeliveredTurnLogsNothing(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "cut off", TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(3), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	if n := store.count(); n != 0 {
+		t.Fatalf("inserts = %d, want 0 (zero-delivered turn logs nothing)", n)
+	}
+}
+
+// TestChunker_ContinuationAcrossChunkClose is #104 rule 4: when a turn's first
+// delivered sentence is the fifth utterance, the chunk closes with that sentence;
+// the turn's next delivered sentence opens a CONTINUATION utterance in the next
+// chunk, with the Agent in that new chunk's participated set and started_at at the
+// continuation's delivery time.
+func TestChunker_ContinuationAcrossChunkClose(t *testing.T) {
+	store := &fakeChunkStore{}
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	bus, c := liveChunker(t, store, nil, ChunkerConfig{}, vs) // default MaxUtterances = 5
+	agentID := uuid.New()
+
+	// Four human utterances fill slots 1–4.
+	for i := 1; i <= 4; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: "h" + string(rune('0'+i)), TurnID: "h"})
+	}
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(5), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	agentReply(bus, "t1", "one", at(5)) // 5th utterance -> closes chunk 1
+	agentReply(bus, "t1", "two", at(6)) // continuation -> opens chunk 2
+
+	// chunk 1 auto-closed; FlushSession closes the continuation chunk 2 and drains.
+	if err := c.FlushSession(context.Background(), vs.ID); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 2 {
+		t.Fatalf("inserts = %d, want 2 (chunk + continuation)", len(got))
+	}
+	want1 := "Player / DM: h1\nPlayer / DM: h2\nPlayer / DM: h3\nPlayer / DM: h4\nBart: one"
+	if got[0].Content != want1 {
+		t.Errorf("chunk 1 content = %q,\nwant %q", got[0].Content, want1)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("chunk 1 participated = %v, want [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+	if got[1].Content != "Bart: two" {
+		t.Errorf("continuation content = %q, want %q", got[1].Content, "Bart: two")
+	}
+	if len(got[1].ParticipatedAgentIDs) != 1 || got[1].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("continuation participated = %v, want [%s] (agent in the new chunk too)", got[1].ParticipatedAgentIDs, agentID)
+	}
+	if !got[1].StartedAt.Equal(at(6)) {
+		t.Errorf("continuation started_at = %s, want the continuation delivery time %s", got[1].StartedAt, at(6))
+	}
+}
+
+// TestChunker_RolloverFlushKeepsOldSessionIDs is #104 WRITE PATH: when the active
+// session changes without a FlushSession, the rollover safety-net flushes the
+// stale open chunk under the PREVIOUS session's ids (not the new session's).
+func TestChunker_RolloverFlushKeepsOldSessionIDs(t *testing.T) {
+	store := &fakeChunkStore{}
+	sessA := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	sessB := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	bus := voiceevent.NewBus()
+	fs := &funcSessions{}
+	fs.set(func() (storage.VoiceSession, bool) { return sessA, true })
+	c := NewChunker(bus, fs, store, nil, slog.New(slog.DiscardHandler), ChunkerConfig{})
+
+	// Two utterances under A open a chunk (default 60s window — not closed).
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "a1", TurnID: "t"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "a2", TurnID: "t"})
+
+	// Session rolls to B; the next event triggers the rollover that flushes A's chunk.
+	fs.set(func() (storage.VoiceSession, bool) { return sessB, true })
+	bus.Publish(voiceevent.STTFinal{At: at(3), Text: "b1", TurnID: "t"})
+
+	if err := c.FlushSession(context.Background(), sessB.ID); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 2 {
+		t.Fatalf("inserts = %d, want 2 (A's stale chunk + B's chunk)", len(got))
+	}
+	// FIFO: the rollover flushed A's chunk first, then FlushSession closed B's.
+	if got[0].VoiceSessionID != sessA.ID || got[0].CampaignID != sessA.CampaignID {
+		t.Errorf("stale chunk FKs = session %s / campaign %s, want A's %s / %s",
+			got[0].VoiceSessionID, got[0].CampaignID, sessA.ID, sessA.CampaignID)
+	}
+	if got[0].Content != "Player / DM: a1\nPlayer / DM: a2" {
+		t.Errorf("stale chunk content = %q", got[0].Content)
+	}
+	if got[1].VoiceSessionID != sessB.ID || got[1].Content != "Player / DM: b1" {
+		t.Errorf("B's chunk = %+v, want session %s with b1", got[1], sessB.ID)
+	}
+}
+
+// TestChunker_NonUUIDAgentIDSkippedAndLogged is #104 rule UTTERANCES: an
+// AddressTarget.AgentID that is not a DB UUID (the well-known "butler" route, or
+// any non-uuid) is skipped from participated_agent_ids and logged — the utterance
+// still lands, but the chunk carries no participant for it.
+func TestChunker_NonUUIDAgentIDSkippedAndLogged(t *testing.T) {
+	store := &fakeChunkStore{}
+	cap := &capHandler{}
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	c := NewChunker(bus, fs, store, nil, slog.New(cap), ChunkerConfig{})
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "butler", AgentRole: "butler", Name: "Butler"},
+	})
+	agentReply(bus, "t1", "At your service.", at(2))
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || got[0].Content != "Butler: At your service." {
+		t.Fatalf("content = %+v, want the butler utterance", got)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 0 {
+		t.Errorf("participated = %v, want empty (non-uuid agent id skipped)", got[0].ParticipatedAgentIDs)
+	}
+	if !cap.has("unparsable agent id") {
+		t.Errorf("non-uuid agent id skip was not logged")
 	}
 }
 

--- a/internal/transcript/chunker_test.go
+++ b/internal/transcript/chunker_test.go
@@ -364,6 +364,68 @@ func TestChunker_ZeroDeliveredTurnLogsNothing(t *testing.T) {
 	}
 }
 
+// TestChunker_SupersededDispatchPurged is #104 + ADR-0012: dispatch is serial
+// single-in-flight and FirstAudio(sN) precedes TTSInvoked(sN+1), so a sentence
+// still pending when the NEXT dispatch arrives start-errored (never delivered). It
+// is purged, not committed — the delivered sentence's text lands, not the unheard
+// one, and the FirstAudio pairing does not shift.
+func TestChunker_SupersededDispatchPurged(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "start-errored", TurnID: "t1"}) // no FirstAudio
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "delivered", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "t1"})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || got[0].Content != "Bart: delivered" {
+		t.Fatalf("content = %+v, want the delivered sentence only (superseded dead dispatch purged)", got)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("participated = %v, want [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+}
+
+// TestChunker_RecoveredMidTurnErrorKeepsPairing is #104 + ADR-0012 — the reachable
+// FIFO/purge pin (a depth-2 pending where BOTH commit cannot occur: serial
+// single-in-flight dispatch means FirstAudio(sN) precedes TTSInvoked(sN+1), so
+// pending never holds two undelivered sentences at once). A middle sentence that
+// start-errors while the turn recovers (s1 delivered, s2 lost, s3 delivered) must
+// commit only s1 and s3, in order, coalesced into the one utterance — never the
+// unheard s2, and without shifting s3 onto s2's slot.
+func TestChunker_RecoveredMidTurnErrorKeepsPairing(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	agentReply(bus, "t1", "Well met.", at(2))                                     // delivered
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "lost", TurnID: "t1"}) // start-error, no FirstAudio
+	agentReply(bus, "t1", "Sit.", at(4))                                          // recovers, delivered
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || got[0].Content != "Bart: Well met. Sit." {
+		t.Fatalf("content = %+v, want only s1 + s3 in order (lost middle sentence excluded)", got)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("participated = %v, want [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+}
+
 // TestChunker_ContinuationAcrossChunkClose is #104 rule 4: when a turn's first
 // delivered sentence is the fifth utterance, the chunk closes with that sentence;
 // the turn's next delivered sentence opens a CONTINUATION utterance in the next

--- a/internal/transcript/chunker_test.go
+++ b/internal/transcript/chunker_test.go
@@ -1,0 +1,363 @@
+package transcript
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// fakeChunkStore is an in-memory ChunkStore: it records the chunks it was asked
+// to insert and models the NULL-embedding backlog as "one more per insert" — the
+// real CountUnembeddedChunks over rows that all land embedding=NULL (#104).
+type fakeChunkStore struct {
+	mu         sync.Mutex
+	chunks     []storage.TranscriptChunk
+	countCalls int
+}
+
+func (f *fakeChunkStore) InsertTranscriptChunk(_ context.Context, c storage.TranscriptChunk) (uuid.UUID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.chunks = append(f.chunks, c)
+	return uuid.New(), nil
+}
+
+func (f *fakeChunkStore) CountUnembeddedChunks(_ context.Context) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.countCalls++
+	return len(f.chunks), nil // every insert is a NULL-embedding row
+}
+
+func (f *fakeChunkStore) all() []storage.TranscriptChunk {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]storage.TranscriptChunk(nil), f.chunks...)
+}
+
+func (f *fakeChunkStore) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.chunks)
+}
+
+// fakeGauge records every SetEmbeddingBacklog call so the "Set-from-COUNT" path
+// is observable.
+type fakeGauge struct {
+	mu   sync.Mutex
+	sets []int
+}
+
+func (g *fakeGauge) SetEmbeddingBacklog(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.sets = append(g.sets, n)
+}
+
+func (g *fakeGauge) snapshot() []int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]int(nil), g.sets...)
+}
+
+// capHandler records log messages so a drop-on-overflow is assertable.
+type capHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (c *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (c *capHandler) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, r.Message)
+	return nil
+}
+func (c *capHandler) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *capHandler) WithGroup(string) slog.Handler      { return c }
+func (c *capHandler) has(sub string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.msgs {
+		if strings.Contains(m, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func newChunker(t *testing.T, store ChunkStore, gauge BacklogGauge, cfg ChunkerConfig) (*voiceevent.Bus, *fakeSessions, *Chunker) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	c := NewChunker(bus, fs, store, gauge, slog.New(slog.DiscardHandler), cfg)
+	return bus, fs, c
+}
+
+// eventually polls fn until it returns true or the deadline passes.
+func eventually(t *testing.T, within time.Duration, fn func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return fn()
+}
+
+// TestChunker_FiveUtterancesOneInsert is #104 rule CLOSE: a chunk closes at the
+// fifth utterance into ONE insert whose content is the five lines in order — not
+// one insert per utterance — and the embedding is never set on the write path.
+func TestChunker_FiveUtterancesOneInsert(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+
+	for i := 1; i <= 5; i++ {
+		bus.Publish(voiceevent.STTFinal{At: at(i), Text: "line" + string(rune('0'+i)), TurnID: "t"})
+	}
+
+	// Drain the async writer via the flush barrier (the auto-close at 5 already
+	// enqueued the insert; FlushSession only adds the barrier here).
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+
+	got := store.all()
+	if len(got) != 1 {
+		t.Fatalf("inserts = %d, want 1 (five utterances = one chunk)", len(got))
+	}
+	want := "Player / DM: line1\nPlayer / DM: line2\nPlayer / DM: line3\nPlayer / DM: line4\nPlayer / DM: line5"
+	if got[0].Content != want {
+		t.Errorf("content = %q,\nwant %q", got[0].Content, want)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 0 {
+		t.Errorf("participated = %v, want empty (human-only chunk)", got[0].ParticipatedAgentIDs)
+	}
+	if len(got[0].SpeakerDiscordUserIDs) != 0 {
+		t.Errorf("speakers = %v, want empty (anonymous STT lane)", got[0].SpeakerDiscordUserIDs)
+	}
+}
+
+// TestChunker_WindowClosesWithTwo is #104 rule CLOSE: with two utterances the
+// window timer closes the chunk on its own (no fifth utterance, no session end).
+func TestChunker_WindowClosesWithTwo(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, _, _ := newChunker(t, store, nil, ChunkerConfig{Window: 40 * time.Millisecond})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "one", TurnID: "t"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "two", TurnID: "t"})
+
+	if !eventually(t, 2*time.Second, func() bool { return store.count() == 1 }) {
+		t.Fatalf("window did not close the 2-utterance chunk: inserts = %d", store.count())
+	}
+	if lines := strings.Count(store.all()[0].Content, "\n") + 1; lines != 2 {
+		t.Errorf("closed chunk has %d lines, want 2", lines)
+	}
+}
+
+// TestChunker_WindowKeepsLoneUtterance is #104 rule CLOSE + ADR-0011: a single
+// utterance is NOT closed by the window (timer fire with count==1 keeps it open);
+// it is flushed only at session end (FlushSession).
+func TestChunker_WindowKeepsLoneUtterance(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{Window: 40 * time.Millisecond})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "alone", TurnID: "t"})
+
+	// Well past the window: the lone utterance must still be open (0 inserts).
+	time.Sleep(150 * time.Millisecond)
+	if n := store.count(); n != 0 {
+		t.Fatalf("lone utterance closed by window: inserts = %d, want 0", n)
+	}
+
+	// Session end is the ONLY way a lone utterance flushes.
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	if n := store.count(); n != 1 {
+		t.Fatalf("session end did not flush the lone utterance: inserts = %d, want 1", n)
+	}
+	if store.all()[0].Content != "Player / DM: alone" {
+		t.Errorf("content = %q", store.all()[0].Content)
+	}
+}
+
+// TestChunker_SecondUtteranceAfterWindowClosesImmediately is #104 rule CLOSE: a
+// timer fire with count==1 leaves the chunk open; the next utterance re-checks
+// elapsed and closes it immediately.
+func TestChunker_SecondUtteranceAfterWindowClosesImmediately(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, _, _ := newChunker(t, store, nil, ChunkerConfig{Window: 40 * time.Millisecond})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "one", TurnID: "t"})
+	time.Sleep(120 * time.Millisecond) // timer fired with count==1, chunk stayed open
+	if n := store.count(); n != 0 {
+		t.Fatalf("chunk closed with a lone utterance: inserts = %d", n)
+	}
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "two", TurnID: "t"})
+
+	if !eventually(t, 2*time.Second, func() bool { return store.count() == 1 }) {
+		t.Fatalf("second utterance past the window did not close immediately: inserts = %d", store.count())
+	}
+}
+
+// TestChunker_AgentReplyCoalesces is #104 rule UTTERANCES: an Agent turn is ONE
+// utterance no matter how many TTS sentences it spans (they append to one line),
+// and participated_agent_ids carries exactly that Agent's DB UUID.
+func TestChunker_AgentReplyCoalesces(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hello Bart", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", Index: 0, TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Sit down.", Index: 1, TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(5), Sentence: "What'll it be?", Index: 2, TurnID: "t1"})
+	bus.Publish(voiceevent.STTFinal{At: at(6), Text: "An ale", TurnID: "t2"})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+
+	got := store.all()
+	if len(got) != 1 {
+		t.Fatalf("inserts = %d, want 1", len(got))
+	}
+	want := "Player / DM: Hello Bart\nBart: Well met. Sit down. What'll it be?\nPlayer / DM: An ale"
+	if got[0].Content != want {
+		t.Errorf("content = %q,\nwant %q", got[0].Content, want)
+	}
+	if len(got[0].ParticipatedAgentIDs) != 1 || got[0].ParticipatedAgentIDs[0] != agentID {
+		t.Errorf("participated = %v, want exactly [%s]", got[0].ParticipatedAgentIDs, agentID)
+	}
+}
+
+// TestChunker_HumanOnlyChunkEmptyParticipants is #104 AC: a chunk with no Agent
+// reply has empty participated_agent_ids.
+func TestChunker_HumanOnlyChunkEmptyParticipants(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "just me", TurnID: "t1"})
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 || len(got[0].ParticipatedAgentIDs) != 0 {
+		t.Fatalf("participated = %v, want empty", got)
+	}
+}
+
+// TestChunker_GaugeSetFromCount is #104 AC: after each written chunk the gauge is
+// Set to the store's live NULL-embedding count, rising by one per new chunk.
+func TestChunker_GaugeSetFromCount(t *testing.T) {
+	store := &fakeChunkStore{}
+	gauge := &fakeGauge{}
+	// MaxUtterances=1 so each STTFinal closes its own chunk.
+	bus, fs, c := newChunker(t, store, gauge, ChunkerConfig{MaxUtterances: 1})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "a", TurnID: "t1"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "b", TurnID: "t2"})
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+
+	sets := gauge.snapshot()
+	if len(sets) != 2 || sets[0] != 1 || sets[1] != 2 {
+		t.Fatalf("gauge sets = %v, want [1 2] (rises by one per written chunk)", sets)
+	}
+}
+
+// blockingChunkStore blocks every InsertTranscriptChunk on release, signalling
+// the first entry on entered — so the writer goroutine can be pinned mid-insert
+// and the bounded queue driven to overflow.
+type blockingChunkStore struct {
+	entered chan struct{}
+	release chan struct{}
+	mu      sync.Mutex
+	inserts int
+}
+
+func (b *blockingChunkStore) InsertTranscriptChunk(_ context.Context, _ storage.TranscriptChunk) (uuid.UUID, error) {
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	<-b.release
+	b.mu.Lock()
+	b.inserts++
+	b.mu.Unlock()
+	return uuid.New(), nil
+}
+func (b *blockingChunkStore) CountUnembeddedChunks(_ context.Context) (int, error) { return 0, nil }
+func (b *blockingChunkStore) done() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.inserts
+}
+
+// TestChunker_BusCallbackNeverBlocks is #104 WRITE PATH (voiceevent.Bus contract):
+// the bus callback must never block on the DB. With the single writer pinned
+// mid-insert and the bounded queue full, further chunk closes are dropped + logged
+// rather than blocking Publish — so only the in-flight + queued chunks (1 + cap)
+// are ever written.
+func TestChunker_BusCallbackNeverBlocks(t *testing.T) {
+	store := &blockingChunkStore{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	cap := &capHandler{}
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	// MaxUtterances=1: each STTFinal closes and enqueues its own chunk insert. The
+	// chunker is driven entirely through the bus, so it needs no local handle.
+	_ = NewChunker(bus, fs, store, nil, slog.New(cap), ChunkerConfig{MaxUtterances: 1})
+
+	// First close: the writer dequeues it and pins on release. entered confirms the
+	// queue is drained to empty before we fill it, so the accepted count is exact.
+	bus.Publish(voiceevent.STTFinal{At: at(0), Text: "0", TurnID: "t0"})
+	select {
+	case <-store.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer never reached InsertTranscriptChunk")
+	}
+
+	// Fill the bounded queue (chunkQueue) and then overflow it. Each Publish must
+	// return promptly; a blocked send would hang the test (caught by go test).
+	total := chunkQueue + 25
+	done := make(chan struct{})
+	go func() {
+		for i := 1; i <= total; i++ {
+			bus.Publish(voiceevent.STTFinal{At: at(i), Text: "x", TurnID: "t" + string(rune(i))})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a full-queue Publish blocked the bus callback")
+	}
+
+	if !cap.has("queue full") {
+		t.Errorf("overflow was not logged")
+	}
+
+	// Release the writer; exactly 1 (in-flight) + chunkQueue accepted are written,
+	// the rest dropped.
+	close(store.release)
+	want := 1 + chunkQueue
+	if !eventually(t, 3*time.Second, func() bool { return store.done() == want }) {
+		t.Fatalf("writer wrote %d chunks, want %d (in-flight + queue; overflow dropped)", store.done(), want)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds the **Transcript Chunk writer** (ADR-0011): a `voiceevent.Bus` subscriber that folds the voice pipeline's utterances into 3-6-utterance chunks and persists each closed chunk with `embedding = NULL`, plus the **live embedding-backlog gauge** (no longer a hardcoded stub).

The chunk grain (NPC Hot Context / ANN retrieval) is independent of the per-line `transcript_line` grain (ADR-0040): a Voice Session's Lines and its Chunks are separate records of the same speech.

Closes #104

## Why is this change needed?

The E3 memory epic embeds Transcripts for NPC retrieval. Chunks are the storage/embedding unit (ADR-0011). This slice lands the writer and the real backlog gauge; the async embedding worker is #116, ANN retrieval is #119.

## How was this tested?

- **Unit** (`internal/transcript/chunker_test.go`): 5-utterance close = one insert; window close with >=2 utterances; lone utterance kept open by the window and flushed only at session end; second utterance past the window closes immediately; Agent reply coalesces across TTS sentences into one utterance with exactly its Agent's UUID in `participated_agent_ids`; human-only chunk has empty participants; gauge Set-from-COUNT rises by one per write; bus callback never blocks (bounded queue drops+logs on overflow).
- **Unit** (`internal/session/manager_test.go`): the Manager flushes the open chunk BEFORE `EndVoiceSession`; a flush error does not fail `Stop`.
- **Integration** (`internal/storage/transcript_chunk_test.go`, `-tags=integration`, pgvector container): insert round-trip with `embedding` NULL, `fts` generated non-null, `text[]`/`uuid[]` arrays scanning back; `CountUnembeddedChunks` counts NULL only; chunk + line rows coexist under one session.
- `go test ./...`, `go test -race ./internal/transcript/ ./internal/session/`, `go vet ./...`, `golangci-lint run` — all green.

- [x] `make check` passes (equivalent: build, test, race, vet, lint run locally)
- [x] New/updated tests cover the change
- [ ] Manual testing (covered by the integration container test)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **No migration**: `transcript_chunk` already exists in `00001_init.sql`; `embedding_model` stays deferred to #116.
- **File scope** stays disjoint from the parallel embeddings/STT PRs (no `pkg/voice/embeddings/**` or `pkg/voice/stt/**` touched, no new `go.mod` deps).
- The write path mirrors the relay's `persist.go` (non-blocking bus tee + single writer + flush barrier); the gauge is always Set-from-COUNT (idempotent across the chunk writer, the future backfill worker #116, and restarts — ADR-0032).
- The Butler route's well-known `"butler"` AgentID is not a UUID, so it is (correctly) skipped from `participated_agent_ids` per the pinned rule; a Character NPC's AgentID IS its DB UUID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Accepted residual

FirstAudio-as-delivered is a proxy for strict ADR-0012 delivery (no per-sentence completion event exists on the bus). A sentence barged after its first tee chunk still commits its full text — architect-ruled acceptable.
