### PR TITLE
feat(#113): DB-backed Tool Grants hydrated into the live loop

### DIFF
--- a/internal/storage/migrations/00013_tool_agent_grant.sql
+++ b/internal/storage/migrations/00013_tool_agent_grant.sql
@@ -1,0 +1,74 @@
+-- +goose Up
+
+-- Per-Agent Tool Grants (ADR-0029): an explicit permission for one Agent to
+-- invoke one named Tool, with an optional per-grant scope/config. This is the DB
+-- home of the in-memory Grant{ToolName, Config?} the live loop already consumes
+-- (#113): grants hydrate from these rows into the identical GrantSet shape, so
+-- tool availability becomes data-driven instead of a compiled-in constant.
+--
+-- config is untyped jsonb (ADR-0029: the grant Config is `any`) — nil for a
+-- grant that carries no narrowing (dice), a scope blob for a future Tool granted
+-- differently per Agent (remember_knowledge "only about yourself" vs
+-- campaign-wide). The scope reaches the Tool handler at execution time and is
+-- enforced THERE, never by the LLM.
+--
+-- UNIQUE(agent_id, tool_name): an Agent grants a Tool at most once. ON DELETE
+-- CASCADE ties a grant to its Agent's lifetime — deleting an Agent drops its
+-- grants with no explicit cleanup code (mirrors the agents FK chain in 00001).
+
+CREATE TABLE tool_agent_grant (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id    uuid NOT NULL REFERENCES agents (id) ON DELETE CASCADE,
+    tool_name   text NOT NULL,
+    config      jsonb,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (agent_id, tool_name)
+);
+
+CREATE INDEX tool_agent_grant_agent_idx ON tool_agent_grant (agent_id);
+
+-- The auto-Butler's default grant is `dice` only (ADR-0009 Q14). 00002 deferred
+-- seeding it to "when that table and the grant-seeding path land" — that is now.
+-- Extend the trigger function (CREATE OR REPLACE) so every future auto-created
+-- Butler also gets its dice grant in the same DB invariant that creates it, so
+-- no application call site can forget to. The grant is a Campaign-existence
+-- invariant exactly as the Butler row is.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_campaign_butler() RETURNS trigger AS $$
+DECLARE
+    butler_id uuid;
+BEGIN
+    INSERT INTO agents (campaign_id, agent_role, name, address_only)
+    VALUES (NEW.id, 'butler', 'Glyphoxa', true)
+    RETURNING id INTO butler_id;
+
+    INSERT INTO tool_agent_grant (agent_id, tool_name)
+    VALUES (butler_id, 'dice');
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Backfill: existing Butlers (created before this migration) get the dice grant
+-- they were always meant to have. Idempotent via the UNIQUE key.
+INSERT INTO tool_agent_grant (agent_id, tool_name)
+SELECT id, 'dice' FROM agents WHERE agent_role = 'butler'
+ON CONFLICT (agent_id, tool_name) DO NOTHING;
+
+-- +goose Down
+
+-- Restore the 00002 trigger function (no grant insert) BEFORE dropping the
+-- table it references, so the function never dangles against a missing table.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_campaign_butler() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO agents (campaign_id, agent_role, name, address_only)
+    VALUES (NEW.id, 'butler', 'Glyphoxa', true);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS tool_agent_grant;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -142,6 +142,21 @@ type Agent struct {
 	UpdatedAt    time.Time
 }
 
+// ToolGrant is an Agent's persisted permission to invoke one named Tool
+// (ADR-0029) — the DB shape of the in-memory Grant the live loop hydrates into a
+// GrantSet (#113). Config is the optional per-grant scope/config (jsonb): nil
+// when the grant carries no narrowing (dice), a scope blob for a Tool granted
+// differently per Agent. It reaches the Tool handler at execution time and is
+// enforced there, never by the LLM.
+type ToolGrant struct {
+	ID        uuid.UUID
+	AgentID   uuid.UUID
+	ToolName  string
+	Config    json.RawMessage
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // User is a human operator authenticated via Discord OAuth (ADR-0016). The
 // Discord snowflake is the stable identity key; Name/Avatar are display-only and
 // refreshed from Discord on each login.

--- a/internal/storage/tool_grant.go
+++ b/internal/storage/tool_grant.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Tool Grant persistence (ADR-0029, #113): the per-Agent rows the live loop
+// hydrates into a GrantSet. The methods are deliberately thin — list-by-agent
+// for hydration, plus create/delete for the seed and the future grant-mutation
+// RPC (#117). The grant Config is untyped jsonb; the layer keeps it a raw blob
+// (the Tool handler is the only place scope is interpreted), so nothing here
+// depends on pkg/tool.
+
+const toolGrantColumns = `
+	id, agent_id, tool_name, config, created_at, updated_at`
+
+func scanToolGrant(row pgx.Row) (ToolGrant, error) {
+	var g ToolGrant
+	err := row.Scan(
+		&g.ID, &g.AgentID, &g.ToolName, &g.Config, &g.CreatedAt, &g.UpdatedAt,
+	)
+	return g, err
+}
+
+// ListToolGrants returns an Agent's Tool Grants ordered by tool_name (a stable
+// order so a hydrated GrantSet — and thus the ADR-0021 prompt_hash — does not
+// thrash between runs). An Agent with no grants yields an empty slice, not an
+// error: least-privilege means such an Agent is shown no Tool at all.
+func (s *Store) ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]ToolGrant, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+toolGrantColumns+`
+		   FROM tool_agent_grant
+		  WHERE agent_id = $1
+		  ORDER BY tool_name`, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list tool grants for agent %s: %w", agentID, err)
+	}
+	defer rows.Close()
+
+	var out []ToolGrant
+	for rows.Next() {
+		g, err := scanToolGrant(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan tool grant: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list tool grants for agent %s: %w", agentID, err)
+	}
+	return out, nil
+}
+
+// NewToolGrant is the input to CreateToolGrant. Config is the optional per-grant
+// scope blob (jsonb); a nil/empty Config persists SQL NULL — "no narrowing"
+// (dice).
+type NewToolGrant struct {
+	AgentID  uuid.UUID
+	ToolName string
+	Config   json.RawMessage
+}
+
+// CreateToolGrant inserts a Tool Grant and returns its generated ID. An empty
+// Config is stored as SQL NULL. A duplicate (agent_id, tool_name) violates the
+// UNIQUE index — an Agent grants a Tool at most once (ADR-0029).
+func (s *Store) CreateToolGrant(ctx context.Context, g NewToolGrant) (uuid.UUID, error) {
+	// A nil interface encodes to SQL NULL; a non-empty blob goes in as jsonb
+	// (pgx maps []byte ↔ jsonb, as agents.voice already relies on).
+	var config any
+	if len(g.Config) > 0 {
+		config = []byte(g.Config)
+	}
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO tool_agent_grant (agent_id, tool_name, config)
+		 VALUES ($1, $2, $3) RETURNING id`,
+		g.AgentID, g.ToolName, config).Scan(&id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: create tool grant (%s/%s): %w", g.AgentID, g.ToolName, err)
+	}
+	return id, nil
+}
+
+// DeleteToolGrant removes an Agent's grant of the named Tool. Deleting a grant
+// that is not present yields ErrNotFound (so the caller can tell "removed" from
+// "was never there"). Removing the row is how a GM revokes a Tool: after
+// hydration the Agent's GrantSet no longer carries it, so the LLM is never shown
+// the Tool and cannot call it.
+func (s *Store) DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error {
+	tag, err := s.db.Exec(ctx,
+		`DELETE FROM tool_agent_grant WHERE agent_id = $1 AND tool_name = $2`,
+		agentID, toolName)
+	if err != nil {
+		return fmt.Errorf("storage: delete tool grant (%s/%s): %w", agentID, toolName, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/tool_grant_test.go
+++ b/internal/storage/tool_grant_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestButlerDiceGrantSeeded is the AC1 bar: the migration seeds the auto-created
+// Butler's dice grant. seedCampaign creates a Campaign, whose auto-Butler
+// trigger (extended in 00013) also inserts the Butler's dice grant — so a fresh
+// Butler comes with exactly one grant, `dice`, carrying no scope config.
+func TestButlerDiceGrantSeeded(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	grants, err := st.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants(butler): %v", err)
+	}
+	if len(grants) != 1 {
+		t.Fatalf("auto-Butler has %d grants, want 1 (dice): %+v", len(grants), grants)
+	}
+	if grants[0].ToolName != "dice" {
+		t.Errorf("Butler grant = %q, want dice", grants[0].ToolName)
+	}
+	if grants[0].Config != nil {
+		t.Errorf("dice grant carries config %q, want nil (no scope narrowing)", grants[0].Config)
+	}
+	if grants[0].AgentID != butler.ID {
+		t.Errorf("grant agent_id = %s, want butler %s", grants[0].AgentID, butler.ID)
+	}
+}
+
+// TestToolGrantRoundTrip round-trips a grant with a jsonb scope config and a
+// nil-config grant, proves the per-grant config survives Postgres (AC4's
+// persistence half), and that delete + Agent-cascade remove them.
+func TestToolGrantRoundTrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	charID, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Bart",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// A grant WITH a scope config — the shape a future per-Agent-scoped Tool uses.
+	scope := json.RawMessage(`{"scope":"self","topics":["rumors"]}`)
+	if _, err := st.CreateToolGrant(ctx, storage.NewToolGrant{
+		AgentID:  charID,
+		ToolName: "remember_knowledge",
+		Config:   scope,
+	}); err != nil {
+		t.Fatalf("CreateToolGrant (scoped): %v", err)
+	}
+	// A grant with NO config — the dice shape.
+	if _, err := st.CreateToolGrant(ctx, storage.NewToolGrant{
+		AgentID:  charID,
+		ToolName: "dice",
+	}); err != nil {
+		t.Fatalf("CreateToolGrant (dice): %v", err)
+	}
+
+	grants, err := st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	if len(grants) != 2 {
+		t.Fatalf("got %d grants, want 2", len(grants))
+	}
+	// ORDER BY tool_name: "dice" then "remember_knowledge".
+	if grants[0].ToolName != "dice" || grants[1].ToolName != "remember_knowledge" {
+		t.Fatalf("grant order = [%q %q], want [dice remember_knowledge]", grants[0].ToolName, grants[1].ToolName)
+	}
+	if grants[0].Config != nil {
+		t.Errorf("dice grant config = %q, want nil", grants[0].Config)
+	}
+	// jsonb reserializes (whitespace/key order), so compare semantically.
+	var got, want map[string]any
+	if err := json.Unmarshal(grants[1].Config, &got); err != nil {
+		t.Fatalf("scoped grant config not valid JSON: %v (%q)", err, grants[1].Config)
+	}
+	if err := json.Unmarshal(scope, &want); err != nil {
+		t.Fatalf("want scope not valid JSON: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("scoped grant config = %+v, want %+v", got, want)
+	}
+
+	// Deleting a present grant succeeds; deleting it again is ErrNotFound.
+	if err := st.DeleteToolGrant(ctx, charID, "dice"); err != nil {
+		t.Fatalf("DeleteToolGrant(dice): %v", err)
+	}
+	if err := st.DeleteToolGrant(ctx, charID, "dice"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("DeleteToolGrant(dice) second time = %v, want ErrNotFound", err)
+	}
+	remaining, err := st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants after delete: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].ToolName != "remember_knowledge" {
+		t.Fatalf("after delete grants = %+v, want [remember_knowledge]", remaining)
+	}
+
+	// Deleting the Agent cascades its grants away (ON DELETE CASCADE) — no
+	// explicit cleanup code.
+	if err := st.DeleteAgent(ctx, charID); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	cascaded, err := st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants after agent delete: %v", err)
+	}
+	if len(cascaded) != 0 {
+		t.Errorf("grants survived Agent delete: %+v (FK CASCADE not honored)", cascaded)
+	}
+}
+
+// TestToolGrantUniquePerTool asserts the UNIQUE(agent_id, tool_name) index: an
+// Agent grants a Tool at most once (ADR-0029).
+func TestToolGrantUniquePerTool(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	charID, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Mira",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	if _, err := st.CreateToolGrant(ctx, storage.NewToolGrant{AgentID: charID, ToolName: "dice"}); err != nil {
+		t.Fatalf("first CreateToolGrant: %v", err)
+	}
+	if _, err := st.CreateToolGrant(ctx, storage.NewToolGrant{AgentID: charID, ToolName: "dice"}); err == nil {
+		t.Fatal("second identical grant succeeded; UNIQUE(agent_id, tool_name) not enforced")
+	}
+}
+
+// TestListToolGrantsEmpty: an Agent with no grant rows yields an empty slice
+// (least-privilege) — the hydration path builds a GrantSet that declares no Tool.
+func TestListToolGrantsEmpty(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	charID, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Silent",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	grants, err := st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Errorf("agent with no grant rows has %d grants, want 0", len(grants))
+	}
+	// A random (nonexistent) agent id is also just empty, not an error.
+	if g, err := st.ListToolGrants(ctx, uuid.New()); err != nil || len(g) != 0 {
+		t.Errorf("ListToolGrants(random) = (%+v, %v), want ([], nil)", g, err)
+	}
+}

--- a/internal/storage/tool_grant_test.go
+++ b/internal/storage/tool_grant_test.go
@@ -191,3 +191,60 @@ func TestListToolGrantsEmpty(t *testing.T) {
 		t.Errorf("ListToolGrants(random) = (%+v, %v), want ([], nil)", g, err)
 	}
 }
+
+// TestBackfillGrantsExistingButler covers the 00013 backfill statement in
+// isolation: a Butler that already existed BEFORE the migration must gain its
+// dice grant when 00013 applies. Every other test creates Butlers via the
+// already-extended trigger and TestMigrateUpDown runs an empty DB, so this is
+// the only coverage of the backfill. It migrates through 00012 (the schema
+// before tool_agent_grant exists, where the unextended 00002 trigger inserts a
+// grantless Butler), creates a Campaign to get such a Butler, then applies 00013
+// and asserts the backfill granted it dice.
+func TestBackfillGrantsExistingButler(t *testing.T) {
+	dsn := startPostgres(t)
+	db := openSQL(t, dsn)
+	pool := openPool(t, dsn)
+	ctx := context.Background()
+
+	provider, err := storage.NewMigrationProvider(db)
+	if err != nil {
+		t.Fatalf("NewMigrationProvider: %v", err)
+	}
+
+	// Apply through 00012 only — tool_agent_grant does not exist yet, and the
+	// auto-Butler trigger here is the unextended 00002 version (Butler, no grant).
+	if _, err := provider.UpTo(ctx, 12); err != nil {
+		t.Fatalf("migrate up to 00012: %v", err)
+	}
+
+	st := storage.New(pool)
+	tenantID, err := st.CreateTenant(ctx, "Backfill Co")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	campaignID, err := st.CreateCampaign(ctx, storage.NewCampaign{TenantID: tenantID, Name: "Old Campaign"})
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	butler, err := st.GetButler(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetButler at v12: %v", err)
+	}
+
+	// Apply 00013: creates the table, extends the trigger, AND backfills the
+	// pre-existing Butler created above.
+	if _, err := provider.UpTo(ctx, 13); err != nil {
+		t.Fatalf("migrate up to 00013: %v", err)
+	}
+
+	grants, err := st.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants after backfill: %v", err)
+	}
+	if len(grants) != 1 || grants[0].ToolName != "dice" {
+		t.Fatalf("pre-existing Butler has grants %+v after backfill, want exactly [dice]", grants)
+	}
+	if grants[0].Config != nil {
+		t.Errorf("backfilled dice grant config = %q, want nil", grants[0].Config)
+	}
+}

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
@@ -47,6 +48,12 @@ const (
 	// stores a sealed placeholder so the NOT NULL column is satisfied without
 	// persisting a secret.
 	credPlaceholderLast4 = "env"
+
+	// diceToolName is the [tool.Tool.Name] of the built-in dice Tool — the demo
+	// NPC's (and the auto-Butler's) default Tool Grant (ADR-0009 Q14). The seed
+	// grants it to Bart so the live loop hydrates his dice ability from the DB
+	// (#113); the Butler's dice grant is seeded by the auto-Butler trigger.
+	diceToolName = "dice"
 )
 
 // SeedNPC creates the demo Tenant, Campaign (which auto-creates its Butler via
@@ -139,7 +146,7 @@ func SeedNPC(ctx context.Context, pool *pgxpool.Pool, cipher *crypto.Cipher, log
 			return err
 		}
 
-		_, err = tx.CreateAgent(ctx, storage.NewAgent{
+		bartID, err := tx.CreateAgent(ctx, storage.NewAgent{
 			CampaignID:            campaignID,
 			Role:                  storage.AgentRoleCharacter,
 			Name:                  npc.name,
@@ -149,6 +156,18 @@ func SeedNPC(ctx context.Context, pool *pgxpool.Pool, cipher *crypto.Cipher, log
 			LLMProviderConfigID:   uuid.NullUUID{UUID: llmCfgID, Valid: true},
 			AddressOnly:           false, // a lone Character NPC catches unaddressed speech
 			Aliases:               npc.aliases,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Seed Bart's dice Tool Grant so the live loop hydrates his dice ability
+		// from the DB (#113) — the persisted equivalent of the in-code default
+		// grant this replaces. The auto-Butler's dice grant lands via the trigger
+		// (migration 00013); Bart is a Character, so his grant is explicit here.
+		_, err = tx.CreateToolGrant(ctx, storage.NewToolGrant{
+			AgentID:  bartID,
+			ToolName: diceToolName,
 		})
 		return err
 	})
@@ -214,9 +233,39 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 		if err != nil {
 			return nil, storage.LoadedAgent{}, storage.Campaign{}, err
 		}
+		// Hydrate this NPC's Tool Grants from its DB rows (#113): tool
+		// availability is data-driven, not compiled in. An NPC with no rows gets
+		// no grants, so its GrantSet declares no Tool to the LLM (least-privilege).
+		grantRows, err := st.ListToolGrants(ctx, c.ID)
+		if err != nil {
+			return nil, storage.LoadedAgent{}, storage.Campaign{}, err
+		}
+		spec.grants = grantsFromRows(grantRows)
 		specs = append(specs, spec)
 	}
 	return specs, primary, campaign, nil
+}
+
+// grantsFromRows maps an Agent's persisted Tool Grant rows to the in-memory
+// [tool.Grant]s the live loop hydrates into a [tool.GrantSet] (#113, ADR-0029) —
+// the identical shape the orchestrator already consumes, so the loop never knows
+// the grants came from the DB. A row's jsonb config becomes Grant.Config as a
+// [json.RawMessage] (nil when the column is NULL — dice's shape), which the Tool
+// handler receives as grantConfig at execution time and enforces there, never
+// the LLM. No rows yields no grants: the Agent is shown no Tool at all.
+func grantsFromRows(rows []storage.ToolGrant) []tool.Grant {
+	if len(rows) == 0 {
+		return nil
+	}
+	grants := make([]tool.Grant, 0, len(rows))
+	for _, r := range rows {
+		g := tool.Grant{ToolName: r.ToolName}
+		if len(r.Config) > 0 {
+			g.Config = r.Config // json.RawMessage; the handler decodes its scope
+		}
+		grants = append(grants, g)
+	}
+	return grants
 }
 
 // npcSpecFromAgent maps a storage.Agent (vendor-neutral) to the voice-domain

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -236,6 +236,12 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 		// Hydrate this NPC's Tool Grants from its DB rows (#113): tool
 		// availability is data-driven, not compiled in. An NPC with no rows gets
 		// no grants, so its GrantSet declares no Tool to the LLM (least-privilege).
+		//
+		// CONTRACT: grants are read ONCE here — at RunFromDB, i.e. per Voice
+		// Session start — and the resulting GrantSet is read-only for the
+		// session's life. A grant row added or removed mid-session (e.g. a GM
+		// toggle via #117) takes effect on the NEXT Voice Session, not the running
+		// one.
 		grantRows, err := st.ListToolGrants(ctx, c.ID)
 		if err != nil {
 			return nil, storage.LoadedAgent{}, storage.Campaign{}, err

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/testcontainers/testcontainers-go"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -321,6 +323,64 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 	}
 	if got := routed[0].Target.AgentID; got != jaegerID.String() {
 		t.Errorf(`"Yeager" routed to AgentID %q, want Jäger %q`, got, jaegerID.String())
+	}
+}
+
+// TestLoadSeededNPCs_HydratesToolGrants is the #113 end-to-end bar over the real
+// DB path: the seeded NPC's Tool Grants come from its tool_agent_grant rows, and
+// removing the dice grant row makes the hydrated GrantSet declare no Tool at all
+// (AC2/AC3) — the LLM is never shown dice, so the NPC cannot roll. dice is the
+// only Tool the demo registry holds, so an empty Declarations() is exactly "the
+// NPC can no longer roll".
+func TestLoadSeededNPCs_HydratesToolGrants(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+
+	// Registry the live loop hydrates grants against (dice is the one v1.0 Tool).
+	reg := tool.NewRegistry()
+	reg.MustRegister(tool.NewDice())
+
+	specs, _, _, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("loaded %d NPCs, want 1", len(specs))
+	}
+	bart := specs[0]
+
+	// Seeded Bart hydrates a dice grant → its GrantSet declares dice to the LLM.
+	if got := tool.NewGrantSet(reg, bart.grants...).Declarations(); len(got) != 1 || got[0].Name != "dice" {
+		t.Fatalf("seeded NPC declared %+v, want exactly [dice]", got)
+	}
+
+	// Resolve Bart's Agent id (the spec.agentID is the UUID string) and remove
+	// his dice grant row — the GM revoking the Tool (#117 owns the RPC; here we
+	// hit storage directly).
+	bartID, err := uuid.Parse(bart.agentID)
+	if err != nil {
+		t.Fatalf("parse agentID %q: %v", bart.agentID, err)
+	}
+	if err := st.DeleteToolGrant(ctx, bartID, "dice"); err != nil {
+		t.Fatalf("DeleteToolGrant(dice): %v", err)
+	}
+
+	// Re-hydrate: with the row gone, the NPC is granted nothing → the LLM is
+	// never shown a Tool, so it cannot roll.
+	respec, _, _, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs after revoke: %v", err)
+	}
+	if len(respec[0].grants) != 0 {
+		t.Fatalf("after removing the dice grant row, NPC still has grants %+v, want none", respec[0].grants)
+	}
+	if got := tool.NewGrantSet(reg, respec[0].grants...).Declarations(); len(got) != 0 {
+		t.Fatalf("after revoke the NPC declared %+v, want none (Tool never declared → cannot roll)", got)
 	}
 }
 

--- a/internal/wirenpc/grants_test.go
+++ b/internal/wirenpc/grants_test.go
@@ -1,0 +1,68 @@
+package wirenpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// These pin the DB-rows → in-memory GrantSet hydration (#113) without a database:
+// grantsFromRows is the pure mapping the live loop uses, so its output can be fed
+// straight into a real GrantSet and its Declarations() (the grant-stripped list
+// handed to the LLM) asserted.
+
+// TestGrantsFromRows_DiceOnly: a single dice grant row hydrates into a GrantSet
+// that declares exactly the dice Tool to the LLM.
+func TestGrantsFromRows_DiceOnly(t *testing.T) {
+	grants := grantsFromRows([]storage.ToolGrant{{ToolName: "dice"}})
+
+	reg := tool.NewRegistry()
+	reg.MustRegister(tool.NewDice())
+	decls := tool.NewGrantSet(reg, grants...).Declarations()
+
+	if len(decls) != 1 || decls[0].Name != "dice" {
+		t.Fatalf("declared %+v, want exactly [dice]", decls)
+	}
+}
+
+// TestGrantsFromRows_NoRowsDeclaresNothing is the AC2/AC3 core: an Agent with no
+// grant rows is granted nothing, so the LLM is never shown a Tool. Removing the
+// last grant row IS this case — the Tool is never declared to the model.
+func TestGrantsFromRows_NoRowsDeclaresNothing(t *testing.T) {
+	grants := grantsFromRows(nil)
+	if len(grants) != 0 {
+		t.Fatalf("no rows produced %d grants, want 0", len(grants))
+	}
+
+	reg := tool.NewRegistry()
+	reg.MustRegister(tool.NewDice())
+	if decls := tool.NewGrantSet(reg, grants...).Declarations(); len(decls) != 0 {
+		t.Fatalf("agent with no grants declared %+v, want none (LLM shown no Tool)", decls)
+	}
+}
+
+// TestGrantsFromRows_PreservesConfig: a grant's jsonb config becomes the
+// in-memory Grant.Config (so scope can reach the Tool handler, ADR-0029), and a
+// nil-config row maps to a nil Config (dice's shape).
+func TestGrantsFromRows_PreservesConfig(t *testing.T) {
+	cfg := json.RawMessage(`{"scope":"self"}`)
+	grants := grantsFromRows([]storage.ToolGrant{
+		{ToolName: "dice"},
+		{ToolName: "remember_knowledge", Config: cfg},
+	})
+	if len(grants) != 2 {
+		t.Fatalf("got %d grants, want 2", len(grants))
+	}
+	if grants[0].ToolName != "dice" || grants[0].Config != nil {
+		t.Errorf("dice grant = %+v, want {dice <nil>}", grants[0])
+	}
+	got, ok := grants[1].Config.(json.RawMessage)
+	if !ok {
+		t.Fatalf("scoped Config type = %T, want json.RawMessage", grants[1].Config)
+	}
+	if string(got) != string(cfg) {
+		t.Errorf("scoped Config = %q, want %q", got, cfg)
+	}
+}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -125,14 +125,15 @@ func (r *Roster) RemoveNPC(agentID string) {
 }
 
 // rosterDepsForLive builds the production rosterDeps: every NPC's Replier is
-// constructed from the shared tool-engine, so N Character NPCs reuse one Groq
-// client and one synthesizer rather than each opening their own. memory is the
-// shared NPC memory recaller (#122) and facts the shared KG-facts recaller (#126);
-// every NPC's loop consults the SAME recallers, which scope by the addressed
-// AgentID / active Campaign per turn. A nil memory/facts disables that slot (the
-// prompt stays byte-identical). language is the Campaign Language selecting the
-// Matcher's phonetic encoder (#199).
-func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller, facts agent.FactsRecaller, language string) rosterDeps {
+// constructed from a per-NPC engine (engineFor), so each NPC carries its own
+// hydrated GrantSet (#113) while still sharing one Groq client and Registry under
+// the hood — N Character NPCs reuse one client rather than each opening their
+// own. memory is the shared NPC memory recaller (#122) and facts the shared
+// KG-facts recaller (#126); every NPC's loop consults the SAME recallers, which
+// scope by the addressed AgentID / active Campaign per turn. A nil memory/facts
+// disables that slot (the prompt stays byte-identical). language is the Campaign
+// Language selecting the Matcher's phonetic encoder (#199).
+func rosterDepsForLive(engineFor func(npcSpec) agent.Engine, synth tts.Synthesizer, historyTurns int, log *slog.Logger, memory agent.MemoryRecaller, facts agent.FactsRecaller, language string) rosterDeps {
 	return rosterDeps{
 		language: language,
 		replierFor: func(spec npcSpec) *agent.Replier {
@@ -142,7 +143,7 @@ func rosterDepsForLive(engine agent.Engine, synth tts.Synthesizer, historyTurns 
 					Markdown: spec.persona,
 					Voice:    spec.voice,
 				},
-				Engine:       engine,
+				Engine:       engineFor(spec),
 				Synthesizer:  synth,
 				HistoryTurns: historyTurns,
 				Memory:       memory,

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -221,6 +221,12 @@ type npcSpec struct {
 	persona string
 	voice   tts.Voice
 	aliases []string
+	// grants are this NPC's Tool Grants (ADR-0029): the DB-path (RunFromDB)
+	// hydrates them from the Agent's tool_agent_grant rows, the env-only path
+	// uses the in-code default. buildConversation resolves each into a
+	// per-NPC GrantSet against the shared Registry, so the LLM only ever sees the
+	// Tools this NPC is granted (#113). nil ⇒ granted nothing.
+	grants []tool.Grant
 }
 
 // hardcodedNPC is the original in-code "Bart" definition. It is the seed source
@@ -237,6 +243,10 @@ func hardcodedNPC() npcSpec {
 		// codec path is encode-only (Discord Opus is 48 kHz — no resampler).
 		voice:   npcVoice(),
 		aliases: []string{"innkeeper", "barkeep"},
+		// The env-only path has no DB to hydrate from, so it carries the in-code
+		// default grant (dice) directly — the persisted equivalent the seed writes
+		// for the DB path (#113).
+		grants: []tool.Grant{{ToolName: diceToolName}},
 	}
 }
 
@@ -733,9 +743,12 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	ttsStage := orchestrator.NewTTS(bus, synth)
 	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics, log)
 
-	// The `dice` grant stays in code: Tool Grants are a #6 table, not yet
-	// seeded. With no grants the tool engine degrades to a single completion
-	// through the same path.
+	// Tool Grants are now DB-backed and hydrated per NPC (#113, ADR-0029): each
+	// NPC carries its own grants (spec.grants — from its tool_agent_grant rows on
+	// the DB path, the in-code default on the env-only path), resolved into a
+	// per-NPC GrantSet against ONE shared Registry. So the LLM only ever sees the
+	// Tools that NPC is granted, and an NPC with no grant rows is shown no Tool at
+	// all — least-privilege, data-driven, not compiled in.
 	//
 	// Groq is the live LLM provider (see the function doc). Its key is keys.llm:
 	// the decrypted saved BYOK key (issue #69) when one is configured, otherwise
@@ -744,22 +757,26 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// (docs/agents/live-npc-run.md). There is no Anthropic key, so wiring the
 	// Anthropic adapter here would pass the keyless cassette tests (which replay
 	// Anthropic) but fail the live run — Groq is the only correct default for a
-	// runnable NPC. One engine is shared across every NPC in the Roster — they
-	// reuse one client rather than each opening their own.
+	// runnable NPC. The Groq client and the Registry are shared across every NPC
+	// — only the GrantSet differs per NPC — so N NPCs reuse one client rather than
+	// each opening their own.
 	provider := newLLM(keys.llm)
 	reg := tool.NewRegistry()
 	reg.MustRegister(tool.NewDice())
-	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
-	toolEngine := agenttool.NewEngine(provider, grants, groq.DefaultModel, 0, 0,
-		// Groq is the wired provider (see the function doc), so the per-round
-		// LLM spans (A3) are labelled groq. The no-op recorder keeps the keyless
-		// path silent; the live binary / benchmark inject a real one.
-		agenttool.WithMetrics(stageMetrics, observe.ProviderGroq))
+	engineFor := func(spec npcSpec) agent.Engine {
+		grants := tool.NewGrantSet(reg, spec.grants...)
+		return agenttool.NewEngine(provider, grants, groq.DefaultModel, 0, 0,
+			// Groq is the wired provider (see the function doc), so the per-round
+			// LLM spans (A3) are labelled groq. The no-op recorder keeps the keyless
+			// path silent; the live binary / benchmark inject a real one.
+			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq))
+	}
 
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
-	// in the Matcher and its Replier (over the shared engine) in the Cast. The
-	// Matcher is built from the first NPC and grown for the rest.
-	roster := newRoster(rosterDepsForLive(toolEngine, newTTS(keys.tts), 16, log, memory, facts, language))
+	// in the Matcher and its Replier (over a per-NPC engine carrying that NPC's
+	// GrantSet) in the Cast. The Matcher is built from the first NPC and grown for
+	// the rest.
+	roster := newRoster(rosterDepsForLive(engineFor, newTTS(keys.tts), 16, log, memory, facts, language))
 	for _, npc := range npcs {
 		roster.AddNPC(npc)
 	}

--- a/pkg/tool/loop_test.go
+++ b/pkg/tool/loop_test.go
@@ -229,6 +229,49 @@ func TestLoopCanceledContextStops(t *testing.T) {
 	}
 }
 
+// TestLoopPassesGrantConfigToHandler pins ADR-0029's per-grant scoping: the
+// Config carried on a Grant reaches the Tool handler as grantConfig at execution
+// time (the only place scope is enforced — never the LLM). It is the tool-side of
+// #113's DB-hydrated config: a grant loaded from a tool_agent_grant row with a
+// jsonb scope must land, unchanged, in Execute — the model cannot widen it.
+func TestLoopPassesGrantConfigToHandler(t *testing.T) {
+	var gotConfig any
+	captor := stubTool{
+		name:     "scoped",
+		readOnly: true,
+		exec: func(_ context.Context, _ json.RawMessage, grant any) (string, error) {
+			gotConfig = grant
+			return "done", nil
+		},
+	}
+	r := NewRegistry()
+	r.MustRegister(captor)
+	scope := json.RawMessage(`{"scope":"self"}`)
+	gs := NewGrantSet(r, Grant{ToolName: "scoped", Config: scope})
+
+	p := &scriptedProvider{
+		t: t,
+		steps: []scriptStep{
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c1", Name: "scoped", Input: json.RawMessage(`{}`)},
+			}}},
+			{reply: AssistantMessage{Text: "ok"}},
+		},
+	}
+	loop := NewLoop(p, gs)
+	if _, err := loop.Run(context.Background(), []Message{{Role: RoleUser, Text: "go"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, ok := gotConfig.(json.RawMessage)
+	if !ok {
+		t.Fatalf("handler received grantConfig of type %T, want json.RawMessage", gotConfig)
+	}
+	if string(got) != string(scope) {
+		t.Errorf("handler grantConfig = %q, want %q (scope must reach the handler unchanged)", got, scope)
+	}
+}
+
 func TestLoopNoToolsImmediateAnswer(t *testing.T) {
 	p := &scriptedProvider{t: t, steps: []scriptStep{{reply: AssistantMessage{Text: "just talking"}}}}
 	loop := diceLoop(t, p)


### PR DESCRIPTION
## What does this PR do?

Closes #113.

Replaces the hardcoded, identical-for-every-Agent dice grant with DB-backed
persistence, so an Agent's tool availability is data-driven instead of compiled
in.

- **Migration 00013** adds `tool_agent_grant(agent_id FK CASCADE, tool_name,
  config jsonb, UNIQUE(agent_id, tool_name))` (ADR-0029; `config` is untyped
  jsonb — the grant Config is `any`). Extends the auto-Butler trigger so every
  auto-created Butler also gets its `dice` grant in the same DB invariant that
  creates it, and backfills the `dice` grant for existing Butler rows.
- **Storage:** `ToolGrant` model + `ListToolGrants` / `CreateToolGrant` /
  `DeleteToolGrant`. The layer keeps config a raw blob, so it imports no
  `pkg/tool`.
- **Live loop:** each `npcSpec` carries its own grants — hydrated from the
  Agent's rows on the DB path (`grantsFromRows`), the in-code default on the
  env-only path. `buildConversation` builds a **per-NPC GrantSet** against one
  shared Registry + Groq client (N NPCs still reuse one client). An NPC with no
  grant rows is granted nothing, so the LLM is never shown a Tool. The demo
  NPC's `dice` grant is seeded so the live loop hydrates it from the DB.
- The in-memory `GrantSet`/`Grant` interface (`pkg/tool`) is **unchanged**
  (AC5).

## Why is this change needed?

Least-privilege, per-Agent tool scoping (ADR-0029): the GM should control which
Tools each Agent may use from data, and a per-grant scope/config must reach the
Tool handler (never the LLM). This is the E5 slice that moves grants from a
compiled constant into the DB.

## How was this tested?

- **Storage integration:** Butler dice grant seeded by the trigger; jsonb config
  round-trips through Postgres; delete + Agent-cascade; `UNIQUE(agent_id,
  tool_name)`; empty for a grantless agent; migrate up/down reversibility.
- **wirenpc unit:** `grantsFromRows` dice-only / no-rows-declares-nothing /
  preserves-config.
- **wirenpc integration (end-to-end DB path):** seed hydrates `dice`; removing
  the grant row re-hydrates to **zero declarations** — the NPC can no longer roll
  (AC2/AC3). Existing seed→load equivalence and multi-NPC tests stay green.
- **pkg/tool unit:** a `Grant.Config` reaches `Tool.Execute`'s `grantConfig`
  unchanged (AC4, tool-side).
- Local: `go build ./...`, full Docker-free `go test ./...` (only failure is a
  pre-existing live-Ollama embed test that skips without Ollama), full
  `-tags=integration` suite for `internal/storage` + `internal/wirenpc`, and
  `golangci-lint` (v2.12.2) — all green.

- [x] New/updated tests cover the change
- [x] Manual testing (via integration tests against real Postgres)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **Migration:** reversible (`down` restores the 00002 trigger function before
  dropping the table). The backfill covers **Butlers only** — Character NPCs are
  granted explicitly (seed / #117), so old Characters are not force-given dice
  (that would reintroduce the very per-Agent-identical grant this removes).
- **Scope:** grant-mutation RPC is #117's; this ships list/create/delete at the
  storage layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)