### PR TITLE
feat(#101): autofill Guild + voice channel from a pasted channel link

### DIFF
--- a/web/src/lib/discordLink.test.ts
+++ b/web/src/lib/discordLink.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { parseChannelLink } from "./discordLink";
+
+// A voice channel's right-click "Copy Link" yields discord.com/channels/{guild}/{channel},
+// carrying BOTH snowflakes. The parser is pure and client-side (#101, ADR-0039):
+// it extracts the two ids or returns null, never touching the network.
+const GUILD = "472093001100472093";
+const CHANNEL = "987654321098765432";
+
+describe("parseChannelLink", () => {
+  it("parses a canonical https channel deep-link into both snowflakes", () => {
+    expect(parseChannelLink(`https://discord.com/channels/${GUILD}/${CHANNEL}`)).toEqual({
+      guildId: GUILD,
+      channelId: CHANNEL,
+    });
+  });
+
+  it("tolerates scheme, subdomain, trailing-slash and query-string variants to the SAME ids", () => {
+    const variants = [
+      `https://discord.com/channels/${GUILD}/${CHANNEL}`,
+      `http://discord.com/channels/${GUILD}/${CHANNEL}`,
+      `discord.com/channels/${GUILD}/${CHANNEL}`,
+      `ptb.discord.com/channels/${GUILD}/${CHANNEL}`,
+      `https://canary.discord.com/channels/${GUILD}/${CHANNEL}`,
+      `https://discord.com/channels/${GUILD}/${CHANNEL}/`,
+      `https://discord.com/channels/${GUILD}/${CHANNEL}?foo=bar`,
+      `  https://discord.com/channels/${GUILD}/${CHANNEL}  `,
+    ];
+    for (const link of variants) {
+      expect(parseChannelLink(link)).toEqual({ guildId: GUILD, channelId: CHANNEL });
+    }
+  });
+
+  it("returns null for a string that is not a channel deep-link", () => {
+    expect(parseChannelLink("hello world")).toBeNull();
+    expect(parseChannelLink("")).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/@me/123456789012345678")).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/12345/67890")).toBeNull();
+    expect(parseChannelLink("https://example.com/channels/" + GUILD + "/" + CHANNEL)).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/" + GUILD)).toBeNull();
+  });
+});

--- a/web/src/lib/discordLink.test.ts
+++ b/web/src/lib/discordLink.test.ts
@@ -26,6 +26,11 @@ describe("parseChannelLink", () => {
       `https://discord.com/channels/${GUILD}/${CHANNEL}/`,
       `https://discord.com/channels/${GUILD}/${CHANNEL}?foo=bar`,
       `  https://discord.com/channels/${GUILD}/${CHANNEL}  `,
+      // Discord's embed-suppressed copy wraps the URL in angle brackets.
+      `<https://discord.com/channels/${GUILD}/${CHANNEL}>`,
+      // Legacy discordapp.com host — old links still resolve.
+      `https://discordapp.com/channels/${GUILD}/${CHANNEL}`,
+      `discordapp.com/channels/${GUILD}/${CHANNEL}`,
     ];
     for (const link of variants) {
       expect(parseChannelLink(link)).toEqual({ guildId: GUILD, channelId: CHANNEL });

--- a/web/src/lib/discordLink.ts
+++ b/web/src/lib/discordLink.ts
@@ -11,14 +11,25 @@ export interface ChannelLink {
 // Discord snowflakes are 17–20 digit ids (a 64-bit id rendered as decimal).
 const SNOWFLAKE = /^\d{17,20}$/;
 
+// A Discord channel host: discord.com, the legacy discordapp.com, or a client
+// subdomain of either (ptb./canary./www.).
+function isDiscordHost(host: string): boolean {
+  return ["discord.com", "discordapp.com"].some(
+    (base) => host === base || host.endsWith(`.${base}`),
+  );
+}
+
 // parseChannelLink extracts the guild + voice channel snowflakes from a pasted
 // channel deep-link, or returns null when the string is not one. It tolerates a
-// missing scheme, http/https, the ptb./canary. client subdomains, a trailing
-// slash, a query string, and surrounding whitespace — every variant resolves to
-// the same two ids. Anything else (a random string, a @me DM link, a non-Discord
-// host, short/invalid ids) yields null so the caller can surface a hint.
+// missing scheme, http/https, the ptb./canary. client subdomains, the legacy
+// discordapp.com host, angle brackets (Discord's embed-suppressed <url> copy), a
+// trailing slash, a query string, and surrounding whitespace — every variant
+// resolves to the same two ids. Anything else (a random string, a @me DM link, a
+// non-Discord host, short/invalid ids) yields null so the caller can surface a hint.
 export function parseChannelLink(input: string): ChannelLink | null {
-  const trimmed = input.trim();
+  // Strip surrounding whitespace, then the <…> Discord wraps a URL in to
+  // suppress its embed.
+  const trimmed = input.trim().replace(/^<(.*)>$/, "$1").trim();
   if (!trimmed) return null;
 
   // A scheme-less paste (the common "discord.com/channels/…") needs one to parse
@@ -32,9 +43,7 @@ export function parseChannelLink(input: string): ChannelLink | null {
     return null;
   }
 
-  // Host must be discord.com or one of its client subdomains (ptb./canary./www.).
-  const host = url.hostname.toLowerCase();
-  if (host !== "discord.com" && !host.endsWith(".discord.com")) return null;
+  if (!isDiscordHost(url.hostname.toLowerCase())) return null;
 
   // /channels/{guild}/{channel}[/…] — filter drops the empty segment a trailing
   // slash leaves behind. The query string lives in url.search, so it's ignored.

--- a/web/src/lib/discordLink.ts
+++ b/web/src/lib/discordLink.ts
@@ -1,0 +1,47 @@
+// discordLink — pure, network-free parsing of a Discord channel deep-link (#101,
+// ADR-0039). A voice channel's right-click "Copy Link" yields
+// discord.com/channels/{guildId}/{channelId}, carrying BOTH snowflakes; the
+// Configuration screen pastes that here to autofill the two ID fields.
+
+export interface ChannelLink {
+  guildId: string;
+  channelId: string;
+}
+
+// Discord snowflakes are 17–20 digit ids (a 64-bit id rendered as decimal).
+const SNOWFLAKE = /^\d{17,20}$/;
+
+// parseChannelLink extracts the guild + voice channel snowflakes from a pasted
+// channel deep-link, or returns null when the string is not one. It tolerates a
+// missing scheme, http/https, the ptb./canary. client subdomains, a trailing
+// slash, a query string, and surrounding whitespace — every variant resolves to
+// the same two ids. Anything else (a random string, a @me DM link, a non-Discord
+// host, short/invalid ids) yields null so the caller can surface a hint.
+export function parseChannelLink(input: string): ChannelLink | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // A scheme-less paste (the common "discord.com/channels/…") needs one to parse
+  // as a URL; add https:// only when no scheme is present.
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+
+  // Host must be discord.com or one of its client subdomains (ptb./canary./www.).
+  const host = url.hostname.toLowerCase();
+  if (host !== "discord.com" && !host.endsWith(".discord.com")) return null;
+
+  // /channels/{guild}/{channel}[/…] — filter drops the empty segment a trailing
+  // slash leaves behind. The query string lives in url.search, so it's ignored.
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "channels") return null;
+  const [, guildId, channelId] = segments;
+  if (!SNOWFLAKE.test(guildId ?? "") || !SNOWFLAKE.test(channelId ?? "")) return null;
+
+  return { guildId, channelId };
+}

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -345,4 +345,68 @@ describe("Configuration", () => {
     );
     expect(await screen.findByText(/Connected as Glyphoxa#4823/)).toBeInTheDocument();
   });
+
+  it("autofills both ID fields from a pasted channel link with no network request (#101)", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    renderScreen(mockBackend({ discordSaves }));
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, {
+      target: { value: "https://discord.com/channels/472093001100472093/987654321098765432" },
+    });
+
+    // Both snowflakes land in the (still editable) ID fields, purely client-side.
+    expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe("472093001100472093");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+    // Parsing issues NO save RPC — the autofill is local until the operator Saves.
+    expect(discordSaves).toHaveLength(0);
+  });
+
+  it("persists autofilled IDs through the existing Save flow (#101)", async () => {
+    renderScreen();
+
+    fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
+      target: { value: "discord.com/channels/472093001100472093/987654321098765432" },
+    });
+    // The autofill marks the fields dirty, so Save picks up the pasted values.
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+
+    expect(await screen.findByDisplayValue("472093001100472093")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("987654321098765432")).toBeInTheDocument();
+  });
+
+  it("rejects a non-link paste with an inline hint and leaves fields unchanged (#101)", async () => {
+    renderScreen();
+
+    // Operator already has a Guild ID typed in.
+    const guild = await screen.findByLabelText("Guild ID");
+    fireEvent.change(guild, { target: { value: "existing-guild" } });
+
+    // A paste that is not a channel deep-link surfaces a hint…
+    const paste = screen.getByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, { target: { value: "not a discord link" } });
+    expect(screen.getByText(/couldn't read that link/i)).toBeInTheDocument();
+
+    // …and does not clobber what the operator already had.
+    expect((guild as HTMLInputElement).value).toBe("existing-guild");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+  });
+
+  it("tolerates scheme/subdomain/trailing-slash/query variants when autofilling (#101)", async () => {
+    renderScreen();
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, {
+      target: { value: "ptb.discord.com/channels/472093001100472093/987654321098765432/?jump=1" },
+    });
+
+    expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe("472093001100472093");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+    // A rejected paste's hint must not linger after a successful one.
+    expect(screen.queryByText(/couldn't read that link/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
 import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
@@ -364,8 +364,10 @@ describe("Configuration", () => {
     expect(discordSaves).toHaveLength(0);
   });
 
-  it("persists autofilled IDs through the existing Save flow (#101)", async () => {
-    renderScreen();
+  it("persists autofilled IDs through Save into the right wire fields and re-seeds them on reload (#101)", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    const transport = mockBackend({ discordSaves });
+    const { unmount } = renderScreen(transport);
 
     fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
       target: { value: "discord.com/channels/472093001100472093/987654321098765432" },
@@ -373,8 +375,25 @@ describe("Configuration", () => {
     // The autofill marks the fields dirty, so Save picks up the pasted values.
     fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
 
-    expect(await screen.findByDisplayValue("472093001100472093")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("987654321098765432")).toBeInTheDocument();
+    // Pin the exact snowflake in the exact wire field: a guild/voice SWAP would
+    // still round-trip through the display, so a value-only check can't catch it.
+    await waitFor(() => expect(discordSaves).toHaveLength(1));
+    expect(discordSaves[0].guildId).toBe("472093001100472093");
+    expect(discordSaves[0].voiceChannelId).toBe("987654321098765432");
+
+    // Reload (AC2): a fresh mount against the SAME stateful backend re-seeds both
+    // fields from what was persisted — the values survive the round-trip, and
+    // each lands back in its OWN field (guild in Guild ID, channel in Voice).
+    unmount();
+    renderScreen(transport);
+    await waitFor(() =>
+      expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe(
+        "472093001100472093",
+      ),
+    );
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
   });
 
   it("rejects a non-link paste with an inline hint and leaves fields unchanged (#101)", async () => {

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-react";
+import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw, Link as LinkIcon } from "lucide-react";
 
 import {
   CampaignService,
@@ -17,6 +17,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { Button } from "@/components/ui/Button";
+import { parseChannelLink } from "@/lib/discordLink";
 
 import "./configuration.css";
 
@@ -94,6 +95,30 @@ export function Configuration() {
     setVoiceChannelId(v);
   };
 
+  // "Paste a Discord link" autofill (#101): a voice channel's Copy-Link carries
+  // both snowflakes, so a well-formed paste fills the two ID fields purely
+  // client-side (parseChannelLink issues no network call) and marks them dirty so
+  // Save picks the values up. A paste that isn't a channel deep-link leaves the
+  // fields untouched and surfaces an inline hint.
+  const [channelLink, setChannelLink] = useState("");
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const pasteChannelLink = (v: string) => {
+    setChannelLink(v);
+    if (!v.trim()) {
+      setLinkError(null);
+      return;
+    }
+    const parsed = parseChannelLink(v);
+    if (!parsed) {
+      setLinkError("Couldn't read that link — paste a Discord channel link.");
+      return;
+    }
+    idsDirty.current = true;
+    setGuildId(parsed.guildId);
+    setVoiceChannelId(parsed.channelId);
+    setLinkError(null);
+  };
+
   return (
     <div className="gx-providers">
       <h1>Providers</h1>
@@ -168,6 +193,15 @@ export function Configuration() {
             // presence), so replacing the token can never clobber the stored IDs —
             // even while the config load is still resolving (#142).
             onSave={(secret) => saveDiscord.mutateAsync({ botToken: secret })}
+          />
+          <Input
+            label="Paste a Discord link"
+            placeholder="https://discord.com/channels/…"
+            icon={<LinkIcon size={15} />}
+            hint="Right-click a voice channel → Copy Link to fill both IDs at once."
+            error={linkError}
+            value={channelLink}
+            onChange={(e) => pasteChannelLink(e.target.value)}
           />
           <div className="gx-discord__ids">
             <Input


### PR DESCRIPTION
## What

Part of #97 (Epic 7/7). Adds a single **"Paste a Discord link"** field to the Configuration screen's Discord connection card. A voice channel's right-click **Copy Link** yields `discord.com/channels/{guild}/{channel}`, carrying BOTH snowflakes — pasting it fills the Guild ID and voice channel ID fields client-side, with **zero network calls**. The fields stay editable and the operator Saves exactly as before.

## How

- New pure parser `web/src/lib/discordLink.ts` (`parseChannelLink`): parses `discord.com/channels/{guildId}/{channelId}`, tolerating missing scheme, `http`/`https`, `ptb.`/`canary.` subdomains, a trailing slash, a query string, and surrounding whitespace — all variants resolve to the same two ids. Validates snowflakes (`^\d{17,20}$`); anything else → `null`.
- Wired into `Configuration.tsx`: a successful parse fills both ID fields and sets the existing `idsDirty` ref so the current Save flow persists them; a non-link paste leaves both fields unchanged and shows an inline "couldn't read that link" hint via the existing `Input` `error`/`hint` props. No proto or Save-RPC change (ADR-0039; presence semantics untouched).

## Tests (TDD, red→green)

- `discordLink.test.ts`: canonical parse, variant-tolerance matrix, reject cases (`@me` DM link, short ids, non-Discord host, missing channel).
- `Configuration.test.tsx` (4 new): parse-and-fill with **no save RPC issued**, persist-through-Save (reload), reject path leaves fields unchanged + shows hint, variant tolerance.

Full web suite: 97 passing. `npm run build` (tsc + vite) green.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)