### PR TITLE
fix(#215): Tool Grant follow-ups — ghost-agent NotFound, canonical mapper, scope-editor UX

### DIFF
--- a/internal/rpc/campaign_grant.go
+++ b/internal/rpc/campaign_grant.go
@@ -35,6 +35,12 @@ func (s *CampaignServer) ListToolGrants(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
 	}
+	// Pre-check the Agent exists so a stale tab (Agent deleted elsewhere) reads a
+	// clean CodeNotFound instead of a fabricated full-catalog-ungranted list
+	// (issue #215) — the sibling CRUD missing-Agent mapping (campaign_crud.go).
+	if err := s.requireAgent(ctx, agentID); err != nil {
+		return nil, err
+	}
 
 	grants, err := s.toolGrantsFor(ctx, agentID)
 	if err != nil {
@@ -65,6 +71,12 @@ func (s *CampaignServer) UpdateToolGrant(
 	registered, ok := s.tools.Get(m.GetToolName())
 	if !ok {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("unknown tool"))
+	}
+	// Pre-check the Agent exists so granting for a deleted Agent (stale second
+	// tab) is CodeNotFound, not a tool_agent_grant FK violation surfaced as a 500
+	// (issue #215) — mirrors the sibling UpdateAgent/DeleteAgent mapping.
+	if err := s.requireAgent(ctx, agentID); err != nil {
+		return nil, err
 	}
 
 	if m.GetGranted() {
@@ -105,6 +117,21 @@ func (s *CampaignServer) UpdateToolGrant(
 	// The Tool is registered, so toolGrantsFor always emits an entry for it.
 	slog.Default().Error("UpdateToolGrant: toggled tool missing from catalog", "tool", registered.Name())
 	return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+}
+
+// requireAgent maps a missing Agent to CodeNotFound (any other lookup failure to
+// CodeInternal) so both grant handlers reject a stale-tab agent_id up front
+// rather than persist against — or fabricate a catalog for — an Agent the FK no
+// longer has (issue #215). Identical shape to the sibling CRUD mutations.
+func (s *CampaignServer) requireAgent(ctx context.Context, agentID uuid.UUID) error {
+	if _, err := s.store.GetAgent(ctx, agentID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("tool grant: agent lookup failed", "agent_id", agentID, "err", err)
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return nil
 }
 
 // toolGrantsFor joins the built-in Tool catalog with an Agent's persisted grant

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -175,25 +175,19 @@ func grantedNames(grants []*managementv1.ToolGrant) []string {
 }
 
 // hydratedDeclarations replays the #113 hydration path against the persisted rows
-// using the PUBLIC tool package the live loop shares: read the Agent's Tool Grant
-// rows, build a real GrantSet over the built-in Registry, and return the Tool
-// names it would declare to the LLM. This is exactly what loadSeededNPCs does at
-// Voice Session start, so it proves a grant mutation takes effect on the next
-// session without new plumbing (AC4).
+// through the SAME canonical mapper the live loop uses ([storage.GrantsFromRows],
+// via wirenpc.grantsFromRows): read the Agent's Tool Grant rows, build a real
+// GrantSet over the built-in Registry, and return the Tool names it would declare
+// to the LLM. Calling the shared mapper — rather than reimplementing it here —
+// means this AC4 assertion can never drift from what loadSeededNPCs actually
+// hydrates at Voice Session start (issue #215).
 func hydratedDeclarations(t *testing.T, store *storage.Store, agentID uuid.UUID) []string {
 	t.Helper()
 	rows, err := store.ListToolGrants(context.Background(), agentID)
 	if err != nil {
 		t.Fatalf("hydrate: ListToolGrants(%s): %v", agentID, err)
 	}
-	grants := make([]tool.Grant, 0, len(rows))
-	for _, r := range rows {
-		g := tool.Grant{ToolName: r.ToolName}
-		if len(r.Config) > 0 {
-			g.Config = r.Config
-		}
-		grants = append(grants, g)
-	}
+	grants := storage.GrantsFromRows(rows)
 	decls := tool.NewGrantSet(tool.BuiltinRegistry(), grants...).Declarations()
 	names := make([]string, len(decls))
 	for i, d := range decls {

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -106,6 +106,53 @@ func TestToolGrants_Integration(t *testing.T) {
 	}
 }
 
+// TestToolGrants_GhostAgent_Integration proves the #215 existence pre-check
+// against a real Postgres: a Character NPC is created, granted dice (a real
+// tool_agent_grant row), then deleted — the FK CASCADE removes the grant, leaving
+// a dangling agent_id (the stale second tab). Operating on the now-ghost id is
+// CodeNotFound on BOTH grant RPCs, not the 500 the FK violation would otherwise
+// surface on the write (the unit fakes can't see the FK — this is the coverage
+// the follow-up adds).
+func TestToolGrants_GhostAgent_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, _ := seedStore(t, dsn)
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	created, err := client.CreateAgent(ctx, connect.NewRequest(&managementv1.CreateAgentRequest{Name: "Doomed"}))
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	ghost := created.Msg.GetAgent().GetId()
+
+	// A real grant row exists, then the Agent is deleted: the FK CASCADE
+	// (tool_agent_grant.agent_id) removes the grant, leaving a dangling id.
+	if _, err := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: ghost, ToolName: "dice", Granted: true,
+	})); err != nil {
+		t.Fatalf("UpdateToolGrant(grant): %v", err)
+	}
+	if _, err := client.DeleteAgent(ctx, connect.NewRequest(&managementv1.DeleteAgentRequest{Id: ghost})); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	_, listErr := client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: ghost}))
+	if got := connect.CodeOf(listErr); got != connect.CodeNotFound {
+		t.Errorf("ListToolGrants(ghost) code = %v, want NotFound", got)
+	}
+	_, updErr := client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: ghost, ToolName: "dice", Granted: true,
+	}))
+	if got := connect.CodeOf(updErr); got != connect.CodeNotFound {
+		t.Errorf("UpdateToolGrant(ghost) code = %v, want NotFound", got)
+	}
+}
+
 // listGrants is a small helper that lists an Agent's grant states or fails the test.
 func listGrants(t *testing.T, client managementv1connect.CampaignServiceClient, agentID string) []*managementv1.ToolGrant {
 	t.Helper()

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
+// registerAgent seeds a bare Agent row so the grant handlers' existence pre-check
+// (issue #215) passes; these tests only need the Agent to exist, not its fields.
+func registerAgent(store *fakeCampaignStore) uuid.UUID {
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id}
+	return id
+}
+
 // TestListToolGrants_CatalogWithState is the AC1 bar over the handler: the list
 // shows EVERY built-in Tool (dice today) with the Agent's current grant state.
 // An ungranted Agent sees dice present-but-off; granting flips it on. Because the
@@ -24,7 +32,7 @@ import (
 func TestListToolGrants_CatalogWithState(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	agentID := uuid.New()
+	agentID := registerAgent(store)
 	client := crudClient(t, store)
 
 	// No grant rows: dice is listed but not granted, and advertises no scope.
@@ -64,6 +72,30 @@ func TestListToolGrants_CatalogWithState(t *testing.T) {
 	}
 }
 
+// TestToolGrant_GhostAgentNotFound: operating on an agent_id that doesn't exist
+// (a stale second tab after the Agent was deleted) is CodeNotFound on BOTH the
+// list read and the grant write. The handler pre-checks Agent existence
+// (GetAgent) rather than letting the write surface the tool_agent_grant FK
+// violation as a 500 (issue #215), mirroring the sibling UpdateAgent/DeleteAgent
+// missing-Agent mapping.
+func TestToolGrant_GhostAgentNotFound(t *testing.T) {
+	t.Parallel()
+	client := crudClient(t, newFakeStore()) // empty store → no Agent exists
+	ghost := uuid.New().String()
+
+	_, listErr := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: ghost}))
+	if got := connect.CodeOf(listErr); got != connect.CodeNotFound {
+		t.Errorf("ListToolGrants(ghost) code = %v, want NotFound", got)
+	}
+
+	_, updErr := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{AgentId: ghost, ToolName: "dice", Granted: true}))
+	if got := connect.CodeOf(updErr); got != connect.CodeNotFound {
+		t.Errorf("UpdateToolGrant(ghost) code = %v, want NotFound", got)
+	}
+}
+
 func TestListToolGrants_InvalidAgentID(t *testing.T) {
 	t.Parallel()
 	client := crudClient(t, newFakeStore())
@@ -80,7 +112,7 @@ func TestListToolGrants_InvalidAgentID(t *testing.T) {
 func TestUpdateToolGrant_ToggleRoundTrips(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	agentID := uuid.New()
+	agentID := registerAgent(store)
 	client := crudClient(t, store)
 
 	on, err := client.UpdateToolGrant(context.Background(),
@@ -118,7 +150,7 @@ func TestUpdateToolGrant_ToggleRoundTrips(t *testing.T) {
 func TestUpdateToolGrant_ConfigRoundTrips(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	agentID := uuid.New()
+	agentID := registerAgent(store)
 	client := crudClient(t, store)
 
 	scope := `{"scope":"self"}`
@@ -169,10 +201,12 @@ func TestUpdateToolGrant_UnknownToolRejected(t *testing.T) {
 
 func TestUpdateToolGrant_InvalidConfigRejected(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	store := newFakeStore()
+	agentID := registerAgent(store)
+	client := crudClient(t, store)
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
-			AgentId: uuid.New().String(), ToolName: "dice", Granted: true, Config: "{not json",
+			AgentId: agentID.String(), ToolName: "dice", Granted: true, Config: "{not json",
 		}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
 		t.Errorf("code = %v, want InvalidArgument for malformed config", got)
@@ -194,10 +228,12 @@ func TestUpdateToolGrant_InvalidAgentID(t *testing.T) {
 // errors.
 func TestUpdateToolGrant_RevokeIsIdempotent(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	store := newFakeStore()
+	agentID := registerAgent(store)
+	client := crudClient(t, store)
 	if _, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
-			AgentId: uuid.New().String(), ToolName: "dice", Granted: false,
+			AgentId: agentID.String(), ToolName: "dice", Granted: false,
 		})); err != nil {
 		t.Errorf("revoking an ungranted Tool should succeed, got %v", err)
 	}

--- a/internal/storage/tool_grant_mapping.go
+++ b/internal/storage/tool_grant_mapping.go
@@ -1,0 +1,32 @@
+package storage
+
+import "github.com/MrWong99/Glyphoxa/pkg/tool"
+
+// GrantsFromRows maps an Agent's persisted Tool Grant rows to the in-memory
+// [tool.Grant]s the live loop hydrates into a [tool.GrantSet] (#113, ADR-0029) —
+// the identical shape the orchestrator consumes, so the loop never knows the
+// grants came from the DB. A row's jsonb config becomes Grant.Config as a
+// [json.RawMessage] (nil when the column is NULL — dice's shape); the Tool
+// handler receives it as grantConfig at execution time and enforces scope there,
+// never the LLM. No rows yields no grants: the Agent is shown no Tool at all.
+//
+// This is the SINGLE canonical row→Grant mapping. wirenpc's live loop and the
+// grant RPC's AC4 hydration test both call it, so neither can drift from the
+// other (issue #215). It is the one place in this package that depends on
+// pkg/tool — the vendor-neutral CRUD in tool_grant.go keeps the storage rows a
+// raw blob; only this shared mapper crosses into the Tool domain, and the
+// dependency is one-way (pkg/tool never imports internal/*).
+func GrantsFromRows(rows []ToolGrant) []tool.Grant {
+	if len(rows) == 0 {
+		return nil
+	}
+	grants := make([]tool.Grant, 0, len(rows))
+	for _, r := range rows {
+		g := tool.Grant{ToolName: r.ToolName}
+		if len(r.Config) > 0 {
+			g.Config = r.Config // json.RawMessage; the handler decodes its scope
+		}
+		grants = append(grants, g)
+	}
+	return grants
+}

--- a/internal/storage/tool_grant_mapping_test.go
+++ b/internal/storage/tool_grant_mapping_test.go
@@ -1,0 +1,66 @@
+package storage_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// GrantsFromRows is the single canonical row→Grant mapper the live loop (wirenpc)
+// and the grant RPC's hydration test both consume (issue #215): keeping it here
+// kills the drift a second reimplementation invited. These pin its behaviour
+// directly, no database.
+
+// TestGrantsFromRows_NoRows: an Agent with no grant rows maps to no grants
+// (least-privilege — the LLM is shown no Tool).
+func TestGrantsFromRows_NoRows(t *testing.T) {
+	if got := storage.GrantsFromRows(nil); len(got) != 0 {
+		t.Fatalf("no rows produced %d grants, want 0", len(got))
+	}
+}
+
+// TestGrantsFromRows_DiceNilConfig: a config-less row (dice's shape) maps to a
+// Grant with a nil Config.
+func TestGrantsFromRows_DiceNilConfig(t *testing.T) {
+	got := storage.GrantsFromRows([]storage.ToolGrant{{ToolName: "dice"}})
+	if len(got) != 1 {
+		t.Fatalf("got %d grants, want 1", len(got))
+	}
+	if got[0].ToolName != "dice" || got[0].Config != nil {
+		t.Errorf("dice grant = %+v, want {dice <nil>}", got[0])
+	}
+}
+
+// TestGrantsFromRows_PreservesConfig: a row's jsonb config becomes Grant.Config
+// as a json.RawMessage with the bytes preserved (so scope reaches the Tool
+// handler, ADR-0029).
+func TestGrantsFromRows_PreservesConfig(t *testing.T) {
+	cfg := json.RawMessage(`{"scope":"self"}`)
+	got := storage.GrantsFromRows([]storage.ToolGrant{
+		{ToolName: "dice"},
+		{ToolName: "remember_knowledge", Config: cfg},
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d grants, want 2", len(got))
+	}
+	raw, ok := got[1].Config.(json.RawMessage)
+	if !ok {
+		t.Fatalf("scoped Config type = %T, want json.RawMessage", got[1].Config)
+	}
+	if string(raw) != string(cfg) {
+		t.Errorf("scoped Config = %q, want %q", raw, cfg)
+	}
+}
+
+// TestGrantsFromRows_HydratesDeclarations: the mapped grants feed a real GrantSet
+// whose Declarations() is exactly the granted Tools — the live-loop hydration the
+// grant RPC's AC4 test asserts through this same function.
+func TestGrantsFromRows_HydratesDeclarations(t *testing.T) {
+	grants := storage.GrantsFromRows([]storage.ToolGrant{{ToolName: "dice"}})
+	decls := tool.NewGrantSet(tool.BuiltinRegistry(), grants...).Declarations()
+	if len(decls) != 1 || decls[0].Name != "dice" {
+		t.Fatalf("declared %+v, want exactly [dice]", decls)
+	}
+}

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -252,26 +252,13 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 	return specs, primary, campaign, nil
 }
 
-// grantsFromRows maps an Agent's persisted Tool Grant rows to the in-memory
-// [tool.Grant]s the live loop hydrates into a [tool.GrantSet] (#113, ADR-0029) —
-// the identical shape the orchestrator already consumes, so the loop never knows
-// the grants came from the DB. A row's jsonb config becomes Grant.Config as a
-// [json.RawMessage] (nil when the column is NULL — dice's shape), which the Tool
-// handler receives as grantConfig at execution time and enforces there, never
-// the LLM. No rows yields no grants: the Agent is shown no Tool at all.
+// grantsFromRows hydrates an Agent's persisted Tool Grant rows into the in-memory
+// [tool.Grant]s the voice loop builds its GrantSet from (#113). It delegates to
+// the canonical [storage.GrantsFromRows] so the live loop and the grant RPC's
+// AC4 hydration test share ONE mapping and can't drift (issue #215) — the
+// behaviour is unchanged, this is just the single source of truth.
 func grantsFromRows(rows []storage.ToolGrant) []tool.Grant {
-	if len(rows) == 0 {
-		return nil
-	}
-	grants := make([]tool.Grant, 0, len(rows))
-	for _, r := range rows {
-		g := tool.Grant{ToolName: r.ToolName}
-		if len(r.Config) > 0 {
-			g.Config = r.Config // json.RawMessage; the handler decodes its scope
-		}
-		grants = append(grants, g)
-	}
-	return grants
+	return storage.GrantsFromRows(rows)
 }
 
 // npcSpecFromAgent maps a storage.Agent (vendor-neutral) to the voice-domain

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -154,6 +154,40 @@ function renderScreen() {
   return { npcs, previewCalls, grants };
 }
 
+// scopedTransport serves a single scope-supporting Tool (remember_knowledge)
+// whose grant state mutates in-closure and records every UpdateToolGrant call, so
+// a test can prove what the grant Switch versus the Save-scope button actually
+// send (#215). It mirrors the handler: a granted=true call with an empty config
+// stores no scope (a fresh grant), and granted=false clears it.
+function scopedTransport(initial: { granted: boolean; config: string }) {
+  const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+  const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+  const npc = create(AgentSchema, { id: "n1", campaignId: "c1", role: "character", name: "Bart", voice: "rachel" });
+  let state = { ...initial };
+  const calls: { granted: boolean; config: string }[] = [];
+  const entry = () =>
+    create(ToolGrantSchema, {
+      toolName: "remember_knowledge",
+      description: "Remember a fact.",
+      granted: state.granted,
+      config: state.config,
+      supportsScope: true,
+    });
+  const transport = createRouterTransport(({ service }) => {
+    service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+    service(CampaignService, {
+      getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+      listToolGrants: () => create(ListToolGrantsResponseSchema, { grants: [entry()] }),
+      updateToolGrant: (req) => {
+        calls.push({ granted: req.granted, config: req.config });
+        state = { granted: req.granted, config: req.granted ? req.config : "" };
+        return create(UpdateToolGrantResponseSchema, { grant: entry() });
+      },
+    });
+  });
+  return { transport, calls, state: () => state };
+}
+
 describe("Campaign", () => {
   it("renders the live campaign title and roster", async () => {
     renderScreen();
@@ -440,5 +474,55 @@ describe("Campaign", () => {
     fireEvent.change(scope, { target: { value: '{"scope":"campaign"}' } });
     fireEvent.click(screen.getByRole("button", { name: /save scope/i }));
     await waitFor(() => expect(configs).toContain('{"scope":"campaign"}'));
+  });
+
+  it("the grant Switch never persists an unsaved scope edit; only Save scope does (#215)", async () => {
+    const { transport, calls } = scopedTransport({ granted: true, config: '{"scope":"self"}' });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    const scope = (await screen.findByLabelText("remember_knowledge scope")) as HTMLInputElement;
+    expect(scope.value).toBe('{"scope":"self"}');
+
+    // Edit the scope but do NOT click Save scope, then flip the grant Switch off.
+    fireEvent.change(scope, { target: { value: '{"scope":"campaign"}' } });
+    fireEvent.click(screen.getByLabelText("remember_knowledge"));
+
+    // The toggle mutation fired for the revoke and carried NO config — the unsaved
+    // draft was never sent, so a stray edit can't silently persist on a toggle.
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].granted).toBe(false);
+    expect(calls[0].config).toBe("");
+  });
+
+  it("toggling a grant off then on does not resurrect the pre-revoke scope (#215)", async () => {
+    const { transport, calls, state } = scopedTransport({ granted: true, config: '{"scope":"self"}' });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("Bart"));
+    const sw = await screen.findByLabelText("remember_knowledge");
+    expect(sw).toBeChecked();
+
+    // Revoke (deletes the row), then re-grant.
+    fireEvent.click(sw);
+    await waitFor(() => expect(screen.getByLabelText("remember_knowledge")).not.toBeChecked());
+    fireEvent.click(screen.getByLabelText("remember_knowledge"));
+    await waitFor(() => expect(screen.getByLabelText("remember_knowledge")).toBeChecked());
+
+    // The re-grant is a FRESH grant with no scope — the deleted config is gone, not
+    // resurrected from local state — and the reappeared editor shows the server
+    // value (empty), not the stale pre-revoke draft.
+    expect(state().config).toBe("");
+    const rescope = (await screen.findByLabelText("remember_knowledge scope")) as HTMLInputElement;
+    expect(rescope.value).toBe("");
+    const onCall = calls[calls.length - 1];
+    expect(onCall.granted).toBe(true);
+    expect(onCall.config).toBe("");
   });
 });

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -445,8 +445,15 @@ function ToolRow({
     onError: (err) => toast.error(`Couldn't update ${grant.toolName}: ${err.message}`),
   });
 
-  const toggle = (granted: boolean) =>
-    update.mutate({ agentId, toolName: grant.toolName, granted, config: scope });
+  // The grant Switch never carries the local scope draft (#215): turning a grant
+  // ON creates a FRESH grant with no scope (empty config → SQL NULL), turning it
+  // OFF deletes the row. Only "Save scope" persists config. Resetting the draft to
+  // the server value on every toggle stops an unsaved edit from silently
+  // persisting and stops an off→on from resurrecting the pre-revoke scope.
+  const toggle = (granted: boolean) => {
+    setScope(grant.config);
+    update.mutate({ agentId, toolName: grant.toolName, granted });
+  };
   const saveScope = () =>
     update.mutate({ agentId, toolName: grant.toolName, granted: true, config: scope });
 


### PR DESCRIPTION
Closes #215

Three accepted-as-follow-up items from the PR #214 (issue #117) review, each a small TDD vertical slice.

## 1. Ghost-agent grant → CodeNotFound, not 500
Both grant RPCs now pre-check the Agent exists (`GetAgent`, in a shared `requireAgent` helper) before touching grants. A stale second tab operating on a deleted Agent gets a clean `CodeNotFound` instead of:
- `UpdateToolGrant`: the `tool_agent_grant` FK violation surfaced as `CodeInternal` (500 + error log).
- `ListToolGrants`: a fabricated full-catalog-ungranted list.

Mirrors the sibling `UpdateAgent`/`DeleteAgent` missing-Agent mapping. Tool-name validation still fires first (unknown tool stays `InvalidArgument`). Covered by unit tests (unknown `agent_id` → NotFound on both RPCs) **and** an integration test that drives a real create→grant→delete→FK-CASCADE against Postgres — the path the unit fakes can't see.

## 2. Single canonical row→Grant mapper
The AC4 hydration test had reimplemented wirenpc's unexported `grantsFromRows`, so a drift in the live mapper would leave the test green while the Voice Session diverged. Moved the canonical mapping to `storage.GrantsFromRows` (the one place in `internal/storage` that imports `pkg/tool`, one-way). `wirenpc.grantsFromRows` now delegates to it (behaviour unchanged, existing wirenpc tests stay green), and the rpc integration test calls the same function instead of its own copy.

## 3. Scope-editor UX quirks
Decided semantics for `ToolRow`: the grant **Switch never carries the local scope draft** — ON creates a fresh grant with `config` null, OFF deletes the row, and only **Save scope** sends config; the draft also resets to the server value on toggle. This kills both quirks: an unsaved edit no longer silently persists on toggle, and off→on no longer resurrects the pre-revoke config from local state. Vitest covers both against a mocked scoped Tool (dice renders no editor).

## Verification (local)
- `go build ./...`, `go vet`, `golangci-lint run` — clean (0 issues)
- `go test -race ./internal/rpc/ ./internal/storage/ ./internal/wirenpc/` — green
- `go test -tags integration ./internal/rpc/ ./internal/wirenpc/` — green (real Postgres)
- `npm run build` (tsc + vite) + `npm run test` — 90/90 web tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)