### PR TITLE
feat(#119): ANN transcript-chunk retrieval — NPC-knowledge vs world context

### DIFF
--- a/internal/storage/transcript_chunk.go
+++ b/internal/storage/transcript_chunk.go
@@ -159,6 +159,91 @@ func encodeVector(v []float32) string {
 	return b.String()
 }
 
+// ChunkMatch is one Transcript Chunk returned by ANN retrieval together with its
+// cosine distance to the query vector (#119, ADR-0011). Distance comes from
+// pgvector's <=> operator: smaller = nearer, ascending order = nearest first.
+type ChunkMatch struct {
+	Chunk    TranscriptChunk
+	Distance float64
+}
+
+func scanChunkMatch(row pgx.Row) (ChunkMatch, error) {
+	var (
+		m    ChunkMatch
+		vsID uuid.NullUUID // column nullable (ADR-0011 SEAM); may be NULL
+	)
+	err := row.Scan(
+		&m.Chunk.ID, &m.Chunk.CampaignID, &vsID, &m.Chunk.Content,
+		&m.Chunk.SpeakerDiscordUserIDs, &m.Chunk.ParticipatedAgentIDs,
+		&m.Chunk.EmbeddingModel, &m.Chunk.StartedAt, &m.Chunk.CreatedAt,
+		&m.Distance,
+	)
+	m.Chunk.VoiceSessionID = vsID.UUID // uuid.Nil when NULL
+	return m, err
+}
+
+// SearchChunksByAgent is NPC-knowledge retrieval (ADR-0011): the k Transcript
+// Chunks in campaignID nearest the query vector by cosine distance whose
+// participated set CONTAINS agentID — "what this NPC could personally know". A
+// multi-agent chunk is returned for every one of its participants (containment,
+// not equality). NULL-embedding rows are excluded (partial HNSW index).
+func (s *Store) SearchChunksByAgent(ctx context.Context, campaignID, agentID uuid.UUID, query []float32, k int) ([]ChunkMatch, error) {
+	return s.searchChunks(ctx, campaignID, &agentID, query, k)
+}
+
+// SearchChunksByCampaign is world-context retrieval (ADR-0011): the k Transcript
+// Chunks in campaignID nearest the query vector by cosine distance, participants
+// ignored — topical Campaign context the NPC "may not personally know".
+// NULL-embedding rows are excluded (partial HNSW index).
+func (s *Store) SearchChunksByCampaign(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]ChunkMatch, error) {
+	return s.searchChunks(ctx, campaignID, nil, query, k)
+}
+
+// searchChunks runs the shared ANN query for both retrieval modes: cosine
+// distance (<=>) against the query vector, ascending (nearest first), matching
+// the partial HNSW vector_cosine_ops index. It is always scoped to one Campaign
+// and to non-null embeddings; a non-nil agentID adds the participated-set
+// containment filter (NPC-knowledge mode). k <= 0 is a caller bug and errors
+// rather than silently defaulting. The query vector reuses encodeVector + a
+// server-side ::vector cast, so storage carries no pgvector-go dependency.
+func (s *Store) searchChunks(ctx context.Context, campaignID uuid.UUID, agentID *uuid.UUID, query []float32, k int) ([]ChunkMatch, error) {
+	if k <= 0 {
+		return nil, fmt.Errorf("storage: search chunks: k must be > 0, got %d", k)
+	}
+	// $1 campaign, $2 query vector (also the <=> operand), [$3 agent], $N limit.
+	args := []any{campaignID, encodeVector(query)}
+	agentFilter := ""
+	if agentID != nil {
+		args = append(args, *agentID)
+		agentFilter = " AND participated_agent_ids @> ARRAY[$3]::uuid[]"
+	}
+	args = append(args, k)
+	sql := `SELECT ` + transcriptChunkColumns + `, embedding <=> $2::vector AS distance
+		   FROM transcript_chunk
+		  WHERE campaign_id = $1 AND embedding IS NOT NULL` + agentFilter + `
+		  ORDER BY distance
+		  LIMIT $` + strconv.Itoa(len(args))
+
+	rows, err := s.db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("storage: search transcript chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ChunkMatch
+	for rows.Next() {
+		m, err := scanChunkMatch(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan chunk match: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: search transcript chunks: %w", err)
+	}
+	return out, nil
+}
+
 // GetEmbeddingsProviderConfig returns the most-recently-updated 'embeddings'
 // Provider Config, or ErrNotFound when none is bound. Process-wide (no tenant
 // filter), mirroring GetActiveCampaign's single-operator posture (ADR-0039): the

--- a/internal/storage/transcript_chunk_search_test.go
+++ b/internal/storage/transcript_chunk_search_test.go
@@ -1,0 +1,267 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+)
+
+// The ANN retrieval tests (#119, ADR-0011) hand-place chunks in a tiny cosine
+// space: the query is the first basis vector e0, and each chunk's leading
+// components set a known angle to it. Cosine distance (<=>) is scale-invariant,
+// so the vectors need no normalization for the ordering to be predictable:
+//
+//	e0=[1,0]         -> distance 0     (identical direction, nearest)
+//	[0.9,0.1]        -> distance ~0.006
+//	[0.5,0.5]        -> distance ~0.293 (45°)
+//	e1=[0,1]         -> distance 1.0   (orthogonal, farthest)
+//
+// All other 766 dimensions are zero, so only the leading components matter.
+
+// vec768 builds an embeddings.Dim-long vector from its leading components,
+// zero-padded — the exact shape SetChunkEmbedding's ::vector(768) cast requires.
+func vec768(lead ...float32) []float32 {
+	v := make([]float32, embeddings.Dim)
+	copy(v, lead)
+	return v
+}
+
+// seedSearchChunk inserts one chunk (real write path) and, when vec is non-nil,
+// embeds it via SetChunkEmbedding. A nil vec leaves the embedding NULL — the
+// backlog state retrieval must skip.
+func seedSearchChunk(t *testing.T, st *storage.Store, campaignID, vsID uuid.UUID, agents []uuid.UUID, vec []float32) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	id, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID:           campaignID,
+		VoiceSessionID:       vsID,
+		Content:              "chunk " + id36(agents),
+		ParticipatedAgentIDs: agents,
+		StartedAt:            time.Date(2026, 7, 5, 18, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+	if vec != nil {
+		if err := st.SetChunkEmbedding(ctx, id, vec, "test-model"); err != nil {
+			t.Fatalf("SetChunkEmbedding: %v", err)
+		}
+	}
+	return id
+}
+
+// id36 renders the agent set into the content so seeded rows are distinguishable
+// in failure output; it carries no assertion weight.
+func id36(agents []uuid.UUID) string {
+	s := ""
+	for _, a := range agents {
+		s += a.String()[:8] + " "
+	}
+	return s
+}
+
+func matchIDs(matches []storage.ChunkMatch) []uuid.UUID {
+	out := make([]uuid.UUID, len(matches))
+	for i, m := range matches {
+		out[i] = m.Chunk.ID
+	}
+	return out
+}
+
+func idSet(ids []uuid.UUID) map[uuid.UUID]bool {
+	m := make(map[uuid.UUID]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK is AC1 + AC5(cap): seeded
+// chunks with known embeddings come back ordered by cosine distance to the query
+// (nearest first, distance monotone nondecreasing), and k caps the result at the
+// k nearest.
+func TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	query := vec768(1, 0)
+	nearest := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(1, 0))     // distance 0
+	near := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.9, 0.1))    // ~0.006
+	mid := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.5, 0.5))     // ~0.293
+	far := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0, 1))         // 1.0
+
+	got, err := st.SearchChunksByCampaign(ctx, campaignID, query, 4)
+	if err != nil {
+		t.Fatalf("SearchChunksByCampaign: %v", err)
+	}
+	wantOrder := []uuid.UUID{nearest, near, mid, far}
+	if ids := matchIDs(got); len(ids) != 4 || ids[0] != wantOrder[0] || ids[1] != wantOrder[1] || ids[2] != wantOrder[2] || ids[3] != wantOrder[3] {
+		t.Fatalf("order = %v, want nearest-first %v", ids, wantOrder)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Distance < got[i-1].Distance {
+			t.Errorf("distance not monotone: got[%d]=%g < got[%d]=%g", i, got[i].Distance, i-1, got[i-1].Distance)
+		}
+	}
+	if got[0].Distance > 1e-4 {
+		t.Errorf("nearest distance = %g, want ~0 (identical direction)", got[0].Distance)
+	}
+	if got[3].Distance < 0.99 {
+		t.Errorf("farthest distance = %g, want ~1 (orthogonal)", got[3].Distance)
+	}
+	// The returned chunk carries its scanned fields, not a zero value.
+	if got[0].Chunk.CampaignID != campaignID || got[0].Chunk.EmbeddingModel != "test-model" {
+		t.Errorf("nearest chunk fields not populated: %+v", got[0].Chunk)
+	}
+
+	// k caps at the k nearest: k=2 -> {nearest, near} only.
+	capped, err := st.SearchChunksByCampaign(ctx, campaignID, query, 2)
+	if err != nil {
+		t.Fatalf("SearchChunksByCampaign (k=2): %v", err)
+	}
+	if ids := matchIDs(capped); len(ids) != 2 || ids[0] != nearest || ids[1] != near {
+		t.Fatalf("k=2 result = %v, want [%s %s] (the 2 nearest)", ids, nearest, near)
+	}
+}
+
+// TestSearchChunksByAgent_ParticipationContainment is AC2: NPC-knowledge mode
+// returns only chunks whose participated set CONTAINS the given agent, and a
+// multi-agent chunk is returned for every one of its participants (containment,
+// not equality). World-context mode ignores participants entirely.
+func TestSearchChunksByAgent_ParticipationContainment(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	agentA, agentB := uuid.New(), uuid.New()
+	query := vec768(1, 0)
+	c1 := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agentA}, vec768(1, 0))
+	c2 := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agentA}, vec768(0.9, 0.1))
+	c3 := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agentB}, vec768(0.5, 0.5))
+	cAB := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agentA, agentB}, vec768(0, 1))
+
+	byA, err := st.SearchChunksByAgent(ctx, campaignID, agentA, query, 10)
+	if err != nil {
+		t.Fatalf("SearchChunksByAgent(A): %v", err)
+	}
+	if set := idSet(matchIDs(byA)); len(set) != 3 || !set[c1] || !set[c2] || !set[cAB] {
+		t.Errorf("ByAgent(A) = %v, want {c1,c2,cAB} (containment)", matchIDs(byA))
+	}
+
+	byB, err := st.SearchChunksByAgent(ctx, campaignID, agentB, query, 10)
+	if err != nil {
+		t.Fatalf("SearchChunksByAgent(B): %v", err)
+	}
+	if set := idSet(matchIDs(byB)); len(set) != 2 || !set[c3] || !set[cAB] {
+		t.Errorf("ByAgent(B) = %v, want {c3,cAB} (containment)", matchIDs(byB))
+	}
+
+	// World-context mode ignores participants: all four chunks come back.
+	world, err := st.SearchChunksByCampaign(ctx, campaignID, query, 10)
+	if err != nil {
+		t.Fatalf("SearchChunksByCampaign: %v", err)
+	}
+	if len(world) != 4 {
+		t.Errorf("world-context returned %d chunks, want all 4 regardless of participant", len(world))
+	}
+}
+
+// TestSearchChunks_ExcludesNullEmbeddingAndOtherCampaigns is AC3 + AC4 + the
+// cross-campaign leak guard: a NULL-embedding chunk that WOULD be a perfect
+// match is never returned by either mode, and a second campaign's identical
+// vector never leaks into a query scoped to the first campaign.
+func TestSearchChunks_ExcludesNullEmbeddingAndOtherCampaigns(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	agent := uuid.New()
+	query := vec768(1, 0)
+
+	// A real, embedded match in campaign 1.
+	real := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agent}, vec768(0.9, 0.1))
+	// A chunk whose vector WOULD be the perfect match, but embedding is left NULL.
+	nullMatch := seedSearchChunk(t, st, campaignID, vs.ID, []uuid.UUID{agent}, nil)
+
+	// A second campaign with an identical-to-query embedded chunk.
+	var campaign2 uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Other', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaign2); err != nil {
+		t.Fatalf("insert campaign2: %v", err)
+	}
+	vs2, err := st.CreateVoiceSession(ctx, campaign2)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession(campaign2): %v", err)
+	}
+	other := seedSearchChunk(t, st, campaign2, vs2.ID, []uuid.UUID{agent}, vec768(1, 0))
+
+	assertAbsent := func(name string, matches []storage.ChunkMatch) {
+		set := idSet(matchIDs(matches))
+		if set[nullMatch] {
+			t.Errorf("%s returned the NULL-embedding chunk %s", name, nullMatch)
+		}
+		if set[other] {
+			t.Errorf("%s leaked cross-campaign chunk %s", name, other)
+		}
+		if !set[real] {
+			t.Errorf("%s missing the real match %s", name, real)
+		}
+	}
+
+	byCampaign, err := st.SearchChunksByCampaign(ctx, campaignID, query, 10)
+	if err != nil {
+		t.Fatalf("SearchChunksByCampaign: %v", err)
+	}
+	assertAbsent("world-context", byCampaign)
+
+	byAgent, err := st.SearchChunksByAgent(ctx, campaignID, agent, query, 10)
+	if err != nil {
+		t.Fatalf("SearchChunksByAgent: %v", err)
+	}
+	assertAbsent("npc-knowledge", byAgent)
+}
+
+// TestSearchChunks_KMustBePositive is AC "capped to k": k<=0 is a caller bug and
+// errors rather than silently defaulting — also covered Docker-free in the unit
+// test, asserted here against a live Store for completeness.
+func TestSearchChunks_KMustBePositive(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	for _, k := range []int{0, -1} {
+		if _, err := st.SearchChunksByCampaign(ctx, campaignID, vec768(1), k); err == nil {
+			t.Errorf("SearchChunksByCampaign k=%d returned nil error", k)
+		}
+		if _, err := st.SearchChunksByAgent(ctx, campaignID, uuid.New(), vec768(1), k); err == nil {
+			t.Errorf("SearchChunksByAgent k=%d returned nil error", k)
+		}
+	}
+}

--- a/internal/storage/transcript_chunk_search_test.go
+++ b/internal/storage/transcript_chunk_search_test.go
@@ -83,6 +83,18 @@ func idSet(ids []uuid.UUID) map[uuid.UUID]bool {
 	return m
 }
 
+func sameOrder(got, want []uuid.UUID) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK is AC1 + AC5(cap): seeded
 // chunks with known embeddings come back ordered by cosine distance to the query
 // (nearest first, distance monotone nondecreasing), and k caps the result at the
@@ -99,18 +111,25 @@ func TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK(t *testing.T) {
 	}
 
 	query := vec768(1, 0)
-	nearest := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(1, 0))     // distance 0
-	near := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.9, 0.1))    // ~0.006
-	mid := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.5, 0.5))     // ~0.293
-	far := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0, 1))         // 1.0
+	// Small vectors at known angles PLUS one large-magnitude near-parallel vector:
+	// `big` = [90,9] shares a near-zero angle with the query (cosine ranks it 2nd,
+	// ~0.005) but its ~90 magnitude makes it the FARTHEST by L2 (~89.5). So the
+	// exact cosine order below differs from the L2 order — it fails if <=> (cosine)
+	// is ever swapped for <-> (L2), a mutant that every small-norm vector alone
+	// (similar magnitudes → L2 order == cosine order) could not catch.
+	nearest := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(1, 0))    // cos 0
+	big := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(90, 9))       // cos ~0.005, L2 ~89.5
+	near := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.9, 0.1))   // cos ~0.006
+	mid := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.5, 0.5))    // cos ~0.293
+	far := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0, 1))        // cos 1.0
 
-	got, err := st.SearchChunksByCampaign(ctx, campaignID, query, 4)
+	got, err := st.SearchChunksByCampaign(ctx, campaignID, query, 5)
 	if err != nil {
 		t.Fatalf("SearchChunksByCampaign: %v", err)
 	}
-	wantOrder := []uuid.UUID{nearest, near, mid, far}
-	if ids := matchIDs(got); len(ids) != 4 || ids[0] != wantOrder[0] || ids[1] != wantOrder[1] || ids[2] != wantOrder[2] || ids[3] != wantOrder[3] {
-		t.Fatalf("order = %v, want nearest-first %v", ids, wantOrder)
+	wantOrder := []uuid.UUID{nearest, big, near, mid, far}
+	if !sameOrder(matchIDs(got), wantOrder) {
+		t.Fatalf("order = %v, want cosine nearest-first %v (L2 would rank the big vector last)", matchIDs(got), wantOrder)
 	}
 	for i := 1; i < len(got); i++ {
 		if got[i].Distance < got[i-1].Distance {
@@ -120,21 +139,21 @@ func TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK(t *testing.T) {
 	if got[0].Distance > 1e-4 {
 		t.Errorf("nearest distance = %g, want ~0 (identical direction)", got[0].Distance)
 	}
-	if got[3].Distance < 0.99 {
-		t.Errorf("farthest distance = %g, want ~1 (orthogonal)", got[3].Distance)
+	if last := got[len(got)-1]; last.Distance < 0.99 {
+		t.Errorf("farthest distance = %g, want ~1 (orthogonal)", last.Distance)
 	}
 	// The returned chunk carries its scanned fields, not a zero value.
 	if got[0].Chunk.CampaignID != campaignID || got[0].Chunk.EmbeddingModel != "test-model" {
 		t.Errorf("nearest chunk fields not populated: %+v", got[0].Chunk)
 	}
 
-	// k caps at the k nearest: k=2 -> {nearest, near} only.
+	// k caps at the k nearest by cosine: k=2 -> {nearest, big} (big by angle, not L2).
 	capped, err := st.SearchChunksByCampaign(ctx, campaignID, query, 2)
 	if err != nil {
 		t.Fatalf("SearchChunksByCampaign (k=2): %v", err)
 	}
-	if ids := matchIDs(capped); len(ids) != 2 || ids[0] != nearest || ids[1] != near {
-		t.Fatalf("k=2 result = %v, want [%s %s] (the 2 nearest)", ids, nearest, near)
+	if ids := matchIDs(capped); len(ids) != 2 || ids[0] != nearest || ids[1] != big {
+		t.Fatalf("k=2 result = %v, want [%s %s] (the 2 nearest by cosine)", ids, nearest, big)
 	}
 }
 

--- a/internal/storage/transcript_chunk_search_unit_test.go
+++ b/internal/storage/transcript_chunk_search_unit_test.go
@@ -1,0 +1,29 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestSearchChunks_KMustBePositiveNoDB pins the caller-bug guard (#119): k<=0
+// errors before any DB access, so it is asserted here Docker-free against a
+// nil-pool Store — the check must reject the bad k without touching s.db.
+func TestSearchChunks_KMustBePositiveNoDB(t *testing.T) {
+	st := storage.New(nil)
+	ctx := context.Background()
+	campaignID, agentID := uuid.New(), uuid.New()
+	query := []float32{1, 0}
+
+	for _, k := range []int{0, -1} {
+		if _, err := st.SearchChunksByCampaign(ctx, campaignID, query, k); err == nil {
+			t.Errorf("SearchChunksByCampaign k=%d returned nil error", k)
+		}
+		if _, err := st.SearchChunksByAgent(ctx, campaignID, agentID, query, k); err == nil {
+			t.Errorf("SearchChunksByAgent k=%d returned nil error", k)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds the ANN retrieval half of the Transcript Chunk store (ADR-0011): two `Store` methods that return the k cosine-nearest chunks in a Campaign, over the partial HNSW `vector_cosine_ops` index.

- `SearchChunksByAgent` — NPC-knowledge mode: only chunks whose `participated_agent_ids` **contains** the Agent ("what this NPC could personally know"). Containment, not equality, so a multi-agent chunk surfaces for every one of its participants.
- `SearchChunksByCampaign` — world-context mode: Campaign-wide, participants ignored ("topical context the NPC may not personally know").

Both scope to one Campaign, exclude `NULL`-embedding rows (matching the partial index), order by `<=>` ascending (nearest first), and cap at `k`. `k <= 0` is a caller bug and errors rather than silently defaulting. `ChunkMatch` carries the cosine distance. The query vector reuses `encodeVector` + a server-side `::vector` cast, so storage keeps no pgvector-go dependency. Two named methods, no mode enum — the consumer (#122) will define its own narrow interface.

Closes #119

## Why is this change needed?

NPC Hot Context assembly needs similarity retrieval with the two hard filters ADR-0011 specifies (participated set vs campaign-wide). This is the storage primitive #122 (speculative recall, ADR-0042) consumes.

## How was this tested?

TDD, red→green. `internal/storage` only; no new deps.

- **Integration (pgvector, `-tags=integration`):** hand-placed vectors at known cosine angles (e0, `[0.9,0.1]`, `[0.5,0.5]`, e1) verify nearest-first ordering + monotone distance and the `k` cap; participation-containment (multi-agent chunk returned for both agents); `NULL`-embedding chunk that would be a perfect match is never returned by either mode; a second Campaign's identical vector never leaks into a scoped query.
- **Unit (Docker-free, default `test` gate):** `k<=0` guard against a nil-pool `Store` — rejects before any DB access.
- Full `internal/storage` integration suite green (`ok … 238s`); default `go test ./...` green; `golangci-lint` 0 issues.

- [x] `make check` passes (build, vet, `go test ./...`, lint, storage integration)
- [x] New/updated tests cover the change
- [ ] Manual testing (n/a — storage-layer methods, exercised by integration tests)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Appended to `internal/storage/transcript_chunk.go` (file well under the ~300-line sibling-split threshold), with a shared private `searchChunks` builder behind the two public methods. No migration — the schema (`vector(768)`, partial HNSW cosine index, `participated_agent_ids`) already exists from #104/#116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)