### PR TITLE
fix(#198): rank equal address-score totals by name similarity

### DIFF
--- a/pkg/voice/address/matcher.go
+++ b/pkg/voice/address/matcher.go
@@ -362,8 +362,18 @@ func (m *Matcher) TargetMatch(text string) []voiceevent.AddressRouted {
 		}
 	}
 
-	// Highest score wins; ties break by Agent order so the result is stable.
-	sort.SliceStable(hits, func(i, j int) bool { return hits[i].total > hits[j].total })
+	// Highest score wins. Equal totals rank by fuzzy name similarity, because
+	// NameMatch contributes a flat weight above its threshold: an exactly heard
+	// name (1.0) and an incidental phonetic collision (0.9, e.g. "gerade" ≈
+	// "Greta" under Double Metaphone, #198) total the same, and only the raw
+	// similarity still tells them apart. Remaining ties break by Agent order so
+	// the result is stable.
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].total != hits[j].total {
+			return hits[i].total > hits[j].total
+		}
+		return nameScores[hits[i].agent.index] > nameScores[hits[j].agent.index]
+	})
 
 	// Cap the published set before building it, so lastAddressed records only
 	// the Agents actually addressed: naming two NPCs under the single-target

--- a/pkg/voice/address/matcher_test.go
+++ b/pkg/voice/address/matcher_test.go
@@ -198,6 +198,31 @@ func TestMatcher_SingleTargetByDefault(t *testing.T) {
 	assertIDs(t, m.TargetMatch("Bart and the Goblin start arguing"), "npc-bart")
 }
 
+// TestMatcher_ExactNameOutranksPhoneticCollision pins the live misroute of
+// issue #198: "gerade" collides with "Greta" under Double Metaphone (both KRT),
+// so Greta clears the name threshold phonetically while Marek is named exactly.
+// Both earn NameMatch's flat weight, and the roster-order tie-break handed the
+// turn to Greta, who precedes Marek on the roster. Equal totals must rank by
+// name similarity, so the exactly-heard name wins the single-target pick. The
+// two prior Greta turns reproduce the live session's continuation state and
+// prove it plays no part (LastAddressed is suppressed by AnyNameMatched).
+func TestMatcher_ExactNameOutranksPhoneticCollision(t *testing.T) {
+	greta := address.Agent{
+		Target: voiceevent.AddressTarget{AgentID: "npc-greta", AgentRole: "character", Name: "Greta"},
+	}
+	marek := address.Agent{
+		Target: voiceevent.AddressTarget{AgentID: "npc-marek", AgentRole: "character", Name: "Marek"},
+	}
+	m := address.NewMatcher(address.Config{Language: "en"}, bart, greta, marek)
+
+	assertIDs(t, m.TargetMatch("Greta, erzähl mir von deinen Kräutern."), "npc-greta")
+	assertIDs(t, m.TargetMatch("und was hilft gegen Kopfschmerzen?"), "npc-greta")
+
+	// Session 545abb84: the exact "Marek" must outrank Greta's incidental
+	// phonetic hit on "gerade".
+	assertIDs(t, m.TargetMatch("Marek, was liegt gerade auf deinem Amboss?"), "npc-marek")
+}
+
 // TestMatcher_MaxTargetsCap proves the cap is configurable: MaxTargets: 2 keeps
 // the top two of a larger named set, while MaxTargets: -1 keeps them all.
 func TestMatcher_MaxTargetsCap(t *testing.T) {


### PR DESCRIPTION
> *This was generated by AI during triage.*

## What

Fixes the live misroute of session 545abb84 (#198): "**Marek**, was liegt gerade auf deinem Amboss?" routed to **Greta**.

## Root cause

- `DoubleMetaphone("gerade")` = `KRT` = `DoubleMetaphone("greta")` → Greta scores 0.9 via the phonetic tier, clearing the NameMatch threshold (0.6).
- `NameMatch` deliberately contributes a **flat** weight above its threshold (ADR-0024: a homophone crosses the address threshold like a crisp name), so Marek (exact, 1.0) and Greta (phonetic, 0.9) both totalled exactly 1.0.
- The tie-break was roster order — `[Bart, Greta, Marek]` — so Greta won the single-target pick. `LastAddressed` played no part (suppressed by `AnyNameMatched`).

## Fix

Equal totals now rank by raw fuzzy name similarity before falling back to Agent order (`TargetMatch` sort). One-line-of-logic change; the flat-weight threshold semantics are untouched, and equal-similarity ties (two crisp names in one utterance) still break by roster order as pinned by `TestMatcher_SingleTargetByDefault`.

## Tests (TDD)

- RED: `TestMatcher_ExactNameOutranksPhoneticCollision` reproduces the live turn verbatim (roster `[Bart, Greta, Marek]`, two prior Greta turns for continuation state) — failed with `addressed [npc-greta], want [npc-marek]`.
- GREEN: full `pkg/voice/address` suite + `go test ./...` pass (sole failure is the pre-existing, environment-broken `TestLive_Ollama_*` live test, also failing on main).

Note: fixing #199 (campaign language wiring) would *not* have fixed this — Kölner Phonetik also collides the pair (`472`).

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
