### PR TITLE
fix(#199): thread campaign.Language into the address matcher

### DIFF
--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -308,17 +308,20 @@ func (s *Store) FindTenantByName(ctx context.Context, name string) (Tenant, erro
 	return t, nil
 }
 
-// FindCampaignByName returns the ID of the Tenant's Campaign with the given
-// name, or ErrNotFound.
-func (s *Store) FindCampaignByName(ctx context.Context, tenantID uuid.UUID, name string) (uuid.UUID, error) {
-	var id uuid.UUID
-	err := s.db.QueryRow(ctx,
-		`SELECT id FROM campaign WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&id)
+// FindCampaignByName returns the Tenant's Campaign with the given name, or
+// ErrNotFound. It returns the full row rather than just the ID so a caller
+// wiring a Voice Session gets the Campaign Language (the matcher's phonetic
+// scheme, #199) from the same lookup.
+func (s *Store) FindCampaignByName(ctx context.Context, tenantID uuid.UUID, name string) (Campaign, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+campaignColumns+`
+		   FROM campaign WHERE tenant_id = $1 AND name = $2`, tenantID, name)
+	c, err := scanCampaign(row)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return uuid.Nil, ErrNotFound
+		return Campaign{}, ErrNotFound
 	}
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("storage: find campaign %q: %w", name, err)
+		return Campaign{}, fmt.Errorf("storage: find campaign %q: %w", name, err)
 	}
-	return id, nil
+	return c, nil
 }

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -172,30 +172,32 @@ func SeedNPC(ctx context.Context, pool *pgxpool.Pool, cipher *crypto.Cipher, log
 // Detection routes on (the in-code path used "bart"; the value only has to be
 // consistent between the matcher and the Persona, which it is).
 //
-// It also surfaces the owning tenant ID and the PRIMARY (first) Character's
-// LoadedAgent — the bits the credential bridge (issue #69) resolves the session
-// BYOK keys from. The primary's LoadedAgent already carries its LLM/TTS provider
-// configs (LoadAgent joins them), so this returns them rather than re-querying.
-// A single set of keys backs the whole session (one shared Groq client + one
-// ElevenLabs synth across the Roster — see buildConversation), so the primary
-// agent is the representative; per-NPC adapter selection is a later concern.
-func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.LoadedAgent, uuid.UUID, error) {
+// It also surfaces the loaded Campaign row — carrying the owning tenant ID
+// (the credential bridge, issue #69) and the Campaign Language (the matcher's
+// phonetic scheme, #199) — and the PRIMARY (first) Character's LoadedAgent, the
+// bit the credential bridge resolves the session BYOK keys from. The primary's
+// LoadedAgent already carries its LLM/TTS provider configs (LoadAgent joins
+// them), so this returns them rather than re-querying. A single set of keys
+// backs the whole session (one shared Groq client + one ElevenLabs synth across
+// the Roster — see buildConversation), so the primary agent is the
+// representative; per-NPC adapter selection is a later concern.
+func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.LoadedAgent, storage.Campaign, error) {
 	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
 	if err != nil {
-		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: find tenant: %w", err)
+		return nil, storage.LoadedAgent{}, storage.Campaign{}, fmt.Errorf("wirenpc: load NPCs: find tenant: %w", err)
 	}
 
-	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
 	if err != nil {
-		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: find campaign: %w", err)
+		return nil, storage.LoadedAgent{}, storage.Campaign{}, fmt.Errorf("wirenpc: load NPCs: find campaign: %w", err)
 	}
 
-	chars, err := st.CharacterAgents(ctx, campaignID)
+	chars, err := st.CharacterAgents(ctx, campaign.ID)
 	if err != nil {
-		return nil, storage.LoadedAgent{}, uuid.Nil, err
+		return nil, storage.LoadedAgent{}, storage.Campaign{}, err
 	}
 	if len(chars) == 0 {
-		return nil, storage.LoadedAgent{}, uuid.Nil, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
+		return nil, storage.LoadedAgent{}, storage.Campaign{}, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
 	}
 
 	specs := make([]npcSpec, 0, len(chars))
@@ -203,18 +205,18 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 	for i, c := range chars {
 		loaded, err := st.LoadAgent(ctx, c.ID)
 		if err != nil {
-			return nil, storage.LoadedAgent{}, uuid.Nil, err
+			return nil, storage.LoadedAgent{}, storage.Campaign{}, err
 		}
 		if i == 0 {
 			primary = loaded
 		}
 		spec, err := npcSpecFromAgent(loaded.Agent)
 		if err != nil {
-			return nil, storage.LoadedAgent{}, uuid.Nil, err
+			return nil, storage.LoadedAgent{}, storage.Campaign{}, err
 		}
 		specs = append(specs, spec)
 	}
-	return specs, primary, tenant.ID, nil
+	return specs, primary, campaign, nil
 }
 
 // npcSpecFromAgent maps a storage.Agent (vendor-neutral) to the voice-domain

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -164,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -206,14 +206,14 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindTenantByName: %v", err)
 	}
-	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
 	if err != nil {
 		t.Fatalf("FindCampaignByName: %v", err)
 	}
 
 	// A second Character NPC in the same campaign — a Voice Session can host ≥2.
 	if _, err := st.CreateAgent(ctx, storage.NewAgent{
-		CampaignID:  campaignID,
+		CampaignID:  campaign.ID,
 		Role:        storage.AgentRoleCharacter,
 		Name:        "Mira",
 		Persona:     "You are Mira, the wandering bard.",
@@ -233,7 +233,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -257,6 +257,73 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 	}
 }
 
+// TestCampaignLanguageDrivesMatcherPhonetics (#199): the loaded campaign's
+// language column reaches the assembled Roster's matcher, selecting the
+// phonetic encoder. A 'de' campaign hosting "Jäger" must route "Yeager" — an
+// EN-biased STT rendering that only Kölner Phonetik matches (both code 047;
+// Double Metaphone separates them and the edit net is out of reach at
+// Damerau-Levenshtein 3). Before #199 the matcher was hardcoded to "en" and
+// this utterance routed to nobody. The seed's Bart keeps the lone-NPC
+// fallback inert, so the route proves the name tier.
+func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	// The demo seed is an "en" campaign; the live German table runs 'de'.
+	if _, err := pool.Exec(ctx, `UPDATE campaign SET language = 'de'`); err != nil {
+		t.Fatalf("set campaign language: %v", err)
+	}
+
+	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+	jaegerID, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaign.ID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Jäger",
+		Persona:    "You are Jäger, the huntsman.",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent (Jäger): %v", err)
+	}
+
+	specs, _, loadedCampaign, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if loadedCampaign.Language != "de" {
+		t.Fatalf("loadSeededNPCs surfaced campaign language %q, want %q", loadedCampaign.Language, "de")
+	}
+
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
+		ttseleven.New(""), nil, providerKeys{}, false, nil)
+	if err != nil {
+		t.Fatalf("buildConversation: %v", err)
+	}
+	defer cleanup()
+	if conv == nil {
+		t.Fatal("buildConversation returned a nil Conversation")
+	}
+
+	routed := roster.matcher.TargetMatch("Yeager, wie läuft die Jagd?")
+	if len(routed) == 0 {
+		t.Fatal(`"Yeager" routed to nobody — campaign language did not reach the matcher`)
+	}
+	if got := routed[0].Target.AgentID; got != jaegerID.String() {
+		t.Errorf(`"Yeager" routed to AgentID %q, want Jäger %q`, got, jaegerID.String())
+	}
+}
+
 // TestBuildConversation_CleanupDoesNotDestroyEngine guards issue #44's reconnect
 // loop against a regression that destroys the process-global Silero/ONNX
 // environment. cleanup() must release only the per-cycle VAD session, NEVER the
@@ -269,7 +336,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -278,7 +345,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}
@@ -308,11 +375,11 @@ func TestSeedIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindTenantByName: %v", err)
 	}
-	campaignID, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
 	if err != nil {
 		t.Fatalf("FindCampaignByName: %v", err)
 	}
-	chars, err := st.CharacterAgents(ctx, campaignID)
+	chars, err := st.CharacterAgents(ctx, campaign.ID)
 	if err != nil {
 		t.Fatalf("CharacterAgents: %v", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, ttseleven.New(""), nil, keys, false, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/credentials_integration_test.go
+++ b/internal/wirenpc/credentials_integration_test.go
@@ -98,12 +98,12 @@ func TestRunFromDB_DecryptsSavedKeys(t *testing.T) {
 
 	tenantID, want := seedRealKeyNPC(t, ctx, st, cipher)
 
-	_, primary, gotTenant, err := loadSeededNPCs(ctx, st)
+	_, primary, gotCampaign, err := loadSeededNPCs(ctx, st)
 	if err != nil {
 		t.Fatalf("loadSeededNPCs: %v", err)
 	}
-	if gotTenant != tenantID {
-		t.Fatalf("loadSeededNPCs tenant = %s, want %s", gotTenant, tenantID)
+	if gotCampaign.TenantID != tenantID {
+		t.Fatalf("loadSeededNPCs tenant = %s, want %s", gotCampaign.TenantID, tenantID)
 	}
 
 	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher)
@@ -134,13 +134,13 @@ func TestRunFromDB_EnvPlaceholderFallsBack(t *testing.T) {
 		t.Fatalf("SeedNPC: %v", err)
 	}
 
-	_, primary, tenantID, err := loadSeededNPCs(ctx, st)
+	_, primary, campaign, err := loadSeededNPCs(ctx, st)
 	if err != nil {
 		t.Fatalf("loadSeededNPCs: %v", err)
 	}
 
 	// A nil cipher is deliberate: the env-placeholder path must not need one.
-	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, nil)
+	keys, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, nil)
 	if err != nil {
 		t.Fatalf("resolveSessionKeys on env placeholders: %v (must fall back to ENV, not error)", err)
 	}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -32,6 +32,10 @@ type Roster struct {
 	matcher *address.Matcher
 	cast    *agent.Cast
 
+	// language is the Campaign Language the Matcher's phonetic tier encodes
+	// names under (#199); set from rosterDeps at construction.
+	language string
+
 	// replierFor builds the [agent.Replier] for one NPC. Production binds it to a
 	// shared tool-engine (so N NPCs share one Groq client); tests inject scripted
 	// engines through it. Always non-nil after [newRoster].
@@ -45,6 +49,10 @@ type Roster struct {
 type rosterDeps struct {
 	// replierFor builds the Replier for one NPC; see [Roster.replierFor].
 	replierFor func(npcSpec) *agent.Replier
+	// language is the Campaign Language (CONTEXT.md) selecting the Matcher's
+	// phonetic encoder (#199): the loaded campaign's language column on the DB
+	// path, "" on the env-only path.
+	language string
 }
 
 // newRoster builds an empty Roster wired to deps. It holds no NPCs yet — the
@@ -57,7 +65,19 @@ func newRoster(deps rosterDeps) *Roster {
 	return &Roster{
 		cast:       agent.NewCast(),
 		replierFor: deps.replierFor,
+		language:   matcherLanguage(deps.language),
 	}
+}
+
+// matcherLanguage returns lang if the address package ships a phonetic encoder
+// for it, else "en" (#199): a Campaign Language the platform has no phonetics
+// for degrades to the EN encoder — the pre-#199 behavior — rather than to the
+// bare edit-distance net.
+func matcherLanguage(lang string) string {
+	if _, ok := address.DefaultEncoders().For(lang); ok {
+		return lang
+	}
+	return "en"
 }
 
 // matcherAgent builds the address.Agent for one NPC: its routing target plus
@@ -85,7 +105,7 @@ func (r *Roster) AddNPC(spec npcSpec) {
 		// First NPC: build the Matcher around it. Single-target by default
 		// (Config.MaxTargets unset ⇒ 1): naming two NPCs fires one turn on the
 		// top-scored, the safe one-floor default (ADR-0025 deferred).
-		r.matcher = address.NewMatcher(address.Config{Language: "en"}, matcherAgent(spec))
+		r.matcher = address.NewMatcher(address.Config{Language: r.language}, matcherAgent(spec))
 	} else {
 		r.matcher.Add(matcherAgent(spec))
 	}
@@ -109,9 +129,11 @@ func (r *Roster) RemoveNPC(agentID string) {
 // client and one synthesizer rather than each opening their own. memory is the
 // shared NPC memory recaller (#122); every NPC's loop consults the SAME recaller,
 // which scopes retrieval by the addressed AgentID per turn. A nil memory disables
-// recall (AC6).
-func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller) rosterDeps {
+// recall (AC6). language is the Campaign Language selecting the Matcher's
+// phonetic encoder (#199).
+func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller, language string) rosterDeps {
 	return rosterDeps{
+		language: language,
 		replierFor: func(spec npcSpec) *agent.Replier {
 			return agent.NewReplier(agent.Config{
 				Persona: agent.Persona{

--- a/internal/wirenpc/roster_test.go
+++ b/internal/wirenpc/roster_test.go
@@ -154,6 +154,58 @@ func newRosterFor(specs []npcSpec, repliers []*agent.Replier, synth tts.Synthesi
 	return r
 }
 
+// TestRoster_MatcherUsesCampaignLanguage (#199): a Roster assembled for a "de"
+// Campaign matches German names through Kölner Phonetik. "Yeager" is an
+// EN-biased STT's rendering of "Jäger" — Kölner Phonetik codes both 047, while
+// Double Metaphone separates them (JKR vs AKR) and the edit net is out of
+// reach (Damerau-Levenshtein 3) — so only the German encoder routes it. Two
+// NPCs keep the lone-NPC fallback inert, so a route proves the name tier.
+func TestRoster_MatcherUsesCampaignLanguage(t *testing.T) {
+	synth := &recordingSynth{}
+	deps := rosterDeps{
+		replierFor: func(s npcSpec) *agent.Replier { return replierFor(s, "(unused)", synth) },
+		language:   "de",
+	}
+	r := newRoster(deps)
+	r.AddNPC(specFor("npc-jaeger", "Jäger", ""))
+	r.AddNPC(specFor("npc-lena", "Lena", ""))
+
+	routed := r.matcher.TargetMatch("Yeager, wie läuft die Jagd?")
+	if len(routed) != 1 || routed[0].Target.AgentID != "npc-jaeger" {
+		got := make([]string, len(routed))
+		for i, rt := range routed {
+			got[i] = rt.Target.AgentID
+		}
+		t.Fatalf(`"Yeager" under language "de" addressed %v, want [npc-jaeger]`, got)
+	}
+}
+
+// TestRoster_UnknownLanguageFallsBackToEnglishPhonetics (#199): a Campaign
+// Language with no registered phonetic encoder degrades to the "en" encoder —
+// pre-#199 behavior — rather than to the bare edit-distance net. "nite" is a
+// phonetic rendering of "Knight" (Double Metaphone NT for both) that the edit
+// net cannot reach (Damerau-Levenshtein 4), so a route proves the EN encoder
+// is live under the unknown code.
+func TestRoster_UnknownLanguageFallsBackToEnglishPhonetics(t *testing.T) {
+	synth := &recordingSynth{}
+	deps := rosterDeps{
+		replierFor: func(s npcSpec) *agent.Replier { return replierFor(s, "(unused)", synth) },
+		language:   "tlh",
+	}
+	r := newRoster(deps)
+	r.AddNPC(specFor("npc-knight", "Knight", ""))
+	r.AddNPC(specFor("npc-lena", "Lena", ""))
+
+	routed := r.matcher.TargetMatch("nite, guard the gate at dawn")
+	if len(routed) != 1 || routed[0].Target.AgentID != "npc-knight" {
+		got := make([]string, len(routed))
+		for i, rt := range routed {
+			got[i] = rt.Target.AgentID
+		}
+		t.Fatalf(`"nite" under unregistered language "tlh" addressed %v, want [npc-knight]`, got)
+	}
+}
+
 // TestRoster_RoutesNamedUtterancesToEachNPC pins multi-NPC routing through the
 // assembled conversation: naming Aldra speaks Aldra; naming Bram speaks Bram.
 // Real Matcher + real Cast over the bus, single-target default.

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -288,6 +288,12 @@ type Config struct {
 	// adapters. An empty key means "adapter ENV fallback", so the zero value (the
 	// env-only Run path) reproduces today's behavior untouched.
 	keys providerKeys
+	// language is the Campaign Language (CONTEXT.md) of the campaign the npcs
+	// were loaded from: it selects the Roster matcher's phonetic encoder (#199).
+	// RunFromDB sets it from the campaign row; the env-only Run path leaves it
+	// "", which — like any code without a registered encoder — resolves to "en"
+	// (see matcherLanguage), preserving the pre-#199 behavior.
+	language string
 
 	// Memory is the NPC memory recaller injected into every NPC's Agent loop
 	// (#122, ADR-0011/0042): it fills the Hot Context memory slot each turn. The
@@ -333,7 +339,7 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *cryp
 	}
 
 	st := storage.New(pool)
-	npcs, primary, tenantID, err := loadSeededNPCs(ctx, st)
+	npcs, primary, campaign, err := loadSeededNPCs(ctx, st)
 	if err != nil {
 		return err
 	}
@@ -345,13 +351,14 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *cryp
 	// A decryption failure (e.g. a real saved key with the wrong/absent cipher)
 	// is fatal here, before any Discord connection — the operator sees a clear
 	// error instead of an NPC that silently ran on the wrong (env) key.
-	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher)
+	keys, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, cipher)
 	if err != nil {
 		return err
 	}
 
 	cfg.npcs = npcs
 	cfg.keys = keys
+	cfg.language = campaign.Language
 	return Run(ctx, cfg)
 }
 
@@ -547,7 +554,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -656,6 +663,11 @@ var (
 // programmatic control surface for adding/removing NPCs at runtime (#49); the
 // caller owns it for the cycle's lifetime. npcs must be non-empty.
 //
+// language is the Campaign Language of the campaign the npcs belong to: it
+// selects the Roster matcher's phonetic encoder (#199). A code with no
+// registered encoder — including the env-only path's "" — resolves to "en"
+// (see matcherLanguage).
+//
 // All NPCs share ONE Groq tool-engine (one client, the `dice` grant in code —
 // Tool Grants are a #6 table, not yet seeded). The LLM provider is Groq (model
 // llama-3.3-70b-versatile via the OpenAI-compat endpoint). The DB Agent's
@@ -669,7 +681,7 @@ var (
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -738,7 +750,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, sy
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over the shared engine) in the Cast. The
 	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory))
+	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory, language))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}


### PR DESCRIPTION
> *This was generated by AI during triage.*

## What

`campaign.Language` now reaches the Roster's address Matcher (#199). Previously `roster.go:88` hardcoded `Language:"en"`, leaving the registered `de` Kölner-Phonetik encoder (ADR-0024) unreachable.

## How

- `storage.FindCampaignByName` returns the full `Campaign` row (was: bare ID), so the Voice Session wiring gets the Language from the same lookup.
- `loadSeededNPCs` surfaces the loaded `storage.Campaign` (replacing the bare tenant ID return; the credential bridge uses `campaign.TenantID`).
- `RunFromDB` → `Config.language` → `buildConversation` → `rosterDeps.language` → `address.Config{Language: ...}`.
- `matcherLanguage` falls back to `"en"` when no phonetic encoder is registered for the code (as specified in the issue) — including the env-only `Run` path's `""` — so behavior degrades to the EN encoder, not the bare edit-distance net.

`npcMatcher` (`wirenpc.go`), the retained single-NPC **test seam**, keeps its hardcoded `en` — it has no production callers; the production path is the Roster.

## Tests (TDD, three red-green cycles)

1. `TestRoster_MatcherUsesCampaignLanguage`: a `de` Roster routes "**Yeager**" → NPC "**Jäger**" — a pair only Kölner Phonetik matches (both `047`; Double Metaphone splits them `JKR`/`AKR`, edit distance 3 is beyond the net). Second NPC keeps the lone-NPC fallback inert.
2. `TestRoster_UnknownLanguageFallsBackToEnglishPhonetics`: language `tlh` still routes "nite" → "Knight" (Double Metaphone `NT`/`NT`, edit distance 4) — proving EN fallback rather than edit-net-only.
3. `TestCampaignLanguageDrivesMatcherPhonetics` (integration, testcontainers): seed → `UPDATE campaign SET language='de'` → `loadSeededNPCs` surfaces `de` → `buildConversation` → matcher routes the German mishearing end-to-end.

Full unit suite green; all 6 wirenpc integration tests green against a real pgvector container. (Sole unrelated failure: the pre-existing, environment-broken `TestLive_Ollama_*` live test, also failing on main.)

## Note for the German live table

Kölner Phonetik still collides "gerade"/"greta" (both `472` — vowels dropped, d/t both code 2), so the session-545abb84 misroute is fixed by #200's similarity tie-break, not by this PR. The two fixes are complementary.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
