### PR TITLE
feat(#227): provider_config.model threads into the engine; dynamic model catalog + free-text entry

### DIFF
--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -29,6 +29,7 @@ const envPlaceholderLast4 = "env"
 // concrete store) so they unit-test keyless with a fake.
 type providerStore interface {
 	ListProviderConfigs(ctx context.Context, tenantID uuid.UUID) ([]storage.ProviderConfig, error)
+	GetProviderConfigByComponent(ctx context.Context, tenantID uuid.UUID, component storage.Component) (storage.ProviderConfig, error)
 	UpsertProviderConfigs(ctx context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error)
 	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
 	SaveDiscordBotToken(ctx context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (storage.DeploymentConfig, error)
@@ -182,10 +183,6 @@ func (s *ProviderServer) SaveProviderConfig(
 	if err != nil {
 		return nil, err
 	}
-	if s.cipher == nil {
-		return nil, connect.NewError(connect.CodeFailedPrecondition,
-			errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
-	}
 
 	slot, ok := slotFor(req.Msg.GetProvider())
 	if !ok {
@@ -194,7 +191,14 @@ func (s *ProviderServer) SaveProviderConfig(
 	}
 	secret := req.Msg.GetSecret()
 	if secret == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("secret is required"))
+		// No secret on the wire = a model-only update for an already-saved key
+		// (#227): free-text model entry must not force the operator to re-paste
+		// the secret. Needs no cipher — nothing is sealed.
+		return s.saveModelOnly(ctx, tenantID, slot, req.Msg.GetModel())
+	}
+	if s.cipher == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
 	}
 
 	sealed, last4, err := s.seal(secret)
@@ -225,6 +229,63 @@ func (s *ProviderServer) SaveProviderConfig(
 	// old key) is stale — bust it so the next health call probes fresh (#150).
 	if s.invalidateHealth != nil {
 		s.invalidateHealth(tenantID)
+	}
+
+	return connect.NewResponse(&managementv1.SaveProviderConfigResponse{
+		Credential: providerCredential(string(slot.components[0]), slot.provider, saved[0]),
+	}), nil
+}
+
+// saveModelOnly handles a SaveProviderConfig carrying no secret (#227): a
+// model-only update for a provider whose key is already stored. Each of the
+// slot's component rows is re-upserted with its stored ciphertext/last4
+// verbatim and the new model — the secret stays write-only and untouched
+// (ADR-0004). With no stored row the request is rejected exactly like the
+// pre-#227 empty-secret save: a model alone cannot create a credential slot.
+// An empty model together with the empty secret is a read-back no-op — such a
+// request only reaches the wire by accident (mirrors #142's posture on empty
+// Discord IDs). The health cache is deliberately NOT busted: the key did not
+// change, so the cached verdict is still valid.
+func (s *ProviderServer) saveModelOnly(
+	ctx context.Context,
+	tenantID uuid.UUID,
+	slot byokSlot,
+	model string,
+) (*connect.Response[managementv1.SaveProviderConfigResponse], error) {
+	existing := make([]storage.ProviderConfig, 0, len(slot.components))
+	for _, comp := range slot.components {
+		cfg, err := s.store.GetProviderConfigByComponent(ctx, tenantID, comp)
+		if errors.Is(err, storage.ErrNotFound) || (err == nil && cfg.Provider != slot.provider) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("secret is required"))
+		}
+		if err != nil {
+			s.log.Error("SaveProviderConfig: read provider_config for model-only save failed", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		existing = append(existing, cfg)
+	}
+
+	if model == "" {
+		return connect.NewResponse(&managementv1.SaveProviderConfigResponse{
+			Credential: providerCredential(string(slot.components[0]), slot.provider, existing[0]),
+		}), nil
+	}
+
+	batch := make([]storage.NewProviderConfig, 0, len(existing))
+	for _, cfg := range existing {
+		batch = append(batch, storage.NewProviderConfig{
+			TenantID:              tenantID,
+			Component:             cfg.Component,
+			Provider:              slot.provider,
+			Model:                 model,
+			CredentialsCiphertext: cfg.CredentialsCiphertext,
+			CredentialsLast4:      cfg.CredentialsLast4,
+		})
+	}
+	saved, err := s.store.UpsertProviderConfigs(ctx, batch)
+	if err != nil {
+		s.log.Error("SaveProviderConfig: model-only upsert failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
 	return connect.NewResponse(&managementv1.SaveProviderConfigResponse{

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -46,6 +46,15 @@ func (f *fakeProviderStore) ListProviderConfigs(_ context.Context, _ uuid.UUID) 
 	return out, nil
 }
 
+func (f *fakeProviderStore) GetProviderConfigByComponent(_ context.Context, _ uuid.UUID, component storage.Component) (storage.ProviderConfig, error) {
+	for _, c := range f.configs {
+		if c.Component == component {
+			return c, nil
+		}
+	}
+	return storage.ProviderConfig{}, storage.ErrNotFound
+}
+
 func (f *fakeProviderStore) UpsertProviderConfigs(_ context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error) {
 	out := make([]storage.ProviderConfig, 0, len(configs))
 	for _, n := range configs {
@@ -419,5 +428,90 @@ func TestProviderList_EnvPlaceholderIsKeyNeeded(t *testing.T) {
 	groq := credByProvider(resp.Msg.GetCredentials(), "groq")
 	if groq.GetEverSaved() {
 		t.Errorf("env-placeholder groq should be key-needed, got ever_saved=true: %+v", groq)
+	}
+}
+
+// TestProviderSave_ModelOnlyKeepsSecret pins the #227 model-only branch: an
+// empty secret with a model updates the stored model and leaves the sealed
+// credential byte-identical. The second client runs WITHOUT a cipher to prove
+// the model-only path never needs one (nothing is sealed).
+func TestProviderSave_ModelOnlyKeepsSecret(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	seedClient, _ := newProviderClient(t, store, testCipher(t))
+	if _, err := seedClient.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "sk-groq-secret-abcd", Model: "old-model",
+	})); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	before, err := store.GetProviderConfigByComponent(context.Background(), uuid.Nil, storage.ComponentLLM)
+	if err != nil {
+		t.Fatalf("read seeded row: %v", err)
+	}
+
+	client, _ := newProviderClient(t, store, nil) // nil cipher: model-only must not need it
+	resp, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "", Model: "custom-model-x",
+	}))
+	if err != nil {
+		t.Fatalf("model-only save: %v", err)
+	}
+	cred := resp.Msg.GetCredential()
+	if cred.GetModel() != "custom-model-x" || !cred.GetEverSaved() || cred.GetLast4() != "abcd" {
+		t.Errorf("credential after model-only save = model %q, everSaved %v, last4 %q; want custom-model-x, true, abcd",
+			cred.GetModel(), cred.GetEverSaved(), cred.GetLast4())
+	}
+	after, err := store.GetProviderConfigByComponent(context.Background(), uuid.Nil, storage.ComponentLLM)
+	if err != nil {
+		t.Fatalf("read updated row: %v", err)
+	}
+	if after.Model != "custom-model-x" {
+		t.Errorf("stored model = %q, want custom-model-x", after.Model)
+	}
+	if string(after.CredentialsCiphertext) != string(before.CredentialsCiphertext) || after.CredentialsLast4 != before.CredentialsLast4 {
+		t.Error("model-only save must leave the sealed credential byte-identical")
+	}
+}
+
+// TestProviderSave_ModelOnlyWithoutKeyRejected: a model alone cannot create a
+// credential slot — with no stored row the empty-secret save is rejected
+// exactly like before #227.
+func TestProviderSave_ModelOnlyWithoutKeyRejected(t *testing.T) {
+	t.Parallel()
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	_, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "", Model: "some-model",
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("model-only save without stored key = %v, want CodeInvalidArgument", err)
+	}
+}
+
+// TestProviderSave_ModelOnlyEmptyModelIsNoOp: empty secret + empty model reads
+// the slot back without writing (such a request only reaches the wire by
+// accident — mirrors #142's posture on empty Discord IDs).
+func TestProviderSave_ModelOnlyEmptyModelIsNoOp(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	client, _ := newProviderClient(t, store, testCipher(t))
+	if _, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "sk-groq-secret-abcd", Model: "old-model",
+	})); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	before, _ := store.GetProviderConfigByComponent(context.Background(), uuid.Nil, storage.ComponentLLM)
+
+	resp, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "groq", Secret: "", Model: "",
+	}))
+	if err != nil {
+		t.Fatalf("empty model-only save: %v", err)
+	}
+	if got := resp.Msg.GetCredential().GetModel(); got != "old-model" {
+		t.Errorf("no-op save returned model %q, want old-model", got)
+	}
+	after, _ := store.GetProviderConfigByComponent(context.Background(), uuid.Nil, storage.ComponentLLM)
+	if !after.UpdatedAt.Equal(before.UpdatedAt) || after.Model != before.Model {
+		t.Error("empty model-only save must not write")
 	}
 }

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -81,6 +82,10 @@ type VoiceServer struct {
 	// pingLLM is the Groq liveness test-call (a real key -> nil). Defaults to a
 	// GET against the Groq models endpoint.
 	pingLLM func(ctx context.Context, apiKey string) error
+	// listModels fetches a provider's live model catalog for the model select
+	// (#227). Defaults to the Groq OpenAI-compatible GET /models via the shared
+	// adapter; unit tests fake it so the default `go test` makes no vendor call.
+	listModels func(ctx context.Context, apiKey string) ([]string, error)
 	// botTag proves the Discord token via REST (GET /users/@me — no gateway
 	// IDENTIFY, #150) and returns the bot tag. Defaults to discordtag.Resolve.
 	botTag func(ctx context.Context, token string) (string, error)
@@ -142,6 +147,7 @@ func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *
 		newLister:    func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
 		newSynth:     func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
 		pingLLM:      livePingGroq,
+		listModels:   func(ctx context.Context, apiKey string) ([]string, error) { return groq.New(apiKey).ListModels(ctx) },
 		botTag:       func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
 		now:          time.Now,
 		probeTimeout: healthProbeTimeout,
@@ -179,20 +185,60 @@ func (s *VoiceServer) tenant(ctx context.Context) (uuid.UUID, error) {
 	return id, nil
 }
 
-// ListModels returns the static model allowlist for a provider. Groq exposes no
-// list-models call we surface, so its select is a curated allowlist (ADR-0039);
-// an unknown provider is a client error.
+// ListModels returns the live Groq model catalog for the model select (#227):
+// the OpenAI-compatible GET /models fetched with the tenant's decrypted BYOK key
+// (the ListVoices / health-check posture, ADR-0039). The default model is pinned
+// first, the rest are sorted and deduped, and the previously-hardcoded allowlist
+// (with its deprecated ids) is gone. A failed fetch degrades gracefully — the
+// screen stays usable — by returning just the default and NO rpc error, since the
+// combobox accepts free-text entry regardless. An unknown provider is a client
+// error (unchanged).
 func (s *VoiceServer) ListModels(
-	_ context.Context,
+	ctx context.Context,
 	req *connect.Request[managementv1.ListModelsRequest],
 ) (*connect.Response[managementv1.ListModelsResponse], error) {
-	switch req.Msg.GetProvider() {
-	case "groq":
-		return connect.NewResponse(&managementv1.ListModelsResponse{Models: groq.Models}), nil
-	default:
+	if req.Msg.GetProvider() != "groq" {
 		return nil, connect.NewError(connect.CodeInvalidArgument,
-			fmt.Errorf("no model allowlist for provider %q", req.Msg.GetProvider()))
+			fmt.Errorf("no model catalog for provider %q", req.Msg.GetProvider()))
 	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentLLM)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := s.listModels(ctx, key)
+	if err != nil {
+		// Never fail the RPC: a broken catalog must not break the Configuration
+		// screen (free-text entry still saves and runs, ADR-0039). Fall back to the
+		// pinned default so the select still renders.
+		s.log.Warn("ListModels: live Groq catalog failed", "err", err)
+		return connect.NewResponse(&managementv1.ListModelsResponse{Models: []string{groq.DefaultModel}}), nil
+	}
+	return connect.NewResponse(&managementv1.ListModelsResponse{Models: groqCatalog(models)}), nil
+}
+
+// groqCatalog shapes a raw Groq /models catalog for the select: the default model
+// is pinned first (even if the live list omits or re-orders it), and the rest are
+// deduped and sorted ascending. Curation of non-chat ids is deliberately NOT done
+// — the pinned default plus free-text entry make the extra ids harmless, and the
+// staleness the static allowlist caused is exactly what this removes (#227).
+func groqCatalog(models []string) []string {
+	out := []string{groq.DefaultModel}
+	seen := map[string]bool{groq.DefaultModel: true}
+	rest := make([]string, 0, len(models))
+	for _, m := range models {
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		rest = append(rest, m)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
 }
 
 // ListVoices maps the ElevenLabs voice catalog onto the wire type for the voice

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -752,6 +752,10 @@ func (stubProviderStore) ListProviderConfigs(context.Context, uuid.UUID) ([]stor
 	return nil, nil
 }
 
+func (stubProviderStore) GetProviderConfigByComponent(context.Context, uuid.UUID, storage.Component) (storage.ProviderConfig, error) {
+	return storage.ProviderConfig{}, storage.ErrNotFound
+}
+
 func (stubProviderStore) UpsertProviderConfigs(_ context.Context, configs []storage.NewProviderConfig) ([]storage.ProviderConfig, error) {
 	out := make([]storage.ProviderConfig, len(configs))
 	for i, n := range configs {

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -103,19 +103,89 @@ func tenantCtx() context.Context {
 	return auth.WithTenant(context.Background(), uuid.New())
 }
 
-func TestListModels_GroqAllowlist(t *testing.T) {
+func TestListModels_GroqLiveCatalog(t *testing.T) {
 	t.Parallel()
 	srv := NewVoiceServer(&fakeVoiceStore{}, nil, nil)
+	// A live Groq /models catalog: unsorted, containing the default in the middle
+	// plus a duplicate. The handler pins the default first, sorts the rest
+	// ascending, and dedupes — and the deprecated hardcoded entries are gone.
+	srv.listModels = func(_ context.Context, _ string) ([]string, error) {
+		return []string{
+			"meta-llama/llama-4-scout-17b-16e-instruct",
+			"llama-3.1-8b-instant",
+			groq.DefaultModel,
+			"llama-3.1-8b-instant", // duplicate
+		}, nil
+	}
 	resp, err := srv.ListModels(tenantCtx(), connect.NewRequest(&managementv1.ListModelsRequest{Provider: "groq"}))
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
 	}
 	got := resp.Msg.GetModels()
-	if len(got) != len(groq.Models) {
-		t.Fatalf("models = %v, want %v", got, groq.Models)
+	want := []string{
+		groq.DefaultModel, // pinned first
+		"llama-3.1-8b-instant",
+		"meta-llama/llama-4-scout-17b-16e-instruct",
 	}
-	if got[0] != groq.DefaultModel {
-		t.Errorf("first model = %q, want default %q", got[0], groq.DefaultModel)
+	if len(got) != len(want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("models[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// The stale hardcoded catalog is retired: a live catalog that never mentions
+	// the deprecated ids must not resurrect them.
+	for _, dead := range []string{"llama3-70b-8192", "llama3-8b-8192"} {
+		for _, m := range got {
+			if m == dead {
+				t.Errorf("deprecated model %q leaked into the catalog", dead)
+			}
+		}
+	}
+}
+
+// TestListModels_GroqCatalogFailureStaysUsable pins the ADR-0039 degradation
+// posture: a failed live catalog fetch does NOT error the RPC (which would break
+// the Configuration screen); it warns and returns just the default so the select
+// still renders and free-text entry keeps working.
+func TestListModels_GroqCatalogFailureStaysUsable(t *testing.T) {
+	t.Parallel()
+	srv := NewVoiceServer(&fakeVoiceStore{}, nil, nil)
+	srv.listModels = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("groq unreachable")
+	}
+	resp, err := srv.ListModels(tenantCtx(), connect.NewRequest(&managementv1.ListModelsRequest{Provider: "groq"}))
+	if err != nil {
+		t.Fatalf("ListModels must not error on catalog failure: %v", err)
+	}
+	got := resp.Msg.GetModels()
+	if len(got) != 1 || got[0] != groq.DefaultModel {
+		t.Fatalf("catalog-failure models = %v, want [%q]", got, groq.DefaultModel)
+	}
+}
+
+// TestListModels_FeedsDecryptedTenantKey pins the credential bridge: the catalog
+// seam is called with the tenant's decrypted BYOK LLM key (health-check posture,
+// like livePingGroq / ListVoices), never a raw ciphertext or a blank key.
+func TestListModels_FeedsDecryptedTenantKey(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := &fakeVoiceStore{configs: map[storage.Component]storage.ProviderConfig{
+		storage.ComponentLLM: savedConfig(t, cipher, storage.ComponentLLM, "groq", "sk-groq-secret"),
+	}}
+	srv := NewVoiceServer(store, cipher, nil)
+	var seen atomic.Value
+	srv.listModels = func(_ context.Context, apiKey string) ([]string, error) {
+		seen.Store(apiKey)
+		return []string{groq.DefaultModel}, nil
+	}
+	if _, err := srv.ListModels(tenantCtx(), connect.NewRequest(&managementv1.ListModelsRequest{Provider: "groq"})); err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if got, _ := seen.Load().(string); got != "sk-groq-secret" {
+		t.Errorf("seam key = %q, want the decrypted tenant key", got)
 	}
 }
 

--- a/internal/wirenpc/agentspec.go
+++ b/internal/wirenpc/agentspec.go
@@ -218,6 +218,19 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 		return nil, storage.LoadedAgent{}, storage.Campaign{}, fmt.Errorf("wirenpc: load NPCs: no Character NPC in %q", SeedCampaignName)
 	}
 
+	// The tenant-level LLM model is the fallback for any NPC not bound to its own
+	// LLM provider_config (#227): web-created Agents carry no LLMProviderConfigID,
+	// but the Configuration screen writes the tenant row — without this fallback
+	// the model fix would miss the operator's own NPCs. Fetched ONCE per session
+	// start (consistent with the credential/grant hydration); no row → "" so the
+	// adapter default applies.
+	tenantLLMModel := ""
+	if cfg, err := st.GetProviderConfigByComponent(ctx, campaign.TenantID, storage.ComponentLLM); err == nil {
+		tenantLLMModel = cfg.Model
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return nil, storage.LoadedAgent{}, storage.Campaign{}, fmt.Errorf("wirenpc: load NPCs: tenant LLM config: %w", err)
+	}
+
 	specs := make([]npcSpec, 0, len(chars))
 	var primary storage.LoadedAgent
 	for i, c := range chars {
@@ -232,6 +245,10 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 		if err != nil {
 			return nil, storage.LoadedAgent{}, storage.Campaign{}, err
 		}
+		// Resolve the model this NPC's engine runs (#227): the Agent's bound LLM
+		// provider_config model when it has one, else the tenant-level fallback.
+		// Empty stays empty so the openaicompat adapter fills groq.DefaultModel.
+		spec.model = resolveNPCModel(loaded.LLMConfig, tenantLLMModel)
 		// Hydrate this NPC's Tool Grants from its DB rows (#113): tool
 		// availability is data-driven, not compiled in. An NPC with no rows gets
 		// no grants, so its GrantSet declares no Tool to the LLM (least-privilege).
@@ -249,6 +266,18 @@ func loadSeededNPCs(ctx context.Context, st *storage.Store) ([]npcSpec, storage.
 		specs = append(specs, spec)
 	}
 	return specs, primary, campaign, nil
+}
+
+// resolveNPCModel picks the model id for one NPC's engine (#227): the Agent's own
+// bound LLM provider_config model wins when present and non-empty, otherwise the
+// tenant-level LLM model fallback. Both empty yields "", which the openaicompat
+// adapter reads as "use the provider default" — the defaulting lives at the
+// adapter, never duplicated here.
+func resolveNPCModel(bound *storage.ProviderConfig, tenantModel string) string {
+	if bound != nil && bound.Model != "" {
+		return bound.Model
+	}
+	return tenantModel
 }
 
 // grantsFromRows hydrates an Agent's persisted Tool Grant rows into the in-memory

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -491,6 +491,133 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	cleanup2()
 }
 
+// TestLoadSeededNPCs_ModelFromBoundLLMConfig is the #227 AC1 bar: a non-default
+// model saved on the Agent's bound LLM provider_config threads through
+// loadSeededNPCs onto the npcSpec, so the live engine runs it instead of the
+// hardcoded default. Update the bound row's model and assert the loaded spec
+// carries it.
+func TestLoadSeededNPCs_ModelFromBoundLLMConfig(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	const want = "meta-llama/llama-4-scout-17b-16e-instruct"
+	if _, err := pool.Exec(ctx, `UPDATE provider_config SET model = $1 WHERE component = 'llm'`, want); err != nil {
+		t.Fatalf("set llm model: %v", err)
+	}
+
+	specs, _, _, err := loadSeededNPCs(ctx, storage.New(pool))
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("loaded %d NPCs, want 1", len(specs))
+	}
+	if specs[0].model != want {
+		t.Errorf("spec.model = %q, want %q (configured model must thread through)", specs[0].model, want)
+	}
+}
+
+// TestLoadSeededNPCs_ModelFallsBackToTenantConfig pins the LOAD-BEARING fallback
+// (#227): a web-created Character NPC has NO LLMProviderConfigID, so its model
+// must come from the tenant-level LLM provider_config the Configuration screen
+// writes. Without this fallback the fix would miss the operator's own NPCs.
+func TestLoadSeededNPCs_ModelFallsBackToTenantConfig(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	const want = "tenant-fallback-model"
+	if _, err := pool.Exec(ctx, `UPDATE provider_config SET model = $1 WHERE component = 'llm'`, want); err != nil {
+		t.Fatalf("set tenant llm model: %v", err)
+	}
+
+	tenant, err := st.FindTenantByName(ctx, SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+	// A web-created NPC: bound to no LLM provider_config (LLMProviderConfigID
+	// omitted → NULL), exactly what the Campaign editor writes.
+	if _, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaign.ID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "WebNPC",
+		Persona:    "You are a web-created NPC.",
+	}); err != nil {
+		t.Fatalf("CreateAgent (WebNPC): %v", err)
+	}
+
+	specs, _, _, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	var web *npcSpec
+	for i := range specs {
+		if specs[i].name == "WebNPC" {
+			web = &specs[i]
+		}
+	}
+	if web == nil {
+		t.Fatal("WebNPC not among loaded specs")
+	}
+	if web.model != want {
+		t.Errorf("web NPC model = %q, want tenant fallback %q", web.model, want)
+	}
+}
+
+// TestLoadSeededNPCs_NoLLMConfigYieldsEmptyModel pins the empty-model edge: a
+// campaign with no LLM provider_config at all leaves spec.model == "" so the
+// adapter default applies (#227 AC2, no defaulting duplicated in wirenpc).
+func TestLoadSeededNPCs_NoLLMConfigYieldsEmptyModel(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Build the demo tenant/campaign by hand WITHOUT any provider_config rows, so
+	// both the bound-config and tenant-fallback lookups miss.
+	tenantID, err := st.CreateTenant(ctx, SeedTenantName)
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	campaignID, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID,
+		Name:     SeedCampaignName,
+		System:   "dnd5e",
+		Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	if _, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID,
+		Role:       storage.AgentRoleCharacter,
+		Name:       "Bart",
+		Persona:    BartPersona,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	specs, _, _, err := loadSeededNPCs(ctx, st)
+	if err != nil {
+		t.Fatalf("loadSeededNPCs: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("loaded %d NPCs, want 1", len(specs))
+	}
+	if specs[0].model != "" {
+		t.Errorf("spec.model = %q, want empty (no config → adapter default)", specs[0].model)
+	}
+}
+
 // TestSeedIdempotent asserts a second SeedNPC is a no-op (the slice re-seeds on
 // every boot in some deploys; it must not duplicate or error).
 func TestSeedIdempotent(t *testing.T) {

--- a/internal/wirenpc/enginefactory_test.go
+++ b/internal/wirenpc/enginefactory_test.go
@@ -1,0 +1,79 @@
+package wirenpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// modelCapturingProvider is a keyless streaming [llm.Provider] that records the
+// Model of every [llm.Request] it is handed, then streams a trivial done event.
+// It lets the engineFactory tests assert the model resolved from provider_config
+// reaches the Groq completion request (#227) with no live API.
+type modelCapturingProvider struct {
+	mu     sync.Mutex
+	models []string
+}
+
+func (p *modelCapturingProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.models = append(p.models, req.Model)
+	p.mu.Unlock()
+	ch := make(chan llm.StreamEvent)
+	go func() {
+		defer close(ch)
+		ch <- llm.StreamEvent{Type: llm.EventText, Text: "ok"}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	}()
+	return ch, nil
+}
+
+func (p *modelCapturingProvider) lastModel(t *testing.T) string {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.models) == 0 {
+		t.Fatal("provider.Complete was never called")
+	}
+	return p.models[len(p.models)-1]
+}
+
+// generateOnce drives one Agent turn through an engine so the provider records
+// the request it carried.
+func generateOnce(t *testing.T, spec npcSpec, prov llm.Provider) {
+	t.Helper()
+	factory := engineFactory(prov, tool.NewRegistry(), "en", observe.Discard{})
+	eng := factory(spec)
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleSystem, Text: "You are Bart."},
+		{Role: llm.RoleUser, Text: "Hello."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+}
+
+// TestEngineFactory_ThreadsConfiguredModel is the #227 unit pin: the model on the
+// npcSpec (resolved from provider_config) is the model the Groq request carries.
+func TestEngineFactory_ThreadsConfiguredModel(t *testing.T) {
+	prov := &modelCapturingProvider{}
+	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: "meta-llama/llama-4-scout-17b-16e-instruct"}, prov)
+	if got := prov.lastModel(t); got != "meta-llama/llama-4-scout-17b-16e-instruct" {
+		t.Errorf("request model = %q, want the configured model", got)
+	}
+}
+
+// TestEngineFactory_EmptyModelFlowsThrough pins the fallback contract: an empty
+// spec.model is passed through as "" at the wirenpc layer (NO fallback code
+// here), leaving the openaicompat adapter to fill its provider default. This
+// keeps the "empty → provider default" behavior with zero duplicated defaulting.
+func TestEngineFactory_EmptyModelFlowsThrough(t *testing.T) {
+	prov := &modelCapturingProvider{}
+	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: ""}, prov)
+	if got := prov.lastModel(t); got != "" {
+		t.Errorf("request model = %q, want empty (adapter fills the default)", got)
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -32,6 +32,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agenttool"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
@@ -226,6 +227,13 @@ type npcSpec struct {
 	// per-NPC GrantSet against the shared Registry, so the LLM only ever sees the
 	// Tools this NPC is granted (#113). nil ⇒ granted nothing.
 	grants []tool.Grant
+	// model is the Groq model id this NPC's engine runs (#227): loadSeededNPCs
+	// resolves it from the Agent's LLM provider_config, falling back to the
+	// tenant-level LLM row. Empty means "adapter default" — it flows verbatim into
+	// [llm.Request.Model], where the openaicompat adapter fills [groq.DefaultModel]
+	// — so there is no defaulting duplicated here. Read once per session start
+	// (like keys and grants); a change applies on the NEXT Voice Session.
+	model string
 }
 
 // hardcodedNPC is the original in-code "Bart" definition. It is the seed source
@@ -866,18 +874,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// each opening their own.
 	provider := newLLM(keys.llm)
 	reg := tool.BuiltinRegistry()
-	engineFor := func(spec npcSpec) agent.Engine {
-		grants := tool.NewGrantSet(reg, spec.grants...)
-		return agenttool.NewEngine(provider, grants, groq.DefaultModel, 0, 0,
-			// Groq is the wired provider (see the function doc), so the per-round
-			// LLM spans (A3) are labelled groq. The no-op recorder keeps the keyless
-			// path silent; the live binary / benchmark inject a real one.
-			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq),
-			// The dice gate selects its keyword set by Campaign Language (#226), so a
-			// German campaign arms the dice Tool for German roll requests instead of
-			// gating it out and forcing the model to improvise the roll.
-			agenttool.WithLanguage(language))
-	}
+	engineFor := engineFactory(provider, reg, language, stageMetrics)
 
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over a per-NPC engine carrying that NPC's
@@ -921,6 +918,32 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		}),
 	)
 	return conv, roster, cleanup, nil
+}
+
+// engineFactory builds the per-NPC engine constructor buildConversation hands the
+// Roster: one shared Groq provider + Registry, one engine per NPC differing only
+// by GrantSet and model. It is a named function (not an inline closure) so the
+// model-threading contract (#227) is unit-testable with a fake provider that
+// captures the [llm.Request].
+//
+// spec.model — resolved from the Agent's LLM provider_config (loadSeededNPCs),
+// tenant-level row as fallback — flows verbatim into the request. Empty passes
+// through as "" so the openaicompat adapter fills [groq.DefaultModel]; there is
+// NO defaulting duplicated here (the AC "empty → provider default" is proven at
+// the adapter). language selects the dice gate's keyword set (#226); stageMetrics
+// labels the per-round LLM spans groq (A3).
+func engineFactory(provider llm.Provider, reg *tool.Registry, language string, stageMetrics observe.StageRecorder) func(npcSpec) agent.Engine {
+	return func(spec npcSpec) agent.Engine {
+		return agenttool.NewEngine(provider, tool.NewGrantSet(reg, spec.grants...), spec.model, 0, 0,
+			// Groq is the wired provider (see buildConversation's doc), so the
+			// per-round LLM spans (A3) are labelled groq. The no-op recorder keeps the
+			// keyless path silent; the live binary / benchmark inject a real one.
+			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq),
+			// The dice gate selects its keyword set by Campaign Language (#226), so a
+			// German campaign arms the dice Tool for German roll requests instead of
+			// gating it out and forcing the model to improvise the roll.
+			agenttool.WithLanguage(language))
+	}
 }
 
 // buildStreamManager returns the streaming-STT manager when streaming is enabled

--- a/pkg/voice/llm/groq/groq.go
+++ b/pkg/voice/llm/groq/groq.go
@@ -49,18 +49,6 @@ const (
 	DefaultMaxTokens = 1024
 )
 
-// Models is the curated allowlist of Groq production models the Configuration
-// model select offers. Groq exposes no programmatic list-models call we surface
-// to the operator (ADR-0039), so the choice is a static, reviewed allowlist
-// rather than live data. [DefaultModel] is first so it is the default selection.
-// Extend this slice (not the UI) to offer another model.
-var Models = []string{
-	DefaultModel, // llama-3.3-70b-versatile
-	"llama-3.1-8b-instant",
-	"llama3-70b-8192",
-	"llama3-8b-8192",
-}
-
 // Client is the Groq LLM adapter: the shared [openaicompat.Client] preconfigured
 // by [New]. Construct with [New]; the zero value is not usable. Safe for
 // concurrent use across goroutines.

--- a/pkg/voice/llm/openaicompat/models.go
+++ b/pkg/voice/llm/openaicompat/models.go
@@ -1,0 +1,31 @@
+package openaicompat
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListModels returns the ids of the models the configured endpoint exposes via
+// the OpenAI-compatible GET {baseURL}/models list call (the "data[].id" array).
+// The list is UNFILTERED — every id the provider returns, in the provider's own
+// order — so pinning a default first, sorting, or dropping non-chat models is the
+// caller's concern (the Configuration model select does that in internal/rpc).
+//
+// A missing key surfaces the same request-time "missing API key" error as
+// [Client.Complete] rather than reaching the endpoint; a non-2xx response or a
+// transport failure is returned verbatim (wrapped with the provider name), so the
+// caller can decide how to degrade — it is never a silent empty list.
+func (c *Client) ListModels(ctx context.Context) ([]string, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("%s.ListModels: missing API key%s", c.name, c.missingKeyHint())
+	}
+	page, err := c.oai.Models.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s.ListModels: %w", c.name, err)
+	}
+	ids := make([]string, 0, len(page.Data))
+	for _, m := range page.Data {
+		ids = append(ids, m.ID)
+	}
+	return ids, nil
+}

--- a/pkg/voice/llm/openaicompat/models_test.go
+++ b/pkg/voice/llm/openaicompat/models_test.go
@@ -1,0 +1,90 @@
+package openaicompat_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/openaicompat"
+)
+
+// modelsServer replies to GET /models with the given raw JSON body and records
+// the request method + path so a test can assert the OpenAI-compatible list call
+// was made — no live endpoint, the cassette-replay posture (ADR-0021).
+func modelsServer(t *testing.T, method, path *atomic.Value, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if method != nil {
+			method.Store(r.Method)
+		}
+		if path != nil {
+			path.Store(r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestListModels_ParsesOpenAIListShape pins the happy path: the adapter GETs the
+// OpenAI-compatible /models list and returns every id in the "data" array,
+// UNFILTERED and in the provider's own order (curation is the caller's concern).
+func TestListModels_ParsesOpenAIListShape(t *testing.T) {
+	var method, path atomic.Value
+	srv := modelsServer(t, &method, &path, http.StatusOK,
+		`{"object":"list","data":[{"id":"llama-3.3-70b-versatile","object":"model"},{"id":"meta-llama/llama-4-scout-17b-16e-instruct","object":"model"},{"id":"whisper-large-v3","object":"model"}]}`)
+	defer srv.Close()
+
+	c := newClient(srv.URL)
+	got, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+
+	want := []string{"llama-3.3-70b-versatile", "meta-llama/llama-4-scout-17b-16e-instruct", "whisper-large-v3"}
+	if len(got) != len(want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("models[%d] = %q, want %q (order/unfiltered)", i, got[i], want[i])
+		}
+	}
+	if m, _ := method.Load().(string); m != http.MethodGet {
+		t.Errorf("method = %q, want GET", m)
+	}
+	if p, _ := path.Load().(string); p != "/models" {
+		t.Errorf("path = %q, want /models", p)
+	}
+}
+
+// TestListModels_Non2xxErrors pins that a non-2xx catalog response is an error,
+// not a silent empty list — the RPC layer decides how to degrade.
+func TestListModels_Non2xxErrors(t *testing.T) {
+	srv := modelsServer(t, nil, nil, http.StatusUnauthorized, `{"error":{"message":"invalid api key"}}`)
+	defer srv.Close()
+
+	if _, err := newClient(srv.URL).ListModels(context.Background()); err == nil {
+		t.Fatal("ListModels against a 401 endpoint returned nil error")
+	}
+}
+
+// TestListModels_MissingKey pins the same request-time missing-key posture as
+// Complete: an empty key never reaches the endpoint.
+func TestListModels_MissingKey(t *testing.T) {
+	c := openaicompat.New(
+		openaicompat.WithProviderName("test"),
+		openaicompat.WithAPIKey(""),
+		openaicompat.WithBaseURL("http://127.0.0.1:0"),
+	)
+	_, err := c.ListModels(context.Background())
+	if err == nil {
+		t.Fatal("ListModels with no key returned nil error")
+	}
+	if !strings.Contains(err.Error(), "missing API key") {
+		t.Errorf("error %q missing %q", err, "missing API key")
+	}
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -623,9 +623,15 @@ message ListProviderConfigsResponse {
 message SaveProviderConfigRequest {
   // provider is the BYOK slot to save: "groq" or "elevenlabs".
   string provider = 1;
-  // secret is the plaintext API key to seal. Write-only: never returned.
+  // secret is the plaintext API key to seal. Write-only: never returned. An
+  // EMPTY secret with existing stored rows is a model-only update (#227): the
+  // stored ciphertext is re-upserted verbatim and only model changes — safe to
+  // key on emptiness because an empty string is never a valid API key. Empty
+  // secret with no stored rows is rejected (a model alone cannot create a
+  // credential slot); empty secret AND empty model is a read-back no-op.
   string secret = 2;
-  // model is the selected model/voice id (optional).
+  // model is the selected model id (optional; free-text — it need not appear
+  // in the ListModels catalog, #227).
   string model = 3;
 }
 
@@ -823,7 +829,7 @@ message StopSessionResponse {
 // VoiceService backs the LIVE provider data the Configuration and Campaign
 // screens render (#70; ADR-0039 single-operator / ADR-0004 BYOK credential
 // bridge). It exposes the ElevenLabs voice catalog and a short voice preview for
-// the voice selects, the Groq model allowlist for the model select, and an async
+// the voice selects, the live Groq model catalog for the model select, and an async
 // provider-health signal that upgrades the Configuration badges from
 // key-presence to a real tested status. Every live call uses the operator's
 // decrypted tenant key; the read RPCs are NO_SIDE_EFFECTS so the SPA probes them
@@ -840,8 +846,12 @@ service VoiceService {
   // provider quota, so unlike the reads it is auth + CSRF guarded like a
   // mutation.
   rpc PreviewVoice(PreviewVoiceRequest) returns (PreviewVoiceResponse);
-  // ListModels returns the static model allowlist for a provider — Groq exposes
-  // no list-models API, so its model select is a curated allowlist (ADR-0039).
+  // ListModels returns the LIVE model catalog for a provider (#227): Groq's
+  // OpenAI-compatible surface exposes GET /models, so the catalog is fetched
+  // with the tenant key — DefaultModel pinned first, rest sorted. A fetch
+  // failure degrades to just the default (never an error), because the model
+  // field is free-text and the Configuration screen must stay usable
+  // (ADR-0039, amended 2026-07-06).
   // Read (NO_SIDE_EFFECTS).
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
@@ -901,15 +911,16 @@ message PreviewVoiceResponse {
   string mime_type = 4;
 }
 
-// ListModelsRequest names the provider whose model allowlist to return.
+// ListModelsRequest names the provider whose model catalog to return.
 message ListModelsRequest {
   // provider is the LLM provider slot (e.g. "groq").
   string provider = 1;
 }
 
-// ListModelsResponse carries the static model allowlist.
+// ListModelsResponse carries the live model catalog (#227).
 message ListModelsResponse {
-  // models is the curated list of selectable model ids (first is the default).
+  // models is the fetched list of selectable model ids (first is the default;
+  // free-text entries outside this list are also valid).
   repeated string models = 1;
 }
 


### PR DESCRIPTION
Closes #227

## What

- **Model threading end-to-end**: `npcSpec.model` resolved at session start — Agent-bound LLM `provider_config.model` first, tenant-level LLM row as fallback (web-created Agents carry no binding), empty = adapter default (`groq.DefaultModel` fills in `openaicompat`, no upstream duplication). `engineFor` closure extracted into the unit-testable `engineFactory` (carries #226's `WithLanguage` verbatim).
- **Live model catalog**: `openaicompat.ListModels` (GET /models); `groq.Models` hardcoded allowlist deleted (grep-guard test). `ListModels` RPC fetches with the tenant BYOK key via a test seam — DefaultModel pinned first, sorted, deduped; fetch failure degrades to `[DefaultModel]` with no RPC error.
- **Model-only save**: `SaveProviderConfig` with empty secret + existing rows re-upserts the sealed key verbatim and updates just the model (free-text entry must not force re-pasting the key); empty secret + no rows stays InvalidArgument; empty+empty is a read-back no-op. No health-cache bust (key unchanged).
- **Web**: `Combobox` gains `allowCustom` (`Use "<typed>"` item, exact-match suppression, custom value renders on trigger); Configuration model select → live-catalog combobox + "Save model" button on a dirty pick; combobox renders even with an empty catalog so a dead catalog never takes free-text entry down.
- **Docs**: proto comments rewritten (comment-only); ADR-0039 amended (2026-07-06, #227) — the "Groq exposes no list-models call" premise was factually wrong.

## Tests

Adapter default ("" → DefaultModel in request body), ListModels httptest table, RPC catalog pin/sort/dedupe + degrade + key-spy, model-only save (keeps ciphertext byte-identical, rejects without rows, no-op on empty), loadSeededNPCs resolution (bound / tenant-fallback / none), engineFactory request capture, Combobox allowCustom (3), Configuration model-only flow + dead-catalog flow + passive-default (3). Full `go test -race` + web suite (111) green locally.

## Provenance note

Three prior agent attempts on this issue fabricated completion reports; this PR was finished and verified by the orchestrator directly. Commit 72038f1 salvages reviewed real agent work; e43b8e3 reviews and keeps a second agent's resolution stage; the rest is orchestrator-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)