### PR TITLE
feat(#102): standing Discord presence + /roll Slash Command

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -409,7 +409,12 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// request; nil in web-only mode (no presence).
 	var presenceRefresh func()
 	if pres != nil {
-		presenceRefresh = func() { _ = pres.Ensure(context.Background()) }
+		presenceRefresh = func() {
+			if err := pres.Ensure(context.Background()); err != nil {
+				log.Warn("presence: refresh after Discord settings save failed; "+
+					"will retry on the next save or Voice Session cycle", "err", err)
+			}
+		}
 	}
 	mounts := managementMounts(store, cipher, log, mgr, relay, presenceRefresh)
 	root := spa.Handler()

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/recall"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
@@ -31,6 +32,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/transcript"
 	"github.com/MrWong99/Glyphoxa/internal/web"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
@@ -282,6 +284,38 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// and sessions. Created here so the same instance feeds both halves.
 	eventBus := voiceevent.NewBus()
 	cfg.Bus = eventBus
+
+	// Standing Discord presence + slash-command surface (#102, ADR-0010
+	// amendment): ONE boot-owned gateway client — shared with the voice Manager,
+	// never a second connection per Voice Session — that registers /roll against
+	// the configured Guild and answers it directly with the built-in Dice Tool,
+	// surviving with no Voice Session active. Built only when this Instance drives
+	// voice (`all` mode); a web-only replica runs no Bot. Declared at function
+	// scope so the shutdown path below can Close it after the Manager drains.
+	var pres *presence.Presence
+	if withVoice {
+		allow := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
+		gate := presence.NewGate(allow, func() string {
+			if pres == nil {
+				return ""
+			}
+			return pres.GuildID()
+		})
+		reg := presence.NewRegistry(gate, log)
+		reg.Register(presence.RollCommand(tool.NewDice()))
+		pres = presence.New(store, cipher, reg, cfg.Token, log)
+		// The voice loop borrows this one client instead of dialing its own per
+		// session; set BEFORE the Manager copies cfg into its base config.
+		cfg.Client = pres.ClientProvider()
+		// Bring the presence up at boot (AC: /roll appears with no Voice Session).
+		// Non-fatal: a bad or absent Bot token must not kill the web tier — it
+		// stays in the wait-state and the RPC refresher retries on the next save.
+		if err := pres.Ensure(ctx); err != nil {
+			log.Warn("presence: initial ensure failed; the slash-command surface "+
+				"will retry when Discord settings are next saved", "err", err)
+		}
+	}
+
 	runner := func(rctx context.Context, c wirenpc.Config) error {
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
@@ -369,7 +403,15 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// (ADR-0013/0039). The SPA handler is the "/" catch-all; ServeMux's
 	// longest-prefix match keeps /api/ and /auth/ ahead of it, so only non-API
 	// paths (and client-side deep links) reach the SPA fallback.
-	mounts := managementMounts(store, cipher, log, mgr, relay)
+	// The presence refresher reconciles the standing gateway after a Discord
+	// settings save (#102), so a newly-saved Bot token / Guild registers the
+	// slash-command surface without a restart. bg-context so it outlives the RPC
+	// request; nil in web-only mode (no presence).
+	var presenceRefresh func()
+	if pres != nil {
+		presenceRefresh = func() { _ = pres.Ensure(context.Background()) }
+	}
+	mounts := managementMounts(store, cipher, log, mgr, relay, presenceRefresh)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -406,6 +448,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// 'running' and the loop's ended_at write never races a closing pool.
 	err = runWebTier(ctx, srv)
 	mgr.Shutdown()
+	// Close the standing presence AFTER the Manager drains, so a live session
+	// releases the shared client before it is torn down (#102).
+	if pres != nil {
+		pres.Close()
+	}
 	return err
 }
 
@@ -425,7 +472,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
 // Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay) []web.Mount {
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, presenceRefresh func()) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses
@@ -464,6 +511,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	// health call probes with the new key instead of serving a stale Degraded
 	// badge for up to the cache TTL (#150).
 	providerSrv.SetHealthInvalidator(voiceSrv.InvalidateHealth)
+	// Saving Discord settings also reconciles the standing presence so the new
+	// token / Guild registers the slash-command surface without a restart (#102).
+	if presenceRefresh != nil {
+		providerSrv.SetPresenceRefresher(presenceRefresh)
+	}
 	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)

--- a/internal/presence/accessors_test.go
+++ b/internal/presence/accessors_test.go
@@ -1,0 +1,70 @@
+package presence
+
+import (
+	"context"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+)
+
+func TestInteractionAccessors(t *testing.T) {
+	resp := &fakeResponder{}
+	ic := &Interaction{
+		guildID: testGuild,
+		userID:  operatorID,
+		opts:    fakeOpts{s: map[string]string{"name": "bart"}, i: map[string]int{"n": 3}},
+		resp:    resp,
+	}
+
+	if ic.GuildID() != testGuild {
+		t.Errorf("GuildID = %q, want %q", ic.GuildID(), testGuild)
+	}
+	if ic.UserID() != operatorID {
+		t.Errorf("UserID = %q, want %q", ic.UserID(), operatorID)
+	}
+	if v, ok := ic.String("name"); !ok || v != "bart" {
+		t.Errorf("String(name) = (%q, %v), want (bart, true)", v, ok)
+	}
+	if _, ok := ic.String("missing"); ok {
+		t.Error("String(missing) ok = true, want false")
+	}
+	if v, ok := ic.Int("n"); !ok || v != 3 {
+		t.Errorf("Int(n) = (%d, %v), want (3, true)", v, ok)
+	}
+	if _, ok := ic.Int("missing"); ok {
+		t.Error("Int(missing) ok = true, want false")
+	}
+
+	// Defer + Followup route through the responder (the slow-handler seam
+	// #108/#120 use).
+	if err := ic.Defer(true); err != nil {
+		t.Fatalf("Defer: %v", err)
+	}
+	if resp.deferred == nil || !*resp.deferred {
+		t.Errorf("Defer did not record an ephemeral defer: %v", resp.deferred)
+	}
+	if err := ic.Followup("later", true); err != nil {
+		t.Fatalf("Followup: %v", err)
+	}
+	if len(resp.followups) != 1 || resp.followups[0].content != "later" || !resp.followups[0].ephemeral {
+		t.Errorf("Followup = %+v, want one ephemeral 'later'", resp.followups)
+	}
+}
+
+func TestInteractionNilOptions(t *testing.T) {
+	ic := &Interaction{resp: &fakeResponder{}}
+	if _, ok := ic.String("x"); ok {
+		t.Error("String on nil options ok = true, want false")
+	}
+	if _, ok := ic.Int("x"); ok {
+		t.Error("Int on nil options ok = true, want false")
+	}
+}
+
+func TestRestRegisterInvalidGuild(t *testing.T) {
+	// snowflake.Parse rejects a non-numeric Guild id before any REST call, so a
+	// nil-Rest client is safe here.
+	if err := restRegister(context.Background(), &bot.Client{}, "not-a-snowflake", nil); err == nil {
+		t.Fatal("restRegister with an invalid guild id = nil, want a parse error")
+	}
+}

--- a/internal/presence/autocomplete_test.go
+++ b/internal/presence/autocomplete_test.go
@@ -1,0 +1,114 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
+)
+
+func choice(name string) discord.AutocompleteChoice {
+	return discord.AutocompleteChoiceString{Name: name, Value: name}
+}
+
+func TestAutocompleteChoicesGating(t *testing.T) {
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(Command{Path: "glyphoxa search", GMOnly: true, Autocomplete: func(context.Context, *Autocomplete) ([]discord.AutocompleteChoice, error) {
+		return []discord.AutocompleteChoice{choice("hit")}, nil
+	}})
+	reg.Register(Command{Path: "roll"}) // no autocomplete handler
+	reg.Register(Command{Path: "find", Autocomplete: func(context.Context, *Autocomplete) ([]discord.AutocompleteChoice, error) {
+		return nil, errors.New("boom")
+	}})
+
+	op := &Autocomplete{guildID: testGuild, userID: operatorID}
+	stranger := &Autocomplete{guildID: testGuild, userID: strangerID}
+	ctx := context.Background()
+
+	if got := reg.autocompleteChoices(ctx, "nope", op); got == nil || len(got) != 0 {
+		t.Errorf("unknown command choices = %v, want empty non-nil", got)
+	}
+	if got := reg.autocompleteChoices(ctx, "roll", op); len(got) != 0 {
+		t.Errorf("no-autocomplete command choices = %v, want empty", got)
+	}
+	if got := reg.autocompleteChoices(ctx, "glyphoxa search", op); len(got) != 1 {
+		t.Errorf("authorized operator choices = %v, want 1", got)
+	}
+	// GM-only command must NOT leak choices (or even their existence) to a
+	// non-operator: an empty, non-nil slice.
+	got := reg.autocompleteChoices(ctx, "glyphoxa search", stranger)
+	if got == nil || len(got) != 0 {
+		t.Errorf("non-operator GM-only choices = %v, want empty non-nil (no leak)", got)
+	}
+	if got := reg.autocompleteChoices(ctx, "find", stranger); len(got) != 0 {
+		t.Errorf("handler-error choices = %v, want empty", got)
+	}
+}
+
+func TestAutocompleteFocused(t *testing.T) {
+	ac := &Autocomplete{
+		guildID: testGuild,
+		userID:  operatorID,
+		data: discord.AutocompleteInteractionData{
+			CommandName: "find",
+			Options: map[string]discord.AutocompleteOption{
+				"query": {
+					Name:    "query",
+					Type:    discord.ApplicationCommandOptionTypeString,
+					Value:   json.RawMessage(`"lich"`),
+					Focused: true,
+				},
+			},
+		},
+	}
+	name, value := ac.Focused()
+	if name != "query" || value != "lich" {
+		t.Errorf("Focused = (%q, %q), want (query, lich)", name, value)
+	}
+	if ac.UserID() != operatorID || ac.GuildID() != testGuild {
+		t.Errorf("identity = (%q, %q), want (%q, %q)", ac.UserID(), ac.GuildID(), operatorID, testGuild)
+	}
+
+	// No focused option (autocomplete fired before typing) must not panic.
+	empty := &Autocomplete{data: discord.AutocompleteInteractionData{}}
+	if n, v := empty.Focused(); n != "" || v != "" {
+		t.Errorf("empty Focused = (%q, %q), want empty", n, v)
+	}
+}
+
+func TestHandleAutocompleteEndToEnd(t *testing.T) {
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(Command{Path: "find", Autocomplete: func(_ context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
+		_, v := ac.Focused()
+		return []discord.AutocompleteChoice{choice(v + "-match")}, nil
+	}})
+
+	payload := `{
+		"id": "1", "application_id": "2", "type": 4, "token": "t", "version": 1,
+		"guild_id": "` + testGuild + `",
+		"member": {"user": {"id": "` + operatorID + `", "username": "gm"}},
+		"data": {"id": "3", "name": "find", "options": [{"type": 3, "name": "query", "value": "li", "focused": true}]}
+	}`
+	var ai discord.AutocompleteInteraction
+	if err := json.Unmarshal([]byte(payload), &ai); err != nil {
+		t.Fatalf("unmarshal autocomplete: %v", err)
+	}
+
+	var got discord.AutocompleteResult
+	e := &events.AutocompleteInteractionCreate{
+		AutocompleteInteraction: ai,
+		Respond: func(_ discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			got = data.(discord.AutocompleteResult)
+			return nil
+		},
+	}
+	reg.HandleAutocomplete(e)
+
+	if len(got.Choices) != 1 || got.Choices[0].ChoiceName() != "li-match" {
+		t.Errorf("autocomplete result = %+v, want one 'li-match' choice", got.Choices)
+	}
+}

--- a/internal/presence/command.go
+++ b/internal/presence/command.go
@@ -64,6 +64,11 @@ type Registry struct {
 	gate *Gate
 	log  *slog.Logger
 
+	// responseTimeout bounds a handler until it first responds (Discord's 3s
+	// deadline); a Defer stops it so a slow deferred handler's own work is not
+	// killed. Field (not the const) so tests drive it with a short deadline.
+	responseTimeout time.Duration
+
 	mu    sync.RWMutex
 	cmds  map[string]Command // dispatch key -> command
 	order []string           // registration order, for deterministic Definitions
@@ -75,7 +80,7 @@ func NewRegistry(gate *Gate, log *slog.Logger) *Registry {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Registry{gate: gate, log: log, cmds: map[string]Command{}}
+	return &Registry{gate: gate, log: log, cmds: map[string]Command{}, responseTimeout: interactionTimeout}
 }
 
 // Register adds commands to the surface. Boot-time only (before the first
@@ -169,8 +174,17 @@ func (r *Registry) dispatch(base context.Context, key string, ic *Interaction) {
 		_ = ic.ReplyEphemeral(gateMessage(err))
 		return
 	}
-	ctx, cancel := context.WithTimeout(base, interactionTimeout)
+	// Bound the handler by Discord's ~3s first-response deadline via a watchdog
+	// that cancels the ctx. A Defer (which ACKs within that window and opens the
+	// minutes-long follow-up window) stops the watchdog so a slow deferred handler
+	// — #120's transcript search — is not killed at the deadline. After a Defer,
+	// ic routes replies through Followup, so a handler error still reaches the
+	// user instead of a Discord 40060 ("already acknowledged") on CreateMessage.
+	ctx, cancel := context.WithCancel(base)
 	defer cancel()
+	watchdog := time.AfterFunc(r.responseTimeout, cancel)
+	defer watchdog.Stop()
+	ic.onDefer = func() { watchdog.Stop() }
 	if err := cmd.Handle(ctx, ic); err != nil {
 		r.log.Error("presence: slash command handler failed", "command", key, "err", err)
 		_ = ic.ReplyEphemeral("Something went wrong handling that command.")
@@ -204,7 +218,7 @@ func (r *Registry) autocompleteChoices(base context.Context, key string, ac *Aut
 	if err := r.authorize(cmd, ac.guildID, ac.userID); err != nil {
 		return empty
 	}
-	ctx, cancel := context.WithTimeout(base, interactionTimeout)
+	ctx, cancel := context.WithTimeout(base, r.responseTimeout)
 	defer cancel()
 	choices, err := cmd.Autocomplete(ctx, ac)
 	if err != nil {
@@ -264,6 +278,13 @@ type Interaction struct {
 	userID  string
 	opts    optionSource
 	resp    responder
+	// deferred is set once Defer succeeds: after it, Reply/ReplyEphemeral route
+	// through Followup, because the interaction is already acknowledged and a
+	// fresh CreateMessage would be a Discord 40060 ("already acknowledged").
+	deferred bool
+	// onDefer is installed by dispatch to stop the first-response watchdog when
+	// the handler Defers; nil when the Interaction is invoked outside dispatch.
+	onDefer func()
 }
 
 // GuildID is the Guild the interaction happened in, or "" for a DM.
@@ -289,16 +310,39 @@ func (ic *Interaction) Int(name string) (int64, bool) {
 	return int64(v), ok
 }
 
-// Reply answers the interaction with a public in-channel message.
-func (ic *Interaction) Reply(content string) error { return ic.resp.reply(content, false) }
+// Reply answers the interaction with a public in-channel message (a Followup
+// once the interaction has been Deferred).
+func (ic *Interaction) Reply(content string) error { return ic.reply(content, false) }
 
-// ReplyEphemeral answers with a message only the invoker sees.
-func (ic *Interaction) ReplyEphemeral(content string) error { return ic.resp.reply(content, true) }
+// ReplyEphemeral answers with a message only the invoker sees (a Followup once
+// Deferred).
+func (ic *Interaction) ReplyEphemeral(content string) error { return ic.reply(content, true) }
+
+// reply routes a message to the correct Discord response call: a fresh
+// CreateMessage before a Defer, a Followup after (a post-ACK CreateMessage is a
+// 40060). This makes both a handler's domain-error reply and the Registry's
+// generic-error reply reach the user after a Defer.
+func (ic *Interaction) reply(content string, ephemeral bool) error {
+	if ic.deferred {
+		return ic.resp.followup(content, ephemeral)
+	}
+	return ic.resp.reply(content, ephemeral)
+}
 
 // Defer acknowledges the interaction with a "thinking…" placeholder, buying a
 // slow handler time past the 3s deadline; it later sends the real reply with
-// Followup.
-func (ic *Interaction) Defer(ephemeral bool) error { return ic.resp.deferResponse(ephemeral) }
+// Followup (or Reply, which routes to Followup once deferred). Defer also stops
+// the dispatch first-response watchdog so the handler's own work is not killed.
+func (ic *Interaction) Defer(ephemeral bool) error {
+	if err := ic.resp.deferResponse(ephemeral); err != nil {
+		return err
+	}
+	ic.deferred = true
+	if ic.onDefer != nil {
+		ic.onDefer()
+	}
+	return nil
+}
 
 // Followup sends a message after a Defer.
 func (ic *Interaction) Followup(content string, ephemeral bool) error {

--- a/internal/presence/command.go
+++ b/internal/presence/command.go
@@ -1,0 +1,394 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// interactionTimeout bounds a handler's work well under Discord's 3s
+// initial-response deadline: past it Discord drops the interaction token and the
+// reply fails. Every dispatched handler runs on a context deadlined to this.
+const interactionTimeout = 2500 * time.Millisecond
+
+// commandGroup is the single grouped-command prefix v1.0 ships (ADR-0010):
+// admin/session commands register as `/glyphoxa <sub>`, merged into one
+// SlashCommandCreate. High-frequency commands (e.g. /roll) stay flat.
+const commandGroup = "glyphoxa"
+
+// commandGroupDescription is the top-level description Discord requires for the
+// merged /glyphoxa command (its subcommands carry their own descriptions).
+const commandGroupDescription = "Glyphoxa game-master commands"
+
+// Handler runs one slash-command interaction. It owns the user-facing reply:
+// domain errors (a malformed argument) are reported with ic.ReplyEphemeral and
+// the handler returns nil; a returned error is an UNEXPECTED failure, which the
+// Registry logs and answers with a generic ephemeral message. Either way the
+// interaction is never left silently un-answered.
+type Handler func(ctx context.Context, ic *Interaction) error
+
+// AutocompleteHandler produces choices for an in-progress option value. A nil
+// AutocompleteHandler on a Command means the command has no autocomplete.
+type AutocompleteHandler func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error)
+
+// Command is one registered slash command. Path is either a flat name ("roll")
+// or a grouped `"glyphoxa <sub>"` (ADR-0010) — the Registry merges every
+// "glyphoxa *" Path into ONE /glyphoxa SlashCommandCreate whose subcommands are
+// the individual Paths.
+type Command struct {
+	Path        string
+	Description string
+	Options     []discord.ApplicationCommandOption
+	// GMOnly false = anyone in the configured Guild (Gate.CheckGuild only); true
+	// = operator-allowlisted GM (Gate.CheckGM).
+	GMOnly bool
+	Handle Handler
+	// Autocomplete is optional. A GM-only command returns empty choices to a
+	// non-operator so a command's option names never leak (handled by dispatch).
+	Autocomplete AutocompleteHandler
+}
+
+// Registry holds the slash-command surface: it produces the per-Guild command
+// definitions and dispatches inbound interactions to the registered handler,
+// authorizing each server-side via the Gate. It is the shared contract issues
+// #108/#120/#211 register additional commands against.
+type Registry struct {
+	gate *Gate
+	log  *slog.Logger
+
+	mu    sync.RWMutex
+	cmds  map[string]Command // dispatch key -> command
+	order []string           // registration order, for deterministic Definitions
+}
+
+// NewRegistry builds an empty Registry over a Gate. Register commands at boot,
+// before the presence opens its gateway.
+func NewRegistry(gate *Gate, log *slog.Logger) *Registry {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Registry{gate: gate, log: log, cmds: map[string]Command{}}
+}
+
+// Register adds commands to the surface. Boot-time only (before the first
+// Ensure); the dispatch key is the command's Path.
+func (r *Registry) Register(cmds ...Command) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range cmds {
+		if _, dup := r.cmds[c.Path]; !dup {
+			r.order = append(r.order, c.Path)
+		}
+		r.cmds[c.Path] = c
+	}
+}
+
+// Definitions is the per-Guild registration payload: flat commands as their own
+// SlashCommandCreate, and every "glyphoxa <sub>" merged into ONE /glyphoxa
+// command carrying each sub as a SubCommand option (ADR-0010). Flat commands
+// come first, then the merged group, in registration order.
+func (r *Registry) Definitions() []discord.ApplicationCommandCreate {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var flat []discord.ApplicationCommandCreate
+	group := discord.SlashCommandCreate{Name: commandGroup, Description: commandGroupDescription}
+	haveGroup := false
+
+	for _, path := range r.order {
+		c := r.cmds[path]
+		prefix, sub, isSub := strings.Cut(path, " ")
+		if !isSub {
+			flat = append(flat, discord.SlashCommandCreate{
+				Name:        path,
+				Description: c.Description,
+				Options:     c.Options,
+			})
+			continue
+		}
+		if prefix != commandGroup {
+			// Only the /glyphoxa group exists in v1.0; a stray grouped Path is a
+			// programming error, but drop it rather than emit a bad command.
+			r.log.Warn("presence: ignoring command with unknown group prefix", "path", path)
+			continue
+		}
+		haveGroup = true
+		group.Options = append(group.Options, discord.ApplicationCommandOptionSubCommand{
+			Name:        sub,
+			Description: c.Description,
+			Options:     c.Options,
+		})
+	}
+
+	defs := make([]discord.ApplicationCommandCreate, 0, len(flat)+1)
+	defs = append(defs, flat...)
+	if haveGroup {
+		defs = append(defs, group)
+	}
+	return defs
+}
+
+// HandleCommand is the disgo listener for slash-command interactions. It builds
+// an Interaction over the event and dispatches it; every path answers the
+// interaction (a reply or an ephemeral error), never a silent drop.
+func (r *Registry) HandleCommand(e *events.ApplicationCommandInteractionCreate) {
+	data, ok := e.Data.(discord.SlashCommandInteractionData)
+	if !ok {
+		// We register only slash commands, so a non-slash application command is
+		// never expected; ignore it rather than panic on the type assertion.
+		return
+	}
+	ic := &Interaction{
+		guildID: snowflakePtrString(e.GuildID()),
+		userID:  e.User().ID.String(),
+		opts:    data,
+		resp:    &eventResponder{event: e},
+	}
+	r.dispatch(context.Background(), dispatchKey(data.CommandName(), data.SubCommandName), ic)
+}
+
+// dispatch is the transport-agnostic command core: look up, authorize, run. It
+// is separated from HandleCommand so it can be unit-tested with a fake
+// Interaction (a fake responder + fake options), no live Discord event needed.
+func (r *Registry) dispatch(base context.Context, key string, ic *Interaction) {
+	cmd, ok := r.lookup(key)
+	if !ok {
+		_ = ic.ReplyEphemeral("Unknown command.")
+		r.log.Warn("presence: unknown slash command", "command", key)
+		return
+	}
+	if err := r.authorize(cmd, ic.guildID, ic.userID); err != nil {
+		_ = ic.ReplyEphemeral(gateMessage(err))
+		return
+	}
+	ctx, cancel := context.WithTimeout(base, interactionTimeout)
+	defer cancel()
+	if err := cmd.Handle(ctx, ic); err != nil {
+		r.log.Error("presence: slash command handler failed", "command", key, "err", err)
+		_ = ic.ReplyEphemeral("Something went wrong handling that command.")
+	}
+}
+
+// HandleAutocomplete is the disgo listener for autocomplete interactions. It
+// always responds with a choice slice (possibly empty), so a focused option
+// never hangs.
+func (r *Registry) HandleAutocomplete(e *events.AutocompleteInteractionCreate) {
+	data := e.Data
+	ac := &Autocomplete{
+		guildID: snowflakePtrString(e.GuildID()),
+		userID:  e.User().ID.String(),
+		data:    data,
+	}
+	choices := r.autocompleteChoices(context.Background(), dispatchKey(data.CommandName, data.SubCommandName), ac)
+	_ = e.AutocompleteResult(choices)
+}
+
+// autocompleteChoices is the testable autocomplete core: it returns the handler
+// choices, or an EMPTY (never nil) slice when the command is unknown, has no
+// autocomplete, the invoker is not authorized (no name leak), or the handler
+// fails.
+func (r *Registry) autocompleteChoices(base context.Context, key string, ac *Autocomplete) []discord.AutocompleteChoice {
+	empty := []discord.AutocompleteChoice{}
+	cmd, ok := r.lookup(key)
+	if !ok || cmd.Autocomplete == nil {
+		return empty
+	}
+	if err := r.authorize(cmd, ac.guildID, ac.userID); err != nil {
+		return empty
+	}
+	ctx, cancel := context.WithTimeout(base, interactionTimeout)
+	defer cancel()
+	choices, err := cmd.Autocomplete(ctx, ac)
+	if err != nil {
+		r.log.Error("presence: autocomplete handler failed", "command", key, "err", err)
+		return empty
+	}
+	if choices == nil {
+		return empty
+	}
+	return choices
+}
+
+// authorize applies the command's server-side permission rule: GM-only commands
+// require an allowlisted operator in the configured Guild, others just require
+// the configured Guild.
+func (r *Registry) authorize(cmd Command, guildID, userID string) error {
+	if cmd.GMOnly {
+		return r.gate.CheckGM(guildID, userID)
+	}
+	return r.gate.CheckGuild(guildID)
+}
+
+func (r *Registry) lookup(key string) (Command, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.cmds[key]
+	return c, ok
+}
+
+// dispatchKey is the map key for an inbound interaction: the flat command name,
+// or "<name> <sub>" for a grouped subcommand — matching Command.Path.
+func dispatchKey(name string, sub *string) string {
+	if sub != nil {
+		return name + " " + *sub
+	}
+	return name
+}
+
+// gateMessage maps a Gate denial to its distinct ephemeral text.
+func gateMessage(err error) string {
+	switch {
+	case errors.Is(err, ErrNotOperator):
+		return "You're not authorized to use this command."
+	case errors.Is(err, ErrWrongGuild):
+		return "This command isn't available here."
+	default:
+		return "You can't use this command."
+	}
+}
+
+// Interaction is the handler's view of one slash-command interaction: its option
+// values, the invoker's identity, and the reply methods. The response path is
+// injectable (responder) so the Registry dispatches in unit tests without a live
+// Discord connection.
+type Interaction struct {
+	guildID string
+	userID  string
+	opts    optionSource
+	resp    responder
+}
+
+// GuildID is the Guild the interaction happened in, or "" for a DM.
+func (ic *Interaction) GuildID() string { return ic.guildID }
+
+// UserID is the invoking Discord User's snowflake.
+func (ic *Interaction) UserID() string { return ic.userID }
+
+// String reads a string option by name; ok is false when it was not supplied.
+func (ic *Interaction) String(name string) (string, bool) {
+	if ic.opts == nil {
+		return "", false
+	}
+	return ic.opts.OptString(name)
+}
+
+// Int reads an integer option by name; ok is false when it was not supplied.
+func (ic *Interaction) Int(name string) (int64, bool) {
+	if ic.opts == nil {
+		return 0, false
+	}
+	v, ok := ic.opts.OptInt(name)
+	return int64(v), ok
+}
+
+// Reply answers the interaction with a public in-channel message.
+func (ic *Interaction) Reply(content string) error { return ic.resp.reply(content, false) }
+
+// ReplyEphemeral answers with a message only the invoker sees.
+func (ic *Interaction) ReplyEphemeral(content string) error { return ic.resp.reply(content, true) }
+
+// Defer acknowledges the interaction with a "thinking…" placeholder, buying a
+// slow handler time past the 3s deadline; it later sends the real reply with
+// Followup.
+func (ic *Interaction) Defer(ephemeral bool) error { return ic.resp.deferResponse(ephemeral) }
+
+// Followup sends a message after a Defer.
+func (ic *Interaction) Followup(content string, ephemeral bool) error {
+	return ic.resp.followup(content, ephemeral)
+}
+
+// Autocomplete is the handler's view of one autocomplete interaction.
+type Autocomplete struct {
+	guildID string
+	userID  string
+	data    discord.AutocompleteInteractionData
+}
+
+// Focused is the option the user is currently typing (its name and partial
+// value). The value is decoded defensively: disgo's own accessor panics on a
+// non-string or absent value, but an autocomplete can fire before any character
+// is typed, so this returns "" rather than crash the gateway goroutine.
+func (ac *Autocomplete) Focused() (name, value string) {
+	f := ac.data.Focused()
+	if len(f.Value) == 0 {
+		return f.Name, ""
+	}
+	var s string
+	if err := json.Unmarshal(f.Value, &s); err == nil {
+		return f.Name, s
+	}
+	return f.Name, strings.TrimSpace(string(f.Value))
+}
+
+// UserID is the invoking Discord User's snowflake.
+func (ac *Autocomplete) UserID() string { return ac.userID }
+
+// GuildID is the Guild the interaction happened in, or "" for a DM.
+func (ac *Autocomplete) GuildID() string { return ac.guildID }
+
+// optionSource is the option-reading surface an Interaction needs;
+// discord.SlashCommandInteractionData satisfies it in production, a fake map in
+// tests.
+type optionSource interface {
+	OptString(name string) (string, bool)
+	OptInt(name string) (int, bool)
+}
+
+// responder is the injectable interaction-response sink: production wraps the
+// disgo event, tests record the calls.
+type responder interface {
+	reply(content string, ephemeral bool) error
+	deferResponse(ephemeral bool) error
+	followup(content string, ephemeral bool) error
+}
+
+// eventResponder is the production responder over a live slash-command event.
+type eventResponder struct {
+	event *events.ApplicationCommandInteractionCreate
+}
+
+func (r *eventResponder) reply(content string, ephemeral bool) error {
+	return r.event.CreateMessage(ephemeralMessage(content, ephemeral))
+}
+
+func (r *eventResponder) deferResponse(ephemeral bool) error {
+	return r.event.DeferCreateMessage(ephemeral)
+}
+
+func (r *eventResponder) followup(content string, ephemeral bool) error {
+	_, err := r.event.Client().Rest.CreateFollowupMessage(
+		r.event.ApplicationID(), r.event.Token(), ephemeralMessage(content, ephemeral))
+	return err
+}
+
+// ephemeralMessage builds a MessageCreate, flagged ephemeral when requested.
+func ephemeralMessage(content string, ephemeral bool) discord.MessageCreate {
+	mc := discord.MessageCreate{Content: content}
+	if ephemeral {
+		mc.Flags = mc.Flags.Add(discord.MessageFlagEphemeral)
+	}
+	return mc
+}
+
+// snowflakePtrString renders an optional Guild snowflake as a string, "" for a
+// nil (DM) pointer.
+func snowflakePtrString(id *snowflake.ID) string {
+	if id == nil {
+		return ""
+	}
+	return id.String()
+}
+
+// compile-time proof the production responder satisfies the seam.
+var _ responder = (*eventResponder)(nil)
+
+// compile-time proof disgo's slash data satisfies the option seam.
+var _ optionSource = discord.SlashCommandInteractionData{}

--- a/internal/presence/command_test.go
+++ b/internal/presence/command_test.go
@@ -1,0 +1,206 @@
+package presence
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+// recordedReply captures one responder call for assertions.
+type recordedReply struct {
+	content   string
+	ephemeral bool
+}
+
+// fakeResponder records reply/defer/followup calls instead of hitting Discord.
+type fakeResponder struct {
+	replies   []recordedReply
+	followups []recordedReply
+	deferred  *bool
+}
+
+func (f *fakeResponder) reply(content string, ephemeral bool) error {
+	f.replies = append(f.replies, recordedReply{content, ephemeral})
+	return nil
+}
+
+func (f *fakeResponder) deferResponse(ephemeral bool) error {
+	f.deferred = &ephemeral
+	return nil
+}
+
+func (f *fakeResponder) followup(content string, ephemeral bool) error {
+	f.followups = append(f.followups, recordedReply{content, ephemeral})
+	return nil
+}
+
+// fakeOpts is a map-backed optionSource for dispatch tests.
+type fakeOpts struct {
+	s map[string]string
+	i map[string]int
+}
+
+func (f fakeOpts) OptString(name string) (string, bool) { v, ok := f.s[name]; return v, ok }
+func (f fakeOpts) OptInt(name string) (int, bool)       { v, ok := f.i[name]; return v, ok }
+
+func testRegistry(guild string, allow string) *Registry {
+	return NewRegistry(NewGate(auth.ParseOperatorAllowlist(allow), fixedGuild(guild)), nil)
+}
+
+func TestDefinitionsMergeFlatAndGroup(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.Register(Command{Path: "roll", Description: "Roll dice"})
+	reg.Register(Command{
+		Path:        "glyphoxa x",
+		Description: "Do x",
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{Name: "q", Description: "query", Required: true},
+		},
+	})
+
+	defs := reg.Definitions()
+	if len(defs) != 2 {
+		t.Fatalf("Definitions len = %d, want 2 (one flat + one merged group)", len(defs))
+	}
+
+	byName := map[string]discord.SlashCommandCreate{}
+	for _, d := range defs {
+		sc, ok := d.(discord.SlashCommandCreate)
+		if !ok {
+			t.Fatalf("definition %T is not a SlashCommandCreate", d)
+		}
+		byName[sc.Name] = sc
+	}
+
+	if _, ok := byName["roll"]; !ok {
+		t.Errorf("missing flat /roll command; have %v", keys(byName))
+	}
+	g, ok := byName["glyphoxa"]
+	if !ok {
+		t.Fatalf("missing merged /glyphoxa command; have %v", keys(byName))
+	}
+	if len(g.Options) != 1 {
+		t.Fatalf("/glyphoxa options = %d, want 1 subcommand", len(g.Options))
+	}
+	sub, ok := g.Options[0].(discord.ApplicationCommandOptionSubCommand)
+	if !ok {
+		t.Fatalf("/glyphoxa option 0 is %T, want SubCommand", g.Options[0])
+	}
+	if sub.Name != "x" {
+		t.Errorf("subcommand name = %q, want x", sub.Name)
+	}
+	if len(sub.Options) != 1 || sub.Options[0].(discord.ApplicationCommandOptionString).Name != "q" {
+		t.Errorf("subcommand did not carry its own option q: %+v", sub.Options)
+	}
+}
+
+func TestDefinitionsMergesMultipleSubcommands(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.Register(
+		Command{Path: "glyphoxa start", Description: "start"},
+		Command{Path: "glyphoxa end", Description: "end"},
+	)
+	defs := reg.Definitions()
+	if len(defs) != 1 {
+		t.Fatalf("Definitions len = %d, want 1 merged /glyphoxa", len(defs))
+	}
+	g := defs[0].(discord.SlashCommandCreate)
+	if len(g.Options) != 2 {
+		t.Errorf("/glyphoxa subcommands = %d, want 2", len(g.Options))
+	}
+}
+
+func TestDispatchRoutesWithParsedOption(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	var gotArg string
+	ran := false
+	reg.Register(Command{Path: "echo", Handle: func(_ context.Context, ic *Interaction) error {
+		ran = true
+		gotArg, _ = ic.String("msg")
+		return ic.Reply("said: " + gotArg)
+	}})
+
+	resp := &fakeResponder{}
+	ic := &Interaction{guildID: testGuild, userID: strangerID, opts: fakeOpts{s: map[string]string{"msg": "hi"}}, resp: resp}
+	reg.dispatch(context.Background(), "echo", ic)
+
+	if !ran {
+		t.Fatal("handler did not run")
+	}
+	if gotArg != "hi" {
+		t.Errorf("parsed option = %q, want hi", gotArg)
+	}
+	if len(resp.replies) != 1 || resp.replies[0].content != "said: hi" || resp.replies[0].ephemeral {
+		t.Errorf("reply = %+v, want one public 'said: hi'", resp.replies)
+	}
+}
+
+func TestDispatchUnknownCommand(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	resp := &fakeResponder{}
+	ic := &Interaction{guildID: testGuild, userID: strangerID, resp: resp}
+
+	// Must not panic and must answer ephemerally.
+	reg.dispatch(context.Background(), "nope", ic)
+
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("unknown command reply = %+v, want one ephemeral", resp.replies)
+	}
+}
+
+func TestDispatchGateDenials(t *testing.T) {
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(Command{Path: "gm", GMOnly: true, Handle: func(context.Context, *Interaction) error {
+		t.Fatal("GM handler ran despite denial")
+		return nil
+	}})
+	reg.Register(Command{Path: "any", Handle: func(_ context.Context, ic *Interaction) error {
+		return ic.Reply("ok")
+	}})
+
+	// Non-operator invoking a GM-only command → ErrNotOperator text.
+	notOp := &fakeResponder{}
+	reg.dispatch(context.Background(), "gm", &Interaction{guildID: testGuild, userID: strangerID, resp: notOp})
+	// Wrong-Guild invoking an anyone command → ErrWrongGuild text.
+	wrongGuild := &fakeResponder{}
+	reg.dispatch(context.Background(), "any", &Interaction{guildID: otherGuild, userID: strangerID, resp: wrongGuild})
+
+	if len(notOp.replies) != 1 || !notOp.replies[0].ephemeral {
+		t.Fatalf("gm denial reply = %+v, want one ephemeral", notOp.replies)
+	}
+	if len(wrongGuild.replies) != 1 || !wrongGuild.replies[0].ephemeral {
+		t.Fatalf("wrong-guild reply = %+v, want one ephemeral", wrongGuild.replies)
+	}
+	if notOp.replies[0].content == wrongGuild.replies[0].content {
+		t.Errorf("ErrNotOperator and ErrWrongGuild map to the same text %q; want distinct", notOp.replies[0].content)
+	}
+}
+
+func TestDispatchHandlerErrorRepliesGeneric(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.Register(Command{Path: "boom", Handle: func(context.Context, *Interaction) error {
+		return context.DeadlineExceeded // stand-in for an unexpected failure
+	}})
+
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "boom", &Interaction{guildID: testGuild, userID: strangerID, resp: resp})
+
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("handler-error reply = %+v, want one ephemeral", resp.replies)
+	}
+	if !strings.Contains(strings.ToLower(resp.replies[0].content), "went wrong") {
+		t.Errorf("handler-error reply = %q, want a generic failure message", resp.replies[0].content)
+	}
+}
+
+func keys(m map[string]discord.SlashCommandCreate) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/presence/defer_test.go
+++ b/internal/presence/defer_test.go
@@ -1,0 +1,90 @@
+package presence
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDispatchDeferExtendsDeadline pins issue #1a: a Defer stops the
+// first-response watchdog, so a slow deferred handler (a #120 transcript search)
+// is NOT killed with DeadlineExceeded when it runs past the ~3s window.
+func TestDispatchDeferExtendsDeadline(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.responseTimeout = 20 * time.Millisecond
+
+	var ctxErrAfterWork error
+	reg.Register(Command{Path: "slow", Handle: func(ctx context.Context, ic *Interaction) error {
+		if err := ic.Defer(false); err != nil {
+			return err
+		}
+		time.Sleep(60 * time.Millisecond) // well past the 20ms watchdog
+		ctxErrAfterWork = ctx.Err()
+		return ic.Followup("done", false)
+	}})
+
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "slow", &Interaction{guildID: testGuild, resp: resp})
+
+	if ctxErrAfterWork != nil {
+		t.Errorf("deferred handler ctx = %v after work; a Defer must stop the first-response watchdog", ctxErrAfterWork)
+	}
+	if resp.deferred == nil {
+		t.Error("no Defer recorded")
+	}
+	if len(resp.followups) != 1 || resp.followups[0].content != "done" {
+		t.Errorf("followups = %+v, want one 'done'", resp.followups)
+	}
+	if len(resp.replies) != 0 {
+		t.Errorf("a deferred handler must not CreateMessage; replies = %+v", resp.replies)
+	}
+}
+
+// TestDispatchDeferredHandlerErrorRepliesViaFollowup pins issue #1b: after a
+// Defer the interaction is already acknowledged, so the Registry's generic error
+// reply must go through Followup — a fresh CreateMessage would be a Discord 40060
+// and the user would be stuck on "thinking…".
+func TestDispatchDeferredHandlerErrorRepliesViaFollowup(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.Register(Command{Path: "boom", Handle: func(_ context.Context, ic *Interaction) error {
+		if err := ic.Defer(true); err != nil {
+			return err
+		}
+		return context.DeadlineExceeded // an unexpected failure after the ACK
+	}})
+
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "boom", &Interaction{guildID: testGuild, resp: resp})
+
+	if len(resp.replies) != 0 {
+		t.Errorf("error reply after Defer used CreateMessage (Discord 40060); replies = %+v", resp.replies)
+	}
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("error reply after Defer = %+v, want one ephemeral Followup", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "went wrong") {
+		t.Errorf("followup = %q, want the generic failure message", resp.followups[0].content)
+	}
+}
+
+// TestDeferredHandlerDomainErrorRepliesViaFollowup covers the handler-owned
+// reply path (the convention #108/#120 use): a deferred handler that hits a
+// domain error and calls ReplyEphemeral routes it to Followup, not CreateMessage.
+func TestDeferredHandlerDomainErrorRepliesViaFollowup(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	reg.Register(Command{Path: "search", Handle: func(_ context.Context, ic *Interaction) error {
+		_ = ic.Defer(true)
+		return ic.ReplyEphemeral("no results")
+	}})
+
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "search", &Interaction{guildID: testGuild, resp: resp})
+
+	if len(resp.replies) != 0 {
+		t.Errorf("domain reply after Defer used CreateMessage; replies = %+v", resp.replies)
+	}
+	if len(resp.followups) != 1 || resp.followups[0].content != "no results" || !resp.followups[0].ephemeral {
+		t.Errorf("followups = %+v, want one ephemeral 'no results'", resp.followups)
+	}
+}

--- a/internal/presence/event_test.go
+++ b/internal/presence/event_test.go
@@ -1,0 +1,74 @@
+package presence
+
+import (
+	"encoding/json"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
+
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// rollInteractionJSON is a real Discord slash-command interaction payload for
+// `/roll dice:<expr>` in the configured Guild, invoked by userID. Building the
+// event from JSON exercises the actual disgo unwrap path (option extraction,
+// Guild/user resolution) that HandleCommand relies on — not just the fake seam.
+func rollInteractionJSON(guildID, userID, expr string) string {
+	return `{
+		"id": "100000000000000001",
+		"application_id": "200000000000000002",
+		"type": 2,
+		"token": "interaction-token",
+		"version": 1,
+		"guild_id": "` + guildID + `",
+		"member": {"user": {"id": "` + userID + `", "username": "gm"}},
+		"data": {
+			"id": "300000000000000003",
+			"name": "roll",
+			"type": 1,
+			"options": [{"name": "dice", "type": 3, "value": "` + expr + `"}]
+		}
+	}`
+}
+
+func TestHandleCommandEndToEndRoll(t *testing.T) {
+	// Seeded dice + an identically-seeded oracle so the reply is checkable.
+	const s1, s2 = 0x243f6a8885a308d3, 0x13198a2e03707344
+	dice := tool.NewDiceWithRand(rand.New(rand.NewPCG(s1, s2)))
+	oracle := tool.NewDiceWithRand(rand.New(rand.NewPCG(s1, s2)))
+
+	reg := testRegistry(testGuild, "")
+	reg.Register(RollCommand(dice))
+
+	var aci discord.ApplicationCommandInteraction
+	if err := json.Unmarshal([]byte(rollInteractionJSON(testGuild, operatorID, "2d6")), &aci); err != nil {
+		t.Fatalf("unmarshal interaction: %v", err)
+	}
+
+	var gotType discord.InteractionResponseType
+	var gotMsg discord.MessageCreate
+	e := &events.ApplicationCommandInteractionCreate{
+		ApplicationCommandInteraction: aci,
+		Respond: func(rt discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			gotType = rt
+			gotMsg = data.(discord.MessageCreate)
+			return nil
+		},
+	}
+
+	reg.HandleCommand(e)
+
+	if gotType != discord.InteractionResponseTypeCreateMessage {
+		t.Errorf("response type = %v, want CreateMessage", gotType)
+	}
+	if gotMsg.Flags.Has(discord.MessageFlagEphemeral) {
+		t.Errorf("a valid roll replied ephemerally; a result is public")
+	}
+	want := oracleRoll(t, oracle, 2, 6)
+	if gotMsg.Content != want {
+		t.Errorf("reply = %q, want the Dice Tool's exact string %q", gotMsg.Content, want)
+	}
+}

--- a/internal/presence/gate.go
+++ b/internal/presence/gate.go
@@ -1,0 +1,58 @@
+package presence
+
+import (
+	"errors"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+// Discord's own command-permission settings are a UX hint a Guild admin can edit
+// (ADR-0010), so every interaction is authorized here, server-side. Two sentinel
+// denials let the Registry map each to its own ephemeral text.
+var (
+	// ErrWrongGuild denies an interaction that did not happen in the configured
+	// Guild (including a DM, which carries no Guild).
+	ErrWrongGuild = errors.New("presence: interaction is not in the configured Guild")
+	// ErrNotOperator denies a GM-only command invoked by a Discord User whose
+	// snowflake is not on the operator allowlist (ADR-0041 v1.0 "GM only").
+	ErrNotOperator = errors.New("presence: user is not on the operator allowlist")
+)
+
+// Gate is the server-side authorization check for slash-command interactions
+// (ADR-0010). It resolves the configured Guild lazily via guildID (the presence
+// only learns its Guild once the deployment config is loaded), so a wait-state
+// presence ("" Guild) denies every command until a Guild is configured.
+type Gate struct {
+	allow   auth.OperatorAllowlist
+	guildID func() string
+}
+
+// NewGate builds a Gate over the operator allowlist and a resolver for the
+// configured Guild (wired to Presence.GuildID). guildID must be non-nil.
+func NewGate(allow auth.OperatorAllowlist, guildID func() string) *Gate {
+	return &Gate{allow: allow, guildID: guildID}
+}
+
+// CheckGuild passes when the interaction happened in the configured Guild. This
+// is the /roll rule (ADR-0010): anyone in the configured Guild, no user check.
+// A DM (empty interactionGuildID) is denied, as is any interaction while the
+// presence has no configured Guild yet.
+func (g *Gate) CheckGuild(interactionGuildID string) error {
+	want := g.guildID()
+	if want == "" || interactionGuildID != want {
+		return ErrWrongGuild
+	}
+	return nil
+}
+
+// CheckGM is CheckGuild plus operator-allowlist membership: the v1.0 "GM only"
+// rule (ADR-0010 amendment / ADR-0041) until a real tenant_members.role exists.
+func (g *Gate) CheckGM(interactionGuildID, userID string) error {
+	if err := g.CheckGuild(interactionGuildID); err != nil {
+		return err
+	}
+	if !g.allow.Contains(userID) {
+		return ErrNotOperator
+	}
+	return nil
+}

--- a/internal/presence/gate_test.go
+++ b/internal/presence/gate_test.go
@@ -1,0 +1,55 @@
+package presence
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+const (
+	testGuild  = "472093001100"
+	otherGuild = "999999999999"
+	operatorID = "111111111111"
+	strangerID = "222222222222"
+)
+
+func fixedGuild(id string) func() string { return func() string { return id } }
+
+func TestGateCheckGuild(t *testing.T) {
+	g := NewGate(auth.ParseOperatorAllowlist(""), fixedGuild(testGuild))
+
+	if err := g.CheckGuild(testGuild); err != nil {
+		t.Errorf("CheckGuild(configured) = %v, want nil", err)
+	}
+	if err := g.CheckGuild(otherGuild); !errors.Is(err, ErrWrongGuild) {
+		t.Errorf("CheckGuild(other) = %v, want ErrWrongGuild", err)
+	}
+	if err := g.CheckGuild(""); !errors.Is(err, ErrWrongGuild) {
+		t.Errorf("CheckGuild(DM) = %v, want ErrWrongGuild", err)
+	}
+}
+
+func TestGateCheckGuildWaitState(t *testing.T) {
+	// No configured Guild yet (presence wait-state): deny everything, even a
+	// well-formed Guild id.
+	g := NewGate(auth.ParseOperatorAllowlist(operatorID), fixedGuild(""))
+	if err := g.CheckGuild(testGuild); !errors.Is(err, ErrWrongGuild) {
+		t.Errorf("CheckGuild while unconfigured = %v, want ErrWrongGuild", err)
+	}
+}
+
+func TestGateCheckGM(t *testing.T) {
+	g := NewGate(auth.ParseOperatorAllowlist(operatorID), fixedGuild(testGuild))
+
+	if err := g.CheckGM(testGuild, operatorID); err != nil {
+		t.Errorf("CheckGM(operator in guild) = %v, want nil", err)
+	}
+	if err := g.CheckGM(testGuild, strangerID); !errors.Is(err, ErrNotOperator) {
+		t.Errorf("CheckGM(stranger in guild) = %v, want ErrNotOperator", err)
+	}
+	// Wrong Guild fails on the Guild check before the operator check.
+	if err := g.CheckGM(otherGuild, operatorID); !errors.Is(err, ErrWrongGuild) {
+		t.Errorf("CheckGM(operator wrong guild) = %v, want ErrWrongGuild", err)
+	}
+}

--- a/internal/presence/grouped_test.go
+++ b/internal/presence/grouped_test.go
@@ -1,0 +1,95 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
+)
+
+// TestHandleCommandEndToEndGroupedSubcommand pins issue #7 for commands: a real
+// grouped `/glyphoxa <sub>` interaction — disgo populates SubCommandName — routes
+// through dispatchKey to the "glyphoxa ping" handler with its option. #108
+// consumes this exact path first.
+func TestHandleCommandEndToEndGroupedSubcommand(t *testing.T) {
+	reg := testRegistry(testGuild, operatorID) // operator is allowlisted for the GM-only command
+	var gotMsg string
+	ran := false
+	reg.Register(Command{Path: "glyphoxa ping", GMOnly: true, Handle: func(_ context.Context, ic *Interaction) error {
+		ran = true
+		gotMsg, _ = ic.String("msg")
+		return ic.Reply("pong: " + gotMsg)
+	}})
+
+	payload := `{
+		"id": "1", "application_id": "2", "type": 2, "token": "t", "version": 1,
+		"guild_id": "` + testGuild + `",
+		"member": {"user": {"id": "` + operatorID + `", "username": "gm"}},
+		"data": {"id": "3", "name": "glyphoxa", "type": 1,
+			"options": [{"type": 1, "name": "ping", "options": [{"type": 3, "name": "msg", "value": "hi"}]}]}
+	}`
+	var aci discord.ApplicationCommandInteraction
+	if err := json.Unmarshal([]byte(payload), &aci); err != nil {
+		t.Fatalf("unmarshal grouped interaction: %v", err)
+	}
+
+	var reply discord.MessageCreate
+	e := &events.ApplicationCommandInteractionCreate{
+		ApplicationCommandInteraction: aci,
+		Respond: func(_ discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			reply = data.(discord.MessageCreate)
+			return nil
+		},
+	}
+	reg.HandleCommand(e)
+
+	if !ran {
+		t.Fatal("grouped subcommand handler did not run (dispatchKey missed SubCommandName?)")
+	}
+	if gotMsg != "hi" {
+		t.Errorf("subcommand option msg = %q, want hi", gotMsg)
+	}
+	if reply.Content != "pong: hi" {
+		t.Errorf("reply = %q, want 'pong: hi'", reply.Content)
+	}
+}
+
+// TestHandleAutocompleteEndToEndGroupedSubcommand pins issue #7 for autocomplete:
+// a real grouped `/glyphoxa search` autocomplete routes to the "glyphoxa search"
+// handler for an authorized operator.
+func TestHandleAutocompleteEndToEndGroupedSubcommand(t *testing.T) {
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(Command{Path: "glyphoxa search", GMOnly: true, Autocomplete: func(_ context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
+		_, v := ac.Focused()
+		return []discord.AutocompleteChoice{choice(v + "-hit")}, nil
+	}})
+
+	payload := `{
+		"id": "1", "application_id": "2", "type": 4, "token": "t", "version": 1,
+		"guild_id": "` + testGuild + `",
+		"member": {"user": {"id": "` + operatorID + `", "username": "gm"}},
+		"data": {"id": "3", "name": "glyphoxa",
+			"options": [{"type": 1, "name": "search", "options": [{"type": 3, "name": "query", "value": "li", "focused": true}]}]}
+	}`
+	var ai discord.AutocompleteInteraction
+	if err := json.Unmarshal([]byte(payload), &ai); err != nil {
+		t.Fatalf("unmarshal grouped autocomplete: %v", err)
+	}
+
+	var got discord.AutocompleteResult
+	e := &events.AutocompleteInteractionCreate{
+		AutocompleteInteraction: ai,
+		Respond: func(_ discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			got = data.(discord.AutocompleteResult)
+			return nil
+		},
+	}
+	reg.HandleAutocomplete(e)
+
+	if len(got.Choices) != 1 || got.Choices[0].ChoiceName() != "li-hit" {
+		t.Errorf("grouped autocomplete result = %+v, want one 'li-hit'", got.Choices)
+	}
+}

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -1,0 +1,241 @@
+// Package presence owns the Bot's standing Discord gateway (ADR-0010 amendment,
+// #102): one shared disgo client, created lazily once a Bot token exists in the
+// deployment config and rebuilt when the token changes, that both registers the
+// v1.0 Slash Command surface against the configured Guild and — shared with the
+// voice Manager — backs live Voice Sessions. It replaces the per-Voice-Session
+// client with a single boot-owned connection so /roll answers with no Voice
+// Session active and a session starting or stopping never breaks the presence.
+package presence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/disgoorg/disgo"
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/rest"
+	"github.com/disgoorg/snowflake/v2"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
+)
+
+// ErrNoClient is returned by Client/ClientProvider while the presence is in its
+// wait-state (no Bot token yet), so a Voice Session cycle that borrows the shared
+// client backs off and retries instead of dialing its own.
+var ErrNoClient = errors.New("presence: no standing Discord client yet (waiting for a Bot token)")
+
+// Store is the deployment-config read the presence needs at boot. It reads the
+// single-operator latest config, tenant-unscoped, because the standing presence
+// starts before any request (no tenant context) — see
+// storage.GetLatestDeploymentConfig.
+type Store interface {
+	GetLatestDeploymentConfig(ctx context.Context) (storage.DeploymentConfig, error)
+}
+
+// ClientBuilder constructs the standing disgo client for a Bot token. The prod
+// default wires the SAME gateway options the voice loop used (Guilds +
+// GuildVoiceStates intents, DAVE) PLUS the interaction listeners and async event
+// delivery; a test injects a fake that returns a sentinel without dialing
+// Discord.
+type ClientBuilder func(token string) (*bot.Client, error)
+
+// commandRegistrar performs the per-Guild command registration (SetGuildCommands
+// PUT). Injected so Ensure is unit-tested without a live REST client; nil defs
+// clears a Guild.
+type commandRegistrar func(ctx context.Context, client *bot.Client, guildID string, defs []discord.ApplicationCommandCreate) error
+
+// Presence is the boot-owned standing gateway + command surface. It is created
+// once at web-tier boot and lives for the process; Ensure is called at boot and
+// again whenever the deployment config changes (the RPC refresher).
+type Presence struct {
+	store    Store
+	cipher   *crypto.Cipher
+	reg      *Registry
+	envToken string
+	log      *slog.Logger
+
+	// Injected seams (prod defaults set in New; tests override).
+	build       ClientBuilder
+	open        func(ctx context.Context, client *bot.Client) error
+	register    commandRegistrar
+	closeClient func(client *bot.Client)
+
+	mu      sync.Mutex
+	client  *bot.Client
+	token   string // token the current client was built with
+	guildID string // last-ensured configured Guild ("" in wait-state)
+}
+
+// New builds a Presence. envToken is the DISCORD_BOT_TOKEN fallback (the
+// deployment-shared Bot); reg is the command surface registered before the first
+// Ensure.
+func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log *slog.Logger) *Presence {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	p := &Presence{
+		store:    store,
+		cipher:   cipher,
+		reg:      reg,
+		envToken: envToken,
+		log:      log,
+	}
+	p.build = defaultClientBuilder(reg, log)
+	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
+	p.register = restRegister
+	p.closeClient = func(client *bot.Client) { client.Close(context.Background()) }
+	return p
+}
+
+// Ensure reconciles the standing client and command registration against the
+// current deployment config. It is lazy and idempotent, serialized under p.mu:
+//
+//   - no config / no token: a wait-state — log and return nil (NOT an error), so
+//     a bad or absent token never kills the web tier.
+//   - token changed (or first token): close the old client, build + open a new
+//     one.
+//   - Guild changed or the client was (re)built: PUT the command definitions to
+//     the configured Guild (idempotent) and best-effort clear the old Guild.
+//
+// A repeat Ensure with the same token and Guild does nothing.
+func (p *Presence) Ensure(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	dep, err := p.store.GetLatestDeploymentConfig(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		p.log.Info("presence: no deployment config yet; standing by for a Bot token")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("presence: load deployment config: %w", err)
+	}
+
+	token, err := wirenpc.ResolveDiscordToken(p.cipher, dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext, p.envToken)
+	if err != nil {
+		return fmt.Errorf("presence: resolve Discord bot token: %w", err)
+	}
+	if token == "" {
+		p.log.Info("presence: no Bot token yet; standing by")
+		return nil
+	}
+
+	rebuilt := false
+	if p.client == nil || token != p.token {
+		if p.client != nil {
+			p.closeClient(p.client)
+			p.client = nil
+		}
+		client, err := p.build(token)
+		if err != nil {
+			return fmt.Errorf("presence: build Discord client: %w", err)
+		}
+		if err := p.open(ctx, client); err != nil {
+			p.closeClient(client)
+			return fmt.Errorf("presence: open gateway: %w", err)
+		}
+		p.client = client
+		p.token = token
+		rebuilt = true
+		p.log.Info("presence: standing Discord gateway up")
+	}
+
+	guild := dep.GuildID
+	oldGuild := p.guildID
+	if guild != "" && (rebuilt || guild != oldGuild) {
+		if oldGuild != "" && oldGuild != guild {
+			if err := p.register(ctx, p.client, oldGuild, nil); err != nil {
+				p.log.Warn("presence: clear old guild commands", "guild", oldGuild, "err", err)
+			}
+		}
+		if err := p.register(ctx, p.client, guild, p.reg.Definitions()); err != nil {
+			return fmt.Errorf("presence: register guild commands: %w", err)
+		}
+		p.log.Info("presence: registered slash commands", "guild", guild)
+	}
+	p.guildID = guild
+	return nil
+}
+
+// GuildID is the last-ensured configured Guild, "" while in the wait-state. It
+// backs the Gate's Guild check.
+func (p *Presence) GuildID() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.guildID
+}
+
+// Client returns the standing shared client, or ErrNoClient in the wait-state.
+func (p *Presence) Client() (*bot.Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.client == nil {
+		return nil, ErrNoClient
+	}
+	return p.client, nil
+}
+
+// ClientProvider adapts the presence to the wirenpc shared-client seam: each
+// Voice Session cycle borrows this one client instead of dialing its own. A
+// wait-state returns ErrNoClient, which the reconnect loop treats as a transient
+// failure and retries (self-healing across presence rebuilds).
+func (p *Presence) ClientProvider() wirenpc.ClientProvider {
+	return func(context.Context) (*bot.Client, error) {
+		return p.Client()
+	}
+}
+
+// Close tears down the standing client. Called after the voice Manager's
+// shutdown so a live session releases the shared client first.
+func (p *Presence) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.client != nil {
+		p.closeClient(p.client)
+		p.client = nil
+	}
+}
+
+// defaultClientBuilder is the production ClientBuilder: it constructs the shared
+// disgo client with the SAME options the per-session voice wiring used (so a
+// shared-client Voice Session keeps its DAVE encryption and voice-state intents,
+// ADR-0006) plus the interaction listeners and async event delivery.
+func defaultClientBuilder(reg *Registry, log *slog.Logger) ClientBuilder {
+	return func(token string) (*bot.Client, error) {
+		return disgo.New(token,
+			bot.WithLogger(log),
+			bot.WithDefaultGateway(),
+			// Guilds + GuildVoiceStates are the minimum for the voice join path
+			// (see wirenpc.connectAndServe); DAVE is wired at construction.
+			bot.WithGatewayConfigOpts(gateway.WithIntents(
+				gateway.IntentGuilds|gateway.IntentGuildVoiceStates,
+			)),
+			gxvoice.DaveOption(),
+			bot.WithEventListenerFunc(reg.HandleCommand),
+			bot.WithEventListenerFunc(reg.HandleAutocomplete),
+			// Deliver events asynchronously so an interaction handler never runs on
+			// the gateway read goroutine and starves voice events (ADR-0010).
+			bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled()),
+		)
+	}
+}
+
+// restRegister is the production commandRegistrar: an idempotent per-Guild PUT.
+func restRegister(ctx context.Context, client *bot.Client, guildID string, defs []discord.ApplicationCommandCreate) error {
+	gid, err := snowflake.Parse(guildID)
+	if err != nil {
+		return fmt.Errorf("presence: parse guild id %q: %w", guildID, err)
+	}
+	if _, err := client.Rest.SetGuildCommands(client.ApplicationID, gid, defs, rest.WithCtx(ctx)); err != nil {
+		return fmt.Errorf("presence: set guild commands: %w", err)
+	}
+	return nil
+}

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/disgoorg/disgo"
 	"github.com/disgoorg/disgo/bot"
@@ -68,10 +69,15 @@ type Presence struct {
 	register    commandRegistrar
 	closeClient func(client *bot.Client)
 
+	// mu serializes Ensure/Close so builds and registrations never overlap; token
+	// is Ensure-local state guarded by it. The read-hot client and guildID are
+	// ATOMICS, not mu-guarded, so the Gate's GuildID() and the voice loop's
+	// Client() never block on a rebuild that holds mu across OpenGateway +
+	// SetGuildCommands REST (seconds of network I/O).
 	mu      sync.Mutex
-	client  *bot.Client
-	token   string // token the current client was built with
-	guildID string // last-ensured configured Guild ("" in wait-state)
+	token   string                     // token the current client was built with
+	client  atomic.Pointer[bot.Client] // nil = wait-state
+	guildID atomic.Value               // string; last-ensured configured Guild ("" in wait-state)
 }
 
 // New builds a Presence. envToken is the DISCORD_BOT_TOKEN fallback (the
@@ -88,6 +94,7 @@ func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log
 		envToken: envToken,
 		log:      log,
 	}
+	p.guildID.Store("")
 	p.build = defaultClientBuilder(reg, log)
 	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
 	p.register = restRegister
@@ -129,66 +136,87 @@ func (p *Presence) Ensure(ctx context.Context) error {
 	}
 
 	rebuilt := false
-	if p.client == nil || token != p.token {
-		if p.client != nil {
-			p.closeClient(p.client)
-			p.client = nil
+	client := p.client.Load()
+	if client == nil || token != p.token {
+		if old := p.client.Load(); old != nil {
+			p.closeClient(old)
+			p.client.Store(nil)
 		}
-		client, err := p.build(token)
+		c, err := p.build(token)
 		if err != nil {
 			return fmt.Errorf("presence: build Discord client: %w", err)
 		}
-		if err := p.open(ctx, client); err != nil {
-			p.closeClient(client)
+		if err := p.open(ctx, c); err != nil {
+			p.closeClient(c)
 			return fmt.Errorf("presence: open gateway: %w", err)
 		}
-		p.client = client
+		client = c
+		p.client.Store(c)
 		p.token = token
 		rebuilt = true
 		p.log.Info("presence: standing Discord gateway up")
 	}
 
 	guild := dep.GuildID
-	oldGuild := p.guildID
-	if guild != "" && (rebuilt || guild != oldGuild) {
+	oldGuild, _ := p.guildID.Load().(string)
+	switch {
+	case guild == "":
+		// The Guild was cleared while a token is still configured: best-effort
+		// remove the commands from the old Guild so a stale /roll doesn't linger.
+		if oldGuild != "" {
+			if err := p.register(ctx, client, oldGuild, nil); err != nil {
+				p.log.Warn("presence: clear commands from removed guild", "guild", oldGuild, "err", err)
+			}
+		}
+	case rebuilt || guild != oldGuild:
 		if oldGuild != "" && oldGuild != guild {
-			if err := p.register(ctx, p.client, oldGuild, nil); err != nil {
+			if err := p.register(ctx, client, oldGuild, nil); err != nil {
 				p.log.Warn("presence: clear old guild commands", "guild", oldGuild, "err", err)
 			}
 		}
-		if err := p.register(ctx, p.client, guild, p.reg.Definitions()); err != nil {
+		if err := p.register(ctx, client, guild, p.reg.Definitions()); err != nil {
 			return fmt.Errorf("presence: register guild commands: %w", err)
 		}
 		p.log.Info("presence: registered slash commands", "guild", guild)
 	}
-	p.guildID = guild
+	p.guildID.Store(guild)
 	return nil
 }
 
 // GuildID is the last-ensured configured Guild, "" while in the wait-state. It
-// backs the Gate's Guild check.
+// backs the Gate's Guild check and reads an atomic, so an in-flight interaction
+// never blocks on a token rebuild that holds mu across REST calls.
 func (p *Presence) GuildID() string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.guildID
+	v, _ := p.guildID.Load().(string)
+	return v
 }
 
 // Client returns the standing shared client, or ErrNoClient in the wait-state.
+// It reads an atomic, so the voice loop's acquireClient never blocks on a
+// rebuild in progress.
 func (p *Presence) Client() (*bot.Client, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.client == nil {
+	c := p.client.Load()
+	if c == nil {
 		return nil, ErrNoClient
 	}
-	return p.client, nil
+	return c, nil
 }
 
 // ClientProvider adapts the presence to the wirenpc shared-client seam: each
-// Voice Session cycle borrows this one client instead of dialing its own. A
-// wait-state returns ErrNoClient, which the reconnect loop treats as a transient
-// failure and retries (self-healing across presence rebuilds).
+// Voice Session cycle borrows this one client instead of dialing its own. When
+// the presence is in the wait-state (never ensured, or a prior Ensure failed on
+// a Discord blip), the provider re-runs Ensure so the standing client self-heals
+// on the next Voice Session cycle instead of staying dead until a restart —
+// runWithReconnect's backoff paces the retries. A still-failing Ensure surfaces
+// its error, which the reconnect loop treats as transient.
 func (p *Presence) ClientProvider() wirenpc.ClientProvider {
-	return func(context.Context) (*bot.Client, error) {
+	return func(ctx context.Context) (*bot.Client, error) {
+		if c, err := p.Client(); err == nil {
+			return c, nil
+		}
+		if err := p.Ensure(ctx); err != nil {
+			return nil, err
+		}
 		return p.Client()
 	}
 }
@@ -198,9 +226,9 @@ func (p *Presence) ClientProvider() wirenpc.ClientProvider {
 func (p *Presence) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.client != nil {
-		p.closeClient(p.client)
-		p.client = nil
+	if c := p.client.Load(); c != nil {
+		p.closeClient(c)
+		p.client.Store(nil)
 	}
 }
 

--- a/internal/presence/presence_selfheal_test.go
+++ b/internal/presence/presence_selfheal_test.go
@@ -1,0 +1,108 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/discord"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+func savedTokenDep(t *testing.T, cipher *crypto.Cipher, guild, tok string) storage.DeploymentConfig {
+	t.Helper()
+	ct, err := cipher.Seal([]byte(tok))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return storage.DeploymentConfig{GuildID: guild, DiscordBotTokenCiphertext: ct, DiscordBotTokenLast4: crypto.Last4(tok)}
+}
+
+// TestClientProviderReEnsuresAfterFailure pins issue #2: a boot-time Discord blip
+// leaves the presence in the wait-state, but the next Voice Session cycle's
+// ClientProvider call re-runs Ensure and self-heals — the presence is not stuck
+// dead (and every Voice Session silently failing) until a restart.
+func TestClientProviderReEnsuresAfterFailure(t *testing.T) {
+	cipher, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	store := &fakePresenceStore{dep: savedTokenDep(t, cipher, "G1", "tok")}
+	reg := NewRegistry(NewGate(auth.ParseOperatorAllowlist(""), fixedGuild("")), nil)
+	reg.Register(Command{Path: "roll", Description: "Roll dice"})
+	p := New(store, cipher, reg, "", nil)
+
+	opens := 0
+	p.open = func(context.Context, *bot.Client) error {
+		opens++
+		if opens == 1 {
+			return errors.New("discord blip at boot")
+		}
+		return nil
+	}
+	p.build = func(string) (*bot.Client, error) { return &bot.Client{}, nil }
+	p.register = func(context.Context, *bot.Client, string, []discord.ApplicationCommandCreate) error { return nil }
+	p.closeClient = func(*bot.Client) {}
+
+	// Boot Ensure fails on the blip → wait-state.
+	if err := p.Ensure(context.Background()); err == nil {
+		t.Fatal("first Ensure = nil, want the open error")
+	}
+	if _, err := p.Client(); !errors.Is(err, ErrNoClient) {
+		t.Fatalf("after failed Ensure = %v, want ErrNoClient (wait-state)", err)
+	}
+
+	// The next Voice Session cycle's ClientProvider re-runs Ensure → success.
+	c, err := p.ClientProvider()(context.Background())
+	if err != nil {
+		t.Fatalf("ClientProvider after failure: %v", err)
+	}
+	if c == nil {
+		t.Fatal("ClientProvider returned a nil client after re-Ensure")
+	}
+	if opens != 2 {
+		t.Errorf("open calls = %d, want 2 (fail at boot, succeed via provider re-Ensure)", opens)
+	}
+}
+
+// TestEnsureClearsCommandsWhenGuildRemoved pins issue #5: clearing the Guild
+// (G1 → "") while a token is still configured must remove the stale commands
+// from the old Guild, not silently skip the register block.
+func TestEnsureClearsCommandsWhenGuildRemoved(t *testing.T) {
+	cipher, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	store := &fakePresenceStore{dep: savedTokenDep(t, cipher, "G1", "tok")}
+	reg := NewRegistry(NewGate(auth.ParseOperatorAllowlist(""), fixedGuild("")), nil)
+	reg.Register(Command{Path: "roll", Description: "Roll dice"})
+	p := New(store, cipher, reg, "", nil)
+
+	var regs []regCall
+	p.build = func(string) (*bot.Client, error) { return &bot.Client{}, nil }
+	p.open = func(context.Context, *bot.Client) error { return nil }
+	p.closeClient = func(*bot.Client) {}
+	p.register = func(_ context.Context, _ *bot.Client, guild string, defs []discord.ApplicationCommandCreate) error {
+		regs = append(regs, regCall{guild: guild, defsLen: len(defs), cleared: defs == nil})
+		return nil
+	}
+
+	mustEnsure(t, p)
+	if len(regs) != 1 || regs[0].guild != "G1" || regs[0].cleared {
+		t.Fatalf("initial regs = %+v, want one full G1", regs)
+	}
+
+	// Guild removed, token still present.
+	store.dep.GuildID = ""
+	mustEnsure(t, p)
+	if p.GuildID() != "" {
+		t.Errorf("GuildID after clear = %q, want empty", p.GuildID())
+	}
+	if len(regs) != 2 || !regs[1].cleared || regs[1].guild != "G1" {
+		t.Errorf("clear regs = %+v, want a clear (nil defs) of the removed G1", regs)
+	}
+}

--- a/internal/presence/presence_test.go
+++ b/internal/presence/presence_test.go
@@ -1,0 +1,162 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/discord"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+type fakePresenceStore struct {
+	dep storage.DeploymentConfig
+	err error
+}
+
+func (f *fakePresenceStore) GetLatestDeploymentConfig(context.Context) (storage.DeploymentConfig, error) {
+	return f.dep, f.err
+}
+
+// regCall records one commandRegistrar invocation.
+type regCall struct {
+	guild   string
+	defsLen int
+	cleared bool // nil defs = clear-old-Guild
+}
+
+func mustEnsure(t *testing.T, p *Presence) {
+	t.Helper()
+	if err := p.Ensure(context.Background()); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+}
+
+func TestPresenceEnsureLifecycle(t *testing.T) {
+	cipher, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	seal := func(tok string) (ct []byte, last4 string) {
+		c, err := cipher.Seal([]byte(tok))
+		if err != nil {
+			t.Fatalf("seal: %v", err)
+		}
+		return c, crypto.Last4(tok)
+	}
+
+	store := &fakePresenceStore{err: storage.ErrNotFound}
+	reg := NewRegistry(NewGate(auth.ParseOperatorAllowlist(""), fixedGuild("")), nil)
+	reg.Register(Command{Path: "roll", Description: "Roll dice"})
+	wantDefs := len(reg.Definitions())
+
+	p := New(store, cipher, reg, "", nil) // envToken "" so the token comes only from the saved config
+
+	var builds []*bot.Client
+	var opens int
+	var closed []*bot.Client
+	var regs []regCall
+	p.build = func(string) (*bot.Client, error) {
+		c := &bot.Client{}
+		builds = append(builds, c)
+		return c, nil
+	}
+	p.open = func(context.Context, *bot.Client) error { opens++; return nil }
+	p.closeClient = func(c *bot.Client) { closed = append(closed, c) }
+	p.register = func(_ context.Context, _ *bot.Client, guild string, defs []discord.ApplicationCommandCreate) error {
+		regs = append(regs, regCall{guild: guild, defsLen: len(defs), cleared: defs == nil})
+		return nil
+	}
+
+	// 1. No config → wait-state: no build, no register, nil error.
+	mustEnsure(t, p)
+	if len(builds) != 0 || len(regs) != 0 {
+		t.Fatalf("no-config: builds=%d regs=%d, want 0/0", len(builds), len(regs))
+	}
+	if _, err := p.Client(); !errors.Is(err, ErrNoClient) {
+		t.Errorf("Client in wait-state = %v, want ErrNoClient", err)
+	}
+	if p.GuildID() != "" {
+		t.Errorf("GuildID in wait-state = %q, want empty", p.GuildID())
+	}
+
+	// 2. Config but no token (nothing saved, empty envToken) → still wait-state.
+	store.err = nil
+	store.dep = storage.DeploymentConfig{GuildID: "G1"}
+	mustEnsure(t, p)
+	if len(builds) != 0 {
+		t.Fatalf("no-token: builds=%d, want 0", len(builds))
+	}
+
+	// 3. A saved token appears → one build + open + one full register of G1.
+	ctA, l4A := seal("tok-A")
+	store.dep = storage.DeploymentConfig{GuildID: "G1", DiscordBotTokenCiphertext: ctA, DiscordBotTokenLast4: l4A}
+	mustEnsure(t, p)
+	if len(builds) != 1 || opens != 1 {
+		t.Fatalf("first token: builds=%d opens=%d, want 1/1", len(builds), opens)
+	}
+	if len(regs) != 1 || regs[0].guild != "G1" || regs[0].cleared || regs[0].defsLen != wantDefs {
+		t.Fatalf("first register = %+v, want one full G1 with %d defs", regs, wantDefs)
+	}
+	if got, err := p.Client(); err != nil || got != builds[0] {
+		t.Errorf("Client = %v/%v, want the built client", got, err)
+	}
+	if p.GuildID() != "G1" {
+		t.Errorf("GuildID = %q, want G1", p.GuildID())
+	}
+
+	// 4. Idempotent repeat: same token + Guild → zero new calls.
+	mustEnsure(t, p)
+	if len(builds) != 1 || opens != 1 || len(regs) != 1 {
+		t.Fatalf("idempotent repeat: builds=%d opens=%d regs=%d, want 1/1/1", len(builds), opens, len(regs))
+	}
+
+	// 5. Guild change only → re-register, no rebuild, clear the old Guild.
+	store.dep.GuildID = "G2"
+	mustEnsure(t, p)
+	if len(builds) != 1 {
+		t.Fatalf("guild change rebuilt the client: builds=%d, want 1", len(builds))
+	}
+	if len(regs) != 3 {
+		t.Fatalf("guild change regs=%d, want 3 (clear G1 + full G2)", len(regs))
+	}
+	if !regs[1].cleared || regs[1].guild != "G1" {
+		t.Errorf("regs[1] = %+v, want a clear of old Guild G1", regs[1])
+	}
+	if regs[2].cleared || regs[2].guild != "G2" || regs[2].defsLen != wantDefs {
+		t.Errorf("regs[2] = %+v, want a full register of G2", regs[2])
+	}
+
+	// 6. Token change → close old client + rebuild + register.
+	ctB, l4B := seal("tok-B")
+	store.dep = storage.DeploymentConfig{GuildID: "G2", DiscordBotTokenCiphertext: ctB, DiscordBotTokenLast4: l4B}
+	mustEnsure(t, p)
+	if len(builds) != 2 {
+		t.Fatalf("token change builds=%d, want 2", len(builds))
+	}
+	if len(closed) != 1 || closed[0] != builds[0] {
+		t.Fatalf("token change closed=%v, want the old client closed exactly once", closed)
+	}
+	if len(regs) != 4 || regs[3].guild != "G2" || regs[3].cleared {
+		t.Errorf("regs[3] = %+v, want a full re-register of G2 after rebuild", regs)
+	}
+
+	// ClientProvider hands out the current standing client.
+	cp := p.ClientProvider()
+	if c, err := cp(context.Background()); err != nil || c != builds[1] {
+		t.Errorf("ClientProvider = %v/%v, want the rebuilt client", c, err)
+	}
+
+	// Close tears the client down and returns to the wait-state.
+	p.Close()
+	if len(closed) != 2 || closed[1] != builds[1] {
+		t.Errorf("Close did not close the standing client: closed=%v", closed)
+	}
+	if _, err := p.Client(); !errors.Is(err, ErrNoClient) {
+		t.Errorf("Client after Close = %v, want ErrNoClient", err)
+	}
+}

--- a/internal/presence/roll.go
+++ b/internal/presence/roll.go
@@ -85,15 +85,18 @@ func parseDiceExpr(expr string) (count, sides int, err error) {
 	return count, sides, nil
 }
 
-// parseNonNegative parses a base-10 non-negative integer, rejecting signs and
-// any non-digit so "+2" / "-2" / "2x" never slip through as a valid dice count.
+// parseNonNegative parses a base-10 non-negative integer. It rejects anything
+// that is not purely digits BEFORE strconv.Atoi, because Atoi accepts a leading
+// sign — so this is what makes "+2" / "-2" / "2x" malformed dice parts rather
+// than sneaking through as a count.
 func parseNonNegative(s string) (int, error) {
-	n, err := strconv.Atoi(s)
-	if err != nil {
-		return 0, err
+	if s == "" {
+		return 0, fmt.Errorf("empty number")
 	}
-	if n < 0 {
-		return 0, fmt.Errorf("negative value %d", n)
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("non-digit %q in %q", r, s)
+		}
 	}
-	return n, nil
+	return strconv.Atoi(s)
 }

--- a/internal/presence/roll.go
+++ b/internal/presence/roll.go
@@ -1,0 +1,99 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/disgoorg/disgo/discord"
+
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// RollCommand builds the /roll slash command (ADR-0010: anyone in the configured
+// Guild). It parses an NdM dice expression and answers with the result of the
+// built-in Dice Tool (pkg/tool.Dice) — the SAME code the Agent tool-use loop
+// rolls with, never a re-implementation. A malformed expression or an
+// out-of-bounds roll is answered with a graceful ephemeral hint, and the handler
+// returns nil (a domain error, not an unexpected failure).
+func RollCommand(dice *tool.Dice) Command {
+	return Command{
+		Path:        "roll",
+		Description: "Roll dice, e.g. 2d6 or d20.",
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{
+				Name:        "dice",
+				Description: "Dice expression like 2d6 or d20.",
+				Required:    true,
+			},
+		},
+		GMOnly: false,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			expr, _ := ic.String("dice")
+			count, sides, err := parseDiceExpr(expr)
+			if err != nil {
+				return ic.ReplyEphemeral(rollHint(expr))
+			}
+			args, err := json.Marshal(struct {
+				Count int `json:"count"`
+				Sides int `json:"sides"`
+			}{count, sides})
+			if err != nil {
+				return err // marshalling two ints cannot fail; propagate if it ever does
+			}
+			// The Dice Tool re-validates the bounds it declares (count 1..100,
+			// sides 2..1000); an out-of-range NdM comes back as an error we turn
+			// into the same graceful hint rather than a crash or silent drop.
+			result, err := dice.Execute(ctx, args, nil)
+			if err != nil {
+				return ic.ReplyEphemeral(rollHint(expr))
+			}
+			return ic.Reply(result)
+		},
+	}
+}
+
+// rollHint is the graceful error reply for an unrollable expression.
+func rollHint(expr string) string {
+	return fmt.Sprintf("Can't roll %q — use NdM like 2d6 (N optional, e.g. d20).", expr)
+}
+
+// parseDiceExpr parses an "NdM" dice expression into (count, sides). N is
+// optional and defaults to 1 (so "d20" == "1d20"); both parts, when present,
+// must be non-negative integers. It validates only the SHAPE — numeric range
+// bounds are the Dice Tool's job (single source of truth, ADR-0028), so "0d6" /
+// "101d6" / "2d1" parse cleanly here and are rejected by dice.Execute.
+func parseDiceExpr(expr string) (count, sides int, err error) {
+	s := strings.ToLower(strings.TrimSpace(expr))
+	left, right, found := strings.Cut(s, "d")
+	if !found || right == "" {
+		return 0, 0, fmt.Errorf("presence: %q is not an NdM dice expression", expr)
+	}
+	count = 1
+	if left != "" {
+		count, err = parseNonNegative(left)
+		if err != nil {
+			return 0, 0, fmt.Errorf("presence: dice count in %q: %w", expr, err)
+		}
+	}
+	sides, err = parseNonNegative(right)
+	if err != nil {
+		return 0, 0, fmt.Errorf("presence: dice sides in %q: %w", expr, err)
+	}
+	return count, sides, nil
+}
+
+// parseNonNegative parses a base-10 non-negative integer, rejecting signs and
+// any non-digit so "+2" / "-2" / "2x" never slip through as a valid dice count.
+func parseNonNegative(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("negative value %d", n)
+	}
+	return n, nil
+}

--- a/internal/presence/roll_test.go
+++ b/internal/presence/roll_test.go
@@ -1,0 +1,88 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// seededDicePair returns two Dice sharing one deterministic PCG seed: rolling the
+// same NdM on each yields identical output, so a test can compare the /roll
+// handler's reply against the Dice Tool's exact string without advancing the
+// roller under test.
+func seededDicePair() (underTest, oracle *tool.Dice) {
+	const s1, s2 = 0x9e3779b97f4a7c15, 0xbf58476d1ce4e5b9
+	return tool.NewDiceWithRand(rand.New(rand.NewPCG(s1, s2))),
+		tool.NewDiceWithRand(rand.New(rand.NewPCG(s1, s2)))
+}
+
+func runRoll(t *testing.T, dice *tool.Dice, expr string) *fakeResponder {
+	t.Helper()
+	cmd := RollCommand(dice)
+	resp := &fakeResponder{}
+	ic := &Interaction{guildID: testGuild, userID: strangerID, opts: fakeOpts{s: map[string]string{"dice": expr}}, resp: resp}
+	if err := cmd.Handle(context.Background(), ic); err != nil {
+		t.Fatalf("roll %q returned error %v; handler must own its reply and return nil", expr, err)
+	}
+	return resp
+}
+
+func oracleRoll(t *testing.T, oracle *tool.Dice, count, sides int) string {
+	t.Helper()
+	args, _ := json.Marshal(struct {
+		Count int `json:"count"`
+		Sides int `json:"sides"`
+	}{count, sides})
+	out, err := oracle.Execute(context.Background(), args, nil)
+	if err != nil {
+		t.Fatalf("oracle roll %dd%d: %v", count, sides, err)
+	}
+	return out
+}
+
+func TestRollValidPublicReply(t *testing.T) {
+	underTest, oracle := seededDicePair()
+	resp := runRoll(t, underTest, "2d6")
+
+	want := oracleRoll(t, oracle, 2, 6)
+	if len(resp.replies) != 1 {
+		t.Fatalf("replies = %+v, want exactly one", resp.replies)
+	}
+	got := resp.replies[0]
+	if got.ephemeral {
+		t.Errorf("valid roll replied ephemerally; a result is public")
+	}
+	if got.content != want {
+		t.Errorf("reply = %q, want the Dice Tool's exact string %q", got.content, want)
+	}
+}
+
+func TestRollDefaultCountIsOne(t *testing.T) {
+	underTest, oracle := seededDicePair()
+	resp := runRoll(t, underTest, "d20")
+
+	want := oracleRoll(t, oracle, 1, 20) // "d20" == "1d20"
+	if len(resp.replies) != 1 || resp.replies[0].content != want {
+		t.Fatalf("d20 reply = %+v, want %q (count defaults to 1)", resp.replies, want)
+	}
+}
+
+func TestRollMalformedAndOutOfBoundsAreGraceful(t *testing.T) {
+	for _, expr := range []string{"banana", "0d6", "2d1", "101d6", "", "d", "2d"} {
+		underTest, _ := seededDicePair()
+		resp := runRoll(t, underTest, expr)
+		if len(resp.replies) != 1 {
+			t.Fatalf("%q: replies = %+v, want one graceful reply", expr, resp.replies)
+		}
+		if !resp.replies[0].ephemeral {
+			t.Errorf("%q: error reply must be ephemeral", expr)
+		}
+		if !strings.Contains(resp.replies[0].content, "NdM") {
+			t.Errorf("%q: reply = %q, want an NdM usage hint", expr, resp.replies[0].content)
+		}
+	}
+}

--- a/internal/presence/roll_test.go
+++ b/internal/presence/roll_test.go
@@ -72,7 +72,9 @@ func TestRollDefaultCountIsOne(t *testing.T) {
 }
 
 func TestRollMalformedAndOutOfBoundsAreGraceful(t *testing.T) {
-	for _, expr := range []string{"banana", "0d6", "2d1", "101d6", "", "d", "2d"} {
+	// Includes signed parts ("+2d6", "2d+6", "-1d6") — a dice count/sides is plain
+	// digits, so a leading sign is malformed (issue #6: parse and comment agree).
+	for _, expr := range []string{"banana", "0d6", "2d1", "101d6", "", "d", "2d", "+2d6", "2d+6", "-1d6", "2d6d8"} {
 		underTest, _ := seededDicePair()
 		resp := runRoll(t, underTest, expr)
 		if len(resp.replies) != 1 {

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -75,6 +75,12 @@ type ProviderServer struct {
 	// credential save (#150), so a cached Degraded badge cannot outlive the
 	// fixed key for up to a TTL. nil (not wired) skips.
 	invalidateHealth func(tenantID uuid.UUID)
+
+	// refreshPresence reconciles the standing Discord presence after a Discord
+	// settings change (#102), so a newly-saved Bot token / Guild registers the
+	// slash-command surface without a restart. Fired in a goroutine (presence
+	// Ensure does network I/O). nil (web-only, or not wired) skips.
+	refreshPresence func()
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -94,6 +100,15 @@ func NewProviderServer(store providerStore, cipher *crypto.Cipher, log *slog.Log
 // lock is needed.
 func (s *ProviderServer) SetHealthInvalidator(fn func(tenantID uuid.UUID)) {
 	s.invalidateHealth = fn
+}
+
+// SetPresenceRefresher wires the standing-presence reconciler fired after a
+// successful SaveDiscordSettings (#102), mirroring SetHealthInvalidator. Called
+// once at boot, before the server serves, so no lock is needed. fn is invoked in
+// a goroutine because presence.Ensure does network I/O (OpenGateway) that must
+// not block the RPC response.
+func (s *ProviderServer) SetPresenceRefresher(fn func()) {
+	s.refreshPresence = fn
 }
 
 // Handler builds the Connect HTTP handler for ProviderService and returns its
@@ -281,6 +296,14 @@ func (s *ProviderServer) SaveDiscordSettings(
 	// verdict so the next health call probes with the new state (#150).
 	if s.invalidateHealth != nil {
 		s.invalidateHealth(tenantID)
+	}
+
+	// Reconcile the standing presence out-of-band so the new token / Guild
+	// registers the slash-command surface without a restart (#102). Only after a
+	// successful save — the error returns above skip it. In a goroutine because
+	// Ensure opens a gateway (network I/O) and must not block this response.
+	if s.refreshPresence != nil {
+		go s.refreshPresence()
 	}
 
 	return connect.NewResponse(&managementv1.SaveDiscordSettingsResponse{

--- a/internal/rpc/provider_presence_test.go
+++ b/internal/rpc/provider_presence_test.go
@@ -1,0 +1,67 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+)
+
+// TestProviderPresenceRefresher pins #102: a successful SaveDiscordSettings fires
+// the presence refresher (so the new token/Guild registers the slash-command
+// surface without a restart), and a REJECTED save does not.
+func TestProviderPresenceRefresher(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	fired := make(chan struct{}, 4)
+	srv.SetPresenceRefresher(func() { fired <- struct{}{} })
+
+	tenantID := uuid.New()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(auth.WithTenant(ctx, tenantID), req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	client := managementv1connect.NewProviderServiceClient(http.DefaultClient, ts.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	// Successful save (token + channels) → refresher fires.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken:       strPtr("some-discord-bot-token-1234"),
+		GuildId:        strPtr("472093001100"),
+		VoiceChannelId: strPtr("472093774421"),
+	})); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("presence refresher did not fire after a successful save")
+	}
+
+	// Rejected save (present-but-empty IDs) → refresher must NOT fire.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		GuildId: strPtr(""), VoiceChannelId: strPtr(""),
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("empty IDs code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	select {
+	case <-fired:
+		t.Fatal("presence refresher fired after a rejected save")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/storage/configuration_test.go
+++ b/internal/storage/configuration_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -155,6 +157,57 @@ func TestDeploymentConfigTokenAndChannels(t *testing.T) {
 	}
 	if idRow.GuildID != "999" || idRow.VoiceChannelID != "888" {
 		t.Errorf("channels not updated: %+v", idRow)
+	}
+}
+
+// TestGetLatestDeploymentConfig asserts the standing presence's boot read (#102,
+// ADR-0010): no row yields ErrNotFound, a saved config is returned, and with more
+// than one deployment_config row the most-recently-updated one wins (the
+// single-operator "latest", tenant-unscoped like GetActiveCampaign).
+func TestGetLatestDeploymentConfig(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Empty → ErrNotFound.
+	if _, err := st.GetLatestDeploymentConfig(ctx); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("get latest on empty: got %v, want ErrNotFound", err)
+	}
+
+	// One tenant's config.
+	if _, err := st.SaveDiscordChannels(ctx, tenantID, "472093001100", "472093774421"); err != nil {
+		t.Fatalf("save channels: %v", err)
+	}
+	if _, err := st.SaveDiscordBotToken(ctx, tenantID, []byte{0x01, 0x99}, "tok1"); err != nil {
+		t.Fatalf("save token: %v", err)
+	}
+	got, err := st.GetLatestDeploymentConfig(ctx)
+	if err != nil {
+		t.Fatalf("get latest: %v", err)
+	}
+	if got.TenantID != tenantID || got.GuildID != "472093001100" || got.DiscordBotTokenLast4 != "tok1" {
+		t.Fatalf("latest = %+v, want the saved single-tenant config", got)
+	}
+
+	// A second tenant with a strictly-newer deployment_config must win "latest".
+	var tenant2 uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenant (name) VALUES ('Beta TTRPG') RETURNING id`).Scan(&tenant2); err != nil {
+		t.Fatalf("insert tenant2: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO deployment_config (tenant_id, guild_id, voice_channel_id, updated_at)
+		 VALUES ($1, '888888888888', '777777777777', now() + interval '1 second')`,
+		tenant2); err != nil {
+		t.Fatalf("insert tenant2 deployment_config: %v", err)
+	}
+	got, err = st.GetLatestDeploymentConfig(ctx)
+	if err != nil {
+		t.Fatalf("get latest after second tenant: %v", err)
+	}
+	if got.TenantID != tenant2 || got.GuildID != "888888888888" {
+		t.Errorf("latest = %+v, want the newer tenant2 config", got)
 	}
 }
 

--- a/internal/storage/deployment.go
+++ b/internal/storage/deployment.go
@@ -45,6 +45,29 @@ func (s *Store) GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (De
 	return d, nil
 }
 
+// GetLatestDeploymentConfig returns the most-recently-updated deployment config,
+// or ErrNotFound when none is saved. The standing presence (#102, ADR-0010)
+// reads this at boot, before any request — so, like GetActiveCampaign, it has no
+// tenant context and reads the single-operator global latest (ADR-0039). More
+// than one deployment_config row only exists under the deferred multi-tenant
+// tier; this returns the newest, and a later WHERE tenant_id = $1 narrows it
+// then (as GetDeploymentConfig already does for the request path).
+func (s *Store) GetLatestDeploymentConfig(ctx context.Context) (DeploymentConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+deploymentConfigColumns+`
+		   FROM deployment_config
+		  ORDER BY updated_at DESC, tenant_id DESC
+		  LIMIT 1`)
+	d, err := scanDeploymentConfig(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return DeploymentConfig{}, ErrNotFound
+	}
+	if err != nil {
+		return DeploymentConfig{}, fmt.Errorf("storage: get latest deployment_config: %w", err)
+	}
+	return d, nil
+}
+
 // SaveDiscordBotToken upserts only the deployment Bot token columns (sealed
 // ciphertext + last4), leaving the Guild / Voice channel IDs untouched. It
 // returns the resulting row. The ciphertext is the caller-sealed secret.

--- a/internal/wirenpc/sharedclient_test.go
+++ b/internal/wirenpc/sharedclient_test.go
@@ -1,0 +1,93 @@
+package wirenpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+func discard() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+// TestAcquireClientSharedBorrows asserts the standing-client path (#102): the
+// injected client is used as-is, reported NOT owned (so the cycle never closes
+// the presence's client), and the disgo constructor is never touched.
+func TestAcquireClientSharedBorrows(t *testing.T) {
+	orig := newDiscordClient
+	called := 0
+	newDiscordClient = func(string, ...bot.ConfigOpt) (*bot.Client, error) {
+		called++
+		return nil, errors.New("constructor must not run on the shared path")
+	}
+	defer func() { newDiscordClient = orig }()
+
+	sentinel := &bot.Client{}
+	cfg := Config{Client: func(context.Context) (*bot.Client, error) { return sentinel, nil }}
+
+	client, owned, err := acquireClient(context.Background(), cfg, discard())
+	if err != nil {
+		t.Fatalf("acquireClient(shared) err = %v", err)
+	}
+	if client != sentinel {
+		t.Errorf("acquireClient returned %p, want the injected client %p", client, sentinel)
+	}
+	if owned {
+		t.Error("shared client reported owned=true; the cycle must NOT close the presence's client")
+	}
+	if called != 0 {
+		t.Errorf("disgo constructor ran %d times on the shared path, want 0", called)
+	}
+}
+
+// TestAcquireClientSharedProviderError asserts a wait-state / rebuilding presence
+// (provider error) fails the cycle so runWithReconnect backs off and retries.
+func TestAcquireClientSharedProviderError(t *testing.T) {
+	boom := errors.New("no token yet")
+	cfg := Config{Client: func(context.Context) (*bot.Client, error) { return nil, boom }}
+
+	if _, _, err := acquireClient(context.Background(), cfg, discard()); !errors.Is(err, boom) {
+		t.Fatalf("acquireClient(shared error) = %v, want it to wrap %v", err, boom)
+	}
+}
+
+// TestAcquireClientOwnedUsesConstructor asserts the per-cycle path (cfg.Client
+// nil) still builds its own client via the disgo constructor seam.
+func TestAcquireClientOwnedUsesConstructor(t *testing.T) {
+	orig := newDiscordClient
+	boom := errors.New("bad token")
+	called := 0
+	newDiscordClient = func(string, ...bot.ConfigOpt) (*bot.Client, error) {
+		called++
+		return nil, boom
+	}
+	defer func() { newDiscordClient = orig }()
+
+	_, _, err := acquireClient(context.Background(), Config{Token: "x"}, discard())
+	if called != 1 {
+		t.Errorf("owned-path constructor calls = %d, want 1", called)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("owned-path error = %v, want it to wrap %v", err, boom)
+	}
+}
+
+// TestConnectAndServeSharedClientErrorIsCycleError asserts connectAndServe
+// surfaces the provider error (returning before it builds any pipeline), so the
+// reconnect loop retries — the self-heal across presence rebuilds.
+func TestConnectAndServeSharedClientErrorIsCycleError(t *testing.T) {
+	boom := errors.New("presence rebuilding")
+	cfg := Config{Client: func(context.Context) (*bot.Client, error) { return nil, boom }}
+
+	connectedCalls := 0
+	err := connectAndServe(context.Background(), cfg, snowflake.ID(1), snowflake.ID(2), discard(),
+		func() { connectedCalls++ })
+	if !errors.Is(err, boom) {
+		t.Fatalf("connectAndServe = %v, want it to surface the provider error %v", err, boom)
+	}
+	if connectedCalls != 0 {
+		t.Errorf("connected() fired %d times on a failed acquire, want 0", connectedCalls)
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -240,6 +240,12 @@ func hardcodedNPC() npcSpec {
 	}
 }
 
+// ClientProvider yields the standing shared Discord client a Voice Session cycle
+// borrows (ADR-0010 amendment, #102). It returns an error while the presence is
+// in its wait-state (no Bot token) or rebuilding; the reconnect loop treats that
+// as a transient failure and retries. See [Config.Client].
+type ClientProvider func(ctx context.Context) (*bot.Client, error)
+
 // Config configures a [Run] of the live NPC voice loop.
 type Config struct {
 	// Token is the Discord bot token (from DISCORD_BOT_TOKEN). Required.
@@ -248,6 +254,14 @@ type Config struct {
 	// channel to join. Required.
 	Guild   string
 	Channel string
+	// Client, when non-nil, is the standing shared Discord client the boot-owned
+	// presence owns (ADR-0010 amendment, #102): connectAndServe borrows it per
+	// cycle instead of constructing its own with disgo.New / OpenGateway, and does
+	// NOT close it at cycle end (the presence owns its lifecycle). A provider error
+	// (the presence is in its wait-state, or rebuilding) fails the cycle, so
+	// runWithReconnect backs off and retries — self-healing across presence
+	// rebuilds. nil keeps today's per-cycle client (env-only voice mode, unchanged).
+	Client ClientProvider
 	// Logger receives structured logs; nil discards them.
 	Logger *slog.Logger
 	// Metrics receives the hot-path voice counters/gauges (A2): inbound frame
@@ -450,23 +464,30 @@ func Run(ctx context.Context, cfg Config) error {
 // join-then-immediate-fail cycle keeps backing off. Any error — or a clean return (a dropped
 // gateway often reports none) — flows back to runWithReconnect, which decides
 // whether to retry; only a cancelled ctx ends the loop.
-func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func()) error {
-	// Per-cycle context: everything this cycle spawns — the stage subscriber's
-	// TTL-sweep goroutine (stageSub.Start), the Discord gateway, and the audio
-	// loop — is bound to cycleCtx, so the deferred cancel reaps it at cycle end.
-	// Without this a flapping Discord (issue #44) would leak one sweeper goroutine
-	// per reconnect: the outer ctx only ends at process shutdown. cycleCtx is a
-	// child of ctx, so a cancelled process still unwinds promptly (pipe.Run et al.
-	// observe the cancellation), and runWithReconnect checks the OUTER ctx to
-	// decide shutdown vs reconnect.
-	cycleCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+// newDiscordClient is the disgo constructor seam (mirrors newLLM/newSTT/newTTS):
+// a test swaps it to assert the owned path calls it and the shared-client path
+// does NOT. Production always uses disgo.New.
+var newDiscordClient = disgo.New
 
-	// Discord client: DAVE/MLS is wired at construction (it cannot be enabled
-	// after disgo builds its VoiceManager). DaveOption() is a no-op stub unless
-	// the binary was built with -tags dave; NewManager(WithDave(true)) then warns
-	// if encryption was expected but unavailable.
-	client, err := disgo.New(cfg.Token,
+// acquireClient yields the Discord client for one connect-and-serve cycle. When
+// cfg.Client is set it BORROWS the standing shared client (already gateway-open,
+// owned by the presence) and reports owned=false so the caller never closes it;
+// a provider error fails the cycle so runWithReconnect retries. Otherwise it
+// builds and opens a per-cycle client (today's behavior) and reports owned=true.
+func acquireClient(ctx context.Context, cfg Config, log *slog.Logger) (client *bot.Client, owned bool, err error) {
+	if cfg.Client != nil {
+		c, err := cfg.Client(ctx)
+		if err != nil {
+			return nil, false, fmt.Errorf("wirenpc: standing Discord client unavailable: %w", err)
+		}
+		return c, false, nil
+	}
+
+	// Per-cycle client: DAVE/MLS is wired at construction (it cannot be enabled
+	// after disgo builds its VoiceManager). DaveOption() is a no-op stub unless the
+	// binary was built with -tags dave; NewManager(WithDave(true)) then warns if
+	// encryption was expected but unavailable.
+	c, err := newDiscordClient(cfg.Token,
 		// Own disgo's logger explicitly (A1): route it through the same filtered
 		// app logger so the benign DAVE-decrypt noise is tamed even if disgo ever
 		// stops reading slog.Default().
@@ -482,12 +503,36 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 		gxvoice.DaveOption(),
 	)
 	if err != nil {
-		return fmt.Errorf("wirenpc: build Discord client: %w", err)
+		return nil, false, fmt.Errorf("wirenpc: build Discord client: %w", err)
 	}
-	defer client.Close(context.Background())
+	if err := c.OpenGateway(ctx); err != nil {
+		c.Close(context.Background())
+		return nil, false, fmt.Errorf("wirenpc: open gateway: %w", err)
+	}
+	return c, true, nil
+}
 
-	if err := client.OpenGateway(cycleCtx); err != nil {
-		return fmt.Errorf("wirenpc: open gateway: %w", err)
+func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func()) error {
+	// Per-cycle context: everything this cycle spawns — the stage subscriber's
+	// TTL-sweep goroutine (stageSub.Start), the Discord gateway, and the audio
+	// loop — is bound to cycleCtx, so the deferred cancel reaps it at cycle end.
+	// Without this a flapping Discord (issue #44) would leak one sweeper goroutine
+	// per reconnect: the outer ctx only ends at process shutdown. cycleCtx is a
+	// child of ctx, so a cancelled process still unwinds promptly (pipe.Run et al.
+	// observe the cancellation), and runWithReconnect checks the OUTER ctx to
+	// decide shutdown vs reconnect.
+	cycleCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Discord client: either the standing shared client the presence owns
+	// (cfg.Client, #102) or a per-cycle client this loop builds and closes. The
+	// shared client is already gateway-open and must NOT be closed here.
+	client, owned, err := acquireClient(cycleCtx, cfg, log)
+	if err != nil {
+		return err
+	}
+	if owned {
+		defer client.Close(context.Background())
 	}
 
 	mgr := gxvoice.NewManager(client,


### PR DESCRIPTION
Closes #102

## What

A boot-owned **standing Discord gateway** (ADR-0010 amendment): ONE shared disgo client — created lazily once a Bot token exists in `deployment_config`, rebuilt when the token changes — that registers the v1.0 Slash Command surface against the configured Guild **and** is shared with the voice `Manager` (no second connection per Voice Session). `/roll <NdM>` is answered directly by the Bot via the built-in Dice Tool (`pkg/tool.Dice`, not a re-implementation).

## Acceptance criteria

- **Boot registers the surface** — `runWeb` (all mode) builds the presence and `Ensure`s at boot; a saved Bot token opens the gateway and PUTs the per-Guild commands. `SetPresenceRefresher` re-registers after a Discord-settings save with no restart.
- **`/roll 2d6` → individual rolls + total** — `RollCommand` parses `NdM` (N optional → `d20` == `1d20`) and returns the Dice Tool's exact string as a public reply. Proven end-to-end against a real JSON interaction.
- **Malformed expr → graceful error** — parse or out-of-bounds (`banana`, `0d6`, `2d1`, `101d6`, …) → ephemeral `use NdM like 2d6` hint, handler returns nil. No crash, no silent drop.
- **Server-side permission check** — `Gate.CheckGuild` (interaction's Guild == configured Guild, DM denied) for `/roll`; `Gate.CheckGM` adds the operator allowlist (ADR-0041) for GM-only commands. Discord command permissions are treated as a UX hint only.
- **Presence survives with no Voice Session, doesn't break start/stop** — the client is boot-owned; `wirenpc` borrows it via `ClientProvider` and never closes it. A wait-state provider error fails the cycle so `runWithReconnect` self-heals across rebuilds. Client carries `DaveOption()` + voice intents so shared-client sessions keep DAVE; events are async so a handler never starves voice.

## Shared contract

New `internal/presence` package (Registry / Command / Interaction / Autocomplete, Gate, Presence, RollCommand) is the command-surface contract **#108 / #120 / #211** consume verbatim — implemented exactly to the architect plan.

## Tests (TDD)

`internal/presence` unit-tested to ~87% (Definitions merge, dispatch + gate denials + handler-error reply, roll happy/malformed, Ensure lifecycle across no-config / no-token / build / idempotent / guild-change / token-change, autocomplete gating + Focused, and a real-JSON `HandleCommand`/`HandleAutocomplete` end-to-end). Plus `wirenpc` shared-client seam tests (borrow vs owned, constructor-not-called, provider-error → cycle error), an `rpc` presence-refresher test (fires on success, not on rejected save), and a `storage.GetLatestDeploymentConfig` integration test. Race-clean.

Local: `go build ./...`, unit tests, `golangci-lint`, and integration-tagged compile all green (the only local failure is a pre-existing broken-Ollama live test that CI skips).