### PR TITLE
[E5] Campaign-screen Tool Grant toggles per Agent (#117)

### DIFF
--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -19,6 +19,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
 // campaignStore is the narrow storage surface CampaignServer needs — the active
@@ -42,18 +43,26 @@ type campaignStore interface {
 	NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
 	SetNodeAgent(ctx context.Context, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
 	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
+	UpsertToolGrant(ctx context.Context, g storage.NewToolGrant) error
+	DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a
-// campaignStore.
+// campaignStore. tools is the built-in Tool catalog the grant editor lists
+// (ADR-0028) — the available-Tools source for ListToolGrants and the registry
+// UpdateToolGrant validates tool_name against (#117).
 type CampaignServer struct {
 	store campaignStore
+	tools *tool.Registry
 }
 
 // NewCampaignServer wraps a campaignStore (e.g. *storage.Store) in a
-// CampaignServer.
+// CampaignServer. The available-Tools catalog is the shared built-in Registry
+// (ADR-0028), so the grants a GM can toggle are exactly the Tools a Voice Session
+// runs; nothing external configures it.
 func NewCampaignServer(s campaignStore) *CampaignServer {
-	return &CampaignServer{store: s}
+	return &CampaignServer{store: s, tools: tool.BuiltinRegistry()}
 }
 
 // compile-time assertion that CampaignServer satisfies the generated handler.

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -70,6 +71,14 @@ type fakeCampaignStore struct {
 	searchLimit   int
 	searchCalls   int
 	nodeSearchErr error
+
+	// Tool Grant state (#117): grants maps agent_id → tool_name → config blob (nil
+	// = no scope), backing the upsert/delete/list round-trip; the *Err hooks force
+	// each failure path.
+	grants         map[uuid.UUID]map[string]json.RawMessage
+	grantListErr   error
+	grantUpsertErr error
+	grantDeleteErr error
 }
 
 // setAgentCall records one SetNodeAgent invocation for assertions.
@@ -243,6 +252,42 @@ func (f *fakeCampaignStore) SearchNodes(_ context.Context, _ uuid.UUID, query st
 		return nil, f.nodeSearchErr
 	}
 	return f.searchResults, nil
+}
+
+func (f *fakeCampaignStore) ListToolGrants(_ context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error) {
+	if f.grantListErr != nil {
+		return nil, f.grantListErr
+	}
+	var out []storage.ToolGrant
+	for tool, cfg := range f.grants[agentID] {
+		out = append(out, storage.ToolGrant{AgentID: agentID, ToolName: tool, Config: cfg})
+	}
+	return out, nil
+}
+
+func (f *fakeCampaignStore) UpsertToolGrant(_ context.Context, g storage.NewToolGrant) error {
+	if f.grantUpsertErr != nil {
+		return f.grantUpsertErr
+	}
+	if f.grants == nil {
+		f.grants = map[uuid.UUID]map[string]json.RawMessage{}
+	}
+	if f.grants[g.AgentID] == nil {
+		f.grants[g.AgentID] = map[string]json.RawMessage{}
+	}
+	f.grants[g.AgentID][g.ToolName] = g.Config
+	return nil
+}
+
+func (f *fakeCampaignStore) DeleteToolGrant(_ context.Context, agentID uuid.UUID, toolName string) error {
+	if f.grantDeleteErr != nil {
+		return f.grantDeleteErr
+	}
+	if _, ok := f.grants[agentID][toolName]; !ok {
+		return storage.ErrNotFound
+	}
+	delete(f.grants[agentID], toolName)
+	return nil
 }
 
 // crudClient stands up the full CampaignService handler over an httptest server

--- a/internal/rpc/campaign_grant.go
+++ b/internal/rpc/campaign_grant.go
@@ -1,0 +1,141 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Campaign-screen Tool Grant handlers (#117) on CampaignServer: list every
+// built-in Tool with an Agent's current grant state, and toggle a grant on/off
+// (editing its scope config) for an Agent. The available-Tools catalog is the
+// built-in Registry (ADR-0028), so the toggles a GM sees are exactly the Tools a
+// Voice Session runs; a change hydrates into the NEXT session (#113, ADR-0029).
+//
+// ListToolGrants is a read (NO_SIDE_EFFECTS) so the CSRF interceptor exempts it;
+// UpdateToolGrant is state-changing so the auth + CSRF interceptors guard it —
+// identical to the sibling agent CRUD mutations (AC5), inherited from the shared
+// interceptor stack the web tier mounts, not re-implemented here.
+
+// ListToolGrants returns, for one Agent, every registered Tool paired with the
+// Agent's grant state (granted, scope config, whether the Tool supports a scope).
+// An unparsable agent_id is CodeInvalidArgument.
+func (s *CampaignServer) ListToolGrants(
+	ctx context.Context,
+	req *connect.Request[managementv1.ListToolGrantsRequest],
+) (*connect.Response[managementv1.ListToolGrantsResponse], error) {
+	agentID, err := uuid.Parse(req.Msg.GetAgentId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	grants, err := s.toolGrantsFor(ctx, agentID)
+	if err != nil {
+		slog.Default().Error("ListToolGrants: read grants failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.ListToolGrantsResponse{Grants: grants}), nil
+}
+
+// UpdateToolGrant toggles an Agent's grant of one Tool and edits its scope config.
+// granted=true upserts the row (with config); granted=false removes it (revoking
+// an already-ungranted Tool is a no-op success). It validates the Tool is
+// registered and any config is valid JSON, then reads the resulting state back so
+// the response is the persisted truth. An unparsable agent_id, an unknown Tool, or
+// invalid config is CodeInvalidArgument.
+func (s *CampaignServer) UpdateToolGrant(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateToolGrantRequest],
+) (*connect.Response[managementv1.UpdateToolGrantResponse], error) {
+	m := req.Msg
+	agentID, err := uuid.Parse(m.GetAgentId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+	// The Tool must be a registered built-in — a grant naming an unregistered Tool
+	// grants access to nothing (ADR-0029), so reject it up front rather than
+	// persist a dead row the hydration path would silently skip.
+	registered, ok := s.tools.Get(m.GetToolName())
+	if !ok {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("unknown tool"))
+	}
+
+	if m.GetGranted() {
+		var config json.RawMessage
+		if raw := m.GetConfig(); raw != "" {
+			if !json.Valid([]byte(raw)) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("config is not valid JSON"))
+			}
+			config = json.RawMessage(raw)
+		}
+		if err := s.store.UpsertToolGrant(ctx, storage.NewToolGrant{
+			AgentID:  agentID,
+			ToolName: registered.Name(),
+			Config:   config,
+		}); err != nil {
+			slog.Default().Error("UpdateToolGrant: upsert failed", "agent_id", agentID, "tool", registered.Name(), "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	} else {
+		// Revoke is idempotent: a not-present grant is already in the desired state.
+		if err := s.store.DeleteToolGrant(ctx, agentID, registered.Name()); err != nil && !errors.Is(err, storage.ErrNotFound) {
+			slog.Default().Error("UpdateToolGrant: delete failed", "agent_id", agentID, "tool", registered.Name(), "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	// Read the state back so the client renders persisted truth (jsonb reformats).
+	grants, err := s.toolGrantsFor(ctx, agentID)
+	if err != nil {
+		slog.Default().Error("UpdateToolGrant: read-back failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	for _, g := range grants {
+		if g.GetToolName() == registered.Name() {
+			return connect.NewResponse(&managementv1.UpdateToolGrantResponse{Grant: g}), nil
+		}
+	}
+	// The Tool is registered, so toolGrantsFor always emits an entry for it.
+	slog.Default().Error("UpdateToolGrant: toggled tool missing from catalog", "tool", registered.Name())
+	return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+}
+
+// toolGrantsFor joins the built-in Tool catalog with an Agent's persisted grant
+// rows into the wire list: one entry per registered Tool (Name order), each
+// carrying its description, the Agent's granted bit + scope config, and whether
+// the Tool supports a scope. It is the shared body of both grant handlers.
+func (s *CampaignServer) toolGrantsFor(ctx context.Context, agentID uuid.UUID) ([]*managementv1.ToolGrant, error) {
+	rows, err := s.store.ListToolGrants(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+	granted := make(map[string]storage.ToolGrant, len(rows))
+	for _, r := range rows {
+		granted[r.ToolName] = r
+	}
+
+	tools := s.tools.Tools()
+	out := make([]*managementv1.ToolGrant, 0, len(tools))
+	for _, t := range tools {
+		entry := &managementv1.ToolGrant{
+			ToolName:      t.Name(),
+			Description:   t.Description(),
+			SupportsScope: t.SupportsScope(),
+		}
+		if row, ok := granted[t.Name()]; ok {
+			entry.Granted = true
+			if len(row.Config) > 0 {
+				entry.Config = string(row.Config)
+			}
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+// Drives the CampaignService Tool Grant handlers (#117) end to end over
+// Connect-JSON against a real *storage.Store (testcontainers Postgres): the
+// seeded auto-Butler's dice grant is listed, an NPC's grant is toggled on and off
+// and survives a reload, a scope config round-trips through the API, and — the AC4
+// bar — the resulting rows are hydrated through the SAME public tool package the
+// live loop uses to prove a revoked Tool is never declared to the LLM in the next
+// Voice Session. Tag-isolated behind `integration`; reuses startPostgres/seedStore
+// from campaign_integration_test.go.
+
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+func TestToolGrants_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, _ := seedStore(t, dsn) // campaign → auto-Butler with a seeded dice grant
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	// The auto-Butler comes seeded with dice (migration 00013).
+	roster, err := client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster: %v", err)
+	}
+	butler := roster.Msg.GetRoster()[0]
+	butlerID := uuid.MustParse(butler.GetId())
+
+	butlerGrants, err := client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: butler.GetId()}))
+	if err != nil {
+		t.Fatalf("ListToolGrants(butler): %v", err)
+	}
+	if g := butlerGrants.Msg.GetGrants(); len(g) != 1 || g[0].GetToolName() != "dice" || !g[0].GetGranted() {
+		t.Fatalf("butler grants = %+v, want dice granted (seeded)", g)
+	}
+
+	// A fresh Character NPC has no grants → dice listed but off.
+	created, err := client.CreateAgent(ctx, connect.NewRequest(&managementv1.CreateAgentRequest{Name: "Bart"}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	npc := created.Msg.GetAgent()
+	npcID := uuid.MustParse(npc.GetId())
+	if grantedNames(listGrants(t, client, npc.GetId())) != nil {
+		t.Fatalf("fresh NPC should have no granted Tools")
+	}
+
+	// AC2: grant dice, reload, confirm it stuck.
+	if _, err := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: npc.GetId(), ToolName: "dice", Granted: true,
+	})); err != nil {
+		t.Fatalf("UpdateToolGrant(npc dice on): %v", err)
+	}
+	if got := grantedNames(listGrants(t, client, npc.GetId())); len(got) != 1 || got[0] != "dice" {
+		t.Fatalf("after grant, NPC granted = %v, want [dice]", got)
+	}
+
+	// AC3: a scope config round-trips through the API (even though dice's UI shows
+	// no editor — the API is scope-capable regardless).
+	if _, err := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: npc.GetId(), ToolName: "dice", Granted: true, Config: `{"scope":"self"}`,
+	})); err != nil {
+		t.Fatalf("UpdateToolGrant(npc dice config): %v", err)
+	}
+	assertScopeSelf(t, listGrants(t, client, npc.GetId())[0].GetConfig())
+
+	// AC4: what the NEXT Voice Session hydrates. The GRANTED NPC's rows hydrate —
+	// through the same public tool package the live loop uses (#113) — into a
+	// GrantSet that declares dice to the LLM.
+	if got := hydratedDeclarations(t, store, npcID); len(got) != 1 || got[0] != "dice" {
+		t.Fatalf("granted NPC hydrates declarations %v, want [dice]", got)
+	}
+
+	// AC4 (revoke): toggle the Butler's dice off; the row is gone, so the next
+	// session hydrates ZERO declarations — the LLM is never shown the Tool.
+	if _, err := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: butler.GetId(), ToolName: "dice", Granted: false,
+	})); err != nil {
+		t.Fatalf("UpdateToolGrant(butler dice off): %v", err)
+	}
+	if got := grantedNames(listGrants(t, client, butler.GetId())); got != nil {
+		t.Fatalf("after revoke, butler granted = %v, want none", got)
+	}
+	if got := hydratedDeclarations(t, store, butlerID); len(got) != 0 {
+		t.Fatalf("revoked Butler hydrates declarations %v, want none (LLM shown no Tool)", got)
+	}
+}
+
+// listGrants is a small helper that lists an Agent's grant states or fails the test.
+func listGrants(t *testing.T, client managementv1connect.CampaignServiceClient, agentID string) []*managementv1.ToolGrant {
+	t.Helper()
+	resp, err := client.ListToolGrants(context.Background(), connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID}))
+	if err != nil {
+		t.Fatalf("ListToolGrants(%s): %v", agentID, err)
+	}
+	return resp.Msg.GetGrants()
+}
+
+// grantedNames returns the names of the Tools currently granted (granted=true).
+func grantedNames(grants []*managementv1.ToolGrant) []string {
+	var out []string
+	for _, g := range grants {
+		if g.GetGranted() {
+			out = append(out, g.GetToolName())
+		}
+	}
+	return out
+}
+
+// hydratedDeclarations replays the #113 hydration path against the persisted rows
+// using the PUBLIC tool package the live loop shares: read the Agent's Tool Grant
+// rows, build a real GrantSet over the built-in Registry, and return the Tool
+// names it would declare to the LLM. This is exactly what loadSeededNPCs does at
+// Voice Session start, so it proves a grant mutation takes effect on the next
+// session without new plumbing (AC4).
+func hydratedDeclarations(t *testing.T, store *storage.Store, agentID uuid.UUID) []string {
+	t.Helper()
+	rows, err := store.ListToolGrants(context.Background(), agentID)
+	if err != nil {
+		t.Fatalf("hydrate: ListToolGrants(%s): %v", agentID, err)
+	}
+	grants := make([]tool.Grant, 0, len(rows))
+	for _, r := range rows {
+		g := tool.Grant{ToolName: r.ToolName}
+		if len(r.Config) > 0 {
+			g.Config = r.Config
+		}
+		grants = append(grants, g)
+	}
+	decls := tool.NewGrantSet(tool.BuiltinRegistry(), grants...).Declarations()
+	names := make([]string, len(decls))
+	for i, d := range decls {
+		names[i] = d.Name
+	}
+	return names
+}

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -1,0 +1,271 @@
+package rpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestListToolGrants_CatalogWithState is the AC1 bar over the handler: the list
+// shows EVERY built-in Tool (dice today) with the Agent's current grant state.
+// An ungranted Agent sees dice present-but-off; granting flips it on. Because the
+// catalog is the built-in Registry, an Agent with no rows still lists dice.
+func TestListToolGrants_CatalogWithState(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	agentID := uuid.New()
+	client := crudClient(t, store)
+
+	// No grant rows: dice is listed but not granted, and advertises no scope.
+	resp, err := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	grants := resp.Msg.GetGrants()
+	if len(grants) != 1 || grants[0].GetToolName() != "dice" {
+		t.Fatalf("catalog = %+v, want exactly [dice]", grants)
+	}
+	if grants[0].GetGranted() {
+		t.Error("dice should be ungranted for a fresh Agent")
+	}
+	if grants[0].GetSupportsScope() {
+		t.Error("dice must not advertise scope support")
+	}
+	if grants[0].GetDescription() == "" {
+		t.Error("dice entry should carry the Tool description as hint text")
+	}
+
+	// Grant dice, then it lists as granted.
+	if _, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: agentID.String(), ToolName: "dice", Granted: true,
+		})); err != nil {
+		t.Fatalf("UpdateToolGrant(on): %v", err)
+	}
+	resp, err = client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("ListToolGrants (after grant): %v", err)
+	}
+	if !resp.Msg.GetGrants()[0].GetGranted() {
+		t.Error("dice should list as granted after UpdateToolGrant(on)")
+	}
+}
+
+func TestListToolGrants_InvalidAgentID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+	_, err := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: "not-a-uuid"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+// TestUpdateToolGrant_ToggleRoundTrips: grant on persists a row and the response
+// reflects granted=true; toggling off removes it and the next list drops it — the
+// AC2 persist-and-reload contract at the handler seam.
+func TestUpdateToolGrant_ToggleRoundTrips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	agentID := uuid.New()
+	client := crudClient(t, store)
+
+	on, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: agentID.String(), ToolName: "dice", Granted: true,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateToolGrant(on): %v", err)
+	}
+	if g := on.Msg.GetGrant(); !g.GetGranted() || g.GetToolName() != "dice" {
+		t.Fatalf("on response = %+v, want granted dice", g)
+	}
+	if _, ok := store.grants[agentID]["dice"]; !ok {
+		t.Error("dice grant row not persisted to the store")
+	}
+
+	off, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: agentID.String(), ToolName: "dice", Granted: false,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateToolGrant(off): %v", err)
+	}
+	if off.Msg.GetGrant().GetGranted() {
+		t.Error("off response should report granted=false")
+	}
+	if _, ok := store.grants[agentID]["dice"]; ok {
+		t.Error("dice grant row should be removed after toggle off")
+	}
+}
+
+// TestUpdateToolGrant_ConfigRoundTrips proves the per-grant scope config
+// round-trips through UpdateToolGrant → ListToolGrants even though dice's UI shows
+// no scope editor (AC3): the API is scope-capable regardless of the Tool's editor.
+func TestUpdateToolGrant_ConfigRoundTrips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	agentID := uuid.New()
+	client := crudClient(t, store)
+
+	scope := `{"scope":"self"}`
+	resp, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: agentID.String(), ToolName: "dice", Granted: true, Config: scope,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateToolGrant(config): %v", err)
+	}
+	assertScopeSelf(t, resp.Msg.GetGrant().GetConfig())
+
+	list, err := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	assertScopeSelf(t, list.Msg.GetGrants()[0].GetConfig())
+}
+
+// assertScopeSelf checks a config JSON string carries scope=self (semantic, since
+// jsonb/JSON reserialization may reorder or respace).
+func assertScopeSelf(t *testing.T, cfg string) {
+	t.Helper()
+	if cfg == "" {
+		t.Fatal("config round-trip lost the scope blob")
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(cfg), &got); err != nil {
+		t.Fatalf("config not valid JSON: %v (%q)", err, cfg)
+	}
+	if got["scope"] != "self" {
+		t.Errorf("config = %+v, want scope=self", got)
+	}
+}
+
+func TestUpdateToolGrant_UnknownToolRejected(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+	_, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: uuid.New().String(), ToolName: "not_a_tool", Granted: true,
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument for an unregistered tool", got)
+	}
+}
+
+func TestUpdateToolGrant_InvalidConfigRejected(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+	_, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: uuid.New().String(), ToolName: "dice", Granted: true, Config: "{not json",
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument for malformed config", got)
+	}
+}
+
+func TestUpdateToolGrant_InvalidAgentID(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+	_, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{AgentId: "nope", ToolName: "dice", Granted: true}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+// TestUpdateToolGrant_RevokeIsIdempotent: revoking a Tool the Agent never held
+// succeeds (the desired end state already holds), so a double-toggle-off never
+// errors.
+func TestUpdateToolGrant_RevokeIsIdempotent(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore())
+	if _, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: uuid.New().String(), ToolName: "dice", Granted: false,
+		})); err != nil {
+		t.Errorf("revoking an ungranted Tool should succeed, got %v", err)
+	}
+}
+
+// denyAuth rejects every session — mounts NewAuthInterceptor into a deny-all gate.
+type denyAuth struct{}
+
+func (denyAuth) AuthenticateSession(context.Context, string) (storage.User, error) {
+	return storage.User{}, storage.ErrNotFound
+}
+
+// TestToolGrant_AuthGatesBothLikeSiblings (AC5, auth half): with the auth
+// interceptor mounted and no valid session, BOTH grant RPCs — the read and the
+// write — are rejected Unauthenticated, exactly like the sibling UpdateAgent
+// mutation. The whole management API is gated (ADR-0016); the list read being
+// side-effect-free exempts it from CSRF, not from auth.
+func TestToolGrant_AuthGatesBothLikeSiblings(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(newFakeStore()).Handler(
+		connect.WithInterceptors(auth.NewAuthInterceptor(denyAuth{})),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	_, listErr := client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: uuid.New().String()}))
+	_, updateErr := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{AgentId: uuid.New().String(), ToolName: "dice", Granted: true}))
+	_, siblingErr := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{Id: uuid.New().String()}))
+
+	for name, err := range map[string]error{"ListToolGrants": listErr, "UpdateToolGrant": updateErr, "UpdateAgent(sibling)": siblingErr} {
+		if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+			t.Errorf("%s code = %v, want Unauthenticated (whole API is auth-gated)", name, got)
+		}
+	}
+}
+
+// TestToolGrant_CSRFGuardsMutationNotRead (AC5, CSRF half): with the CSRF
+// interceptor mounted and no double-submit token, the state-changing
+// UpdateToolGrant is rejected PermissionDenied exactly like the sibling
+// UpdateAgent mutation, while the side-effect-free ListToolGrants (NO_SIDE_EFFECTS)
+// is exempt and reaches the handler.
+func TestToolGrant_CSRFGuardsMutationNotRead(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(newFakeStore()).Handler(
+		connect.WithInterceptors(auth.NewCSRFInterceptor()),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	// The write is CSRF-guarded — no token → PermissionDenied, like the sibling.
+	_, updateErr := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{AgentId: uuid.New().String(), ToolName: "dice", Granted: true}))
+	if got := connect.CodeOf(updateErr); got != connect.CodePermissionDenied {
+		t.Errorf("UpdateToolGrant code = %v, want PermissionDenied (CSRF-guarded mutation)", got)
+	}
+	_, siblingErr := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(siblingErr); got != connect.CodePermissionDenied {
+		t.Errorf("UpdateAgent(sibling) code = %v, want PermissionDenied — parity check", got)
+	}
+
+	// The read is exempt — no token still reaches the handler (returns its own
+	// result, never PermissionDenied).
+	if _, err := client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: uuid.New().String()})); connect.CodeOf(err) == connect.CodePermissionDenied {
+		t.Error("ListToolGrants must be CSRF-exempt (NO_SIDE_EFFECTS read)")
+	}
+}

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -75,6 +75,15 @@ func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.NullUUID) (stora
 func (fakeReader) SearchNodes(context.Context, uuid.UUID, string, int) ([]storage.KGNode, error) {
 	return nil, nil
 }
+func (fakeReader) ListToolGrants(context.Context, uuid.UUID) ([]storage.ToolGrant, error) {
+	return nil, nil
+}
+func (fakeReader) UpsertToolGrant(context.Context, storage.NewToolGrant) error {
+	return nil
+}
+func (fakeReader) DeleteToolGrant(context.Context, uuid.UUID, string) error {
+	return nil
+}
 
 // newClient stands up the CampaignServer handler behind an httptest server and
 // returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on

--- a/internal/storage/tool_grant.go
+++ b/internal/storage/tool_grant.go
@@ -86,6 +86,31 @@ func (s *Store) CreateToolGrant(ctx context.Context, g NewToolGrant) (uuid.UUID,
 	return id, nil
 }
 
+// UpsertToolGrant grants a Tool to an Agent, or edits an existing grant's scope
+// Config in place — the #117 mutation path. It INSERTs the (agent_id, tool_name)
+// row when absent and UPDATEs its Config when present, keyed off the
+// UNIQUE(agent_id, tool_name) index, so "grant on" and "edit scope" are one call
+// and a repeated grant never trips the unique constraint. An empty Config stores
+// SQL NULL (no narrowing — dice's shape), so re-upserting nil clears a prior
+// scope. The Agent's next Voice Session hydrates the resulting row (#113).
+func (s *Store) UpsertToolGrant(ctx context.Context, g NewToolGrant) error {
+	// A nil interface encodes to SQL NULL; a non-empty blob goes in as jsonb.
+	var config any
+	if len(g.Config) > 0 {
+		config = []byte(g.Config)
+	}
+	_, err := s.db.Exec(ctx,
+		`INSERT INTO tool_agent_grant (agent_id, tool_name, config)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (agent_id, tool_name)
+		 DO UPDATE SET config = EXCLUDED.config, updated_at = now()`,
+		g.AgentID, g.ToolName, config)
+	if err != nil {
+		return fmt.Errorf("storage: upsert tool grant (%s/%s): %w", g.AgentID, g.ToolName, err)
+	}
+	return nil
+}
+
 // DeleteToolGrant removes an Agent's grant of the named Tool. Deleting a grant
 // that is not present yields ErrNotFound (so the caller can tell "removed" from
 // "was never there"). Removing the row is how a GM revokes a Tool: after

--- a/internal/storage/tool_grant_test.go
+++ b/internal/storage/tool_grant_test.go
@@ -137,6 +137,71 @@ func TestToolGrantRoundTrip(t *testing.T) {
 	}
 }
 
+// TestUpsertToolGrant covers the #117 grant-mutation path: UpsertToolGrant both
+// GRANTS a Tool (inserts a row) and EDITS an existing grant's scope config
+// (updates in place, no UNIQUE violation), so the RPC toggle-on and scope-edit
+// share one storage call. The nil-config insert is the dice shape.
+func TestUpsertToolGrant(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	charID, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Toggler",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// First upsert INSERTS the grant (no row existed) with no scope config.
+	if err := st.UpsertToolGrant(ctx, storage.NewToolGrant{AgentID: charID, ToolName: "dice"}); err != nil {
+		t.Fatalf("UpsertToolGrant (insert): %v", err)
+	}
+	grants, err := st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	if len(grants) != 1 || grants[0].ToolName != "dice" || grants[0].Config != nil {
+		t.Fatalf("after insert = %+v, want exactly [dice] with nil config", grants)
+	}
+
+	// Second upsert of the SAME (agent, tool) must UPDATE in place, not violate
+	// the UNIQUE index — this is the RPC's scope-edit path.
+	scope := json.RawMessage(`{"scope":"self"}`)
+	if err := st.UpsertToolGrant(ctx, storage.NewToolGrant{AgentID: charID, ToolName: "dice", Config: scope}); err != nil {
+		t.Fatalf("UpsertToolGrant (update): %v", err)
+	}
+	grants, err = st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants after update: %v", err)
+	}
+	if len(grants) != 1 {
+		t.Fatalf("upsert created a duplicate row: %+v", grants)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(grants[0].Config, &got); err != nil {
+		t.Fatalf("updated config not valid JSON: %v (%q)", err, grants[0].Config)
+	}
+	if got["scope"] != "self" {
+		t.Errorf("scope config not updated: %+v", got)
+	}
+
+	// Upserting nil config back clears the scope (SQL NULL) in place.
+	if err := st.UpsertToolGrant(ctx, storage.NewToolGrant{AgentID: charID, ToolName: "dice"}); err != nil {
+		t.Fatalf("UpsertToolGrant (clear): %v", err)
+	}
+	grants, err = st.ListToolGrants(ctx, charID)
+	if err != nil {
+		t.Fatalf("ListToolGrants after clear: %v", err)
+	}
+	if len(grants) != 1 || grants[0].Config != nil {
+		t.Fatalf("after clear = %+v, want [dice] with nil config", grants)
+	}
+}
+
 // TestToolGrantUniquePerTool asserts the UNIQUE(agent_id, tool_name) index: an
 // Agent grants a Tool at most once (ADR-0029).
 func TestToolGrantUniquePerTool(t *testing.T) {

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -761,8 +761,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// — only the GrantSet differs per NPC — so N NPCs reuse one client rather than
 	// each opening their own.
 	provider := newLLM(keys.llm)
-	reg := tool.NewRegistry()
-	reg.MustRegister(tool.NewDice())
+	reg := tool.BuiltinRegistry()
 	engineFor := func(spec npcSpec) agent.Engine {
 		grants := tool.NewGrantSet(reg, spec.grants...)
 		return agenttool.NewEngine(provider, grants, groq.DefaultModel, 0, 0,

--- a/pkg/tool/builtins.go
+++ b/pkg/tool/builtins.go
@@ -1,0 +1,16 @@
+package tool
+
+// BuiltinRegistry returns a Registry holding every built-in Tool v1.0 ships
+// (ADR-0028: exactly one, `dice`). It is the single source of truth for "which
+// Tools exist" — the live voice loop (wirenpc), the benchmark rig, and the grant
+// editor RPC (#117) all build from it, so the Tools an operator can toggle on the
+// Campaign screen are exactly the Tools a Voice Session can actually run. When a
+// new built-in lands it is registered here once and appears everywhere.
+//
+// dice is registered with a non-deterministic production roller; tests that need
+// a pinned roll construct their own Registry with [NewDiceWithRand].
+func BuiltinRegistry() *Registry {
+	r := NewRegistry()
+	r.MustRegister(NewDice())
+	return r
+}

--- a/pkg/tool/dice.go
+++ b/pkg/tool/dice.go
@@ -77,6 +77,10 @@ func (*Dice) InputSchema() json.RawMessage { return diceInputSchema }
 // ReadOnly implements [Tool]: rolling dice mutates no state.
 func (*Dice) ReadOnly() bool { return true }
 
+// SupportsScope implements [Tool]: dice carries no per-grant Config (its authority
+// cannot be narrowed per Agent), so it is a plain on/off grant with no scope editor.
+func (*Dice) SupportsScope() bool { return false }
+
 // diceArgs is the decoded shape of [Dice]'s LLM-supplied arguments.
 type diceArgs struct {
 	Count int `json:"count"`

--- a/pkg/tool/registry.go
+++ b/pkg/tool/registry.go
@@ -1,6 +1,9 @@
 package tool
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Registry maps a Tool name to its [Tool]. It is deliberately dumb (ADR-0028):
 // a map with registration and lookup, no lifecycle ceremony. The API makes no
@@ -50,4 +53,18 @@ func (r *Registry) MustRegister(t Tool) {
 func (r *Registry) Get(name string) (Tool, bool) {
 	t, ok := r.tools[name]
 	return t, ok
+}
+
+// Tools returns every registered Tool sorted by [Tool.Name]. This is the full
+// available-Tools catalog — NOT grant-stripped, unlike [GrantSet.Declarations] —
+// so the grant editor can list every Tool an Agent could be granted with its
+// current grant state (#117). The stable sort keeps the rendered list order
+// deterministic across process restarts.
+func (r *Registry) Tools() []Tool {
+	out := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
 }

--- a/pkg/tool/registry_test.go
+++ b/pkg/tool/registry_test.go
@@ -9,15 +9,17 @@ import (
 // stubTool is a minimal [Tool] for registry/grant tests, parameterized on the
 // fields those tests vary (name, read-only bit) without needing a real handler.
 type stubTool struct {
-	name     string
-	readOnly bool
-	exec     func(ctx context.Context, args json.RawMessage, grant any) (string, error)
+	name          string
+	readOnly      bool
+	supportsScope bool
+	exec          func(ctx context.Context, args json.RawMessage, grant any) (string, error)
 }
 
 func (s stubTool) Name() string                 { return s.name }
 func (s stubTool) Description() string          { return s.name + " stub" }
 func (s stubTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
 func (s stubTool) ReadOnly() bool               { return s.readOnly }
+func (s stubTool) SupportsScope() bool          { return s.supportsScope }
 func (s stubTool) Execute(ctx context.Context, args json.RawMessage, grant any) (string, error) {
 	if s.exec != nil {
 		return s.exec(ctx, args, grant)
@@ -37,6 +39,42 @@ func TestRegistryRegisterAndGet(t *testing.T) {
 	}
 	if _, ok := r.Get("nope"); ok {
 		t.Error("Get(nope) found a tool that was never registered")
+	}
+}
+
+// TestRegistryToolsSorted: Tools() returns the full catalog (not grant-stripped)
+// in stable Name order, so the #117 grant editor lists every registerable Tool
+// deterministically.
+func TestRegistryToolsSorted(t *testing.T) {
+	r := NewRegistry()
+	for _, n := range []string{"charlie", "alpha", "bravo"} {
+		r.MustRegister(stubTool{name: n, readOnly: true})
+	}
+	got := r.Tools()
+	if len(got) != 3 {
+		t.Fatalf("Tools() len = %d, want 3", len(got))
+	}
+	want := []string{"alpha", "bravo", "charlie"}
+	for i, w := range want {
+		if got[i].Name() != w {
+			t.Fatalf("Tools() order = %v, want %v", []string{got[0].Name(), got[1].Name(), got[2].Name()}, want)
+		}
+	}
+}
+
+// TestBuiltinRegistryIsDiceOnly: the shared built-in set is exactly [dice] and it
+// is a plain on/off grant (no scope editor). This is the source the grant editor
+// and the live loop both build from — they must agree on the available Tools.
+func TestBuiltinRegistryIsDiceOnly(t *testing.T) {
+	tools := BuiltinRegistry().Tools()
+	if len(tools) != 1 || tools[0].Name() != "dice" {
+		t.Fatalf("BuiltinRegistry Tools = %+v, want exactly [dice]", tools)
+	}
+	if tools[0].SupportsScope() {
+		t.Error("dice must not advertise scope support (it carries no per-grant config)")
+	}
+	if _, ok := BuiltinRegistry().Get("dice"); !ok {
+		t.Error("BuiltinRegistry must have dice registered")
 	}
 }
 

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -47,6 +47,15 @@ type Tool interface {
 	// from a possibly-discarded draft.
 	ReadOnly() bool
 
+	// SupportsScope reports whether a per-grant Config can NARROW this Tool's
+	// authority for one Agent (ADR-0029) — the bit the grant editor keys its
+	// scope UI off. A Tool that supports a scope (a future remember_knowledge
+	// granted "only about yourself" vs campaign-wide) exposes a scope editor; one
+	// that does not (dice carries no config) is a plain on/off grant. It is a
+	// declaration ABOUT the grant config, independent of ReadOnly: the LLM never
+	// sees the scope, and the handler still enforces whatever Config it receives.
+	SupportsScope() bool
+
 	// Execute runs the Tool with the LLM-supplied args and the caller's
 	// per-grant config (ADR-0029). grantConfig narrows the Tool's authority for
 	// this Agent and is enforced here, in the handler, never by the LLM — the

--- a/pkg/voice/voicebench/rig.go
+++ b/pkg/voice/voicebench/rig.go
@@ -64,8 +64,7 @@ func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 		rec = observe.Discard{}
 	}
 
-	reg := tool.NewRegistry()
-	reg.MustRegister(tool.NewDice())
+	reg := tool.BuiltinRegistry()
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
 	engine := agenttool.NewEngine(cfg.Provider, grants, "", 0, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -94,6 +94,80 @@ service CampaignService {
   rpc SearchNodes(SearchNodesRequest) returns (SearchNodesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+
+  // ListToolGrants returns, for one Agent, EVERY built-in Tool (the ADR-0028
+  // Registry is the available-Tools source) paired with the Agent's current grant
+  // state — granted or not, its per-grant scope config, and whether the Tool
+  // supports a scope. It backs the Campaign screen's per-Agent grant toggles
+  // (#117). An unparsable agent_id is CodeInvalidArgument. It is a read
+  // (NO_SIDE_EFFECTS), so the CSRF check is exempt.
+  rpc ListToolGrants(ListToolGrantsRequest) returns (ListToolGrantsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // UpdateToolGrant toggles an Agent's grant of one Tool on or off and edits its
+  // per-grant scope config (ADR-0029). granted=true upserts the row (with the
+  // supplied config); granted=false removes it (idempotent — revoking an
+  // already-ungranted Tool succeeds). The change takes effect in the Agent's NEXT
+  // Voice Session via the hydration path (#113), not any running one. An
+  // unparsable agent_id or an unknown/invalid config is CodeInvalidArgument; an
+  // unregistered tool_name is CodeInvalidArgument. State-changing: the auth + CSRF
+  // interceptors guard it exactly like the other CampaignService mutations.
+  rpc UpdateToolGrant(UpdateToolGrantRequest) returns (UpdateToolGrantResponse);
+}
+
+// ToolGrant is one built-in Tool's availability and grant state for a single
+// Agent (#117, ADR-0028/0029): the Tool's identity and description, whether the
+// Agent is granted it, the per-grant scope config, and whether the Tool accepts a
+// scope. The LLM is only ever shown granted Tools (least-privilege); this is the
+// GM-facing editor view, so it lists ungranted Tools too.
+message ToolGrant {
+  // tool_name is the built-in Tool's stable [Tool.Name] (e.g. "dice").
+  string tool_name = 1;
+  // description is the Tool's natural-language summary (the editor's hint text).
+  string description = 2;
+  // granted is true when the Agent currently holds this Tool grant.
+  bool granted = 3;
+  // config is the per-grant scope blob as raw JSON (empty = no narrowing, dice's
+  // shape). It round-trips verbatim through UpdateToolGrant; the Tool handler is
+  // the only place it is interpreted, never the LLM (ADR-0029).
+  string config = 4;
+  // supports_scope is true when a per-grant config can narrow the Tool's authority
+  // — the bit the editor keys its scope UI off. dice is false → no scope editor.
+  bool supports_scope = 5;
+}
+
+// ListToolGrantsRequest names the Agent whose grant states to list.
+message ListToolGrantsRequest {
+  // agent_id is the Agent (Butler or Character NPC) to list grant state for.
+  string agent_id = 1;
+}
+
+// ListToolGrantsResponse carries one entry per built-in Tool, in Tool-name order,
+// each with the Agent's current grant state.
+message ListToolGrantsResponse {
+  // grants is every built-in Tool paired with this Agent's grant state.
+  repeated ToolGrant grants = 1;
+}
+
+// UpdateToolGrantRequest toggles one Agent's grant of one Tool (and its scope).
+message UpdateToolGrantRequest {
+  // agent_id is the Agent whose grant to change.
+  string agent_id = 1;
+  // tool_name is the built-in Tool to grant or revoke; must be registered.
+  string tool_name = 2;
+  // granted turns the grant on (upsert) or off (remove).
+  bool granted = 3;
+  // config is the per-grant scope blob as raw JSON, applied when granted=true and
+  // ignored when granted=false. Empty = no narrowing. Non-empty must be valid JSON.
+  string config = 4;
+}
+
+// UpdateToolGrantResponse carries the resulting grant state for the toggled Tool,
+// read back after the mutation so the client renders the persisted truth.
+message UpdateToolGrantResponse {
+  // grant is the toggled Tool's grant state after the change.
+  ToolGrant grant = 1;
 }
 
 // EdgeType is a Knowledge Graph Edge's type (CONTEXT.md "Edge", ADR-0008 v1.0).

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -15,6 +15,9 @@ import {
   ListVoicesResponseSchema,
   VoiceSchema,
   PreviewVoiceResponseSchema,
+  ToolGrantSchema,
+  ListToolGrantsResponseSchema,
+  UpdateToolGrantResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -64,6 +67,25 @@ function mockTransport() {
   ];
   const previewCalls: string[] = [];
 
+  // Per-agent Tool grant state (#117). The catalog is dice-only (matching the
+  // server's built-in Registry): the Butler comes granted, Bart ungranted. An
+  // unknown agent (a freshly added NPC) defaults to dice-ungranted so the section
+  // always renders the catalog. dice supports no scope, so no scope editor shows.
+  const grants: Record<string, { granted: boolean; config: string }> = {
+    "butler-1": { granted: true, config: "" },
+    "npc-1": { granted: false, config: "" },
+  };
+  const grantEntry = (agentId: string) => {
+    const state = grants[agentId] ?? { granted: false, config: "" };
+    return create(ToolGrantSchema, {
+      toolName: "dice",
+      description: "Roll dice.",
+      granted: state.granted,
+      config: state.config,
+      supportsScope: false,
+    });
+  };
+
   const transport = createRouterTransport(({ service }) => {
     service(VoiceService, {
       listVoices: () => create(ListVoicesResponseSchema, { voices: liveVoices }),
@@ -111,19 +133,25 @@ function mockTransport() {
         if (i >= 0) npcs.splice(i, 1);
         return create(DeleteAgentResponseSchema, {});
       },
+      listToolGrants: (req) =>
+        create(ListToolGrantsResponseSchema, { grants: [grantEntry(req.agentId)] }),
+      updateToolGrant: (req) => {
+        grants[req.agentId] = { granted: req.granted, config: req.granted ? req.config : "" };
+        return create(UpdateToolGrantResponseSchema, { grant: grantEntry(req.agentId) });
+      },
     });
   });
-  return { transport, npcs, previewCalls };
+  return { transport, npcs, previewCalls, grants };
 }
 
 function renderScreen() {
-  const { transport, npcs, previewCalls } = mockTransport();
+  const { transport, npcs, previewCalls, grants } = mockTransport();
   render(
     <Providers transport={transport} queryClient={makeQueryClient()}>
       <Campaign />
     </Providers>,
   );
-  return { npcs, previewCalls };
+  return { npcs, previewCalls, grants };
 }
 
 describe("Campaign", () => {
@@ -291,5 +319,126 @@ describe("Campaign", () => {
     // The preview RPC fired for the selected voice (audio playback is a no-op in
     // jsdom; the RPC call is the observable behaviour).
     await waitFor(() => expect(previewCalls).toEqual(["rachel"]));
+  });
+
+  it("shows the per-agent Tools section with each grant's current state (#117)", async () => {
+    renderScreen();
+    // Bart (npc-1) is dice-ungranted; the toggle renders unchecked.
+    fireEvent.click(await screen.findByText("Bart"));
+    const dice = await screen.findByLabelText("dice");
+    expect(dice).not.toBeChecked();
+
+    // The Butler (butler-1) is dice-granted; its toggle renders checked.
+    fireEvent.click(screen.getByText("Glyphoxa"));
+    expect(await screen.findByLabelText("dice")).toBeChecked();
+  });
+
+  it("toggles a grant on and it persists across a reload (#117 AC2)", async () => {
+    const { grants } = renderScreen();
+    fireEvent.click(await screen.findByText("Bart"));
+    const dice = await screen.findByLabelText("dice");
+    expect(dice).not.toBeChecked();
+
+    fireEvent.click(dice);
+
+    // The mutation persisted to the store and the invalidated query re-read it as
+    // granted — the toggle sticks after the reload the invalidation triggers.
+    await waitFor(() => expect(screen.getByLabelText("dice")).toBeChecked());
+    expect(grants["npc-1"].granted).toBe(true);
+  });
+
+  it("disables the grant toggle while its mutation is in flight (#117)", async () => {
+    // A deferred UpdateToolGrant holds the toggle pending until we resolve it.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+    let resolveUpdate: () => void = () => {};
+    let updateCalls = 0;
+    let granted = false;
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+        listToolGrants: () =>
+          create(ListToolGrantsResponseSchema, {
+            grants: [create(ToolGrantSchema, { toolName: "dice", description: "Roll dice.", granted })],
+          }),
+        updateToolGrant: async (req) => {
+          updateCalls += 1;
+          await new Promise<void>((r) => (resolveUpdate = r));
+          granted = req.granted;
+          return create(UpdateToolGrantResponseSchema, {
+            grant: create(ToolGrantSchema, { toolName: "dice", granted }),
+          });
+        },
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    const dice = await screen.findByLabelText("dice");
+    fireEvent.click(dice);
+
+    // In flight: the toggle is disabled, so a second click can't double-submit.
+    await waitFor(() => expect(screen.getByLabelText("dice")).toBeDisabled());
+    fireEvent.click(screen.getByLabelText("dice"));
+    expect(updateCalls).toBe(1);
+
+    resolveUpdate();
+    await waitFor(() => expect(screen.getByLabelText("dice")).toBeChecked());
+  });
+
+  it("renders a scope editor only for a Tool that supports one, and round-trips its config (#117 AC3)", async () => {
+    // A scope-supporting Tool exercises the editor half of AC3; dice (no scope)
+    // proves the editor is absent for a Tool without one.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+    const configs: string[] = [];
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+        listToolGrants: () =>
+          create(ListToolGrantsResponseSchema, {
+            grants: [
+              create(ToolGrantSchema, { toolName: "dice", description: "Roll dice.", granted: true, supportsScope: false }),
+              create(ToolGrantSchema, {
+                toolName: "remember_knowledge",
+                description: "Remember a fact.",
+                granted: true,
+                supportsScope: true,
+                config: '{"scope":"self"}',
+              }),
+            ],
+          }),
+        updateToolGrant: (req) => {
+          configs.push(req.config);
+          return create(UpdateToolGrantResponseSchema, {
+            grant: create(ToolGrantSchema, { toolName: req.toolName, granted: req.granted, config: req.config, supportsScope: true }),
+          });
+        },
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+
+    // dice supports no scope → no scope field; remember_knowledge does → one shows.
+    await screen.findByLabelText("dice");
+    expect(screen.queryByLabelText("dice scope")).not.toBeInTheDocument();
+    const scope = (await screen.findByLabelText("remember_knowledge scope")) as HTMLInputElement;
+    expect(scope.value).toBe('{"scope":"self"}');
+
+    // Edit the scope and save it: the new config round-trips through UpdateToolGrant.
+    fireEvent.change(scope, { target: { value: '{"scope":"campaign"}' } });
+    fireEvent.click(screen.getByRole("button", { name: /save scope/i }));
+    await waitFor(() => expect(configs).toContain('{"scope":"campaign"}'));
   });
 });

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { Lock, Plus, Sparkles, Trash2, Volume2 } from "lucide-react";
 
 import { CampaignService, VoiceService } from "@gen/glyphoxa/management/v1/management_pb";
-import type { Agent, Voice } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent, Voice, ToolGrant } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
@@ -354,6 +354,8 @@ function AgentEditor({
         </span>
       </div>
 
+      <ToolGrants agentId={agent.id} />
+
       <div className="gx-editor__actions">
         <Button variant="primary" onClick={save} disabled={update.isPending}>
           {update.isPending ? "Saving…" : "Save changes"}
@@ -383,5 +385,97 @@ function AgentEditor({
         </span>
       </div>
     </Card>
+  );
+}
+
+// ToolGrants renders the per-Agent Tool grant toggles (#117): one row per
+// available built-in Tool with its current grant state, backed by
+// CampaignService.ListToolGrants. Toggling invalidates the grants query so the
+// list re-reads the persisted state (AC2). The available Tools are whatever the
+// server's built-in Registry exposes (dice today, ADR-0028); the LLM is only ever
+// shown granted Tools (ADR-0029), and a change hydrates into the NEXT session.
+function ToolGrants({ agentId }: { agentId: string }) {
+  const queryClient = useQueryClient();
+  const { data, status } = useQuery(CampaignService.method.listToolGrants, { agentId });
+  const grants = data?.grants ?? [];
+
+  const invalidateGrants = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listToolGrants,
+        cardinality: "finite",
+      }),
+    });
+
+  return (
+    <div className="gx-editor__tools">
+      <span className="gx-field__label">Tools</span>
+      <span className="gx-field__hint">
+        Grant the Tools this agent may use. Changes take effect in the next session.
+      </span>
+      {status === "pending" ? (
+        <div className="gx-skeleton" data-testid="tools-loading" />
+      ) : grants.length === 0 ? (
+        <span className="gx-field__hint">No tools available.</span>
+      ) : (
+        grants.map((g) => <ToolRow key={g.toolName} agentId={agentId} grant={g} onChanged={invalidateGrants} />)
+      )}
+    </div>
+  );
+}
+
+// ToolRow is one Tool's grant toggle plus, for a Tool that supports a per-grant
+// scope (ADR-0029), an inline scope editor. dice supports no scope, so only the
+// on/off Switch renders for it; a scope-supporting Tool also exposes a raw-JSON
+// scope field that round-trips through UpdateToolGrant's config. The Switch is
+// disabled while its mutation is in flight so a grant can't be double-submitted.
+function ToolRow({
+  agentId,
+  grant,
+  onChanged,
+}: {
+  agentId: string;
+  grant: ToolGrant;
+  onChanged: () => void;
+}) {
+  const [scope, setScope] = useState(grant.config);
+
+  const update = useMutation(CampaignService.method.updateToolGrant, {
+    onSuccess: () => onChanged(),
+    onError: (err) => toast.error(`Couldn't update ${grant.toolName}: ${err.message}`),
+  });
+
+  const toggle = (granted: boolean) =>
+    update.mutate({ agentId, toolName: grant.toolName, granted, config: scope });
+  const saveScope = () =>
+    update.mutate({ agentId, toolName: grant.toolName, granted: true, config: scope });
+
+  return (
+    <div className="gx-editor__tool">
+      <div className="gx-editor__tool-head">
+        <Switch
+          label={grant.toolName}
+          checked={grant.granted}
+          disabled={update.isPending}
+          onCheckedChange={toggle}
+        />
+        {grant.description && <span className="gx-field__hint">{grant.description}</span>}
+      </div>
+      {/* Scope editor only for Tools that support one AND are granted; dice does
+          not, so it renders no scope editor (#117). */}
+      {grant.supportsScope && grant.granted && (
+        <div className="gx-editor__tool-scope">
+          <Input
+            label={`${grant.toolName} scope`}
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+            placeholder='{"scope":"self"}'
+          />
+          <Button variant="secondary" size="sm" onClick={saveScope} disabled={update.isPending}>
+            Save scope
+          </Button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -401,6 +401,35 @@
   gap: var(--spacing-xs);
 }
 
+/* Per-Agent Tool grant toggles (#117): a labelled section of on/off Switches,
+ * one per available built-in Tool, each with the Tool's description as hint text
+ * and — for a scope-supporting Tool — an inline scope editor. */
+.gx-editor__tools {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.gx-editor__tool {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-editor__tool-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-editor__tool-scope {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  padding-left: var(--spacing-md);
+}
+
 .gx-editor__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #117

Surfaces per-Agent Tool Grants in the Campaign screen and adds the management RPCs behind them. Builds on #113 (DB-backed grants hydrated into the live loop).

## Acceptance criteria
- [x] Campaign screen shows, per Agent, the available Tools with their current grant state — a Tools section in the agent editor, one Switch per built-in Tool from `ListToolGrants`.
- [x] Toggling a grant persists and survives a reload — `UpdateToolGrant` upserts/removes the row; the mutation invalidates the grants query so the state re-reads.
- [x] A per-grant scope round-trips through the API — `config` (raw JSON) round-trips via `UpdateToolGrant`/`ListToolGrants`; a scope editor renders only for a Tool that advertises `supports_scope` (dice does not, so no editor for it).
- [x] A newly granted/revoked Tool takes effect in the next Voice Session — asserted end-to-end: after a revoke the persisted rows hydrate (through the same public `tool` package the loop uses) into zero LLM declarations. No live re-hydration; the per-session read contract from #113 is the mechanism.
- [x] Grant mutations are auth + CSRF guarded like other mutations; the list read is side-effect-free — `ListToolGrants` is `NO_SIDE_EFFECTS` (CSRF-exempt); `UpdateToolGrant` inherits the shared auth+CSRF interceptor stack, proven at parity with `UpdateAgent`.

## Shape
- `pkg/tool`: `SupportsScope()` on the Tool interface, `Registry.Tools()` (full catalog), `BuiltinRegistry()` as the single source of which Tools exist — wirenpc + voicebench now build from it, so the toggles a GM sees match what a session runs.
- `internal/storage`: `UpsertToolGrant` (`ON CONFLICT DO UPDATE`) folds grant-on and scope-edit into one call.
- `proto`: `CampaignService.ListToolGrants` / `UpdateToolGrant` + `ToolGrant` message.
- `internal/rpc`: handlers join the built-in catalog with persisted rows; the available-Tools source is the Registry (ADR-0028), scope enforced server-side (ADR-0029).
- `web`: `ToolGrants`/`ToolRow` in the agent editor.

## Tests (TDD, per slice)
- `pkg/tool`: catalog ordering, builtin set, scope bit.
- `internal/storage` (integration): upsert insert/update/clear.
- `internal/rpc` (unit): list state, toggle round-trip, config round-trip, unknown-tool/invalid-config/invalid-id rejects, idempotent revoke, auth+CSRF parity with `UpdateAgent`.
- `internal/rpc` (integration): seeded Butler grant, NPC toggle+reload, scope round-trip, and revoke → zero next-session declarations via the real hydration path.
- `web` (vitest): grant states render, toggle persists across reload, disabled while pending, scope editor only for scope-supporting Tools + config round-trip.

Local: Go build/vet/golangci-lint clean; keyless + touched-package integration tests green; web 78 tests + tsc + build green; `buf lint`/`buf generate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)