### PR TITLE
refactor(#208): remove dead ListPublicNodes storage read

### DIFF
--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -219,32 +219,3 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 	}
 	return out, nil
 }
-
-// ListPublicNodes returns the Campaign's gm-public Nodes ordered newest-first
-// (updated_at DESC, id), capped — the Hot Context prompt-injection read (#126).
-// gm_private Nodes are excluded so a GM-only fact never reaches an NPC's prompt.
-func (s *Store) ListPublicNodes(ctx context.Context, campaignID uuid.UUID) ([]KGNode, error) {
-	rows, err := s.db.Query(ctx,
-		`SELECT `+kgNodeColumns+`
-		   FROM kg_node
-		  WHERE campaign_id = $1 AND NOT gm_private
-		  ORDER BY updated_at DESC, id
-		  LIMIT $2`, campaignID, kgFactsCap)
-	if err != nil {
-		return nil, fmt.Errorf("storage: list public kg nodes for campaign %s: %w", campaignID, err)
-	}
-	defer rows.Close()
-
-	var out []KGNode
-	for rows.Next() {
-		n, err := scanKGNode(rows)
-		if err != nil {
-			return nil, fmt.Errorf("storage: scan public kg node: %w", err)
-		}
-		out = append(out, n)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("storage: list public kg nodes for campaign %s: %w", campaignID, err)
-	}
-	return out, nil
-}

--- a/internal/storage/kg_node_search.go
+++ b/internal/storage/kg_node_search.go
@@ -13,7 +13,7 @@ import (
 // (tsvector) only"). The kg_node.fts generated column (migration 00011) weights
 // name over body; SearchNodes ranks matches with ts_rank. This is the GM-facing
 // wiki search, so gm_private Nodes are INCLUDED — the NPC-prompt exclusion lives
-// only in ListPublicNodes and is unchanged.
+// only in AgentNodeFacts (#133) and is unchanged.
 
 // BuildTSQuery turns a raw GM query string into a safe to_tsquery('simple') input.
 // tsquery operator characters (& | ! ( ) : * …) are never passed through as

--- a/internal/storage/kg_node_test.go
+++ b/internal/storage/kg_node_test.go
@@ -74,60 +74,6 @@ func TestKGNodeCreateListRoundTrip(t *testing.T) {
 	}
 }
 
-// TestKGNodeListPublicNodes is #126 AC3: the prompt-injection read excludes
-// gm_private Nodes and orders by updated_at DESC — the newest public Node first.
-func TestKGNodeListPublicNodes(t *testing.T) {
-	dsn := startPostgres(t)
-	pool, _, campaignID := seedCampaign(t, dsn)
-	ctx := context.Background()
-	st := storage.New(pool)
-
-	// Two public and one private. Force distinct updated_at ordering by inserting
-	// in a known sequence and stamping updated_at explicitly for determinism.
-	pubOld, err := st.CreateNode(ctx, storage.NewKGNode{
-		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Old public", Body: "old",
-	})
-	if err != nil {
-		t.Fatalf("CreateNode pubOld: %v", err)
-	}
-	if _, err := st.CreateNode(ctx, storage.NewKGNode{
-		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Secret", Body: "hidden", GMPrivate: true,
-	}); err != nil {
-		t.Fatalf("CreateNode secret: %v", err)
-	}
-	pubNew, err := st.CreateNode(ctx, storage.NewKGNode{
-		CampaignID: campaignID, Type: storage.KGNodeNote, Name: "New public", Body: "new",
-	})
-	if err != nil {
-		t.Fatalf("CreateNode pubNew: %v", err)
-	}
-	// Make pubNew strictly newer than pubOld regardless of insert-time granularity.
-	if _, err := pool.Exec(ctx,
-		`UPDATE kg_node SET updated_at = now() + interval '1 hour' WHERE id = $1`, pubNew.ID); err != nil {
-		t.Fatalf("bump pubNew updated_at: %v", err)
-	}
-	if _, err := pool.Exec(ctx,
-		`UPDATE kg_node SET updated_at = now() - interval '1 hour' WHERE id = $1`, pubOld.ID); err != nil {
-		t.Fatalf("bump pubOld updated_at: %v", err)
-	}
-
-	pub, err := st.ListPublicNodes(ctx, campaignID)
-	if err != nil {
-		t.Fatalf("ListPublicNodes: %v", err)
-	}
-	if len(pub) != 2 {
-		t.Fatalf("ListPublicNodes returned %d, want 2 (gm_private excluded)", len(pub))
-	}
-	if pub[0].Name != "New public" || pub[1].Name != "Old public" {
-		t.Errorf("order = [%q %q], want [New public, Old public] (updated_at DESC)", pub[0].Name, pub[1].Name)
-	}
-	for _, n := range pub {
-		if n.GMPrivate {
-			t.Errorf("ListPublicNodes leaked a gm_private node: %+v", n)
-		}
-	}
-}
-
 // TestKGNodeUpdate is #129 AC2/AC3: UpdateNode persists name/body/gm_private,
 // bumps updated_at (never touching node_type — immutable, ADR-0008), and yields
 // ErrNotFound for an id that does not exist.
@@ -213,9 +159,7 @@ func TestKGNodeDelete(t *testing.T) {
 
 // TestKGNodeCreateEditDeleteAcrossTypes is #129 AC5's storage grain: the full
 // create → edit → delete lifecycle across two distinct Node types (Location and
-// Faction), with the gm_private toggle round-tripping, and AC4's boundary — a
-// gm-public Node of either type surfaces into the Hot Context read while a
-// gm_private one of any type is excluded.
+// Faction), with the gm_private toggle round-tripping through ListNodes.
 func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, _, campaignID := seedCampaign(t, dsn)
@@ -247,17 +191,26 @@ func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 		t.Fatalf("UpdateNode faction: %v", err)
 	}
 
-	// AC4: the public Location surfaces into the Hot Context read; the now-private
-	// Faction is excluded — proving the visibility filter is type-agnostic.
-	pub, err := st.ListPublicNodes(ctx, campaignID)
+	// The edits round-trip across both types: the Location stays public with its
+	// new name/body, the Faction flips to gm_private with its new body. ListNodes
+	// orders by node_type enum (location < faction), so the Location is first.
+	afterEdit, err := st.ListNodes(ctx, campaignID)
 	if err != nil {
-		t.Fatalf("ListPublicNodes: %v", err)
+		t.Fatalf("ListNodes after edit: %v", err)
 	}
-	if len(pub) != 1 || pub[0].Type != storage.KGNodeLocation || pub[0].Name != "Old Harbor" {
-		t.Fatalf("public read = %+v, want only the public Location", pub)
+	if len(afterEdit) != 2 {
+		t.Fatalf("after edit want 2 nodes, got %+v", afterEdit)
+	}
+	if afterEdit[0].ID != loc.ID || afterEdit[0].Type != storage.KGNodeLocation ||
+		afterEdit[0].Name != "Old Harbor" || afterEdit[0].GMPrivate {
+		t.Errorf("location edit not persisted: %+v", afterEdit[0])
+	}
+	if afterEdit[1].ID != fac.ID || afterEdit[1].Type != storage.KGNodeFaction ||
+		afterEdit[1].Body != "A secret cabal." || !afterEdit[1].GMPrivate {
+		t.Errorf("faction edit not persisted: %+v", afterEdit[1])
 	}
 
-	// Delete the Location; the (private) Faction remains but stays out of the public read.
+	// Delete the Location; only the (private) Faction remains.
 	if err := st.DeleteNode(ctx, loc.ID); err != nil {
 		t.Fatalf("DeleteNode location: %v", err)
 	}
@@ -267,12 +220,5 @@ func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 	}
 	if len(all) != 1 || all[0].ID != fac.ID || !all[0].GMPrivate {
 		t.Errorf("after delete want only the private Faction, got %+v", all)
-	}
-	pub, err = st.ListPublicNodes(ctx, campaignID)
-	if err != nil {
-		t.Fatalf("ListPublicNodes after delete: %v", err)
-	}
-	if len(pub) != 0 {
-		t.Errorf("gm_private Faction leaked into the Hot Context read: %+v", pub)
 	}
 }


### PR DESCRIPTION
Closes #208.

`storage.ListPublicNodes` lost its last production caller when #133 swapped the Hot Context facts source to `AgentNodeFacts`. It survived only in its own tests, and its doc comment still claimed it was "the Hot Context prompt-injection read (#126)" — a future caller trusting that comment would reintroduce the campaign-wide dump that #133 deliberately removed (unlinked NPCs get zero wiki facts by design).

## Changes
- Delete `ListPublicNodes` and its dedicated test `TestKGNodeListPublicNodes` from `internal/storage`.
- `TestKGNodeCreateEditDeleteAcrossTypes` (a #129 lifecycle test that merely *used* the read) now round-trips the `gm_private` toggle through `ListNodes` — same lifecycle coverage, no dependency on the removed function.
- Fix the `kg_node_search.go` comment: the NPC-prompt gm_private exclusion now lives only in `AgentNodeFacts` (#133), not `ListPublicNodes`.

## AC
- [x] `ListPublicNodes` + its dedicated tests deleted from `internal/storage`.
- [x] No production behavior change; internal package, zero API-stability cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)