### PR TITLE
fix(#220): idle GetSession resolves campaign durable-first

### DIFF
--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -100,9 +100,12 @@ func (s *SessionServer) GetSession(
 		}), nil
 	}
 
-	// Idle: surface the last session for the active campaign, if any. A missing
-	// campaign or no prior session is the never-run state, not an error.
-	campaign, err := s.store.GetActiveCampaign(ctx)
+	// Idle: surface the last session for the active campaign, if any. Resolve it
+	// with the SAME profile-first startCampaign StartSession binds (durable
+	// /glyphoxa use selection → most-recent fallback, #216/#220) so the idle summary
+	// never describes a different campaign than Start would run or search would scope
+	// to. A missing campaign or no prior session is the never-run state, not an error.
+	campaign, err := s.startCampaign(ctx)
 	if errors.Is(err, storage.ErrNotFound) {
 		return connect.NewResponse(&managementv1.GetSessionResponse{Active: false}), nil
 	}

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -148,12 +148,13 @@ func (f *fakeSessionManager) mutedIDsLocked() []string {
 // (#120), recording the campaign + query the handler resolved so the scope
 // precedence can be asserted.
 type fakeSessionStore struct {
-	forUser     storage.Campaign // the operator's /glyphoxa use selection (#108)
-	forUserErr  error            // set to storage.ErrNotFound to force the fallback
-	campaign    storage.Campaign
-	campaignErr error
-	latest      storage.VoiceSession
-	latestErr   error
+	forUser        storage.Campaign // the operator's /glyphoxa use selection (#108)
+	forUserErr     error            // set to storage.ErrNotFound to force the fallback
+	campaign       storage.Campaign
+	campaignErr    error
+	latest         storage.VoiceSession
+	latestErr      error
+	latestCampaign uuid.UUID // the campaign id the idle GetSession resolved (#220)
 
 	searchLines    []storage.TranscriptLine
 	searchErr      error
@@ -179,7 +180,8 @@ func (f *fakeSessionStore) GetActiveCampaign(context.Context) (storage.Campaign,
 	return f.campaign, nil
 }
 
-func (f *fakeSessionStore) GetLatestVoiceSession(context.Context, uuid.UUID) (storage.VoiceSession, error) {
+func (f *fakeSessionStore) GetLatestVoiceSession(_ context.Context, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	f.latestCampaign = campaignID
 	if f.latestErr != nil {
 		return storage.VoiceSession{}, f.latestErr
 	}
@@ -607,6 +609,46 @@ func TestSessionStartFallsBackWithoutSelection(t *testing.T) {
 	}
 	if start.Msg.GetSession().GetCampaignId() != newer.ID.String() {
 		t.Errorf("bound campaign = %s, want the fallback %s", start.Msg.GetSession().GetCampaignId(), newer.ID)
+	}
+}
+
+// TestSessionGetIdleHonorsDurableSelection is #220: with the operator's /glyphoxa
+// use selection set (campaign A) AND a newer implicit default (campaign B) and no
+// live session, the idle GetSession last-session summary resolves campaign A — the
+// SAME profile-first startCampaign StartSession binds — so the Session screen never
+// describes campaign B while Start would run A. Repro: /use A, newer B exists, no
+// session running → idle summary must scope to A (GetLatestVoiceSession(A)).
+func TestSessionGetIdleHonorsDurableSelection(t *testing.T) {
+	t.Parallel()
+	selected := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Selected A"}
+	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer B"}
+	store := &fakeSessionStore{forUser: selected, campaign: newer, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, &fakeSessionManager{}, store, storage.User{DiscordUserID: "999"})
+
+	if _, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{})); err != nil {
+		t.Fatalf("GetSession idle: %v", err)
+	}
+	if store.latestCampaign != selected.ID {
+		t.Errorf("idle summary scoped to %s, want the durable selection %s (not the newer default %s)",
+			store.latestCampaign, selected.ID, newer.ID)
+	}
+}
+
+// TestSessionGetIdleFallsBackWithoutSelection pins the fallback half of #220: an
+// operator with no /glyphoxa use selection falls back to the most-recently-created
+// campaign (GetActiveCampaign) for the idle summary — mirroring StartSession, so the
+// deleted-campaign SET NULL path (selection → ErrNotFound) still surfaces a summary.
+func TestSessionGetIdleFallsBackWithoutSelection(t *testing.T) {
+	t.Parallel()
+	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer B"}
+	store := &fakeSessionStore{forUserErr: storage.ErrNotFound, campaign: newer, latestErr: storage.ErrNotFound}
+	client := newSessionClientAs(t, &fakeSessionManager{}, store, storage.User{DiscordUserID: "999"})
+
+	if _, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{})); err != nil {
+		t.Fatalf("GetSession idle: %v", err)
+	}
+	if store.latestCampaign != newer.ID {
+		t.Errorf("idle summary scoped to %s, want the fallback %s", store.latestCampaign, newer.ID)
 	}
 }
 


### PR DESCRIPTION
## What

`SessionService.GetSession`'s **idle** last-session summary path resolved the campaign via plain `store.GetActiveCampaign` (most-recently-created), while `StartSession` (#216) and `SearchTranscriptLines` (#219) already resolve **profile-first** via `startCampaign` (the operator's durable `/glyphoxa use` selection → most-recent fallback).

Symptom: operator selects an older campaign A via `/glyphoxa use`, no session running → the Session screen idle summary describes campaign B (newest), while Start would bind A and search scopes to A. One screen, two campaigns.

## Fix

Route `GetSession`'s idle branch through the **same** `startCampaign` helper `StartSession` uses. Now `GetSession` / `StartSession` / `SearchTranscriptLines` are coherent: live (Snapshot-first) → durable (`GetActiveCampaignForUser`) → legacy (`GetActiveCampaign`) fallback. The LIVE Snapshot-first path is untouched, and the selection-`ErrNotFound` fallback (deleted-campaign `SET NULL`) still surfaces a summary.

No new resolution copy — reuses the existing profile-first helper.

## Tests (TDD, red first)

- `TestSessionGetIdleHonorsDurableSelection` — operator selected older A, newer B exists, no live session → idle summary scopes to A (was RED: scoped to B).
- `TestSessionGetIdleFallsBackWithoutSelection` — no `/glyphoxa use` selection → falls back to most-recent (the `SET NULL` path).
- Live-precedence + existing idle/last-session tests stay green.

The `fakeSessionStore` now records the campaign id the idle `GetSession` passed to `GetLatestVoiceSession`, so scope precedence is asserted directly.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)