### PR TITLE
[E5] Per-Agent mute + mute-all: Voice control panel + /glyphoxa mute/muteall

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -293,6 +293,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// voice (`all` mode); a web-only replica runs no Bot. Declared at function
 	// scope so the shutdown path below can Close it after the Manager drains.
 	var pres *presence.Presence
+	var reg *presence.Registry
 	if withVoice {
 		allow := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
 		gate := presence.NewGate(allow, func() string {
@@ -301,25 +302,33 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			}
 			return pres.GuildID()
 		})
-		reg := presence.NewRegistry(gate, log)
+		reg = presence.NewRegistry(gate, log)
 		reg.Register(presence.RollCommand(tool.NewDice()))
 		pres = presence.New(store, cipher, reg, cfg.Token, log)
 		// The voice loop borrows this one client instead of dialing its own per
 		// session; set BEFORE the Manager copies cfg into its base config.
 		cfg.Client = pres.ClientProvider()
-		// Bring the presence up at boot (AC: /roll appears with no Voice Session).
-		// Non-fatal: a bad or absent Bot token must not kill the web tier — it
-		// stays in the wait-state and the RPC refresher retries on the next save.
-		if err := pres.Ensure(ctx); err != nil {
-			log.Warn("presence: initial ensure failed; the slash-command surface "+
-				"will retry when Discord settings are next saved", "err", err)
-		}
+		// Ensure is deferred until after the Manager is built: /glyphoxa mute /
+		// muteall (#211) need the Manager (their SessionMuter), so they register just
+		// below and the first Ensure registers the FULL command surface.
 	}
 
 	runner := func(rctx context.Context, c wirenpc.Config) error {
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
 	mgr := session.NewManager(store, runner, cfg, cipher, log, withVoice)
+	if withVoice {
+		// The Manager is the mute commands' SessionMuter and the mute view the live
+		// loop reads (NewManager wired cfg.Mutes = mgr, #211). Register the mute
+		// surface now, then bring the presence up at boot (AC: the commands appear
+		// with no Voice Session active). Ensure is non-fatal: a bad/absent Bot token
+		// keeps the presence in its wait-state and the RPC refresher retries.
+		reg.Register(presence.MuteCommand(mgr, store), presence.MuteAllCommand(mgr))
+		if err := pres.Ensure(ctx); err != nil {
+			log.Warn("presence: initial ensure failed; the slash-command surface "+
+				"will retry when Discord settings are next saved", "err", err)
+		}
+	}
 	// Boot-time reconciliation (#143): close voice_sessions rows a previous run
 	// left 'running' (crash / failed end-write). No loop is live yet, so every
 	// such row is an orphan; done before the web tier serves so GetSession never

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -121,6 +121,10 @@ const (
 	// ReasonProviderError: the reply producer (LLM round / tool loop) failed before
 	// the turn could produce audio.
 	ReasonProviderError TurnReason = "provider_error"
+	// ReasonMute: a GM muted the Agent, cutting its turn (#211) — distinct from
+	// ReasonBarge (human interruption), so a mute does not collapse into
+	// no_first_audio.
+	ReasonMute TurnReason = "mute"
 )
 
 // StageRecorder records the orchestrator's per-stage / per-turn latency

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -313,6 +313,8 @@ func turnEndOutcome(r voiceevent.TurnEndReason) (TurnOutcome, TurnReason, string
 		return TurnYielded, ReasonSupersessionGrace, "yielded"
 	case voiceevent.TurnEndBarge:
 		return TurnAbandoned, ReasonBarge, "abandoned"
+	case voiceevent.TurnEndMute:
+		return TurnAbandoned, ReasonMute, "abandoned"
 	case voiceevent.TurnEndTTSError:
 		return TurnAbandoned, ReasonTTSError, "abandoned"
 	case voiceevent.TurnEndProviderError:

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -359,6 +359,7 @@ func TestStageSubscriberTurnEndedReasons(t *testing.T) {
 		{"barge", voiceevent.TurnEndBarge, TurnAbandoned, ReasonBarge},
 		{"tts_error", voiceevent.TurnEndTTSError, TurnAbandoned, ReasonTTSError},
 		{"provider_error", voiceevent.TurnEndProviderError, TurnAbandoned, ReasonProviderError},
+		{"mute", voiceevent.TurnEndMute, TurnAbandoned, ReasonMute},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/presence/mute.go
+++ b/internal/presence/mute.go
@@ -1,0 +1,169 @@
+package presence
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// SessionMuter is the live Voice Session control surface the mute commands drive
+// (#211): the active-session snapshot (for the guard + the campaign the
+// autocomplete lists against) and the per-Agent / all mute toggles.
+// *session.Manager satisfies it structurally — no import, mirroring the RPC seam.
+type SessionMuter interface {
+	Snapshot() (storage.VoiceSession, bool)
+	SetAgentMute(agentID string, muted bool) ([]string, error)
+	SetAllMute(ctx context.Context, muted bool) ([]string, error)
+}
+
+// AgentLister is the Active Campaign roster read the mute autocomplete + resolver
+// need (#211): the Butler + Character NPCs, from the agents table (not the voiced
+// wirenpc Roster, which is unreachable here). *storage.Store satisfies it.
+type AgentLister interface {
+	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+}
+
+// maxAutocompleteChoices is Discord's hard cap on autocomplete choices per
+// response.
+const maxAutocompleteChoices = 25
+
+// MuteCommand builds /glyphoxa mute <npc> (#211, ADR-0010 GM-only): it mutes one
+// Agent of the Active Campaign in the live Voice Session. The option is named
+// `npc` for table-facing familiarity but accepts ANY Agent (the Butler included).
+// Its autocomplete offers each Agent (Name shown, Agent UUID as the value); the
+// handler resolves a picked UUID against the roster, or a typed free-text name
+// (then aliases, case-insensitive), and replies with a clear ephemeral error on
+// no/ambiguous match. A mute with no active Voice Session is refused ephemerally.
+// There is deliberately NO unmute command — the web panel owns un-muting.
+func MuteCommand(mgr SessionMuter, agents AgentLister) Command {
+	return Command{
+		Path:        "glyphoxa mute",
+		Description: "Mute one NPC voice in the active Voice Session.",
+		GMOnly:      true,
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{
+				Name:         "npc",
+				Description:  "The NPC (or Butler) to mute.",
+				Required:     true,
+				Autocomplete: true,
+			},
+		},
+		Autocomplete: func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
+			vs, active := mgr.Snapshot()
+			if !active {
+				return nil, nil // no session: nothing to mute, offer nothing
+			}
+			roster, err := agents.ListAgents(ctx, vs.CampaignID)
+			if err != nil {
+				return nil, err
+			}
+			_, focused := ac.Focused()
+			prefix := strings.ToLower(strings.TrimSpace(focused))
+			choices := make([]discord.AutocompleteChoice, 0, len(roster))
+			for _, a := range roster {
+				if prefix != "" && !strings.HasPrefix(strings.ToLower(a.Name), prefix) {
+					continue
+				}
+				choices = append(choices, discord.AutocompleteChoiceString{Name: a.Name, Value: a.ID.String()})
+				if len(choices) >= maxAutocompleteChoices {
+					break
+				}
+			}
+			return choices, nil
+		},
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			vs, active := mgr.Snapshot()
+			if !active {
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			input, _ := ic.String("npc")
+			roster, err := agents.ListAgents(ctx, vs.CampaignID)
+			if err != nil {
+				return fmt.Errorf("presence: list agents for mute: %w", err) // unexpected → generic reply
+			}
+			agent, found, ambiguous := resolveAgent(roster, input)
+			if ambiguous {
+				return ic.ReplyEphemeral(fmt.Sprintf("%q matches more than one Agent — pick one from the list.", strings.TrimSpace(input)))
+			}
+			if !found {
+				return ic.ReplyEphemeral(fmt.Sprintf("No Agent named %q in the Active Campaign.", strings.TrimSpace(input)))
+			}
+			if _, err := mgr.SetAgentMute(agent.ID.String(), true); err != nil {
+				// The only expected failure is a session ending between the snapshot and
+				// the write; surface it as the same ephemeral guard rather than a generic
+				// error, so a racing Stop reads cleanly.
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			return ic.ReplyEphemeral(fmt.Sprintf("%s is muted.", agent.Name))
+		},
+	}
+}
+
+// MuteAllCommand builds /glyphoxa muteall (#211, ADR-0010 GM-only): it mutes every
+// Agent of the Active Campaign in the live Voice Session, refused ephemerally when
+// no Voice Session is active. Un-muting everyone is the web panel's job.
+func MuteAllCommand(mgr SessionMuter) Command {
+	return Command{
+		Path:        "glyphoxa muteall",
+		Description: "Mute every NPC voice in the active Voice Session.",
+		GMOnly:      true,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			if _, active := mgr.Snapshot(); !active {
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			ids, err := mgr.SetAllMute(ctx, true)
+			if err != nil {
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			return ic.ReplyEphemeral(fmt.Sprintf("Muted all %d Agent voices.", len(ids)))
+		},
+	}
+}
+
+// resolveAgent resolves a /glyphoxa mute npc value to a roster Agent (#211):
+// first as an Agent UUID (the autocomplete-picked value), else a case-insensitive
+// name match, else a case-insensitive alias match. It reports found, and
+// ambiguous when a free-text term matches more than one Agent.
+func resolveAgent(roster []storage.Agent, input string) (agent storage.Agent, found, ambiguous bool) {
+	trimmed := strings.TrimSpace(input)
+	if id, err := uuid.Parse(trimmed); err == nil {
+		for _, a := range roster {
+			if a.ID == id {
+				return a, true, false
+			}
+		}
+		return storage.Agent{}, false, false
+	}
+
+	lower := strings.ToLower(trimmed)
+	var byName []storage.Agent
+	for _, a := range roster {
+		if strings.ToLower(a.Name) == lower {
+			byName = append(byName, a)
+		}
+	}
+	matches := byName
+	if len(matches) == 0 {
+		for _, a := range roster {
+			for _, al := range a.Aliases {
+				if strings.ToLower(al) == lower {
+					matches = append(matches, a)
+					break
+				}
+			}
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return storage.Agent{}, false, false
+	case 1:
+		return matches[0], true, false
+	default:
+		return storage.Agent{}, false, true
+	}
+}

--- a/internal/presence/mute.go
+++ b/internal/presence/mute.go
@@ -17,7 +17,7 @@ import (
 // *session.Manager satisfies it structurally — no import, mirroring the RPC seam.
 type SessionMuter interface {
 	Snapshot() (storage.VoiceSession, bool)
-	SetAgentMute(agentID string, muted bool) ([]string, error)
+	SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error)
 	SetAllMute(ctx context.Context, muted bool) ([]string, error)
 }
 
@@ -93,10 +93,11 @@ func MuteCommand(mgr SessionMuter, agents AgentLister) Command {
 			if !found {
 				return ic.ReplyEphemeral(fmt.Sprintf("No Agent named %q in the Active Campaign.", strings.TrimSpace(input)))
 			}
-			if _, err := mgr.SetAgentMute(agent.ID.String(), true); err != nil {
-				// The only expected failure is a session ending between the snapshot and
-				// the write; surface it as the same ephemeral guard rather than a generic
-				// error, so a racing Stop reads cleanly.
+			if _, err := mgr.SetAgentMute(ctx, agent.ID.String(), true); err != nil {
+				// The expected failures are a session ending between the snapshot and the
+				// write, or the resolved Agent no longer being in the (now-different)
+				// active Campaign; both surface as the same ephemeral guard rather than a
+				// generic error, so a racing Stop / session swap reads cleanly.
 				return ic.ReplyEphemeral("No Voice Session is active.")
 			}
 			return ic.ReplyEphemeral(fmt.Sprintf("%s is muted.", agent.Name))

--- a/internal/presence/mute_test.go
+++ b/internal/presence/mute_test.go
@@ -1,0 +1,270 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeMuter is a SessionMuter for the mute-command tests.
+type fakeMuter struct {
+	active     bool
+	campaignID uuid.UUID
+	agentCalls []muteCall
+	allCalls   []bool
+	mutedIDs   []string
+}
+
+type muteCall struct {
+	id    string
+	muted bool
+}
+
+func (f *fakeMuter) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{CampaignID: f.campaignID}, f.active
+}
+
+func (f *fakeMuter) SetAgentMute(id string, muted bool) ([]string, error) {
+	f.agentCalls = append(f.agentCalls, muteCall{id, muted})
+	return f.mutedIDs, nil
+}
+
+func (f *fakeMuter) SetAllMute(_ context.Context, muted bool) ([]string, error) {
+	f.allCalls = append(f.allCalls, muted)
+	return f.mutedIDs, nil
+}
+
+// fakeLister is an AgentLister for the mute-command tests.
+type fakeLister struct {
+	agents []storage.Agent
+	err    error
+}
+
+func (f *fakeLister) ListAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return f.agents, f.err
+}
+
+func muteIC(resp *fakeResponder, npc string) *Interaction {
+	return &Interaction{
+		guildID: testGuild,
+		userID:  operatorID,
+		opts:    fakeOpts{s: map[string]string{"npc": npc}},
+		resp:    resp,
+	}
+}
+
+func muteAC(npc string) *Autocomplete {
+	return &Autocomplete{
+		guildID: testGuild,
+		userID:  operatorID,
+		data: discord.AutocompleteInteractionData{
+			CommandName:    commandGroup,
+			SubCommandName: strPtr("mute"),
+			Options: map[string]discord.AutocompleteOption{
+				"npc": {
+					Name:    "npc",
+					Type:    discord.ApplicationCommandOptionTypeString,
+					Value:   json.RawMessage(`"` + npc + `"`),
+					Focused: true,
+				},
+			},
+		},
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// TestMuteCommand_IsGMOnlyWithAutocomplete pins the command shape (AC4): GM-only,
+// a required "npc" string option, and an autocomplete handler.
+func TestMuteCommand_IsGMOnlyWithAutocomplete(t *testing.T) {
+	cmd := MuteCommand(&fakeMuter{}, &fakeLister{})
+	if cmd.Path != "glyphoxa mute" || !cmd.GMOnly || cmd.Autocomplete == nil {
+		t.Fatalf("MuteCommand shape = {path %q GMOnly %v autocomplete %v}, want GM-only /glyphoxa mute with autocomplete", cmd.Path, cmd.GMOnly, cmd.Autocomplete != nil)
+	}
+	if len(cmd.Options) != 1 {
+		t.Fatalf("MuteCommand options = %d, want 1 (npc)", len(cmd.Options))
+	}
+}
+
+// TestMuteCommand_IdleEphemeral pins the active-session requirement (AC4): with no
+// Voice Session, the handler replies ephemerally and mutes nothing.
+func TestMuteCommand_IdleEphemeral(t *testing.T) {
+	mgr := &fakeMuter{active: false}
+	cmd := MuteCommand(mgr, &fakeLister{})
+	resp := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp, "Bart")); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("idle reply = %+v, want one ephemeral", resp.replies)
+	}
+	if len(mgr.agentCalls) != 0 {
+		t.Fatalf("idle handler muted %v, want nothing", mgr.agentCalls)
+	}
+}
+
+// TestMuteCommand_ResolvesUUIDValue pins the autocomplete-picked path: the npc
+// value is an Agent UUID, resolved against the roster, and muted.
+func TestMuteCommand_ResolvesUUIDValue(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{bart}})
+	resp := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp, bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(mgr.agentCalls) != 1 || mgr.agentCalls[0].id != bart.ID.String() || !mgr.agentCalls[0].muted {
+		t.Fatalf("mute calls = %+v, want one {%s true}", mgr.agentCalls, bart.ID)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral || !strings.Contains(resp.replies[0].content, "Bart") {
+		t.Fatalf("success reply = %+v, want an ephemeral naming Bart", resp.replies)
+	}
+}
+
+// TestMuteCommand_ResolvesFreeTextName pins the typed-name path: a case-insensitive
+// name (then alias) match resolves to the Agent and mutes it.
+func TestMuteCommand_ResolvesFreeTextName(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart", Aliases: []string{"Innkeeper"}}
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{bart}})
+
+	// By name (different case).
+	resp := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp, "bart")); err != nil {
+		t.Fatalf("Handle name: %v", err)
+	}
+	// By alias.
+	resp2 := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp2, "innkeeper")); err != nil {
+		t.Fatalf("Handle alias: %v", err)
+	}
+	if len(mgr.agentCalls) != 2 || mgr.agentCalls[0].id != bart.ID.String() || mgr.agentCalls[1].id != bart.ID.String() {
+		t.Fatalf("mute calls = %+v, want two for Bart (name + alias)", mgr.agentCalls)
+	}
+}
+
+// TestMuteCommand_UnknownNameEphemeral pins AC4's clear error: an unknown name
+// replies ephemerally naming the input and mutes nothing.
+func TestMuteCommand_UnknownNameEphemeral(t *testing.T) {
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{{ID: uuid.New(), Name: "Bart"}}})
+	resp := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp, "Zaphod")); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral || !strings.Contains(resp.replies[0].content, "Zaphod") {
+		t.Fatalf("unknown-name reply = %+v, want an ephemeral naming the input", resp.replies)
+	}
+	if len(mgr.agentCalls) != 0 {
+		t.Fatalf("unknown name muted %v, want nothing", mgr.agentCalls)
+	}
+}
+
+// TestMuteCommand_Autocomplete pins the autocomplete: prefix-filtered choices whose
+// Value is the Agent UUID and Name the display name, capped at 25; empty when idle.
+func TestMuteCommand_Autocomplete(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	greta := storage.Agent{ID: uuid.New(), Name: "Greta"}
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{bart, greta}})
+
+	choices, err := cmd.Autocomplete(context.Background(), muteAC("bar"))
+	if err != nil {
+		t.Fatalf("Autocomplete: %v", err)
+	}
+	if len(choices) != 1 {
+		t.Fatalf("prefix 'bar' choices = %d, want 1 (Bart)", len(choices))
+	}
+	if choices[0].ChoiceName() != "Bart" {
+		t.Fatalf("choice name = %q, want Bart", choices[0].ChoiceName())
+	}
+	sc, ok := choices[0].(discord.AutocompleteChoiceString)
+	if !ok || sc.Value != bart.ID.String() {
+		t.Fatalf("choice value = %v, want the Agent UUID %s", choices[0], bart.ID)
+	}
+
+	// Idle: no choices (no campaign to list against).
+	mgr.active = false
+	idle, err := cmd.Autocomplete(context.Background(), muteAC(""))
+	if err != nil {
+		t.Fatalf("Autocomplete idle: %v", err)
+	}
+	if len(idle) != 0 {
+		t.Fatalf("idle autocomplete = %d choices, want 0", len(idle))
+	}
+}
+
+// TestMuteCommand_AutocompleteCapsAt25 pins the Discord 25-choice limit.
+func TestMuteCommand_AutocompleteCapsAt25(t *testing.T) {
+	agents := make([]storage.Agent, 30)
+	for i := range agents {
+		agents[i] = storage.Agent{ID: uuid.New(), Name: "Agent"}
+	}
+	cmd := MuteCommand(&fakeMuter{active: true, campaignID: uuid.New()}, &fakeLister{agents: agents})
+	choices, err := cmd.Autocomplete(context.Background(), muteAC(""))
+	if err != nil {
+		t.Fatalf("Autocomplete: %v", err)
+	}
+	if len(choices) > 25 {
+		t.Fatalf("autocomplete returned %d choices, want <= 25", len(choices))
+	}
+}
+
+// TestMuteAllCommand pins /glyphoxa muteall (AC4): GM-only, idle-ephemeral, and an
+// active session mutes every Agent (SetAllMute(true)).
+func TestMuteAllCommand(t *testing.T) {
+	cmd := MuteAllCommand(&fakeMuter{})
+	if cmd.Path != "glyphoxa muteall" || !cmd.GMOnly {
+		t.Fatalf("MuteAllCommand shape = {path %q GMOnly %v}, want GM-only /glyphoxa muteall", cmd.Path, cmd.GMOnly)
+	}
+
+	// Idle: ephemeral, mutes nothing.
+	idleMgr := &fakeMuter{active: false}
+	idleResp := &fakeResponder{}
+	if err := MuteAllCommand(idleMgr).Handle(context.Background(), &Interaction{guildID: testGuild, userID: operatorID, resp: idleResp}); err != nil {
+		t.Fatalf("Handle idle: %v", err)
+	}
+	if len(idleResp.replies) != 1 || !idleResp.replies[0].ephemeral || len(idleMgr.allCalls) != 0 {
+		t.Fatalf("idle muteall reply = %+v, allCalls = %v; want one ephemeral, no mute", idleResp.replies, idleMgr.allCalls)
+	}
+
+	// Active: mutes all.
+	mgr := &fakeMuter{active: true, campaignID: uuid.New(), mutedIDs: []string{"a", "b"}}
+	resp := &fakeResponder{}
+	if err := MuteAllCommand(mgr).Handle(context.Background(), &Interaction{guildID: testGuild, userID: operatorID, resp: resp}); err != nil {
+		t.Fatalf("Handle active: %v", err)
+	}
+	if len(mgr.allCalls) != 1 || !mgr.allCalls[0] {
+		t.Fatalf("muteall SetAllMute calls = %v, want one true", mgr.allCalls)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("muteall reply = %+v, want one ephemeral", resp.replies)
+	}
+}
+
+// TestMuteCommands_RefusedForNonOperator pins AC4's GM-only gate end-to-end: a
+// non-operator invoking either command is denied and nothing is muted.
+func TestMuteCommands_RefusedForNonOperator(t *testing.T) {
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(MuteCommand(mgr, &fakeLister{agents: []storage.Agent{{ID: uuid.New(), Name: "Bart"}}}))
+	reg.Register(MuteAllCommand(mgr))
+
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "glyphoxa mute", &Interaction{guildID: testGuild, userID: strangerID, opts: fakeOpts{s: map[string]string{"npc": "Bart"}}, resp: resp})
+	resp2 := &fakeResponder{}
+	reg.dispatch(context.Background(), "glyphoxa muteall", &Interaction{guildID: testGuild, userID: strangerID, resp: resp2})
+
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral || len(resp2.replies) != 1 || !resp2.replies[0].ephemeral {
+		t.Fatalf("non-operator replies = %+v / %+v, want one ephemeral denial each", resp.replies, resp2.replies)
+	}
+	if len(mgr.agentCalls) != 0 || len(mgr.allCalls) != 0 {
+		t.Fatalf("a non-operator muted something: agent=%v all=%v", mgr.agentCalls, mgr.allCalls)
+	}
+}

--- a/internal/presence/mute_test.go
+++ b/internal/presence/mute_test.go
@@ -30,7 +30,7 @@ func (f *fakeMuter) Snapshot() (storage.VoiceSession, bool) {
 	return storage.VoiceSession{CampaignID: f.campaignID}, f.active
 }
 
-func (f *fakeMuter) SetAgentMute(id string, muted bool) ([]string, error) {
+func (f *fakeMuter) SetAgentMute(_ context.Context, id string, muted bool) ([]string, error) {
 	f.agentCalls = append(f.agentCalls, muteCall{id, muted})
 	return f.mutedIDs, nil
 }

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -25,8 +25,10 @@ type SessionManager interface {
 	Stop(ctx context.Context) (storage.VoiceSession, error)
 	Snapshot() (storage.VoiceSession, bool)
 	// SetAgentMute / SetAllMute toggle the live per-Agent mute set (#211), returning
-	// the resulting sorted muted-id set; both fail ErrNoActiveSession when idle.
-	SetAgentMute(agentID string, muted bool) ([]string, error)
+	// the resulting sorted muted-id set; both fail ErrNoActiveSession when idle, and
+	// SetAgentMute fails ErrAgentNotInCampaign for an agent outside the active
+	// session's Campaign (validated atomically against that session).
+	SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error)
 	SetAllMute(ctx context.Context, muted bool) ([]string, error)
 	// MutedAgentIDs is the reload truth (AC5): the muted set while active, nil idle.
 	MutedAgentIDs() []string
@@ -38,9 +40,6 @@ type SessionManager interface {
 type SessionStore interface {
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
-	// ListAgents is the Active Campaign roster (#211): SetAgentMute validates the
-	// target agent_id is an Agent of the active session's campaign.
-	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 }
 
 // SessionServer implements the Connect SessionService over a SessionManager +
@@ -195,43 +194,25 @@ func (s *SessionServer) StopSession(
 // SetAgentMute mutes or unmutes one Agent of the Active Campaign in the live
 // Voice Session (#211). It refuses when no session is active
 // (CodeFailedPrecondition) and rejects an agent_id that is not an Agent of the
-// active session's campaign — or an unparsable id — with CodeNotFound.
+// active session's campaign — or an unparsable id — with CodeNotFound. The
+// Manager validates campaign membership atomically against the SAME session it
+// writes, so a session swap can't slip a foreign agent into the new session's set.
 func (s *SessionServer) SetAgentMute(
 	ctx context.Context,
 	req *connect.Request[managementv1.SetAgentMuteRequest],
 ) (*connect.Response[managementv1.SetAgentMuteResponse], error) {
-	vs, active := s.mgr.Snapshot()
-	if !active {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
-	}
-
 	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such Agent in the Active Campaign"))
-	agentID, err := uuid.Parse(req.Msg.GetAgentId())
-	if err != nil {
-		return nil, notFound
-	}
-	agents, err := s.store.ListAgents(ctx, vs.CampaignID)
-	if err != nil {
-		s.log.Error("SetAgentMute: list agents failed", "err", err)
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
-	}
-	found := false
-	for _, a := range agents {
-		if a.ID == agentID {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, notFound
+	if _, err := uuid.Parse(req.Msg.GetAgentId()); err != nil {
+		return nil, notFound // a non-UUID id names no Agent (session-independent)
 	}
 
-	ids, err := s.mgr.SetAgentMute(req.Msg.GetAgentId(), req.Msg.GetMuted())
-	if errors.Is(err, session.ErrNoActiveSession) {
-		// The session ended between the snapshot and the mute write.
+	ids, err := s.mgr.SetAgentMute(ctx, req.Msg.GetAgentId(), req.Msg.GetMuted())
+	switch {
+	case errors.Is(err, session.ErrNoActiveSession):
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
-	}
-	if err != nil {
+	case errors.Is(err, session.ErrAgentNotInCampaign):
+		return nil, notFound
+	case err != nil:
 		s.log.Error("SetAgentMute: manager mute failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -24,6 +24,12 @@ type SessionManager interface {
 	Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error)
 	Stop(ctx context.Context) (storage.VoiceSession, error)
 	Snapshot() (storage.VoiceSession, bool)
+	// SetAgentMute / SetAllMute toggle the live per-Agent mute set (#211), returning
+	// the resulting sorted muted-id set; both fail ErrNoActiveSession when idle.
+	SetAgentMute(agentID string, muted bool) ([]string, error)
+	SetAllMute(ctx context.Context, muted bool) ([]string, error)
+	// MutedAgentIDs is the reload truth (AC5): the muted set while active, nil idle.
+	MutedAgentIDs() []string
 }
 
 // SessionStore is the narrow storage surface SessionServer needs: the active
@@ -32,6 +38,9 @@ type SessionManager interface {
 type SessionStore interface {
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
+	// ListAgents is the Active Campaign roster (#211): SetAgentMute validates the
+	// target agent_id is an Agent of the active session's campaign.
+	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 }
 
 // SessionServer implements the Connect SessionService over a SessionManager +
@@ -77,8 +86,9 @@ func (s *SessionServer) GetSession(
 ) (*connect.Response[managementv1.GetSessionResponse], error) {
 	if vs, active := s.mgr.Snapshot(); active {
 		return connect.NewResponse(&managementv1.GetSessionResponse{
-			Session: toProtoVoiceSession(vs),
-			Active:  true,
+			Session:       toProtoVoiceSession(vs),
+			Active:        true,
+			MutedAgentIds: s.mgr.MutedAgentIDs(), // reload truth while live (AC5)
 		}), nil
 	}
 
@@ -180,6 +190,69 @@ func (s *SessionServer) StopSession(
 	return connect.NewResponse(&managementv1.StopSessionResponse{
 		Session: toProtoVoiceSession(vs),
 	}), nil
+}
+
+// SetAgentMute mutes or unmutes one Agent of the Active Campaign in the live
+// Voice Session (#211). It refuses when no session is active
+// (CodeFailedPrecondition) and rejects an agent_id that is not an Agent of the
+// active session's campaign — or an unparsable id — with CodeNotFound.
+func (s *SessionServer) SetAgentMute(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetAgentMuteRequest],
+) (*connect.Response[managementv1.SetAgentMuteResponse], error) {
+	vs, active := s.mgr.Snapshot()
+	if !active {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
+	}
+
+	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such Agent in the Active Campaign"))
+	agentID, err := uuid.Parse(req.Msg.GetAgentId())
+	if err != nil {
+		return nil, notFound
+	}
+	agents, err := s.store.ListAgents(ctx, vs.CampaignID)
+	if err != nil {
+		s.log.Error("SetAgentMute: list agents failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	found := false
+	for _, a := range agents {
+		if a.ID == agentID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, notFound
+	}
+
+	ids, err := s.mgr.SetAgentMute(req.Msg.GetAgentId(), req.Msg.GetMuted())
+	if errors.Is(err, session.ErrNoActiveSession) {
+		// The session ended between the snapshot and the mute write.
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
+	}
+	if err != nil {
+		s.log.Error("SetAgentMute: manager mute failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.SetAgentMuteResponse{MutedAgentIds: ids}), nil
+}
+
+// SetAllMute mutes or unmutes every Agent of the Active Campaign in the live Voice
+// Session (#211). It refuses when no session is active (CodeFailedPrecondition).
+func (s *SessionServer) SetAllMute(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetAllMuteRequest],
+) (*connect.Response[managementv1.SetAllMuteResponse], error) {
+	ids, err := s.mgr.SetAllMute(ctx, req.Msg.GetMuted())
+	if errors.Is(err, session.ErrNoActiveSession) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
+	}
+	if err != nil {
+		s.log.Error("SetAllMute: manager mute failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.SetAllMuteResponse{MutedAgentIds: ids}), nil
 }
 
 // toProtoVoiceSession maps a storage.VoiceSession onto its wire view. A zero

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ type fakeSessionManager struct {
 	startErr   error
 	stopErr    error
 	startCalls int
+	muted      map[string]struct{}
+	rosterIDs  []string // ids SetAllMute mutes (the campaign roster the real Manager lists)
 }
 
 func (f *fakeSessionManager) Start(_ context.Context, _, campaignID uuid.UUID) (storage.VoiceSession, error) {
@@ -72,12 +75,69 @@ func (f *fakeSessionManager) Snapshot() (storage.VoiceSession, bool) {
 	return f.current, f.active
 }
 
+func (f *fakeSessionManager) SetAgentMute(agentID string, muted bool) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.active {
+		return nil, session.ErrNoActiveSession
+	}
+	if f.muted == nil {
+		f.muted = map[string]struct{}{}
+	}
+	if muted {
+		f.muted[agentID] = struct{}{}
+	} else {
+		delete(f.muted, agentID)
+	}
+	return f.mutedIDsLocked(), nil
+}
+
+func (f *fakeSessionManager) SetAllMute(_ context.Context, muted bool) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.active {
+		return nil, session.ErrNoActiveSession
+	}
+	if muted {
+		f.muted = map[string]struct{}{}
+		for _, id := range f.rosterIDs {
+			f.muted[id] = struct{}{}
+		}
+	} else {
+		f.muted = map[string]struct{}{}
+	}
+	return f.mutedIDsLocked(), nil
+}
+
+func (f *fakeSessionManager) MutedAgentIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.active {
+		return nil
+	}
+	return f.mutedIDsLocked()
+}
+
+func (f *fakeSessionManager) mutedIDsLocked() []string {
+	if len(f.muted) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(f.muted))
+	for id := range f.muted {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // fakeSessionStore serves the active campaign and the latest ended session.
 type fakeSessionStore struct {
 	campaign    storage.Campaign
 	campaignErr error
 	latest      storage.VoiceSession
 	latestErr   error
+	agents      []storage.Agent // the Active Campaign roster (#211 mute validation)
+	agentsErr   error
 }
 
 func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
@@ -92,6 +152,13 @@ func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (st
 		return storage.VoiceSession{}, f.latestErr
 	}
 	return f.latest, nil
+}
+
+func (f *fakeSessionStore) ListAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	if f.agentsErr != nil {
+		return nil, f.agentsErr
+	}
+	return f.agents, nil
 }
 
 func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
@@ -159,6 +226,152 @@ func TestSessionStartStopReflectsSnapshot(t *testing.T) {
 	}
 	if stop.Msg.GetSession().GetStatus() != "ended" || stop.Msg.GetSession().GetEndedAt() == nil {
 		t.Errorf("stopped session = %+v, want ended with ended_at", stop.Msg.GetSession())
+	}
+}
+
+// activeMgr returns a fake manager already in an active session for campaignID.
+func activeMgr(t *testing.T, campaignID uuid.UUID) *fakeSessionManager {
+	t.Helper()
+	mgr := &fakeSessionManager{}
+	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+		t.Fatalf("activate fake manager: %v", err)
+	}
+	return mgr
+}
+
+// TestSetAgentMute_Success mutes an Agent of the Active Campaign and returns the
+// muted-id set, then unmutes it (#211).
+func TestSetAgentMute_Success(t *testing.T) {
+	t.Parallel()
+	campaign := storage.Campaign{ID: uuid.New()}
+	agent := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID, Name: "Bart"}
+	mgr := activeMgr(t, campaign.ID)
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{agent}}
+	client := newSessionClient(t, mgr, store)
+
+	resp, err := client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: agent.ID.String(), Muted: true}))
+	if err != nil {
+		t.Fatalf("SetAgentMute: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 1 || got[0] != agent.ID.String() {
+		t.Fatalf("muted ids = %v, want [%s]", got, agent.ID)
+	}
+
+	resp, err = client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: agent.ID.String(), Muted: false}))
+	if err != nil {
+		t.Fatalf("unmute: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 0 {
+		t.Fatalf("muted ids after unmute = %v, want empty", got)
+	}
+}
+
+// TestSetAgentMute_IdleFailedPrecondition maps the no-active-session refusal to
+// FailedPrecondition (AC4).
+func TestSetAgentMute_IdleFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	client := newSessionClient(t, &fakeSessionManager{}, activeStore())
+	_, err := client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: uuid.NewString(), Muted: true}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("idle SetAgentMute code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestSetAgentMute_UnknownAgentNotFound maps an agent_id that is not an Agent of
+// the Active Campaign — or an unparsable id — to CodeNotFound.
+func TestSetAgentMute_UnknownAgentNotFound(t *testing.T) {
+	t.Parallel()
+	campaign := storage.Campaign{ID: uuid.New()}
+	inRoster := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID}
+	mgr := activeMgr(t, campaign.ID)
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{inRoster}}
+	client := newSessionClient(t, mgr, store)
+
+	// A valid UUID that is not in the roster.
+	_, err := client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: uuid.NewString(), Muted: true}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("foreign-agent code = %v, want NotFound", connect.CodeOf(err))
+	}
+	// A non-UUID agent_id.
+	_, err = client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: "not-a-uuid", Muted: true}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("non-uuid code = %v, want NotFound", connect.CodeOf(err))
+	}
+}
+
+// TestSetAllMute_Success mutes then unmutes every Agent of the Active Campaign.
+func TestSetAllMute_Success(t *testing.T) {
+	t.Parallel()
+	campaign := storage.Campaign{ID: uuid.New()}
+	mgr := activeMgr(t, campaign.ID)
+	mgr.rosterIDs = []string{"aaa", "bbb"}
+	client := newSessionClient(t, mgr, &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound})
+
+	resp, err := client.SetAllMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: true}))
+	if err != nil {
+		t.Fatalf("SetAllMute: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 2 {
+		t.Fatalf("muted ids after mute-all = %v, want 2", got)
+	}
+
+	resp, err = client.SetAllMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: false}))
+	if err != nil {
+		t.Fatalf("SetAllMute unmute: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 0 {
+		t.Fatalf("muted ids after unmute-all = %v, want empty", got)
+	}
+}
+
+// TestSetAllMute_IdleFailedPrecondition maps the no-active-session refusal.
+func TestSetAllMute_IdleFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	client := newSessionClient(t, &fakeSessionManager{}, activeStore())
+	_, err := client.SetAllMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: true}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("idle SetAllMute code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestGetSession_CarriesMutedAgentIds pins AC5's reload truth: GetSession carries
+// the muted-Agent id set while active, and none when idle.
+func TestGetSession_CarriesMutedAgentIds(t *testing.T) {
+	t.Parallel()
+	campaign := storage.Campaign{ID: uuid.New()}
+	agent := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID}
+	mgr := activeMgr(t, campaign.ID)
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{agent}}
+	client := newSessionClient(t, mgr, store)
+
+	if _, err := client.SetAgentMute(context.Background(),
+		connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: agent.ID.String(), Muted: true})); err != nil {
+		t.Fatalf("mute: %v", err)
+	}
+	resp, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 1 || got[0] != agent.ID.String() {
+		t.Fatalf("live GetSession muted ids = %v, want [%s]", got, agent.ID)
+	}
+
+	// Idle: no muted ids.
+	idle := newSessionClient(t, &fakeSessionManager{}, activeStore())
+	resp, err = idle.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession idle: %v", err)
+	}
+	if got := resp.Msg.GetMutedAgentIds(); len(got) != 0 {
+		t.Fatalf("idle GetSession muted ids = %v, want empty", got)
 	}
 }
 

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -23,14 +23,15 @@ import (
 // fakeSessionManager mimics the SessionManager's single-active lifecycle so the
 // handler's error mapping + snapshot wiring can be unit-tested without Discord.
 type fakeSessionManager struct {
-	mu         sync.Mutex
-	active     bool
-	current    storage.VoiceSession
-	startErr   error
-	stopErr    error
-	startCalls int
-	muted      map[string]struct{}
-	rosterIDs  []string // ids SetAllMute mutes (the campaign roster the real Manager lists)
+	mu               sync.Mutex
+	active           bool
+	current          storage.VoiceSession
+	startErr         error
+	stopErr          error
+	startCalls       int
+	muted            map[string]struct{}
+	rosterIDs        []string // ids SetAllMute mutes (the campaign roster the real Manager lists)
+	campaignAgentIDs []string // ids SetAgentMute accepts; others → ErrAgentNotInCampaign (Manager validates now)
 }
 
 func (f *fakeSessionManager) Start(_ context.Context, _, campaignID uuid.UUID) (storage.VoiceSession, error) {
@@ -75,11 +76,14 @@ func (f *fakeSessionManager) Snapshot() (storage.VoiceSession, bool) {
 	return f.current, f.active
 }
 
-func (f *fakeSessionManager) SetAgentMute(agentID string, muted bool) ([]string, error) {
+func (f *fakeSessionManager) SetAgentMute(_ context.Context, agentID string, muted bool) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if !f.active {
 		return nil, session.ErrNoActiveSession
+	}
+	if !f.inRoster(agentID) {
+		return nil, session.ErrAgentNotInCampaign
 	}
 	if f.muted == nil {
 		f.muted = map[string]struct{}{}
@@ -90,6 +94,15 @@ func (f *fakeSessionManager) SetAgentMute(agentID string, muted bool) ([]string,
 		delete(f.muted, agentID)
 	}
 	return f.mutedIDsLocked(), nil
+}
+
+func (f *fakeSessionManager) inRoster(agentID string) bool {
+	for _, id := range f.campaignAgentIDs {
+		if id == agentID {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *fakeSessionManager) SetAllMute(_ context.Context, muted bool) ([]string, error) {
@@ -136,8 +149,6 @@ type fakeSessionStore struct {
 	campaignErr error
 	latest      storage.VoiceSession
 	latestErr   error
-	agents      []storage.Agent // the Active Campaign roster (#211 mute validation)
-	agentsErr   error
 }
 
 func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
@@ -152,13 +163,6 @@ func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (st
 		return storage.VoiceSession{}, f.latestErr
 	}
 	return f.latest, nil
-}
-
-func (f *fakeSessionStore) ListAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
-	if f.agentsErr != nil {
-		return nil, f.agentsErr
-	}
-	return f.agents, nil
 }
 
 func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
@@ -229,10 +233,11 @@ func TestSessionStartStopReflectsSnapshot(t *testing.T) {
 	}
 }
 
-// activeMgr returns a fake manager already in an active session for campaignID.
-func activeMgr(t *testing.T, campaignID uuid.UUID) *fakeSessionManager {
+// activeMgr returns a fake manager already in an active session for campaignID,
+// whose Campaign roster (SetAgentMute membership check) is agentIDs.
+func activeMgr(t *testing.T, campaignID uuid.UUID, agentIDs ...string) *fakeSessionManager {
 	t.Helper()
-	mgr := &fakeSessionManager{}
+	mgr := &fakeSessionManager{campaignAgentIDs: agentIDs}
 	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
 		t.Fatalf("activate fake manager: %v", err)
 	}
@@ -245,8 +250,8 @@ func TestSetAgentMute_Success(t *testing.T) {
 	t.Parallel()
 	campaign := storage.Campaign{ID: uuid.New()}
 	agent := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID, Name: "Bart"}
-	mgr := activeMgr(t, campaign.ID)
-	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{agent}}
+	mgr := activeMgr(t, campaign.ID, agent.ID.String())
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound}
 	client := newSessionClient(t, mgr, store)
 
 	resp, err := client.SetAgentMute(context.Background(),
@@ -286,8 +291,8 @@ func TestSetAgentMute_UnknownAgentNotFound(t *testing.T) {
 	t.Parallel()
 	campaign := storage.Campaign{ID: uuid.New()}
 	inRoster := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID}
-	mgr := activeMgr(t, campaign.ID)
-	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{inRoster}}
+	mgr := activeMgr(t, campaign.ID, inRoster.ID.String())
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound}
 	client := newSessionClient(t, mgr, store)
 
 	// A valid UUID that is not in the roster.
@@ -348,8 +353,8 @@ func TestGetSession_CarriesMutedAgentIds(t *testing.T) {
 	t.Parallel()
 	campaign := storage.Campaign{ID: uuid.New()}
 	agent := storage.Agent{ID: uuid.New(), CampaignID: campaign.ID}
-	mgr := activeMgr(t, campaign.ID)
-	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound, agents: []storage.Agent{agent}}
+	mgr := activeMgr(t, campaign.ID, agent.ID.String())
+	store := &fakeSessionStore{campaign: campaign, latestErr: storage.ErrNotFound}
 	client := newSessionClient(t, mgr, store)
 
 	if _, err := client.SetAgentMute(context.Background(),
@@ -372,6 +377,36 @@ func TestGetSession_CarriesMutedAgentIds(t *testing.T) {
 	}
 	if got := resp.Msg.GetMutedAgentIds(); len(got) != 0 {
 		t.Fatalf("idle GetSession muted ids = %v, want empty", got)
+	}
+}
+
+// TestSessionMute_CSRFGuardsMutationNotRead pins the mutation guard (#211): with
+// the CSRF interceptor mounted and no double-submit token, the state-changing
+// SetAgentMute/SetAllMute are rejected PermissionDenied, while the
+// side-effect-free GetSession (NO_SIDE_EFFECTS) is exempt and reaches the handler.
+// It fails if someone later mis-marks a mute RPC NO_SIDE_EFFECTS.
+func TestSessionMute_CSRFGuardsMutationNotRead(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+		connect.WithInterceptors(auth.NewCSRFInterceptor()),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	_, agentErr := client.SetAgentMute(ctx, connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: uuid.NewString(), Muted: true}))
+	if got := connect.CodeOf(agentErr); got != connect.CodePermissionDenied {
+		t.Errorf("SetAgentMute code = %v, want PermissionDenied (CSRF-guarded mutation)", got)
+	}
+	_, allErr := client.SetAllMute(ctx, connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: true}))
+	if got := connect.CodeOf(allErr); got != connect.CodePermissionDenied {
+		t.Errorf("SetAllMute code = %v, want PermissionDenied (CSRF-guarded mutation)", got)
+	}
+	// The read is exempt — no token still reaches the handler.
+	if _, err := client.GetSession(ctx, connect.NewRequest(&managementv1.GetSessionRequest{})); connect.CodeOf(err) == connect.CodePermissionDenied {
+		t.Error("GetSession must be CSRF-exempt (NO_SIDE_EFFECTS read)")
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
 // endTimeout bounds the ended_at write after the loop exits, so a Stop / shutdown
@@ -66,6 +68,9 @@ type Store interface {
 	CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
 	EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error)
 	ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, error)
+	// ListAgents returns the Active Campaign's roster (Butler + Character NPCs) so
+	// mute-all (#211) can target EVERY Agent, not just the voiced wirenpc Roster.
+	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 }
 
 // TranscriptFinalizer drains the live transcript's writer queue for a session and
@@ -108,6 +113,11 @@ type activeSession struct {
 	endErr     error
 	cancel     context.CancelFunc
 	done       chan struct{}
+	// muted is the volatile, session-local per-Agent mute set (#211), keyed by
+	// AgentID. Fresh-empty per Start, so every new Voice Session begins with all
+	// Agents unmuted (AC5) — there is NO DB column and NO migration; the set dies
+	// with the session. Guarded by Manager.mu.
+	muted map[string]struct{}
 }
 
 // Manager owns at most one live voice session at a time (the single-active
@@ -141,7 +151,12 @@ func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled, endTimeout: endTimeout}
+	m := &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled, endTimeout: endTimeout}
+	// The Manager IS the live mute view (#211): it owns the session-local mute set,
+	// so wire it as the base voice config's MuteView. Every session Start copies
+	// base, so each session's Conversation reads this Manager's set.
+	m.base.Mutes = m
+	return m
 }
 
 // SetTranscript wires the transcript finalizer the Manager calls on Stop / loop
@@ -267,6 +282,7 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		session:    vs,
 		cancel:     cancel,
 		done:       make(chan struct{}),
+		muted:      map[string]struct{}{}, // fresh: every new session starts all-unmuted (AC5)
 	}
 	m.active = as
 	go m.runLoop(runCtx, as, cfg)
@@ -392,4 +408,135 @@ func (m *Manager) Shutdown() {
 	}
 	as.cancel()
 	<-as.done
+}
+
+// Muted reports whether the Agent with agentID is muted in the live session,
+// satisfying [orchestrator.MuteView] (#211). It is the authoritative live read the
+// voice loop's replier gate consults per route. Idle (no active session) is
+// always unmuted — the feature is off between sessions.
+func (m *Manager) Muted(agentID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil {
+		return false
+	}
+	_, ok := m.active.muted[agentID]
+	return ok
+}
+
+// MutedAgentIDs is a sorted snapshot of the currently-muted Agent ids, or nil when
+// idle. It backs GetSession's reload truth (AC5): a mid-session page reload reads
+// the true current mute state from here.
+func (m *Manager) MutedAgentIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil {
+		return nil
+	}
+	return mutedIDsLocked(m.active.muted)
+}
+
+// SetAgentMute mutes or unmutes one Agent in the live session, returning the
+// resulting sorted muted-id set (#211). It refuses when idle (ErrNoActiveSession,
+// AC4). The set is written UNDER m.mu and the resulting MuteChanged is published
+// OUTSIDE it — the bus fan-out touches other locks (the relay, the wirenpc
+// roster), so publishing under m.mu risks a lock-order inversion. The write
+// happening BEFORE the publish is load-bearing: the replier gate reading the set
+// on this event always sees the change. An idempotent re-mute (no actual change)
+// publishes nothing.
+func (m *Manager) SetAgentMute(agentID string, muted bool) ([]string, error) {
+	m.mu.Lock()
+	if m.active == nil {
+		m.mu.Unlock()
+		return nil, ErrNoActiveSession
+	}
+	changed := applyMuteLocked(m.active.muted, agentID, muted)
+	ids := mutedIDsLocked(m.active.muted)
+	bus := m.base.Bus
+	m.mu.Unlock()
+
+	if changed && bus != nil {
+		bus.Publish(voiceevent.MuteChanged{At: time.Now(), AgentID: agentID, Muted: muted})
+	}
+	return ids, nil
+}
+
+// SetAllMute mutes or unmutes EVERY Agent of the Active Campaign (Butler +
+// Character NPCs, from store.ListAgents — not just the voiced wirenpc Roster),
+// returning the resulting sorted muted-id set (#211). It refuses when idle
+// (ErrNoActiveSession). The campaign is captured under m.mu, the roster is listed
+// with m.mu released (the store read may block), then the set is re-locked and
+// applied only if the SAME session is still active — a session that ended (or a
+// new one that started) while listing aborts with ErrNoActiveSession. One
+// MuteChanged per ACTUAL change is published OUTSIDE m.mu.
+func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) {
+	m.mu.Lock()
+	as := m.active
+	if as == nil {
+		m.mu.Unlock()
+		return nil, ErrNoActiveSession
+	}
+	campaignID := as.campaignID
+	m.mu.Unlock()
+
+	agents, err := m.store.ListAgents(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("session: list agents for mute-all: %w", err)
+	}
+
+	m.mu.Lock()
+	if m.active != as {
+		// The session ended or rolled over while we listed agents: abort rather than
+		// mutate a set that no longer belongs to this session.
+		m.mu.Unlock()
+		return nil, ErrNoActiveSession
+	}
+	changes := make([]voiceevent.MuteChanged, 0, len(agents))
+	for _, a := range agents {
+		id := a.ID.String()
+		if applyMuteLocked(m.active.muted, id, muted) {
+			changes = append(changes, voiceevent.MuteChanged{AgentID: id, Muted: muted})
+		}
+	}
+	ids := mutedIDsLocked(m.active.muted)
+	bus := m.base.Bus
+	m.mu.Unlock()
+
+	if bus != nil {
+		now := time.Now()
+		for _, c := range changes {
+			c.At = now
+			bus.Publish(c)
+		}
+	}
+	return ids, nil
+}
+
+// applyMuteLocked sets or clears agentID in the mute set, reporting whether the
+// set actually changed (so an idempotent re-mute publishes nothing). Caller holds
+// Manager.mu.
+func applyMuteLocked(set map[string]struct{}, agentID string, muted bool) bool {
+	_, was := set[agentID]
+	if muted == was {
+		return false
+	}
+	if muted {
+		set[agentID] = struct{}{}
+	} else {
+		delete(set, agentID)
+	}
+	return true
+}
+
+// mutedIDsLocked returns the muted ids as a sorted slice. Caller holds Manager.mu.
+func mutedIDsLocked(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -57,6 +57,11 @@ var (
 	// wrapped in the chain. Mapped to CodeFailedPrecondition (a self-host
 	// misconfig), not an opaque Internal.
 	ErrDiscordTokenUndecryptable = errors.New("session: saved Discord bot token could not be decrypted")
+	// ErrAgentNotInCampaign is returned by SetAgentMute when the target agent_id is
+	// not an Agent of the active session's Campaign (#211) — validated atomically
+	// against the SAME session the mute writes to, so a session swap can't sneak a
+	// foreign agent into the new session's mute set. Mapped to CodeNotFound.
+	ErrAgentNotInCampaign = errors.New("session: no such Agent in the Active Campaign")
 )
 
 // Store is the narrow storage surface the Manager needs: the saved Discord
@@ -136,6 +141,16 @@ type Manager struct {
 	mu     sync.Mutex
 	active *activeSession
 	closed bool // terminal: set by Shutdown; Start refuses with ErrManagerClosed (#157)
+
+	// pubMu serializes the whole write-set→publish-MuteChanged sequence across the
+	// mute ops (#211), so two overlapping ops (a per-Agent toggle racing a mute-all)
+	// can never publish events in the reverse order of their set writes — which
+	// would let a stale event de-sync the wirenpc matcher from the authoritative
+	// set. Ordered AFTER m.mu: an op takes pubMu, then m.mu for the set write, drops
+	// m.mu, publishes while still holding pubMu, then drops pubMu. Muted() (the
+	// re-read subscribers do during that publish) takes only m.mu, which is free —
+	// no inversion.
+	pubMu sync.Mutex
 }
 
 // NewManager wraps the store, loop runner and base config in a Manager. base
@@ -438,15 +453,41 @@ func (m *Manager) MutedAgentIDs() []string {
 
 // SetAgentMute mutes or unmutes one Agent in the live session, returning the
 // resulting sorted muted-id set (#211). It refuses when idle (ErrNoActiveSession,
-// AC4). The set is written UNDER m.mu and the resulting MuteChanged is published
-// OUTSIDE it — the bus fan-out touches other locks (the relay, the wirenpc
-// roster), so publishing under m.mu risks a lock-order inversion. The write
-// happening BEFORE the publish is load-bearing: the replier gate reading the set
-// on this event always sees the change. An idempotent re-mute (no actual change)
-// publishes nothing.
-func (m *Manager) SetAgentMute(agentID string, muted bool) ([]string, error) {
+// AC4) and rejects an agentID that is not an Agent of the active session's
+// Campaign with ErrAgentNotInCampaign.
+//
+// Validation and the write are SESSION-ATOMIC (mirrors SetAllMute): the active
+// session is captured, its Campaign is listed with m.mu released (the store read
+// may block), then the set is written only if the SAME session is still active —
+// so a session swap between the roster read and the write can never sneak a
+// foreign agent (valid in the old Campaign, not the new) into the new session's
+// mute set. The write-then-publish runs under pubMu so it is globally ordered
+// against a concurrent SetAllMute (no reverse-order events).
+func (m *Manager) SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error) {
 	m.mu.Lock()
-	if m.active == nil {
+	as := m.active
+	if as == nil {
+		m.mu.Unlock()
+		return nil, ErrNoActiveSession
+	}
+	campaignID := as.campaignID
+	m.mu.Unlock()
+
+	agents, err := m.store.ListAgents(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("session: list agents for mute: %w", err)
+	}
+	if !agentInList(agents, agentID) {
+		return nil, ErrAgentNotInCampaign
+	}
+
+	m.pubMu.Lock()
+	defer m.pubMu.Unlock()
+
+	m.mu.Lock()
+	if m.active != as {
+		// The session ended or rolled over between the roster read and the write:
+		// abort rather than mutate a set that belongs to a different session.
 		m.mu.Unlock()
 		return nil, ErrNoActiveSession
 	}
@@ -467,8 +508,9 @@ func (m *Manager) SetAgentMute(agentID string, muted bool) ([]string, error) {
 // (ErrNoActiveSession). The campaign is captured under m.mu, the roster is listed
 // with m.mu released (the store read may block), then the set is re-locked and
 // applied only if the SAME session is still active — a session that ended (or a
-// new one that started) while listing aborts with ErrNoActiveSession. One
-// MuteChanged per ACTUAL change is published OUTSIDE m.mu.
+// new one that started) while listing aborts with ErrNoActiveSession. The apply +
+// its per-change MuteChanged burst run under pubMu, so the whole mute-all is
+// ordered atomically against a concurrent per-Agent toggle.
 func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) {
 	m.mu.Lock()
 	as := m.active
@@ -483,6 +525,9 @@ func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) 
 	if err != nil {
 		return nil, fmt.Errorf("session: list agents for mute-all: %w", err)
 	}
+
+	m.pubMu.Lock()
+	defer m.pubMu.Unlock()
 
 	m.mu.Lock()
 	if m.active != as {
@@ -510,6 +555,16 @@ func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) 
 		}
 	}
 	return ids, nil
+}
+
+// agentInList reports whether agentID (a UUID string) names an Agent in agents.
+func agentInList(agents []storage.Agent, agentID string) bool {
+	for _, a := range agents {
+		if a.ID.String() == agentID {
+			return true
+		}
+	}
+	return false
 }
 
 // applyMuteLocked sets or clears agentID in the mute set, reporting whether the

--- a/internal/session/manager_mute_test.go
+++ b/internal/session/manager_mute_test.go
@@ -3,6 +3,8 @@ package session_test
 import (
 	"context"
 	"log/slog"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -42,12 +44,37 @@ func startMuteSession(t *testing.T, mgr *session.Manager) uuid.UUID {
 	return campaignID
 }
 
+// seedAgents makes n agents and puts them on the store's ListAgents roster (the
+// membership SetAgentMute now validates against).
+func seedAgents(store *fakeStore, n int) []storage.Agent {
+	agents := make([]storage.Agent, n)
+	for i := range agents {
+		agents[i] = storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter}
+	}
+	store.mu.Lock()
+	store.agents = agents
+	store.mu.Unlock()
+	return agents
+}
+
 // TestSetAgentMute_IdleReturnsNoActiveSession pins the active-session requirement
-// (AC4): muting with no live session is refused.
+// (AC4): muting with no live session is refused before any roster lookup.
 func TestSetAgentMute_IdleReturnsNoActiveSession(t *testing.T) {
 	mgr, _ := muteManager(t, newFakeStore())
-	if _, err := mgr.SetAgentMute("agent-1", true); err != session.ErrNoActiveSession {
+	if _, err := mgr.SetAgentMute(context.Background(), uuid.NewString(), true); err != session.ErrNoActiveSession {
 		t.Fatalf("SetAgentMute while idle = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestSetAgentMute_ForeignAgentRejected pins the campaign-membership guard: an
+// agent not in the active session's roster is refused ErrAgentNotInCampaign.
+func TestSetAgentMute_ForeignAgentRejected(t *testing.T) {
+	store := newFakeStore()
+	seedAgents(store, 1)
+	mgr, _ := muteManager(t, store)
+	startMuteSession(t, mgr)
+	if _, err := mgr.SetAgentMute(context.Background(), uuid.NewString(), true); err != session.ErrAgentNotInCampaign {
+		t.Fatalf("muting a foreign agent = %v, want ErrAgentNotInCampaign", err)
 	}
 }
 
@@ -55,63 +82,80 @@ func TestSetAgentMute_IdleReturnsNoActiveSession(t *testing.T) {
 // 8): a mute publishes exactly one MuteChanged; a redundant re-mute publishes
 // none; an unmute publishes one. The set + the returned sorted ids track each.
 func TestSetAgentMute_PublishesOncePerActualChange(t *testing.T) {
-	mgr, bus := muteManager(t, newFakeStore())
+	store := newFakeStore()
+	bart := seedAgents(store, 1)[0]
+	bartID := bart.ID.String()
+	mgr, bus := muteManager(t, store)
 	startMuteSession(t, mgr)
 
+	var mu sync.Mutex
 	var events []voiceevent.MuteChanged
-	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { events = append(events, e) }))
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}))
+	eventCount := func() int { mu.Lock(); defer mu.Unlock(); return len(events) }
 
-	ids, err := mgr.SetAgentMute("bart", true)
+	ids, err := mgr.SetAgentMute(context.Background(), bartID, true)
 	if err != nil {
 		t.Fatalf("SetAgentMute: %v", err)
 	}
-	if len(ids) != 1 || ids[0] != "bart" {
-		t.Fatalf("muted ids = %v, want [bart]", ids)
+	if len(ids) != 1 || ids[0] != bartID {
+		t.Fatalf("muted ids = %v, want [%s]", ids, bartID)
 	}
-	if !mgr.Muted("bart") {
+	if !mgr.Muted(bartID) {
 		t.Fatal("Muted(bart) = false after mute, want true")
 	}
-	if len(events) != 1 || events[0].AgentID != "bart" || !events[0].Muted {
-		t.Fatalf("events after mute = %+v, want one {bart true}", events)
+	if eventCount() != 1 {
+		t.Fatalf("events after mute = %d, want 1", eventCount())
 	}
 
 	// Idempotent re-mute publishes nothing and stays muted.
-	if _, err := mgr.SetAgentMute("bart", true); err != nil {
+	if _, err := mgr.SetAgentMute(context.Background(), bartID, true); err != nil {
 		t.Fatalf("re-mute: %v", err)
 	}
-	if len(events) != 1 {
-		t.Fatalf("re-mute published %d events, want 0 more (idempotent)", len(events)-1)
+	if eventCount() != 1 {
+		t.Fatalf("re-mute published %d events, want 0 more (idempotent)", eventCount()-1)
 	}
 
 	// Unmute publishes one and clears the set.
-	ids, err = mgr.SetAgentMute("bart", false)
+	ids, err = mgr.SetAgentMute(context.Background(), bartID, false)
 	if err != nil {
 		t.Fatalf("unmute: %v", err)
 	}
 	if len(ids) != 0 {
 		t.Fatalf("muted ids after unmute = %v, want empty", ids)
 	}
-	if mgr.Muted("bart") {
+	if mgr.Muted(bartID) {
 		t.Fatal("Muted(bart) = true after unmute")
 	}
-	if len(events) != 2 || events[1].Muted {
-		t.Fatalf("events after unmute = %+v, want a second {bart false}", events)
+	if eventCount() != 2 {
+		t.Fatalf("events after unmute = %d, want 2", eventCount())
 	}
 }
 
 // TestMutedAgentIDs_SortedSnapshot pins the reload truth (AC5): MutedAgentIDs is a
 // sorted snapshot of the current muted set.
 func TestMutedAgentIDs_SortedSnapshot(t *testing.T) {
-	mgr, _ := muteManager(t, newFakeStore())
+	store := newFakeStore()
+	agents := seedAgents(store, 2)
+	mgr, _ := muteManager(t, store)
 	startMuteSession(t, mgr)
 	if got := mgr.MutedAgentIDs(); len(got) != 0 {
 		t.Fatalf("a fresh session has muted ids %v, want none (AC5 all-unmuted at start)", got)
 	}
-	_, _ = mgr.SetAgentMute("greta", true)
-	_, _ = mgr.SetAgentMute("bart", true)
+	for _, a := range agents {
+		if _, err := mgr.SetAgentMute(context.Background(), a.ID.String(), true); err != nil {
+			t.Fatalf("mute %s: %v", a.ID, err)
+		}
+	}
 	got := mgr.MutedAgentIDs()
-	if len(got) != 2 || got[0] != "bart" || got[1] != "greta" {
-		t.Fatalf("MutedAgentIDs = %v, want sorted [bart greta]", got)
+	if len(got) != 2 {
+		t.Fatalf("MutedAgentIDs = %v, want 2", got)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("MutedAgentIDs = %v, want sorted", got)
 	}
 }
 
@@ -119,23 +163,25 @@ func TestMutedAgentIDs_SortedSnapshot(t *testing.T) {
 // unmuted — the volatile set is fresh per Start, so a mute from a prior session
 // does not leak.
 func TestStartResetsMuteSet(t *testing.T) {
-	mgr, _ := muteManager(t, newFakeStore())
-	campaignID := uuid.New()
-	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+	store := newFakeStore()
+	bart := seedAgents(store, 1)[0]
+	bartID := bart.ID.String()
+	mgr, _ := muteManager(t, store)
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("Start 1: %v", err)
 	}
-	if _, err := mgr.SetAgentMute("bart", true); err != nil {
+	if _, err := mgr.SetAgentMute(context.Background(), bartID, true); err != nil {
 		t.Fatalf("mute: %v", err)
 	}
 	if _, err := mgr.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 
-	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("Start 2: %v", err)
 	}
 	t.Cleanup(mgr.Shutdown)
-	if mgr.Muted("bart") {
+	if mgr.Muted(bartID) {
 		t.Fatal("a new Voice Session must start with Bart unmuted (AC5)")
 	}
 	if got := mgr.MutedAgentIDs(); len(got) != 0 {
@@ -155,8 +201,14 @@ func TestSetAllMute_MutesAndClearsEveryAgent(t *testing.T) {
 	mgr, bus := muteManager(t, store)
 	startMuteSession(t, mgr)
 
+	var mu sync.Mutex
 	var events []voiceevent.MuteChanged
-	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { events = append(events, e) }))
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}))
+	eventCount := func() int { mu.Lock(); defer mu.Unlock(); return len(events) }
 
 	ids, err := mgr.SetAllMute(context.Background(), true)
 	if err != nil {
@@ -168,11 +220,13 @@ func TestSetAllMute_MutesAndClearsEveryAgent(t *testing.T) {
 	if !mgr.Muted(butler.ID.String()) || !mgr.Muted(bart.ID.String()) {
 		t.Fatal("mute-all must mute every Agent including the Butler")
 	}
-	if len(events) != 2 {
-		t.Fatalf("mute-all published %d events, want 2 (one per Agent)", len(events))
+	if eventCount() != 2 {
+		t.Fatalf("mute-all published %d events, want 2 (one per Agent)", eventCount())
 	}
 
+	mu.Lock()
 	events = nil
+	mu.Unlock()
 	ids, err = mgr.SetAllMute(context.Background(), false)
 	if err != nil {
 		t.Fatalf("SetAllMute(false): %v", err)
@@ -180,8 +234,8 @@ func TestSetAllMute_MutesAndClearsEveryAgent(t *testing.T) {
 	if len(ids) != 0 {
 		t.Fatalf("muted ids after unmute-all = %v, want none", ids)
 	}
-	if len(events) != 2 {
-		t.Fatalf("unmute-all published %d events, want 2", len(events))
+	if eventCount() != 2 {
+		t.Fatalf("unmute-all published %d events, want 2", eventCount())
 	}
 }
 
@@ -190,5 +244,56 @@ func TestSetAllMute_IdleReturnsNoActiveSession(t *testing.T) {
 	mgr, _ := muteManager(t, newFakeStore())
 	if _, err := mgr.SetAllMute(context.Background(), true); err != session.ErrNoActiveSession {
 		t.Fatalf("SetAllMute while idle = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestMute_ConcurrentOpsConvergeSubscriberToManager pins the cross-op publish
+// ordering fix (#211): SetAllMute racing a per-Agent unmute must never leave a
+// re-reading subscriber (the wirenpc matcher) out of sync with the Manager's
+// authoritative set. A subscriber that re-reads Muted() on every event ends
+// EXACTLY matching Manager.Muted for every Agent, regardless of interleave. Run
+// with -race.
+func TestMute_ConcurrentOpsConvergeSubscriberToManager(t *testing.T) {
+	store := newFakeStore()
+	agents := seedAgents(store, 6)
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+
+	// The subscriber mimics wirenpc.wireMutes: on each event it re-reads the
+	// authoritative view (Manager.Muted), NOT the event payload.
+	var mu sync.Mutex
+	applied := map[string]bool{}
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) {
+		v := mgr.Muted(e.AgentID)
+		mu.Lock()
+		applied[e.AgentID] = v
+		mu.Unlock()
+	}))
+
+	// Interleave a mute-all with per-Agent unmutes of half the roster.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = mgr.SetAllMute(context.Background(), true)
+	}()
+	for i := 0; i < len(agents); i += 2 {
+		a := agents[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = mgr.SetAgentMute(context.Background(), a.ID.String(), false)
+		}()
+	}
+	wg.Wait()
+
+	// After the dust settles, the subscriber's applied view must match the
+	// Manager's authoritative Muted for every Agent that saw an event.
+	mu.Lock()
+	defer mu.Unlock()
+	for id, gotMuted := range applied {
+		if want := mgr.Muted(id); gotMuted != want {
+			t.Fatalf("subscriber diverged for %s: applied muted=%v, Manager.Muted=%v", id, gotMuted, want)
+		}
 	}
 }

--- a/internal/session/manager_mute_test.go
+++ b/internal/session/manager_mute_test.go
@@ -1,0 +1,194 @@
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// reRunnableRunner blocks until ctx is cancelled and is safe to run more than
+// once (the shared blockingRunner closes a one-shot channel), so a test can Start
+// the same Manager twice (the AC5 reset).
+func reRunnableRunner(ctx context.Context, _ wirenpc.Config) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// muteManager builds a Manager wired to a real voiceevent.Bus (so MuteChanged
+// publications are observable) over store, with a re-runnable blocking runner.
+func muteManager(t *testing.T, store session.Store) (*session.Manager, *voiceevent.Bus) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	mgr := session.NewManager(store, reRunnableRunner,
+		wirenpc.Config{Token: "test-token", Bus: bus}, nil, slog.New(slog.DiscardHandler), true)
+	return mgr, bus
+}
+
+// startMuteSession starts a session and returns its campaign id.
+func startMuteSession(t *testing.T, mgr *session.Manager) uuid.UUID {
+	t.Helper()
+	campaignID := uuid.New()
+	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(mgr.Shutdown)
+	return campaignID
+}
+
+// TestSetAgentMute_IdleReturnsNoActiveSession pins the active-session requirement
+// (AC4): muting with no live session is refused.
+func TestSetAgentMute_IdleReturnsNoActiveSession(t *testing.T) {
+	mgr, _ := muteManager(t, newFakeStore())
+	if _, err := mgr.SetAgentMute("agent-1", true); err != session.ErrNoActiveSession {
+		t.Fatalf("SetAgentMute while idle = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestSetAgentMute_PublishesOncePerActualChange pins the idempotent publish (test
+// 8): a mute publishes exactly one MuteChanged; a redundant re-mute publishes
+// none; an unmute publishes one. The set + the returned sorted ids track each.
+func TestSetAgentMute_PublishesOncePerActualChange(t *testing.T) {
+	mgr, bus := muteManager(t, newFakeStore())
+	startMuteSession(t, mgr)
+
+	var events []voiceevent.MuteChanged
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { events = append(events, e) }))
+
+	ids, err := mgr.SetAgentMute("bart", true)
+	if err != nil {
+		t.Fatalf("SetAgentMute: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "bart" {
+		t.Fatalf("muted ids = %v, want [bart]", ids)
+	}
+	if !mgr.Muted("bart") {
+		t.Fatal("Muted(bart) = false after mute, want true")
+	}
+	if len(events) != 1 || events[0].AgentID != "bart" || !events[0].Muted {
+		t.Fatalf("events after mute = %+v, want one {bart true}", events)
+	}
+
+	// Idempotent re-mute publishes nothing and stays muted.
+	if _, err := mgr.SetAgentMute("bart", true); err != nil {
+		t.Fatalf("re-mute: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("re-mute published %d events, want 0 more (idempotent)", len(events)-1)
+	}
+
+	// Unmute publishes one and clears the set.
+	ids, err = mgr.SetAgentMute("bart", false)
+	if err != nil {
+		t.Fatalf("unmute: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("muted ids after unmute = %v, want empty", ids)
+	}
+	if mgr.Muted("bart") {
+		t.Fatal("Muted(bart) = true after unmute")
+	}
+	if len(events) != 2 || events[1].Muted {
+		t.Fatalf("events after unmute = %+v, want a second {bart false}", events)
+	}
+}
+
+// TestMutedAgentIDs_SortedSnapshot pins the reload truth (AC5): MutedAgentIDs is a
+// sorted snapshot of the current muted set.
+func TestMutedAgentIDs_SortedSnapshot(t *testing.T) {
+	mgr, _ := muteManager(t, newFakeStore())
+	startMuteSession(t, mgr)
+	if got := mgr.MutedAgentIDs(); len(got) != 0 {
+		t.Fatalf("a fresh session has muted ids %v, want none (AC5 all-unmuted at start)", got)
+	}
+	_, _ = mgr.SetAgentMute("greta", true)
+	_, _ = mgr.SetAgentMute("bart", true)
+	got := mgr.MutedAgentIDs()
+	if len(got) != 2 || got[0] != "bart" || got[1] != "greta" {
+		t.Fatalf("MutedAgentIDs = %v, want sorted [bart greta]", got)
+	}
+}
+
+// TestStartResetsMuteSet pins AC5: every new Voice Session starts with all Agents
+// unmuted — the volatile set is fresh per Start, so a mute from a prior session
+// does not leak.
+func TestStartResetsMuteSet(t *testing.T) {
+	mgr, _ := muteManager(t, newFakeStore())
+	campaignID := uuid.New()
+	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+		t.Fatalf("Start 1: %v", err)
+	}
+	if _, err := mgr.SetAgentMute("bart", true); err != nil {
+		t.Fatalf("mute: %v", err)
+	}
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), campaignID); err != nil {
+		t.Fatalf("Start 2: %v", err)
+	}
+	t.Cleanup(mgr.Shutdown)
+	if mgr.Muted("bart") {
+		t.Fatal("a new Voice Session must start with Bart unmuted (AC5)")
+	}
+	if got := mgr.MutedAgentIDs(); len(got) != 0 {
+		t.Fatalf("a new session has muted ids %v, want none", got)
+	}
+}
+
+// TestSetAllMute_MutesAndClearsEveryAgent pins muteall (test 8): SetAllMute(true)
+// mutes every Agent of the Active Campaign (Butler + NPCs) with one MuteChanged
+// each; SetAllMute(false) clears them.
+func TestSetAllMute_MutesAndClearsEveryAgent(t *testing.T) {
+	store := newFakeStore()
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Butler"}
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	store.agents = []storage.Agent{butler, bart}
+
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+
+	var events []voiceevent.MuteChanged
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { events = append(events, e) }))
+
+	ids, err := mgr.SetAllMute(context.Background(), true)
+	if err != nil {
+		t.Fatalf("SetAllMute(true): %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("muted ids after mute-all = %v, want 2 (Butler + Bart)", ids)
+	}
+	if !mgr.Muted(butler.ID.String()) || !mgr.Muted(bart.ID.String()) {
+		t.Fatal("mute-all must mute every Agent including the Butler")
+	}
+	if len(events) != 2 {
+		t.Fatalf("mute-all published %d events, want 2 (one per Agent)", len(events))
+	}
+
+	events = nil
+	ids, err = mgr.SetAllMute(context.Background(), false)
+	if err != nil {
+		t.Fatalf("SetAllMute(false): %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("muted ids after unmute-all = %v, want none", ids)
+	}
+	if len(events) != 2 {
+		t.Fatalf("unmute-all published %d events, want 2", len(events))
+	}
+}
+
+// TestSetAllMute_IdleReturnsNoActiveSession pins the active-session requirement.
+func TestSetAllMute_IdleReturnsNoActiveSession(t *testing.T) {
+	mgr, _ := muteManager(t, newFakeStore())
+	if _, err := mgr.SetAllMute(context.Background(), true); err != session.ErrNoActiveSession {
+		t.Fatalf("SetAllMute while idle = %v, want ErrNoActiveSession", err)
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -30,7 +30,7 @@ type fakeStore struct {
 	depReads   int
 	reconciles int
 	tick       int
-	endErr     error // injected EndVoiceSession failure (#143 Defect A)
+	endErr     error           // injected EndVoiceSession failure (#143 Defect A)
 	agents     []storage.Agent // the Active Campaign's roster for ListAgents (#211 mute-all)
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -31,6 +31,7 @@ type fakeStore struct {
 	reconciles int
 	tick       int
 	endErr     error // injected EndVoiceSession failure (#143 Defect A)
+	agents     []storage.Agent // the Active Campaign's roster for ListAgents (#211 mute-all)
 }
 
 func newFakeStore() *fakeStore {
@@ -119,6 +120,13 @@ func (f *fakeStore) ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, 
 		n++
 	}
 	return n, nil
+}
+
+// ListAgents serves the campaign's roster for the mute-all path (#211).
+func (f *fakeStore) ListAgents(_ context.Context, _ uuid.UUID) ([]storage.Agent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]storage.Agent(nil), f.agents...), nil
 }
 
 func (f *fakeStore) counts() (created, ended int) {

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -111,6 +111,14 @@ type status struct {
 	Typing Typing `json:"typing"`
 }
 
+// muteFrame is the payload of a "mute" SSE frame (#211): one Agent's mute state
+// flipped, so the web Voice panel patches that row without a reload. Deliberately
+// minimal — the authoritative current set is GetSession.muted_agent_ids.
+type muteFrame struct {
+	AgentID string `json:"agent_id"`
+	Muted   bool   `json:"muted"`
+}
+
 // View is the snapshot the JSON endpoint returns and the unit tests assert on:
 // the current coalesced lines plus the derived status/typing.
 type View struct {
@@ -305,6 +313,12 @@ func (r *Relay) project(e voiceevent.Event) {
 		// Agent off mid-reply.
 		r.turn(ev.TurnID).ended = true
 		r.setTyping(r.liveTyping())
+	case voiceevent.MuteChanged:
+		// One Agent's mute flipped (#211): forward a "mute" frame so the web Voice
+		// panel tracks a Discord (or web) mute without a reload (AC5). It rides the
+		// ring for Last-Event-ID replay; there is NO transcript-line change and NO
+		// snapshot change — a mid-session reload reads the true state from GetSession.
+		r.emit(Frame{Event: "mute", Data: mustJSON(muteFrame{AgentID: ev.AgentID, Muted: ev.Muted})})
 	}
 }
 

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -84,6 +84,56 @@ func TestProjection_LinesAndOrder(t *testing.T) {
 	}
 }
 
+// TestProjection_MuteFrame pins the mute relay (#211): a MuteChanged projects a
+// "mute" frame carrying agent_id + muted, and the frame rides the ring so a
+// Last-Event-ID reconnect replays it (no snapshot change — the reload truth is
+// GetSession).
+func TestProjection_MuteFrame(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.MuteChanged{At: at(1), AgentID: "bart", Muted: true})
+
+	frames := r.Frames(id, 0)
+	var mute *Frame
+	for i := range frames {
+		if frames[i].Event == "mute" {
+			mute = &frames[i]
+			break
+		}
+	}
+	if mute == nil {
+		t.Fatalf("no mute frame emitted; frames: %+v", frames)
+	}
+	var payload struct {
+		AgentID string `json:"agent_id"`
+		Muted   bool   `json:"muted"`
+	}
+	if err := json.Unmarshal(mute.Data, &payload); err != nil {
+		t.Fatalf("mute frame payload: %v", err)
+	}
+	if payload.AgentID != "bart" || !payload.Muted {
+		t.Fatalf("mute frame payload = %+v, want {bart true}", payload)
+	}
+
+	// An unmute rides the ring too.
+	bus.Publish(voiceevent.MuteChanged{At: at(2), AgentID: "bart", Muted: false})
+	frames = r.Frames(id, 0)
+	unmutes := 0
+	for _, f := range frames {
+		if f.Event == "mute" {
+			unmutes++
+		}
+	}
+	if unmutes != 2 {
+		t.Fatalf("mute frames on the ring = %d, want 2 (mute + unmute)", unmutes)
+	}
+
+	// The mute frame does NOT change the transcript snapshot lines.
+	if v := r.View(id); len(v.Lines) != 0 {
+		t.Fatalf("mute frame added %d transcript lines, want 0 (reload truth is GetSession)", len(v.Lines))
+	}
+}
+
 // TestProjection_ButlerKind checks the butler role maps to the butler kind + tag.
 func TestProjection_ButlerKind(t *testing.T) {
 	bus, r, _, id := liveRelay(t)

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -166,7 +166,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -46,6 +46,13 @@ type Roster struct {
 	// Matcher but keeps its spec here, since the Cast entry is deliberately left
 	// untouched. Populated by [Roster.AddNPC], pruned by [Roster.RemoveNPC].
 	specs map[string]npcSpec
+	// muted tracks which NPCs are currently dropped from the Matcher (#211), so
+	// [Roster.SetMuted] is IDEMPOTENT: it touches the Matcher only on an actual
+	// mute↔unmute transition. Load-bearing — [address.Matcher.Add] panics on a
+	// duplicate agent, so a re-applied unmute (the authoritative-view re-read in
+	// wireMutes fires SetMuted per event, sometimes for an already-correct state)
+	// must be a no-op, not a re-Add.
+	muted map[string]struct{}
 }
 
 // rosterDeps carries what a [Roster] needs to assemble an NPC beyond the NPC's
@@ -73,6 +80,7 @@ func newRoster(deps rosterDeps) *Roster {
 		replierFor: deps.replierFor,
 		language:   matcherLanguage(deps.language),
 		specs:      map[string]npcSpec{},
+		muted:      map[string]struct{}{},
 	}
 }
 
@@ -131,6 +139,7 @@ func (r *Roster) RemoveNPC(agentID string) {
 	}
 	r.cast.Remove(agentID)
 	delete(r.specs, agentID)
+	delete(r.muted, agentID)
 }
 
 // SetMuted toggles one NPC's mute in the live scene (#211). It is deliberately
@@ -145,17 +154,23 @@ func (r *Roster) RemoveNPC(agentID string) {
 //
 // This is NOT [Roster.RemoveNPC]: removing the Cast entry would destroy the
 // Replier and its history, the exact failure to avoid. Muting an id the Roster
-// never held is a no-op.
+// never held is a no-op, and re-applying the current state (mute an already-muted
+// NPC, unmute an already-unmuted one) is idempotent — no Matcher churn.
 func (r *Roster) SetMuted(agentID string, muted bool) {
 	spec, ok := r.specs[agentID]
 	if !ok || r.matcher == nil {
 		return // unknown NPC (or no matcher yet): nothing to route or de-route
 	}
+	if _, alreadyMuted := r.muted[agentID]; muted == alreadyMuted {
+		return // already in the requested state: idempotent no-op (Matcher.Add panics on a dup)
+	}
 	if muted {
 		r.matcher.Remove(agentID)
+		r.muted[agentID] = struct{}{}
 		return
 	}
 	r.matcher.Add(matcherAgent(spec))
+	delete(r.muted, agentID)
 }
 
 // rosterDepsForLive builds the production rosterDeps: every NPC's Replier is

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -40,6 +40,12 @@ type Roster struct {
 	// shared tool-engine (so N NPCs share one Groq client); tests inject scripted
 	// engines through it. Always non-nil after [newRoster].
 	replierFor func(npcSpec) *agent.Replier
+
+	// specs retains each held NPC's spec by agentID so [Roster.SetMuted] can
+	// rebuild its matcher Agent on unmute (#211) — a mute drops the NPC from the
+	// Matcher but keeps its spec here, since the Cast entry is deliberately left
+	// untouched. Populated by [Roster.AddNPC], pruned by [Roster.RemoveNPC].
+	specs map[string]npcSpec
 }
 
 // rosterDeps carries what a [Roster] needs to assemble an NPC beyond the NPC's
@@ -66,6 +72,7 @@ func newRoster(deps rosterDeps) *Roster {
 		cast:       agent.NewCast(),
 		replierFor: deps.replierFor,
 		language:   matcherLanguage(deps.language),
+		specs:      map[string]npcSpec{},
 	}
 }
 
@@ -110,6 +117,7 @@ func (r *Roster) AddNPC(spec npcSpec) {
 		r.matcher.Add(matcherAgent(spec))
 	}
 	r.cast.Add(r.replierFor(spec))
+	r.specs[spec.agentID] = spec
 }
 
 // RemoveNPC drops the NPC with agentID from the scene: it leaves the Matcher (so
@@ -122,6 +130,32 @@ func (r *Roster) RemoveNPC(agentID string) {
 		r.matcher.Remove(agentID)
 	}
 	r.cast.Remove(agentID)
+	delete(r.specs, agentID)
+}
+
+// SetMuted toggles one NPC's mute in the live scene (#211). It is deliberately
+// MATCHER-ONLY: muting drops the NPC from the address Matcher (so nothing routes
+// to it — its name/aliases stop matching AND its lastAddressed is pruned so an
+// unnamed continuation re-routes / the remaining-NPC fallback emerges), while
+// unmuting re-adds its matcher Agent from the retained spec. The Cast is NEVER
+// touched, so the NPC's SAME [agent.Replier] — and its ADR-0012 delivered-only
+// history — survives a mute and is intact the instant it is unmuted (AC3 "context
+// intact"). A muted NPC therefore stays in the scene (the conversation keeps
+// accruing around it) but produces no audio and no transcript line.
+//
+// This is NOT [Roster.RemoveNPC]: removing the Cast entry would destroy the
+// Replier and its history, the exact failure to avoid. Muting an id the Roster
+// never held is a no-op.
+func (r *Roster) SetMuted(agentID string, muted bool) {
+	spec, ok := r.specs[agentID]
+	if !ok || r.matcher == nil {
+		return // unknown NPC (or no matcher yet): nothing to route or de-route
+	}
+	if muted {
+		r.matcher.Remove(agentID)
+		return
+	}
+	r.matcher.Add(matcherAgent(spec))
 }
 
 // rosterDepsForLive builds the production rosterDeps: every NPC's Replier is

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -2,6 +2,7 @@ package wirenpc
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
@@ -53,6 +54,14 @@ type Roster struct {
 	// wireMutes fires SetMuted per event, sometimes for an already-correct state)
 	// must be a no-op, not a re-Add.
 	muted map[string]struct{}
+
+	// mu guards the specs/muted maps (and the Matcher mutations they drive). Mute
+	// control breaks the "one goroutine owns the Roster" contract (#211): wireMutes
+	// calls [Roster.SetMuted] from the bus-event callback (the MuteChanged
+	// publisher's goroutine) AND seeds from connectAndServe's goroutine — a
+	// mid-session reconnect racing a GM mute would otherwise be a concurrent map
+	// write (a fatal). All specs/muted access goes under mu.
+	mu sync.Mutex
 }
 
 // rosterDeps carries what a [Roster] needs to assemble an NPC beyond the NPC's
@@ -116,6 +125,8 @@ func matcherAgent(spec npcSpec) address.Agent {
 // ones extend the live roster via [address.Matcher.Add]. Both halves move
 // together so an NPC is never routable-but-silent or speaking-but-unroutable.
 func (r *Roster) AddNPC(spec npcSpec) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.matcher == nil {
 		// First NPC: build the Matcher around it. Single-target by default
 		// (Config.MaxTargets unset ⇒ 1): naming two NPCs fires one turn on the
@@ -134,12 +145,14 @@ func (r *Roster) AddNPC(spec npcSpec) {
 // route says nothing). Removing an unknown agentID is a no-op. Removing every
 // NPC leaves the Matcher routing to nobody — the voice loop simply stays quiet.
 func (r *Roster) RemoveNPC(agentID string) {
+	r.mu.Lock()
 	if r.matcher != nil {
 		r.matcher.Remove(agentID)
 	}
-	r.cast.Remove(agentID)
 	delete(r.specs, agentID)
 	delete(r.muted, agentID)
+	r.mu.Unlock()
+	r.cast.Remove(agentID) // Cast is independently concurrency-safe; outside r.mu
 }
 
 // SetMuted toggles one NPC's mute in the live scene (#211). It is deliberately
@@ -156,7 +169,30 @@ func (r *Roster) RemoveNPC(agentID string) {
 // Replier and its history, the exact failure to avoid. Muting an id the Roster
 // never held is a no-op, and re-applying the current state (mute an already-muted
 // NPC, unmute an already-unmuted one) is idempotent — no Matcher churn.
+//
+// Concurrency-safe: SetMuted is called from the bus-event goroutine AND the seed
+// path (see [Roster.mu]).
 func (r *Roster) SetMuted(agentID string, muted bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setMutedLocked(agentID, muted)
+}
+
+// ApplyMutes reconciles the whole roster to the authoritative view under the
+// Roster lock (#211): for each held NPC it sets its mute to muted(agentID). It is
+// the seed/reconnect path — a mid-session Discord reconnect re-applies the mutes
+// that were in effect — run under [Roster.mu] so it never races the bus-event
+// SetMuted. muted must be non-nil.
+func (r *Roster) ApplyMutes(muted func(agentID string) bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id := range r.specs {
+		r.setMutedLocked(id, muted(id))
+	}
+}
+
+// setMutedLocked is the mute transition; the caller holds r.mu.
+func (r *Roster) setMutedLocked(agentID string, muted bool) {
 	spec, ok := r.specs[agentID]
 	if !ok || r.matcher == nil {
 		return // unknown NPC (or no matcher yet): nothing to route or de-route

--- a/internal/wirenpc/roster_test.go
+++ b/internal/wirenpc/roster_test.go
@@ -449,6 +449,38 @@ func TestWireMutes_AppliesBusEvents(t *testing.T) {
 	}
 }
 
+// TestWireMutes_ReReadsAuthoritativeViewNotPayload pins the cross-op ordering fix
+// (#211): wireMutes applies the AUTHORITATIVE view (mutes.Muted), never the
+// event's payload — so a stale/reordered MuteChanged (e.g. a mute-all event that
+// straddled a later unmute) cannot de-sync the matcher from the Manager. A
+// payload that disagrees with the view is ignored in favour of the view.
+func TestWireMutes_ReReadsAuthoritativeViewNotPayload(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("aldra", "Aldra", ""), specFor("bram", "Bram", "")}
+	roster := newRosterFor(specs, []*agent.Replier{
+		replierFor(specs[0], "Aldra here.", synth),
+		replierFor(specs[1], "Bram here.", synth),
+	}, synth)
+
+	view := fixedMutes{} // authoritative: bram currently UNMUTED
+	t.Cleanup(wireMutes(bus, roster, view))
+
+	// A stale event claims bram is muted, but the view says unmuted → ignored.
+	bus.Publish(voiceevent.MuteChanged{AgentID: "bram", Muted: true})
+	if got := routedTo(roster, "Bram, are you there?"); got != "bram" {
+		t.Fatalf("a stale {bram,true} event de-routed Bram against the view (routed to %q) — payload was trusted over the view", got)
+	}
+
+	// Flip the authoritative view to muted; a stale {bram,false} event must not
+	// re-route him.
+	view["bram"] = true
+	bus.Publish(voiceevent.MuteChanged{AgentID: "bram", Muted: false})
+	if routedTo(roster, "Bram, are you there?") == "bram" {
+		t.Fatal("a stale {bram,false} event routed to Bram against the muted view — payload trusted over the view")
+	}
+}
+
 // TestWireMutes_SeedsFromView pins the reconnect re-apply (#211, AC5): on connect
 // a freshly-rebuilt roster seeds the current mute state from the view, so an NPC
 // muted before a Discord reconnect stays muted after it — with no bus event.

--- a/internal/wirenpc/roster_test.go
+++ b/internal/wirenpc/roster_test.go
@@ -449,6 +449,46 @@ func TestWireMutes_AppliesBusEvents(t *testing.T) {
 	}
 }
 
+// TestWireMutes_ConcurrentSeedAndBusEvents_RaceClean pins the Roster-lock fix
+// (#211): SetMuted is called from the bus-event goroutine (a GM mute) AND the seed
+// goroutine (connectAndServe re-applying mutes on a mid-session reconnect). Both
+// mutate the Roster's muted/specs maps, so without the lock this is a concurrent
+// map write (a runtime FATAL). Run with -race.
+func TestWireMutes_ConcurrentSeedAndBusEvents_RaceClean(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("aldra", "Aldra", ""), specFor("bram", "Bram", ""), specFor("cyra", "Cyra", "")}
+	roster := newRosterFor(specs, []*agent.Replier{
+		replierFor(specs[0], "a", synth),
+		replierFor(specs[1], "b", synth),
+		replierFor(specs[2], "c", synth),
+	}, synth)
+	ids := []string{"aldra", "bram", "cyra"}
+	view := fixedMutes{"bram": true}
+
+	t.Cleanup(wireMutes(bus, roster, view)) // subscribes (bus-event → SetMuted) + seeds once
+
+	var wg sync.WaitGroup
+	// Bus-event side: each MuteChanged fires the subscription's SetMuted on THIS
+	// goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			bus.Publish(voiceevent.MuteChanged{AgentID: ids[i%len(ids)], Muted: i%2 == 0})
+		}
+	}()
+	// Seed side: connectAndServe's reconnect reconcile, hammered concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			roster.ApplyMutes(view.Muted)
+		}
+	}()
+	wg.Wait()
+}
+
 // TestWireMutes_ReReadsAuthoritativeViewNotPayload pins the cross-op ordering fix
 // (#211): wireMutes applies the AUTHORITATIVE view (mutes.Muted), never the
 // event's payload — so a stale/reordered MuteChanged (e.g. a mute-all event that

--- a/internal/wirenpc/roster_test.go
+++ b/internal/wirenpc/roster_test.go
@@ -315,6 +315,172 @@ func TestRoster_RemoveNPC_GoesSilentAndStopsContinuations(t *testing.T) {
 	}
 }
 
+// TestRoster_SetMuted_DropsAndRestoresMatching pins the matcher-only mute (#211):
+// a muted NPC is never matched by name/alias nor caught as an unnamed
+// continuation (its lastAddressed is pruned), so a 2-NPC scene's unnamed speech
+// re-routes to the remaining NPC; unmuting makes it addressable again.
+func TestRoster_SetMuted_DropsAndRestoresMatching(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{
+		specFor("aldra", "Aldra", ""),
+		specFor("bram", "Bram", ""),
+	}
+	lines := map[string]string{"aldra": "Aldra here.", "bram": "Bram here."}
+	roster, publish := testRoster(t, bus, synth, specs, lines)
+
+	publish("Bram, stay a while.")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("Bram spoke %d times before mute, want 1", len(got))
+	}
+
+	roster.SetMuted("bram", true)
+
+	// Named: muted Bram says nothing (its name no longer matches — it left the Matcher).
+	publish("Bram, are you there?")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("muted Bram spoke when named (%d total), want 1 (silent)", len(got))
+	}
+	// Unnamed: the continuation must NOT resurrect Bram (his lastAddressed was
+	// pruned) — it re-routes to the remaining NPC (Aldra), who stays reachable.
+	publish("Anyone still around?")
+	if got := synth.spokenBy("bram"); len(got) != 1 {
+		t.Fatalf("muted Bram caught an unnamed continuation (%d total), want 1 — lastAddressed not pruned", len(got))
+	}
+	if got := synth.spokenBy("aldra"); len(got) < 1 {
+		t.Fatal("with Bram muted the remaining NPC (Aldra) must still catch unnamed speech — the 2-NPC fallback")
+	}
+
+	roster.SetMuted("bram", false)
+
+	// Unmuted: Bram is addressable again.
+	publish("Bram, welcome back.")
+	if got := synth.spokenBy("bram"); len(got) != 2 {
+		t.Fatalf("unmuted Bram spoke %d times total, want 2 (addressable again)", len(got))
+	}
+}
+
+// TestRoster_SetMuted_UnmuteKeepsReplierHistory pins AC3's "context intact":
+// SetMuted touches ONLY the Matcher, never the Cast, so a muted-then-unmuted NPC
+// keeps its SAME agent.Replier — its conversation history (ADR-0012 delivered-only
+// commit log) survives the mute. Implementing mute as RemoveNPC would destroy that
+// history; this proves it does not.
+func TestRoster_SetMuted_UnmuteKeepsReplierHistory(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{
+		specFor("aldra", "Aldra", ""),
+		specFor("bram", "Bram", ""),
+	}
+	// Real agent.Repliers (over scripted engines) so history accumulates per turn.
+	aldra := replierFor(specs[0], "Aldra here.", synth)
+	bram := replierFor(specs[1], "Bram here.", synth)
+	roster := newRosterFor(specs, []*agent.Replier{aldra, bram}, synth)
+
+	ttsStage := orchestrator.NewTTS(bus, synth)
+	detector := orchestrator.NewAddressDetector(roster.matcher)
+	replier := orchestrator.NewStreamReplier(ttsStage, roster.cast.ReplyStream(), nil)
+	t.Cleanup(orchestrator.Bind(context.Background(), bus, detector, replier))
+	publish := func(text string) { bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: text}) }
+
+	publish("Bram, tell me a tale.")
+	before := len(bram.HistorySnapshot())
+	if before != 2 { // user + assistant
+		t.Fatalf("Bram history after turn 1 = %d messages, want 2", before)
+	}
+
+	roster.SetMuted("bram", true)
+	roster.SetMuted("bram", false)
+
+	publish("Bram, and then?")
+	hist := bram.HistorySnapshot()
+	if len(hist) != 4 {
+		t.Fatalf("Bram history after unmute+turn 2 = %d messages, want 4 (turn 1 preserved — same Replier survived the mute)", len(hist))
+	}
+	// Turn 1's user message must still be first — the mute did not reset the log.
+	if !strings.Contains(hist[0].Text, "tell me a tale") {
+		t.Fatalf("Bram history[0] = %q, want turn 1's message preserved", hist[0].Text)
+	}
+}
+
+// TestRoster_SetMuted_UnknownIDNoOp proves muting an id the Roster never held is a
+// clean no-op (it neither panics nor touches the Matcher).
+func TestRoster_SetMuted_UnknownIDNoOp(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("bart", "Bart", "")}
+	lines := map[string]string{"bart": "What'll it be?"}
+	roster, publish := testRoster(t, bus, synth, specs, lines)
+
+	roster.SetMuted("ghost", true) // unknown id
+	publish("Bart, a room please.")
+	if got := synth.spokenBy("bart"); len(got) != 1 {
+		t.Fatalf("Bart spoke %d times after an unknown-id mute, want 1 (no-op)", len(got))
+	}
+}
+
+// fixedMutes is a fixed-membership orchestrator.MuteView for the wireMutes tests.
+type fixedMutes map[string]bool
+
+func (m fixedMutes) Muted(agentID string) bool { return m[agentID] }
+
+// TestWireMutes_AppliesBusEvents pins the live control path (#211): a MuteChanged
+// on the bus de-routes the NPC via the roster, and an unmute restores it —
+// without touching the Cast.
+func TestWireMutes_AppliesBusEvents(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("aldra", "Aldra", ""), specFor("bram", "Bram", "")}
+	roster := newRosterFor(specs, []*agent.Replier{
+		replierFor(specs[0], "Aldra here.", synth),
+		replierFor(specs[1], "Bram here.", synth),
+	}, synth)
+
+	t.Cleanup(wireMutes(bus, roster, nil))
+
+	bus.Publish(voiceevent.MuteChanged{AgentID: "bram", Muted: true})
+	if routedTo(roster, "Bram, are you there?") == "bram" {
+		t.Fatal("after a mute bus event, naming Bram still routed to Bram — he must have left the Matcher")
+	}
+	bus.Publish(voiceevent.MuteChanged{AgentID: "bram", Muted: false})
+	routed := roster.matcher.TargetMatch("Bram, are you there?")
+	if len(routed) != 1 || routed[0].Target.AgentID != "bram" {
+		t.Fatalf("after an unmute bus event, naming Bram routed to %v, want [bram]", routed)
+	}
+}
+
+// TestWireMutes_SeedsFromView pins the reconnect re-apply (#211, AC5): on connect
+// a freshly-rebuilt roster seeds the current mute state from the view, so an NPC
+// muted before a Discord reconnect stays muted after it — with no bus event.
+func TestWireMutes_SeedsFromView(t *testing.T) {
+	bus := voiceevent.NewBus()
+	synth := &recordingSynth{}
+	specs := []npcSpec{specFor("aldra", "Aldra", ""), specFor("bram", "Bram", "")}
+	roster := newRosterFor(specs, []*agent.Replier{
+		replierFor(specs[0], "Aldra here.", synth),
+		replierFor(specs[1], "Bram here.", synth),
+	}, synth)
+
+	t.Cleanup(wireMutes(bus, roster, fixedMutes{"bram": true}))
+
+	if routedTo(roster, "Bram, are you there?") == "bram" {
+		t.Fatal("a roster seeded with Bram muted still routed his name to Bram, want de-routed")
+	}
+	// The un-muted NPC is unaffected by the seed.
+	if got := routedTo(roster, "Aldra, hello"); got != "aldra" {
+		t.Fatalf("seed muted the wrong NPC: Aldra routed to %q, want aldra", got)
+	}
+}
+
+// routedTo returns the AgentID the matcher routes text to, or "" for no route.
+func routedTo(r *Roster, text string) string {
+	routed := r.matcher.TargetMatch(text)
+	if len(routed) == 0 {
+		return ""
+	}
+	return routed[0].Target.AgentID
+}
+
 // TestRoster_SingleNPCBehaviorPreserved pins the Stage-2 acceptance bar: with a
 // Roster holding exactly one NPC, both a named utterance and an unnamed one route
 // to it (the lone-NPC fallback) — identical to the pre-Roster single-NPC loop.

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -785,11 +785,11 @@ func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView)
 		roster.SetMuted(e.AgentID, muted)
 	})
 	if mutes != nil {
-		for id := range roster.specs {
-			if mutes.Muted(id) {
-				roster.SetMuted(id, true)
-			}
-		}
+		// Seed via the locked reconcile, NOT a raw range over roster.specs: this runs
+		// on connectAndServe's goroutine while the subscription above may fire
+		// SetMuted on the publisher's goroutine (a concurrent GM mute), so the whole
+		// seed must be under the Roster lock.
+		roster.ApplyMutes(mutes.Muted)
 	}
 	return unsub
 }

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -336,6 +336,15 @@ type Config struct {
 	// Memory. nil (voice/bench standalone) disables facts entirely, so the prompt is
 	// byte-identical to the pre-facts behavior (#126).
 	Facts agent.FactsRecaller
+
+	// Mutes is the live per-Agent mute view (#211): the session Manager satisfies it
+	// (its volatile, session-local mute set), and the web tier sets it on the base
+	// voice config so every manager-started session copies it. It flows through
+	// connectAndServe (which subscribes roster.SetMuted to MuteChanged and seeds the
+	// current mute state on connect — a mid-session Discord reconnect re-applies the
+	// mutes) → buildConversation (orchestrator.WithMute). nil is the feature-off
+	// default: voice standalone / the benchmark are byte-for-byte unchanged.
+	Mutes orchestrator.MuteView
 }
 
 // RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
@@ -618,7 +627,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, _, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts)
+	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -626,6 +635,13 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// buildConversation). Without it each reconnect cycle (issue #44) would leak a
 	// Silero session that nothing ever closed.
 	defer cleanup()
+
+	// Mute control (#211): subscribe roster.SetMuted to MuteChanged so a GM mute
+	// (web panel or /glyphoxa mute) de-routes the NPC live, and seed the current
+	// mute state so a mid-session Discord RECONNECT re-applies the mutes onto the
+	// freshly-rebuilt roster. nil Mutes = feature off, so both are inert (voice
+	// standalone / bench unchanged).
+	defer wireMutes(bus, roster, cfg.Mutes)()
 
 	// Inbound (hear): the pipeline pumps Session.Inbound through the same Codec's
 	// DecodeInbound into the orchestrator. It tags its inbound counters (A2) with
@@ -745,7 +761,28 @@ var (
 // synthesized audio is tee'd to the playback path while the orchestrator keeps
 // draining-and-dropping it (ADR-0021); a bare ElevenLabs synthesizer also works
 // (no audio is played). It must not be nil.
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller) (*orchestrator.Conversation, *Roster, func(), error) {
+// wireMutes subscribes roster.SetMuted to [voiceevent.MuteChanged] on bus (so a
+// GM mute from either surface de-routes / restores the NPC live) and seeds the
+// current mute state from mutes, so a mid-session Discord RECONNECT — which
+// rebuilds the roster from scratch — re-applies the mutes that were in effect
+// (#211). It returns the unsubscribe func; the caller defers it for the cycle's
+// lifetime. A nil mutes view still subscribes (a mute can arrive after connect)
+// but seeds nothing.
+func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView) func() {
+	unsub := voiceevent.On(bus, func(e voiceevent.MuteChanged) {
+		roster.SetMuted(e.AgentID, e.Muted)
+	})
+	if mutes != nil {
+		for id := range roster.specs {
+			if mutes.Muted(id) {
+				roster.SetMuted(id, true)
+			}
+		}
+	}
+	return unsub
+}
+
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -845,6 +882,11 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		// batch path, so this option is unconditional — buildStreamManager returns nil
 		// unless GLYPHOXA_STT_STREAMING is set AND the adapter is a StreamingRecognizer.
 		orchestrator.WithStreamingSTT(streamMgr),
+		// Per-Agent mute (#211): the replier discards a muted addressee's route
+		// before taking the floor, and a MuteCut reactor cuts the floor when the
+		// speaking Agent is muted. A nil view is the feature-off default (voice
+		// standalone / bench), so this option is unconditional.
+		orchestrator.WithMute(mutes),
 		// Handles failures the reactors fire off the audio loop: the replier's TTS
 		// dispatch and the segmenter's off-loop STT call (#24). The wrapped error
 		// names its stage (orchestrator.TTS.Dispatch / orchestrator.STT.Transcribe).

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -768,9 +768,21 @@ var (
 // (#211). It returns the unsubscribe func; the caller defers it for the cycle's
 // lifetime. A nil mutes view still subscribes (a mute can arrive after connect)
 // but seeds nothing.
+//
+// On each event the roster is set from the AUTHORITATIVE view (mutes.Muted), NOT
+// the event's payload: the Manager can publish two overlapping ops' events in an
+// order that no longer reflects the final set (a mute-all straddling a per-Agent
+// unmute), so trusting a stale payload could leave an NPC de-routed while the
+// Manager says unmuted. Re-reading the view makes every event converge the roster
+// to the current truth — and closes the subscribe-then-seed window too (a mute
+// landing between subscribe and seed applies the same current value either way).
 func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView) func() {
 	unsub := voiceevent.On(bus, func(e voiceevent.MuteChanged) {
-		roster.SetMuted(e.AgentID, e.Muted)
+		muted := e.Muted
+		if mutes != nil {
+			muted = mutes.Muted(e.AgentID) // authoritative re-read; ignore the (possibly stale) payload
+		}
+		roster.SetMuted(e.AgentID, muted)
 	})
 	if mutes != nil {
 		for id := range roster.specs {

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -38,6 +38,11 @@ type Conversation struct {
 	bargeConfirm  time.Duration
 	floorCoalesce time.Duration
 	bargeEnabled  bool
+
+	// mutes is the live mute view ([WithMute], #211): nil = feature off. When set,
+	// Register gates the replier's routes on it and — when barge-in built the floor
+	// — binds a [MuteCut] reactor beside [BargeIn].
+	mutes MuteView
 }
 
 // Option configures a [Conversation] at construction.
@@ -164,6 +169,10 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 		} else {
 			replier = NewReplier(c.tts, c.reply, c.onError)
 		}
+		// Live mute view (#211): the replier discards a muted addressee's route
+		// before taking the floor, so an addressed-but-muted Agent opens no turn.
+		// Independent of barge-in; nil is the feature-off default.
+		replier.mutes = c.mutes
 		if c.bargeEnabled {
 			// Barge-in mode: the replier runs turns on the floor, and the BargeIn
 			// reactor yields it on a human interruption. Bind BargeIn before the
@@ -178,6 +187,12 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 			}
 			replier.floor = c.floor
 			reactors = append(reactors, NewBargeIn(c.floor, c.bargeConfirm))
+			// Mute cut (#211): muting the Agent that is speaking cuts its floor. Bound
+			// beside BargeIn (before the replier) on the same floor; only when a mute
+			// view is wired.
+			if c.mutes != nil {
+				reactors = append(reactors, NewMuteCut(c.floor))
+			}
 		}
 		reactors = append(reactors, replier)
 	}

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -15,6 +15,11 @@ func (f *Floor) SetClock(now func() time.Time) {
 // Conversation.Register.
 func (r *Replier) SetFloor(floor *Floor) { r.floor = floor }
 
+// SetMutes installs the live mute view on the replier for the mute-gate tests
+// (external test package, #211). Production wiring sets r.mutes inside
+// Conversation.Register from [WithMute].
+func (r *Replier) SetMutes(v MuteView) { r.mutes = v }
+
 // SetErrorHandler installs onError on the segmenter for the off-loop STT error
 // tests (external test package). Production wiring sets it inside
 // Conversation.Register from [WithErrorHandler].

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -168,6 +168,35 @@ func (f *Floor) Yield() (turnID string, yielded bool) {
 	return turnID, true
 }
 
+// YieldAgent cancels the turn holding the floor ONLY when agentID is that turn's
+// target Agent, reporting the cut turn's TurnID and yielded=true; otherwise it is
+// a no-op reporting ("", false) and the floor is left untouched. It is the
+// per-Agent mute cut (#211): muting the Agent that is speaking cuts it, while
+// muting anyone else never disturbs whoever holds the floor (AC3).
+//
+// Unlike the barge gate ([Floor.Speaking]) this deliberately ignores f.speaking:
+// a mute is a deliberate GM action that kills a held-but-silent pre-audio turn
+// too (the LLM "thinking" phase), so a just-muted Agent never starts speaking
+// after the fact (AC2). Mechanically identical to [Floor.Yield] once the holder
+// matches — the same forward-boundary hard cut (ADR-0027) — differing only in the
+// holder-match guard.
+func (f *Floor) YieldAgent(agentID string) (turnID string, yielded bool) {
+	f.mu.Lock()
+	if f.cancel == nil || f.holderAgent != agentID {
+		f.mu.Unlock()
+		return "", false
+	}
+	c := f.cancel
+	turnID = f.holderTurn
+	f.cancel = nil
+	f.holderTurn = ""
+	f.holderAgent = ""
+	f.speaking = false
+	f.mu.Unlock()
+	c()
+	return turnID, true
+}
+
 // Active reports whether a turn currently holds the floor (a turn is in flight,
 // from its [Floor.Take] until release/Yield — which spans the pre-audio LLM phase
 // as well as playback). It is a point-in-time read; callers must tolerate the

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -274,3 +274,76 @@ func TestFloor_StaleReleaseDoesNotClearNewerTurn(t *testing.T) {
 		t.Fatal("a stale release must not clear the newer turn's floor")
 	}
 }
+
+// TestFloor_YieldAgentCutsMatchingHolder pins the per-Agent mute cut (#211): a
+// YieldAgent whose agentID matches the current holder's target cancels that turn
+// and reports its TurnID — the same hard cut Yield does, but keyed to one Agent.
+func TestFloor_YieldAgentCutsMatchingHolder(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Tm")
+	ctx, release, _ := f.Take(parent, "bart")
+	defer release()
+
+	turnID, yielded := f.YieldAgent("bart")
+	if !yielded {
+		t.Fatal("YieldAgent must report true when the matching Agent holds the floor")
+	}
+	if turnID != "Tm" {
+		t.Fatalf("YieldAgent returned turnID %q, want the held turn's Tm", turnID)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("YieldAgent must cancel the matching holder's turn ctx")
+	}
+	if f.Active() {
+		t.Fatal("floor must be free after a matching YieldAgent")
+	}
+}
+
+// TestFloor_YieldAgentIgnoresNonHolder proves a mute of an Agent that is NOT the
+// current holder is a no-op: the speaking Agent keeps the floor (a muted
+// addressee must never disturb whoever holds the floor, AC3).
+func TestFloor_YieldAgentIgnoresNonHolder(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Tb")
+	ctx, release, _ := f.Take(parent, "bart")
+	defer release()
+
+	turnID, yielded := f.YieldAgent("greta")
+	if yielded || turnID != "" {
+		t.Fatalf("YieldAgent for a non-holder must report (\"\", false), got (%q, %v)", turnID, yielded)
+	}
+	if ctx.Err() != nil {
+		t.Fatal("YieldAgent for a non-holder must NOT cancel the current holder's turn")
+	}
+	if !f.Active() {
+		t.Fatal("the current holder must keep the floor after a non-matching YieldAgent")
+	}
+}
+
+// TestFloor_YieldAgentCutsHeldButSilentTurn pins AC2: muting the holder kills its
+// turn even in the pre-audio (held-but-silent LLM "thinking") phase — YieldAgent
+// deliberately ignores f.speaking, unlike the barge gate, so a just-muted Agent
+// never starts speaking after the fact.
+func TestFloor_YieldAgentCutsHeldButSilentTurn(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Ts")
+	ctx, release, _ := f.Take(parent, "bart") // never marked speaking (no FirstOpus)
+	defer release()
+
+	turnID, yielded := f.YieldAgent("bart")
+	if !yielded || turnID != "Ts" {
+		t.Fatalf("YieldAgent must cut a held-but-silent turn: got (%q, %v)", turnID, yielded)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("YieldAgent must cancel a held-but-silent (pre-audio) holder — a mute kills the thinking turn too")
+	}
+}
+
+// TestFloor_YieldAgentOnFreeFloorReportsFalse proves a mute with nothing speaking
+// is a clean no-op.
+func TestFloor_YieldAgentOnFreeFloorReportsFalse(t *testing.T) {
+	f := orchestrator.NewFloor()
+	if turnID, yielded := f.YieldAgent("bart"); yielded || turnID != "" {
+		t.Fatalf("YieldAgent on a free floor must report (\"\", false), got (%q, %v)", turnID, yielded)
+	}
+}

--- a/pkg/voice/orchestrator/mute.go
+++ b/pkg/voice/orchestrator/mute.go
@@ -1,0 +1,73 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// MuteView is the live authoritative read of which Agents are muted in the
+// current Voice Session (#211). The session Manager satisfies it. The
+// orchestrator keeps NO duplicated mute set of its own — the [Replier] gate and
+// the reload/route paths always ask this view, so the set the Manager wrote
+// before publishing [voiceevent.MuteChanged] is the single source of truth and
+// the check is airtight against the publish/read race (the set is written first).
+type MuteView interface {
+	// Muted reports whether the Agent with agentID is currently muted.
+	Muted(agentID string) bool
+}
+
+// WithMute wires the live mute view into the conversation (#211). Register stores
+// it on the [Replier] (so a muted addressee's route is discarded before the floor
+// is taken) and, when barge-in built the floor, binds a [MuteCut] reactor beside
+// [BargeIn] (so muting the speaking Agent cuts its turn). A nil view is the
+// feature-off default — voice standalone / the benchmark are byte-for-byte
+// unchanged.
+func WithMute(v MuteView) Option {
+	return func(c *Conversation) { c.mutes = v }
+}
+
+// MuteCut is the [Reactor] that cuts a speaking Agent's turn the moment it is
+// muted (#211, AC2). On a [voiceevent.MuteChanged] with Muted=true it asks the
+// [Floor] to yield ONLY if that Agent holds it ([Floor.YieldAgent] — a held-but-
+// silent pre-audio turn is killed too), and on an actual cut publishes
+// [voiceevent.TurnEnded] with the distinct [voiceevent.TurnEndMute] reason. It
+// NEVER publishes [voiceevent.BargeDetected]: a mute is a deliberate GM control
+// action, not a human barge (CONTEXT.md reserves Barge-in for the
+// human-interrupts-Agent case). An unmute does nothing here — re-enabling an
+// Agent is the matcher-restore / route-gate path, not a floor cut.
+//
+// It is bound beside [BargeIn] (before the [Replier]) on the same barge-in floor;
+// muting an Agent that is not the current holder is a no-op, so it never disturbs
+// whoever holds the floor (AC3).
+type MuteCut struct {
+	floor *Floor
+}
+
+// NewMuteCut builds a mute-cut reactor over floor. floor must be non-nil.
+func NewMuteCut(floor *Floor) *MuteCut {
+	if floor == nil {
+		panic("orchestrator.NewMuteCut: floor must not be nil")
+	}
+	return &MuteCut{floor: floor}
+}
+
+// Bind subscribes the reactor to [voiceevent.MuteChanged] on bus and returns the
+// unsubscribe func. It implements [Reactor]; bus must be non-nil.
+func (m *MuteCut) Bind(_ context.Context, bus *voiceevent.Bus) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.MuteCut.Bind: bus must not be nil")
+	}
+	return voiceevent.On(bus, func(e voiceevent.MuteChanged) {
+		if !e.Muted {
+			return // an unmute never cuts a turn
+		}
+		if turnID, ok := m.floor.YieldAgent(e.AgentID); ok {
+			// The mute cut the Agent's turn — announce it with the distinct mute
+			// reason so the transcript/history commit as a barge would (delivered
+			// sentences only, ADR-0012) while the cause stays a mute, never a barge.
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: turnID, Reason: voiceevent.TurnEndMute})
+		}
+	})
+}

--- a/pkg/voice/orchestrator/mute_conversation_test.go
+++ b/pkg/voice/orchestrator/mute_conversation_test.go
@@ -1,0 +1,159 @@
+package orchestrator_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// pausingEngine is a scripted [agent.StreamingEngine] that emits deltas in order
+// but blocks after the FIRST one until released or the turn ctx is cancelled — so
+// a test can cut the turn mid-stream (after one spoken sentence) and observe the
+// deliver-then-commit rule (ADR-0012) under a mute exactly as under a barge.
+type pausingEngine struct {
+	deltas     []string
+	firstDone  chan struct{} // closed once the first delta has been pushed
+	release    chan struct{} // closed by the test to let the remaining deltas flow
+	closeFirst sync.Once
+}
+
+func (e *pausingEngine) Generate(context.Context, []llm.Message) (string, error) {
+	return strings.Join(e.deltas, ""), nil
+}
+
+func (e *pausingEngine) GenerateStream(ctx context.Context, _ []llm.Message, onText func(string) error) (string, error) {
+	var full strings.Builder
+	for i, d := range e.deltas {
+		if err := onText(d); err != nil {
+			return full.String(), err
+		}
+		full.WriteString(d)
+		if i == 0 {
+			e.closeFirst.Do(func() { close(e.firstDone) })
+			select {
+			case <-e.release:
+			case <-ctx.Done():
+				return full.String(), ctx.Err()
+			}
+		}
+	}
+	return full.String(), nil
+}
+
+// recSynth records every dispatched sentence so a test can assert which sentences
+// actually reached the pump (the delivered set, ADR-0012). It returns an
+// immediately-closed channel — no audio.
+type recSynth struct {
+	mu    sync.Mutex
+	spoke []string
+}
+
+func (s *recSynth) Synthesize(_ context.Context, req tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	s.mu.Lock()
+	s.spoke = append(s.spoke, req.Sentence)
+	s.mu.Unlock()
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (s *recSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+func (s *recSynth) spoken() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.spoke...)
+}
+
+// TestMute_ConversationCutsSpeakingTurnLikeBarge is the mute e2e (#211, AC2): a
+// real Agent streaming turn is cut mid-sentence by a MuteChanged for the speaking
+// Agent — its audio stops, the turn ends with the distinct mute reason (never a
+// BargeDetected), and the Agent's history commits ONLY the delivered sentence,
+// exactly as the shipped barge path does (deliver-then-commit, ADR-0012). The
+// mute reuses the SAME floor-cancel mechanism as a barge, so the commit is
+// identical.
+func TestMute_ConversationCutsSpeakingTurnLikeBarge(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recSynth{}
+	ttsStage := orchestrator.NewTTS(h.Bus, synth)
+
+	eng := &pausingEngine{
+		deltas:    []string{"First. ", "Second. ", "Third."},
+		firstDone: make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	replier := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: tts.Voice{ProviderID: "test", VoiceID: "bart"}},
+		Engine:      eng,
+		Synthesizer: synth, // used only for the audio-markup prompt; Dispatch drives the TTS stage
+	})
+	cast := agent.NewCast(replier)
+
+	floor := orchestrator.NewFloor()
+	mutes := muteSet{}
+	streamer := orchestrator.NewStreamReplier(ttsStage, cast.ReplyStream(), nil)
+	streamer.SetFloor(floor)
+	streamer.SetMutes(mutes)
+	t.Cleanup(orchestrator.Bind(t.Context(), h.Bus, orchestrator.NewMuteCut(floor), streamer))
+
+	// Drive one turn addressed to Bart.
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Te2e", Text: "Bart, tell me about the inn",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	// Wait until the first sentence has been dispatched (the Agent is speaking).
+	select {
+	case <-eng.firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the Agent never dispatched its first sentence")
+	}
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Te2e"}) // audible on the wire
+
+	// Mute Bart mid-sentence: the set is written BEFORE the event (Manager ordering).
+	mutes["bart"] = true
+	h.Bus.Publish(voiceevent.MuteChanged{AgentID: "bart", Muted: true})
+
+	// Let the paused stream unwind (it should observe the cancelled ctx).
+	close(eng.release)
+
+	// The turn ended with the mute reason, never a barge.
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Te2e" && e.Reason == voiceevent.TurnEndMute },
+		"turn.ended (mute) for the cut speaking turn",
+	)
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+
+	// Only the delivered sentence reached the pump — the never-dispatched tail was dropped.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		hist := replier.HistorySnapshot()
+		if len(hist) >= 2 { // user + committed assistant
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("history never committed the spoken turn: %+v", hist)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := synth.spoken(); len(got) != 1 || strings.TrimSpace(got[0]) != "First." {
+		t.Fatalf("delivered sentences = %q, want exactly [\"First.\"] (mid-sentence cut drops the tail)", got)
+	}
+	hist := replier.HistorySnapshot()
+	assistant := hist[len(hist)-1]
+	if string(assistant.Role) != "assistant" || strings.TrimSpace(assistant.Text) != "First." {
+		t.Fatalf("committed assistant turn = {%s %q}, want the delivered sentence only (ADR-0012, identical to barge)", assistant.Role, assistant.Text)
+	}
+	if strings.Contains(assistant.Text, "Second") || strings.Contains(assistant.Text, "Third") {
+		t.Fatalf("committed assistant turn = %q, want the never-dispatched tail dropped", assistant.Text)
+	}
+}

--- a/pkg/voice/orchestrator/mute_test.go
+++ b/pkg/voice/orchestrator/mute_test.go
@@ -1,0 +1,194 @@
+package orchestrator_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// muteSet is a fixed-membership [orchestrator.MuteView] for the gate tests.
+type muteSet map[string]bool
+
+func (m muteSet) Muted(agentID string) bool { return m[agentID] }
+
+// flipMute is a [orchestrator.MuteView] that reports target NOT muted until the
+// nth Muted call, then muted — modelling the mute view flipping between the
+// replier's pre-Take check and its post-Take double-check (the race the airtight
+// closure must catch).
+type flipMute struct {
+	mu          sync.Mutex
+	calls       int
+	target      string
+	mutedAtCall int
+}
+
+func (f *flipMute) Muted(agentID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return agentID == f.target && f.calls >= f.mutedAtCall
+}
+
+// TestMuteCut_CutsHolderWithMuteReason pins the mute cut (#211, AC2): a
+// MuteChanged{Muted:true} for the Agent currently holding the floor cancels its
+// turn and announces TurnEnded with the distinct mute reason — and NEVER a
+// BargeDetected (Barge-in is strictly the human-interrupts-Agent case).
+func TestMuteCut_CutsHolderWithMuteReason(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Tm")
+	turnCtx, release, _ := floor.Take(parent, "bart")
+	defer release()
+
+	t.Cleanup(orchestrator.NewMuteCut(floor).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.MuteChanged{AgentID: "bart", Muted: true})
+
+	if turnCtx.Err() == nil {
+		t.Fatal("muting the speaking Agent must cancel its turn ctx")
+	}
+	if floor.Active() {
+		t.Fatal("muting the speaking Agent must free the floor")
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Tm" && e.Reason == voiceevent.TurnEndMute },
+		"turn.ended (mute) carrying the cut turn's TurnID",
+	)
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+}
+
+// TestMuteCut_IgnoresNonHolder proves muting an Agent that is NOT speaking never
+// disturbs whoever holds the floor (AC3): no cut, no TurnEnded.
+func TestMuteCut_IgnoresNonHolder(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Tb")
+	turnCtx, release, _ := floor.Take(parent, "bart")
+	defer release()
+
+	t.Cleanup(orchestrator.NewMuteCut(floor).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.MuteChanged{AgentID: "greta", Muted: true})
+
+	if turnCtx.Err() != nil {
+		t.Fatal("muting a non-holder must not cancel the current holder's turn")
+	}
+	if !floor.Active() {
+		t.Fatal("muting a non-holder must leave the current holder on the floor")
+	}
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestMuteCut_UnmuteIsNoOp proves an unmute (Muted:false) does nothing in the
+// cut reactor — restoring an Agent is the matcher/route path's job, not a floor
+// cut. The speaking Agent keeps its floor.
+func TestMuteCut_UnmuteIsNoOp(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "Tu")
+	turnCtx, release, _ := floor.Take(parent, "bart")
+	defer release()
+
+	t.Cleanup(orchestrator.NewMuteCut(floor).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.MuteChanged{AgentID: "bart", Muted: false})
+
+	if turnCtx.Err() != nil {
+		t.Fatal("an unmute must not cancel any turn")
+	}
+	if !floor.Active() {
+		t.Fatal("an unmute must leave the holder on the floor")
+	}
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestReplier_MutedAddresseeNeverTakesFloor pins the pre-Take gate (#211, AC3): a
+// route to a muted Agent is discarded before Floor.Take, so it opens no turn (its
+// producer never runs) and never disturbs whoever holds the floor — a
+// TurnEnded(mute) for the routed TurnID is announced.
+func TestReplier_MutedAddresseeNeverTakesFloor(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	ran := make(chan string, 2)
+	reply := func(_ context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		ran <- e.TurnID
+		return nil
+	}
+
+	floor := orchestrator.NewFloor()
+	// Greta is already speaking (holds the floor) — the muted route must not touch it.
+	gretaParent := voiceevent.WithTurnID(context.Background(), "Tgreta")
+	gretaCtx, gretaRelease, _ := floor.Take(gretaParent, "greta")
+	defer gretaRelease()
+
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	replier.SetMutes(muteSet{"bart": true})
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Tbart", Text: "Bart, a room",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case id := <-ran:
+		t.Fatalf("a muted addressee's producer ran for %q — the route must be discarded before Floor.Take", id)
+	case <-time.After(100 * time.Millisecond):
+		// Correct: no producer for the muted route.
+	}
+	if gretaCtx.Err() != nil {
+		t.Fatal("a muted addressee must not disturb the Agent holding the floor (AC3)")
+	}
+	if !floor.Active() {
+		t.Fatal("Greta must keep the floor after a muted route was discarded")
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Tbart" && e.Reason == voiceevent.TurnEndMute },
+		"turn.ended (mute) for the discarded muted route",
+	)
+}
+
+// TestReplier_MutePostTakeDoubleCheckReleases pins the race closure (#211): if the
+// mute view flips to muted AFTER the pre-Take check but the Take already
+// succeeded, the post-Take double-check releases the floor and ends the turn with
+// the mute reason — no goroutine, no TTS.
+func TestReplier_MutePostTakeDoubleCheckReleases(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	ran := make(chan string, 2)
+	reply := func(_ context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		ran <- e.TurnID
+		return nil
+	}
+
+	floor := orchestrator.NewFloor()
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	// Not muted on the pre-Take check (call 1), muted on the post-Take check (call 2).
+	replier.SetMutes(&flipMute{target: "bart", mutedAtCall: 2})
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Trace", Text: "Bart, a room",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case id := <-ran:
+		t.Fatalf("the turn's producer ran for %q — a mute flipping after Take must still stop it (no TTS)", id)
+	case <-time.After(100 * time.Millisecond):
+		// Correct: the double-check released the floor before any producer ran.
+	}
+	if floor.Active() {
+		t.Fatal("the post-Take double-check must release the floor when the Agent is muted")
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Trace" && e.Reason == voiceevent.TurnEndMute },
+		"turn.ended (mute) for the post-Take-muted turn",
+	)
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -529,7 +529,10 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		// its own error (a real TTS/provider failure) before producing audio so the
 		// metrics subscriber records the precise reason, not the coarse no-first-audio
 		// TTL reap (#20) — mirroring the floor branch below. The sync path has no
-		// barge/supersede, so a non-cancelled ctx is the only guard needed.
+		// barge/supersede, so a non-cancelled ctx is the only guard needed. NOTE: the
+		// mute gate (#211) below lives in the floor branch only; the no-floor path
+		// never wires a MuteView in prod (mute needs the barge-in floor to cut a
+		// speaker), so a muted addressee here is unreachable, not silently voiced.
 		if r.floor == nil {
 			if reason := r.dispatchAll(ctx, e); reason != "" && ctx.Err() == nil {
 				bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: reason})

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -472,6 +472,13 @@ type Replier struct {
 	// mid-sentence (ADR-0027). Nil keeps the default synchronous dispatch. Set
 	// only via the orchestrator wiring ([WithBargeIn]); not part of [NewReplier].
 	floor *Floor
+
+	// mutes, when non-nil, is the live mute view (#211, [WithMute]): a route whose
+	// target Agent is muted is discarded before the floor is taken, so an
+	// addressed-but-muted Agent opens no turn — no floor churn, no LLM call, no
+	// TTS, no transcript line, and it can never supersede whoever holds the floor
+	// (AC3). Set only via the orchestrator wiring; not part of [NewReplier].
+	mutes MuteView
 }
 
 // NewReplier wires ttsStage and reply together. Both must be non-nil; passing
@@ -529,6 +536,16 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 			}
 			return
 		}
+		// Muted addressee (#211, AC3): discard the route BEFORE taking the floor, so
+		// a muted Agent opens no turn (no floor churn, no LLM call, no TTS, no
+		// transcript line) and can never supersede whoever holds the floor. The
+		// Manager writes its mute set before publishing MuteChanged, so this read is
+		// authoritative. Announce a mute-reason TurnEnded for the routed TurnID so
+		// the metrics subscriber records the precise cause.
+		if r.mutes != nil && r.mutes.Muted(e.Target.AgentID) {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndMute})
+			return
+		}
 		// Barge-in: take the floor and run the turn on its own goroutine so the
 		// inbound loop keeps feeding VAD during playback. A barge cancels turnCtx,
 		// which unwinds TTS synthesis and playback and breaks the dispatch loop.
@@ -547,6 +564,16 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 			// spawned.
 			release() // no-op on the floor, but keeps the take/release pairing honest
 			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSupersedeCoalesced, Text: e.Text})
+			return
+		}
+		// Race closure (#211): the mute view can flip to muted between the pre-Take
+		// check and this Take (a Discord/web mute landing exactly then). Re-check now
+		// that this turn holds the floor: if muted, release it and end the turn with
+		// the mute reason before any goroutine, TTS or transcript — airtight because
+		// the Manager writes the set before publishing MuteChanged.
+		if r.mutes != nil && r.mutes.Muted(e.Target.AgentID) {
+			release()
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndMute})
 			return
 		}
 		go func() {

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -226,6 +226,12 @@ const (
 	// TurnEndProviderError: the reply producer (LLM round/tool loop) failed before
 	// the turn could produce audio.
 	TurnEndProviderError TurnEndReason = "provider_error"
+	// TurnEndMute: a GM muted the Agent, cutting its turn (#211). It is a
+	// deliberate control action, DISTINCT from a human [BargeDetected] — CONTEXT.md
+	// reserves Barge-in for the human-interrupts-Agent case. Transcript and history
+	// commit exactly as a barge would (delivered-sentences-only, ADR-0012), but the
+	// cause is a mute, never a barge.
+	TurnEndMute TurnEndReason = "mute"
 )
 
 // TurnEnded marks a turn that ended for a known reason — distinct from a turn
@@ -264,6 +270,26 @@ type BargeDetected struct {
 
 // EventName implements [Event].
 func (BargeDetected) EventName() string { return "barge.detected" }
+
+// MuteChanged marks a change to one Agent's mute state in the live Voice Session
+// (#211). It is the mute-control event on the shared bus: the session Manager
+// publishes it AFTER writing its authoritative mute set, and both surfaces react —
+// the orchestrator's mute reactor cuts the floor / gates routes, the wirenpc
+// wiring prunes the address matcher, and the SSE relay forwards it to the web
+// panel. The ordering is load-bearing: the set is written before the event, so a
+// reactor reading the set on this event always sees the change.
+//
+// Muted=true means the Agent is now muted (produces no audio, no transcript);
+// Muted=false restores it. AgentID is the Agent's stable id (a Character NPC's
+// primary key, or the Butler's).
+type MuteChanged struct {
+	At      time.Time
+	AgentID string
+	Muted   bool
+}
+
+// EventName implements [Event].
+func (MuteChanged) EventName() string { return "mute.changed" }
 
 // Bus is an in-process pub/sub channel. Subscribers register a callback;
 // Publish invokes every callback synchronously in the calling goroutine.

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -105,6 +105,15 @@ func TestTurnEnded_EventName(t *testing.T) {
 	}
 }
 
+func TestMuteChanged_EventName(t *testing.T) {
+	t.Parallel()
+
+	got := MuteChanged{}.EventName()
+	if got != "mute.changed" {
+		t.Errorf("EventName = %q, want %q", got, "mute.changed")
+	}
+}
+
 func TestBus_PublishDeliversToSubscriber(t *testing.T) {
 	t.Parallel()
 

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -679,6 +679,17 @@ service SessionService {
   // StopSession cancels the active voice loop and returns the ended session. It
   // fails with CodeFailedPrecondition when no session is active. State-changing.
   rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
+  // SetAgentMute mutes or unmutes one Agent of the Active Campaign in the live
+  // Voice Session (#211), returning the resulting muted-Agent id set. It fails
+  // with CodeFailedPrecondition when no Voice Session is active, and CodeNotFound
+  // when agent_id is not an Agent of the Active Campaign. State-changing: the auth
+  // + CSRF interceptors guard it exactly like the other session mutations.
+  rpc SetAgentMute(SetAgentMuteRequest) returns (SetAgentMuteResponse);
+  // SetAllMute mutes or unmutes EVERY Agent of the Active Campaign in the live
+  // Voice Session (#211) — the Mute all / Unmute all button — returning the
+  // resulting muted-Agent id set. It fails with CodeFailedPrecondition when no
+  // Voice Session is active. State-changing.
+  rpc SetAllMute(SetAllMuteRequest) returns (SetAllMuteResponse);
 }
 
 // VoiceSession is the wire view of a voice_sessions row (#72): the Bot's
@@ -710,6 +721,37 @@ message GetSessionResponse {
   VoiceSession session = 1;
   // active is true exactly when a voice loop is running in this process.
   bool active = 2;
+  // muted_agent_ids are the currently-muted Agents' ids (#211), set ONLY while a
+  // Voice Session is active — the reload truth for a mid-session page reload
+  // (AC5). Empty when idle (a new session starts all-unmuted).
+  repeated string muted_agent_ids = 3;
+}
+
+// SetAgentMuteRequest toggles one Agent's mute in the live Voice Session (#211).
+message SetAgentMuteRequest {
+  // agent_id is the Agent (Butler or Character NPC) of the Active Campaign to
+  // mute or unmute.
+  string agent_id = 1;
+  // muted turns the mute on (true) or off (false).
+  bool muted = 2;
+}
+
+// SetAgentMuteResponse carries the muted-Agent id set after the change.
+message SetAgentMuteResponse {
+  // muted_agent_ids are the currently-muted Agents' ids after the toggle.
+  repeated string muted_agent_ids = 1;
+}
+
+// SetAllMuteRequest mutes or unmutes every Agent of the Active Campaign (#211).
+message SetAllMuteRequest {
+  // muted turns every Agent's mute on (true) or off (false).
+  bool muted = 1;
+}
+
+// SetAllMuteResponse carries the muted-Agent id set after the change.
+message SetAllMuteResponse {
+  // muted_agent_ids are the currently-muted Agents' ids after the toggle.
+  repeated string muted_agent_ids = 1;
 }
 
 // StartSessionRequest is the (empty) request; the active campaign is resolved

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -11,6 +11,7 @@ import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { useSessionEvents, formatClock } from "./useSessionEvents";
+import { VoicePanel } from "./VoicePanel";
 
 import "./session.css";
 
@@ -125,6 +126,7 @@ export function Session() {
 
   return (
     <div className="gx-session">
+      <div className="gx-session__main">
       <header className="gx-session__header">
         {campaignName && <span className="gx-overline">{campaignName}</span>}
         <h1>Voice session</h1>
@@ -212,6 +214,9 @@ export function Session() {
           )}
         </Card>
       </section>
+      </div>
+
+      <VoicePanel active={active} mutedIds={data?.mutedAgentIds ?? []} />
     </div>
   );
 }

--- a/web/src/screens/session/VoicePanel.test.tsx
+++ b/web/src/screens/session/VoicePanel.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}));
+
+import {
+  SessionService,
+  CampaignService,
+  VoiceSessionSchema,
+  GetSessionResponseSchema,
+  StartSessionResponseSchema,
+  StopSessionResponseSchema,
+  SetAgentMuteResponseSchema,
+  SetAllMuteResponseSchema,
+  GetActiveCampaignResponseSchema,
+  GetCampaignRosterResponseSchema,
+  CampaignSchema,
+  AgentSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { MockEventSource } from "@/test/mockEventSource";
+import { Session } from "./Session";
+
+const BUTLER = create(AgentSchema, { id: "butler-1", campaignId: "c1", role: "butler", name: "Butler", speakerColor: 0 });
+const BART = create(AgentSchema, { id: "bart-1", campaignId: "c1", role: "character", name: "Bart", speakerColor: 1 });
+const GRETA = create(AgentSchema, { id: "greta-1", campaignId: "c1", role: "character", name: "Greta", speakerColor: 2 });
+const ROSTER = [BUTLER, BART, GRETA];
+
+// panelTransport serves a live-or-idle session with a mutable muted set plus the
+// campaign roster, so the Voice panel renders and its mutations round-trip in the
+// closure (mirroring the server's authoritative muted-id response).
+function panelTransport(opts: { active: boolean; muted?: string[] }) {
+  let muted = opts.muted ?? [];
+  const current = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "running",
+    startedAt: timestampFromDate(new Date()),
+  });
+  return createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () =>
+        create(GetSessionResponseSchema, {
+          session: opts.active ? current : undefined,
+          active: opts.active,
+          mutedAgentIds: muted,
+        }),
+      startSession: () => create(StartSessionResponseSchema, { session: current }),
+      stopSession: () => create(StopSessionResponseSchema, { session: current }),
+      setAgentMute: (req) => {
+        muted = req.muted ? [...new Set([...muted, req.agentId])] : muted.filter((id) => id !== req.agentId);
+        return create(SetAgentMuteResponseSchema, { mutedAgentIds: muted });
+      },
+      setAllMute: (req) => {
+        muted = req.muted ? ROSTER.map((a) => a.id) : [];
+        return create(SetAllMuteResponseSchema, { mutedAgentIds: muted });
+      },
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+      getCampaignRoster: () =>
+        create(GetCampaignRosterResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+          roster: ROSTER,
+        }),
+    });
+  });
+}
+
+function renderPanel(opts: { active: boolean; muted?: string[] }) {
+  render(
+    <Providers transport={panelTransport(opts)} queryClient={makeQueryClient()}>
+      <Session />
+    </Providers>,
+  );
+}
+
+describe("VoicePanel (#211)", () => {
+  beforeEach(() => {
+    // A live snapshot so the SSE stream opens for the no-reload test.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ lines: [], status: "live", typing: { active: false, label: "" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+  });
+
+  it("renders one row per Agent (Butler + NPCs) with the voicing count", async () => {
+    renderPanel({ active: true });
+    expect(await screen.findByText("NPC voices")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByTestId("voice-row")).toHaveLength(3));
+    expect(screen.getByText("Butler")).toBeInTheDocument();
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+    expect(screen.getByText("Greta")).toBeInTheDocument();
+    expect(screen.getByTestId("voicing-count")).toHaveTextContent("3 of 3 voicing");
+  });
+
+  it("disables every control when no Voice Session is live", async () => {
+    renderPanel({ active: false });
+    expect(await screen.findByText("NPC voices")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByTestId("voice-row")).toHaveLength(3));
+    // Mute-all + every per-Agent toggle disabled; count reads 0 while idle.
+    expect(screen.getByRole("button", { name: /unmute all/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /mute bart/i })).toBeDisabled();
+    expect(screen.getByTestId("voicing-count")).toHaveTextContent("0 of 3 voicing");
+  });
+
+  it("mutes an Agent on click, dimming its row and dropping the count", async () => {
+    renderPanel({ active: true });
+    await screen.findByText("Bart");
+    const bartRow = () => screen.getByText("Bart").closest('[data-testid="voice-row"]') as HTMLElement;
+    expect(bartRow()).not.toHaveAttribute("data-muted");
+
+    fireEvent.click(screen.getByRole("button", { name: /mute bart/i }));
+
+    await waitFor(() => expect(bartRow()).toHaveAttribute("data-muted"));
+    expect(within(bartRow()).getByText("Muted")).toBeInTheDocument();
+    // The mutation patched the shared cache, so the count reflects the mute.
+    await waitFor(() => expect(screen.getByTestId("voicing-count")).toHaveTextContent("2 of 3 voicing"));
+    // The toggle now offers to unmute Bart.
+    expect(screen.getByRole("button", { name: /unmute bart/i })).toBeInTheDocument();
+  });
+
+  it("flips the mute-all button label between Mute all and Unmute all", async () => {
+    renderPanel({ active: true });
+    await screen.findByText("Bart");
+    // Any Agent voicing → Mute all.
+    expect(screen.getByRole("button", { name: /mute all/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /mute all/i }));
+
+    // Now everyone is muted → Unmute all.
+    expect(await screen.findByRole("button", { name: /unmute all/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("voicing-count")).toHaveTextContent("0 of 3 voicing"));
+  });
+
+  it("flips a row from an SSE mute frame without a reload (AC5)", async () => {
+    renderPanel({ active: true });
+    await screen.findByText("Bart");
+    const bartRow = () => screen.getByText("Bart").closest('[data-testid="voice-row"]') as HTMLElement;
+    expect(bartRow()).not.toHaveAttribute("data-muted");
+
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("EventSource not opened yet");
+      return inst;
+    });
+
+    // A mute from the OTHER surface (Discord) arrives over the relay: the row dims
+    // without any refetch/reload.
+    act(() => es.emit("mute", { agent_id: "bart-1", muted: true }));
+
+    await waitFor(() => expect(bartRow()).toHaveAttribute("data-muted"));
+    expect(within(bartRow()).getByText("Muted")).toBeInTheDocument();
+    expect(screen.getByTestId("voicing-count")).toHaveTextContent("2 of 3 voicing");
+  });
+});

--- a/web/src/screens/session/VoicePanel.tsx
+++ b/web/src/screens/session/VoicePanel.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { useQuery, useMutation } from "@connectrpc/connect-query";
+import { Volume2, VolumeX } from "lucide-react";
+
+import { SessionService, CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
+import { Avatar } from "@/components/ui/Avatar";
+import { useMuteCache } from "./muteCache";
+
+// The Voice control panel (#211): the Session screen's right rail listing every
+// Agent of the Active Campaign (Butler first, then Character NPCs, from the
+// getCampaignRoster read — NOT the voiced wirenpc Roster). Each row toggles that
+// Agent's mute in the live Voice Session; the mute-all button mutes everyone while
+// any Agent is voicing (unmuted), else unmutes everyone. With no live Voice
+// Session every row shows unmuted and the toggles are disabled — mute is only
+// actionable while a session is live, mirroring the /glyphoxa mute commands.
+
+// speakerVar maps a server-assigned palette slot onto the 6-colour speaker palette
+// (tokens.css --speaker-1..6). The slot is 0-based; the palette is 1-based.
+function speakerVar(slot: number): string {
+  return `var(--speaker-${(slot % 6) + 1})`;
+}
+
+function isButler(a: Agent): boolean {
+  return a.role === "butler";
+}
+
+export function VoicePanel({ active, mutedIds }: { active: boolean; mutedIds: string[] }) {
+  const { replace } = useMuteCache();
+  const rosterQuery = useQuery(CampaignService.method.getCampaignRoster, {});
+  const roster = useMemo(() => rosterQuery.data?.roster ?? [], [rosterQuery.data]);
+  const muted = useMemo(() => new Set(mutedIds), [mutedIds]);
+
+  // Both mutations patch the SHARED getSession cache from their authoritative
+  // response, so the panel (and any other reader) reflects the new set instantly.
+  const setAgentMute = useMutation(SessionService.method.setAgentMute, {
+    onSuccess: (res) => replace(res.mutedAgentIds),
+  });
+  const setAllMute = useMutation(SessionService.method.setAllMute, {
+    onSuccess: (res) => replace(res.mutedAgentIds),
+  });
+
+  const total = roster.length;
+  // "voicing" is the panel's label for unmuted; the count reflects live voicing,
+  // so it is 0 while idle (no session is producing audio).
+  const voicing = active ? roster.filter((a) => !muted.has(a.id)).length : 0;
+  const anyVoicing = voicing > 0;
+  const pending = setAgentMute.isPending || setAllMute.isPending;
+
+  return (
+    <aside className="gx-voice-panel" aria-label="Voice control">
+      <div className="gx-voice-panel__head">
+        <span className="gx-overline">Voice control</span>
+        <h2 className="gx-voice-panel__title">NPC voices</h2>
+        <p className="gx-voice-panel__count" data-testid="voicing-count">
+          {voicing} of {total} voicing
+        </p>
+      </div>
+
+      <button
+        type="button"
+        className="gx-voice-panel__all"
+        disabled={!active || pending}
+        onClick={() => setAllMute.mutate({ muted: anyVoicing })}
+      >
+        {anyVoicing ? <VolumeX size={15} /> : <Volume2 size={15} />}
+        {anyVoicing ? "Mute all" : "Unmute all"}
+      </button>
+
+      <ul className="gx-voice-panel__rows">
+        {roster.map((a) => {
+          const isMuted = active && muted.has(a.id);
+          const state = isMuted ? "Muted" : isButler(a) ? "Butler · voicing" : "Voicing";
+          return (
+            <li key={a.id} className="gx-voice-row" data-muted={isMuted || undefined} data-testid="voice-row">
+              {isButler(a) ? (
+                <Avatar name={a.name} size="sm" />
+              ) : (
+                <span className="gx-voice-row__dot" style={{ background: speakerVar(a.speakerColor) }} aria-hidden />
+              )}
+              <span className="gx-voice-row__meta">
+                <span className="gx-voice-row__name">{a.name}</span>
+                <span className="gx-voice-row__state">{state}</span>
+              </span>
+              <button
+                type="button"
+                className="gx-voice-row__toggle"
+                data-muted={isMuted || undefined}
+                disabled={!active || pending}
+                aria-label={isMuted ? `Unmute ${a.name}` : `Mute ${a.name}`}
+                onClick={() => setAgentMute.mutate({ agentId: a.id, muted: !isMuted })}
+              >
+                {isMuted ? <Volume2 size={15} /> : <VolumeX size={15} />}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="gx-voice-panel__hint">
+        Muted NPCs stay in the scene but won&apos;t speak aloud. Unmute any voice mid-session.
+      </p>
+    </aside>
+  );
+}

--- a/web/src/screens/session/muteCache.ts
+++ b/web/src/screens/session/muteCache.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from "react";
+import { createConnectQueryKey, useTransport } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { SessionService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { GetSessionResponse } from "@gen/glyphoxa/management/v1/management_pb";
+
+// useMuteCache patches the muted-Agent set on the SHARED getSession connect-query
+// cache — the single source of truth the Voice control panel reads (ADR-0018: no
+// parallel React state tree). Both mute surfaces converge here without a reload
+// (#211, AC5): a mute mutation `replace`s the set from its authoritative response,
+// and an SSE "mute" frame (a Discord/web mute reaching this browser) flips ONE
+// Agent via `patchOne`. The interval getSession refetch reconciles against the
+// server's true set, so a patch is only an instant-update optimisation.
+export function useMuteCache() {
+  const transport = useTransport();
+  const queryClient = useQueryClient();
+
+  // The EXACT key useQuery(getSession, {}) writes — transport + empty input +
+  // finite cardinality — so setQueryData hits that same cache entry. Memoised on
+  // the (stable) transport so the returned setters stay referentially stable and
+  // never re-run the SSE effect that depends on patchOne.
+  const key = useMemo(
+    () =>
+      createConnectQueryKey({
+        schema: SessionService.method.getSession,
+        transport,
+        input: {},
+        cardinality: "finite",
+      }),
+    [transport],
+  );
+
+  const replace = useCallback(
+    (mutedAgentIds: string[]) =>
+      queryClient.setQueryData<GetSessionResponse>(key, (prev) => (prev ? { ...prev, mutedAgentIds } : prev)),
+    [queryClient, key],
+  );
+
+  const patchOne = useCallback(
+    (agentId: string, muted: boolean) =>
+      queryClient.setQueryData<GetSessionResponse>(key, (prev) => {
+        if (!prev) return prev;
+        const set = new Set(prev.mutedAgentIds);
+        if (muted) set.add(agentId);
+        else set.delete(agentId);
+        return { ...prev, mutedAgentIds: [...set] };
+      }),
+    [queryClient, key],
+  );
+
+  return { replace, patchOne };
+}

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -3,11 +3,159 @@
  */
 
 /* Page gutter (#88 slice 1): the screen root had no padding, so the content sat
- * flush against the topbar and the content edges. */
+ * flush against the topbar and the content edges. The Voice control panel (#211)
+ * makes this a two-column layout — the session content, then a fixed-width right
+ * rail — that stacks on a narrow viewport. */
 .gx-session {
   padding: var(--spacing-xl);
   max-width: var(--content-lg);
   margin: 0 auto;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xl);
+}
+
+.gx-session__main {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Voice control panel (#211): the right rail listing every Agent with a mute
+ * toggle, a mute-all button, and the voicing count. */
+.gx-voice-panel {
+  flex: 0 0 308px;
+  align-self: stretch;
+  padding: var(--spacing-lg);
+  border-left: 1px solid var(--border);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.gx-voice-panel__head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gx-voice-panel__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.gx-voice-panel__count {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Full-width Mute all / Unmute all button. */
+.gx-voice-panel__all {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+  color: var(--text-default);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.gx-voice-panel__all:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gx-voice-panel__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs, 4px);
+}
+
+.gx-voice-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs, 4px) 0;
+}
+.gx-voice-row[data-muted] {
+  opacity: 0.5;
+}
+
+.gx-voice-row__dot {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.gx-voice-row__meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.gx-voice-row__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-default);
+}
+
+.gx-voice-row__state {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* 34px square icon toggle; the muted state is red-tinted. */
+.gx-voice-row__toggle {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-default);
+  cursor: pointer;
+}
+.gx-voice-row__toggle[data-muted] {
+  border-color: rgba(255, 79, 94, 0.42);
+  background: rgba(255, 79, 94, 0.09);
+  color: rgb(255, 79, 94);
+}
+.gx-voice-row__toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gx-voice-panel__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 900px) {
+  .gx-session {
+    flex-direction: column;
+  }
+  .gx-voice-panel {
+    flex-basis: auto;
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
 }
 
 .gx-session__header {

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { useMuteCache } from "./muteCache";
+
 // useSessionEvents is the SSE transcript client (#73, ADR-0014 Hop-B). When a
 // voice session is live it seeds a TanStack query from the JSON snapshot
 // (GET /api/v1/sessions/:id) then keeps it fresh by amending the SAME cache
@@ -53,6 +55,10 @@ function upsertLine(prev: Transcript | undefined, line: TranscriptLine): Transcr
 
 export function useSessionEvents(sessionId: string | undefined, active: boolean): Transcript {
   const queryClient = useQueryClient();
+  // The SSE "mute" frame patches the SHARED getSession cache (not the transcript
+  // cache), so the Voice panel reflects a mute from EITHER surface without a
+  // reload (#211, AC5). patchOne is referentially stable, so it is a safe effect dep.
+  const { patchOne } = useMuteCache();
   // Fetch the snapshot for ANY session that exists — live OR ended. A reload of
   // an ended session replays its persisted history from the DB-backed snapshot
   // (#74); the live stream below only opens while the session is active.
@@ -103,9 +109,13 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
       const s = JSON.parse((e as MessageEvent).data) as { status: "live" | "idle"; typing: TypingState };
       queryClient.setQueryData<Transcript>(key, (prev) => ({ ...(prev ?? EMPTY), status: s.status, typing: s.typing }));
     });
+    es.addEventListener("mute", (e) => {
+      const m = JSON.parse((e as MessageEvent).data) as { agent_id: string; muted: boolean };
+      patchOne(m.agent_id, m.muted);
+    });
 
     return () => es.close();
-  }, [active, sessionId, isSuccess, queryClient]);
+  }, [active, sessionId, isSuccess, queryClient, patchOne]);
 
   return data ?? EMPTY;
 }


### PR DESCRIPTION
Closes #211

## [E5] Per-Agent mute + mute-all

The GM can now silence any Agent voice from **both** surfaces — the Session
screen's Voice control panel and Discord `/glyphoxa mute` / `muteall` — sharing
one live mute set keyed by AgentID and reset at every Voice Session start.

### How it works
- **Mute set** is volatile, session-local state on `session.Manager` (no DB
  column, no migration). The Manager *is* the `orchestrator.MuteView`; it writes
  the set **before** publishing `MuteChanged` on the shared bus (ordering is
  load-bearing), then both surfaces react.
- **Cutting a speaker** — `Floor.YieldAgent(agentID)` yields only if that Agent
  holds the floor (ignoring `speaking`, so a held-but-silent pre-audio turn dies
  too). A `MuteCut` reactor bound beside `BargeIn` publishes `TurnEnded{Reason:
  mute}` — never `BargeDetected`. Transcript + Agent history commit exactly as a
  barge would (delivered sentences only, ADR-0012), proven by a conversation e2e.
- **Blocking a muted addressee** — the replier discards a muted route *before*
  `Floor.Take` (pre-Take gate) with a post-Take race re-check, so a muted Agent
  opens no turn and never supersedes the floor holder (AC3).
- **Live re-route** — `Roster.SetMuted` is matcher-only (prunes the address
  matcher, never the Cast), so unmuting restores the SAME `agent.Replier` with its
  history intact. `wireMutes` subscribes it to the bus and re-seeds on a Discord
  reconnect.
- **Both surfaces agree** — a new SSE `mute` frame flips the web panel without a
  reload; `GetSession.muted_agent_ids` is the mid-session reload truth.

### Notes
- `/glyphoxa muteall` maps to `SetAllMute(true)` per the architect plan (the web
  button keeps the mute-all / unmute-all toggle).
- Butler is panel/state-only today (it is not in the voice Roster) — by design.
- No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
