### PR TITLE
feat(#129): all seven Node types + gm_private (edit/delete/grouped list)

### DIFF
--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -42,6 +42,11 @@ const (
 	// MaxFactChars caps one fact's body length in runes; a longer body is
 	// rune-safe-truncated with a trailing ellipsis.
 	MaxFactChars = 500
+	// MaxNameChars caps a fact's Node-name length in runes. Without it a single
+	// pathological name could push one fact past MaxBlockChars — and since the read
+	// is newest-first, that oversized fact would land first and the deterministic
+	// prefix-stop would drop the ENTIRE block (review finding, PR #202).
+	MaxNameChars = 200
 	// MaxBlockChars bounds the whole assembled facts block (header + joins + facts)
 	// so the prompt budget holds regardless of wiki size (#126 AC4).
 	MaxBlockChars = 4000
@@ -210,11 +215,12 @@ func renderFacts(nodes []storage.KGNode) []string {
 	return out
 }
 
-// renderFact renders one Node as "### <Name> (<TypeLabel>)\n<Body>", with the body
-// trimmed and rune-safe-truncated to MaxFactChars. A bodiless Node emits only its
-// header line (no dangling newline).
+// renderFact renders one Node as "### <Name> (<TypeLabel>)\n<Body>". The name is
+// rune-safe-truncated to MaxNameChars and the body to MaxFactChars, each with a
+// trailing ellipsis when cut, so no single Node can blow the block budget. A
+// bodiless Node emits only its header line (no dangling newline).
 func renderFact(n storage.KGNode) string {
-	head := fmt.Sprintf("### %s (%s)", n.Name, typeLabel(n.Type))
+	head := fmt.Sprintf("### %s (%s)", truncateRunes(n.Name, MaxNameChars), typeLabel(n.Type))
 	body := truncateRunes(strings.TrimSpace(n.Body), MaxFactChars)
 	if body == "" {
 		return head

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -138,6 +138,34 @@ func TestFacts_TruncatesBodyByRunes(t *testing.T) {
 	}
 }
 
+// TestFacts_TruncatesLongName pins the PR #202 finding: a pathologically long
+// Node name is rune-capped so it can't single-handedly blow MaxBlockChars. Since
+// the read is newest-first, an un-capped huge name would land first and the
+// deterministic prefix-stop would drop the whole block; here the second Node must
+// still surface.
+func TestFacts_TruncatesLongName(t *testing.T) {
+	camp := uuid.New()
+	huge := strings.Repeat("A", 5000) // one name larger than MaxBlockChars
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: huge, Body: "short"},
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: "Small", Body: "also short"},
+	}}
+	r := newRecaller(t, nodes, activeSessions(camp), &fakeMetrics{})
+
+	facts := r.Facts(context.Background(), "bart")
+	if len(facts) != 2 {
+		t.Fatalf("got %d facts, want 2 (a long name must not kill the block)", len(facts))
+	}
+	head, _, _ := strings.Cut(facts[0], "\n")
+	if !strings.Contains(head, "…") {
+		t.Errorf("long name not truncated: %.40q", head)
+	}
+	// The header is bounded: name (≤ MaxNameChars + ellipsis) + "### " + " (Note)".
+	if got := len([]rune(head)); got > kgfacts.MaxNameChars+20 {
+		t.Errorf("header still oversized: %d runes", got)
+	}
+}
+
 // TestFacts_CapsAtMaxFacts pins the MaxFacts cap: a wiki larger than the cap yields
 // exactly MaxFacts facts, the deterministic storage-order prefix.
 func TestFacts_CapsAtMaxFacts(t *testing.T) {

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -35,6 +35,8 @@ type campaignStore interface {
 	DeleteAgent(ctx context.Context, id uuid.UUID) error
 	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
 	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
+	UpdateNode(ctx context.Context, u storage.KGNodeUpdate) (storage.KGNode, error)
+	DeleteNode(ctx context.Context, id uuid.UUID) error
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -39,12 +39,14 @@ type fakeCampaignStore struct {
 
 	created []storage.NewAgent
 
-	// KG Node state (#126): nodes backs ListNodes; nodesCreated records the
-	// storage inputs; nodeCreateErr forces the create failure path.
+	// KG Node state (#126, #129): nodes backs ListNodes/Update/Delete; nodesCreated
+	// records the storage inputs; the *Err hooks force each failure path.
 	nodes         []storage.KGNode
 	nodesCreated  []storage.NewKGNode
 	nodeCreateErr error
 	nodeListErr   error
+	nodeUpdateErr error
+	nodeDeleteErr error
 }
 
 func newFakeStore() *fakeCampaignStore {
@@ -141,6 +143,34 @@ func (f *fakeCampaignStore) CreateNode(_ context.Context, n storage.NewKGNode) (
 
 func (f *fakeCampaignStore) ListNodes(_ context.Context, _ uuid.UUID) ([]storage.KGNode, error) {
 	return f.nodes, f.nodeListErr
+}
+
+func (f *fakeCampaignStore) UpdateNode(_ context.Context, u storage.KGNodeUpdate) (storage.KGNode, error) {
+	if f.nodeUpdateErr != nil {
+		return storage.KGNode{}, f.nodeUpdateErr
+	}
+	for i := range f.nodes {
+		if f.nodes[i].ID == u.ID {
+			f.nodes[i].Name = u.Name
+			f.nodes[i].Body = u.Body
+			f.nodes[i].GMPrivate = u.GMPrivate
+			return f.nodes[i], nil
+		}
+	}
+	return storage.KGNode{}, storage.ErrNotFound
+}
+
+func (f *fakeCampaignStore) DeleteNode(_ context.Context, id uuid.UUID) error {
+	if f.nodeDeleteErr != nil {
+		return f.nodeDeleteErr
+	}
+	for i := range f.nodes {
+		if f.nodes[i].ID == id {
+			f.nodes = append(f.nodes[:i], f.nodes[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
 }
 
 // crudClient stands up the full CampaignService handler over an httptest server

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -54,6 +54,12 @@ func (fakeReader) CreateNode(context.Context, storage.NewKGNode) (storage.KGNode
 func (fakeReader) ListNodes(context.Context, uuid.UUID) ([]storage.KGNode, error) {
 	return nil, nil
 }
+func (fakeReader) UpdateNode(context.Context, storage.KGNodeUpdate) (storage.KGNode, error) {
+	return storage.KGNode{}, nil
+}
+func (fakeReader) DeleteNode(context.Context, uuid.UUID) error {
+	return nil
+}
 
 // newClient stands up the CampaignServer handler behind an httptest server and
 // returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on

--- a/internal/rpc/kg_node.go
+++ b/internal/rpc/kg_node.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
@@ -83,6 +84,60 @@ func (s *CampaignServer) ListNodes(
 		out = append(out, toProtoNode(n))
 	}
 	return connect.NewResponse(&managementv1.ListNodesResponse{Nodes: out}), nil
+}
+
+// UpdateNode saves a Node's editor fields (name/body/gm_private) and returns the
+// updated Node. node_type is immutable, so it is never sent nor changed. An empty
+// name or an unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
+func (s *CampaignServer) UpdateNode(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateNodeRequest],
+) (*connect.Response[managementv1.UpdateNodeResponse], error) {
+	m := req.Msg
+	id, err := uuid.Parse(m.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid node id"))
+	}
+	if strings.TrimSpace(m.GetName()) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+
+	updated, err := s.store.UpdateNode(ctx, storage.KGNodeUpdate{
+		ID:        id,
+		Name:      m.GetName(),
+		Body:      m.GetBody(),
+		GMPrivate: m.GetGmPrivate(),
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("node not found"))
+		}
+		slog.Default().Error("UpdateNode: store update failed", "node_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UpdateNodeResponse{Node: toProtoNode(updated)}), nil
+}
+
+// DeleteNode removes a Node by id. An unparsable id is CodeInvalidArgument; a
+// missing id is CodeNotFound; a storage failure is CodeInternal.
+func (s *CampaignServer) DeleteNode(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteNodeRequest],
+) (*connect.Response[managementv1.DeleteNodeResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid node id"))
+	}
+
+	switch err := s.store.DeleteNode(ctx, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.DeleteNodeResponse{}), nil
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("node not found"))
+	default:
+		slog.Default().Error("DeleteNode: store delete failed", "node_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }
 
 // toProtoNode maps a storage.KGNode onto its wire representation.

--- a/internal/rpc/kg_node.go
+++ b/internal/rpc/kg_node.go
@@ -46,7 +46,7 @@ func (s *CampaignServer) CreateNode(
 	created, err := s.store.CreateNode(ctx, storage.NewKGNode{
 		CampaignID: c.ID,
 		Type:       nodeType,
-		Name:       m.GetName(),
+		Name:       strings.TrimSpace(m.GetName()),
 		Body:       m.GetBody(),
 		GMPrivate:  m.GetGmPrivate(),
 	})
@@ -104,7 +104,7 @@ func (s *CampaignServer) UpdateNode(
 
 	updated, err := s.store.UpdateNode(ctx, storage.KGNodeUpdate{
 		ID:        id,
-		Name:      m.GetName(),
+		Name:      strings.TrimSpace(m.GetName()),
 		Body:      m.GetBody(),
 		GMPrivate: m.GetGmPrivate(),
 	})

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -134,3 +134,137 @@ func TestListNodes_NoCampaignIsNotFound(t *testing.T) {
 		t.Errorf("code = %v, want NotFound", got)
 	}
 }
+
+func TestUpdateNode_MapsAndPersists(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.nodes = []storage.KGNode{
+		{ID: id, CampaignID: uuid.New(), Type: storage.KGNodeLocation, Name: "Harbor", Body: "old"},
+	}
+	client := crudClient(t, store)
+
+	resp, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{
+			Id: id.String(), Name: "Old Harbor", Body: "new prose", GmPrivate: true,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	node := resp.Msg.GetNode()
+	if node.GetName() != "Old Harbor" || node.GetBody() != "new prose" || !node.GetGmPrivate() {
+		t.Errorf("fields not mapped: %+v", node)
+	}
+	// node_type is immutable: the request carries none, and the stored Location type
+	// survives the update.
+	if node.GetNodeType() != managementv1.NodeType_NODE_TYPE_LOCATION {
+		t.Errorf("node_type = %v, want the immutable LOCATION", node.GetNodeType())
+	}
+	if store.nodes[0].Name != "Old Harbor" || !store.nodes[0].GMPrivate {
+		t.Errorf("storage not updated: %+v", store.nodes[0])
+	}
+}
+
+func TestUpdateNode_EmptyNameIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "x"}}
+	client := crudClient(t, store)
+
+	_, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "   "}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateNode_InvalidIdIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	client := crudClient(t, store)
+
+	_, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: "not-a-uuid", Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateNode_NotFoundIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore() // no nodes seeded
+	client := crudClient(t, store)
+
+	_, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestUpdateNode_StorageErrorIsInternal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.nodeUpdateErr = errAny
+	client := crudClient(t, store)
+
+	_, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestDeleteNode_Deletes(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "gone soon"}}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+	if len(store.nodes) != 0 {
+		t.Errorf("node not removed from store: %+v", store.nodes)
+	}
+}
+
+func TestDeleteNode_InvalidIdIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	client := crudClient(t, store)
+
+	_, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestDeleteNode_NotFoundIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	client := crudClient(t, store)
+
+	_, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestDeleteNode_StorageErrorIsInternal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.nodeDeleteErr = errAny
+	client := crudClient(t, store)
+
+	_, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -49,6 +49,29 @@ func TestCreateNode_MapsAndPersists(t *testing.T) {
 	}
 }
 
+func TestCreateNode_TrimsName(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	client := crudClient(t, store)
+
+	resp, err := client.CreateNode(context.Background(),
+		connect.NewRequest(&managementv1.CreateNodeRequest{
+			NodeType: managementv1.NodeType_NODE_TYPE_NOTE, Name: "  Bob  ",
+		}))
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	// The stored name — and the echoed one — must be trimmed, not " Bob " (which
+	// would render "###  Bob " into a prompt).
+	if store.nodesCreated[0].Name != "Bob" {
+		t.Errorf("stored name = %q, want trimmed %q", store.nodesCreated[0].Name, "Bob")
+	}
+	if resp.Msg.GetNode().GetName() != "Bob" {
+		t.Errorf("echoed name = %q, want trimmed", resp.Msg.GetNode().GetName())
+	}
+}
+
 func TestCreateNode_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
@@ -135,6 +158,20 @@ func TestListNodes_NoCampaignIsNotFound(t *testing.T) {
 	}
 }
 
+func TestListNodes_StorageErrorIsInternal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.nodeListErr = errAny
+	client := crudClient(t, store)
+
+	_, err := client.ListNodes(context.Background(),
+		connect.NewRequest(&managementv1.ListNodesRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
 func TestUpdateNode_MapsAndPersists(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
@@ -162,6 +199,26 @@ func TestUpdateNode_MapsAndPersists(t *testing.T) {
 	}
 	if store.nodes[0].Name != "Old Harbor" || !store.nodes[0].GMPrivate {
 		t.Errorf("storage not updated: %+v", store.nodes[0])
+	}
+}
+
+func TestUpdateNode_TrimsName(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "old"}}
+	client := crudClient(t, store)
+
+	resp, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "  Alice  "}))
+	if err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	if store.nodes[0].Name != "Alice" {
+		t.Errorf("stored name = %q, want trimmed %q", store.nodes[0].Name, "Alice")
+	}
+	if resp.Msg.GetNode().GetName() != "Alice" {
+		t.Errorf("echoed name = %q, want trimmed", resp.Msg.GetNode().GetName())
 	}
 }
 

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -78,6 +79,52 @@ func (s *Store) CreateNode(ctx context.Context, n NewKGNode) (KGNode, error) {
 		return KGNode{}, fmt.Errorf("storage: create kg node: %w", err)
 	}
 	return created, nil
+}
+
+// KGNodeUpdate is the input to UpdateNode — the Knowledge panel's editor fields
+// (#129). It carries no Type (node_type is immutable, ADR-0008) and no CampaignID
+// (a Node never moves between campaigns); the row is addressed by ID alone.
+type KGNodeUpdate struct {
+	ID        uuid.UUID
+	Name      string
+	Body      string
+	GMPrivate bool
+}
+
+// UpdateNode saves a Knowledge Graph Node's editor fields (name/body/gm_private)
+// and returns the updated row, stamping updated_at = now(). node_type is never
+// touched (immutable, ADR-0008). A missing id yields ErrNotFound.
+func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE kg_node SET
+		    name = $2,
+		    body = $3,
+		    gm_private = $4,
+		    updated_at = now()
+		  WHERE id = $1
+		 RETURNING `+kgNodeColumns,
+		u.ID, u.Name, u.Body, u.GMPrivate)
+	updated, err := scanKGNode(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return KGNode{}, ErrNotFound
+	}
+	if err != nil {
+		return KGNode{}, fmt.Errorf("storage: update kg node %s: %w", u.ID, err)
+	}
+	return updated, nil
+}
+
+// DeleteNode removes a Knowledge Graph Node by id. A missing id yields
+// ErrNotFound so the RPC can distinguish "gone" from "never existed".
+func (s *Store) DeleteNode(ctx context.Context, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM kg_node WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("storage: delete kg node %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // ListNodes returns every Knowledge Graph Node in a Campaign in a stable display

--- a/internal/storage/kg_node_test.go
+++ b/internal/storage/kg_node_test.go
@@ -4,7 +4,10 @@ package storage_test
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -122,5 +125,154 @@ func TestKGNodeListPublicNodes(t *testing.T) {
 		if n.GMPrivate {
 			t.Errorf("ListPublicNodes leaked a gm_private node: %+v", n)
 		}
+	}
+}
+
+// TestKGNodeUpdate is #129 AC2/AC3: UpdateNode persists name/body/gm_private,
+// bumps updated_at (never touching node_type — immutable, ADR-0008), and yields
+// ErrNotFound for an id that does not exist.
+func TestKGNodeUpdate(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	created, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Barrow", Body: "A haunted mound.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	updated, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
+		ID: created.ID, Name: "Old Barrow", Body: "A very haunted mound.", GMPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	if updated.ID != created.ID || updated.CampaignID != campaignID {
+		t.Errorf("update changed identity: %+v", updated)
+	}
+	if updated.Name != "Old Barrow" || updated.Body != "A very haunted mound." || !updated.GMPrivate {
+		t.Errorf("fields not persisted: %+v", updated)
+	}
+	if updated.Type != storage.KGNodeLocation {
+		t.Errorf("node_type must be immutable, got %q", updated.Type)
+	}
+	if !updated.UpdatedAt.After(created.UpdatedAt) {
+		t.Errorf("updated_at not bumped: created %v updated %v", created.UpdatedAt, updated.UpdatedAt)
+	}
+
+	// The change is durable — a fresh read reflects the new fields.
+	nodes, err := st.ListNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Name != "Old Barrow" || !nodes[0].GMPrivate {
+		t.Errorf("update did not persist across reload: %+v", nodes)
+	}
+
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: uuid.New(), Name: "ghost"}); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("UpdateNode missing id err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestKGNodeDelete is #129 AC2: DeleteNode removes the row and yields ErrNotFound
+// for a missing id.
+func TestKGNodeDelete(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	created, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "The Cult",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	if err := st.DeleteNode(ctx, created.ID); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+	nodes, err := st.ListNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Errorf("node not deleted: %+v", nodes)
+	}
+
+	if err := st.DeleteNode(ctx, created.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("second DeleteNode err = %v, want ErrNotFound", err)
+	}
+	if err := st.DeleteNode(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("DeleteNode unknown id err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestKGNodeCreateEditDeleteAcrossTypes is #129 AC5's storage grain: the full
+// create → edit → delete lifecycle across two distinct Node types (Location and
+// Faction), with the gm_private toggle round-tripping, and AC4's boundary — a
+// gm-public Node of either type surfaces into the Hot Context read while a
+// gm_private one of any type is excluded.
+func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	loc, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Harbor", Body: "Ships dock here.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode location: %v", err)
+	}
+	fac, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "Dockers Guild", Body: "They run the docks.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode faction: %v", err)
+	}
+
+	// Edit both: flip the Faction to gm_private, leave the Location public.
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
+		ID: loc.ID, Name: "Old Harbor", Body: "Ships used to dock here.",
+	}); err != nil {
+		t.Fatalf("UpdateNode location: %v", err)
+	}
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
+		ID: fac.ID, Name: "Dockers Guild", Body: "A secret cabal.", GMPrivate: true,
+	}); err != nil {
+		t.Fatalf("UpdateNode faction: %v", err)
+	}
+
+	// AC4: the public Location surfaces into the Hot Context read; the now-private
+	// Faction is excluded — proving the visibility filter is type-agnostic.
+	pub, err := st.ListPublicNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListPublicNodes: %v", err)
+	}
+	if len(pub) != 1 || pub[0].Type != storage.KGNodeLocation || pub[0].Name != "Old Harbor" {
+		t.Fatalf("public read = %+v, want only the public Location", pub)
+	}
+
+	// Delete the Location; the (private) Faction remains but stays out of the public read.
+	if err := st.DeleteNode(ctx, loc.ID); err != nil {
+		t.Fatalf("DeleteNode location: %v", err)
+	}
+	all, err := st.ListNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != fac.ID || !all[0].GMPrivate {
+		t.Errorf("after delete want only the private Faction, got %+v", all)
+	}
+	pub, err = st.ListPublicNodes(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListPublicNodes after delete: %v", err)
+	}
+	if len(pub) != 0 {
+		t.Errorf("gm_private Faction leaked into the Hot Context read: %+v", pub)
 	}
 }

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -52,6 +52,15 @@ service CampaignService {
   rpc ListNodes(ListNodesRequest) returns (ListNodesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+
+  // UpdateNode saves a Knowledge Graph Node's editor fields (name/body/gm_private)
+  // and returns the updated Node (#129). node_type is immutable, so it is not in
+  // the request. An empty name is CodeInvalidArgument; an unknown id is CodeNotFound.
+  rpc UpdateNode(UpdateNodeRequest) returns (UpdateNodeResponse);
+
+  // DeleteNode removes a Knowledge Graph Node by id (#129). An unknown id is
+  // CodeNotFound.
+  rpc DeleteNode(DeleteNodeRequest) returns (DeleteNodeResponse);
 }
 
 // NodeType is a Knowledge Graph Node's type (CONTEXT.md "Node", ADR-0008 v1.0).
@@ -120,6 +129,35 @@ message ListNodesResponse {
   // nodes is the campaign's Knowledge Graph Nodes.
   repeated Node nodes = 1;
 }
+
+// UpdateNodeRequest carries a Node's editor fields. node_type is deliberately
+// absent — a Node's type is immutable after create (ADR-0008). An empty name is
+// rejected; an unknown id fails with CodeNotFound.
+message UpdateNodeRequest {
+  // id is the node to update.
+  string id = 1;
+  // name is the entry's display name; empty is rejected.
+  string name = 2;
+  // body is the entry's prose (optional).
+  string body = 3;
+  // gm_private keeps the entry out of every NPC's prompt (#126).
+  bool gm_private = 4;
+}
+
+// UpdateNodeResponse carries the updated Node.
+message UpdateNodeResponse {
+  // node is the updated Knowledge Graph Node.
+  Node node = 1;
+}
+
+// DeleteNodeRequest names the Node to delete; an unknown id is CodeNotFound.
+message DeleteNodeRequest {
+  // id is the node to delete.
+  string id = 1;
+}
+
+// DeleteNodeResponse is the (empty) response for DeleteNode.
+message DeleteNodeResponse {}
 
 // Campaign is the wire representation of a campaign record.
 message Campaign {

--- a/web/src/screens/campaign/KnowledgePanel.test.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
@@ -9,29 +9,37 @@ import {
   NodeType,
   CreateNodeResponseSchema,
   ListNodesResponseSchema,
+  UpdateNodeResponseSchema,
+  DeleteNodeResponseSchema,
   type CreateNodeRequest,
+  type UpdateNodeRequest,
+  type DeleteNodeRequest,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { KnowledgePanel } from "./KnowledgePanel";
 
-// An in-memory KG store served over a router transport (no network): createNode
-// pushes into the closure and listNodes reads it back, so an Add → invalidate →
-// refetch proves the entry round-trips, and the recorded request proves the
-// gm_private switch + fixed NOTE type reach the wire.
-function mockTransport() {
-  const nodes = [
-    create(NodeSchema, {
-      id: "n1",
-      campaignId: "c1",
-      nodeType: NodeType.NOTE,
-      name: "The sealed vault",
-      body: "Nobody has opened it in a century.",
-      gmPrivate: false,
-    }),
-  ];
+// An in-memory KG store served over a router transport (no network): the four
+// CampaignService node RPCs mutate a closure so create/edit/delete each round-trip
+// through invalidate → refetch, and the recorded requests prove the chosen
+// NodeType, the update fields, and the delete id reach the wire.
+function mockTransport(seed?: ReturnType<typeof create<typeof NodeSchema>>[]) {
+  const nodes =
+    seed ??
+    [
+      create(NodeSchema, {
+        id: "n1",
+        campaignId: "c1",
+        nodeType: NodeType.NOTE,
+        name: "The sealed vault",
+        body: "Nobody has opened it in a century.",
+        gmPrivate: false,
+      }),
+    ];
   let nextId = 2;
   const createCalls: CreateNodeRequest[] = [];
+  const updateCalls: UpdateNodeRequest[] = [];
+  const deleteCalls: DeleteNodeRequest[] = [];
 
   const transport = createRouterTransport(({ service }) => {
     service(CampaignService, {
@@ -49,19 +57,39 @@ function mockTransport() {
         nodes.push(node);
         return create(CreateNodeResponseSchema, { node });
       },
+      updateNode: (req) => {
+        updateCalls.push(req);
+        const node = nodes.find((n) => n.id === req.id)!;
+        node.name = req.name;
+        node.body = req.body;
+        node.gmPrivate = req.gmPrivate;
+        return create(UpdateNodeResponseSchema, { node });
+      },
+      deleteNode: (req) => {
+        deleteCalls.push(req);
+        const i = nodes.findIndex((n) => n.id === req.id);
+        if (i >= 0) nodes.splice(i, 1);
+        return create(DeleteNodeResponseSchema, {});
+      },
     });
   });
-  return { transport, nodes, createCalls };
+  return { transport, nodes, createCalls, updateCalls, deleteCalls };
 }
 
-function renderPanel() {
-  const { transport, nodes, createCalls } = mockTransport();
+function renderPanel(seed?: ReturnType<typeof create<typeof NodeSchema>>[]) {
+  const ctx = mockTransport(seed);
   render(
-    <Providers transport={transport} queryClient={makeQueryClient()}>
+    <Providers transport={ctx.transport} queryClient={makeQueryClient()}>
       <KnowledgePanel />
     </Providers>,
   );
-  return { nodes, createCalls };
+  return ctx;
+}
+
+// pickType opens the Radix Type select and chooses the named option.
+function pickType(label: string) {
+  fireEvent.keyDown(screen.getByRole("combobox", { name: "Type" }), { key: "Enter" });
+  fireEvent.click(screen.getByRole("option", { name: label }));
 }
 
 describe("KnowledgePanel", () => {
@@ -71,53 +99,92 @@ describe("KnowledgePanel", () => {
     expect(screen.getByText(/Nobody has opened it/)).toBeInTheDocument();
   });
 
-  it("adds a gm-private entry that appears in the list, sending NOTE + gm_private", async () => {
+  it("creates an entry of a chosen type, sending that NodeType", async () => {
     const { nodes, createCalls } = renderPanel();
     await screen.findByText("The sealed vault");
 
+    pickType("Location");
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "The old harbor" } });
+    fireEvent.change(screen.getByLabelText(/content/i), { target: { value: "Ships dock here." } });
+    fireEvent.click(screen.getByRole("button", { name: /add entry/i }));
+
+    expect(await screen.findByText("The old harbor")).toBeInTheDocument();
+    expect(nodes).toHaveLength(2);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].nodeType).toBe(NodeType.LOCATION);
+    expect(createCalls[0].name).toBe("The old harbor");
+  });
+
+  it("creates a gm-private entry, sending the gm_private flag", async () => {
+    const { createCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Hidden cult" } });
-    fireEvent.change(screen.getByLabelText(/content/i), { target: { value: "They meet at midnight." } });
-    // Toggle the GM-private switch on.
     fireEvent.click(screen.getByLabelText(/gm private/i));
     fireEvent.click(screen.getByRole("button", { name: /add entry/i }));
 
-    // The new entry round-trips into the list (invalidate → refetch).
     expect(await screen.findByText("Hidden cult")).toBeInTheDocument();
-    expect(nodes).toHaveLength(2);
-
-    // The request carried the fixed NOTE type and the gm_private flag.
-    expect(createCalls).toHaveLength(1);
-    expect(createCalls[0].nodeType).toBe(NodeType.NOTE);
-    expect(createCalls[0].name).toBe("Hidden cult");
     expect(createCalls[0].gmPrivate).toBe(true);
   });
 
+  it("edits an entry: name + gm_private round-trip via UpdateNode", async () => {
+    const { updateCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /edit the sealed vault/i }));
+    // The editor is now in edit mode and pre-filled.
+    expect(screen.getByRole("heading", { name: /edit entry/i })).toBeInTheDocument();
+    const name = screen.getByLabelText("Name") as HTMLInputElement;
+    expect(name.value).toBe("The sealed vault");
+    // The type is not editable while editing.
+    expect(screen.getByRole("combobox", { name: "Type" })).toBeDisabled();
+
+    fireEvent.change(name, { target: { value: "The opened vault" } });
+    fireEvent.click(screen.getByLabelText(/gm private/i));
+    fireEvent.click(screen.getByRole("button", { name: /save entry/i }));
+
+    expect(await screen.findByText("The opened vault")).toBeInTheDocument();
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].id).toBe("n1");
+    expect(updateCalls[0].name).toBe("The opened vault");
+    expect(updateCalls[0].gmPrivate).toBe(true);
+  });
+
+  it("deletes an entry from its card via DeleteNode", async () => {
+    const { deleteCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+
+    await screen.findByText(/no entries yet/i);
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].id).toBe("n1");
+  });
+
+  it("groups the list by node type", async () => {
+    renderPanel([
+      create(NodeSchema, { id: "a", campaignId: "c1", nodeType: NodeType.LOCATION, name: "Harbor" }),
+      create(NodeSchema, { id: "b", campaignId: "c1", nodeType: NodeType.FACTION, name: "Dockers Guild" }),
+    ]);
+    // A group heading per distinct type, and each entry under its own group.
+    const locGroup = await screen.findByRole("region", { name: "Location" });
+    expect(within(locGroup).getByText("Harbor")).toBeInTheDocument();
+    const facGroup = screen.getByRole("region", { name: "Faction" });
+    expect(within(facGroup).getByText("Dockers Guild")).toBeInTheDocument();
+  });
+
   it("marks a gm-private entry with a private badge", async () => {
-    const { transport } = (() => {
-      const nodes = [
-        create(NodeSchema, {
-          id: "n1",
-          campaignId: "c1",
-          nodeType: NodeType.NOTE,
-          name: "Secret pact",
-          body: "signed in blood",
-          gmPrivate: true,
-        }),
-      ];
-      const t = createRouterTransport(({ service }) => {
-        service(CampaignService, {
-          listNodes: () => create(ListNodesResponseSchema, { nodes }),
-        });
-      });
-      return { transport: t };
-    })();
-    render(
-      <Providers transport={transport} queryClient={makeQueryClient()}>
-        <KnowledgePanel />
-      </Providers>,
-    );
+    renderPanel([
+      create(NodeSchema, {
+        id: "n1",
+        campaignId: "c1",
+        nodeType: NodeType.NOTE,
+        name: "Secret pact",
+        body: "signed in blood",
+        gmPrivate: true,
+      }),
+    ]);
     expect(await screen.findByText("Secret pact")).toBeInTheDocument();
-    // The private badge (exact) — distinct from the create form's switch label.
     expect(screen.getByText("GM private")).toBeInTheDocument();
   });
 });

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -1,7 +1,20 @@
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { EyeOff, Plus, StickyNote } from "lucide-react";
+import {
+  EyeOff,
+  Plus,
+  Pencil,
+  Trash2,
+  User,
+  VenetianMask,
+  MapPin,
+  Flag,
+  Gem,
+  GitBranch,
+  StickyNote,
+  type LucideIcon,
+} from "lucide-react";
 
 import { CampaignService, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
 import type { Node } from "@gen/glyphoxa/management/v1/management_pb";
@@ -10,21 +23,59 @@ import { Badge } from "@/components/ui/Badge";
 import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
 
-// The Knowledge panel (#126) backs the Campaign screen's "Knowledge" view on the
-// live CampaignService ListNodes/CreateNode RPCs (ADR-0008 v1.0). For this slice
-// the only Node type authored from the UI is a Note ("entry", GM-facing copy —
-// the code keeps the Node domain term). Public entries are injected into NPC
-// prompts; a GM-private entry never reaches the table (the gm_private flag). Full
-// 7-type authoring, search and edges arrive in later slices.
+// The Knowledge panel (#126, #129) backs the Campaign screen's "Knowledge" view
+// on the live CampaignService node RPCs (ADR-0008 v1.0). An "entry" is the
+// GM-facing name for a Node (the code keeps the Node domain term). This slice
+// authors all seven Node types (type chosen once on create — immutable per
+// ADR-0008), edits and deletes entries, and groups the list by type. Public
+// entries are injected into NPC prompts; a gm_private entry never reaches the
+// table. Type-filter chips + fulltext search arrive in #131.
 
-// noteColor is the design's Note type-color, applied to the entry icon.
-const noteColor = "#8b93a7";
+type TypeMeta = { label: string; color: string; Icon: LucideIcon };
+
+// Per-type label, design color, and lucide icon (approved #129 design). The Note
+// entry's neutral grey doubles as the defensive fallback for an unknown type.
+const TYPE_META: Record<number, TypeMeta> = {
+  [NodeType.CHARACTER]: { label: "Character", color: "#4fa9ff", Icon: User },
+  [NodeType.NPC]: { label: "NPC", color: "#9059ff", Icon: VenetianMask },
+  [NodeType.LOCATION]: { label: "Location", color: "#35c48d", Icon: MapPin },
+  [NodeType.FACTION]: { label: "Faction", color: "#ffbd4f", Icon: Flag },
+  [NodeType.ITEM]: { label: "Item", color: "#ff7139", Icon: Gem },
+  [NodeType.PLOT_THREAD]: { label: "Plot thread", color: "#ff4f5e", Icon: GitBranch },
+  [NodeType.NOTE]: { label: "Note", color: "#8b93a7", Icon: StickyNote },
+};
+
+// The authorable types in enum order; UNSPECIFIED (0) is never offered, and this
+// order also drives the grouped list and the type-select options.
+const TYPE_ORDER: NodeType[] = [
+  NodeType.CHARACTER,
+  NodeType.NPC,
+  NodeType.LOCATION,
+  NodeType.FACTION,
+  NodeType.ITEM,
+  NodeType.PLOT_THREAD,
+  NodeType.NOTE,
+];
+
+const TYPE_OPTIONS = TYPE_ORDER.map((t) => ({ value: String(t), label: TYPE_META[t].label }));
+const TYPE_HINT = TYPE_ORDER.map((t) => TYPE_META[t].label).join(" · ");
+
+function metaOf(t: NodeType): TypeMeta {
+  return TYPE_META[t] ?? TYPE_META[NodeType.NOTE];
+}
+
+// alphaBg tints a type color to the design's 14%-alpha tile background (0x24 ≈ 14%).
+function alphaBg(color: string): string {
+  return `${color}24`;
+}
 
 export function KnowledgePanel() {
   const queryClient = useQueryClient();
   const { data, status, error } = useQuery(CampaignService.method.listNodes, {});
   const nodes = useMemo(() => data?.nodes ?? [], [data]);
+  const [editing, setEditing] = useState<Node | null>(null);
 
   const invalidateNodes = () =>
     queryClient.invalidateQueries({
@@ -35,6 +86,15 @@ export function KnowledgePanel() {
     });
 
   const createNode = useMutation(CampaignService.method.createNode, {
+    onSuccess: () => void invalidateNodes(),
+  });
+  const updateNode = useMutation(CampaignService.method.updateNode, {
+    onSuccess: () => {
+      setEditing(null);
+      void invalidateNodes();
+    },
+  });
+  const deleteNode = useMutation(CampaignService.method.deleteNode, {
     onSuccess: () => void invalidateNodes(),
   });
 
@@ -49,11 +109,35 @@ export function KnowledgePanel() {
     );
   }
 
+  // Group by type in enum order; empty groups are dropped so the list only shows
+  // the types actually present.
+  const groups = TYPE_ORDER.map((t) => ({
+    type: t,
+    items: nodes.filter((n) => n.nodeType === t),
+  })).filter((g) => g.items.length > 0);
+
+  const removeNode = (n: Node) =>
+    deleteNode.mutate(
+      { id: n.id },
+      { onSuccess: () => setEditing((e) => (e?.id === n.id ? null : e)) },
+    );
+
   return (
     <div className="gx-kg-layout">
       <div className="gx-kg-list">
-        {nodes.map((n) => (
-          <KnowledgeCard key={n.id} node={n} />
+        {groups.map((g) => (
+          <section key={g.type} className="gx-kg-group" aria-label={metaOf(g.type).label}>
+            <h3 className="gx-kg-group__title">{metaOf(g.type).label}</h3>
+            {g.items.map((n) => (
+              <KnowledgeCard
+                key={n.id}
+                node={n}
+                onEdit={() => setEditing(n)}
+                onDelete={() => removeNode(n)}
+                deleting={deleteNode.isPending && deleteNode.variables?.id === n.id}
+              />
+            ))}
+          </section>
         ))}
         {nodes.length === 0 && (
           <p className="gx-kg-empty">
@@ -62,74 +146,171 @@ export function KnowledgePanel() {
         )}
       </div>
 
-      <AddEntry
-        pending={createNode.isPending}
-        error={createNode.isError ? createNode.error.message : null}
-        onAdd={(name, body, gmPrivate, reset) =>
-          createNode.mutate(
-            { nodeType: NodeType.NOTE, name, body, gmPrivate },
-            { onSuccess: reset },
-          )
+      <EntryEditor
+        key={editing?.id ?? "new"}
+        node={editing}
+        pending={editing ? updateNode.isPending : createNode.isPending}
+        error={
+          editing
+            ? updateNode.isError
+              ? updateNode.error.message
+              : null
+            : createNode.isError
+              ? createNode.error.message
+              : null
         }
+        onCancel={() => setEditing(null)}
+        onDelete={editing ? () => removeNode(editing) : undefined}
+        onSubmit={(fields, reset) => {
+          if (editing) {
+            updateNode.mutate({
+              id: editing.id,
+              name: fields.name,
+              body: fields.body,
+              gmPrivate: fields.gmPrivate,
+            });
+          } else {
+            createNode.mutate(
+              { nodeType: fields.nodeType, name: fields.name, body: fields.body, gmPrivate: fields.gmPrivate },
+              { onSuccess: reset },
+            );
+          }
+        }}
       />
     </div>
   );
 }
 
-// KnowledgeCard renders one entry: the Note icon, name, a "Note" type badge, a
-// "GM private" badge (EyeOff) when private, and a one-line body snippet.
-function KnowledgeCard({ node }: { node: Node }) {
+// KnowledgeCard renders one entry: a type-colored icon tile, the name, a
+// type-colored badge, a "GM private" badge (EyeOff) when private, a one-line body
+// snippet, and edit/delete affordances.
+function KnowledgeCard({
+  node,
+  onEdit,
+  onDelete,
+  deleting,
+}: {
+  node: Node;
+  onEdit: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  const meta = metaOf(node.nodeType);
   return (
     <Card className="gx-kg-card">
-      <span className="gx-kg-card__icon" style={{ color: noteColor }} aria-hidden>
-        <StickyNote size={16} />
+      <span
+        className="gx-kg-card__icon"
+        style={{ color: meta.color, background: alphaBg(meta.color) }}
+        aria-hidden
+      >
+        <meta.Icon size={16} />
       </span>
       <div className="gx-kg-card__meta">
         <div className="gx-kg-card__head">
           <span className="gx-kg-card__name">{node.name}</span>
-          <Badge variant="neutral" size="sm">
-            Note
+          <Badge
+            size="sm"
+            className="gx-kg-card__type"
+            style={{ color: meta.color, background: alphaBg(meta.color) }}
+          >
+            {meta.label}
           </Badge>
           {node.gmPrivate && (
-            <Badge variant="warning" size="sm">
+            <Badge variant="neutral" size="sm">
               <EyeOff size={11} /> GM private
             </Badge>
           )}
         </div>
         {node.body && <span className="gx-kg-card__snippet">{node.body}</span>}
       </div>
+      <div className="gx-kg-card__actions">
+        <button
+          type="button"
+          className="gx-kg-iconbtn"
+          aria-label={`Edit ${node.name}`}
+          onClick={onEdit}
+        >
+          <Pencil size={14} />
+        </button>
+        <button
+          type="button"
+          className="gx-kg-iconbtn gx-kg-iconbtn--danger"
+          aria-label={`Delete ${node.name}`}
+          onClick={onDelete}
+          disabled={deleting}
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
     </Card>
   );
 }
 
-// AddEntry is the sticky create form: Name, Content, and the GM-private switch.
-// The type is fixed to Note for this slice.
-function AddEntry({
+type EditorFields = { nodeType: NodeType; name: string; body: string; gmPrivate: boolean };
+
+// EntryEditor is the sticky editor card. In create mode it offers the Type select
+// (all seven types) plus Name/Content/GM-private; in edit mode the type is fixed
+// (immutable, ADR-0008) so the select is disabled, and a delete button + Cancel
+// appear. Remounting on a key change (editing id) resets its fields.
+function EntryEditor({
+  node,
   pending,
   error,
-  onAdd,
+  onSubmit,
+  onDelete,
+  onCancel,
 }: {
+  node: Node | null;
   pending: boolean;
   error: string | null;
-  onAdd: (name: string, body: string, gmPrivate: boolean, reset: () => void) => void;
+  onSubmit: (fields: EditorFields, reset: () => void) => void;
+  onDelete?: () => void;
+  onCancel: () => void;
 }) {
-  const [name, setName] = useState("");
-  const [body, setBody] = useState("");
-  const [gmPrivate, setGmPrivate] = useState(false);
+  const isEdit = node != null;
+  const [nodeType, setNodeType] = useState<NodeType>(node?.nodeType ?? NodeType.NOTE);
+  const [name, setName] = useState(node?.name ?? "");
+  const [body, setBody] = useState(node?.body ?? "");
+  const [gmPrivate, setGmPrivate] = useState(node?.gmPrivate ?? false);
 
   const reset = () => {
+    setNodeType(NodeType.NOTE);
     setName("");
     setBody("");
     setGmPrivate(false);
   };
-  const add = () => {
+  const submit = () => {
     if (name.trim() === "") return;
-    onAdd(name.trim(), body, gmPrivate, reset);
+    onSubmit({ nodeType, name: name.trim(), body, gmPrivate }, reset);
   };
 
   return (
     <Card accent className="gx-kg-editor">
-      <h2 className="gx-kg-editor__title">Add entry</h2>
+      <div className="gx-kg-editor__bar">
+        <h2 className="gx-kg-editor__title">{isEdit ? "Edit entry" : "Add entry"}</h2>
+        {isEdit && onDelete && (
+          <button
+            type="button"
+            className="gx-kg-iconbtn gx-kg-iconbtn--danger"
+            aria-label="Delete entry"
+            onClick={onDelete}
+            disabled={pending}
+          >
+            <Trash2 size={15} />
+          </button>
+        )}
+      </div>
+
+      <div className="gx-field">
+        <Select
+          label="Type"
+          options={TYPE_OPTIONS}
+          value={String(nodeType)}
+          onValueChange={(v) => setNodeType(Number(v) as NodeType)}
+          disabled={isEdit}
+        />
+        <span className="gx-field__hint">{TYPE_HINT}</span>
+      </div>
 
       <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} placeholder="What is it called?" />
 
@@ -161,12 +342,22 @@ function AddEntry({
       </div>
 
       <div className="gx-kg-editor__actions">
-        <Button variant="primary" iconStart={<Plus size={14} />} onClick={add} disabled={pending || name.trim() === ""}>
-          {pending ? "Adding…" : "Add entry"}
+        <Button
+          variant="primary"
+          iconStart={isEdit ? undefined : <Plus size={14} />}
+          onClick={submit}
+          disabled={pending || name.trim() === ""}
+        >
+          {pending ? "Saving…" : isEdit ? "Save entry" : "Add entry"}
         </Button>
+        {isEdit && (
+          <Button variant="ghost" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+        )}
         {error && (
           <span className="gx-editor__status gx-editor__status--error" role="alert">
-            Couldn't add: {error}
+            Couldn't save: {error}
           </span>
         )}
       </div>

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -75,7 +75,23 @@
 .gx-kg-list {
   display: flex;
   flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+/* Each node type is its own titled group in the list. */
+.gx-kg-group {
+  display: flex;
+  flex-direction: column;
   gap: var(--spacing-xs);
+}
+
+.gx-kg-group__title {
+  margin: 0;
+  font-size: var(--mono-sm, var(--body-xs));
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-subtle);
 }
 
 .gx-kg-card {
@@ -85,9 +101,15 @@
   padding: var(--spacing-sm) var(--spacing-md);
 }
 
+/* Type-colored icon tile: 38px rounded square, color + 14%-alpha bg set inline. */
 .gx-kg-card__icon {
   flex: 0 0 auto;
-  margin-top: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-md, 10px);
 }
 
 .gx-kg-card__meta {
@@ -121,6 +143,45 @@
   white-space: nowrap;
 }
 
+/* Per-card edit/delete affordances, right-aligned. */
+.gx-kg-card__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-left: auto;
+}
+
+.gx-kg-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm, 8px);
+  background: transparent;
+  color: var(--text-subtle);
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.gx-kg-iconbtn:hover {
+  color: var(--text-strong);
+  background: var(--surface-2, rgba(255, 255, 255, 0.06));
+}
+
+.gx-kg-iconbtn--danger:hover {
+  color: var(--danger, #ff4f5e);
+}
+
+.gx-kg-iconbtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .gx-kg-empty {
   padding: var(--spacing-md);
   color: var(--text-subtle);
@@ -135,6 +196,14 @@
   padding: var(--spacing-lg);
   position: sticky;
   top: var(--spacing-lg);
+}
+
+/* Editor header row: title left, delete button pinned right (edit mode). */
+.gx-kg-editor__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
 }
 
 .gx-kg-editor__title {

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -27,6 +27,17 @@ if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
 
+// jsdom implements none of the Pointer Capture APIs that Radix Select (the KG
+// entry Type picker, #129) probes when opening its listbox. Stub them so the
+// dropdown mounts and its options are selectable under test — the observable
+// behaviour is the chosen NodeType, not pointer capture.
+if (typeof Element !== "undefined") {
+  const el = Element.prototype as unknown as Record<string, unknown>;
+  el.hasPointerCapture ??= () => false;
+  el.setPointerCapture ??= () => {};
+  el.releasePointerCapture ??= () => {};
+}
+
 // jsdom has no EventSource; the Session screen opens one for the live transcript
 // (#73). Install the mock globally so every test renders without crashing, and a
 // transcript test can drive frames via MockEventSource.last().


### PR DESCRIPTION
Closes #129 — [E4] all seven Node types and the gm_private visibility flag.

**Supersedes #203.** That PR targeted `e4-126`, which was squash-merged into `main` and deleted; this branch is the same work rebased cleanly onto `main` (linear history, no cross-branch merge commit).

## What
- **storage** (`internal/storage/kg_node.go`): `UpdateNode` (saves name/body/gm_private, bumps `updated_at`, never touches the immutable `node_type` — ADR-0008) and `DeleteNode`; both return `ErrNotFound` on 0 rows.
- **proto/RPC**: `UpdateNode`/`DeleteNode` on `CampaignService`. `UpdateNodeRequest` carries **no** `node_type` (type immutable). Handlers map empty name / bad id → `InvalidArgument`, `ErrNotFound` → `NotFound`, storage failure → `Internal`. Create/Update persist `TrimSpace(name)`.
- **web** (`KnowledgePanel.tsx`): create form gains a Type select over all seven types (create-only; disabled while editing), list cards get type-colored icon tiles + type badges and edit/delete buttons, the editor doubles as an edit form (name/content/gm_private round-trip via `UpdateNode`), and the list is grouped by node type.

## Acceptance criteria
- **AC1** create a Node of any of the 7 types; type persisted + rendered — type select + grouped/typed cards.
- **AC2** edit + delete from the Campaign screen, persists across reload — Update/Delete flows + invalidate→refetch; storage integration proves durability.
- **AC3** gm_private editable per Node, round-trips — edit-form switch → `UpdateNode`; unit + integration round-trip.
- **AC4** gm-public Nodes of every type surface into Hot Context; gm_private of any type excluded — `ListPublicNodes` filters type-agnostically; integration test proves a public Location surfaces while a gm_private Faction is excluded.
- **AC5** integration test covering create/edit/delete across ≥2 distinct types — `TestKGNodeCreateEditDeleteAcrossTypes` (Location + Faction).

## Review findings folded from #126 review
- `kgfacts.renderFact` now rune-caps the Node **name** (`MaxNameChars`), not just the body — an un-capped long name could push one fact past `MaxBlockChars` and, newest-first, drop the whole facts block. Test verified red-without/green-with.
- Create **and** Update persist `strings.TrimSpace(name)` so `" Bob "` can't render as `###  Bob ` in a prompt.
- Added `TestListNodes_StorageErrorIsInternal` (exercises the previously-dead `nodeListErr` fixture).

## Tests
storage integration (`//go:build integration`): Update, Delete, create/edit/delete across Location+Faction. rpc unit (keyless fake store): all code paths incl. trim + NotFound/Internal. web (vitest, router transport): type-select create, edit round-trip, card delete, grouping. kgfacts: long-name truncation.

Local: `go build ./...`, `go vet ./...` (+`-tags=record`), `go test -race ./internal/...`, kg storage integration, `golangci-lint` 0 issues, `npm run build` + vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)