### PR TITLE
feat(#125): wire dead Provider observability — STT/TTS calls+errors and the six reserved histograms

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -556,6 +556,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	if presenceRefresh != nil {
 		providerSrv.SetPresenceRefresher(presenceRefresh)
 	}
+	// The OAuth client id is the Discord application id; ListProviderConfigs
+	// echoes it so the Configuration screen builds the bot-authorization URL
+	// (#110). Empty when DISCORD_OAUTH_CLIENT_ID is unset — the screen's disabled
+	// fallback.
+	providerSrv.SetDiscordApplicationID(clientID)
 	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)

--- a/docs/adr/0044-provider-retry-policy-and-metric-placement.md
+++ b/docs/adr/0044-provider-retry-policy-and-metric-placement.md
@@ -21,3 +21,11 @@ Implementing #124/#125 (E6) required deciding where retries live, what is retrya
 ## Relationship to other ADRs
 
 ADR-0019/0026 (stages own resilience, adapters stay thin), ADR-0021 (injected time), ADR-0027 (barge-in cancellation contract), ADR-0032 (bounded labels, final-outcome-only series), ADR-0004 (provider interfaces unchanged).
+
+## Amendment 2026-07-07 (#239 review)
+
+Two refinements from the #125 PR review, both narrowing the metric semantics the section above records:
+
+- **`tts_total` is a *deliver* span, not synthesis time.** The lockstep `TeeSynthesizer` forwards each synthesized chunk in step with the playback pump (disgo's 20 ms sender), so the TTS stage's chunk drain is paced by playback: its duration tracks how long the sentence takes to *speak*, not to synthesize. True synthesis time is therefore unobservable at this seam, and the provider-latency signal already lives in `tts_ttfb`. `tts_total` is consequently recorded and documented as a deliver span — "synthesis plus paced playback delivery of one sentence" — and given its own wide buckets (0.5, 1, 2, 5, 10, 20, 30, 60 s) instead of the shared sub-5s SLO `latencyBuckets`, which would dump every real sentence into `+Inf`.
+
+- **`observe.CallOutcome` gains a fourth outcome, `canceled`.** The original classifier collapsed every non-nil ctx error into `timeout`. It now distinguishes a `context.Canceled` call ctx — a caller-driven barge-in / supersede (ADR-0027) — as `OutcomeCanceled`, while `context.DeadlineExceeded` stays `timeout`. A `canceled` outcome counts the call in `provider_calls` but does **not** increment `provider_errors`: a barge-in is not a vendor fault and must not inflate the error ratio. `timeout` and `error` remain faults and still bump `provider_errors`. The rule is shared verbatim across the STT, TTS and LLM stages (`Outcome.IsFault` gates the error bump). `canceled` is a bounded enum value (ADR-0032).

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -23,6 +23,15 @@ var latencyBuckets = []float64{
 	0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1.0, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0,
 }
 
+// ttsDeliverBuckets size the tts_total DELIVER span, which is not a sub-second
+// latency but the whole-sentence delivery time: under the lockstep TeeSynthesizer
+// the drain is paced by the playback pump, so a sentence takes as long to deliver
+// as it takes to speak (seconds to tens of seconds). The SLO latencyBuckets top out
+// at 5s and would dump every real sentence into +Inf, so this series gets its own
+// wide bins (ADR-0044 amendment, #239 review). The provider-latency signal lives
+// in tts_ttfb (which keeps the SLO buckets).
+var ttsDeliverBuckets = []float64{0.5, 1, 2, 5, 10, 20, 30, 60}
+
 // PrometheusRecorder is the single adapter implementing both metric contracts —
 // pkg/voice's [voice.MetricsRecorder] (hot-path plumbing) and [StageRecorder]
 // (orchestrator stage/turn timings + provider calls). It owns its own
@@ -173,7 +182,16 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 	r.codecEncode = plainHist("codec_encode_seconds", "PCM->Opus encode per outbound frame.")
 	r.sttRequest = hist("stt_request_seconds", "STT provider POST round-trip.", "provider")
 	r.ttsTTFB = hist("tts_ttfb_seconds", "TTS Synthesize call to first audio chunk.", "provider")
-	r.ttsTotal = hist("tts_total_seconds", "Full TTS synthesis.", "provider")
+	// tts_total is a DELIVER span (synthesis + paced playback), not synthesis time,
+	// so it uses the wide ttsDeliverBuckets rather than the shared SLO buckets
+	// (ADR-0044 amendment, #239 review). Built inline because hist() bakes in
+	// latencyBuckets.
+	r.ttsTotal = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace, Subsystem: subsystem,
+		Name:    "tts_total_seconds",
+		Help:    "TTS deliver span: synthesis plus paced playback delivery of one sentence. Provider latency lives in tts_ttfb.",
+		Buckets: ttsDeliverBuckets,
+	}, []string{"provider"})
 	r.llmRound = hist("llm_round_seconds", "One LLM Complete round inside the agenttool loop.", "provider", "round_index", "had_tool_call")
 	r.llmTurn = hist("llm_turn_seconds", "Full agenttool loop (all rounds + tool exec).", "provider")
 

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -159,26 +159,23 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 	r.playbackTotal = counterVec("playback_total", "Playbacks finished, by whether they were interrupted.", "interrupted")
 	r.bargeCancels = counter("barge_cancels_total", "Confirmed barge-ins that tore down an Agent's active turn (ADR-0027).")
 
-	// Of the per-stage histograms, only response_latency, address_detect and
-	// tts_ttfb have a live emit-site this sprint (the bus subscriber); llm_round
-	// is emitted by the agenttool adapter. The remaining six — vad_hangover,
-	// stt_request, tts_total, codec_decode, codec_encode, llm_turn — are RESERVED:
-	// registered so the /metrics surface is spec-complete (ADR-0032), but their
-	// emit-sites are carry-over task #11, so they expose an empty histogram (0
-	// observations) until wired. The Help text says so, so a consumer doesn't read
-	// the absence of samples as a fault.
-	const reserved = " RESERVED: emit-site not yet wired (carry-over task #11); empty until then."
-
+	// Every per-stage histogram now has a live emit-site (#125): response_latency,
+	// address_detect and tts_ttfb from the bus subscriber; llm_round from the
+	// agenttool adapter; and the six formerly-reserved families — vad_hangover,
+	// stt_request, tts_total, codec_decode, codec_encode, llm_turn — from the VAD /
+	// STT / TTS orchestrator stages, the wire codec, and the agenttool loop wrapper.
+	// So none carries a RESERVED marker: a consumer that sees no samples is reading a
+	// genuinely idle stage, not an unwired one.
 	r.responseLatency = hist("response_latency_seconds", "Headline SLO: VAD speech-end to first audio chunk handed to the playback pump.", "agent_role")
-	r.vadHangover = plainHist("vad_hangover_seconds", "VAD end-of-speech detection lag (minSilenceFrames*frameMs)."+reserved)
+	r.vadHangover = plainHist("vad_hangover_seconds", "VAD end-of-speech detection lag (minSilenceFrames*frameMs).")
 	r.addressDetect = plainHist("address_detect_seconds", "Address-detection stage duration.")
-	r.codecDecode = plainHist("codec_decode_seconds", "Opus->PCM decode per inbound frame."+reserved)
-	r.codecEncode = plainHist("codec_encode_seconds", "PCM->Opus encode per outbound frame."+reserved)
-	r.sttRequest = hist("stt_request_seconds", "STT provider POST round-trip."+reserved, "provider")
+	r.codecDecode = plainHist("codec_decode_seconds", "Opus->PCM decode per inbound frame.")
+	r.codecEncode = plainHist("codec_encode_seconds", "PCM->Opus encode per outbound frame.")
+	r.sttRequest = hist("stt_request_seconds", "STT provider POST round-trip.", "provider")
 	r.ttsTTFB = hist("tts_ttfb_seconds", "TTS Synthesize call to first audio chunk.", "provider")
-	r.ttsTotal = hist("tts_total_seconds", "Full TTS synthesis."+reserved, "provider")
+	r.ttsTotal = hist("tts_total_seconds", "Full TTS synthesis.", "provider")
 	r.llmRound = hist("llm_round_seconds", "One LLM Complete round inside the agenttool loop.", "provider", "round_index", "had_tool_call")
-	r.llmTurn = hist("llm_turn_seconds", "Full agenttool loop (all rounds + tool exec)."+reserved, "provider")
+	r.llmTurn = hist("llm_turn_seconds", "Full agenttool loop (all rounds + tool exec).", "provider")
 
 	r.providerCalls = counterVec("provider_calls_total", "Vendor calls by stage, provider and outcome.", "stage", "provider", "outcome")
 	r.providerErrors = counterVec("provider_errors_total", "Vendor call errors by stage and provider.", "stage", "provider")

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -156,6 +156,29 @@ func TestWiredHistogramsAndProviderCounters(t *testing.T) {
 	}
 }
 
+// TestTTSTotalDeliverSpanBucketsAndHelp pins the #239 re-scope: tts_total is a
+// deliver span carrying its own wide buckets (0.5–60s), NOT the shared sub-5s SLO
+// buckets, and its help text names it a deliver span and points provider latency at
+// tts_ttfb.
+func TestTTSTotalDeliverSpanBucketsAndHelp(t *testing.T) {
+	rec := NewPrometheusRecorder()
+	rec.TTSTotal(ProviderElevenLabs, 12*time.Second)
+	out := scrape(t, rec)
+
+	wantHelp := `# HELP glyphoxa_voice_tts_total_seconds TTS deliver span: synthesis plus paced playback delivery of one sentence. Provider latency lives in tts_ttfb.`
+	if !strings.Contains(out, wantHelp) {
+		t.Errorf("tts_total help missing/wrong; want:\n%s\ngot:\n%s", wantHelp, filterGlyphoxa(out))
+	}
+	// A wide bin must exist (deliver buckets), and the sub-second SLO bin must NOT.
+	// (Prometheus orders the histogram's le label after the user labels.)
+	if !strings.Contains(out, `glyphoxa_voice_tts_total_seconds_bucket{provider="elevenlabs",le="60"}`) {
+		t.Errorf("tts_total missing the wide le=60 bucket:\n%s", filterGlyphoxa(out))
+	}
+	if strings.Contains(out, `glyphoxa_voice_tts_total_seconds_bucket{provider="elevenlabs",le="0.05"`) {
+		t.Errorf("tts_total still carries the shared SLO buckets (le=0.05); want its own wide buckets:\n%s", filterGlyphoxa(out))
+	}
+}
+
 func TestSessionGaugeTracksOpenClose(t *testing.T) {
 	rec := NewPrometheusRecorder()
 	rec.SessionOpened("a")

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -104,6 +104,58 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	}
 }
 
+// TestWiredHistogramsAndProviderCounters is the #125 AC pin: after one real
+// observation on each previously-reserved instrument, every one of the six
+// histogram families exposes a non-empty series, the STT and TTS provider-call /
+// provider-error counters carry the right stage labels, and NO help text still
+// advertises "RESERVED" (the markers are dropped as each emit-site is wired).
+func TestWiredHistogramsAndProviderCounters(t *testing.T) {
+	rec := NewPrometheusRecorder()
+
+	// One observation on each of the six formerly-reserved histograms.
+	rec.VADHangover(384 * time.Millisecond)
+	rec.CodecDecode(2 * time.Millisecond)
+	rec.CodecEncode(1 * time.Millisecond)
+	rec.STTRequest(ProviderElevenLabs, 700*time.Millisecond)
+	rec.TTSTotal(ProviderElevenLabs, 900*time.Millisecond)
+	rec.LLMTurn(ProviderGroq, 1500*time.Millisecond)
+
+	// STT and TTS provider health: a call + error at each stage.
+	rec.ProviderCall(StageSTT, ProviderElevenLabs, OutcomeOK)
+	rec.ProviderError(StageSTT, ProviderElevenLabs)
+	rec.ProviderCall(StageTTS, ProviderElevenLabs, OutcomeError)
+	rec.ProviderError(StageTTS, ProviderElevenLabs)
+
+	out := scrape(t, rec)
+
+	wantSeries := []string{
+		`glyphoxa_voice_vad_hangover_seconds_count 1`,
+		`glyphoxa_voice_codec_decode_seconds_count 1`,
+		`glyphoxa_voice_codec_encode_seconds_count 1`,
+		`glyphoxa_voice_stt_request_seconds_count{provider="elevenlabs"} 1`,
+		`glyphoxa_voice_tts_total_seconds_count{provider="elevenlabs"} 1`,
+		`glyphoxa_voice_llm_turn_seconds_count{provider="groq"} 1`,
+		`glyphoxa_voice_provider_calls_total{outcome="ok",provider="elevenlabs",stage="stt"} 1`,
+		`glyphoxa_voice_provider_calls_total{outcome="error",provider="elevenlabs",stage="tts"} 1`,
+		`glyphoxa_voice_provider_errors_total{provider="elevenlabs",stage="stt"} 1`,
+		`glyphoxa_voice_provider_errors_total{provider="elevenlabs",stage="tts"} 1`,
+	}
+	for _, want := range wantSeries {
+		if !strings.Contains(out, want) {
+			t.Errorf("scrape missing %q\n%s", want, filterGlyphoxa(out))
+		}
+	}
+
+	// AC: the RESERVED markers are removed from the help text as each is wired.
+	if strings.Contains(out, "RESERVED") {
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, "RESERVED") {
+				t.Errorf("help text still carries RESERVED after wiring: %q", line)
+			}
+		}
+	}
+}
+
 func TestSessionGaugeTracksOpenClose(t *testing.T) {
 	rec := NewPrometheusRecorder()
 	rec.SessionOpened("a")

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -29,20 +29,33 @@ import (
 )
 
 // CallOutcome classifies a provider call's terminal state from its error and the
-// call ctx, so the STT and TTS stages record [StageRecorder.ProviderCall] with
-// the same rule the agenttool adapter already applies: a nil err is [OutcomeOK];
-// a non-nil ctx error (a fired deadline or a barge/supersede cancel) is the
-// timeout-shaped [OutcomeTimeout] regardless of the returned err; any other error
-// is a vendor [OutcomeError]. Keeping the classification in one place means the
-// three provider stages agree on the outcome label.
+// call ctx, so the STT, TTS and LLM stages record [StageRecorder.ProviderCall]
+// with one shared rule: a nil err is [OutcomeOK]; a [context.Canceled] call ctx is
+// [OutcomeCanceled] (a caller-driven barge-in / supersede, NOT a vendor fault); a
+// [context.DeadlineExceeded] call ctx is [OutcomeTimeout] (a fault); any other
+// error is a vendor [OutcomeError] (a fault). The ctx state is checked before the
+// err's own type because a cancelled/expired ctx is the authoritative reason the
+// call ended even when the adapter surfaces its own wrapped error.
 func CallOutcome(ctx context.Context, err error) Outcome {
 	if err == nil {
 		return OutcomeOK
 	}
-	if ctx.Err() != nil {
+	switch ctx.Err() {
+	case context.Canceled:
+		return OutcomeCanceled
+	case context.DeadlineExceeded:
 		return OutcomeTimeout
+	default:
+		return OutcomeError
 	}
-	return OutcomeError
+}
+
+// IsFault reports whether an outcome should increment provider_errors: a vendor
+// [OutcomeError] or a [OutcomeTimeout], but never [OutcomeOK] or the caller-driven
+// [OutcomeCanceled] (a barge-in / supersede is not a provider fault, so it must not
+// inflate the error-ratio). The three provider stages gate ProviderError on this.
+func (o Outcome) IsFault() bool {
+	return o == OutcomeError || o == OutcomeTimeout
 }
 
 // AgentRole is the bounded role label substituted for the unbounded agent_id /
@@ -87,6 +100,11 @@ const (
 	OutcomeOK      Outcome = "ok"
 	OutcomeError   Outcome = "error"
 	OutcomeTimeout Outcome = "timeout"
+	// OutcomeCanceled is a caller-driven cancel (a barge-in / supersede cutting the
+	// call's ctx), distinct from a vendor error or a timeout: it counts the call but
+	// is NOT a provider fault (see [Outcome.IsFault]). A bounded enum value per
+	// ADR-0032.
+	OutcomeCanceled Outcome = "canceled"
 )
 
 // TurnOutcome is the bounded result label on the turn-lifecycle counter
@@ -186,9 +204,14 @@ type StageRecorder interface {
 	// TTSTimeToFirstByte is the Synthesize call → first AudioChunk span
 	// (glyphoxa_voice_tts_ttfb_seconds{provider}) — WIRED by the bus subscriber.
 	TTSTimeToFirstByte(provider Provider, d time.Duration)
-	// TTSTotal is the full synthesis. (glyphoxa_voice_tts_total_seconds{provider})
-	// WIRED (#125) by the TTS stage: one span per successful Dispatch (Synthesize
-	// call through the full audio-chunk drain).
+	// TTSTotal is the per-sentence TTS DELIVER span, NOT synthesis time.
+	// (glyphoxa_voice_tts_total_seconds{provider}) WIRED (#125) by the TTS stage:
+	// one span per successful Dispatch (Synthesize call through the full audio-chunk
+	// drain). Under the lockstep TeeSynthesizer the drain is paced by the playback
+	// pump (disgo's 20 ms sender), so this span tracks synthesis PLUS paced playback
+	// delivery of the sentence — true synthesis time is unobservable at this seam.
+	// The provider-latency signal lives in [StageRecorder.TTSTimeToFirstByte]; this
+	// series carries its own wide buckets (ADR-0044 amendment, #239 review).
 	TTSTotal(provider Provider, d time.Duration)
 
 	// LLMRound is one Provider.Complete round inside the agenttool loop. roundIndex

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -23,7 +23,27 @@
 // nil-check-free, matching pkg/voice's discardMetrics convention.
 package observe
 
-import "time"
+import (
+	"context"
+	"time"
+)
+
+// CallOutcome classifies a provider call's terminal state from its error and the
+// call ctx, so the STT and TTS stages record [StageRecorder.ProviderCall] with
+// the same rule the agenttool adapter already applies: a nil err is [OutcomeOK];
+// a non-nil ctx error (a fired deadline or a barge/supersede cancel) is the
+// timeout-shaped [OutcomeTimeout] regardless of the returned err; any other error
+// is a vendor [OutcomeError]. Keeping the classification in one place means the
+// three provider stages agree on the outcome label.
+func CallOutcome(ctx context.Context, err error) Outcome {
+	if err == nil {
+		return OutcomeOK
+	}
+	if ctx.Err() != nil {
+		return OutcomeTimeout
+	}
+	return OutcomeError
+}
 
 // AgentRole is the bounded role label substituted for the unbounded agent_id /
 // guild on every stage histogram (ADR-0032 §2.1). Exactly two values reach a
@@ -146,36 +166,29 @@ type StageRecorder interface {
 
 	// VADHangover is the speech-end detection lag (minSilenceFrames*frameMs),
 	// a fixed per-turn cost B3 tunes. (glyphoxa_voice_vad_hangover_seconds)
-	//
-	// RESERVED — emit-site not yet wired (carry-over task #11). Defined so the
-	// /metrics surface is spec-complete (ADR-0032), but no caller invokes it yet;
-	// the histogram stays empty until the VAD/segmenter (orchestrator) stamps it.
-	// An empty series here is expected, not a fault.
+	// WIRED (#125) by the VAD stage: one span per VADSpeechEnd, the constant the
+	// stage is constructed with.
 	VADHangover(d time.Duration)
 	// AddressDetect is the address-detection stage duration.
 	// (glyphoxa_voice_address_detect_seconds) — WIRED by the bus subscriber.
 	AddressDetect(d time.Duration)
 	// CodecDecode / CodecEncode are the per-direction Opus<->PCM costs.
-	// (glyphoxa_voice_codec_decode_seconds / _codec_encode_seconds)
-	//
-	// RESERVED — emit-site not yet wired (carry-over task #11); the wire codec
-	// (pkg/voice/wire/codec) stamps these. Empty until then, expected.
+	// (glyphoxa_voice_codec_decode_seconds / _codec_encode_seconds) — WIRED (#125)
+	// by the wire codec: CodecDecode per inbound frame decoded, CodecEncode per
+	// outbound frame encoded (the enc.Encode section only, never the chunk wait).
 	CodecDecode(d time.Duration)
 	CodecEncode(d time.Duration)
 
 	// STTRequest is the STT provider POST round-trip.
-	// (glyphoxa_voice_stt_request_seconds{provider})
-	//
-	// RESERVED — emit-site not yet wired (carry-over task #11); the STT adapter
-	// (pkg/voice/stt/elevenlabs) stamps it. Empty until then, expected.
+	// (glyphoxa_voice_stt_request_seconds{provider}) — WIRED by the STT stage
+	// (batch Transcribe and the streamed commit path).
 	STTRequest(provider Provider, d time.Duration)
 	// TTSTimeToFirstByte is the Synthesize call → first AudioChunk span
 	// (glyphoxa_voice_tts_ttfb_seconds{provider}) — WIRED by the bus subscriber.
 	TTSTimeToFirstByte(provider Provider, d time.Duration)
 	// TTSTotal is the full synthesis. (glyphoxa_voice_tts_total_seconds{provider})
-	//
-	// RESERVED — emit-site not yet wired (carry-over task #11); the TTS stage/
-	// adapter stamps it. Empty until then, expected.
+	// WIRED (#125) by the TTS stage: one span per successful Dispatch (Synthesize
+	// call through the full audio-chunk drain).
 	TTSTotal(provider Provider, d time.Duration)
 
 	// LLMRound is one Provider.Complete round inside the agenttool loop. roundIndex
@@ -186,11 +199,9 @@ type StageRecorder interface {
 	// — WIRED by agenttool.providerAdapter.Generate.
 	LLMRound(provider Provider, roundIndex int, hadToolCall bool, d time.Duration)
 	// LLMTurn is the full agenttool loop (all rounds + tool exec) for the turn.
-	// (glyphoxa_voice_llm_turn_seconds{provider})
-	//
-	// RESERVED — emit-site not yet wired (carry-over task #11); the agenttool loop
-	// wrapper stamps the full-turn span (it currently records only per-round
-	// LLMRound). Empty until then, expected.
+	// (glyphoxa_voice_llm_turn_seconds{provider}) — WIRED (#125) by the agenttool
+	// Engine: one span per Generate/GenerateStream, spanning every round, recorded
+	// on the success AND error path so a failed turn's latency is still visible.
 	LLMTurn(provider Provider, d time.Duration)
 
 	// ProviderCall counts one vendor call at stage with its outcome; ProviderError

--- a/internal/observe/recorder_test.go
+++ b/internal/observe/recorder_test.go
@@ -1,0 +1,43 @@
+package observe
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestCallOutcome_ClassifiesErrAndCtx pins the shared provider-call classifier
+// (#125): a nil error is OK; a non-nil ctx error (deadline/cancel) is a
+// timeout-shaped outcome regardless of the returned err; any other error is a
+// vendor error. It mirrors the agenttool adapter's existing rule so the three
+// stages agree on the outcome label.
+func TestCallOutcome_ClassifiesErrAndCtx(t *testing.T) {
+	t.Run("nil err is ok", func(t *testing.T) {
+		if got := CallOutcome(context.Background(), nil); got != OutcomeOK {
+			t.Errorf("CallOutcome(bg, nil) = %q, want ok", got)
+		}
+	})
+
+	t.Run("err with live ctx is error", func(t *testing.T) {
+		if got := CallOutcome(context.Background(), errors.New("provider 500")); got != OutcomeError {
+			t.Errorf("CallOutcome(bg, err) = %q, want error", got)
+		}
+	})
+
+	t.Run("err with cancelled ctx is timeout", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if got := CallOutcome(ctx, context.Canceled); got != OutcomeTimeout {
+			t.Errorf("CallOutcome(cancelled, err) = %q, want timeout", got)
+		}
+	})
+
+	t.Run("err with deadline-exceeded ctx is timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+		<-ctx.Done()
+		if got := CallOutcome(ctx, context.DeadlineExceeded); got != OutcomeTimeout {
+			t.Errorf("CallOutcome(deadline, err) = %q, want timeout", got)
+		}
+	})
+}

--- a/internal/observe/recorder_test.go
+++ b/internal/observe/recorder_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 // TestCallOutcome_ClassifiesErrAndCtx pins the shared provider-call classifier
-// (#125): a nil error is OK; a non-nil ctx error (deadline/cancel) is a
-// timeout-shaped outcome regardless of the returned err; any other error is a
-// vendor error. It mirrors the agenttool adapter's existing rule so the three
-// stages agree on the outcome label.
+// (#125, refined #239): a nil error is OK; a context.Canceled ctx is CANCELED (a
+// caller barge-in, not a fault); a context.DeadlineExceeded ctx is TIMEOUT (a
+// fault); any other error is a vendor error. The three stages code against this so
+// they agree on the outcome label — and on which outcomes count as errors.
 func TestCallOutcome_ClassifiesErrAndCtx(t *testing.T) {
 	t.Run("nil err is ok", func(t *testing.T) {
 		if got := CallOutcome(context.Background(), nil); got != OutcomeOK {
@@ -24,11 +24,11 @@ func TestCallOutcome_ClassifiesErrAndCtx(t *testing.T) {
 		}
 	})
 
-	t.Run("err with cancelled ctx is timeout", func(t *testing.T) {
+	t.Run("err with cancelled ctx is canceled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		if got := CallOutcome(ctx, context.Canceled); got != OutcomeTimeout {
-			t.Errorf("CallOutcome(cancelled, err) = %q, want timeout", got)
+		if got := CallOutcome(ctx, context.Canceled); got != OutcomeCanceled {
+			t.Errorf("CallOutcome(cancelled, err) = %q, want canceled (a barge-in is not a fault)", got)
 		}
 	})
 
@@ -40,4 +40,23 @@ func TestCallOutcome_ClassifiesErrAndCtx(t *testing.T) {
 			t.Errorf("CallOutcome(deadline, err) = %q, want timeout", got)
 		}
 	})
+}
+
+// TestOutcome_IsFault pins which outcomes bump provider_errors: error and timeout
+// are faults; ok and canceled are not (a barge-in must never inflate the error
+// ratio).
+func TestOutcome_IsFault(t *testing.T) {
+	for _, tc := range []struct {
+		outcome Outcome
+		fault   bool
+	}{
+		{OutcomeOK, false},
+		{OutcomeError, true},
+		{OutcomeTimeout, true},
+		{OutcomeCanceled, false},
+	} {
+		if got := tc.outcome.IsFault(); got != tc.fault {
+			t.Errorf("Outcome(%q).IsFault() = %v, want %v", tc.outcome, got, tc.fault)
+		}
+	}
 }

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -82,6 +82,12 @@ type ProviderServer struct {
 	// slash-command surface without a restart. Fired in a goroutine (presence
 	// Ensure does network I/O). nil (web-only, or not wired) skips.
 	refreshPresence func()
+
+	// discordAppID is the Discord application (client) id backing operator login
+	// (ADR-0016), surfaced on ListProviderConfigs so the SPA composes the
+	// bot-authorization URL (#110). Non-secret; empty when DISCORD_OAUTH_CLIENT_ID
+	// is unset, which the screen renders as a disabled action.
+	discordAppID string
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -110,6 +116,15 @@ func (s *ProviderServer) SetHealthInvalidator(fn func(tenantID uuid.UUID)) {
 // not block the RPC response.
 func (s *ProviderServer) SetPresenceRefresher(fn func()) {
 	s.refreshPresence = fn
+}
+
+// SetDiscordApplicationID wires the Discord application (client) id ListProviderConfigs
+// echoes so the SPA composes the bot-authorization URL (#110), mirroring
+// SetHealthInvalidator/SetPresenceRefresher. Called once at boot, before the
+// server serves, so no lock is needed. The empty string (DISCORD_OAUTH_CLIENT_ID
+// unset) is the missing-app-id fallback the screen renders as disabled.
+func (s *ProviderServer) SetDiscordApplicationID(id string) {
+	s.discordAppID = id
 }
 
 // Handler builds the Connect HTTP handler for ProviderService and returns its
@@ -167,9 +182,10 @@ func (s *ProviderServer) ListProviderConfigs(
 	}
 
 	return connect.NewResponse(&managementv1.ListProviderConfigsResponse{
-		Credentials:    creds,
-		GuildId:        dep.GuildID,
-		VoiceChannelId: dep.VoiceChannelID,
+		Credentials:          creds,
+		GuildId:              dep.GuildID,
+		VoiceChannelId:       dep.VoiceChannelID,
+		DiscordApplicationId: s.discordAppID,
 	}), nil
 }
 

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -114,6 +114,16 @@ func testCipher(t *testing.T) *crypto.Cipher {
 // Connect-JSON client. WithProtoJSON also asserts the RPCs work over JSON.
 func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Cipher) (managementv1connect.ProviderServiceClient, uuid.UUID) {
 	t.Helper()
+	return clientForServer(t, rpc.NewProviderServer(store, cipher, nil))
+}
+
+// clientForServer mounts a PRE-BUILT ProviderServer behind the fixed-tenant
+// interceptor and returns a Connect-JSON client + the injected tenant. Callers
+// that must configure the server before it serves (e.g. SetDiscordApplicationID,
+// #110) build it and pass it in; newProviderClient is the common store+cipher
+// shortcut over this.
+func clientForServer(t *testing.T, server *rpc.ProviderServer) (managementv1connect.ProviderServiceClient, uuid.UUID) {
+	t.Helper()
 	tenantID := uuid.New()
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
@@ -121,7 +131,7 @@ func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Ci
 		}
 	})
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewProviderServer(store, cipher, nil).Handler(connect.WithInterceptors(inject)))
+	mux.Handle(server.Handler(connect.WithInterceptors(inject)))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return managementv1connect.NewProviderServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON()), tenantID
@@ -135,6 +145,37 @@ func credByProvider(creds []*managementv1.ProviderCredential, provider string) *
 		}
 	}
 	return nil
+}
+
+// TestProviderList_DiscordApplicationID pins #110: the configured Discord
+// application (client) id — the same app that backs operator login (ADR-0016) —
+// is exposed on the read so the SPA composes the bot-authorization URL without
+// hardcoding anything. Without the setter wired it reads empty, the fallback the
+// SPA renders as a disabled action + note.
+func TestProviderList_DiscordApplicationID(t *testing.T) {
+	t.Parallel()
+
+	srv := rpc.NewProviderServer(newFakeProviderStore(), testCipher(t), nil)
+	srv.SetDiscordApplicationID("123456789012345678")
+	client, _ := clientForServer(t, srv)
+
+	resp, err := client.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got := resp.Msg.GetDiscordApplicationId(); got != "123456789012345678" {
+		t.Errorf("discord_application_id = %q, want 123456789012345678", got)
+	}
+
+	// No setter → empty on the wire (the missing-app-id fallback).
+	bare, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	resp2, err := bare.ListProviderConfigs(context.Background(), connect.NewRequest(&managementv1.ListProviderConfigsRequest{}))
+	if err != nil {
+		t.Fatalf("List (bare): %v", err)
+	}
+	if got := resp2.Msg.GetDiscordApplicationId(); got != "" {
+		t.Errorf("discord_application_id without setter = %q, want empty", got)
+	}
 }
 
 func TestProviderList_EmptyShowsKeyNeeded(t *testing.T) {

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -608,7 +608,11 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// knowledge: a default build still constructs and runs, just deaf+mute.
 	// Living in the shared Run core, this audio path covers BOTH the hardcoded
 	// and the RunFromDB paths (RunFromDB resolves the NPC then delegates here).
-	cdc := codec.New()
+	//
+	// codec_decode / codec_encode (#125): the codec stamps the per-frame Opus<->PCM
+	// costs against cfg.StageMetrics. A nil StageMetrics (env-only) keeps the no-op
+	// default via WithMetrics; the stub build accepts and ignores the same option.
+	cdc := codec.New(codec.WithMetrics(cfg.StageMetrics))
 
 	// Outbound (speak): the PlaybackPump drives the codec's PlaybackSource onto
 	// the Session, one sentence at a time (Session.Play auto-interrupts, so
@@ -844,7 +848,12 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	cleanup := func() {
 		_ = vadSession.Close()
 	}
-	vadStage := orchestrator.NewVAD(bus, vadSession)
+	// vad_hangover (#125): the fixed end-of-speech detection lag is a constant the
+	// stage cannot read off the Silero session (vad.Session doesn't expose
+	// minSilenceFrames), so compute it here from the same consts the session is
+	// configured with — vadMinSilenceFrames*vadFrameMs (= 384 ms).
+	vadStage := orchestrator.NewVAD(bus, vadSession,
+		orchestrator.WithVADMetrics(stageMetrics, vadMinSilenceFrames*vadFrameMs*time.Millisecond))
 
 	// One recognizer instance backs both the batch stage and — when streaming is
 	// enabled and the adapter supports it — the stream manager (the ElevenLabs
@@ -852,7 +861,10 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	var recognizer stt.Recognizer = newSTT(keys.stt)
 	sttStage := orchestrator.NewSTT(bus, recognizer,
 		orchestrator.WithSTTMetrics(stageMetrics, observe.ProviderElevenLabs))
-	ttsStage := orchestrator.NewTTS(bus, synth)
+	// tts_total + tts-stage provider health (#125): ElevenLabs is the wired TTS
+	// provider (ADR-0039), so the spans are labelled elevenlabs.
+	ttsStage := orchestrator.NewTTS(bus, synth,
+		orchestrator.WithTTSMetrics(stageMetrics, observe.ProviderElevenLabs))
 	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics, log)
 
 	// Tool Grants are now DB-backed and hydrated per NPC (#113, ADR-0029): each

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -194,6 +194,15 @@ type Engine struct {
 	// The zero value "" selects the English keyword set ([needsDice] maps it to
 	// "en") — the default when no Campaign Language is wired.
 	language string
+
+	// rec/provName carry the #125 full-turn instrumentation: one
+	// [observe.StageRecorder.LLMTurn] span per Generate/GenerateStream (the whole
+	// tool loop — all rounds + tool exec), distinct from the per-round LLMRound the
+	// adapter records. Recorded on the success AND error path so a failed turn's
+	// latency is still visible. Default no-ops (observe.Discard, empty provider
+	// label), so the keyless path stays silent.
+	rec      observe.StageRecorder
+	provName observe.Provider
 }
 
 // loopFor selects the loop for this turn: the full grants when the utterance
@@ -277,6 +286,8 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 		full:     newLoop(grants),
 		gated:    newLoop(grants.Without(diceToolName)),
 		language: cfg.language,
+		rec:      cfg.rec,
+		provName: cfg.provName,
 	}
 }
 
@@ -285,7 +296,12 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 // per-turn round counter into ctx so the adapter's LLMRound spans index from 0
 // for this turn and never share state with a concurrent turn (barge-in).
 func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, error) {
-	return e.loopFor(messages).Run(withRoundCounter(ctx), toToolMessages(messages))
+	start := time.Now()
+	out, err := e.loopFor(messages).Run(withRoundCounter(ctx), toToolMessages(messages))
+	// #125: one full-turn span per Generate, spanning every round, recorded on the
+	// success AND error path so a turn that fails mid-loop is still measured.
+	e.rec.LLMTurn(e.provName, time.Since(start))
+	return out, err
 }
 
 // GenerateStream implements [agent.StreamingEngine] (B1): it runs the same
@@ -295,7 +311,12 @@ func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, 
 // [Engine.Generate], so the A3 LLMRound / provider-call metrics are recorded
 // identically on the streaming production path. Returns the full final text.
 func (e *Engine) GenerateStream(ctx context.Context, messages []llm.Message, onText func(delta string) error) (string, error) {
-	return e.loopFor(messages).RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
+	start := time.Now()
+	out, err := e.loopFor(messages).RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
+	// #125: the streaming production path records the same one-per-turn LLMTurn span
+	// Generate does, on success and error alike.
+	e.rec.LLMTurn(e.provName, time.Since(start))
+	return out, err
 }
 
 // toToolMessages converts the agent loop's [llm.Message]s into [tool.Message]s.

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -115,15 +115,17 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 		Tools:     toLLMToolDefs(tools),
 	})
 	if err != nil {
-		// A start failure is a provider error with no round span (no completion
-		// happened); attribute it to the LLM stage. A cancelled ctx is a timeout-
-		// shaped outcome rather than a vendor error.
-		outcome := observe.OutcomeError
-		if ctx.Err() != nil {
-			outcome = observe.OutcomeTimeout
-		}
+		// A start failure has no round span (no completion happened); attribute it to
+		// the LLM stage via the shared [observe.CallOutcome] rule so LLM agrees with
+		// STT/TTS: a barge-in cancel is OutcomeCanceled (NOT a vendor fault), a fired
+		// deadline is OutcomeTimeout, anything else is OutcomeError. ProviderError is
+		// bumped only on a fault, so a barge before first token does not inflate the
+		// error ratio (#239 review).
+		outcome := observe.CallOutcome(ctx, err)
 		a.rec.ProviderCall(observe.StageLLM, a.provName, outcome)
-		a.rec.ProviderError(observe.StageLLM, a.provName)
+		if outcome.IsFault() {
+			a.rec.ProviderError(observe.StageLLM, a.provName)
+		}
 		return tool.AssistantMessage{}, err
 	}
 

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -3,6 +3,7 @@ package agenttool_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math/rand/v2"
 	"strings"
 	"sync"
@@ -174,11 +175,13 @@ type llmRound struct {
 // no-ops. Safe for the loop's single-goroutine use plus the race detector.
 type recordingStage struct {
 	observe.Discard
-	mu       sync.Mutex
-	rounds   []llmRound
-	callsOK  int
-	callsErr int
-	turns    []observe.Provider // one LLMTurn span per Engine.Generate/GenerateStream
+	mu           sync.Mutex
+	rounds       []llmRound
+	callsOK      int
+	callsErr     int
+	turns        []observe.Provider // one LLMTurn span per Engine.Generate/GenerateStream
+	outcomes     []observe.Outcome  // every ProviderCall outcome, in order
+	providerErrs int                // ProviderError invocations
 }
 
 func (r *recordingStage) LLMRound(p observe.Provider, idx int, hadToolCall bool, _ time.Duration) {
@@ -202,6 +205,7 @@ func (r *recordingStage) turnSpans() []observe.Provider {
 func (r *recordingStage) ProviderCall(_ observe.Stage, _ observe.Provider, outcome observe.Outcome) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.outcomes = append(r.outcomes, outcome)
 	if outcome == observe.OutcomeOK {
 		r.callsOK++
 	} else {
@@ -209,10 +213,22 @@ func (r *recordingStage) ProviderCall(_ observe.Stage, _ observe.Provider, outco
 	}
 }
 
+func (r *recordingStage) ProviderError(observe.Stage, observe.Provider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.providerErrs++
+}
+
 func (r *recordingStage) snapshot() ([]llmRound, int, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]llmRound(nil), r.rounds...), r.callsOK, r.callsErr
+}
+
+func (r *recordingStage) providerCalls() ([]observe.Outcome, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]observe.Outcome(nil), r.outcomes...), r.providerErrs
 }
 
 // TestEngine_LLMRoundSpans_IndexAndToolCallPerRound pins the A3 per-round
@@ -635,6 +651,79 @@ func TestEngine_TruncatedStream_ReturnsError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "without done") {
 		t.Fatalf("Generate on truncated stream = %v, want truncation error", err)
 	}
+}
+
+// startErrProvider fails the Complete call itself (start error, no stream), the
+// shape a 4xx/5xx takes.
+type startErrProvider struct{}
+
+func (startErrProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	return nil, errors.New("provider: start boom")
+}
+
+// bargeStartProvider blocks the Complete call until the ctx is cancelled, then
+// returns ctx.Err() — a barge-in that cuts the dial in flight (a pre-cancelled ctx
+// would instead make the tool loop bail before it ever calls the provider).
+type bargeStartProvider struct{}
+
+func (bargeStartProvider) Complete(ctx context.Context, _ llm.Request) (<-chan llm.StreamEvent, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestEngine_StartError_ClassifiesOutcomeLikeStages pins the #239 alignment: the
+// LLM start-error path classifies via the shared observe.CallOutcome rule, so a
+// barge cancelling the dial in flight is outcome=canceled with NO provider_error
+// (not a fault), while a live-ctx start failure is outcome=error WITH a
+// provider_error. This keeps the LLM stage in agreement with STT/TTS.
+func TestEngine_StartError_ClassifiesOutcomeLikeStages(t *testing.T) {
+	empty := tool.NewGrantSet(tool.NewRegistry())
+
+	t.Run("barge cancel is canceled, not a fault", func(t *testing.T) {
+		rec := &recordingStage{}
+		eng := agenttool.NewEngine(bargeStartProvider{}, empty, "m", 0, 0,
+			agenttool.WithMetrics(rec, observe.ProviderGroq))
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := eng.Generate(ctx, []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
+			done <- err
+		}()
+		time.Sleep(20 * time.Millisecond) // let the loop reach the blocked Complete
+		cancel()                          // barge-in cuts the dial
+
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatal("Generate returned nil on a cancelled dial")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Generate did not return after the ctx was cancelled")
+		}
+		outcomes, provErrs := rec.providerCalls()
+		if len(outcomes) != 1 || outcomes[0] != observe.OutcomeCanceled {
+			t.Errorf("provider_call outcomes = %v, want [canceled]", outcomes)
+		}
+		if provErrs != 0 {
+			t.Errorf("provider_errors = %d on a barge cancel, want 0 (not a fault)", provErrs)
+		}
+	})
+
+	t.Run("live-ctx start failure is error + fault", func(t *testing.T) {
+		rec := &recordingStage{}
+		eng := agenttool.NewEngine(startErrProvider{}, empty, "m", 0, 0,
+			agenttool.WithMetrics(rec, observe.ProviderGroq))
+		if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
+			t.Fatal("Generate returned nil on a start failure")
+		}
+		outcomes, provErrs := rec.providerCalls()
+		if len(outcomes) != 1 || outcomes[0] != observe.OutcomeError {
+			t.Errorf("provider_call outcomes = %v, want [error]", outcomes)
+		}
+		if provErrs != 1 {
+			t.Errorf("provider_errors = %d on a vendor start failure, want 1", provErrs)
+		}
+	})
 }
 
 // errorEventProvider terminates the stream with an [llm.EventError].

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -178,12 +178,25 @@ type recordingStage struct {
 	rounds   []llmRound
 	callsOK  int
 	callsErr int
+	turns    []observe.Provider // one LLMTurn span per Engine.Generate/GenerateStream
 }
 
 func (r *recordingStage) LLMRound(p observe.Provider, idx int, hadToolCall bool, _ time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.rounds = append(r.rounds, llmRound{provider: p, roundIndex: idx, hadToolCall: hadToolCall})
+}
+
+func (r *recordingStage) LLMTurn(p observe.Provider, _ time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.turns = append(r.turns, p)
+}
+
+func (r *recordingStage) turnSpans() []observe.Provider {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]observe.Provider(nil), r.turns...)
 }
 
 func (r *recordingStage) ProviderCall(_ observe.Stage, _ observe.Provider, outcome observe.Outcome) {
@@ -269,6 +282,78 @@ func TestEngine_LLMRoundSpans_IndexResetsPerTurn(t *testing.T) {
 		if r.roundIndex != 0 {
 			t.Errorf("turn %d round_index = %d, want 0 (per-turn reset)", i, r.roundIndex)
 		}
+	}
+}
+
+// TestEngine_LLMTurn_OneSpanPerTurnAcrossRounds pins the #125 llm_turn wiring:
+// the Engine records exactly ONE LLMTurn span per Generate — the full agenttool
+// loop, spanning both rounds of a dice round-trip — labelled with the injected
+// provider, distinct from the per-round LLMRound spans (two here).
+func TestEngine_LLMTurn_OneSpanPerTurnAcrossRounds(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "You rolled well, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleUser, Text: "Roll a d20 for me."},
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	rounds, _, _ := rec.snapshot()
+	if len(rounds) != 2 {
+		t.Fatalf("recorded %d LLMRound spans, want 2 (round-trip)", len(rounds))
+	}
+	turns := rec.turnSpans()
+	if len(turns) != 1 {
+		t.Fatalf("recorded %d LLMTurn spans, want exactly 1 per turn (across all rounds)", len(turns))
+	}
+	if turns[0] != observe.ProviderGroq {
+		t.Errorf("LLMTurn provider = %q, want the injected groq label", turns[0])
+	}
+}
+
+// TestEngine_GenerateStream_RecordsOneLLMTurn pins that the streaming production
+// path records the SAME single LLMTurn span Generate does — the metric must not be
+// dropped by the streaming loop.
+func TestEngine_GenerateStream_RecordsOneLLMTurn(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "You rolled well, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	if _, err := eng.GenerateStream(context.Background(),
+		[]llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}},
+		func(string) error { return nil },
+	); err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+
+	if turns := rec.turnSpans(); len(turns) != 1 {
+		t.Fatalf("streaming recorded %d LLMTurn spans, want exactly 1", len(turns))
+	}
+}
+
+// TestEngine_LLMTurn_RecordsOnError pins that a turn whose loop fails still records
+// its LLMTurn span — the full-turn latency series must see failed turns too, not
+// just successful ones (otherwise a provider outage silently drops the samples).
+func TestEngine_LLMTurn_RecordsOnError(t *testing.T) {
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(errorEventProvider{}, tool.NewGrantSet(tool.NewRegistry()), "m", 0, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
+		t.Fatal("Generate on a failing provider returned nil error")
+	}
+	if turns := rec.turnSpans(); len(turns) != 1 {
+		t.Fatalf("recorded %d LLMTurn spans on the error path, want exactly 1", len(turns))
 	}
 }
 

--- a/pkg/voice/orchestrator/metrics_spy_test.go
+++ b/pkg/voice/orchestrator/metrics_spy_test.go
@@ -1,0 +1,78 @@
+package orchestrator_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// providerCall is one captured [observe.StageRecorder.ProviderCall]: the bounded
+// labels the counter carries.
+type providerCall struct {
+	stage    observe.Stage
+	provider observe.Provider
+	outcome  observe.Outcome
+}
+
+// providerErr is one captured [observe.StageRecorder.ProviderError].
+type providerErr struct {
+	stage    observe.Stage
+	provider observe.Provider
+}
+
+// metricsSpy is a [observe.StageRecorder] that captures the #125-wired emit-sites
+// (STTRequest, TTSTotal, VADHangover, ProviderCall, ProviderError) so the stage
+// tests can assert the counters/histograms move with the right labels without a
+// Prometheus backend. Embeds [observe.Discard] so every other method is a no-op.
+// Safe for concurrent use.
+type metricsSpy struct {
+	observe.Discard
+	mu sync.Mutex
+
+	sttRequests []observe.Provider
+	ttsTotals   []observe.Provider
+	vadHangs    []time.Duration
+	calls       []providerCall
+	errs        []providerErr
+}
+
+func (s *metricsSpy) STTRequest(p observe.Provider, _ time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sttRequests = append(s.sttRequests, p)
+}
+
+func (s *metricsSpy) TTSTotal(p observe.Provider, _ time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ttsTotals = append(s.ttsTotals, p)
+}
+
+func (s *metricsSpy) VADHangover(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.vadHangs = append(s.vadHangs, d)
+}
+
+func (s *metricsSpy) ProviderCall(stage observe.Stage, p observe.Provider, o observe.Outcome) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, providerCall{stage: stage, provider: p, outcome: o})
+}
+
+func (s *metricsSpy) ProviderError(stage observe.Stage, p observe.Provider) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs = append(s.errs, providerErr{stage: stage, provider: p})
+}
+
+func (s *metricsSpy) snapshot() ([]observe.Provider, []observe.Provider, []time.Duration, []providerCall, []providerErr) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]observe.Provider(nil), s.sttRequests...),
+		append([]observe.Provider(nil), s.ttsTotals...),
+		append([]time.Duration(nil), s.vadHangs...),
+		append([]providerCall(nil), s.calls...),
+		append([]providerErr(nil), s.errs...)
+}

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -122,7 +122,13 @@ func (s *STT) Transcribe(ctx context.Context, frames []audio.Frame) error {
 	// real wall-clock inside the response_latency span, and a failed/slow scribe
 	// call is exactly what this series exists to surface.
 	s.rec.STTRequest(s.provider, time.Since(start))
+	// Provider health (#125): count the call with its final outcome (ok/error/
+	// timeout) and, on any non-OK outcome, bump the error-only sibling so the
+	// error-ratio query is well-defined. The outcome mirrors the agenttool rule
+	// (a cancelled ctx — the per-request timeout firing — is timeout-shaped).
+	s.rec.ProviderCall(observe.StageSTT, s.provider, observe.CallOutcome(ctx, err))
 	if err != nil {
+		s.rec.ProviderError(observe.StageSTT, s.provider)
 		return fmt.Errorf("orchestrator.STT.Transcribe: %w", err)
 	}
 	s.PublishFinal(ctx, t)

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -122,13 +122,17 @@ func (s *STT) Transcribe(ctx context.Context, frames []audio.Frame) error {
 	// real wall-clock inside the response_latency span, and a failed/slow scribe
 	// call is exactly what this series exists to surface.
 	s.rec.STTRequest(s.provider, time.Since(start))
-	// Provider health (#125): count the call with its final outcome (ok/error/
-	// timeout) and, on any non-OK outcome, bump the error-only sibling so the
-	// error-ratio query is well-defined. The outcome mirrors the agenttool rule
-	// (a cancelled ctx — the per-request timeout firing — is timeout-shaped).
-	s.rec.ProviderCall(observe.StageSTT, s.provider, observe.CallOutcome(ctx, err))
+	// Provider health (#125): count the call with its final outcome and bump the
+	// error-only sibling ONLY on a fault (error/timeout), never on a caller-driven
+	// cancel — a barge-in that cuts the recognizer ctx is OutcomeCanceled and must
+	// not inflate the error ratio (#239 review). The shared [observe.CallOutcome]
+	// rule keeps STT/TTS/LLM in agreement (a fired per-request timeout is timeout).
+	outcome := observe.CallOutcome(ctx, err)
+	s.rec.ProviderCall(observe.StageSTT, s.provider, outcome)
 	if err != nil {
-		s.rec.ProviderError(observe.StageSTT, s.provider)
+		if outcome.IsFault() {
+			s.rec.ProviderError(observe.StageSTT, s.provider)
+		}
 		return fmt.Errorf("orchestrator.STT.Transcribe: %w", err)
 	}
 	s.PublishFinal(ctx, t)

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -122,6 +122,46 @@ func TestSTT_Transcribe_RecordsProviderCallOutcomes(t *testing.T) {
 	}
 }
 
+// TestSTT_Transcribe_BargeCancelIsNotFault pins the #239 refinement: a barge-in
+// that cancels the recognizer ctx mid-call records provider_calls with
+// outcome=canceled and does NOT bump provider_errors — a caller cancel is not a
+// vendor fault and must not inflate the error ratio. The per-request timeout is
+// disabled so ONLY the caller cancel drives the outcome. stt_request still records.
+func TestSTT_Transcribe_BargeCancelIsNotFault(t *testing.T) {
+	h := voicetest.New(t)
+	spy := &metricsSpy{}
+	stage := orchestrator.NewSTT(h.Bus, hangingRecognizer{},
+		orchestrator.WithSTTMetrics(spy, observe.ProviderElevenLabs),
+		orchestrator.WithSTTTimeout(0)) // disable the per-request bound: only the caller cancel drives it
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- stage.Transcribe(ctx, []audio.Frame{}) }()
+	time.Sleep(20 * time.Millisecond) // let it reach the blocked recognizer
+	cancel()                          // barge-in
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Transcribe returned nil on a cancelled ctx; want the cancel error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Transcribe did not return after the ctx was cancelled")
+	}
+
+	sttReqs, _, _, calls, errs := spy.snapshot()
+	if len(sttReqs) != 1 {
+		t.Errorf("stt_request recorded %d spans on a barge, want 1", len(sttReqs))
+	}
+	want := providerCall{stage: observe.StageSTT, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeCanceled}
+	if len(calls) != 1 || calls[0] != want {
+		t.Errorf("provider_calls = %+v, want one %+v", calls, want)
+	}
+	if len(errs) != 0 {
+		t.Errorf("provider_errors = %+v on a barge cancel, want none (a cancel is not a fault)", errs)
+	}
+}
+
 // TestSTT_Transcribe_BoundsHungRecognizer pins the wedge fix: a recognizer call
 // that would otherwise block forever is bounded by the stage's per-request
 // timeout ([orchestrator.WithSTTTimeout]). Without the bound, the single serial

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
@@ -39,6 +40,86 @@ type hangingRecognizer struct{}
 func (hangingRecognizer) Transcribe(ctx context.Context, _ []audio.Frame) (stt.Transcript, error) {
 	<-ctx.Done()
 	return stt.Transcript{}, ctx.Err()
+}
+
+// errorRecognizer is a [stt.Recognizer] that always returns a non-nil error with
+// a live context — a provider-side failure (a 500, a bad request), distinct from
+// the hung-then-cancelled recognizer whose error is ctx-driven.
+type errorRecognizer struct{}
+
+func (errorRecognizer) Transcribe(context.Context, []audio.Frame) (stt.Transcript, error) {
+	return stt.Transcript{}, errors.New("scribe 500")
+}
+
+// TestSTT_Transcribe_RecordsProviderCallOutcomes pins the #125 provider-health
+// wiring on the batch STT stage: a successful Transcribe moves provider_calls with
+// outcome=ok and no provider_errors; a provider error moves outcome=error PLUS
+// provider_errors; a call that hangs past the per-request timeout moves
+// outcome=timeout PLUS provider_errors. In all three the stt_request round-trip
+// histogram still records (the regression guard — it must not be dropped by the
+// new counter wiring). Labels stay the bounded stt/elevenlabs enums (ADR-0032).
+func TestSTT_Transcribe_RecordsProviderCallOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		recognizer  stt.Recognizer
+		opts        []orchestrator.STTOption
+		wantOutcome observe.Outcome
+		wantErr     bool
+	}{
+		{
+			name:        "success",
+			recognizer:  stubRecognizer{transcript: stt.Transcript{Text: "roll a d20"}},
+			wantOutcome: observe.OutcomeOK,
+		},
+		{
+			name:        "provider error",
+			recognizer:  errorRecognizer{},
+			wantOutcome: observe.OutcomeError,
+			wantErr:     true,
+		},
+		{
+			name:        "hung past timeout",
+			recognizer:  hangingRecognizer{},
+			opts:        []orchestrator.STTOption{orchestrator.WithSTTTimeout(30 * time.Millisecond)},
+			wantOutcome: observe.OutcomeTimeout,
+			wantErr:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := voicetest.New(t)
+			spy := &metricsSpy{}
+			opts := append([]orchestrator.STTOption{
+				orchestrator.WithSTTMetrics(spy, observe.ProviderElevenLabs),
+			}, tc.opts...)
+			stage := orchestrator.NewSTT(h.Bus, tc.recognizer, opts...)
+
+			err := stage.Transcribe(context.Background(), []audio.Frame{})
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("Transcribe err = %v, wantErr = %v", err, tc.wantErr)
+			}
+
+			sttReqs, _, _, calls, errs := spy.snapshot()
+
+			// The round-trip histogram records on every path — success, error, timeout.
+			if len(sttReqs) != 1 || sttReqs[0] != observe.ProviderElevenLabs {
+				t.Errorf("stt_request recorded %v, want exactly one elevenlabs span", sttReqs)
+			}
+			if len(calls) != 1 {
+				t.Fatalf("provider_calls recorded %d times, want exactly 1", len(calls))
+			}
+			want := providerCall{stage: observe.StageSTT, provider: observe.ProviderElevenLabs, outcome: tc.wantOutcome}
+			if calls[0] != want {
+				t.Errorf("provider_call = %+v, want %+v", calls[0], want)
+			}
+			if tc.wantErr {
+				if len(errs) != 1 || errs[0] != (providerErr{stage: observe.StageSTT, provider: observe.ProviderElevenLabs}) {
+					t.Errorf("provider_errors = %+v, want one stt/elevenlabs error", errs)
+				}
+			} else if len(errs) != 0 {
+				t.Errorf("provider_errors = %+v, want none on the success path", errs)
+			}
+		})
+	}
 }
 
 // TestSTT_Transcribe_BoundsHungRecognizer pins the wedge fix: a recognizer call

--- a/pkg/voice/orchestrator/sttstream.go
+++ b/pkg/voice/orchestrator/sttstream.go
@@ -386,16 +386,23 @@ func (m *StreamManager) awaitCommit(ch <-chan stt.CommitResult, sentAt time.Time
 	case res := <-ch:
 		m.metrics.STTRequest(m.provider, m.now().Sub(sentAt))
 		if res.Err != nil {
+			// Provider health (#125): a resolved-but-failed commit is a stt-stage error.
+			m.metrics.ProviderCall(observe.StageSTT, m.provider, observe.OutcomeError)
+			m.metrics.ProviderError(observe.StageSTT, m.provider)
 			m.noteAuthBackoff(res.Err)
 			return stt.Transcript{}, false
 		}
+		m.metrics.ProviderCall(observe.StageSTT, m.provider, observe.OutcomeOK)
 		m.resetBackoff()
 		return res.Transcript, true
 	case <-timer.C:
 		// Record the span on timeout too: a stalled provider is exactly what this
 		// series exists to surface, and the batch adapter records its call on failure
-		// as well (batch parity).
+		// as well (batch parity). The provider-call counter mirrors it with a
+		// timeout outcome plus the error-only sibling (#125).
 		m.metrics.STTRequest(m.provider, m.now().Sub(sentAt))
+		m.metrics.ProviderCall(observe.StageSTT, m.provider, observe.OutcomeTimeout)
+		m.metrics.ProviderError(observe.StageSTT, m.provider)
 		return stt.Transcript{}, false
 	}
 }

--- a/pkg/voice/orchestrator/sttstream_internal_test.go
+++ b/pkg/voice/orchestrator/sttstream_internal_test.go
@@ -98,13 +98,22 @@ func (r *fakeStreamingRecognizer) openCount() int {
 	return r.opens
 }
 
-// spyStage records STTRequest calls; every other StageRecorder method is the no-op
-// from the embedded Discard.
+// spyStage records STTRequest and provider-call/error invocations; every other
+// StageRecorder method is the no-op from the embedded Discard.
 type spyStage struct {
 	observe.Discard
 	mu           sync.Mutex
 	sttRequests  int
 	lastProvider observe.Provider
+	calls        []spyProviderCall
+	errs         int
+}
+
+// spyProviderCall is one captured ProviderCall's bounded labels.
+type spyProviderCall struct {
+	stage    observe.Stage
+	provider observe.Provider
+	outcome  observe.Outcome
 }
 
 func (s *spyStage) STTRequest(p observe.Provider, _ time.Duration) {
@@ -114,10 +123,28 @@ func (s *spyStage) STTRequest(p observe.Provider, _ time.Duration) {
 	s.mu.Unlock()
 }
 
+func (s *spyStage) ProviderCall(stage observe.Stage, p observe.Provider, o observe.Outcome) {
+	s.mu.Lock()
+	s.calls = append(s.calls, spyProviderCall{stage: stage, provider: p, outcome: o})
+	s.mu.Unlock()
+}
+
+func (s *spyStage) ProviderError(observe.Stage, observe.Provider) {
+	s.mu.Lock()
+	s.errs++
+	s.mu.Unlock()
+}
+
 func (s *spyStage) requests() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sttRequests
+}
+
+func (s *spyStage) providerCalls() ([]spyProviderCall, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]spyProviderCall(nil), s.calls...), s.errs
 }
 
 // streamFrame builds a 32 ms / 16 kHz frame with marker written to sample 0, so a
@@ -306,6 +333,15 @@ func TestStreamManager_AwaitCommitSuccess(t *testing.T) {
 	if spy.lastProvider != observe.ProviderElevenLabs {
 		t.Errorf("stt_request provider = %q, want elevenlabs", spy.lastProvider)
 	}
+	// #125: a resolved commit moves provider_calls with outcome=ok and no errors.
+	calls, errs := spy.providerCalls()
+	wantOK := spyProviderCall{stage: observe.StageSTT, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeOK}
+	if len(calls) != 1 || calls[0] != wantOK {
+		t.Errorf("provider_calls = %+v, want one %+v", calls, wantOK)
+	}
+	if errs != 0 {
+		t.Errorf("provider_errors = %d on a healthy commit, want 0", errs)
+	}
 	m.mu.Lock()
 	b := m.backoff
 	m.mu.Unlock()
@@ -351,6 +387,15 @@ func TestStreamManager_AwaitCommitTimesOut(t *testing.T) {
 	if spy.requests() != 1 {
 		t.Errorf("commit timeout recorded %d stt_request spans, want 1 (a stalled provider is a recorded round-trip)", spy.requests())
 	}
+	// #125: a stalled commit moves provider_calls with outcome=timeout PLUS one error.
+	calls, errs := spy.providerCalls()
+	wantTimeout := spyProviderCall{stage: observe.StageSTT, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeTimeout}
+	if len(calls) != 1 || calls[0] != wantTimeout {
+		t.Errorf("provider_calls = %+v, want one %+v", calls, wantTimeout)
+	}
+	if errs != 1 {
+		t.Errorf("provider_errors = %d on a commit timeout, want 1", errs)
+	}
 }
 
 // TestStreamManager_AuthDialBacksOffAtCap pins that an auth-class DIAL rejection
@@ -390,12 +435,28 @@ func TestStreamManager_AuthDialBacksOffAtCap(t *testing.T) {
 // TestStreamManager_AwaitCommitErrorFallsBack pins that a provider commit error
 // falls back to batch (ok=false) and does not reset the backoff.
 func TestStreamManager_AwaitCommitErrorFallsBack(t *testing.T) {
-	m := NewStreamManager(&fakeStreamingRecognizer{}, WithStreamBackoff(time.Second, 30*time.Second), WithCommitTimeout(time.Second))
+	spy := &spyStage{}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithStreamMetrics(spy, observe.ProviderElevenLabs),
+		WithStreamBackoff(time.Second, 30*time.Second), WithCommitTimeout(time.Second))
 	m.backoff = 8 * time.Second
 	ch := make(chan stt.CommitResult, 1)
 	ch <- stt.CommitResult{Err: &stt.StreamError{Code: "commit_throttled", Fatal: false, Err: errors.New("throttled")}}
 	if _, ok := m.awaitCommit(ch, time.Now()); ok {
 		t.Fatal("awaitCommit ok=true on a commit error; want false → batch fallback")
+	}
+	// #125: a commit error moves provider_calls with outcome=error PLUS one error,
+	// and still records the round-trip span (batch parity).
+	if spy.requests() != 1 {
+		t.Errorf("commit error recorded %d stt_request spans, want 1", spy.requests())
+	}
+	calls, errs := spy.providerCalls()
+	wantErr := spyProviderCall{stage: observe.StageSTT, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeError}
+	if len(calls) != 1 || calls[0] != wantErr {
+		t.Errorf("provider_calls = %+v, want one %+v", calls, wantErr)
+	}
+	if errs != 1 {
+		t.Errorf("provider_errors = %d on a commit error, want 1", errs)
 	}
 	m.mu.Lock()
 	b := m.backoff

--- a/pkg/voice/orchestrator/tts.go
+++ b/pkg/voice/orchestrator/tts.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -22,19 +23,51 @@ type TTS struct {
 	bus         *voiceevent.Bus
 	synthesizer tts.Synthesizer
 
+	// rec/provider carry the #125 instrumentation: one tts_total span per
+	// successful [Dispatch] (the full Synthesize-through-drain synthesis) and a
+	// provider-call/error counter per Dispatch. Both default to no-ops
+	// (observe.Discard, empty provider label) so the keyless path stays silent —
+	// the mirror of [STT]'s stt_request wiring.
+	rec      observe.StageRecorder
+	provider observe.Provider
+
 	mu        sync.Mutex
 	nextIndex int
 }
 
+// TTSOption configures a [TTS] at construction. [WithTTSMetrics] opts the
+// tts_total / provider-call instrumentation in.
+type TTSOption func(*TTS)
+
+// WithTTSMetrics injects the #125 instrumentation: rec receives one
+// [observe.StageRecorder.TTSTotal] span per successful [Dispatch] plus the
+// provider-call/error counters, labelled with provider (the bounded provider enum
+// for the wired synthesizer). A nil rec leaves the no-op default in place. It is
+// the TTS mirror of [WithSTTMetrics].
+func WithTTSMetrics(rec observe.StageRecorder, provider observe.Provider) TTSOption {
+	return func(s *TTS) {
+		if rec != nil {
+			s.rec = rec
+		}
+		s.provider = provider
+	}
+}
+
 // NewTTS wires synthesizer into bus. Both must be non-nil; passing nil panics.
-func NewTTS(bus *voiceevent.Bus, synthesizer tts.Synthesizer) *TTS {
+// Pass [WithTTSMetrics] to record the synthesis round-trip and provider health;
+// without it the stage records nothing (the keyless default).
+func NewTTS(bus *voiceevent.Bus, synthesizer tts.Synthesizer, opts ...TTSOption) *TTS {
 	if bus == nil {
 		panic("orchestrator.NewTTS: bus must not be nil")
 	}
 	if synthesizer == nil {
 		panic("orchestrator.NewTTS: synthesizer must not be nil")
 	}
-	return &TTS{bus: bus, synthesizer: synthesizer}
+	s := &TTS{bus: bus, synthesizer: synthesizer, rec: observe.Discard{}}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 // Dispatch hands one sentence to the configured synthesizer and publishes a
@@ -83,14 +116,26 @@ func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) er
 		TurnID:   voiceevent.TurnIDFrom(ctx),
 	})
 
+	start := time.Now()
 	ch, err := s.synthesizer.Synthesize(ctx, tts.SynthesizeRequest{
 		Sentence: sentence,
 		Voice:    voice,
 	})
 	if err != nil {
+		// A start error is a provider error at the TTS stage (#125): count the call
+		// with its outcome (a cancelled ctx is timeout-shaped) and bump the
+		// error-only sibling. No tts_total — there was no synthesis to time.
+		s.rec.ProviderCall(observe.StageTTS, s.provider, observe.CallOutcome(ctx, err))
+		s.rec.ProviderError(observe.StageTTS, s.provider)
 		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
 	}
 	for range ch {
 	}
+	// The synthesis completed (the channel closed): record the full-synthesis span
+	// and count the call OK. A mid-stream barge (ctx cancel closing the channel
+	// early) is NOT a provider error — the vendor call itself succeeded — so it
+	// still counts OK, mirroring the agenttool adapter.
+	s.rec.TTSTotal(s.provider, time.Since(start))
+	s.rec.ProviderCall(observe.StageTTS, s.provider, observe.OutcomeOK)
 	return nil
 }

--- a/pkg/voice/orchestrator/tts.go
+++ b/pkg/voice/orchestrator/tts.go
@@ -122,19 +122,26 @@ func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) er
 		Voice:    voice,
 	})
 	if err != nil {
-		// A start error is a provider error at the TTS stage (#125): count the call
-		// with its outcome (a cancelled ctx is timeout-shaped) and bump the
-		// error-only sibling. No tts_total — there was no synthesis to time.
-		s.rec.ProviderCall(observe.StageTTS, s.provider, observe.CallOutcome(ctx, err))
-		s.rec.ProviderError(observe.StageTTS, s.provider)
+		// A start error at the TTS stage (#125): count the call with its outcome and
+		// bump the error-only sibling ONLY on a fault (error/timeout). A barge-in that
+		// cuts the ctx before Synthesize returns is OutcomeCanceled — a caller cancel,
+		// not a vendor error — so it does not inflate the error ratio (#239 review).
+		// No tts_total — there was no synthesis to time.
+		outcome := observe.CallOutcome(ctx, err)
+		s.rec.ProviderCall(observe.StageTTS, s.provider, outcome)
+		if outcome.IsFault() {
+			s.rec.ProviderError(observe.StageTTS, s.provider)
+		}
 		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
 	}
 	for range ch {
 	}
-	// The synthesis completed (the channel closed): record the full-synthesis span
-	// and count the call OK. A mid-stream barge (ctx cancel closing the channel
-	// early) is NOT a provider error — the vendor call itself succeeded — so it
-	// still counts OK, mirroring the agenttool adapter.
+	// The channel closed: record the DELIVER span and count the call OK. tts_total is
+	// NOT synthesis time — under the lockstep TeeSynthesizer the drain is paced by the
+	// playback pump, so it measures synthesis plus paced delivery of the sentence
+	// (ADR-0044 amendment, #239 review); the provider-latency signal is tts_ttfb. A
+	// mid-stream barge (ctx cancel closing the channel early) is NOT a provider error
+	// — the vendor call itself succeeded — so it still counts OK, mirroring agenttool.
 	s.rec.TTSTotal(s.provider, time.Since(start))
 	s.rec.ProviderCall(observe.StageTTS, s.provider, observe.OutcomeOK)
 	return nil

--- a/pkg/voice/orchestrator/tts_test.go
+++ b/pkg/voice/orchestrator/tts_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
@@ -55,6 +56,71 @@ func TestTTS_DispatchPublishesInvokedOnStartError(t *testing.T) {
 		func(e voiceevent.TTSInvoked) bool { return e.Sentence == sentence && e.Index == 0 },
 		"tts.invoked published for a start-errored sentence",
 	)
+}
+
+// TestTTS_Dispatch_RecordsProviderCallOutcomes pins the #125 provider-health
+// wiring on the TTS stage: a successful Dispatch records tts_total exactly once
+// and moves provider_calls with outcome=ok and no provider_errors; a Synthesize
+// start error moves provider_calls outcome=error PLUS provider_errors and records
+// NO tts_total (there was no synthesis to time). Labels stay the bounded
+// tts/elevenlabs enums (ADR-0032).
+func TestTTS_Dispatch_RecordsProviderCallOutcomes(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewTTS(h.Bus, closedChanSynth{},
+			orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Dispatch(context.Background(), "Aye.", voicetest.LiveElevenLabsVoice()); err != nil {
+			t.Fatalf("Dispatch: %v", err)
+		}
+
+		_, ttsTotals, _, calls, errs := spy.snapshot()
+		if len(ttsTotals) != 1 || ttsTotals[0] != observe.ProviderElevenLabs {
+			t.Errorf("tts_total recorded %v, want exactly one elevenlabs span", ttsTotals)
+		}
+		want := providerCall{stage: observe.StageTTS, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeOK}
+		if len(calls) != 1 || calls[0] != want {
+			t.Errorf("provider_calls = %+v, want one %+v", calls, want)
+		}
+		if len(errs) != 0 {
+			t.Errorf("provider_errors = %+v, want none on the success path", errs)
+		}
+	})
+
+	t.Run("start error", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewTTS(h.Bus, startErrSynth{},
+			orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Dispatch(context.Background(), "boom", voicetest.LiveElevenLabsVoice()); err == nil {
+			t.Fatal("Dispatch: expected the synth start error to propagate")
+		}
+
+		_, ttsTotals, _, calls, errs := spy.snapshot()
+		if len(ttsTotals) != 0 {
+			t.Errorf("tts_total recorded %v on a start error, want none (no synthesis timed)", ttsTotals)
+		}
+		want := providerCall{stage: observe.StageTTS, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeError}
+		if len(calls) != 1 || calls[0] != want {
+			t.Errorf("provider_calls = %+v, want one %+v", calls, want)
+		}
+		if len(errs) != 1 || errs[0] != (providerErr{stage: observe.StageTTS, provider: observe.ProviderElevenLabs}) {
+			t.Errorf("provider_errors = %+v, want one tts/elevenlabs error", errs)
+		}
+	})
+}
+
+// TestTTS_Dispatch_KeylessRecordsNothing pins the keyless default: an option-less
+// NewTTS never nil-panics on the metric calls — the recorder defaults to
+// observe.Discard, so Dispatch works exactly as before the #125 wiring.
+func TestTTS_Dispatch_KeylessRecordsNothing(t *testing.T) {
+	h := voicetest.New(t)
+	stage := orchestrator.NewTTS(h.Bus, closedChanSynth{})
+	if err := stage.Dispatch(context.Background(), "Aye.", voicetest.LiveElevenLabsVoice()); err != nil {
+		t.Fatalf("Dispatch on a keyless TTS stage: %v", err)
+	}
 }
 
 // TestTTS_HelloTest_DispatchesSentence is TB6: the first TTS tracer bullet,

--- a/pkg/voice/orchestrator/tts_test.go
+++ b/pkg/voice/orchestrator/tts_test.go
@@ -123,6 +123,83 @@ func TestTTS_Dispatch_KeylessRecordsNothing(t *testing.T) {
 	}
 }
 
+// TestTTS_Dispatch_BargeCancelIsNotFault pins the #239 refinement on the TTS stage:
+// a barge-in that cancels the ctx before Synthesize returns records
+// provider_calls with outcome=canceled and does NOT bump provider_errors — a
+// caller cancel is not a vendor fault. There is no tts_total (no synthesis).
+func TestTTS_Dispatch_BargeCancelIsNotFault(t *testing.T) {
+	h := voicetest.New(t)
+	spy := &metricsSpy{}
+	// startErrSynth returns an error; a pre-cancelled ctx makes the outcome canceled
+	// (the ctx state is authoritative, matching a real barge cutting the call).
+	stage := orchestrator.NewTTS(h.Bus, startErrSynth{},
+		orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := stage.Dispatch(ctx, "boom", voicetest.LiveElevenLabsVoice()); err == nil {
+		t.Fatal("Dispatch: expected an error on the cancelled path")
+	}
+
+	_, ttsTotals, _, calls, errs := spy.snapshot()
+	if len(ttsTotals) != 0 {
+		t.Errorf("tts_total recorded %v on a cancelled start, want none", ttsTotals)
+	}
+	want := providerCall{stage: observe.StageTTS, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeCanceled}
+	if len(calls) != 1 || calls[0] != want {
+		t.Errorf("provider_calls = %+v, want one %+v", calls, want)
+	}
+	if len(errs) != 0 {
+		t.Errorf("provider_errors = %+v on a barge cancel, want none (a cancel is not a fault)", errs)
+	}
+}
+
+// earlyCloseSynth emits a couple of audio chunks then closes the channel WITHOUT
+// an error and with a live ctx — a mid-synthesis provider outage the Synthesizer
+// contract renders indistinguishable from a clean completion.
+type earlyCloseSynth struct{}
+
+func (earlyCloseSynth) Synthesize(context.Context, tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	ch := make(chan tts.AudioChunk, 2)
+	ch <- tts.AudioChunk{PCM: []byte{0, 0}}
+	ch <- tts.AudioChunk{PCM: []byte{0, 0}}
+	close(ch)
+	return ch, nil
+}
+
+func (earlyCloseSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestTTS_Dispatch_MidStreamCloseIsAcceptedBlindSpot documents the accepted
+// Synthesizer-contract blind spot (#239 review): a channel that delivers some
+// chunks then closes with no error — a streaming outage mid-synthesis — is
+// INVISIBLE at this seam. Dispatch sees a clean close, so it records outcome=ok and
+// NO provider_error. This is by design: the tts.Synthesizer channel-close carries
+// no error signal, so a truncated stream cannot be distinguished from a complete
+// one here. If that blind spot must be closed, it belongs in the adapter, not this
+// stage.
+func TestTTS_Dispatch_MidStreamCloseIsAcceptedBlindSpot(t *testing.T) {
+	h := voicetest.New(t)
+	spy := &metricsSpy{}
+	stage := orchestrator.NewTTS(h.Bus, earlyCloseSynth{},
+		orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+
+	if err := stage.Dispatch(context.Background(), "cut short", voicetest.LiveElevenLabsVoice()); err != nil {
+		t.Fatalf("Dispatch: %v (a clean mid-stream close is not an error at this seam)", err)
+	}
+
+	_, ttsTotals, _, calls, errs := spy.snapshot()
+	if len(ttsTotals) != 1 {
+		t.Errorf("tts_total recorded %d, want 1 (the drain completed)", len(ttsTotals))
+	}
+	want := providerCall{stage: observe.StageTTS, provider: observe.ProviderElevenLabs, outcome: observe.OutcomeOK}
+	if len(calls) != 1 || calls[0] != want {
+		t.Errorf("provider_calls = %+v, want one %+v (mid-stream close reads as ok)", calls, want)
+	}
+	if len(errs) != 0 {
+		t.Errorf("provider_errors = %+v, want none (the blind spot: a truncated stream is invisible here)", errs)
+	}
+}
+
 // TestTTS_HelloTest_DispatchesSentence is TB6: the first TTS tracer bullet,
 // per ADR-0021's TTS cassette policy.
 //

--- a/pkg/voice/orchestrator/vad.go
+++ b/pkg/voice/orchestrator/vad.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -29,18 +30,51 @@ import (
 type VAD struct {
 	bus     *voiceevent.Bus
 	session vad.SessionHandle
+
+	// rec/hangover carry the #125 instrumentation: one vad_hangover span per
+	// speech_end, recording the fixed end-of-speech detection lag
+	// (minSilenceFrames*frameMs) the stage is constructed with. The value is a
+	// constant, not derived per-frame, because vad.Session does not expose its
+	// minSilenceFrames — wirenpc computes it from the same consts it configures the
+	// session with. rec defaults to a no-op (observe.Discard) so the keyless path
+	// stays silent.
+	rec      observe.StageRecorder
+	hangover time.Duration
+}
+
+// VADOption configures a [VAD] at construction. [WithVADMetrics] opts the
+// vad_hangover instrumentation in.
+type VADOption func(*VAD)
+
+// WithVADMetrics injects the #125 instrumentation: rec receives one
+// [observe.StageRecorder.VADHangover] span per speech_end, valued hangover (the
+// fixed minSilenceFrames*frameMs end-of-speech lag). A nil rec leaves the no-op
+// default in place.
+func WithVADMetrics(rec observe.StageRecorder, hangover time.Duration) VADOption {
+	return func(v *VAD) {
+		if rec != nil {
+			v.rec = rec
+		}
+		v.hangover = hangover
+	}
 }
 
 // NewVAD wires session into bus. Both must be non-nil; passing nil for
 // either panics. The caller owns session and is responsible for closing it.
-func NewVAD(bus *voiceevent.Bus, session vad.SessionHandle) *VAD {
+// Pass [WithVADMetrics] to record the end-of-speech hangover; without it the
+// stage records nothing (the keyless default).
+func NewVAD(bus *voiceevent.Bus, session vad.SessionHandle, opts ...VADOption) *VAD {
 	if bus == nil {
 		panic("orchestrator.NewVAD: bus must not be nil")
 	}
 	if session == nil {
 		panic("orchestrator.NewVAD: session must not be nil")
 	}
-	return &VAD{bus: bus, session: session}
+	v := &VAD{bus: bus, session: session, rec: observe.Discard{}}
+	for _, o := range opts {
+		o(v)
+	}
+	return v
 }
 
 // Process feeds one PCM frame through the underlying VAD session and
@@ -64,6 +98,8 @@ func (v *VAD) Process(frame audio.Frame) error {
 			At:          time.Now(),
 			Probability: evt.Probability,
 		})
+		// #125: stamp the fixed end-of-speech detection lag once per speech_end.
+		v.rec.VADHangover(v.hangover)
 	}
 	return nil
 }

--- a/pkg/voice/orchestrator/vad_test.go
+++ b/pkg/voice/orchestrator/vad_test.go
@@ -2,11 +2,68 @@ package orchestrator_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
 )
+
+// TestVAD_RecordsHangoverOnSpeechEnd pins the #125 vad_hangover wiring: the stage
+// records exactly one VADHangover span — the fixed end-of-speech detection lag it
+// is constructed with — per speech_end transition, and none for a speech_start or
+// a silence frame. The value is the configured constant (minSilenceFrames*frameMs),
+// not derived per-frame, so a single 384 ms observation is what the histogram gets.
+func TestVAD_RecordsHangoverOnSpeechEnd(t *testing.T) {
+	const hangover = 384 * time.Millisecond
+	bus := voiceevent.NewBus()
+	spy := &metricsSpy{}
+	// Script: start (no hangover), continue (no hangover), end (one hangover).
+	stage := orchestrator.NewVAD(bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechContinue, vad.VADSpeechEnd,
+	}}, orchestrator.WithVADMetrics(spy, hangover))
+
+	silent, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	for i := 0; i < 4; i++ { // start, continue, end, silence
+		if err := stage.Process(silent); err != nil {
+			t.Fatalf("frame %d: Process: %v", i, err)
+		}
+	}
+
+	_, _, hangs, _, _ := spy.snapshot()
+	if len(hangs) != 1 {
+		t.Fatalf("recorded %d vad_hangover spans, want exactly 1 (one per speech_end)", len(hangs))
+	}
+	if hangs[0] != hangover {
+		t.Errorf("vad_hangover = %v, want the configured constant %v", hangs[0], hangover)
+	}
+}
+
+// TestVAD_KeylessRecordsNoHangover pins the keyless default: an option-less NewVAD
+// records nothing on speech_end (the recorder defaults to observe.Discard) and
+// never nil-panics.
+func TestVAD_KeylessRecordsNoHangover(t *testing.T) {
+	bus := voiceevent.NewBus()
+	stage := orchestrator.NewVAD(bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechEnd,
+	}})
+	silent, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := stage.Process(silent); err != nil {
+			t.Fatalf("frame %d: Process: %v", i, err)
+		}
+	}
+	// No assertion beyond "did not panic": the Discard default has no observable
+	// sink, so reaching speech_end without a wired recorder must stay silent.
+}
 
 // TestVAD_HelloTest_EmitsSpeechStart is TB1: the foundation tracer bullet
 // for the orchestrator-first TDD voice pipeline (ADR-0019).

--- a/pkg/voice/wire/codec/codec.go
+++ b/pkg/voice/wire/codec/codec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/hraban/opus"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
@@ -94,11 +95,38 @@ type Codec struct {
 	mu       sync.Mutex
 	decoders map[snowflake.ID]*inboundStream
 	calls    int // DecodeInbound calls since the last idle-stream sweep
+
+	// rec carries the #125 per-frame codec instrumentation: CodecDecode per inbound
+	// frame decoded, CodecEncode per outbound frame encoded. Defaults to a no-op
+	// (observe.Discard) so the keyless path stays silent.
+	rec observe.StageRecorder
 }
 
-// New returns a Codec ready to transcode. It implements [wire.Codec].
-func New() *Codec {
-	return &Codec{decoders: make(map[snowflake.ID]*inboundStream)}
+// Option configures a [Codec] at construction. [WithMetrics] opts the per-frame
+// codec_decode / codec_encode instrumentation in.
+type Option func(*Codec)
+
+// WithMetrics injects the #125 instrumentation: rec receives one
+// [observe.StageRecorder.CodecDecode] span per decoded inbound frame and one
+// CodecEncode per encoded outbound frame. A nil rec leaves the no-op default in
+// place. The stub build (no -tags opus) accepts the same option and ignores it.
+func WithMetrics(rec observe.StageRecorder) Option {
+	return func(c *Codec) {
+		if rec != nil {
+			c.rec = rec
+		}
+	}
+}
+
+// New returns a Codec ready to transcode. It implements [wire.Codec]. Pass
+// [WithMetrics] to record the per-frame codec spans; without it the codec records
+// nothing (the keyless default).
+func New(opts ...Option) *Codec {
+	c := &Codec{decoders: make(map[snowflake.ID]*inboundStream), rec: observe.Discard{}}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
 }
 
 var _ wire.Codec = (*Codec)(nil)
@@ -143,12 +171,17 @@ func (c *Codec) DecodeInbound(frame gxvoice.Frame) ([]audio.Frame, error) {
 	stream.lastPTS = frame.PTS
 	stream.hasPTS = true
 
+	// Time the decode+reframe work: one codec_decode span per inbound frame (#125).
+	// The measured section is exactly the Opus->PCM decode and the reframer regroup,
+	// the per-inbound-frame cost the series names.
+	decodeStart := time.Now()
 	n, err := stream.dec.Decode(frame.Opus, stream.pcm)
 	if err != nil {
 		return nil, fmt.Errorf("codec: decode Opus for user %s: %w", frame.UserID, err)
 	}
 
 	grouped := stream.reframe.Push(stream.pcm[:n])
+	c.rec.CodecDecode(time.Since(decodeStart))
 	if len(grouped) == 0 {
 		return nil, nil
 	}
@@ -213,6 +246,7 @@ func (c *Codec) PlaybackSource(chunks <-chan tts.AudioChunk) (gxvoice.Source, er
 		enc:     enc,
 		reframe: dsp.NewReframer(opusFrameSamples),
 		encBuf:  make([]byte, maxEncodedBytes),
+		rec:     c.rec,
 	}, nil
 }
 
@@ -227,6 +261,7 @@ type playbackSource struct {
 	resamp  *dsp.Resampler // built lazily from the first chunk's rate
 	reframe *dsp.Reframer
 	encBuf  []byte
+	rec     observe.StageRecorder // #125: codec_encode per outbound frame
 
 	ready   [][]int16 // resampled+reframed frames awaiting encode
 	drained bool      // chunk channel closed; flush the reframer tail once
@@ -260,7 +295,12 @@ func (p *playbackSource) NextFrame(ctx context.Context) ([]byte, error) {
 
 	frame := p.ready[0]
 	p.ready = p.ready[1:]
+	// Time ONLY the encode: one codec_encode span per outbound frame (#125). The
+	// <-chunks wait in pull() is deliberately excluded — it is synthesis network
+	// time, not codec cost, and would corrupt the series.
+	encStart := time.Now()
 	n, err := p.enc.Encode(frame, p.encBuf)
+	p.rec.CodecEncode(time.Since(encStart))
 	if err != nil {
 		return nil, fmt.Errorf("codec: encode Opus frame: %w", err)
 	}

--- a/pkg/voice/wire/codec/codec_stub.go
+++ b/pkg/voice/wire/codec/codec_stub.go
@@ -3,6 +3,7 @@
 package codec
 
 import (
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
@@ -17,8 +18,25 @@ import (
 // build. The pure-Go DSP in ./dsp is always built and tested regardless.
 type Codec struct{}
 
-// New returns the stub Codec. It implements [wire.Codec].
-func New() *Codec { return &Codec{} }
+// Option configures a [Codec]. The stub accepts the same construction shape as the
+// opus build (so wirenpc's codec.New(codec.WithMetrics(...)) compiles tag-lessly)
+// but has nothing to configure.
+type Option func(*Codec)
+
+// WithMetrics is the stub's no-op counterpart to the opus build's per-frame codec
+// instrumentation: it accepts the recorder and ignores it (the stub decodes and
+// encodes nothing).
+func WithMetrics(observe.StageRecorder) Option { return func(*Codec) {} }
+
+// New returns the stub Codec. It implements [wire.Codec]. Options are accepted for
+// signature parity with the opus build and ignored.
+func New(opts ...Option) *Codec {
+	c := &Codec{}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
 
 var _ wire.Codec = (*Codec)(nil)
 

--- a/pkg/voice/wire/codec/codec_stub_test.go
+++ b/pkg/voice/wire/codec/codec_stub_test.go
@@ -1,0 +1,23 @@
+//go:build !opus
+
+package codec
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/wire"
+)
+
+// TestStubAcceptsMetricsOption pins that the default (no -tags opus) build accepts
+// the same New(WithMetrics(...)) construction the opus build does (#125): the
+// option must exist and be ignored in the stub, or the tag-less CI that wires
+// codec.New(codec.WithMetrics(...)) fails to compile. The stub still reports the
+// codec unavailable.
+func TestStubAcceptsMetricsOption(t *testing.T) {
+	c := New(WithMetrics(observe.Discard{}))
+	if _, err := c.DecodeInbound(gxvoice.Frame{UserID: 1, Opus: []byte{0x1}}); err != wire.ErrCodecUnavailable {
+		t.Fatalf("stub DecodeInbound err = %v, want ErrCodecUnavailable", err)
+	}
+}

--- a/pkg/voice/wire/codec/codec_test.go
+++ b/pkg/voice/wire/codec/codec_test.go
@@ -8,14 +8,109 @@ import (
 	"errors"
 	"io"
 	"math"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/hraban/opus"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	gxvoice "github.com/MrWong99/Glyphoxa/pkg/voice"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 )
+
+// codecSpy is a [observe.StageRecorder] that counts the per-frame codec spans
+// (#125). Embeds [observe.Discard] so every other method is a no-op. Safe for
+// concurrent use (PlaybackSource may pull from another goroutine).
+type codecSpy struct {
+	observe.Discard
+	mu      sync.Mutex
+	decodes int
+	encodes int
+}
+
+func (s *codecSpy) CodecDecode(time.Duration) {
+	s.mu.Lock()
+	s.decodes++
+	s.mu.Unlock()
+}
+
+func (s *codecSpy) CodecEncode(time.Duration) {
+	s.mu.Lock()
+	s.encodes++
+	s.mu.Unlock()
+}
+
+func (s *codecSpy) counts() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.decodes, s.encodes
+}
+
+// TestDecodeInbound_RecordsCodecDecodePerFrame pins the #125 codec_decode wiring:
+// each non-empty inbound Opus frame decoded records exactly one CodecDecode span,
+// so N inbound packets → N observations (the histogram's "per inbound frame"
+// contract). An empty payload decodes nothing and records nothing.
+func TestDecodeInbound_RecordsCodecDecodePerFrame(t *testing.T) {
+	packets := encodeOpus(t, sine(48000, 48000, 330), 48000)
+	spy := &codecSpy{}
+	c := New(WithMetrics(spy))
+	user := snowflake.ID(7)
+	for _, pkt := range packets {
+		if _, err := c.DecodeInbound(gxvoice.Frame{UserID: user, Opus: pkt}); err != nil {
+			t.Fatalf("DecodeInbound: %v", err)
+		}
+	}
+	// An empty payload is a no-op — it must not record a decode span.
+	if _, err := c.DecodeInbound(gxvoice.Frame{UserID: user, Opus: nil}); err != nil {
+		t.Fatalf("DecodeInbound(empty): %v", err)
+	}
+
+	decodes, _ := spy.counts()
+	if decodes != len(packets) {
+		t.Errorf("codec_decode recorded %d spans, want %d (one per decoded inbound frame)", decodes, len(packets))
+	}
+}
+
+// TestPlaybackSource_RecordsCodecEncodePerFrame pins the #125 codec_encode wiring:
+// each outbound Opus frame the playback source produces records exactly one
+// CodecEncode span. The chunk channel is PRE-FILLED and closed before the first
+// pull, so the measured cost is the enc.Encode work, never the synthesis-network
+// <-chunks wait (which would corrupt the series).
+func TestPlaybackSource_RecordsCodecEncodePerFrame(t *testing.T) {
+	const rate = 48000
+	chunks := make(chan tts.AudioChunk, 1)
+	chunks <- tts.AudioChunk{PCM: pcmBytes(sine(rate, rate, 440)), SampleRate: rate, Channels: 1}
+	close(chunks) // pre-filled + closed: NextFrame never blocks on synthesis
+
+	spy := &codecSpy{}
+	c := New(WithMetrics(spy))
+	src, err := c.PlaybackSource(chunks)
+	if err != nil {
+		t.Fatalf("PlaybackSource: %v", err)
+	}
+
+	var frames int
+	for {
+		_, err := src.NextFrame(context.Background())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextFrame: %v", err)
+		}
+		frames++
+	}
+
+	_, encodes := spy.counts()
+	if frames == 0 {
+		t.Fatal("playback produced no frames")
+	}
+	if encodes != frames {
+		t.Errorf("codec_encode recorded %d spans, want %d (one per outbound frame)", encodes, frames)
+	}
+}
 
 // encodeOpus encodes mono int16 PCM at rate into 20 ms Opus packets, the shape
 // Discord delivers. Used to synthesize inbound frames for DecodeInbound.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -617,6 +617,10 @@ message ListProviderConfigsResponse {
   string guild_id = 2;
   // voice_channel_id is the channel sessions join (non-secret; may be empty).
   string voice_channel_id = 3;
+  // discord_application_id is the Discord application (client) id backing
+  // operator login (ADR-0016), reused for the bot-authorization URL; non-secret;
+  // empty when DISCORD_OAUTH_CLIENT_ID unset.
+  string discord_application_id = 4;
 }
 
 // SaveProviderConfigRequest seals one BYOK provider key.

--- a/web/src/lib/discordLink.test.ts
+++ b/web/src/lib/discordLink.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+import { parseChannelLink } from "./discordLink";
+
+// A voice channel's right-click "Copy Link" yields discord.com/channels/{guild}/{channel},
+// carrying BOTH snowflakes. The parser is pure and client-side (#101, ADR-0039):
+// it extracts the two ids or returns null, never touching the network.
+const GUILD = "472093001100472093";
+const CHANNEL = "987654321098765432";
+
+describe("parseChannelLink", () => {
+  it("parses a canonical https channel deep-link into both snowflakes", () => {
+    expect(parseChannelLink(`https://discord.com/channels/${GUILD}/${CHANNEL}`)).toEqual({
+      guildId: GUILD,
+      channelId: CHANNEL,
+    });
+  });
+
+  it("tolerates scheme, subdomain, trailing-slash and query-string variants to the SAME ids", () => {
+    const variants = [
+      `https://discord.com/channels/${GUILD}/${CHANNEL}`,
+      `http://discord.com/channels/${GUILD}/${CHANNEL}`,
+      `discord.com/channels/${GUILD}/${CHANNEL}`,
+      `ptb.discord.com/channels/${GUILD}/${CHANNEL}`,
+      `https://canary.discord.com/channels/${GUILD}/${CHANNEL}`,
+      `https://discord.com/channels/${GUILD}/${CHANNEL}/`,
+      `https://discord.com/channels/${GUILD}/${CHANNEL}?foo=bar`,
+      `  https://discord.com/channels/${GUILD}/${CHANNEL}  `,
+      // Discord's embed-suppressed copy wraps the URL in angle brackets.
+      `<https://discord.com/channels/${GUILD}/${CHANNEL}>`,
+      // Legacy discordapp.com host — old links still resolve.
+      `https://discordapp.com/channels/${GUILD}/${CHANNEL}`,
+      `discordapp.com/channels/${GUILD}/${CHANNEL}`,
+    ];
+    for (const link of variants) {
+      expect(parseChannelLink(link)).toEqual({ guildId: GUILD, channelId: CHANNEL });
+    }
+  });
+
+  it("returns null for a string that is not a channel deep-link", () => {
+    expect(parseChannelLink("hello world")).toBeNull();
+    expect(parseChannelLink("")).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/@me/123456789012345678")).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/12345/67890")).toBeNull();
+    expect(parseChannelLink("https://example.com/channels/" + GUILD + "/" + CHANNEL)).toBeNull();
+    expect(parseChannelLink("https://discord.com/channels/" + GUILD)).toBeNull();
+  });
+});

--- a/web/src/lib/discordLink.ts
+++ b/web/src/lib/discordLink.ts
@@ -1,0 +1,56 @@
+// discordLink — pure, network-free parsing of a Discord channel deep-link (#101,
+// ADR-0039). A voice channel's right-click "Copy Link" yields
+// discord.com/channels/{guildId}/{channelId}, carrying BOTH snowflakes; the
+// Configuration screen pastes that here to autofill the two ID fields.
+
+export interface ChannelLink {
+  guildId: string;
+  channelId: string;
+}
+
+// Discord snowflakes are 17–20 digit ids (a 64-bit id rendered as decimal).
+const SNOWFLAKE = /^\d{17,20}$/;
+
+// A Discord channel host: discord.com, the legacy discordapp.com, or a client
+// subdomain of either (ptb./canary./www.).
+function isDiscordHost(host: string): boolean {
+  return ["discord.com", "discordapp.com"].some(
+    (base) => host === base || host.endsWith(`.${base}`),
+  );
+}
+
+// parseChannelLink extracts the guild + voice channel snowflakes from a pasted
+// channel deep-link, or returns null when the string is not one. It tolerates a
+// missing scheme, http/https, the ptb./canary. client subdomains, the legacy
+// discordapp.com host, angle brackets (Discord's embed-suppressed <url> copy), a
+// trailing slash, a query string, and surrounding whitespace — every variant
+// resolves to the same two ids. Anything else (a random string, a @me DM link, a
+// non-Discord host, short/invalid ids) yields null so the caller can surface a hint.
+export function parseChannelLink(input: string): ChannelLink | null {
+  // Strip surrounding whitespace, then the <…> Discord wraps a URL in to
+  // suppress its embed.
+  const trimmed = input.trim().replace(/^<(.*)>$/, "$1").trim();
+  if (!trimmed) return null;
+
+  // A scheme-less paste (the common "discord.com/channels/…") needs one to parse
+  // as a URL; add https:// only when no scheme is present.
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+
+  if (!isDiscordHost(url.hostname.toLowerCase())) return null;
+
+  // /channels/{guild}/{channel}[/…] — filter drops the empty segment a trailing
+  // slash leaves behind. The query string lives in url.search, so it's ignored.
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments[0] !== "channels") return null;
+  const [, guildId, channelId] = segments;
+  if (!SNOWFLAKE.test(guildId ?? "") || !SNOWFLAKE.test(channelId ?? "")) return null;
+
+  return { guildId, channelId };
+}

--- a/web/src/screens/configuration/AddBotLink.test.tsx
+++ b/web/src/screens/configuration/AddBotLink.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AddBotLink, botAuthorizeUrl } from "./AddBotLink";
+
+// The bot-authorization URL is a fixed contract (#110): Discord's authorize
+// endpoint, scope=bot + applications.commands (so /glyphoxa slash commands
+// appear in a fresh guild), and permissions 3146752 = View Channel (0x400) +
+// Connect (0x100000) + Speak (0x200000) — the set a voice-join needs.
+const PINNED = "https://discord.com/oauth2/authorize?client_id=123&scope=bot%20applications.commands&permissions=3146752";
+
+describe("botAuthorizeUrl", () => {
+  it("composes the pinned authorize URL from the application id", () => {
+    expect(botAuthorizeUrl("123")).toBe(PINNED);
+  });
+
+  it("url-encodes the application id", () => {
+    expect(botAuthorizeUrl("a b")).toContain("client_id=a%20b");
+  });
+});
+
+describe("AddBotLink", () => {
+  it("renders an authorize anchor opening in a new tab", () => {
+    render(<AddBotLink applicationId="123" />);
+    const link = screen.getByRole("link", { name: /add glyphoxa to your server/i });
+    expect(link).toHaveAttribute("href", PINNED);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("states adding the bot is a separate, prerequisite step", () => {
+    render(<AddBotLink applicationId="123" />);
+    // Copy must distinguish this from saving the IDs and mark it a prerequisite.
+    expect(screen.getByText(/separate step from saving the ids/i)).toBeInTheDocument();
+    expect(screen.getByText(/before a voice session can join/i)).toBeInTheDocument();
+  });
+
+  it("disables the action with a note when no application id is configured", () => {
+    render(<AddBotLink applicationId="" />);
+    // No broken link: the anchor is absent, a disabled button stands in.
+    expect(screen.queryByRole("link", { name: /add glyphoxa to your server/i })).not.toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /add glyphoxa to your server/i });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText(/no discord application id is configured/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/configuration/AddBotLink.tsx
+++ b/web/src/screens/configuration/AddBotLink.tsx
@@ -1,0 +1,57 @@
+import { ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+
+// AddBotLink — the Configuration Discord card's "Add Glyphoxa to your server"
+// action (#110). Adding the Bot to a Guild is a SEPARATE, prerequisite step from
+// saving the Guild / Voice channel IDs: neither pasted-link format joins the Bot,
+// so a Voice Session cannot join voice until the operator authorizes it here.
+//
+// The URL is built entirely from the server-provided Discord application id (the
+// same app that backs operator login, ADR-0016) — nothing secret is hardcoded.
+// With no application id (DISCORD_OAUTH_CLIENT_ID unset) the action is disabled
+// with an explanatory note instead of producing a broken link.
+
+// botAuthorizeUrl composes Discord's bot-authorization URL for one application.
+// scope=bot pulls the Bot into the Guild; applications.commands registers the
+// /glyphoxa slash commands in a fresh guild; permissions 3146752 = View Channel
+// (0x400) + Connect (0x100000) + Speak (0x200000) — the minimum a voice-join Bot
+// needs.
+export function botAuthorizeUrl(applicationId: string): string {
+  return `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(applicationId)}&scope=bot%20applications.commands&permissions=3146752`;
+}
+
+// The always-visible copy distinguishing this step from saving the IDs and
+// marking it a prerequisite for voice-join. "above" because the action renders
+// at the foot of the card, below the ID inputs.
+const COPY =
+  "Adding the Bot to a server is a separate step from saving the IDs above — the Bot must be a member before a Voice Session can join voice.";
+
+// The anchor wears the Button classes because the Button primitive is
+// button-only; a real <a> is needed to open Discord in a new tab.
+const BTN_CLASS = "gx-btn gx-btn--secondary gx-btn--sm";
+
+export function AddBotLink({ applicationId }: { applicationId: string }) {
+  return (
+    <div className="gx-add-bot">
+      <p className="gx-add-bot__copy">{COPY}</p>
+      {applicationId ? (
+        <a className={BTN_CLASS} href={botAuthorizeUrl(applicationId)} target="_blank" rel="noopener noreferrer">
+          <span className="gx-btn__icon">
+            <ExternalLink size={16} />
+          </span>
+          Add Glyphoxa to your server
+        </a>
+      ) : (
+        <>
+          <Button variant="secondary" size="sm" disabled iconStart={<ExternalLink size={16} />}>
+            Add Glyphoxa to your server
+          </Button>
+          <p className="gx-add-bot__note">
+            No Discord application id is configured (DISCORD_OAUTH_CLIENT_ID), so this link can&apos;t be built.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
 import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
@@ -71,6 +71,9 @@ function mockBackend(
     // listModelsError makes the catalog fetch fail at the transport, pinning
     // that free-text model entry survives a dead catalog (#227).
     listModelsError?: string;
+    // discordApplicationId seeds the server-provided Discord application id the
+    // read echoes so the screen composes the bot-authorization URL (#110).
+    discordApplicationId?: string;
   } = {},
 ) {
   const state = {
@@ -104,6 +107,7 @@ function mockBackend(
           ],
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
+          discordApplicationId: opts.discordApplicationId ?? "",
         }),
       saveProviderConfig: (req) => {
         opts.providerSaves?.push({ provider: req.provider, secret: req.secret, model: req.model });
@@ -371,6 +375,112 @@ describe("Configuration", () => {
       }),
     );
     expect(await screen.findByText(/Connected as Glyphoxa#4823/)).toBeInTheDocument();
+  });
+
+  it("shows the Add-Glyphoxa-to-your-server link built from the server app id (#110)", async () => {
+    renderScreen(mockBackend({ discordApplicationId: "987654321098765432" }));
+    const link = await screen.findByRole("link", { name: /add glyphoxa to your server/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("client_id=987654321098765432"));
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("disables the Add-Glyphoxa action when no application id is configured (#110)", async () => {
+    renderScreen(); // default mock: empty discordApplicationId
+    expect(await screen.findByText(/no discord application id is configured/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /add glyphoxa to your server/i })).not.toBeInTheDocument();
+  });
+
+  it("does not flash the missing-app-id note while the config query is loading (#110)", async () => {
+    renderScreen(); // default mock resolves success with an empty id
+    // Synchronously after render the list query is still pending — the note must
+    // not flash (nor would it stick on a query error): only a resolved empty id
+    // is the disabled fallback.
+    expect(screen.queryByText(/no discord application id is configured/i)).not.toBeInTheDocument();
+    // Once the read resolves with an empty id, the disabled action + note appear.
+    expect(await screen.findByText(/no discord application id is configured/i)).toBeInTheDocument();
+  });
+
+  it("autofills both ID fields from a pasted channel link with no network request (#101)", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    renderScreen(mockBackend({ discordSaves }));
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, {
+      target: { value: "https://discord.com/channels/472093001100472093/987654321098765432" },
+    });
+
+    // Both snowflakes land in the (still editable) ID fields, purely client-side.
+    expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe("472093001100472093");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+    // Parsing issues NO save RPC — the autofill is local until the operator Saves.
+    expect(discordSaves).toHaveLength(0);
+  });
+
+  it("persists autofilled IDs through Save into the right wire fields and re-seeds them on reload (#101)", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    const transport = mockBackend({ discordSaves });
+    const { unmount } = renderScreen(transport);
+
+    fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
+      target: { value: "discord.com/channels/472093001100472093/987654321098765432" },
+    });
+    // The autofill marks the fields dirty, so Save picks up the pasted values.
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+
+    // Pin the exact snowflake in the exact wire field: a guild/voice SWAP would
+    // still round-trip through the display, so a value-only check can't catch it.
+    await waitFor(() => expect(discordSaves).toHaveLength(1));
+    expect(discordSaves[0].guildId).toBe("472093001100472093");
+    expect(discordSaves[0].voiceChannelId).toBe("987654321098765432");
+
+    // Reload (AC2): a fresh mount against the SAME stateful backend re-seeds both
+    // fields from what was persisted — the values survive the round-trip, and
+    // each lands back in its OWN field (guild in Guild ID, channel in Voice).
+    unmount();
+    renderScreen(transport);
+    await waitFor(() =>
+      expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe(
+        "472093001100472093",
+      ),
+    );
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+  });
+
+  it("rejects a non-link paste with an inline hint and leaves fields unchanged (#101)", async () => {
+    renderScreen();
+
+    // Operator already has a Guild ID typed in.
+    const guild = await screen.findByLabelText("Guild ID");
+    fireEvent.change(guild, { target: { value: "existing-guild" } });
+
+    // A paste that is not a channel deep-link surfaces a hint…
+    const paste = screen.getByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, { target: { value: "not a discord link" } });
+    expect(screen.getByText(/couldn't read that link/i)).toBeInTheDocument();
+
+    // …and does not clobber what the operator already had.
+    expect((guild as HTMLInputElement).value).toBe("existing-guild");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+  });
+
+  it("tolerates scheme/subdomain/trailing-slash/query variants when autofilling (#101)", async () => {
+    renderScreen();
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, {
+      target: { value: "ptb.discord.com/channels/472093001100472093/987654321098765432/?jump=1" },
+    });
+
+    expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe("472093001100472093");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+    // A rejected paste's hint must not linger after a successful one.
+    expect(screen.queryByText(/couldn't read that link/i)).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-react";
+import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw, Link as LinkIcon } from "lucide-react";
 
 import {
   CampaignService,
@@ -17,6 +17,8 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
 import { Combobox } from "@/components/ui/Combobox";
 import { Button } from "@/components/ui/Button";
+import { parseChannelLink } from "@/lib/discordLink";
+import { AddBotLink } from "./AddBotLink";
 
 import "./configuration.css";
 
@@ -96,6 +98,30 @@ export function Configuration() {
     setVoiceChannelId(v);
   };
 
+  // "Paste a Discord link" autofill (#101): a voice channel's Copy-Link carries
+  // both snowflakes, so a well-formed paste fills the two ID fields purely
+  // client-side (parseChannelLink issues no network call) and marks them dirty so
+  // Save picks the values up. A paste that isn't a channel deep-link leaves the
+  // fields untouched and surfaces an inline hint.
+  const [channelLink, setChannelLink] = useState("");
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const pasteChannelLink = (v: string) => {
+    setChannelLink(v);
+    if (!v.trim()) {
+      setLinkError(null);
+      return;
+    }
+    const parsed = parseChannelLink(v);
+    if (!parsed) {
+      setLinkError("Couldn't read that link — paste a Discord channel link.");
+      return;
+    }
+    idsDirty.current = true;
+    setGuildId(parsed.guildId);
+    setVoiceChannelId(parsed.channelId);
+    setLinkError(null);
+  };
+
   return (
     <div className="gx-providers">
       <h1>Providers</h1>
@@ -172,6 +198,15 @@ export function Configuration() {
             // even while the config load is still resolving (#142).
             onSave={(secret) => saveDiscord.mutateAsync({ botToken: secret })}
           />
+          <Input
+            label="Paste a Discord link"
+            placeholder="https://discord.com/channels/…"
+            icon={<LinkIcon size={15} />}
+            hint="Right-click a voice channel → Copy Link to fill both IDs at once."
+            error={linkError}
+            value={channelLink}
+            onChange={(e) => pasteChannelLink(e.target.value)}
+          />
           <div className="gx-discord__ids">
             <Input
               label="Guild ID"
@@ -209,6 +244,12 @@ export function Configuration() {
               </span>
             )}
           </div>
+          {/* Authorizing the Bot into the Guild is a separate, prerequisite step
+              from saving the IDs — neither pasted-link format joins the Bot (#110).
+              Gated on a resolved read so the "no application id" note can't flash
+              while the config loads, nor stick on a query error — only a genuine
+              empty id (query succeeded) is the disabled fallback. */}
+          {config.isSuccess && <AddBotLink applicationId={config.data.discordApplicationId} />}
         </div>
       </Card>
 

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -73,6 +73,30 @@
   color: var(--status-danger);
 }
 
+/* "Add Glyphoxa to your server" bot-authorization action (#110): a separate,
+ * prerequisite step from saving the IDs, sits at the foot of the Discord card
+ * above a top divider so the distinction reads. */
+.gx-add-bot {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.gx-add-bot__copy {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
+.gx-add-bot__note {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
 /* Resolved Discord bot tag from the live gateway login (#70), under the name. */
 .gx-provider-row__tag {
   font-size: var(--text-xs, 0.75rem);


### PR DESCRIPTION
Closes #125

## What
Wires the Provider-health counters and stage-latency histograms that were registered on `/metrics` but had **no live emit-site**. STT and TTS now record a provider-calls outcome + provider-errors like the LLM stage already did, and the six previously-reserved histograms get real observations and shed their `RESERVED` help text.

`stt_request` was already wired (its RESERVED help text was stale); this PR drops all six RESERVED suffixes and wires the remaining five.

## Emit-sites (per the architect PLAN)
- **`observe.CallOutcome(ctx, err)`** — shared `ok/error/timeout` classifier (mirrors agenttool's rule).
- **STT** `Transcribe` + StreamManager `awaitCommit` — `ProviderCall(stt,…)` + `ProviderError` beside the existing `STTRequest` (batch + streamed commit).
- **TTS** `Dispatch` — `TTSTotal` + `ProviderCall/Error`. Start error → error+ProviderError, no TTSTotal; a mid-stream barge is **not** a provider error (counts OK).
- **VAD** `WithVADMetrics` — one `VADHangover` per `speech_end`, the fixed `minSilenceFrames*frameMs` (=384 ms) constant computed in wirenpc.
- **codec** `WithMetrics` (both opus + stub build variants) — `CodecDecode` per inbound frame; `CodecEncode` times **only** the `enc.Encode` section, never the `<-chunks` synthesis wait.
- **agenttool** `Engine` — one `LLMTurn` per `Generate`/`GenerateStream`, spanning all rounds, on success **and** error.
- **wirenpc** wires VAD/TTS/codec metrics; **prometheus** drops the six RESERVED help-text suffixes.

All labels stay bounded enums (`stage`/`provider`/`outcome`) per ADR-0032 — no tenant/guild/agent/turn ids.

## Placement note for #124 / #127
This PR lands first on the shared STT/TTS seam. The `#125` emit-sites were placed to the architect's exact line layout so #124 (retry) and #127 (usage) can build around them without restructuring the calls.

## Tests (TDD, red→green)
- `observe.CallOutcome` table (ok/error/timeout).
- STT stage: success/error/timeout → correct ProviderCall outcome + ProviderError; `STTRequest` recorded in all three (regression).
- TTS stage: success → one TTSTotal + ok; start error → error+ProviderError, no TTSTotal; keyless default records nothing.
- StreamManager `awaitCommit`: ok/error/timeout ProviderCall variants.
- VAD: exactly one `VADHangover(384ms)` per speech_end; keyless silent.
- agenttool: 2-round loop → exactly one LLMTurn; streaming identical; error path records too.
- codec (opus-tagged): N inbound frames → N CodecDecode; pre-filled channel → CodecEncode per outbound frame; stub build compiles + ignores the option.
- prometheus registry: every wired instrument has a non-empty series after one call; **no help text contains `RESERVED`** (pins the AC).

Local: affected packages green (`go test`), opus codec test green, `golangci-lint` v2.12.2 clean, gofmt clean.
