### PR TITLE
feat(#116): async embedding backfill worker drains the backlog

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
@@ -315,6 +316,21 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		log.Warn("seed embedding-backlog gauge", "err", err)
 	} else {
 		metrics.SetEmbeddingBacklog(n)
+	}
+
+	// Async embedding backfill worker (#116, ADR-0011): a background loop that
+	// claims chunks written with embedding NULL, embeds their text, and UPDATEs
+	// each row — draining the backlog gauge toward zero and making the chunks
+	// returnable by embedding-filtered retrieval. It needs only the DB + the
+	// embeddings provider (not the voice loop), so it runs in web AND all mode.
+	// An unsupported provider is loud-but-non-fatal: log ERROR and skip the worker
+	// — the backlog gauge then exposes the permanent stall rather than the process
+	// crashing. The worker rides the process signal ctx, so SIGTERM stops it and
+	// any in-flight provider call aborts with the same context.
+	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
+		log.Error("unsupported embeddings provider, backfill disabled", "err", err)
+	} else {
+		go embedworker.New(store, provider, model, metrics, log, embedworker.Config{}).Run(ctx)
 	}
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -323,12 +323,13 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// each row — draining the backlog gauge toward zero and making the chunks
 	// returnable by embedding-filtered retrieval. It needs only the DB + the
 	// embeddings provider (not the voice loop), so it runs in web AND all mode.
-	// An unsupported provider is loud-but-non-fatal: log ERROR and skip the worker
-	// — the backlog gauge then exposes the permanent stall rather than the process
-	// crashing. The worker rides the process signal ctx, so SIGTERM stops it and
-	// any in-flight provider call aborts with the same context.
+	// A resolve failure (an unsupported provider OR a config-read error) is
+	// loud-but-non-fatal: log ERROR and skip the worker — the backlog gauge then
+	// exposes the permanent stall rather than the process crashing. The worker
+	// rides the process signal ctx, so SIGTERM stops it and any in-flight provider
+	// call aborts with the same context.
 	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
-		log.Error("unsupported embeddings provider, backfill disabled", "err", err)
+		log.Error("embeddings provider unavailable, backfill disabled", "err", err)
 	} else {
 		go embedworker.New(store, provider, model, metrics, log, embedworker.Config{}).Run(ctx)
 	}

--- a/internal/embedworker/worker.go
+++ b/internal/embedworker/worker.go
@@ -1,0 +1,230 @@
+// Package embedworker is the async embedding backfill worker (#116, ADR-0011).
+//
+// The Transcript Chunk writer (#104) inserts rows with embedding NULL; this
+// worker is the second half of that eventually-consistent pipeline. A background
+// loop in the web/all process periodically claims the oldest NULL-embedding
+// chunks, embeds their text through the configured [embeddings.Provider], and
+// UPDATEs each row with its 768-dim vector plus the model stamp — draining the
+// backlog toward zero and making the chunks returnable by the embedding-filtered
+// retrieval query (embedding IS NOT NULL).
+//
+// Retry is implicit and stateless: any pass error (provider outage, timeout, a
+// DB write) abandons the pass WITHOUT writing partial results, so the affected
+// chunks stay NULL and are re-claimed on the next pass. There is no backoff
+// bookkeeping and no dead-letter state — a chunk that cannot be embedded now is
+// simply retried later, forever, while the worker keeps running. The loop stops
+// cleanly when its context is cancelled (process shutdown): in-flight provider
+// calls carry that context, so they abort rather than pinning the shutdown.
+package embedworker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/ollama"
+)
+
+// Store is the narrow persistence surface the worker needs. *storage.Store
+// satisfies it; tests fake it.
+type Store interface {
+	// ListUnembeddedChunks returns up to limit chunks still awaiting an embedding,
+	// oldest first — the worker's per-pass work queue.
+	ListUnembeddedChunks(ctx context.Context, limit int) ([]storage.TranscriptChunk, error)
+	// SetChunkEmbedding fills one chunk's vector and stamps the model.
+	SetChunkEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error
+	// CountUnembeddedChunks reports the remaining NULL-embedding backlog (gauge).
+	CountUnembeddedChunks(ctx context.Context) (int, error)
+}
+
+// BacklogGauge receives the current NULL-embedding backlog after each pass that
+// wrote at least one embedding (Set-from-COUNT, never Inc/Dec — ADR-0032).
+// *observe.PrometheusRecorder satisfies it; a nil gauge disables the update.
+type BacklogGauge interface {
+	SetEmbeddingBacklog(n int)
+}
+
+// ProviderConfigStore is the single read [ResolveProvider] needs; *storage.Store
+// satisfies it. Kept narrow so the resolution is unit-testable with a fake.
+type ProviderConfigStore interface {
+	GetEmbeddingsProviderConfig(ctx context.Context) (storage.ProviderConfig, error)
+}
+
+const (
+	defaultInterval    = 10 * time.Second
+	defaultBatchSize   = 16
+	defaultCallTimeout = 60 * time.Second // Ollama's cold model load can take tens of seconds
+)
+
+// Config tunes the worker. Zero values fall back to the defaults above.
+type Config struct {
+	// Interval is the sleep between passes (and between an empty backlog and the
+	// next look). Default 10s.
+	Interval time.Duration
+	// BatchSize is the max chunks claimed and embedded per pass. Default 16.
+	BatchSize int
+	// CallTimeout bounds one provider Embed call (derived from the run context).
+	// Default 60s to survive an Ollama cold-start.
+	CallTimeout time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.Interval <= 0 {
+		c.Interval = defaultInterval
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultBatchSize
+	}
+	if c.CallTimeout <= 0 {
+		c.CallTimeout = defaultCallTimeout
+	}
+	return c
+}
+
+// Worker drains the embedding backlog. Construct with [New]; run with [Run].
+type Worker struct {
+	store    Store
+	provider embeddings.Provider
+	model    string
+	gauge    BacklogGauge
+	log      *slog.Logger
+	cfg      Config
+}
+
+// New builds a Worker. model is the embedding model stamped onto each row (the
+// provider must produce vectors for it); gauge may be nil to disable the backlog
+// metric. Config zero values take the package defaults.
+func New(store Store, provider embeddings.Provider, model string, gauge BacklogGauge, log *slog.Logger, cfg Config) *Worker {
+	return &Worker{
+		store:    store,
+		provider: provider,
+		model:    model,
+		gauge:    gauge,
+		log:      log,
+		cfg:      cfg.withDefaults(),
+	}
+}
+
+// Run drives the backfill loop until ctx is cancelled, then returns. Each
+// iteration runs one pass and sleeps Interval; a cancel during either the pass
+// (carried into the provider call) or the sleep unwinds promptly. Run blocks, so
+// callers launch it as a goroutine.
+func (w *Worker) Run(ctx context.Context) {
+	for ctx.Err() == nil {
+		w.pass(ctx)
+
+		timer := time.NewTimer(w.cfg.Interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// pass claims one batch, embeds it, and writes the vectors. Any error abandons
+// the pass without a partial write — the affected chunks stay NULL and are
+// re-claimed next pass (the retry). A pass that embeds nothing (empty backlog or
+// any error) leaves the gauge untouched; only a successful write re-reads it.
+func (w *Worker) pass(ctx context.Context) {
+	chunks, err := w.store.ListUnembeddedChunks(ctx, w.cfg.BatchSize)
+	if err != nil {
+		w.log.Warn("embed backfill: list unembedded chunks failed; retrying next pass", "err", err)
+		return
+	}
+	if len(chunks) == 0 {
+		return // backlog drained; the loop sleeps
+	}
+
+	texts := make([]string, len(chunks))
+	for i, c := range chunks {
+		texts[i] = c.Content
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, w.cfg.CallTimeout)
+	defer cancel()
+	vecs, err := w.provider.Embed(callCtx, texts)
+	if err != nil {
+		w.log.Warn("embed backfill: provider embed failed; chunks stay NULL, retrying next pass",
+			"batch", len(chunks), "err", err)
+		return
+	}
+	if len(vecs) != len(chunks) {
+		w.log.Warn("embed backfill: provider returned wrong vector count; abandoning pass",
+			"want", len(chunks), "got", len(vecs))
+		return
+	}
+	// Validate every dimension BEFORE writing any row: a wrong dimension signals a
+	// mis-configured model, so the whole batch is suspect — write none and retry
+	// rather than corrupt the vector store with a partial, wrong-shape write.
+	for i, v := range vecs {
+		if len(v) != embeddings.Dim {
+			w.log.Warn("embed backfill: provider returned a wrong-dimension vector; abandoning pass",
+				"index", i, "want", embeddings.Dim, "got", len(v))
+			return
+		}
+	}
+
+	for i, c := range chunks {
+		if err := w.store.SetChunkEmbedding(ctx, c.ID, vecs[i], w.model); err != nil {
+			w.log.Warn("embed backfill: set chunk embedding failed; remaining chunks retry next pass",
+				"chunk_id", c.ID, "err", err)
+			return
+		}
+	}
+
+	n, err := w.store.CountUnembeddedChunks(ctx)
+	if err != nil {
+		w.log.Warn("embed backfill: recount backlog failed; gauge left stale", "err", err)
+		return
+	}
+	if w.gauge != nil {
+		w.gauge.SetEmbeddingBacklog(n)
+	}
+}
+
+// ResolveProvider resolves the process's embeddings Provider and its model from
+// the saved Provider Config (#116, reused by #122). No bound config falls back to
+// the local Ollama default (ADR-0004/0011); a saved 'ollama' config honours its
+// model (or the default when blank) and the GLYPHOXA_OLLAMA_URL endpoint
+// override; any other provider is unsupported in v1.0 and returns an error (the
+// caller logs it and skips the worker — a loud, non-fatal stall the gauge shows).
+func ResolveProvider(ctx context.Context, store ProviderConfigStore) (embeddings.Provider, string, error) {
+	cfg, err := store.GetEmbeddingsProviderConfig(ctx)
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		return newOllama(ollama.DefaultModel), ollama.DefaultModel, nil
+	case err != nil:
+		return nil, "", fmt.Errorf("embedworker: resolve embeddings provider: %w", err)
+	}
+
+	switch cfg.Provider {
+	case "", ollama.ProviderID:
+		model := cfg.Model
+		if model == "" {
+			model = ollama.DefaultModel
+		}
+		return newOllama(model), model, nil
+	default:
+		return nil, "", fmt.Errorf("embedworker: unsupported embeddings provider %q (v1.0 supports only %q)",
+			cfg.Provider, ollama.ProviderID)
+	}
+}
+
+// newOllama builds an Ollama embeddings client for model, pointed at the
+// GLYPHOXA_OLLAMA_URL endpoint when set (else the loopback default).
+func newOllama(model string) *ollama.Client {
+	opts := []ollama.Option{ollama.WithModel(model)}
+	if u := os.Getenv("GLYPHOXA_OLLAMA_URL"); u != "" {
+		opts = append(opts, ollama.WithBaseURL(u))
+	}
+	return ollama.New(opts...)
+}

--- a/internal/embedworker/worker.go
+++ b/internal/embedworker/worker.go
@@ -8,13 +8,16 @@
 // backlog toward zero and making the chunks returnable by the embedding-filtered
 // retrieval query (embedding IS NOT NULL).
 //
-// Retry is implicit and stateless: any pass error (provider outage, timeout, a
-// DB write) abandons the pass WITHOUT writing partial results, so the affected
-// chunks stay NULL and are re-claimed on the next pass. There is no backoff
-// bookkeeping and no dead-letter state — a chunk that cannot be embedded now is
-// simply retried later, forever, while the worker keeps running. The loop stops
-// cleanly when its context is cancelled (process shutdown): in-flight provider
-// calls carry that context, so they abort rather than pinning the shutdown.
+// Retry is implicit and stateless: a pass that hits an error stops early and
+// re-claims the leftover work next pass. A failure BEFORE the writes (list, the
+// provider call, a wrong vector count or dimension) writes nothing; a failure
+// DURING the per-chunk writes keeps the rows already written — each embedding is
+// an independent, valid row — and leaves the rest NULL. Either way the still-NULL
+// chunks are re-claimed on the next pass. There is no backoff bookkeeping and no
+// dead-letter state — a chunk that cannot be embedded now is simply retried
+// later, forever, while the worker keeps running. The loop stops cleanly when its
+// context is cancelled (process shutdown): in-flight provider calls carry that
+// context, so they abort rather than pinning the shutdown.
 package embedworker
 
 import (
@@ -130,10 +133,12 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 }
 
-// pass claims one batch, embeds it, and writes the vectors. Any error abandons
-// the pass without a partial write — the affected chunks stay NULL and are
-// re-claimed next pass (the retry). A pass that embeds nothing (empty backlog or
-// any error) leaves the gauge untouched; only a successful write re-reads it.
+// pass claims one batch, embeds it, and writes each vector. An error stops the
+// pass early: a pre-write error (list, provider, wrong count/dimension) writes
+// nothing, while a mid-batch write error keeps the rows already written and
+// leaves the rest NULL. The still-NULL chunks are re-claimed next pass (the
+// retry). The gauge is re-read only after the whole batch of writes succeeds; a
+// short or aborted pass leaves it as the last pass set it.
 func (w *Worker) pass(ctx context.Context) {
 	chunks, err := w.store.ListUnembeddedChunks(ctx, w.cfg.BatchSize)
 	if err != nil {
@@ -173,9 +178,12 @@ func (w *Worker) pass(ctx context.Context) {
 		}
 	}
 
+	// Write each row; a failure stops the loop but keeps the rows already written
+	// (each is an independent, committed embedding). This chunk and the untried
+	// remainder stay NULL and are re-claimed next pass.
 	for i, c := range chunks {
 		if err := w.store.SetChunkEmbedding(ctx, c.ID, vecs[i], w.model); err != nil {
-			w.log.Warn("embed backfill: set chunk embedding failed; remaining chunks retry next pass",
+			w.log.Warn("embed backfill: set chunk embedding failed; this and later chunks retry next pass",
 				"chunk_id", c.ID, "err", err)
 			return
 		}

--- a/internal/embedworker/worker_test.go
+++ b/internal/embedworker/worker_test.go
@@ -25,14 +25,16 @@ func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard,
 
 // fakeStore is an in-memory embed backlog: pending holds the still-NULL chunks
 // (the ListUnembeddedChunks queue), embedded records what SetChunkEmbedding
-// stored, and Count reports len(pending). The *Err fields inject failures.
+// stored, and Count reports len(pending). listErr/countErr fail those reads;
+// setFailID fails SetChunkEmbedding for exactly one chunk id, so a test can land
+// a write error mid-batch (rows before it commit, rows from it on stay NULL).
 type fakeStore struct {
-	mu       sync.Mutex
-	pending  []storage.TranscriptChunk
-	embedded map[uuid.UUID]embedRecord
-	listErr  error
-	setErr   error
-	countErr error
+	mu        sync.Mutex
+	pending   []storage.TranscriptChunk
+	embedded  map[uuid.UUID]embedRecord
+	listErr   error
+	setFailID uuid.UUID
+	countErr  error
 }
 
 type embedRecord struct {
@@ -58,8 +60,8 @@ func (f *fakeStore) ListUnembeddedChunks(_ context.Context, limit int) ([]storag
 func (f *fakeStore) SetChunkEmbedding(_ context.Context, id uuid.UUID, vec []float32, model string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.setErr != nil {
-		return f.setErr
+	if f.setFailID != uuid.Nil && id == f.setFailID {
+		return errors.New("set chunk embedding: injected write failure")
 	}
 	for i, c := range f.pending {
 		if c.ID == id {
@@ -93,6 +95,13 @@ func (f *fakeStore) pendingCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.pending)
+}
+
+func (f *fakeStore) isEmbedded(id uuid.UUID) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.embedded[id]
+	return ok
 }
 
 // fakeGauge records every Set so a test can assert the backlog curve.
@@ -292,6 +301,118 @@ func TestPassRejectsWrongDimension(t *testing.T) {
 	w.pass(context.Background())
 	if store.embeddedCount() != 0 {
 		t.Errorf("embedded = %d after retry, want 0 (still wrong dimension)", store.embeddedCount())
+	}
+}
+
+// Test: a List read error abandons the pass without embedding anything or
+// touching the gauge, and the worker keeps running — a later pass recovers.
+func TestPassAbandonedOnListError(t *testing.T) {
+	store := &fakeStore{
+		pending: []storage.TranscriptChunk{chunk("alpha")},
+		listErr: errors.New("db unavailable"),
+	}
+	gauge := &fakeGauge{}
+	w := New(store, embeddingstest.Deterministic{}, "m", gauge, discardLog(), Config{})
+
+	w.pass(context.Background())
+	if store.embeddedCount() != 0 {
+		t.Errorf("embedded = %d, want 0 (list failed, nothing embedded)", store.embeddedCount())
+	}
+	if got := gauge.snapshot(); len(got) != 0 {
+		t.Errorf("gauge Set %d times, want 0 (no successful pass)", len(got))
+	}
+
+	store.mu.Lock()
+	store.listErr = nil
+	store.mu.Unlock()
+	w.pass(context.Background())
+	if store.embeddedCount() != 1 {
+		t.Errorf("embedded = %d after recovery pass, want 1 (worker kept running)", store.embeddedCount())
+	}
+}
+
+// Test: a write error mid-batch commits the rows written before it (each
+// embedding is an independent, valid row) and leaves the failing chunk plus the
+// untried remainder NULL; a later pass drains them (the retry).
+func TestPassKeepsWrittenRowsOnMidBatchSetError(t *testing.T) {
+	c0, c1, c2 := chunk("alpha"), chunk("beta"), chunk("gamma")
+	store := &fakeStore{
+		pending:   []storage.TranscriptChunk{c0, c1, c2},
+		setFailID: c1.ID, // the second write fails
+	}
+	w := New(store, embeddingstest.Deterministic{}, "m", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+	if !store.isEmbedded(c0.ID) {
+		t.Error("c0 not embedded; the pre-error write must commit")
+	}
+	if store.isEmbedded(c1.ID) || store.isEmbedded(c2.ID) {
+		t.Error("c1/c2 embedded; the failing chunk and the untried remainder must stay NULL")
+	}
+	if store.pendingCount() != 2 {
+		t.Fatalf("pending = %d, want 2 (c1 failed + c2 untried)", store.pendingCount())
+	}
+
+	// Clear the injected failure: the next pass drains the leftover backlog.
+	store.mu.Lock()
+	store.setFailID = uuid.Nil
+	store.mu.Unlock()
+	w.pass(context.Background())
+	if store.pendingCount() != 0 || store.embeddedCount() != 3 {
+		t.Fatalf("after retry pass: pending=%d embedded=%d, want 0/3", store.pendingCount(), store.embeddedCount())
+	}
+}
+
+// Test: a recount error after the writes leaves the gauge unset (stale, not
+// zeroed) while the embeddings still commit, and the worker keeps running.
+func TestPassLeavesGaugeStaleOnCountError(t *testing.T) {
+	store := &fakeStore{
+		pending:  []storage.TranscriptChunk{chunk("alpha"), chunk("beta")},
+		countErr: errors.New("count failed"),
+	}
+	gauge := &fakeGauge{}
+	w := New(store, embeddingstest.Deterministic{}, "m", gauge, discardLog(), Config{})
+
+	w.pass(context.Background())
+	if store.embeddedCount() != 2 {
+		t.Fatalf("embedded = %d, want 2 (writes precede the recount)", store.embeddedCount())
+	}
+	if got := gauge.snapshot(); len(got) != 0 {
+		t.Errorf("gauge Set %d times, want 0 (recount failed → gauge stays stale)", len(got))
+	}
+
+	// Worker keeps running: with the backlog drained, the next pass is a no-op.
+	store.mu.Lock()
+	store.countErr = nil
+	store.mu.Unlock()
+	w.pass(context.Background())
+	if store.embeddedCount() != 2 {
+		t.Errorf("embedded = %d, want 2 (no work left)", store.embeddedCount())
+	}
+}
+
+// shortProvider returns one fewer vector than requested — a broken provider that
+// violates the order-preserving, total contract.
+type shortProvider struct{}
+
+func (shortProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	return embeddingstest.Deterministic{}.Embed(ctx, texts[:len(texts)-1])
+}
+
+// Test: a vector-count mismatch (len(vecs) != len(chunks)) abandons the pass
+// without writing any row — a provider that can't return one vector per input is
+// mis-behaving, and a positional write would embed rows with the wrong vector.
+func TestPassRejectsVectorCountMismatch(t *testing.T) {
+	store := &fakeStore{pending: []storage.TranscriptChunk{chunk("alpha"), chunk("beta")}}
+	w := New(store, shortProvider{}, "m", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+	if store.embeddedCount() != 0 || store.pendingCount() != 2 {
+		t.Fatalf("embedded=%d pending=%d, want 0/2 (count mismatch abandons the pass)",
+			store.embeddedCount(), store.pendingCount())
 	}
 }
 

--- a/internal/embedworker/worker_test.go
+++ b/internal/embedworker/worker_test.go
@@ -1,0 +1,344 @@
+package embedworker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/ollama"
+)
+
+// discardLog is a logger that swallows output — most tests assert on the store
+// and gauge, not on log lines.
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// fakeStore is an in-memory embed backlog: pending holds the still-NULL chunks
+// (the ListUnembeddedChunks queue), embedded records what SetChunkEmbedding
+// stored, and Count reports len(pending). The *Err fields inject failures.
+type fakeStore struct {
+	mu       sync.Mutex
+	pending  []storage.TranscriptChunk
+	embedded map[uuid.UUID]embedRecord
+	listErr  error
+	setErr   error
+	countErr error
+}
+
+type embedRecord struct {
+	vec   []float32
+	model string
+}
+
+func (f *fakeStore) ListUnembeddedChunks(_ context.Context, limit int) ([]storage.TranscriptChunk, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	n := limit
+	if n > len(f.pending) {
+		n = len(f.pending)
+	}
+	out := make([]storage.TranscriptChunk, n)
+	copy(out, f.pending[:n])
+	return out, nil
+}
+
+func (f *fakeStore) SetChunkEmbedding(_ context.Context, id uuid.UUID, vec []float32, model string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.setErr != nil {
+		return f.setErr
+	}
+	for i, c := range f.pending {
+		if c.ID == id {
+			f.pending = append(f.pending[:i], f.pending[i+1:]...)
+			break
+		}
+	}
+	if f.embedded == nil {
+		f.embedded = map[uuid.UUID]embedRecord{}
+	}
+	f.embedded[id] = embedRecord{vec: append([]float32(nil), vec...), model: model}
+	return nil
+}
+
+func (f *fakeStore) CountUnembeddedChunks(_ context.Context) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	return len(f.pending), nil
+}
+
+func (f *fakeStore) embeddedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.embedded)
+}
+
+func (f *fakeStore) pendingCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pending)
+}
+
+// fakeGauge records every Set so a test can assert the backlog curve.
+type fakeGauge struct {
+	mu   sync.Mutex
+	sets []int
+}
+
+func (g *fakeGauge) SetEmbeddingBacklog(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.sets = append(g.sets, n)
+}
+
+func (g *fakeGauge) snapshot() []int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]int(nil), g.sets...)
+}
+
+func chunk(content string) storage.TranscriptChunk {
+	return storage.TranscriptChunk{ID: uuid.New(), CampaignID: uuid.New(), Content: content}
+}
+
+// Test 1: three NULL chunks are all embedded with 768-dim vectors and the model
+// stamp in one pass.
+func TestPassEmbedsWholeBatch(t *testing.T) {
+	store := &fakeStore{pending: []storage.TranscriptChunk{
+		chunk("alpha"), chunk("beta"), chunk("gamma"),
+	}}
+	w := New(store, embeddingstest.Deterministic{}, "nomic-embed-text", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+
+	if store.pendingCount() != 0 {
+		t.Fatalf("pending after pass = %d, want 0 (all embedded)", store.pendingCount())
+	}
+	if store.embeddedCount() != 3 {
+		t.Fatalf("embedded = %d, want 3", store.embeddedCount())
+	}
+	for id, rec := range store.embedded {
+		if len(rec.vec) != embeddings.Dim {
+			t.Errorf("chunk %s vector = %d dims, want %d", id, len(rec.vec), embeddings.Dim)
+		}
+		if rec.model != "nomic-embed-text" {
+			t.Errorf("chunk %s model = %q, want nomic-embed-text", id, rec.model)
+		}
+	}
+}
+
+// flakyProvider errors on the first Embed call and delegates to inner after.
+type flakyProvider struct {
+	calls int
+	inner embeddings.Provider
+}
+
+func (p *flakyProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	p.calls++
+	if p.calls == 1 {
+		return nil, errors.New("provider unavailable")
+	}
+	return p.inner.Embed(ctx, texts)
+}
+
+// Test 2: a provider error on pass 1 leaves every chunk NULL; pass 2 succeeds and
+// embeds them. The worker itself never exits — pass returns and is re-driven.
+func TestPassRetriesAfterProviderError(t *testing.T) {
+	store := &fakeStore{pending: []storage.TranscriptChunk{chunk("alpha"), chunk("beta")}}
+	prov := &flakyProvider{inner: embeddingstest.Deterministic{}}
+	w := New(store, prov, "m", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+	if store.pendingCount() != 2 || store.embeddedCount() != 0 {
+		t.Fatalf("after failing pass: pending=%d embedded=%d, want 2/0 (all stay NULL)",
+			store.pendingCount(), store.embeddedCount())
+	}
+
+	w.pass(context.Background())
+	if store.pendingCount() != 0 || store.embeddedCount() != 2 {
+		t.Fatalf("after recovery pass: pending=%d embedded=%d, want 0/2",
+			store.pendingCount(), store.embeddedCount())
+	}
+	if prov.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2 (failed then retried)", prov.calls)
+	}
+}
+
+// Test 3: the gauge is Set from the true remaining count after each pass and the
+// curve is monotone non-increasing, reaching zero when the backlog drains.
+func TestGaugeDecreasesToZero(t *testing.T) {
+	var pending []storage.TranscriptChunk
+	for i := 0; i < 5; i++ {
+		pending = append(pending, chunk("c"))
+	}
+	store := &fakeStore{pending: pending}
+	gauge := &fakeGauge{}
+	w := New(store, embeddingstest.Deterministic{}, "m", gauge, discardLog(), Config{BatchSize: 2})
+
+	for store.pendingCount() > 0 {
+		w.pass(context.Background())
+	}
+
+	sets := gauge.snapshot()
+	if len(sets) == 0 {
+		t.Fatal("gauge was never Set")
+	}
+	prev := 1 << 30
+	for i, n := range sets {
+		if n > prev {
+			t.Errorf("gauge Set %d = %d rose above previous %d (must be monotone non-increasing)", i, n, prev)
+		}
+		prev = n
+	}
+	if sets[len(sets)-1] != 0 {
+		t.Errorf("final gauge Set = %d, want 0 (backlog drained)", sets[len(sets)-1])
+	}
+}
+
+// blockingProvider blocks inside Embed until the context is cancelled, so a test
+// can cancel mid-call and assert the loop unwinds.
+type blockingProvider struct {
+	once    sync.Once
+	entered chan struct{}
+}
+
+func (p *blockingProvider) Embed(ctx context.Context, _ []string) ([][]float32, error) {
+	p.once.Do(func() { close(p.entered) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// Test 4a: cancelling the context while the worker sleeps between passes returns
+// Run promptly.
+func TestRunReturnsOnCancelMidSleep(t *testing.T) {
+	store := &fakeStore{} // empty backlog: pass does nothing, Run sleeps
+	w := New(store, embeddingstest.Deterministic{}, "m", nil, discardLog(), Config{Interval: time.Hour})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { w.Run(ctx); close(done) }()
+
+	time.Sleep(20 * time.Millisecond) // let Run reach the inter-pass sleep
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return promptly after cancel during sleep")
+	}
+}
+
+// Test 4b: cancelling the context while a provider call is in flight aborts the
+// call (ctx is carried into Embed) and Run returns promptly.
+func TestRunReturnsOnCancelMidCall(t *testing.T) {
+	store := &fakeStore{pending: []storage.TranscriptChunk{chunk("alpha")}}
+	prov := &blockingProvider{entered: make(chan struct{})}
+	w := New(store, prov, "m", nil, discardLog(), Config{Interval: time.Hour})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { w.Run(ctx); close(done) }()
+
+	<-prov.entered // block until the worker is inside Embed
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return promptly after cancel during a provider call")
+	}
+	if store.embeddedCount() != 0 {
+		t.Errorf("embedded = %d, want 0 (call aborted, nothing written)", store.embeddedCount())
+	}
+}
+
+// Test 5: a wrong-dimension vector from the provider leaves every chunk NULL,
+// logs, and the loop keeps running (a later pass can retry).
+func TestPassRejectsWrongDimension(t *testing.T) {
+	c := chunk("hello")
+	store := &fakeStore{pending: []storage.TranscriptChunk{c}}
+	prov := embeddingstest.Fixed{"hello": {1, 2, 3, 4}} // 4 dims, not 768
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	w := New(store, prov, "m", nil, log, Config{})
+
+	w.pass(context.Background())
+
+	if store.pendingCount() != 1 || store.embeddedCount() != 0 {
+		t.Fatalf("pending=%d embedded=%d, want 1/0 (wrong-dim vector must not be written)",
+			store.pendingCount(), store.embeddedCount())
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "dimension") {
+		t.Errorf("expected a logged dimension warning, got: %q", buf.String())
+	}
+
+	// The loop keeps running: a second pass is a no-op, not a panic.
+	w.pass(context.Background())
+	if store.embeddedCount() != 0 {
+		t.Errorf("embedded = %d after retry, want 0 (still wrong dimension)", store.embeddedCount())
+	}
+}
+
+// fakeCfgStore is a ProviderConfigStore double for ResolveProvider.
+type fakeCfgStore struct {
+	cfg storage.ProviderConfig
+	err error
+}
+
+func (f fakeCfgStore) GetEmbeddingsProviderConfig(context.Context) (storage.ProviderConfig, error) {
+	return f.cfg, f.err
+}
+
+// Test 7: ResolveProvider defaults to Ollama+DefaultModel when no config is
+// bound, honours a saved Ollama model, and rejects an unsupported provider.
+func TestResolveProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("not found defaults to ollama", func(t *testing.T) {
+		prov, model, err := ResolveProvider(ctx, fakeCfgStore{err: storage.ErrNotFound})
+		if err != nil {
+			t.Fatalf("ResolveProvider: %v", err)
+		}
+		if model != ollama.DefaultModel {
+			t.Errorf("model = %q, want %q (the ollama default)", model, ollama.DefaultModel)
+		}
+		if _, ok := prov.(*ollama.Client); !ok {
+			t.Errorf("provider %T, want *ollama.Client", prov)
+		}
+	})
+
+	t.Run("saved ollama model honoured", func(t *testing.T) {
+		_, model, err := ResolveProvider(ctx, fakeCfgStore{cfg: storage.ProviderConfig{
+			Provider: "ollama", Model: "mxbai-embed-large",
+		}})
+		if err != nil {
+			t.Fatalf("ResolveProvider: %v", err)
+		}
+		if model != "mxbai-embed-large" {
+			t.Errorf("model = %q, want mxbai-embed-large", model)
+		}
+	})
+
+	t.Run("unsupported provider errors", func(t *testing.T) {
+		_, _, err := ResolveProvider(ctx, fakeCfgStore{cfg: storage.ProviderConfig{Provider: "openai"}})
+		if err == nil {
+			t.Fatal("ResolveProvider(openai) = nil error, want an unsupported-provider error")
+		}
+	})
+}

--- a/internal/storage/migrations/00009_chunk_embedding_model.sql
+++ b/internal/storage/migrations/00009_chunk_embedding_model.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+-- The async embedding worker (#116, ADR-0011) stamps WHICH model produced a
+-- chunk's vector when it fills the embedding. That provenance matters because
+-- switching the embedding model (or Matryoshka dimensions) changes the vector
+-- space and requires a backfill — a mixed-model column is how a re-embed pass
+-- knows which rows are stale. Additive with a '' default so the migration is
+-- safe over existing rows (the chunk writer inserts with embedding NULL, so the
+-- default empty model is correct until the worker embeds the row).
+ALTER TABLE transcript_chunk
+    ADD COLUMN embedding_model text NOT NULL DEFAULT '';
+
+-- +goose Down
+
+ALTER TABLE transcript_chunk
+    DROP COLUMN IF EXISTS embedding_model;

--- a/internal/storage/transcript_chunk.go
+++ b/internal/storage/transcript_chunk.go
@@ -2,10 +2,14 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // Transcript-chunk persistence (#104, ADR-0011): the chunk writer inserts one row
@@ -16,8 +20,9 @@ import (
 // independent records of the same speech and do not share rows.
 
 // TranscriptChunk is one persisted Transcript Chunk. embedding is always NULL at
-// insert (the async embedding pipeline, ADR-0011); EmbeddingModel is deferred to
-// #116 (no column yet), so it is neither written nor read here and scans "".
+// insert (the async embedding pipeline, ADR-0011); EmbeddingModel is empty until
+// the backfill worker (#116) embeds the row and stamps which model produced the
+// vector — the provenance a model-switch re-embed pass keys off (ADR-0011).
 type TranscriptChunk struct {
 	ID                    uuid.UUID
 	CampaignID            uuid.UUID
@@ -25,15 +30,15 @@ type TranscriptChunk struct {
 	Content               string      // the chunk's utterances joined "\n"
 	SpeakerDiscordUserIDs []string    // empty in v1.0: anonymous STT lane (ADR-0039)
 	ParticipatedAgentIDs  []uuid.UUID // Agents that spoke in the chunk (NPC-knowledge filter)
-	EmbeddingModel        string      // deferred to #116; not persisted here
+	EmbeddingModel        string      // '' until the backfill worker embeds the row (#116)
 	StartedAt             time.Time
 	CreatedAt             time.Time
 }
 
 // InsertTranscriptChunk writes one closed chunk and returns its generated id. The
 // embedding is left NULL — the async pipeline fills it later (ADR-0011) — and the
-// arrays default to empty (never NULL). embedding_model is deferred (#116), so it
-// is not written here.
+// arrays default to empty (never NULL). embedding_model is left at its empty
+// column default; the backfill worker (#116) stamps it when it embeds the row.
 func (s *Store) InsertTranscriptChunk(ctx context.Context, c TranscriptChunk) (uuid.UUID, error) {
 	speakers := c.SpeakerDiscordUserIDs
 	if speakers == nil {
@@ -68,4 +73,110 @@ func (s *Store) CountUnembeddedChunks(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("storage: count unembedded transcript chunks: %w", err)
 	}
 	return n, nil
+}
+
+const transcriptChunkColumns = `
+	id, campaign_id, voice_session_id, content,
+	speaker_discord_user_ids, participated_agent_ids,
+	embedding_model, started_at, created_at`
+
+func scanTranscriptChunk(row pgx.Row) (TranscriptChunk, error) {
+	var (
+		c    TranscriptChunk
+		vsID uuid.NullUUID // column is nullable (ADR-0011 SEAM); may be NULL
+	)
+	err := row.Scan(
+		&c.ID, &c.CampaignID, &vsID, &c.Content,
+		&c.SpeakerDiscordUserIDs, &c.ParticipatedAgentIDs,
+		&c.EmbeddingModel, &c.StartedAt, &c.CreatedAt,
+	)
+	c.VoiceSessionID = vsID.UUID // uuid.Nil when NULL
+	return c, err
+}
+
+// ListUnembeddedChunks returns up to limit Transcript Chunks still awaiting an
+// embedding (embedding IS NULL), oldest first — the backfill worker's work queue
+// (#116, ADR-0011). Ordering by (created_at, id) makes each pass drain the oldest
+// backlog first and be a stable, deterministic batch. An empty result is not an
+// error: it means the backlog is drained and the worker sleeps.
+func (s *Store) ListUnembeddedChunks(ctx context.Context, limit int) ([]TranscriptChunk, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+transcriptChunkColumns+`
+		   FROM transcript_chunk
+		  WHERE embedding IS NULL
+		  ORDER BY created_at, id
+		  LIMIT $1`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list unembedded transcript chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []TranscriptChunk
+	for rows.Next() {
+		c, err := scanTranscriptChunk(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan transcript chunk: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list unembedded transcript chunks: %w", err)
+	}
+	return out, nil
+}
+
+// SetChunkEmbedding fills one chunk's embedding vector and stamps the model that
+// produced it (#116, ADR-0011). The vector is passed as pgvector's text form and
+// cast server-side (::vector) so storage carries no pgvector-go dependency; the
+// column is vector(768), so a wrong-length vector is rejected by Postgres. Once
+// set, the row leaves the NULL-embedding backlog and becomes returnable by the
+// embedding-filtered retrieval query (embedding IS NOT NULL).
+func (s *Store) SetChunkEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error {
+	if _, err := s.db.Exec(ctx,
+		`UPDATE transcript_chunk
+		    SET embedding = $2::vector, embedding_model = $3
+		  WHERE id = $1`, id, encodeVector(vec), model); err != nil {
+		return fmt.Errorf("storage: set chunk embedding %s: %w", id, err)
+	}
+	return nil
+}
+
+// encodeVector renders a float32 vector as pgvector's text input form,
+// "[0.1,0.2,...]", for a server-side ::vector cast. Each element uses the
+// shortest round-trippable float32 decimal ('g', 32-bit) so the stored value is
+// exactly what was embedded. Keeping this a plain string keeps the storage layer
+// free of a pgvector-go binding.
+func encodeVector(v []float32) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, f := range v {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.FormatFloat(float64(f), 'g', -1, 32))
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// GetEmbeddingsProviderConfig returns the most-recently-updated 'embeddings'
+// Provider Config, or ErrNotFound when none is bound. Process-wide (no tenant
+// filter), mirroring GetActiveCampaign's single-operator posture (ADR-0039): the
+// backfill worker resolves ONE embeddings provider for the process. Not-found is
+// not fatal — the worker falls back to the local Ollama default (ADR-0004/0011).
+func (s *Store) GetEmbeddingsProviderConfig(ctx context.Context) (ProviderConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+providerConfigColumns+`
+		   FROM provider_config
+		  WHERE component = 'embeddings'
+		  ORDER BY updated_at DESC, id DESC
+		  LIMIT 1`)
+	p, err := scanProviderConfig(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ProviderConfig{}, ErrNotFound
+	}
+	if err != nil {
+		return ProviderConfig{}, fmt.Errorf("storage: get embeddings provider_config: %w", err)
+	}
+	return p, nil
 }

--- a/internal/storage/transcript_chunk_embed_test.go
+++ b/internal/storage/transcript_chunk_embed_test.go
@@ -1,0 +1,217 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
+)
+
+// TestSetChunkEmbeddingRoundtrip is #116's storage half against a real pgvector
+// DB: a chunk inserted with embedding NULL is filled by SetChunkEmbedding with a
+// 768-dim vector + model stamp; it then becomes returnable by the
+// embedding-filtered retrieval query (embedding IS NOT NULL) while a still-NULL
+// sibling is excluded, the backlog COUNT drops, and ListUnembeddedChunks returns
+// only the un-embedded rows (oldest first). The vector round-trips exactly
+// through encodeVector + the ::vector cast (proven element-wise), and the
+// migration's embedding_model column carries the stamp.
+func TestSetChunkEmbeddingRoundtrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	// Two chunks, both embedding NULL. Explicit, ordered created_at so the
+	// oldest-first ListUnembeddedChunks ordering is deterministic to assert.
+	t0 := time.Date(2026, 7, 5, 18, 0, 0, 0, time.UTC)
+	older := insertChunkAt(t, pool, campaignID, vs.ID, "older chunk", t0)
+	newer := insertChunkAt(t, pool, campaignID, vs.ID, "newer chunk", t0.Add(time.Minute))
+
+	// Backlog starts at 2 and the queue is oldest-first.
+	if n, err := st.CountUnembeddedChunks(ctx); err != nil || n != 2 {
+		t.Fatalf("CountUnembeddedChunks = %d, %v; want 2", n, err)
+	}
+	queue, err := st.ListUnembeddedChunks(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListUnembeddedChunks: %v", err)
+	}
+	if len(queue) != 2 || queue[0].ID != older || queue[1].ID != newer {
+		t.Fatalf("queue order = %v, want [%s %s] (oldest first)", ids(queue), older, newer)
+	}
+	if queue[0].Content != "older chunk" || queue[0].EmbeddingModel != "" {
+		t.Errorf("queue[0] = %+v, want content 'older chunk' and empty model (still NULL)", queue[0])
+	}
+
+	// Embed the older chunk with a real 768-dim vector + model stamp.
+	vec := deterministicVector(t, "older chunk")
+	if err := st.SetChunkEmbedding(ctx, older, vec, "nomic-embed-text"); err != nil {
+		t.Fatalf("SetChunkEmbedding: %v", err)
+	}
+
+	// The embedded row: dims = 768, model stamped, and the stored vector equals
+	// the input element-wise (encodeVector + ::vector round-trip, exact float32).
+	var (
+		dims       int
+		model      string
+		storedText string
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT vector_dims(embedding), embedding_model, embedding::text
+		   FROM transcript_chunk WHERE id = $1`, older).
+		Scan(&dims, &model, &storedText); err != nil {
+		t.Fatalf("read embedded row: %v", err)
+	}
+	if dims != embeddings.Dim {
+		t.Errorf("vector_dims = %d, want %d", dims, embeddings.Dim)
+	}
+	if model != "nomic-embed-text" {
+		t.Errorf("embedding_model = %q, want nomic-embed-text", model)
+	}
+	assertVectorEqual(t, storedText, vec)
+
+	// Embedding-filtered query returns the embedded chunk and excludes the NULL
+	// sibling (the retrieval contract, ADR-0011).
+	nonNull := selectNonNullIDs(t, pool, vs.ID)
+	if len(nonNull) != 1 || nonNull[0] != older {
+		t.Errorf("WHERE embedding IS NOT NULL = %v, want [%s] only", nonNull, older)
+	}
+
+	// The backlog dropped to just the still-NULL sibling, and the queue now
+	// excludes the embedded row.
+	if n, err := st.CountUnembeddedChunks(ctx); err != nil || n != 1 {
+		t.Fatalf("CountUnembeddedChunks after embed = %d, %v; want 1", n, err)
+	}
+	queue, err = st.ListUnembeddedChunks(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListUnembeddedChunks (after embed): %v", err)
+	}
+	if len(queue) != 1 || queue[0].ID != newer {
+		t.Errorf("queue after embed = %v, want [%s] (only the still-NULL sibling)", ids(queue), newer)
+	}
+}
+
+// TestGetEmbeddingsProviderConfig covers the worker's provider-resolution read:
+// ErrNotFound when nothing is bound, and the most-recently-updated 'embeddings'
+// row otherwise (process-wide, no tenant filter).
+func TestGetEmbeddingsProviderConfig(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.GetEmbeddingsProviderConfig(ctx); err != storage.ErrNotFound {
+		t.Fatalf("GetEmbeddingsProviderConfig with none bound = %v, want ErrNotFound", err)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO provider_config
+		   (tenant_id, component, provider, model, credentials_ciphertext, credentials_last4)
+		 VALUES ($1, 'embeddings', 'ollama', 'nomic-embed-text', '\x00', 'ab12')`, tenantID); err != nil {
+		t.Fatalf("insert embeddings config: %v", err)
+	}
+
+	cfg, err := st.GetEmbeddingsProviderConfig(ctx)
+	if err != nil {
+		t.Fatalf("GetEmbeddingsProviderConfig: %v", err)
+	}
+	if cfg.Component != storage.ComponentEmbeddings || cfg.Provider != "ollama" || cfg.Model != "nomic-embed-text" {
+		t.Errorf("cfg = %+v, want the embeddings/ollama/nomic-embed-text row", cfg)
+	}
+}
+
+// insertChunkAt inserts a NULL-embedding chunk with an explicit created_at so
+// ordering assertions are deterministic (InsertTranscriptChunk defaults now()).
+func insertChunkAt(t *testing.T, pool *pgxpool.Pool, campaignID, vsID uuid.UUID, content string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := pool.QueryRow(context.Background(),
+		`INSERT INTO transcript_chunk (campaign_id, voice_session_id, content, started_at, created_at)
+		 VALUES ($1, $2, $3, $4, $4) RETURNING id`, campaignID, vsID, content, createdAt).Scan(&id); err != nil {
+		t.Fatalf("insert chunk %q: %v", content, err)
+	}
+	return id
+}
+
+func deterministicVector(t *testing.T, text string) []float32 {
+	t.Helper()
+	vecs, err := (embeddingstest.Deterministic{}).Embed(context.Background(), []string{text})
+	if err != nil {
+		t.Fatalf("deterministic embed: %v", err)
+	}
+	return vecs[0]
+}
+
+func assertVectorEqual(t *testing.T, storedText string, want []float32) {
+	t.Helper()
+	got := parseVector(t, storedText)
+	if len(got) != len(want) {
+		t.Fatalf("stored vector len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(float64(got[i]-want[i])) > 1e-6 {
+			t.Fatalf("stored vector[%d] = %g, want %g (round-trip not exact)", i, got[i], want[i])
+		}
+	}
+}
+
+func parseVector(t *testing.T, s string) []float32 {
+	t.Helper()
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	parts := strings.Split(s, ",")
+	out := make([]float32, len(parts))
+	for i, p := range parts {
+		f, err := strconv.ParseFloat(strings.TrimSpace(p), 32)
+		if err != nil {
+			t.Fatalf("parse vector element %q: %v", p, err)
+		}
+		out[i] = float32(f)
+	}
+	return out
+}
+
+func selectNonNullIDs(t *testing.T, pool *pgxpool.Pool, vsID uuid.UUID) []uuid.UUID {
+	t.Helper()
+	rows, err := pool.Query(context.Background(),
+		`SELECT id FROM transcript_chunk
+		  WHERE voice_session_id = $1 AND embedding IS NOT NULL
+		  ORDER BY created_at`, vsID)
+	if err != nil {
+		t.Fatalf("select non-null: %v", err)
+	}
+	defer rows.Close()
+	var out []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan id: %v", err)
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+func ids(chunks []storage.TranscriptChunk) []uuid.UUID {
+	out := make([]uuid.UUID, len(chunks))
+	for i, c := range chunks {
+		out[i] = c.ID
+	}
+	return out
+}

--- a/internal/storage/vector_test.go
+++ b/internal/storage/vector_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import "testing"
+
+// TestEncodeVector locks pgvector's text input format: a bracketed,
+// comma-separated list with shortest round-trippable float32 decimals and no
+// spaces. This is the exact string handed to a server-side ::vector cast, so its
+// shape is load-bearing (a malformed literal is a runtime write failure, not a
+// compile error). The integration test proves the same string round-trips
+// through a real ::vector column.
+func TestEncodeVector(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []float32
+		want string
+	}{
+		{"empty", []float32{}, "[]"},
+		{"single", []float32{0.5}, "[0.5]"},
+		{"signs and zero", []float32{0.5, -0.25, 0}, "[0.5,-0.25,0]"},
+		{"needs precision", []float32{0.1, 0.2, 0.3}, "[0.1,0.2,0.3]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encodeVector(tc.in); got != tc.want {
+				t.Errorf("encodeVector(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #116

## What

The async embedding backfill worker — the second half of the ADR-0011
eventually-consistent embedding pipeline. The chunk writer (#104) inserts rows
with `embedding NULL`; this worker drains that backlog.

## How

- **Migration 00009** adds `transcript_chunk.embedding_model text NOT NULL DEFAULT ''`
  — provenance of which model produced a vector (a model switch needs a backfill,
  so a mixed-model column is how a re-embed pass finds stale rows). Additive +
  reversible.
- **Storage** (`internal/storage/transcript_chunk.go`): `ListUnembeddedChunks`
  (oldest-first work queue), `SetChunkEmbedding` (fills the vector via a
  server-side `::vector` cast + stamps the model — no `pgvector-go` dep),
  `encodeVector`, and `GetEmbeddingsProviderConfig` (process-wide, `ErrNotFound`
  when unbound).
- **Worker** (`internal/embedworker`): a background loop that claims a batch,
  makes one provider `Embed` call (bounded by `CallTimeout`, default 60s for
  Ollama cold-start), validates every dimension, then writes each vector. An
  error stops the pass early and the leftover work is re-claimed next pass (that
  IS the retry; no backoff bookkeeping). A pre-write error (list, provider, wrong
  vector count/dimension) writes nothing; a mid-batch write error keeps the rows
  already written — each embedding is an independent, valid row — and leaves the
  rest NULL. The gauge is Set-from-COUNT after a full batch of writes succeeds,
  converging to zero. In-flight calls carry the run context, so shutdown aborts
  them and `Run` returns promptly. `ResolveProvider` is exported for #122 reuse.
- **Wiring** (`cmd/glyphoxa/main.go`): launched in `runWeb` on the process signal
  context, so it runs in `web` **and** `all` mode and stops on SIGTERM. A resolve
  failure (unsupported provider OR a config-read error) is loud-but-non-fatal
  (log ERROR, skip — the gauge shows the stall).

## Acceptance criteria

- [x] NULL-embedding chunks are picked up and updated with a 768-dim vector, no manual intervention
- [x] The backlog gauge decreases as chunks are embedded and reaches zero
- [x] A provider error/timeout leaves the chunk NULL and it is retried on a later pass; the worker keeps running
- [x] Embedded chunks become returnable by `WHERE embedding IS NOT NULL`; still-NULL chunks excluded
- [x] Runs as a background loop in the owning process and stops cleanly on shutdown

## Tests (TDD, red -> green)

14 test functions. Unit (`internal/embedworker`, race-clean): whole-batch embed,
retry-after-provider-error, monotone gauge -> 0, ctx-cancel mid-sleep and
mid-call (prompt return), wrong-dimension rejection, vector-count-mismatch
rejection, List-error abandonment + recovery, mid-batch write error (rows <k
commit, >=k stay NULL, retried next pass), recount-error leaves gauge stale, and
the `ResolveProvider` matrix. `encodeVector` format locked as a pure unit test.
Integration (`-tags=integration`, real pgvector): exact float32 round-trip,
`embedding_model` stamped, backlog drop, embedding-filtered query membership, and
`GetEmbeddingsProviderConfig`. Migration reversibility (`TestMigrateUpDown`) and
#104's existing persistence test still pass.

## Not in scope

No new `go.mod` deps. Touched only the migration, `transcript_chunk.go`,
`internal/embedworker/*`, and `main.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
