### PR TITLE
feat(#179): streaming STT adapter — ElevenLabs Scribe v2 Realtime, manual commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	connectrpc.com/connect v1.20.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/hraban/opus v0.0.0-20251117090126-c76ea7e21bf3
 	github.com/openai/openai-go/v3 v3.41.0
 	github.com/prometheus/client_golang v1.23.2
@@ -52,7 +53,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/pkg/voice/stt/elevenlabs/stream.go
+++ b/pkg/voice/stt/elevenlabs/stream.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,19 +77,41 @@ const (
 	msgInsufficientAudio = "insufficient_audio_activity"
 )
 
-// codeSampleRate is the [stt.StreamError.Code] for a frame whose sample rate
-// does not match the session's declared rate — a caller (not transport) error.
-const codeSampleRate = "sample_rate_mismatch"
-
-// recoverableErrorCodes are provider error-frame types after which the session
-// stays usable: the failing operation is reported but Send/Commit continue to
-// work. Every other error frame is treated as fatal (session dead).
-var recoverableErrorCodes = map[string]bool{
-	"commit_throttled":    true,
-	"rate_limited":        true,
-	"chunk_size_exceeded": true,
-	"input_error":         true,
-}
+// Provider error-frame classification. A frame's message_type decides how it is
+// routed (see routeErrorFrame):
+//
+//   - commitScopedErrorCodes pertain to a specific commit and resolve the oldest
+//     in-flight commit with the error; the session stays usable.
+//   - droppableErrorCodes are recoverable but NOT tied to a commit (a rejected
+//     chunk or a transient throttle), so they are logged and dropped rather than
+//     misattributed to whichever commit happens to be pending.
+//   - fatalErrorCodes kill the session.
+//
+// An unrecognized message_type carrying an error payload is treated as fatal
+// (safe default); one with no error payload is an unknown benign frame (e.g. a
+// future language_detection frame) and is ignored like a malformed frame.
+var (
+	commitScopedErrorCodes = map[string]bool{
+		"commit_throttled": true,
+	}
+	droppableErrorCodes = map[string]bool{
+		// rate_limited is treated as not-commit-scoped: the provider docs do not
+		// tie it to a specific commit, so dropping it avoids misattribution.
+		"rate_limited":        true,
+		"chunk_size_exceeded": true,
+		"input_error":         true,
+	}
+	fatalErrorCodes = map[string]bool{
+		"error":                       true,
+		"auth_error":                  true,
+		"quota_exceeded":              true,
+		"unaccepted_terms":            true,
+		"queue_overflow":              true,
+		"resource_exhausted":          true,
+		"session_time_limit_exceeded": true,
+		"transcriber_error":           true,
+	}
+)
 
 // OpenStream implements [stt.StreamingRecognizer]. It dials a fresh Scribe v2
 // Realtime session honoring ADR-0042: manual commit strategy, sample rate
@@ -222,7 +245,7 @@ func (s *stream) Send(frame audio.Frame) error {
 	}
 	if frame.SampleRate() != s.cfg.SampleRate {
 		return &stt.StreamError{
-			Code:  codeSampleRate,
+			Code:  stt.CodeSampleRateMismatch,
 			Fatal: false,
 			Err:   fmt.Errorf("frame sample rate %d != stream sample rate %d", frame.SampleRate(), s.cfg.SampleRate),
 		}
@@ -240,7 +263,17 @@ func (s *stream) Send(frame audio.Frame) error {
 	if chunk == nil {
 		return nil
 	}
-	return s.enqueue(wsWrite{audioB64: base64.StdEncoding.EncodeToString(chunk)})
+	if err := s.enqueue(wsWrite{audioB64: base64.StdEncoding.EncodeToString(chunk)}); err != nil {
+		// The flush could not be queued (queue full or session dead). Put the
+		// bytes back at the front of the aggregation buffer so no audio is
+		// dropped — a later flush retries them. Send is single-goroutine, so no
+		// concurrent Send appended behind us.
+		s.aggMu.Lock()
+		s.agg = append(chunk, s.agg...)
+		s.aggMu.Unlock()
+		return err
+	}
+	return nil
 }
 
 // Commit implements [stt.Stream].
@@ -296,7 +329,7 @@ func (s *stream) enqueue(w wsWrite) error {
 		if de := s.deadErr.Load(); de != nil {
 			return de
 		}
-		return &stt.StreamError{Code: stt.CodeTransport, Fatal: false, Err: fmt.Errorf("write queue full")}
+		return &stt.StreamError{Code: stt.CodeQueueFull, Fatal: false, Err: fmt.Errorf("write queue full")}
 	}
 }
 
@@ -391,13 +424,48 @@ func (s *stream) readPump() {
 			// Empty utterance: resolve like the batch adapter's empty text.
 			s.resolveEmpty()
 		default:
-			se := classifyError(msg.MessageType, msg.Error)
-			if se.Fatal {
-				s.shutdown(se)
-				return
+			if s.routeErrorFrame(msg.MessageType, msg.Error) {
+				return // fatal: session dead, stop reading
 			}
-			s.resolveFront(stt.CommitResult{Err: se})
 		}
+	}
+}
+
+// routeErrorFrame classifies a non-normal server frame and acts on it. It
+// returns true when the frame killed the session, so the read pump stops.
+//
+// Only commit-scoped errors consume a pending commit; chunk-scoped and other
+// recoverable errors are logged and dropped so they cannot be misattributed to
+// whichever commit happens to be in flight. Fatal errors tear the session down.
+func (s *stream) routeErrorFrame(code, detail string) (fatal bool) {
+	switch {
+	case commitScopedErrorCodes[code]:
+		s.resolveFront(stt.CommitResult{Err: &stt.StreamError{
+			Code:  code,
+			Fatal: false,
+			Err:   fmt.Errorf("provider error %q: %s", code, detail),
+		}})
+		return false
+	case droppableErrorCodes[code]:
+		slog.Default().Debug("stt stream: dropping recoverable provider error frame",
+			"code", code, "detail", detail)
+		return false
+	case fatalErrorCodes[code], detail != "":
+		// Known fatal code, or an unrecognized frame that still carries an error
+		// payload (safe default: treat unknown errors as fatal).
+		s.shutdown(&stt.StreamError{
+			Code:  code,
+			Fatal: true,
+			Err:   fmt.Errorf("provider error %q: %s", code, detail),
+		})
+		return true
+	default:
+		// Unknown message_type with no error payload — a benign frame the adapter
+		// does not model (e.g. a future language_detection frame). Ignore it, the
+		// same posture as a malformed frame.
+		slog.Default().Debug("stt stream: ignoring unrecognized non-error frame",
+			"message_type", code)
+		return false
 	}
 }
 
@@ -481,14 +549,6 @@ func (s *stream) failCommit(ch chan stt.CommitResult, err error) {
 	s.mu.Unlock()
 	if removed {
 		ch <- stt.CommitResult{Err: err}
-	}
-}
-
-func classifyError(code, detail string) *stt.StreamError {
-	return &stt.StreamError{
-		Code:  code,
-		Fatal: !recoverableErrorCodes[code],
-		Err:   fmt.Errorf("provider error %q: %s", code, detail),
 	}
 }
 

--- a/pkg/voice/stt/elevenlabs/stream.go
+++ b/pkg/voice/stt/elevenlabs/stream.go
@@ -1,0 +1,517 @@
+package elevenlabs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+)
+
+// Compile-time assertion: the ElevenLabs [Client] is a streaming recognizer in
+// addition to the batch [stt.Recognizer] it already implements. The batch
+// files (elevenlabs.go, transcribe.go) are untouched — same key, base URL, and
+// ProviderID cover both surfaces (ADR-0004).
+var _ stt.StreamingRecognizer = (*Client)(nil)
+
+const (
+	// StreamModel is the ElevenLabs Scribe v2 Realtime model — the websocket
+	// sibling of the batch [Model] ("scribe_v2"). Only a live run can prove
+	// this identifier against the provider.
+	StreamModel = "scribe_v2_realtime"
+
+	// AudioFormatPCM16000 is the realtime `audio_format` value for raw
+	// little-endian signed-16-bit PCM at 16 kHz mono — the format [audio.Frame]
+	// already carries, so no re-encoding is needed.
+	AudioFormatPCM16000 = "pcm_16000"
+
+	// streamPath is the realtime websocket endpoint path.
+	streamPath = "/v1/speech-to-text/realtime"
+
+	// supportedSampleRate is the only PCM rate the v1 realtime adapter accepts;
+	// it matches audio_format=pcm_16000.
+	supportedSampleRate = 16000
+
+	// minChunkMs is the minimum audio duration aggregated into one
+	// input_audio_chunk. ElevenLabs recommends 0.1–1s chunks; sending smaller
+	// buffers adds websocket framing overhead for no benefit. Send flushes the
+	// aggregation buffer the moment it crosses this threshold (no timers).
+	minChunkMs = 100
+
+	// writeQueueLen bounds the write pump's inbound queue. Send/Commit are
+	// non-blocking: once the queue is full they surface a *stt.StreamError
+	// instead of blocking the audio pump.
+	writeQueueLen = 64
+
+	// defaultPingInterval is how often the write pump sends a keepalive ping.
+	defaultPingInterval = 20 * time.Second
+
+	// writeWait bounds a single websocket write (frame or control).
+	writeWait = 10 * time.Second
+
+	// pongWait is the read deadline; it is refreshed on every message and pong.
+	// Generously larger than defaultPingInterval so a healthy peer never trips it.
+	pongWait = 60 * time.Second
+
+	// msgInputAudioChunk is the sole client->server message type.
+	msgInputAudioChunk = "input_audio_chunk"
+)
+
+// server->client message types.
+const (
+	msgSessionStarted    = "session_started"
+	msgPartialTranscript = "partial_transcript"
+	msgCommitted         = "committed_transcript"
+	msgInsufficientAudio = "insufficient_audio_activity"
+)
+
+// codeSampleRate is the [stt.StreamError.Code] for a frame whose sample rate
+// does not match the session's declared rate — a caller (not transport) error.
+const codeSampleRate = "sample_rate_mismatch"
+
+// recoverableErrorCodes are provider error-frame types after which the session
+// stays usable: the failing operation is reported but Send/Commit continue to
+// work. Every other error frame is treated as fatal (session dead).
+var recoverableErrorCodes = map[string]bool{
+	"commit_throttled":    true,
+	"rate_limited":        true,
+	"chunk_size_exceeded": true,
+	"input_error":         true,
+}
+
+// OpenStream implements [stt.StreamingRecognizer]. It dials a fresh Scribe v2
+// Realtime session honoring ADR-0042: manual commit strategy, sample rate
+// declared, key drawn from the same ElevenLabs Provider Config as the batch
+// adapter.
+func (c *Client) OpenStream(ctx context.Context, cfg stt.StreamConfig) (stt.Stream, error) {
+	return c.openStream(ctx, cfg, defaultPingInterval)
+}
+
+// openStream is OpenStream with the keepalive interval injected, so internal
+// tests can shorten it without exporting a knob.
+func (c *Client) openStream(ctx context.Context, cfg stt.StreamConfig, pingInterval time.Duration) (stt.Stream, error) {
+	if cfg.SampleRate != supportedSampleRate {
+		return nil, fmt.Errorf("elevenlabs.OpenStream: unsupported sample rate %d (only %d supported)", cfg.SampleRate, supportedSampleRate)
+	}
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("elevenlabs.OpenStream: missing API key (set %s or pass it to New)", APIKeyEnv)
+	}
+
+	u, err := streamURL(c.baseURL, cfg.Language)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs.OpenStream: %w", err)
+	}
+
+	hdr := http.Header{}
+	hdr.Set("xi-api-key", c.apiKey)
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, u, hdr)
+	if err != nil {
+		return nil, &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: dialError(err, resp)}
+	}
+
+	s := &stream{
+		conn:      conn,
+		cfg:       cfg,
+		writeCh:   make(chan wsWrite, writeQueueLen),
+		stopCh:    make(chan struct{}),
+		threshold: supportedSampleRate * minChunkMs / 1000 * 2, // bytes of s16le
+	}
+	s.wg.Add(3)
+	go s.readPump()
+	go s.writePump(pingInterval)
+	go s.ctxWatch(ctx)
+	return s, nil
+}
+
+// streamURL derives the realtime websocket URL from a batch base URL, mapping
+// https->wss and http->ws so WithBaseURL(httptest.URL) works verbatim.
+func streamURL(baseURL, language string) (string, error) {
+	pu, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("parse base URL %q: %w", baseURL, err)
+	}
+	switch pu.Scheme {
+	case "https", "wss":
+		pu.Scheme = "wss"
+	case "http", "ws":
+		pu.Scheme = "ws"
+	default:
+		return "", fmt.Errorf("unsupported base URL scheme %q", pu.Scheme)
+	}
+	pu.Path = streamPath
+	q := url.Values{}
+	q.Set("model_id", StreamModel)
+	q.Set("audio_format", AudioFormatPCM16000)
+	q.Set("commit_strategy", "manual")
+	if language != "" {
+		q.Set("language_code", language)
+	}
+	pu.RawQuery = q.Encode()
+	return pu.String(), nil
+}
+
+func dialError(err error, resp *http.Response) error {
+	if resp != nil {
+		return fmt.Errorf("websocket dial: HTTP %d: %w", resp.StatusCode, err)
+	}
+	return fmt.Errorf("websocket dial: %w", err)
+}
+
+// wsWrite is one queued client->server write: either an audio chunk (commit
+// false) or a manual commit sentinel (commit true, empty audio).
+type wsWrite struct {
+	audioB64 string
+	commit   bool
+}
+
+func (w wsWrite) marshal(sampleRate int) ([]byte, error) {
+	return json.Marshal(struct {
+		MessageType string `json:"message_type"`
+		AudioBase64 string `json:"audio_base_64"`
+		Commit      bool   `json:"commit"`
+		SampleRate  int    `json:"sample_rate"`
+	}{
+		MessageType: msgInputAudioChunk,
+		AudioBase64: w.audioB64,
+		Commit:      w.commit,
+		SampleRate:  sampleRate,
+	})
+}
+
+// stream is a live realtime session. One write pump owns every websocket write
+// (gorilla's single-writer rule); one read pump routes server frames.
+type stream struct {
+	conn      *websocket.Conn
+	cfg       stt.StreamConfig
+	writeCh   chan wsWrite
+	stopCh    chan struct{}
+	threshold int // aggregation flush threshold in bytes
+	wg        sync.WaitGroup
+
+	closeOnce sync.Once
+	deadErr   atomic.Pointer[stt.StreamError]
+
+	// aggMu guards the Send/Commit audio aggregation buffer.
+	aggMu sync.Mutex
+	agg   []byte
+
+	// mu guards the FIFO pending-commit queue, the auto-commit carryover text,
+	// and the pendingClosed latch.
+	mu            sync.Mutex
+	pending       []chan stt.CommitResult
+	autoText      string
+	pendingClosed bool
+}
+
+// Send implements [stt.Stream].
+func (s *stream) Send(frame audio.Frame) error {
+	if de := s.deadErr.Load(); de != nil {
+		return de
+	}
+	if frame.SampleRate() != s.cfg.SampleRate {
+		return &stt.StreamError{
+			Code:  codeSampleRate,
+			Fatal: false,
+			Err:   fmt.Errorf("frame sample rate %d != stream sample rate %d", frame.SampleRate(), s.cfg.SampleRate),
+		}
+	}
+
+	s.aggMu.Lock()
+	appendPCM16LE(&s.agg, frame.Samples())
+	var chunk []byte
+	if len(s.agg) >= s.threshold {
+		chunk = s.agg
+		s.agg = nil
+	}
+	s.aggMu.Unlock()
+
+	if chunk == nil {
+		return nil
+	}
+	return s.enqueue(wsWrite{audioB64: base64.StdEncoding.EncodeToString(chunk)})
+}
+
+// Commit implements [stt.Stream].
+func (s *stream) Commit() (<-chan stt.CommitResult, error) {
+	if de := s.deadErr.Load(); de != nil {
+		return nil, de
+	}
+
+	s.aggMu.Lock()
+	rem := s.agg
+	s.agg = nil
+	s.aggMu.Unlock()
+
+	ch := make(chan stt.CommitResult, 1)
+	s.mu.Lock()
+	if s.pendingClosed {
+		de := s.deadErr.Load()
+		s.mu.Unlock()
+		return nil, de
+	}
+	s.pending = append(s.pending, ch)
+	s.mu.Unlock()
+
+	if len(rem) > 0 {
+		if err := s.enqueue(wsWrite{audioB64: base64.StdEncoding.EncodeToString(rem)}); err != nil {
+			s.failCommit(ch, err)
+			return ch, nil
+		}
+	}
+	if err := s.enqueue(wsWrite{commit: true}); err != nil {
+		s.failCommit(ch, err)
+		return ch, nil
+	}
+	return ch, nil
+}
+
+// Close implements [stt.Stream].
+func (s *stream) Close() error {
+	s.shutdown(&stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errStreamClosed})
+	s.wg.Wait()
+	return nil
+}
+
+var errStreamClosed = fmt.Errorf("stt stream closed")
+
+// enqueue offers a write to the write pump without blocking. It returns the
+// session's death error once dead, or a recoverable queue-full error.
+func (s *stream) enqueue(w wsWrite) error {
+	select {
+	case s.writeCh <- w:
+		return nil
+	default:
+		if de := s.deadErr.Load(); de != nil {
+			return de
+		}
+		return &stt.StreamError{Code: stt.CodeTransport, Fatal: false, Err: fmt.Errorf("write queue full")}
+	}
+}
+
+// shutdown tears the session down exactly once: it records the death cause,
+// signals the pumps, and closes the connection to unblock the read pump.
+func (s *stream) shutdown(cause *stt.StreamError) {
+	s.closeOnce.Do(func() {
+		s.deadErr.Store(cause)
+		close(s.stopCh)
+		_ = s.conn.Close()
+	})
+}
+
+// ctxWatch mirrors context cancellation onto session teardown (cancel == Close).
+func (s *stream) ctxWatch(ctx context.Context) {
+	defer s.wg.Done()
+	select {
+	case <-ctx.Done():
+		s.shutdown(&stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: ctx.Err()})
+	case <-s.stopCh:
+	}
+}
+
+// writePump owns every websocket write: audio chunks, commit sentinels, and
+// keepalive pings.
+func (s *stream) writePump(pingInterval time.Duration) {
+	defer s.wg.Done()
+	ping := time.NewTicker(pingInterval)
+	defer ping.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case w := <-s.writeCh:
+			data, err := w.marshal(s.cfg.SampleRate)
+			if err != nil {
+				s.shutdown(transportErr(err))
+				return
+			}
+			_ = s.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := s.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				s.shutdown(transportErr(err))
+				return
+			}
+		case <-ping.C:
+			if err := s.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeWait)); err != nil {
+				s.shutdown(transportErr(err))
+				return
+			}
+		}
+	}
+}
+
+// readPump routes server frames until the connection fails or is closed, then
+// resolves any still-pending commits.
+func (s *stream) readPump() {
+	defer s.wg.Done()
+	defer s.drainPending()
+
+	_ = s.conn.SetReadDeadline(time.Now().Add(pongWait))
+	s.conn.SetPongHandler(func(string) error {
+		return s.conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
+	for {
+		_, data, err := s.conn.ReadMessage()
+		if err != nil {
+			s.shutdown(transportErr(err))
+			return
+		}
+		_ = s.conn.SetReadDeadline(time.Now().Add(pongWait))
+
+		var msg struct {
+			MessageType string `json:"message_type"`
+			Text        string `json:"text"`
+			Error       string `json:"error"`
+		}
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue // ignore malformed frames
+		}
+
+		switch msg.MessageType {
+		case msgSessionStarted:
+			// nothing to do; the session is live once the read pump runs.
+		case msgPartialTranscript:
+			if s.cfg.OnPartial != nil {
+				s.cfg.OnPartial(msg.Text)
+			}
+		case msgCommitted:
+			s.resolveCommitted(msg.Text)
+		case msgInsufficientAudio:
+			// Empty utterance: resolve like the batch adapter's empty text.
+			s.resolveEmpty()
+		default:
+			se := classifyError(msg.MessageType, msg.Error)
+			if se.Fatal {
+				s.shutdown(se)
+				return
+			}
+			s.resolveFront(stt.CommitResult{Err: se})
+		}
+	}
+}
+
+// resolveCommitted resolves the front pending commit with text, prepending any
+// carried-over auto-commit text. With no pending commit the text is an
+// unsolicited 90s auto-commit and is carried onto the next commit.
+func (s *stream) resolveCommitted(text string) {
+	s.mu.Lock()
+	if len(s.pending) == 0 {
+		s.autoText = spaceJoin(s.autoText, text)
+		s.mu.Unlock()
+		return
+	}
+	ch := s.pending[0]
+	s.pending = s.pending[1:]
+	full := spaceJoin(s.autoText, text)
+	s.autoText = ""
+	s.mu.Unlock()
+	ch <- stt.CommitResult{Transcript: stt.Transcript{Text: full}}
+}
+
+// resolveEmpty resolves the front pending commit with empty (or carried-over)
+// text and no error.
+func (s *stream) resolveEmpty() {
+	s.mu.Lock()
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return
+	}
+	ch := s.pending[0]
+	s.pending = s.pending[1:]
+	full := s.autoText
+	s.autoText = ""
+	s.mu.Unlock()
+	ch <- stt.CommitResult{Transcript: stt.Transcript{Text: full}}
+}
+
+// resolveFront resolves the front pending commit with res (a recoverable error).
+func (s *stream) resolveFront(res stt.CommitResult) {
+	s.mu.Lock()
+	if len(s.pending) == 0 {
+		s.mu.Unlock()
+		return
+	}
+	ch := s.pending[0]
+	s.pending = s.pending[1:]
+	s.mu.Unlock()
+	ch <- res
+}
+
+// drainPending resolves every still-pending commit with the death cause and
+// latches the queue closed so no later Commit can register an orphan.
+func (s *stream) drainPending() {
+	de := s.deadErr.Load()
+	if de == nil {
+		de = transportErr(errStreamClosed)
+	}
+	s.mu.Lock()
+	s.pendingClosed = true
+	pend := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+	for _, ch := range pend {
+		ch <- stt.CommitResult{Err: de}
+	}
+}
+
+// failCommit resolves ch with err, but only if it is still pending — the read
+// pump's drainPending may already have resolved it, and a channel resolves
+// exactly once.
+func (s *stream) failCommit(ch chan stt.CommitResult, err error) {
+	s.mu.Lock()
+	removed := false
+	for i, c := range s.pending {
+		if c == ch {
+			s.pending = append(s.pending[:i], s.pending[i+1:]...)
+			removed = true
+			break
+		}
+	}
+	s.mu.Unlock()
+	if removed {
+		ch <- stt.CommitResult{Err: err}
+	}
+}
+
+func classifyError(code, detail string) *stt.StreamError {
+	return &stt.StreamError{
+		Code:  code,
+		Fatal: !recoverableErrorCodes[code],
+		Err:   fmt.Errorf("provider error %q: %s", code, detail),
+	}
+}
+
+func transportErr(err error) *stt.StreamError {
+	return &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: err}
+}
+
+// appendPCM16LE appends the little-endian int16 byte encoding of samples to *b.
+func appendPCM16LE(b *[]byte, samples []int16) {
+	var buf [2]byte
+	for _, s := range samples {
+		binary.LittleEndian.PutUint16(buf[:], uint16(s))
+		*b = append(*b, buf[:]...)
+	}
+}
+
+func spaceJoin(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + " " + b
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream_internal_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_internal_test.go
@@ -2,6 +2,7 @@ package elevenlabs
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
 )
 
@@ -53,5 +55,53 @@ func TestWritePump_SendsKeepalivePing(t *testing.T) {
 	case <-pinged:
 	case <-time.After(2 * time.Second):
 		t.Fatal("no keepalive ping observed within 2s (ping interval was 30ms)")
+	}
+}
+
+// TestSend_WriteQueueFull_RestoresAggregatedAudio pins Finding 4: when a flush
+// cannot be enqueued (write queue full), Send reports a recoverable queue-full
+// *StreamError AND keeps the flushed bytes in the aggregation buffer so no
+// audio is dropped. It builds a stream with a one-slot, undrained write queue
+// (no pumps started), which is why it is an internal test.
+func TestSend_WriteQueueFull_RestoresAggregatedAudio(t *testing.T) {
+	s := &stream{
+		cfg:       stt.StreamConfig{SampleRate: 16000},
+		writeCh:   make(chan wsWrite, 1),
+		stopCh:    make(chan struct{}),
+		threshold: 16000 * minChunkMs / 1000 * 2, // 100 ms in bytes
+	}
+	s.writeCh <- wsWrite{} // occupy the only slot; the next enqueue must fail
+
+	samples := make([]int16, 512)
+	for i := range samples {
+		samples[i] = int16(i + 1)
+	}
+
+	// Four 32 ms frames cross the 100 ms threshold on the fourth, triggering a
+	// flush that cannot enqueue.
+	var lastErr error
+	for i := 0; i < 4; i++ {
+		f, err := audio.NewFrame(samples, 16000, 32)
+		if err != nil {
+			t.Fatalf("NewFrame: %v", err)
+		}
+		lastErr = s.Send(f)
+	}
+
+	if lastErr == nil {
+		t.Fatal("Send on a full write queue returned nil error")
+	}
+	var se *stt.StreamError
+	if !errors.As(lastErr, &se) || se.Code != stt.CodeQueueFull {
+		t.Fatalf("error = %v, want a *StreamError with code %q", lastErr, stt.CodeQueueFull)
+	}
+	if se.Fatal {
+		t.Error("queue-full should be recoverable, not Fatal")
+	}
+
+	// All four frames' bytes must still be buffered for a later flush.
+	wantBytes := 4 * 512 * 2
+	if len(s.agg) != wantBytes {
+		t.Errorf("aggregation buffer = %d bytes, want %d (flushed audio must not be lost)", len(s.agg), wantBytes)
 	}
 }

--- a/pkg/voice/stt/elevenlabs/stream_internal_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_internal_test.go
@@ -1,0 +1,57 @@
+package elevenlabs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+)
+
+// TestWritePump_SendsKeepalivePing pins that the write pump emits websocket
+// keepalive pings on its interval. It drives the unexported openStream knob so
+// the interval is milliseconds instead of the 20s production default; this is
+// an internal test because that knob is deliberately not exported.
+func TestWritePump_SendsKeepalivePing(t *testing.T) {
+	pinged := make(chan struct{}, 1)
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.SetPingHandler(func(string) error {
+			select {
+			case pinged <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		// ReadMessage processes incoming control frames (invoking the ping
+		// handler) and blocks until the client closes the connection.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := New("k", WithBaseURL(srv.URL))
+	s, err := c.openStream(context.Background(), stt.StreamConfig{SampleRate: 16000}, 30*time.Millisecond)
+	if err != nil {
+		t.Fatalf("openStream: %v", err)
+	}
+	defer s.Close()
+
+	select {
+	case <-pinged:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no keepalive ping observed within 2s (ping interval was 30ms)")
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream_live_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_live_test.go
@@ -1,0 +1,74 @@
+//go:build live
+
+// Live smoke for the Scribe v2 Realtime streaming adapter. Excluded from the
+// default keyless suite by the `live` tag — it opens a real websocket to
+// ElevenLabs and only runs with `go test -tags=live` and ELEVENLABS_API_KEY set
+// (key from the environment, never printed).
+//
+// The one thing only a live run can prove is the StreamModel constant
+// ("scribe_v2_realtime"): a wrong model_id is rejected by the provider, either
+// at the handshake (dial StreamError) or as an error frame that resolves the
+// commit with a *stt.StreamError. This test drives a short silent utterance
+// through OpenStream -> Send -> Commit and fails loudly with the provider's
+// error text (which lists accepted model ids) so the constant can be corrected.
+package elevenlabs_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+)
+
+func TestLive_StreamingScribeV2Realtime_CommitResolves(t *testing.T) {
+	if os.Getenv("ELEVENLABS_API_KEY") == "" {
+		t.Skip("ELEVENLABS_API_KEY not set; skipping live streaming smoke")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	c := elevenlabs.New("")
+	partials := 0
+	s, err := c.OpenStream(ctx, stt.StreamConfig{
+		SampleRate: 16000,
+		OnPartial:  func(string) { partials++ },
+	})
+	if err != nil {
+		t.Fatalf("OpenStream failed (a model_id rejection surfaces here as a dial StreamError): %v", err)
+	}
+	defer s.Close()
+
+	// ~2.5s of 32 ms silent frames — the provider begins processing after the
+	// first 2s, so this is enough audio to elicit a committed_transcript (empty
+	// text is a valid result for silence).
+	silence := make([]int16, 512)
+	for i := 0; i < 78; i++ {
+		f, err := audio.NewFrame(silence, 16000, 32)
+		if err != nil {
+			t.Fatalf("NewFrame: %v", err)
+		}
+		if err := s.Send(f); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	select {
+	case res := <-commitCh:
+		if res.Err != nil {
+			t.Fatalf("commit resolved with error (check the code/text for accepted model ids): %v", res.Err)
+		}
+		t.Logf("live commit resolved: text=%q partials=%d", res.Transcript.Text, partials)
+	case <-time.After(20 * time.Second):
+		t.Fatal("commit did not resolve within 20s")
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_test.go
@@ -1,0 +1,270 @@
+package elevenlabs_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
+)
+
+// Compile-time assertion: [elevenlabs.Client] satisfies the streaming surface
+// exactly as it already satisfies [stt.Recognizer], and the batch adapter is
+// untouched.
+var _ stt.StreamingRecognizer = (*elevenlabs.Client)(nil)
+
+// --- scripted websocket server harness (ADR-0021 deterministic posture) ---
+
+// scriptedServer is an httptest server that upgrades every connection to a
+// websocket and runs a per-connection script. It records the upgrade request
+// so dial-contract assertions can inspect path, query, and headers, and counts
+// upgrades so the reconnect test can prove a fresh session.
+type scriptedServer struct {
+	*httptest.Server
+	upgrades atomic.Int64
+	lastReq  atomic.Pointer[dialInfo]
+}
+
+type dialInfo struct {
+	path   string
+	query  map[string][]string
+	apiKey string
+}
+
+// newScriptedServer starts a server whose every websocket connection is driven
+// by script. The caller owns shutdown via defer srv.Close() so goroutine-leak
+// tests can order the close before the leak assertion.
+func newScriptedServer(t *testing.T, script func(t *testing.T, conn *websocket.Conn)) *scriptedServer {
+	t.Helper()
+	ss := &scriptedServer{}
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ss.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ss.upgrades.Add(1)
+		ss.lastReq.Store(&dialInfo{
+			path:   r.URL.Path,
+			query:  r.URL.Query(),
+			apiKey: r.Header.Get("xi-api-key"),
+		})
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		script(t, conn)
+	}))
+	return ss
+}
+
+// chunkMsg is a decoded client->server input_audio_chunk message.
+type chunkMsg struct {
+	pcm          []byte
+	commit       bool
+	sampleRate   int
+	previousText string
+}
+
+// readChunk reads one input_audio_chunk from the client and decodes its base64
+// audio into raw PCM bytes.
+func readChunk(t *testing.T, conn *websocket.Conn) chunkMsg {
+	t.Helper()
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("readChunk: ReadMessage: %v", err)
+	}
+	var raw struct {
+		MessageType  string `json:"message_type"`
+		AudioBase64  string `json:"audio_base_64"`
+		Commit       bool   `json:"commit"`
+		SampleRate   int    `json:"sample_rate"`
+		PreviousText string `json:"previous_text"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("readChunk: unmarshal %q: %v", data, err)
+	}
+	if raw.MessageType != "input_audio_chunk" {
+		t.Fatalf("readChunk: message_type = %q, want input_audio_chunk", raw.MessageType)
+	}
+	pcm, err := base64.StdEncoding.DecodeString(raw.AudioBase64)
+	if err != nil {
+		t.Fatalf("readChunk: base64 decode: %v", err)
+	}
+	return chunkMsg{pcm: pcm, commit: raw.Commit, sampleRate: raw.SampleRate, previousText: raw.PreviousText}
+}
+
+func sendJSON(t *testing.T, conn *websocket.Conn, v any) {
+	t.Helper()
+	if err := conn.WriteJSON(v); err != nil {
+		t.Fatalf("sendJSON: %v", err)
+	}
+}
+
+func partialMsg(text string) map[string]any {
+	return map[string]any{"message_type": "partial_transcript", "text": text}
+}
+
+func committedMsg(text string) map[string]any {
+	return map[string]any{"message_type": "committed_transcript", "text": text}
+}
+
+func errorMsg(code, detail string) map[string]any {
+	return map[string]any{"message_type": code, "error": detail}
+}
+
+// frame16k is one 16 kHz / 32 ms mono frame (512 samples) filled with samples.
+func frame16k(t *testing.T, samples []int16) audio.Frame {
+	t.Helper()
+	f, err := audio.NewFrame(samples, 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// rampFrame builds a 512-sample frame whose values are start..start+511, so a
+// concatenated PCM stream is order-sensitive.
+func rampFrame(t *testing.T, start int) audio.Frame {
+	s := make([]int16, 512)
+	for i := range s {
+		s[i] = int16(start + i)
+	}
+	return frame16k(t, s)
+}
+
+func pcmOf(frames ...audio.Frame) []byte {
+	var out []byte
+	var buf [2]byte
+	for _, f := range frames {
+		for _, s := range f.Samples() {
+			binary.LittleEndian.PutUint16(buf[:], uint16(s))
+			out = append(out, buf[:]...)
+		}
+	}
+	return out
+}
+
+// openTestStream dials the scripted server with a working key.
+func openTestStream(t *testing.T, ss *scriptedServer, cfg stt.StreamConfig) stt.Stream {
+	t.Helper()
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	return s
+}
+
+// --- Test 1: dial contract ---
+
+func TestOpenStream_DialContract_PinsPathQueryAndKey(t *testing.T) {
+	ss := newScriptedServer(t, func(t *testing.T, conn *websocket.Conn) {
+		// keep the connection open until the client closes it
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	defer ss.Close()
+
+	c := elevenlabs.New("expected-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close()
+
+	info := ss.lastReq.Load()
+	if info == nil {
+		t.Fatal("server recorded no upgrade request")
+	}
+	if info.path != "/v1/speech-to-text/realtime" {
+		t.Errorf("path = %q, want /v1/speech-to-text/realtime", info.path)
+	}
+	if got := info.query["model_id"]; len(got) != 1 || got[0] != "scribe_v2_realtime" {
+		t.Errorf("model_id = %v, want [scribe_v2_realtime]", got)
+	}
+	if got := info.query["audio_format"]; len(got) != 1 || got[0] != "pcm_16000" {
+		t.Errorf("audio_format = %v, want [pcm_16000]", got)
+	}
+	if got := info.query["commit_strategy"]; len(got) != 1 || got[0] != "manual" {
+		t.Errorf("commit_strategy = %v, want [manual]", got)
+	}
+	if _, ok := info.query["language_code"]; ok {
+		t.Errorf("language_code present but Language was empty: %v", info.query["language_code"])
+	}
+	if info.apiKey != "expected-key" {
+		t.Errorf("xi-api-key = %q, want expected-key", info.apiKey)
+	}
+}
+
+func TestOpenStream_DialContract_LanguageCode(t *testing.T) {
+	ss := newScriptedServer(t, func(t *testing.T, conn *websocket.Conn) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000, Language: "de"})
+	defer s.Close()
+
+	info := ss.lastReq.Load()
+	if got := info.query["language_code"]; len(got) != 1 || got[0] != "de" {
+		t.Errorf("language_code = %v, want [de]", got)
+	}
+}
+
+// --- Test 2: missing key ---
+
+func TestOpenStream_NoKey_NoEnv_Errors(t *testing.T) {
+	t.Setenv("ELEVENLABS_API_KEY", "")
+	c := elevenlabs.New("")
+	_, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})
+	if err == nil {
+		t.Fatal("OpenStream without API key returned nil error")
+	}
+	if !strings.Contains(err.Error(), "missing API key") {
+		t.Errorf("error %q does not mention missing API key", err)
+	}
+}
+
+// --- Test 11 (part): OpenStream rejects unsupported sample rate ---
+
+func TestOpenStream_UnsupportedSampleRate_Errors(t *testing.T) {
+	c := elevenlabs.New("k")
+	_, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 48000})
+	if err == nil {
+		t.Fatal("OpenStream with 48000 Hz returned nil error")
+	}
+}
+
+// --- helper for typed-error assertions ---
+
+func asStreamError(t *testing.T, err error) *stt.StreamError {
+	t.Helper()
+	var se *stt.StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("error %v (%T) is not a *stt.StreamError", err, err)
+	}
+	return se
+}
+
+// silence keeps unused harness helpers referenced until later tests use them.
+var _ = sync.Mutex{}
+var _ = time.Second
+var _ = asStreamError

--- a/pkg/voice/stt/elevenlabs/stream_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,12 +25,15 @@ import (
 // untouched.
 var _ stt.StreamingRecognizer = (*elevenlabs.Client)(nil)
 
-// --- scripted websocket server harness (ADR-0021 deterministic posture) ---
+const recvTimeout = 2 * time.Second
 
-// scriptedServer is an httptest server that upgrades every connection to a
-// websocket and runs a per-connection script. It records the upgrade request
-// so dial-contract assertions can inspect path, query, and headers, and counts
-// upgrades so the reconnect test can prove a fresh session.
+// --- scripted websocket server harness (ADR-0021 deterministic posture) ---
+//
+// Scripts run in the server's per-connection goroutine and therefore MUST NOT
+// call t.Fatal*/t.FailNow (those are legal only on the test goroutine). Scripts
+// do I/O only and relay observations back to the test goroutine over channels;
+// every assertion runs on the test goroutine.
+
 type scriptedServer struct {
 	*httptest.Server
 	upgrades atomic.Int64
@@ -44,10 +46,7 @@ type dialInfo struct {
 	apiKey string
 }
 
-// newScriptedServer starts a server whose every websocket connection is driven
-// by script. The caller owns shutdown via defer srv.Close() so goroutine-leak
-// tests can order the close before the leak assertion.
-func newScriptedServer(t *testing.T, script func(t *testing.T, conn *websocket.Conn)) *scriptedServer {
+func newScriptedServer(t *testing.T, script func(conn *websocket.Conn)) *scriptedServer {
 	t.Helper()
 	ss := &scriptedServer{}
 	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
@@ -63,7 +62,7 @@ func newScriptedServer(t *testing.T, script func(t *testing.T, conn *websocket.C
 			return
 		}
 		defer conn.Close()
-		script(t, conn)
+		script(conn)
 	}))
 	return ss
 }
@@ -74,15 +73,15 @@ type chunkMsg struct {
 	commit       bool
 	sampleRate   int
 	previousText string
+	ok           bool // false once the connection is closed / a read fails
 }
 
-// readChunk reads one input_audio_chunk from the client and decodes its base64
-// audio into raw PCM bytes.
-func readChunk(t *testing.T, conn *websocket.Conn) chunkMsg {
-	t.Helper()
+// readChunk reads and decodes one input_audio_chunk. It never touches *testing.T
+// (it runs on the server goroutine); ok=false signals the connection is done.
+func readChunk(conn *websocket.Conn) chunkMsg {
 	_, data, err := conn.ReadMessage()
 	if err != nil {
-		t.Fatalf("readChunk: ReadMessage: %v", err)
+		return chunkMsg{}
 	}
 	var raw struct {
 		MessageType  string `json:"message_type"`
@@ -92,22 +91,34 @@ func readChunk(t *testing.T, conn *websocket.Conn) chunkMsg {
 		PreviousText string `json:"previous_text"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("readChunk: unmarshal %q: %v", data, err)
+		return chunkMsg{}
 	}
-	if raw.MessageType != "input_audio_chunk" {
-		t.Fatalf("readChunk: message_type = %q, want input_audio_chunk", raw.MessageType)
+	pcm, _ := base64.StdEncoding.DecodeString(raw.AudioBase64)
+	return chunkMsg{
+		pcm:          pcm,
+		commit:       raw.Commit,
+		sampleRate:   raw.SampleRate,
+		previousText: raw.PreviousText,
+		ok:           raw.MessageType == msgInputAudioChunkWire,
 	}
-	pcm, err := base64.StdEncoding.DecodeString(raw.AudioBase64)
-	if err != nil {
-		t.Fatalf("readChunk: base64 decode: %v", err)
-	}
-	return chunkMsg{pcm: pcm, commit: raw.Commit, sampleRate: raw.SampleRate, previousText: raw.PreviousText}
 }
 
-func sendJSON(t *testing.T, conn *websocket.Conn, v any) {
-	t.Helper()
-	if err := conn.WriteJSON(v); err != nil {
-		t.Fatalf("sendJSON: %v", err)
+const msgInputAudioChunkWire = "input_audio_chunk"
+
+// readUntilCommit drains chunks (relaying each onto sink, if non-nil) until it
+// sees commit:true. Returns false if the connection closed first.
+func readUntilCommit(conn *websocket.Conn, sink chan<- chunkMsg) bool {
+	for {
+		c := readChunk(conn)
+		if !c.ok {
+			return false
+		}
+		if sink != nil {
+			sink <- c
+		}
+		if c.commit {
+			return true
+		}
 	}
 }
 
@@ -123,7 +134,6 @@ func errorMsg(code, detail string) map[string]any {
 	return map[string]any{"message_type": code, "error": detail}
 }
 
-// frame16k is one 16 kHz / 32 ms mono frame (512 samples) filled with samples.
 func frame16k(t *testing.T, samples []int16) audio.Frame {
 	t.Helper()
 	f, err := audio.NewFrame(samples, 16000, 32)
@@ -136,6 +146,7 @@ func frame16k(t *testing.T, samples []int16) audio.Frame {
 // rampFrame builds a 512-sample frame whose values are start..start+511, so a
 // concatenated PCM stream is order-sensitive.
 func rampFrame(t *testing.T, start int) audio.Frame {
+	t.Helper()
 	s := make([]int16, 512)
 	for i := range s {
 		s[i] = int16(start + i)
@@ -155,7 +166,6 @@ func pcmOf(frames ...audio.Frame) []byte {
 	return out
 }
 
-// openTestStream dials the scripted server with a working key.
 func openTestStream(t *testing.T, ss *scriptedServer, cfg stt.StreamConfig) stt.Stream {
 	t.Helper()
 	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
@@ -166,17 +176,50 @@ func openTestStream(t *testing.T, ss *scriptedServer, cfg stt.StreamConfig) stt.
 	return s
 }
 
+func recvChunk(t *testing.T, ch <-chan chunkMsg) chunkMsg {
+	t.Helper()
+	select {
+	case c := <-ch:
+		return c
+	case <-time.After(recvTimeout):
+		t.Fatal("timed out waiting for a chunk")
+		return chunkMsg{}
+	}
+}
+
+func recvCommit(t *testing.T, ch <-chan stt.CommitResult) stt.CommitResult {
+	t.Helper()
+	select {
+	case r := <-ch:
+		return r
+	case <-time.After(recvTimeout):
+		t.Fatal("timed out waiting for commit result")
+		return stt.CommitResult{}
+	}
+}
+
+func asStreamError(t *testing.T, err error) *stt.StreamError {
+	t.Helper()
+	var se *stt.StreamError
+	if !errors.As(err, &se) {
+		t.Fatalf("error %v (%T) is not a *stt.StreamError", err, err)
+	}
+	return se
+}
+
+// echoUntilClose keeps a connection open, discarding client frames until close.
+func echoUntilClose(conn *websocket.Conn) {
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+	}
+}
+
 // --- Test 1: dial contract ---
 
 func TestOpenStream_DialContract_PinsPathQueryAndKey(t *testing.T) {
-	ss := newScriptedServer(t, func(t *testing.T, conn *websocket.Conn) {
-		// keep the connection open until the client closes it
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	})
+	ss := newScriptedServer(t, echoUntilClose)
 	defer ss.Close()
 
 	c := elevenlabs.New("expected-key", elevenlabs.WithBaseURL(ss.URL))
@@ -211,13 +254,7 @@ func TestOpenStream_DialContract_PinsPathQueryAndKey(t *testing.T) {
 }
 
 func TestOpenStream_DialContract_LanguageCode(t *testing.T) {
-	ss := newScriptedServer(t, func(t *testing.T, conn *websocket.Conn) {
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	})
+	ss := newScriptedServer(t, echoUntilClose)
 	defer ss.Close()
 
 	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000, Language: "de"})
@@ -243,7 +280,7 @@ func TestOpenStream_NoKey_NoEnv_Errors(t *testing.T) {
 	}
 }
 
-// --- Test 11 (part): OpenStream rejects unsupported sample rate ---
+// --- Test 11a: OpenStream rejects unsupported sample rate ---
 
 func TestOpenStream_UnsupportedSampleRate_Errors(t *testing.T) {
 	c := elevenlabs.New("k")
@@ -253,18 +290,228 @@ func TestOpenStream_UnsupportedSampleRate_Errors(t *testing.T) {
 	}
 }
 
-// --- helper for typed-error assertions ---
+// --- Test 3: Send aggregation to >=100ms chunks, order-preserving ---
 
-func asStreamError(t *testing.T, err error) *stt.StreamError {
-	t.Helper()
-	var se *stt.StreamError
-	if !errors.As(err, &se) {
-		t.Fatalf("error %v (%T) is not a *stt.StreamError", err, err)
+func TestSend_AggregatesTo100msChunk_PreservesOrder(t *testing.T) {
+	chunks := make(chan chunkMsg, 8)
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		for {
+			c := readChunk(conn)
+			if !c.ok {
+				return
+			}
+			chunks <- c
+		}
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	// Four 32 ms frames = 128 ms, crossing the 100 ms threshold on the fourth,
+	// so they flush as ONE chunk in frame order.
+	frames := []audio.Frame{rampFrame(t, 0), rampFrame(t, 1000), rampFrame(t, 2000), rampFrame(t, 3000)}
+	for _, f := range frames {
+		if err := s.Send(f); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
 	}
-	return se
+
+	c := recvChunk(t, chunks)
+	if c.commit {
+		t.Error("aggregated audio chunk had commit=true, want false")
+	}
+	if c.sampleRate != 16000 {
+		t.Errorf("sample_rate = %d, want 16000", c.sampleRate)
+	}
+	want := pcmOf(frames...)
+	if len(c.pcm) != len(want) {
+		t.Fatalf("chunk pcm len = %d, want %d (should be 4 frames concatenated)", len(c.pcm), len(want))
+	}
+	for i := range want {
+		if c.pcm[i] != want[i] {
+			t.Fatalf("chunk pcm differs at byte %d: got 0x%02x want 0x%02x", i, c.pcm[i], want[i])
+		}
+	}
 }
 
-// silence keeps unused harness helpers referenced until later tests use them.
-var _ = sync.Mutex{}
-var _ = time.Second
-var _ = asStreamError
+// --- Test 4: partials arrive in order via OnPartial ---
+
+func TestPartials_DeliveredInOrder(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		_ = conn.WriteJSON(partialMsg("hel"))
+		_ = conn.WriteJSON(partialMsg("hello wor"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	partials := make(chan string, 8)
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(context.Background(), stt.StreamConfig{
+		SampleRate: 16000,
+		OnPartial:  func(text string) { partials <- text },
+	})
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close()
+
+	if got := recvString(t, partials); got != "hel" {
+		t.Errorf("first partial = %q, want %q", got, "hel")
+	}
+	if got := recvString(t, partials); got != "hello wor" {
+		t.Errorf("second partial = %q, want %q", got, "hello wor")
+	}
+}
+
+func recvString(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case s := <-ch:
+		return s
+	case <-time.After(recvTimeout):
+		t.Fatal("timed out waiting for a partial")
+		return ""
+	}
+}
+
+// --- Test 5: commit flushes pending audio then commit sentinel; resolves ---
+
+func TestCommit_FlushesThenResolves_AfterPartials(t *testing.T) {
+	seen := make(chan chunkMsg, 8)
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, seen) {
+			return
+		}
+		_ = conn.WriteJSON(partialMsg("interim"))
+		_ = conn.WriteJSON(committedMsg("final text"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	partials := make(chan string, 8)
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(context.Background(), stt.StreamConfig{
+		SampleRate: 16000,
+		OnPartial:  func(text string) { partials <- text },
+	})
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close()
+
+	// Two 32 ms frames = 64 ms < 100 ms, so nothing flushes until Commit.
+	f0, f1 := rampFrame(t, 0), rampFrame(t, 500)
+	if err := s.Send(f0); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := s.Send(f1); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Server sees the flushed remainder (commit=false) THEN the commit sentinel.
+	audioChunk := recvChunk(t, seen)
+	if audioChunk.commit {
+		t.Error("first chunk had commit=true, want the flushed audio remainder")
+	}
+	if want := pcmOf(f0, f1); len(audioChunk.pcm) != len(want) {
+		t.Errorf("remainder pcm len = %d, want %d", len(audioChunk.pcm), len(want))
+	}
+	commitChunk := recvChunk(t, seen)
+	if !commitChunk.commit {
+		t.Error("second chunk commit=false, want the manual commit sentinel")
+	}
+	if len(commitChunk.pcm) != 0 {
+		t.Errorf("commit sentinel carried %d audio bytes, want 0", len(commitChunk.pcm))
+	}
+
+	res := recvCommit(t, commitCh)
+	if res.Err != nil {
+		t.Fatalf("commit resolved with error: %v", res.Err)
+	}
+	if res.Transcript.Text != "final text" {
+		t.Errorf("committed text = %q, want %q", res.Transcript.Text, "final text")
+	}
+	// The partial was processed on the read pump before the committed frame, so
+	// by the time the commit resolves it is already delivered.
+	select {
+	case p := <-partials:
+		if p != "interim" {
+			t.Errorf("partial = %q, want %q", p, "interim")
+		}
+	default:
+		t.Error("expected the interim partial to have been delivered before commit resolution")
+	}
+}
+
+func TestCommit_ZeroPartials_StillResolves(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("just this"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	res := recvCommit(t, commitCh)
+	if res.Err != nil {
+		t.Fatalf("commit resolved with error: %v", res.Err)
+	}
+	if res.Transcript.Text != "just this" {
+		t.Errorf("committed text = %q, want %q", res.Transcript.Text, "just this")
+	}
+}
+
+// --- Test 6: two utterances in one session map FIFO ---
+
+func TestTwoUtterances_OneSession_FIFO(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("first"))
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("second"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	if err := s.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send 1: %v", err)
+	}
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+	if err := s.Send(rampFrame(t, 100)); err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+	c2, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+
+	if got := recvCommit(t, c1).Transcript.Text; got != "first" {
+		t.Errorf("commit 1 = %q, want first", got)
+	}
+	if got := recvCommit(t, c2).Transcript.Text; got != "second" {
+		t.Errorf("commit 2 = %q, want second", got)
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_test.go
@@ -679,9 +679,13 @@ func TestAutoCommit_PrependedToNextCommit(t *testing.T) {
 
 func TestAbruptClose_SurfacesTransportFatal_NoLeak(t *testing.T) {
 	ss := newScriptedServer(t, func(conn *websocket.Conn) {
-		// Read one chunk mid-utterance, then kill the TCP connection with no
-		// websocket close handshake.
-		_ = readChunk(conn)
+		// Read through the commit sentinel (so the client has registered its
+		// pending commit) but NEVER answer it — then kill the TCP connection with
+		// no websocket close handshake. Waiting for the sentinel makes the death
+		// deterministic: Commit has already returned before the transport dies,
+		// so the pending resolves via the read pump rather than Commit itself
+		// racing the close.
+		_ = readUntilCommit(conn, nil)
 		_ = conn.UnderlyingConn().Close()
 	})
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
@@ -720,10 +724,18 @@ func TestAbruptClose_SurfacesTransportFatal_NoLeak(t *testing.T) {
 // --- Test 10: reconnect opens a fresh session on the same server ---
 
 func TestReconnect_FreshSessionAfterAbruptClose(t *testing.T) {
+	// proceed gates the server's abrupt close on the test having RECEIVED
+	// session 1's commit resolution, so the close cannot race the resolution on
+	// a slow runner.
+	proceed := make(chan struct{})
 	var ss *scriptedServer
 	ss = newScriptedServer(t, func(conn *websocket.Conn) {
 		if ss.upgrades.Load() == 1 {
-			_ = readChunk(conn)
+			if !readUntilCommit(conn, nil) {
+				return
+			}
+			_ = conn.WriteJSON(committedMsg("first"))
+			<-proceed // wait until the test received the resolution
 			_ = conn.UnderlyingConn().Close()
 			return
 		}
@@ -741,17 +753,20 @@ func TestReconnect_FreshSessionAfterAbruptClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenStream 1: %v", err)
 	}
-	for _, start := range []int{0, 1000, 2000, 3000} {
-		_ = s1.Send(rampFrame(t, start))
+	if err := s1.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send 1: %v", err)
 	}
 	commit1, err := s1.Commit()
 	if err != nil {
 		t.Fatalf("Commit 1: %v", err)
 	}
-	if se := asStreamError(t, recvCommit(t, commit1).Err); !se.Fatal {
-		t.Error("first session should have died fatally on abrupt close")
+	if got := recvCommit(t, commit1).Transcript.Text; got != "first" {
+		t.Errorf("commit 1 = %q, want first", got)
 	}
-	_ = s1.Close()
+	close(proceed) // release the server to abruptly kill session 1
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close 1: %v", err)
+	}
 
 	// A fresh OpenStream against the same server works as a new session.
 	s2, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})

--- a/pkg/voice/stt/elevenlabs/stream_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_test.go
@@ -325,6 +325,9 @@ func TestSend_AggregatesTo100msChunk_PreservesOrder(t *testing.T) {
 	if c.sampleRate != 16000 {
 		t.Errorf("sample_rate = %d, want 16000", c.sampleRate)
 	}
+	if c.previousText != "" {
+		t.Errorf("previous_text = %q, want empty (the adapter never sets it)", c.previousText)
+	}
 	want := pcmOf(frames...)
 	if len(c.pcm) != len(want) {
 		t.Fatalf("chunk pcm len = %d, want %d (should be 4 frames concatenated)", len(c.pcm), len(want))
@@ -768,5 +771,228 @@ func TestReconnect_FreshSessionAfterAbruptClose(t *testing.T) {
 	}
 	if n := ss.upgrades.Load(); n != 2 {
 		t.Errorf("server upgrade count = %d, want 2 (one per session)", n)
+	}
+}
+
+// --- Finding 1: chunk-scoped error must not consume a pending commit ---
+
+func TestErrorFrame_ChunkSizeExceeded_DoesNotConsumeOrDuplicate(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		// A chunk-scoped error arrives while a commit is pending: it must be
+		// dropped, not attributed to the pending commit. The real result then
+		// resolves that same commit.
+		_ = conn.WriteJSON(errorMsg("chunk_size_exceeded", "chunk too large"))
+		_ = conn.WriteJSON(committedMsg("real one"))
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("real two"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	if err := s.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send 1: %v", err)
+	}
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+	if res := recvCommit(t, c1); res.Err != nil || res.Transcript.Text != "real one" {
+		t.Fatalf("commit 1 = %+v, want text %q with nil error (chunk error must not be attributed here)", res, "real one")
+	}
+
+	if err := s.Send(rampFrame(t, 100)); err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+	c2, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+	// No duplication: had the chunk error consumed c1, "real one" would have
+	// become autoText and leaked into this commit as "real one real two".
+	if got := recvCommit(t, c2).Transcript.Text; got != "real two" {
+		t.Errorf("commit 2 = %q, want %q (no carried-over duplication)", got, "real two")
+	}
+}
+
+// --- Finding 2: unknown frames ---
+
+func TestUnknownFrame_NoErrorPayload_SessionSurvives(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		// A frame the adapter does not model, carrying no error field.
+		_ = conn.WriteJSON(map[string]any{"message_type": "language_detection", "language_code": "de"})
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("still alive"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	res := recvCommit(t, c1)
+	if res.Err != nil {
+		t.Fatalf("unknown benign frame killed the session: %v", res.Err)
+	}
+	if res.Transcript.Text != "still alive" {
+		t.Errorf("committed text = %q, want %q", res.Transcript.Text, "still alive")
+	}
+}
+
+func TestUnknownFrame_WithErrorPayload_IsFatal(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(errorMsg("some_future_error_code", "boom"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	se := asStreamError(t, recvCommit(t, c1).Err)
+	if !se.Fatal {
+		t.Error("an unrecognized error-bearing frame should be fatal (safe default)")
+	}
+	if se.Code != "some_future_error_code" {
+		t.Errorf("code = %q, want the verbatim wire code", se.Code)
+	}
+}
+
+// --- Finding 3: lifecycle ---
+
+func TestCtxCancel_TearsDownSessionAndResolvesPending(t *testing.T) {
+	ss := newScriptedServer(t, echoUntilClose)
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer ss.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(ctx, stt.StreamConfig{SampleRate: 16000})
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close()
+
+	commitCh, err := s.Commit() // server never answers
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	cancel() // cancel == Close
+
+	if se := asStreamError(t, recvCommit(t, commitCh).Err); !se.Fatal {
+		t.Error("ctx-cancel should resolve the pending commit with a fatal error")
+	}
+	if err := s.Send(rampFrame(t, 0)); err == nil {
+		t.Error("Send after ctx-cancel returned nil error")
+	}
+}
+
+func TestClose_ResolvesPendingCommitFatally(t *testing.T) {
+	ss := newScriptedServer(t, echoUntilClose)
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Close drained the pumps before returning, so the resolution is ready.
+	if se := asStreamError(t, recvCommit(t, commitCh).Err); !se.Fatal {
+		t.Error("Close should resolve pending commits with a fatal *StreamError")
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	ss := newScriptedServer(t, echoUntilClose)
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	if err := s.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close (must be idempotent): %v", err)
+	}
+}
+
+func TestCommit_AfterClose_Errors(t *testing.T) {
+	ss := newScriptedServer(t, echoUntilClose)
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	ch, err := s.Commit()
+	if err == nil {
+		t.Error("Commit after Close returned nil error")
+	}
+	if ch != nil {
+		t.Error("Commit after Close returned a non-nil channel")
+	}
+}
+
+func TestTwoPending_InterleavedCommitScopedError_FIFO(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("one"))
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(errorMsg("commit_throttled", "slow down"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	if err := s.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send 1: %v", err)
+	}
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+	if err := s.Send(rampFrame(t, 100)); err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+	c2, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+
+	if got := recvCommit(t, c1).Transcript.Text; got != "one" {
+		t.Errorf("commit 1 = %q, want one", got)
+	}
+	// The interleaved commit-scoped error consumes the SECOND pending, FIFO.
+	if se := asStreamError(t, recvCommit(t, c2).Err); se.Code != "commit_throttled" {
+		t.Errorf("commit 2 error code = %q, want commit_throttled", se.Code)
 	}
 }

--- a/pkg/voice/stt/elevenlabs/stream_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"go.uber.org/goleak"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
@@ -513,5 +514,259 @@ func TestTwoUtterances_OneSession_FIFO(t *testing.T) {
 	}
 	if got := recvCommit(t, c2).Transcript.Text; got != "second" {
 		t.Errorf("commit 2 = %q, want second", got)
+	}
+}
+
+// --- Test 7: error frames ---
+
+func TestErrorFrame_AuthError_ResolvesFatalAndKillsSession(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(errorMsg("auth_error", "invalid xi-api-key"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	if err := s.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	res := recvCommit(t, commitCh)
+	se := asStreamError(t, res.Err)
+	if se.Code != "auth_error" {
+		t.Errorf("code = %q, want auth_error", se.Code)
+	}
+	if !se.Fatal {
+		t.Error("auth_error should be Fatal")
+	}
+
+	// The session is dead: a later Send surfaces a typed fatal error.
+	sendErr := s.Send(rampFrame(t, 0))
+	if sendErr == nil {
+		t.Fatal("Send after auth_error returned nil error")
+	}
+	if se2 := asStreamError(t, sendErr); !se2.Fatal {
+		t.Error("Send after fatal error should return a Fatal *StreamError")
+	}
+}
+
+func TestErrorFrame_CommitThrottled_RecoverableSessionSurvives(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(errorMsg("commit_throttled", "slow down"))
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("recovered"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+	se := asStreamError(t, recvCommit(t, c1).Err)
+	if se.Code != "commit_throttled" {
+		t.Errorf("code = %q, want commit_throttled", se.Code)
+	}
+	if se.Fatal {
+		t.Error("commit_throttled should be recoverable (Fatal=false)")
+	}
+
+	// Session still usable: a fresh commit resolves normally.
+	if err := s.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send after throttle: %v", err)
+	}
+	c2, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+	if got := recvCommit(t, c2).Transcript.Text; got != "recovered" {
+		t.Errorf("recovered commit = %q, want recovered", got)
+	}
+}
+
+func TestErrorFrame_InsufficientAudio_ResolvesEmptyNoError(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(errorMsg("insufficient_audio_activity", "too quiet"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	c1, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	res := recvCommit(t, c1)
+	if res.Err != nil {
+		t.Errorf("insufficient_audio_activity resolved with error %v, want nil (empty utterance)", res.Err)
+	}
+	if res.Transcript.Text != "" {
+		t.Errorf("transcript = %q, want empty", res.Transcript.Text)
+	}
+}
+
+// --- Test 8: 90s auto-commit carries onto the next manual commit ---
+
+func TestAutoCommit_PrependedToNextCommit(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		// Unsolicited committed_transcript (the provider's 90s auto-commit),
+		// then a partial as a synchronization barrier so the client is proven
+		// to have processed the auto-commit before it registers a pending commit.
+		_ = conn.WriteJSON(committedMsg("auto part"))
+		_ = conn.WriteJSON(partialMsg("barrier"))
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("manual part"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	partials := make(chan string, 4)
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+	s, err := c.OpenStream(context.Background(), stt.StreamConfig{
+		SampleRate: 16000,
+		OnPartial:  func(text string) { partials <- text },
+	})
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close()
+
+	// Barrier: the auto-commit was processed before this partial (serial read pump).
+	if got := recvString(t, partials); got != "barrier" {
+		t.Fatalf("barrier partial = %q, want barrier", got)
+	}
+
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	res := recvCommit(t, commitCh)
+	if res.Err != nil {
+		t.Fatalf("commit resolved with error: %v", res.Err)
+	}
+	if res.Transcript.Text != "auto part manual part" {
+		t.Errorf("committed text = %q, want %q", res.Transcript.Text, "auto part manual part")
+	}
+}
+
+// --- Test 9: abrupt TCP close surfaces transport-fatal, no goroutine leak ---
+
+func TestAbruptClose_SurfacesTransportFatal_NoLeak(t *testing.T) {
+	ss := newScriptedServer(t, func(conn *websocket.Conn) {
+		// Read one chunk mid-utterance, then kill the TCP connection with no
+		// websocket close handshake.
+		_ = readChunk(conn)
+		_ = conn.UnderlyingConn().Close()
+	})
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer ss.Close()
+
+	s := openTestStream(t, ss, stt.StreamConfig{SampleRate: 16000})
+	defer s.Close()
+
+	// 128 ms auto-flushes one chunk, then commit registers a pending resolution.
+	for _, start := range []int{0, 1000, 2000, 3000} {
+		if err := s.Send(rampFrame(t, start)); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	}
+	commitCh, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	se := asStreamError(t, recvCommit(t, commitCh).Err)
+	if se.Code != stt.CodeTransport {
+		t.Errorf("commit error code = %q, want %q", se.Code, stt.CodeTransport)
+	}
+	if !se.Fatal {
+		t.Error("transport error should be Fatal")
+	}
+
+	// A later Send also surfaces the typed transport-fatal error.
+	if sendErr := s.Send(rampFrame(t, 0)); sendErr == nil {
+		t.Error("Send after abrupt close returned nil error")
+	} else if se2 := asStreamError(t, sendErr); !se2.Fatal {
+		t.Error("Send after abrupt close should be Fatal")
+	}
+}
+
+// --- Test 10: reconnect opens a fresh session on the same server ---
+
+func TestReconnect_FreshSessionAfterAbruptClose(t *testing.T) {
+	var ss *scriptedServer
+	ss = newScriptedServer(t, func(conn *websocket.Conn) {
+		if ss.upgrades.Load() == 1 {
+			_ = readChunk(conn)
+			_ = conn.UnderlyingConn().Close()
+			return
+		}
+		if !readUntilCommit(conn, nil) {
+			return
+		}
+		_ = conn.WriteJSON(committedMsg("reconnected"))
+		echoUntilClose(conn)
+	})
+	defer ss.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(ss.URL))
+
+	s1, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})
+	if err != nil {
+		t.Fatalf("OpenStream 1: %v", err)
+	}
+	for _, start := range []int{0, 1000, 2000, 3000} {
+		_ = s1.Send(rampFrame(t, start))
+	}
+	commit1, err := s1.Commit()
+	if err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+	if se := asStreamError(t, recvCommit(t, commit1).Err); !se.Fatal {
+		t.Error("first session should have died fatally on abrupt close")
+	}
+	_ = s1.Close()
+
+	// A fresh OpenStream against the same server works as a new session.
+	s2, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})
+	if err != nil {
+		t.Fatalf("OpenStream 2 (reconnect): %v", err)
+	}
+	defer s2.Close()
+	if err := s2.Send(rampFrame(t, 0)); err != nil {
+		t.Fatalf("Send on reconnect: %v", err)
+	}
+	commit2, err := s2.Commit()
+	if err != nil {
+		t.Fatalf("Commit 2: %v", err)
+	}
+	if got := recvCommit(t, commit2).Transcript.Text; got != "reconnected" {
+		t.Errorf("reconnect commit = %q, want reconnected", got)
+	}
+	if n := ss.upgrades.Load(); n != 2 {
+		t.Errorf("server upgrade count = %d, want 2 (one per session)", n)
 	}
 }

--- a/pkg/voice/stt/streaming.go
+++ b/pkg/voice/stt/streaming.go
@@ -77,10 +77,26 @@ type StreamingRecognizer interface {
 	OpenStream(ctx context.Context, cfg StreamConfig) (Stream, error)
 }
 
-// CodeTransport is the [StreamError.Code] for websocket-level failures the
-// adapter synthesizes itself (dial failure, read/write error, abrupt close).
-// Provider error frames carry their own wire code verbatim.
-const CodeTransport = "transport"
+// These are the [StreamError.Code] values an adapter synthesizes itself, as
+// opposed to provider error frames (see ADR-0042), which carry their own wire
+// code verbatim. A caller switching on Code to decide fallback-vs-retry can
+// rely on exactly these three originating in the adapter.
+const (
+	// CodeTransport marks a websocket-level failure: dial failure, a read or
+	// write error, an abrupt close, or context cancellation. Always Fatal — the
+	// session is dead and the caller should reopen or fall back to batch.
+	CodeTransport = "transport"
+
+	// CodeSampleRateMismatch marks a [Stream.Send] frame whose SampleRate does
+	// not equal the session's declared rate. Recoverable: only that frame is
+	// rejected, the session continues.
+	CodeSampleRateMismatch = "sample_rate_mismatch"
+
+	// CodeQueueFull marks a non-blocking Send or Commit that could not enqueue
+	// because the internal write queue is full (backpressure). Recoverable: the
+	// caller may retry once the write pump drains.
+	CodeQueueFull = "queue_full"
+)
 
 // StreamError is the typed error surfaced by every streaming operation. Code
 // is the provider's error-frame type (see ADR-0042) or [CodeTransport] for

--- a/pkg/voice/stt/streaming.go
+++ b/pkg/voice/stt/streaming.go
@@ -1,0 +1,106 @@
+package stt
+
+import (
+	"context"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+)
+
+// StreamConfig configures a single streaming-recognition session opened with
+// [StreamingRecognizer.OpenStream].
+type StreamConfig struct {
+	// SampleRate is the PCM sample rate (Hz) of every [audio.Frame] the caller
+	// will Send. Frames whose rate differs are rejected by [Stream.Send]. The
+	// v1 adapter supports only 16000; other values fail at OpenStream.
+	SampleRate int
+
+	// Language is the BCP-47 language hint, or "" to let the provider
+	// auto-detect (mirrors the batch adapter, which leaves language unset so
+	// the operator may speak EN or DE).
+	Language string
+
+	// OnPartial receives the mutable interim transcript of the in-progress
+	// utterance as it arrives. Each call REPLACES the previous partial — it is
+	// not cumulative. Invoked serially from the stream's read goroutine, so it
+	// must not block. A nil OnPartial drops partials silently.
+	OnPartial func(text string)
+}
+
+// CommitResult is the resolution of one [Stream.Commit]. Exactly one of the
+// fields is meaningful: Err is non-nil (a *[StreamError]) when the segment
+// could not be committed, otherwise Transcript carries the committed text.
+type CommitResult struct {
+	// Transcript is the authoritative committed text for the segment, mirroring
+	// the batch [Recognizer]'s result. Empty text is a valid result (silent or
+	// activity-free segment).
+	Transcript Transcript
+
+	// Err is nil on success, or a *[StreamError] describing why the commit
+	// failed. A Fatal error means the session is dead and the caller should
+	// reopen or fall back to the batch adapter.
+	Err error
+}
+
+// Stream is a live streaming-recognition session over a persistent transport.
+// It is NOT safe to Send from multiple goroutines concurrently; the intended
+// caller is the single per-Voice-Session audio pump. Commit and Close may be
+// called from any goroutine.
+type Stream interface {
+	// Send enqueues one audio frame toward the recognizer. It is non-blocking:
+	// frames are buffered and flushed by an internal write pump. Send returns a
+	// *[StreamError] once the session is dead or the internal queue is full, or
+	// when frame.SampleRate does not equal the configured SampleRate. A nil
+	// return does not mean the frame reached the wire, only that it was accepted.
+	Send(frame audio.Frame) error
+
+	// Commit requests a manual commit of the audio sent since the previous
+	// commit and returns a channel that resolves exactly once with the
+	// committed transcript (or a *[StreamError]). It is non-blocking. Multiple
+	// in-flight commits resolve in FIFO order. Commit returns a non-nil error
+	// (no channel) only when the session is already dead at call time.
+	Commit() (<-chan CommitResult, error)
+
+	// Close tears the session down. Pending commit channels resolve with a
+	// *[StreamError]. Close is idempotent and blocks until the session's
+	// goroutines have drained.
+	Close() error
+}
+
+// StreamingRecognizer opens streaming-recognition sessions. It is the
+// streaming sibling of [Recognizer]; the batch adapter is unaffected.
+type StreamingRecognizer interface {
+	// OpenStream dials a fresh session. The supplied context bounds both the
+	// dial and the whole session lifetime: cancelling it is equivalent to
+	// calling [Stream.Close]. A websocket-level dial failure returns a
+	// *[StreamError] with Fatal set, which the caller can use to fall back to
+	// the batch adapter.
+	OpenStream(ctx context.Context, cfg StreamConfig) (Stream, error)
+}
+
+// CodeTransport is the [StreamError.Code] for websocket-level failures the
+// adapter synthesizes itself (dial failure, read/write error, abrupt close).
+// Provider error frames carry their own wire code verbatim.
+const CodeTransport = "transport"
+
+// StreamError is the typed error surfaced by every streaming operation. Code
+// is the provider's error-frame type (see ADR-0042) or [CodeTransport] for
+// transport-level failures. Fatal reports whether the whole session is dead
+// (reopen or fall back) versus only the single operation having failed.
+type StreamError struct {
+	Code  string
+	Fatal bool
+	Err   error
+}
+
+func (e *StreamError) Error() string {
+	fatal := "recoverable"
+	if e.Fatal {
+		fatal = "fatal"
+	}
+	if e.Err != nil {
+		return "stt stream error [" + e.Code + ", " + fatal + "]: " + e.Err.Error()
+	}
+	return "stt stream error [" + e.Code + ", " + fatal + "]"
+}
+
+func (e *StreamError) Unwrap() error { return e.Err }


### PR DESCRIPTION
## What does this PR do?

Adds a streaming Speech-to-Text surface alongside the existing batch one, and an ElevenLabs Scribe v2 Realtime adapter that implements it. Closes #179.

- New `stt.StreamingRecognizer` / `stt.Stream` / `StreamConfig` / `CommitResult` / `StreamError` in `pkg/voice/stt/streaming.go`. The batch `stt.Recognizer`, `transcribe.go`, and `elevenlabs.go` are **untouched** (verified: `git diff origin/main` shows no edit to the batch files).
- `pkg/voice/stt/elevenlabs/stream.go`: `Client.OpenStream` dials `wss://…/v1/speech-to-text/realtime` with `model_id=scribe_v2_realtime`, `audio_format=pcm_16000`, `commit_strategy=manual` and the `xi-api-key` header, reusing the same key / base URL / `ProviderID` as the batch adapter.
- One write pump owns every websocket write (gorilla single-writer rule): audio chunks, the manual-commit sentinel, and 20s keepalive pings. One read pump routes `partial_transcript` → `OnPartial`, `committed_transcript` → the FIFO pending-commit queue, and error frames → typed classification.
- `Send` aggregates frames into ≥100 ms `input_audio_chunk` messages (flush on threshold-cross, no timers, order preserved). `Commit` flushes the remainder then the commit sentinel and resolves its channel exactly once.

Semantics implemented per ADR-0042:
- Manual commit strategy; sample rate declared on every chunk; 16 kHz only (other rates fail at `OpenStream`).
- Websocket failure (dial, read/write, abrupt close) surfaces a typed `*stt.StreamError{Code:"transport", Fatal:true}` the caller can use to fall back to batch; a fresh `OpenStream` reconnects cleanly.
- `auth_error` → fatal; `commit_throttled`/`rate_limited`/`chunk_size_exceeded`/`input_error` → recoverable (session survives); `insufficient_audio_activity` → empty transcript, no error; unsolicited `committed_transcript` (90s auto-commit) → prepended to the next commit.

Scope is the adapter only — no orchestrator/bus/voiceevent/wirenpc changes (those are #180).

## Why is this change needed?

ADR-0042: the batch STT POST (~1.5s) dominates response latency and yields no text to speculate on until `STTFinal`. Streaming STT with local-VAD manual commit is the transport rebuild that unlocks endpoint→final in ~100–300ms and speculative memory recall over partials. This PR lands the provider adapter that #180 wires into the pipeline.

## How was this tested?

Deterministic tests use a scripted `httptest` + gorilla-`Upgrader` server (ADR-0021 posture; no cassettes needed for a fake-websocket harness, no live network). 17 tests cover: dial contract (path/query/header + `language_code`), missing key, unsupported sample rate, Send aggregation + byte-order, partials ordering, commit happy-path + zero-partial, two-utterance FIFO, all error-frame classes, 90s auto-commit carryover, abrupt-close transport-fatal + goroutine-leak (goleak), reconnect (fresh session), and keepalive ping.

A `//go:build live` smoke (`stream_live_test.go`, skipped without `ELEVENLABS_API_KEY`) is the only check that can prove the `StreamModel` constant against the provider — **ran once against the real endpoint: PASS** (commit resolved, empty text for a silent utterance).

- [x] `go test -race ./pkg/voice/stt/...` passes (10x stress on the concurrency tests, no flakes)
- [x] `golangci-lint run ./pkg/voice/stt/...` (v2.12.2, the CI version) — 0 issues
- [x] New/updated tests cover the change
- [x] Manual testing: live ElevenLabs streaming smoke, one paid call, PASS

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./pkg/voice/stt/...`
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- `go.mod`: promoted `github.com/gorilla/websocket v1.5.3` from indirect to direct (it is now imported directly). `go mod tidy` can't complete in a fresh worktree because the `gen/` protobuf stubs are gitignored and generated in CI; the promotion is exactly what `tidy` would produce once `gen/` exists.
- The keepalive interval is injected through an unexported `openStream` knob so the internal test can shorten it without exporting test-only surface (`elevenlabs.go`'s `Client` struct is deliberately not modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)