### PR TITLE
fix(#209): confirm dialog before KG node/edge hard-delete

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@connectrpc/connect": "^2.1.0",
         "@connectrpc/connect-query": "^2.1.0",
         "@connectrpc/connect-web": "^2.1.0",
+        "@radix-ui/react-alert-dialog": "^1.1.18",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-switch": "^1.2.6",
         "@tanstack/react-query": "^5.90.2",
@@ -769,6 +770,56 @@
       "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.18.tgz",
+      "integrity": "sha512-6c2cXpNlAgHDhKguK24XcWHHayMpK+lk7/WwBXBco+ZJ4Dv7xP++GBM280KgTD/HCRu3jSdfe8WQiZssonYaIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dialog": "1.1.18",
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
@@ -849,25 +900,124 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
-      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz",
+      "integrity": "sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-focus-scope": "1.1.11",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz",
+      "integrity": "sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz",
+      "integrity": "sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "@connectrpc/connect": "^2.1.0",
     "@connectrpc/connect-query": "^2.1.0",
     "@connectrpc/connect-web": "^2.1.0",
+    "@radix-ui/react-alert-dialog": "^1.1.18",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-switch": "^1.2.6",
     "@tanstack/react-query": "^5.90.2",

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,28 +1,29 @@
+import { forwardRef } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 // Button — ported from the handoff components/core/Button.jsx onto the .gx-btn
 // class vocabulary (CSS lifted into styles/components.css). Protocol mechanics:
 // 2px border, bold, invert/glow on hover, in arcane dress.
+//
+// forwardRef so Radix `asChild` slots (e.g. AlertDialog Cancel/Action in
+// ConfirmDialog, #209) can attach their ref — without it the ref is dropped and
+// AlertDialog's focus management silently no-ops.
 
 type Variant = "primary" | "secondary" | "ghost" | "gold" | "danger";
 type Size = "sm" | "md" | "lg";
 
-export function Button({
-  variant = "primary",
-  size = "md",
-  block = false,
-  iconStart,
-  iconEnd,
-  className = "",
-  children,
-  ...props
-}: {
+type ButtonProps = {
   variant?: Variant;
   size?: Size;
   block?: boolean;
   iconStart?: ReactNode;
   iconEnd?: ReactNode;
-} & ButtonHTMLAttributes<HTMLButtonElement>) {
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "primary", size = "md", block = false, iconStart, iconEnd, className = "", children, ...props },
+  ref,
+) {
   const cls = [
     "gx-btn",
     `gx-btn--${variant}`,
@@ -34,10 +35,10 @@ export function Button({
     .join(" ");
 
   return (
-    <button className={cls} {...props}>
+    <button ref={ref} className={cls} {...props}>
       {iconStart && <span className="gx-btn__icon">{iconStart}</span>}
       {children}
       {iconEnd && <span className="gx-btn__icon">{iconEnd}</span>}
     </button>
   );
-}
+});

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 import { ConfirmDialog } from "./ConfirmDialog";
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("ConfirmDialog", () => {
   it("renders the title, description, and both buttons when open", () => {
@@ -81,5 +83,48 @@ describe("ConfirmDialog", () => {
     fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape" });
     expect(onConfirm).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // Adversarial focus probe: the Cancel/Action buttons are rendered via Radix
+  // `asChild` onto our Button, so Button MUST forward its ref or Radix's Slot
+  // drops it — the AlertDialog then can't move focus into the dialog and logs
+  // "Function components cannot be given refs" on every render.
+  it("does not warn about refs on function components", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete?"
+        description="gone forever"
+        onConfirm={() => {}}
+      />,
+    );
+    const refWarnings = err.mock.calls.filter((c) =>
+      String(c[0]).includes("Function components cannot be given refs"),
+    );
+    expect(refWarnings).toHaveLength(0);
+  });
+
+  it("moves initial focus onto the Cancel button (AlertDialog contract)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const trigger = document.createElement("button");
+    trigger.textContent = "outside trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete?"
+        description="gone forever"
+        onConfirm={() => {}}
+      />,
+    );
+    await screen.findByRole("alertdialog");
+    // If the ref never attached, focus stays on the outside trigger behind the
+    // now-aria-hidden app — keyboard/SR users are stranded.
+    const cancel = screen.getByRole("button", { name: /cancel/i });
+    expect(document.activeElement).toBe(cancel);
   });
 });

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -85,6 +85,25 @@ describe("ConfirmDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("confirmDisabled disables the confirm button and blocks onConfirm on click", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete the vault?"
+        confirmLabel="Delete entry"
+        confirmDisabled
+        onConfirm={onConfirm}
+      />,
+    );
+    const confirm = screen.getByRole("button", { name: "Delete entry" });
+    expect(confirm).toBeDisabled();
+    // A disabled destructive button must not fire the side effect.
+    fireEvent.click(confirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   // Adversarial focus probe: the Cancel/Action buttons are rendered via Radix
   // `asChild` onto our Button, so Button MUST forward its ref or Radix's Slot
   // drops it — the AlertDialog then can't move focus into the dialog and logs

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("renders the title, description, and both buttons when open", () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete the vault?"
+        description="This can't be undone."
+        confirmLabel="Delete entry"
+        onConfirm={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("Delete the vault?");
+    expect(dialog).toHaveTextContent("This can't be undone.");
+    expect(screen.getByRole("button", { name: "Delete entry" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        onOpenChange={() => {}}
+        title="Delete the vault?"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("confirm fires onConfirm exactly once and closes", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Delete the vault?"
+        confirmLabel="Delete entry"
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete entry" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancel closes without firing onConfirm", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Delete the vault?"
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("Escape closes without firing onConfirm", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        title="Delete the vault?"
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape" });
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -19,6 +19,7 @@ export function ConfirmDialog({
   confirmLabel = "Delete",
   cancelLabel = "Cancel",
   onConfirm,
+  confirmDisabled = false,
   destructive = true,
 }: {
   open: boolean;
@@ -28,6 +29,7 @@ export function ConfirmDialog({
   confirmLabel?: string;
   cancelLabel?: string;
   onConfirm: () => void;
+  confirmDisabled?: boolean;
   destructive?: boolean;
 }) {
   return (
@@ -45,7 +47,11 @@ export function ConfirmDialog({
               <Button variant="ghost">{cancelLabel}</Button>
             </RAlert.Cancel>
             <RAlert.Action asChild>
-              <Button variant={destructive ? "danger" : "primary"} onClick={onConfirm}>
+              <Button
+                variant={destructive ? "danger" : "primary"}
+                onClick={onConfirm}
+                disabled={confirmDisabled}
+              >
                 {confirmLabel}
               </Button>
             </RAlert.Action>

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import * as RAlert from "@radix-ui/react-alert-dialog";
+
+import { Button } from "./Button";
+
+// ConfirmDialog — a modal confirmation gate on a Radix AlertDialog (ADR-0017:
+// Radix backs the accessibility-heavy primitives). Built for destructive actions
+// that must not fire on a single click (#209 hard-delete): the caller drives it
+// controlled via `open`, issues the side effect in `onConfirm`, and clears its
+// state in `onOpenChange`. AlertDialog's native behaviour supplies the rest —
+// Escape and Cancel dismiss without confirming, focus is trapped, and the
+// overlay does NOT close on click (a mis-click can't destroy data).
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Delete",
+  cancelLabel = "Cancel",
+  onConfirm,
+  destructive = true,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  destructive?: boolean;
+}) {
+  return (
+    <RAlert.Root open={open} onOpenChange={onOpenChange}>
+      <RAlert.Portal>
+        <RAlert.Overlay className="gx-confirm__overlay" />
+        {/* Radix auto-wires aria-describedby to the Description below when present. */}
+        <RAlert.Content className="gx-confirm">
+          <RAlert.Title className="gx-confirm__title">{title}</RAlert.Title>
+          {description && (
+            <RAlert.Description className="gx-confirm__desc">{description}</RAlert.Description>
+          )}
+          <div className="gx-confirm__actions">
+            <RAlert.Cancel asChild>
+              <Button variant="ghost">{cancelLabel}</Button>
+            </RAlert.Cancel>
+            <RAlert.Action asChild>
+              <Button variant={destructive ? "danger" : "primary"} onClick={onConfirm}>
+                {confirmLabel}
+              </Button>
+            </RAlert.Action>
+          </div>
+        </RAlert.Content>
+      </RAlert.Portal>
+    </RAlert.Root>
+  );
+}

--- a/web/src/screens/campaign/KnowledgePanel.test.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.test.tsx
@@ -30,7 +30,7 @@ import { KnowledgePanel } from "./KnowledgePanel";
 // NodeType, the update fields, and the delete id reach the wire.
 function mockTransport(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts: { failDelete?: boolean; failSearch?: boolean; edges?: PbEdge[] } = {},
+  opts: { failDelete?: boolean; failSearch?: boolean; failEdges?: boolean; edges?: PbEdge[] } = {},
 ) {
   const nodes =
     seed ??
@@ -57,11 +57,15 @@ function mockTransport(
       listNodes: () => create(ListNodesResponseSchema, { nodes }),
       // The delete-confirm dialog fetches a node's edges to show the cascade
       // count; split the seeded edges by which side touches the asked node.
-      listNodeEdges: (req) =>
-        create(ListNodeEdgesResponseSchema, {
+      listNodeEdges: (req) => {
+        if (opts.failEdges) {
+          throw new ConnectError("edges boom", Code.Internal);
+        }
+        return create(ListNodeEdgesResponseSchema, {
           outgoing: edges.filter((e) => e.fromNodeId === req.nodeId),
           incoming: edges.filter((e) => e.toNodeId === req.nodeId),
-        }),
+        });
+      },
       // Stand-in for the tsvector search: a case-insensitive substring over
       // name + body. The panel only cares that matches filter the visible list;
       // relevance ranking is asserted server-side. gm_private is not filtered.
@@ -113,7 +117,7 @@ function mockTransport(
 
 function renderPanel(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts?: { failDelete?: boolean; failSearch?: boolean; edges?: PbEdge[] },
+  opts?: { failDelete?: boolean; failSearch?: boolean; failEdges?: boolean; edges?: PbEdge[] },
 ) {
   const ctx = mockTransport(seed, opts);
   render(
@@ -125,10 +129,14 @@ function renderPanel(
 }
 
 // Delete is now guarded by a confirm dialog: open it via the card/editor trash
-// button, then click the destructive button inside the dialog itself.
+// button, then click the destructive button inside the dialog itself. The
+// confirm stays disabled until the cascade-edge count has loaded, so wait for it
+// to enable before clicking.
 async function confirmInDialog() {
   const dialog = await screen.findByRole("alertdialog");
-  fireEvent.click(within(dialog).getByRole("button", { name: /^delete/i }));
+  const btn = within(dialog).getByRole("button", { name: /^delete/i });
+  await waitFor(() => expect(btn).toBeEnabled());
+  fireEvent.click(btn);
 }
 
 // pickType opens the Radix Type select and chooses the named option.
@@ -258,11 +266,29 @@ describe("KnowledgePanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit the sealed vault/i }));
     fireEvent.click(screen.getByRole("button", { name: /^delete entry$/i }));
-    await confirmInDialog();
+    // The editor trash opens the confirm dialog; no RPC until confirmed.
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+    expect(deleteCalls).toHaveLength(0);
 
+    await confirmInDialog();
     await screen.findByText(/no entries yet/i);
     expect(deleteCalls).toHaveLength(1);
     expect(deleteCalls[0].id).toBe("n1");
+  });
+
+  it("when the cascade count can't be fetched, admits it instead of implying zero — and still deletes", async () => {
+    const { deleteCalls } = renderPanel(undefined, { failEdges: true });
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    // Never a bare "0 relationships"; the dialog says the count is unknown.
+    await waitFor(() => expect(dialog).toHaveTextContent(/couldn't be counted/i));
+
+    // The delete itself is not blocked by a failed count (cascade runs server-side).
+    await confirmInDialog();
+    await screen.findByText(/no entries yet/i);
+    expect(deleteCalls).toHaveLength(1);
   });
 
   it("refreshes the filtered search results when an entry is deleted while searching", async () => {

--- a/web/src/screens/campaign/KnowledgePanel.test.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.test.tsx
@@ -7,11 +7,15 @@ import {
   CampaignService,
   NodeSchema,
   NodeType,
+  EdgeSchema,
+  EdgeType,
   CreateNodeResponseSchema,
   ListNodesResponseSchema,
+  ListNodeEdgesResponseSchema,
   UpdateNodeResponseSchema,
   DeleteNodeResponseSchema,
   SearchNodesResponseSchema,
+  type Edge as PbEdge,
   type CreateNodeRequest,
   type UpdateNodeRequest,
   type DeleteNodeRequest,
@@ -26,7 +30,7 @@ import { KnowledgePanel } from "./KnowledgePanel";
 // NodeType, the update fields, and the delete id reach the wire.
 function mockTransport(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts: { failDelete?: boolean; failSearch?: boolean } = {},
+  opts: { failDelete?: boolean; failSearch?: boolean; edges?: PbEdge[] } = {},
 ) {
   const nodes =
     seed ??
@@ -46,9 +50,18 @@ function mockTransport(
   const deleteCalls: DeleteNodeRequest[] = [];
   const searchCalls: string[] = [];
 
+  const edges = opts.edges ?? [];
+
   const transport = createRouterTransport(({ service }) => {
     service(CampaignService, {
       listNodes: () => create(ListNodesResponseSchema, { nodes }),
+      // The delete-confirm dialog fetches a node's edges to show the cascade
+      // count; split the seeded edges by which side touches the asked node.
+      listNodeEdges: (req) =>
+        create(ListNodeEdgesResponseSchema, {
+          outgoing: edges.filter((e) => e.fromNodeId === req.nodeId),
+          incoming: edges.filter((e) => e.toNodeId === req.nodeId),
+        }),
       // Stand-in for the tsvector search: a case-insensitive substring over
       // name + body. The panel only cares that matches filter the visible list;
       // relevance ranking is asserted server-side. gm_private is not filtered.
@@ -100,7 +113,7 @@ function mockTransport(
 
 function renderPanel(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts?: { failDelete?: boolean; failSearch?: boolean },
+  opts?: { failDelete?: boolean; failSearch?: boolean; edges?: PbEdge[] },
 ) {
   const ctx = mockTransport(seed, opts);
   render(
@@ -109,6 +122,13 @@ function renderPanel(
     </Providers>,
   );
   return ctx;
+}
+
+// Delete is now guarded by a confirm dialog: open it via the card/editor trash
+// button, then click the destructive button inside the dialog itself.
+async function confirmInDialog() {
+  const dialog = await screen.findByRole("alertdialog");
+  fireEvent.click(within(dialog).getByRole("button", { name: /^delete/i }));
 }
 
 // pickType opens the Radix Type select and chooses the named option.
@@ -175,11 +195,70 @@ describe("KnowledgePanel", () => {
     expect(updateCalls[0].gmPrivate).toBe(true);
   });
 
-  it("deletes an entry from its card via DeleteNode", async () => {
+  it("deletes an entry from its card via DeleteNode, after confirming", async () => {
+    const { deleteCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    // The card trash button opens a confirm dialog; no RPC yet.
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent(/sealed vault/i);
+    expect(deleteCalls).toHaveLength(0);
+
+    // Confirming issues exactly one DeleteNode for the right id.
+    await confirmInDialog();
+    await screen.findByText(/no entries yet/i);
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].id).toBe("n1");
+  });
+
+  it("cancelling the confirm dialog issues no delete RPC and leaves the entry", async () => {
     const { deleteCalls } = renderPanel();
     await screen.findByText("The sealed vault");
 
     fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(deleteCalls).toHaveLength(0);
+    expect(screen.getByText("The sealed vault")).toBeInTheDocument();
+  });
+
+  it("Escape dismisses the confirm dialog without deleting", async () => {
+    const { deleteCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(deleteCalls).toHaveLength(0);
+    expect(screen.getByText("The sealed vault")).toBeInTheDocument();
+  });
+
+  it("shows the count of edges that will cascade-delete in the confirm dialog", async () => {
+    const edges = [
+      create(EdgeSchema, { id: "e1", fromNodeId: "n1", toNodeId: "n2", edgeType: EdgeType.KNOWS }),
+      create(EdgeSchema, { id: "e2", fromNodeId: "n1", toNodeId: "n3", edgeType: EdgeType.OWNS }),
+      create(EdgeSchema, { id: "e3", fromNodeId: "n4", toNodeId: "n1", edgeType: EdgeType.ALLY_OF }),
+    ];
+    renderPanel(undefined, { edges });
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    // Two outgoing + one incoming = three cascade edges.
+    await waitFor(() => expect(dialog).toHaveTextContent(/3 relationship/i));
+  });
+
+  it("deletes from the editor's delete button, after confirming", async () => {
+    const { deleteCalls } = renderPanel();
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /edit the sealed vault/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^delete entry$/i }));
+    await confirmInDialog();
 
     await screen.findByText(/no entries yet/i);
     expect(deleteCalls).toHaveLength(1);
@@ -197,6 +276,7 @@ describe("KnowledgePanel", () => {
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "vault" } });
     await waitFor(() => expect(screen.queryByText("Quiet Harbor")).not.toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    await confirmInDialog();
 
     // The mutation must invalidate the SEARCH cache too, so the deleted entry
     // leaves the filtered view instead of lingering (stale search results).
@@ -231,6 +311,7 @@ describe("KnowledgePanel", () => {
     await screen.findByText("The sealed vault");
 
     fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    await confirmInDialog();
 
     // The failure is announced, not swallowed — and the entry is still present.
     const alert = await screen.findByRole("alert");

--- a/web/src/screens/campaign/KnowledgePanel.test.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.test.tsx
@@ -30,7 +30,13 @@ import { KnowledgePanel } from "./KnowledgePanel";
 // NodeType, the update fields, and the delete id reach the wire.
 function mockTransport(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts: { failDelete?: boolean; failSearch?: boolean; failEdges?: boolean; edges?: PbEdge[] } = {},
+  opts: {
+    failDelete?: boolean;
+    failSearch?: boolean;
+    failEdges?: boolean;
+    hangEdges?: boolean;
+    edges?: PbEdge[];
+  } = {},
 ) {
   const nodes =
     seed ??
@@ -60,6 +66,11 @@ function mockTransport(
       listNodeEdges: (req) => {
         if (opts.failEdges) {
           throw new ConnectError("edges boom", Code.Internal);
+        }
+        // A never-settling response models a slow/stuck count: the dialog must
+        // stay in its "counting…" + confirm-disabled state, never implying 0.
+        if (opts.hangEdges) {
+          return new Promise<never>(() => {});
         }
         return create(ListNodeEdgesResponseSchema, {
           outgoing: edges.filter((e) => e.fromNodeId === req.nodeId),
@@ -117,7 +128,13 @@ function mockTransport(
 
 function renderPanel(
   seed?: ReturnType<typeof create<typeof NodeSchema>>[],
-  opts?: { failDelete?: boolean; failSearch?: boolean; failEdges?: boolean; edges?: PbEdge[] },
+  opts?: {
+    failDelete?: boolean;
+    failSearch?: boolean;
+    failEdges?: boolean;
+    hangEdges?: boolean;
+    edges?: PbEdge[];
+  },
 ) {
   const ctx = mockTransport(seed, opts);
   render(
@@ -289,6 +306,27 @@ describe("KnowledgePanel", () => {
     await confirmInDialog();
     await screen.findByText(/no entries yet/i);
     expect(deleteCalls).toHaveLength(1);
+  });
+
+  it("holds the confirm disabled while the cascade count is still loading; Cancel still exits", async () => {
+    const { deleteCalls } = renderPanel(undefined, { hangEdges: true });
+    await screen.findByText("The sealed vault");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete the sealed vault/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    // Counting…, and the destructive button is held disabled so nobody confirms
+    // against an as-yet-unknown (would-read-0) count.
+    expect(dialog).toHaveTextContent(/counting its relationships/i);
+    const confirm = within(dialog).getByRole("button", { name: /delete entry/i });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(deleteCalls).toHaveLength(0);
+
+    // Cancel is always available — the operator is never trapped in a stuck dialog.
+    fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(deleteCalls).toHaveLength(0);
+    expect(screen.getByText("The sealed vault")).toBeInTheDocument();
   });
 
   it("refreshes the filtered search results when an entry is deleted while searching", async () => {

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import {
@@ -140,6 +141,20 @@ export function KnowledgePanel() {
     });
   };
 
+  // A node hard-delete cascades to every edge that touches it (ADR-0008 ON
+  // DELETE CASCADE), so it can silently kill edges belonging to OTHER nodes.
+  // Drop every cached ListNodeEdges result so the next relations view / delete
+  // dialog doesn't count a dead edge (the query's staleTime would otherwise
+  // serve it). No input key = prefix match across all node ids.
+  const invalidateEdges = () => {
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listNodeEdges,
+        cardinality: "finite",
+      }),
+    });
+  };
+
   const createNode = useMutation(CampaignService.method.createNode, {
     onSuccess: () => void invalidateNodes(),
   });
@@ -150,7 +165,10 @@ export function KnowledgePanel() {
     },
   });
   const deleteNode = useMutation(CampaignService.method.deleteNode, {
-    onSuccess: () => void invalidateNodes(),
+    onSuccess: () => {
+      invalidateNodes();
+      invalidateEdges();
+    },
   });
 
   if (status === "pending") {
@@ -278,6 +296,10 @@ export function KnowledgePanel() {
 // NodeDeleteConfirm is the delete gate for one entry. Mounted only while a delete
 // is pending confirmation, it fetches the node's edges so the dialog can name how
 // many relationships the cascade (ADR-0008 ON DELETE CASCADE) will take with it.
+// The count must never be IMPLIED — while the fetch is in flight a raw 0 would
+// falsely promise "no cascade", so the dialog says "counting…" and holds the
+// confirm disabled until the real count lands; a failed fetch says so plainly
+// rather than showing 0 (deletion still cascades server-side either way).
 function NodeDeleteConfirm({
   node,
   onConfirm,
@@ -287,9 +309,35 @@ function NodeDeleteConfirm({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  const edgesQuery = useQuery(CampaignService.method.listNodeEdges, { nodeId: node.id });
+  // retry:false so a failed count settles into isError at once — this query
+  // blocks a modal, so backing off silently for seconds would leave "counting…"
+  // stuck and the confirm disabled. Fail fast and say so.
+  const edgesQuery = useQuery(
+    CampaignService.method.listNodeEdges,
+    { nodeId: node.id },
+    { retry: false },
+  );
   const edgeCount =
     (edgesQuery.data?.outgoing.length ?? 0) + (edgesQuery.data?.incoming.length ?? 0);
+
+  let cascade: ReactNode;
+  if (edgesQuery.isPending) {
+    cascade = <> Counting its relationships…</>;
+  } else if (edgesQuery.isError) {
+    cascade = <> Its relationships couldn't be counted, but any it has will be deleted too.</>;
+  } else if (edgeCount > 0) {
+    cascade = (
+      <>
+        {" This also deletes its "}
+        <strong>
+          {edgeCount} relationship{edgeCount === 1 ? "" : "s"}
+        </strong>
+        .
+      </>
+    );
+  } else {
+    cascade = null;
+  }
 
   return (
     <ConfirmDialog
@@ -300,19 +348,14 @@ function NodeDeleteConfirm({
       title={`Delete “${node.name}”?`}
       description={
         <>
-          This permanently deletes this entry
-          {edgeCount > 0 && (
-            <>
-              {" and its "}
-              <strong>
-                {edgeCount} relationship{edgeCount === 1 ? "" : "s"}
-              </strong>
-            </>
-          )}
-          . Hard delete — this can't be undone.
+          This permanently deletes this entry. Hard delete — this can't be undone.
+          {cascade}
         </>
       }
       confirmLabel="Delete entry"
+      // Don't let the operator confirm against an unknown count; a fetch failure
+      // is not a reason to block the delete itself.
+      confirmDisabled={edgesQuery.isPending}
       onConfirm={onConfirm}
     />
   );

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -26,6 +26,7 @@ import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { NodeRelations } from "./NodeRelations";
 
 // The Knowledge panel (#126, #129) backs the Campaign screen's "Knowledge" view
@@ -78,6 +79,10 @@ export function KnowledgePanel() {
   const queryClient = useQueryClient();
   const listQuery = useQuery(CampaignService.method.listNodes, {});
   const [editing, setEditing] = useState<Node | null>(null);
+  // The entry a delete has been requested for; drives the confirm dialog. Delete
+  // is a hard, cascading DELETE (ADR-0008), so no DeleteNode fires until the
+  // operator confirms here (#209).
+  const [confirmNode, setConfirmNode] = useState<Node | null>(null);
 
   // Live wiki search (#131, ADR-0008 tsvector): the raw box value drives a
   // 200ms-debounced SearchNodes query. The RPC runs only while the debounced
@@ -214,7 +219,7 @@ export function KnowledgePanel() {
                     key={n.id}
                     node={n}
                     onEdit={() => setEditing(n)}
-                    onDelete={() => removeNode(n)}
+                    onDelete={() => setConfirmNode(n)}
                     deleting={deleteNode.isPending && deleteNode.variables?.id === n.id}
                   />
                 ))}
@@ -238,7 +243,7 @@ export function KnowledgePanel() {
         pending={editing ? updateNode.isPending : createNode.isPending}
         error={editorError}
         onCancel={() => setEditing(null)}
-        onDelete={editing ? () => removeNode(editing) : undefined}
+        onDelete={editing ? () => setConfirmNode(editing) : undefined}
         onSubmit={(fields, reset) => {
           if (editing) {
             updateNode.mutate({
@@ -255,7 +260,61 @@ export function KnowledgePanel() {
           }
         }}
       />
+
+      {confirmNode && (
+        <NodeDeleteConfirm
+          node={confirmNode}
+          onCancel={() => setConfirmNode(null)}
+          onConfirm={() => {
+            removeNode(confirmNode);
+            setConfirmNode(null);
+          }}
+        />
+      )}
     </div>
+  );
+}
+
+// NodeDeleteConfirm is the delete gate for one entry. Mounted only while a delete
+// is pending confirmation, it fetches the node's edges so the dialog can name how
+// many relationships the cascade (ADR-0008 ON DELETE CASCADE) will take with it.
+function NodeDeleteConfirm({
+  node,
+  onConfirm,
+  onCancel,
+}: {
+  node: Node;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const edgesQuery = useQuery(CampaignService.method.listNodeEdges, { nodeId: node.id });
+  const edgeCount =
+    (edgesQuery.data?.outgoing.length ?? 0) + (edgesQuery.data?.incoming.length ?? 0);
+
+  return (
+    <ConfirmDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+      title={`Delete “${node.name}”?`}
+      description={
+        <>
+          This permanently deletes this entry
+          {edgeCount > 0 && (
+            <>
+              {" and its "}
+              <strong>
+                {edgeCount} relationship{edgeCount === 1 ? "" : "s"}
+              </strong>
+            </>
+          )}
+          . Hard delete — this can't be undone.
+        </>
+      }
+      confirmLabel="Delete entry"
+      onConfirm={onConfirm}
+    />
   );
 }
 

--- a/web/src/screens/campaign/NodeRelations.test.tsx
+++ b/web/src/screens/campaign/NodeRelations.test.tsx
@@ -126,6 +126,13 @@ async function pick(combobox: string, option: string) {
   fireEvent.click(await screen.findByRole("option", { name: option }));
 }
 
+// Edge delete is confirm-gated too (#209): the row's X opens a dialog; click the
+// destructive button inside it to actually issue DeleteEdge.
+async function confirmInDialog() {
+  const dialog = await screen.findByRole("alertdialog");
+  fireEvent.click(within(dialog).getByRole("button", { name: /^delete/i }));
+}
+
 describe("NodeRelations", () => {
   it("renders outgoing and incoming edges in separate sections", async () => {
     renderRelations(npcNode, {
@@ -181,7 +188,33 @@ describe("NodeRelations", () => {
     expect(createCalls[0].toNodeId).toBe("loc");
   });
 
-  it("deletes an outgoing relation", async () => {
+  it("deletes an outgoing relation after confirming", async () => {
+    const { deleteCalls } = renderRelations(npcNode, {
+      node: npcNode,
+      outgoing: [
+        create(EdgeSchema, {
+          id: "e1",
+          fromNodeId: "n1",
+          toNodeId: "loc",
+          edgeType: EdgeType.RESIDES_IN,
+          toNodeName: "Barrow",
+          toNodeType: NodeType.LOCATION,
+        }),
+      ],
+    });
+    await screen.findByText("Barrow");
+
+    // The row's X opens a confirm dialog naming the relation; no RPC yet.
+    fireEvent.click(screen.getByRole("button", { name: /delete relation/i }));
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent(/resides_in/i);
+    expect(deleteCalls).toHaveLength(0);
+
+    await confirmInDialog();
+    await waitFor(() => expect(deleteCalls).toHaveLength(1));
+    expect(deleteCalls[0].id).toBe("e1");
+  });
+
+  it("cancelling the relation-delete dialog issues no RPC and keeps the edge", async () => {
     const { deleteCalls } = renderRelations(npcNode, {
       node: npcNode,
       outgoing: [
@@ -198,9 +231,12 @@ describe("NodeRelations", () => {
     await screen.findByText("Barrow");
 
     fireEvent.click(screen.getByRole("button", { name: /delete relation/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
 
-    await waitFor(() => expect(deleteCalls).toHaveLength(1));
-    expect(deleteCalls[0].id).toBe("e1");
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(deleteCalls).toHaveLength(0);
+    expect(screen.getByText("Barrow")).toBeInTheDocument();
   });
 
   it("links a Character NPC agent from the Voiced by select (NPC node only)", async () => {
@@ -265,6 +301,7 @@ describe("NodeRelations", () => {
     await screen.findByText("Barrow");
 
     fireEvent.click(screen.getByRole("button", { name: /delete relation/i }));
+    await confirmInDialog();
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't delete/i);
   });

--- a/web/src/screens/campaign/NodeRelations.tsx
+++ b/web/src/screens/campaign/NodeRelations.tsx
@@ -8,6 +8,7 @@ import type { Node as PbNode, Edge as PbEdge } from "@gen/glyphoxa/management/v1
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 // NodeRelations (#132) is the editor card's "Relations · N" section on the live
 // CampaignService edge RPCs (ADR-0008 v1.0 + 2026-07-04 amendment). Edges are
@@ -99,6 +100,9 @@ export function NodeRelations({ node }: { node: PbNode }) {
   const [adding, setAdding] = useState(false);
   const [relType, setRelType] = useState<string>("");
   const [target, setTarget] = useState<string>("");
+  // The outgoing edge a delete has been requested for; drives the confirm dialog
+  // so no DeleteEdge fires on a single click (#209).
+  const [confirmEdge, setConfirmEdge] = useState<PbEdge | null>(null);
 
   // The linked agent is held locally so the select reflects a fresh choice: the
   // `node` prop is a snapshot of the editor's `editing` state that setNodeAgent
@@ -207,7 +211,7 @@ export function NodeRelations({ node }: { node: PbNode }) {
 
       <section className="gx-kg-relations__list" aria-label="Outgoing relations">
         {outgoing.map((e) => (
-          <OutgoingRow key={e.id} edge={e} onDelete={() => deleteEdge.mutate({ id: e.id })} />
+          <OutgoingRow key={e.id} edge={e} onDelete={() => setConfirmEdge(e)} />
         ))}
         {outgoing.length === 0 && <p className="gx-kg-relations__empty">No outgoing relations yet.</p>}
         {deleteEdge.isError && (
@@ -226,6 +230,30 @@ export function NodeRelations({ node }: { node: PbNode }) {
             Relations are one-way. Incoming ones are shown for context and edited from the other entry.
           </p>
         </section>
+      )}
+
+      {confirmEdge && (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setConfirmEdge(null);
+          }}
+          title="Delete this relation?"
+          description={
+            <>
+              Removes the{" "}
+              <strong>
+                {EDGE_LABEL.get(confirmEdge.edgeType) ?? ""} → {confirmEdge.toNodeName}
+              </strong>{" "}
+              relationship. This can't be undone.
+            </>
+          }
+          confirmLabel="Delete relation"
+          onConfirm={() => {
+            deleteEdge.mutate({ id: confirmEdge.id });
+            setConfirmEdge(null);
+          }}
+        />
       )}
     </div>
   );

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -1014,3 +1014,52 @@ textarea.gx-input {
     padding: var(--spacing-md);
   }
 }
+
+/* ===================== Confirm dialog (#209) ===========================
+ * A modal AlertDialog gate for destructive actions (hard-delete a KG entry or a
+ * relation). The overlay dims the app; the card is centred and sits above every
+ * other layer. Styled on the same surface/border/shadow vocabulary as the cards.
+ */
+.gx-confirm__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.6);
+}
+.gx-confirm {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 91;
+  width: min(440px, calc(100vw - 2 * var(--spacing-lg)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+}
+.gx-confirm__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+.gx-confirm__desc {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.gx-confirm__desc strong {
+  color: var(--text-default);
+}
+.gx-confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}


### PR DESCRIPTION
Closes #209

## Problem
Deleting a KG entry (node) or relation (edge) was a one-click **hard delete** with no undo — the card, editor, and edge-row trash buttons fired `DeleteNode`/`DeleteEdge` immediately.

## Change (frontend-only)
- New reusable **`ConfirmDialog`** in `web/src/components/ui/` on `@radix-ui/react-alert-dialog` (same Radix-wrapper pattern as `Select`/`Switch`). Modal, focus-trapped, overlay-click does not dismiss; Escape/Cancel dismiss without acting.
- Every delete path is now gated behind it:
  - **KnowledgePanel** — card trash + editor trash open a confirm before any `DeleteNode`.
  - **NodeRelations** — outgoing-edge trash opens a confirm before any `DeleteEdge`.
- The node dialog fetches the node's edges via the existing **`ListNodeEdges`** RPC (no new RPC) and names how many relationships the `ON DELETE CASCADE` (ADR-0008) will take with it.
- Confirming deletes **exactly as before** — hard delete, cascade intact. Cancel/Escape leave data untouched. No undo/soft-delete added (explicitly out of scope, CONTEXT.md).

## Acceptance criteria
- [x] Delete from card or editor opens a confirm dialog before any delete RPC; cancel/Escape leaves data untouched.
- [x] The node dialog shows the correct count of edges that will cascade-delete.
- [x] Edge deletion also requires confirmation.
- [x] Confirming deletes exactly as today (hard delete, cascade intact).
- [x] No schema, RPC, or storage changes.

## Tests (TDD, red→green)
- `ConfirmDialog.test.tsx` — new, 5 tests (open/closed render, confirm fires once + closes, cancel/Escape close without confirming).
- `KnowledgePanel.test.tsx` — delete tests rewired through the dialog; added cancel, Escape, cascade-count, and editor-delete cases.
- `NodeRelations.test.tsx` — edge-delete rewired through the dialog; added a cancel case.
- Full web suite: **100 passed**; `vite build` (tsc `--noEmit`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)