### PR TITLE
fix(#226): language-aware dice gate (en + de)

### DIFF
--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -862,7 +862,11 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 			// Groq is the wired provider (see the function doc), so the per-round
 			// LLM spans (A3) are labelled groq. The no-op recorder keeps the keyless
 			// path silent; the live binary / benchmark inject a real one.
-			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq))
+			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq),
+			// The dice gate selects its keyword set by Campaign Language (#226), so a
+			// German campaign arms the dice Tool for German roll requests instead of
+			// gating it out and forcing the model to improvise the roll.
+			agenttool.WithLanguage(language))
 	}
 
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -188,9 +188,11 @@ type Engine struct {
 	gated *tool.Loop // grants minus the dice Tool
 
 	// language is the gate language the dice keyword set is selected by (#226):
-	// the Campaign Language normalized via [gateLanguage] at construction, so the
-	// hot path never resolves language per turn. The zero value "" gates in
-	// English ([needsDice] normalizes it), matching the pre-#226 behavior.
+	// the Campaign Language, subtag-normalized via [gateLanguage] once at
+	// construction ([WithLanguage]), so an arbitrary campaign string is parsed
+	// once and the per-turn gate only does a cheap table lookup on the result.
+	// The zero value "" selects the English keyword set ([needsDice] maps it to
+	// "en") — the default when no Campaign Language is wired.
 	language string
 }
 
@@ -235,9 +237,10 @@ func WithMetrics(rec observe.StageRecorder, provName observe.Provider) EngineOpt
 }
 
 // WithLanguage selects the dice gate's keyword set by Campaign Language (#226):
-// lang is normalized once here via [gateLanguage] ("de-DE" → "de"; an unknown
-// language degrades to "en", ADR-0024), so the hot path never resolves language
-// per turn. Without this option the gate stays English (the pre-#226 behavior).
+// lang is subtag-normalized here via [gateLanguage] ("de-DE" → "de"; an unknown
+// language degrades to "en", ADR-0024), so the arbitrary campaign string is
+// parsed once and the per-turn gate only does a cheap table lookup. Without this
+// option the gate defaults to the English keyword set.
 func WithLanguage(lang string) EngineOption {
 	return func(c *engineConfig) {
 		c.language = gateLanguage(lang)

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -186,27 +186,36 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 type Engine struct {
 	full  *tool.Loop // every granted Tool declared
 	gated *tool.Loop // grants minus the dice Tool
+
+	// language is the gate language the dice keyword set is selected by (#226):
+	// the Campaign Language normalized via [gateLanguage] at construction, so the
+	// hot path never resolves language per turn. The zero value "" gates in
+	// English ([needsDice] normalizes it), matching the pre-#226 behavior.
+	language string
 }
 
 // loopFor selects the loop for this turn: the full grants when the utterance
 // plausibly needs dice, the dice-less grants otherwise.
 func (e *Engine) loopFor(messages []llm.Message) *tool.Loop {
-	if needsDice(messages) {
+	if needsDice(e.language, messages) {
 		return e.full
 	}
 	return e.gated
 }
 
-// EngineOption configures a [NewEngine]. The only option today is
-// [WithMetrics], which opts the per-round LLM instrumentation in; without it
-// the Engine records nothing (the keyless default).
+// EngineOption configures a [NewEngine]: [WithMetrics] opts the per-round LLM
+// instrumentation in, and [WithLanguage] selects the dice gate's keyword set.
+// Without either, the Engine records nothing and gates dice in English (the
+// keyless, pre-#226 default).
 type EngineOption func(*engineConfig)
 
 // engineConfig collects the optional [NewEngine] settings before the adapter is
-// built. The zero value is the no-op recorder + empty provider label.
+// built. The zero value is the no-op recorder + empty provider label + the
+// English dice gate ("" normalizes to "en" in [needsDice]).
 type engineConfig struct {
 	rec      observe.StageRecorder
 	provName observe.Provider
+	language string
 }
 
 // WithMetrics injects the A3 per-round instrumentation: rec receives one
@@ -222,6 +231,16 @@ func WithMetrics(rec observe.StageRecorder, provName observe.Provider) EngineOpt
 			c.rec = rec
 		}
 		c.provName = provName
+	}
+}
+
+// WithLanguage selects the dice gate's keyword set by Campaign Language (#226):
+// lang is normalized once here via [gateLanguage] ("de-DE" → "de"; an unknown
+// language degrades to "en", ADR-0024), so the hot path never resolves language
+// per turn. Without this option the gate stays English (the pre-#226 behavior).
+func WithLanguage(lang string) EngineOption {
+	return func(c *engineConfig) {
+		c.language = gateLanguage(lang)
 	}
 }
 
@@ -252,8 +271,9 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 	// Per turn (Generate/GenerateStream) the dice gate picks between them so a
 	// non-dice utterance never declares the dice Tool — one round, not two.
 	return &Engine{
-		full:  newLoop(grants),
-		gated: newLoop(grants.Without(diceToolName)),
+		full:     newLoop(grants),
+		gated:    newLoop(grants.Without(diceToolName)),
+		language: cfg.language,
 	}
 }
 

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -438,6 +438,70 @@ func TestEngine_DiceGate_HistoryDiceDoesNotArmCurrentTurn(t *testing.T) {
 	}
 }
 
+// TestEngine_DiceGate_GermanUtteranceOffersDiceWithLanguage is the #226 pin: a
+// German campaign (WithLanguage("de")) arms the dice Tool for the exact live
+// failure utterance — „Würfelwerkzeug … würfle zwei sechsseitige Würfel" — so
+// the model gets a real tool round-trip instead of improvising the roll.
+func TestEngine_DiceGate_GermanUtteranceOffersDiceWithLanguage(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":2,"sides":6}`)}}, stop: "tool_use"},
+		{text: "Eine Vier und eine Zwei.", stop: "end_turn"},
+	}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+		agenttool.WithLanguage("de-DE"))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Bart, benutze dein Würfelwerkzeug und würfle zwei sechsseitige Würfel."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 2 {
+		t.Fatalf("provider called %d times, want 2 (German dice intent → tool round-trip)", len(reqs))
+	}
+	if len(reqs[0].Tools) != 1 || reqs[0].Tools[0].Name != "dice" {
+		t.Errorf("German dice turn tools = %+v, want the dice decl offered", reqs[0].Tools)
+	}
+}
+
+// TestEngine_DiceGate_GermanPlainTurnGatedWithLanguage proves the other #226
+// direction: with WithLanguage("de") the German article „die" no longer trips
+// the gate, so a plain German turn stays a single dice-less round.
+func TestEngine_DiceGate_GermanPlainTurnGatedWithLanguage(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{{text: "Es war einmal…", stop: "end_turn"}}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+		agenttool.WithLanguage("de"))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Erzähl mir die Geschichte von diesem Ort."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 1 || len(reqs[0].Tools) != 0 {
+		t.Errorf("plain German turn: reqs=%d tools=%+v, want 1 req / 0 tools (article „die\" gated)", len(reqs), reqs[0].Tools)
+	}
+}
+
+// TestEngine_DiceGate_GermanUtteranceWithoutLanguageStaysEnglish pins that the
+// language must be threaded to fix #226: without WithLanguage the gate stays
+// English (the pre-#226 behavior, byte-for-byte), so the same German dice
+// utterance is gated out — reproducing the live false negative.
+func TestEngine_DiceGate_GermanUtteranceWithoutLanguageStaysEnglish(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{{text: "role-played roll", stop: "end_turn"}}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Bart, benutze dein Würfelwerkzeug und würfle zwei sechsseitige Würfel."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 1 || len(reqs[0].Tools) != 0 {
+		t.Errorf("German utterance under the EN default: reqs=%d tools=%+v, want 1 req / 0 tools (dice gated — the #226 failure)", len(reqs), reqs[0].Tools)
+	}
+}
+
 // TestEngine_AsAgentEngine_DrivesReplier pins that the bridge slots into the
 // agent loop via agent.Config.Engine — the production wiring path — so an
 // addressed utterance flows utterance → Hot Context → tool loop → spoken reply.

--- a/pkg/voice/agenttool/dicegate.go
+++ b/pkg/voice/agenttool/dicegate.go
@@ -14,9 +14,12 @@ const diceToolName = "dice"
 
 // diceNotation matches explicit die notation anywhere in the text, in any
 // language: an optional count, a 'd' (NdM: 2d6, d20, d%) or a 'w' (the German
-// wN form: 2w6, w20), then sides (a number or '%' for d100). Word boundaries
-// keep it from firing inside unrelated words (e.g. "add", "model", "würfle").
-var diceNotation = regexp.MustCompile(`(?i)\b\d*[dw](\d+|%)\b`)
+// wN form: 2w6, w20), then sides — a number or '%' (d100). The leading \b and
+// the \b inside the digit branch keep the numeric form from firing inside
+// unrelated words ("add", "model", "würfle"); the '%' branch carries no
+// trailing \b because '%' is not a word char, so "d%"/"w%" match on their own
+// (a \b after '%' would require a following word char and could never fire).
+var diceNotation = regexp.MustCompile(`(?i)\b\d*[dw](\d+\b|%)`)
 
 // diceKeywords maps a gate language (the normalized primary subtag) to the
 // keyword pattern whose match in an utterance marks plausible dice intent. The
@@ -32,11 +35,13 @@ var diceNotation = regexp.MustCompile(`(?i)\b\d*[dw](\d+|%)\b`)
 //     the substring false-positive class #226 also flags in the other direction.
 //   - de: bare substrings, because the roll cue lives inside compounds
 //     ("Würfelwerkzeug", "Rettungswurf", "Fertigkeitsprobe") that word anchors
-//     would miss. This deliberately accepts rare compound false positives
-//     (Entwurf, Vorwurf) — the recall bias above makes that the cheap side.
+//     would miss. würf/wurf/wirf/werf cover würfeln + the werfen ("throw a die")
+//     verb family (imperative „wirf", „werft", „werfen wir"). This deliberately
+//     accepts rare compound false positives (Entwurf, Vorwurf, verwerfen) — the
+//     recall bias above makes that the cheap side.
 var diceKeywords = map[string]*regexp.Regexp{
 	"en": regexp.MustCompile(`(?i)\b(roll|dice|die|d20|d6|d100|saving throw|initiative|advantage|disadvantage|to hit|attack roll|ability check|skill check)`),
-	"de": regexp.MustCompile(`(?i)(würf|wurf|probe|initiative)`),
+	"de": regexp.MustCompile(`(?i)(würf|wurf|wirf|werf|probe|initiative)`),
 }
 
 // gateLanguage normalizes a Campaign Language to a key in [diceKeywords]: it

--- a/pkg/voice/agenttool/dicegate.go
+++ b/pkg/voice/agenttool/dicegate.go
@@ -12,23 +12,49 @@ import (
 // it drops without widening this package's coupling.
 const diceToolName = "dice"
 
-// dicePattern matches an explicit NdM / dM die notation anywhere in the text:
-// an optional count, a 'd', then sides (a number or '%' for d100). Word
-// boundaries keep it from firing inside unrelated words (e.g. "add", "model").
-var dicePattern = regexp.MustCompile(`(?i)\b\d*d(\d+|%)\b`)
+// diceNotation matches explicit die notation anywhere in the text, in any
+// language: an optional count, a 'd' (NdM: 2d6, d20, d%) or a 'w' (the German
+// wN form: 2w6, w20), then sides (a number or '%' for d100). Word boundaries
+// keep it from firing inside unrelated words (e.g. "add", "model", "würfle").
+var diceNotation = regexp.MustCompile(`(?i)\b\d*[dw](\d+|%)\b`)
 
-// diceKeywords are the lowercase substrings whose presence in an utterance marks
-// plausible dice intent. The set is biased for HIGH RECALL: a false positive
-// only costs the (rare) extra tool-call round the system already paid
-// unconditionally before this gate, whereas a false negative would withhold the
-// dice Tool when it is genuinely needed — breaking the tool path. So the keep-IN
-// side is generous (anything ttrpg-roll-shaped) and the keep-OUT side is
-// conservative. Tune here.
-var diceKeywords = []string{
-	"roll", "dice", "die", "d20", "d6", "d100",
-	// ttrpg cues that imply a roll even without the word "roll":
-	"saving throw", "initiative", "advantage", "disadvantage",
-	"to hit", "attack roll", "ability check", "skill check",
+// diceKeywords maps a gate language (the normalized primary subtag) to the
+// keyword pattern whose match in an utterance marks plausible dice intent. The
+// set is biased for HIGH RECALL: a false positive only costs the (rare) extra
+// tool-call round the system already paid unconditionally before this gate,
+// whereas a false negative would withhold the dice Tool when it is genuinely
+// needed — breaking the tool path. So the keep-IN side is generous (anything
+// ttrpg-roll-shaped) and the keep-OUT side is conservative. Tune here; adding a
+// language is a data change (one entry), not a logic change.
+//
+//   - en: \b-anchored PREFIX so inflections stay armed ("rolls", "rolling") while
+//     the "die" substring no longer trips inside unrelated words ("studied") —
+//     the substring false-positive class #226 also flags in the other direction.
+//   - de: bare substrings, because the roll cue lives inside compounds
+//     ("Würfelwerkzeug", "Rettungswurf", "Fertigkeitsprobe") that word anchors
+//     would miss. This deliberately accepts rare compound false positives
+//     (Entwurf, Vorwurf) — the recall bias above makes that the cheap side.
+var diceKeywords = map[string]*regexp.Regexp{
+	"en": regexp.MustCompile(`(?i)\b(roll|dice|die|d20|d6|d100|saving throw|initiative|advantage|disadvantage|to hit|attack roll|ability check|skill check)`),
+	"de": regexp.MustCompile(`(?i)(würf|wurf|probe|initiative)`),
+}
+
+// gateLanguage normalizes a Campaign Language to a key in [diceKeywords]: it
+// lowercases the primary subtag ("de-DE" → "de") and degrades any language with
+// no registered keyword table to "en". This mirrors the address matcher's EN
+// fallback (matcherLanguage, ADR-0024): an unknown Campaign Language degrades to
+// English, never to nothing — a language with no table still gets the EN gate,
+// not a gate that never arms dice.
+func gateLanguage(lang string) string {
+	primary := lang
+	if i := strings.IndexAny(primary, "-_"); i >= 0 {
+		primary = primary[:i]
+	}
+	primary = strings.ToLower(primary)
+	if _, ok := diceKeywords[primary]; ok {
+		return primary
+	}
+	return "en"
 }
 
 // needsDice reports whether the latest user utterance in the assembled Hot
@@ -38,24 +64,19 @@ var diceKeywords = []string{
 //
 // It inspects ONLY the most recent user message (the turn's actual request);
 // older history must not keep dice armed for every subsequent turn. Matching is
-// case-insensitive over explicit die notation (2d6, d20, d%) and a small,
-// recall-biased keyword set. An empty/absent user message yields false (nothing
-// to roll for).
-func needsDice(messages []llm.Message) bool {
+// case-insensitive over explicit die notation (2d6, d20, d%, w20) and the
+// recall-biased keyword set selected by lang ([gateLanguage] normalizes it; an
+// unknown language falls back to the EN set). An empty/absent user message
+// yields false (nothing to roll for).
+func needsDice(lang string, messages []llm.Message) bool {
 	text := latestUserText(messages)
 	if text == "" {
 		return false
 	}
-	if dicePattern.MatchString(text) {
+	if diceNotation.MatchString(text) {
 		return true
 	}
-	lower := strings.ToLower(text)
-	for _, kw := range diceKeywords {
-		if strings.Contains(lower, kw) {
-			return true
-		}
-	}
-	return false
+	return diceKeywords[gateLanguage(lang)].MatchString(text)
 }
 
 // latestUserText returns the Text of the last user-role message, or "" if there

--- a/pkg/voice/agenttool/dicegate_test.go
+++ b/pkg/voice/agenttool/dicegate_test.go
@@ -9,38 +9,66 @@ import (
 func TestNeedsDice(t *testing.T) {
 	cases := []struct {
 		name string
+		lang string
 		text string
 		want bool
 	}{
-		// Explicit die notation.
-		{"d20", "Roll a d20 for me.", true},
-		{"NdM", "I attack with 2d6 damage.", true},
-		{"d100", "Give me a d100.", true},
-		{"d-percent", "Roll d% for the table.", true},
-		{"bare die word", "Throw the dice.", true},
+		// --- English: explicit die notation. ---
+		{"en d20", "en", "Roll a d20 for me.", true},
+		{"en NdM", "en", "I attack with 2d6 damage.", true},
+		{"en d100", "en", "Give me a d100.", true},
+		{"en d-percent", "en", "Roll d% for the table.", true},
+		{"en bare die word", "en", "Throw the dice.", true},
 
-		// ttrpg roll intent without explicit notation.
-		{"saving throw", "Make a saving throw against the poison.", true},
-		{"initiative", "Everyone roll initiative.", true},
-		{"check", "Give me an ability check.", true},
-		{"to hit", "What's my to hit?", true},
+		// --- English: ttrpg roll intent without explicit notation. ---
+		{"en saving throw", "en", "Make a saving throw against the poison.", true},
+		{"en initiative", "en", "Everyone roll initiative.", true},
+		{"en check", "en", "Give me an ability check.", true},
+		{"en to hit", "en", "What's my to hit?", true},
+		// \b-anchored prefix keeps inflections (rolls/rolling) armed.
+		{"en rolling", "en", "He keeps rolling his eyes.", true},
 
-		// Plain conversation — must NOT arm dice.
-		{"room price", "How much for a room and a pint?", false},
-		{"greeting", "Hello Bart, how are you?", false},
-		{"rumors", "Heard any good rumors lately?", false},
+		// --- English: plain conversation — must NOT arm dice. ---
+		{"en room price", "en", "How much for a room and a pint?", false},
+		{"en greeting", "en", "Hello Bart, how are you?", false},
+		{"en rumors", "en", "Heard any good rumors lately?", false},
 
-		// False-positive guards: dice-shaped substrings inside unrelated words.
-		{"model not d-something", "Tell me about your business model.", false},
-		{"add not a die", "Can you add another log to the fire?", false},
-		{"addled", "The traveler looks addled.", false},
-		{"empty", "", false},
+		// --- English: false-positive guards. ---
+		{"en model not d-something", "en", "Tell me about your business model.", false},
+		{"en add not a die", "en", "Can you add another log to the fire?", false},
+		{"en addled", "en", "The traveler looks addled.", false},
+		// \b-anchoring: "die" substring inside "studied" no longer trips (#226).
+		{"en studied not die", "en", "She studied the map.", false},
+		{"en empty", "en", "", false},
+
+		// --- German: the live failure — must arm dice (#226). ---
+		{"de Würfelwerkzeug", "de", "Bart, benutze dein Würfelwerkzeug und würfle zwei sechsseitige Würfel.", true},
+		// German article „die" must NOT trip the gate (#226).
+		{"de article die", "de", "Erzähl mir die Geschichte von diesem Ort.", false},
+		{"de w20 notation", "de", "würfle zwei w20", true},
+		{"de bare notation", "de", "nimm zwei w20", true},
+		{"de Probe", "de", "mach eine Probe", true},
+		{"de Rettungswurf", "de", "mach einen Rettungswurf gegen das Gift", true},
+		{"de Initiative", "de", "alle würfeln Initiative", true},
+		// German plain conversation — must NOT arm dice.
+		{"de greeting", "de", "Hallo Bart, wie geht es dir?", false},
+		{"de room", "de", "Was kostet ein Zimmer für die Nacht?", false},
+
+		// --- Cross-language notation trips in any language (AC). ---
+		{"de NdM notation", "de", "2d6 Schaden", true},
+		{"en wN notation", "en", "roll 2w6", true},
+
+		// --- Unknown/empty language behaves as en. ---
+		{"unknown lang en keyword", "fr", "Roll a d20.", true},
+		{"unknown lang de keyword ignored", "fr", "würfle zwei Würfel", false},
+		{"empty lang en keyword", "", "Roll a d20.", true},
+		{"empty lang notation", "", "2d6", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := needsDice([]llm.Message{{Role: llm.RoleUser, Text: tc.text}})
+			got := needsDice(tc.lang, []llm.Message{{Role: llm.RoleUser, Text: tc.text}})
 			if got != tc.want {
-				t.Errorf("needsDice(%q) = %v, want %v", tc.text, got, tc.want)
+				t.Errorf("needsDice(%q, %q) = %v, want %v", tc.lang, tc.text, got, tc.want)
 			}
 		})
 	}
@@ -56,7 +84,29 @@ func TestNeedsDice_LatestUserOnly(t *testing.T) {
 		{Role: llm.RoleAssistant, Text: "You rolled a 14."},
 		{Role: llm.RoleUser, Text: "Thanks, where's the bar?"}, // current: plain
 	}
-	if needsDice(msgs) {
+	if needsDice("en", msgs) {
 		t.Error("needsDice must key on the latest user message (plain), not history or the system prompt")
+	}
+}
+
+// TestGateLanguage covers the language-subtag normalization the gate applies
+// before selecting a keyword table: a known primary subtag is kept, a region
+// tag is stripped, and anything without a registered table degrades to "en"
+// (mirroring the address matcher's fallback, ADR-0024).
+func TestGateLanguage(t *testing.T) {
+	cases := map[string]string{
+		"de":    "de",
+		"de-DE": "de",
+		"DE":    "de",
+		"en":    "en",
+		"en-US": "en",
+		"":      "en",
+		"fr":    "en",
+		"xx":    "en",
+	}
+	for in, want := range cases {
+		if got := gateLanguage(in); got != want {
+			t.Errorf("gateLanguage(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/pkg/voice/agenttool/dicegate_test.go
+++ b/pkg/voice/agenttool/dicegate_test.go
@@ -18,6 +18,10 @@ func TestNeedsDice(t *testing.T) {
 		{"en NdM", "en", "I attack with 2d6 damage.", true},
 		{"en d100", "en", "Give me a d100.", true},
 		{"en d-percent", "en", "Roll d% for the table.", true},
+		// Notation-only rows with NO keyword: prove the '%' branch bites on its own,
+		// not via "roll" — the trailing-\b bug that made "d%"/"w%" dead notation.
+		{"en d-percent notation only", "en", "Give me a d% please.", true},
+		{"en w-percent notation only", "en", "hand me a w%", true},
 		{"en bare die word", "en", "Throw the dice.", true},
 
 		// --- English: ttrpg roll intent without explicit notation. ---
@@ -50,6 +54,11 @@ func TestNeedsDice(t *testing.T) {
 		{"de Probe", "de", "mach eine Probe", true},
 		{"de Rettungswurf", "de", "mach einen Rettungswurf gegen das Gift", true},
 		{"de Initiative", "de", "alle würfeln Initiative", true},
+		// werfen ("throw a die") verb family — imperative „wirf", „werfen" (#226).
+		{"de wirf imperative", "de", "Wirf noch einmal!", true},
+		{"de werfen", "de", "Kannst du nochmal werfen?", true},
+		// d-percent + notation-only in German (no keyword): '%' branch bites.
+		{"de d-percent notation only", "de", "gib mir ein d%", true},
 		// German plain conversation — must NOT arm dice.
 		{"de greeting", "de", "Hallo Bart, wie geht es dir?", false},
 		{"de room", "de", "Was kostet ein Zimmer für die Nacht?", false},


### PR DESCRIPTION
Closes #226

## Problem

The per-turn dice gate (`needsDice`) that decides whether the dice Tool is *declared* to the LLM was English-only, matched keywords by raw `strings.Contains`, plus an NdM-notation regex. Two live failure modes (German campaign, 2026-07-06):

1. **False negatives break the tool path.** German dice requests never armed the dice Tool — even „Bart, benutze dein Würfelwerkzeug und würfle zwei sechsseitige Würfel" — so the LLM improvised roll results (every round `had_tool_call="false"`). The one accidental tool call happened only because „diesmal" substring-matched the keyword `"die"`.
2. **False positives evaporate the latency win.** The keyword `"die"` substring-matched the German article („die", „diesem"), so many plain German turns ran the full loop anyway.

## Fix (architect plan, ADR-0024)

- `diceKeywords` becomes a `map[string]*regexp.Regexp` keyed by gate language. `en` is a `\b`-anchored prefix pattern (inflections like `rolls`/`rolling` stay armed; `studied` no longer trips `die`); `de` uses bare substrings so the roll cue matches inside compounds (`Würfelwerkzeug`, `Rettungswurf`, `Fertigkeitsprobe`).
- `diceNotation` is language-independent and now also matches the German `wN` form (`w20`, `2w6`) alongside NdM (`2d6`, `d%`).
- `gateLanguage` normalizes the primary subtag (`de-DE` → `de`) and degrades any unknown/empty language to `en` — mirroring the address matcher's fallback (`matcherLanguage`, ADR-0024). An unknown Campaign Language gets the EN gate, never a gate that never arms dice.
- Language is threaded into the `Engine` at construction via a new `WithLanguage` option (the campaign string is subtag-normalized once; the per-turn gate then does a cheap table lookup). `internal/wirenpc` passes the Campaign Language it already holds. Without the option the gate defaults to the English keyword set. (The EN set itself changed from raw substring to `\b`-prefix matching, so English behavior is not identical to pre-#226 — "she studied the map" no longer trips.)

The gate's recall bias is preserved and documented: a false positive costs one cheap extra tool round; a false negative breaks dice. The German set is deliberately generous (accepts `Entwurf`/`Vorwurf` FPs).

## Tests (TDD, red first)

- `dicegate_test.go`: table gains a `lang` column — German positives (the live utterance, `w20`, „mach eine Probe", `Rettungswurf`), German article „die" negative, English substring FP (`studied`), cross-language notation, and unknown/empty-language → EN fallback. New `TestGateLanguage` covers subtag normalization.
- `agenttool_test.go`: three engine-level pins through the scripted provider — German dice utterance under `WithLanguage("de")` produces a real dice tool round-trip; a plain German turn stays a single gated round; the same German utterance under the EN default stays gated (reproducing the #226 false negative).

## AC coverage

- [x] German „Würfelwerkzeug … würfle zwei sechsseitige Würfel" declares dice (red test first)
- [x] German „erzähl mir die Geschichte …" does NOT declare it
- [x] German „würfle zwei w20" and „mach eine Probe" declare it
- [x] English positives stay green; „she studied the map" no longer trips
- [x] Unknown/empty campaign language behaves as `en`
- [x] NdM notation still trips in any language

Local: `go test -race`, `go vet`, `gofmt`, `golangci-lint` all green on the affected packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)