### PR TITLE
feat(#110): Add Glyphoxa to your server (bot-authorization link)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -556,6 +556,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	if presenceRefresh != nil {
 		providerSrv.SetPresenceRefresher(presenceRefresh)
 	}
+	// The OAuth client id is the Discord application id; ListProviderConfigs
+	// echoes it so the Configuration screen builds the bot-authorization URL
+	// (#110). Empty when DISCORD_OAUTH_CLIENT_ID is unset — the screen's disabled
+	// fallback.
+	providerSrv.SetDiscordApplicationID(clientID)
 	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -82,6 +82,12 @@ type ProviderServer struct {
 	// slash-command surface without a restart. Fired in a goroutine (presence
 	// Ensure does network I/O). nil (web-only, or not wired) skips.
 	refreshPresence func()
+
+	// discordAppID is the Discord application (client) id backing operator login
+	// (ADR-0016), surfaced on ListProviderConfigs so the SPA composes the
+	// bot-authorization URL (#110). Non-secret; empty when DISCORD_OAUTH_CLIENT_ID
+	// is unset, which the screen renders as a disabled action.
+	discordAppID string
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -110,6 +116,15 @@ func (s *ProviderServer) SetHealthInvalidator(fn func(tenantID uuid.UUID)) {
 // not block the RPC response.
 func (s *ProviderServer) SetPresenceRefresher(fn func()) {
 	s.refreshPresence = fn
+}
+
+// SetDiscordApplicationID wires the Discord application (client) id ListProviderConfigs
+// echoes so the SPA composes the bot-authorization URL (#110), mirroring
+// SetHealthInvalidator/SetPresenceRefresher. Called once at boot, before the
+// server serves, so no lock is needed. The empty string (DISCORD_OAUTH_CLIENT_ID
+// unset) is the missing-app-id fallback the screen renders as disabled.
+func (s *ProviderServer) SetDiscordApplicationID(id string) {
+	s.discordAppID = id
 }
 
 // Handler builds the Connect HTTP handler for ProviderService and returns its
@@ -167,9 +182,10 @@ func (s *ProviderServer) ListProviderConfigs(
 	}
 
 	return connect.NewResponse(&managementv1.ListProviderConfigsResponse{
-		Credentials:    creds,
-		GuildId:        dep.GuildID,
-		VoiceChannelId: dep.VoiceChannelID,
+		Credentials:          creds,
+		GuildId:              dep.GuildID,
+		VoiceChannelId:       dep.VoiceChannelID,
+		DiscordApplicationId: s.discordAppID,
 	}), nil
 }
 

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -114,6 +114,16 @@ func testCipher(t *testing.T) *crypto.Cipher {
 // Connect-JSON client. WithProtoJSON also asserts the RPCs work over JSON.
 func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Cipher) (managementv1connect.ProviderServiceClient, uuid.UUID) {
 	t.Helper()
+	return clientForServer(t, rpc.NewProviderServer(store, cipher, nil))
+}
+
+// clientForServer mounts a PRE-BUILT ProviderServer behind the fixed-tenant
+// interceptor and returns a Connect-JSON client + the injected tenant. Callers
+// that must configure the server before it serves (e.g. SetDiscordApplicationID,
+// #110) build it and pass it in; newProviderClient is the common store+cipher
+// shortcut over this.
+func clientForServer(t *testing.T, server *rpc.ProviderServer) (managementv1connect.ProviderServiceClient, uuid.UUID) {
+	t.Helper()
 	tenantID := uuid.New()
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
@@ -121,7 +131,7 @@ func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Ci
 		}
 	})
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewProviderServer(store, cipher, nil).Handler(connect.WithInterceptors(inject)))
+	mux.Handle(server.Handler(connect.WithInterceptors(inject)))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return managementv1connect.NewProviderServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON()), tenantID
@@ -135,6 +145,37 @@ func credByProvider(creds []*managementv1.ProviderCredential, provider string) *
 		}
 	}
 	return nil
+}
+
+// TestProviderList_DiscordApplicationID pins #110: the configured Discord
+// application (client) id — the same app that backs operator login (ADR-0016) —
+// is exposed on the read so the SPA composes the bot-authorization URL without
+// hardcoding anything. Without the setter wired it reads empty, the fallback the
+// SPA renders as a disabled action + note.
+func TestProviderList_DiscordApplicationID(t *testing.T) {
+	t.Parallel()
+
+	srv := rpc.NewProviderServer(newFakeProviderStore(), testCipher(t), nil)
+	srv.SetDiscordApplicationID("123456789012345678")
+	client, _ := clientForServer(t, srv)
+
+	resp, err := client.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got := resp.Msg.GetDiscordApplicationId(); got != "123456789012345678" {
+		t.Errorf("discord_application_id = %q, want 123456789012345678", got)
+	}
+
+	// No setter → empty on the wire (the missing-app-id fallback).
+	bare, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	resp2, err := bare.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List (bare): %v", err)
+	}
+	if got := resp2.Msg.GetDiscordApplicationId(); got != "" {
+		t.Errorf("discord_application_id without setter = %q, want empty", got)
+	}
 }
 
 func TestProviderList_EmptyShowsKeyNeeded(t *testing.T) {

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -617,6 +617,10 @@ message ListProviderConfigsResponse {
   string guild_id = 2;
   // voice_channel_id is the channel sessions join (non-secret; may be empty).
   string voice_channel_id = 3;
+  // discord_application_id is the Discord application (client) id backing
+  // operator login (ADR-0016), reused for the bot-authorization URL; non-secret;
+  // empty when DISCORD_OAUTH_CLIENT_ID unset.
+  string discord_application_id = 4;
 }
 
 // SaveProviderConfigRequest seals one BYOK provider key.

--- a/web/src/screens/configuration/AddBotLink.test.tsx
+++ b/web/src/screens/configuration/AddBotLink.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AddBotLink, botAuthorizeUrl } from "./AddBotLink";
+
+// The bot-authorization URL is a fixed contract (#110): Discord's authorize
+// endpoint, scope=bot + applications.commands (so /glyphoxa slash commands
+// appear in a fresh guild), and permissions 3146752 = View Channel (0x400) +
+// Connect (0x100000) + Speak (0x200000) — the set a voice-join needs.
+const PINNED = "https://discord.com/oauth2/authorize?client_id=123&scope=bot%20applications.commands&permissions=3146752";
+
+describe("botAuthorizeUrl", () => {
+  it("composes the pinned authorize URL from the application id", () => {
+    expect(botAuthorizeUrl("123")).toBe(PINNED);
+  });
+
+  it("url-encodes the application id", () => {
+    expect(botAuthorizeUrl("a b")).toContain("client_id=a%20b");
+  });
+});
+
+describe("AddBotLink", () => {
+  it("renders an authorize anchor opening in a new tab", () => {
+    render(<AddBotLink applicationId="123" />);
+    const link = screen.getByRole("link", { name: /add glyphoxa to your server/i });
+    expect(link).toHaveAttribute("href", PINNED);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("states adding the bot is a separate, prerequisite step", () => {
+    render(<AddBotLink applicationId="123" />);
+    // Copy must distinguish this from saving the IDs and mark it a prerequisite.
+    expect(screen.getByText(/separate step from saving the ids/i)).toBeInTheDocument();
+    expect(screen.getByText(/before a voice session can join/i)).toBeInTheDocument();
+  });
+
+  it("disables the action with a note when no application id is configured", () => {
+    render(<AddBotLink applicationId="" />);
+    // No broken link: the anchor is absent, a disabled button stands in.
+    expect(screen.queryByRole("link", { name: /add glyphoxa to your server/i })).not.toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /add glyphoxa to your server/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/no discord application id is configured/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/configuration/AddBotLink.tsx
+++ b/web/src/screens/configuration/AddBotLink.tsx
@@ -1,0 +1,56 @@
+import { ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+
+// AddBotLink — the Configuration Discord card's "Add Glyphoxa to your server"
+// action (#110). Adding the Bot to a Guild is a SEPARATE, prerequisite step from
+// saving the Guild / Voice channel IDs: neither pasted-link format joins the Bot,
+// so a Voice Session cannot join voice until the operator authorizes it here.
+//
+// The URL is built entirely from the server-provided Discord application id (the
+// same app that backs operator login, ADR-0016) — nothing secret is hardcoded.
+// With no application id (DISCORD_OAUTH_CLIENT_ID unset) the action is disabled
+// with an explanatory note instead of producing a broken link.
+
+// botAuthorizeUrl composes Discord's bot-authorization URL for one application.
+// scope=bot pulls the Bot into the Guild; applications.commands registers the
+// /glyphoxa slash commands in a fresh guild; permissions 3146752 = View Channel
+// (0x400) + Connect (0x100000) + Speak (0x200000) — the minimum a voice-join Bot
+// needs.
+export function botAuthorizeUrl(applicationId: string): string {
+  return `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(applicationId)}&scope=bot%20applications.commands&permissions=3146752`;
+}
+
+// The always-visible copy distinguishing this step from saving the IDs and
+// marking it a prerequisite for voice-join.
+const COPY =
+  "Adding the Bot to a server is a separate step from saving the IDs below — the Bot must be a member before a Voice Session can join voice.";
+
+// The anchor wears the Button classes because the Button primitive is
+// button-only; a real <a> is needed to open Discord in a new tab.
+const BTN_CLASS = "gx-btn gx-btn--secondary gx-btn--sm";
+
+export function AddBotLink({ applicationId }: { applicationId: string }) {
+  return (
+    <div className="gx-add-bot">
+      <p className="gx-add-bot__copy">{COPY}</p>
+      {applicationId ? (
+        <a className={BTN_CLASS} href={botAuthorizeUrl(applicationId)} target="_blank" rel="noopener noreferrer">
+          <span className="gx-btn__icon">
+            <ExternalLink size={16} />
+          </span>
+          Add Glyphoxa to your server
+        </a>
+      ) : (
+        <>
+          <Button variant="secondary" size="sm" disabled iconStart={<ExternalLink size={16} />}>
+            Add Glyphoxa to your server
+          </Button>
+          <p className="gx-add-bot__note">
+            No Discord application id is configured (DISCORD_OAUTH_CLIENT_ID), so this link can&apos;t be built.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/configuration/AddBotLink.tsx
+++ b/web/src/screens/configuration/AddBotLink.tsx
@@ -22,9 +22,10 @@ export function botAuthorizeUrl(applicationId: string): string {
 }
 
 // The always-visible copy distinguishing this step from saving the IDs and
-// marking it a prerequisite for voice-join.
+// marking it a prerequisite for voice-join. "above" because the action renders
+// at the foot of the card, below the ID inputs.
 const COPY =
-  "Adding the Bot to a server is a separate step from saving the IDs below — the Bot must be a member before a Voice Session can join voice.";
+  "Adding the Bot to a server is a separate step from saving the IDs above — the Bot must be a member before a Voice Session can join voice.";
 
 // The anchor wears the Button classes because the Button primitive is
 // button-only; a real <a> is needed to open Discord in a new tab.

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -71,6 +71,9 @@ function mockBackend(
     // listModelsError makes the catalog fetch fail at the transport, pinning
     // that free-text model entry survives a dead catalog (#227).
     listModelsError?: string;
+    // discordApplicationId seeds the server-provided Discord application id the
+    // read echoes so the screen composes the bot-authorization URL (#110).
+    discordApplicationId?: string;
   } = {},
 ) {
   const state = {
@@ -104,6 +107,7 @@ function mockBackend(
           ],
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
+          discordApplicationId: opts.discordApplicationId ?? "",
         }),
       saveProviderConfig: (req) => {
         opts.providerSaves?.push({ provider: req.provider, secret: req.secret, model: req.model });
@@ -371,6 +375,19 @@ describe("Configuration", () => {
       }),
     );
     expect(await screen.findByText(/Connected as Glyphoxa#4823/)).toBeInTheDocument();
+  });
+
+  it("shows the Add-Glyphoxa-to-your-server link built from the server app id (#110)", async () => {
+    renderScreen(mockBackend({ discordApplicationId: "987654321098765432" }));
+    const link = await screen.findByRole("link", { name: /add glyphoxa to your server/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("client_id=987654321098765432"));
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("disables the Add-Glyphoxa action when no application id is configured (#110)", async () => {
+    renderScreen(); // default mock: empty discordApplicationId
+    expect(await screen.findByText(/no discord application id is configured/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /add glyphoxa to your server/i })).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -389,6 +389,16 @@ describe("Configuration", () => {
     expect(await screen.findByText(/no discord application id is configured/i)).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /add glyphoxa to your server/i })).not.toBeInTheDocument();
   });
+
+  it("does not flash the missing-app-id note while the config query is loading (#110)", async () => {
+    renderScreen(); // default mock resolves success with an empty id
+    // Synchronously after render the list query is still pending — the note must
+    // not flash (nor would it stick on a query error): only a resolved empty id
+    // is the disabled fallback.
+    expect(screen.queryByText(/no discord application id is configured/i)).not.toBeInTheDocument();
+    // Once the read resolves with an empty id, the disabled action + note appear.
+    expect(await screen.findByText(/no discord application id is configured/i)).toBeInTheDocument();
+  });
 });
 
 describe("Configuration model entry (#227)", () => {

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -211,8 +211,11 @@ export function Configuration() {
             )}
           </div>
           {/* Authorizing the Bot into the Guild is a separate, prerequisite step
-              from saving the IDs — neither pasted-link format joins the Bot (#110). */}
-          <AddBotLink applicationId={config.data?.discordApplicationId ?? ""} />
+              from saving the IDs — neither pasted-link format joins the Bot (#110).
+              Gated on a resolved read so the "no application id" note can't flash
+              while the config loads, nor stick on a query error — only a genuine
+              empty id (query succeeded) is the disabled fallback. */}
+          {config.isSuccess && <AddBotLink applicationId={config.data.discordApplicationId} />}
         </div>
       </Card>
 

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -17,6 +17,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
 import { Combobox } from "@/components/ui/Combobox";
 import { Button } from "@/components/ui/Button";
+import { AddBotLink } from "./AddBotLink";
 
 import "./configuration.css";
 
@@ -209,6 +210,9 @@ export function Configuration() {
               </span>
             )}
           </div>
+          {/* Authorizing the Bot into the Guild is a separate, prerequisite step
+              from saving the IDs — neither pasted-link format joins the Bot (#110). */}
+          <AddBotLink applicationId={config.data?.discordApplicationId ?? ""} />
         </div>
       </Card>
 

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -73,6 +73,30 @@
   color: var(--status-danger);
 }
 
+/* "Add Glyphoxa to your server" bot-authorization action (#110): a separate,
+ * prerequisite step from saving the IDs, sits at the foot of the Discord card
+ * above a top divider so the distinction reads. */
+.gx-add-bot {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.gx-add-bot__copy {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
+.gx-add-bot__note {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
 /* Resolved Discord bot tag from the live gateway login (#70), under the name. */
 .gx-provider-row__tag {
   font-size: var(--text-xs, 0.75rem);


### PR DESCRIPTION
Closes #110

## What
Adds an "Add Glyphoxa to your server" bot-authorization action to the Configuration Discord connection card (Epic 7/7, #97). Closes the gotcha that neither pasted-link format joins the Bot to the Guild.

## How
- **Proto**: `ListProviderConfigsResponse.discord_application_id` (field 4) — the same Discord application (client) id that backs operator login (ADR-0016), non-secret, empty when `DISCORD_OAUTH_CLIENT_ID` is unset.
- **Backend** (`internal/rpc/provider.go`): `SetDiscordApplicationID` setter (mirrors `SetHealthInvalidator`/`SetPresenceRefresher`), echoed on the read. Wired at boot in `cmd/glyphoxa/main.go` from the OAuth client id.
- **Web** (`web/src/screens/configuration/AddBotLink.tsx`): `botAuthorizeUrl(id)` composes `https://discord.com/oauth2/authorize?client_id=…&scope=bot%20applications.commands&permissions=3146752` (View Channel 0x400 + Connect 0x100000 + Speak 0x200000). Enabled → styled `<a target="_blank" rel="noopener noreferrer">`. Empty id → disabled Button + note, no broken link. Always-visible copy marks it a separate, prerequisite step from saving the IDs.

## Tests
- Go: `TestProviderList_DiscordApplicationID` (setter round-trips; empty without setter).
- Web `AddBotLink.test.tsx`: pinned URL composition, encoding, anchor attrs, separate-step copy, missing-id fallback.
- Web `Configuration.test.tsx`: anchor appears with server app id in href; disabled when unconfigured.

## Note
Backend commit was recovered via cherry-pick after another worktree's branch-rename swept it up; content is the clean 4-file backend change plus the web slice.
