### PR TITLE
feat(#122): NPC memory recall in Hot Context (speculative + bounded inline)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/recall"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
@@ -321,20 +322,36 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		metrics.SetEmbeddingBacklog(n)
 	}
 
-	// Async embedding backfill worker (#116, ADR-0011): a background loop that
-	// claims chunks written with embedding NULL, embeds their text, and UPDATEs
-	// each row — draining the backlog gauge toward zero and making the chunks
-	// returnable by embedding-filtered retrieval. It needs only the DB + the
-	// embeddings provider (not the voice loop), so it runs in web AND all mode.
-	// A resolve failure (an unsupported provider OR a config-read error) is
-	// loud-but-non-fatal: log ERROR and skip the worker — the backlog gauge then
-	// exposes the permanent stall rather than the process crashing. The worker
-	// rides the process signal ctx, so SIGTERM stops it and any in-flight provider
-	// call aborts with the same context.
+	// Resolve the process embeddings provider ONCE and share it across the two
+	// consumers (#122): the async backfill worker (#116) drains the NULL-embedding
+	// backlog, and the NPC memory recaller (#122) embeds utterances for Hot Context
+	// retrieval. Resolving it twice would open two independent clients. A resolve
+	// failure (an unsupported provider OR a config-read error) is loud-but-non-fatal
+	// for BOTH: the backlog gauge exposes the permanent stall and NPC memory recall
+	// stays disabled (AC6 — Agent turns behave exactly as before), rather than
+	// crashing the process.
 	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
-		log.Error("embeddings provider unavailable, backfill disabled", "err", err)
+		log.Error("embeddings provider unavailable; embedding backfill and NPC memory recall disabled", "err", err)
 	} else {
+		// Backfill worker (#116, ADR-0011): claims chunks written with embedding NULL,
+		// embeds their text, and UPDATEs each row — draining the gauge toward zero and
+		// making the chunks returnable by embedding-filtered retrieval. It needs only
+		// the DB + provider (not the voice loop), so it runs in web AND all mode. It
+		// rides the process signal ctx, so SIGTERM stops it and any in-flight provider
+		// call aborts with the same context.
 		go embedworker.New(store, provider, model, metrics, log, embedworker.Config{}).Run(ctx)
+
+		// NPC memory recall (#122, ADR-0011/0042): one recaller over the shared
+		// provider + the process store (ANN retriever, #119) + the session Manager
+		// (the active Campaign) + the process bus (STTPartial speculation). Set on the
+		// Manager's base voice config so every manager-started session's Agent loops
+		// fill the reserved Hot Context memory slot; a slow/unavailable path degrades
+		// to no-memory within the turn budget. Bound to the run ctx — AfterFunc drops
+		// the bus subscription and stops the speculator on shutdown. In web-only mode
+		// the Manager starts no sessions, so the recaller stays dormant (bus idle).
+		recaller := recall.New(provider, store, mgr, eventBus, metrics, log, recall.Config{})
+		context.AfterFunc(ctx, recaller.Close)
+		mgr.SetMemory(recaller)
 	}
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -68,7 +68,32 @@ type PrometheusRecorder struct {
 	// backfill worker (#116) Sets it too. Always Set-from-COUNT, never Inc/Dec, so
 	// it stays idempotent across writers and restarts.
 	embeddingBacklog prometheus.Gauge
+
+	// memory recall (#122, ADR-0042/0032): NPC Hot Context recalls by outcome —
+	// a speculation hit, an inline miss, or a degraded/unconfigured skip. The
+	// outcome label is a bounded three-value enum (ADR-0032).
+	memoryRecall *prometheus.CounterVec // outcome
 }
+
+// RecallOutcome is the bounded outcome label on the NPC memory-recall counter
+// (glyphoxa_voice_memory_recall_total, #122). Exactly three values reach a series
+// (ADR-0032): a speculation hit reused a partial-prefetched query, an inline miss
+// embedded+searched within the turn budget, and a skip degraded to no-memory
+// (budget exceeded, provider/DB down, or a defensive guard).
+type RecallOutcome string
+
+const (
+	// RecallHit: the final utterance matched a speculated partial, so the
+	// prefetched vector/world chunks were reused at zero added turn latency.
+	RecallHit RecallOutcome = "hit"
+	// RecallMiss: no usable speculation, so recall embedded and searched inline
+	// within the bounded-sync budget (ADR-0042).
+	RecallMiss RecallOutcome = "miss"
+	// RecallSkip: recall degraded to no-memory — the budget elapsed, the
+	// embeddings/DB path failed, or a defensive guard (unparseable agent id / no
+	// active session) tripped. A barge cancel is NOT a skip (it counts nothing).
+	RecallSkip RecallOutcome = "skip"
+)
 
 // NewPrometheusRecorder builds the adapter and registers every glyphoxa_voice_*
 // series on a fresh registry, plus the standard process/Go collectors so
@@ -143,12 +168,17 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		Help:      "Transcript chunks awaiting embedding (embedding IS NULL).",
 	})
 
+	r.memoryRecall = counterVec("memory_recall_total",
+		"NPC memory recalls by outcome (#122, ADR-0042): a speculation hit, an inline miss, or a degraded skip.",
+		"outcome")
+
 	reg.MustRegister(
 		r.framesDropped, r.undecodable, r.daveDecryptErrs, r.sessions,
 		r.playbackTotal, r.bargeCancels,
 		r.responseLatency, r.vadHangover, r.addressDetect, r.codecDecode,
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
+		r.memoryRecall,
 		// Standard runtime collectors so /metrics also reports process/Go health.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
@@ -218,6 +248,14 @@ func (r *PrometheusRecorder) ProviderError(s Stage, p Provider) {
 }
 func (r *PrometheusRecorder) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
 	r.turnTotal.WithLabelValues(string(outcome), string(reason)).Inc()
+}
+
+// MemoryRecall counts one NPC memory recall by its bounded outcome (#122,
+// ADR-0042/0032). It is the standalone recall-metrics sink the internal/recall
+// component records against (its local Metrics interface), separate from the
+// StageRecorder contract: recall is not an orchestrator stage.
+func (r *PrometheusRecorder) MemoryRecall(o RecallOutcome) {
+	r.memoryRecall.WithLabelValues(string(o)).Inc()
 }
 
 // SetEmbeddingBacklog publishes the current count of transcript chunks awaiting an

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -56,6 +56,10 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.TurnOutcome(TurnAbandoned, ReasonTTSError)
 	rec.TurnOutcome(TurnAbandoned, ReasonProviderError)
 
+	rec.MemoryRecall(RecallHit)
+	rec.MemoryRecall(RecallMiss)
+	rec.MemoryRecall(RecallSkip)
+
 	out := scrape(t, rec)
 
 	// Every family is present and namespaced glyphoxa_voice_* (embedding_backlog
@@ -81,6 +85,9 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_voice_turn_total{outcome="abandoned",reason="barge"} 1`,
 		`glyphoxa_voice_turn_total{outcome="abandoned",reason="tts_error"} 1`,
 		`glyphoxa_voice_turn_total{outcome="abandoned",reason="provider_error"} 1`,
+		`glyphoxa_voice_memory_recall_total{outcome="hit"} 1`,
+		`glyphoxa_voice_memory_recall_total{outcome="miss"} 1`,
+		`glyphoxa_voice_memory_recall_total{outcome="skip"} 1`,
 		`glyphoxa_embedding_backlog 0`,
 	}
 	for _, want := range wantSubstrings {

--- a/internal/recall/normalize.go
+++ b/internal/recall/normalize.go
@@ -1,0 +1,37 @@
+package recall
+
+import (
+	"strings"
+	"unicode"
+)
+
+// normalize folds an utterance to its speculation-cache comparison form: lower
+// case, punctuation stripped, whitespace collapsed to single spaces and trimmed.
+// It is the self-heal key of ADR-0042 — the [STTFinal] text is normalized and
+// matched against the normalized partial a speculation prefetched on, so casing,
+// trailing punctuation, and interim-whitespace jitter between the partial and the
+// final do not defeat the cache. Deliberately a tiny local function: the recall
+// path must not import the voicetest helpers.
+func normalize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	pendingSpace := false
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			if pendingSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			pendingSpace = false
+			b.WriteRune(unicode.ToLower(r))
+		case unicode.IsSpace(r):
+			pendingSpace = true
+		default:
+			// Punctuation is dropped without joining the surrounding words: it acts
+			// as a soft boundary so "well,now" and "well now" both normalize to
+			// "well now", but the space is only emitted if a word actually follows.
+			pendingSpace = true
+		}
+	}
+	return b.String()
+}

--- a/internal/recall/normalize_test.go
+++ b/internal/recall/normalize_test.go
@@ -1,0 +1,37 @@
+package recall
+
+import "testing"
+
+// TestNormalize_VariantsMatch pins the self-heal key (ADR-0042): case,
+// trailing/embedded punctuation and whitespace jitter all fold to the same
+// comparison form, so a speculated partial matches its STTFinal.
+func TestNormalize_VariantsMatch(t *testing.T) {
+	canonical := "do you remember the ruby dagger"
+	variants := []string{
+		"Do you remember the Ruby Dagger?",
+		"do you remember the ruby dagger",
+		"  DO   you remember the ruby dagger!!!  ",
+		"Do you remember the ruby dagger...",
+		"do you, remember the ruby dagger",
+	}
+	for _, v := range variants {
+		if got := normalize(v); got != canonical {
+			t.Errorf("normalize(%q) = %q, want %q", v, got, canonical)
+		}
+	}
+}
+
+// TestNormalize_DifferentWordsDiffer pins that distinct utterances do NOT
+// collapse together — a mismatch must fall back to inline retrieval, not reuse a
+// stale prefetch.
+func TestNormalize_DifferentWordsDiffer(t *testing.T) {
+	if normalize("the ruby dagger") == normalize("the golden crown") {
+		t.Error("distinct utterances must normalize differently")
+	}
+	if normalize("") != "" {
+		t.Errorf("normalize(empty) = %q, want empty", normalize(""))
+	}
+	if normalize("!!! ??? ...") != "" {
+		t.Errorf("normalize(punct-only) = %q, want empty", normalize("!!! ??? ..."))
+	}
+}

--- a/internal/recall/recall.go
+++ b/internal/recall/recall.go
@@ -1,0 +1,284 @@
+// Package recall is the NPC memory-recall component (#122, ADR-0011/0042): the
+// production [agent.MemoryRecaller] the voice loop consults each turn to fill the
+// Hot Context memory slot.
+//
+// Two paths, one contract (recall NEVER stalls the turn and NEVER errors):
+//
+//   - Speculative: during speech, the recaller subscribes to [voiceevent.STTPartial]
+//     and, off the turn path, embeds the stabilized interim text and prefetches the
+//     world-context ANN chunks (ADR-0011's campaign-scoped mode). At [Recaller.Recall]
+//     time, if the final utterance matches the speculated query (normalized), the
+//     prefetched vector and world chunks are reused and only the NPC-knowledge ANN
+//     (target-agent-scoped, unknown during speech) runs — a single indexed query — so
+//     memory injects at effectively zero added latency (a "hit").
+//   - Inline: no usable speculation (mismatch, no partials, batch STT) falls back to
+//     embedding the utterance and running BOTH ANN modes within a hard budget
+//     (~250ms, ADR-0042) inside the turn ctx (a "miss").
+//
+// A slow or unavailable embeddings/DB path, or the budget elapsing, degrades to a
+// zero [agent.Memory] ("skip", counted). A barge cancels the turn ctx, which
+// cancels retrieval and yields zero Memory WITHOUT counting a skip — the turn is
+// gone, nothing was wasted (ADR-0042). With no configured recaller the agent loop
+// never constructs one, so the turn behaves exactly as before (AC6).
+package recall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Retriever is the ANN retrieval surface the recaller needs (#119, ADR-0011):
+// NPC-knowledge (participated-agent filter) and world-context (campaign only).
+// *storage.Store satisfies it.
+type Retriever interface {
+	SearchChunksByAgent(ctx context.Context, campaignID, agentID uuid.UUID, query []float32, k int) ([]storage.ChunkMatch, error)
+	SearchChunksByCampaign(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.ChunkMatch, error)
+}
+
+// Sessions is the narrow read the recaller needs from the SessionManager: which
+// Voice Session (hence which Campaign) is active, so retrieval is campaign-scoped.
+// *session.Manager satisfies it via Snapshot (the same shape the transcript relay
+// depends on); defined locally so recall does not import session.
+type Sessions interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// Metrics records recall outcomes (#122, ADR-0032). *observe.PrometheusRecorder
+// satisfies it; a nil Metrics is replaced with a no-op so call sites never check.
+type Metrics interface {
+	MemoryRecall(observe.RecallOutcome)
+}
+
+// Config tunes the recaller. Zero values take the package defaults.
+type Config struct {
+	// Budget is the hard inline-retrieval budget inside the turn ctx (ADR-0042):
+	// embed + both ANN searches must finish within it or recall degrades to
+	// no-memory. Default 250ms.
+	Budget time.Duration
+	// K is the number of chunks fetched per retrieval mode. Default 3.
+	K int
+}
+
+const (
+	defaultBudget = 250 * time.Millisecond
+	defaultK      = 3
+
+	// minSpeculateWords is the shortest normalized partial worth embedding: a one-
+	// or two-word interim ("do you") carries no retrieval signal and would only
+	// churn the provider.
+	minSpeculateWords = 3
+	// minEmbedInterval rate-limits speculative embeds so a fast partial stream does
+	// not fire an embed per interim; the latest text is picked up on the next tick.
+	minEmbedInterval = 200 * time.Millisecond
+	// speculateTimeout bounds one off-path speculative embed+prefetch so a wedged
+	// provider cannot pin the single speculator goroutine forever (it just misses
+	// the chance to help; the inline path self-heals at the final).
+	speculateTimeout = 5 * time.Second
+)
+
+func (c Config) withDefaults() Config {
+	if c.Budget <= 0 {
+		c.Budget = defaultBudget
+	}
+	if c.K <= 0 {
+		c.K = defaultK
+	}
+	return c
+}
+
+// Recaller is the production [agent.MemoryRecaller]. Construct with [New]; it
+// subscribes to the bus and starts one speculator goroutine at construction, both
+// released by [Recaller.Close]. Safe for concurrent use.
+type Recaller struct {
+	embedder  embeddings.Provider
+	retriever Retriever
+	sessions  Sessions
+	metrics   Metrics
+	log       *slog.Logger
+	budget    time.Duration
+	k         int
+
+	now func() time.Time // injected in tests; time.Now in production
+
+	// speculation state (see speculate.go)
+	ctx         context.Context
+	cancel      context.CancelFunc
+	unsubscribe func()
+	signal      chan struct{} // 1-slot wake for the speculator
+	specDone    chan struct{} // closed when the speculator goroutine exits
+	speculated  chan struct{} // 1-slot test notify: a speculation pass completed
+
+	mailMu     sync.Mutex
+	pending    string
+	hasPending bool
+
+	// lastEmbed* gate the speculator; touched only by the speculator goroutine.
+	lastEmbedNorm string
+	lastEmbedAt   time.Time
+
+	cacheMu sync.Mutex
+	cache   specCache
+}
+
+// New builds a Recaller wired to the embeddings provider, the ANN retriever, the
+// session source (for the active Campaign), the process bus (for STTPartial
+// speculation), and the metrics sink. It subscribes to the bus and launches the
+// speculator goroutine immediately; call [Recaller.Close] on shutdown to release
+// both.
+func New(embedder embeddings.Provider, retriever Retriever, sessions Sessions, bus *voiceevent.Bus, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
+	cfg = cfg.withDefaults()
+	if log == nil {
+		log = slog.Default()
+	}
+	if metrics == nil {
+		metrics = discardMetrics{}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Recaller{
+		embedder:   embedder,
+		retriever:  retriever,
+		sessions:   sessions,
+		metrics:    metrics,
+		log:        log,
+		budget:     cfg.Budget,
+		k:          cfg.K,
+		now:        time.Now,
+		ctx:        ctx,
+		cancel:     cancel,
+		signal:     make(chan struct{}, 1),
+		specDone:   make(chan struct{}),
+		speculated: make(chan struct{}, 1),
+	}
+	r.unsubscribe = voiceevent.On(bus, r.onPartial)
+	go r.speculateLoop()
+	return r
+}
+
+// Close unsubscribes from the bus and stops the speculator goroutine. It is
+// idempotent-safe only once (a second call blocks on the closed done channel);
+// wire it once, on process shutdown. Tests defer it.
+func (r *Recaller) Close() {
+	r.unsubscribe()
+	r.cancel()
+	<-r.specDone
+}
+
+// Recall implements [agent.MemoryRecaller]. It returns the Hot Context memory for
+// this turn, honoring the bounded-sync budget and degrading to a zero Memory
+// rather than stalling. It never returns an error and never panics.
+func (r *Recaller) Recall(ctx context.Context, agentID, utterance string) agent.Memory {
+	aid, err := uuid.Parse(agentID)
+	if err != nil {
+		// Defensive, consistent with the chunker's posture: an unparseable agent id
+		// is a wiring bug, not a turn failure — skip and move on.
+		r.log.Warn("memory recall: unparseable agent id; skipping", "agent_id", agentID, "err", err)
+		r.metrics.MemoryRecall(observe.RecallSkip)
+		return agent.Memory{}
+	}
+	campaignID, ok := r.campaign()
+	if !ok {
+		// No active session to scope retrieval — recall runs during a live turn, so
+		// this is defensive; count it as a skip.
+		r.metrics.MemoryRecall(observe.RecallSkip)
+		return agent.Memory{}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.budget)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		// The turn ctx was already cancelled (a barge before recall even started):
+		// yield nothing and count nothing.
+		return r.degrade(ctx, err)
+	}
+
+	norm := normalize(utterance)
+	vec, world, hit := r.cacheLookup(norm)
+
+	if !hit {
+		vecs, err := r.embedder.Embed(ctx, []string{utterance})
+		if err != nil {
+			return r.degrade(ctx, fmt.Errorf("embed utterance: %w", err))
+		}
+		if len(vecs) != 1 {
+			return r.degrade(ctx, fmt.Errorf("embed returned %d vectors, want 1", len(vecs)))
+		}
+		vec = vecs[0]
+		w, err := r.retriever.SearchChunksByCampaign(ctx, campaignID, vec, r.k)
+		if err != nil {
+			return r.degrade(ctx, fmt.Errorf("search world chunks: %w", err))
+		}
+		world = w
+	}
+
+	// NPC-knowledge is always run at Recall time: the target agent is unknown
+	// during speech, so a hit still owes this one indexed, sub-ms query.
+	personal, err := r.retriever.SearchChunksByAgent(ctx, campaignID, aid, vec, r.k)
+	if err != nil {
+		return r.degrade(ctx, fmt.Errorf("search agent chunks: %w", err))
+	}
+
+	if hit {
+		r.metrics.MemoryRecall(observe.RecallHit)
+	} else {
+		r.metrics.MemoryRecall(observe.RecallMiss)
+	}
+	return agent.Memory{
+		Personal: chunkContents(personal),
+		World:    chunkContents(world),
+	}
+}
+
+// degrade yields a zero Memory. A cancelled ctx is a barge (ADR-0042): silent,
+// NOT counted — the turn is gone, nothing was wasted. Any other failure (budget
+// elapsed, provider/DB error) logs and counts a skip.
+func (r *Recaller) degrade(ctx context.Context, cause error) agent.Memory {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return agent.Memory{}
+	}
+	r.log.Warn("memory recall degraded to no-memory", "err", cause)
+	r.metrics.MemoryRecall(observe.RecallSkip)
+	return agent.Memory{}
+}
+
+// campaign reads the active session's Campaign id, or false when idle.
+func (r *Recaller) campaign() (uuid.UUID, bool) {
+	vs, ok := r.sessions.Snapshot()
+	if !ok {
+		return uuid.Nil, false
+	}
+	return vs.CampaignID, true
+}
+
+// chunkContents projects ANN matches to their chunk contents in rank order
+// (nearest first). Tolerant of fewer than k results (the HNSW post-filter can
+// return fewer — normal, ADR-0011).
+func chunkContents(matches []storage.ChunkMatch) []string {
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m.Chunk.Content)
+	}
+	return out
+}
+
+// discardMetrics is the no-op Metrics used when none is configured.
+type discardMetrics struct{}
+
+func (discardMetrics) MemoryRecall(observe.RecallOutcome) {}
+
+// Static assertion that Recaller is a MemoryRecaller.
+var _ agent.MemoryRecaller = (*Recaller)(nil)

--- a/internal/recall/recall.go
+++ b/internal/recall/recall.go
@@ -110,7 +110,8 @@ type Recaller struct {
 	budget    time.Duration
 	k         int
 
-	now func() time.Time // injected in tests; time.Now in production
+	now   func() time.Time                                 // injected in tests; time.Now in production
+	sleep func(ctx context.Context, d time.Duration) error // injected in tests; a ctx-aware timer in production
 
 	// speculation state (see speculate.go)
 	ctx         context.Context
@@ -138,6 +139,16 @@ type Recaller struct {
 // speculator goroutine immediately; call [Recaller.Close] on shutdown to release
 // both.
 func New(embedder embeddings.Provider, retriever Retriever, sessions Sessions, bus *voiceevent.Bus, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
+	r := newRecaller(embedder, retriever, sessions, metrics, log, cfg)
+	r.start(bus)
+	return r
+}
+
+// newRecaller builds the Recaller struct with production seams but does NOT
+// subscribe or start the goroutine — the split lets white-box tests inject the
+// now/sleep clock seams BEFORE the speculator goroutine reads them (no data race),
+// then call [Recaller.start]. Production goes through [New].
+func newRecaller(embedder embeddings.Provider, retriever Retriever, sessions Sessions, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
 	cfg = cfg.withDefaults()
 	if log == nil {
 		log = slog.Default()
@@ -146,7 +157,7 @@ func New(embedder embeddings.Provider, retriever Retriever, sessions Sessions, b
 		metrics = discardMetrics{}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	r := &Recaller{
+	return &Recaller{
 		embedder:   embedder,
 		retriever:  retriever,
 		sessions:   sessions,
@@ -155,20 +166,39 @@ func New(embedder embeddings.Provider, retriever Retriever, sessions Sessions, b
 		budget:     cfg.Budget,
 		k:          cfg.K,
 		now:        time.Now,
+		sleep:      sleepCtx,
 		ctx:        ctx,
 		cancel:     cancel,
 		signal:     make(chan struct{}, 1),
 		specDone:   make(chan struct{}),
 		speculated: make(chan struct{}, 1),
 	}
-	r.unsubscribe = voiceevent.On(bus, r.onPartial)
-	go r.speculateLoop()
-	return r
 }
 
-// Close unsubscribes from the bus and stops the speculator goroutine. It is
-// idempotent-safe only once (a second call blocks on the closed done channel);
-// wire it once, on process shutdown. Tests defer it.
+// start subscribes to the bus and launches the speculator goroutine. Called once
+// by [New] (production) or a white-box test after seams are set.
+func (r *Recaller) start(bus *voiceevent.Bus) {
+	r.unsubscribe = voiceevent.On(bus, r.onPartial)
+	go r.speculateLoop()
+}
+
+// sleepCtx blocks for d or until ctx is cancelled, returning ctx.Err() on cancel.
+// A timer (not time.Sleep) so a cancelled ctx returns immediately.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// Close unsubscribes from the bus and stops the speculator goroutine. Idempotent:
+// unsubscribe and cancel are each no-ops on a second call, and the closed done
+// channel returns immediately — but wire it once, on process shutdown. Tests defer
+// it.
 func (r *Recaller) Close() {
 	r.unsubscribe()
 	r.cancel()
@@ -204,9 +234,27 @@ func (r *Recaller) Recall(ctx context.Context, agentID, utterance string) agent.
 	}
 
 	norm := normalize(utterance)
-	vec, world, hit := r.cacheLookup(norm)
+	cached, hit := r.cacheLookup(norm)
 
-	if !hit {
+	var vec []float32
+	var world []storage.ChunkMatch
+	switch {
+	case hit && cached.worldOK:
+		// Full speculation hit: reuse the vector AND the prefetched world chunks.
+		vec = cached.vec
+		world = cached.world
+	case hit:
+		// The vector was cached but its world prefetch had failed (worldOK false):
+		// reuse the vector (skip the embed) and fetch world inline within the budget,
+		// so a hit never silently returns empty world.
+		vec = cached.vec
+		w, err := r.retriever.SearchChunksByCampaign(ctx, campaignID, vec, r.k)
+		if err != nil {
+			return r.degrade(ctx, fmt.Errorf("search world chunks (hit, prefetch had failed): %w", err))
+		}
+		world = w
+	default:
+		// Miss: embed the utterance and run BOTH modes inline under the budget.
 		vecs, err := r.embedder.Embed(ctx, []string{utterance})
 		if err != nil {
 			return r.degrade(ctx, fmt.Errorf("embed utterance: %w", err))
@@ -228,6 +276,11 @@ func (r *Recaller) Recall(ctx context.Context, agentID, utterance string) agent.
 	if err != nil {
 		return r.degrade(ctx, fmt.Errorf("search agent chunks: %w", err))
 	}
+
+	// A chunk the NPC participated in can also land in the campaign-wide top-k;
+	// drop it from World so a fact is never framed BOTH as personally witnessed and
+	// as possibly-not-witnessed (ADR-0011). Personal wins.
+	world = excludeByID(world, chunkIDSet(personal))
 
 	if hit {
 		r.metrics.MemoryRecall(observe.RecallHit)
@@ -271,6 +324,33 @@ func chunkContents(matches []storage.ChunkMatch) []string {
 	out := make([]string, 0, len(matches))
 	for _, m := range matches {
 		out = append(out, m.Chunk.Content)
+	}
+	return out
+}
+
+// chunkIDSet collects the chunk ids of a match set.
+func chunkIDSet(matches []storage.ChunkMatch) map[uuid.UUID]bool {
+	if len(matches) == 0 {
+		return nil
+	}
+	s := make(map[uuid.UUID]bool, len(matches))
+	for _, m := range matches {
+		s[m.Chunk.ID] = true
+	}
+	return s
+}
+
+// excludeByID returns the matches whose chunk id is not in exclude, preserving
+// order. It allocates a fresh slice so the cached prefetch slice is never mutated.
+func excludeByID(matches []storage.ChunkMatch, exclude map[uuid.UUID]bool) []storage.ChunkMatch {
+	if len(matches) == 0 || len(exclude) == 0 {
+		return matches
+	}
+	out := make([]storage.ChunkMatch, 0, len(matches))
+	for _, m := range matches {
+		if !exclude[m.Chunk.ID] {
+			out = append(out, m)
+		}
 	}
 	return out
 }

--- a/internal/recall/recall_integration_test.go
+++ b/internal/recall/recall_integration_test.go
@@ -13,7 +13,6 @@ package recall
 import (
 	"context"
 	"database/sql"
-	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -35,8 +34,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
-
-func testLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
 
 const pgImage = "pgvector/pgvector:pg17"
 
@@ -209,19 +206,24 @@ func TestRecall_Integration_FactLandsInCorrectSection(t *testing.T) {
 		t.Fatalf("AC1: established fact not recalled into the prompt:\n%s", sys)
 	}
 	iWitnessed := strings.Index(sys, "You personally witnessed:")
-	iSecondHand := strings.Index(sys, "You may have heard second-hand")
-	if iWitnessed < 0 || iSecondHand < 0 || iWitnessed > iSecondHand {
-		t.Fatalf("AC2: both memory sections must be present, witnessed before second-hand:\n%s", sys)
+	iWorld := strings.Index(sys, "You may know these from around the campaign")
+	if iWitnessed < 0 || iWorld < 0 || iWitnessed > iWorld {
+		t.Fatalf("AC2: both memory sections must be present, witnessed before world context:\n%s", sys)
 	}
-	witnessed, secondHand := sys[iWitnessed:iSecondHand], sys[iSecondHand:]
+	witnessed, world := sys[iWitnessed:iWorld], sys[iWorld:]
 	if !strings.Contains(witnessed, rubyText) {
 		t.Errorf("AC2: participated fact not in the witnessed section:\n%s", witnessed)
 	}
 	if strings.Contains(witnessed, dragText) {
 		t.Errorf("AC2: a non-participated fact leaked into the witnessed section:\n%s", witnessed)
 	}
-	if !strings.Contains(secondHand, dragText) {
-		t.Errorf("AC2: campaign fact not framed as second-hand:\n%s", secondHand)
+	if !strings.Contains(world, dragText) {
+		t.Errorf("AC2: campaign fact not framed as world context:\n%s", world)
+	}
+	// Dedup (finding 1a): the participated fact must appear ONLY in the witnessed
+	// section, never duplicated into world context with contradictory framing.
+	if strings.Contains(world, rubyText) {
+		t.Errorf("AC2: participated fact duplicated into the world-context section:\n%s", world)
 	}
 
 	// Recall OFF (AC6): the same turn without a recaller never mentions the fact.

--- a/internal/recall/recall_integration_test.go
+++ b/internal/recall/recall_integration_test.go
@@ -1,0 +1,272 @@
+//go:build integration
+
+// This test stands up a real pgvector Postgres (testcontainers), embeds seeded
+// Transcript Chunks through the real #116 backfill path (embedworker over an
+// embeddingstest.Fixed provider), and drives a real Agent turn with the recaller
+// wired in — the content-ful proof of AC1 (an NPC references a fact established in
+// an earlier embedded chunk that it could not without retrieval) and AC2 (personal
+// vs world framing). Tag-isolated behind `integration` (ADR-0021/0033); run with
+// `go test -tags=integration ./internal/recall/`.
+
+package recall
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/embedworker"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+const pgImage = "pgvector/pgvector:pg17"
+
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("GLYPHOXA_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?). "+
+			"Set GLYPHOXA_TEST_DSN to an external pgvector Postgres to run without Docker. err: %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+// migratedPool migrates the schema up and returns an app pool.
+func migratedPool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// recallVec768 builds an embeddings.Dim vector from its leading components,
+// zero-padded to the vector(768) shape the storage layer requires.
+func recallVec768(lead ...float32) []float32 {
+	v := make([]float32, embeddings.Dim)
+	copy(v, lead)
+	return v
+}
+
+// captureEngine is a scripted [agent.Engine] that records the exact messages the
+// loop assembled, so the test asserts on the real system prompt.
+type captureEngine struct {
+	reply string
+	msgs  []llm.Message
+}
+
+func (e *captureEngine) Generate(_ context.Context, messages []llm.Message) (string, error) {
+	e.msgs = append([]llm.Message(nil), messages...)
+	return e.reply, nil
+}
+
+func (e *captureEngine) systemPrompt(t *testing.T) string {
+	t.Helper()
+	if len(e.msgs) == 0 {
+		t.Fatal("engine was never called")
+	}
+	if e.msgs[0].Role != llm.RoleSystem {
+		t.Fatalf("first message role = %q, want system", e.msgs[0].Role)
+	}
+	return e.msgs[0].Text
+}
+
+// silentSynth returns an empty audio-markup instruction, so the system prompt is
+// Persona + the recalled memory block — nothing else to disentangle.
+type silentSynth struct{}
+
+func (silentSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+func (silentSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestRecall_Integration_FactLandsInCorrectSection is AC1 + AC2 end-to-end: a fact
+// established in an embedded chunk the NPC participated in surfaces in the
+// "personally witnessed" section, a campaign fact the NPC did NOT participate in
+// surfaces only in the "second-hand" section, and with recall disabled neither
+// reaches the prompt.
+func TestRecall_Integration_FactLandsInCorrectSection(t *testing.T) {
+	dsn := startPostgres(t)
+	pool := migratedPool(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Seed a tenant + campaign + voice session (FKs for chunks).
+	var tenantID, campaignID uuid.UUID
+	if err := pool.QueryRow(ctx, `INSERT INTO tenant (name) VALUES ('Acme') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language) VALUES ($1, 'Lost Mine', 'dnd5e', 'en') RETURNING id`,
+		tenantID).Scan(&campaignID); err != nil {
+		t.Fatalf("insert campaign: %v", err)
+	}
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	targetAgent, otherAgent := uuid.New(), uuid.New()
+
+	const (
+		utterance = "do you remember the ruby dagger"
+		rubyText  = "The ruby dagger was stolen from the vault."
+		dragText  = "A dragon was seen near the northern pass."
+		breadText = "The tavern serves warm bread each morning."
+	)
+
+	// A tiny cosine space keyed on the query direction e0.
+	fixed := embeddingstest.Fixed{
+		utterance: recallVec768(1, 0),
+		rubyText:  recallVec768(0.95, 0.05),
+		dragText:  recallVec768(0.9, 0.2),
+		breadText: recallVec768(0, 1),
+	}
+
+	// Insert the chunks with embedding NULL (the real writer path).
+	insertChunk := func(content string, agents []uuid.UUID) {
+		if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+			CampaignID:           campaignID,
+			VoiceSessionID:       vs.ID,
+			Content:              content,
+			ParticipatedAgentIDs: agents,
+			StartedAt:            time.Date(2026, 7, 5, 18, 0, 0, 0, time.UTC),
+		}); err != nil {
+			t.Fatalf("InsertTranscriptChunk %q: %v", content, err)
+		}
+	}
+	insertChunk(rubyText, []uuid.UUID{targetAgent}) // NPC personally participated
+	insertChunk(dragText, []uuid.UUID{otherAgent})  // campaign-wide only
+	insertChunk(breadText, []uuid.UUID{otherAgent})
+
+	// Embed them through the real #116 backfill worker over the Fixed provider.
+	drainBacklog(t, st, fixed)
+
+	bus := voiceevent.NewBus()
+	recaller := New(fixed, st, fakeSessions{campaignID: campaignID, active: true}, bus, newFakeMetrics(),
+		testLogger(), Config{})
+	t.Cleanup(recaller.Close)
+
+	// Recall ON: the fact must reach the prompt in the correct section.
+	eng := &captureEngine{reply: "Aye, I recall it."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: targetAgent.String(), Markdown: "You are the tavern keeper.", Voice: tts.Voice{ProviderID: "elevenlabs", VoiceID: "v"}},
+		Engine:      eng,
+		Synthesizer: silentSynth{},
+		Memory:      recaller,
+	})
+	r.Reply()(ctx, addressRouted(targetAgent.String(), utterance))
+
+	sys := eng.systemPrompt(t)
+	if !strings.Contains(sys, rubyText) {
+		t.Fatalf("AC1: established fact not recalled into the prompt:\n%s", sys)
+	}
+	iWitnessed := strings.Index(sys, "You personally witnessed:")
+	iSecondHand := strings.Index(sys, "You may have heard second-hand")
+	if iWitnessed < 0 || iSecondHand < 0 || iWitnessed > iSecondHand {
+		t.Fatalf("AC2: both memory sections must be present, witnessed before second-hand:\n%s", sys)
+	}
+	witnessed, secondHand := sys[iWitnessed:iSecondHand], sys[iSecondHand:]
+	if !strings.Contains(witnessed, rubyText) {
+		t.Errorf("AC2: participated fact not in the witnessed section:\n%s", witnessed)
+	}
+	if strings.Contains(witnessed, dragText) {
+		t.Errorf("AC2: a non-participated fact leaked into the witnessed section:\n%s", witnessed)
+	}
+	if !strings.Contains(secondHand, dragText) {
+		t.Errorf("AC2: campaign fact not framed as second-hand:\n%s", secondHand)
+	}
+
+	// Recall OFF (AC6): the same turn without a recaller never mentions the fact.
+	engOff := &captureEngine{reply: "Hmm."}
+	rOff := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: targetAgent.String(), Markdown: "You are the tavern keeper.", Voice: tts.Voice{ProviderID: "elevenlabs", VoiceID: "v"}},
+		Engine:      engOff,
+		Synthesizer: silentSynth{},
+		// Memory nil.
+	})
+	rOff.Reply()(ctx, addressRouted(targetAgent.String(), utterance))
+	if off := engOff.systemPrompt(t); strings.Contains(off, rubyText) || strings.Contains(off, "You personally witnessed:") {
+		t.Errorf("AC6: with recall disabled the prompt must carry no memory:\n%s", off)
+	}
+}
+
+// drainBacklog runs the real backfill worker over provider until the
+// NULL-embedding backlog reaches zero, then stops it.
+func drainBacklog(t *testing.T, st *storage.Store, provider embeddings.Provider) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go embedworker.New(st, provider, "test-model", nil, testLogger(),
+		embedworker.Config{Interval: 10 * time.Millisecond, BatchSize: 16}).Run(ctx)
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		n, err := st.CountUnembeddedChunks(context.Background())
+		if err != nil {
+			t.Fatalf("CountUnembeddedChunks: %v", err)
+		}
+		if n == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("backfill did not drain the embedding backlog in time (%d left)", n)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func addressRouted(agentID, text string) voiceevent.AddressRouted {
+	return voiceevent.AddressRouted{
+		At:     time.Now(),
+		Text:   text,
+		Target: voiceevent.AddressTarget{AgentID: agentID, AgentRole: "character", Name: "Keeper"},
+	}
+}

--- a/internal/recall/recall_test.go
+++ b/internal/recall/recall_test.go
@@ -1,0 +1,350 @@
+package recall
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// --- fakes ---
+
+type fakeEmbedder struct {
+	mu    sync.Mutex
+	calls int
+	vec   []float32
+	block bool  // block until ctx is done, then return ctx.Err()
+	err   error // forced error
+}
+
+func (f *fakeEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = f.vec
+	}
+	return out, nil
+}
+
+func (f *fakeEmbedder) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+type fakeRetriever struct {
+	mu           sync.Mutex
+	byAgentCalls int
+	byCampCalls  int
+	agentChunks  []storage.ChunkMatch
+	campChunks   []storage.ChunkMatch
+	agentErr     error
+	campErr      error
+}
+
+func (f *fakeRetriever) SearchChunksByAgent(_ context.Context, _, _ uuid.UUID, _ []float32, _ int) ([]storage.ChunkMatch, error) {
+	f.mu.Lock()
+	f.byAgentCalls++
+	f.mu.Unlock()
+	if f.agentErr != nil {
+		return nil, f.agentErr
+	}
+	return f.agentChunks, nil
+}
+
+func (f *fakeRetriever) SearchChunksByCampaign(_ context.Context, _ uuid.UUID, _ []float32, _ int) ([]storage.ChunkMatch, error) {
+	f.mu.Lock()
+	f.byCampCalls++
+	f.mu.Unlock()
+	if f.campErr != nil {
+		return nil, f.campErr
+	}
+	return f.campChunks, nil
+}
+
+func (f *fakeRetriever) agentN() int { f.mu.Lock(); defer f.mu.Unlock(); return f.byAgentCalls }
+func (f *fakeRetriever) campN() int  { f.mu.Lock(); defer f.mu.Unlock(); return f.byCampCalls }
+
+type fakeSessions struct {
+	campaignID uuid.UUID
+	active     bool
+}
+
+func (f fakeSessions) Snapshot() (storage.VoiceSession, bool) {
+	if !f.active {
+		return storage.VoiceSession{}, false
+	}
+	return storage.VoiceSession{ID: uuid.New(), CampaignID: f.campaignID}, true
+}
+
+type fakeMetrics struct {
+	mu     sync.Mutex
+	counts map[observe.RecallOutcome]int
+}
+
+func newFakeMetrics() *fakeMetrics { return &fakeMetrics{counts: map[observe.RecallOutcome]int{}} }
+
+func (f *fakeMetrics) MemoryRecall(o observe.RecallOutcome) {
+	f.mu.Lock()
+	f.counts[o]++
+	f.mu.Unlock()
+}
+
+func (f *fakeMetrics) count(o observe.RecallOutcome) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.counts[o]
+}
+
+func (f *fakeMetrics) total() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, v := range f.counts {
+		n += v
+	}
+	return n
+}
+
+// --- helpers ---
+
+func fixedVec() []float32 { return []float32{0.1, 0.2, 0.3} }
+
+func chunkMatch(content string) storage.ChunkMatch {
+	return storage.ChunkMatch{Chunk: storage.TranscriptChunk{Content: content}}
+}
+
+func newTestRecaller(t *testing.T, emb embeddings.Provider, ret Retriever, sess Sessions, m Metrics, bus *voiceevent.Bus, cfg Config) *Recaller {
+	t.Helper()
+	r := New(emb, ret, sess, bus, m, slog.New(slog.DiscardHandler), cfg)
+	t.Cleanup(r.Close)
+	return r
+}
+
+func waitSpeculated(t *testing.T, r *Recaller) {
+	t.Helper()
+	select {
+	case <-r.speculated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a speculation pass")
+	}
+}
+
+// --- tests ---
+
+// TestRecall_NoPartials_InlineQueriesBothModes_CountsMiss pins the inline
+// bounded-sync path (ADR-0042): with no speculation, Recall embeds the utterance
+// and runs BOTH ANN modes, returns the chunks split by mode, and counts a miss.
+func TestRecall_NoPartials_InlineQueriesBothModes_CountsMiss(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{
+		agentChunks: []storage.ChunkMatch{chunkMatch("I poured his ale.")},
+		campChunks:  []storage.ChunkMatch{chunkMatch("A dragon flew over the pass.")},
+	}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, voiceevent.NewBus(), Config{})
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "do you remember the ale")
+
+	if emb.callCount() != 1 {
+		t.Errorf("embed calls = %d, want 1 (inline embed)", emb.callCount())
+	}
+	if ret.campN() != 1 || ret.agentN() != 1 {
+		t.Errorf("want both ANN modes queried once: camp=%d agent=%d", ret.campN(), ret.agentN())
+	}
+	if len(mem.Personal) != 1 || mem.Personal[0] != "I poured his ale." {
+		t.Errorf("personal = %v, want the NPC-knowledge chunk", mem.Personal)
+	}
+	if len(mem.World) != 1 || mem.World[0] != "A dragon flew over the pass." {
+		t.Errorf("world = %v, want the world-context chunk", mem.World)
+	}
+	if m.count(observe.RecallMiss) != 1 || m.count(observe.RecallHit) != 0 {
+		t.Errorf("outcomes: miss=%d hit=%d, want miss=1 hit=0", m.count(observe.RecallMiss), m.count(observe.RecallHit))
+	}
+}
+
+// TestRecall_SpeculationHit_ReusesPrefetch_CountsHit pins the speculative path:
+// a partial is embedded + world-prefetched off the turn; a matching final reuses
+// the vector and prefetched world chunks, runs ONLY the deferred NPC-knowledge
+// query, and counts a hit — no second embed.
+func TestRecall_SpeculationHit_ReusesPrefetch_CountsHit(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{
+		agentChunks: []storage.ChunkMatch{chunkMatch("I served the knight last night.")},
+		campChunks:  []storage.ChunkMatch{chunkMatch("Bandits on the north road.")},
+	}
+	m := newFakeMetrics()
+	bus := voiceevent.NewBus()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, bus, Config{})
+
+	bus.Publish(voiceevent.STTPartial{Text: "Do you remember the knight?", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+
+	if emb.callCount() != 1 {
+		t.Fatalf("speculator embed calls = %d, want 1", emb.callCount())
+	}
+	if ret.campN() != 1 {
+		t.Fatalf("world prefetch calls = %d, want 1", ret.campN())
+	}
+	if ret.agentN() != 0 {
+		t.Fatalf("NPC-knowledge must be deferred during speech; byAgent = %d, want 0", ret.agentN())
+	}
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "do you remember the knight")
+
+	if emb.callCount() != 1 {
+		t.Errorf("embed called again on a hit: calls = %d, want 1", emb.callCount())
+	}
+	if ret.agentN() != 1 {
+		t.Errorf("byAgent = %d, want exactly 1 (deferred NPC-knowledge at recall)", ret.agentN())
+	}
+	if ret.campN() != 1 {
+		t.Errorf("world re-queried on a hit: byCamp = %d, want 1 (prefetch only)", ret.campN())
+	}
+	if len(mem.World) != 1 || mem.World[0] != "Bandits on the north road." {
+		t.Errorf("world not reused from prefetch: %v", mem.World)
+	}
+	if len(mem.Personal) != 1 || mem.Personal[0] != "I served the knight last night." {
+		t.Errorf("personal = %v", mem.Personal)
+	}
+	if m.count(observe.RecallHit) != 1 || m.count(observe.RecallMiss) != 0 {
+		t.Errorf("outcomes: hit=%d miss=%d, want hit=1 miss=0", m.count(observe.RecallHit), m.count(observe.RecallMiss))
+	}
+}
+
+// TestRecall_SpeculationMiss_FallsBackInline_CountsMiss pins that a final NOT
+// matching the speculated partial re-embeds inline and counts a miss.
+func TestRecall_SpeculationMiss_FallsBackInline_CountsMiss(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{
+		agentChunks: []storage.ChunkMatch{chunkMatch("personal")},
+		campChunks:  []storage.ChunkMatch{chunkMatch("world")},
+	}
+	m := newFakeMetrics()
+	bus := voiceevent.NewBus()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, bus, Config{})
+
+	bus.Publish(voiceevent.STTPartial{Text: "Do you remember the knight?", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 1 {
+		t.Fatalf("speculator embed = %d, want 1", emb.callCount())
+	}
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "what about the golden crown")
+
+	if emb.callCount() != 2 {
+		t.Errorf("embed calls = %d, want 2 (speculation + inline miss)", emb.callCount())
+	}
+	if ret.agentN() != 1 {
+		t.Errorf("byAgent = %d, want 1", ret.agentN())
+	}
+	if ret.campN() != 2 {
+		t.Errorf("byCamp = %d, want 2 (prefetch + inline)", ret.campN())
+	}
+	if m.count(observe.RecallMiss) != 1 || m.count(observe.RecallHit) != 0 {
+		t.Errorf("outcomes: miss=%d hit=%d, want miss=1 hit=0", m.count(observe.RecallMiss), m.count(observe.RecallHit))
+	}
+	_ = mem
+}
+
+// TestRecall_BudgetExceeded_DegradesToSkip pins the hard budget (ADR-0042): an
+// embed that outlasts the budget yields zero Memory within ~budget and counts a
+// skip.
+func TestRecall_BudgetExceeded_DegradesToSkip(t *testing.T) {
+	emb := &fakeEmbedder{block: true}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true}, m,
+		voiceevent.NewBus(), Config{Budget: 50 * time.Millisecond})
+
+	start := time.Now()
+	mem := r.Recall(context.Background(), uuid.NewString(), "do you remember the ale")
+	elapsed := time.Since(start)
+
+	if !mem.IsZero() {
+		t.Errorf("want zero Memory on budget exceed, got %+v", mem)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("recall took %v, want ~budget (50ms)", elapsed)
+	}
+	if m.count(observe.RecallSkip) != 1 {
+		t.Errorf("skip = %d, want 1", m.count(observe.RecallSkip))
+	}
+}
+
+// TestRecall_RetrieverError_DegradesToSkip pins the DB-down degradation: a
+// retrieval error yields zero Memory and counts a skip.
+func TestRecall_RetrieverError_DegradesToSkip(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{campErr: errors.New("db down")}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, voiceevent.NewBus(), Config{})
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "do you remember the ale")
+	if !mem.IsZero() {
+		t.Errorf("want zero Memory on retriever error, got %+v", mem)
+	}
+	if m.count(observe.RecallSkip) != 1 {
+		t.Errorf("skip = %d, want 1", m.count(observe.RecallSkip))
+	}
+}
+
+// TestRecall_BargeCancel_ZeroMemoryNoCounter pins that a barge (a cancelled turn
+// ctx) yields zero Memory and counts NOTHING — not even a skip (ADR-0042): the
+// turn is gone, so the recall is not a degradation to record.
+func TestRecall_BargeCancel_ZeroMemoryNoCounter(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{agentChunks: []storage.ChunkMatch{chunkMatch("x")}}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, voiceevent.NewBus(), Config{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // barge cancelled the turn before recall started
+
+	mem := r.Recall(ctx, uuid.NewString(), "do you remember the ale")
+	if !mem.IsZero() {
+		t.Errorf("want zero Memory on barge, got %+v", mem)
+	}
+	if m.total() != 0 {
+		t.Errorf("a barge must count nothing; total outcomes = %d", m.total())
+	}
+	if emb.callCount() != 0 {
+		t.Errorf("a barge must not embed; calls = %d", emb.callCount())
+	}
+}
+
+// TestRecall_UnparseableAgentID_Skips pins the defensive guard: a non-uuid agent
+// id yields zero Memory and counts a skip, never a panic.
+func TestRecall_UnparseableAgentID_Skips(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true}, m, voiceevent.NewBus(), Config{})
+
+	mem := r.Recall(context.Background(), "not-a-uuid", "do you remember the ale")
+	if !mem.IsZero() {
+		t.Errorf("want zero Memory for a bad agent id, got %+v", mem)
+	}
+	if m.count(observe.RecallSkip) != 1 {
+		t.Errorf("skip = %d, want 1", m.count(observe.RecallSkip))
+	}
+	if emb.callCount() != 0 {
+		t.Errorf("must not embed with a bad agent id; calls = %d", emb.callCount())
+	}
+}

--- a/internal/recall/recall_test.go
+++ b/internal/recall/recall_test.go
@@ -51,13 +51,14 @@ func (f *fakeEmbedder) callCount() int {
 }
 
 type fakeRetriever struct {
-	mu           sync.Mutex
-	byAgentCalls int
-	byCampCalls  int
-	agentChunks  []storage.ChunkMatch
-	campChunks   []storage.ChunkMatch
-	agentErr     error
-	campErr      error
+	mu            sync.Mutex
+	byAgentCalls  int
+	byCampCalls   int
+	agentChunks   []storage.ChunkMatch
+	campChunks    []storage.ChunkMatch
+	agentErr      error
+	campErr       error
+	campFailFirst bool // fail only the FIRST ByCampaign call (a failed speculation prefetch)
 }
 
 func (f *fakeRetriever) SearchChunksByAgent(_ context.Context, _, _ uuid.UUID, _ []float32, _ int) ([]storage.ChunkMatch, error) {
@@ -73,9 +74,13 @@ func (f *fakeRetriever) SearchChunksByAgent(_ context.Context, _, _ uuid.UUID, _
 func (f *fakeRetriever) SearchChunksByCampaign(_ context.Context, _ uuid.UUID, _ []float32, _ int) ([]storage.ChunkMatch, error) {
 	f.mu.Lock()
 	f.byCampCalls++
+	n := f.byCampCalls
 	f.mu.Unlock()
 	if f.campErr != nil {
 		return nil, f.campErr
+	}
+	if f.campFailFirst && n == 1 {
+		return nil, errors.New("world prefetch failed")
 	}
 	return f.campChunks, nil
 }
@@ -126,15 +131,55 @@ func (f *fakeMetrics) total() int {
 
 // --- helpers ---
 
+func testLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
 func fixedVec() []float32 { return []float32{0.1, 0.2, 0.3} }
 
+// chunkMatch builds a match with a fresh unique chunk id, so distinct chunks in a
+// test never accidentally collide under the personal↔world dedup.
 func chunkMatch(content string) storage.ChunkMatch {
-	return storage.ChunkMatch{Chunk: storage.TranscriptChunk{Content: content}}
+	return storage.ChunkMatch{Chunk: storage.TranscriptChunk{ID: uuid.New(), Content: content}}
+}
+
+// chunkMatchID builds a match with a caller-chosen id, so a test can make the SAME
+// chunk appear in both the personal and world result sets (the dedup case).
+func chunkMatchID(id uuid.UUID, content string) storage.ChunkMatch {
+	return storage.ChunkMatch{Chunk: storage.TranscriptChunk{ID: id, Content: content}}
+}
+
+// fakeClock is a deterministic clock + ctx-aware sleep seam: sleeping simply
+// advances the clock, so rate-limit deferral is exercised without real waits.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1_700_000_000, 0)} }
+
+func (c *fakeClock) now() time.Time { c.mu.Lock(); defer c.mu.Unlock(); return c.t }
+
+func (c *fakeClock) sleep(_ context.Context, d time.Duration) error {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+	return nil
 }
 
 func newTestRecaller(t *testing.T, emb embeddings.Provider, ret Retriever, sess Sessions, m Metrics, bus *voiceevent.Bus, cfg Config) *Recaller {
 	t.Helper()
-	r := New(emb, ret, sess, bus, m, slog.New(slog.DiscardHandler), cfg)
+	r := New(emb, ret, sess, bus, m, testLogger(), cfg)
+	t.Cleanup(r.Close)
+	return r
+}
+
+// newSeamRecaller builds a recaller with injected now/sleep seams (set BEFORE the
+// speculator starts, so no data race) for deterministic speculator-gating tests.
+func newSeamRecaller(t *testing.T, emb embeddings.Provider, ret Retriever, sess Sessions, m Metrics, bus *voiceevent.Bus, cfg Config, clock *fakeClock) *Recaller {
+	t.Helper()
+	r := newRecaller(emb, ret, sess, m, testLogger(), cfg)
+	r.now = clock.now
+	r.sleep = clock.sleep
+	r.start(bus)
 	t.Cleanup(r.Close)
 	return r
 }
@@ -346,5 +391,157 @@ func TestRecall_UnparseableAgentID_Skips(t *testing.T) {
 	}
 	if emb.callCount() != 0 {
 		t.Errorf("must not embed with a bad agent id; calls = %d", emb.callCount())
+	}
+}
+
+// TestRecall_DedupsPersonalOutOfWorld pins finding 1a: a chunk the NPC
+// participated in that ALSO lands in the campaign-wide top-k is dropped from World,
+// so a fact is never framed both as personally witnessed AND as world context.
+func TestRecall_DedupsPersonalOutOfWorld(t *testing.T) {
+	shared := uuid.New()
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{
+		agentChunks: []storage.ChunkMatch{chunkMatchID(shared, "I saw the ritual myself.")},
+		campChunks: []storage.ChunkMatch{
+			chunkMatchID(shared, "I saw the ritual myself."), // same chunk, campaign-wide
+			chunkMatch("Bandits were spotted on the road."),  // world-only
+		},
+	}
+	m := newFakeMetrics()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, voiceevent.NewBus(), Config{})
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "what happened at the ritual")
+
+	if len(mem.Personal) != 1 || mem.Personal[0] != "I saw the ritual myself." {
+		t.Errorf("personal = %v, want the witnessed chunk", mem.Personal)
+	}
+	if len(mem.World) != 1 || mem.World[0] != "Bandits were spotted on the road." {
+		t.Errorf("world = %v, want ONLY the world-only chunk (participated chunk deduped out)", mem.World)
+	}
+}
+
+// TestRecall_HitWithFailedPrefetch_FetchesWorldInline pins finding 3: when the
+// speculation world prefetch failed (vector cached, worldOK false), a later hit
+// reuses the vector (no re-embed) and fetches world inline within the budget rather
+// than silently returning empty world — still counting a hit.
+func TestRecall_HitWithFailedPrefetch_FetchesWorldInline(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	ret := &fakeRetriever{
+		campFailFirst: true, // the speculation world prefetch fails
+		agentChunks:   []storage.ChunkMatch{chunkMatch("I served the duke.")},
+		campChunks:    []storage.ChunkMatch{chunkMatch("The duke rides north.")},
+	}
+	m := newFakeMetrics()
+	bus := voiceevent.NewBus()
+	r := newTestRecaller(t, emb, ret, fakeSessions{campaignID: uuid.New(), active: true}, m, bus, Config{})
+
+	bus.Publish(voiceevent.STTPartial{Text: "Do you remember the duke?", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 1 {
+		t.Fatalf("speculator embed = %d, want 1", emb.callCount())
+	}
+	if ret.campN() != 1 {
+		t.Fatalf("byCamp = %d, want 1 (the failed prefetch)", ret.campN())
+	}
+
+	mem := r.Recall(context.Background(), uuid.NewString(), "do you remember the duke")
+
+	if emb.callCount() != 1 {
+		t.Errorf("a hit must not re-embed; calls = %d, want 1", emb.callCount())
+	}
+	if ret.campN() != 2 {
+		t.Errorf("byCamp = %d, want 2 (failed prefetch + inline hit-fetch)", ret.campN())
+	}
+	if len(mem.World) != 1 || mem.World[0] != "The duke rides north." {
+		t.Errorf("world not fetched inline after a failed prefetch: %v", mem.World)
+	}
+	if len(mem.Personal) != 1 {
+		t.Errorf("personal = %v", mem.Personal)
+	}
+	if m.count(observe.RecallHit) != 1 {
+		t.Errorf("hit = %d, want 1", m.count(observe.RecallHit))
+	}
+}
+
+// TestSpeculator_SkipsShortPartials pins the ≥3-word gate: a one/two-word interim
+// carries no retrieval signal and must not embed.
+func TestSpeculator_SkipsShortPartials(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	bus := voiceevent.NewBus()
+	r := newSeamRecaller(t, emb, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true},
+		newFakeMetrics(), bus, Config{}, newFakeClock())
+
+	bus.Publish(voiceevent.STTPartial{Text: "do you", UtteranceID: "u1"}) // 2 words
+	waitSpeculated(t, r)
+	if emb.callCount() != 0 {
+		t.Errorf("a short partial embedded; calls = %d, want 0", emb.callCount())
+	}
+}
+
+// TestSpeculator_SkipsUnchangedNorm pins the changed-since-last-embed gate: a
+// partial whose normalized form equals the last embed is skipped even inside the
+// interval window.
+func TestSpeculator_SkipsUnchangedNorm(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	bus := voiceevent.NewBus()
+	r := newSeamRecaller(t, emb, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true},
+		newFakeMetrics(), bus, Config{}, newFakeClock())
+
+	bus.Publish(voiceevent.STTPartial{Text: "Do you remember the knight?", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 1 {
+		t.Fatalf("first embed = %d, want 1", emb.callCount())
+	}
+
+	// Same normalized text (different case/punct) → unchanged → skip.
+	bus.Publish(voiceevent.STTPartial{Text: "do you remember the knight", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 1 {
+		t.Errorf("an unchanged-norm partial re-embedded; calls = %d, want 1", emb.callCount())
+	}
+}
+
+// TestSpeculator_RateLimitDefersNotDrops pins finding 2 + the ≥200ms spacing gate:
+// a NEW candidate arriving inside the interval window is DEFERRED and embedded once
+// the interval elapses — never dropped (the last pre-final partial must still
+// speculate). Driven through the injected now/sleep clock so it is deterministic.
+func TestSpeculator_RateLimitDefersNotDrops(t *testing.T) {
+	emb := &fakeEmbedder{vec: fixedVec()}
+	bus := voiceevent.NewBus()
+	r := newSeamRecaller(t, emb, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true},
+		newFakeMetrics(), bus, Config{}, newFakeClock())
+
+	bus.Publish(voiceevent.STTPartial{Text: "do you remember the knight", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 1 {
+		t.Fatalf("first embed = %d, want 1", emb.callCount())
+	}
+
+	// New text within the window (clock not advanced): deferred, not dropped.
+	bus.Publish(voiceevent.STTPartial{Text: "do you recall the golden crown", UtteranceID: "u1"})
+	waitSpeculated(t, r)
+	if emb.callCount() != 2 {
+		t.Errorf("a rate-limited candidate was dropped; calls = %d, want 2 (deferred then embedded)", emb.callCount())
+	}
+}
+
+// TestMailbox_LatestWins pins the 1-slot latest-wins mailbox under a partial flood:
+// only the newest text survives to the speculator. Tests the mailbox directly (no
+// goroutine) so it is deterministic.
+func TestMailbox_LatestWins(t *testing.T) {
+	r := newRecaller(&fakeEmbedder{}, &fakeRetriever{}, fakeSessions{campaignID: uuid.New(), active: true},
+		newFakeMetrics(), testLogger(), Config{})
+	t.Cleanup(r.cancel)
+
+	r.onPartial(voiceevent.STTPartial{Text: "one"})
+	r.onPartial(voiceevent.STTPartial{Text: "two"})
+	r.onPartial(voiceevent.STTPartial{Text: "three"})
+
+	got, ok := r.takePending()
+	if !ok || got != "three" {
+		t.Errorf("takePending = (%q, %v), want (three, true) — latest wins", got, ok)
+	}
+	if _, ok := r.takePending(); ok {
+		t.Error("mailbox not empty after a drain")
 	}
 }

--- a/internal/recall/speculate.go
+++ b/internal/recall/speculate.go
@@ -3,6 +3,7 @@ package recall
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -11,12 +12,16 @@ import (
 // specCache holds the recaller's single speculated utterance (latest only): the
 // normalized query text, the embedded vector, and the world-context chunks
 // prefetched with that vector. A Recall whose normalized final matches norm reuses
-// vec + world and skips the inline embed (the "hit" path). Guarded by cacheMu.
+// vec (skipping the inline embed) and, when worldOK, the prefetched world chunks —
+// the "hit" path. worldOK is false when the vector embedded but the world prefetch
+// failed, so a hit knows to fetch world inline rather than return empty. Guarded by
+// cacheMu.
 type specCache struct {
-	norm  string
-	vec   []float32
-	world []storage.ChunkMatch
-	valid bool
+	norm    string
+	vec     []float32
+	world   []storage.ChunkMatch
+	worldOK bool
+	valid   bool
 }
 
 // onPartial is the bus callback for [voiceevent.STTPartial]. The bus delivers
@@ -59,9 +64,7 @@ func (r *Recaller) speculateLoop() {
 		case <-r.ctx.Done():
 			return
 		case <-r.signal:
-			if text, ok := r.takePending(); ok {
-				r.maybeSpeculate(text)
-			}
+			r.drainAndSpeculate()
 			// Notify a white-box test that one pass completed (non-blocking).
 			select {
 			case r.speculated <- struct{}{}:
@@ -71,26 +74,57 @@ func (r *Recaller) speculateLoop() {
 	}
 }
 
-// maybeSpeculate embeds text and prefetches its world-context chunks when the text
-// is worth it: at least [minSpeculateWords] words, changed since the last embed,
-// and no more than one embed per [minEmbedInterval]. World context is prefetched
-// here (the vector is in hand); NPC-knowledge is deferred to Recall (the target
-// agent is unknown during speech). On success it replaces the single-slot cache.
-func (r *Recaller) maybeSpeculate(text string) {
-	norm := normalize(text)
-	if wordCount(norm) < minSpeculateWords {
+// drainAndSpeculate speculates on the latest pending text, honoring the embed rate
+// limit WITHOUT dropping the candidate: when [maybeSpeculate] reports the interval
+// has not elapsed, it waits out the remainder and retries on the latest text (a
+// newer partial supersedes, else the same one). Without this the last pre-final
+// partial inside the interval window would never be embedded — a systematic
+// speculation miss on exactly the utterance the final matches.
+func (r *Recaller) drainAndSpeculate() {
+	text, ok := r.takePending()
+	if !ok {
 		return
 	}
+	for {
+		wait := r.maybeSpeculate(text)
+		if wait <= 0 {
+			return
+		}
+		if err := r.sleep(r.ctx, wait); err != nil {
+			return // Close cancelled the recaller
+		}
+		if newer, ok := r.takePending(); ok {
+			text = newer
+		}
+	}
+}
+
+// maybeSpeculate embeds text and prefetches its world-context chunks when the text
+// is worth it: at least [minSpeculateWords] words and changed since the last embed.
+// It returns 0 when the pass is done (embedded, or permanently skipped as too-short
+// / unchanged); it returns a positive duration when the embed rate limit
+// ([minEmbedInterval]) has not yet elapsed — the remaining wait the caller sleeps
+// before retrying, so the candidate is deferred, never dropped. World context is
+// prefetched here (the vector is in hand); NPC-knowledge is deferred to Recall (the
+// target agent is unknown during speech). On success it replaces the single-slot
+// cache.
+func (r *Recaller) maybeSpeculate(text string) time.Duration {
+	norm := normalize(text)
+	if wordCount(norm) < minSpeculateWords {
+		return 0 // no retrieval signal in a one/two-word interim
+	}
 	if norm == r.lastEmbedNorm {
-		return // unchanged since the last embed
+		return 0 // unchanged since the last embed
 	}
 	now := r.now()
-	if !r.lastEmbedAt.IsZero() && now.Sub(r.lastEmbedAt) < minEmbedInterval {
-		return // rate-limited; the next partial after the interval is embedded
+	if !r.lastEmbedAt.IsZero() {
+		if since := now.Sub(r.lastEmbedAt); since < minEmbedInterval {
+			return minEmbedInterval - since // defer, do not drop (finding 2)
+		}
 	}
 	campaignID, ok := r.campaign()
 	if !ok {
-		return // no active session to scope the prefetch
+		return 0 // no active session to scope the prefetch
 	}
 	// Commit to this attempt BEFORE the call so a failing/hung provider is not
 	// hammered and the same text is not re-embedded on the next tick.
@@ -103,34 +137,37 @@ func (r *Recaller) maybeSpeculate(text string) {
 	vecs, err := r.embedder.Embed(ctx, []string{text})
 	if err != nil || len(vecs) != 1 {
 		r.log.Warn("memory speculation: embed failed; will retry on the next partial", "err", err)
-		return
+		return 0
 	}
-	// Prefetch world context with the vector. A failure still caches the vector so a
-	// later hit skips the (expensive) embed and only owes the NPC-knowledge query.
+	// Prefetch world context with the vector. A failure still caches the vector
+	// (worldOK false) so a later hit skips the (expensive) embed and fetches world
+	// inline, rather than silently returning empty world.
 	world, err := r.retriever.SearchChunksByCampaign(ctx, campaignID, vecs[0], r.k)
+	worldOK := err == nil
 	if err != nil {
 		r.log.Warn("memory speculation: world prefetch failed; caching vector only", "err", err)
 		world = nil
 	}
-	r.storeCache(norm, vecs[0], world)
+	r.storeCache(norm, vecs[0], world, worldOK)
+	return 0
 }
 
 // storeCache replaces the single speculated entry (latest utterance only).
-func (r *Recaller) storeCache(norm string, vec []float32, world []storage.ChunkMatch) {
+func (r *Recaller) storeCache(norm string, vec []float32, world []storage.ChunkMatch, worldOK bool) {
 	r.cacheMu.Lock()
-	r.cache = specCache{norm: norm, vec: vec, world: world, valid: true}
+	r.cache = specCache{norm: norm, vec: vec, world: world, worldOK: worldOK, valid: true}
 	r.cacheMu.Unlock()
 }
 
-// cacheLookup returns the cached vector and world chunks when norm matches the
-// speculated query, and whether it was a hit.
-func (r *Recaller) cacheLookup(norm string) (vec []float32, world []storage.ChunkMatch, hit bool) {
+// cacheLookup returns the cached entry when norm matches the speculated query, and
+// whether it was a hit.
+func (r *Recaller) cacheLookup(norm string) (specCache, bool) {
 	r.cacheMu.Lock()
 	defer r.cacheMu.Unlock()
 	if r.cache.valid && r.cache.norm == norm {
-		return r.cache.vec, r.cache.world, true
+		return r.cache, true
 	}
-	return nil, nil, false
+	return specCache{}, false
 }
 
 // wordCount counts whitespace-separated tokens in an already-normalized string.

--- a/internal/recall/speculate.go
+++ b/internal/recall/speculate.go
@@ -1,0 +1,137 @@
+package recall
+
+import (
+	"context"
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// specCache holds the recaller's single speculated utterance (latest only): the
+// normalized query text, the embedded vector, and the world-context chunks
+// prefetched with that vector. A Recall whose normalized final matches norm reuses
+// vec + world and skips the inline embed (the "hit" path). Guarded by cacheMu.
+type specCache struct {
+	norm  string
+	vec   []float32
+	world []storage.ChunkMatch
+	valid bool
+}
+
+// onPartial is the bus callback for [voiceevent.STTPartial]. The bus delivers
+// synchronously and callbacks MUST NOT block (relay/chunker precedent), so it only
+// stows the latest text in a 1-slot latest-wins mailbox and pokes the speculator;
+// all embedding/retrieval happens on the speculator goroutine. A stale-text
+// partial (a previous utterance's interim arriving ~1 RTT after speech_start, per
+// the #180 STTPartial doc) is harmless: it is just another candidate, and the
+// final's normalized match self-heals a wrong speculation.
+func (r *Recaller) onPartial(p voiceevent.STTPartial) {
+	r.mailMu.Lock()
+	r.pending = p.Text
+	r.hasPending = true
+	r.mailMu.Unlock()
+	select {
+	case r.signal <- struct{}{}:
+	default: // a wake is already pending; the speculator will read the latest text
+	}
+}
+
+// takePending drains the latest-wins mailbox.
+func (r *Recaller) takePending() (string, bool) {
+	r.mailMu.Lock()
+	defer r.mailMu.Unlock()
+	if !r.hasPending {
+		return "", false
+	}
+	r.hasPending = false
+	return r.pending, true
+}
+
+// speculateLoop is the single speculator goroutine: it wakes on the mailbox
+// signal, speculates on the latest pending text, and exits when the recaller's
+// context is cancelled ([Recaller.Close]). One goroutine gives single-flight for
+// free — a slow embed simply defers the next candidate.
+func (r *Recaller) speculateLoop() {
+	defer close(r.specDone)
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-r.signal:
+			if text, ok := r.takePending(); ok {
+				r.maybeSpeculate(text)
+			}
+			// Notify a white-box test that one pass completed (non-blocking).
+			select {
+			case r.speculated <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// maybeSpeculate embeds text and prefetches its world-context chunks when the text
+// is worth it: at least [minSpeculateWords] words, changed since the last embed,
+// and no more than one embed per [minEmbedInterval]. World context is prefetched
+// here (the vector is in hand); NPC-knowledge is deferred to Recall (the target
+// agent is unknown during speech). On success it replaces the single-slot cache.
+func (r *Recaller) maybeSpeculate(text string) {
+	norm := normalize(text)
+	if wordCount(norm) < minSpeculateWords {
+		return
+	}
+	if norm == r.lastEmbedNorm {
+		return // unchanged since the last embed
+	}
+	now := r.now()
+	if !r.lastEmbedAt.IsZero() && now.Sub(r.lastEmbedAt) < minEmbedInterval {
+		return // rate-limited; the next partial after the interval is embedded
+	}
+	campaignID, ok := r.campaign()
+	if !ok {
+		return // no active session to scope the prefetch
+	}
+	// Commit to this attempt BEFORE the call so a failing/hung provider is not
+	// hammered and the same text is not re-embedded on the next tick.
+	r.lastEmbedNorm = norm
+	r.lastEmbedAt = now
+
+	ctx, cancel := context.WithTimeout(r.ctx, speculateTimeout)
+	defer cancel()
+
+	vecs, err := r.embedder.Embed(ctx, []string{text})
+	if err != nil || len(vecs) != 1 {
+		r.log.Warn("memory speculation: embed failed; will retry on the next partial", "err", err)
+		return
+	}
+	// Prefetch world context with the vector. A failure still caches the vector so a
+	// later hit skips the (expensive) embed and only owes the NPC-knowledge query.
+	world, err := r.retriever.SearchChunksByCampaign(ctx, campaignID, vecs[0], r.k)
+	if err != nil {
+		r.log.Warn("memory speculation: world prefetch failed; caching vector only", "err", err)
+		world = nil
+	}
+	r.storeCache(norm, vecs[0], world)
+}
+
+// storeCache replaces the single speculated entry (latest utterance only).
+func (r *Recaller) storeCache(norm string, vec []float32, world []storage.ChunkMatch) {
+	r.cacheMu.Lock()
+	r.cache = specCache{norm: norm, vec: vec, world: world, valid: true}
+	r.cacheMu.Unlock()
+}
+
+// cacheLookup returns the cached vector and world chunks when norm matches the
+// speculated query, and whether it was a hit.
+func (r *Recaller) cacheLookup(norm string) (vec []float32, world []storage.ChunkMatch, hit bool) {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	if r.cache.valid && r.cache.norm == norm {
+		return r.cache.vec, r.cache.world, true
+	}
+	return nil, nil, false
+}
+
+// wordCount counts whitespace-separated tokens in an already-normalized string.
+func wordCount(s string) int { return len(strings.Fields(s)) }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 )
 
 // endTimeout bounds the ended_at write after the loop exits, so a Stop / shutdown
@@ -159,6 +160,17 @@ func (m *Manager) SetTranscript(t TranscriptFinalizer) {
 // line persistence).
 func (m *Manager) SetChunkFlusher(f ChunkFinalizer) {
 	m.chunker = f
+}
+
+// SetMemory wires the NPC memory recaller onto the base voice config every
+// manager-started session copies (#122): it flows through Start → RunFromDB →
+// connectAndServe → buildConversation into each NPC's Agent loop. Like
+// SetTranscript / SetChunkFlusher it is set once at boot — the recaller needs the
+// Manager as its Sessions source (the active Campaign), so the Manager is built
+// first and the recaller back-wired — before any session can start, so no lock is
+// needed. nil (an unavailable embeddings/DB path) leaves recall off (AC6).
+func (m *Manager) SetMemory(r agent.MemoryRecaller) {
+	m.base.Memory = r
 }
 
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -164,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys, false)
+		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -106,8 +106,11 @@ func (r *Roster) RemoveNPC(agentID string) {
 
 // rosterDepsForLive builds the production rosterDeps: every NPC's Replier is
 // constructed from the shared tool-engine, so N Character NPCs reuse one Groq
-// client and one synthesizer rather than each opening their own.
-func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger) rosterDeps {
+// client and one synthesizer rather than each opening their own. memory is the
+// shared NPC memory recaller (#122); every NPC's loop consults the SAME recaller,
+// which scopes retrieval by the addressed AgentID per turn. A nil memory disables
+// recall (AC6).
+func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller) rosterDeps {
 	return rosterDeps{
 		replierFor: func(spec npcSpec) *agent.Replier {
 			return agent.NewReplier(agent.Config{
@@ -119,6 +122,7 @@ func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns 
 				Engine:       engine,
 				Synthesizer:  synth,
 				HistoryTurns: historyTurns,
+				Memory:       memory,
 				OnError: func(err error) {
 					log.Warn("agent reply failed", "npc", spec.name, "err", err)
 				},

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -31,6 +31,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agenttool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
@@ -287,6 +288,15 @@ type Config struct {
 	// adapters. An empty key means "adapter ENV fallback", so the zero value (the
 	// env-only Run path) reproduces today's behavior untouched.
 	keys providerKeys
+
+	// Memory is the NPC memory recaller injected into every NPC's Agent loop
+	// (#122, ADR-0011/0042): it fills the Hot Context memory slot each turn. The
+	// web tier resolves one recaller (over the shared embeddings provider + the
+	// process store/bus) and sets it on the session Manager's base config; it flows
+	// through connectAndServe → buildConversation → the Roster. nil (voice/bench
+	// standalone, or an unavailable embeddings/DB path) disables recall entirely,
+	// so Agent turns behave exactly as before (AC6).
+	Memory agent.MemoryRecaller
 }
 
 // RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
@@ -537,7 +547,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -659,7 +669,7 @@ var (
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -728,7 +738,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over the shared engine) in the Cast. The
 	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log))
+	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -85,6 +85,33 @@ type StreamingEngine interface {
 	GenerateStream(ctx context.Context, messages []llm.Message, onText func(delta string) error) (full string, err error)
 }
 
+// Memory is the recalled Hot Context memory slot (ADR-0011/0042): the Transcript
+// Chunks an Agent may reference this turn, split by retrieval mode. Personal is
+// NPC-knowledge — chunks the Agent personally participated in ("witnessed") —
+// while World is campaign-wide topical context the Agent may not have been present
+// for, framed as possibly second-hand (ADR-0011). Each string is one chunk's
+// content. A zero Memory (both empty) injects nothing, leaving the prompt
+// byte-identical to the no-memory path.
+type Memory struct {
+	// Personal is NPC-knowledge: chunks the Agent participated in.
+	Personal []string
+	// World is campaign-wide context — framed "may be second-hand" (ADR-0011).
+	World []string
+}
+
+// IsZero reports whether the Memory carries no chunks in either mode — the
+// signal to omit the whole memory block from the system prompt.
+func (m Memory) IsZero() bool { return len(m.Personal) == 0 && len(m.World) == 0 }
+
+// MemoryRecaller retrieves the Hot Context [Memory] for one turn: the chunks the
+// Agent (agentID) may reference given the current utterance. It NEVER returns an
+// error — degradation (an embeddings/DB timeout or an unavailable provider)
+// yields a zero Memory rather than stalling the turn (ADR-0042). Implementations
+// respect ctx: a barge-in cancels retrieval and yields zero Memory.
+type MemoryRecaller interface {
+	Recall(ctx context.Context, agentID, utterance string) Memory
+}
+
 // Config configures a [Replier].
 type Config struct {
 	// Persona is the Agent this loop voices.
@@ -135,6 +162,13 @@ type Config struct {
 	// negative disables the deadline (the turn is still cancellable via the
 	// caller's ctx, e.g. barge-in).
 	TurnTimeout time.Duration
+
+	// Memory recalls the Hot Context memory chunks injected into the system prompt
+	// each turn (ADR-0011/0042). It is consulted under the turn ctx, OUTSIDE the
+	// history lock (it is network-adjacent), and never blocks the turn: a slow or
+	// unavailable path degrades to a zero Memory. nil disables recall entirely —
+	// the prompt is then byte-identical to the pre-memory behavior (AC6).
+	Memory MemoryRecaller
 }
 
 // DefaultTurnTimeout is the per-turn LLM deadline applied when
@@ -237,7 +271,15 @@ func (r *Replier) turn(ctx context.Context, text string) []orchestrator.Reply {
 	r.mu.Lock()
 	r.history = append(r.history, llm.Message{Role: llm.RoleUser, Text: text})
 	r.trimHistoryLocked()
-	messages := r.hotContextLocked()
+	r.mu.Unlock()
+
+	// Recall runs BETWEEN the two lock sections, never under r.mu: it is
+	// network-adjacent (embeddings + DB) and must not hold the loop's lock across
+	// that call (ADR-0042). It respects ctx, so a barge cancels it.
+	mem := r.recall(ctx, text)
+
+	r.mu.Lock()
+	messages := r.hotContextLocked(mem)
 	r.mu.Unlock()
 
 	reply, err := r.engine.Generate(ctx, messages)
@@ -295,7 +337,14 @@ func (r *Replier) streamTurn(ctx context.Context, text string, dispatch func(orc
 	r.mu.Lock()
 	r.history = append(r.history, llm.Message{Role: llm.RoleUser, Text: text})
 	r.trimHistoryLocked()
-	messages := r.hotContextLocked()
+	r.mu.Unlock()
+
+	// Recall between the lock sections (see [Replier.turn]): outside r.mu, under
+	// ctx, degrading to zero Memory rather than stalling the streaming turn.
+	mem := r.recall(ctx, text)
+
+	r.mu.Lock()
+	messages := r.hotContextLocked(mem)
 	r.mu.Unlock()
 
 	streamer, ok := r.engine.(StreamingEngine)
@@ -442,33 +491,77 @@ func (e providerEngine) Generate(ctx context.Context, messages []llm.Message) (s
 	return b.String(), nil
 }
 
+// recall consults the configured [MemoryRecaller] for this turn's Hot Context
+// memory, keyed by the Agent's id and the current utterance. A nil recaller (the
+// unconfigured default) returns a zero Memory, so the prompt stays byte-identical
+// to the pre-memory path (AC6). The recaller never errors and respects ctx.
+func (r *Replier) recall(ctx context.Context, text string) Memory {
+	if r.cfg.Memory == nil {
+		return Memory{}
+	}
+	return r.cfg.Memory.Recall(ctx, r.cfg.Persona.AgentID, text)
+}
+
 // hotContextLocked assembles the Hot Context message list for one call: the
-// system prompt (Persona + KG-facts placeholder + audio-markup instruction)
-// followed by the recent Transcript (the bounded history). Caller holds r.mu.
-func (r *Replier) hotContextLocked() []llm.Message {
+// system prompt (Persona + recalled memory + audio-markup instruction) followed
+// by the recent Transcript (the bounded history). mem is the memory recalled for
+// this turn (zero when unconfigured or degraded). Caller holds r.mu.
+func (r *Replier) hotContextLocked(mem Memory) []llm.Message {
 	msgs := make([]llm.Message, 0, len(r.history)+1)
-	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt()})
+	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt(mem)})
 	msgs = append(msgs, r.history...)
 	return msgs
 }
 
-// systemPrompt builds the system prompt from the three Hot Context inputs:
-// the Persona, a KG-facts placeholder (the KG layer lands later — ADR-0008),
-// and the Voice's provider-specific audio-markup instruction from
-// [tts.Synthesizer.AudioMarkupPrompt] (required by ADR-0022).
-func (r *Replier) systemPrompt() string {
+// systemPrompt builds the system prompt from the three Hot Context inputs in slot
+// order: the Persona, the recalled memory block (the reserved Hot Context memory
+// slot, ADR-0011/0042/0012 — memory touches the SYSTEM prompt only), and the
+// Voice's provider-specific audio-markup instruction from
+// [tts.Synthesizer.AudioMarkupPrompt] (required by ADR-0022). A zero mem omits
+// the memory block entirely, leaving the prompt byte-identical to today (AC6).
+func (r *Replier) systemPrompt(mem Memory) string {
 	var b strings.Builder
 	if p := strings.TrimSpace(r.cfg.Persona.Markdown); p != "" {
 		b.WriteString(p)
 	}
-	// KG facts placeholder: the per-Campaign knowledge graph is wired in later
-	// (ADR-0008). Hot Context reserves the slot now so the prompt shape is
-	// stable when facts arrive.
+	if block := memoryBlock(mem); block != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(block)
+	}
 	if markup := r.cfg.Synthesizer.AudioMarkupPrompt(r.cfg.Persona.Voice); markup != "" {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
 		b.WriteString(markup)
+	}
+	return b.String()
+}
+
+// memoryBlock renders the recalled [Memory] as a flat-text prompt section that
+// distinguishes NPC-knowledge (personally witnessed) from world context (framed
+// as possibly second-hand rumor, ADR-0011). An empty half omits its whole
+// subsection; a zero Memory yields "" so the block is dropped entirely.
+func memoryBlock(mem Memory) string {
+	if mem.IsZero() {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Things you remember from this campaign")
+	if len(mem.Personal) > 0 {
+		b.WriteString("\n\nYou personally witnessed:")
+		for _, c := range mem.Personal {
+			b.WriteString("\n- ")
+			b.WriteString(c)
+		}
+	}
+	if len(mem.World) > 0 {
+		b.WriteString("\n\nYou may have heard second-hand (you were not present; treat as rumor):")
+		for _, c := range mem.World {
+			b.WriteString("\n- ")
+			b.WriteString(c)
+		}
 	}
 	return b.String()
 }

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -540,8 +540,11 @@ func (r *Replier) systemPrompt(mem Memory) string {
 }
 
 // memoryBlock renders the recalled [Memory] as a flat-text prompt section that
-// distinguishes NPC-knowledge (personally witnessed) from world context (framed
-// as possibly second-hand rumor, ADR-0011). An empty half omits its whole
+// distinguishes NPC-knowledge (personally witnessed) from world context. Per
+// ADR-0011 world context is "topical, may not personally know" — so it is framed
+// as things the Agent may know of but may not have witnessed first-hand, NOT as an
+// assertion the Agent was absent (a chunk it participated in but that fell outside
+// its NPC-knowledge top-k can still land here). An empty half omits its whole
 // subsection; a zero Memory yields "" so the block is dropped entirely.
 func memoryBlock(mem Memory) string {
 	if mem.IsZero() {
@@ -557,7 +560,7 @@ func memoryBlock(mem Memory) string {
 		}
 	}
 	if len(mem.World) > 0 {
-		b.WriteString("\n\nYou may have heard second-hand (you were not present; treat as rumor):")
+		b.WriteString("\n\nYou may know these from around the campaign, though you may not have witnessed them personally:")
 		for _, c := range mem.World {
 			b.WriteString("\n- ")
 			b.WriteString(c)

--- a/pkg/voice/agent/memory_test.go
+++ b/pkg/voice/agent/memory_test.go
@@ -1,0 +1,168 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// fakeRecaller is a scripted [agent.MemoryRecaller]: it records the args it was
+// called with and returns a fixed Memory (or runs a probe hook). nil probe/mem
+// yields zero Memory.
+type fakeRecaller struct {
+	mem     agent.Memory
+	calls   int
+	agentID string
+	text    string
+	probe   func()
+}
+
+func (f *fakeRecaller) Recall(_ context.Context, agentID, utterance string) agent.Memory {
+	f.calls++
+	f.agentID = agentID
+	f.text = utterance
+	if f.probe != nil {
+		f.probe()
+	}
+	return f.mem
+}
+
+// TestSystemPrompt_NilMemory_ByteIdenticalToToday locks AC6: with Config.Memory
+// nil the assembled system prompt is exactly Persona + markup, byte-for-byte the
+// pre-memory behavior — no memory block, no stray whitespace.
+func TestSystemPrompt_NilMemory_ByteIdenticalToToday(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		// Memory deliberately nil: today's behavior exactly.
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Hello, innkeeper."))
+
+	sys := prov.lastRequest(t).Messages[0]
+	if sys.Role != llm.RoleSystem {
+		t.Fatalf("first message role = %q, want system", sys.Role)
+	}
+	want := "You are Bart, the innkeeper.\n\n" + sentinelMarkup
+	if sys.Text != want {
+		t.Errorf("nil-memory system prompt not byte-identical to today:\n got %q\nwant %q", sys.Text, want)
+	}
+}
+
+// TestSystemPrompt_Memory_LabeledSectionsInSlotOrder pins AC2 + AC5: a non-zero
+// Memory injects a memory block between the Persona and the audio markup, with
+// the Personal chunks under a witnessed heading and the World chunks framed as
+// possibly second-hand (rumor). Slot order is Persona → memory → markup.
+func TestSystemPrompt_Memory_LabeledSectionsInSlotOrder(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	rec := &fakeRecaller{mem: agent.Memory{
+		Personal: []string{"The ruby dagger was stolen from the vault."},
+		World:    []string{"A dragon was seen near the northern pass."},
+	}}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		Memory:      rec,
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Do you remember the ruby dagger?"))
+
+	if rec.calls != 1 {
+		t.Fatalf("recaller called %d times, want 1", rec.calls)
+	}
+	if rec.agentID != "bart" || rec.text != "Do you remember the ruby dagger?" {
+		t.Errorf("recaller args = (%q, %q), want (bart, the utterance)", rec.agentID, rec.text)
+	}
+
+	sys := prov.lastRequest(t).Messages[0].Text
+
+	// Both chunk contents present, each under the right framing.
+	if !strings.Contains(sys, "The ruby dagger was stolen from the vault.") {
+		t.Errorf("system prompt missing personal chunk: %q", sys)
+	}
+	if !strings.Contains(sys, "A dragon was seen near the northern pass.") {
+		t.Errorf("system prompt missing world chunk: %q", sys)
+	}
+	// World context framed as second-hand / rumor (ADR-0011).
+	if !strings.Contains(strings.ToLower(sys), "second-hand") && !strings.Contains(strings.ToLower(sys), "rumor") {
+		t.Errorf("world context not framed as possibly second-hand: %q", sys)
+	}
+
+	// Slot order: Persona precedes the memory block precedes the markup.
+	iPersona := strings.Index(sys, "You are Bart.")
+	iPersonal := strings.Index(sys, "The ruby dagger was stolen from the vault.")
+	iWorld := strings.Index(sys, "A dragon was seen near the northern pass.")
+	iMarkup := strings.Index(sys, sentinelMarkup)
+	ordered := iPersona < iPersonal && iPersonal < iWorld && iWorld < iMarkup
+	if !ordered {
+		t.Errorf("slot order wrong (want persona<personal<world<markup): "+
+			"persona=%d personal=%d world=%d markup=%d\n%q",
+			iPersona, iPersonal, iWorld, iMarkup, sys)
+	}
+}
+
+// TestSystemPrompt_Memory_OmitsEmptyHalves pins that an empty Personal or World
+// half drops its whole subsection (heading + bullets), never emits an empty
+// labeled list.
+func TestSystemPrompt_Memory_OmitsEmptyHalves(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	rec := &fakeRecaller{mem: agent.Memory{
+		Personal: []string{"I served him ale last night."},
+		// World empty.
+	}}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		Memory:      rec,
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Who came in last night?"))
+
+	sys := prov.lastRequest(t).Messages[0].Text
+	if !strings.Contains(sys, "I served him ale last night.") {
+		t.Errorf("system prompt missing personal chunk: %q", sys)
+	}
+	// No world subsection when World is empty.
+	if strings.Contains(strings.ToLower(sys), "second-hand") || strings.Contains(strings.ToLower(sys), "rumor") {
+		t.Errorf("empty World half must omit its second-hand subsection: %q", sys)
+	}
+}
+
+// TestRecall_RunsOutsideHistoryLock proves recall runs OUTSIDE r.mu (ADR-0042):
+// a MemoryRecaller that probes the loop's own lock (HistorySnapshot) must not
+// deadlock. If recall ran while the loop held r.mu this test would hang.
+func TestRecall_RunsOutsideHistoryLock(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	rec := &fakeRecaller{}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		Memory:      rec,
+	})
+	// The probe reaches back into the loop's mutex-guarded history — a deadlock if
+	// recall were called under r.mu.
+	rec.probe = func() { _ = r.HistorySnapshot() }
+
+	done := make(chan struct{})
+	go func() {
+		r.Reply()(t.Context(), routed("bart", "Hello."))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn deadlocked: recall must run outside the history lock")
+	}
+	if rec.calls != 1 {
+		t.Errorf("recaller called %d times, want 1", rec.calls)
+	}
+}

--- a/pkg/voice/agent/memory_test.go
+++ b/pkg/voice/agent/memory_test.go
@@ -90,9 +90,10 @@ func TestSystemPrompt_Memory_LabeledSectionsInSlotOrder(t *testing.T) {
 	if !strings.Contains(sys, "A dragon was seen near the northern pass.") {
 		t.Errorf("system prompt missing world chunk: %q", sys)
 	}
-	// World context framed as second-hand / rumor (ADR-0011).
-	if !strings.Contains(strings.ToLower(sys), "second-hand") && !strings.Contains(strings.ToLower(sys), "rumor") {
-		t.Errorf("world context not framed as possibly second-hand: %q", sys)
+	// World context framed as "may not personally know" (ADR-0011), NOT an
+	// assertion the NPC was absent.
+	if !strings.Contains(strings.ToLower(sys), "may not have witnessed") {
+		t.Errorf("world context not framed as possibly-not-witnessed (ADR-0011): %q", sys)
 	}
 
 	// Slot order: Persona precedes the memory block precedes the markup.
@@ -131,8 +132,8 @@ func TestSystemPrompt_Memory_OmitsEmptyHalves(t *testing.T) {
 		t.Errorf("system prompt missing personal chunk: %q", sys)
 	}
 	// No world subsection when World is empty.
-	if strings.Contains(strings.ToLower(sys), "second-hand") || strings.Contains(strings.ToLower(sys), "rumor") {
-		t.Errorf("empty World half must omit its second-hand subsection: %q", sys)
+	if strings.Contains(strings.ToLower(sys), "may not have witnessed") {
+		t.Errorf("empty World half must omit its world-context subsection: %q", sys)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Closes #122 — the final slice of epic #98. Gives NPCs **memory recall in Hot Context**: each Agent turn fills the reserved memory slot in the system prompt with Transcript Chunks retrieved by ANN (ADR-0011 two modes), threaded through the streaming path per ADR-0042.

- **agent** (`pkg/voice/agent`): new `Memory{Personal, World}` + `MemoryRecaller` interface + `Config.Memory`. Recall runs **between** the two history-lock sections (never under `r.mu` — it is network-adjacent) in both `turn()` and `streamTurn()`. The memory block slots **Persona → memory → audio-markup**; World is framed "may be second-hand" (ADR-0011). A zero/nil `Memory` keeps the prompt **byte-identical** to today (AC6).
- **internal/recall** (new): `New/Recall/Close`. Speculation subscribes to `STTPartial` through a 1-slot latest-wins mailbox feeding **one single-flight** speculator goroutine that embeds stabilized partials (≥3 words, changed, ≥200ms apart) and prefetches world-context ANN with the vector. At `Recall`, a normalized self-heal match reuses the prefetch and runs **only** the deferred NPC-knowledge query (a **hit**); a mismatch / no partials embeds + runs both modes inline under a **~250ms budget** (a **miss**); budget-exceeded or a provider/DB error degrades to no-memory (a **skip**); a barge (cancelled ctx) yields zero Memory and **counts nothing**.
- **observe**: `glyphoxa_voice_memory_recall_total{outcome=hit|miss|skip}` (bounded enum, ADR-0032).
- **wiring**: one embeddings provider resolved **once** in `runWeb` and shared with the #116 backfill worker; `recall.New` over the store (Retriever), the session Manager (active Campaign), the process bus; `session.Manager.SetMemory` threads it onto the base config → `buildConversation` → `rosterDepsForLive` → `agent.Config.Memory`. Unconfigured/unavailable → nil → AC6.

## Why is this change needed?

An NPC asked about a fact established in an earlier embedded chunk should reference it — impossible without retrieval. This is the payoff of the chunker (#104), embeddings (#111), backfill (#116), ANN retrieval (#119) and streaming (#179/#180) slices.

## How was this tested?

TDD, red→green per slice. New coverage:

- **agent**: nil-Memory byte-identical prompt (AC6); labeled sections in slot order + world second-hand framing (AC2/AC5); empty-half omission; recall-runs-outside-the-history-lock seam (no deadlock).
- **recall**: normalize variants; inline both-modes → miss; speculation hit reuses prefetch + runs ByAgent exactly once; mismatch → inline miss; budget-exceeded → skip; retriever error → skip; barge → zero + no counter; unparseable agentID → skip.
- **observe**: the new counter surfaces all three outcomes on `/metrics`.
- **integration** (`-tags=integration`, real pgvector): chunks embedded through the **#116 backfill path** with `embeddingstest.Fixed`; a participated fact lands in the "personally witnessed" section, a campaign-only fact in the "second-hand" section, and with recall disabled neither reaches the prompt (content-ful AC1 proof). **Ran green against a live pgvector container.**

- [x] `go test ./...` green; `go test -race ./internal/recall/ ./pkg/voice/agent/` green
- [x] `go test -tags=integration ./internal/recall/` green (live pgvector)
- [x] `golangci-lint run` (v2.12.2, incl. `--build-tags=integration`) — 0 issues
- [x] New/updated tests cover the change

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **AC3 latency**: a hit reuses the partial-prefetched vector + world chunks and owes only one indexed NPC-knowledge query — effectively zero added turn latency. A miss stays within the 250ms bounded-sync budget.
- One shared recaller serves all NPCs; the world prefetch is agent-independent and the per-NPC `AgentID` scopes the NPC-knowledge query at recall time.
- `session.Manager.SetMemory` mirrors the existing `SetTranscript`/`SetChunkFlusher` back-wiring (recaller needs the Manager as its Sessions source, so the Manager is built first). No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
