### PR TITLE
[E5] /glyphoxa use, start, end drive the Active Campaign and Voice Session (#108)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -293,6 +293,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// voice (`all` mode); a web-only replica runs no Bot. Declared at function
 	// scope so the shutdown path below can Close it after the Manager drains.
 	var pres *presence.Presence
+	var reg *presence.Registry
 	if withVoice {
 		allow := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
 		gate := presence.NewGate(allow, func() string {
@@ -301,19 +302,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			}
 			return pres.GuildID()
 		})
-		reg := presence.NewRegistry(gate, log)
+		reg = presence.NewRegistry(gate, log)
 		reg.Register(presence.RollCommand(tool.NewDice()))
 		pres = presence.New(store, cipher, reg, cfg.Token, log)
 		// The voice loop borrows this one client instead of dialing its own per
 		// session; set BEFORE the Manager copies cfg into its base config.
 		cfg.Client = pres.ClientProvider()
-		// Bring the presence up at boot (AC: /roll appears with no Voice Session).
-		// Non-fatal: a bad or absent Bot token must not kill the web tier — it
-		// stays in the wait-state and the RPC refresher retries on the next save.
-		if err := pres.Ensure(ctx); err != nil {
-			log.Warn("presence: initial ensure failed; the slash-command surface "+
-				"will retry when Discord settings are next saved", "err", err)
-		}
+		// The GM session commands (#108) register below, once the Manager exists,
+		// and Ensure runs after them so all commands are in one registration.
 	}
 
 	runner := func(rctx context.Context, c wirenpc.Config) error {
@@ -327,6 +323,27 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// rows). A failure here is a broken DB — fail the boot loudly.
 	if err := mgr.ReconcileOrphans(ctx); err != nil {
 		return fmt.Errorf("web: %w", err)
+	}
+
+	if withVoice {
+		// The GM admin/session commands (#108, ADR-0010): /glyphoxa use sets the
+		// durable Active Campaign; start/end drive the SAME in-process Manager the
+		// web Session screen uses, so the two surfaces share one session record and
+		// never diverge (AC4). Registered here (not in the presence block above)
+		// because they need the Manager, and BEFORE Ensure so they land in the one
+		// per-Guild registration alongside /roll.
+		reg.Register(
+			presence.UseCommand(store),
+			presence.StartCommand(store, mgr),
+			presence.EndCommand(mgr),
+		)
+		// Bring the presence up at boot (AC: the commands appear with no Voice
+		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier
+		// — it stays in the wait-state and the RPC refresher retries on the next save.
+		if err := pres.Ensure(ctx); err != nil {
+			log.Warn("presence: initial ensure failed; the slash-command surface "+
+				"will retry when Discord settings are next saved", "err", err)
+		}
 	}
 
 	// The SSE transcript relay (issue #73, ADR-0014 Hop-B) subscribes to the

--- a/internal/presence/session_commands.go
+++ b/internal/presence/session_commands.go
@@ -25,22 +25,22 @@ const sessionOpTimeout = 30 * time.Second
 // discordChoiceLimit is Discord's hard cap on autocomplete choices per response.
 const discordChoiceLimit = 25
 
-// ErrNoActiveCampaign is returned by resolveActiveCampaign when every ADR-0009
-// step comes up empty: no live Voice Session, no durable /glyphoxa use selection,
-// and no campaign at all to fall back to.
+// ErrNoActiveCampaign is returned by resolveActiveCampaign when neither a live
+// Voice Session nor the operator's durable /glyphoxa use selection resolves a
+// campaign. The slash surface deliberately has NO most-recently-created fallback
+// (ADR-0009): it fails and tells the GM to run /glyphoxa use — an affordance the
+// GM has right there.
 var ErrNoActiveCampaign = errors.New("presence: no active campaign")
 
 // SessionStore is the storage surface the /glyphoxa session commands need:
 // listing campaigns for `use` and its autocomplete, loading one by id, durably
-// persisting the operator's Active Campaign choice, and the two Active Campaign
-// resolution reads (the per-operator selection, then the most-recently-created
-// fallback). *storage.Store satisfies it; tests use a fake.
+// persisting the operator's Active Campaign choice, and reading that per-operator
+// selection back. *storage.Store satisfies it; tests use a fake.
 type SessionStore interface {
 	ListCampaigns(ctx context.Context) ([]storage.Campaign, error)
 	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
 	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
 	GetActiveCampaignForUser(ctx context.Context, discordUserID string) (storage.Campaign, error)
-	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 }
 
 // VoiceControl is the in-process voice-loop control surface /glyphoxa start and
@@ -55,7 +55,7 @@ type VoiceControl interface {
 
 // UseCommand builds `/glyphoxa use <campaign>` (ADR-0010, GM only): it durably
 // records the operator's Active Campaign choice so both the slash-command surface
-// and the web Session screen honor one explicit selection instead of the implicit
+// and the web Session screen honor one explicit selection over the implicit
 // most-recently-created default (AC1). The `campaign` option resolves by campaign
 // UUID (the value an autocomplete choice carries) or, as a free-text fallback, by
 // case-insensitive name; an unresolvable input is answered with a graceful
@@ -107,9 +107,9 @@ func UseCommand(store SessionStore) Command {
 // Active Campaign (ADR-0009) and drives the SAME in-process session.Manager the
 // web Start button uses, binding a Voice Session to that campaign (AC2/AC4). It
 // Defers first — the manager write is a domain operation that must not race
-// Discord's 3s deadline — then Follows up with a public confirmation, or an
-// ephemeral precondition error mirroring the web surface (no campaign, already
-// active, Discord unconfigured, …).
+// Discord's 3s deadline — then follows up with the outcome (an ephemeral
+// confirmation, or an ephemeral precondition error mirroring the web surface:
+// no campaign, already active, Discord unconfigured, …).
 func StartCommand(store SessionStore, voice VoiceControl) Command {
 	return Command{
 		Path:        "glyphoxa start",
@@ -124,7 +124,7 @@ func StartCommand(store SessionStore, voice VoiceControl) Command {
 
 			c, err := resolveActiveCampaign(ctx, store, voice, ic.UserID())
 			if errors.Is(err, ErrNoActiveCampaign) {
-				return ic.ReplyEphemeral("No Active Campaign yet — run /glyphoxa use <campaign> first.")
+				return ic.ReplyEphemeral("No Active Campaign yet — run /glyphoxa use campaign:<name> first.")
 			}
 			if err != nil {
 				return fmt.Errorf("presence: resolve active campaign: %w", err)
@@ -136,7 +136,7 @@ func StartCommand(store SessionStore, voice VoiceControl) Command {
 				}
 				return fmt.Errorf("presence: start voice session: %w", err)
 			}
-			return ic.Reply(fmt.Sprintf("Voice session running for %q.", c.Name))
+			return ic.ReplyEphemeral(fmt.Sprintf("Voice session running for %q.", c.Name))
 		},
 	}
 }
@@ -145,7 +145,8 @@ func StartCommand(store SessionStore, voice VoiceControl) Command {
 // in-process session.Manager the web Stop button uses, so ending is reflected in
 // the one session record both surfaces read (AC2/AC4). Ending when none is
 // running returns a clear ephemeral error (AC3). Like start it Defers, because
-// Stop waits on the loop unwinding plus the ended_at write.
+// Stop waits on the loop unwinding plus the ended_at write, and follows up
+// ephemerally.
 func EndCommand(voice VoiceControl) Command {
 	return Command{
 		Path:        "glyphoxa end",
@@ -164,17 +165,18 @@ func EndCommand(voice VoiceControl) Command {
 				}
 				return fmt.Errorf("presence: stop voice session: %w", err)
 			}
-			return ic.Reply("Voice session ended.")
+			return ic.ReplyEphemeral("Voice session ended.")
 		},
 	}
 }
 
 // resolveActiveCampaign resolves the operator's Active Campaign in the ADR-0009
 // order: (1) the campaign of the live Voice Session, if one is running; (2) the
-// operator's durable /glyphoxa use selection; (3) the most-recently-created
-// campaign (the legacy implicit default the web surface still uses, kept so the
-// two surfaces agree before any explicit selection). ErrNoActiveCampaign only
-// when all three come up empty.
+// operator's durable /glyphoxa use selection; else (3) FAIL with
+// ErrNoActiveCampaign. There is deliberately NO most-recently-created fallback on
+// the slash surface (unlike the web tier) — the GM has the /glyphoxa use
+// affordance right there, so the strict path avoids silently binding the wrong
+// campaign.
 func resolveActiveCampaign(ctx context.Context, store SessionStore, voice VoiceControl, discordUserID string) (storage.Campaign, error) {
 	// (1) A live Voice Session pins the Active Campaign to its own campaign, so
 	// start/end operate on exactly what is running (and a second start collides).
@@ -191,14 +193,7 @@ func resolveActiveCampaign(ctx context.Context, store SessionStore, voice VoiceC
 	}
 
 	// (2) The operator's explicit, durable choice.
-	if c, err := store.GetActiveCampaignForUser(ctx, discordUserID); err == nil {
-		return c, nil
-	} else if !errors.Is(err, storage.ErrNotFound) {
-		return storage.Campaign{}, err
-	}
-
-	// (3) Legacy implicit default: the most-recently-created campaign.
-	c, err := store.GetActiveCampaign(ctx)
+	c, err := store.GetActiveCampaignForUser(ctx, discordUserID)
 	if errors.Is(err, storage.ErrNotFound) {
 		return storage.Campaign{}, ErrNoActiveCampaign
 	}

--- a/internal/presence/session_commands.go
+++ b/internal/presence/session_commands.go
@@ -1,0 +1,271 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// sessionOpTimeout bounds the deferred work of /glyphoxa start and end. After a
+// Defer the dispatch first-response watchdog is stopped, so the interaction ctx
+// no longer carries Discord's 3s deadline; the manager Start/Stop — which can
+// wait on the voice loop unwinding and the ended_at write — runs under this
+// explicit budget instead of an open-ended one. It sits comfortably inside
+// Discord's minutes-long follow-up window.
+const sessionOpTimeout = 30 * time.Second
+
+// discordChoiceLimit is Discord's hard cap on autocomplete choices per response.
+const discordChoiceLimit = 25
+
+// ErrNoActiveCampaign is returned by resolveActiveCampaign when every ADR-0009
+// step comes up empty: no live Voice Session, no durable /glyphoxa use selection,
+// and no campaign at all to fall back to.
+var ErrNoActiveCampaign = errors.New("presence: no active campaign")
+
+// SessionStore is the storage surface the /glyphoxa session commands need:
+// listing campaigns for `use` and its autocomplete, loading one by id, durably
+// persisting the operator's Active Campaign choice, and the two Active Campaign
+// resolution reads (the per-operator selection, then the most-recently-created
+// fallback). *storage.Store satisfies it; tests use a fake.
+type SessionStore interface {
+	ListCampaigns(ctx context.Context) ([]storage.Campaign, error)
+	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
+	GetActiveCampaignForUser(ctx context.Context, discordUserID string) (storage.Campaign, error)
+	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
+}
+
+// VoiceControl is the in-process voice-loop control surface /glyphoxa start and
+// end drive — the SAME *session.Manager the web SessionService RPC uses, so both
+// surfaces share one active-session record and can never double-start or diverge
+// (AC4). *session.Manager satisfies it; tests use a fake.
+type VoiceControl interface {
+	Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error)
+	Stop(ctx context.Context) (storage.VoiceSession, error)
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// UseCommand builds `/glyphoxa use <campaign>` (ADR-0010, GM only): it durably
+// records the operator's Active Campaign choice so both the slash-command surface
+// and the web Session screen honor one explicit selection instead of the implicit
+// most-recently-created default (AC1). The `campaign` option resolves by campaign
+// UUID (the value an autocomplete choice carries) or, as a free-text fallback, by
+// case-insensitive name; an unresolvable input is answered with a graceful
+// ephemeral error naming it.
+func UseCommand(store SessionStore) Command {
+	return Command{
+		Path:        "glyphoxa use",
+		Description: "Set the Active Campaign.",
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{
+				Name:         "campaign",
+				Description:  "Campaign to make active.",
+				Required:     true,
+				Autocomplete: true,
+			},
+		},
+		GMOnly: true,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			input, _ := ic.String("campaign")
+			input = strings.TrimSpace(input)
+			if input == "" {
+				return ic.ReplyEphemeral("Name a campaign, e.g. /glyphoxa use campaign:<name>.")
+			}
+			campaigns, err := store.ListCampaigns(ctx)
+			if err != nil {
+				return fmt.Errorf("presence: list campaigns: %w", err)
+			}
+			c, ok := matchCampaign(campaigns, input)
+			if !ok {
+				return ic.ReplyEphemeral(fmt.Sprintf("No campaign matches %q. Pick one from the autocomplete list.", input))
+			}
+			if err := store.SetActiveCampaign(ctx, ic.UserID(), c.ID); err != nil {
+				return fmt.Errorf("presence: set active campaign: %w", err)
+			}
+			return ic.ReplyEphemeral(fmt.Sprintf("Active Campaign set to %q.", c.Name))
+		},
+		Autocomplete: func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
+			_, typed := ac.Focused()
+			campaigns, err := store.ListCampaigns(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return campaignChoices(campaigns, typed), nil
+		},
+	}
+}
+
+// StartCommand builds `/glyphoxa start` (ADR-0010, GM only): it resolves the
+// Active Campaign (ADR-0009) and drives the SAME in-process session.Manager the
+// web Start button uses, binding a Voice Session to that campaign (AC2/AC4). It
+// Defers first — the manager write is a domain operation that must not race
+// Discord's 3s deadline — then Follows up with a public confirmation, or an
+// ephemeral precondition error mirroring the web surface (no campaign, already
+// active, Discord unconfigured, …).
+func StartCommand(store SessionStore, voice VoiceControl) Command {
+	return Command{
+		Path:        "glyphoxa start",
+		Description: "Start the voice session for the Active Campaign.",
+		GMOnly:      true,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			if err := ic.Defer(true); err != nil {
+				return fmt.Errorf("presence: defer start: %w", err)
+			}
+			ctx, cancel := context.WithTimeout(ctx, sessionOpTimeout)
+			defer cancel()
+
+			c, err := resolveActiveCampaign(ctx, store, voice, ic.UserID())
+			if errors.Is(err, ErrNoActiveCampaign) {
+				return ic.ReplyEphemeral("No Active Campaign yet — run /glyphoxa use <campaign> first.")
+			}
+			if err != nil {
+				return fmt.Errorf("presence: resolve active campaign: %w", err)
+			}
+
+			if _, err := voice.Start(ctx, c.TenantID, c.ID); err != nil {
+				if msg, ok := startErrorMessage(err); ok {
+					return ic.ReplyEphemeral(msg)
+				}
+				return fmt.Errorf("presence: start voice session: %w", err)
+			}
+			return ic.Reply(fmt.Sprintf("Voice session running for %q.", c.Name))
+		},
+	}
+}
+
+// EndCommand builds `/glyphoxa end` (ADR-0010, GM only): it Stops the SAME
+// in-process session.Manager the web Stop button uses, so ending is reflected in
+// the one session record both surfaces read (AC2/AC4). Ending when none is
+// running returns a clear ephemeral error (AC3). Like start it Defers, because
+// Stop waits on the loop unwinding plus the ended_at write.
+func EndCommand(voice VoiceControl) Command {
+	return Command{
+		Path:        "glyphoxa end",
+		Description: "End the active voice session.",
+		GMOnly:      true,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			if err := ic.Defer(true); err != nil {
+				return fmt.Errorf("presence: defer end: %w", err)
+			}
+			ctx, cancel := context.WithTimeout(ctx, sessionOpTimeout)
+			defer cancel()
+
+			if _, err := voice.Stop(ctx); err != nil {
+				if errors.Is(err, session.ErrNoActiveSession) {
+					return ic.ReplyEphemeral("No voice session is running.")
+				}
+				return fmt.Errorf("presence: stop voice session: %w", err)
+			}
+			return ic.Reply("Voice session ended.")
+		},
+	}
+}
+
+// resolveActiveCampaign resolves the operator's Active Campaign in the ADR-0009
+// order: (1) the campaign of the live Voice Session, if one is running; (2) the
+// operator's durable /glyphoxa use selection; (3) the most-recently-created
+// campaign (the legacy implicit default the web surface still uses, kept so the
+// two surfaces agree before any explicit selection). ErrNoActiveCampaign only
+// when all three come up empty.
+func resolveActiveCampaign(ctx context.Context, store SessionStore, voice VoiceControl, discordUserID string) (storage.Campaign, error) {
+	// (1) A live Voice Session pins the Active Campaign to its own campaign, so
+	// start/end operate on exactly what is running (and a second start collides).
+	if vs, active := voice.Snapshot(); active {
+		c, err := store.GetCampaign(ctx, vs.CampaignID)
+		if err == nil {
+			return c, nil
+		}
+		if !errors.Is(err, storage.ErrNotFound) {
+			return storage.Campaign{}, err
+		}
+		// A running session whose campaign row has vanished is not expected; fall
+		// through to the durable selection rather than fail the command.
+	}
+
+	// (2) The operator's explicit, durable choice.
+	if c, err := store.GetActiveCampaignForUser(ctx, discordUserID); err == nil {
+		return c, nil
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return storage.Campaign{}, err
+	}
+
+	// (3) Legacy implicit default: the most-recently-created campaign.
+	c, err := store.GetActiveCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return storage.Campaign{}, ErrNoActiveCampaign
+	}
+	if err != nil {
+		return storage.Campaign{}, err
+	}
+	return c, nil
+}
+
+// startErrorMessage maps a manager Start precondition failure to its ephemeral
+// GM-facing text, mirroring the web SessionService's Connect-code mapping so both
+// surfaces report the same preconditions (AC3/AC4). ok is false for an unexpected
+// error, which the caller propagates for a generic reply + log.
+func startErrorMessage(err error) (string, bool) {
+	switch {
+	case errors.Is(err, session.ErrSessionActive):
+		return "A voice session is already active — /glyphoxa end it first.", true
+	case errors.Is(err, session.ErrDiscordNotConfigured):
+		return "Discord isn't configured yet — set the Guild and voice channel on the web Configuration screen.", true
+	case errors.Is(err, session.ErrDiscordTokenMissing):
+		return "No Discord bot token is configured — add it on the web Configuration screen.", true
+	case errors.Is(err, session.ErrDiscordTokenUndecryptable):
+		return "The saved Discord bot token could not be decrypted; check the server $GLYPHOXA_SECRET (ADR-0004).", true
+	case errors.Is(err, session.ErrVoiceUnavailable):
+		return "Voice isn't available in this deployment mode.", true
+	case errors.Is(err, session.ErrManagerClosed):
+		return "The server is shutting down — try again shortly.", true
+	default:
+		return "", false
+	}
+}
+
+// matchCampaign resolves a /glyphoxa use input to a campaign: first as a campaign
+// UUID (the value an autocomplete choice carries), else as a case-insensitive
+// exact name (the free-text fallback). ok is false when nothing matches.
+func matchCampaign(campaigns []storage.Campaign, input string) (storage.Campaign, bool) {
+	if id, err := uuid.Parse(input); err == nil {
+		for _, c := range campaigns {
+			if c.ID == id {
+				return c, true
+			}
+		}
+		return storage.Campaign{}, false
+	}
+	for _, c := range campaigns {
+		if strings.EqualFold(c.Name, input) {
+			return c, true
+		}
+	}
+	return storage.Campaign{}, false
+}
+
+// campaignChoices builds the /glyphoxa use autocomplete choices: campaigns whose
+// name contains the typed substring (case-insensitive), each choice DISPLAYING
+// the name and CARRYING the campaign UUID as its value so a pick resolves
+// unambiguously (no name collision). Capped at Discord's 25-choice limit.
+func campaignChoices(campaigns []storage.Campaign, typed string) []discord.AutocompleteChoice {
+	needle := strings.ToLower(strings.TrimSpace(typed))
+	choices := make([]discord.AutocompleteChoice, 0, len(campaigns))
+	for _, c := range campaigns {
+		if needle != "" && !strings.Contains(strings.ToLower(c.Name), needle) {
+			continue
+		}
+		choices = append(choices, discord.AutocompleteChoiceString{Name: c.Name, Value: c.ID.String()})
+		if len(choices) == discordChoiceLimit {
+			break
+		}
+	}
+	return choices
+}

--- a/internal/presence/session_commands_test.go
+++ b/internal/presence/session_commands_test.go
@@ -31,8 +31,6 @@ type fakeSessionStore struct {
 	byIDErr    error
 	forUser    *storage.Campaign
 	forUserErr error
-	active     *storage.Campaign
-	activeErr  error
 	setErr     error
 	setCalls   []setActiveCall
 }
@@ -65,16 +63,6 @@ func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (st
 		return storage.Campaign{}, storage.ErrNotFound
 	}
 	return *f.forUser, nil
-}
-
-func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
-	if f.activeErr != nil {
-		return storage.Campaign{}, f.activeErr
-	}
-	if f.active == nil {
-		return storage.Campaign{}, storage.ErrNotFound
-	}
-	return *f.active, nil
 }
 
 // startCall records the (tenant, campaign) a Start was driven with.
@@ -213,8 +201,10 @@ func TestStartSuccessUsesResolvedCampaign(t *testing.T) {
 	if resp.deferred == nil {
 		t.Error("start did not Defer before the slow work")
 	}
-	if len(resp.followups) != 1 || resp.followups[0].ephemeral || !strings.Contains(resp.followups[0].content, "Lost Mine") {
-		t.Errorf("followup = %+v, want one public confirmation naming the campaign", resp.followups)
+	// The confirmation is ephemeral: the first followup after Defer(true) inherits
+	// ephemerality in the real client, and no AC requires a public reply.
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral || !strings.Contains(resp.followups[0].content, "Lost Mine") {
+		t.Errorf("followup = %+v, want one ephemeral confirmation naming the campaign", resp.followups)
 	}
 }
 
@@ -236,7 +226,8 @@ func TestStartAlreadyActive(t *testing.T) {
 }
 
 func TestStartNoActiveCampaign(t *testing.T) {
-	// No live session, no selection, no campaign at all → the run-/use hint.
+	// No live session and no durable selection → fail with the run-/use hint (the
+	// slash surface has no most-recently-created fallback, ADR-0009).
 	store := &fakeSessionStore{}
 	voice := &fakeVoice{}
 	reg := testRegistry(testGuild, operatorID)
@@ -282,8 +273,9 @@ func TestEndSuccess(t *testing.T) {
 	if resp.deferred == nil {
 		t.Error("end did not Defer before the slow work")
 	}
-	if len(resp.followups) != 1 || resp.followups[0].ephemeral {
-		t.Errorf("followup = %+v, want one public confirmation", resp.followups)
+	// Ephemeral confirmation (see TestStartSuccessUsesResolvedCampaign).
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Errorf("followup = %+v, want one ephemeral confirmation", resp.followups)
 	}
 }
 
@@ -323,35 +315,28 @@ func TestSessionCommandsRefusedForNonGM(t *testing.T) {
 func TestResolveActiveCampaignOrder(t *testing.T) {
 	live := campaign("Live Session Campaign")
 	selected := campaign("Selected Campaign")
-	fallback := campaign("Fallback Campaign")
 	ctx := context.Background()
 
-	// (1) A live Voice Session wins over everything.
+	// (1) A live Voice Session wins even over a durable selection.
 	s1 := &fakeSessionStore{
 		byID:    map[uuid.UUID]storage.Campaign{live.ID: live},
 		forUser: &selected,
-		active:  &fallback,
 	}
 	v1 := &fakeVoice{active: true, snap: storage.VoiceSession{CampaignID: live.ID}}
 	if c, err := resolveActiveCampaign(ctx, s1, v1, operatorID); err != nil || c.ID != live.ID {
 		t.Errorf("step 1: got %s, %v; want live session campaign %s", c.ID, err, live.ID)
 	}
 
-	// (2) No live session → the operator's durable selection beats the fallback.
-	s2 := &fakeSessionStore{forUser: &selected, active: &fallback}
+	// (2) No live session → the operator's durable selection.
+	s2 := &fakeSessionStore{forUser: &selected}
 	if c, err := resolveActiveCampaign(ctx, s2, &fakeVoice{}, operatorID); err != nil || c.ID != selected.ID {
 		t.Errorf("step 2: got %s, %v; want selection %s", c.ID, err, selected.ID)
 	}
 
-	// (3) No session, no selection → the most-recently-created fallback.
-	s3 := &fakeSessionStore{active: &fallback}
-	if c, err := resolveActiveCampaign(ctx, s3, &fakeVoice{}, operatorID); err != nil || c.ID != fallback.ID {
-		t.Errorf("step 3: got %s, %v; want fallback %s", c.ID, err, fallback.ID)
-	}
-
-	// Nothing anywhere → ErrNoActiveCampaign.
+	// (3) No session and no selection → FAIL (no most-recently-created fallback on
+	// the slash surface, ADR-0009).
 	if _, err := resolveActiveCampaign(ctx, &fakeSessionStore{}, &fakeVoice{}, operatorID); err != ErrNoActiveCampaign {
-		t.Errorf("empty: err = %v, want ErrNoActiveCampaign", err)
+		t.Errorf("no session + no selection: err = %v, want ErrNoActiveCampaign", err)
 	}
 }
 
@@ -392,5 +377,48 @@ func TestGlyphoxaUseEndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(reply.Content, "Lost Mine") {
 		t.Errorf("reply = %q, want a confirmation naming the campaign", reply.Content)
+	}
+}
+
+// TestGlyphoxaUseAutocompleteEndToEnd routes a real grouped `/glyphoxa use`
+// AUTOCOMPLETE JSON interaction through HandleAutocomplete: disgo flattens the
+// subcommand into AutocompleteInteractionData.SubCommandName + Focused option, so
+// this pins that flattening (against a disgo upgrade) for a grouped autocomplete
+// — #213's e2e only covers a FLAT autocomplete. It asserts the focused substring
+// filters the campaigns and each choice carries the campaign UUID as its value.
+func TestGlyphoxaUseAutocompleteEndToEnd(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{campaign("Curse of Strahd"), lost}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(UseCommand(store))
+
+	payload := `{
+		"id": "1", "application_id": "2", "type": 4, "token": "t", "version": 1,
+		"guild_id": "` + testGuild + `",
+		"member": {"user": {"id": "` + operatorID + `", "username": "gm"}},
+		"data": {"id": "3", "name": "glyphoxa",
+			"options": [{"type": 1, "name": "use", "options": [{"type": 3, "name": "campaign", "value": "lost", "focused": true}]}]}
+	}`
+	var ai discord.AutocompleteInteraction
+	if err := json.Unmarshal([]byte(payload), &ai); err != nil {
+		t.Fatalf("unmarshal grouped autocomplete: %v", err)
+	}
+
+	var got discord.AutocompleteResult
+	e := &events.AutocompleteInteractionCreate{
+		AutocompleteInteraction: ai,
+		Respond: func(_ discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			got = data.(discord.AutocompleteResult)
+			return nil
+		},
+	}
+	reg.HandleAutocomplete(e)
+
+	if len(got.Choices) != 1 {
+		t.Fatalf("grouped autocomplete choices = %+v, want only the 'lost' match", got.Choices)
+	}
+	c := got.Choices[0].(discord.AutocompleteChoiceString)
+	if c.Name != "Lost Mine" || c.Value != lost.ID.String() {
+		t.Errorf("choice = %+v, want name 'Lost Mine' value %s", c, lost.ID)
 	}
 }

--- a/internal/presence/session_commands_test.go
+++ b/internal/presence/session_commands_test.go
@@ -1,0 +1,396 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/rest"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// setActiveCall records one SetActiveCampaign invocation for assertions.
+type setActiveCall struct {
+	discordUserID string
+	campaignID    uuid.UUID
+}
+
+// fakeSessionStore is a configurable in-memory SessionStore for the /glyphoxa
+// command unit tests (no DB). A nil *storage.Campaign pointer field models the
+// ErrNotFound "absent" state so the resolution order can be driven precisely.
+type fakeSessionStore struct {
+	list       []storage.Campaign
+	listErr    error
+	byID       map[uuid.UUID]storage.Campaign
+	byIDErr    error
+	forUser    *storage.Campaign
+	forUserErr error
+	active     *storage.Campaign
+	activeErr  error
+	setErr     error
+	setCalls   []setActiveCall
+}
+
+func (f *fakeSessionStore) ListCampaigns(context.Context) ([]storage.Campaign, error) {
+	return f.list, f.listErr
+}
+
+func (f *fakeSessionStore) GetCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	if f.byIDErr != nil {
+		return storage.Campaign{}, f.byIDErr
+	}
+	c, ok := f.byID[id]
+	if !ok {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeSessionStore) SetActiveCampaign(_ context.Context, discordUserID string, campaignID uuid.UUID) error {
+	f.setCalls = append(f.setCalls, setActiveCall{discordUserID, campaignID})
+	return f.setErr
+}
+
+func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
+	if f.forUserErr != nil {
+		return storage.Campaign{}, f.forUserErr
+	}
+	if f.forUser == nil {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return *f.forUser, nil
+}
+
+func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	if f.activeErr != nil {
+		return storage.Campaign{}, f.activeErr
+	}
+	if f.active == nil {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return *f.active, nil
+}
+
+// startCall records the (tenant, campaign) a Start was driven with.
+type startCall struct {
+	tenantID   uuid.UUID
+	campaignID uuid.UUID
+}
+
+// fakeVoice is a configurable VoiceControl for the start/end command tests.
+type fakeVoice struct {
+	snap       storage.VoiceSession
+	active     bool
+	startVS    storage.VoiceSession
+	startErr   error
+	started    *startCall
+	stopVS     storage.VoiceSession
+	stopErr    error
+	stopCalled bool
+}
+
+func (f *fakeVoice) Start(_ context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	f.started = &startCall{tenantID, campaignID}
+	if f.startErr != nil {
+		return storage.VoiceSession{}, f.startErr
+	}
+	return f.startVS, nil
+}
+
+func (f *fakeVoice) Stop(context.Context) (storage.VoiceSession, error) {
+	f.stopCalled = true
+	return f.stopVS, f.stopErr
+}
+
+func (f *fakeVoice) Snapshot() (storage.VoiceSession, bool) { return f.snap, f.active }
+
+func campaign(name string) storage.Campaign {
+	return storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: name}
+}
+
+// dispatchAs runs one interaction through the registry as the given user with
+// the given string options, returning the recorded responder.
+func dispatchAs(reg *Registry, key, userID string, opts map[string]string) *fakeResponder {
+	resp := &fakeResponder{}
+	ic := &Interaction{guildID: testGuild, userID: userID, opts: fakeOpts{s: opts}, resp: resp}
+	reg.dispatch(context.Background(), key, ic)
+	return resp
+}
+
+func TestUseSetsActiveCampaignByName(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{campaign("Curse of Strahd"), lost}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(UseCommand(store))
+
+	// Case-insensitive free-text name resolves.
+	resp := dispatchAs(reg, "glyphoxa use", operatorID, map[string]string{"campaign": "lost mine"})
+
+	if len(store.setCalls) != 1 {
+		t.Fatalf("SetActiveCampaign calls = %d, want 1", len(store.setCalls))
+	}
+	if store.setCalls[0].discordUserID != operatorID || store.setCalls[0].campaignID != lost.ID {
+		t.Errorf("SetActiveCampaign = %+v, want operator %s + campaign %s", store.setCalls[0], operatorID, lost.ID)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral || !strings.Contains(resp.replies[0].content, "Lost Mine") {
+		t.Errorf("reply = %+v, want one ephemeral naming the campaign", resp.replies)
+	}
+}
+
+func TestUseResolvesByUUIDValue(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{lost}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(UseCommand(store))
+
+	// The autocomplete choice value is the campaign UUID.
+	dispatchAs(reg, "glyphoxa use", operatorID, map[string]string{"campaign": lost.ID.String()})
+
+	if len(store.setCalls) != 1 || store.setCalls[0].campaignID != lost.ID {
+		t.Fatalf("SetActiveCampaign = %+v, want campaign %s", store.setCalls, lost.ID)
+	}
+}
+
+func TestUseUnknownCampaign(t *testing.T) {
+	store := &fakeSessionStore{list: []storage.Campaign{campaign("Lost Mine")}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(UseCommand(store))
+
+	resp := dispatchAs(reg, "glyphoxa use", operatorID, map[string]string{"campaign": "Nonexistent"})
+
+	if len(store.setCalls) != 0 {
+		t.Errorf("SetActiveCampaign called %d times for an unknown campaign, want 0", len(store.setCalls))
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral || !strings.Contains(resp.replies[0].content, "Nonexistent") {
+		t.Errorf("reply = %+v, want one ephemeral error naming the input", resp.replies)
+	}
+}
+
+func TestUseAutocompleteListsAndFilters(t *testing.T) {
+	strahd := campaign("Curse of Strahd")
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{strahd, lost}}
+	cmd := UseCommand(store)
+
+	// Empty focus lists all; each choice DISPLAYS the name, CARRIES the UUID value.
+	all, err := cmd.Autocomplete(context.Background(), &Autocomplete{})
+	if err != nil {
+		t.Fatalf("autocomplete all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("empty-focus choices = %d, want 2", len(all))
+	}
+	got := all[0].(discord.AutocompleteChoiceString)
+	if got.Name != "Curse of Strahd" || got.Value != strahd.ID.String() {
+		t.Errorf("choice 0 = %+v, want name 'Curse of Strahd' value %s", got, strahd.ID)
+	}
+
+	// A typed substring filters case-insensitively.
+	filtered := campaignChoices(store.list, "lost")
+	if len(filtered) != 1 || filtered[0].(discord.AutocompleteChoiceString).Value != lost.ID.String() {
+		t.Errorf("filtered choices = %+v, want only Lost Mine", filtered)
+	}
+}
+
+func TestStartSuccessUsesResolvedCampaign(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{forUser: &lost}
+	voice := &fakeVoice{startVS: storage.VoiceSession{ID: uuid.New(), CampaignID: lost.ID}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if voice.started == nil || voice.started.tenantID != lost.TenantID || voice.started.campaignID != lost.ID {
+		t.Fatalf("Start called with %+v, want tenant %s campaign %s", voice.started, lost.TenantID, lost.ID)
+	}
+	if resp.deferred == nil {
+		t.Error("start did not Defer before the slow work")
+	}
+	if len(resp.followups) != 1 || resp.followups[0].ephemeral || !strings.Contains(resp.followups[0].content, "Lost Mine") {
+		t.Errorf("followup = %+v, want one public confirmation naming the campaign", resp.followups)
+	}
+}
+
+func TestStartAlreadyActive(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{forUser: &lost}
+	voice := &fakeVoice{startErr: session.ErrSessionActive}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("already-active reply = %+v, want one ephemeral error", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "already active") {
+		t.Errorf("already-active reply = %q, want a clear 'already active' message", resp.followups[0].content)
+	}
+}
+
+func TestStartNoActiveCampaign(t *testing.T) {
+	// No live session, no selection, no campaign at all → the run-/use hint.
+	store := &fakeSessionStore{}
+	voice := &fakeVoice{}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if voice.started != nil {
+		t.Error("Start was driven despite no resolvable campaign")
+	}
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral || !strings.Contains(resp.followups[0].content, "use") {
+		t.Errorf("reply = %+v, want one ephemeral hint to run /glyphoxa use", resp.followups)
+	}
+}
+
+func TestStartDiscordNotConfigured(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{forUser: &lost}
+	voice := &fakeVoice{startErr: session.ErrDiscordNotConfigured}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("not-configured reply = %+v, want one ephemeral error", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "configur") {
+		t.Errorf("not-configured reply = %q, want a clear configuration hint", resp.followups[0].content)
+	}
+}
+
+func TestEndSuccess(t *testing.T) {
+	voice := &fakeVoice{stopVS: storage.VoiceSession{ID: uuid.New()}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(EndCommand(voice))
+
+	resp := dispatchAs(reg, "glyphoxa end", operatorID, nil)
+
+	if !voice.stopCalled {
+		t.Fatal("Stop was not called")
+	}
+	if resp.deferred == nil {
+		t.Error("end did not Defer before the slow work")
+	}
+	if len(resp.followups) != 1 || resp.followups[0].ephemeral {
+		t.Errorf("followup = %+v, want one public confirmation", resp.followups)
+	}
+}
+
+func TestEndNoneRunning(t *testing.T) {
+	voice := &fakeVoice{stopErr: session.ErrNoActiveSession}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(EndCommand(voice))
+
+	resp := dispatchAs(reg, "glyphoxa end", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("none-running reply = %+v, want one ephemeral error", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "no voice session") {
+		t.Errorf("none-running reply = %q, want a clear 'none running' message", resp.followups[0].content)
+	}
+}
+
+func TestSessionCommandsRefusedForNonGM(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{lost}, forUser: &lost}
+	voice := &fakeVoice{}
+	reg := testRegistry(testGuild, operatorID) // only operatorID is allowlisted
+	reg.Register(UseCommand(store), StartCommand(store, voice), EndCommand(voice))
+
+	for _, key := range []string{"glyphoxa use", "glyphoxa start", "glyphoxa end"} {
+		resp := dispatchAs(reg, key, strangerID, map[string]string{"campaign": "Lost Mine"})
+		if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+			t.Errorf("%s by non-GM: reply = %+v, want one ephemeral denial", key, resp.replies)
+		}
+	}
+	if len(store.setCalls) != 0 || voice.started != nil || voice.stopCalled {
+		t.Errorf("a non-GM reached a handler: set=%d start=%v stop=%v", len(store.setCalls), voice.started, voice.stopCalled)
+	}
+}
+
+func TestResolveActiveCampaignOrder(t *testing.T) {
+	live := campaign("Live Session Campaign")
+	selected := campaign("Selected Campaign")
+	fallback := campaign("Fallback Campaign")
+	ctx := context.Background()
+
+	// (1) A live Voice Session wins over everything.
+	s1 := &fakeSessionStore{
+		byID:    map[uuid.UUID]storage.Campaign{live.ID: live},
+		forUser: &selected,
+		active:  &fallback,
+	}
+	v1 := &fakeVoice{active: true, snap: storage.VoiceSession{CampaignID: live.ID}}
+	if c, err := resolveActiveCampaign(ctx, s1, v1, operatorID); err != nil || c.ID != live.ID {
+		t.Errorf("step 1: got %s, %v; want live session campaign %s", c.ID, err, live.ID)
+	}
+
+	// (2) No live session → the operator's durable selection beats the fallback.
+	s2 := &fakeSessionStore{forUser: &selected, active: &fallback}
+	if c, err := resolveActiveCampaign(ctx, s2, &fakeVoice{}, operatorID); err != nil || c.ID != selected.ID {
+		t.Errorf("step 2: got %s, %v; want selection %s", c.ID, err, selected.ID)
+	}
+
+	// (3) No session, no selection → the most-recently-created fallback.
+	s3 := &fakeSessionStore{active: &fallback}
+	if c, err := resolveActiveCampaign(ctx, s3, &fakeVoice{}, operatorID); err != nil || c.ID != fallback.ID {
+		t.Errorf("step 3: got %s, %v; want fallback %s", c.ID, err, fallback.ID)
+	}
+
+	// Nothing anywhere → ErrNoActiveCampaign.
+	if _, err := resolveActiveCampaign(ctx, &fakeSessionStore{}, &fakeVoice{}, operatorID); err != ErrNoActiveCampaign {
+		t.Errorf("empty: err = %v, want ErrNoActiveCampaign", err)
+	}
+}
+
+// TestGlyphoxaUseEndToEnd routes a real grouped `/glyphoxa use` JSON interaction
+// through HandleCommand (the disgo listener), proving the wiring from a live
+// event to SetActiveCampaign + reply — the same harness the #102 grouped test
+// pins.
+func TestGlyphoxaUseEndToEnd(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{list: []storage.Campaign{lost}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(UseCommand(store))
+
+	payload := `{
+		"id": "1", "application_id": "2", "type": 2, "token": "t", "version": 1,
+		"guild_id": "` + testGuild + `",
+		"member": {"user": {"id": "` + operatorID + `", "username": "gm"}},
+		"data": {"id": "3", "name": "glyphoxa", "type": 1,
+			"options": [{"type": 1, "name": "use", "options": [{"type": 3, "name": "campaign", "value": "Lost Mine"}]}]}
+	}`
+	var aci discord.ApplicationCommandInteraction
+	if err := json.Unmarshal([]byte(payload), &aci); err != nil {
+		t.Fatalf("unmarshal grouped interaction: %v", err)
+	}
+
+	var reply discord.MessageCreate
+	e := &events.ApplicationCommandInteractionCreate{
+		ApplicationCommandInteraction: aci,
+		Respond: func(_ discord.InteractionResponseType, data discord.InteractionResponseData, _ ...rest.RequestOpt) error {
+			reply = data.(discord.MessageCreate)
+			return nil
+		},
+	}
+	reg.HandleCommand(e)
+
+	if len(store.setCalls) != 1 || store.setCalls[0].campaignID != lost.ID {
+		t.Fatalf("SetActiveCampaign = %+v, want campaign %s", store.setCalls, lost.ID)
+	}
+	if !strings.Contains(reply.Content, "Lost Mine") {
+		t.Errorf("reply = %q, want a confirmation naming the campaign", reply.Content)
+	}
+}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -26,10 +26,12 @@ type SessionManager interface {
 	Snapshot() (storage.VoiceSession, bool)
 }
 
-// SessionStore is the narrow storage surface SessionServer needs: the active
-// campaign to scope a session, and the latest ended session for the idle
+// SessionStore is the narrow storage surface SessionServer needs: the operator's
+// durable Active Campaign selection (#108), the most-recently-created campaign as
+// the fallback that scopes a session, and the latest ended session for the idle
 // last-session summary (#72).
 type SessionStore interface {
+	GetActiveCampaignForUser(ctx context.Context, discordUserID string) (storage.Campaign, error)
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
 }
@@ -117,12 +119,12 @@ func (s *SessionServer) StartSession(
 		return nil, err
 	}
 
-	campaign, err := s.store.GetActiveCampaign(ctx)
+	campaign, err := s.startCampaign(ctx)
 	if errors.Is(err, storage.ErrNotFound) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active campaign to start a session for"))
 	}
 	if err != nil {
-		s.log.Error("StartSession: get active campaign failed", "err", err)
+		s.log.Error("StartSession: resolve active campaign failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
@@ -133,6 +135,27 @@ func (s *SessionServer) StartSession(
 	return connect.NewResponse(&managementv1.StartSessionResponse{
 		Session: toProtoVoiceSession(vs),
 	}), nil
+}
+
+// startCampaign resolves the campaign a web Start binds to, honoring the durable
+// /glyphoxa use selection so the web Start button and the slash command agree
+// (ADR-0009, #108): the logged-in operator's active_campaign_id when set, else the
+// most-recently-created campaign — kept as the fallback so a fresh install that
+// has never run /glyphoxa use still starts. The slash surface is strict (no
+// fallback) because it has the /use affordance; the web has no such hint, so it
+// keeps the legacy default.
+func (s *SessionServer) startCampaign(ctx context.Context) (storage.Campaign, error) {
+	if u, ok := auth.CurrentUser(ctx); ok && u.DiscordUserID != "" {
+		c, err := s.store.GetActiveCampaignForUser(ctx, u.DiscordUserID)
+		if err == nil {
+			return c, nil
+		}
+		if !errors.Is(err, storage.ErrNotFound) {
+			return storage.Campaign{}, err
+		}
+		// No durable selection yet — fall back to the implicit default.
+	}
+	return s.store.GetActiveCampaign(ctx)
 }
 
 // startError maps a manager Start failure onto a Connect status code: the

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -72,12 +72,25 @@ func (f *fakeSessionManager) Snapshot() (storage.VoiceSession, bool) {
 	return f.current, f.active
 }
 
-// fakeSessionStore serves the active campaign and the latest ended session.
+// fakeSessionStore serves the durable per-operator selection, the implicit active
+// campaign, and the latest ended session.
 type fakeSessionStore struct {
+	forUser     storage.Campaign // the operator's /glyphoxa use selection (#108)
+	forUserErr  error            // set to storage.ErrNotFound to force the fallback
 	campaign    storage.Campaign
 	campaignErr error
 	latest      storage.VoiceSession
 	latestErr   error
+}
+
+func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
+	if f.forUserErr != nil {
+		return storage.Campaign{}, f.forUserErr
+	}
+	if f.forUser.ID == uuid.Nil {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return f.forUser, nil
 }
 
 func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
@@ -95,11 +108,22 @@ func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (st
 }
 
 func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
+	return newSessionClientAs(t, mgr, store, storage.User{})
+}
+
+// newSessionClientAs is newSessionClient plus an injected authenticated operator,
+// so StartSession's durable-selection lookup (#108) sees a Discord identity. A
+// zero user injects only the tenant (the legacy no-user path).
+func newSessionClientAs(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore, user storage.User) managementv1connect.SessionServiceClient {
 	t.Helper()
 	tenantID := uuid.New()
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			return next(auth.WithTenant(ctx, tenantID), req)
+			ctx = auth.WithTenant(ctx, tenantID)
+			if user.DiscordUserID != "" {
+				ctx = auth.WithUser(ctx, user)
+			}
+			return next(ctx, req)
 		}
 	})
 	mux := http.NewServeMux()
@@ -279,5 +303,43 @@ func TestSessionGetIdleReturnsLastSession(t *testing.T) {
 	got := resp.Msg.GetSession()
 	if got == nil || got.GetStatus() != "ended" || got.GetLineCount() != 12 {
 		t.Errorf("idle session = %+v, want ended with 12 lines", got)
+	}
+}
+
+// TestSessionStartHonorsDurableSelection is #108 web parity: with the operator's
+// /glyphoxa use selection set (campaign A) AND a newer implicit default (campaign
+// B), the web StartSession binds A — so the Session screen and the slash command
+// agree on the campaign.
+func TestSessionStartHonorsDurableSelection(t *testing.T) {
+	t.Parallel()
+	selected := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Selected"}
+	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer"}
+	store := &fakeSessionStore{forUser: selected, campaign: newer, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, &fakeSessionManager{}, store, storage.User{DiscordUserID: "999"})
+
+	start, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if start.Msg.GetSession().GetCampaignId() != selected.ID.String() {
+		t.Errorf("bound campaign = %s, want the durable selection %s", start.Msg.GetSession().GetCampaignId(), selected.ID)
+	}
+}
+
+// TestSessionStartFallsBackWithoutSelection pins the existing web behavior: an
+// operator with no /glyphoxa use selection falls back to the most-recently-created
+// campaign (GetActiveCampaign).
+func TestSessionStartFallsBackWithoutSelection(t *testing.T) {
+	t.Parallel()
+	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer"}
+	store := &fakeSessionStore{forUserErr: storage.ErrNotFound, campaign: newer, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, &fakeSessionManager{}, store, storage.User{DiscordUserID: "999"})
+
+	start, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if start.Msg.GetSession().GetCampaignId() != newer.ID.String() {
+		t.Errorf("bound campaign = %s, want the fallback %s", start.Msg.GetSession().GetCampaignId(), newer.ID)
 	}
 }

--- a/internal/storage/active_campaign_test.go
+++ b/internal/storage/active_campaign_test.go
@@ -90,10 +90,11 @@ func TestActiveCampaignPersistsAcrossReopen(t *testing.T) {
 }
 
 // TestActiveCampaignOverridesImplicitDefault is the ADR-0009 resolution
-// precedence at the storage grain: the operator's explicit selection (step 2)
-// diverges from — and is honored over — the most-recently-created implicit
-// default (step 3, GetActiveCampaign). #108's resolveActiveCampaign layers the
-// live-session step on top of this.
+// precedence at the storage grain: the operator's explicit selection
+// (GetActiveCampaignForUser) diverges from — and is honored over — the
+// most-recently-created implicit default (GetActiveCampaign). This is what lets
+// the web StartSession honor the durable /glyphoxa use choice (#108) while
+// keeping GetActiveCampaign as its fresh-install fallback.
 func TestActiveCampaignOverridesImplicitDefault(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, older := seedCampaign(t, dsn)
@@ -118,11 +119,12 @@ func TestActiveCampaignOverridesImplicitDefault(t *testing.T) {
 	}
 }
 
-// TestGetActiveCampaignForUserFallsThroughOnDeletedCampaign proves the FK's ON
-// DELETE SET NULL clears a stale selection: deleting the chosen campaign makes
-// GetActiveCampaignForUser return ErrNotFound (so resolution falls to step 3),
-// and a user with a NULL selection is likewise ErrNotFound.
-func TestGetActiveCampaignForUserFallsThroughOnDeletedCampaign(t *testing.T) {
+// TestGetActiveCampaignForUserClearedOnDeletedCampaign proves the FK's ON DELETE
+// SET NULL clears a stale selection: deleting the chosen campaign makes
+// GetActiveCampaignForUser return ErrNotFound (so the slash surface then fails
+// with the /use hint, and the web tier falls back to GetActiveCampaign), and a
+// user with a NULL selection is likewise ErrNotFound.
+func TestGetActiveCampaignForUserClearedOnDeletedCampaign(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, _ := seedCampaign(t, dsn)
 	ctx := context.Background()

--- a/internal/storage/active_campaign_test.go
+++ b/internal/storage/active_campaign_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const gmSnowflake = "555000111222"
+
+// insertCampaign adds a second campaign in the same tenant, returning its id.
+func insertCampaign(t *testing.T, st *storage.Store, tenantID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	// Use a direct write through the pool the Store already holds; CreateCampaign
+	// needs a NewCampaign — but the campaign-creation seam differs across tests, so
+	// keep this local to the active-campaign concern.
+	id, err := st.CreateCampaign(context.Background(), storage.NewCampaign{
+		TenantID: tenantID, Name: name, System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("create campaign %q: %v", name, err)
+	}
+	return id
+}
+
+// TestActiveCampaignRoundTrip proves the #108 durable selection against a real
+// Postgres: SetActiveCampaign upserts the operator's users row (even before any
+// web login) and GetActiveCampaignForUser reads the chosen campaign back;
+// re-selecting a different campaign updates in place.
+func TestActiveCampaignRoundTrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, first := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// No selection yet (and no user row at all) → ErrNotFound.
+	if _, err := st.GetActiveCampaignForUser(ctx, gmSnowflake); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("GetActiveCampaignForUser before any selection = %v, want ErrNotFound", err)
+	}
+
+	// SetActiveCampaign upserts the user row and records the choice.
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, first); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	if _, err := st.GetUserByDiscordID(ctx, gmSnowflake); err != nil {
+		t.Fatalf("SetActiveCampaign did not create the user row: %v", err)
+	}
+	got, err := st.GetActiveCampaignForUser(ctx, gmSnowflake)
+	if err != nil {
+		t.Fatalf("GetActiveCampaignForUser: %v", err)
+	}
+	if got.ID != first {
+		t.Errorf("active campaign = %s, want %s", got.ID, first)
+	}
+
+	// Re-selecting a different campaign updates the same row in place.
+	second := insertCampaign(t, st, tenantID, "Second Campaign")
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, second); err != nil {
+		t.Fatalf("SetActiveCampaign (re-select): %v", err)
+	}
+	got, err = st.GetActiveCampaignForUser(ctx, gmSnowflake)
+	if err != nil || got.ID != second {
+		t.Fatalf("after re-select = %s, %v; want %s", got.ID, err, second)
+	}
+}
+
+// TestActiveCampaignPersistsAcrossReopen proves AC1 "persists across a process
+// restart": a fresh Store over the same DSN reads the same selection.
+func TestActiveCampaignPersistsAcrossReopen(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+
+	if err := storage.New(pool).SetActiveCampaign(ctx, gmSnowflake, campaignID); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+
+	// A brand-new pool + Store (a "restarted process") sees the persisted choice.
+	reopened := storage.New(openPool(t, dsn))
+	got, err := reopened.GetActiveCampaignForUser(ctx, gmSnowflake)
+	if err != nil || got.ID != campaignID {
+		t.Fatalf("after reopen = %s, %v; want %s", got.ID, err, campaignID)
+	}
+}
+
+// TestActiveCampaignOverridesImplicitDefault is the ADR-0009 resolution
+// precedence at the storage grain: the operator's explicit selection (step 2)
+// diverges from — and is honored over — the most-recently-created implicit
+// default (step 3, GetActiveCampaign). #108's resolveActiveCampaign layers the
+// live-session step on top of this.
+func TestActiveCampaignOverridesImplicitDefault(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, older := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A newer campaign becomes the implicit default (most-recently-created).
+	newer := insertCampaign(t, st, tenantID, "Newer Campaign")
+	def, err := st.GetActiveCampaign(ctx)
+	if err != nil || def.ID != newer {
+		t.Fatalf("implicit default = %s, %v; want the newer campaign %s", def.ID, err, newer)
+	}
+
+	// The operator explicitly selects the OLDER campaign; the per-operator read
+	// must return that, not the implicit default.
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, older); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	got, err := st.GetActiveCampaignForUser(ctx, gmSnowflake)
+	if err != nil || got.ID != older {
+		t.Fatalf("per-operator selection = %s, %v; want the older campaign %s", got.ID, err, older)
+	}
+}
+
+// TestGetActiveCampaignForUserFallsThroughOnDeletedCampaign proves the FK's ON
+// DELETE SET NULL clears a stale selection: deleting the chosen campaign makes
+// GetActiveCampaignForUser return ErrNotFound (so resolution falls to step 3),
+// and a user with a NULL selection is likewise ErrNotFound.
+func TestGetActiveCampaignForUserFallsThroughOnDeletedCampaign(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A user with a row but no selection → ErrNotFound.
+	if _, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: gmSnowflake}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	if _, err := st.GetActiveCampaignForUser(ctx, gmSnowflake); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("NULL selection = %v, want ErrNotFound", err)
+	}
+
+	// Select a throwaway campaign, then delete it: the FK nulls the pointer.
+	victim := insertCampaign(t, st, tenantID, "Doomed Campaign")
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, victim); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM campaign WHERE id = $1`, victim); err != nil {
+		t.Fatalf("delete campaign: %v", err)
+	}
+	if _, err := st.GetActiveCampaignForUser(ctx, gmSnowflake); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("selection after campaign delete = %v, want ErrNotFound (FK SET NULL)", err)
+	}
+}
+
+// TestListAndGetCampaign covers the /glyphoxa use autocomplete + resolution
+// reads: ListCampaigns returns every campaign name-ordered, GetCampaign fetches
+// one by id, and an unknown id is ErrNotFound.
+func TestListAndGetCampaign(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, first := seedCampaign(t, dsn) // seeded name: "Lost Mine"
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	second := insertCampaign(t, st, tenantID, "Alpha Quest")
+
+	list, err := st.ListCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("ListCampaigns len = %d, want 2", len(list))
+	}
+	// Ordered by name: "Alpha Quest" before "Lost Mine".
+	if list[0].ID != second || list[1].ID != first {
+		t.Errorf("ListCampaigns order = [%s %s], want name-ordered [%s %s]", list[0].ID, list[1].ID, second, first)
+	}
+
+	got, err := st.GetCampaign(ctx, first)
+	if err != nil || got.ID != first {
+		t.Fatalf("GetCampaign(%s) = %s, %v", first, got.ID, err)
+	}
+	if _, err := st.GetCampaign(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetCampaign(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -78,6 +78,47 @@ func (s *Store) GetUserByDiscordID(ctx context.Context, discordUserID string) (U
 	return u, nil
 }
 
+// SetActiveCampaign records the operator's durable Active Campaign choice (#108,
+// ADR-0009) on the users row keyed by Discord snowflake. It UPSERTS the row so a
+// GM who drives the slash-command surface before ever logging into the web tier
+// still gets a persisted selection; a later OAuth login refreshes the display
+// fields (UpsertUser) and preserves this selection. Idempotent.
+func (s *Store) SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error {
+	_, err := s.db.Exec(ctx,
+		`INSERT INTO users (discord_user_id, active_campaign_id)
+		 VALUES ($1, $2)
+		 ON CONFLICT (discord_user_id) DO UPDATE
+		   SET active_campaign_id = EXCLUDED.active_campaign_id, updated_at = now()`,
+		discordUserID, campaignID)
+	if err != nil {
+		return fmt.Errorf("storage: set active campaign for %q: %w", discordUserID, err)
+	}
+	return nil
+}
+
+// GetActiveCampaignForUser returns the Campaign the operator selected via
+// /glyphoxa use (#108, ADR-0009 step 2), joining the users row's
+// active_campaign_id to campaign. ErrNotFound when the operator has no row, has
+// made no selection, or the chosen campaign has since been deleted (the FK's ON
+// DELETE SET NULL nulled the pointer) — the caller then falls through to the
+// GetActiveCampaign fallback (step 3). The columns are qualified to `c` because
+// users and campaign share id/name/created_at/updated_at.
+func (s *Store) GetActiveCampaignForUser(ctx context.Context, discordUserID string) (Campaign, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT c.id, c.tenant_id, c.gm_member_id, c.name, c.system, c.language,
+		        c.created_at, c.updated_at
+		   FROM users u JOIN campaign c ON c.id = u.active_campaign_id
+		  WHERE u.discord_user_id = $1`, discordUserID)
+	c, err := scanCampaign(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Campaign{}, ErrNotFound
+	}
+	if err != nil {
+		return Campaign{}, fmt.Errorf("storage: active campaign for %q: %w", discordUserID, err)
+	}
+	return c, nil
+}
+
 // NewSession is the input to CreateSession. Token is the opaque random secret
 // the auth tier minted; ExpiresAt is the absolute expiry the validator enforces.
 type NewSession struct {

--- a/internal/storage/migrations/00014_active_campaign.sql
+++ b/internal/storage/migrations/00014_active_campaign.sql
@@ -8,9 +8,10 @@
 -- OAuth web tier upserts (00003) — so one column serves both surfaces.
 --
 -- ON DELETE SET NULL: deleting the chosen campaign clears the selection rather
--- than cascading the user away; Active Campaign resolution then falls through to
--- the most-recently-created fallback (ADR-0009 step 3), so a stale pointer can
--- never wedge the two commands that depend on it.
+-- than cascading the user away. The slash-command surface then has no Active
+-- Campaign and asks the GM to run /glyphoxa use again (ADR-0009: it has NO
+-- most-recently-created fallback); the web tier keeps that fallback for
+-- fresh-install UX. Either way a stale pointer can never wedge a command.
 
 ALTER TABLE users
     ADD COLUMN active_campaign_id uuid REFERENCES campaign (id) ON DELETE SET NULL;

--- a/internal/storage/migrations/00014_active_campaign.sql
+++ b/internal/storage/migrations/00014_active_campaign.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- The operator's durable Active Campaign selection (#108, ADR-0009). Until now
+-- the Active Campaign was implicitly the most-recently-created campaign
+-- (storage.GetActiveCampaign); /glyphoxa use makes it an explicit per-operator
+-- choice that both the slash-command surface and the web Session screen honor.
+-- It lives on the users row keyed by discord_user_id — the same identity the
+-- OAuth web tier upserts (00003) — so one column serves both surfaces.
+--
+-- ON DELETE SET NULL: deleting the chosen campaign clears the selection rather
+-- than cascading the user away; Active Campaign resolution then falls through to
+-- the most-recently-created fallback (ADR-0009 step 3), so a stale pointer can
+-- never wedge the two commands that depend on it.
+
+ALTER TABLE users
+    ADD COLUMN active_campaign_id uuid REFERENCES campaign (id) ON DELETE SET NULL;
+
+-- +goose Down
+
+ALTER TABLE users DROP COLUMN IF EXISTS active_campaign_id;

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -97,6 +97,45 @@ func (s *Store) GetActiveCampaign(ctx context.Context) (Campaign, error) {
 	return c, nil
 }
 
+// GetCampaign loads one Campaign by id, or ErrNotFound. It backs the /glyphoxa
+// use resolution step that turns a live Voice Session's campaign_id back into the
+// full Campaign (#108).
+func (s *Store) GetCampaign(ctx context.Context, id uuid.UUID) (Campaign, error) {
+	row := s.db.QueryRow(ctx, `SELECT `+campaignColumns+` FROM campaign WHERE id = $1`, id)
+	c, err := scanCampaign(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Campaign{}, ErrNotFound
+	}
+	if err != nil {
+		return Campaign{}, fmt.Errorf("storage: get campaign %s: %w", id, err)
+	}
+	return c, nil
+}
+
+// ListCampaigns returns every Campaign ordered by name (then id for a stable
+// tie-break) — the /glyphoxa use autocomplete source (#108). Single-operator
+// today, so it is unscoped, mirroring GetActiveCampaign; tenant scoping fills in
+// behind the X-Tenant-Id pass-through later (ADR-0039).
+func (s *Store) ListCampaigns(ctx context.Context) ([]Campaign, error) {
+	rows, err := s.db.Query(ctx, `SELECT `+campaignColumns+` FROM campaign ORDER BY name, id`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list campaigns: %w", err)
+	}
+	defer rows.Close()
+	var out []Campaign
+	for rows.Next() {
+		c, err := scanCampaign(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan campaign: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list campaigns: %w", err)
+	}
+	return out, nil
+}
+
 const agentColumns = `
 	id, campaign_id, agent_role, name, title, persona, voice,
 	voice_provider_config_id, llm_provider_config_id,


### PR DESCRIPTION
## What does this PR do?

Adds the GM-only `/glyphoxa use`, `/glyphoxa start` and `/glyphoxa end` slash
commands over the standing Discord presence (#102/#213).

Closes #108

- **`/glyphoxa use <campaign>`** durably sets the operator's Active Campaign
  (new `users.active_campaign_id` column, migration `00014`). The option
  autocompletes campaigns (display name, value = UUID) and also accepts a
  free-text case-insensitive name; an unresolvable input gets a graceful
  ephemeral error.
- **`/glyphoxa start` / `end`** drive the **same in-process `session.Manager`**
  the web Session screen uses, so both surfaces share one active-session record
  and never double-start or diverge (AC4). They Defer and bound their manager
  call with an explicit timeout, then follow up **ephemerally** (the first
  followup after `Defer(true)` inherits ephemerality in the real client, and no
  AC requires a public reply), mapping the manager's typed preconditions
  (already-active, none-running, Discord unconfigured, undecryptable/missing
  token, wrong mode, shutting down) to clear ephemeral errors mirroring the web
  surface.
- **Active Campaign resolution** follows ADR-0009 strictly on the slash surface:
  (1) live Voice Session → its campaign, (2) the operator's durable `/glyphoxa
  use` selection, else **FAIL** with a `/glyphoxa use campaign:<name>` hint —
  **no** most-recently-created fallback (the GM has the `/use` affordance).
- **Web parity**: `rpc.StartSession` now honors the operator's durable selection
  first (`active_campaign_id`), falling back to `GetActiveCampaign` for a fresh
  install — so the web Start button and the slash command bind the same campaign.
- All three commands are **GM-only** — refused server-side by the `Gate`
  (operator allowlist, ADR-0041/0010); handlers never re-check permissions.

## Why is this change needed?

Epic 5 (#95) GM control surface: the Active Campaign was an implicit
most-recently-created default. This makes it an explicit, durable selection and
gives the GM in-Discord control of the Voice Session that the web tier already
had — one Manager, one session record, one source of truth.

## How was this tested?

- `internal/presence/session_commands_test.go` — unit tests (fake manager/store)
  for use (set by name, by UUID, unknown input, autocomplete list+filter),
  start (success, already-active, no-campaign→fail-with-hint,
  Discord-not-configured), end (success, none-running), non-GM refusal for all
  three, the resolution order (live > selection > fail), a real-JSON grouped
  end-to-end dispatch, and a real-JSON grouped **autocomplete** e2e (pins
  disgo's SubCommandName flattening).
- `internal/rpc/session_test.go` — web parity: durable selection binds A over a
  newer B; unset selection pins the `GetActiveCampaign` fallback.
- `internal/storage/active_campaign_test.go` — integration: round-trip,
  persistence across a reopened Store (restart), selection overriding the
  implicit default, FK `ON DELETE SET NULL` clearing, List/GetCampaign.
- `go test -race ./internal/presence/ ./internal/rpc/ ./cmd/glyphoxa/` green;
  storage integration green against a pgvector testcontainer; `golangci-lint`
  clean on the changed packages.

- [x] New/updated tests cover the change
- [x] Manual testing: n/a (covered by unit + integration tests)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (pre-existing live-Ollama test
      needs an external server; skips in CI)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Migration `00014` is coordinated with #120 taking `00015`. The slash surface is
strict per ADR-0009 (no fallback, it has the `/use` hint); the web tier keeps
`GetActiveCampaign` as its fresh-install fallback while now honoring the durable
selection first — so the shared Manager keeps a single active session in sync
across both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
