### PR TITLE
docs: ADR-0043..0047 — E6/E7 implementation decisions

### DIFF
--- a/docs/adr/0043-gateway-fatal-transient-classification.md
+++ b/docs/adr/0043-gateway-fatal-transient-classification.md
@@ -1,0 +1,22 @@
+# Gateway fatal-vs-transient classification and the connection-state taxonomy
+
+Implementing #123 (E6) required deciding what counts as a *fatal* Discord gateway failure, how a fatal failure is persisted and surfaced, and what the connection-state event vocabulary is. The operator delegated these decisions to the implementation run (2026-07-07); this ADR records them.
+
+## What this decides
+
+- **Classification is by typed error, at the reconnect loop.** `internal/wirenpc` gains a `classifyFatal(err)` step inside `runWithReconnect`: gorilla `*websocket.CloseError` 4004 → `invalid_bot_token`, 4013/4014 → `disallowed_intents`, 4010–4012 → `gateway_rejected`; disgo `*rest.Error` HTTP 401 → `invalid_bot_token`, 403 → `bot_not_authorized`. Everything else (429, 5xx, network errors) stays transient and keeps the existing bounded backoff. Validated against disgo v0.19.6: an invalid token surfaces from `OpenGateway` as a wrapped close 4004 (the `/gateway` preflight is unauthenticated), and disgo does not internally retry non-reconnectable closes.
+- **`end_reason` is a stable machine prefix plus prose**: `"invalid_bot_token: gateway rejected identify (close 4004: …)"`. The prefix set (`invalid_bot_token`, `disallowed_intents`, `bot_not_authorized`, `gateway_rejected`, `loop_error`, and `spend_cap_hard` from ADR-0046) is greppable and UI-renderable; the suffix stays human. Any non-context loop error — not just classified-fatal ones — closes the row as `failed` (prefix `loop_error:`), so no failure mode can leave a row `running`.
+- **Connection state joins the shared voice event taxonomy (ADR-0020)** as `ConnectionStateChanged` with states `connecting` / `connected` / `failed` (event name `connection.state`). The SSE relay forwards it as a `connection` frame; live reload truth is the relay snapshot, terminal reload truth is `GetSession` (status `failed` + `end_reason`).
+- **No new gRPC error mapping on Start.** Session start is asynchronous; a fatal rejection lands seconds later. The failure reaches the operator via the SSE `connection` frame and the persisted `failed` row, not a Start error.
+- **Storage closes sessions through one seam.** `CloseVoiceSession(id, status, lineCount, endReason)` replaces `EndVoiceSession` as the session-manager contract (`EndVoiceSession` remains as a delegating wrapper); `VoiceSessionStatus` gains `failed`. No migration: status is unconstrained text and `end_reason` already exists.
+- **Accepted behavior change:** env-only voice mode now *exits* on an invalid token instead of retrying forever. In Kubernetes this is a crashloop-with-backoff, which is the correct operational signal; the #44 resilience work targeted transient drops, and an invalid token is not transient.
+
+## Considered and rejected
+
+- **String-matching error text** — brittle across disgo versions; typed `errors.As` chains survive `%w` wrapping through both client paths (per-cycle acquire and presence provider).
+- **Machine-code-only `end_reason`** — the Session screen would need a client-side catalogue; prefix+prose gives both audiences one field.
+- **Mapping fatal failures onto the Start RPC** — wrong shape for an async failure; would race the gateway handshake.
+
+## Relationship to other ADRs
+
+ADR-0020 (taxonomy gains `connection.state`), ADR-0014 (frame rides the SSE ring), ADR-0039 (Session screen consumes it), ADR-0031 (no schema migration needed).

--- a/docs/adr/0044-provider-retry-policy-and-metric-placement.md
+++ b/docs/adr/0044-provider-retry-policy-and-metric-placement.md
@@ -1,0 +1,23 @@
+# Provider retry policy and provider-call metric placement
+
+Implementing #124/#125 (E6) required deciding where retries live, what is retryable, how retries interact with the per-turn deadline and barge-in, and how retry attempts appear in metrics. The operator delegated these decisions to the implementation run (2026-07-07); this ADR records them.
+
+## What this decides
+
+- **Retry lives in the orchestrator stages, not the provider adapters.** A small generic helper `pkg/voice/retry` (`Do[T]` + `Retryable`) wraps the three call sites: `orchestrator.STT.Transcribe`, `orchestrator.TTS.Dispatch`, and the LLM start in `agenttool`/`agent.providerEngine`. Adapters stay dumb and only gain *typed* errors: `pkg/voice/providererr.HTTPError{Op, StatusCode, Status, Body}` with error text byte-identical to today's, so classification is `errors.As`, never string matching.
+- **Policy defaults:** 3 attempts total, full-jitter exponential backoff 250ms→1s, injected `Sleep`/`Rand` (cassette determinism, ADR-0021 — tests never sleep wall-clock). Retryable: HTTP 429 and ≥500, `net.Error`. Non-retryable: other 4xx, context errors, untyped prose errors (under-retry is the safe default).
+- **The deadline is never extended.** Before each backoff the helper gives up if the remaining context deadline is smaller than the pause; a context cancellation (barge-in, ADR-0027) aborts immediately — including mid-backoff — and returns the context error, not a provider failure.
+- **Start-errors only.** Mid-stream failures (LLM deltas, TTS audio chunks) are not retried: output may already have been dispatched and a retry would re-speak. All three adapters surface 429/5xx as start errors anyway.
+- **The existing STT 15s request timeout becomes the *total* retry budget**, wrapping the whole retry loop — never per-attempt. A per-attempt budget (3×15s) would recreate the serial-transcription-worker wedge (#91-class NPC-goes-silent).
+- **Metrics record final outcomes only.** `ProviderCall`/`ProviderError` (wired by #125 with a shared `observe.CallOutcome(ctx, err)` classifier: ok / timeout / error) fire once per logical call after retries resolve; per-attempt detail is slog only. Stage histograms span the whole logical call including backoffs. A barge mid-TTS-stream is not a provider error. `TTSInvoked` publishes once per Dispatch, never per attempt.
+- **#125 scope note:** `stt_request` was already wired; its RESERVED help text was stale. The slice wires the remaining five reserved histograms (tts_total, codec_decode, codec_encode, vad_hangover, llm_turn) and drops all RESERVED markers. Codec encode timing covers only the encode section, never the synthesis-channel wait.
+
+## Considered and rejected
+
+- **Retry inside each provider adapter** — duplicates policy three times and hides attempts from the orchestrator's deadline logic.
+- **Per-attempt Prometheus series** — cardinality noise for a debugging concern; slog covers it (ADR-0032).
+- **Retrying mid-stream failures** — re-speak risk; rejected outright for MVP.
+
+## Relationship to other ADRs
+
+ADR-0019/0026 (stages own resilience, adapters stay thin), ADR-0021 (injected time), ADR-0027 (barge-in cancellation contract), ADR-0032 (bounded labels, final-outcome-only series), ADR-0004 (provider interfaces unchanged).

--- a/docs/adr/0045-provider-usage-metering-estimates.md
+++ b/docs/adr/0045-provider-usage-metering-estimates.md
@@ -1,0 +1,21 @@
+# Provider usage metering: event shape, labels, and estimate fallbacks
+
+Implementing #127 (E6, under the ADR-0004 amendment and ADR-0042) required deciding how usage figures travel from provider adapters to counters, what the Prometheus label shape is, and what happens when a provider reports no usage. The operator delegated these decisions to the implementation run (2026-07-07); this ADR records them.
+
+## What this decides
+
+- **Usage rides a new additive `EventUsage` stream event** (`llm.StreamEvent` gains a `Usage{InputTokens, OutputTokens}` field), not a mutated `EventDone`. Old cassettes never contain the event, so they replay unchanged (ADR-0021); consumers already drain streams to close.
+- **StageRecorder gains three usage methods** — `LLMTokens(provider, model, in, out)`, `TTSCharacters(provider, chars)`, `STTAudioSeconds(provider, d)`. The `model` parameter exists for the spend meter (ADR-0046 prices per model); **Prometheus drops it** — model is never a label. New series: `glyphoxa_voice_llm_tokens_total{provider, direction=input|output}` (direction is required: Groq prices directions differently), `glyphoxa_voice_tts_characters_total{provider}`, `glyphoxa_voice_stt_audio_seconds_total{provider}`. Bounded labels per ADR-0032.
+- **Estimate fallbacks (documented, tested, never zero):** LLM without reported usage → `ceil(chars/4)` per direction over the sent/received text; TTS → `utf8.RuneCountInString(sentence)` on accepted request (ElevenLabs bills submitted characters; counted even if later barged); STT → summed frame durations — batch: submitted audio length; streaming: voiced+pre-roll duration accumulated per utterance, recorded at end-utterance regardless of commit outcome (audio sent is audio billed; a batch fallback after a failed commit truthfully double-records, since both calls billed).
+- **`include_usage` is preset-gated in openaicompat**: on for Groq and OpenAI presets, off for Gemini until verified — a gateway that rejects `stream_options` would 400 every turn. The trailing usage chunk arrives with empty `choices`; capture happens before the empty-choices skip guard.
+- **Capture is inline at the call sites** (atomic counter adds, nanoseconds); no deferral machinery. Usage capture never blocks or fails a turn. Error/barge paths record provider-reported usage if received, otherwise nothing.
+
+## Considered and rejected
+
+- **Usage on `EventDone`** — mutating an existing event's semantics risks ordering assumptions in consumers and cassette drift.
+- **Model as a Prometheus label** — unbounded-ish cardinality for no dashboard need; the spend meter is the only consumer of model granularity.
+- **Deferred/batched usage recording** — complexity without measurable hot-path win.
+
+## Relationship to other ADRs
+
+ADR-0004 (amendment 2026-07-04 defines the metering mandate), ADR-0042 (STT duration cost), ADR-0032 (label bounds), ADR-0021 (additive event, cassette stability), ADR-0046 (spend meter consumes these capture points).

--- a/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
+++ b/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
@@ -1,0 +1,22 @@
+# Per-session spend meter: ownership, price map, and cap mechanics
+
+Implementing #130 (E6, under the ADR-0004 amendment) required deciding where the per-session spend accumulator lives, where prices come from, and the precise soft/hard-cap semantics. The operator delegated these decisions to the implementation run (2026-07-07); this ADR records them.
+
+## What this decides
+
+- **`internal/spend.Meter` implements `observe.UsageSink`** (the three usage methods from ADR-0045) and is teed into the session's recorder via `observe.TeeUsage(base, sink)` at `session.Manager.Start` — zero new plumbing through the voice pipeline; the meter rides the existing recorder config copy. No caps configured → no meter, no tee, no gate: byte-for-byte today's behavior.
+- **The session manager owns cap consequences.** The meter takes `onSoft`/`onHard` callbacks (each fires once, outside the meter mutex, never blocking). Soft: publish `SpendCapReached{soft}`; the orchestrator `TurnGate` (`AllowTurn() bool`, wired as a replier pre-check beside the mute check) refuses *new* turns — in-flight turns complete, transcription continues. Hard: publish `SpendCapReached{hard}` and cancel the session context on a fresh goroutine (avoids lock-order deadlocks, #211 pattern); the row closes via `CloseVoiceSession` (ADR-0043) with status **`ended`** — a deliberate policy stop, not a failure — and `end_reason` prefix `spend_cap_hard`.
+- **Prices are code constants** (`internal/spend/prices.go`), keyed `(component, provider, model)`, each entry carrying a source comment and date, all surfaced numbers labelled *estimates*. Unknown key → conservative documented default plus a warn-once log. A DB/config price surface is deferred until someone actually needs to edit prices without a deploy.
+- **Caps are per-Tenant nullable columns** (`spend_cap_soft_usd`, `spend_cap_hard_usd`, migration; either alone valid, both ⇒ hard ≥ soft, enforced at the RPC). New `GetSpendCaps`/`SetSpendCaps` RPCs; `GetSessionResponse` gains `spend_cap_state` and `estimated_spend_usd`. Caps snapshot at session start; edits apply to the next session.
+- **Refused turns are observable:** `TurnEnded` reason `spend_cap` maps to `TurnOutcome(abandoned, spend_cap)`; the relay forwards `SpendCapReached` as a `spendcap` SSE frame for the Session screen.
+- **Mutex, not atomics**, guards the accumulator: float math plus threshold-callback dispatch under one small lock beats a lock-free scheme nobody can review.
+
+## Considered and rejected
+
+- **Prometheus per-session labels for spend** — forbidden by ADR-0032's cardinality bound; the accumulator is session-local state, not a metric.
+- **Gating inside the address detector or segmenter** — would silence transcription; the AC requires transcription to continue under a soft cap.
+- **Failed-status rows on hard cap** — the session did exactly what it was configured to do; `failed` is reserved for faults (ADR-0043).
+
+## Relationship to other ADRs
+
+ADR-0004 (amendment is the spec this implements), ADR-0045 (usage capture points), ADR-0043 (close seam + end_reason prefixes), ADR-0032 (no session labels), ADR-0020/0014/0039 (event + SSE + screen surface).

--- a/docs/adr/0047-discord-invite-resolver-bot-authorization.md
+++ b/docs/adr/0047-discord-invite-resolver-bot-authorization.md
@@ -1,0 +1,22 @@
+# Discord invite resolver and bot-authorization surface
+
+Implementing E7 (#101/#105/#110) required deciding the wire contract for invite resolution, the shape of the Discord REST client, error semantics, and the bot-authorization URL. The operator delegated these decisions to the implementation run (2026-07-07); this ADR records them.
+
+## What this decides
+
+- **The client owns link parsing; the server receives a bare `invite_code`.** The #101 client-side parser (`web/src/lib/discordLink.ts`, zero network) grows an invite branch (`discord.gg/{code}`, `discord.com/invite/{code}`, scheme/subdomain/trailing-slash/query tolerant); `ResolveGuildInvite` validates `^[A-Za-z0-9-]{2,64}$` and path-escapes. URL-parsing bugs stay client-side and testable in vitest.
+- **`internal/discordinvite` mirrors `internal/discordtag` exactly**: plain `net/http` (not disgo's rest client — its rate limiter leaks a goroutine per call), 15s client timeout, `Bot` auth header, package-private `resolve` with a base-URL + `export_test.go` seam. Flow: `GET /invites/{code}` → guild; `GET /guilds/{id}/channels` → keep only type-2 `GUILD_VOICE` (stage channels excluded for MVP), sorted by position then name.
+- **Error semantics:** invite 404 or guild-less (group-DM) invite → `ErrNotFound` → gRPC `NotFound` ("invalid or expired"); channels 403 *or* 404 → `ErrNoAccess` → `FailedPrecondition` ("the Bot is not a member of that server" — Discord is inconsistent about which code it returns for non-member guilds, so both map identically); no saved bot token → `FailedPrecondition` with a distinct message. The RPC is `NO_SIDE_EFFECTS` (CSRF-exempt read, same precedent as `GetProviderHealth`); the deployment Bot token is decrypted server-side and never crosses the wire.
+- **The bot-authorization link (#110)** is built client-side from a server-provided application id: `ListProviderConfigsResponse.discord_application_id` (non-secret, sourced from `DISCORD_OAUTH_CLIENT_ID`, empty when unset → disabled control with note). Scope is **`bot applications.commands`** — not bare `bot` — because Glyphoxa registers `/glyphoxa` slash commands (E5) that would otherwise be invisible in freshly added guilds. Permissions constant: View Channel + Connect + Speak = `3146752`; a mute bot that can only connect fails its purpose.
+- **UI fill path:** picker selections and link autofill go through the Configuration screen's dirty-tracking edit path (`idsDirty`), never raw state set — otherwise a config refetch clobbers the fill. Failed resolves leave fields and any previous picker untouched.
+
+## Considered and rejected
+
+- **Sending the full invite URL to the server** — moves parsing behind the RPC boundary where UI iteration is slowest; the client already owns link parsing for #101.
+- **disgo rest client for the two REST calls** — known goroutine leak per call (documented at `discordtag.go`); plain HTTP matches the established seam pattern.
+- **Including stage channels** — a Voice Session has no stage semantics (speaker requests); revisit on demand.
+- **A dedicated RPC for the application id** — one non-secret string on an existing read response is strictly simpler.
+
+## Relationship to other ADRs
+
+ADR-0016 (the operator-login application backs the bot-authorization URL), ADR-0033 (live Discord behind seams, keyless default suite), ADR-0004/0039 (token sealed at rest, decrypted server-side only), ADR-0014 (management RPC surface).


### PR DESCRIPTION
Records decisions the operator delegated to the implementation run (2026-07-07), one ADR per cluster:

- ADR-0043 — gateway fatal-vs-transient classification, connection-state taxonomy (#123)
- ADR-0044 — provider retry policy + provider-call metric placement (#124/#125)
- ADR-0045 — usage metering event shape, labels, estimate fallbacks (#127)
- ADR-0046 — per-session spend meter ownership, price map, cap mechanics (#130)
- ADR-0047 — Discord invite resolver + bot-authorization surface (#101/#105/#110)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)