### PR TITLE
[E5] Transcript search: tsvector query path, web search UI, and /glyphoxa search (#120) (supersedes #217)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
@@ -336,22 +335,15 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		// web Session screen uses, so the two surfaces share one session record and
 		// never diverge (AC4). Registered here (not in the presence block above)
 		// because they need the Manager, and BEFORE Ensure so they land in the one
-		// per-Guild registration alongside /roll.
-		// /glyphoxa search (#120) scopes to the operator's Active Campaign: the live
-		// session's campaign when one is running, else the stored Active Campaign
-		// (resolved inside the command). Registered here too because it reads the
-		// Manager snapshot.
-		activeCampaign := func() (uuid.UUID, bool) {
-			if vs, active := mgr.Snapshot(); active {
-				return vs.CampaignID, true
-			}
-			return uuid.Nil, false
-		}
+		// per-Guild registration alongside /roll. /glyphoxa search (#120) joins them:
+		// it resolves the Active Campaign through the SAME shared slash resolver
+		// (resolveActiveCampaign over the store + Manager), so it can never diverge
+		// from /glyphoxa start.
 		reg.Register(
 			presence.UseCommand(store),
 			presence.StartCommand(store, mgr),
 			presence.EndCommand(mgr),
-			presence.SearchCommand(store, activeCampaign),
+			presence.SearchCommand(store, mgr),
 		)
 		// Bring the presence up at boot (AC: the commands appear with no Voice
 		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
@@ -332,10 +333,21 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		// never diverge (AC4). Registered here (not in the presence block above)
 		// because they need the Manager, and BEFORE Ensure so they land in the one
 		// per-Guild registration alongside /roll.
+		// /glyphoxa search (#120) scopes to the operator's Active Campaign: the live
+		// session's campaign when one is running, else the stored Active Campaign
+		// (resolved inside the command). Registered here too because it reads the
+		// Manager snapshot.
+		activeCampaign := func() (uuid.UUID, bool) {
+			if vs, active := mgr.Snapshot(); active {
+				return vs.CampaignID, true
+			}
+			return uuid.Nil, false
+		}
 		reg.Register(
 			presence.UseCommand(store),
 			presence.StartCommand(store, mgr),
 			presence.EndCommand(mgr),
+			presence.SearchCommand(store, activeCampaign),
 		)
 		// Bring the presence up at boot (AC: the commands appear with no Voice
 		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -307,10 +307,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		reg.Register(presence.RollCommand(tool.NewDice()))
 		pres = presence.New(store, cipher, reg, cfg.Token, log)
 		// The voice loop borrows this one client instead of dialing its own per
-		// session; set BEFORE the Manager copies cfg into its base config.
+		// session; set BEFORE the Manager copies cfg into its base config. Note:
+		// pres.Ensure is deliberately NOT called here — it opens the gateway, whose
+		// interaction goroutines read `mgr` via the /glyphoxa search resolver, so it
+		// must run AFTER mgr is assigned (below) to establish the happens-before edge.
 		cfg.Client = pres.ClientProvider()
-		// The GM session commands (#108) register below, once the Manager exists,
-		// and Ensure runs after them so all commands are in one registration.
+		// The GM session commands (#108) + /glyphoxa search (#120) register below,
+		// once the Manager exists, and Ensure runs after them so all commands are in
+		// one registration.
 	}
 
 	runner := func(rctx context.Context, c wirenpc.Config) error {

--- a/internal/presence/search.go
+++ b/internal/presence/search.go
@@ -1,0 +1,133 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// transcriptSearchLimit is how many top matches /glyphoxa search quotes back
+// (ADR-0011 amendment: a short list of the most relevant lines). Kept small so
+// the ephemeral reply stays readable; the web surfaces the full ranked set.
+const transcriptSearchLimit = 5
+
+// transcriptSearchTimeout bounds the DB search AFTER the interaction is Deferred.
+// Post-Defer the dispatch watchdog is stopped, so the ctx has no deadline (that is
+// the whole point of Defer, ADR-0010 amendment); a slow or stuck DB would
+// otherwise hang the handler indefinitely, so the handler caps its own DB work.
+const transcriptSearchTimeout = 10 * time.Second
+
+// TranscriptSearch is the storage surface /glyphoxa search needs: the ONE shared
+// search path (AC4 — the same storage.SearchTranscriptLines the web RPC calls)
+// plus the stored Active Campaign fallback. The live Voice Session's campaign is
+// resolved separately (activeCampaign), matching the web RPC's scope precedence.
+type TranscriptSearch interface {
+	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
+	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
+}
+
+// SearchCommand builds the /glyphoxa search slash command (ADR-0010: GM-only,
+// operator-allowlisted). It searches the operator's Active Campaign transcript via
+// the SAME storage path the web uses (AC4) and quotes the top matches with speaker
+// + timestamp (ADR-0011 amendment). The Campaign is resolved server-side — the
+// live Voice Session's campaign (activeCampaign), else the stored Active Campaign —
+// never client-supplied (AC5), so a search never crosses into another campaign.
+//
+// The DB search can exceed Discord's ~2.5s interaction deadline, so the handler
+// Defers first (which stops the dispatch first-response watchdog) and then bounds
+// its own DB work with transcriptSearchTimeout, because the post-Defer ctx no
+// longer carries that deadline.
+func SearchCommand(search TranscriptSearch, activeCampaign func() (uuid.UUID, bool)) Command {
+	return Command{
+		Path:        "glyphoxa search",
+		Description: "Search the Active Campaign's transcript.",
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{
+				Name:        "query",
+				Description: "What to search the transcript for.",
+				Required:    true,
+			},
+		},
+		GMOnly: true,
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			raw, _ := ic.String("query")
+			query := strings.TrimSpace(raw)
+			if query == "" {
+				// A blank/whitespace query has nothing to search — a clear ephemeral
+				// hint, no Defer and no DB round trip.
+				return ic.ReplyEphemeral("Give me something to search for, e.g. `/glyphoxa search dragon`.")
+			}
+
+			// Defer (ephemeral): the DB search may run past the 3s window, and the
+			// results are GM-only. After Defer the ctx has no deadline, so the DB work
+			// below is bounded by our own timeout.
+			if err := ic.Defer(true); err != nil {
+				return err
+			}
+			dbCtx, cancel := context.WithTimeout(ctx, transcriptSearchTimeout)
+			defer cancel()
+
+			campaignID, ok, err := resolveSearchCampaign(dbCtx, search, activeCampaign)
+			if err != nil {
+				return fmt.Errorf("presence: resolve active campaign for search: %w", err)
+			}
+			if !ok {
+				return ic.ReplyEphemeral("No Active Campaign yet — run `/glyphoxa use` to set one.")
+			}
+
+			lines, err := search.SearchTranscriptLines(dbCtx, campaignID, query, transcriptSearchLimit)
+			if err != nil {
+				return fmt.Errorf("presence: search transcript for campaign %s: %w", campaignID, err)
+			}
+			if len(lines) == 0 {
+				return ic.ReplyEphemeral(fmt.Sprintf("No lines match %q.", query))
+			}
+			return ic.ReplyEphemeral(formatTranscriptMatches(query, lines))
+		},
+	}
+}
+
+// resolveSearchCampaign returns the Campaign to search, matching the web RPC's
+// precedence: the live Voice Session's campaign first, else the stored Active
+// Campaign. ok is false only when there is neither (never-run state), which the
+// caller answers with the "/glyphoxa use" hint. A storage error other than
+// ErrNotFound is propagated.
+func resolveSearchCampaign(ctx context.Context, search TranscriptSearch, activeCampaign func() (uuid.UUID, bool)) (uuid.UUID, bool, error) {
+	if activeCampaign != nil {
+		if id, ok := activeCampaign(); ok {
+			return id, true, nil
+		}
+	}
+	c, err := search.GetActiveCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return uuid.Nil, false, nil
+	}
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	return c.ID, true, nil
+}
+
+// formatTranscriptMatches renders the top matches as an ephemeral reply: a header
+// plus each hit quoted with its speaker (and pill tag, e.g. "Bart (NPC)") and a
+// UTC HH:MM:SS timestamp (ADR-0011 amendment: quotes lines with speaker +
+// timestamp). UTC keeps it deterministic — the bot has no per-user timezone.
+func formatTranscriptMatches(query string, lines []storage.TranscriptLine) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Top matches for %q:\n", query)
+	for _, l := range lines {
+		who := l.Who
+		if l.Tag != "" {
+			who = fmt.Sprintf("%s (%s)", l.Who, l.Tag)
+		}
+		fmt.Fprintf(&b, "**%s** · %s — %q\n", who, l.TS.UTC().Format("15:04:05"), l.Text)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/presence/search.go
+++ b/internal/presence/search.go
@@ -35,27 +35,31 @@ const (
 	maxQueryEcho        = 100
 )
 
-// TranscriptSearch is the storage surface /glyphoxa search needs: the ONE shared
-// search path (AC4 — the same storage.SearchTranscriptLines the web RPC calls)
-// plus the stored Active Campaign fallback. The live Voice Session's campaign is
-// resolved separately (activeCampaign), matching the web RPC's scope precedence.
-type TranscriptSearch interface {
+// SearchStore is the storage surface /glyphoxa search needs: the shared slash
+// Active-Campaign resolution (SessionStore, reused by resolveActiveCampaign so the
+// slash surface has ONE resolver, not a divergent copy — #216/#108) plus the ONE
+// shared transcript search path (AC4 — the same storage.SearchTranscriptLines the
+// web RPC calls). *storage.Store satisfies it; tests use a fake.
+type SearchStore interface {
+	SessionStore
 	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
-	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 }
 
 // SearchCommand builds the /glyphoxa search slash command (ADR-0010: GM-only,
 // operator-allowlisted). It searches the operator's Active Campaign transcript via
 // the SAME storage path the web uses (AC4) and quotes the top matches with speaker
-// + timestamp (ADR-0011 amendment). The Campaign is resolved server-side — the
-// live Voice Session's campaign (activeCampaign), else the stored Active Campaign —
-// never client-supplied (AC5), so a search never crosses into another campaign.
+// + timestamp (ADR-0011 amendment). The Campaign is resolved server-side by the
+// SHARED slash resolver resolveActiveCampaign (ADR-0009 order: live Voice Session's
+// campaign → the operator's durable /glyphoxa use selection → fail) — never
+// client-supplied (AC5), and identical to /glyphoxa start so the two never diverge.
+// There is deliberately no most-recently-created fallback on the slash surface (the
+// GM has the /glyphoxa use affordance right there).
 //
 // The DB search can exceed Discord's ~2.5s interaction deadline, so the handler
 // Defers first (which stops the dispatch first-response watchdog) and then bounds
 // its own DB work with transcriptSearchTimeout, because the post-Defer ctx no
 // longer carries that deadline.
-func SearchCommand(search TranscriptSearch, activeCampaign func() (uuid.UUID, bool)) Command {
+func SearchCommand(store SearchStore, voice VoiceControl) Command {
 	return Command{
 		Path:        "glyphoxa search",
 		Description: "Search the Active Campaign's transcript.",
@@ -85,17 +89,19 @@ func SearchCommand(search TranscriptSearch, activeCampaign func() (uuid.UUID, bo
 			dbCtx, cancel := context.WithTimeout(ctx, transcriptSearchTimeout)
 			defer cancel()
 
-			campaignID, ok, err := resolveSearchCampaign(dbCtx, search, activeCampaign)
+			// The SAME resolver /glyphoxa start uses (no divergent copy): live session
+			// → durable /glyphoxa use selection → ErrNoActiveCampaign.
+			c, err := resolveActiveCampaign(dbCtx, store, voice, ic.UserID())
+			if errors.Is(err, ErrNoActiveCampaign) {
+				return ic.ReplyEphemeral("No Active Campaign yet — run /glyphoxa use campaign:<name> first.")
+			}
 			if err != nil {
 				return fmt.Errorf("presence: resolve active campaign for search: %w", err)
 			}
-			if !ok {
-				return ic.ReplyEphemeral("No Active Campaign yet — run `/glyphoxa use` to set one.")
-			}
 
-			lines, err := search.SearchTranscriptLines(dbCtx, campaignID, query, transcriptSearchLimit)
+			lines, err := store.SearchTranscriptLines(dbCtx, c.ID, query, transcriptSearchLimit)
 			if err != nil {
-				return fmt.Errorf("presence: search transcript for campaign %s: %w", campaignID, err)
+				return fmt.Errorf("presence: search transcript for campaign %s: %w", c.ID, err)
 			}
 			if len(lines) == 0 {
 				return ic.ReplyEphemeral(fmt.Sprintf("No lines match %q.", truncateRunes(query, maxQueryEcho)))
@@ -103,27 +109,6 @@ func SearchCommand(search TranscriptSearch, activeCampaign func() (uuid.UUID, bo
 			return ic.ReplyEphemeral(formatTranscriptMatches(query, lines))
 		},
 	}
-}
-
-// resolveSearchCampaign returns the Campaign to search, matching the web RPC's
-// precedence: the live Voice Session's campaign first, else the stored Active
-// Campaign. ok is false only when there is neither (never-run state), which the
-// caller answers with the "/glyphoxa use" hint. A storage error other than
-// ErrNotFound is propagated.
-func resolveSearchCampaign(ctx context.Context, search TranscriptSearch, activeCampaign func() (uuid.UUID, bool)) (uuid.UUID, bool, error) {
-	if activeCampaign != nil {
-		if id, ok := activeCampaign(); ok {
-			return id, true, nil
-		}
-	}
-	c, err := search.GetActiveCampaign(ctx)
-	if errors.Is(err, storage.ErrNotFound) {
-		return uuid.Nil, false, nil
-	}
-	if err != nil {
-		return uuid.Nil, false, err
-	}
-	return c.ID, true, nil
 }
 
 // formatTranscriptMatches renders the top matches as an ephemeral reply: a header

--- a/internal/presence/search.go
+++ b/internal/presence/search.go
@@ -24,6 +24,17 @@ const transcriptSearchLimit = 5
 // otherwise hang the handler indefinitely, so the handler caps its own DB work.
 const transcriptSearchTimeout = 10 * time.Second
 
+// Discord rejects a message whose content exceeds 2000 characters (a Followup over
+// it 400s and the GM sees nothing), so replies are bounded: discordMessageLimit is
+// the hard cap, maxQuoteChars caps a single quoted line (a coalesced Agent reply is
+// multi-sentence and can be long), and maxQueryEcho caps an echoed query (a string
+// option can be up to 6000 chars).
+const (
+	discordMessageLimit = 2000
+	maxQuoteChars       = 200
+	maxQueryEcho        = 100
+)
+
 // TranscriptSearch is the storage surface /glyphoxa search needs: the ONE shared
 // search path (AC4 — the same storage.SearchTranscriptLines the web RPC calls)
 // plus the stored Active Campaign fallback. The live Voice Session's campaign is
@@ -87,7 +98,7 @@ func SearchCommand(search TranscriptSearch, activeCampaign func() (uuid.UUID, bo
 				return fmt.Errorf("presence: search transcript for campaign %s: %w", campaignID, err)
 			}
 			if len(lines) == 0 {
-				return ic.ReplyEphemeral(fmt.Sprintf("No lines match %q.", query))
+				return ic.ReplyEphemeral(fmt.Sprintf("No lines match %q.", truncateRunes(query, maxQueryEcho)))
 			}
 			return ic.ReplyEphemeral(formatTranscriptMatches(query, lines))
 		},
@@ -118,16 +129,34 @@ func resolveSearchCampaign(ctx context.Context, search TranscriptSearch, activeC
 // formatTranscriptMatches renders the top matches as an ephemeral reply: a header
 // plus each hit quoted with its speaker (and pill tag, e.g. "Bart (NPC)") and a
 // UTC HH:MM:SS timestamp (ADR-0011 amendment: quotes lines with speaker +
-// timestamp). UTC keeps it deterministic — the bot has no per-user timezone.
+// timestamp). UTC keeps it deterministic — the bot has no per-user timezone. Every
+// quoted line is truncated (a coalesced Agent reply can be long) and the whole
+// reply is kept under Discord's 2000-char cap: a line that would push it over is
+// dropped rather than risking a 400 that hides ALL the matches from the GM.
 func formatTranscriptMatches(query string, lines []storage.TranscriptLine) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Top matches for %q:\n", query)
+	fmt.Fprintf(&b, "Top matches for %q:", truncateRunes(query, maxQueryEcho))
 	for _, l := range lines {
 		who := l.Who
 		if l.Tag != "" {
 			who = fmt.Sprintf("%s (%s)", l.Who, l.Tag)
 		}
-		fmt.Fprintf(&b, "**%s** · %s — %q\n", who, l.TS.UTC().Format("15:04:05"), l.Text)
+		line := fmt.Sprintf("\n**%s** · %s — %q", who, l.TS.UTC().Format("15:04:05"), truncateRunes(l.Text, maxQuoteChars))
+		if b.Len()+len(line) > discordMessageLimit {
+			break
+		}
+		b.WriteString(line)
 	}
-	return strings.TrimRight(b.String(), "\n")
+	return b.String()
+}
+
+// truncateRunes clips s to at most max runes (never bytes — German campaigns), so
+// a long line or query can't blow the Discord content cap; a clipped value gets a
+// trailing ellipsis to signal the cut.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }

--- a/internal/presence/search_test.go
+++ b/internal/presence/search_test.go
@@ -247,3 +247,71 @@ func TestSearchCommandNonOperatorDenied(t *testing.T) {
 		t.Fatalf("denial = %+v, want one ephemeral reply", resp.replies)
 	}
 }
+
+// TestSearchCommandTruncatesLongLine (#120 review): a coalesced Agent reply can be
+// long; the quoted line is truncated (…) so it never blows Discord's 2000-char
+// content cap and 400s the Followup (which would hide ALL matches from the GM).
+func TestSearchCommandTruncatesLongLine(t *testing.T) {
+	campaignID := uuid.New()
+	long := strings.Repeat("dragon fire ", 60) // ~720 chars, well over the per-line cap
+	fake := &fakeTranscriptSearch{
+		campaign: storage.Campaign{ID: campaignID},
+		lines: []storage.TranscriptLine{
+			{VoiceSessionID: uuid.New(), CampaignID: campaignID, LineID: "a:t1", Seq: 1, Who: "Bart", Tag: "NPC", Kind: "npc", TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: long},
+		},
+	}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+
+	if len(resp.followups) != 1 {
+		t.Fatalf("want one Followup, got %+v", resp.followups)
+	}
+	body := resp.followups[0].content
+	if !strings.Contains(body, "…") {
+		t.Errorf("long line was not truncated (no ellipsis); got:\n%s", body)
+	}
+	if strings.Contains(body, long) {
+		t.Errorf("reply carries the full untruncated line; got len %d", len([]rune(body)))
+	}
+	if n := len([]rune(body)); n > discordMessageLimit {
+		t.Errorf("reply is %d runes, want <= %d (Discord cap)", n, discordMessageLimit)
+	}
+}
+
+// TestFormatTranscriptMatchesCapsTotalLength (#120 review): even 5 pathologically
+// long lines never produce a reply over the Discord content cap — a line that would
+// push it over is dropped, so the message always sends.
+func TestFormatTranscriptMatchesCapsTotalLength(t *testing.T) {
+	lines := make([]storage.TranscriptLine, transcriptSearchLimit)
+	for i := range lines {
+		lines[i] = storage.TranscriptLine{
+			Who:  strings.Repeat("W", 900), // long speaker label, untruncated, forces the total-cap break
+			Kind: "npc",
+			TS:   time.Date(2026, 6, 27, 18, 0, i, 0, time.UTC),
+			Text: strings.Repeat("x", 1000),
+		}
+	}
+	got := formatTranscriptMatches("q", lines)
+	if len(got) > discordMessageLimit {
+		t.Errorf("formatted reply is %d bytes, want <= %d (Discord cap)", len(got), discordMessageLimit)
+	}
+}
+
+// TestSearchCommandGiantQueryNoMatch (#120 review): a string option can be up to
+// 6000 chars; the no-match reply echoes only a truncated query, so it stays well
+// under the Discord cap and never 400s.
+func TestSearchCommandGiantQueryNoMatch(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}} // no lines -> no match
+	giant := strings.Repeat("a", 6000)
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, giant)
+
+	if len(resp.followups) != 1 {
+		t.Fatalf("want one Followup, got %+v", resp.followups)
+	}
+	body := resp.followups[0].content
+	if !strings.Contains(body, "No lines match") || !strings.Contains(body, "…") {
+		t.Errorf("giant-query no-match reply = %q, want a no-match line with a truncated (…) query", body)
+	}
+	if n := len([]rune(body)); n > discordMessageLimit {
+		t.Errorf("no-match reply is %d runes, want <= %d (Discord cap)", n, discordMessageLimit)
+	}
+}

--- a/internal/presence/search_test.go
+++ b/internal/presence/search_test.go
@@ -12,23 +12,20 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// fakeTranscriptSearch records the campaign + query the handler resolved and
-// returns canned lines/errors, so the scope precedence and formatting can be
-// asserted without a DB.
-type fakeTranscriptSearch struct {
+// fakeSearchStore reuses #216's fakeSessionStore (the shared slash Active-Campaign
+// resolver) and adds the transcript search path, recording the campaign + query
+// the handler resolved so the scope precedence can be asserted without a DB.
+type fakeSearchStore struct {
+	*fakeSessionStore
 	lines       []storage.TranscriptLine
 	searchErr   error
-	campaign    storage.Campaign
-	campaignErr error
-
-	gotCampaign    uuid.UUID
-	gotQuery       string
-	gotLimit       int
-	searchCalls    int
-	getActiveCalls int
+	gotCampaign uuid.UUID
+	gotQuery    string
+	gotLimit    int
+	searchCalls int
 }
 
-func (f *fakeTranscriptSearch) SearchTranscriptLines(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error) {
+func (f *fakeSearchStore) SearchTranscriptLines(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error) {
 	f.searchCalls++
 	f.gotCampaign = campaignID
 	f.gotQuery = query
@@ -36,31 +33,23 @@ func (f *fakeTranscriptSearch) SearchTranscriptLines(_ context.Context, campaign
 	return f.lines, f.searchErr
 }
 
-func (f *fakeTranscriptSearch) GetActiveCampaign(context.Context) (storage.Campaign, error) {
-	f.getActiveCalls++
-	if f.campaignErr != nil {
-		return storage.Campaign{}, f.campaignErr
+// selectionStore is a fakeSearchStore whose Active Campaign resolves via the
+// operator's durable /glyphoxa use selection (the common case for these tests).
+func selectionStore(selected storage.Campaign, lines ...storage.TranscriptLine) *fakeSearchStore {
+	return &fakeSearchStore{
+		fakeSessionStore: &fakeSessionStore{forUser: &selected},
+		lines:            lines,
 	}
-	return f.campaign, nil
 }
 
-// dispatchSearch registers the SearchCommand on a GM-configured registry and
-// dispatches it as the allowlisted operator with the given query, returning the
-// recorded responder + the fake. The GM path is exercised end-to-end (auth gate,
-// Defer watchdog, reply routing).
-func dispatchSearch(t *testing.T, fake *fakeTranscriptSearch, activeCampaign func() (uuid.UUID, bool), query string) *fakeResponder {
+// dispatchSearch registers /glyphoxa search on a GM-configured registry and
+// dispatches it as the allowlisted operator with the given query, exercising the
+// full GM path (auth gate, Defer watchdog, reply routing).
+func dispatchSearch(t *testing.T, store SearchStore, voice VoiceControl, query string) *fakeResponder {
 	t.Helper()
 	reg := testRegistry(testGuild, operatorID)
-	reg.Register(SearchCommand(fake, activeCampaign))
-	resp := &fakeResponder{}
-	ic := &Interaction{
-		guildID: testGuild,
-		userID:  operatorID,
-		opts:    fakeOpts{s: map[string]string{"query": query}},
-		resp:    resp,
-	}
-	reg.dispatch(context.Background(), "glyphoxa search", ic)
-	return resp
+	reg.Register(SearchCommand(store, voice))
+	return dispatchAs(reg, "glyphoxa search", operatorID, map[string]string{"query": query})
 }
 
 func bartLine(campaignID uuid.UUID) storage.TranscriptLine {
@@ -75,15 +64,12 @@ func bartLine(campaignID uuid.UUID) storage.TranscriptLine {
 // shared storage path with the resolved campaign + raw query + small limit, and
 // quotes the top matches with speaker + timestamp in ONE ephemeral Followup.
 func TestSearchCommandQuotesTopMatches(t *testing.T) {
-	campaignID := uuid.New()
-	fake := &fakeTranscriptSearch{
-		campaign: storage.Campaign{ID: campaignID},
-		lines: []storage.TranscriptLine{
-			bartLine(campaignID),
-			{VoiceSessionID: uuid.New(), CampaignID: campaignID, LineID: "u:1", Seq: 1, Who: "Player / DM", Kind: "player", TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: "Where is the dragon?"},
-		},
-	}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+	c := campaign("Lost Mine")
+	store := selectionStore(c,
+		bartLine(c.ID),
+		storage.TranscriptLine{VoiceSessionID: uuid.New(), CampaignID: c.ID, LineID: "u:1", Seq: 1, Who: "Player / DM", Kind: "player", TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: "Where is the dragon?"},
+	)
+	resp := dispatchSearch(t, store, &fakeVoice{}, "dragon")
 
 	if resp.deferred == nil || !*resp.deferred {
 		t.Fatalf("search must Defer ephemerally before the DB round trip; deferred = %v", resp.deferred)
@@ -94,11 +80,11 @@ func TestSearchCommandQuotesTopMatches(t *testing.T) {
 	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
 		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
 	}
-	if fake.searchCalls != 1 || fake.gotQuery != "dragon" || fake.gotCampaign != campaignID {
-		t.Errorf("search call = (calls %d, query %q, campaign %s), want (1, dragon, %s)", fake.searchCalls, fake.gotQuery, fake.gotCampaign, campaignID)
+	if store.searchCalls != 1 || store.gotQuery != "dragon" || store.gotCampaign != c.ID {
+		t.Errorf("search call = (calls %d, query %q, campaign %s), want (1, dragon, %s)", store.searchCalls, store.gotQuery, store.gotCampaign, c.ID)
 	}
-	if fake.gotLimit != transcriptSearchLimit {
-		t.Errorf("search limit = %d, want %d", fake.gotLimit, transcriptSearchLimit)
+	if store.gotLimit != transcriptSearchLimit {
+		t.Errorf("search limit = %d, want %d", store.gotLimit, transcriptSearchLimit)
 	}
 	body := resp.followups[0].content
 	for _, want := range []string{"Bart (NPC)", "18:00:02", "Well met, traveller.", "Player / DM", "Where is the dragon?"} {
@@ -111,8 +97,7 @@ func TestSearchCommandQuotesTopMatches(t *testing.T) {
 // TestSearchCommandNoMatches is #120 AC3's no-match case: a clear ephemeral reply
 // quoting the query.
 func TestSearchCommandNoMatches(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "unicorn")
+	resp := dispatchSearch(t, selectionStore(campaign("Lost Mine")), &fakeVoice{}, "unicorn")
 
 	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
 		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
@@ -125,8 +110,8 @@ func TestSearchCommandNoMatches(t *testing.T) {
 // TestSearchCommandEmptyQuery: a blank/whitespace query short-circuits with a
 // hint, WITHOUT Deferring or touching the DB.
 func TestSearchCommandEmptyQuery(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "   ")
+	store := selectionStore(campaign("Lost Mine"))
+	resp := dispatchSearch(t, store, &fakeVoice{}, "   ")
 
 	if resp.deferred != nil {
 		t.Errorf("empty query must not Defer; deferred = %v", resp.deferred)
@@ -137,16 +122,17 @@ func TestSearchCommandEmptyQuery(t *testing.T) {
 	if !strings.Contains(strings.ToLower(resp.replies[0].content), "search for") {
 		t.Errorf("empty-query hint = %q, want a search-for hint", resp.replies[0].content)
 	}
-	if fake.searchCalls != 0 || fake.getActiveCalls != 0 {
-		t.Errorf("empty query touched storage: search=%d getActive=%d, want 0/0", fake.searchCalls, fake.getActiveCalls)
+	if store.searchCalls != 0 {
+		t.Errorf("empty query touched storage: search=%d, want 0", store.searchCalls)
 	}
 }
 
-// TestSearchCommandNoActiveCampaign: with no live session and no stored Active
-// Campaign, the reply points the operator at /glyphoxa use — and no search runs.
+// TestSearchCommandNoActiveCampaign: with no live session and no durable /glyphoxa
+// use selection, the reply points the operator at /glyphoxa use (the SHARED slash
+// resolver's ErrNoActiveCampaign, no most-recent fallback) — and no search runs.
 func TestSearchCommandNoActiveCampaign(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaignErr: storage.ErrNotFound}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+	store := &fakeSearchStore{fakeSessionStore: &fakeSessionStore{}} // forUser nil -> ErrNotFound
+	resp := dispatchSearch(t, store, &fakeVoice{}, "dragon")
 
 	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
 		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
@@ -154,40 +140,41 @@ func TestSearchCommandNoActiveCampaign(t *testing.T) {
 	if !strings.Contains(resp.followups[0].content, "/glyphoxa use") {
 		t.Errorf("no-campaign reply = %q, want the /glyphoxa use hint", resp.followups[0].content)
 	}
-	if fake.searchCalls != 0 {
-		t.Errorf("search ran %d times with no Active Campaign, want 0", fake.searchCalls)
+	if store.searchCalls != 0 {
+		t.Errorf("search ran %d times with no Active Campaign, want 0", store.searchCalls)
 	}
 }
 
-// TestSearchCommandPrefersLiveSessionCampaign: while a session is live the search
-// scopes to the live campaign and never falls back to GetActiveCampaign (AC5
-// scope precedence, matching the web RPC).
-func TestSearchCommandPrefersLiveSessionCampaign(t *testing.T) {
-	live := uuid.New()
-	other := uuid.New()
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: other}, lines: []storage.TranscriptLine{bartLine(live)}}
-	dispatchSearch(t, fake, func() (uuid.UUID, bool) { return live, true }, "dragon")
-
-	if fake.gotCampaign != live {
-		t.Errorf("searched campaign = %s, want the live session's %s (not GetActiveCampaign %s)", fake.gotCampaign, live, other)
+// TestSearchCommandResolvesLiveSessionCampaign: while a session is live the search
+// scopes to the LIVE session's campaign (the shared resolver's first choice), NOT
+// the durable selection — matching /glyphoxa start (AC5 scope precedence).
+func TestSearchCommandResolvesLiveSessionCampaign(t *testing.T) {
+	live := campaign("Live")
+	other := campaign("Other")
+	store := &fakeSearchStore{
+		fakeSessionStore: &fakeSessionStore{
+			byID:    map[uuid.UUID]storage.Campaign{live.ID: live},
+			forUser: &other, // a different durable selection; the live session must win
+		},
+		lines: []storage.TranscriptLine{bartLine(live.ID)},
 	}
-	if fake.getActiveCalls != 0 {
-		t.Errorf("GetActiveCampaign called %d times while a session was live, want 0", fake.getActiveCalls)
+	voice := &fakeVoice{active: true, snap: storage.VoiceSession{CampaignID: live.ID}}
+	dispatchSearch(t, store, voice, "dragon")
+
+	if store.gotCampaign != live.ID {
+		t.Errorf("searched campaign = %s, want the live session's %s (not the durable selection %s)", store.gotCampaign, live.ID, other.ID)
 	}
 }
 
-// TestSearchCommandFallsBackToActiveCampaign: with no live session it resolves the
-// stored Active Campaign.
-func TestSearchCommandFallsBackToActiveCampaign(t *testing.T) {
-	stored := uuid.New()
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: stored}, lines: []storage.TranscriptLine{bartLine(stored)}}
-	dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+// TestSearchCommandFallsBackToDurableSelection: with no live session it resolves
+// the operator's durable /glyphoxa use selection.
+func TestSearchCommandFallsBackToDurableSelection(t *testing.T) {
+	selected := campaign("Selected")
+	store := selectionStore(selected, bartLine(selected.ID))
+	dispatchSearch(t, store, &fakeVoice{}, "dragon")
 
-	if fake.gotCampaign != stored {
-		t.Errorf("searched campaign = %s, want the stored Active Campaign %s", fake.gotCampaign, stored)
-	}
-	if fake.getActiveCalls != 1 {
-		t.Errorf("GetActiveCampaign called %d times, want 1 (the fallback)", fake.getActiveCalls)
+	if store.gotCampaign != selected.ID {
+		t.Errorf("searched campaign = %s, want the durable selection %s", store.gotCampaign, selected.ID)
 	}
 }
 
@@ -195,8 +182,9 @@ func TestSearchCommandFallsBackToActiveCampaign(t *testing.T) {
 // from the handler, which the Registry answers with the generic ephemeral reply
 // via Followup (post-Defer), never leaving the interaction on "thinking…".
 func TestSearchCommandStorageErrorRepliesGeneric(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}, searchErr: context.DeadlineExceeded}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+	store := selectionStore(campaign("Lost Mine"))
+	store.searchErr = context.DeadlineExceeded
+	resp := dispatchSearch(t, store, &fakeVoice{}, "dragon")
 
 	if len(resp.replies) != 0 {
 		t.Errorf("post-Defer error must not CreateMessage; replies = %+v", resp.replies)
@@ -212,7 +200,7 @@ func TestSearchCommandStorageErrorRepliesGeneric(t *testing.T) {
 // TestSearchCommandIsGMOnly pins the command's surface: it is the grouped
 // /glyphoxa search, GM-only (ADR-0010), with a required query option.
 func TestSearchCommandIsGMOnly(t *testing.T) {
-	cmd := SearchCommand(&fakeTranscriptSearch{}, nil)
+	cmd := SearchCommand(&fakeSearchStore{fakeSessionStore: &fakeSessionStore{}}, &fakeVoice{})
 	if cmd.Path != "glyphoxa search" {
 		t.Errorf("Path = %q, want \"glyphoxa search\"", cmd.Path)
 	}
@@ -231,16 +219,12 @@ func TestSearchCommandIsGMOnly(t *testing.T) {
 // TestSearchCommandNonOperatorDenied: a non-allowlisted user's /glyphoxa search is
 // denied by the Gate before the handler runs (GM-only, ADR-0041) — no search.
 func TestSearchCommandNonOperatorDenied(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
+	store := selectionStore(campaign("Lost Mine"))
 	reg := testRegistry(testGuild, operatorID)
-	reg.Register(SearchCommand(fake, func() (uuid.UUID, bool) { return uuid.Nil, false }))
-	resp := &fakeResponder{}
-	reg.dispatch(context.Background(), "glyphoxa search", &Interaction{
-		guildID: testGuild, userID: strangerID,
-		opts: fakeOpts{s: map[string]string{"query": "dragon"}}, resp: resp,
-	})
+	reg.Register(SearchCommand(store, &fakeVoice{}))
+	resp := dispatchAs(reg, "glyphoxa search", strangerID, map[string]string{"query": "dragon"})
 
-	if fake.searchCalls != 0 {
+	if store.searchCalls != 0 {
 		t.Errorf("search ran for a non-operator, want 0 (GM-only gate)")
 	}
 	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
@@ -252,15 +236,13 @@ func TestSearchCommandNonOperatorDenied(t *testing.T) {
 // long; the quoted line is truncated (…) so it never blows Discord's 2000-char
 // content cap and 400s the Followup (which would hide ALL matches from the GM).
 func TestSearchCommandTruncatesLongLine(t *testing.T) {
-	campaignID := uuid.New()
+	c := campaign("Lost Mine")
 	long := strings.Repeat("dragon fire ", 60) // ~720 chars, well over the per-line cap
-	fake := &fakeTranscriptSearch{
-		campaign: storage.Campaign{ID: campaignID},
-		lines: []storage.TranscriptLine{
-			{VoiceSessionID: uuid.New(), CampaignID: campaignID, LineID: "a:t1", Seq: 1, Who: "Bart", Tag: "NPC", Kind: "npc", TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: long},
-		},
-	}
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+	store := selectionStore(c, storage.TranscriptLine{
+		VoiceSessionID: uuid.New(), CampaignID: c.ID, LineID: "a:t1", Seq: 1, Who: "Bart", Tag: "NPC", Kind: "npc",
+		TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: long,
+	})
+	resp := dispatchSearch(t, store, &fakeVoice{}, "dragon")
 
 	if len(resp.followups) != 1 {
 		t.Fatalf("want one Followup, got %+v", resp.followups)
@@ -300,9 +282,9 @@ func TestFormatTranscriptMatchesCapsTotalLength(t *testing.T) {
 // 6000 chars; the no-match reply echoes only a truncated query, so it stays well
 // under the Discord cap and never 400s.
 func TestSearchCommandGiantQueryNoMatch(t *testing.T) {
-	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}} // no lines -> no match
+	store := selectionStore(campaign("Lost Mine")) // no lines -> no match
 	giant := strings.Repeat("a", 6000)
-	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, giant)
+	resp := dispatchSearch(t, store, &fakeVoice{}, giant)
 
 	if len(resp.followups) != 1 {
 		t.Fatalf("want one Followup, got %+v", resp.followups)

--- a/internal/presence/search_test.go
+++ b/internal/presence/search_test.go
@@ -1,0 +1,249 @@
+package presence
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeTranscriptSearch records the campaign + query the handler resolved and
+// returns canned lines/errors, so the scope precedence and formatting can be
+// asserted without a DB.
+type fakeTranscriptSearch struct {
+	lines       []storage.TranscriptLine
+	searchErr   error
+	campaign    storage.Campaign
+	campaignErr error
+
+	gotCampaign    uuid.UUID
+	gotQuery       string
+	gotLimit       int
+	searchCalls    int
+	getActiveCalls int
+}
+
+func (f *fakeTranscriptSearch) SearchTranscriptLines(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error) {
+	f.searchCalls++
+	f.gotCampaign = campaignID
+	f.gotQuery = query
+	f.gotLimit = limit
+	return f.lines, f.searchErr
+}
+
+func (f *fakeTranscriptSearch) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	f.getActiveCalls++
+	if f.campaignErr != nil {
+		return storage.Campaign{}, f.campaignErr
+	}
+	return f.campaign, nil
+}
+
+// dispatchSearch registers the SearchCommand on a GM-configured registry and
+// dispatches it as the allowlisted operator with the given query, returning the
+// recorded responder + the fake. The GM path is exercised end-to-end (auth gate,
+// Defer watchdog, reply routing).
+func dispatchSearch(t *testing.T, fake *fakeTranscriptSearch, activeCampaign func() (uuid.UUID, bool), query string) *fakeResponder {
+	t.Helper()
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(SearchCommand(fake, activeCampaign))
+	resp := &fakeResponder{}
+	ic := &Interaction{
+		guildID: testGuild,
+		userID:  operatorID,
+		opts:    fakeOpts{s: map[string]string{"query": query}},
+		resp:    resp,
+	}
+	reg.dispatch(context.Background(), "glyphoxa search", ic)
+	return resp
+}
+
+func bartLine(campaignID uuid.UUID) storage.TranscriptLine {
+	return storage.TranscriptLine{
+		VoiceSessionID: uuid.New(), CampaignID: campaignID, LineID: "a:t1", Seq: 2,
+		Who: "Bart", Tag: "NPC", Kind: "npc",
+		TS: time.Date(2026, 6, 27, 18, 0, 2, 0, time.UTC), Text: "Well met, traveller.",
+	}
+}
+
+// TestSearchCommandQuotesTopMatches is #120 AC3: /glyphoxa search Defers, calls the
+// shared storage path with the resolved campaign + raw query + small limit, and
+// quotes the top matches with speaker + timestamp in ONE ephemeral Followup.
+func TestSearchCommandQuotesTopMatches(t *testing.T) {
+	campaignID := uuid.New()
+	fake := &fakeTranscriptSearch{
+		campaign: storage.Campaign{ID: campaignID},
+		lines: []storage.TranscriptLine{
+			bartLine(campaignID),
+			{VoiceSessionID: uuid.New(), CampaignID: campaignID, LineID: "u:1", Seq: 1, Who: "Player / DM", Kind: "player", TS: time.Date(2026, 6, 27, 18, 0, 1, 0, time.UTC), Text: "Where is the dragon?"},
+		},
+	}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+
+	if resp.deferred == nil || !*resp.deferred {
+		t.Fatalf("search must Defer ephemerally before the DB round trip; deferred = %v", resp.deferred)
+	}
+	if len(resp.replies) != 0 {
+		t.Errorf("a deferred handler must not CreateMessage; replies = %+v", resp.replies)
+	}
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
+	}
+	if fake.searchCalls != 1 || fake.gotQuery != "dragon" || fake.gotCampaign != campaignID {
+		t.Errorf("search call = (calls %d, query %q, campaign %s), want (1, dragon, %s)", fake.searchCalls, fake.gotQuery, fake.gotCampaign, campaignID)
+	}
+	if fake.gotLimit != transcriptSearchLimit {
+		t.Errorf("search limit = %d, want %d", fake.gotLimit, transcriptSearchLimit)
+	}
+	body := resp.followups[0].content
+	for _, want := range []string{"Bart (NPC)", "18:00:02", "Well met, traveller.", "Player / DM", "Where is the dragon?"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("reply missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+// TestSearchCommandNoMatches is #120 AC3's no-match case: a clear ephemeral reply
+// quoting the query.
+func TestSearchCommandNoMatches(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "unicorn")
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
+	}
+	if got := resp.followups[0].content; got != `No lines match "unicorn".` {
+		t.Errorf("no-match reply = %q, want the clear no-match line", got)
+	}
+}
+
+// TestSearchCommandEmptyQuery: a blank/whitespace query short-circuits with a
+// hint, WITHOUT Deferring or touching the DB.
+func TestSearchCommandEmptyQuery(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "   ")
+
+	if resp.deferred != nil {
+		t.Errorf("empty query must not Defer; deferred = %v", resp.deferred)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("empty query = %+v, want one ephemeral Reply hint", resp.replies)
+	}
+	if !strings.Contains(strings.ToLower(resp.replies[0].content), "search for") {
+		t.Errorf("empty-query hint = %q, want a search-for hint", resp.replies[0].content)
+	}
+	if fake.searchCalls != 0 || fake.getActiveCalls != 0 {
+		t.Errorf("empty query touched storage: search=%d getActive=%d, want 0/0", fake.searchCalls, fake.getActiveCalls)
+	}
+}
+
+// TestSearchCommandNoActiveCampaign: with no live session and no stored Active
+// Campaign, the reply points the operator at /glyphoxa use — and no search runs.
+func TestSearchCommandNoActiveCampaign(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaignErr: storage.ErrNotFound}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
+	}
+	if !strings.Contains(resp.followups[0].content, "/glyphoxa use") {
+		t.Errorf("no-campaign reply = %q, want the /glyphoxa use hint", resp.followups[0].content)
+	}
+	if fake.searchCalls != 0 {
+		t.Errorf("search ran %d times with no Active Campaign, want 0", fake.searchCalls)
+	}
+}
+
+// TestSearchCommandPrefersLiveSessionCampaign: while a session is live the search
+// scopes to the live campaign and never falls back to GetActiveCampaign (AC5
+// scope precedence, matching the web RPC).
+func TestSearchCommandPrefersLiveSessionCampaign(t *testing.T) {
+	live := uuid.New()
+	other := uuid.New()
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: other}, lines: []storage.TranscriptLine{bartLine(live)}}
+	dispatchSearch(t, fake, func() (uuid.UUID, bool) { return live, true }, "dragon")
+
+	if fake.gotCampaign != live {
+		t.Errorf("searched campaign = %s, want the live session's %s (not GetActiveCampaign %s)", fake.gotCampaign, live, other)
+	}
+	if fake.getActiveCalls != 0 {
+		t.Errorf("GetActiveCampaign called %d times while a session was live, want 0", fake.getActiveCalls)
+	}
+}
+
+// TestSearchCommandFallsBackToActiveCampaign: with no live session it resolves the
+// stored Active Campaign.
+func TestSearchCommandFallsBackToActiveCampaign(t *testing.T) {
+	stored := uuid.New()
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: stored}, lines: []storage.TranscriptLine{bartLine(stored)}}
+	dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+
+	if fake.gotCampaign != stored {
+		t.Errorf("searched campaign = %s, want the stored Active Campaign %s", fake.gotCampaign, stored)
+	}
+	if fake.getActiveCalls != 1 {
+		t.Errorf("GetActiveCampaign called %d times, want 1 (the fallback)", fake.getActiveCalls)
+	}
+}
+
+// TestSearchCommandStorageErrorRepliesGeneric: a storage failure returns an error
+// from the handler, which the Registry answers with the generic ephemeral reply
+// via Followup (post-Defer), never leaving the interaction on "thinking…".
+func TestSearchCommandStorageErrorRepliesGeneric(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}, searchErr: context.DeadlineExceeded}
+	resp := dispatchSearch(t, fake, func() (uuid.UUID, bool) { return uuid.Nil, false }, "dragon")
+
+	if len(resp.replies) != 0 {
+		t.Errorf("post-Defer error must not CreateMessage; replies = %+v", resp.replies)
+	}
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("want one ephemeral Followup, got %+v", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "went wrong") {
+		t.Errorf("storage-error reply = %q, want the generic failure message", resp.followups[0].content)
+	}
+}
+
+// TestSearchCommandIsGMOnly pins the command's surface: it is the grouped
+// /glyphoxa search, GM-only (ADR-0010), with a required query option.
+func TestSearchCommandIsGMOnly(t *testing.T) {
+	cmd := SearchCommand(&fakeTranscriptSearch{}, nil)
+	if cmd.Path != "glyphoxa search" {
+		t.Errorf("Path = %q, want \"glyphoxa search\"", cmd.Path)
+	}
+	if !cmd.GMOnly {
+		t.Error("GMOnly = false, want true (transcript search is GM-only, ADR-0010)")
+	}
+	if len(cmd.Options) != 1 {
+		t.Fatalf("Options = %d, want 1 (query)", len(cmd.Options))
+	}
+	opt, ok := cmd.Options[0].(discord.ApplicationCommandOptionString)
+	if !ok || opt.Name != "query" || !opt.Required {
+		t.Errorf("option = %+v, want a required string 'query'", cmd.Options[0])
+	}
+}
+
+// TestSearchCommandNonOperatorDenied: a non-allowlisted user's /glyphoxa search is
+// denied by the Gate before the handler runs (GM-only, ADR-0041) — no search.
+func TestSearchCommandNonOperatorDenied(t *testing.T) {
+	fake := &fakeTranscriptSearch{campaign: storage.Campaign{ID: uuid.New()}}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(SearchCommand(fake, func() (uuid.UUID, bool) { return uuid.Nil, false }))
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "glyphoxa search", &Interaction{
+		guildID: testGuild, userID: strangerID,
+		opts: fakeOpts{s: map[string]string{"query": "dragon"}}, resp: resp,
+	})
+
+	if fake.searchCalls != 0 {
+		t.Errorf("search ran for a non-operator, want 0 (GM-only gate)")
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("denial = %+v, want one ephemeral reply", resp.replies)
+	}
+}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -214,12 +214,14 @@ func (s *SessionServer) StopSession(
 
 // SearchTranscriptLines returns the operator's Active Campaign transcript Lines
 // matching the query, ranked by relevance (#120). The Campaign is resolved
-// server-side — the active Voice Session's campaign when live, else the Active
-// Campaign (GetActiveCampaign) — NEVER a client-supplied id, so a search can
-// never cross into another campaign's transcript (AC5). It shares ONE query path
-// (storage.SearchTranscriptLines) with the `/glyphoxa search` slash command
-// (AC4). An empty/whitespace query is CodeInvalidArgument; no Active Campaign
-// yields an empty result (nothing to search, not an error); a storage failure is
+// server-side by the SAME profile-first resolver StartSession uses (startCampaign:
+// the logged-in operator's durable /glyphoxa use selection, else the
+// most-recently-created campaign) — NEVER a client-supplied id, so a search can
+// never cross into another campaign's transcript (AC5) and the web search + Start
+// button always agree on which campaign. It shares ONE query path
+// (storage.SearchTranscriptLines) with the `/glyphoxa search` slash command (AC4).
+// An empty/whitespace query is CodeInvalidArgument; no Active Campaign yields an
+// empty result (nothing to search, not an error); a storage failure is
 // CodeInternal. A read (NO_SIDE_EFFECTS).
 func (s *SessionServer) SearchTranscriptLines(
 	ctx context.Context,
@@ -229,19 +231,19 @@ func (s *SessionServer) SearchTranscriptLines(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("query must not be empty"))
 	}
 
-	campaignID, ok, err := s.activeCampaignID(ctx)
+	campaign, err := s.startCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		// No Active Campaign: nothing to search yet (never-run state), not an error.
+		return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{}), nil
+	}
 	if err != nil {
 		s.log.Error("SearchTranscriptLines: resolve active campaign failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
-	if !ok {
-		// No Active Campaign: nothing to search yet (never-run state), not an error.
-		return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{}), nil
-	}
 
-	lines, err := s.store.SearchTranscriptLines(ctx, campaignID, req.Msg.GetQuery(), searchTranscriptLimit)
+	lines, err := s.store.SearchTranscriptLines(ctx, campaign.ID, req.Msg.GetQuery(), searchTranscriptLimit)
 	if err != nil {
-		s.log.Error("SearchTranscriptLines: store search failed", "campaign_id", campaignID, "err", err)
+		s.log.Error("SearchTranscriptLines: store search failed", "campaign_id", campaign.ID, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
@@ -250,25 +252,6 @@ func (s *SessionServer) SearchTranscriptLines(
 		out = append(out, toProtoTranscriptLineMatch(l))
 	}
 	return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{Lines: out}), nil
-}
-
-// activeCampaignID resolves the operator's Active Campaign for a read: the live
-// Voice Session's campaign when one is running (the same in-process truth
-// GetSession uses), otherwise the stored Active Campaign. ok is false only when
-// there is neither — a never-run state the caller treats gracefully. A storage
-// error other than ErrNotFound is returned.
-func (s *SessionServer) activeCampaignID(ctx context.Context) (uuid.UUID, bool, error) {
-	if vs, active := s.mgr.Snapshot(); active {
-		return vs.CampaignID, true, nil
-	}
-	campaign, err := s.store.GetActiveCampaign(ctx)
-	if errors.Is(err, storage.ErrNotFound) {
-		return uuid.Nil, false, nil
-	}
-	if err != nil {
-		return uuid.Nil, false, err
-	}
-	return campaign.ID, true, nil
 }
 
 // toProtoTranscriptLineMatch maps a storage.TranscriptLine onto the wire search

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -214,15 +214,17 @@ func (s *SessionServer) StopSession(
 
 // SearchTranscriptLines returns the operator's Active Campaign transcript Lines
 // matching the query, ranked by relevance (#120). The Campaign is resolved
-// server-side by the SAME profile-first resolver StartSession uses (startCampaign:
-// the logged-in operator's durable /glyphoxa use selection, else the
-// most-recently-created campaign) — NEVER a client-supplied id, so a search can
-// never cross into another campaign's transcript (AC5) and the web search + Start
-// button always agree on which campaign. It shares ONE query path
-// (storage.SearchTranscriptLines) with the `/glyphoxa search` slash command (AC4).
-// An empty/whitespace query is CodeInvalidArgument; no Active Campaign yields an
-// empty result (nothing to search, not an error); a storage failure is
-// CodeInternal. A read (NO_SIDE_EFFECTS).
+// server-side — the LIVE Voice Session's campaign first (exactly like GetSession:
+// the Session screen renders that session's transcript, so search must scope to
+// it, not a durable selection changed mid-session), else the same profile-first
+// startCampaign StartSession uses (durable /glyphoxa use selection → most-recent
+// fallback). NEVER a client-supplied id, so a search can never cross into another
+// campaign's transcript (AC5). It shares ONE query path
+// (storage.SearchTranscriptLines) with the `/glyphoxa search` slash command, whose
+// resolveActiveCampaign is live-session-first for the same reason (AC4). An
+// empty/whitespace query is CodeInvalidArgument; no Active Campaign yields an empty
+// result (nothing to search, not an error); a storage failure is CodeInternal. A
+// read (NO_SIDE_EFFECTS).
 func (s *SessionServer) SearchTranscriptLines(
 	ctx context.Context,
 	req *connect.Request[managementv1.SearchTranscriptLinesRequest],
@@ -231,19 +233,19 @@ func (s *SessionServer) SearchTranscriptLines(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("query must not be empty"))
 	}
 
-	campaign, err := s.startCampaign(ctx)
-	if errors.Is(err, storage.ErrNotFound) {
-		// No Active Campaign: nothing to search yet (never-run state), not an error.
-		return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{}), nil
-	}
+	campaignID, ok, err := s.searchCampaign(ctx)
 	if err != nil {
 		s.log.Error("SearchTranscriptLines: resolve active campaign failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
+	if !ok {
+		// No Active Campaign: nothing to search yet (never-run state), not an error.
+		return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{}), nil
+	}
 
-	lines, err := s.store.SearchTranscriptLines(ctx, campaign.ID, req.Msg.GetQuery(), searchTranscriptLimit)
+	lines, err := s.store.SearchTranscriptLines(ctx, campaignID, req.Msg.GetQuery(), searchTranscriptLimit)
 	if err != nil {
-		s.log.Error("SearchTranscriptLines: store search failed", "campaign_id", campaign.ID, "err", err)
+		s.log.Error("SearchTranscriptLines: store search failed", "campaign_id", campaignID, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
@@ -252,6 +254,27 @@ func (s *SessionServer) SearchTranscriptLines(
 		out = append(out, toProtoTranscriptLineMatch(l))
 	}
 	return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{Lines: out}), nil
+}
+
+// searchCampaign resolves the campaign the web transcript search scopes to: the
+// live Voice Session's campaign first (the same in-process truth GetSession uses,
+// so search scopes to exactly the transcript on screen), otherwise the
+// profile-first startCampaign (the operator's durable /glyphoxa use selection, else
+// the most-recently-created fallback). ok is false only when neither resolves — a
+// never-run state the caller answers with an empty result. A storage error other
+// than ErrNotFound is returned.
+func (s *SessionServer) searchCampaign(ctx context.Context) (uuid.UUID, bool, error) {
+	if vs, active := s.mgr.Snapshot(); active {
+		return vs.CampaignID, true, nil
+	}
+	campaign, err := s.startCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return uuid.Nil, false, nil
+	}
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	return campaign.ID, true, nil
 }
 
 // toProtoTranscriptLineMatch maps a storage.TranscriptLine onto the wire search

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -28,13 +29,19 @@ type SessionManager interface {
 
 // SessionStore is the narrow storage surface SessionServer needs: the operator's
 // durable Active Campaign selection (#108), the most-recently-created campaign as
-// the fallback that scopes a session, and the latest ended session for the idle
-// last-session summary (#72).
+// the fallback that scopes a session, the latest ended session for the idle
+// last-session summary (#72), and the campaign-scoped transcript search (#120).
 type SessionStore interface {
 	GetActiveCampaignForUser(ctx context.Context, discordUserID string) (storage.Campaign, error)
 	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
 	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
+	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
 }
+
+// searchTranscriptLimit caps a transcript search result set (#120). It is a fixed
+// server policy for the single-operator web tier (ADR-0039), mirroring
+// searchNodesLimit; the client sends no limit.
+const searchTranscriptLimit = 50
 
 // SessionServer implements the Connect SessionService over a SessionManager +
 // SessionStore: Start/Stop drive the in-process loop, GetSession reports the live
@@ -203,6 +210,80 @@ func (s *SessionServer) StopSession(
 	return connect.NewResponse(&managementv1.StopSessionResponse{
 		Session: toProtoVoiceSession(vs),
 	}), nil
+}
+
+// SearchTranscriptLines returns the operator's Active Campaign transcript Lines
+// matching the query, ranked by relevance (#120). The Campaign is resolved
+// server-side — the active Voice Session's campaign when live, else the Active
+// Campaign (GetActiveCampaign) — NEVER a client-supplied id, so a search can
+// never cross into another campaign's transcript (AC5). It shares ONE query path
+// (storage.SearchTranscriptLines) with the `/glyphoxa search` slash command
+// (AC4). An empty/whitespace query is CodeInvalidArgument; no Active Campaign
+// yields an empty result (nothing to search, not an error); a storage failure is
+// CodeInternal. A read (NO_SIDE_EFFECTS).
+func (s *SessionServer) SearchTranscriptLines(
+	ctx context.Context,
+	req *connect.Request[managementv1.SearchTranscriptLinesRequest],
+) (*connect.Response[managementv1.SearchTranscriptLinesResponse], error) {
+	if strings.TrimSpace(req.Msg.GetQuery()) == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("query must not be empty"))
+	}
+
+	campaignID, ok, err := s.activeCampaignID(ctx)
+	if err != nil {
+		s.log.Error("SearchTranscriptLines: resolve active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if !ok {
+		// No Active Campaign: nothing to search yet (never-run state), not an error.
+		return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{}), nil
+	}
+
+	lines, err := s.store.SearchTranscriptLines(ctx, campaignID, req.Msg.GetQuery(), searchTranscriptLimit)
+	if err != nil {
+		s.log.Error("SearchTranscriptLines: store search failed", "campaign_id", campaignID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := make([]*managementv1.TranscriptLineMatch, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, toProtoTranscriptLineMatch(l))
+	}
+	return connect.NewResponse(&managementv1.SearchTranscriptLinesResponse{Lines: out}), nil
+}
+
+// activeCampaignID resolves the operator's Active Campaign for a read: the live
+// Voice Session's campaign when one is running (the same in-process truth
+// GetSession uses), otherwise the stored Active Campaign. ok is false only when
+// there is neither — a never-run state the caller treats gracefully. A storage
+// error other than ErrNotFound is returned.
+func (s *SessionServer) activeCampaignID(ctx context.Context) (uuid.UUID, bool, error) {
+	if vs, active := s.mgr.Snapshot(); active {
+		return vs.CampaignID, true, nil
+	}
+	campaign, err := s.store.GetActiveCampaign(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		return uuid.Nil, false, nil
+	}
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	return campaign.ID, true, nil
+}
+
+// toProtoTranscriptLineMatch maps a storage.TranscriptLine onto the wire search
+// hit: the rendered fields plus the owning session + stable line id the web
+// deep-links with (#120).
+func toProtoTranscriptLineMatch(l storage.TranscriptLine) *managementv1.TranscriptLineMatch {
+	return &managementv1.TranscriptLineMatch{
+		SessionId: l.VoiceSessionID.String(),
+		LineId:    l.LineID,
+		Who:       l.Who,
+		Tag:       l.Tag,
+		Kind:      l.Kind,
+		Ts:        timestamppb.New(l.TS),
+		Text:      l.Text,
+	}
 }
 
 // toProtoVoiceSession maps a storage.VoiceSession onto its wire view. A zero

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -401,29 +401,25 @@ func TestSearchTranscriptIdleScopesToActiveCampaign(t *testing.T) {
 	}
 }
 
-// TestSearchTranscriptPrefersLiveSessionCampaign is #120's scope precedence: while
-// a Voice Session is live, the search scopes to the LIVE session's campaign (the
-// same in-process truth GetSession uses), NOT GetActiveCampaign — so it never
-// returns a different campaign's transcript (AC5).
-func TestSearchTranscriptPrefersLiveSessionCampaign(t *testing.T) {
+// TestSearchTranscriptHonorsDurableSelection is #120 aligned to #108: the web
+// search resolves the campaign with the SAME profile-first startCampaign path as
+// StartSession — the logged-in operator's durable /glyphoxa use selection outranks
+// the most-recently-created default, so the web search box and the Start button
+// always agree on which campaign is searched (AC5, no divergent resolution).
+func TestSearchTranscriptHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
-	liveCampaign := uuid.New()
-	otherCampaign := uuid.New()
-	mgr := &fakeSessionManager{
-		active:  true,
-		current: storage.VoiceSession{ID: uuid.New(), CampaignID: liveCampaign, Status: storage.VoiceSessionRunning},
-	}
-	// GetActiveCampaign returns a DIFFERENT campaign; the live session must win.
-	store := &fakeSessionStore{campaign: storage.Campaign{ID: otherCampaign}}
-	client := newSessionClient(t, mgr, store)
+	selected := storage.Campaign{ID: uuid.New(), Name: "Selected"}
+	newer := storage.Campaign{ID: uuid.New(), Name: "Newer"}
+	store := &fakeSessionStore{forUser: selected, campaign: newer, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, &fakeSessionManager{}, store, storage.User{DiscordUserID: "999"})
 
 	if _, err := client.SearchTranscriptLines(context.Background(),
 		connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"})); err != nil {
 		t.Fatalf("SearchTranscriptLines: %v", err)
 	}
-	if store.searchCampaign != liveCampaign {
-		t.Errorf("searched campaign = %s, want the LIVE session's campaign %s (not GetActiveCampaign %s)",
-			store.searchCampaign, liveCampaign, otherCampaign)
+	if store.searchCampaign != selected.ID {
+		t.Errorf("searched campaign = %s, want the durable selection %s (profile-first, not the fallback %s)",
+			store.searchCampaign, selected.ID, newer.ID)
 	}
 }
 

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -73,7 +73,9 @@ func (f *fakeSessionManager) Snapshot() (storage.VoiceSession, bool) {
 }
 
 // fakeSessionStore serves the durable per-operator selection, the implicit active
-// campaign, and the latest ended session.
+// campaign, the latest ended session, and the campaign-scoped transcript search
+// (#120), recording the campaign + query the handler resolved so the scope
+// precedence can be asserted.
 type fakeSessionStore struct {
 	forUser     storage.Campaign // the operator's /glyphoxa use selection (#108)
 	forUserErr  error            // set to storage.ErrNotFound to force the fallback
@@ -81,6 +83,12 @@ type fakeSessionStore struct {
 	campaignErr error
 	latest      storage.VoiceSession
 	latestErr   error
+
+	searchLines    []storage.TranscriptLine
+	searchErr      error
+	searchCampaign uuid.UUID // the campaign id the handler passed to search
+	searchQuery    string
+	searchCalls    int
 }
 
 func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
@@ -105,6 +113,16 @@ func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (st
 		return storage.VoiceSession{}, f.latestErr
 	}
 	return f.latest, nil
+}
+
+func (f *fakeSessionStore) SearchTranscriptLines(_ context.Context, campaignID uuid.UUID, query string, _ int) ([]storage.TranscriptLine, error) {
+	f.searchCalls++
+	f.searchCampaign = campaignID
+	f.searchQuery = query
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return f.searchLines, nil
 }
 
 func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
@@ -341,5 +359,160 @@ func TestSessionStartFallsBackWithoutSelection(t *testing.T) {
 	}
 	if start.Msg.GetSession().GetCampaignId() != newer.ID.String() {
 		t.Errorf("bound campaign = %s, want the fallback %s", start.Msg.GetSession().GetCampaignId(), newer.ID)
+	}
+}
+
+// TestSearchTranscriptIdleScopesToActiveCampaign is #120 AC1 + AC5 (server, idle):
+// with no live session, the search resolves the operator's Active Campaign via
+// GetActiveCampaign, passes THAT campaign id to the one storage search method, and
+// maps the ranked rows to the wire hits (speaker/tag/kind/ts/text + session/line
+// id for deep-linking).
+func TestSearchTranscriptIdleScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	sessionID := uuid.New()
+	store := &fakeSessionStore{
+		campaign: storage.Campaign{ID: campaignID, Name: "Sunless Citadel"},
+		searchLines: []storage.TranscriptLine{
+			{VoiceSessionID: sessionID, CampaignID: campaignID, LineID: "a:t1", Seq: 2, Who: "Bart", Tag: "NPC", Kind: "npc", TS: time.Date(2026, 6, 27, 18, 0, 2, 0, time.UTC), Text: "Well met, traveller."},
+		},
+	}
+	client := newSessionClient(t, &fakeSessionManager{}, store)
+
+	resp, err := client.SearchTranscriptLines(context.Background(),
+		connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"}))
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines: %v", err)
+	}
+	if store.searchCampaign != campaignID {
+		t.Errorf("searched campaign = %s, want the Active Campaign %s (AC5 scope)", store.searchCampaign, campaignID)
+	}
+	if store.searchQuery != "dragon" {
+		t.Errorf("searched query = %q, want %q (raw query passed through to the shared path)", store.searchQuery, "dragon")
+	}
+	lines := resp.Msg.GetLines()
+	if len(lines) != 1 {
+		t.Fatalf("got %d hits, want 1", len(lines))
+	}
+	m := lines[0]
+	if m.GetSessionId() != sessionID.String() || m.GetLineId() != "a:t1" || m.GetWho() != "Bart" ||
+		m.GetTag() != "NPC" || m.GetKind() != "npc" || m.GetText() != "Well met, traveller." {
+		t.Errorf("hit = %+v, want the mapped Bart NPC line with its session + line id", m)
+	}
+}
+
+// TestSearchTranscriptPrefersLiveSessionCampaign is #120's scope precedence: while
+// a Voice Session is live, the search scopes to the LIVE session's campaign (the
+// same in-process truth GetSession uses), NOT GetActiveCampaign — so it never
+// returns a different campaign's transcript (AC5).
+func TestSearchTranscriptPrefersLiveSessionCampaign(t *testing.T) {
+	t.Parallel()
+	liveCampaign := uuid.New()
+	otherCampaign := uuid.New()
+	mgr := &fakeSessionManager{
+		active:  true,
+		current: storage.VoiceSession{ID: uuid.New(), CampaignID: liveCampaign, Status: storage.VoiceSessionRunning},
+	}
+	// GetActiveCampaign returns a DIFFERENT campaign; the live session must win.
+	store := &fakeSessionStore{campaign: storage.Campaign{ID: otherCampaign}}
+	client := newSessionClient(t, mgr, store)
+
+	if _, err := client.SearchTranscriptLines(context.Background(),
+		connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"})); err != nil {
+		t.Fatalf("SearchTranscriptLines: %v", err)
+	}
+	if store.searchCampaign != liveCampaign {
+		t.Errorf("searched campaign = %s, want the LIVE session's campaign %s (not GetActiveCampaign %s)",
+			store.searchCampaign, liveCampaign, otherCampaign)
+	}
+}
+
+// TestSearchTranscriptEmptyQueryIsInvalidArgument mirrors SearchNodes: an
+// empty/whitespace query is CodeInvalidArgument and never reaches storage.
+func TestSearchTranscriptEmptyQueryIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	store := &fakeSessionStore{campaign: storage.Campaign{ID: uuid.New()}}
+	client := newSessionClient(t, &fakeSessionManager{}, store)
+
+	for _, q := range []string{"", "   "} {
+		_, err := client.SearchTranscriptLines(context.Background(),
+			connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: q}))
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Errorf("SearchTranscriptLines(%q) code = %v, want InvalidArgument", q, got)
+		}
+	}
+	if store.searchCalls != 0 {
+		t.Errorf("store.SearchTranscriptLines called %d times for empty queries, want 0", store.searchCalls)
+	}
+}
+
+// TestSearchTranscriptNoCampaignReturnsEmpty: with no live session and no Active
+// Campaign (never-run state), the search returns an empty result gracefully — not
+// an error — and never reaches storage.
+func TestSearchTranscriptNoCampaignReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	store := &fakeSessionStore{campaignErr: storage.ErrNotFound}
+	client := newSessionClient(t, &fakeSessionManager{}, store)
+
+	resp, err := client.SearchTranscriptLines(context.Background(),
+		connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"}))
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines with no campaign = %v, want nil (graceful empty)", err)
+	}
+	if len(resp.Msg.GetLines()) != 0 {
+		t.Errorf("got %d hits, want 0 when there is no Active Campaign", len(resp.Msg.GetLines()))
+	}
+	if store.searchCalls != 0 {
+		t.Errorf("store.SearchTranscriptLines called %d times with no campaign, want 0", store.searchCalls)
+	}
+}
+
+// TestSearchTranscriptAuthGatesLikeSiblings (auth half): the whole SessionService
+// is auth-gated (ADR-0016) — with no valid session BOTH the SearchTranscriptLines
+// read and the StartSession mutation are Unauthenticated. The read being
+// side-effect-free exempts it from CSRF, never from auth.
+func TestSearchTranscriptAuthGatesLikeSiblings(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+		connect.WithInterceptors(auth.NewAuthInterceptor(denyAuth{})),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	_, searchErr := client.SearchTranscriptLines(ctx, connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"}))
+	_, startErr := client.StartSession(ctx, connect.NewRequest(&managementv1.StartSessionRequest{}))
+	for name, err := range map[string]error{"SearchTranscriptLines": searchErr, "StartSession(sibling)": startErr} {
+		if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+			t.Errorf("%s code = %v, want Unauthenticated (whole API is auth-gated)", name, got)
+		}
+	}
+}
+
+// TestSearchTranscriptCSRFExemptAsRead (CSRF half): with the CSRF interceptor
+// mounted and no double-submit token, the state-changing StartSession is
+// PermissionDenied while the side-effect-free SearchTranscriptLines (NO_SIDE_EFFECTS)
+// is exempt and reaches the handler.
+func TestSearchTranscriptCSRFExemptAsRead(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+		connect.WithInterceptors(auth.NewCSRFInterceptor()),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	ctx := context.Background()
+
+	// The mutation is CSRF-guarded — no token → PermissionDenied.
+	_, startErr := client.StartSession(ctx, connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if got := connect.CodeOf(startErr); got != connect.CodePermissionDenied {
+		t.Errorf("StartSession code = %v, want PermissionDenied (CSRF-guarded mutation)", got)
+	}
+	// The read is exempt — no token still reaches the handler.
+	if _, err := client.SearchTranscriptLines(ctx, connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"})); connect.CodeOf(err) == connect.CodePermissionDenied {
+		t.Error("SearchTranscriptLines must be CSRF-exempt (NO_SIDE_EFFECTS read)")
 	}
 }

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -401,11 +401,41 @@ func TestSearchTranscriptIdleScopesToActiveCampaign(t *testing.T) {
 	}
 }
 
-// TestSearchTranscriptHonorsDurableSelection is #120 aligned to #108: the web
-// search resolves the campaign with the SAME profile-first startCampaign path as
-// StartSession — the logged-in operator's durable /glyphoxa use selection outranks
-// the most-recently-created default, so the web search box and the Start button
-// always agree on which campaign is searched (AC5, no divergent resolution).
+// TestSearchTranscriptPrefersLiveSessionCampaign is #120's live-session precedence
+// (restored after the #108 alignment dropped it): while a Voice Session is live the
+// web search scopes to the LIVE session's campaign — exactly like GetSession, which
+// renders that session's transcript — so it never diverges from what is on screen,
+// even if the durable /glyphoxa use selection was changed mid-session (AC5). Repro:
+// /use B → start (live B) → /use A must still search B, not A.
+func TestSearchTranscriptPrefersLiveSessionCampaign(t *testing.T) {
+	t.Parallel()
+	liveCampaign := uuid.New()
+	durable := storage.Campaign{ID: uuid.New(), Name: "Durable A"} // a since-changed /glyphoxa use selection
+	legacy := storage.Campaign{ID: uuid.New(), Name: "Most recent"}
+	mgr := &fakeSessionManager{
+		active:  true,
+		current: storage.VoiceSession{ID: uuid.New(), CampaignID: liveCampaign, Status: storage.VoiceSessionRunning},
+	}
+	// Both the durable selection and the legacy default differ from the live
+	// session; the live session must win over both (Snapshot before startCampaign).
+	store := &fakeSessionStore{forUser: durable, campaign: legacy, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, mgr, store, storage.User{DiscordUserID: "999"})
+
+	if _, err := client.SearchTranscriptLines(context.Background(),
+		connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"})); err != nil {
+		t.Fatalf("SearchTranscriptLines: %v", err)
+	}
+	if store.searchCampaign != liveCampaign {
+		t.Errorf("searched campaign = %s, want the LIVE session's %s (not the durable %s or legacy %s)",
+			store.searchCampaign, liveCampaign, durable.ID, legacy.ID)
+	}
+}
+
+// TestSearchTranscriptHonorsDurableSelection is #120 aligned to #108: with NO live
+// session the web search resolves the campaign with the SAME profile-first
+// startCampaign path as StartSession — the logged-in operator's durable /glyphoxa
+// use selection outranks the most-recently-created default, so the web search box
+// and the Start button always agree on which campaign is searched (AC5).
 func TestSearchTranscriptHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	selected := storage.Campaign{ID: uuid.New(), Name: "Selected"}

--- a/internal/storage/migrations/00015_transcript_line_fts.sql
+++ b/internal/storage/migrations/00015_transcript_line_fts.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- User-facing transcript search at the Line grain (#120, ADR-0011 amendment
+-- 2026-07-04). A generated tsvector over the rendered line text backs the web
+-- search box + `/glyphoxa search`; a line hit carries an exact speaker/timestamp
+-- and deep-links to the rendered line, which a chunk hit cannot. The 'simple'
+-- config mirrors kg_node (00011) and transcript_chunk (00001) — language-agnostic,
+-- right for mixed German/English tables. This is an ALTER on the existing table
+-- (ADR-0031: a migration never rewrites 00007). The chunk grain's own fts column
+-- (00001) stays reserved for the later embedding-augmented overlay; this is the
+-- user-facing path.
+ALTER TABLE transcript_line ADD COLUMN fts tsvector GENERATED ALWAYS AS (
+    to_tsvector('simple', text)) STORED;
+
+CREATE INDEX transcript_line_fts_idx ON transcript_line USING gin (fts);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS transcript_line_fts_idx;
+ALTER TABLE transcript_line DROP COLUMN IF EXISTS fts;

--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -106,3 +106,44 @@ func (s *Store) CountTranscriptLines(ctx context.Context, sessionID uuid.UUID) (
 	}
 	return n, nil
 }
+
+// SearchTranscriptLines returns a Campaign's persisted transcript Lines whose text
+// matches the query, ranked by relevance (#120, ADR-0011 amendment). This is the
+// SINGLE user-facing search path — both the web SearchTranscriptLines RPC and the
+// `/glyphoxa search` slash command call exactly this method (AC4: no divergent
+// search logic). The match is served by the transcript_line_fts_idx GIN index
+// (fts @@ q), not a substring scan, and ranked with ts_rank (a line that mentions
+// the term more often ranks higher), then newest-first, then a stable tiebreak.
+// The query is scoped by campaign_id, so another Campaign's transcript is NEVER
+// returned (AC5). The raw query is sanitized by BuildTSQuery (the same helper the
+// KG search uses), so injected tsquery operators can only ever split words; an
+// empty result from that yields (nil, nil) — no matches, not an error.
+func (s *Store) SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]TranscriptLine, error) {
+	tsq := BuildTSQuery(query)
+	if tsq == "" {
+		return nil, nil
+	}
+	rows, err := s.db.Query(ctx,
+		`SELECT `+transcriptLineColumns+`
+		   FROM transcript_line, to_tsquery('simple', $2) q
+		  WHERE campaign_id = $1 AND fts @@ q
+		  ORDER BY ts_rank(fts, q) DESC, ts DESC, voice_session_id, line_id
+		  LIMIT $3`, campaignID, tsq, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: search transcript lines for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []TranscriptLine
+	for rows.Next() {
+		l, err := scanTranscriptLine(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan transcript line search row: %w", err)
+		}
+		out = append(out, l)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: search transcript lines for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}

--- a/internal/storage/transcript_line_search_test.go
+++ b/internal/storage/transcript_line_search_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// searchLineTexts pulls the text out of a search result in rank order.
+func searchLineTexts(lines []storage.TranscriptLine) []string {
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = l.Text
+	}
+	return out
+}
+
+// seedLine upserts one transcript Line for a session under a campaign at a given
+// second, returning nothing (the test asserts on search results, not the row).
+func seedLine(t *testing.T, st *storage.Store, vsID, campaignID uuid.UUID, lineID string, seq int64, ts time.Time, text string) {
+	t.Helper()
+	if err := st.UpsertTranscriptLine(context.Background(), storage.TranscriptLine{
+		VoiceSessionID: vsID, CampaignID: campaignID, LineID: lineID, Seq: seq,
+		Who: "Player / DM", Kind: "player", TS: ts, Text: text,
+	}); err != nil {
+		t.Fatalf("UpsertTranscriptLine %s: %v", lineID, err)
+	}
+}
+
+// TestSearchTranscriptLines is #120 AC1 + AC5: a full-text query over the
+// Active Campaign's persisted transcript returns ranked matches (a line that
+// mentions the term more often outranks a single mention), the search is
+// Campaign-scoped so another Campaign's identical match NEVER leaks (AC5), and
+// an empty / all-punctuation query is a no-op (no matches, no error). Injected
+// tsquery operators are neutralized by BuildTSQuery — a query full of &, |,
+// parens and quotes must not error.
+func TestSearchTranscriptLines(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	ts := func(sec int) time.Time { return time.Date(2026, 6, 27, 18, 0, sec, 0, time.UTC) }
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	// Two matching lines: the term appears twice in one (higher ts_rank) and once
+	// in the other, so the ranking is deterministic. A third line never matches.
+	seedLine(t, st, vs.ID, campaignID, "u:1", 1, ts(1), "The dragon breathes fire and the dragon roars")
+	seedLine(t, st, vs.ID, campaignID, "u:2", 2, ts(2), "Long ago I once saw a dragon far away")
+	seedLine(t, st, vs.ID, campaignID, "u:3", 3, ts(3), "We rested quietly at the inn")
+
+	// A second Campaign whose line matches "dragon" identically — must not leak.
+	var campaign2 uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Other', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaign2); err != nil {
+		t.Fatalf("insert campaign2: %v", err)
+	}
+	vs2, err := st.CreateVoiceSession(ctx, campaign2)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession campaign2: %v", err)
+	}
+	seedLine(t, st, vs2.ID, campaign2, "u:1", 1, ts(1), "A different dragon guards the eastern gate")
+
+	got, err := st.SearchTranscriptLines(ctx, campaignID, "dragon", 50)
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d matches %v, want 2 (both campaign-1 dragon lines, no leak)", len(got), searchLineTexts(got))
+	}
+	// AC1: the twice-mentioning line outranks the single mention.
+	if got[0].LineID != "u:1" {
+		t.Errorf("rank[0] = %q (%s), want the twice-mentioning line u:1", got[0].Text, got[0].LineID)
+	}
+	// AC5: no cross-campaign row leaks — every hit is campaign-1's session.
+	for _, l := range got {
+		if l.VoiceSessionID != vs.ID {
+			t.Errorf("cross-campaign leak: line %q belongs to session %s, not campaign-1 %s", l.Text, l.VoiceSessionID, vs.ID)
+		}
+	}
+
+	// Typeahead: a prefix term matches a longer word ("drag" → "dragon").
+	pref, err := st.SearchTranscriptLines(ctx, campaignID, "drag", 50)
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines prefix: %v", err)
+	}
+	if len(pref) != 2 {
+		t.Errorf("prefix 'drag' = %v, want the two dragon lines (typeahead prefix)", searchLineTexts(pref))
+	}
+
+	// An empty / all-punctuation query is a no-op: no matches, no error.
+	for _, q := range []string{"", "   ", "!@#$"} {
+		empty, err := st.SearchTranscriptLines(ctx, campaignID, q, 50)
+		if err != nil {
+			t.Errorf("SearchTranscriptLines(%q) err = %v, want nil", q, err)
+		}
+		if len(empty) != 0 {
+			t.Errorf("SearchTranscriptLines(%q) = %v, want no matches", q, searchLineTexts(empty))
+		}
+	}
+
+	// tsquery hardening: injected operators are sanitized to term separators by
+	// BuildTSQuery, so a query full of specials must not error — it still finds the
+	// two dragon lines (the surviving words AND-join).
+	hard, err := st.SearchTranscriptLines(ctx, campaignID, `dragon & fire | (roars) "!"`, 50)
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines with tsquery specials errored (must sanitize, not 500): %v", err)
+	}
+	if len(hard) != 1 || hard[0].LineID != "u:1" {
+		t.Errorf("specials query = %v, want only u:1 (dragon & fire & roars all in u:1)", searchLineTexts(hard))
+	}
+
+	// limit caps the result set.
+	one, err := st.SearchTranscriptLines(ctx, campaignID, "dragon", 1)
+	if err != nil {
+		t.Fatalf("SearchTranscriptLines limit=1: %v", err)
+	}
+	if len(one) != 1 {
+		t.Errorf("limit=1 returned %d rows, want 1", len(one))
+	}
+}
+
+// TestSearchTranscriptLines_UsesFtsIndex is #120's index proof: the fts match is
+// served by the transcript_line_fts_idx GIN index, not a substring scan. On a
+// tiny table the planner would prefer a seqscan, so enable_seqscan is turned off
+// inside a transaction to force the index path to show — an ILIKE substring
+// implementation could never produce this plan.
+func TestSearchTranscriptLines_UsesFtsIndex(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	for i, text := range []string{"the dragon roars", "a quiet inn", "old stone bridge"} {
+		seedLine(t, st, vs.ID, campaignID, "u:"+string(rune('1'+i)), int64(i+1), time.Now(), text)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, "SET LOCAL enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+	rows, err := tx.Query(ctx,
+		`EXPLAIN SELECT id FROM transcript_line WHERE fts @@ to_tsquery('simple', 'drag:*')`)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+	if !strings.Contains(plan.String(), "transcript_line_fts_idx") {
+		t.Errorf("query plan does not use the fts GIN index (substring scan?):\n%s", plan.String())
+	}
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -679,6 +679,52 @@ service SessionService {
   // StopSession cancels the active voice loop and returns the ended session. It
   // fails with CodeFailedPrecondition when no session is active. State-changing.
   rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
+  // SearchTranscriptLines returns the operator's Active Campaign transcript Lines
+  // whose text matches the query, ranked by relevance (#120, ADR-0011 amendment).
+  // It backs the Session screen's transcript search box and shares ONE query path
+  // (storage.SearchTranscriptLines) with `/glyphoxa search` (AC4). The Campaign is
+  // resolved server-side — the active Voice Session's campaign when live, else the
+  // Active Campaign — never a client-supplied id, so it never crosses into another
+  // campaign's transcript (AC5). An empty/whitespace query is CodeInvalidArgument.
+  // It is a read (NO_SIDE_EFFECTS), so the CSRF check is exempt.
+  rpc SearchTranscriptLines(SearchTranscriptLinesRequest) returns (SearchTranscriptLinesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}
+
+// TranscriptLineMatch is one transcript-search hit (#120): the rendered Line's
+// speaker/tag/kind, its instant and text, plus the owning session + stable line
+// id the web uses to deep-link and highlight the exact line in the Session screen.
+message TranscriptLineMatch {
+  // session_id is the Voice Session the matched Line belongs to.
+  string session_id = 1;
+  // line_id is the relay's stable Line.ID ("u:<n>" / "a:<turn>") — the key the
+  // web scrolls-to / highlights in the rendered transcript.
+  string line_id = 2;
+  // who is the speaker label (e.g. "Bart", "Player / DM").
+  string who = 3;
+  // tag is the optional pill (e.g. "NPC"); empty when none.
+  string tag = 4;
+  // kind is the line kind ∈ {gm,player,npc,butler} (ADR-0039), for styling.
+  string kind = 5;
+  // ts is when the Line was spoken.
+  google.protobuf.Timestamp ts = 6;
+  // text is the rendered Line text (the matched content).
+  string text = 7;
+}
+
+// SearchTranscriptLinesRequest carries the operator's raw search query; the
+// Active Campaign is resolved server-side (single operator, ADR-0039). An
+// empty/whitespace query is rejected with CodeInvalidArgument.
+message SearchTranscriptLinesRequest {
+  // query is the operator's raw keyword search over the transcript.
+  string query = 1;
+}
+
+// SearchTranscriptLinesResponse carries the matching Lines in relevance rank order.
+message SearchTranscriptLinesResponse {
+  // lines are the matching transcript Lines, ranked by relevance.
+  repeated TranscriptLineMatch lines = 1;
 }
 
 // VoiceSession is the wire view of a voice_sessions row (#72): the Bot's

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
 import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
@@ -21,6 +21,8 @@ import {
   StopSessionResponseSchema,
   GetActiveCampaignResponseSchema,
   CampaignSchema,
+  TranscriptLineMatchSchema,
+  SearchTranscriptLinesResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -436,5 +438,139 @@ describe("Session live transcript (#73)", () => {
     act(() => es.emit("open", null));
     act(() => es.emit("open", null));
     await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+});
+
+// searchTransport is an ended session whose persisted transcript renders, plus a
+// transcript-search RPC that filters a fixed match set by substring (a stand-in
+// for the server-side tsvector search). searchCalls records the debounced queries.
+function searchTransport(searchCalls: string[]) {
+  const started = new Date(Date.now() - 60 * 60 * 1000);
+  const ended = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "ended",
+    startedAt: timestampFromDate(started),
+    endedAt: timestampFromDate(new Date()),
+    lineCount: 2,
+  });
+  const matches = [
+    create(TranscriptLineMatchSchema, {
+      sessionId: "vs1", lineId: "a:t1", who: "Bart", tag: "NPC", kind: "npc",
+      ts: timestampFromDate(new Date()), text: "Well met, traveller.",
+    }),
+    create(TranscriptLineMatchSchema, {
+      sessionId: "vs1", lineId: "u:1", who: "Player / DM", kind: "player",
+      ts: timestampFromDate(new Date()), text: "Where is the dragon?",
+    }),
+  ];
+  return createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () => create(GetSessionResponseSchema, { session: ended, active: false }),
+      searchTranscriptLines: (req) => {
+        searchCalls.push(req.query);
+        const q = req.query.toLowerCase();
+        return create(SearchTranscriptLinesResponseSchema, {
+          lines: matches.filter((m) => m.text.toLowerCase().includes(q)),
+        });
+      },
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+}
+
+// persistedTranscriptFetch stubs the DB-backed snapshot so the ended session's
+// transcript renders (needed for the click-to-highlight deep-link).
+function persistedTranscriptFetch() {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        lines: [
+          { id: "a:t1", who: "Bart", tag: "NPC", kind: "npc", ts: new Date().toISOString(), text: "Well met, traveller." },
+          { id: "u:1", who: "Player / DM", kind: "player", ts: new Date().toISOString(), text: "Where is the dragon?" },
+        ],
+        status: "idle",
+        typing: { active: false, label: "" },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
+}
+
+function renderSearch(searchCalls: string[] = []) {
+  render(
+    <Providers transport={searchTransport(searchCalls)} queryClient={makeQueryClient()}>
+      <Session />
+    </Providers>,
+  );
+}
+
+describe("Session transcript search (#120)", () => {
+  beforeEach(persistedTranscriptFetch);
+
+  it("renders ranked matches with speaker + time for a query, no RPC before typing", async () => {
+    const searchCalls: string[] = [];
+    renderSearch(searchCalls);
+
+    await screen.findByText("Idle");
+    const box = screen.getByRole("searchbox", { name: /search the transcript/i });
+    expect(searchCalls).toHaveLength(0);
+
+    fireEvent.change(box, { target: { value: "dragon" } });
+
+    const results = await screen.findByTestId("transcript-search-results");
+    await waitFor(() => expect(within(results).getByText("Where is the dragon?")).toBeInTheDocument());
+    expect(within(results).getByText("Player / DM")).toBeInTheDocument();
+    expect(searchCalls.at(-1)).toBe("dragon");
+    // A term matching only one line does not surface the other.
+    expect(within(results).queryByText("Well met, traveller.")).not.toBeInTheDocument();
+  });
+
+  it("shows a graceful no-match message", async () => {
+    renderSearch();
+    await screen.findByText("Idle");
+    fireEvent.change(screen.getByRole("searchbox", { name: /search the transcript/i }), {
+      target: { value: "unicorn" },
+    });
+    expect(await screen.findByText(/no lines match/i)).toHaveTextContent(/unicorn/);
+  });
+
+  it("highlights the transcript line when a result is clicked (deep-link)", async () => {
+    renderSearch();
+    // The persisted transcript renders both lines.
+    expect(await screen.findByText("Where is the dragon?")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("searchbox", { name: /search the transcript/i }), {
+      target: { value: "dragon" },
+    });
+    const results = await screen.findByTestId("transcript-search-results");
+    fireEvent.click(await within(results).findByText("Where is the dragon?"));
+
+    await waitFor(() => {
+      const li = document.querySelector('[data-line-id="u:1"]');
+      expect(li).toHaveAttribute("data-highlighted", "true");
+    });
+  });
+
+  it("fires no RPC for a whitespace box and drops results when cleared", async () => {
+    const searchCalls: string[] = [];
+    renderSearch(searchCalls);
+    await screen.findByText("Idle");
+    const box = screen.getByRole("searchbox", { name: /search the transcript/i });
+
+    fireEvent.change(box, { target: { value: "   " } });
+    await new Promise((r) => setTimeout(r, 250)); // outlast the debounce
+    expect(searchCalls).toHaveLength(0);
+
+    fireEvent.change(box, { target: { value: "dragon" } });
+    await screen.findByTestId("transcript-search-results");
+    fireEvent.change(box, { target: { value: "" } });
+    await waitFor(() =>
+      expect(screen.queryByTestId("transcript-search-results")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -463,10 +463,12 @@ function searchTransport(searchCalls: string[]) {
       sessionId: "vs1", lineId: "u:1", who: "Player / DM", kind: "player",
       ts: timestampFromDate(new Date()), text: "Where is the dragon?",
     }),
-    // A hit from an EARLIER session — its line id is not in the rendered transcript.
+    // A hit from an EARLIER session that SHARES the rendered session's line id
+    // ("u:1") — relay ids restart per session, so this collision must NOT be treated
+    // as in-view (would highlight the wrong line).
     create(TranscriptLineMatchSchema, {
-      sessionId: "vsOld", lineId: "old:9", who: "Grumnir", kind: "npc",
-      ts: timestampFromDate(new Date()), text: "ancient dragon lore",
+      sessionId: "vsOld", lineId: "u:1", who: "Grumnir", kind: "npc",
+      ts: timestampFromDate(new Date()), text: "old dragon mention",
     }),
   ];
   return createRouterTransport(({ service }) => {
@@ -561,7 +563,7 @@ describe("Session transcript search (#120)", () => {
     });
   });
 
-  it("hints when a clicked hit is from an earlier session not in the view", async () => {
+  it("hints for an earlier-session hit that shares a line id, without highlighting the rendered line", async () => {
     renderSearch();
     expect(await screen.findByText("Where is the dragon?")).toBeInTheDocument();
 
@@ -570,15 +572,18 @@ describe("Session transcript search (#120)", () => {
     });
     const results = await screen.findByTestId("transcript-search-results");
 
-    // The out-of-view hit (older session) shows the hint on click.
-    fireEvent.click(await within(results).findByText("ancient dragon lore"));
+    // Click the older-session hit whose line id ("u:1") COLLIDES with the rendered
+    // line: it must show the hint AND must not highlight the rendered u:1.
+    fireEvent.click(await within(results).findByText("old dragon mention"));
     expect(await within(results).findByText(/not in the view/i)).toBeInTheDocument();
+    expect(document.querySelector('[data-line-id="u:1"]')).not.toHaveAttribute("data-highlighted");
 
-    // Clicking an in-view hit clears it — that line IS in the rendered transcript.
+    // Clicking the in-view hit (same session) highlights that line and clears the hint.
     fireEvent.click(within(results).getByText("Where is the dragon?"));
     await waitFor(() =>
-      expect(within(results).queryByText(/not in the view/i)).not.toBeInTheDocument(),
+      expect(document.querySelector('[data-line-id="u:1"]')).toHaveAttribute("data-highlighted", "true"),
     );
+    expect(within(results).queryByText(/not in the view/i)).not.toBeInTheDocument();
   });
 
   it("fires no RPC for a whitespace box and drops results when cleared", async () => {

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -463,6 +463,11 @@ function searchTransport(searchCalls: string[]) {
       sessionId: "vs1", lineId: "u:1", who: "Player / DM", kind: "player",
       ts: timestampFromDate(new Date()), text: "Where is the dragon?",
     }),
+    // A hit from an EARLIER session — its line id is not in the rendered transcript.
+    create(TranscriptLineMatchSchema, {
+      sessionId: "vsOld", lineId: "old:9", who: "Grumnir", kind: "npc",
+      ts: timestampFromDate(new Date()), text: "ancient dragon lore",
+    }),
   ];
   return createRouterTransport(({ service }) => {
     service(SessionService, {
@@ -554,6 +559,26 @@ describe("Session transcript search (#120)", () => {
       const li = document.querySelector('[data-line-id="u:1"]');
       expect(li).toHaveAttribute("data-highlighted", "true");
     });
+  });
+
+  it("hints when a clicked hit is from an earlier session not in the view", async () => {
+    renderSearch();
+    expect(await screen.findByText("Where is the dragon?")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("searchbox", { name: /search the transcript/i }), {
+      target: { value: "dragon" },
+    });
+    const results = await screen.findByTestId("transcript-search-results");
+
+    // The out-of-view hit (older session) shows the hint on click.
+    fireEvent.click(await within(results).findByText("ancient dragon lore"));
+    expect(await within(results).findByText(/not in the view/i)).toBeInTheDocument();
+
+    // Clicking an in-view hit clears it — that line IS in the rendered transcript.
+    fireEvent.click(within(results).getByText("Where is the dragon?"));
+    await waitFor(() =>
+      expect(within(results).queryByText(/not in the view/i)).not.toBeInTheDocument(),
+    );
   });
 
   it("fires no RPC for a whitespace box and drops results when cleared", async () => {

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -135,9 +135,12 @@ export function Session() {
   // where the browser supports it, scrolls to) that line in the rendered
   // transcript. A hit for a line NOT in the current view — e.g. an older session —
   // can't scroll anywhere, so the search box shows an inline "not in the view" hint
-  // instead of a dead click (ADR-0011 amendment). renderedLineIds is the set of
-  // line ids currently on screen, so the search box can tell the two apart.
+  // instead of a dead click (ADR-0011 amendment). Relay line ids RESTART per
+  // session ("u:<n>"/"a:<turn>"), so "in view" must match the hit's SESSION too —
+  // renderedSessionId + renderedLineIds — otherwise an older session's "u:3" would
+  // collide with the rendered session's own "u:3" and highlight the wrong line.
   const [highlightedLineId, setHighlightedLineId] = useState<string | null>(null);
+  const renderedSessionId = session?.id ?? null;
   const renderedLineIds = useMemo(
     () => new Set(transcript.lines.map((l) => l.id)),
     [transcript.lines],
@@ -204,7 +207,11 @@ export function Session() {
 
       <section className="gx-session__transcript">
         <h2 className="gx-section-title">{active ? "Live transcript" : "Session transcript"}</h2>
-        <TranscriptSearch onJump={jumpToLine} renderedLineIds={renderedLineIds} />
+        <TranscriptSearch
+          onJump={jumpToLine}
+          renderedSessionId={renderedSessionId}
+          renderedLineIds={renderedLineIds}
+        />
         <Card>
           {!hasLines && !showTyping ? (
             <p className="gx-session__transcript-empty">
@@ -258,14 +265,19 @@ export function Session() {
 // The server scopes the search to the operator's Active Campaign and shares the
 // one storage search path with /glyphoxa search (AC4/AC5). Each hit renders its
 // speaker, tag, timestamp, and matched text; clicking it asks the parent to
-// deep-link the line in the rendered transcript (onJump). A hit whose line is not
-// in the rendered transcript (renderedLineIds) — an older session's line — shows an
-// inline "not in the view" hint on that result rather than clicking to nothing.
+// deep-link the line in the rendered transcript (onJump). "In view" means the hit
+// belongs to the RENDERED session (renderedSessionId) AND its line is on screen
+// (renderedLineIds) — line ids restart per session, so the session must match too.
+// A hit that isn't in view (an older session's line) shows an inline "not in the
+// view" hint on that result and does NOT highlight, rather than jumping to an
+// unrelated line that happens to share the id.
 function TranscriptSearch({
   onJump,
+  renderedSessionId,
   renderedLineIds,
 }: {
   onJump: (lineId: string) => void;
+  renderedSessionId: string | null;
   renderedLineIds: Set<string>;
 }) {
   const [search, setSearch] = useState("");
@@ -286,13 +298,19 @@ function TranscriptSearch({
   );
   const lines = searchQuery.data?.lines ?? [];
 
-  // The clicked hit whose line isn't in the rendered transcript — flagged for the
-  // inline hint. Cleared on a new query so a stale hint never lingers.
-  const [notInViewLineId, setNotInViewLineId] = useState<string | null>(null);
-  useEffect(() => setNotInViewLineId(null), [debounced]);
-  const openHit = (lineId: string) => {
-    onJump(lineId);
-    setNotInViewLineId(renderedLineIds.has(lineId) ? null : lineId);
+  // The clicked hit that isn't in the rendered view — flagged for the inline hint,
+  // keyed by sessionId:lineId (line ids collide across sessions). Cleared on a new
+  // query so a stale hint never lingers.
+  const [notInViewKey, setNotInViewKey] = useState<string | null>(null);
+  useEffect(() => setNotInViewKey(null), [debounced]);
+  const hitKey = (sessionId: string, lineId: string) => `${sessionId}:${lineId}`;
+  const openHit = (sessionId: string, lineId: string) => {
+    if (sessionId === renderedSessionId && renderedLineIds.has(lineId)) {
+      onJump(lineId); // in view: highlight + scroll the rendered line
+      setNotInViewKey(null);
+    } else {
+      setNotInViewKey(hitKey(sessionId, lineId)); // older session: hint, no false highlight
+    }
   };
 
   return (
@@ -314,8 +332,8 @@ function TranscriptSearch({
         ) : lines.length > 0 ? (
           <ul className="gx-tsearch__results" data-testid="transcript-search-results">
             {lines.map((m) => (
-              <li key={`${m.sessionId}:${m.lineId}`}>
-                <button type="button" className="gx-tsearch__result" onClick={() => openHit(m.lineId)}>
+              <li key={hitKey(m.sessionId, m.lineId)}>
+                <button type="button" className="gx-tsearch__result" onClick={() => openHit(m.sessionId, m.lineId)}>
                   <span className="gx-line__who" data-kind={m.kind}>
                     {m.who}
                   </span>
@@ -327,7 +345,7 @@ function TranscriptSearch({
                   <time className="gx-line__ts">{matchClock(m.ts)}</time>
                   <span className="gx-tsearch__text">{m.text}</span>
                 </button>
-                {notInViewLineId === m.lineId && (
+                {notInViewKey === hitKey(m.sessionId, m.lineId) && (
                   <span className="gx-tsearch__hint" role="note">
                     From an earlier session — not in the view.
                   </span>

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
-import { useQueryClient } from "@tanstack/react-query";
-import { Play, Square } from "lucide-react";
+import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { Play, Square, Search } from "lucide-react";
 import { toast } from "sonner";
 import { timestampMs } from "@bufbuild/protobuf/wkt";
 
 import { SessionService, CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
-import type { VoiceSession } from "@gen/glyphoxa/management/v1/management_pb";
+import type { VoiceSession, TranscriptLineMatch } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 import { useSessionEvents, formatClock } from "./useSessionEvents";
 
 import "./session.css";
@@ -45,6 +46,13 @@ export function sessionRefetchInterval(query: { state: { data?: { active?: boole
 // tsMs converts a protobuf Timestamp to epoch milliseconds, or null when unset.
 function tsMs(ts: VoiceSession["startedAt"] | undefined): number | null {
   return ts ? Number(timestampMs(ts)) : null;
+}
+
+// matchClock renders a search hit's protobuf Timestamp as HH:MM:SS, matching the
+// transcript line timestamps (reusing formatClock via the RFC3339 instant).
+function matchClock(ts: TranscriptLineMatch["ts"] | undefined): string {
+  const ms = ts ? Number(timestampMs(ts)) : null;
+  return ms == null ? "" : formatClock(new Date(ms).toISOString());
 }
 
 // useElapsed ticks a once-per-second elapsed-seconds counter from a start instant
@@ -123,6 +131,21 @@ export function Session() {
   const hasLines = transcript.lines.length > 0;
   const showTyping = active && transcript.typing.active;
 
+  // Transcript search deep-link (#120): clicking a search hit highlights (and,
+  // where the browser supports it, scrolls to) that line in the rendered
+  // transcript. A hit for a line not in the current view — e.g. an older session —
+  // simply sets the highlight with nothing to scroll to (ADR-0011 amendment).
+  const [highlightedLineId, setHighlightedLineId] = useState<string | null>(null);
+  const jumpToLine = (lineId: string) => {
+    setHighlightedLineId(lineId);
+    const el = document.querySelector(`[data-line-id="${lineId}"]`);
+    try {
+      (el as HTMLElement | null)?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+    } catch {
+      // jsdom / older browsers: scrollIntoView is a no-op; the highlight still applies.
+    }
+  };
+
   return (
     <div className="gx-session">
       <header className="gx-session__header">
@@ -175,6 +198,7 @@ export function Session() {
 
       <section className="gx-session__transcript">
         <h2 className="gx-section-title">{active ? "Live transcript" : "Session transcript"}</h2>
+        <TranscriptSearch onJump={jumpToLine} />
         <Card>
           {!hasLines && !showTyping ? (
             <p className="gx-session__transcript-empty">
@@ -185,7 +209,12 @@ export function Session() {
           ) : (
             <ol className="gx-transcript">
               {transcript.lines.map((line) => (
-                <li key={line.id} className="gx-line">
+                <li
+                  key={line.id}
+                  className={`gx-line${highlightedLineId === line.id ? " gx-line--highlighted" : ""}`}
+                  data-line-id={line.id}
+                  data-highlighted={highlightedLineId === line.id ? "true" : undefined}
+                >
                   <span className="gx-line__who" data-kind={line.kind}>
                     {line.who}
                   </span>
@@ -212,6 +241,75 @@ export function Session() {
           )}
         </Card>
       </section>
+    </div>
+  );
+}
+
+// TranscriptSearch is the Session screen's transcript search box (#120, ADR-0011
+// amendment). It debounces the raw box value into a SearchTranscriptLines query
+// that runs ONLY while the trimmed query is non-empty — an empty box is the prompt
+// state, no RPC (keepPreviousData holds the last matches steady across keystrokes).
+// The server scopes the search to the operator's Active Campaign and shares the
+// one storage search path with /glyphoxa search (AC4/AC5). Each hit renders its
+// speaker, tag, timestamp, and matched text; clicking it asks the parent to
+// deep-link the line in the rendered transcript (onJump).
+function TranscriptSearch({ onJump }: { onJump: (lineId: string) => void }) {
+  const [search, setSearch] = useState("");
+  const [debounced, setDebounced] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 200);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const trimmed = debounced.trim();
+  const searching = trimmed !== "";
+  const searchQuery = useQuery(
+    SessionService.method.searchTranscriptLines,
+    { query: debounced },
+    // retry:false surfaces a failure promptly; a typeahead re-fires on the next
+    // keystroke anyway. keepPreviousData avoids flashing empty between keystrokes.
+    { enabled: searching, placeholderData: keepPreviousData, retry: false },
+  );
+  const lines = searchQuery.data?.lines ?? [];
+
+  return (
+    <div className="gx-tsearch">
+      <Input
+        type="search"
+        aria-label="Search the transcript"
+        icon={<Search size={15} />}
+        placeholder="Search the transcript — speakers and text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="gx-tsearch__input"
+      />
+      {searching &&
+        (searchQuery.isError ? (
+          <p className="gx-session__transcript-empty" role="alert">
+            Couldn't search the transcript: {searchQuery.error?.message}
+          </p>
+        ) : lines.length > 0 ? (
+          <ul className="gx-tsearch__results" data-testid="transcript-search-results">
+            {lines.map((m) => (
+              <li key={`${m.sessionId}:${m.lineId}`}>
+                <button type="button" className="gx-tsearch__result" onClick={() => onJump(m.lineId)}>
+                  <span className="gx-line__who" data-kind={m.kind}>
+                    {m.who}
+                  </span>
+                  {m.tag && (
+                    <span className="gx-line__tag" data-kind={m.kind}>
+                      {m.tag}
+                    </span>
+                  )}
+                  <time className="gx-line__ts">{matchClock(m.ts)}</time>
+                  <span className="gx-tsearch__text">{m.text}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          !searchQuery.isPending && <p className="gx-tsearch__empty">No lines match “{trimmed}”.</p>
+        ))}
     </div>
   );
 }

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { Play, Square, Search } from "lucide-react";
@@ -133,9 +133,15 @@ export function Session() {
 
   // Transcript search deep-link (#120): clicking a search hit highlights (and,
   // where the browser supports it, scrolls to) that line in the rendered
-  // transcript. A hit for a line not in the current view — e.g. an older session —
-  // simply sets the highlight with nothing to scroll to (ADR-0011 amendment).
+  // transcript. A hit for a line NOT in the current view — e.g. an older session —
+  // can't scroll anywhere, so the search box shows an inline "not in the view" hint
+  // instead of a dead click (ADR-0011 amendment). renderedLineIds is the set of
+  // line ids currently on screen, so the search box can tell the two apart.
   const [highlightedLineId, setHighlightedLineId] = useState<string | null>(null);
+  const renderedLineIds = useMemo(
+    () => new Set(transcript.lines.map((l) => l.id)),
+    [transcript.lines],
+  );
   const jumpToLine = (lineId: string) => {
     setHighlightedLineId(lineId);
     const el = document.querySelector(`[data-line-id="${lineId}"]`);
@@ -198,7 +204,7 @@ export function Session() {
 
       <section className="gx-session__transcript">
         <h2 className="gx-section-title">{active ? "Live transcript" : "Session transcript"}</h2>
-        <TranscriptSearch onJump={jumpToLine} />
+        <TranscriptSearch onJump={jumpToLine} renderedLineIds={renderedLineIds} />
         <Card>
           {!hasLines && !showTyping ? (
             <p className="gx-session__transcript-empty">
@@ -252,8 +258,16 @@ export function Session() {
 // The server scopes the search to the operator's Active Campaign and shares the
 // one storage search path with /glyphoxa search (AC4/AC5). Each hit renders its
 // speaker, tag, timestamp, and matched text; clicking it asks the parent to
-// deep-link the line in the rendered transcript (onJump).
-function TranscriptSearch({ onJump }: { onJump: (lineId: string) => void }) {
+// deep-link the line in the rendered transcript (onJump). A hit whose line is not
+// in the rendered transcript (renderedLineIds) — an older session's line — shows an
+// inline "not in the view" hint on that result rather than clicking to nothing.
+function TranscriptSearch({
+  onJump,
+  renderedLineIds,
+}: {
+  onJump: (lineId: string) => void;
+  renderedLineIds: Set<string>;
+}) {
   const [search, setSearch] = useState("");
   const [debounced, setDebounced] = useState("");
   useEffect(() => {
@@ -271,6 +285,15 @@ function TranscriptSearch({ onJump }: { onJump: (lineId: string) => void }) {
     { enabled: searching, placeholderData: keepPreviousData, retry: false },
   );
   const lines = searchQuery.data?.lines ?? [];
+
+  // The clicked hit whose line isn't in the rendered transcript — flagged for the
+  // inline hint. Cleared on a new query so a stale hint never lingers.
+  const [notInViewLineId, setNotInViewLineId] = useState<string | null>(null);
+  useEffect(() => setNotInViewLineId(null), [debounced]);
+  const openHit = (lineId: string) => {
+    onJump(lineId);
+    setNotInViewLineId(renderedLineIds.has(lineId) ? null : lineId);
+  };
 
   return (
     <div className="gx-tsearch">
@@ -292,7 +315,7 @@ function TranscriptSearch({ onJump }: { onJump: (lineId: string) => void }) {
           <ul className="gx-tsearch__results" data-testid="transcript-search-results">
             {lines.map((m) => (
               <li key={`${m.sessionId}:${m.lineId}`}>
-                <button type="button" className="gx-tsearch__result" onClick={() => onJump(m.lineId)}>
+                <button type="button" className="gx-tsearch__result" onClick={() => openHit(m.lineId)}>
                   <span className="gx-line__who" data-kind={m.kind}>
                     {m.who}
                   </span>
@@ -304,6 +327,11 @@ function TranscriptSearch({ onJump }: { onJump: (lineId: string) => void }) {
                   <time className="gx-line__ts">{matchClock(m.ts)}</time>
                   <span className="gx-tsearch__text">{m.text}</span>
                 </button>
+                {notInViewLineId === m.lineId && (
+                  <span className="gx-tsearch__hint" role="note">
+                    From an earlier session — not in the view.
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -124,6 +124,15 @@
   color: var(--text-muted);
 }
 
+/* Inline hint on a hit whose line isn't in the rendered transcript (an older
+ * session): explains why the click didn't scroll anywhere. */
+.gx-tsearch__hint {
+  display: block;
+  padding: 0 var(--spacing-sm) var(--spacing-xs, 4px);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 /* Deep-link highlight: the line a search hit points at, briefly emphasized. */
 .gx-line--highlighted {
   background: var(--rune-soft, rgba(120, 160, 255, 0.14));

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -76,6 +76,61 @@
   color: var(--text-muted);
 }
 
+/* Transcript search (#120): the search box sits above the transcript Card; its
+ * ranked results drop in beneath, each a clickable row that deep-links the line. */
+.gx-tsearch {
+  margin-bottom: var(--spacing-md);
+}
+
+.gx-tsearch__results {
+  list-style: none;
+  margin: var(--spacing-sm) 0 0;
+  padding: var(--spacing-xs, 4px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--border-subtle, var(--surface-inset));
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+}
+
+/* Each result: a full-width, left-aligned button styled like a transcript line. */
+.gx-tsearch__result {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  width: 100%;
+  text-align: left;
+  padding: var(--spacing-xs, 4px) var(--spacing-sm);
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1.5;
+}
+.gx-tsearch__result:hover,
+.gx-tsearch__result:focus-visible {
+  background: var(--surface-raised, rgba(255, 255, 255, 0.04));
+}
+
+.gx-tsearch__text {
+  color: var(--text-default);
+}
+
+.gx-tsearch__empty {
+  margin: var(--spacing-sm) 0 0;
+  color: var(--text-muted);
+}
+
+/* Deep-link highlight: the line a search hit points at, briefly emphasized. */
+.gx-line--highlighted {
+  background: var(--rune-soft, rgba(120, 160, 255, 0.14));
+  border-radius: var(--radius-sm, 4px);
+  box-shadow: 0 0 0 2px var(--rune, rgba(120, 160, 255, 0.5)) inset;
+}
+
 /* Live transcript list: one row per line — speaker name, optional tag pill,
  * timestamp, then the utterance text. */
 .gx-transcript {


### PR DESCRIPTION
Closes #120
Supersedes #217 (this is #217 rebased onto #216 + an alignment commit; pushed as a fresh branch to avoid a force-push of a published ref).

## What

One user-facing full-text search over the Active Campaign's persisted transcript, surfaced in both the web Session screen and Discord, sharing a single query path.

- **Storage (migration 00015):** a generated `fts tsvector` column + GIN index on `transcript_line` (Line grain, ADR-0011 2026-07-04 amendment), and `storage.SearchTranscriptLines(campaignID, query, limit)` — the ONE search path, campaign-scoped, ranked with `ts_rank`, reusing the existing `BuildTSQuery` sanitizer.
- **RPC:** `SessionService.SearchTranscriptLines` (NO_SIDE_EFFECTS, CSRF-exempt read). Campaign resolved server-side via the SAME profile-first `startCampaign` as `StartSession` (durable `/glyphoxa use` selection → most-recent fallback) — never a client id (AC5).
- **Discord:** `/glyphoxa search <query>` (GM-only, operator-allowlisted). Defers, bounds its own DB timeout, resolves the Active Campaign via the SHARED `resolveActiveCampaign` (live session → durable selection → strict `run /glyphoxa use` hint), quotes the top 5 matches with speaker + timestamp. Replies are capped under Discord's 2000-char limit (per-line + total truncation).
- **Web:** a debounced transcript search box on the Session screen; ranked results with speaker/tag/timestamp/text; clicking a hit deep-links + highlights the line, or shows a "from an earlier session — not in the view" hint when it isn't rendered. Empty query = prompt state (no RPC), no-match = graceful message.

## Relationship to #216 / #108

Both search surfaces now route through #108's shared Active-Campaign resolution — no divergent copy: the slash command reuses `presence.resolveActiveCampaign`, the web RPC reuses `startCampaign`. So `/glyphoxa search`, `/glyphoxa start`, and the web Start button always agree on which campaign is in scope.

## Acceptance criteria

- [x] AC1 — ranked full-text matches for a query term
- [x] AC2 — web search box with speaker + time; empty-query & no-match handled gracefully
- [x] AC3 — `/glyphoxa search <query>` returns top matches, GM-only + permission-checked
- [x] AC4 — web + slash command share one query path; no divergent search logic
- [x] AC5 — scoped to the operator's Active Campaign; never another campaign's transcript

## Tests

Storage integration (ranking, campaign isolation, empty/no-match, tsquery hardening, GIN plan, migration up/down on the 00014+00015 stack); RPC (profile-first scope, empty-query, no-campaign empty, mapping, auth + CSRF-exemption parity); presence (Defer, formatting, empty/no-match, no-campaign hint, live-vs-durable precedence, GM-only, truncation caps); web vitest (results, no-match, click-to-highlight, out-of-view hint, empty/clear).

Local: `go build`/`vet ./...` clean, golangci-lint 0 issues, `presence`+`rpc` `-race` green, web `npm run build` + vitest green, storage integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)