### PR TITLE
[E6] Voice Session connection-state: classify fatal vs transient gateway failures (#123)

### DIFF
--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -350,7 +350,9 @@ func toProtoTranscriptLineMatch(l storage.TranscriptLine) *managementv1.Transcri
 
 // toProtoVoiceSession maps a storage.VoiceSession onto its wire view. A zero
 // value (no session) maps to nil so the screen renders the never-run state;
-// ended_at is set only once the session has ended.
+// ended_at is set only once the session has ended, and end_reason carries the
+// readable cause of an abnormal end (a fatal "failed" session, #123, or a
+// boot-orphaned row, #143) — empty for a clean stop.
 func toProtoVoiceSession(v storage.VoiceSession) *managementv1.VoiceSession {
 	if v.ID == uuid.Nil {
 		return nil
@@ -364,6 +366,9 @@ func toProtoVoiceSession(v storage.VoiceSession) *managementv1.VoiceSession {
 	}
 	if v.EndedAt != nil {
 		pb.EndedAt = timestamppb.New(*v.EndedAt)
+	}
+	if v.EndReason != nil {
+		pb.EndReason = *v.EndReason
 	}
 	return pb
 }

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -585,6 +585,38 @@ func TestSessionGetIdleReturnsLastSession(t *testing.T) {
 	}
 }
 
+// TestSessionGetIdleReturnsFailedSessionReason is #123 (AC1/AC3 reload truth): a
+// session that ended in a fatal gateway rejection is surfaced idle as status
+// "failed" with its readable end_reason, so a page reload after a fatal start shows
+// why. Proves toProtoVoiceSession maps EndReason and GetSession's idle path carries it.
+func TestSessionGetIdleReturnsFailedSessionReason(t *testing.T) {
+	t.Parallel()
+	end := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	reason := "invalid_bot_token: wirenpc: open gateway: websocket: close 4004: Authentication failed"
+	store := &fakeSessionStore{
+		campaign: storage.Campaign{ID: uuid.New(), Name: "Sunless Citadel"},
+		latest: storage.VoiceSession{
+			ID: uuid.New(), Status: storage.VoiceSessionFailed, EndedAt: &end, EndReason: &reason,
+		},
+	}
+	client := newSessionClient(t, &fakeSessionManager{}, store)
+
+	resp, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if resp.Msg.GetActive() {
+		t.Error("active = true, want false when idle")
+	}
+	got := resp.Msg.GetSession()
+	if got == nil || got.GetStatus() != "failed" {
+		t.Fatalf("idle session = %+v, want failed", got)
+	}
+	if got.GetEndReason() != reason {
+		t.Errorf("end_reason = %q, want %q", got.GetEndReason(), reason)
+	}
+}
+
 // TestSessionStartHonorsDurableSelection is #108 web parity: with the operator's
 // /glyphoxa use selection set (campaign A) AND a newer implicit default (campaign
 // B), the web StartSession binds A — so the Session screen and the slash command

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -71,7 +71,10 @@ var (
 type Store interface {
 	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
 	CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
-	EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error)
+	// CloseVoiceSession writes the terminal row: 'ended' (NULL reason) for a clean
+	// stop, or 'failed' + the readable reason for a fatal gateway rejection (#123).
+	// One write preserves the #143 end-write atomicity.
+	CloseVoiceSession(ctx context.Context, id uuid.UUID, status storage.VoiceSessionStatus, lineCount int, endReason *string) (storage.VoiceSession, error)
 	ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, error)
 	// ListAgents returns the Active Campaign's roster (Butler + Character NPCs) so
 	// mute-all (#211) can target EVERY Agent, not just the voiced wirenpc Roster.
@@ -310,10 +313,16 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Config) {
 	defer close(as.done)
 
-	if err := m.run(ctx, cfg); err != nil && ctx.Err() == nil {
-		// A real loop error (not the expected cancellation) — log it; the session
-		// still ends cleanly below so the row never stays stuck 'running'.
-		m.log.Error("voice session loop exited with error", "err", err, "voice_session", as.session.ID)
+	loopErr := m.run(ctx, cfg)
+	// A non-nil loop error while ctx was NOT cancelled is a real failure, not the
+	// expected Stop/Shutdown cancellation: the session ends 'failed' with a readable
+	// reason instead of the clean 'ended' (#123). A fatal gateway rejection carries a
+	// classified reason ("invalid_bot_token: …"); any other loop error is recorded as
+	// "loop_error: …". Either way a single terminal write lands, so the row is never
+	// stuck 'running' (#143).
+	failed := loopErr != nil && ctx.Err() == nil
+	if failed {
+		m.log.Error("voice session loop exited with error", "err", loopErr, "voice_session", as.session.ID)
 	}
 
 	// The run ctx is cancelled on a Stop, so both end steps run on detached,
@@ -351,19 +360,28 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		chunkCancel()
 	}
 
-	// A FRESH deadline for the ended_at write, regardless of what Finalize
-	// consumed (#143): the row landing 'ended' is the invariant that matters.
+	// A FRESH deadline for the terminal write, regardless of what Finalize consumed
+	// (#143): the row landing terminal is the invariant that matters. One
+	// CloseVoiceSession stamps 'failed' + the readable reason, or 'ended' + NULL for
+	// a clean stop — the single write preserves #143's end-write atomicity.
+	status := storage.VoiceSessionEnded
+	var endReason *string
+	if failed {
+		status = storage.VoiceSessionFailed
+		reason := failureReason(loopErr)
+		endReason = &reason
+	}
 	endCtx, cancel := context.WithTimeout(base, m.endTimeout)
 	defer cancel()
-	ended, err := m.store.EndVoiceSession(endCtx, as.session.ID, lineCount)
+	ended, err := m.store.CloseVoiceSession(endCtx, as.session.ID, status, lineCount, endReason)
 
 	m.mu.Lock()
 	if err != nil {
 		// The row is still 'running' in the DB. Remember the failure so a waiting
 		// Stop surfaces it (#143 Defect A); the startup reconciliation repairs the
 		// row on the next boot. Still clear the active slot — the loop is gone.
-		as.endErr = fmt.Errorf("session: end voice session %s: %w", as.session.ID, err)
-		m.log.Error("end voice session", "err", err, "voice_session", as.session.ID)
+		as.endErr = fmt.Errorf("session: close voice session %s: %w", as.session.ID, err)
+		m.log.Error("close voice session", "err", err, "voice_session", as.session.ID)
 	} else {
 		as.session = ended
 	}
@@ -371,6 +389,19 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		m.active = nil
 	}
 	m.mu.Unlock()
+}
+
+// failureReason renders the persisted end_reason for a failed session (#123): a
+// fatal gateway rejection carries its classified "<reason>: <prose>" verbatim (so
+// the Session screen shows "invalid_bot_token: …"), while any other loop error is
+// tagged "loop_error: …" — distinguishing a classified fatal from an unexpected
+// exit in the durable record.
+func failureReason(loopErr error) string {
+	var fe *wirenpc.FatalError
+	if errors.As(loopErr, &fe) {
+		return fe.Error()
+	}
+	return "loop_error: " + loopErr.Error()
 }
 
 // Stop cancels the active session's loop and waits for it to end, returning the

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -73,8 +75,8 @@ func (f *fakeStore) CreateVoiceSession(_ context.Context, campaignID uuid.UUID) 
 	return vs, nil
 }
 
-func (f *fakeStore) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (storage.VoiceSession, error) {
-	// A real EndVoiceSession fails on an expired context (#143 Defect B pins
+func (f *fakeStore) CloseVoiceSession(ctx context.Context, id uuid.UUID, status storage.VoiceSessionStatus, lineCount int, endReason *string) (storage.VoiceSession, error) {
+	// A real CloseVoiceSession fails on an expired context (#143 Defect B pins
 	// exactly that), so the fake honours ctx like pgx would.
 	if err := ctx.Err(); err != nil {
 		return storage.VoiceSession{}, err
@@ -91,8 +93,9 @@ func (f *fakeStore) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount
 	}
 	end := f.now()
 	vs.EndedAt = &end
-	vs.Status = storage.VoiceSessionEnded
+	vs.Status = status
 	vs.LineCount = lineCount
+	vs.EndReason = endReason
 	f.sessions[id] = vs
 	return vs, nil
 }
@@ -689,6 +692,120 @@ func TestLoopExitClearsActive(t *testing.T) {
 	}
 	if _, ended := store.counts(); ended != 1 {
 		t.Errorf("ended rows = %d, want 1 after self-exit", ended)
+	}
+}
+
+// waitIdle polls Snapshot until the Manager reports no active session — the loop
+// exited and the terminal row landed. Fails the test if it stays active.
+func waitIdle(t *testing.T, mgr *session.Manager) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, active := mgr.Snapshot(); !active {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("session still active; loop did not exit")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestFatalLoopErrorRecordsFailed is #123 (AC1/AC4): a loop that exits with a
+// classified fatal gateway rejection (NOT via Stop-cancellation) records the row
+// as 'failed' with ended_at set and an end_reason carrying the fatal reason —
+// "invalid_bot_token: …". The single-active guard is then freed, so a new Start is
+// accepted at once. errors.As recovers the *FatalError through the loop's %w wrap.
+func TestFatalLoopErrorRecordsFailed(t *testing.T) {
+	store := newFakeStore()
+	fatal := fmt.Errorf("wirenpc: run: %w", &wirenpc.FatalError{
+		Reason: wirenpc.ReasonInvalidBotToken,
+		Err:    errors.New("open gateway: websocket: close 4004: Authentication failed"),
+	})
+	mgr := newManager(t, store, func(context.Context, wirenpc.Config) error { return fatal }, true)
+
+	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitIdle(t, mgr)
+
+	store.mu.Lock()
+	row := store.sessions[vs.ID]
+	store.mu.Unlock()
+	if row.Status != storage.VoiceSessionFailed {
+		t.Errorf("failed session status = %q, want failed", row.Status)
+	}
+	if row.EndedAt == nil {
+		t.Error("failed session ended_at is nil, want set (no row stuck running, AC4)")
+	}
+	if row.EndReason == nil || !strings.HasPrefix(*row.EndReason, wirenpc.ReasonInvalidBotToken+":") {
+		t.Errorf("failed end_reason = %v, want %q prefix", row.EndReason, wirenpc.ReasonInvalidBotToken+":")
+	}
+
+	// Guard freed: idle after the fatal exit, and a new Start is accepted (AC4).
+	if _, active := mgr.Snapshot(); active {
+		t.Error("Snapshot still active after a fatal loop exit")
+	}
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Errorf("Start after a fatal failure = %v, want success (single-active guard freed)", err)
+	}
+	waitIdle(t, mgr) // let the second (also-fatal) loop unwind before the test ends
+}
+
+// TestPlainLoopErrorRecordsFailedLoopError is #123: a non-classified loop error
+// (an unexpected exit that is NOT a fatal gateway rejection) still ends the session
+// 'failed', tagged "loop_error: …" so the durable record distinguishes it from a
+// classified fatal.
+func TestPlainLoopErrorRecordsFailedLoopError(t *testing.T) {
+	store := newFakeStore()
+	mgr := newManager(t, store, func(context.Context, wirenpc.Config) error {
+		return errors.New("silero: onnx init failed")
+	}, true)
+
+	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitIdle(t, mgr)
+
+	store.mu.Lock()
+	row := store.sessions[vs.ID]
+	store.mu.Unlock()
+	if row.Status != storage.VoiceSessionFailed {
+		t.Errorf("status = %q, want failed", row.Status)
+	}
+	if row.EndReason == nil || !strings.HasPrefix(*row.EndReason, "loop_error:") {
+		t.Errorf("end_reason = %v, want %q prefix", row.EndReason, "loop_error:")
+	}
+}
+
+// TestCancelledLoopEndsCleanNilReason pins that a Stop-cancelled loop is a CLEAN
+// stop, NOT a failure: even though the runner returns ctx.Err() (non-nil), ctx was
+// cancelled, so the row lands 'ended' with a NULL end_reason — never 'failed' (#123).
+func TestCancelledLoopEndsCleanNilReason(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+
+	ended, err := mgr.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded {
+		t.Errorf("status = %q, want ended (a Stop-cancelled loop is a clean stop, not failed)", ended.Status)
+	}
+	if ended.EndReason != nil {
+		t.Errorf("end_reason = %q, want NULL for a clean stop", *ended.EndReason)
 	}
 }
 

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -82,12 +82,20 @@ type DeploymentConfig struct {
 }
 
 // VoiceSessionStatus is a Voice Session's lifecycle state (#72). A session is
-// 'running' from Start until Stop (or loop exit), then 'ended'.
+// 'running' from Start until Stop (or loop exit), then 'ended' — or 'failed' when
+// a fatal, non-retryable gateway rejection ended it (#123).
 type VoiceSessionStatus string
 
 const (
 	VoiceSessionRunning VoiceSessionStatus = "running"
 	VoiceSessionEnded   VoiceSessionStatus = "ended"
+	// VoiceSessionFailed is the terminal state of a session whose Discord gateway
+	// connection failed FATALLY — a non-retryable rejection (invalid Bot token,
+	// disallowed intents, gateway reject) the reconnect loop stopped on rather than
+	// backing off forever (#123). The row's end_reason carries the readable cause.
+	// Like 'ended' it is terminal (never revived), but records that the session
+	// never served — distinct from a clean stop.
+	VoiceSessionFailed VoiceSessionStatus = "failed"
 )
 
 // VoiceSessionReasonOrphaned is the end_reason stamped by the boot-time
@@ -99,8 +107,9 @@ const VoiceSessionReasonOrphaned = "orphaned: reconciled at startup"
 // VoiceSession is one run of the live voice loop — the Bot's presence in one
 // Discord voice channel, bound to a Campaign (CONTEXT.md "Voice Session", #72).
 // EndedAt is nil while running; LineCount records transcript lines produced (0
-// for this stage — the live feed is #73). EndReason is nil for a clean end and
-// set when the boot reconciliation closed an orphaned row (#143).
+// for this stage — the live feed is #73). EndReason is nil for a clean end, and
+// set when the boot reconciliation closed an orphaned row (#143) or a fatal
+// gateway rejection ended the session as 'failed' (#123, the readable cause).
 type VoiceSession struct {
 	ID         uuid.UUID
 	CampaignID uuid.UUID

--- a/internal/storage/voice_session.go
+++ b/internal/storage/voice_session.go
@@ -41,24 +41,35 @@ func (s *Store) CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (V
 	return v, nil
 }
 
-// EndVoiceSession closes a running Voice Session: it sets ended_at=now(),
-// status='ended' and the final line_count, returning the updated row. A missing
-// id yields ErrNotFound.
-func (s *Store) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (VoiceSession, error) {
+// CloseVoiceSession closes a running Voice Session with an explicit terminal
+// status and end_reason: it sets ended_at=now(), status, the final line_count, and
+// end_reason (NULL when endReason is nil), returning the updated row. A missing id
+// yields ErrNotFound. It is the single terminal-write seam (#123): [EndVoiceSession]
+// delegates to it for a clean stop ('ended', NULL reason), and the session Manager
+// calls it directly with 'failed' + the readable cause on a fatal gateway rejection.
+func (s *Store) CloseVoiceSession(ctx context.Context, id uuid.UUID, status VoiceSessionStatus, lineCount int, endReason *string) (VoiceSession, error) {
 	row := s.db.QueryRow(ctx,
 		`UPDATE voice_sessions
-		    SET ended_at = now(), status = $2, line_count = $3
+		    SET ended_at = now(), status = $2, line_count = $3, end_reason = $4
 		  WHERE id = $1
 		 RETURNING `+voiceSessionColumns,
-		id, VoiceSessionEnded, lineCount)
+		id, status, lineCount, endReason)
 	v, err := scanVoiceSession(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return VoiceSession{}, ErrNotFound
 	}
 	if err != nil {
-		return VoiceSession{}, fmt.Errorf("storage: end voice session %s: %w", id, err)
+		return VoiceSession{}, fmt.Errorf("storage: close voice session %s: %w", id, err)
 	}
 	return v, nil
+}
+
+// EndVoiceSession closes a running Voice Session cleanly: status='ended' with a
+// NULL end_reason and the final line_count, returning the updated row. A missing
+// id yields ErrNotFound. It is a thin wrapper over [CloseVoiceSession] — the
+// clean-stop path that leaves end_reason NULL (distinct from orphaned/failed).
+func (s *Store) EndVoiceSession(ctx context.Context, id uuid.UUID, lineCount int) (VoiceSession, error) {
+	return s.CloseVoiceSession(ctx, id, VoiceSessionEnded, lineCount, nil)
 }
 
 // ReconcileOrphanedVoiceSessions closes every Voice Session row still marked

--- a/internal/storage/voice_session_test.go
+++ b/internal/storage/voice_session_test.go
@@ -144,6 +144,93 @@ func TestReconcileOrphanedVoiceSessions(t *testing.T) {
 	}
 }
 
+// TestCloseVoiceSessionFailed is #123: a fatal gateway rejection closes the row
+// with status='failed', ended_at set, and a readable end_reason — it round-trips
+// through Get/GetLatest, and the boot reconciliation (which targets only 'running')
+// leaves the terminal failed row untouched.
+func TestCloseVoiceSessionFailed(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+
+	reason := "invalid_bot_token: wirenpc: open gateway: websocket: close 4004: Authentication failed"
+	failed, err := st.CloseVoiceSession(ctx, vs.ID, storage.VoiceSessionFailed, 0, &reason)
+	if err != nil {
+		t.Fatalf("CloseVoiceSession(failed): %v", err)
+	}
+	if failed.Status != storage.VoiceSessionFailed {
+		t.Errorf("status = %q, want failed", failed.Status)
+	}
+	if failed.EndedAt == nil {
+		t.Fatal("ended_at is nil after a fatal close")
+	}
+	if failed.EndReason == nil || *failed.EndReason != reason {
+		t.Errorf("end_reason = %v, want %q", failed.EndReason, reason)
+	}
+
+	// The failed session is the latest — the idle Session screen surfaces it with
+	// its reason (AC1/AC3 reload truth).
+	latest, err := st.GetLatestVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("GetLatestVoiceSession: %v", err)
+	}
+	if latest.ID != vs.ID || latest.Status != storage.VoiceSessionFailed ||
+		latest.EndReason == nil || *latest.EndReason != reason {
+		t.Errorf("latest = %+v, want failed %s with reason", latest, vs.ID)
+	}
+
+	// A failed row is already terminal: boot reconciliation only closes 'running'
+	// rows, so it must count zero and leave this row exactly as it is (AC4).
+	n, err := st.ReconcileOrphanedVoiceSessions(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOrphanedVoiceSessions: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reconciled = %d, want 0 (a failed row is not an orphan)", n)
+	}
+	after, err := st.GetVoiceSession(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("GetVoiceSession: %v", err)
+	}
+	if after.Status != storage.VoiceSessionFailed || after.EndReason == nil || *after.EndReason != reason {
+		t.Errorf("failed row after reconcile = %+v, want unchanged failed with reason", after)
+	}
+}
+
+// TestEndVoiceSessionDelegatesToEnded is #123: EndVoiceSession stays a thin
+// delegating wrapper over CloseVoiceSession — a normal stop still lands 'ended'
+// with a NULL end_reason (distinguishable from both orphaned and failed).
+func TestEndVoiceSessionDelegatesToEnded(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	ended, err := st.EndVoiceSession(ctx, vs.ID, 4)
+	if err != nil {
+		t.Fatalf("EndVoiceSession: %v", err)
+	}
+	if ended.Status != storage.VoiceSessionEnded || ended.EndedAt == nil {
+		t.Errorf("ended = %+v, want ended with ended_at", ended)
+	}
+	if ended.LineCount != 4 {
+		t.Errorf("line_count = %d, want 4", ended.LineCount)
+	}
+	if ended.EndReason != nil {
+		t.Errorf("end_reason = %q, want NULL for a clean end", *ended.EndReason)
+	}
+}
+
 // TestEndVoiceSessionNotFound asserts ending an unknown id is ErrNotFound (the
 // RPC maps it accordingly).
 func TestEndVoiceSessionNotFound(t *testing.T) {

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -119,12 +119,27 @@ type muteFrame struct {
 	Muted   bool   `json:"muted"`
 }
 
+// connectionFrame is the payload of a "connection" SSE frame (#123): the Voice
+// Session's gateway connection state (connecting/connected/failed) and, on a fatal
+// failure, the readable reason. The Session screen flips its badge from this live;
+// the terminal reload truth for a failed session is GetSession (status + end_reason).
+type connectionFrame struct {
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
+}
+
 // View is the snapshot the JSON endpoint returns and the unit tests assert on:
-// the current coalesced lines plus the derived status/typing.
+// the current coalesced lines plus the derived status/typing and the live
+// connection state (#123).
 type View struct {
 	Lines  []Line `json:"lines"`
 	Status string `json:"status"`
 	Typing Typing `json:"typing"`
+	// Connection is the latest gateway connection state (connecting/connected/
+	// failed) for the live session, "" before the first transition. It is the
+	// live reload truth for a mid-session reconnect; a terminal failed session
+	// reads its truth from GetSession instead.
+	Connection string `json:"connection,omitempty"`
 }
 
 // Frame is one buffered SSE frame. Seq is the monotonic `id:` field a browser
@@ -181,6 +196,7 @@ type Relay struct {
 	buf              []Frame
 	lines            []Line
 	typing           Typing
+	connection       string // latest gateway connection state for the live session (#123); "" until the first transition
 	turns            map[string]*turn
 	nextSeq          uint64
 	humanSeq         uint64
@@ -319,6 +335,14 @@ func (r *Relay) project(e voiceevent.Event) {
 		// ring for Last-Event-ID replay; there is NO transcript-line change and NO
 		// snapshot change — a mid-session reload reads the true state from GetSession.
 		r.emit(Frame{Event: "mute", Data: mustJSON(muteFrame{AgentID: ev.AgentID, Muted: ev.Muted})})
+	case voiceevent.ConnectionStateChanged:
+		// The gateway connection state moved (#123): forward a "connection" frame so
+		// the Session screen flips connecting→connected, or to failed with its reason,
+		// live and without a reload (AC3). It rides the ring for Last-Event-ID replay;
+		// the live snapshot carries the state via View.Connection, while a terminal
+		// failed session's reload truth is GetSession (status + end_reason).
+		r.connection = string(ev.State)
+		r.emit(Frame{Event: "connection", Data: mustJSON(connectionFrame{State: string(ev.State), Detail: ev.Detail})})
 	}
 }
 
@@ -356,6 +380,7 @@ func (r *Relay) rollover(vs storage.VoiceSession) {
 	r.nextSeq = 0
 	r.humanSeq = 0
 	r.typing = r.liveTyping()
+	r.connection = "" // a fresh session has no connection state until its first transition (#123)
 	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "live", Typing: r.typing})})
 }
 
@@ -456,9 +481,10 @@ func (r *Relay) View(id string) View {
 		return View{Lines: []Line{}, Status: "idle", Typing: Typing{}}
 	}
 	return View{
-		Lines:  append([]Line(nil), r.lines...),
-		Status: "live",
-		Typing: r.typing,
+		Lines:      append([]Line(nil), r.lines...),
+		Status:     "live",
+		Typing:     r.typing,
+		Connection: r.connection,
 	}
 }
 
@@ -470,7 +496,7 @@ func (r *Relay) snapshot(ctx context.Context, id string) View {
 	r.mu.Lock()
 	live := r.currentSessionID() == id && id == r.activeID
 	if live {
-		v := View{Lines: append([]Line(nil), r.lines...), Status: "live", Typing: r.typing}
+		v := View{Lines: append([]Line(nil), r.lines...), Status: "live", Typing: r.typing, Connection: r.connection}
 		r.mu.Unlock()
 		return v
 	}

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -134,6 +134,71 @@ func TestProjection_MuteFrame(t *testing.T) {
 	}
 }
 
+// connFrame is the decoded payload of a "connection" SSE frame.
+type connFrame struct {
+	State  string `json:"state"`
+	Detail string `json:"detail"`
+}
+
+// connectionFrames extracts and decodes the "connection" frames from a ring dump.
+func connectionFrames(t *testing.T, frames []Frame) []connFrame {
+	t.Helper()
+	var out []connFrame
+	for _, f := range frames {
+		if f.Event != "connection" {
+			continue
+		}
+		var c connFrame
+		if err := json.Unmarshal(f.Data, &c); err != nil {
+			t.Fatalf("connection frame payload: %v", err)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// TestProjection_ConnectionState is #123 (AC3): connecting→connected while active
+// emits two "connection" frames onto the ring and the live View reflects the latest
+// state; a fatal {failed} frame — published by the loop while the session is STILL
+// active (before the Manager clears the slot) — rides the ring too, carrying the
+// readable reason, so the Session screen flips to failed without a reload.
+func TestProjection_ConnectionState(t *testing.T) {
+	bus, r, fs, id := liveRelay(t)
+
+	bus.Publish(voiceevent.ConnectionStateChanged{At: at(1), State: voiceevent.ConnectionConnecting})
+	bus.Publish(voiceevent.ConnectionStateChanged{At: at(2), State: voiceevent.ConnectionConnected})
+
+	conns := connectionFrames(t, r.Frames(id, 0))
+	if len(conns) != 2 {
+		t.Fatalf("connection frames = %d, want 2 (connecting + connected)", len(conns))
+	}
+	if conns[0].State != "connecting" || conns[1].State != "connected" {
+		t.Errorf("connection frame states = %q/%q, want connecting/connected", conns[0].State, conns[1].State)
+	}
+	if v := r.View(id); v.Connection != "connected" {
+		t.Errorf("View().Connection = %q, want connected", v.Connection)
+	}
+
+	// The {failed} event arrives while the session is still active.
+	if _, active := fs.Snapshot(); !active {
+		t.Fatal("precondition: session must still be active when {failed} is published")
+	}
+	detail := "invalid_bot_token: wirenpc: open gateway: websocket: close 4004: Authentication failed"
+	bus.Publish(voiceevent.ConnectionStateChanged{At: at(3), State: voiceevent.ConnectionFailed, Detail: detail})
+
+	conns = connectionFrames(t, r.Frames(id, 0))
+	if len(conns) == 0 {
+		t.Fatal("no connection frames after failed")
+	}
+	last := conns[len(conns)-1]
+	if last.State != "failed" || last.Detail != detail {
+		t.Errorf("failed connection frame = %+v, want failed with detail %q", last, detail)
+	}
+	if v := r.View(id); v.Connection != "failed" {
+		t.Errorf("View().Connection = %q, want failed", v.Connection)
+	}
+}
+
 // TestProjection_ButlerKind checks the butler role maps to the butler kind + tag.
 func TestProjection_ButlerKind(t *testing.T) {
 	bus, r, _, id := liveRelay(t)

--- a/internal/wirenpc/connectionstate_test.go
+++ b/internal/wirenpc/connectionstate_test.go
@@ -1,0 +1,89 @@
+package wirenpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/gorilla/websocket"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestRun_PublishesConnectingThenFailedOnFatalClient is #123 test-seq 3: when the
+// standing-client provider yields a fatal rejection (a wrapped close 4004), Run
+// publishes connection.state{connecting} BEFORE the provider is consulted, returns
+// the classified *FatalError (no retry), and publishes a terminal
+// connection.state{failed} carrying the readable reason on cfg.Bus. The provider
+// error short-circuits before any Discord/ONNX work, so the test needs no network.
+func TestRun_PublishesConnectingThenFailedOnFatalClient(t *testing.T) {
+	bus := voiceevent.NewBus()
+
+	var mu sync.Mutex
+	var states []voiceevent.ConnectionState
+	var details []string
+	voiceevent.On(bus, func(e voiceevent.ConnectionStateChanged) {
+		mu.Lock()
+		states = append(states, e.State)
+		details = append(details, e.Detail)
+		mu.Unlock()
+	})
+
+	fatal := fmt.Errorf("wirenpc: open gateway: %w",
+		&websocket.CloseError{Code: 4004, Text: "Authentication failed"})
+
+	connectingBeforeProvider := false
+	cfg := Config{
+		Guild:   "111222333",
+		Channel: "444555666",
+		Bus:     bus,
+		Client: func(context.Context) (*bot.Client, error) {
+			mu.Lock()
+			connectingBeforeProvider = len(states) == 1 && states[0] == voiceevent.ConnectionConnecting
+			mu.Unlock()
+			return nil, fatal
+		},
+	}
+
+	err := Run(context.Background(), cfg)
+
+	var fe *FatalError
+	if !errors.As(err, &fe) || fe.Reason != ReasonInvalidBotToken {
+		t.Fatalf("Run returned %v, want *FatalError invalid_bot_token", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !connectingBeforeProvider {
+		t.Errorf("connection.state{connecting} was not published before the client provider ran; states seen = %v", states)
+	}
+	if len(states) == 0 || states[len(states)-1] != voiceevent.ConnectionFailed {
+		t.Fatalf("states = %v, want to end with failed", states)
+	}
+	if got := details[len(details)-1]; !strings.Contains(got, ReasonInvalidBotToken) {
+		t.Errorf("failed detail = %q, want it to name %q", got, ReasonInvalidBotToken)
+	}
+}
+
+// TestRun_NoBusFatalClientStillReturnsFatal is the env-only path (cfg.Bus nil): a
+// fatal client rejection still returns the *FatalError — the connection.state
+// publishes are simply nil-guarded no-ops. This pins the KNOWN BEHAVIOR CHANGE:
+// env-only voice mode now EXITS on an invalid token instead of retrying forever.
+func TestRun_NoBusFatalClientStillReturnsFatal(t *testing.T) {
+	cfg := Config{
+		Guild:   "111222333",
+		Channel: "444555666",
+		Client: func(context.Context) (*bot.Client, error) {
+			return nil, &websocket.CloseError{Code: 4004, Text: "Authentication failed"}
+		},
+	}
+
+	var fe *FatalError
+	if err := Run(context.Background(), cfg); !errors.As(err, &fe) || fe.Reason != ReasonInvalidBotToken {
+		t.Fatalf("Run (no bus) returned %v, want *FatalError invalid_bot_token", err)
+	}
+}

--- a/internal/wirenpc/gatewayfatal.go
+++ b/internal/wirenpc/gatewayfatal.go
@@ -1,0 +1,101 @@
+package wirenpc
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/disgoorg/disgo/rest"
+	"github.com/gorilla/websocket"
+)
+
+// Fatal reason codes (#123). A FatalError.Reason is exactly one of these: a
+// non-retryable Discord gateway/REST rejection the reconnect loop must NOT keep
+// backing off against. They are part of the observable failure contract — the
+// session's persisted end_reason and the SSE connection.state Detail carry them —
+// so keep the set small and the values stable.
+const (
+	// ReasonInvalidBotToken: the Bot token was rejected. Gateway close 4004
+	// (Authentication failed) or REST 401 (Unauthorized).
+	ReasonInvalidBotToken = "invalid_bot_token"
+	// ReasonDisallowedIntents: the Bot requested gateway intents it is not
+	// approved for. Gateway close 4013 (invalid intents) / 4014 (disallowed
+	// intents).
+	ReasonDisallowedIntents = "disallowed_intents"
+	// ReasonBotNotAuthorized: the Bot lacks authorization for the action. REST 403
+	// (Forbidden).
+	ReasonBotNotAuthorized = "bot_not_authorized"
+	// ReasonGatewayRejected: the gateway rejected the session for a
+	// non-authentication reason it will not accept on retry. Gateway close 4010
+	// (invalid shard) / 4011 (sharding required) / 4012 (invalid API version).
+	ReasonGatewayRejected = "gateway_rejected"
+)
+
+// FatalError marks a Voice Session connection failure that is TERMINAL, not
+// transient: retrying can never succeed (a bad Bot token, disallowed intents, a
+// gateway rejection), so the reconnect loop must stop and surface it instead of
+// backing off forever (#123). runWithReconnect returns it immediately; the
+// session Manager records the persisted status as failed with Reason.
+//
+// It wraps the originating error, so errors.As recovers it through the %w chains
+// both client paths build (per-cycle acquireClient and the presence
+// Ensure→ClientProvider), and errors.Is still matches the underlying cause.
+type FatalError struct {
+	// Reason is one of the reason codes above — the bounded, stable classification.
+	Reason string
+	// Err is the originating gateway/REST error, preserved for Unwrap so the full
+	// %w chain (and its detail) survives.
+	Err error
+}
+
+// Error renders "<reason>: <prose>" — the reason code followed by the underlying
+// error's message, e.g. "invalid_bot_token: wirenpc: open gateway: websocket:
+// close 4004: Authentication failed". It is the readable Detail the SSE
+// connection.state{failed} frame and the persisted end_reason carry.
+func (e *FatalError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Reason, e.Err)
+}
+
+// Unwrap exposes the originating error so errors.Is/As traverse into the cause.
+func (e *FatalError) Unwrap() error { return e.Err }
+
+// classifyFatal inspects a connect-and-serve error and returns a *FatalError when
+// it is a terminal, non-retryable gateway/REST rejection — else nil, meaning the
+// failure is transient and the reconnect loop should keep backing off (#123).
+//
+// It matches through errors.As, so a rejection wrapped by both client paths' %w
+// chains still classifies. A gorilla *websocket.CloseError with a non-reconnectable
+// close code (disgo returns exactly these from OpenGateway) is fatal; a REST
+// *rest.Error with a 401/403 status is fatal. Everything else — reconnectable
+// closes, 429/5xx, network errors, nil — is transient.
+func classifyFatal(err error) *FatalError {
+	if err == nil {
+		return nil
+	}
+
+	var closeErr *websocket.CloseError
+	if errors.As(err, &closeErr) {
+		switch closeErr.Code {
+		case 4004: // Authentication failed
+			return &FatalError{Reason: ReasonInvalidBotToken, Err: err}
+		case 4013, 4014: // invalid / disallowed gateway intents
+			return &FatalError{Reason: ReasonDisallowedIntents, Err: err}
+		case 4010, 4011, 4012: // invalid shard / sharding required / invalid API version
+			return &FatalError{Reason: ReasonGatewayRejected, Err: err}
+		}
+		return nil // reconnectable close (4000, 4009, …) — transient
+	}
+
+	var restErr *rest.Error
+	if errors.As(err, &restErr) && restErr.Response != nil {
+		switch restErr.Response.StatusCode {
+		case http.StatusUnauthorized: // 401 — the token is not valid
+			return &FatalError{Reason: ReasonInvalidBotToken, Err: err}
+		case http.StatusForbidden: // 403 — the bot is not authorized
+			return &FatalError{Reason: ReasonBotNotAuthorized, Err: err}
+		}
+		return nil // 429 / 5xx — transient
+	}
+
+	return nil
+}

--- a/internal/wirenpc/gatewayfatal_test.go
+++ b/internal/wirenpc/gatewayfatal_test.go
@@ -1,0 +1,97 @@
+package wirenpc
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/rest"
+	"github.com/gorilla/websocket"
+)
+
+// restErr builds a disgo *rest.Error carrying an HTTP status, the way the REST
+// client surfaces a Discord API rejection (401/403/…).
+func restErr(status int) *rest.Error {
+	return &rest.Error{Response: &http.Response{StatusCode: status}}
+}
+
+// TestClassifyFatal maps gateway/REST rejections onto their fatal reason, and
+// leaves transient failures (reconnectable closes, rate limits, 5xx, net, nil)
+// unclassified so the reconnect loop keeps backing off (#123).
+func TestClassifyFatal(t *testing.T) {
+	t.Parallel()
+
+	// A 4004 wrapped through the presence + open-gateway %w chain, mimicking how
+	// the error actually reaches the classifier (acquireClient / Ensure wrap it).
+	wrapped4004 := fmt.Errorf("wirenpc: standing Discord client unavailable: %w",
+		fmt.Errorf("wirenpc: open gateway: %w", &websocket.CloseError{Code: 4004, Text: "Authentication failed"}))
+
+	tests := []struct {
+		name string
+		err  error
+		want string // "" means classifyFatal must return nil (transient)
+	}{
+		{"close 4004 wrapped -> invalid_bot_token", wrapped4004, ReasonInvalidBotToken},
+		{"close 4013 -> disallowed_intents", &websocket.CloseError{Code: 4013}, ReasonDisallowedIntents},
+		{"close 4014 -> disallowed_intents", &websocket.CloseError{Code: 4014}, ReasonDisallowedIntents},
+		{"close 4010 -> gateway_rejected", &websocket.CloseError{Code: 4010}, ReasonGatewayRejected},
+		{"close 4011 -> gateway_rejected", &websocket.CloseError{Code: 4011}, ReasonGatewayRejected},
+		{"close 4012 -> gateway_rejected", &websocket.CloseError{Code: 4012}, ReasonGatewayRejected},
+		{"close 4000 reconnectable -> transient", &websocket.CloseError{Code: 4000}, ""},
+		{"close 4009 reconnectable -> transient", &websocket.CloseError{Code: 4009}, ""},
+		{"plain net error -> transient", errors.New("dial tcp: connection refused"), ""},
+		{"nil -> transient", nil, ""},
+		{"rest 401 -> invalid_bot_token", restErr(http.StatusUnauthorized), ReasonInvalidBotToken},
+		{"rest 403 -> bot_not_authorized", restErr(http.StatusForbidden), ReasonBotNotAuthorized},
+		{"rest 429 -> transient", restErr(http.StatusTooManyRequests), ""},
+		{"rest 500 -> transient", restErr(http.StatusInternalServerError), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyFatal(tt.err)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("classifyFatal(%v) = %+v, want nil (transient)", tt.err, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("classifyFatal(%v) = nil, want reason %q", tt.err, tt.want)
+			}
+			if got.Reason != tt.want {
+				t.Errorf("classifyFatal reason = %q, want %q", got.Reason, tt.want)
+			}
+		})
+	}
+}
+
+// TestFatalError_ErrorAndUnwrap pins the readable "<reason>: <prose>" message and
+// that errors.As recovers a *FatalError through a further %w wrap — the exact read
+// the session Manager does to record the failed reason (#123).
+func TestFatalError_ErrorAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	cause := &websocket.CloseError{Code: 4004, Text: "Authentication failed"}
+	fe := classifyFatal(fmt.Errorf("wirenpc: open gateway: %w", cause))
+	if fe == nil {
+		t.Fatal("classifyFatal returned nil for a 4004")
+	}
+	if !strings.HasPrefix(fe.Error(), ReasonInvalidBotToken+": ") {
+		t.Errorf("FatalError.Error() = %q, want %q prefix", fe.Error(), ReasonInvalidBotToken+": ")
+	}
+	if !errors.Is(fe, cause) {
+		t.Errorf("errors.Is(FatalError, cause) = false, want the CloseError in the chain")
+	}
+
+	// The Manager wraps the loop error again before recording it; errors.As must
+	// still recover the classification from that outer chain.
+	outer := fmt.Errorf("session: loop exited: %w", error(fe))
+	var recovered *FatalError
+	if !errors.As(outer, &recovered) || recovered.Reason != ReasonInvalidBotToken {
+		t.Errorf("errors.As through outer wrap = %v/%+v, want *FatalError invalid_bot_token", errors.As(outer, &recovered), recovered)
+	}
+}

--- a/internal/wirenpc/reconnect_test.go
+++ b/internal/wirenpc/reconnect_test.go
@@ -3,10 +3,13 @@ package wirenpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // fakeSleep records the backoff delays runWithReconnect asks it to wait and
@@ -237,6 +240,44 @@ func TestRunWithReconnect_CleanSessionCloseReconnects(t *testing.T) {
 	}
 	if fs.callCount != 1 {
 		t.Errorf("sleep called %d times, want 1 (a clean session close reconnects, it is not a shutdown)", fs.callCount)
+	}
+}
+
+// TestRunWithReconnect_FatalErrorStopsImmediately pins the #123 core: a
+// connect-and-serve attempt that returns a FATAL, non-retryable gateway rejection
+// (a wrapped close 4004) makes the loop STOP at once — it returns the classified
+// *FatalError, calls attempt exactly once, and NEVER sleeps. A transient failure
+// still backs off (the existing growing-backoff tests pin that), so this only
+// changes the terminal case.
+func TestRunWithReconnect_FatalErrorStopsImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// cancelAt is far past the single expected attempt: if the loop ever sleeps,
+	// callCount goes non-zero and the test fails before any cancel would fire.
+	fs := &fakeSleep{cancelAt: 99, cancel: cancel}
+	p := reconnectPolicy{initial: time.Second, max: 30 * time.Second, factor: 2, sleep: fs.sleep}
+
+	fatal := fmt.Errorf("wirenpc: open gateway: %w",
+		&websocket.CloseError{Code: 4004, Text: "Authentication failed"})
+	calls := 0
+	err := runWithReconnect(ctx, discardLogger(), p,
+		func(ctx context.Context, connected func()) error {
+			calls++
+			return fatal
+		})
+
+	var fe *FatalError
+	if !errors.As(err, &fe) {
+		t.Fatalf("runWithReconnect returned %v, want a *FatalError", err)
+	}
+	if fe.Reason != ReasonInvalidBotToken {
+		t.Errorf("fatal reason = %q, want %q", fe.Reason, ReasonInvalidBotToken)
+	}
+	if calls != 1 {
+		t.Errorf("attempt called %d times, want 1 (a fatal error must not retry)", calls)
+	}
+	if fs.callCount != 0 {
+		t.Errorf("sleep called %d times, want 0 (no backoff on a fatal error)", fs.callCount)
 	}
 }
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -504,10 +504,30 @@ func Run(ctx context.Context, cfg Config) error {
 	// Note: disgo runs its own bounded reconnect during OpenGateway, so this
 	// policy governs the inter-cycle gap and post-join drops (a session that joins
 	// then later disconnects), not the initial dial retries disgo already handles.
-	return runWithReconnect(ctx, log, defaultReconnectPolicy(),
+	runErr := runWithReconnect(ctx, log, defaultReconnectPolicy(),
 		func(ctx context.Context, connected func()) error {
 			return connectAndServe(ctx, cfg, guild, channel, log, connected)
 		})
+	// A non-nil return is a FATAL, terminal failure (a classified *FatalError):
+	// publish the terminal connection.state{failed} with its readable reason so the
+	// Session screen flips to failed without a reload (#123). nil is a clean
+	// ctx-cancel shutdown — no failed frame. Nil-guarded: the env-only/bench paths
+	// carry no shared bus and this is a no-op there.
+	if runErr != nil {
+		publishConnectionState(cfg.Bus, voiceevent.ConnectionFailed, runErr.Error())
+	}
+	return runErr
+}
+
+// publishConnectionState publishes a [voiceevent.ConnectionStateChanged] onto bus,
+// unless bus is nil (the env-only/bench paths carry no shared bus). It is the one
+// seam the connection-state transitions go through so the nil-guard lives in one
+// place (#123).
+func publishConnectionState(bus *voiceevent.Bus, state voiceevent.ConnectionState, detail string) {
+	if bus == nil {
+		return
+	}
+	bus.Publish(voiceevent.ConnectionStateChanged{At: time.Now(), State: state, Detail: detail})
 }
 
 // connectAndServe runs ONE connect-and-serve cycle: build the Discord client,
@@ -579,6 +599,19 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	cycleCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// The orchestrator bus is created here (not deeper) so the connection-state
+	// transitions ride the SAME bus as the pipeline's events (#123). The web tier
+	// injects ONE process-wide bus (cfg.Bus, issue #73) so the SSE relay subscribes
+	// once and keeps observing events across reconnect cycles and sessions; the
+	// env-only voice/bench paths leave it nil and get a fresh per-cycle bus (today's
+	// behavior, unchanged). Hoisted above acquireClient so {connecting} is published
+	// first thing each cycle, BEFORE the (possibly fatal) Discord client is acquired.
+	bus := cfg.Bus
+	if bus == nil {
+		bus = voiceevent.NewBus()
+	}
+	publishConnectionState(bus, voiceevent.ConnectionConnecting, "")
+
 	// Discord client: either the standing shared client the presence owns
 	// (cfg.Client, #102) or a per-cycle client this loop builds and closes. The
 	// shared client is already gateway-open and must NOT be closed here.
@@ -607,6 +640,9 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// a session that serves for a while and later drops reconnects on the initial
 	// delay (issue #44) while a join-then-immediate-fail keeps backing off.
 	connected()
+	// Announce the Bot is connected and serving so the Session screen flips
+	// connecting → connected live (#123). Rides the same bus as {connecting}.
+	publishConnectionState(bus, voiceevent.ConnectionConnected, "")
 	log.Info("joined voice channel", "guild", guild, "channel", channel, "npcs", npcNames(cfg.npcs))
 
 	// One Codec instance serves both directions: DecodeInbound (called from the
@@ -632,20 +668,10 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// (line above), and pipe.Run's own deferred cancel stops the Conversation
 	// first — so teardown order is conv-stop → pump.Close() → sess.Close(), which
 	// is the deterministic ordering the pump's Close() contract requires.
-	// The orchestrator bus is created here (not inside buildConversation) so the
-	// tee can publish FirstAudio (A3 hook 1) and the pump can publish FirstOpus
-	// (task #7, the audible-on-wire SLO end) onto the same bus the conversation's
-	// stages publish on and the metrics subscriber reads.
-	//
-	// The web tier injects ONE process-wide bus (cfg.Bus, issue #73) so the SSE
-	// transcript relay subscribes once and keeps observing events across reconnect
-	// cycles and sessions; the env-only voice/bench paths leave it nil and get a
-	// fresh per-cycle bus (today's behavior, unchanged).
-	bus := cfg.Bus
-	if bus == nil {
-		bus = voiceevent.NewBus()
-	}
-
+	// The orchestrator bus was created at the top of this cycle (so the tee can
+	// publish FirstAudio and the pump FirstOpus onto the same bus the conversation's
+	// stages publish on and the metrics/SSE subscribers read) and already carries
+	// this cycle's connection.state{connecting}/{connected} (#123).
 	pump := wire.NewPlaybackPump(sess, cdc, log, bus)
 	defer pump.Close()
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -188,6 +188,15 @@ func runWithReconnect(ctx context.Context, log *slog.Logger, p reconnectPolicy, 
 		if ctx.Err() != nil {
 			return nil // shutdown requested — stop retrying, exit clean (fixes SIGTERM->exit1)
 		}
+		// A fatal, non-retryable gateway rejection (bad Bot token, disallowed
+		// intents, gateway reject) can never succeed on retry, so stop at once and
+		// surface the classification instead of backing off forever (#123). The
+		// session Manager reads this to record the persisted status as failed. A
+		// transient failure (or a clean nil return) falls through to the backoff.
+		if fe := classifyFatal(err); fe != nil {
+			log.Error("voice connection failed fatally; not retrying", "err", fe, "reason", fe.Reason)
+			return fe
+		}
 		if !connectedAt.IsZero() && now().Sub(connectedAt) >= p.healthyAfter {
 			delay = p.initial // served healthily — forgive past failures (issue #44)
 		}

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -291,6 +291,40 @@ type MuteChanged struct {
 // EventName implements [Event].
 func (MuteChanged) EventName() string { return "mute.changed" }
 
+// ConnectionState is the Voice Session's Discord gateway connection lifecycle as
+// seen by the web Session screen (#123, ADR-0020). It is a coarse UI/telemetry
+// state DISTINCT from the low-level pkg/voice voice.State: this taxonomy lives in
+// voiceevent so both the SSE relay and the deferred split-Mode VoiceControlService
+// path (ADR-0039) name the same states.
+type ConnectionState string
+
+const (
+	// ConnectionConnecting: a connect-and-serve cycle has begun but the voice
+	// channel join has not yet succeeded.
+	ConnectionConnecting ConnectionState = "connecting"
+	// ConnectionConnected: the Bot joined the voice channel and is serving.
+	ConnectionConnected ConnectionState = "connected"
+	// ConnectionFailed: the session hit a FATAL, non-retryable gateway rejection
+	// (invalid Bot token, disallowed intents, …) and reached its terminal failed
+	// state — the loop stops retrying rather than backing off forever.
+	ConnectionFailed ConnectionState = "failed"
+)
+
+// ConnectionStateChanged marks a transition of the Voice Session's gateway
+// connection state (#123). connectAndServe publishes {connecting} at the start of
+// each cycle and {connected} once the join succeeds; Run publishes {failed} with a
+// readable Detail when the loop returns a fatal classification. Detail carries the
+// [wirenpc.FatalError.Error] prose on a failed transition and is empty otherwise.
+// The SSE relay forwards it to the live Session screen (ADR-0014 Hop-B).
+type ConnectionStateChanged struct {
+	At     time.Time
+	State  ConnectionState
+	Detail string
+}
+
+// EventName implements [Event].
+func (ConnectionStateChanged) EventName() string { return "connection.state" }
+
 // Bus is an in-process pub/sub channel. Subscribers register a callback;
 // Publish invokes every callback synchronously in the calling goroutine.
 //

--- a/pkg/voice/voiceevent/event_test.go
+++ b/pkg/voice/voiceevent/event_test.go
@@ -114,6 +114,27 @@ func TestMuteChanged_EventName(t *testing.T) {
 	}
 }
 
+func TestConnectionStateChanged_EventName(t *testing.T) {
+	t.Parallel()
+
+	got := ConnectionStateChanged{}.EventName()
+	if got != "connection.state" {
+		t.Errorf("EventName = %q, want %q", got, "connection.state")
+	}
+}
+
+// TestConnectionState_WireValues pins the connecting/connected/failed wire values.
+// They are the shared voice-event taxonomy the deferred split-Mode relay path
+// stays contract-compatible with (#123 AC5), so a rename here is a wire break.
+func TestConnectionState_WireValues(t *testing.T) {
+	t.Parallel()
+
+	if ConnectionConnecting != "connecting" || ConnectionConnected != "connected" || ConnectionFailed != "failed" {
+		t.Errorf("connection states = %q/%q/%q, want connecting/connected/failed",
+			ConnectionConnecting, ConnectionConnected, ConnectionFailed)
+	}
+}
+
 func TestBus_PublishDeliversToSubscriber(t *testing.T) {
 	t.Parallel()
 

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -751,7 +751,7 @@ message VoiceSession {
   string id = 1;
   // campaign_id is the campaign the session runs for.
   string campaign_id = 2;
-  // status is the lifecycle state: "running" or "ended".
+  // status is the lifecycle state: "running", "ended", or "failed" (#123).
   string status = 3;
   // started_at is when the session started.
   google.protobuf.Timestamp started_at = 4;
@@ -760,6 +760,10 @@ message VoiceSession {
   // line_count is how many transcript lines the session produced (0 this stage;
   // the live transcript feed is #73).
   uint32 line_count = 6;
+  // end_reason is the readable cause an abnormal end carries: the fatal gateway
+  // rejection reason for a "failed" session (#123), or the reconciled reason for a
+  // boot-orphaned row (#143). Empty for a clean "ended" stop and while running.
+  string end_reason = 7;
 }
 
 // GetSessionRequest is the (empty) request; the active campaign and the

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -441,6 +441,111 @@ describe("Session live transcript (#73)", () => {
   });
 });
 
+// failedTransport reports a terminal FAILED session (active:false) carrying an
+// end_reason — the reload-of-a-failed-session case (#123): the durable status is
+// the reload truth, so the screen must show Failed + the reason with no live stream.
+function failedTransport() {
+  const started = new Date(Date.now() - 5 * 1000);
+  const failed = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "failed",
+    startedAt: timestampFromDate(started),
+    endedAt: timestampFromDate(new Date()),
+    endReason: "invalid_bot_token: wirenpc: open gateway: websocket: close 4004: Authentication failed",
+  });
+  return createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () => create(GetSessionResponseSchema, { session: failed, active: false }),
+      startSession: () => create(StartSessionResponseSchema, { session: failed }),
+      stopSession: () => create(StopSessionResponseSchema, { session: failed }),
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+}
+
+describe("Session gateway connection state (#123)", () => {
+  it("reflects connecting then connected during a normal start", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ lines: [], status: "live", typing: { active: true, label: "Listening to the table…" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    await screen.findByText("Live");
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("EventSource not opened yet");
+      return inst;
+    });
+
+    act(() => es.emit("connection", { state: "connecting" }));
+    expect(await screen.findByTestId("connection-state")).toHaveTextContent(/connecting/i);
+
+    act(() => es.emit("connection", { state: "connected" }));
+    await waitFor(() => expect(screen.getByTestId("connection-state")).toHaveTextContent(/connected/i));
+  });
+
+  it("shows Failed with a readable reason on a fatal rejection, without a reload", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ lines: [], status: "live", typing: { active: false, label: "" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    await screen.findByText("Live");
+    const es = await waitFor(() => {
+      const inst = MockEventSource.last();
+      if (!inst) throw new Error("EventSource not opened yet");
+      return inst;
+    });
+
+    act(() =>
+      es.emit("connection", {
+        state: "failed",
+        detail: "invalid_bot_token: wirenpc: open gateway: websocket: close 4004: Authentication failed",
+      }),
+    );
+
+    expect(await screen.findByText("Failed")).toBeInTheDocument();
+    expect(await screen.findByTestId("connection-failed")).toHaveTextContent(/invalid_bot_token/);
+  });
+
+  it("surfaces a failed session's reason on reload from getSession (terminal truth)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ lines: [], status: "idle", typing: { active: false, label: "" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    render(
+      <Providers transport={failedTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    expect(await screen.findByText("Failed")).toBeInTheDocument();
+    expect(await screen.findByTestId("connection-failed")).toHaveTextContent(/invalid_bot_token/);
+    // A terminal (non-active) session opens no live stream.
+    expect(MockEventSource.last()).toBeUndefined();
+  });
+});
+
 // searchTransport is an ended session whose persisted transcript renders, plus a
 // transcript-search RPC that filters a fixed match set by substring (a stand-in
 // for the server-side tsvector search). searchCalls records the debounced queries.

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -73,6 +73,21 @@ function useElapsed(startMs: number | null): number {
   return elapsed;
 }
 
+// connectionLabel renders the live gateway connection sub-state beside the Live
+// badge during a normal start (#123): "Connecting…" then "Connected". A failed
+// state is rendered as its own badge + reason, not here, so this returns null for
+// it (and for the pre-first-transition undefined).
+function connectionLabel(state: string | undefined): string | null {
+  switch (state) {
+    case "connecting":
+      return "Connecting…";
+    case "connected":
+      return "Connected";
+    default:
+      return null;
+  }
+}
+
 // lastSummary renders the idle "Last session ended …" line from an ended session.
 function lastSummary(session: VoiceSession): string {
   const endedMs = tsMs(session.endedAt);
@@ -132,6 +147,16 @@ export function Session() {
   const hasLines = transcript.lines.length > 0;
   const showTyping = active && transcript.typing.active;
 
+  // Gateway connection state (#123): a fatal rejection is failed from EITHER the
+  // durable session status (the reload/poll truth: status "failed" + end_reason) OR
+  // the live SSE "connection" frame (immediate, with its detail). The live
+  // connecting/connected labels reflect a normal start without a reload.
+  const sessionFailed = session?.status === "failed";
+  const liveFailed = active && transcript.connection === "failed";
+  const failed = sessionFailed || liveFailed;
+  const failureReason = sessionFailed ? session?.endReason : transcript.connectionDetail;
+  const connectingLabel = active && !failed ? connectionLabel(transcript.connection) : null;
+
   // Transcript search deep-link (#120): clicking a search hit highlights (and,
   // where the browser supports it, scrolls to) that line in the rendered
   // transcript. A hit for a line NOT in the current view — e.g. an older session —
@@ -166,7 +191,11 @@ export function Session() {
 
       <Card accent className="gx-session__control">
         <div className="gx-session__status">
-          {active ? (
+          {failed ? (
+            <Badge variant="danger" dot>
+              Failed
+            </Badge>
+          ) : active ? (
             <Badge variant="live" dot pulse>
               Live
             </Badge>
@@ -174,6 +203,11 @@ export function Session() {
             <Badge variant="neutral" dot>
               Idle
             </Badge>
+          )}
+          {connectingLabel && (
+            <span className="gx-session__conn" data-testid="connection-state">
+              {connectingLabel}
+            </span>
           )}
           <span className="gx-session__timer" data-testid="elapsed">
             {formatElapsed(elapsed)}
@@ -202,6 +236,12 @@ export function Session() {
           )}
         </div>
       </Card>
+
+      {failed && (
+        <div className="gx-session__failed" role="alert" data-testid="connection-failed">
+          {failureReason ? `Voice connection failed: ${failureReason}` : "Voice connection failed."}
+        </div>
+      )}
 
       {!active && session && session.status === "ended" && (
         <div className="gx-session__last">{lastSummary(session)}</div>

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -199,6 +199,12 @@
   gap: var(--spacing-sm);
 }
 
+/* Live gateway connection sub-state beside the Live badge (Connecting…/Connected). */
+.gx-session__conn {
+  color: var(--text-subtle);
+  font-size: 0.875rem;
+}
+
 /* Subtle inset summary of the prior session, shown only while idle. */
 .gx-session__last {
   margin-top: var(--spacing-md);
@@ -206,6 +212,17 @@
   border-radius: var(--radius-md);
   background: var(--surface-inset);
   color: var(--text-subtle);
+  font-size: 0.875rem;
+}
+
+/* A fatal gateway rejection: a prominent, readable failure banner (#123). */
+.gx-session__failed {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--danger, #b3261e);
+  background: color-mix(in srgb, var(--danger, #b3261e) 12%, transparent);
+  color: var(--danger, #b3261e);
   font-size: 0.875rem;
 }
 

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -28,11 +28,21 @@ export interface TypingState {
   label: string;
 }
 
-// Transcript is the cached view the screen renders: the lines plus status/typing.
+// ConnectionState is the Voice Session's Discord gateway connection lifecycle as
+// the Session screen renders it (#123): connecting → connected on a normal start,
+// or failed with a readable reason on a fatal rejection.
+export type ConnectionState = "connecting" | "connected" | "failed";
+
+// Transcript is the cached view the screen renders: the lines plus status/typing
+// and the live gateway connection state (#123).
 export interface Transcript {
   lines: TranscriptLine[];
   status: "live" | "idle";
   typing: TypingState;
+  // connection is the latest gateway connection state, undefined before the first
+  // transition; connectionDetail is the readable reason on a failed connection.
+  connection?: ConnectionState;
+  connectionDetail?: string;
 }
 
 const EMPTY: Transcript = { lines: [], status: "idle", typing: { active: false, label: "" } };
@@ -112,6 +122,16 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
     es.addEventListener("mute", (e) => {
       const m = JSON.parse((e as MessageEvent).data) as { agent_id: string; muted: boolean };
       patchOne(m.agent_id, m.muted);
+    });
+    es.addEventListener("connection", (e) => {
+      // The gateway connection state moved (#123): reflect connecting → connected
+      // live, or failed with its readable reason — no page reload.
+      const c = JSON.parse((e as MessageEvent).data) as { state: ConnectionState; detail?: string };
+      queryClient.setQueryData<Transcript>(key, (prev) => ({
+        ...(prev ?? EMPTY),
+        connection: c.state,
+        connectionDetail: c.detail ?? "",
+      }));
     });
 
     return () => es.close();


### PR DESCRIPTION
## What does this PR do?

Closes #123. Classifies fatal vs transient Discord gateway failures so a Voice Session started with a bad Bot token fails terminally in seconds instead of retrying forever, while a transient drop still reconnects under the existing bounded backoff. Implements ADR-0043.

- `internal/wirenpc`: new `FatalError` + `classifyFatal` — gorilla `*websocket.CloseError` 4004 → `invalid_bot_token`, 4013/4014 → `disallowed_intents`, 4010–4012 → `gateway_rejected`; disgo `*rest.Error` HTTP 401 → `invalid_bot_token`, 403 → `bot_not_authorized`; everything else (reconnectable closes, 429/5xx, network, nil) stays transient. `runWithReconnect` returns the classification at once instead of backing off.
- New `voiceevent.ConnectionStateChanged` (`connecting`/`connected`/`failed`, event name `connection.state`) — shared taxonomy (ADR-0020) so the deferred split-Mode relay path stays contract-compatible. The loop publishes `{connecting}` first thing each cycle, `{connected}` on join, and `{failed}` with a readable reason on a fatal exit.
- `internal/storage`: new terminal status `failed` and `CloseVoiceSession(id, status, lineCount, endReason)`; `EndVoiceSession` becomes a delegating wrapper (`ended`, NULL reason). No migration (status is unconstrained text; `end_reason` already exists).
- `internal/session`: the Manager records a non-context loop error as `failed` with `end_reason` = the classified reason (`invalid_bot_token: …`) or `loop_error: …` for an unexpected exit, in one write (preserves #143 atomicity). The single-active guard is freed so a new Start is accepted immediately.
- SSE relay projects a `connection` frame (state + detail) onto the ring and exposes live `View.Connection`. Proto `VoiceSession` gains `end_reason = 7`; the idle Session screen surfaces a failed last session with its reason (terminal reload truth = `GetSession`).
- Web Session screen reflects `Connecting…` → `Connected` during a normal start, and a `Failed` badge + readable reason banner on a fatal rejection — live via the SSE frame or the durable status, no page reload.

## Why is this change needed?

Before this, an invalid Bot token drove the #44 reconnect loop forever with a silent, ever-growing backoff and no operator-visible signal — the Session screen never left "connecting", and the row stayed `running`. #123 makes a non-retryable rejection a first-class terminal state with a persisted, readable cause.

**Accepted behavior change (ADR-0043):** env-only voice mode now *exits* on an invalid token instead of retrying forever. In Kubernetes that is a crashloop-with-backoff, the correct operational signal; #44 targeted transient drops, and an invalid token is not transient.

## How was this tested?

TDD, red→green per slice.

- `internal/wirenpc`: `TestClassifyFatal` (14 cases incl. wrapped `%w` chains), `TestFatalError_ErrorAndUnwrap`, `TestRunWithReconnect_FatalErrorStopsImmediately` (zero sleeps), `TestRun_PublishesConnectingThenFailedOnFatalClient`, `TestRun_NoBusFatalClientStillReturnsFatal`.
- `pkg/voice/voiceevent`: `TestConnectionStateChanged_EventName`, `TestConnectionState_WireValues`.
- `internal/storage` (integration, real Postgres): `TestCloseVoiceSessionFailed`, `TestEndVoiceSessionDelegatesToEnded`.
- `internal/session`: `TestFatalLoopErrorRecordsFailed` (failed + guard freed), `TestPlainLoopErrorRecordsFailedLoopError`, `TestCancelledLoopEndsCleanNilReason`.
- `internal/transcript`: `TestProjection_ConnectionState`.
- `internal/rpc`: `TestSessionGetIdleReturnsFailedSessionReason`.
- `web`: 3 new Session tests (connecting→connected; failed live; failed reload from `GetSession`). Full web suite 114/114, `tsc --noEmit` + `vite build` clean.

Local gates green: `go vet ./...`, `go test -race` on all touched packages, `go test -tags integration ./internal/storage/` (Docker Postgres), `golangci-lint run ./...` (0 issues, isolated cache), web build + vitest.

- [x] New/updated tests cover the change
- [x] Manual testing: deferred to the team's final live Chrome + Discord verification pass

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Additional Notes

Implements ADR-0043 exactly (classifier codes, `end_reason` prefix+prose, `loop_error:` for non-fatal exits, `CloseVoiceSession` seam, `connection.state` taxonomy, no Start RPC mapping, env-only exit).

Worktree note: the orchestrator-assigned dir `issue-110-bot-authorization-link` was occupied by another agent's branch + uncommitted changes, so this work was done in a fresh dedicated worktree off `main` to avoid clobbering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
