### PR TITLE
feat(#227): web free-text model entry + ADR-0039 amendment (completes #234)

### DIFF
--- a/docs/adr/0039-mvp-ui-backend-single-operator-web-tier.md
+++ b/docs/adr/0039-mvp-ui-backend-single-operator-web-tier.md
@@ -14,7 +14,32 @@ The MVP UI ships as a Claude Design handoff — three screens (Configuration, Ca
 
 - **Health and connection badges render instantly, upgrade async.** The Configuration "Healthy / Key needed" badge and the bot-connected tag render immediately from presence of a `provider_config` row / a saved token, then an async test-call (ElevenLabs `/v1/voices` is already wired; a Groq ping) and a real Discord gateway login upgrade or downgrade the badge and resolve the live bot tag (`Glyphoxa#4823` in the mock). No live call blocks page load.
 
-- **MVP provider matrix = Groq (LLM) + ElevenLabs (STT + TTS) only.** Matches the design's "more providers soon" and the only adapters built. The Configuration voice dropdown is live data from ElevenLabs `ListVoices` (already implemented); Groq exposes no list-models call, so its model select is a static allowlist. Preview-voice wraps the existing `Synthesize`. OpenAI TTS (ADR-0023) and Gemini (ADR-0035) stay out of this increment.
+- **MVP provider matrix = Groq (LLM) + ElevenLabs (STT + TTS) only.** Matches the design's "more providers soon" and the only adapters built. The Configuration voice dropdown is live data from ElevenLabs `ListVoices` (already implemented); ~~Groq exposes no list-models call, so its model select is a static allowlist~~ (superseded — see the 2026-07-06 amendment: the claim was factually wrong). Preview-voice wraps the existing `Synthesize`. OpenAI TTS (ADR-0023) and Gemini (ADR-0035) stay out of this increment.
+
+## Amendment: live Groq model catalog + free-text model entry (2026-07-06, #227)
+
+The premise "Groq exposes no list-models call" was factually wrong: Groq's
+OpenAI-compatible surface serves `GET /models` (the health check's
+`livePingGroq` was already calling it). The static allowlist it justified went
+stale — deprecated ids lingered, new models never appeared — and the hardcoded
+`groq.Models` var is deleted.
+
+Decided instead:
+
+- **Live catalog.** `ListModels` fetches the catalog through the tenant's
+  decrypted key (the same hybrid credential policy as the health check),
+  unfiltered, with `groq.DefaultModel` pinned first. A fetch failure degrades
+  to just the default and never errors: the Configuration screen must stay
+  usable without a catalog.
+- **Free-text model entry.** The Configuration model control is a combobox
+  that accepts any typed model id, catalog-listed or not — curation is exactly
+  the staleness this amendment removes. A typed model saves via a model-only
+  `SaveProviderConfig` (empty secret + existing rows), which re-upserts the
+  sealed key verbatim; the secret stays write-only (ADR-0004).
+- **End-to-end threading.** `provider_config.model` now reaches the engine:
+  Agent-bound LLM config first, tenant-level row as fallback, empty meaning
+  "adapter default" (resolved in the openaicompat adapter, never duplicated
+  upstream).
 
 ## Why
 

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -650,3 +650,25 @@ func TestSeedIdempotent(t *testing.T) {
 		t.Fatalf("expected 1 Character NPC after two seeds, got %d", len(chars))
 	}
 }
+
+
+// TestResolveNPCModel_BoundConfigOutranksTenantFallback pins the precedence
+// pure-functionally (#227 review finding): a resolver that ignored the bound
+// config and always returned the tenant fallback would pass the DB-backed
+// tests, whose single provider_config row is simultaneously both sources.
+func TestResolveNPCModel_BoundConfigOutranksTenantFallback(t *testing.T) {
+	t.Parallel()
+	bound := &storage.ProviderConfig{Model: "bound-model"}
+	if got := resolveNPCModel(bound, "tenant-model"); got != "bound-model" {
+		t.Errorf("bound + tenant = %q, want bound-model", got)
+	}
+	if got := resolveNPCModel(&storage.ProviderConfig{}, "tenant-model"); got != "tenant-model" {
+		t.Errorf("empty bound model + tenant = %q, want tenant-model", got)
+	}
+	if got := resolveNPCModel(nil, "tenant-model"); got != "tenant-model" {
+		t.Errorf("nil bound + tenant = %q, want tenant-model", got)
+	}
+	if got := resolveNPCModel(nil, ""); got != "" {
+		t.Errorf("nil bound + no tenant = %q, want empty (adapter default)", got)
+	}
+}

--- a/web/src/components/ui/Combobox.test.tsx
+++ b/web/src/components/ui/Combobox.test.tsx
@@ -102,3 +102,34 @@ describe("Combobox", () => {
     expect(within(trigger).getByText("Marcus")).toBeInTheDocument();
   });
 });
+
+describe("Combobox allowCustom (#227)", () => {
+  it("offers the typed text as a Use item and picks it verbatim", () => {
+    const onChange = vi.fn();
+    render(<Combobox label="Model" options={OPTS} value="" onValueChange={onChange} allowCustom />);
+    fireEvent.click(screen.getByRole("button", { name: "Model" }));
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "my-custom-model " } });
+    const useItem = screen.getByRole("option", { name: /use "my-custom-model"/i });
+    fireEvent.click(useItem);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("my-custom-model");
+  });
+
+  it("suppresses the Use item on an exact match (case-insensitive) and on empty search", () => {
+    render(<Combobox label="Model" options={OPTS} value="" onValueChange={() => {}} allowCustom />);
+    fireEvent.click(screen.getByRole("button", { name: "Model" }));
+    // Empty search: no phantom item.
+    expect(screen.queryByRole("option", { name: /use "/i })).not.toBeInTheDocument();
+    // Exact label match, different case: the real item is selectable, no Use item.
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "RACHEL" } });
+    expect(screen.getByRole("option", { name: /rachel/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /use "/i })).not.toBeInTheDocument();
+  });
+
+  it("renders a custom (non-catalog) value verbatim on the trigger", () => {
+    render(
+      <Combobox label="Model" options={OPTS} value="my-custom-model" onValueChange={() => {}} allowCustom />,
+    );
+    expect(screen.getByRole("button", { name: "Model" })).toHaveTextContent("my-custom-model");
+  });
+});

--- a/web/src/components/ui/Combobox.tsx
+++ b/web/src/components/ui/Combobox.tsx
@@ -32,6 +32,7 @@ export function Combobox({
   placeholder = "Select…",
   searchPlaceholder = "Search…",
   emptyText = "No matches",
+  allowCustom = false,
   id,
   "aria-label": ariaLabel,
 }: {
@@ -43,6 +44,10 @@ export function Combobox({
   placeholder?: string;
   searchPlaceholder?: string;
   emptyText?: string;
+  // allowCustom offers the raw typed text as a pickable `Use "…"` item when it
+  // matches no option exactly (#227 free-text model entry). The value passed to
+  // onValueChange is the trimmed text verbatim.
+  allowCustom?: boolean;
   id?: string;
   "aria-label"?: string;
 }) {
@@ -53,6 +58,23 @@ export function Combobox({
   const wrapRef = useRef<HTMLDivElement>(null);
 
   const selected = options.find((o) => o.value === value);
+  // With allowCustom a saved value may not appear in the catalog (free-text
+  // model, or the catalog fetch degraded) — render it verbatim, not as the
+  // unselected placeholder.
+  const triggerLabel = selected ? selected.label : allowCustom && value ? value : null;
+
+  // The `Use "…"` item exists only while typed text matches no option exactly
+  // (case-insensitive, on value or label) — an exact hit means the real item is
+  // already selectable. Empty search offers nothing.
+  const customText = search.trim();
+  const customItem =
+    allowCustom &&
+    customText !== "" &&
+    !options.some(
+      (o) =>
+        o.value.toLowerCase() === customText.toLowerCase() ||
+        o.label.toLowerCase() === customText.toLowerCase(),
+    );
 
   // Close on outside click / Escape so the popover behaves like a native select.
   // Whenever the popover is closed — pick, Escape or outside click — the search
@@ -100,8 +122,8 @@ export function Combobox({
           data-state={open ? "open" : "closed"}
           onClick={() => setOpen((o) => !o)}
         >
-          <span className={selected ? "gx-combobox__value" : "gx-combobox__placeholder"}>
-            {selected ? selected.label : placeholder}
+          <span className={triggerLabel ? "gx-combobox__value" : "gx-combobox__placeholder"}>
+            {triggerLabel ?? placeholder}
           </span>
           <ChevronDown size={14} className="gx-select-chevron" />
         </button>
@@ -124,7 +146,25 @@ export function Combobox({
                 />
               </div>
               <Command.List className="gx-combobox__list">
-                <Command.Empty className="gx-combobox__empty">{emptyText}</Command.Empty>
+                {!customItem && (
+                  <Command.Empty className="gx-combobox__empty">{emptyText}</Command.Empty>
+                )}
+                {customItem && (
+                  <Command.Item
+                    // forceMount: the item's visibility is governed by the
+                    // customItem condition above, not by cmdk's filter — the
+                    // trimmed value would lose against an untrimmed search.
+                    forceMount
+                    key={`custom:${customText}`}
+                    value={customText}
+                    className="gx-select__item gx-combobox__item"
+                    onSelect={() => pick(customText)}
+                  >
+                    <span>
+                      Use &quot;{customText}&quot;
+                    </span>
+                  </Command.Item>
+                )}
                 {options.map((o) => (
                   <Command.Item
                     key={o.value}

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -33,13 +33,14 @@ const CAMPAIGN = {
 };
 
 // cred builds a ProviderCredential the List RPC returns. saved => masked + last4.
-function cred(component: string, provider: string, last4?: string) {
+function cred(component: string, provider: string, last4?: string, model = "") {
   return create(ProviderCredentialSchema, {
     component,
     provider,
     everSaved: Boolean(last4),
     showMasked: Boolean(last4),
     last4: last4 ?? "",
+    model,
   });
 }
 
@@ -64,9 +65,16 @@ function mockBackend(
     // discordSaveError makes SaveDiscordSettings fail (simulates a server-side
     // failure) so tests can pin that the screen surfaces the rejection.
     discordSaveError?: string;
+    // providerSaves captures every SaveProviderConfig request so tests can pin
+    // the model-only wire shape (#227: secret "" + model).
+    providerSaves?: Array<{ provider: string; secret: string; model: string }>;
+    // listModelsError makes the catalog fetch fail at the transport, pinning
+    // that free-text model entry survives a dead catalog (#227).
+    listModelsError?: string;
   } = {},
 ) {
   const state = {
+    groqModel: "",
     groq: opts.saved?.groq,
     elevenlabs: opts.saved?.elevenlabs,
     discord: opts.saved?.discord,
@@ -77,7 +85,10 @@ function mockBackend(
     service(VoiceService, {
       getProviderHealth: () =>
         create(GetProviderHealthResponseSchema, { providers: opts.health ?? [] }),
-      listModels: () => create(ListModelsResponseSchema, { models: GROQ_MODELS }),
+      listModels: () => {
+        if (opts.listModelsError) throw new ConnectError(opts.listModelsError, Code.Unavailable);
+        return create(ListModelsResponseSchema, { models: GROQ_MODELS });
+      },
     });
     service(CampaignService, {
       getActiveCampaign: () =>
@@ -88,18 +99,33 @@ function mockBackend(
         create(ListProviderConfigsResponseSchema, {
           credentials: [
             cred("discord", "discord", state.discord),
-            cred("llm", "groq", state.groq),
+            cred("llm", "groq", state.groq, state.groqModel),
             cred("tts", "elevenlabs", state.elevenlabs),
           ],
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
         }),
       saveProviderConfig: (req) => {
+        opts.providerSaves?.push({ provider: req.provider, secret: req.secret, model: req.model });
+        if (req.secret === "") {
+          // Model-only save (#227): mirrors internal/rpc/provider.go — a stored
+          // key is required, the sealed key is untouched, only model changes.
+          if (req.provider !== "groq" || !state.groq) {
+            throw new ConnectError("secret is required", Code.InvalidArgument);
+          }
+          state.groqModel = req.model;
+          return create(SaveProviderConfigResponseSchema, {
+            credential: cred("llm", "groq", state.groq, state.groqModel),
+          });
+        }
         const last4 = req.secret.slice(-4);
-        if (req.provider === "groq") state.groq = last4;
+        if (req.provider === "groq") {
+          state.groq = last4;
+          state.groqModel = req.model;
+        }
         if (req.provider === "elevenlabs") state.elevenlabs = last4;
         return create(SaveProviderConfigResponseSchema, {
-          credential: cred(req.provider === "groq" ? "llm" : "tts", req.provider, last4),
+          credential: cred(req.provider === "groq" ? "llm" : "tts", req.provider, last4, req.model),
         });
       },
       saveDiscordSettings: (req) => {
@@ -315,11 +341,12 @@ describe("Configuration", () => {
     expect(alert).toHaveTextContent(/database is down/);
   });
 
-  it("renders the Groq model allowlist select (ListModels)", async () => {
+  it("renders the Groq model combobox defaulting to the catalog's first model (ListModels)", async () => {
     renderScreen();
-    // The Groq row's model select defaults to the first allowlisted model.
+    // The combobox mounts before the catalog resolves (#227 renders it even for
+    // an empty list), so await the default value, not just the control.
     const groqModelSelect = await screen.findByLabelText("Groq model");
-    expect(within(groqModelSelect).getByText("llama-3.3-70b-versatile")).toBeInTheDocument();
+    expect(await within(groqModelSelect).findByText("llama-3.3-70b-versatile")).toBeInTheDocument();
   });
 
   it("upgrades a saved provider's badge to Degraded from the health RPC", async () => {
@@ -344,5 +371,51 @@ describe("Configuration", () => {
       }),
     );
     expect(await screen.findByText(/Connected as Glyphoxa#4823/)).toBeInTheDocument();
+  });
+});
+
+describe("Configuration model entry (#227)", () => {
+  it("saves a free-text model without re-pasting the key (model-only save)", async () => {
+    const providerSaves: Array<{ provider: string; secret: string; model: string }> = [];
+    renderScreen(mockBackend({ saved: { groq: "eeee" }, providerSaves }));
+
+    // Open the Groq model combobox and type a model the catalog doesn't list.
+    fireEvent.click(await screen.findByRole("button", { name: "Groq model" }));
+    fireEvent.change(screen.getByPlaceholderText(/search or type/i), {
+      target: { value: "my-custom-model" },
+    });
+    fireEvent.click(screen.getByRole("option", { name: /use "my-custom-model"/i }));
+
+    // The dirty pick grows a Save model button; clicking it fires the
+    // model-only mutation: empty secret, the typed model.
+    fireEvent.click(await screen.findByRole("button", { name: "Save model" }));
+    await screen.findByRole("button", { name: "Groq model" }); // settle
+    expect(providerSaves).toContainEqual({ provider: "groq", secret: "", model: "my-custom-model" });
+    // The key was never touched: the row still shows the masked saved state.
+    expect(screen.getByText("••••••••")).toBeInTheDocument();
+  });
+
+  it("keeps free-text model entry usable when the catalog fetch fails", async () => {
+    const providerSaves: Array<{ provider: string; secret: string; model: string }> = [];
+    renderScreen(
+      mockBackend({ saved: { groq: "eeee" }, providerSaves, listModelsError: "catalog down" }),
+    );
+
+    // The combobox renders despite the dead catalog (empty list)…
+    fireEvent.click(await screen.findByRole("button", { name: "Groq model" }));
+    fireEvent.change(screen.getByPlaceholderText(/search or type/i), {
+      target: { value: "llama-fallback" },
+    });
+    // …and the typed id is still offered and saveable.
+    fireEvent.click(screen.getByRole("option", { name: /use "llama-fallback"/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save model" }));
+    await screen.findByRole("button", { name: "Groq model" });
+    expect(providerSaves).toContainEqual({ provider: "groq", secret: "", model: "llama-fallback" });
+  });
+
+  it("shows no Save model button for the passive catalog-default display", async () => {
+    renderScreen(mockBackend({ saved: { groq: "eeee" } }));
+    await screen.findByRole("button", { name: "Groq model" });
+    expect(screen.queryByRole("button", { name: "Save model" })).not.toBeInTheDocument();
   });
 });

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -15,7 +15,7 @@ import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
-import { Select } from "@/components/ui/Select";
+import { Combobox } from "@/components/ui/Combobox";
 import { Button } from "@/components/ui/Button";
 
 import "./configuration.css";
@@ -62,7 +62,9 @@ export function Configuration() {
   const healthQuery = useQuery(VoiceService.method.getProviderHealth, {});
   const health = healthQuery.data?.providers ?? [];
 
-  // Groq model allowlist (static; Groq has no list-models API, ADR-0039).
+  // Live Groq model catalog (#227): fetched with the tenant key; the server
+  // degrades to just the default on a failed fetch, and the combobox accepts
+  // free text either way, so this query can never wedge the screen.
   const groqModels = useQuery(VoiceService.method.listModels, { provider: "groq" });
   const models = groqModels.data?.models ?? [];
 
@@ -145,8 +147,9 @@ export function Configuration() {
             placeholder={slot.placeholder}
             credential={credentialFor(creds, slot.provider)}
             health={healthFor(health, slot.provider)}
-            // Groq's model select is the static allowlist (#70); the chosen model
-            // rides along when the key is saved (SaveProviderConfig carries it).
+            // Groq's model combobox lists the live catalog with free-text entry
+            // (#227); the chosen model rides along when the key is saved, or
+            // alone via the model-only save once a key exists.
             models={slot.provider === "groq" ? models : undefined}
             onSave={(secret, model) => saveProvider.mutateAsync({ provider: slot.provider, secret, model })}
           />
@@ -278,9 +281,30 @@ function SecretRow({
 
   const saved = Boolean(credential?.showMasked);
   const masked = saved && !editing;
-  // The select shows the saved model, the operator's pick, or the allowlist
+  // The combobox shows the operator's pick, the saved model, or the catalog
   // default (first), in that order.
   const selectedModel = model ?? (credential?.model || undefined) ?? models?.[0];
+  // "Save model" appears only when a saved key exists AND the operator actively
+  // picked something different from the stored model (#227) — never for the
+  // passive catalog-default display, which stores nothing.
+  const modelDirty =
+    saved && model !== undefined && model !== (credential?.model || undefined);
+
+  // Model-only save (#227): empty secret tells the server to keep the sealed
+  // key verbatim and update just the model.
+  async function handleSaveModel() {
+    if (!selectedModel || busy) return;
+    setBusy(true);
+    setSaveError(null);
+    try {
+      await onSave("", selectedModel);
+      setModel(undefined); // the refreshed credential now carries it
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function handleSave() {
     if (!value || busy) return;
@@ -311,14 +335,26 @@ function SecretRow({
           )}
         </div>
 
-        {models && models.length > 0 && (
-          <Select
-            aria-label={`${name} model`}
-            options={models}
-            value={selectedModel}
-            onValueChange={setModel}
-            placeholder="Model…"
-          />
+        {/* Rendered whenever this slot HAS a model concept (groq), even with an
+            empty catalog — a hard transport failure must not take free-text
+            entry down with it (#227): allowCustom still accepts any id. */}
+        {models && (
+          <div className="gx-provider-row__model">
+            <Combobox
+              aria-label={`${name} model`}
+              options={models.map((m) => ({ value: m, label: m }))}
+              value={selectedModel}
+              onValueChange={setModel}
+              placeholder="Model…"
+              searchPlaceholder="Search or type a model id…"
+              allowCustom
+            />
+            {modelDirty && (
+              <Button variant="secondary" size="sm" disabled={busy} onClick={handleSaveModel}>
+                Save model
+              </Button>
+            )}
+          </div>
         )}
 
         <div className="gx-secret">

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -80,7 +80,14 @@
   margin-top: 2px;
 }
 
-/* Groq model allowlist select sits between the row meta and the secret control. */
+/* Groq model combobox (live catalog + free text, #227) sits between the row
+   meta and the secret control; a dirty pick grows a Save model button beside it. */
 .gx-provider-row .gx-select-field {
   min-width: 12rem;
+}
+
+.gx-provider-row__model {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }


### PR DESCRIPTION
Completes issue #227 / PR #234, whose web slice + ADR amendment were lost pre-push: the final commit was swallowed by a git hook that blocked a compound command (false-positive on `--base main` in the same string as `git push`), the split retry only re-ran the push, and the uncommitted files were destroyed with the worktree. Recreated verbatim + review finding fixed.

## What

- **Combobox `allowCustom`**: `Use "<typed>"` item when the trimmed search matches no option exactly (case-insensitive on value/label); no phantom item on empty search; custom saved values render verbatim on the trigger; `forceMount` so cmdk's filter can't hide the item.
- **Configuration**: Groq model `Select` → live-catalog `Combobox` with free text; "Save model" button appears only on an active dirty pick and fires the model-only save (`{secret: "", model}`) that PR #234's backend already accepts; combobox renders even with an empty catalog so a dead fetch never takes free-text entry down.
- **ADR-0039**: dated amendment (2026-07-06, #227) — the one the proto comment merged in #234 already cites.
- **resolveNPCModel precedence unit test** (#234 review finding 3): bound-model-wins was unpinned because the DB tests' single provider_config row is both sources at once.

## Tests

3 Combobox unit (Use-item pick, exact-match/empty suppression, custom trigger render), 3 Configuration integration on the mock-transport harness (model-only wire shape, dead-catalog free text, no button on passive default), 1 Go precedence test. Web suite 111/111, `tsc --noEmit` clean, `go build ./...` + wirenpc tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)