### PR TITLE
feat(#180): streaming transcription pipeline — per-session stream manager, STTPartial, batch fallback

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -81,6 +81,19 @@ func devMode(getenv func(string) string) bool {
 	return true
 }
 
+// sttStreaming reports whether the GLYPHOXA_STT_STREAMING opt-in enables the
+// streaming-STT transport (ADR-0042, issue #180). Same truthy parse as [devMode]:
+// blank or an explicit falsy spelling ("0"/"false"/"no"/"off", any case) is OFF;
+// anything else is ON. Default OFF keeps the batch STT path byte-for-byte, so the
+// streaming path ships dark until an operator opts in.
+func sttStreaming(getenv func(string) string) bool {
+	switch strings.ToLower(strings.TrimSpace(getenv("GLYPHOXA_STT_STREAMING"))) {
+	case "", "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
 // forceLoopback rewrites a listen address to bind 127.0.0.1, preserving the port
 // (":8080" → "127.0.0.1:8080", "0.0.0.0:9000" → "127.0.0.1:9000"). GLYPHOXA_DEV_MODE
 // pins the host to loopback so a mis-set flag in production is blunted: a

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -175,6 +175,31 @@ func TestDevMode(t *testing.T) {
 	}
 }
 
+// TestSTTStreaming: the streaming-STT opt-in (ADR-0042, issue #180) is on only
+// when GLYPHOXA_STT_STREAMING holds a non-blank, non-falsy value, so the batch
+// path stays the byte-for-byte default until an operator explicitly opts in.
+func TestSTTStreaming(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"   ", false},
+		{"0", false},
+		{"false", false},
+		{"OFF", false},
+		{" no ", false},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+	}
+	for _, c := range cases {
+		if got := sttStreaming(envMap(map[string]string{"GLYPHOXA_STT_STREAMING": c.val})); got != c.want {
+			t.Errorf("sttStreaming(%q) = %v, want %v", c.val, got, c.want)
+		}
+	}
+}
+
 // TestForceLoopback pins the listen host to 127.0.0.1 while preserving the port,
 // so a GLYPHOXA_DEV_MODE instance is structurally unreachable from a container
 // port-mapping (ADR-0041) regardless of the configured -web-addr.

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -74,6 +74,9 @@ func main() {
 	var cfg wirenpc.Config
 	flag.StringVar(&cfg.Guild, "guild", "", "Discord guild (server) snowflake ID")
 	flag.StringVar(&cfg.Channel, "channel", "", "Discord voice channel snowflake ID")
+	// Streaming STT (ADR-0042, issue #180) is an env opt-in shared by voice and
+	// all mode; default OFF keeps the batch STT path byte-for-byte.
+	cfg.STTStreaming = sttStreaming(os.Getenv)
 	hardcoded := flag.Bool("hardcoded", false, "use the in-code NPC instead of loading from the database — no Postgres needed, for smoke-testing audio without a seeded DB")
 	metricsAddr := flag.String("metrics-addr", ":9090", "address for the /metrics + /healthz + /readyz listener (all Modes; kept off the public web API port, ADR-0032); empty disables it")
 	webAddr := flag.String("web-addr", ":8080", "address for the web/all-mode Connect RPC API listener (ADR-0039); observability is on -metrics-addr")

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -164,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{})
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{})
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{})
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{})
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys)
+		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys, false)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/sttstream_test.go
+++ b/internal/wirenpc/sttstream_test.go
@@ -1,0 +1,40 @@
+package wirenpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+)
+
+// batchOnlyRecognizer implements only the batch [stt.Recognizer] — no streaming.
+type batchOnlyRecognizer struct{}
+
+func (batchOnlyRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcript, error) {
+	return stt.Transcript{}, nil
+}
+
+// streamingRecognizer implements both the batch and streaming interfaces, like the
+// real ElevenLabs Client (ADR-0042).
+type streamingRecognizer struct{ batchOnlyRecognizer }
+
+func (streamingRecognizer) OpenStream(context.Context, stt.StreamConfig) (stt.Stream, error) {
+	return nil, nil
+}
+
+// TestBuildStreamManager_Gating pins the selection seam (issue #180, C6): a manager
+// is wired only when streaming is enabled AND the recognizer supports streaming;
+// otherwise the byte-for-byte batch path (nil manager) is kept.
+func TestBuildStreamManager_Gating(t *testing.T) {
+	if got := buildStreamManager(streamingRecognizer{}, true, observe.Discard{}); got == nil {
+		t.Error("streaming enabled + a streaming recognizer must wire a manager")
+	}
+	if got := buildStreamManager(streamingRecognizer{}, false, observe.Discard{}); got != nil {
+		t.Error("streaming disabled must not wire a manager, even for a streaming recognizer")
+	}
+	if got := buildStreamManager(batchOnlyRecognizer{}, true, observe.Discard{}); got != nil {
+		t.Error("a batch-only recognizer must not wire a manager, even with streaming enabled")
+	}
+}

--- a/internal/wirenpc/sttstream_test.go
+++ b/internal/wirenpc/sttstream_test.go
@@ -1,7 +1,10 @@
 package wirenpc
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
@@ -24,17 +27,41 @@ func (streamingRecognizer) OpenStream(context.Context, stt.StreamConfig) (stt.St
 	return nil, nil
 }
 
+func discardLog() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
 // TestBuildStreamManager_Gating pins the selection seam (issue #180, C6): a manager
 // is wired only when streaming is enabled AND the recognizer supports streaming;
 // otherwise the byte-for-byte batch path (nil manager) is kept.
 func TestBuildStreamManager_Gating(t *testing.T) {
-	if got := buildStreamManager(streamingRecognizer{}, true, observe.Discard{}); got == nil {
+	if got := buildStreamManager(streamingRecognizer{}, true, observe.Discard{}, discardLog()); got == nil {
 		t.Error("streaming enabled + a streaming recognizer must wire a manager")
 	}
-	if got := buildStreamManager(streamingRecognizer{}, false, observe.Discard{}); got != nil {
+	if got := buildStreamManager(streamingRecognizer{}, false, observe.Discard{}, discardLog()); got != nil {
 		t.Error("streaming disabled must not wire a manager, even for a streaming recognizer")
 	}
-	if got := buildStreamManager(batchOnlyRecognizer{}, true, observe.Discard{}); got != nil {
+	if got := buildStreamManager(batchOnlyRecognizer{}, true, observe.Discard{}, discardLog()); got != nil {
 		t.Error("a batch-only recognizer must not wire a manager, even with streaming enabled")
+	}
+}
+
+// TestBuildStreamManager_WarnsOnUnsupported pins that opting into streaming with a
+// batch-only provider logs a warning (not a silent fall-through), so the operator
+// learns why the batch path is in effect.
+func TestBuildStreamManager_WarnsOnUnsupported(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	if got := buildStreamManager(batchOnlyRecognizer{}, true, observe.Discard{}, log); got != nil {
+		t.Fatal("batch-only recognizer must not wire a manager")
+	}
+	if !strings.Contains(buf.String(), "does not support it") {
+		t.Errorf("expected a warning about the unsupported provider, got log: %q", buf.String())
+	}
+
+	// The supported path must stay quiet — no spurious warning.
+	buf.Reset()
+	buildStreamManager(streamingRecognizer{}, true, observe.Discard{}, log)
+	if buf.Len() != 0 {
+		t.Errorf("a supported streaming recognizer must not warn, got log: %q", buf.String())
 	}
 }

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -34,6 +34,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agenttool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
 	stteleven "github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
@@ -261,6 +262,12 @@ type Config struct {
 	// nothing. The live binary injects the Prometheus adapter; the benchmark
 	// injects its own; the keyless default is the no-op recorder.
 	StageMetrics observe.StageRecorder
+	// STTStreaming opts the voice loop into the streaming-STT transport (ADR-0042,
+	// issue #180): when the wired STT recognizer supports it, utterances stream over
+	// a persistent websocket and finalize on a local-VAD manual commit, with the
+	// batch adapter as automatic fallback. Default OFF reproduces today's batch path
+	// byte-for-byte. Parsed from GLYPHOXA_STT_STREAMING in cmd/glyphoxa.
+	STTStreaming bool
 	// Bus, when non-nil, is the process-wide voiceevent.Bus the orchestrator
 	// publishes onto INSTEAD of a fresh per-cycle bus (issue #73, ADR-0014).
 	// The web tier injects ONE bus so the SSE transcript relay can subscribe
@@ -530,7 +537,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -652,7 +659,7 @@ var (
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -686,9 +693,14 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	}
 	vadStage := orchestrator.NewVAD(bus, vadSession)
 
-	sttStage := orchestrator.NewSTT(bus, newSTT(keys.stt),
+	// One recognizer instance backs both the batch stage and — when streaming is
+	// enabled and the adapter supports it — the stream manager (the ElevenLabs
+	// Client is both a batch stt.Recognizer and a stt.StreamingRecognizer, ADR-0042).
+	var recognizer stt.Recognizer = newSTT(keys.stt)
+	sttStage := orchestrator.NewSTT(bus, recognizer,
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
+	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics)
 
 	// The `dice` grant stays in code: Tool Grants are a #6 table, not yet
 	// seeded. With no grants the tool engine degrades to a single completion
@@ -737,6 +749,10 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 		// self-cancel the latency investigation found. With B1 a confirmed barge
 		// cancels mid-generation, not just pending dispatch.
 		orchestrator.WithBargeInCoalesce(bargeConfirmWindow, floorCoalesceWindow),
+		// Streaming STT (ADR-0042, issue #180): a nil manager is byte-for-byte the
+		// batch path, so this option is unconditional — buildStreamManager returns nil
+		// unless GLYPHOXA_STT_STREAMING is set AND the adapter is a StreamingRecognizer.
+		orchestrator.WithStreamingSTT(streamMgr),
 		// Handles failures the reactors fire off the audio loop: the replier's TTS
 		// dispatch and the segmenter's off-loop STT call (#24). The wrapped error
 		// names its stage (orchestrator.TTS.Dispatch / orchestrator.STT.Transcribe).
@@ -745,4 +761,22 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 		}),
 	)
 	return conv, roster, cleanup, nil
+}
+
+// buildStreamManager returns the streaming-STT manager when streaming is enabled
+// AND the wired recognizer implements [stt.StreamingRecognizer], else nil (the
+// byte-for-byte batch default). It is the selection seam (ADR-0042, issue #180):
+// keeping it a small pure function lets the gating be unit-tested without standing
+// up the whole Silero/ONNX pipeline. The provider label is elevenlabs (the only
+// streaming STT adapter in the MVP matrix, ADR-0039).
+func buildStreamManager(recognizer stt.Recognizer, streaming bool, stageMetrics observe.StageRecorder) *orchestrator.StreamManager {
+	if !streaming {
+		return nil
+	}
+	sr, ok := recognizer.(stt.StreamingRecognizer)
+	if !ok {
+		return nil
+	}
+	return orchestrator.NewStreamManager(sr,
+		orchestrator.WithStreamMetrics(stageMetrics, observe.ProviderElevenLabs))
 }

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -700,7 +700,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	sttStage := orchestrator.NewSTT(bus, recognizer,
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
 	ttsStage := orchestrator.NewTTS(bus, synth)
-	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics)
+	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics, log)
 
 	// The `dice` grant stays in code: Tool Grants are a #6 table, not yet
 	// seeded. With no grants the tool engine degrades to a single completion
@@ -769,12 +769,17 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 // keeping it a small pure function lets the gating be unit-tested without standing
 // up the whole Silero/ONNX pipeline. The provider label is elevenlabs (the only
 // streaming STT adapter in the MVP matrix, ADR-0039).
-func buildStreamManager(recognizer stt.Recognizer, streaming bool, stageMetrics observe.StageRecorder) *orchestrator.StreamManager {
+func buildStreamManager(recognizer stt.Recognizer, streaming bool, stageMetrics observe.StageRecorder, log *slog.Logger) *orchestrator.StreamManager {
 	if !streaming {
 		return nil
 	}
 	sr, ok := recognizer.(stt.StreamingRecognizer)
 	if !ok {
+		// Opting in but the wired provider can't stream is a misconfiguration worth
+		// surfacing — otherwise the operator sees the batch path with no hint why.
+		if log != nil {
+			log.Warn("STT streaming requested but provider does not support it; using batch")
+		}
 		return nil
 	}
 	return orchestrator.NewStreamManager(sr,

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -104,6 +104,15 @@ func WithBargeInCoalesce(confirmWindow, coalesceWindow time.Duration) Option {
 	}
 }
 
+// WithStreamingSTT wires a streaming-STT transport (ADR-0042) into the segmenter:
+// each utterance is mirrored onto the persistent websocket (pre-roll + voiced
+// frames) and finalized by a manual commit at the local VAD speech-end, with the
+// batch recognizer as the automatic fallback. A nil sm is ZERO behaviour change —
+// the byte-for-byte no-streaming default — so callers can wire it unconditionally.
+func WithStreamingSTT(sm *StreamManager) Option {
+	return func(c *Conversation) { c.seg.stream = sm }
+}
+
 // WithErrorHandler sets the [ErrorFunc] used to report failures from stage calls
 // the reactors fire inside bus callbacks (currently the replier's TTS dispatch).
 // Without it such failures are dropped silently.

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -19,3 +19,21 @@ func (r *Replier) SetFloor(floor *Floor) { r.floor = floor }
 // tests (external test package). Production wiring sets it inside
 // Conversation.Register from [WithErrorHandler].
 func (s *Segmenter) SetErrorHandler(fn ErrorFunc) { s.onError = fn }
+
+// WaitStreamUp blocks until the manager has a live session or timeout elapses,
+// reporting whether one came up. Test-only: pipeline tests feed the first
+// utterance only after the eager dial completes, so utterance 1 streams
+// deterministically instead of racing the maintainer.
+func (m *StreamManager) WaitStreamUp(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		up := m.stream != nil
+		m.mu.Unlock()
+		if up {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -87,6 +88,17 @@ type Segmenter struct {
 	inflight sync.WaitGroup
 	worker   sync.WaitGroup
 
+	// stream is the optional streaming-STT transport (ADR-0042, [WithStreamingSTT]).
+	// When non-nil the segmenter mirrors each utterance onto it — pre-roll while
+	// idle, voiced frames while listening, a manual commit at speech-end — and the
+	// worker prefers the committed text, falling back to the batch recognizer on any
+	// failure. Nil is the byte-for-byte no-streaming default: none of the stream
+	// hooks fire and the batch path is untouched.
+	stream *StreamManager
+	// streamCancel stops the stream manager's maintainer; set at Bind (when stream
+	// is non-nil), called from the returned teardown.
+	streamCancel func()
+
 	mu sync.Mutex
 	// speechEndAt is the [voiceevent.VADSpeechEnd.At] of the most recent
 	// speech-end transition, captured so the flushed utterance's STTFinal can
@@ -94,6 +106,13 @@ type Segmenter struct {
 	// turn's true speech-end without the metrics subscriber guessing. Zero until
 	// the first speech-end, and for a Flush with no preceding transition.
 	speechEndAt time.Time
+	// curUtteranceID and pendCommit/pendCommitSentAt carry the current utterance's
+	// streaming state from the VAD callbacks to the flush that enqueues its job. The
+	// id is minted at speech_start (beginUtterance); the commit handle is captured at
+	// speech_end (endUtterance) and consumed by the flush. All guarded by mu.
+	curUtteranceID   string
+	pendCommit       <-chan stt.CommitResult
+	pendCommitSentAt time.Time
 	// ctx is the context handed to STT.Transcribe when a segment flushes. It is
 	// the conversation's lifetime context, captured at Bind and cleared by the
 	// returned cancel; storing it lets Process stay frame-only (ctx-free) so the
@@ -107,10 +126,19 @@ type Segmenter struct {
 // segment frames plus the per-segment state STT needs (the lifetime ctx and the
 // turn's speech-end time), snapshotted at enqueue so the worker never reads
 // mutable Segmenter state.
+//
+// On the streaming path (ADR-0042) it additionally carries the utterance's manual
+// commit handle (nil = pure batch), the moment that commit was sent (for the
+// stt_request span), and the utterance id (stamped on the STTFinal so it joins its
+// partials). The worker prefers the committed text and falls back to the batch
+// recognizer — with these SAME locally-buffered seg frames — on any commit failure.
 type transcribeJob struct {
-	ctx         context.Context
-	seg         []audio.Frame
-	speechEndAt time.Time
+	ctx          context.Context
+	seg          []audio.Frame
+	speechEndAt  time.Time
+	commit       <-chan stt.CommitResult
+	commitSentAt time.Time
+	utteranceID  string
 }
 
 // transcribeQueueDepth is the buffer on the worker's job channel. A flush enqueues
@@ -148,20 +176,34 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 	s.jobs = jobs
 	s.mu.Unlock()
 
+	// Start the streaming transport's maintainer (eager dial) so utterance 1 can
+	// stream; nil stream = no-op (byte-for-byte batch path).
+	if s.stream != nil {
+		s.streamCancel = s.stream.bind(ctx, bus)
+	}
+
 	// One serial worker drains the queue, so transcriptions stay in speech order.
 	s.worker.Go(func() {
 		for job := range jobs {
-			if err := s.transcribe(job.ctx, job.seg, job.speechEndAt); err != nil && s.onError != nil {
+			if err := s.transcribe(job); err != nil && s.onError != nil {
 				s.onError(err)
 			}
 			s.inflight.Done()
 		}
 	})
 
-	unsubStart := voiceevent.On(bus, func(voiceevent.VADSpeechStart) {
+	unsubStart := voiceevent.On(bus, func(start voiceevent.VADSpeechStart) {
 		s.mu.Lock()
 		s.listening = true
 		s.mu.Unlock()
+		// Mint this utterance's id and, if the stream is up, flush the pre-roll ring —
+		// voiced frames then follow from Process (see [Segmenter.Process]).
+		if s.stream != nil {
+			id := s.stream.beginUtterance(start.At)
+			s.mu.Lock()
+			s.curUtteranceID = id
+			s.mu.Unlock()
+		}
 	})
 	unsubEnd := voiceevent.On(bus, func(end voiceevent.VADSpeechEnd) {
 		s.mu.Lock()
@@ -170,10 +212,28 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 		// can carry it (A3); the next Process call after speech ends flushes.
 		s.speechEndAt = end.At
 		s.mu.Unlock()
+		// Local VAD is the sole endpointing authority (ADR-0042): the manual commit
+		// fires HERE, at the VAD speech-end, never provider-side. The handle is stashed
+		// for the imminent flush to attach to the job.
+		if s.stream != nil {
+			commit, sentAt, ok := s.stream.endUtterance()
+			s.mu.Lock()
+			if ok {
+				s.pendCommit = commit
+				s.pendCommitSentAt = sentAt
+			} else {
+				s.pendCommit = nil
+			}
+			s.mu.Unlock()
+		}
 	})
 	return func() {
 		unsubStart()
 		unsubEnd()
+		if s.streamCancel != nil {
+			s.streamCancel()
+			s.streamCancel = nil
+		}
 		s.mu.Lock()
 		s.ctx = nil
 		s.jobs = nil
@@ -208,15 +268,29 @@ func (s *Segmenter) Process(frame audio.Frame) error {
 	if s.listening {
 		s.buf = append(s.buf, frame)
 		s.mu.Unlock()
+		// Mirror the voiced frame onto the stream (additive; the local buffer above
+		// stays authoritative for the batch fallback). No-op when no stream is wired.
+		if s.stream != nil {
+			s.stream.send(frame)
+		}
 		return nil
 	}
 	seg := s.buf
 	s.buf = nil
 	ctx := s.ctx
 	speechEndAt := s.speechEndAt
+	commit := s.pendCommit
+	commitSentAt := s.pendCommitSentAt
+	utteranceID := s.curUtteranceID
+	s.pendCommit = nil
 	s.mu.Unlock()
 
-	s.dispatchTranscription(ctx, seg, speechEndAt)
+	// A non-listening frame is pre-speech silence: fill the pre-roll ring (never
+	// streamed until the next utterance begins, so silence is not billed).
+	if s.stream != nil {
+		s.stream.idleFrame(frame)
+	}
+	s.dispatchTranscription(ctx, seg, speechEndAt, commit, commitSentAt, utteranceID)
 	return nil
 }
 
@@ -229,9 +303,17 @@ func (s *Segmenter) Process(frame audio.Frame) error {
 // only if the queue is full (see [transcribeQueueDepth]). A recognizer error is
 // reported by the worker through onError — the side channel that replaces the
 // inline call's return value.
-func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame, speechEndAt time.Time) {
+func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame, speechEndAt time.Time, commit <-chan stt.CommitResult, commitSentAt time.Time, utteranceID string) {
 	if len(seg) == 0 {
 		return
+	}
+	job := transcribeJob{
+		ctx:          ctx,
+		seg:          seg,
+		speechEndAt:  speechEndAt,
+		commit:       commit,
+		commitSentAt: commitSentAt,
+		utteranceID:  utteranceID,
 	}
 	s.mu.Lock()
 	jobs := s.jobs
@@ -239,13 +321,13 @@ func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame
 	if jobs == nil {
 		// Not bound (or already torn down): transcribe inline so a late flush still
 		// completes rather than dropping the utterance.
-		if err := s.transcribe(ctx, seg, speechEndAt); err != nil && s.onError != nil {
+		if err := s.transcribe(job); err != nil && s.onError != nil {
 			s.onError(err)
 		}
 		return
 	}
 	s.inflight.Add(1)
-	jobs <- transcribeJob{ctx: ctx, seg: seg, speechEndAt: speechEndAt}
+	jobs <- job
 }
 
 // Flush transcribes any buffered utterance audio immediately, regardless of
@@ -268,31 +350,66 @@ func (s *Segmenter) Flush() error {
 	s.mu.Lock()
 	seg := s.buf
 	s.buf = nil
+	wasListening := s.listening
 	s.listening = false
 	ctx := s.ctx
-	// A Flush has no speech-end transition (end-of-stream), so it carries the
-	// zero time — the STTFinal's SpeechEndAt is unset for a flushed final turn.
+	commit := s.pendCommit
+	commitSentAt := s.pendCommitSentAt
+	utteranceID := s.curUtteranceID
+	s.pendCommit = nil
 	s.mu.Unlock()
 
-	s.dispatchTranscription(ctx, seg, time.Time{})
+	// If the stream ended while speech was still active there was no VAD speech-end,
+	// so the open utterance never got its manual commit — request it now (ADR-0042),
+	// or fall to batch if the stream is down. A speech-end already emitted a handle
+	// captured above, so this only fires for a truly mid-utterance end-of-stream.
+	if wasListening && s.stream != nil {
+		if c, sentAt, ok := s.stream.endUtterance(); ok {
+			commit = c
+			commitSentAt = sentAt
+		}
+	}
+
+	// A Flush has no speech-end transition (end-of-stream), so it carries the
+	// zero time — the STTFinal's SpeechEndAt is unset for a flushed final turn.
+	s.dispatchTranscription(ctx, seg, time.Time{}, commit, commitSentAt, utteranceID)
 	s.inflight.Wait()
 	return nil
 }
 
-// transcribe hands a flushed segment to STT under ctx, carrying the turn's
-// speech-end time so STT can stamp it on the published STTFinal (A3). An empty
-// segment is a no-op (a speech-end with nothing buffered, or a redundant Flush).
-// A nil ctx — the segmenter was never bound, or was already torn down — falls
-// back to a background context so a late flush still completes rather than
-// panicking.
-func (s *Segmenter) transcribe(ctx context.Context, seg []audio.Frame, speechEndAt time.Time) error {
-	if len(seg) == 0 {
+// transcribe produces one utterance's authoritative STTFinal, carrying the turn's
+// speech-end time and (on the streaming path) utterance id via ctx so STT stamps
+// them on the published event (A3, ADR-0042). An empty segment is a no-op (a
+// speech-end with nothing buffered, or a redundant Flush). A nil ctx — the
+// segmenter was never bound, or was already torn down — falls back to a background
+// context so a late flush still completes rather than panicking.
+//
+// When the utterance streamed (job.commit != nil), it waits for the manual commit
+// and publishes the committed text directly, skipping the batch POST. On ANY commit
+// error or timeout it falls back to the batch recognizer with these SAME
+// locally-buffered frames — streaming is additive, never authoritative — so no
+// utterance is lost when the stream degrades.
+func (s *Segmenter) transcribe(job transcribeJob) error {
+	if len(job.seg) == 0 {
 		return nil
 	}
+	ctx := job.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return s.stt.Transcribe(withSpeechEndAt(ctx, speechEndAt), seg)
+	ctx = withSpeechEndAt(ctx, job.speechEndAt)
+	ctx = withUtteranceID(ctx, job.utteranceID)
+
+	if job.commit != nil && s.stream != nil {
+		if t, ok := s.stream.awaitCommit(job.commit, job.commitSentAt); ok {
+			// Committed text is authoritative: publish it as this utterance's STTFinal
+			// with the SAME TurnID minting the batch path uses.
+			s.stt.PublishFinal(ctx, t)
+			return nil
+		}
+		// Commit errored or timed out: degrade to the batch adapter below.
+	}
+	return s.stt.Transcribe(ctx, job.seg)
 }
 
 // Reply is one thing an addressed Agent should say: a single sentence and the

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -125,16 +125,29 @@ func (s *STT) Transcribe(ctx context.Context, frames []audio.Frame) error {
 	if err != nil {
 		return fmt.Errorf("orchestrator.STT.Transcribe: %w", err)
 	}
-	// A turn is born here (A3): mint its correlation id and carry forward the
-	// segment's speech-end time (from the Segmenter via ctx) so the headline
-	// response-latency span is anchored at the true end-of-speech.
+	s.PublishFinal(ctx, t)
+	return nil
+}
+
+// PublishFinal fans an authoritative [stt.Transcript] out as a
+// [voiceevent.STTFinal]. A turn is born here (A3): its TurnID is minted fresh,
+// and the per-segment correlation the ctx carries — the [Segmenter]'s speech-end
+// time (so the headline response-latency span is anchored at true end-of-speech)
+// and, on the streaming path, the utterance id (ADR-0042, joining this final to
+// its partials) — is stamped on the event.
+//
+// It is the shared publish tail of both transcription paths: the batch
+// [STT.Transcribe] above, and the [StreamManager] commit path, which resolves a
+// streamed commit and publishes the committed text directly (skipping the batch
+// POST) while keeping TurnID/SpeechEndAt minted exactly as today.
+func (s *STT) PublishFinal(ctx context.Context, t stt.Transcript) {
 	s.bus.Publish(voiceevent.STTFinal{
 		At:          time.Now(),
 		Text:        t.Text,
 		TurnID:      voiceevent.NewTurnID(),
 		SpeechEndAt: speechEndAtFrom(ctx),
+		UtteranceID: utteranceIDFrom(ctx),
 	})
-	return nil
 }
 
 // speechEndAtKey carries the segment's [voiceevent.VADSpeechEnd.At] from the
@@ -155,4 +168,26 @@ func withSpeechEndAt(ctx context.Context, at time.Time) context.Context {
 func speechEndAtFrom(ctx context.Context) time.Time {
 	at, _ := ctx.Value(speechEndAtKey{}).(time.Time)
 	return at
+}
+
+// utteranceIDKey carries the streaming utterance id (ADR-0042) from the
+// [Segmenter] to [STT.PublishFinal] without widening the publish signature —
+// pattern-copied from [speechEndAtKey]. Unexported and orchestrator-internal.
+type utteranceIDKey struct{}
+
+// withUtteranceID returns ctx carrying the utterance's correlation id; an empty
+// id (the batch path, which has no stream and no partials) leaves ctx unchanged,
+// so [utteranceIDFrom] yields "" and STTFinal.UtteranceID stays empty.
+func withUtteranceID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, utteranceIDKey{}, id)
+}
+
+// utteranceIDFrom recovers the streaming utterance id, or "" when the segment was
+// transcribed without one (the batch path, or a direct Transcribe call).
+func utteranceIDFrom(ctx context.Context) string {
+	id, _ := ctx.Value(utteranceIDKey{}).(string)
+	return id
 }

--- a/pkg/voice/orchestrator/sttstream.go
+++ b/pkg/voice/orchestrator/sttstream.go
@@ -216,7 +216,14 @@ func (m *StreamManager) maintain(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			continue // transport dial failure: back off and retry
+			// An auth-class dial rejection (401/403 → auth_error) is durable: jump the
+			// backoff to the cap so a revoked key is not hammered with fast redials.
+			if authClassCodes[serr.Code] {
+				m.mu.Lock()
+				m.backoff = m.backoffMax
+				m.mu.Unlock()
+			}
+			continue // dial failure: back off and retry
 		}
 		if ctx.Err() != nil {
 			return
@@ -385,6 +392,10 @@ func (m *StreamManager) awaitCommit(ch <-chan stt.CommitResult, sentAt time.Time
 		m.resetBackoff()
 		return res.Transcript, true
 	case <-timer.C:
+		// Record the span on timeout too: a stalled provider is exactly what this
+		// series exists to surface, and the batch adapter records its call on failure
+		// as well (batch parity).
+		m.metrics.STTRequest(m.provider, m.now().Sub(sentAt))
 		return stt.Transcript{}, false
 	}
 }

--- a/pkg/voice/orchestrator/sttstream.go
+++ b/pkg/voice/orchestrator/sttstream.go
@@ -1,0 +1,456 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// StreamManager is the streaming-STT transport that replaces the serial batch
+// POST worker with a persistent per-Voice-Session websocket (ADR-0042). It owns
+// one [stt.StreamingRecognizer] session at a time, opened eagerly at [bind] and
+// re-established with bounded backoff when it drops. The local VAD stays the sole
+// endpointing authority: the [Segmenter] drives the manager's per-utterance
+// lifecycle (idle pre-roll → begin → voiced sends → end/commit), so the manual
+// commit fires only from a VAD speech_end (or Flush), never provider-side.
+//
+// It is additive, never authoritative: the Segmenter keeps buffering the same
+// locally-segmented frames, so a stream that is down, dies mid-utterance, or
+// commits too slowly degrades to the batch adapter WITHOUT losing the utterance's
+// transcription. Streamed [voiceevent.STTPartial]s are a live-view signal only;
+// exactly one [voiceevent.STTFinal] per utterance reaches Address Detection and
+// the Transcript, from the commit on the happy path or the batch fallback.
+//
+// A nil StreamManager wired into a [Conversation] ([WithStreamingSTT]) is zero
+// behaviour change — the byte-for-byte no-streaming default.
+type StreamManager struct {
+	rec stt.StreamingRecognizer
+
+	backoffInitial time.Duration
+	backoffMax     time.Duration
+	commitTimeout  time.Duration
+	preRoll        int
+
+	metrics  observe.StageRecorder
+	provider observe.Provider
+
+	// sleep/now are the deterministic-test seams, copied from wirenpc.reconnectPolicy:
+	// sleep blocks for d or until ctx is cancelled; now stamps the commit-latency
+	// span and partial timestamps. Production uses real time.
+	sleep func(ctx context.Context, d time.Duration) error
+	now   func() time.Time
+
+	// poke nudges the maintainer to (re)establish the stream after a death. Buffered
+	// depth 1: a coalesced nudge is enough because the maintainer re-reads state.
+	poke chan struct{}
+
+	mu  sync.Mutex
+	bus *voiceevent.Bus // captured at bind; where STTPartial is published
+	// stream is the current live session, nil while down (the maintainer is dialing).
+	stream stt.Stream
+	// backoff is the current re-establish delay; grows on dial failure, jumps to the
+	// cap on an auth-class death, resets to the initial on the first successful commit.
+	backoff time.Duration
+	// per-utterance streaming state, all set from the audio-loop goroutine:
+	curUtterID  string // minted at beginUtterance; stamped on this utterance's partials
+	utterOpen   bool   // between beginUtterance and endUtterance — partials publish only then
+	utterDead   bool   // stream was down at begin, or a send failed → this utterance is batch
+	lastPartial string // last published partial text, for consecutive-duplicate dedupe
+
+	// ring is the pre-roll buffer of the most recent idle (pre-speech) frames,
+	// streamed as context at beginUtterance. Audio-loop-only (idleFrame/beginUtterance
+	// run on the same goroutine), so it needs no lock. Wire-only: it is never added to
+	// the Segmenter's fallback segment, so batch cassette hashes stay stable.
+	ring []audio.Frame
+}
+
+// streamSampleRate is the PCM rate every streamed session declares. It matches the
+// VAD/STT frame geometry (wirenpc.vadSampleRate) and the only rate the ElevenLabs
+// realtime adapter accepts; frames the Segmenter sends carry this rate.
+const streamSampleRate = 16000
+
+// authClassCodes are the provider fatal codes that reflect a durable
+// configuration/quota problem rather than a transient blip (ADR-0042). Observing
+// one jumps the re-establish backoff straight to the cap so the manager does not
+// hammer a session that will keep being rejected.
+var authClassCodes = map[string]bool{
+	"auth_error":       true,
+	"unaccepted_terms": true,
+	"quota_exceeded":   true,
+}
+
+// StreamManagerOption configures a [StreamManager] at construction.
+type StreamManagerOption func(*StreamManager)
+
+// WithStreamBackoff overrides the re-establish backoff schedule (default 1s,
+// doubling to a 30s cap, no jitter — one session to one provider has no
+// thundering herd to spread).
+func WithStreamBackoff(initial, max time.Duration) StreamManagerOption {
+	return func(m *StreamManager) {
+		m.backoffInitial = initial
+		m.backoffMax = max
+	}
+}
+
+// WithCommitTimeout bounds how long a streamed commit may take to resolve before
+// the manager falls back to the batch adapter for that utterance (default 3s). It
+// guards a rate_limited-stalled pending commit from wedging the transcription
+// worker — the streaming analogue of the batch [WithSTTTimeout].
+func WithCommitTimeout(d time.Duration) StreamManagerOption {
+	return func(m *StreamManager) { m.commitTimeout = d }
+}
+
+// WithPreRoll overrides the number of pre-speech idle frames streamed as context
+// at the start of an utterance (default 10 frames ≈ 320 ms at the 32 ms cadence).
+func WithPreRoll(n int) StreamManagerOption {
+	return func(m *StreamManager) { m.preRoll = n }
+}
+
+// WithStreamMetrics injects the stt_request instrumentation for the streaming
+// path: rec receives one [observe.StageRecorder.STTRequest] span per resolved
+// commit (commit sent → committed), labelled provider. A nil rec keeps the no-op
+// default. Per ADR-0032 UtteranceID/TurnID are never metric labels.
+func WithStreamMetrics(rec observe.StageRecorder, p observe.Provider) StreamManagerOption {
+	return func(m *StreamManager) {
+		if rec != nil {
+			m.metrics = rec
+		}
+		m.provider = p
+	}
+}
+
+// NewStreamManager wires rec as the streaming recognizer. rec must be non-nil;
+// passing nil panics. The manager does nothing until [bind] starts its maintainer.
+func NewStreamManager(rec stt.StreamingRecognizer, opts ...StreamManagerOption) *StreamManager {
+	if rec == nil {
+		panic("orchestrator.NewStreamManager: rec must not be nil")
+	}
+	m := &StreamManager{
+		rec:            rec,
+		backoffInitial: time.Second,
+		backoffMax:     30 * time.Second,
+		commitTimeout:  3 * time.Second,
+		preRoll:        10,
+		metrics:        observe.Discard{},
+		sleep:          sleepCtx,
+		now:            time.Now,
+		poke:           make(chan struct{}, 1),
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	m.backoff = m.backoffInitial
+	return m
+}
+
+// sleepCtx blocks for d or until ctx is cancelled, returning ctx.Err() on cancel.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// bind starts the maintainer goroutine (which dials EAGERLY, so utterance 1 can
+// stream) and captures bus for STTPartial publishing. The returned func stops the
+// maintainer and closes the live session; the [Segmenter] calls it from its own
+// Bind teardown.
+func (m *StreamManager) bind(ctx context.Context, bus *voiceevent.Bus) func() {
+	m.mu.Lock()
+	m.bus = bus
+	m.mu.Unlock()
+
+	mctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.maintain(mctx)
+	}()
+
+	return func() {
+		cancel()
+		wg.Wait()
+		m.mu.Lock()
+		s := m.stream
+		m.stream = nil
+		m.mu.Unlock()
+		if s != nil {
+			_ = s.Close()
+		}
+	}
+}
+
+// maintain keeps one live session available, re-establishing it with bounded
+// backoff after a death (ADR-0042). The first dial is eager (no leading sleep) so
+// the first utterance can stream; every later attempt sleeps the current backoff
+// first. A successful dial serves until a death pokes the maintainer awake.
+func (m *StreamManager) maintain(ctx context.Context) {
+	first := true
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if !first {
+			m.mu.Lock()
+			delay := m.backoff
+			m.backoff = nextStreamBackoff(m.backoff, m.backoffMax)
+			m.mu.Unlock()
+			if err := m.sleep(ctx, delay); err != nil {
+				return
+			}
+		}
+		first = false
+
+		if serr := m.dial(ctx); serr != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			continue // transport dial failure: back off and retry
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		// The session is up. Drain any stale poke (the death we just healed, or a send
+		// that raced the redial), then block until a fresh death or shutdown.
+		select {
+		case <-m.poke:
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-m.poke:
+		}
+	}
+}
+
+// dial opens one fresh session and installs it. It returns the *StreamError on a
+// dial failure (always transport-fatal from the adapter) so the maintainer backs
+// off; nil means the session is live.
+func (m *StreamManager) dial(ctx context.Context) *stt.StreamError {
+	s, err := m.rec.OpenStream(ctx, stt.StreamConfig{
+		SampleRate: streamSampleRate,
+		OnPartial:  m.onPartial,
+	})
+	if err != nil {
+		var se *stt.StreamError
+		if errors.As(err, &se) {
+			return se
+		}
+		return &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: err}
+	}
+	m.mu.Lock()
+	m.stream = s
+	m.mu.Unlock()
+	return nil
+}
+
+// nextStreamBackoff doubles d toward max, clamping at the cap (and guarding
+// overflow).
+func nextStreamBackoff(d, max time.Duration) time.Duration {
+	n := d * 2
+	if n <= 0 || n > max {
+		return max
+	}
+	return n
+}
+
+// pokeMaintainer nudges the maintainer to re-establish the session, without
+// blocking the caller (a coalesced nudge suffices).
+func (m *StreamManager) pokeMaintainer() {
+	select {
+	case m.poke <- struct{}{}:
+	default:
+	}
+}
+
+// idleFrame pushes one pre-speech frame into the bounded pre-roll ring. Idle
+// frames are NEVER streamed to the provider (silence is not billed) — they only
+// become context if speech starts, when [beginUtterance] streams the ring.
+func (m *StreamManager) idleFrame(f audio.Frame) {
+	if m.preRoll <= 0 {
+		return
+	}
+	if len(m.ring) < m.preRoll {
+		m.ring = append(m.ring, f)
+		return
+	}
+	copy(m.ring, m.ring[1:])
+	m.ring[m.preRoll-1] = f
+}
+
+// beginUtterance mints this utterance's id and, if the session is up, streams the
+// pre-roll ring as leading context (voiced frames then follow via [send]). If the
+// session is down at speech_start the utterance is marked pure-batch — there is no
+// mid-utterance catch-up — and the maintainer is nudged to heal in the background.
+// at is the VAD speech_start time (reserved for future speculation anchoring).
+func (m *StreamManager) beginUtterance(at time.Time) string {
+	id := voiceevent.NewUtteranceID()
+
+	m.mu.Lock()
+	m.curUtterID = id
+	m.utterOpen = true
+	m.lastPartial = ""
+	s := m.stream
+	m.utterDead = s == nil
+	m.mu.Unlock()
+
+	preRoll := m.ring
+	m.ring = m.ring[:0]
+
+	if s == nil {
+		m.pokeMaintainer()
+		return id
+	}
+	for _, f := range preRoll {
+		if err := s.Send(f); err != nil {
+			m.streamFailed(s, err)
+			break
+		}
+	}
+	return id
+}
+
+// send streams one voiced frame to the session. On any send error the utterance is
+// marked dead (it falls back to batch with the Segmenter's locally-buffered frames)
+// and, if the error is fatal, the dead session is dropped and the maintainer nudged.
+// A no-op once the utterance is dead or the session is down.
+func (m *StreamManager) send(f audio.Frame) {
+	m.mu.Lock()
+	dead := m.utterDead
+	s := m.stream
+	m.mu.Unlock()
+	if dead {
+		return
+	}
+	if s == nil {
+		m.mu.Lock()
+		m.utterDead = true
+		m.mu.Unlock()
+		m.pokeMaintainer()
+		return
+	}
+	if err := s.Send(f); err != nil {
+		m.streamFailed(s, err)
+	}
+}
+
+// endUtterance closes the utterance. When it streamed live to a healthy session it
+// requests the manual commit and returns the resolving channel plus the sent-at
+// time; ok is false when the utterance never streamed (session down at begin, or a
+// send died), meaning the caller transcribes it via the pure batch path.
+func (m *StreamManager) endUtterance() (commit <-chan stt.CommitResult, sentAt time.Time, ok bool) {
+	m.mu.Lock()
+	m.utterOpen = false
+	dead := m.utterDead
+	s := m.stream
+	m.mu.Unlock()
+	if dead || s == nil {
+		return nil, time.Time{}, false
+	}
+	ch, err := s.Commit()
+	if err != nil {
+		m.streamFailed(s, err)
+		return nil, time.Time{}, false
+	}
+	return ch, m.now(), true
+}
+
+// awaitCommit waits up to commitTimeout for a streamed commit to resolve. On a
+// committed transcript it records the stt_request span, resets the backoff (a
+// healthy session forgives past failures), and returns ok=true — the authoritative
+// streamed text. On a provider error or a timeout it returns ok=false so the caller
+// falls back to the batch adapter with the same locally-buffered frames.
+func (m *StreamManager) awaitCommit(ch <-chan stt.CommitResult, sentAt time.Time) (stt.Transcript, bool) {
+	timer := time.NewTimer(m.commitTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-ch:
+		m.metrics.STTRequest(m.provider, m.now().Sub(sentAt))
+		if res.Err != nil {
+			m.noteAuthBackoff(res.Err)
+			return stt.Transcript{}, false
+		}
+		m.resetBackoff()
+		return res.Transcript, true
+	case <-timer.C:
+		return stt.Transcript{}, false
+	}
+}
+
+// onPartial publishes a streamed interim hypothesis as [voiceevent.STTPartial],
+// stamped with the current utterance id. It drops partials that arrive with no open
+// utterance, and dedupes a partial identical to the one just published (the adapter
+// can repeat a stabilized hypothesis). Runs on the adapter's read goroutine, so it
+// may fan out concurrently with the audio loop.
+func (m *StreamManager) onPartial(text string) {
+	m.mu.Lock()
+	if !m.utterOpen || text == m.lastPartial {
+		m.mu.Unlock()
+		return
+	}
+	m.lastPartial = text
+	id := m.curUtterID
+	bus := m.bus
+	m.mu.Unlock()
+	if bus == nil {
+		return
+	}
+	bus.Publish(voiceevent.STTPartial{At: m.now(), Text: text, UtteranceID: id})
+}
+
+// streamFailed records a send/commit failure against session s: the utterance is
+// marked batch, an auth-class code jumps the backoff to the cap, and a fatal error
+// on the still-current session drops it and nudges the maintainer to re-establish.
+func (m *StreamManager) streamFailed(s stt.Stream, err error) {
+	var se *stt.StreamError
+	isSE := errors.As(err, &se)
+	fatal := !isSE || se.Fatal
+
+	m.mu.Lock()
+	m.utterDead = true
+	if isSE && authClassCodes[se.Code] {
+		m.backoff = m.backoffMax
+	}
+	poke := false
+	if fatal && m.stream == s {
+		m.stream = nil
+		poke = true
+	}
+	m.mu.Unlock()
+	if poke {
+		m.pokeMaintainer()
+	}
+}
+
+// noteAuthBackoff jumps the backoff to the cap when err is an auth-class provider
+// error observed off the audio loop (a commit resolving fatal on the worker). It
+// does not touch the session pointer — the worker may be resolving an old
+// utterance's commit while the maintainer has already moved on.
+func (m *StreamManager) noteAuthBackoff(err error) {
+	var se *stt.StreamError
+	if errors.As(err, &se) && authClassCodes[se.Code] {
+		m.mu.Lock()
+		m.backoff = m.backoffMax
+		m.mu.Unlock()
+	}
+}
+
+// resetBackoff forgives past failures after a healthy commit, so a later drop
+// re-establishes promptly at the initial delay.
+func (m *StreamManager) resetBackoff() {
+	m.mu.Lock()
+	m.backoff = m.backoffInitial
+	m.mu.Unlock()
+}

--- a/pkg/voice/orchestrator/sttstream_internal_test.go
+++ b/pkg/voice/orchestrator/sttstream_internal_test.go
@@ -332,9 +332,13 @@ func TestStreamManager_AwaitCommitEmptyIsFinal(t *testing.T) {
 
 // TestStreamManager_AwaitCommitTimesOut pins the commit-timeout guard (R2): a
 // stalled pending commit falls back to batch (ok=false) rather than wedging the
-// worker.
+// worker, and it STILL records an stt_request span — a stalled provider is exactly
+// what the series surfaces (batch parity).
 func TestStreamManager_AwaitCommitTimesOut(t *testing.T) {
-	m := NewStreamManager(&fakeStreamingRecognizer{}, WithCommitTimeout(20*time.Millisecond))
+	spy := &spyStage{}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithStreamMetrics(spy, observe.ProviderElevenLabs),
+		WithCommitTimeout(20*time.Millisecond))
 	ch := make(chan stt.CommitResult) // never resolves
 
 	start := time.Now()
@@ -343,6 +347,43 @@ func TestStreamManager_AwaitCommitTimesOut(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("awaitCommit blocked %v; the commit timeout did not fire", elapsed)
+	}
+	if spy.requests() != 1 {
+		t.Errorf("commit timeout recorded %d stt_request spans, want 1 (a stalled provider is a recorded round-trip)", spy.requests())
+	}
+}
+
+// TestStreamManager_AuthDialBacksOffAtCap pins that an auth-class DIAL rejection
+// (401/403 → auth_error from the adapter) jumps the re-establish backoff straight
+// to the cap, so a revoked key is not hammered with the 1,2,4,8,16,30s fast redials
+// a plain transport failure would get.
+func TestStreamManager_AuthDialBacksOffAtCap(t *testing.T) {
+	rec := &fakeStreamingRecognizer{openErr: &stt.StreamError{Code: "auth_error", Fatal: true, Err: errors.New("HTTP 401")}}
+	m := NewStreamManager(rec, WithStreamBackoff(time.Second, 30*time.Second))
+
+	delays := make(chan time.Duration, 1)
+	m.sleep = func(ctx context.Context, d time.Duration) error {
+		select {
+		case delays <- d:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		<-ctx.Done() // hold until the test cancels, so only the first sleep is observed
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := m.bind(ctx, voiceevent.NewBus())
+	defer stop()
+	defer cancel()
+
+	select {
+	case d := <-delays:
+		if d != 30*time.Second {
+			t.Errorf("first backoff after an auth-class dial = %v, want the 30s cap", d)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no backoff sleep observed after an auth-class dial failure")
 	}
 }
 

--- a/pkg/voice/orchestrator/sttstream_internal_test.go
+++ b/pkg/voice/orchestrator/sttstream_internal_test.go
@@ -1,0 +1,431 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// fakeStream is a scriptable [stt.Stream] for StreamManager unit tests: it records
+// the frames it is Sent and how many times it is Committed, can be told to fail
+// Send, and resolves each Commit with a preset result (or leaves it pending for the
+// commit-timeout path).
+type fakeStream struct {
+	mu        sync.Mutex
+	sent      []audio.Frame
+	commits   int
+	closed    bool
+	sendErr   error             // returned by Send once set
+	result    *stt.CommitResult // resolves each Commit; nil leaves the commit pending
+	onPartial func(string)
+}
+
+func (f *fakeStream) Send(frame audio.Frame) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sent = append(f.sent, frame)
+	return nil
+}
+
+func (f *fakeStream) Commit() (<-chan stt.CommitResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.commits++
+	ch := make(chan stt.CommitResult, 1)
+	if f.result != nil {
+		ch <- *f.result
+	}
+	return ch, nil
+}
+
+func (f *fakeStream) Close() error {
+	f.mu.Lock()
+	f.closed = true
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeStream) sentFrames() []audio.Frame {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]audio.Frame(nil), f.sent...)
+}
+
+func (f *fakeStream) commitCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.commits
+}
+
+// fakeStreamingRecognizer hands out a scripted [fakeStream] (or a dial error) and
+// counts OpenStream calls; it wires each session's OnPartial back onto the stream
+// so a test can drive partials through the adapter's callback path.
+type fakeStreamingRecognizer struct {
+	mu      sync.Mutex
+	opens   int
+	stream  *fakeStream
+	openErr error
+	lastCfg stt.StreamConfig
+}
+
+func (r *fakeStreamingRecognizer) OpenStream(_ context.Context, cfg stt.StreamConfig) (stt.Stream, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.opens++
+	r.lastCfg = cfg
+	if r.openErr != nil {
+		return nil, r.openErr
+	}
+	if r.stream != nil {
+		r.stream.onPartial = cfg.OnPartial
+	}
+	return r.stream, nil
+}
+
+func (r *fakeStreamingRecognizer) openCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.opens
+}
+
+// spyStage records STTRequest calls; every other StageRecorder method is the no-op
+// from the embedded Discard.
+type spyStage struct {
+	observe.Discard
+	mu           sync.Mutex
+	sttRequests  int
+	lastProvider observe.Provider
+}
+
+func (s *spyStage) STTRequest(p observe.Provider, _ time.Duration) {
+	s.mu.Lock()
+	s.sttRequests++
+	s.lastProvider = p
+	s.mu.Unlock()
+}
+
+func (s *spyStage) requests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sttRequests
+}
+
+// streamFrame builds a 32 ms / 16 kHz frame with marker written to sample 0, so a
+// test can read back which frame reached the stream and in what order.
+func streamFrame(t *testing.T, marker int16) audio.Frame {
+	t.Helper()
+	s := make([]int16, 512)
+	s[0] = marker
+	f, err := audio.NewFrame(s, streamSampleRate, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// TestStreamManager_BeginSendsPreRollThenLiveFrames pins the per-utterance wire
+// contract: idle frames only fill the pre-roll ring (silence is not billed);
+// beginUtterance streams the ring first, in order; voiced frames follow via send;
+// and endUtterance requests exactly one manual commit for a live utterance.
+func TestStreamManager_BeginSendsPreRollThenLiveFrames(t *testing.T) {
+	fs := &fakeStream{result: &stt.CommitResult{Transcript: stt.Transcript{Text: "ok"}}}
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithPreRoll(3))
+	m.stream = fs
+	m.bus = voiceevent.NewBus()
+
+	m.idleFrame(streamFrame(t, 1))
+	m.idleFrame(streamFrame(t, 2))
+	if got := len(fs.sentFrames()); got != 0 {
+		t.Fatalf("idle frames streamed %d frames; want 0 (silence must not be billed)", got)
+	}
+
+	id := m.beginUtterance(time.Now())
+	if id == "" {
+		t.Fatal("beginUtterance returned an empty utterance id")
+	}
+	m.send(streamFrame(t, 9))
+
+	sent := fs.sentFrames()
+	if len(sent) != 3 {
+		t.Fatalf("streamed %d frames; want 3 (2 pre-roll + 1 voiced)", len(sent))
+	}
+	markers := []int16{sent[0].Samples()[0], sent[1].Samples()[0], sent[2].Samples()[0]}
+	want := []int16{1, 2, 9}
+	for i := range want {
+		if markers[i] != want[i] {
+			t.Fatalf("streamed frame order = %v, want %v (pre-roll ring in order, then voiced)", markers, want)
+		}
+	}
+
+	commit, _, ok := m.endUtterance()
+	if !ok || commit == nil {
+		t.Fatalf("endUtterance = (nil? %v, ok=%v); want a commit handle for a live utterance", commit == nil, ok)
+	}
+	if fs.commitCount() != 1 {
+		t.Errorf("Commit called %d times; want exactly 1", fs.commitCount())
+	}
+}
+
+// TestStreamManager_IdleFrameRingIsBounded pins that the pre-roll ring keeps only
+// the most recent preRoll frames (a paused speaker leaves unbounded idle silence).
+func TestStreamManager_IdleFrameRingIsBounded(t *testing.T) {
+	fs := &fakeStream{}
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithPreRoll(2))
+	m.stream = fs
+	m.bus = voiceevent.NewBus()
+
+	for i := int16(1); i <= 5; i++ {
+		m.idleFrame(streamFrame(t, i))
+	}
+	m.beginUtterance(time.Now())
+
+	sent := fs.sentFrames()
+	if len(sent) != 2 {
+		t.Fatalf("pre-roll streamed %d frames; want 2 (bounded ring)", len(sent))
+	}
+	if sent[0].Samples()[0] != 4 || sent[1].Samples()[0] != 5 {
+		t.Errorf("pre-roll = [%d %d], want the two most recent idle frames [4 5]",
+			sent[0].Samples()[0], sent[1].Samples()[0])
+	}
+}
+
+// TestStreamManager_PublishesPartialsWithDedupe pins the STTPartial contract:
+// interim texts publish with the utterance id, a consecutive duplicate is deduped,
+// and once the utterance is committed no further partial publishes (no open
+// utterance to attribute it to).
+func TestStreamManager_PublishesPartialsWithDedupe(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var partials []voiceevent.STTPartial
+	voiceevent.On(bus, func(e voiceevent.STTPartial) { partials = append(partials, e) })
+
+	fs := &fakeStream{result: &stt.CommitResult{Transcript: stt.Transcript{Text: "hello"}}}
+	m := NewStreamManager(&fakeStreamingRecognizer{})
+	m.stream = fs
+	m.bus = bus
+
+	id := m.beginUtterance(time.Now())
+	m.onPartial("he")
+	m.onPartial("he") // consecutive duplicate → deduped
+	m.onPartial("hello")
+
+	if len(partials) != 2 {
+		t.Fatalf("published %d partials; want 2 (consecutive duplicate deduped)", len(partials))
+	}
+	if partials[0].Text != "he" || partials[1].Text != "hello" {
+		t.Errorf("partial texts = [%q %q], want [he hello]", partials[0].Text, partials[1].Text)
+	}
+	if partials[0].UtteranceID != id || partials[1].UtteranceID != id {
+		t.Errorf("partials not stamped with the utterance id %q", id)
+	}
+
+	m.endUtterance()
+	m.onPartial("late")
+	if len(partials) != 2 {
+		t.Errorf("a partial published after endUtterance (%d total); want dropped (no open utterance)", len(partials))
+	}
+}
+
+// TestStreamManager_SendFailureMakesUtteranceBatch pins mid-utterance stream death
+// (AC): a fatal send drops the dead session, nudges the maintainer, and forces the
+// utterance onto the batch path (endUtterance ok=false), so no in-flight utterance
+// is lost.
+func TestStreamManager_SendFailureMakesUtteranceBatch(t *testing.T) {
+	fs := &fakeStream{sendErr: &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errors.New("ws dead")}}
+	m := NewStreamManager(&fakeStreamingRecognizer{})
+	m.stream = fs
+	m.bus = voiceevent.NewBus()
+
+	m.beginUtterance(time.Now())
+	m.send(streamFrame(t, 1))
+
+	if _, _, ok := m.endUtterance(); ok {
+		t.Fatal("endUtterance ok=true after a fatal send; want batch fallback (ok=false)")
+	}
+	m.mu.Lock()
+	s := m.stream
+	m.mu.Unlock()
+	if s != nil {
+		t.Error("a fatal send did not drop the dead session")
+	}
+	select {
+	case <-m.poke:
+	default:
+		t.Error("a fatal send did not poke the maintainer to re-establish")
+	}
+}
+
+// TestStreamManager_StreamDownAtBeginIsBatch pins the "stream down at speech_start"
+// AC: the utterance is pure batch (no mid-utterance catch-up) and the maintainer is
+// nudged to heal in the background.
+func TestStreamManager_StreamDownAtBeginIsBatch(t *testing.T) {
+	m := NewStreamManager(&fakeStreamingRecognizer{})
+	m.bus = voiceevent.NewBus() // m.stream stays nil: session down
+
+	m.beginUtterance(time.Now())
+	m.send(streamFrame(t, 1)) // no-op: utterance already batch
+	if _, _, ok := m.endUtterance(); ok {
+		t.Fatal("endUtterance ok=true with no session; want batch (ok=false)")
+	}
+	select {
+	case <-m.poke:
+	default:
+		t.Error("a stream-down begin did not nudge the maintainer")
+	}
+}
+
+// TestStreamManager_AwaitCommitSuccess pins the happy path: a resolved commit
+// yields the committed transcript (ok=true), records one stt_request span, and
+// resets the backoff (a healthy session forgives past failures).
+func TestStreamManager_AwaitCommitSuccess(t *testing.T) {
+	spy := &spyStage{}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithStreamMetrics(spy, observe.ProviderElevenLabs),
+		WithStreamBackoff(time.Second, 30*time.Second),
+		WithCommitTimeout(time.Second))
+	m.backoff = 8 * time.Second // grown by prior failures
+
+	ch := make(chan stt.CommitResult, 1)
+	ch <- stt.CommitResult{Transcript: stt.Transcript{Text: "roll a d20"}}
+	tr, ok := m.awaitCommit(ch, time.Now())
+	if !ok || tr.Text != "roll a d20" {
+		t.Fatalf("awaitCommit = (%q, %v); want (roll a d20, true)", tr.Text, ok)
+	}
+	if spy.requests() != 1 {
+		t.Errorf("stt_request recorded %d times; want exactly 1 per streamed commit", spy.requests())
+	}
+	if spy.lastProvider != observe.ProviderElevenLabs {
+		t.Errorf("stt_request provider = %q, want elevenlabs", spy.lastProvider)
+	}
+	m.mu.Lock()
+	b := m.backoff
+	m.mu.Unlock()
+	if b != time.Second {
+		t.Errorf("backoff after a successful commit = %v, want reset to the initial 1s", b)
+	}
+}
+
+// TestStreamManager_AwaitCommitEmptyIsFinal pins insufficient_audio parity: an
+// empty committed transcript with a nil error is a SUCCESS (ok=true, empty text),
+// not a fallback — the batch path publishes an empty STTFinal too.
+func TestStreamManager_AwaitCommitEmptyIsFinal(t *testing.T) {
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithCommitTimeout(time.Second))
+	ch := make(chan stt.CommitResult, 1)
+	ch <- stt.CommitResult{Transcript: stt.Transcript{Text: ""}}
+	tr, ok := m.awaitCommit(ch, time.Now())
+	if !ok {
+		t.Fatal("empty commit treated as a fallback; want ok=true (empty text is a valid final)")
+	}
+	if tr.Text != "" {
+		t.Errorf("empty commit text = %q, want empty", tr.Text)
+	}
+}
+
+// TestStreamManager_AwaitCommitTimesOut pins the commit-timeout guard (R2): a
+// stalled pending commit falls back to batch (ok=false) rather than wedging the
+// worker.
+func TestStreamManager_AwaitCommitTimesOut(t *testing.T) {
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithCommitTimeout(20*time.Millisecond))
+	ch := make(chan stt.CommitResult) // never resolves
+
+	start := time.Now()
+	if _, ok := m.awaitCommit(ch, time.Now()); ok {
+		t.Fatal("awaitCommit ok=true on a stalled commit; want false → batch fallback")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("awaitCommit blocked %v; the commit timeout did not fire", elapsed)
+	}
+}
+
+// TestStreamManager_AwaitCommitErrorFallsBack pins that a provider commit error
+// falls back to batch (ok=false) and does not reset the backoff.
+func TestStreamManager_AwaitCommitErrorFallsBack(t *testing.T) {
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithStreamBackoff(time.Second, 30*time.Second), WithCommitTimeout(time.Second))
+	m.backoff = 8 * time.Second
+	ch := make(chan stt.CommitResult, 1)
+	ch <- stt.CommitResult{Err: &stt.StreamError{Code: "commit_throttled", Fatal: false, Err: errors.New("throttled")}}
+	if _, ok := m.awaitCommit(ch, time.Now()); ok {
+		t.Fatal("awaitCommit ok=true on a commit error; want false → batch fallback")
+	}
+	m.mu.Lock()
+	b := m.backoff
+	m.mu.Unlock()
+	if b != 8*time.Second {
+		t.Errorf("a recoverable commit error changed the backoff to %v; want it unchanged", b)
+	}
+}
+
+// TestStreamManager_AuthClassBacksOffAtCap pins that an auth-class error jumps the
+// re-establish backoff straight to the cap (a durable rejection must not hammer),
+// and that a healthy commit resets it back to the initial delay.
+func TestStreamManager_AuthClassBacksOffAtCap(t *testing.T) {
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithStreamBackoff(time.Second, 30*time.Second))
+	if m.backoff != time.Second {
+		t.Fatalf("initial backoff = %v, want 1s", m.backoff)
+	}
+	m.noteAuthBackoff(&stt.StreamError{Code: "auth_error", Fatal: true})
+	if m.backoff != 30*time.Second {
+		t.Errorf("after auth_error backoff = %v, want the 30s cap", m.backoff)
+	}
+	m.resetBackoff()
+	if m.backoff != time.Second {
+		t.Errorf("after a healthy commit backoff = %v, want reset to 1s", m.backoff)
+	}
+}
+
+// TestStreamManager_BoundedBackoff pins the dial re-establish schedule: with the
+// sleep seam injected, repeated dial failures back off 1s → 2s → 4s → … → 30s cap,
+// no jitter.
+func TestStreamManager_BoundedBackoff(t *testing.T) {
+	rec := &fakeStreamingRecognizer{openErr: &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errors.New("dial fail")}}
+	m := NewStreamManager(rec, WithStreamBackoff(time.Second, 30*time.Second))
+
+	delays := make(chan time.Duration)
+	release := make(chan struct{})
+	m.sleep = func(ctx context.Context, d time.Duration) error {
+		select {
+		case delays <- d:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := m.bind(ctx, voiceevent.NewBus())
+	defer stop()
+	defer cancel()
+
+	want := []time.Duration{
+		time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+		16 * time.Second, 30 * time.Second, 30 * time.Second,
+	}
+	for i, w := range want {
+		select {
+		case d := <-delays:
+			if d != w {
+				t.Errorf("backoff sleep[%d] = %v, want %v", i, d, w)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("backoff sleep[%d]: none observed", i)
+		}
+		release <- struct{}{}
+	}
+	if rec.openCount() < len(want) {
+		t.Errorf("only %d dial attempts; want at least %d (one per failed dial)", rec.openCount(), len(want))
+	}
+}

--- a/pkg/voice/orchestrator/sttstream_pipeline_test.go
+++ b/pkg/voice/orchestrator/sttstream_pipeline_test.go
@@ -32,7 +32,6 @@ type scriptedStream struct {
 	onPartial  func(string)
 	partialIdx int
 	sends      int
-	commits    int
 }
 
 func (s *scriptedStream) Send(audio.Frame) error {
@@ -60,7 +59,6 @@ func (s *scriptedStream) Send(audio.Frame) error {
 func (s *scriptedStream) Commit() (<-chan stt.CommitResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.commits++
 	ch := make(chan stt.CommitResult, 1)
 	ch <- s.committed
 	return ch, nil

--- a/pkg/voice/orchestrator/sttstream_pipeline_test.go
+++ b/pkg/voice/orchestrator/sttstream_pipeline_test.go
@@ -1,0 +1,475 @@
+package orchestrator_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// scriptedStream is a deterministic [stt.Stream] for pipeline tests: it emits one
+// scripted partial per successful Send (simulating provider partials during
+// speech), can fail Send after a threshold (mid-utterance death), and resolves
+// each Commit with a preset result.
+type scriptedStream struct {
+	partials  []string
+	committed stt.CommitResult
+	// failAfterSends > 0 makes Send fail (fatal transport) once that many sends have
+	// succeeded — the mid-utterance websocket death. 0 never fails.
+	failAfterSends int
+
+	mu         sync.Mutex
+	onPartial  func(string)
+	partialIdx int
+	sends      int
+	commits    int
+}
+
+func (s *scriptedStream) Send(audio.Frame) error {
+	s.mu.Lock()
+	if s.failAfterSends > 0 && s.sends >= s.failAfterSends {
+		s.mu.Unlock()
+		return &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errors.New("scripted mid-utterance death")}
+	}
+	s.sends++
+	var partial string
+	var has bool
+	if s.partialIdx < len(s.partials) {
+		partial = s.partials[s.partialIdx]
+		s.partialIdx++
+		has = true
+	}
+	cb := s.onPartial
+	s.mu.Unlock()
+	if has && cb != nil {
+		cb(partial) // provider emits an interim hypothesis as audio arrives
+	}
+	return nil
+}
+
+func (s *scriptedStream) Commit() (<-chan stt.CommitResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commits++
+	ch := make(chan stt.CommitResult, 1)
+	ch <- s.committed
+	return ch, nil
+}
+
+func (s *scriptedStream) Close() error { return nil }
+
+// multiStreamRecognizer hands out its streams in order (one per OpenStream), wiring
+// each session's OnPartial back onto the stream. A recognizer with a single stream
+// models a stable session; several model reconnects across mid-session deaths.
+type multiStreamRecognizer struct {
+	mu      sync.Mutex
+	streams []*scriptedStream
+	idx     int
+}
+
+func (r *multiStreamRecognizer) OpenStream(_ context.Context, cfg stt.StreamConfig) (stt.Stream, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.idx >= len(r.streams) {
+		return nil, &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errors.New("no more scripted streams")}
+	}
+	s := r.streams[r.idx]
+	r.idx++
+	s.onPartial = cfg.OnPartial
+	return s, nil
+}
+
+func (r *multiStreamRecognizer) opens() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.idx
+}
+
+// metricSpy records STTRequest calls; other StageRecorder methods no-op via Discard.
+type metricSpy struct {
+	observe.Discard
+	mu          sync.Mutex
+	sttRequests int
+}
+
+func (s *metricSpy) STTRequest(observe.Provider, time.Duration) {
+	s.mu.Lock()
+	s.sttRequests++
+	s.mu.Unlock()
+}
+
+func (s *metricSpy) requests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sttRequests
+}
+
+// feedConv pushes n silent frames through the conversation's audio loop.
+func feedConv(t *testing.T, conv *orchestrator.Conversation, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := conv.Feed(segFrame(t)); err != nil {
+			t.Fatalf("frame %d: Feed: %v", i, err)
+		}
+	}
+}
+
+// partialsAndFinals splits the harness event log into the utterance's streamed
+// partials and its authoritative finals.
+func partialsAndFinals(h *voicetest.Harness) (partials []voiceevent.STTPartial, finals []voiceevent.STTFinal) {
+	for _, e := range h.Events() {
+		switch ev := e.(type) {
+		case voiceevent.STTPartial:
+			partials = append(partials, ev)
+		case voiceevent.STTFinal:
+			finals = append(finals, ev)
+		}
+	}
+	return partials, finals
+}
+
+// TestConversation_StreamingUtterance_FinalFromCommit is the streaming happy path
+// (TDD step 5): an utterance produces STTPartials during speech and an STTFinal
+// from the manual commit at the local VAD endpoint — carrying a fresh TurnID, the
+// speech-end time, and the utterance id its partials share — WITHOUT the batch
+// recognizer being called at all.
+func TestConversation_StreamingUtterance_FinalFromCommit(t *testing.T) {
+	h := voicetest.New(t)
+
+	// The batch recognizer is a spy that must stay untouched on the happy path.
+	batch := &recordingRecognizer{}
+	sttStage := orchestrator.NewSTT(h.Bus, batch)
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}})
+	stream := &scriptedStream{
+		partials:  []string{"roll", "roll a", "roll a d20"},
+		committed: stt.CommitResult{Transcript: stt.Transcript{Text: "roll a d20"}},
+	}
+	sm := orchestrator.NewStreamManager(&multiStreamRecognizer{streams: []*scriptedStream{stream}})
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("the eager dial never brought a session up; utterance 1 could not stream")
+	}
+
+	var speechEnd time.Time
+	voiceevent.On(h.Bus, func(e voiceevent.VADSpeechEnd) { speechEnd = e.At })
+
+	feedConv(t, conv, 5) // start, continue, continue, end, (flush frame)
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	partials, finals := partialsAndFinals(h)
+	if len(partials) == 0 {
+		t.Error("no STTPartial published during speech")
+	}
+	if len(finals) != 1 {
+		t.Fatalf("%d STTFinal published, want exactly 1", len(finals))
+	}
+	f := finals[0]
+	if f.Text != "roll a d20" {
+		t.Errorf("STTFinal.Text = %q, want the committed text %q", f.Text, "roll a d20")
+	}
+	if f.TurnID == "" {
+		t.Error("streamed STTFinal carried no TurnID")
+	}
+	if f.UtteranceID == "" {
+		t.Error("streamed STTFinal carried no UtteranceID")
+	}
+	if !f.SpeechEndAt.Equal(speechEnd) || f.SpeechEndAt.IsZero() {
+		t.Errorf("STTFinal.SpeechEndAt = %v, want the VAD speech-end %v", f.SpeechEndAt, speechEnd)
+	}
+	if partials[len(partials)-1].UtteranceID != f.UtteranceID {
+		t.Error("partials and the final do not share the utterance id")
+	}
+	if got := len(batch.batches()); got != 0 {
+		t.Errorf("batch recognizer called %d times; want 0 on the streaming happy path", got)
+	}
+}
+
+// TestConversation_StreamingCommitError_FallsBackToBatch is TDD step 6: a commit
+// that resolves with a provider error degrades to the batch recognizer, which
+// receives EXACTLY the locally-buffered voiced frames (the pre-roll ring is never
+// added, so cassette hashes stay stable) and produces the STTFinal. No utterance is
+// lost.
+func TestConversation_StreamingCommitError_FallsBackToBatch(t *testing.T) {
+	h := voicetest.New(t)
+
+	batch := &recordingRecognizer{} // returns "ok"
+	sttStage := orchestrator.NewSTT(h.Bus, batch)
+	// Two leading silences fill the pre-roll ring; the utterance is 3 voiced frames.
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSilence, vad.VADSilence,
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}})
+	stream := &scriptedStream{
+		committed: stt.CommitResult{Err: &stt.StreamError{Code: "commit_throttled", Fatal: false, Err: errors.New("throttled")}},
+	}
+	sm := orchestrator.NewStreamManager(&multiStreamRecognizer{streams: []*scriptedStream{stream}})
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("eager dial never came up")
+	}
+
+	feedConv(t, conv, 7) // 2 silence + start,cont,cont,end + flush frame
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	batches := batch.batches()
+	if len(batches) != 1 {
+		t.Fatalf("batch recognizer called %d times, want 1 (commit-error fallback)", len(batches))
+	}
+	if got := len(batches[0]); got != 3 {
+		t.Errorf("batch segment had %d frames, want 3 (voiced only; pre-roll must not leak into the segment)", got)
+	}
+	_, finals := partialsAndFinals(h)
+	if len(finals) != 1 || finals[0].Text != "ok" {
+		t.Fatalf("STTFinal = %+v, want exactly 1 with the batch text %q", finals, "ok")
+	}
+	if finals[0].UtteranceID == "" {
+		t.Error("a fallback STTFinal carried no UtteranceID; it should still join its partials")
+	}
+}
+
+// TestConversation_MidUtteranceDeath_BatchThenReconnect is TDD step 7: the
+// websocket dies mid-utterance; that utterance degrades to batch with its full
+// segment intact (no transcription lost), and after the maintainer redials a later
+// utterance streams again.
+func TestConversation_MidUtteranceDeath_BatchThenReconnect(t *testing.T) {
+	h := voicetest.New(t)
+
+	batch := &recordingRecognizer{} // returns "ok"
+	sttStage := orchestrator.NewSTT(h.Bus, batch)
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue, vad.VADSpeechEnd, // utterance 1: dies mid-stream
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechEnd, // utterance 2: streams on the fresh session
+	}})
+	dying := &scriptedStream{failAfterSends: 2} // f0,f1 ok; f2 kills the session
+	healthy := &scriptedStream{
+		partials:  []string{"hi", "hi there"},
+		committed: stt.CommitResult{Transcript: stt.Transcript{Text: "hi there"}},
+	}
+	rec := &multiStreamRecognizer{streams: []*scriptedStream{dying, healthy}}
+	sm := orchestrator.NewStreamManager(rec, orchestrator.WithStreamBackoff(time.Millisecond, 10*time.Millisecond))
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("eager dial never came up")
+	}
+
+	feedConv(t, conv, 4) // utterance 1: start, cont, cont(death), end(flush)
+	// The session must re-establish after the mid-utterance death before utterance 2.
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("the stream did not re-establish after the mid-utterance death")
+	}
+	if rec.opens() != 2 {
+		t.Fatalf("recognizer opened %d sessions, want 2 (eager dial + one reconnect)", rec.opens())
+	}
+	feedConv(t, conv, 3) // utterance 2: start, cont, end
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Utterance 1 fell to batch with its full 3-frame segment; utterance 2 streamed.
+	batches := batch.batches()
+	if len(batches) != 1 {
+		t.Fatalf("batch recognizer called %d times, want 1 (only the dead utterance)", len(batches))
+	}
+	if got := len(batches[0]); got != 3 {
+		t.Errorf("dead utterance's batch segment had %d frames, want 3 (full utterance, nothing lost)", got)
+	}
+	_, finals := partialsAndFinals(h)
+	if len(finals) != 2 {
+		t.Fatalf("%d STTFinal, want 2 (batch fallback + reconnected stream)", len(finals))
+	}
+	texts := map[string]bool{finals[0].Text: true, finals[1].Text: true}
+	if !texts["ok"] || !texts["hi there"] {
+		t.Errorf("STTFinal texts = %v, want {ok (batch), hi there (streamed)}", texts)
+	}
+}
+
+// TestConversation_EmptyCommit_PublishesEmptyFinal is TDD step 9: an
+// insufficient-audio commit (empty transcript, nil error) is a success, not a
+// fallback — it publishes an empty STTFinal (batch parity), and the batch
+// recognizer is not called.
+func TestConversation_EmptyCommit_PublishesEmptyFinal(t *testing.T) {
+	h := voicetest.New(t)
+
+	batch := &recordingRecognizer{}
+	sttStage := orchestrator.NewSTT(h.Bus, batch)
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechEnd,
+	}})
+	stream := &scriptedStream{committed: stt.CommitResult{Transcript: stt.Transcript{Text: ""}}}
+	sm := orchestrator.NewStreamManager(&multiStreamRecognizer{streams: []*scriptedStream{stream}})
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("eager dial never came up")
+	}
+
+	feedConv(t, conv, 3)
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	_, finals := partialsAndFinals(h)
+	if len(finals) != 1 || finals[0].Text != "" {
+		t.Fatalf("STTFinal = %+v, want exactly 1 with empty text", finals)
+	}
+	if got := len(batch.batches()); got != 0 {
+		t.Errorf("batch recognizer called %d times for an empty commit, want 0 (empty is a valid final)", got)
+	}
+}
+
+// TestConversation_PartialsNeverRoute is TDD step 10's new assertion: partials are
+// a live-view signal only — the address detector routes exactly one AddressRouted
+// per STTFinal, and never on a partial. The routed text is the final's, not any
+// interim hypothesis.
+func TestConversation_PartialsNeverRoute(t *testing.T) {
+	h := voicetest.New(t)
+
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}})
+	stream := &scriptedStream{
+		partials:  []string{"bart", "bart hel", "bart hello"},
+		committed: stt.CommitResult{Transcript: stt.Transcript{Text: "bart hello"}},
+	}
+	sm := orchestrator.NewStreamManager(&multiStreamRecognizer{streams: []*scriptedStream{stream}})
+	detector := orchestrator.NewAddressDetector(
+		address.NewMatcher(address.Config{Language: "en"},
+			address.Agent{Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"}}),
+	)
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm),
+		orchestrator.WithDetector(detector))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("eager dial never came up")
+	}
+
+	feedConv(t, conv, 5)
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	partials, finals := partialsAndFinals(h)
+	if len(partials) < 2 {
+		t.Fatalf("expected several partials during speech, got %d", len(partials))
+	}
+	if len(finals) != 1 {
+		t.Fatalf("%d STTFinal, want 1", len(finals))
+	}
+	var routes []voiceevent.AddressRouted
+	for _, e := range h.Events() {
+		if r, ok := e.(voiceevent.AddressRouted); ok {
+			routes = append(routes, r)
+		}
+	}
+	if len(routes) != 1 {
+		t.Fatalf("%d AddressRouted, want exactly 1 (only the final routes; partials never do)", len(routes))
+	}
+	if routes[0].Text != "bart hello" {
+		t.Errorf("AddressRouted.Text = %q, want the final %q (never an interim partial)", routes[0].Text, "bart hello")
+	}
+}
+
+// TestConversation_StreamedUtterance_RecordsOneSTTRequest is TDD step 11: a
+// streamed utterance records exactly one stt_request span (the commit round-trip),
+// and the STTFinal carries the speech-end time the response-latency subscriber
+// derives its headline span from.
+func TestConversation_StreamedUtterance_RecordsOneSTTRequest(t *testing.T) {
+	h := voicetest.New(t)
+
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}})
+	stream := &scriptedStream{committed: stt.CommitResult{Transcript: stt.Transcript{Text: "hi"}}}
+	spy := &metricSpy{}
+	sm := orchestrator.NewStreamManager(&multiStreamRecognizer{streams: []*scriptedStream{stream}},
+		orchestrator.WithStreamMetrics(spy, observe.ProviderElevenLabs))
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(sm))
+	t.Cleanup(conv.Register(t.Context()))
+	if !sm.WaitStreamUp(2 * time.Second) {
+		t.Fatal("eager dial never came up")
+	}
+
+	var speechEnd time.Time
+	voiceevent.On(h.Bus, func(e voiceevent.VADSpeechEnd) { speechEnd = e.At })
+
+	feedConv(t, conv, 4)
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := spy.requests(); got != 1 {
+		t.Errorf("stt_request recorded %d times, want exactly 1 per streamed utterance", got)
+	}
+	_, finals := partialsAndFinals(h)
+	if len(finals) != 1 {
+		t.Fatalf("%d STTFinal, want 1", len(finals))
+	}
+	if !finals[0].SpeechEndAt.Equal(speechEnd) || finals[0].SpeechEndAt.IsZero() {
+		t.Errorf("STTFinal.SpeechEndAt = %v, want the VAD speech-end %v (response-latency anchor)", finals[0].SpeechEndAt, speechEnd)
+	}
+}
+
+// TestConversation_NilStreamingSTT_IsBatchParity pins the byte-for-byte default:
+// WithStreamingSTT(nil) is zero behaviour change — no partials, and the STTFinal
+// carries an empty UtteranceID exactly like the no-streaming path.
+func TestConversation_NilStreamingSTT_IsBatchParity(t *testing.T) {
+	h := voicetest.New(t)
+
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}})
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithStreamingSTT(nil)) // nil is the no-streaming default
+	t.Cleanup(conv.Register(t.Context()))
+
+	feedConv(t, conv, 4)
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	partials, finals := partialsAndFinals(h)
+	if len(partials) != 0 {
+		t.Errorf("nil streaming published %d partials, want 0", len(partials))
+	}
+	if len(finals) != 1 {
+		t.Fatalf("%d STTFinal, want 1", len(finals))
+	}
+	if finals[0].UtteranceID != "" {
+		t.Errorf("batch-path STTFinal.UtteranceID = %q, want empty (byte-for-byte default)", finals[0].UtteranceID)
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream.go
+++ b/pkg/voice/stt/elevenlabs/stream.go
@@ -299,6 +299,13 @@ func (s *stream) Commit() (<-chan stt.CommitResult, error) {
 
 	if len(rem) > 0 {
 		if err := s.enqueue(wsWrite{audioB64: base64.StdEncoding.EncodeToString(rem)}); err != nil {
+			// The remainder could not be queued (queue full or session dead). Restore
+			// it to the front of the aggregation buffer — mirroring the Send-path
+			// restore — so a retried Commit does not lose the utterance's tail. Commit
+			// swapped agg to nil; prepend rem ahead of anything a racing Send appended.
+			s.aggMu.Lock()
+			s.agg = append(rem, s.agg...)
+			s.aggMu.Unlock()
 			s.failCommit(ch, err)
 			return ch, nil
 		}

--- a/pkg/voice/stt/elevenlabs/stream.go
+++ b/pkg/voice/stt/elevenlabs/stream.go
@@ -141,7 +141,7 @@ func (c *Client) openStream(ctx context.Context, cfg stt.StreamConfig, pingInter
 
 	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, u, hdr)
 	if err != nil {
-		return nil, &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: dialError(err, resp)}
+		return nil, dialStreamError(err, resp)
 	}
 
 	s := &stream{
@@ -190,6 +190,20 @@ func dialError(err error, resp *http.Response) error {
 		return fmt.Errorf("websocket dial: HTTP %d: %w", resp.StatusCode, err)
 	}
 	return fmt.Errorf("websocket dial: %w", err)
+}
+
+// dialStreamError classifies a websocket-handshake failure. An HTTP 401/403 on the
+// upgrade response is a durable credential/permission rejection, so it carries the
+// auth_error code — the stream manager backs a durable rejection off straight to
+// the cap (ADR-0042) instead of the ~6 fast redials (1,2,4,8,16,30s) a revoked key
+// would otherwise get. Every other handshake failure is a transport blip. Always
+// Fatal: the session never opened.
+func dialStreamError(err error, resp *http.Response) *stt.StreamError {
+	code := stt.CodeTransport
+	if resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+		code = "auth_error"
+	}
+	return &stt.StreamError{Code: code, Fatal: true, Err: dialError(err, resp)}
 }
 
 // wsWrite is one queued client->server write: either an audio chunk (commit

--- a/pkg/voice/stt/elevenlabs/stream_internal_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_internal_test.go
@@ -105,3 +105,42 @@ func TestSend_WriteQueueFull_RestoresAggregatedAudio(t *testing.T) {
 		t.Errorf("aggregation buffer = %d bytes, want %d (flushed audio must not be lost)", len(s.agg), wantBytes)
 	}
 }
+
+// TestCommit_WriteQueueFull_RestoresRemainder pins the R1 fix: when Commit cannot
+// enqueue the swapped-out aggregation remainder (write queue full), it restores
+// that remainder into the aggregation buffer — mirroring the Send-path restore —
+// so a retried Commit does not lose the utterance's tail. Without it the tail
+// bytes vanished with the failed enqueue and the retried commit was short.
+func TestCommit_WriteQueueFull_RestoresRemainder(t *testing.T) {
+	s := &stream{
+		cfg:       stt.StreamConfig{SampleRate: 16000},
+		writeCh:   make(chan wsWrite, 1),
+		stopCh:    make(chan struct{}),
+		threshold: 16000 * minChunkMs / 1000 * 2,
+	}
+	s.writeCh <- wsWrite{} // occupy the only slot; the remainder enqueue must fail
+
+	// A sub-threshold remainder sits in the aggregation buffer (never flushed by
+	// Send because it is under the 100 ms threshold).
+	remainder := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	s.agg = append([]byte(nil), remainder...)
+
+	ch, err := s.Commit()
+	if err != nil {
+		t.Fatalf("Commit returned a call-time error %v; want a resolving channel", err)
+	}
+
+	select {
+	case res := <-ch:
+		var se *stt.StreamError
+		if !errors.As(res.Err, &se) || se.Code != stt.CodeQueueFull {
+			t.Fatalf("commit resolved with %v; want a *StreamError code %q", res.Err, stt.CodeQueueFull)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("commit channel never resolved on a queue-full remainder enqueue")
+	}
+
+	if string(s.agg) != string(remainder) {
+		t.Errorf("aggregation buffer = %v, want the restored remainder %v (utterance tail must not be lost)", s.agg, remainder)
+	}
+}

--- a/pkg/voice/stt/elevenlabs/stream_internal_test.go
+++ b/pkg/voice/stt/elevenlabs/stream_internal_test.go
@@ -58,6 +58,43 @@ func TestWritePump_SendsKeepalivePing(t *testing.T) {
 	}
 }
 
+// TestOpenStream_Unauthorized_MapsToAuthError pins that an HTTP 401/403 on the
+// websocket handshake surfaces as a *StreamError with the auth_error code (not the
+// generic transport code), so the stream manager backs a revoked/forbidden key off
+// straight to the cap instead of ~6 fast redials.
+func TestOpenStream_Unauthorized_MapsToAuthError(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"unauthorized", http.StatusUnauthorized},
+		{"forbidden", http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status) // reject the upgrade
+			}))
+			defer srv.Close()
+
+			c := New("k", WithBaseURL(srv.URL))
+			_, err := c.OpenStream(context.Background(), stt.StreamConfig{SampleRate: 16000})
+			if err == nil {
+				t.Fatal("OpenStream returned nil on a rejected handshake; want an error")
+			}
+			var se *stt.StreamError
+			if !errors.As(err, &se) {
+				t.Fatalf("error %v is not a *stt.StreamError", err)
+			}
+			if se.Code != "auth_error" {
+				t.Errorf("dial error code = %q, want auth_error for HTTP %d", se.Code, tc.status)
+			}
+			if !se.Fatal {
+				t.Error("a rejected handshake must be Fatal (the session never opened)")
+			}
+		})
+	}
+}
+
 // TestSend_WriteQueueFull_RestoresAggregatedAudio pins Finding 4: when a flush
 // cannot be enqueued (write queue full), Send reports a recoverable queue-full
 // *StreamError AND keeps the flushed bytes in the aggregation buffer so no

--- a/pkg/voice/stt/streaming.go
+++ b/pkg/voice/stt/streaming.go
@@ -98,10 +98,12 @@ const (
 	CodeQueueFull = "queue_full"
 )
 
-// StreamError is the typed error surfaced by every streaming operation. Code
-// is the provider's error-frame type (see ADR-0042) or [CodeTransport] for
-// transport-level failures. Fatal reports whether the whole session is dead
-// (reopen or fall back) versus only the single operation having failed.
+// StreamError is the typed error surfaced by every streaming operation. Code is
+// either the provider's error-frame type (see ADR-0042) or one of the three
+// adapter-synthesized codes above — [CodeTransport] for transport-level
+// failures, [CodeSampleRateMismatch] for a rejected frame, and [CodeQueueFull]
+// for backpressure. Fatal reports whether the whole session is dead (reopen or
+// fall back) versus only the single operation having failed.
 type StreamError struct {
 	Code  string
 	Fatal bool

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -50,6 +50,13 @@ func (VADSpeechEnd) EventName() string { return "vad.speech_end" }
 // metrics/SSE subscriber may observe it interleaved. Consumers MUST correlate by
 // UtteranceID and never assume "latest partial": utterance N+1's partial can
 // precede utterance N's STTFinal.
+//
+// UtteranceID is stamped manager-side from the CURRENT utterance, so for up to
+// ~one round-trip after a new speech_start an in-flight partial for the PREVIOUS
+// utterance can arrive carrying the new utterance's id (a stale-text partial).
+// Speculation consumers must tolerate this: the STTFinal's normalized match
+// against the speculated query self-heals it, and a mismatch falls back to inline
+// retrieval (ADR-0042).
 type STTPartial struct {
 	At   time.Time
 	Text string

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -39,6 +39,28 @@ type VADSpeechEnd struct {
 // EventName implements [Event].
 func (VADSpeechEnd) EventName() string { return "vad.speech_end" }
 
+// STTPartial is the MUTABLE interim hypothesis of the in-progress utterance
+// (ADR-0042/0020). Text REPLACES all previous partials for the same UtteranceID —
+// it is not cumulative. Only [STTFinal] reaches Address Detection and the
+// Transcript (ADR-0012); a partial is a live-view/speculation signal, never
+// routed and never persisted.
+//
+// A partial may be published CONCURRENTLY with other turns' events: it originates
+// on the streaming adapter's read goroutine (the [FirstAudio] precedent), so a
+// metrics/SSE subscriber may observe it interleaved. Consumers MUST correlate by
+// UtteranceID and never assume "latest partial": utterance N+1's partial can
+// precede utterance N's STTFinal.
+type STTPartial struct {
+	At   time.Time
+	Text string
+	// UtteranceID is minted at the local VAD speech_start ([NewUtteranceID]) and
+	// joins this utterance's partials to the [STTFinal] its manual commit yields.
+	UtteranceID string
+}
+
+// EventName implements [Event].
+func (STTPartial) EventName() string { return "stt.partial" }
+
 // STTFinal is an authoritative transcript for one completed utterance, as
 // committed by the STT provider. Per ADR-0021 the same event is emitted on
 // the cassette-replay and live paths; the orchestrator does not distinguish.
@@ -59,6 +81,10 @@ type STTFinal struct {
 	Text        string
 	TurnID      string
 	SpeechEndAt time.Time
+	// UtteranceID joins this final to the [STTPartial]s of the utterance it came
+	// from (ADR-0042), minted at the local VAD speech_start. It is empty on the
+	// batch path (no stream, no partials) — the byte-for-byte no-streaming default.
+	UtteranceID string
 }
 
 // EventName implements [Event].

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -32,6 +32,34 @@ func TestSTTFinal_EventName(t *testing.T) {
 	}
 }
 
+func TestSTTPartial_EventName(t *testing.T) {
+	t.Parallel()
+
+	got := STTPartial{}.EventName()
+	if got != "stt.partial" {
+		t.Errorf("EventName = %q, want %q", got, "stt.partial")
+	}
+}
+
+// TestNewUtteranceID_UniqueNonEmpty pins that utterance ids are minted non-empty
+// and distinct (ADR-0042): they join an utterance's partials to its final, so a
+// collision would cross-link two utterances' streams.
+func TestNewUtteranceID_UniqueNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]bool, 128)
+	for range 128 {
+		id := NewUtteranceID()
+		if id == "" {
+			t.Fatal("NewUtteranceID returned an empty id")
+		}
+		if seen[id] {
+			t.Fatalf("NewUtteranceID returned a duplicate id %q", id)
+		}
+		seen[id] = true
+	}
+}
+
 func TestAddressRouted_EventName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/voice/voiceevent/turnid.go
+++ b/pkg/voice/voiceevent/turnid.go
@@ -28,6 +28,22 @@ func NewTurnID() string {
 	return hex.EncodeToString(b[:])
 }
 
+// NewUtteranceID returns a fresh, unique utterance correlation id (ADR-0042). It
+// is the streaming-STT sibling of [NewTurnID]: minted at the local VAD
+// speech_start, it joins an utterance's [STTPartial]s to the [STTFinal] the
+// manual commit produces. Like a turn id it is an opaque short hex token with no
+// structure callers should parse; distinct from a turn id because one utterance's
+// stream (partials → final) precedes the turn the final then opens.
+func NewUtteranceID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is catastrophic, but a correlation id is not
+		// security-critical; fall back to a fixed marker rather than panic the loop.
+		return "utterance-rand-unavailable"
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // WithTurnID returns a copy of ctx carrying id, so a downstream stage
 // ([TTS.Dispatch], the wire tee) can recover it with [TurnIDFrom]. The reply
 // reactor installs it at the top of a turn; an empty id leaves ctx unchanged.


### PR DESCRIPTION
## What does this PR do?

Closes #180.

Adds the streaming-transcription pipeline (ADR-0042): a per-Voice-Session
`StreamManager` replaces the batch-only POST worker with a persistent websocket,
publishing `STTPartial` events during speech and finalizing each utterance from a
manual commit fired at the **local VAD endpoint** — never provider-side.

- **`voiceevent`**: new `STTPartial` (mutable interim, never routed/persisted),
  additive `STTFinal.UtteranceID` (empty on batch = byte-for-byte default),
  `NewUtteranceID`.
- **`orchestrator.StreamManager`** (`sttstream.go`): eager-dialed session with
  bounded-backoff re-establish (1s→30s cap, auth-class starts at cap, resets on a
  healthy commit), a pre-roll ring (idle frames buffered but never streamed — silence
  isn't billed), per-utterance manual commit, `STTPartial` publishing with
  consecutive-dup dedupe, and a commit-timeout fallback guard.
- **Segmenter integration** (`WithStreamingSTT`): idle→ring, voiced→send,
  speech-end/`Flush`→commit. The worker prefers the committed text and falls back
  to the batch recognizer with the SAME locally-buffered frames on any commit
  error/timeout/stream-death — additive, never authoritative, no utterance lost.
  `PublishFinal` is the shared publish tail (TurnID/SpeechEndAt minted as today).
- **Selection seam** (`GLYPHOXA_STT_STREAMING`, `wirenpc`): type-asserts the wired
  recognizer to `stt.StreamingRecognizer`; default OFF or a batch-only recognizer
  is byte-for-byte today's path.
- **#179 review residuals**: R1 — `Commit()` restores the swapped-out remainder on a
  queue-full enqueue so a retried commit keeps the utterance tail; R3 — `StreamError`
  doc references all three adapter-synthesized codes.

## Why is this change needed?

The batch STT POST (~1.5s) dominates the ~1.7s p95 response latency and yields no
text to speculate on until `STTFinal`. Streaming drops endpoint→final to a manual
commit finalization and unlocks the partials #122 (speculative memory recall) needs,
while keeping barge-in / turn semantics keyed on the local VAD exactly as today.

## How was this tested?

Deterministic, keyless, per ADR-0021 — no live network:

- **StreamManager unit** (fake `stt.Stream`): pre-roll-then-voiced ordering, bounded
  ring, partial dedupe, mid-utterance death → batch, stream-down-at-begin → batch,
  commit success/empty/error/timeout, and the 1s→2s→…→30s backoff schedule (auth-class
  at cap; reset on commit) via an injected sleep seam.
- **Full pipeline** (`Conversation` + scripted streaming recognizer + spy batch
  recognizer): partials during speech + `STTFinal` from commit with the batch
  recognizer untouched; commit-error fallback receives EXACTLY the voiced frames (no
  pre-roll leak); mid-utterance death → batch with full segment intact then reconnect;
  empty commit → empty `STTFinal`; partials never route; one `stt_request` span per
  streamed utterance; `WithStreamingSTT(nil)` is batch parity.
- Existing barge/floor/turn tests stay green (zero assertion edits).

- [x] `make check` equivalents pass: `go test -race ./...`, `golangci-lint run ./...`
  (0 issues), `go build`/`vet` under default, `record`, `opus nolibopusfile`,
  `bench`, and `integration` tags.
- [x] New/updated tests cover the change
- [ ] Manual testing (deterministic tests only; no live ElevenLabs run)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Additional Notes

Default OFF: `GLYPHOXA_STT_STREAMING` gates the whole path, so this ships dark until
an operator opts in — every no-streaming path is byte-for-byte unchanged. Rebased on
current `main` (includes #116); `cmd/glyphoxa/main.go` delta is just the env parse +
one field, merged cleanly with #116's embed-worker wiring.
