### PR TITLE
feat(#126): Note Node round-trips into an NPC's Hot Context

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
+	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/recall"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
@@ -353,6 +354,15 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		context.AfterFunc(ctx, recaller.Close)
 		mgr.SetMemory(recaller)
 	}
+
+	// NPC KG-facts recall (#126, ADR-0008): the reserved Hot Context KG-facts slot,
+	// filled per turn from the active Campaign's gm-public Nodes. UNCONDITIONAL —
+	// OUTSIDE the embeddings-provider branch above — because it needs no embeddings
+	// provider, only the process store (an indexed OLTP read) and the session
+	// Manager (the active Campaign). Gating it on the provider would silently lose
+	// the feature on keyless deployments. It owns no goroutine/subscription, so
+	// there is nothing to Close.
+	mgr.SetFacts(kgfacts.New(store, mgr, metrics, log, kgfacts.Config{}))
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /

--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -1,0 +1,267 @@
+// Package kgfacts is the NPC Knowledge Graph fact-recall component (#126,
+// ADR-0008 v1.0 / v1.5): the production [agent.FactsRecaller] the voice loop
+// consults each turn to fill the reserved Hot Context KG-facts slot.
+//
+// It mirrors internal/recall's shape but is deliberately simpler — INLINE only,
+// no speculation, no goroutine, no bus, no Close. The read is an indexed OLTP
+// query (ListPublicNodes), sub-millisecond, so speculation buys nothing
+// (ADR-0042): the fact is that a per-turn read means a gm_private flip mid-session
+// takes effect on the very next turn, with no cache to invalidate.
+//
+// One contract, shared with [agent.MemoryRecaller]: Facts NEVER errors and NEVER
+// stalls the turn. A slow/unavailable DB path, or the hard budget elapsing,
+// degrades to nil (counted "degraded"). A barge cancels the turn ctx, which
+// yields nil WITHOUT counting — the turn is gone, nothing was wasted. With no
+// active session there is nothing to scope, so it yields nil ("empty"). A nil
+// recaller is never constructed by the loop, so the turn behaves exactly as
+// before (#126 byte-identical guarantee).
+package kgfacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+)
+
+const (
+	// DefaultBudget is the hard inline-read budget inside the turn ctx: the public
+	// Node read must finish within it or facts degrade to nil. An indexed OLTP read
+	// is sub-ms, so this is a generous ceiling that only fires on a wedged DB.
+	DefaultBudget = 50 * time.Millisecond
+	// MaxFacts caps how many Node facts are injected in one turn.
+	MaxFacts = 20
+	// MaxFactChars caps one fact's body length in runes; a longer body is
+	// rune-safe-truncated with a trailing ellipsis.
+	MaxFactChars = 500
+	// MaxBlockChars bounds the whole assembled facts block (header + joins + facts)
+	// so the prompt budget holds regardless of wiki size (#126 AC4).
+	MaxBlockChars = 4000
+)
+
+// factsHeader is the block header the agent's factsBlock prepends. kgfacts does
+// NOT emit it — the agent is the joiner — but the block-budget accounting reserves
+// its length so MaxBlockChars bounds the FINAL rendered block, header included.
+const factsHeader = "## What you know about the world"
+
+// blockJoin is the separator between the header and each fact (and between facts)
+// in the agent's rendered block. Reserved in the block-budget accounting.
+const blockJoin = "\n\n"
+
+// Nodes is the narrow storage read kgfacts needs: the Campaign's gm-public Nodes,
+// newest-first, bounded (the prompt-injection read). *storage.Store satisfies it.
+type Nodes interface {
+	ListPublicNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
+}
+
+// Sessions is the narrow read kgfacts needs from the SessionManager: which Voice
+// Session (hence Campaign) is active, so the fact read is campaign-scoped.
+// *session.Manager satisfies it via Snapshot (the same shape recall depends on);
+// defined locally so kgfacts does not import session.
+type Sessions interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// Metrics records KG-fact-read outcomes (#126, ADR-0032). *observe.PrometheusRecorder
+// satisfies it; a nil Metrics is replaced with a no-op so call sites never check.
+type Metrics interface {
+	KGFacts(observe.FactsOutcome)
+}
+
+// Config tunes the recaller. Zero values take the package defaults.
+type Config struct {
+	// Budget is the hard inline-read budget inside the turn ctx. Default DefaultBudget.
+	Budget time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.Budget <= 0 {
+		c.Budget = DefaultBudget
+	}
+	return c
+}
+
+// Recaller is the production [agent.FactsRecaller]. It holds no goroutine and no
+// subscription (unlike recall) — the read is inline per turn. Safe for concurrent
+// use (its deps are).
+type Recaller struct {
+	nodes    Nodes
+	sessions Sessions
+	metrics  Metrics
+	log      *slog.Logger
+	budget   time.Duration
+}
+
+// New builds a Recaller wired to the public-Node read, the session source (for the
+// active Campaign), and the metrics sink. Unlike recall it starts nothing and owns
+// no resources to release.
+func New(nodes Nodes, sessions Sessions, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
+	cfg = cfg.withDefaults()
+	if log == nil {
+		log = slog.Default()
+	}
+	if metrics == nil {
+		metrics = discardMetrics{}
+	}
+	return &Recaller{
+		nodes:    nodes,
+		sessions: sessions,
+		metrics:  metrics,
+		log:      log,
+		budget:   cfg.Budget,
+	}
+}
+
+// Facts implements [agent.FactsRecaller]. It returns the gm-public Node facts for
+// the active Campaign this turn, bounded and rendered, honoring the hard budget and
+// degrading to nil rather than stalling. agentID is unused in #126 (facts are
+// campaign-wide gm-public Nodes); the NPC-scoped filter arrives with edges (#133).
+// It never returns an error and never panics.
+func (r *Recaller) Facts(ctx context.Context, agentID string) []string {
+	campaignID, ok := r.campaign()
+	if !ok {
+		// No active session to scope the read: nothing to inject (defensive — Facts
+		// runs during a live turn). Count it as an empty read, not a degradation.
+		r.metrics.KGFacts(observe.FactsEmpty)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, r.budget)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		// The turn ctx was already cancelled (a barge before the read even started):
+		// yield nothing and count nothing.
+		return r.degrade(ctx, err)
+	}
+
+	nodes, err := r.nodes.ListPublicNodes(ctx, campaignID)
+	if err != nil {
+		return r.degrade(ctx, fmt.Errorf("list public nodes: %w", err))
+	}
+
+	facts := renderFacts(nodes)
+	if len(facts) == 0 {
+		r.metrics.KGFacts(observe.FactsEmpty)
+		return nil
+	}
+	r.metrics.KGFacts(observe.FactsOK)
+	return facts
+}
+
+// degrade yields nil. A cancelled ctx is a barge (ADR-0042): silent, NOT counted —
+// the turn is gone, nothing was wasted. Any other failure (budget elapsed, DB
+// error) logs and counts a degraded read.
+func (r *Recaller) degrade(ctx context.Context, cause error) []string {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil
+	}
+	r.log.Warn("kg facts degraded to no-facts", "err", cause)
+	r.metrics.KGFacts(observe.FactsDegraded)
+	return nil
+}
+
+// campaign reads the active session's Campaign id, or false when idle.
+func (r *Recaller) campaign() (uuid.UUID, bool) {
+	vs, ok := r.sessions.Snapshot()
+	if !ok {
+		return uuid.Nil, false
+	}
+	return vs.CampaignID, true
+}
+
+// renderFacts projects the public Nodes (in storage order) into rendered fact
+// strings, applying the per-fact truncation and the MaxFacts / MaxBlockChars caps.
+// The block-budget accounting reserves the agent's header + joins so the FINAL
+// rendered block (header included) stays within MaxBlockChars. It stops at the
+// first fact that would overrun either cap — a deterministic prefix, never a
+// skip-scan — so a huge Node cannot let a later small one sneak in past the budget.
+func renderFacts(nodes []storage.KGNode) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(nodes))
+	// Every fact in the assembled block is preceded by a blockJoin (the first by the
+	// header's join, the rest by the inter-fact join), so the running total starts at
+	// the header length and each fact adds len(join)+len(fact).
+	total := len(factsHeader)
+	for _, n := range nodes {
+		if len(out) >= MaxFacts {
+			break
+		}
+		fact := renderFact(n)
+		delta := len(blockJoin) + len(fact)
+		if total+delta > MaxBlockChars {
+			break
+		}
+		total += delta
+		out = append(out, fact)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// renderFact renders one Node as "### <Name> (<TypeLabel>)\n<Body>", with the body
+// trimmed and rune-safe-truncated to MaxFactChars. A bodiless Node emits only its
+// header line (no dangling newline).
+func renderFact(n storage.KGNode) string {
+	head := fmt.Sprintf("### %s (%s)", n.Name, typeLabel(n.Type))
+	body := truncateRunes(strings.TrimSpace(n.Body), MaxFactChars)
+	if body == "" {
+		return head
+	}
+	return head + "\n" + body
+}
+
+// typeLabel maps a Node type onto its GM-facing label (#126 test contract). An
+// unknown type falls back to "Note" defensively (the DB enum keeps this exhaustive).
+func typeLabel(t storage.KGNodeType) string {
+	switch t {
+	case storage.KGNodeCharacter:
+		return "Character"
+	case storage.KGNodeNPC:
+		return "NPC"
+	case storage.KGNodeLocation:
+		return "Location"
+	case storage.KGNodeFaction:
+		return "Faction"
+	case storage.KGNodeItem:
+		return "Item"
+	case storage.KGNodePlotThread:
+		return "Plot thread"
+	case storage.KGNodeNote:
+		return "Note"
+	default:
+		return "Note"
+	}
+}
+
+// truncateRunes trims s to at most max runes, appending an ellipsis when it cut —
+// rune-safe so a multibyte character is never split mid-codepoint.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}
+
+// discardMetrics is the no-op Metrics used when none is configured.
+type discardMetrics struct{}
+
+func (discardMetrics) KGFacts(observe.FactsOutcome) {}
+
+// Static assertion that Recaller is a FactsRecaller.
+var _ agent.FactsRecaller = (*Recaller)(nil)

--- a/internal/kgfacts/kgfacts_integration_test.go
+++ b/internal/kgfacts/kgfacts_integration_test.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+// This drives the #126 AC5 end-to-end round-trip against a real Postgres
+// (testcontainers): storage.CreateNode(Note) → kgfacts over the real Store +
+// a fake Sessions → an agent.Replier with a capturing engine → the Note body
+// appears in the assembled system prompt; flipping gm_private removes it next
+// turn; and with no public Notes the prompt is byte-identical to the no-facts
+// path. Tag-isolated behind `integration` (ADR-0033).
+
+package kgfacts_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+// startPostgres spins up a pgvector container (or GLYPHOXA_TEST_DSN), skipping
+// cleanly when Docker is unavailable — mirrors the storage harness.
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("GLYPHOXA_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?). "+
+			"Set GLYPHOXA_TEST_DSN to run without Docker. err: %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+func seedCampaign(t *testing.T, dsn string) (*pgxpool.Pool, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var tenantID, campaignID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenant (name) VALUES ('Acme TTRPG') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Lost Mine', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaignID); err != nil {
+		t.Fatalf("insert campaign: %v", err)
+	}
+	return pool, campaignID
+}
+
+// captureEngine is a minimal agent.Engine that records the assembled messages.
+type captureEngine struct {
+	reply    string
+	captured []llm.Message
+}
+
+func (e *captureEngine) Generate(_ context.Context, msgs []llm.Message) (string, error) {
+	e.captured = msgs
+	return e.reply, nil
+}
+
+// nullSynth is a minimal tts.Synthesizer emitting no audio and no markup.
+type nullSynth struct{}
+
+func (nullSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+func (nullSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+func routedTo(agentID, text string) voiceevent.AddressRouted {
+	return voiceevent.AddressRouted{
+		At:     time.Now(),
+		Text:   text,
+		Target: voiceevent.AddressTarget{AgentID: agentID, AgentRole: "character", Name: "Bart"},
+	}
+}
+
+// TestKGFacts_EndToEnd_Integration is #126 AC5: the create → persist → surfaced-in-
+// the-prompt round-trip over a real Store, plus the gm_private hide and the
+// byte-identical no-facts guarantee.
+func TestKGFacts_EndToEnd_Integration(t *testing.T) {
+	pool, campID := seedCampaign(t, startPostgres(t))
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	rec := kgfacts.New(st, activeSessions(campID), &fakeMetrics{}, nil, kgfacts.Config{})
+
+	// runTurn drives one batch turn and returns the assembled system prompt.
+	runTurn := func(facts agent.FactsRecaller) string {
+		eng := &captureEngine{reply: "Aye."}
+		r := agent.NewReplier(agent.Config{
+			Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: tts.Voice{ProviderID: "elevenlabs", VoiceID: "v1"}},
+			Engine:      eng,
+			Synthesizer: nullSynth{},
+			Facts:       facts,
+		})
+		r.Reply()(ctx, routedTo("bart", "What do you know?"))
+		if len(eng.captured) == 0 {
+			t.Fatal("engine captured no messages")
+		}
+		return eng.captured[0].Text
+	}
+
+	// Baseline: no Facts recaller at all.
+	base := runTurn(nil)
+
+	// With the recaller but no Nodes yet: byte-identical to the baseline (the
+	// reserved slot stays empty).
+	if empty := runTurn(rec); empty != base {
+		t.Errorf("no-notes prompt not byte-identical to the no-facts path:\n base=%q\n  rec=%q", base, empty)
+	}
+
+	// Create a gm-public Note; its body must surface in the assembled prompt.
+	note, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campID, Type: storage.KGNodeNote,
+		Name: "The Vault", Body: "It has never been opened.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	withFacts := runTurn(rec)
+	if !strings.Contains(withFacts, "It has never been opened.") {
+		t.Errorf("public Note body not injected into the prompt: %q", withFacts)
+	}
+	if !strings.Contains(withFacts, "## What you know about the world") {
+		t.Errorf("facts block header missing: %q", withFacts)
+	}
+	if !strings.Contains(withFacts, "### The Vault (Note)") {
+		t.Errorf("fact heading missing: %q", withFacts)
+	}
+
+	// Flip gm_private: the fact must vanish on the very next turn (no cache).
+	if _, err := pool.Exec(ctx, `UPDATE kg_node SET gm_private = true WHERE id = $1`, note.ID); err != nil {
+		t.Fatalf("flip gm_private: %v", err)
+	}
+	hidden := runTurn(rec)
+	if strings.Contains(hidden, "It has never been opened.") {
+		t.Errorf("gm_private Note leaked into the prompt: %q", hidden)
+	}
+	// With the sole Note now private, the prompt is byte-identical to the baseline.
+	if hidden != base {
+		t.Errorf("all-private prompt not byte-identical to the no-facts baseline:\n base=%q\n hidden=%q", base, hidden)
+	}
+}

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -1,0 +1,275 @@
+package kgfacts_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeNodes is a scripted kgfacts.Nodes: it returns fixed Nodes or an error, and
+// can block until ctx is cancelled to exercise the budget timeout.
+type fakeNodes struct {
+	nodes   []storage.KGNode
+	err     error
+	block   bool // block until ctx done, then return ctx.Err()
+	gotCamp uuid.UUID
+}
+
+func (f *fakeNodes) ListPublicNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error) {
+	f.gotCamp = campaignID
+	if f.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return f.nodes, f.err
+}
+
+// fakeSessions is a scripted kgfacts.Sessions.
+type fakeSessions struct {
+	vs storage.VoiceSession
+	ok bool
+}
+
+func (f fakeSessions) Snapshot() (storage.VoiceSession, bool) { return f.vs, f.ok }
+
+// fakeMetrics records the outcomes it was handed.
+type fakeMetrics struct{ outcomes []observe.FactsOutcome }
+
+func (f *fakeMetrics) KGFacts(o observe.FactsOutcome) { f.outcomes = append(f.outcomes, o) }
+
+func (f *fakeMetrics) count(o observe.FactsOutcome) int {
+	n := 0
+	for _, got := range f.outcomes {
+		if got == o {
+			n++
+		}
+	}
+	return n
+}
+
+func activeSessions(campaignID uuid.UUID) fakeSessions {
+	return fakeSessions{vs: storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID}, ok: true}
+}
+
+func newRecaller(t *testing.T, nodes kgfacts.Nodes, sessions kgfacts.Sessions, m kgfacts.Metrics) *kgfacts.Recaller {
+	t.Helper()
+	return kgfacts.New(nodes, sessions, m, nil, kgfacts.Config{})
+}
+
+// TestFacts_RenderFormatExact pins #126 AC2's rendering contract: each fact is
+// "### <Name> (<TypeLabel>)\n<Body>" with the domain TypeLabel, and the recaller
+// returns them in storage order.
+func TestFacts_RenderFormatExact(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: "The Bell", Body: "It tolls at dusk."},
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeLocation, Name: "Ravenhollow", Body: "A misty vale."},
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodePlotThread, Name: "The Heist", Body: "Someone plans a robbery."},
+	}}
+	m := &fakeMetrics{}
+	r := newRecaller(t, nodes, activeSessions(camp), m)
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) != 3 {
+		t.Fatalf("got %d facts, want 3", len(facts))
+	}
+	if facts[0] != "### The Bell (Note)\nIt tolls at dusk." {
+		t.Errorf("fact[0] = %q", facts[0])
+	}
+	if facts[1] != "### Ravenhollow (Location)\nA misty vale." {
+		t.Errorf("fact[1] = %q", facts[1])
+	}
+	if facts[2] != "### The Heist (Plot thread)\nSomeone plans a robbery." {
+		t.Errorf("fact[2] = %q (want the 'Plot thread' TypeLabel)", facts[2])
+	}
+	if nodes.gotCamp != camp {
+		t.Errorf("read scoped to %s, want active campaign %s", nodes.gotCamp, camp)
+	}
+	if m.count(observe.FactsOK) != 1 {
+		t.Errorf("want one ok outcome, got %v", m.outcomes)
+	}
+}
+
+// TestFacts_EmptyBodyRendersHeaderOnly pins that a bodiless Node emits just its
+// header line (no dangling newline).
+func TestFacts_EmptyBodyRendersHeaderOnly(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: "Loose end", Body: "   "},
+	}}
+	r := newRecaller(t, nodes, activeSessions(camp), &fakeMetrics{})
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) != 1 || facts[0] != "### Loose end (Note)" {
+		t.Errorf("empty-body fact = %q, want header only", facts)
+	}
+}
+
+// TestFacts_TruncatesBodyByRunes pins rune-safe truncation to MaxFactChars + "…".
+func TestFacts_TruncatesBodyByRunes(t *testing.T) {
+	camp := uuid.New()
+	body := strings.Repeat("é", kgfacts.MaxFactChars+50) // multibyte runes past the cap
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: "Long", Body: body},
+	}}
+	r := newRecaller(t, nodes, activeSessions(camp), &fakeMetrics{})
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) != 1 {
+		t.Fatalf("got %d facts, want 1", len(facts))
+	}
+	// The body portion after the header line: MaxFactChars runes + the ellipsis.
+	_, bodyPart, _ := strings.Cut(facts[0], "\n")
+	gotRunes := []rune(bodyPart)
+	if len(gotRunes) != kgfacts.MaxFactChars+1 {
+		t.Errorf("truncated body = %d runes, want %d + ellipsis", len(gotRunes), kgfacts.MaxFactChars)
+	}
+	if !strings.HasSuffix(bodyPart, "…") {
+		t.Errorf("truncated body missing ellipsis: %q", bodyPart[len(bodyPart)-8:])
+	}
+}
+
+// TestFacts_CapsAtMaxFacts pins the MaxFacts cap: a wiki larger than the cap yields
+// exactly MaxFacts facts, the deterministic storage-order prefix.
+func TestFacts_CapsAtMaxFacts(t *testing.T) {
+	camp := uuid.New()
+	var ns []storage.KGNode
+	for i := 0; i < kgfacts.MaxFacts+5; i++ {
+		ns = append(ns, storage.KGNode{
+			ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote,
+			Name: fmt.Sprintf("Node %02d", i), Body: "short",
+		})
+	}
+	nodes := &fakeNodes{nodes: ns}
+	r := newRecaller(t, nodes, activeSessions(camp), &fakeMetrics{})
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) != kgfacts.MaxFacts {
+		t.Fatalf("got %d facts, want the MaxFacts cap %d", len(facts), kgfacts.MaxFacts)
+	}
+	if !strings.Contains(facts[0], "Node 00") {
+		t.Errorf("first fact not the storage-order prefix: %q", facts[0])
+	}
+}
+
+// TestFacts_CapsAtMaxBlockChars pins the block-budget cap: enough large facts to
+// blow MaxBlockChars yields a deterministic prefix whose total stays within budget.
+func TestFacts_CapsAtMaxBlockChars(t *testing.T) {
+	camp := uuid.New()
+	big := strings.Repeat("x", kgfacts.MaxFactChars) // each fact ~MaxFactChars body
+	var ns []storage.KGNode
+	// MaxBlockChars / MaxFactChars facts would just fit; add more to force the stop.
+	for i := 0; i < (kgfacts.MaxBlockChars/kgfacts.MaxFactChars)+5; i++ {
+		ns = append(ns, storage.KGNode{
+			ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote,
+			Name: fmt.Sprintf("N%02d", i), Body: big,
+		})
+	}
+	nodes := &fakeNodes{nodes: ns}
+	r := newRecaller(t, nodes, activeSessions(camp), &fakeMetrics{})
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) == 0 {
+		t.Fatal("no facts returned")
+	}
+	if len(facts) >= len(ns) {
+		t.Errorf("block cap did not trim: got %d of %d facts", len(facts), len(ns))
+	}
+	// Total block length (header + "\n\n"-joined facts) stays within MaxBlockChars.
+	total := len("## What you know about the world") + len("\n\n") + len(strings.Join(facts, "\n\n"))
+	if total > kgfacts.MaxBlockChars {
+		t.Errorf("assembled block = %d bytes, exceeds MaxBlockChars %d", total, kgfacts.MaxBlockChars)
+	}
+}
+
+// TestFacts_NoSession_Nil pins that with no active session there is nothing to
+// scope, so no facts are returned.
+func TestFacts_NoSession_Nil(t *testing.T) {
+	m := &fakeMetrics{}
+	r := newRecaller(t, &fakeNodes{}, fakeSessions{ok: false}, m)
+
+	if facts := r.Facts(context.Background(), "bart"); facts != nil {
+		t.Errorf("facts with no session = %v, want nil", facts)
+	}
+	if m.count(observe.FactsDegraded) != 0 {
+		t.Errorf("no-session must not count a degraded read: %v", m.outcomes)
+	}
+}
+
+// TestFacts_NoPublicNodes_Empty pins that a read finding no public Nodes returns
+// nil and counts an empty outcome (not degraded).
+func TestFacts_NoPublicNodes_Empty(t *testing.T) {
+	camp := uuid.New()
+	m := &fakeMetrics{}
+	r := newRecaller(t, &fakeNodes{nodes: nil}, activeSessions(camp), m)
+
+	if facts := r.Facts(context.Background(), "bart"); facts != nil {
+		t.Errorf("facts = %v, want nil", facts)
+	}
+	if m.count(observe.FactsEmpty) != 1 || m.count(observe.FactsDegraded) != 0 {
+		t.Errorf("want one empty, zero degraded: %v", m.outcomes)
+	}
+}
+
+// TestFacts_DBError_DegradedNil pins that a DB failure degrades to nil and counts
+// a degraded read.
+func TestFacts_DBError_DegradedNil(t *testing.T) {
+	camp := uuid.New()
+	m := &fakeMetrics{}
+	r := newRecaller(t, &fakeNodes{err: errors.New("db down")}, activeSessions(camp), m)
+
+	if facts := r.Facts(context.Background(), "bart"); facts != nil {
+		t.Errorf("facts on DB error = %v, want nil", facts)
+	}
+	if m.count(observe.FactsDegraded) != 1 {
+		t.Errorf("DB error must count one degraded read: %v", m.outcomes)
+	}
+}
+
+// TestFacts_CtxCancel_SilentNil pins the barge posture: a cancelled turn ctx yields
+// nil and counts NOTHING (the turn is gone, nothing wasted — mirrors recall).
+func TestFacts_CtxCancel_SilentNil(t *testing.T) {
+	camp := uuid.New()
+	m := &fakeMetrics{}
+	r := newRecaller(t, &fakeNodes{}, activeSessions(camp), m)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // barge before the read starts
+
+	if facts := r.Facts(ctx, "bart"); facts != nil {
+		t.Errorf("facts on cancelled ctx = %v, want nil", facts)
+	}
+	if len(m.outcomes) != 0 {
+		t.Errorf("a barge cancel must count nothing: %v", m.outcomes)
+	}
+}
+
+// TestFacts_BudgetTimeout_DegradedNil pins the hard budget: a read that overruns
+// the budget degrades to nil and counts a degraded read.
+func TestFacts_BudgetTimeout_DegradedNil(t *testing.T) {
+	camp := uuid.New()
+	m := &fakeMetrics{}
+	r := kgfacts.New(&fakeNodes{block: true}, activeSessions(camp), m, nil,
+		kgfacts.Config{Budget: 20 * time.Millisecond})
+
+	start := time.Now()
+	facts := r.Facts(context.Background(), "bart")
+	if facts != nil {
+		t.Errorf("facts on budget timeout = %v, want nil", facts)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("Facts blocked %v past its budget — the hard timeout did not fire", elapsed)
+	}
+	if m.count(observe.FactsDegraded) != 1 {
+		t.Errorf("budget timeout must count one degraded read: %v", m.outcomes)
+	}
+}

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -73,7 +73,29 @@ type PrometheusRecorder struct {
 	// a speculation hit, an inline miss, or a degraded/unconfigured skip. The
 	// outcome label is a bounded three-value enum (ADR-0032).
 	memoryRecall *prometheus.CounterVec // outcome
+
+	// KG facts (#126, ADR-0008/0032): NPC Hot Context KG-fact reads by outcome —
+	// facts injected (ok), no public Nodes / no session (empty), or a degraded read
+	// (timeout/DB error). Process-level (like embedding_backlog), bounded 3-value
+	// outcome label (ADR-0032).
+	kgFacts *prometheus.CounterVec // outcome
 }
+
+// FactsOutcome is the bounded outcome label on the KG-fact-read counter
+// (glyphoxa_kg_facts_total, #126). Exactly three values reach a series (ADR-0032):
+// facts were injected, the read found none to inject, or it degraded to nothing.
+type FactsOutcome string
+
+const (
+	// FactsOK: at least one gm-public Node fact was injected into the prompt.
+	FactsOK FactsOutcome = "ok"
+	// FactsEmpty: the read succeeded but had nothing to inject — no public Nodes,
+	// or no active session to scope the Campaign.
+	FactsEmpty FactsOutcome = "empty"
+	// FactsDegraded: the read degraded to no-facts — the budget elapsed or the DB
+	// read failed. A barge cancel is NOT degraded (it counts nothing).
+	FactsDegraded FactsOutcome = "degraded"
+)
 
 // RecallOutcome is the bounded outcome label on the NPC memory-recall counter
 // (glyphoxa_voice_memory_recall_total, #122). Exactly three values reach a series
@@ -172,13 +194,21 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		"NPC memory recalls by outcome (#122, ADR-0042): a speculation hit, an inline miss, or a degraded skip.",
 		"outcome")
 
+	// Process-level (namespace only, no voice subsystem) like embedding_backlog: the
+	// KG-fact read is an OLTP read shared by any NPC turn, not a voice-pipeline stage.
+	r.kgFacts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "kg_facts_total",
+		Help:      "NPC Hot Context KG-fact reads by outcome (#126): facts injected (ok), none to inject (empty), or degraded.",
+	}, []string{"outcome"})
+
 	reg.MustRegister(
 		r.framesDropped, r.undecodable, r.daveDecryptErrs, r.sessions,
 		r.playbackTotal, r.bargeCancels,
 		r.responseLatency, r.vadHangover, r.addressDetect, r.codecDecode,
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
-		r.memoryRecall,
+		r.memoryRecall, r.kgFacts,
 		// Standard runtime collectors so /metrics also reports process/Go health.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
@@ -256,6 +286,14 @@ func (r *PrometheusRecorder) TurnOutcome(outcome TurnOutcome, reason TurnReason)
 // StageRecorder contract: recall is not an orchestrator stage.
 func (r *PrometheusRecorder) MemoryRecall(o RecallOutcome) {
 	r.memoryRecall.WithLabelValues(string(o)).Inc()
+}
+
+// KGFacts counts one NPC Hot Context KG-fact read by its bounded outcome (#126,
+// ADR-0008/0032). It is the standalone facts-metrics sink the internal/kgfacts
+// component records against (its local Metrics interface), separate from the
+// StageRecorder contract: the KG read is not an orchestrator stage.
+func (r *PrometheusRecorder) KGFacts(o FactsOutcome) {
+	r.kgFacts.WithLabelValues(string(o)).Inc()
 }
 
 // SetEmbeddingBacklog publishes the current count of transcript chunks awaiting an

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -60,6 +60,10 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.MemoryRecall(RecallMiss)
 	rec.MemoryRecall(RecallSkip)
 
+	rec.KGFacts(FactsOK)
+	rec.KGFacts(FactsEmpty)
+	rec.KGFacts(FactsDegraded)
+
 	out := scrape(t, rec)
 
 	// Every family is present and namespaced glyphoxa_voice_* (embedding_backlog
@@ -89,6 +93,9 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_voice_memory_recall_total{outcome="miss"} 1`,
 		`glyphoxa_voice_memory_recall_total{outcome="skip"} 1`,
 		`glyphoxa_embedding_backlog 0`,
+		`glyphoxa_kg_facts_total{outcome="ok"} 1`,
+		`glyphoxa_kg_facts_total{outcome="empty"} 1`,
+		`glyphoxa_kg_facts_total{outcome="degraded"} 1`,
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(out, want) {

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -33,6 +33,8 @@ type campaignStore interface {
 	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
 	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
 	DeleteAgent(ctx context.Context, id uuid.UUID) error
+	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
+	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +15,9 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
+
+// errAny is an opaque storage failure the fake returns to force the Internal path.
+var errAny = errors.New("kg fake failure")
 
 // fakeCampaignStore is a small in-memory campaignStore for the CRUD handlers'
 // keyless unit tests. Error hooks (campErr/butlerErr/…) force the failure paths;
@@ -34,6 +38,13 @@ type fakeCampaignStore struct {
 	nextColor int
 
 	created []storage.NewAgent
+
+	// KG Node state (#126): nodes backs ListNodes; nodesCreated records the
+	// storage inputs; nodeCreateErr forces the create failure path.
+	nodes         []storage.KGNode
+	nodesCreated  []storage.NewKGNode
+	nodeCreateErr error
+	nodeListErr   error
 }
 
 func newFakeStore() *fakeCampaignStore {
@@ -109,6 +120,27 @@ func (f *fakeCampaignStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
 	}
 	delete(f.agents, id)
 	return nil
+}
+
+func (f *fakeCampaignStore) CreateNode(_ context.Context, n storage.NewKGNode) (storage.KGNode, error) {
+	if f.nodeCreateErr != nil {
+		return storage.KGNode{}, f.nodeCreateErr
+	}
+	f.nodesCreated = append(f.nodesCreated, n)
+	created := storage.KGNode{
+		ID:         uuid.New(),
+		CampaignID: n.CampaignID,
+		Type:       n.Type,
+		Name:       n.Name,
+		Body:       n.Body,
+		GMPrivate:  n.GMPrivate,
+	}
+	f.nodes = append(f.nodes, created)
+	return created, nil
+}
+
+func (f *fakeCampaignStore) ListNodes(_ context.Context, _ uuid.UUID) ([]storage.KGNode, error) {
+	return f.nodes, f.nodeListErr
 }
 
 // crudClient stands up the full CampaignService handler over an httptest server

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -48,6 +48,12 @@ func (fakeReader) UpdateAgent(context.Context, storage.AgentUpdate) (storage.Age
 func (fakeReader) DeleteAgent(context.Context, uuid.UUID) error {
 	return nil
 }
+func (fakeReader) CreateNode(context.Context, storage.NewKGNode) (storage.KGNode, error) {
+	return storage.KGNode{}, nil
+}
+func (fakeReader) ListNodes(context.Context, uuid.UUID) ([]storage.KGNode, error) {
+	return nil, nil
+}
 
 // newClient stands up the CampaignServer handler behind an httptest server and
 // returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on

--- a/internal/rpc/kg_node.go
+++ b/internal/rpc/kg_node.go
@@ -1,0 +1,147 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Knowledge Graph Node handlers (#126, ADR-0008 v1.0) on CampaignServer: create
+// and list the campaign's wiki Nodes. Like the agent CRUD they resolve the single
+// operator's active campaign server-side (ADR-0039).
+
+// CreateNode adds a Knowledge Graph Node to the active campaign and returns it. An
+// UNSPECIFIED node_type or an empty name is CodeInvalidArgument; no campaign is
+// CodeNotFound; a storage failure is CodeInternal.
+func (s *CampaignServer) CreateNode(
+	ctx context.Context,
+	req *connect.Request[managementv1.CreateNodeRequest],
+) (*connect.Response[managementv1.CreateNodeResponse], error) {
+	m := req.Msg
+	nodeType, ok := toStorageNodeType(m.GetNodeType())
+	if !ok {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("node type must be specified"))
+	}
+	if strings.TrimSpace(m.GetName()) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("CreateNode: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	created, err := s.store.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: c.ID,
+		Type:       nodeType,
+		Name:       m.GetName(),
+		Body:       m.GetBody(),
+		GMPrivate:  m.GetGmPrivate(),
+	})
+	if err != nil {
+		slog.Default().Error("CreateNode: store create failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.CreateNodeResponse{Node: toProtoNode(created)}), nil
+}
+
+// ListNodes returns the active campaign's Knowledge Graph Nodes in the storage
+// display order (type, then case-insensitive name). No campaign is CodeNotFound;
+// a storage failure is CodeInternal.
+func (s *CampaignServer) ListNodes(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListNodesRequest],
+) (*connect.Response[managementv1.ListNodesResponse], error) {
+	c, err := s.store.GetActiveCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ListNodes: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	nodes, err := s.store.ListNodes(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("ListNodes: store list failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := make([]*managementv1.Node, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, toProtoNode(n))
+	}
+	return connect.NewResponse(&managementv1.ListNodesResponse{Nodes: out}), nil
+}
+
+// toProtoNode maps a storage.KGNode onto its wire representation.
+func toProtoNode(n storage.KGNode) *managementv1.Node {
+	return &managementv1.Node{
+		Id:         n.ID.String(),
+		CampaignId: n.CampaignID.String(),
+		NodeType:   toProtoNodeType(n.Type),
+		Name:       n.Name,
+		Body:       n.Body,
+		GmPrivate:  n.GMPrivate,
+		CreatedAt:  timestamppb.New(n.CreatedAt),
+		UpdatedAt:  timestamppb.New(n.UpdatedAt),
+	}
+}
+
+// toStorageNodeType maps a wire NodeType onto the storage enum. The UNSPECIFIED
+// zero value (and any unknown) returns ok=false so the handler rejects it with
+// CodeInvalidArgument rather than persisting a garbage type.
+func toStorageNodeType(t managementv1.NodeType) (storage.KGNodeType, bool) {
+	switch t {
+	case managementv1.NodeType_NODE_TYPE_CHARACTER:
+		return storage.KGNodeCharacter, true
+	case managementv1.NodeType_NODE_TYPE_NPC:
+		return storage.KGNodeNPC, true
+	case managementv1.NodeType_NODE_TYPE_LOCATION:
+		return storage.KGNodeLocation, true
+	case managementv1.NodeType_NODE_TYPE_FACTION:
+		return storage.KGNodeFaction, true
+	case managementv1.NodeType_NODE_TYPE_ITEM:
+		return storage.KGNodeItem, true
+	case managementv1.NodeType_NODE_TYPE_PLOT_THREAD:
+		return storage.KGNodePlotThread, true
+	case managementv1.NodeType_NODE_TYPE_NOTE:
+		return storage.KGNodeNote, true
+	default:
+		return "", false
+	}
+}
+
+// toProtoNodeType maps the storage enum back onto the wire NodeType. An unknown
+// stored value maps to UNSPECIFIED (defensive; the DB enum keeps this exhaustive).
+func toProtoNodeType(t storage.KGNodeType) managementv1.NodeType {
+	switch t {
+	case storage.KGNodeCharacter:
+		return managementv1.NodeType_NODE_TYPE_CHARACTER
+	case storage.KGNodeNPC:
+		return managementv1.NodeType_NODE_TYPE_NPC
+	case storage.KGNodeLocation:
+		return managementv1.NodeType_NODE_TYPE_LOCATION
+	case storage.KGNodeFaction:
+		return managementv1.NodeType_NODE_TYPE_FACTION
+	case storage.KGNodeItem:
+		return managementv1.NodeType_NODE_TYPE_ITEM
+	case storage.KGNodePlotThread:
+		return managementv1.NodeType_NODE_TYPE_PLOT_THREAD
+	case storage.KGNodeNote:
+		return managementv1.NodeType_NODE_TYPE_NOTE
+	default:
+		return managementv1.NodeType_NODE_TYPE_UNSPECIFIED
+	}
+}

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -1,0 +1,136 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func TestCreateNode_MapsAndPersists(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	client := crudClient(t, store)
+
+	resp, err := client.CreateNode(context.Background(),
+		connect.NewRequest(&managementv1.CreateNodeRequest{
+			NodeType:  managementv1.NodeType_NODE_TYPE_NOTE,
+			Name:      "The sealed vault",
+			Body:      "Nobody has opened it in a century.",
+			GmPrivate: true,
+		}))
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	node := resp.Msg.GetNode()
+	if node.GetNodeType() != managementv1.NodeType_NODE_TYPE_NOTE {
+		t.Errorf("node_type = %v, want NOTE", node.GetNodeType())
+	}
+	if node.GetName() != "The sealed vault" || node.GetBody() != "Nobody has opened it in a century." {
+		t.Errorf("fields not mapped: %+v", node)
+	}
+	if !node.GetGmPrivate() {
+		t.Error("gm_private did not round-trip")
+	}
+	if node.GetId() == "" || node.GetCampaignId() != store.campaign.ID.String() {
+		t.Errorf("ids not mapped: %+v", node)
+	}
+	// The handler forwarded the Note type + gm_private to storage.
+	if len(store.nodesCreated) != 1 {
+		t.Fatalf("store saw %d creates, want 1", len(store.nodesCreated))
+	}
+	if store.nodesCreated[0].Type != storage.KGNodeNote || !store.nodesCreated[0].GMPrivate {
+		t.Errorf("storage input wrong: %+v", store.nodesCreated[0])
+	}
+}
+
+func TestCreateNode_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	client := crudClient(t, store)
+
+	_, err := client.CreateNode(context.Background(),
+		connect.NewRequest(&managementv1.CreateNodeRequest{Name: "x"})) // type unset = UNSPECIFIED
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestCreateNode_EmptyNameIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	client := crudClient(t, store)
+
+	_, err := client.CreateNode(context.Background(),
+		connect.NewRequest(&managementv1.CreateNodeRequest{
+			NodeType: managementv1.NodeType_NODE_TYPE_NOTE, Name: "   ",
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestCreateNode_StorageErrorIsInternal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.nodeCreateErr = errAny
+	client := crudClient(t, store)
+
+	_, err := client.CreateNode(context.Background(),
+		connect.NewRequest(&managementv1.CreateNodeRequest{
+			NodeType: managementv1.NodeType_NODE_TYPE_NOTE, Name: "x",
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestListNodes_MapsInStorageOrder(t *testing.T) {
+	t.Parallel()
+	campID := uuid.New()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine"}
+	// The storage layer owns the ordering; the handler must preserve it 1:1.
+	store.nodes = []storage.KGNode{
+		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodeLocation, Name: "Barrow"},
+		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodeNote, Name: "Rumor", Body: "hush", GMPrivate: true},
+	}
+	client := crudClient(t, store)
+
+	resp, err := client.ListNodes(context.Background(),
+		connect.NewRequest(&managementv1.ListNodesRequest{}))
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	nodes := resp.Msg.GetNodes()
+	if len(nodes) != 2 {
+		t.Fatalf("len = %d, want 2", len(nodes))
+	}
+	if nodes[0].GetNodeType() != managementv1.NodeType_NODE_TYPE_LOCATION || nodes[0].GetName() != "Barrow" {
+		t.Errorf("nodes[0] not mapped in order: %+v", nodes[0])
+	}
+	if nodes[1].GetNodeType() != managementv1.NodeType_NODE_TYPE_NOTE || !nodes[1].GetGmPrivate() {
+		t.Errorf("nodes[1] not mapped: %+v", nodes[1])
+	}
+}
+
+func TestListNodes_NoCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.ListNodes(context.Background(),
+		connect.NewRequest(&managementv1.ListNodesRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -1,10 +1,20 @@
 package session
 
-import "time"
+import (
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+)
 
 // SetEndTimeoutForTest shrinks the per-step end budget (Finalize / end-write)
 // so the #143 budget-separation tests run in milliseconds instead of the
 // production 5s. Test-only; called before any session starts.
 func (m *Manager) SetEndTimeoutForTest(d time.Duration) {
 	m.endTimeout = d
+}
+
+// BaseFactsForTest returns the FactsRecaller threaded onto the base voice config,
+// so a test can assert SetFacts wired it (#126). Test-only.
+func (m *Manager) BaseFactsForTest() agent.FactsRecaller {
+	return m.base.Facts
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -173,6 +173,17 @@ func (m *Manager) SetMemory(r agent.MemoryRecaller) {
 	m.base.Memory = r
 }
 
+// SetFacts wires the NPC KG-facts recaller onto the base voice config every
+// manager-started session copies (#126): it flows through Start → RunFromDB →
+// connectAndServe → buildConversation into each NPC's Agent loop, filling the
+// reserved Hot Context KG-facts slot. Like SetMemory it is set once at boot — the
+// recaller needs the Manager as its Sessions source (the active Campaign), so the
+// Manager is built first and the recaller back-wired — before any session can
+// start, so no lock is needed. nil leaves facts off (the prompt stays byte-identical).
+func (m *Manager) SetFacts(f agent.FactsRecaller) {
+	m.base.Facts = f
+}
+
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no
 // live loop owns (#143). Called once at boot, before any session can start: at
 // that point NO loop is live, so every 'running' row is an orphan — stranded by

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -171,6 +171,26 @@ func newManager(t *testing.T, store session.Store, run session.LoopRunner, enabl
 		slog.New(slog.DiscardHandler), enabled)
 }
 
+// fakeFactsRecaller is a no-op agent.FactsRecaller for the SetFacts wiring test.
+type fakeFactsRecaller struct{}
+
+func (fakeFactsRecaller) Facts(context.Context, string) []string { return nil }
+
+// TestSetFacts_ThreadsOntoBaseConfig mirrors the SetMemory/SetChunkFlusher wiring
+// (#126): SetFacts sets the recaller on the base voice config every session copies,
+// so it flows through Start → RunFromDB → buildConversation into each NPC's loop.
+func TestSetFacts_ThreadsOntoBaseConfig(t *testing.T) {
+	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, true)
+	if mgr.BaseFactsForTest() != nil {
+		t.Fatal("base Facts should start nil")
+	}
+	rec := fakeFactsRecaller{}
+	mgr.SetFacts(rec)
+	if mgr.BaseFactsForTest() != rec {
+		t.Errorf("SetFacts did not thread the recaller onto the base config: got %v", mgr.BaseFactsForTest())
+	}
+}
+
 // newCipher builds a Cipher on a fresh random AES-256 key for the #87 saved-token
 // path — keyless and Docker-free, so the resolution logic is proven in the
 // default suite.

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -1,0 +1,143 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Knowledge Graph Node persistence (#126, ADR-0008 v1.0): the structured wiki /
+// GM notes for a Campaign. This slice ships the full 7-value node_type enum and
+// the create/list reads; typed Edges (#132) and fulltext search (#131) layer on
+// the same table without a migration.
+
+// KGNodeType is a Knowledge Graph Node's type (CONTEXT.md "Node", ADR-0008). It
+// mirrors the kg_node_type Postgres enum; the value is immutable after create.
+type KGNodeType string
+
+const (
+	KGNodeCharacter  KGNodeType = "character"
+	KGNodeNPC        KGNodeType = "npc"
+	KGNodeLocation   KGNodeType = "location"
+	KGNodeFaction    KGNodeType = "faction"
+	KGNodeItem       KGNodeType = "item"
+	KGNodePlotThread KGNodeType = "plot_thread"
+	KGNodeNote       KGNodeType = "note"
+)
+
+// KGNode is one persisted Knowledge Graph Node in a Campaign. GMPrivate hides the
+// Node from any NPC's Hot Context (#126); Body is the Node's prose (empty by
+// default).
+type KGNode struct {
+	ID         uuid.UUID
+	CampaignID uuid.UUID
+	Type       KGNodeType
+	Name       string
+	Body       string
+	GMPrivate  bool
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// NewKGNode is the input to CreateNode. node_type is set once at insert and never
+// updated (ADR-0008: type is immutable).
+type NewKGNode struct {
+	CampaignID uuid.UUID
+	Type       KGNodeType
+	Name       string
+	Body       string
+	GMPrivate  bool
+}
+
+const kgNodeColumns = `
+	id, campaign_id, node_type, name, body, gm_private, created_at, updated_at`
+
+func scanKGNode(row pgx.Row) (KGNode, error) {
+	var n KGNode
+	err := row.Scan(
+		&n.ID, &n.CampaignID, &n.Type, &n.Name, &n.Body, &n.GMPrivate,
+		&n.CreatedAt, &n.UpdatedAt,
+	)
+	return n, err
+}
+
+// CreateNode inserts a Knowledge Graph Node and returns the persisted row. The
+// node_type is cast server-side to the kg_node_type enum, so an out-of-enum type
+// is rejected by Postgres rather than silently stored.
+func (s *Store) CreateNode(ctx context.Context, n NewKGNode) (KGNode, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO kg_node (campaign_id, node_type, name, body, gm_private)
+		 VALUES ($1, $2::kg_node_type, $3, $4, $5)
+		 RETURNING `+kgNodeColumns,
+		n.CampaignID, n.Type, n.Name, n.Body, n.GMPrivate)
+	created, err := scanKGNode(row)
+	if err != nil {
+		return KGNode{}, fmt.Errorf("storage: create kg node: %w", err)
+	}
+	return created, nil
+}
+
+// ListNodes returns every Knowledge Graph Node in a Campaign in a stable display
+// order (node_type enum order, then case-insensitive name, then id) — the
+// Knowledge panel's list. An empty result is not an error.
+func (s *Store) ListNodes(ctx context.Context, campaignID uuid.UUID) ([]KGNode, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+kgNodeColumns+`
+		   FROM kg_node
+		  WHERE campaign_id = $1
+		  ORDER BY node_type, lower(name), id`, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list kg nodes for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []KGNode
+	for rows.Next() {
+		n, err := scanKGNode(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan kg node: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list kg nodes for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}
+
+// kgFactsCap bounds the prompt-injection read so a large wiki can never blow the
+// Hot Context budget at the SQL layer (#126 AC4); the kgfacts renderer applies
+// the finer per-block/per-fact caps on top.
+const kgFactsCap = 50
+
+// ListPublicNodes returns the Campaign's gm-public Nodes ordered newest-first
+// (updated_at DESC, id), capped — the Hot Context prompt-injection read (#126).
+// gm_private Nodes are excluded so a GM-only fact never reaches an NPC's prompt.
+func (s *Store) ListPublicNodes(ctx context.Context, campaignID uuid.UUID) ([]KGNode, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+kgNodeColumns+`
+		   FROM kg_node
+		  WHERE campaign_id = $1 AND NOT gm_private
+		  ORDER BY updated_at DESC, id
+		  LIMIT $2`, campaignID, kgFactsCap)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list public kg nodes for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []KGNode
+	for rows.Next() {
+		n, err := scanKGNode(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan public kg node: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list public kg nodes for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}

--- a/internal/storage/kg_node_test.go
+++ b/internal/storage/kg_node_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestKGNodeCreateListRoundTrip is #126 AC1 + the ADR-0008 v1.0 grain: a Node is
+// inserted with its type/name/body/gm_private and read back in list order
+// (node_type enum, lower(name), id). It exercises Note AND Location so the schema
+// sized for all 7 types is proven on more than one enum value.
+func TestKGNodeCreateListRoundTrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Insert out of both alphabetical and type order so ORDER BY is actually tested.
+	zebra, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Zebra rumor", Body: "A striped horse was seen.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode zebra: %v", err)
+	}
+	if zebra.ID.String() == "" || zebra.CampaignID != campaignID {
+		t.Fatalf("created node missing ids: %+v", zebra)
+	}
+	if zebra.Type != storage.KGNodeNote || zebra.Name != "Zebra rumor" || zebra.Body != "A striped horse was seen." {
+		t.Fatalf("created node fields not persisted: %+v", zebra)
+	}
+	if zebra.CreatedAt.IsZero() || zebra.UpdatedAt.IsZero() {
+		t.Errorf("timestamps not defaulted: %+v", zebra)
+	}
+
+	if _, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "apple orchard", Body: "Sweet fruit grows east.", GMPrivate: true,
+	}); err != nil {
+		t.Fatalf("CreateNode apple: %v", err)
+	}
+	loc, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Barrow", Body: "A haunted mound.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode location: %v", err)
+	}
+	if loc.Type != storage.KGNodeLocation {
+		t.Errorf("location type not persisted: %+v", loc)
+	}
+
+	nodes, err := st.ListNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("ListNodes returned %d nodes, want 3", len(nodes))
+	}
+	// Order: node_type enum first (location < note in the CREATE TYPE order), then
+	// lower(name): so Barrow (location), then apple orchard, then Zebra rumor.
+	if nodes[0].Name != "Barrow" {
+		t.Errorf("nodes[0] = %q, want Barrow (location sorts before note)", nodes[0].Name)
+	}
+	if nodes[1].Name != "apple orchard" || !nodes[1].GMPrivate {
+		t.Errorf("nodes[1] = %q (gm_private=%v), want apple orchard gm_private=true", nodes[1].Name, nodes[1].GMPrivate)
+	}
+	if nodes[2].Name != "Zebra rumor" {
+		t.Errorf("nodes[2] = %q, want Zebra rumor (case-insensitive name order)", nodes[2].Name)
+	}
+}
+
+// TestKGNodeListPublicNodes is #126 AC3: the prompt-injection read excludes
+// gm_private Nodes and orders by updated_at DESC — the newest public Node first.
+func TestKGNodeListPublicNodes(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Two public and one private. Force distinct updated_at ordering by inserting
+	// in a known sequence and stamping updated_at explicitly for determinism.
+	pubOld, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Old public", Body: "old",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode pubOld: %v", err)
+	}
+	if _, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Secret", Body: "hidden", GMPrivate: true,
+	}); err != nil {
+		t.Fatalf("CreateNode secret: %v", err)
+	}
+	pubNew, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "New public", Body: "new",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode pubNew: %v", err)
+	}
+	// Make pubNew strictly newer than pubOld regardless of insert-time granularity.
+	if _, err := pool.Exec(ctx,
+		`UPDATE kg_node SET updated_at = now() + interval '1 hour' WHERE id = $1`, pubNew.ID); err != nil {
+		t.Fatalf("bump pubNew updated_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE kg_node SET updated_at = now() - interval '1 hour' WHERE id = $1`, pubOld.ID); err != nil {
+		t.Fatalf("bump pubOld updated_at: %v", err)
+	}
+
+	pub, err := st.ListPublicNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListPublicNodes: %v", err)
+	}
+	if len(pub) != 2 {
+		t.Fatalf("ListPublicNodes returned %d, want 2 (gm_private excluded)", len(pub))
+	}
+	if pub[0].Name != "New public" || pub[1].Name != "Old public" {
+		t.Errorf("order = [%q %q], want [New public, Old public] (updated_at DESC)", pub[0].Name, pub[1].Name)
+	}
+	for _, n := range pub {
+		if n.GMPrivate {
+			t.Errorf("ListPublicNodes leaked a gm_private node: %+v", n)
+		}
+	}
+}

--- a/internal/storage/migrations/00010_kg_node.sql
+++ b/internal/storage/migrations/00010_kg_node.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+
+-- kg_node is the Knowledge Graph's typed-Node table (ADR-0008 v1.0): the
+-- structured wiki / GM notes for one Campaign. The full 7-value node_type enum
+-- ships now so later KG slices (#129 all types, #132 Edges) need no schema
+-- change; node_type is IMMUTABLE after create (no UPDATE path). body holds the
+-- Node's prose; gm_private hides a Node from any NPC's Hot Context (#126). The
+-- UNIQUE (id, campaign_id) is the composite-FK target #132's Edges reference so
+-- an Edge's endpoints are provably same-Campaign without a trigger (ADR-0008
+-- 2026-07-04 amendment).
+CREATE TYPE kg_node_type AS ENUM
+  ('character','npc','location','faction','item','plot_thread','note');
+
+CREATE TABLE kg_node (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id  uuid NOT NULL REFERENCES campaign (id) ON DELETE CASCADE,
+    node_type    kg_node_type NOT NULL,
+    name         text NOT NULL,
+    body         text NOT NULL DEFAULT '',
+    gm_private   boolean NOT NULL DEFAULT false,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT kg_node_id_campaign_unique UNIQUE (id, campaign_id)
+);
+
+-- Nodes are always read scoped to their Campaign (list, prompt injection).
+CREATE INDEX kg_node_campaign_idx ON kg_node (campaign_id);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS kg_node;
+DROP TYPE IF EXISTS kg_node_type;

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -164,7 +164,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil)
+		ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -345,7 +345,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -127,11 +127,12 @@ func (r *Roster) RemoveNPC(agentID string) {
 // rosterDepsForLive builds the production rosterDeps: every NPC's Replier is
 // constructed from the shared tool-engine, so N Character NPCs reuse one Groq
 // client and one synthesizer rather than each opening their own. memory is the
-// shared NPC memory recaller (#122); every NPC's loop consults the SAME recaller,
-// which scopes retrieval by the addressed AgentID per turn. A nil memory disables
-// recall (AC6). language is the Campaign Language selecting the Matcher's
-// phonetic encoder (#199).
-func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller, language string) rosterDeps {
+// shared NPC memory recaller (#122) and facts the shared KG-facts recaller (#126);
+// every NPC's loop consults the SAME recallers, which scope by the addressed
+// AgentID / active Campaign per turn. A nil memory/facts disables that slot (the
+// prompt stays byte-identical). language is the Campaign Language selecting the
+// Matcher's phonetic encoder (#199).
+func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller, facts agent.FactsRecaller, language string) rosterDeps {
 	return rosterDeps{
 		language: language,
 		replierFor: func(spec npcSpec) *agent.Replier {
@@ -145,6 +146,7 @@ func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns 
 				Synthesizer:  synth,
 				HistoryTurns: historyTurns,
 				Memory:       memory,
+				Facts:        facts,
 				OnError: func(err error) {
 					log.Warn("agent reply failed", "npc", spec.name, "err", err)
 				},

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -303,6 +303,15 @@ type Config struct {
 	// standalone, or an unavailable embeddings/DB path) disables recall entirely,
 	// so Agent turns behave exactly as before (AC6).
 	Memory agent.MemoryRecaller
+
+	// Facts is the NPC KG-facts recaller injected into every NPC's Agent loop (#126,
+	// ADR-0008): it fills the reserved Hot Context KG-facts slot each turn with the
+	// Campaign's gm-public Node facts. The web tier resolves one recaller (over the
+	// process store + session Manager) and sets it on the session Manager's base
+	// config; it flows through connectAndServe → buildConversation → the Roster like
+	// Memory. nil (voice/bench standalone) disables facts entirely, so the prompt is
+	// byte-identical to the pre-facts behavior (#126).
+	Facts agent.FactsRecaller
 }
 
 // RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
@@ -554,7 +563,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory)
+	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -681,7 +690,7 @@ var (
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -750,7 +759,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over the shared engine) in the Cast. The
 	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory, language))
+	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory, facts, language))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -112,6 +112,17 @@ type MemoryRecaller interface {
 	Recall(ctx context.Context, agentID, utterance string) Memory
 }
 
+// FactsRecaller fills the KG-facts slot of Hot Context (ADR-0008 v1.5 / #126): the
+// gm-public Knowledge Graph Node facts the Agent's Campaign wants injected into its
+// system prompt, each element an already-rendered fact string. It shares the
+// [MemoryRecaller] contract: it NEVER errors, respects ctx (a barge-in yields nil),
+// and degrades to nil rather than stalling the turn. A nil FactsRecaller (the
+// unconfigured default) leaves the slot empty, so the prompt is byte-identical to
+// the pre-facts path.
+type FactsRecaller interface {
+	Facts(ctx context.Context, agentID string) []string
+}
+
 // Config configures a [Replier].
 type Config struct {
 	// Persona is the Agent this loop voices.
@@ -169,6 +180,13 @@ type Config struct {
 	// unavailable path degrades to a zero Memory. nil disables recall entirely —
 	// the prompt is then byte-identical to the pre-memory behavior (AC6).
 	Memory MemoryRecaller
+
+	// Facts fills the reserved KG-facts slot of the system prompt each turn (#126,
+	// ADR-0008): the Campaign's gm-public Knowledge Graph Node facts. Consulted
+	// under the turn ctx alongside Memory, OUTSIDE the history lock, never blocking
+	// the turn: a slow/unavailable path degrades to nil. nil disables facts — the
+	// slot stays empty and the prompt is byte-identical to the pre-facts behavior.
+	Facts FactsRecaller
 }
 
 // DefaultTurnTimeout is the per-turn LLM deadline applied when
@@ -273,13 +291,14 @@ func (r *Replier) turn(ctx context.Context, text string) []orchestrator.Reply {
 	r.trimHistoryLocked()
 	r.mu.Unlock()
 
-	// Recall runs BETWEEN the two lock sections, never under r.mu: it is
-	// network-adjacent (embeddings + DB) and must not hold the loop's lock across
-	// that call (ADR-0042). It respects ctx, so a barge cancels it.
+	// Recall + facts run BETWEEN the two lock sections, never under r.mu: they are
+	// network-/DB-adjacent and must not hold the loop's lock across the call
+	// (ADR-0042). Both respect ctx, so a barge cancels them.
 	mem := r.recall(ctx, text)
+	facts := r.facts(ctx)
 
 	r.mu.Lock()
-	messages := r.hotContextLocked(mem)
+	messages := r.hotContextLocked(mem, facts)
 	r.mu.Unlock()
 
 	reply, err := r.engine.Generate(ctx, messages)
@@ -339,12 +358,13 @@ func (r *Replier) streamTurn(ctx context.Context, text string, dispatch func(orc
 	r.trimHistoryLocked()
 	r.mu.Unlock()
 
-	// Recall between the lock sections (see [Replier.turn]): outside r.mu, under
-	// ctx, degrading to zero Memory rather than stalling the streaming turn.
+	// Recall + facts between the lock sections (see [Replier.turn]): outside r.mu,
+	// under ctx, each degrading to nothing rather than stalling the streaming turn.
 	mem := r.recall(ctx, text)
+	facts := r.facts(ctx)
 
 	r.mu.Lock()
-	messages := r.hotContextLocked(mem)
+	messages := r.hotContextLocked(mem, facts)
 	r.mu.Unlock()
 
 	streamer, ok := r.engine.(StreamingEngine)
@@ -502,27 +522,47 @@ func (r *Replier) recall(ctx context.Context, text string) Memory {
 	return r.cfg.Memory.Recall(ctx, r.cfg.Persona.AgentID, text)
 }
 
+// facts consults the configured [FactsRecaller] for this turn's Hot Context
+// KG-facts, keyed by the Agent's id. A nil recaller (the unconfigured default)
+// returns no facts, so the reserved slot stays empty and the prompt is
+// byte-identical to the pre-facts path (#126). The recaller never errors and
+// respects ctx.
+func (r *Replier) facts(ctx context.Context) []string {
+	if r.cfg.Facts == nil {
+		return nil
+	}
+	return r.cfg.Facts.Facts(ctx, r.cfg.Persona.AgentID)
+}
+
 // hotContextLocked assembles the Hot Context message list for one call: the
-// system prompt (Persona + recalled memory + audio-markup instruction) followed
-// by the recent Transcript (the bounded history). mem is the memory recalled for
-// this turn (zero when unconfigured or degraded). Caller holds r.mu.
-func (r *Replier) hotContextLocked(mem Memory) []llm.Message {
+// system prompt (Persona + KG facts + recalled memory + audio-markup instruction)
+// followed by the recent Transcript (the bounded history). mem is the memory
+// recalled for this turn and facts are the KG-facts (each nil/zero when
+// unconfigured or degraded). Caller holds r.mu.
+func (r *Replier) hotContextLocked(mem Memory, facts []string) []llm.Message {
 	msgs := make([]llm.Message, 0, len(r.history)+1)
-	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt(mem)})
+	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt(mem, facts)})
 	msgs = append(msgs, r.history...)
 	return msgs
 }
 
-// systemPrompt builds the system prompt from the three Hot Context inputs in slot
-// order: the Persona, the recalled memory block (the reserved Hot Context memory
-// slot, ADR-0011/0042/0012 — memory touches the SYSTEM prompt only), and the
-// Voice's provider-specific audio-markup instruction from
-// [tts.Synthesizer.AudioMarkupPrompt] (required by ADR-0022). A zero mem omits
-// the memory block entirely, leaving the prompt byte-identical to today (AC6).
-func (r *Replier) systemPrompt(mem Memory) string {
+// systemPrompt builds the system prompt from the Hot Context inputs in slot order:
+// the Persona, the KG-facts block (the reserved facts slot, ADR-0008/#126), the
+// recalled memory block (ADR-0011/0042/0012 — both touch the SYSTEM prompt only),
+// and the Voice's provider-specific audio-markup instruction from
+// [tts.Synthesizer.AudioMarkupPrompt] (required by ADR-0022). Empty facts AND a
+// zero mem omit their blocks entirely, leaving the prompt byte-identical to the
+// pre-facts/pre-memory path (#126 / AC6).
+func (r *Replier) systemPrompt(mem Memory, facts []string) string {
 	var b strings.Builder
 	if p := strings.TrimSpace(r.cfg.Persona.Markdown); p != "" {
 		b.WriteString(p)
+	}
+	if block := factsBlock(facts); block != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(block)
 	}
 	if block := memoryBlock(mem); block != "" {
 		if b.Len() > 0 {
@@ -536,6 +576,22 @@ func (r *Replier) systemPrompt(mem Memory) string {
 		}
 		b.WriteString(markup)
 	}
+	return b.String()
+}
+
+// factsBlock renders the KG-facts slot as a flat-text prompt section: a fixed
+// header followed by the already-rendered fact strings joined by blank lines. The
+// agent is a dumb joiner — the fact strings arrive fully formatted from the
+// FactsRecaller (#126). No facts yields "" so the block is dropped entirely
+// (the byte-identical guarantee).
+func factsBlock(facts []string) string {
+	if len(facts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## What you know about the world")
+	b.WriteString("\n\n")
+	b.WriteString(strings.Join(facts, "\n\n"))
 	return b.String()
 }
 

--- a/pkg/voice/agent/facts_test.go
+++ b/pkg/voice/agent/facts_test.go
@@ -1,0 +1,165 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+)
+
+// fakeFacts is a scripted [agent.FactsRecaller]: it records the agentID it was
+// called with and returns a fixed slice of already-rendered fact strings.
+type fakeFacts struct {
+	facts   []string
+	calls   int
+	agentID string
+}
+
+func (f *fakeFacts) Facts(_ context.Context, agentID string) []string {
+	f.calls++
+	f.agentID = agentID
+	return f.facts
+}
+
+// TestSystemPrompt_NilFacts_ByteIdenticalToToday locks the #126 byte-identical
+// guarantee: with Config.Facts nil the prompt is exactly Persona + markup, the
+// reserved KG-facts slot emitting zero bytes.
+func TestSystemPrompt_NilFacts_ByteIdenticalToToday(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		// Facts deliberately nil.
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Hello, innkeeper."))
+
+	sys := prov.lastRequest(t).Messages[0].Text
+	want := "You are Bart, the innkeeper.\n\n" + sentinelMarkup
+	if sys != want {
+		t.Errorf("nil-facts prompt not byte-identical:\n got %q\nwant %q", sys, want)
+	}
+}
+
+// TestSystemPrompt_EmptyFacts_ByteIdenticalToToday pins that a recaller returning
+// NO facts (an empty/nil slice) also emits zero bytes — the reserved slot stays
+// empty, so an idle wiki is byte-identical to the no-facts path.
+func TestSystemPrompt_EmptyFacts_ByteIdenticalToToday(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	rec := &fakeFacts{facts: nil}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart, the innkeeper.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		Facts:       rec,
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Hello."))
+
+	if rec.calls != 1 || rec.agentID != "bart" {
+		t.Errorf("facts recaller args = (calls %d, agent %q), want (1, bart)", rec.calls, rec.agentID)
+	}
+	sys := prov.lastRequest(t).Messages[0].Text
+	want := "You are Bart, the innkeeper.\n\n" + sentinelMarkup
+	if sys != want {
+		t.Errorf("empty-facts prompt not byte-identical:\n got %q\nwant %q", sys, want)
+	}
+}
+
+// TestSystemPrompt_Facts_BlockInSlotOrder pins #126 AC2: public Node facts inject
+// a "## What you know about the world" block between the Persona and the memory
+// block (slot order Persona → facts → memory → markup), joined by blank lines.
+func TestSystemPrompt_Facts_BlockInSlotOrder(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye."}
+	facts := &fakeFacts{facts: []string{
+		"### The Sealed Vault (Location)\nNobody has opened it in a century.",
+		"### Guild of Ash (Faction)\nThey control the docks.",
+	}}
+	mem := &fakeRecaller{mem: agent.Memory{Personal: []string{"I served him ale."}}}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+		Facts:       facts,
+		Memory:      mem,
+	})
+
+	r.Reply()(t.Context(), routed("bart", "Tell me about the town."))
+
+	sys := prov.lastRequest(t).Messages[0].Text
+	if !strings.Contains(sys, "## What you know about the world") {
+		t.Errorf("facts block header missing: %q", sys)
+	}
+	if !strings.Contains(sys, "The Sealed Vault") || !strings.Contains(sys, "Guild of Ash") {
+		t.Errorf("facts content missing: %q", sys)
+	}
+	// Both facts joined by a blank line.
+	if !strings.Contains(sys, "Nobody has opened it in a century.\n\n### Guild of Ash") {
+		t.Errorf("facts not joined by a blank line: %q", sys)
+	}
+	// Slot order: Persona < facts header < memory block < markup.
+	iPersona := strings.Index(sys, "You are Bart.")
+	iFacts := strings.Index(sys, "## What you know about the world")
+	iMemory := strings.Index(sys, "I served him ale.")
+	iMarkup := strings.Index(sys, sentinelMarkup)
+	if !(iPersona < iFacts && iFacts < iMemory && iMemory < iMarkup) {
+		t.Errorf("slot order wrong (want persona<facts<memory<markup): persona=%d facts=%d memory=%d markup=%d\n%q",
+			iPersona, iFacts, iMemory, iMarkup, sys)
+	}
+}
+
+// captureStreamEngine is a [agent.StreamingEngine] that records the messages it is
+// handed on BOTH the batch and streaming paths, so a test can assert the assembled
+// system prompt reaches the streaming turn (the path production wires).
+type captureStreamEngine struct {
+	reply    string
+	captured []llm.Message
+}
+
+func (e *captureStreamEngine) Generate(_ context.Context, msgs []llm.Message) (string, error) {
+	e.captured = msgs
+	return e.reply, nil
+}
+
+func (e *captureStreamEngine) GenerateStream(_ context.Context, msgs []llm.Message, onText func(string) error) (string, error) {
+	e.captured = msgs
+	if err := onText(e.reply); err != nil {
+		return e.reply, err
+	}
+	return e.reply, nil
+}
+
+// TestStreamTurn_InjectsFacts pins that the STREAMING turn path (the one
+// production wires via WithReplyStream) also consults the FactsRecaller and folds
+// the facts block into the system prompt — a batch-only wiring would silently
+// ship nothing here.
+func TestStreamTurn_InjectsFacts(t *testing.T) {
+	eng := &captureStreamEngine{reply: "Aye, traveller."}
+	facts := &fakeFacts{facts: []string{"### The Sealed Vault (Location)\nNobody has opened it."}}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Engine:      eng,
+		Synthesizer: stubSynth{},
+		Facts:       facts,
+	})
+
+	err := r.ReplyStream()(t.Context(), routed("bart", "What lies in the keep?"),
+		func(orchestrator.Reply) error { return nil })
+	if err != nil {
+		t.Fatalf("ReplyStream: %v", err)
+	}
+	if facts.calls != 1 || facts.agentID != "bart" {
+		t.Fatalf("facts recaller args = (calls %d, agent %q), want (1, bart)", facts.calls, facts.agentID)
+	}
+	if len(eng.captured) == 0 {
+		t.Fatal("streaming engine captured no messages")
+	}
+	sys := eng.captured[0].Text
+	if !strings.Contains(sys, "## What you know about the world") || !strings.Contains(sys, "The Sealed Vault") {
+		t.Errorf("streaming system prompt missing facts block: %q", sys)
+	}
+}

--- a/pkg/voice/agent/facts_test.go
+++ b/pkg/voice/agent/facts_test.go
@@ -106,7 +106,8 @@ func TestSystemPrompt_Facts_BlockInSlotOrder(t *testing.T) {
 	iFacts := strings.Index(sys, "## What you know about the world")
 	iMemory := strings.Index(sys, "I served him ale.")
 	iMarkup := strings.Index(sys, sentinelMarkup)
-	if !(iPersona < iFacts && iFacts < iMemory && iMemory < iMarkup) {
+	ordered := iPersona < iFacts && iFacts < iMemory && iMemory < iMarkup
+	if !ordered {
 		t.Errorf("slot order wrong (want persona<facts<memory<markup): persona=%d facts=%d memory=%d markup=%d\n%q",
 			iPersona, iFacts, iMemory, iMarkup, sys)
 	}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -40,6 +40,85 @@ service CampaignService {
   // CodeFailedPrecondition (it is undeletable, ADR-0009); a missing id fails with
   // CodeNotFound.
   rpc DeleteAgent(DeleteAgentRequest) returns (DeleteAgentResponse);
+
+  // CreateNode adds a Knowledge Graph Node ("entry") to the active campaign and
+  // returns the created Node (ADR-0008 v1.0). An UNSPECIFIED node_type or an empty
+  // name fails with CodeInvalidArgument; the campaign is resolved server-side.
+  rpc CreateNode(CreateNodeRequest) returns (CreateNodeResponse);
+
+  // ListNodes returns the active campaign's Knowledge Graph Nodes in stable
+  // display order (type, then case-insensitive name). It is a read
+  // (NO_SIDE_EFFECTS), so the CSRF check is exempt.
+  rpc ListNodes(ListNodesRequest) returns (ListNodesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+// NodeType is a Knowledge Graph Node's type (CONTEXT.md "Node", ADR-0008 v1.0).
+// The full 7-value set ships now; #126 only creates NOTE from the UI, but the
+// wire type is complete so later slices (#129) need no proto change.
+enum NodeType {
+  // NODE_TYPE_UNSPECIFIED is the zero value; the server rejects it on create.
+  NODE_TYPE_UNSPECIFIED = 0;
+  NODE_TYPE_CHARACTER = 1;
+  NODE_TYPE_NPC = 2;
+  NODE_TYPE_LOCATION = 3;
+  NODE_TYPE_FACTION = 4;
+  NODE_TYPE_ITEM = 5;
+  NODE_TYPE_PLOT_THREAD = 6;
+  NODE_TYPE_NOTE = 7;
+}
+
+// Node is the wire representation of a Knowledge Graph Node — a typed wiki entry
+// in one campaign (ADR-0008 v1.0). gm_private hides it from every NPC's Hot
+// Context (#126).
+message Node {
+  // id is the node's UUID.
+  string id = 1;
+  // campaign_id is the owning campaign's UUID.
+  string campaign_id = 2;
+  // node_type is the node's type; immutable after create.
+  NodeType node_type = 3;
+  // name is the node's display name.
+  string name = 4;
+  // body is the node's prose (may be empty).
+  string body = 5;
+  // gm_private hides the node from every NPC's assembled prompt (#126).
+  bool gm_private = 6;
+  // created_at is when the node was created.
+  google.protobuf.Timestamp created_at = 7;
+  // updated_at is when the node was last modified.
+  google.protobuf.Timestamp updated_at = 8;
+  // field 9 = agent_id, reserved for the NPC-Node ↔ Agent link (#132).
+}
+
+// CreateNodeRequest is the Knowledge panel's "Add entry" payload. The campaign is
+// resolved server-side (single operator, ADR-0039).
+message CreateNodeRequest {
+  // node_type is the entry's type; UNSPECIFIED is rejected.
+  NodeType node_type = 1;
+  // name is the entry's display name; empty is rejected.
+  string name = 2;
+  // body is the entry's prose (optional).
+  string body = 3;
+  // gm_private keeps the entry out of every NPC's prompt (#126).
+  bool gm_private = 4;
+}
+
+// CreateNodeResponse carries the created Node.
+message CreateNodeResponse {
+  // node is the newly created Knowledge Graph Node.
+  Node node = 1;
+}
+
+// ListNodesRequest is the (empty) request; the active campaign is resolved
+// server-side for the single operator.
+message ListNodesRequest {}
+
+// ListNodesResponse carries the campaign's Knowledge Graph Nodes in display order.
+message ListNodesResponse {
+  // nodes is the campaign's Knowledge Graph Nodes.
+  repeated Node nodes = 1;
 }
 
 // Campaign is the wire representation of a campaign record.

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
 import { playAudioBlob } from "@/lib/audio";
+import { KnowledgePanel } from "./KnowledgePanel";
 
 import "./campaign.css";
 
@@ -55,6 +56,10 @@ export function Campaign() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selected = roster.find((a) => a.id === selectedId) ?? roster[0];
 
+  // Cast (roster editor) vs Knowledge (KG entries) — the design's seg-control
+  // beside the title. Cast is the default so the roster is what loads first (#71).
+  const [view, setView] = useState<"cast" | "knowledge">("cast");
+
   const invalidateRoster = () =>
     queryClient.invalidateQueries({
       queryKey: createConnectQueryKey({
@@ -76,43 +81,57 @@ export function Campaign() {
     },
   });
 
-  if (status === "pending") {
-    return (
-      <div className="gx-campaign-screen">
-        <h1>Campaign</h1>
-        <div className="gx-skeleton" data-testid="roster-loading" />
-      </div>
-    );
-  }
-  if (status === "error") {
-    return (
-      <div className="gx-campaign-screen">
-        <h1>Campaign</h1>
-        <p className="gx-campaign__error" role="alert">
-          Could not load the campaign: {error.message}
-        </p>
-      </div>
-    );
-  }
-
   const campaign = data?.campaign;
   const npcs = roster.filter((a) => !isButler(a));
 
   return (
     <div className="gx-campaign-screen">
       <header className="gx-campaign-screen__header">
-        <h1>{campaign?.name ?? "Campaign"}</h1>
+        <div className="gx-campaign-screen__title-row">
+          <h1>{campaign?.name ?? "Campaign"}</h1>
+          <div className="gx-seg" role="tablist" aria-label="Campaign view">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "cast"}
+              data-active={view === "cast" ? "true" : undefined}
+              onClick={() => setView("cast")}
+            >
+              Cast
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "knowledge"}
+              data-active={view === "knowledge" ? "true" : undefined}
+              onClick={() => setView("knowledge")}
+            >
+              Knowledge
+            </button>
+          </div>
+        </div>
         <div className="gx-campaign-screen__sub">
           {campaign?.system && <span className="gx-campaign-screen__system">{campaign.system}</span>}
           <span className="gx-campaign-screen__lede">
-            One Butler is required; add as many NPCs as your table needs.
+            {view === "knowledge"
+              ? "What the world knows. Public entries prime your NPCs; GM-private ones stay yours."
+              : "One Butler is required; add as many NPCs as your table needs."}
           </span>
         </div>
       </header>
 
-      <div className="gx-roster-layout">
-        {/* Roster list */}
-        <div className="gx-roster">
+      {view === "knowledge" ? (
+        <KnowledgePanel />
+      ) : status === "pending" ? (
+        <div className="gx-skeleton" data-testid="roster-loading" />
+      ) : status === "error" ? (
+        <p className="gx-campaign__error" role="alert">
+          Could not load the campaign: {error.message}
+        </p>
+      ) : (
+        <div className="gx-roster-layout">
+          {/* Roster list */}
+          <div className="gx-roster">
           {roster.map((a) => (
             <button
               key={a.id}
@@ -181,7 +200,8 @@ export function Campaign() {
             deleting={deleteAgent.isPending}
           />
         )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/screens/campaign/KnowledgePanel.test.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  CampaignService,
+  NodeSchema,
+  NodeType,
+  CreateNodeResponseSchema,
+  ListNodesResponseSchema,
+  type CreateNodeRequest,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { KnowledgePanel } from "./KnowledgePanel";
+
+// An in-memory KG store served over a router transport (no network): createNode
+// pushes into the closure and listNodes reads it back, so an Add → invalidate →
+// refetch proves the entry round-trips, and the recorded request proves the
+// gm_private switch + fixed NOTE type reach the wire.
+function mockTransport() {
+  const nodes = [
+    create(NodeSchema, {
+      id: "n1",
+      campaignId: "c1",
+      nodeType: NodeType.NOTE,
+      name: "The sealed vault",
+      body: "Nobody has opened it in a century.",
+      gmPrivate: false,
+    }),
+  ];
+  let nextId = 2;
+  const createCalls: CreateNodeRequest[] = [];
+
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listNodes: () => create(ListNodesResponseSchema, { nodes }),
+      createNode: (req) => {
+        createCalls.push(req);
+        const node = create(NodeSchema, {
+          id: `n${nextId++}`,
+          campaignId: "c1",
+          nodeType: req.nodeType,
+          name: req.name,
+          body: req.body,
+          gmPrivate: req.gmPrivate,
+        });
+        nodes.push(node);
+        return create(CreateNodeResponseSchema, { node });
+      },
+    });
+  });
+  return { transport, nodes, createCalls };
+}
+
+function renderPanel() {
+  const { transport, nodes, createCalls } = mockTransport();
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <KnowledgePanel />
+    </Providers>,
+  );
+  return { nodes, createCalls };
+}
+
+describe("KnowledgePanel", () => {
+  it("lists the campaign's knowledge entries from ListNodes", async () => {
+    renderPanel();
+    expect(await screen.findByText("The sealed vault")).toBeInTheDocument();
+    expect(screen.getByText(/Nobody has opened it/)).toBeInTheDocument();
+  });
+
+  it("adds a gm-private entry that appears in the list, sending NOTE + gm_private", async () => {
+    const { nodes, createCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Hidden cult" } });
+    fireEvent.change(screen.getByLabelText(/content/i), { target: { value: "They meet at midnight." } });
+    // Toggle the GM-private switch on.
+    fireEvent.click(screen.getByLabelText(/gm private/i));
+    fireEvent.click(screen.getByRole("button", { name: /add entry/i }));
+
+    // The new entry round-trips into the list (invalidate → refetch).
+    expect(await screen.findByText("Hidden cult")).toBeInTheDocument();
+    expect(nodes).toHaveLength(2);
+
+    // The request carried the fixed NOTE type and the gm_private flag.
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].nodeType).toBe(NodeType.NOTE);
+    expect(createCalls[0].name).toBe("Hidden cult");
+    expect(createCalls[0].gmPrivate).toBe(true);
+  });
+
+  it("marks a gm-private entry with a private badge", async () => {
+    const { transport } = (() => {
+      const nodes = [
+        create(NodeSchema, {
+          id: "n1",
+          campaignId: "c1",
+          nodeType: NodeType.NOTE,
+          name: "Secret pact",
+          body: "signed in blood",
+          gmPrivate: true,
+        }),
+      ];
+      const t = createRouterTransport(({ service }) => {
+        service(CampaignService, {
+          listNodes: () => create(ListNodesResponseSchema, { nodes }),
+        });
+      });
+      return { transport: t };
+    })();
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <KnowledgePanel />
+      </Providers>,
+    );
+    expect(await screen.findByText("Secret pact")).toBeInTheDocument();
+    // The private badge (exact) — distinct from the create form's switch label.
+    expect(screen.getByText("GM private")).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { EyeOff, Plus, StickyNote } from "lucide-react";
+
+import { CampaignService, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Node } from "@gen/glyphoxa/management/v1/management_pb";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Input } from "@/components/ui/Input";
+import { Switch } from "@/components/ui/Switch";
+import { Button } from "@/components/ui/Button";
+
+// The Knowledge panel (#126) backs the Campaign screen's "Knowledge" view on the
+// live CampaignService ListNodes/CreateNode RPCs (ADR-0008 v1.0). For this slice
+// the only Node type authored from the UI is a Note ("entry", GM-facing copy —
+// the code keeps the Node domain term). Public entries are injected into NPC
+// prompts; a GM-private entry never reaches the table (the gm_private flag). Full
+// 7-type authoring, search and edges arrive in later slices.
+
+// noteColor is the design's Note type-color, applied to the entry icon.
+const noteColor = "#8b93a7";
+
+export function KnowledgePanel() {
+  const queryClient = useQueryClient();
+  const { data, status, error } = useQuery(CampaignService.method.listNodes, {});
+  const nodes = useMemo(() => data?.nodes ?? [], [data]);
+
+  const invalidateNodes = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listNodes,
+        cardinality: "finite",
+      }),
+    });
+
+  const createNode = useMutation(CampaignService.method.createNode, {
+    onSuccess: () => void invalidateNodes(),
+  });
+
+  if (status === "pending") {
+    return <div className="gx-skeleton" data-testid="kg-loading" />;
+  }
+  if (status === "error") {
+    return (
+      <p className="gx-campaign__error" role="alert">
+        Could not load knowledge entries: {error.message}
+      </p>
+    );
+  }
+
+  return (
+    <div className="gx-kg-layout">
+      <div className="gx-kg-list">
+        {nodes.map((n) => (
+          <KnowledgeCard key={n.id} node={n} />
+        ))}
+        {nodes.length === 0 && (
+          <p className="gx-kg-empty">
+            No entries yet. Add what the world knows and your NPCs will speak to it.
+          </p>
+        )}
+      </div>
+
+      <AddEntry
+        pending={createNode.isPending}
+        error={createNode.isError ? createNode.error.message : null}
+        onAdd={(name, body, gmPrivate, reset) =>
+          createNode.mutate(
+            { nodeType: NodeType.NOTE, name, body, gmPrivate },
+            { onSuccess: reset },
+          )
+        }
+      />
+    </div>
+  );
+}
+
+// KnowledgeCard renders one entry: the Note icon, name, a "Note" type badge, a
+// "GM private" badge (EyeOff) when private, and a one-line body snippet.
+function KnowledgeCard({ node }: { node: Node }) {
+  return (
+    <Card className="gx-kg-card">
+      <span className="gx-kg-card__icon" style={{ color: noteColor }} aria-hidden>
+        <StickyNote size={16} />
+      </span>
+      <div className="gx-kg-card__meta">
+        <div className="gx-kg-card__head">
+          <span className="gx-kg-card__name">{node.name}</span>
+          <Badge variant="neutral" size="sm">
+            Note
+          </Badge>
+          {node.gmPrivate && (
+            <Badge variant="warning" size="sm">
+              <EyeOff size={11} /> GM private
+            </Badge>
+          )}
+        </div>
+        {node.body && <span className="gx-kg-card__snippet">{node.body}</span>}
+      </div>
+    </Card>
+  );
+}
+
+// AddEntry is the sticky create form: Name, Content, and the GM-private switch.
+// The type is fixed to Note for this slice.
+function AddEntry({
+  pending,
+  error,
+  onAdd,
+}: {
+  pending: boolean;
+  error: string | null;
+  onAdd: (name: string, body: string, gmPrivate: boolean, reset: () => void) => void;
+}) {
+  const [name, setName] = useState("");
+  const [body, setBody] = useState("");
+  const [gmPrivate, setGmPrivate] = useState(false);
+
+  const reset = () => {
+    setName("");
+    setBody("");
+    setGmPrivate(false);
+  };
+  const add = () => {
+    if (name.trim() === "") return;
+    onAdd(name.trim(), body, gmPrivate, reset);
+  };
+
+  return (
+    <Card accent className="gx-kg-editor">
+      <h2 className="gx-kg-editor__title">Add entry</h2>
+
+      <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} placeholder="What is it called?" />
+
+      <div className="gx-field">
+        <label className="gx-field__label" htmlFor="gx-kg-body">
+          Content
+        </label>
+        <textarea
+          id="gx-kg-body"
+          className="gx-input gx-textarea"
+          rows={4}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+        />
+        <span className="gx-field__hint">
+          What the world knows. Public entries are injected into NPC prompts.
+        </span>
+      </div>
+
+      <div className="gx-kg-editor__switch">
+        <Switch
+          label="GM private — never enters an NPC's prompt"
+          checked={gmPrivate}
+          onCheckedChange={setGmPrivate}
+        />
+        <span className="gx-field__hint">
+          Private entries stay searchable for you and never reach the table.
+        </span>
+      </div>
+
+      <div className="gx-kg-editor__actions">
+        <Button variant="primary" iconStart={<Plus size={14} />} onClick={add} disabled={pending || name.trim() === ""}>
+          {pending ? "Adding…" : "Add entry"}
+        </Button>
+        {error && (
+          <span className="gx-editor__status gx-editor__status--error" role="alert">
+            Couldn't add: {error}
+          </span>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -15,6 +15,147 @@
   margin-bottom: var(--spacing-lg);
 }
 
+/* Title + Cast|Knowledge seg-control on one row (#126). */
+.gx-campaign-screen__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+/* Segmented control (Cast | Knowledge), mirroring the Session screen's seg. */
+.gx-seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--surface-inset, var(--surface-card));
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+}
+
+.gx-seg > button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-pill);
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.gx-seg > button:hover {
+  color: var(--text-strong);
+}
+
+.gx-seg > button[data-active="true"] {
+  background: var(--surface-card);
+  color: var(--text-strong);
+  box-shadow: var(--glow-arcane-soft);
+}
+
+/* Knowledge view: list left, sticky editor card right (mirrors the roster grid). */
+.gx-kg-layout {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+@media (max-width: 720px) {
+  .gx-kg-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gx-kg-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.gx-kg-card__icon {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
+.gx-kg-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.gx-kg-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.gx-kg-card__name {
+  font-weight: var(--weight-semibold);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-kg-card__snippet {
+  font-size: var(--body-xs);
+  color: var(--text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gx-kg-empty {
+  padding: var(--spacing-md);
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+}
+
+/* Sticky create card on the right. */
+.gx-kg-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  position: sticky;
+  top: var(--spacing-lg);
+}
+
+.gx-kg-editor__title {
+  font-size: var(--heading-sm, var(--body-lg));
+  color: var(--text-strong);
+  margin: 0;
+}
+
+.gx-kg-editor__switch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-editor__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
 .gx-campaign-screen__sub {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #126

First slice of the KG epic (#99): a gm-public Knowledge Graph Node authored on the Campaign screen persists and is injected into a Character NPC's assembled system prompt. Owns the shared surface later slices (#129/#131/#132/#133) build on unchanged.

## What lands
- **Migration `00010_kg_node.sql`** — full 7-value `kg_node_type` enum + `kg_node` table with `UNIQUE(id, campaign_id)` (the composite-FK target #132 needs) and a `campaign_id` index. `node_type` is immutable (no UPDATE path).
- **Storage** (`internal/storage/kg_node.go`) — `CreateNode` / `ListNodes` (type, lower(name), id order) / `ListPublicNodes` (the prompt-injection read: `NOT gm_private`, `updated_at DESC`, LIMIT 50).
- **Proto + RPC** — `NodeType` enum, `Node` message (field 9 reserved for #132's `agent_id`), `CreateNode`/`ListNodes` on `CampaignService`. Handler: UNSPECIFIED type + empty name → `InvalidArgument`, no campaign → `NotFound`, storage error → `Internal`.
- **Agent seam** (`agent.FactsRecaller`) — a reserved KG-facts slot in the system prompt, slot order Persona → **facts** → memory → audio markup. Empty facts emit zero bytes (the byte-identical guarantee). Threaded through **both** the batch `turn()` and the streaming `streamTurn()` paths.
- **`internal/kgfacts`** — the production `FactsRecaller`: INLINE, bounded (50ms), no speculation. Renders `### Name (TypeLabel)\nBody` with rune-safe truncation (`MaxFactChars`) and deterministic `MaxFacts` / `MaxBlockChars` prefix caps. Degrades to nil on DB error / budget timeout (counted `degraded`); barge-cancel is silent; no session / no public nodes counts `empty`. New metric `glyphoxa_kg_facts_total{outcome}`.
- **Wiring** — `Manager.SetFacts` → base voice config → `buildConversation` → `rosterDepsForLive` → every NPC's loop. `main.go` wires `kgfacts.New(...)` **unconditionally**, outside the embeddings-provider branch, so keyless deployments keep the feature. No cache — a `gm_private` flip takes effect on the next turn.
- **Web** — a Cast | Knowledge seg-control on the Campaign screen; the Knowledge view lists entries and adds Note entries (type fixed to NOTE), the GM-private switch flowing to the wire.

## Acceptance criteria
- AC1 (create → persist → survives reload, in the Node list): storage round-trip test + web add-round-trip test.
- AC2 (public Note body in the assembled prompt; no Notes → byte-identical): agent slot-order tests + the end-to-end integration test.
- AC3 (gm_private never injected): `ListPublicNodes` test + the integration gm_private-flip.
- AC4 (bounded by a fixed cap): `MaxFacts` / `MaxBlockChars` / `MaxFactChars` tests; storage LIMIT.
- AC5 (tag-isolated end-to-end round-trip, all-green): `internal/kgfacts/kgfacts_integration_test.go`.

## Local verification
- `go build ./...`, `go vet ./...` (+ `-tags=record`), `go test -race ./...` — green (only the pre-existing broken-local-Ollama live test fails; CI skips it with no Ollama).
- `go test -race -tags=integration ./internal/storage/ ./internal/kgfacts/ ./internal/rpc/` — green.
- `golangci-lint run` on touched packages — 0 issues.
- `buf lint` + `buf generate` — clean.
- web: `npm run build` + `npm run test` (57 tests) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)