### PR TITLE
[E7] Resolve a Guild invite and pick its voice channel (#105)

### DIFF
--- a/internal/discordinvite/discordinvite.go
+++ b/internal/discordinvite/discordinvite.go
@@ -1,0 +1,184 @@
+// Package discordinvite resolves a pasted Discord invite code to its Guild and
+// that Guild's voice channels (#105, ADR-0047), backing the Configuration
+// screen's invite picker. It makes two REST calls with the deployment Bot token:
+// `GET /invites/{code}` for the guild, then `GET /guilds/{id}/channels` filtered
+// to type-2 GUILD_VOICE.
+//
+// Like internal/discordtag, the calls are plain net/http GETs, deliberately NOT
+// disgo's rest.NewClient: that client's rate limiter starts a cleanup goroutine
+// (`for range ticker.C`) its Close never stops, leaking one goroutine + ticker
+// per call.
+//
+// These are LIVE network calls. The RPC layer hides Resolve behind a seam so
+// unit tests fake the resolver and never touch the network; offline tests drive
+// the package-private base-URL seam ([ResolveAt]) at a fake HTTP server.
+package discordinvite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"time"
+)
+
+// liveAPIBaseURL is Discord's REST API root, matching the version disgo pins.
+const liveAPIBaseURL = "https://discord.com/api/v10"
+
+// userAgent is the DiscordBot form Discord requires of bot REST callers, matching
+// internal/discordtag.
+const userAgent = "DiscordBot (https://github.com/MrWong99/Glyphoxa_v2, v2)"
+
+// guildVoiceType is Discord's channel type for a standard voice channel
+// (GUILD_VOICE). Text (0), category (4), and stage (13) are excluded (ADR-0047).
+const guildVoiceType = 2
+
+// inviteClient is shared across calls (http.Client is safe for concurrent use);
+// its Timeout is a belt on top of the caller's ctx deadline so a resolver invoked
+// without one still cannot hang.
+var inviteClient = &http.Client{Timeout: 15 * time.Second}
+
+// ErrNotFound means the invite code is invalid/expired, or resolves to something
+// without a guild (a group-DM invite) — either way there is no server to pick a
+// voice channel from.
+var ErrNotFound = errors.New("discordinvite: invite not found or expired")
+
+// ErrNoAccess means the Bot is not a member of the resolved guild: the channels
+// read came back 403 or 404 (Discord is inconsistent about which for a non-member).
+var ErrNoAccess = errors.New("discordinvite: the Bot is not a member of that guild")
+
+// Guild is the resolved server's identity.
+type Guild struct {
+	ID   string
+	Name string
+}
+
+// VoiceChannel is one type-2 GUILD_VOICE channel: its snowflake and name.
+type VoiceChannel struct {
+	ID   string
+	Name string
+}
+
+// Resolved is the invite resolution: the guild plus its voice channels, sorted
+// by position then name.
+type Resolved struct {
+	Guild         Guild
+	VoiceChannels []VoiceChannel
+}
+
+// Resolve resolves invite code to its guild and voice channels using token
+// (a Discord Bot token). An empty token fails fast (no dial). A ctx deadline
+// bounds each call. log may be nil.
+func Resolve(ctx context.Context, token, code string, log *slog.Logger) (Resolved, error) {
+	return resolve(ctx, token, code, "", log)
+}
+
+// resolve is Resolve with a base-URL seam: "" means the live Discord API, tests
+// point it at a fake HTTP server.
+func resolve(ctx context.Context, token, code, baseURL string, log *slog.Logger) (Resolved, error) {
+	if token == "" {
+		return Resolved{}, errors.New("discordinvite: empty bot token")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	if baseURL == "" {
+		baseURL = liveAPIBaseURL
+	}
+
+	// GET /invites/{code} → the invite's guild (nil for a group-DM invite).
+	var invite struct {
+		Guild *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"guild"`
+	}
+	status, err := getJSON(ctx, token, baseURL+"/invites/"+url.PathEscape(code), &invite)
+	if err != nil {
+		return Resolved{}, fmt.Errorf("discordinvite: GET /invites: %w", err)
+	}
+	if status == http.StatusNotFound {
+		return Resolved{}, ErrNotFound
+	}
+	if status != http.StatusOK {
+		return Resolved{}, fmt.Errorf("discordinvite: GET /invites: HTTP %d", status)
+	}
+	if invite.Guild == nil {
+		return Resolved{}, ErrNotFound
+	}
+	guild := Guild{ID: invite.Guild.ID, Name: invite.Guild.Name}
+
+	// GET /guilds/{id}/channels → the guild's channels; a non-member Bot gets
+	// 403 or 404 (Discord is inconsistent), both → ErrNoAccess.
+	var channels []struct {
+		ID       string `json:"id"`
+		Type     int    `json:"type"`
+		Name     string `json:"name"`
+		Position int    `json:"position"`
+	}
+	status, err = getJSON(ctx, token, baseURL+"/guilds/"+url.PathEscape(guild.ID)+"/channels", &channels)
+	if err != nil {
+		return Resolved{}, fmt.Errorf("discordinvite: GET /guilds/channels: %w", err)
+	}
+	if status == http.StatusForbidden || status == http.StatusNotFound {
+		return Resolved{}, ErrNoAccess
+	}
+	if status != http.StatusOK {
+		return Resolved{}, fmt.Errorf("discordinvite: GET /guilds/channels: HTTP %d", status)
+	}
+
+	// Keep only voice channels, remembering position for the sort.
+	type positioned struct {
+		vc  VoiceChannel
+		pos int
+	}
+	kept := make([]positioned, 0, len(channels))
+	for _, c := range channels {
+		if c.Type != guildVoiceType {
+			continue
+		}
+		kept = append(kept, positioned{vc: VoiceChannel{ID: c.ID, Name: c.Name}, pos: c.Position})
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		if kept[i].pos != kept[j].pos {
+			return kept[i].pos < kept[j].pos
+		}
+		return kept[i].vc.Name < kept[j].vc.Name
+	})
+	voices := make([]VoiceChannel, len(kept))
+	for i, k := range kept {
+		voices[i] = k.vc
+	}
+
+	log.Debug("resolved Discord invite", "guild", guild.Name, "voiceChannels", len(voices))
+	return Resolved{Guild: guild, VoiceChannels: voices}, nil
+}
+
+// getJSON issues an authenticated Bot GET and, on 200, decodes the body into out.
+// It returns the HTTP status (so the caller maps 403/404 to sentinels) and an
+// error only for transport or decode failures.
+func getJSON(ctx context.Context, token, rawURL string, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+token)
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := inviteClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return resp.StatusCode, fmt.Errorf("decode: %w", err)
+	}
+	return resp.StatusCode, nil
+}

--- a/internal/discordinvite/discordinvite_test.go
+++ b/internal/discordinvite/discordinvite_test.go
@@ -1,0 +1,197 @@
+package discordinvite_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/discordinvite"
+)
+
+// recordedReq captures the parts of a REST call the resolver's contract pins:
+// method + path (so path-escaping is observable) and the auth + UA headers
+// Discord requires of a bot.
+type recordedReq struct {
+	method, path, auth, userAgent string
+}
+
+// TestResolve_HappyPath_OnlyVoiceChannelsSortedAndMapped is the golden path: an
+// invite resolves to its guild, and the guild's channel list is filtered to
+// type-2 GUILD_VOICE only (text=0, category=4, stage=13 dropped), sorted by
+// position then name, and mapped to {id,name}. Both calls carry Bot auth + the
+// DiscordBot User-Agent, and the code lands path-escaped in the invite URL.
+func TestResolve_HappyPath_OnlyVoiceChannelsSortedAndMapped(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		reqs []recordedReq
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		reqs = append(reqs, recordedReq{r.Method, r.URL.Path, r.Header.Get("Authorization"), r.Header.Get("User-Agent")})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/invites/abc-123":
+			_, _ = w.Write([]byte(`{"guild":{"id":"111","name":"The Keep"}}`))
+		case "/guilds/111/channels":
+			_, _ = w.Write([]byte(`[
+				{"id":"1","type":0,"name":"general","position":0},
+				{"id":"2","type":2,"name":"Bravo","position":5},
+				{"id":"3","type":2,"name":"Alpha","position":5},
+				{"id":"4","type":2,"name":"Lobby","position":1},
+				{"id":"5","type":4,"name":"Voice Lounge","position":0},
+				{"id":"6","type":13,"name":"Stage","position":2}
+			]`))
+		default:
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := discordinvite.ResolveAt(ctx, "tok-xyz", "abc-123", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("ResolveAt: %v", err)
+	}
+	if got.Guild.ID != "111" || got.Guild.Name != "The Keep" {
+		t.Errorf("guild = %+v, want {ID:111 Name:The Keep}", got.Guild)
+	}
+
+	// Only type-2, sorted position then name: Lobby(pos1), Alpha(pos5), Bravo(pos5).
+	want := []discordinvite.VoiceChannel{
+		{ID: "4", Name: "Lobby"},
+		{ID: "3", Name: "Alpha"},
+		{ID: "2", Name: "Bravo"},
+	}
+	if len(got.VoiceChannels) != len(want) {
+		t.Fatalf("voice channels = %+v, want %+v", got.VoiceChannels, want)
+	}
+	for i := range want {
+		if got.VoiceChannels[i] != want[i] {
+			t.Errorf("voice[%d] = %+v, want %+v", i, got.VoiceChannels[i], want[i])
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(reqs) != 2 {
+		t.Fatalf("requests = %+v, want 2 (invite, channels)", reqs)
+	}
+	for _, rq := range reqs {
+		if rq.method != http.MethodGet {
+			t.Errorf("method = %q, want GET", rq.method)
+		}
+		if rq.auth != "Bot tok-xyz" {
+			t.Errorf("auth = %q, want 'Bot tok-xyz'", rq.auth)
+		}
+		if !strings.HasPrefix(rq.userAgent, "DiscordBot ") {
+			t.Errorf("user-agent = %q, want a DiscordBot form", rq.userAgent)
+		}
+	}
+	if reqs[0].path != "/invites/abc-123" {
+		t.Errorf("invite path = %q, want /invites/abc-123 (path-escaped code)", reqs[0].path)
+	}
+	if reqs[1].path != "/guilds/111/channels" {
+		t.Errorf("channels path = %q, want /guilds/111/channels", reqs[1].path)
+	}
+}
+
+// TestResolve_InviteNotFound: a 404 on /invites → ErrNotFound (invalid/expired).
+func TestResolve_InviteNotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Unknown Invite","code":10006}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	_, err := discordinvite.ResolveAt(context.Background(), "tok", "gone", srv.URL, nil)
+	if !errors.Is(err, discordinvite.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestResolve_GuildlessInvite_NotFound: a group-DM invite resolves 200 but carries
+// no guild — it maps to ErrNotFound, same as a missing invite (there is no server
+// to pick a voice channel from).
+func TestResolve_GuildlessInvite_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"guild":null,"channel":{"id":"5","type":3}}`))
+	}))
+	defer srv.Close()
+	_, err := discordinvite.ResolveAt(context.Background(), "tok", "grpdm", srv.URL, nil)
+	if !errors.Is(err, discordinvite.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestResolve_ChannelsForbiddenOrNotFound_NoAccess: the invite resolves, but the
+// channels read comes back 403 OR 404 — Discord is inconsistent about which it
+// returns when the Bot is not a member of the guild, so both map to ErrNoAccess.
+func TestResolve_ChannelsForbiddenOrNotFound_NoAccess(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/invites/code" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"guild":{"id":"222","name":"Elsewhere"}}`))
+				return
+			}
+			http.Error(w, "no", status)
+		}))
+		_, err := discordinvite.ResolveAt(context.Background(), "tok", "code", srv.URL, nil)
+		srv.Close()
+		if !errors.Is(err, discordinvite.ErrNoAccess) {
+			t.Errorf("channels HTTP %d: err = %v, want ErrNoAccess", status, err)
+		}
+	}
+}
+
+// TestResolve_EmptyToken_NoNetwork: an empty token fails fast, before any dial —
+// the guard mirrors discordtag, so the default `go test` makes no live call. The
+// error is NOT one of the sentinels (they mean specific upstream states).
+func TestResolve_EmptyToken_NoNetwork(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	_, err := discordinvite.ResolveAt(context.Background(), "", "code", srv.URL, nil)
+	if err == nil {
+		t.Fatal("empty token returned nil error")
+	}
+	if errors.Is(err, discordinvite.ErrNotFound) || errors.Is(err, discordinvite.ErrNoAccess) {
+		t.Errorf("empty-token error must not be a sentinel: %v", err)
+	}
+	if n := atomic.LoadInt32(&hits); n != 0 {
+		t.Errorf("empty token made %d HTTP calls, want 0", n)
+	}
+}
+
+// TestResolve_UpstreamServerError_Generic: a 500 on /invites is a generic wrapped
+// error, NOT ErrNotFound/ErrNoAccess — the handler must not translate an outage
+// into "invalid invite" or "not a member".
+func TestResolve_UpstreamServerError_Generic(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	_, err := discordinvite.ResolveAt(context.Background(), "tok", "code", srv.URL, nil)
+	if err == nil {
+		t.Fatal("upstream 500 returned nil error")
+	}
+	if errors.Is(err, discordinvite.ErrNotFound) || errors.Is(err, discordinvite.ErrNoAccess) {
+		t.Errorf("upstream 500 must be a generic error, not a sentinel: %v", err)
+	}
+}

--- a/internal/discordinvite/export_test.go
+++ b/internal/discordinvite/export_test.go
@@ -1,0 +1,5 @@
+package discordinvite
+
+// ResolveAt exposes the base-URL seam so tests can point the resolver at a fake
+// Discord REST server instead of the live API.
+var ResolveAt = resolve

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -14,9 +15,16 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/discordinvite"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 )
+
+// inviteCodePattern bounds an accepted Discord invite code: 2–64 chars of
+// letters, digits, and hyphens (vanity codes included). The SPA already extracted
+// the bare code from the pasted URL; this rejects anything that could not be one
+// before it reaches the REST call (which is also path-escaped, ADR-0047).
+var inviteCodePattern = regexp.MustCompile(`^[A-Za-z0-9-]{2,64}$`)
 
 // envPlaceholderLast4 is the credentials_last4 the seed writes for a
 // provider_config whose real key lives in ENV/the keyring, not the DB (ADR-0039;
@@ -88,6 +96,12 @@ type ProviderServer struct {
 	// bot-authorization URL (#110). Non-secret; empty when DISCORD_OAUTH_CLIENT_ID
 	// is unset, which the screen renders as a disabled action.
 	discordAppID string
+
+	// resolveInvite resolves a Discord invite code to its guild + voice channels
+	// using the decrypted Bot token (#105). It is a seam: NewProviderServer
+	// defaults it to the live discordinvite.Resolve, and unit tests override it
+	// with a fake so ResolveGuildInvite never touches the network.
+	resolveInvite func(ctx context.Context, token, code string) (discordinvite.Resolved, error)
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -99,7 +113,11 @@ func NewProviderServer(store providerStore, cipher *crypto.Cipher, log *slog.Log
 	if log == nil {
 		log = slog.Default()
 	}
-	return &ProviderServer{store: store, cipher: cipher, log: log}
+	s := &ProviderServer{store: store, cipher: cipher, log: log}
+	s.resolveInvite = func(ctx context.Context, token, code string) (discordinvite.Resolved, error) {
+		return discordinvite.Resolve(ctx, token, code, log)
+	}
+	return s
 }
 
 // SetHealthInvalidator wires the health-cache buster called after a successful
@@ -388,6 +406,98 @@ func (s *ProviderServer) SaveDiscordSettings(
 		GuildId:        dep.GuildID,
 		VoiceChannelId: dep.VoiceChannelID,
 	}), nil
+}
+
+// ResolveGuildInvite resolves a pasted Discord invite code to its Guild and that
+// Guild's voice channels, using the decrypted saved Bot token server-side (#105,
+// ADR-0047). It is a no-side-effects read: the resolver makes only Discord REST
+// GETs, and no state is written. The code is validated + path-escaped before the
+// call; ErrNotFound → NotFound, ErrNoAccess → FailedPrecondition ("not a member"),
+// and a missing saved token → FailedPrecondition ("save the token first").
+func (s *ProviderServer) ResolveGuildInvite(
+	ctx context.Context,
+	req *connect.Request[managementv1.ResolveGuildInviteRequest],
+) (*connect.Response[managementv1.ResolveGuildInviteResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	code := req.Msg.GetInviteCode()
+	if !inviteCodePattern.MatchString(code) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid invite code"))
+	}
+
+	token, err := s.resolveBotToken(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		// No saved Bot token (nor the ENV placeholder): the resolver cannot
+		// authenticate. Same code as "not a member" — the screen renders whichever
+		// message it gets, so they must differ (ADR-0047).
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("save the Discord bot token first"))
+	}
+
+	resolved, err := s.resolveInvite(ctx, token, code)
+	if err != nil {
+		switch {
+		case errors.Is(err, discordinvite.ErrNotFound):
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("invalid or expired invite"))
+		case errors.Is(err, discordinvite.ErrNoAccess):
+			return nil, connect.NewError(connect.CodeFailedPrecondition,
+				errors.New("the Bot is not a member of that server"))
+		default:
+			s.log.Error("ResolveGuildInvite: resolve failed", "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	channels := make([]*managementv1.VoiceChannel, 0, len(resolved.VoiceChannels))
+	for _, vc := range resolved.VoiceChannels {
+		channels = append(channels, &managementv1.VoiceChannel{Id: vc.ID, Name: vc.Name})
+	}
+	return connect.NewResponse(&managementv1.ResolveGuildInviteResponse{
+		GuildId:       resolved.Guild.ID,
+		GuildName:     resolved.Guild.Name,
+		VoiceChannels: channels,
+	}), nil
+}
+
+// resolveBotToken resolves the deployment Bot token for ResolveGuildInvite,
+// mirroring VoiceServer.resolveDiscordToken: no row / ENV placeholder -> "" (the
+// caller maps that to a FailedPrecondition), a real saved token -> decrypted
+// plaintext, a saved token with no cipher -> FailedPrecondition.
+func (s *ProviderServer) resolveBotToken(ctx context.Context, tenantID uuid.UUID) (string, error) {
+	dep, err := s.store.GetDeploymentConfig(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		s.log.Error("resolveBotToken: store read failed", "err", err)
+		return "", connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return s.openKey(dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext)
+}
+
+// openKey applies the hybrid decision to one (last4, ciphertext) pair, mirroring
+// VoiceServer.openKey: an unsaved/placeholder last4 -> "", a real key with no
+// cipher -> FailedPrecondition, otherwise the decrypted plaintext.
+func (s *ProviderServer) openKey(last4 string, ciphertext []byte) (string, error) {
+	if !isSaved(last4) {
+		return "", nil
+	}
+	if s.cipher == nil {
+		return "", connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
+	}
+	plaintext, err := s.cipher.Open(ciphertext)
+	if err != nil {
+		s.log.Error("openKey: decrypt failed", "err", err)
+		return "", connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return string(plaintext), nil
 }
 
 // seal encrypts a plaintext secret and returns the ciphertext + its last4. The

--- a/internal/rpc/provider_invite_test.go
+++ b/internal/rpc/provider_invite_test.go
@@ -1,0 +1,230 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/discordinvite"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// fakeInviteStore is a minimal providerStore for the ResolveGuildInvite tests:
+// only GetDeploymentConfig carries behaviour (the Bot-token source); the rest of
+// the interface is inert. The package rpc_test fakeProviderStore is unreachable
+// from this internal (package rpc) test that overrides the unexported seam.
+type fakeInviteStore struct {
+	dep    storage.DeploymentConfig
+	depSet bool
+}
+
+func (f *fakeInviteStore) GetDeploymentConfig(context.Context, uuid.UUID) (storage.DeploymentConfig, error) {
+	if !f.depSet {
+		return storage.DeploymentConfig{}, storage.ErrNotFound
+	}
+	return f.dep, nil
+}
+
+func (f *fakeInviteStore) ListProviderConfigs(context.Context, uuid.UUID) ([]storage.ProviderConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeInviteStore) GetProviderConfigByComponent(context.Context, uuid.UUID, storage.Component) (storage.ProviderConfig, error) {
+	return storage.ProviderConfig{}, storage.ErrNotFound
+}
+
+func (f *fakeInviteStore) UpsertProviderConfigs(context.Context, []storage.NewProviderConfig) ([]storage.ProviderConfig, error) {
+	return nil, nil
+}
+
+func (f *fakeInviteStore) SaveDiscordBotToken(context.Context, uuid.UUID, []byte, string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, nil
+}
+
+func (f *fakeInviteStore) SaveDiscordChannels(context.Context, uuid.UUID, string, string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, nil
+}
+
+// savedInviteStore builds a store holding a real Bot token sealed under a fresh
+// cipher, returning both so the test decrypts the token the handler passes to
+// the seam.
+func savedInviteStore(t *testing.T) (*fakeInviteStore, *crypto.Cipher) {
+	t.Helper()
+	cipher := voiceTestCipher(t)
+	ct, err := cipher.Seal([]byte("bot-secret-token"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	store := &fakeInviteStore{depSet: true, dep: storage.DeploymentConfig{
+		DiscordBotTokenCiphertext: ct,
+		DiscordBotTokenLast4:      crypto.Last4("bot-secret-token"),
+	}}
+	return store, cipher
+}
+
+// TestResolveGuildInvite_HappyPath_DecryptedTokenAndMapping pins that the handler
+// decrypts the saved Bot token and passes it (with the bare code) to the resolver
+// seam, then maps the seam's Resolved onto the wire response.
+func TestResolveGuildInvite_HappyPath_DecryptedTokenAndMapping(t *testing.T) {
+	t.Parallel()
+	store, cipher := savedInviteStore(t)
+	srv := NewProviderServer(store, cipher, nil)
+
+	var gotToken, gotCode string
+	srv.resolveInvite = func(_ context.Context, token, code string) (discordinvite.Resolved, error) {
+		gotToken, gotCode = token, code
+		return discordinvite.Resolved{
+			Guild:         discordinvite.Guild{ID: "111", Name: "The Keep"},
+			VoiceChannels: []discordinvite.VoiceChannel{{ID: "9", Name: "Lobby"}, {ID: "8", Name: "Tavern"}},
+		}, nil
+	}
+
+	resp, err := srv.ResolveGuildInvite(tenantCtx(),
+		connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: "abc123"}))
+	if err != nil {
+		t.Fatalf("ResolveGuildInvite: %v", err)
+	}
+	if gotToken != "bot-secret-token" {
+		t.Errorf("seam token = %q, want the decrypted 'bot-secret-token'", gotToken)
+	}
+	if gotCode != "abc123" {
+		t.Errorf("seam code = %q, want abc123", gotCode)
+	}
+	msg := resp.Msg
+	if msg.GetGuildId() != "111" || msg.GetGuildName() != "The Keep" {
+		t.Errorf("guild = %q/%q, want 111/The Keep", msg.GetGuildId(), msg.GetGuildName())
+	}
+	vc := msg.GetVoiceChannels()
+	if len(vc) != 2 || vc[0].GetId() != "9" || vc[0].GetName() != "Lobby" || vc[1].GetId() != "8" {
+		t.Errorf("voice channels = %+v, want [{9 Lobby} {8 Tavern}]", vc)
+	}
+}
+
+// TestResolveGuildInvite_NoToken_FailedPrecondition_SeamNotCalled: with no saved
+// token (no dep row, or the ENV placeholder), the RPC fails FailedPrecondition
+// BEFORE touching the resolver — no live call fires without a real token.
+func TestResolveGuildInvite_NoToken_FailedPrecondition_SeamNotCalled(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		store *fakeInviteStore
+	}{
+		{"no dep row", &fakeInviteStore{}},
+		{"env placeholder", &fakeInviteStore{depSet: true, dep: storage.DeploymentConfig{DiscordBotTokenLast4: "env"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewProviderServer(tc.store, voiceTestCipher(t), nil)
+			called := false
+			srv.resolveInvite = func(context.Context, string, string) (discordinvite.Resolved, error) {
+				called = true
+				return discordinvite.Resolved{}, nil
+			}
+			_, err := srv.ResolveGuildInvite(tenantCtx(),
+				connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: "abc123"}))
+			if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+				t.Errorf("code = %v, want FailedPrecondition", got)
+			}
+			if called {
+				t.Error("resolver seam called despite no saved token")
+			}
+		})
+	}
+}
+
+// TestResolveGuildInvite_SavedTokenNilCipher_FailedPrecondition: a saved token
+// with no cipher configured cannot be decrypted → FailedPrecondition, seam not
+// called.
+func TestResolveGuildInvite_SavedTokenNilCipher_FailedPrecondition(t *testing.T) {
+	t.Parallel()
+	store := &fakeInviteStore{depSet: true, dep: storage.DeploymentConfig{
+		DiscordBotTokenLast4:      "abcd",
+		DiscordBotTokenCiphertext: []byte("x"),
+	}}
+	srv := NewProviderServer(store, nil, nil) // nil cipher
+	called := false
+	srv.resolveInvite = func(context.Context, string, string) (discordinvite.Resolved, error) {
+		called = true
+		return discordinvite.Resolved{}, nil
+	}
+	_, err := srv.ResolveGuildInvite(tenantCtx(),
+		connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: "abc123"}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	if called {
+		t.Error("resolver seam called despite nil cipher")
+	}
+}
+
+// TestResolveGuildInvite_SeamErrorMapping pins the sentinel → gRPC code mapping:
+// ErrNotFound → NotFound, ErrNoAccess → FailedPrecondition, anything else →
+// Internal (an opaque upstream error must not leak as a client-fault code).
+func TestResolveGuildInvite_SeamErrorMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want connect.Code
+	}{
+		{"not found", discordinvite.ErrNotFound, connect.CodeNotFound},
+		{"no access", discordinvite.ErrNoAccess, connect.CodeFailedPrecondition},
+		{"opaque", errors.New("upstream 500"), connect.CodeInternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cipher := savedInviteStore(t)
+			srv := NewProviderServer(store, cipher, nil)
+			srv.resolveInvite = func(context.Context, string, string) (discordinvite.Resolved, error) {
+				return discordinvite.Resolved{}, tc.err
+			}
+			_, err := srv.ResolveGuildInvite(tenantCtx(),
+				connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: "abc123"}))
+			if got := connect.CodeOf(err); got != tc.want {
+				t.Errorf("code = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveGuildInvite_BadCode_InvalidArgument: codes failing ^[A-Za-z0-9-]{2,64}$
+// are rejected before any store read or seam call.
+func TestResolveGuildInvite_BadCode_InvalidArgument(t *testing.T) {
+	t.Parallel()
+	store, cipher := savedInviteStore(t)
+	for _, code := range []string{"", "a", "a b", "abc/def", strings.Repeat("a", 65)} {
+		srv := NewProviderServer(store, cipher, nil)
+		called := false
+		srv.resolveInvite = func(context.Context, string, string) (discordinvite.Resolved, error) {
+			called = true
+			return discordinvite.Resolved{}, nil
+		}
+		_, err := srv.ResolveGuildInvite(tenantCtx(),
+			connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: code}))
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Errorf("code %q: got %v, want InvalidArgument", code, got)
+		}
+		if called {
+			t.Errorf("code %q: seam called for an invalid code", code)
+		}
+	}
+}
+
+// TestResolveGuildInvite_NoTenant_Unauthenticated: with no tenant in context the
+// RPC is Unauthenticated, matching the other management reads.
+func TestResolveGuildInvite_NoTenant_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	store, cipher := savedInviteStore(t)
+	srv := NewProviderServer(store, cipher, nil)
+	_, err := srv.ResolveGuildInvite(context.Background(),
+		connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: "abc123"}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", got)
+	}
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -576,6 +576,17 @@ service ProviderService {
   // channel IDs. An omitted bot_token leaves the stored token unchanged, so the
   // IDs can be saved without re-entering the secret. State-changing.
   rpc SaveDiscordSettings(SaveDiscordSettingsRequest) returns (SaveDiscordSettingsResponse);
+  // ResolveGuildInvite resolves a pasted Discord invite code to its Guild and
+  // that Guild's voice channels, using the decrypted saved deployment Bot token
+  // server-side (#105, ADR-0047). The SPA extracts the bare code from the pasted
+  // link (parseDiscordLink, zero network) and sends it here — the URL never
+  // crosses the wire. It is a no-side-effects read (CSRF-exempt), consistent with
+  // the other management reads: an invalid/expired code fails with CodeNotFound;
+  // a Guild the Bot is not a member of fails with CodeFailedPrecondition; a
+  // missing saved Bot token also fails with CodeFailedPrecondition.
+  rpc ResolveGuildInvite(ResolveGuildInviteRequest) returns (ResolveGuildInviteResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 // ProviderCredential is the WRITE-ONLY view of a saved secret: never its value,
@@ -666,6 +677,37 @@ message SaveDiscordSettingsResponse {
   ProviderCredential credential = 1;
   string guild_id = 2;
   string voice_channel_id = 3;
+}
+
+// ResolveGuildInviteRequest carries the bare Discord invite code the SPA
+// extracted from a pasted invite link (parseDiscordLink, zero network), NOT the
+// full URL. The server validates ^[A-Za-z0-9-]{2,64}$ and path-escapes it before
+// the REST call (#105, ADR-0047).
+message ResolveGuildInviteRequest {
+  // invite_code is the bare invite code (e.g. "abc123"), not the full URL.
+  string invite_code = 1;
+}
+
+// VoiceChannel is one selectable Discord voice channel in the resolved Guild:
+// its snowflake and human-readable name. Only type-2 GUILD_VOICE channels are
+// returned — text, category, and stage channels are excluded (ADR-0047).
+message VoiceChannel {
+  // id is the channel's snowflake.
+  string id = 1;
+  // name is the channel's human-readable name.
+  string name = 2;
+}
+
+// ResolveGuildInviteResponse carries the resolved Guild and its voice channels,
+// sorted by Discord position then name.
+message ResolveGuildInviteResponse {
+  // guild_id is the resolved Guild's snowflake.
+  string guild_id = 1;
+  // guild_name is the resolved Guild's display name.
+  string guild_name = 2;
+  // voice_channels are the Guild's GUILD_VOICE channels, sorted by position then
+  // name; empty when the Guild has none.
+  repeated VoiceChannel voice_channels = 3;
 }
 
 // SessionService drives the live Voice Session from the Session screen (#72,

--- a/web/src/lib/discordLink.test.ts
+++ b/web/src/lib/discordLink.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { parseChannelLink } from "./discordLink";
+import { parseChannelLink, parseDiscordLink } from "./discordLink";
 
 // A voice channel's right-click "Copy Link" yields discord.com/channels/{guild}/{channel},
 // carrying BOTH snowflakes. The parser is pure and client-side (#101, ADR-0039):
@@ -44,5 +44,57 @@ describe("parseChannelLink", () => {
     expect(parseChannelLink("https://discord.com/channels/12345/67890")).toBeNull();
     expect(parseChannelLink("https://example.com/channels/" + GUILD + "/" + CHANNEL)).toBeNull();
     expect(parseChannelLink("https://discord.com/channels/" + GUILD)).toBeNull();
+  });
+});
+
+// parseDiscordLink is the union front door (#105): a channel deep-link OR an
+// invite link. An invite carries only a code (discord.gg/{code} or
+// discord.com/invite/{code}); the guild + channels are resolved server-side.
+const INVITE_CODE = "abc123XYZ-";
+
+describe("parseDiscordLink", () => {
+  it("routes a channel deep-link to the channel branch (checked first)", () => {
+    expect(parseDiscordLink(`https://discord.com/channels/${GUILD}/${CHANNEL}`)).toEqual({
+      kind: "channel",
+      guildId: GUILD,
+      channelId: CHANNEL,
+    });
+    // The channel regression suite's tolerances still hold through the union.
+    expect(parseDiscordLink(`ptb.discord.com/channels/${GUILD}/${CHANNEL}/?jump=1`)).toEqual({
+      kind: "channel",
+      guildId: GUILD,
+      channelId: CHANNEL,
+    });
+  });
+
+  it("parses invite links to the bare code across scheme/host/wrapper variants", () => {
+    const variants = [
+      `https://discord.gg/${INVITE_CODE}`,
+      `http://discord.gg/${INVITE_CODE}`,
+      `discord.gg/${INVITE_CODE}`,
+      `https://discord.gg/${INVITE_CODE}/`,
+      `https://discord.gg/${INVITE_CODE}?utm=x`,
+      `  discord.gg/${INVITE_CODE}  `,
+      `<https://discord.gg/${INVITE_CODE}>`,
+      `https://discord.com/invite/${INVITE_CODE}`,
+      `discord.com/invite/${INVITE_CODE}`,
+      `https://discordapp.com/invite/${INVITE_CODE}`,
+      `https://ptb.discord.com/invite/${INVITE_CODE}`,
+    ];
+    for (const link of variants) {
+      expect(parseDiscordLink(link)).toEqual({ kind: "invite", code: INVITE_CODE });
+    }
+  });
+
+  it("returns null for a bare invite host with no code", () => {
+    expect(parseDiscordLink("discord.gg/")).toBeNull();
+    expect(parseDiscordLink("https://discord.gg/")).toBeNull();
+    expect(parseDiscordLink("https://discord.com/invite/")).toBeNull();
+  });
+
+  it("returns null for a non-Discord string", () => {
+    expect(parseDiscordLink("hello world")).toBeNull();
+    expect(parseDiscordLink("")).toBeNull();
+    expect(parseDiscordLink("https://example.com/invite/abc123")).toBeNull();
   });
 });

--- a/web/src/lib/discordLink.ts
+++ b/web/src/lib/discordLink.ts
@@ -1,15 +1,29 @@
-// discordLink — pure, network-free parsing of a Discord channel deep-link (#101,
-// ADR-0039). A voice channel's right-click "Copy Link" yields
-// discord.com/channels/{guildId}/{channelId}, carrying BOTH snowflakes; the
-// Configuration screen pastes that here to autofill the two ID fields.
+// discordLink — pure, network-free parsing of a pasted Discord link (#101/#105,
+// ADR-0039/0047). Two shapes matter to the Configuration screen:
+//   - a channel deep-link (discord.com/channels/{guildId}/{channelId}) carries
+//     BOTH snowflakes, so it autofills the two ID fields locally;
+//   - an invite link (discord.gg/{code} or discord.com/invite/{code}) carries
+//     only a code — the guild + its voice channels are resolved server-side by
+//     ResolveGuildInvite, because a non-member Bot cannot read them client-side.
+// Everything here is client-side and issues no network call.
 
 export interface ChannelLink {
   guildId: string;
   channelId: string;
 }
 
+// DiscordLink is the union front door: a resolved channel link, or an invite
+// carrying only its code.
+export type DiscordLink =
+  | { kind: "channel"; guildId: string; channelId: string }
+  | { kind: "invite"; code: string };
+
 // Discord snowflakes are 17–20 digit ids (a 64-bit id rendered as decimal).
 const SNOWFLAKE = /^\d{17,20}$/;
+
+// An invite code is 2–64 chars of letters, digits, and hyphens (vanity codes
+// included) — matching the server's ^[A-Za-z0-9-]{2,64}$ validation (ADR-0047).
+const INVITE_CODE = /^[A-Za-z0-9-]{2,64}$/;
 
 // A Discord channel host: discord.com, the legacy discordapp.com, or a client
 // subdomain of either (ptb./canary./www.).
@@ -17,6 +31,25 @@ function isDiscordHost(host: string): boolean {
   return ["discord.com", "discordapp.com"].some(
     (base) => host === base || host.endsWith(`.${base}`),
   );
+}
+
+// The short invite host discord.gg (and any client subdomain of it).
+function isInviteHost(host: string): boolean {
+  return host === "discord.gg" || host.endsWith(".discord.gg");
+}
+
+// toURL normalises a pasted string into a URL: it strips surrounding whitespace,
+// unwraps the <…> Discord adds to suppress an embed, adds https:// when the paste
+// is scheme-less, and parses. It returns null when the result is not a URL.
+function toURL(input: string): URL | null {
+  const trimmed = input.trim().replace(/^<(.*)>$/, "$1").trim();
+  if (!trimmed) return null;
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(withScheme);
+  } catch {
+    return null;
+  }
 }
 
 // parseChannelLink extracts the guild + voice channel snowflakes from a pasted
@@ -27,22 +60,8 @@ function isDiscordHost(host: string): boolean {
 // resolves to the same two ids. Anything else (a random string, a @me DM link, a
 // non-Discord host, short/invalid ids) yields null so the caller can surface a hint.
 export function parseChannelLink(input: string): ChannelLink | null {
-  // Strip surrounding whitespace, then the <…> Discord wraps a URL in to
-  // suppress its embed.
-  const trimmed = input.trim().replace(/^<(.*)>$/, "$1").trim();
-  if (!trimmed) return null;
-
-  // A scheme-less paste (the common "discord.com/channels/…") needs one to parse
-  // as a URL; add https:// only when no scheme is present.
-  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-
-  let url: URL;
-  try {
-    url = new URL(withScheme);
-  } catch {
-    return null;
-  }
-
+  const url = toURL(input);
+  if (!url) return null;
   if (!isDiscordHost(url.hostname.toLowerCase())) return null;
 
   // /channels/{guild}/{channel}[/…] — filter drops the empty segment a trailing
@@ -53,4 +72,36 @@ export function parseChannelLink(input: string): ChannelLink | null {
   if (!SNOWFLAKE.test(guildId ?? "") || !SNOWFLAKE.test(channelId ?? "")) return null;
 
   return { guildId, channelId };
+}
+
+// parseInviteCode extracts the bare invite code from a pasted invite link, or
+// returns null. It accepts discord.gg/{code} and discord(app).com/invite/{code}
+// with the same tolerances as parseChannelLink. A bare host with no code segment
+// yields null.
+export function parseInviteCode(input: string): string | null {
+  const url = toURL(input);
+  if (!url) return null;
+  const host = url.hostname.toLowerCase();
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  let code: string | undefined;
+  if (isInviteHost(host)) {
+    code = segments[0];
+  } else if (isDiscordHost(host) && segments[0] === "invite") {
+    code = segments[1];
+  }
+  if (!code || !INVITE_CODE.test(code)) return null;
+  return code;
+}
+
+// parseDiscordLink resolves a paste to either a channel deep-link or an invite,
+// or null. The channel branch is checked first: a channel link is fully
+// self-describing (both ids), while an invite needs a server round-trip, so a
+// paste that is both should take the cheaper local path.
+export function parseDiscordLink(input: string): DiscordLink | null {
+  const channel = parseChannelLink(input);
+  if (channel) return { kind: "channel", ...channel };
+  const code = parseInviteCode(input);
+  if (code) return { kind: "invite", code };
+  return null;
 }

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -17,6 +17,7 @@ import {
   GetProviderHealthResponseSchema,
   ProviderHealthSchema,
   ListModelsResponseSchema,
+  ResolveGuildInviteResponseSchema,
   type ProviderHealth,
   type SaveDiscordSettingsRequest,
 } from "@gen/glyphoxa/management/v1/management_pb";
@@ -74,6 +75,13 @@ function mockBackend(
     // discordApplicationId seeds the server-provided Discord application id the
     // read echoes so the screen composes the bot-authorization URL (#110).
     discordApplicationId?: string;
+    // inviteResolve seeds the guild + voice channels ResolveGuildInvite returns
+    // for a pasted invite (#105). inviteError makes it fail instead.
+    inviteResolve?: { guildId: string; guildName: string; voiceChannels: { id: string; name: string }[] };
+    inviteError?: { code: Code; message: string };
+    // inviteCodes captures every ResolveGuildInvite request's code so a test can
+    // pin that the SPA sent the BARE code (not the full URL).
+    inviteCodes?: string[];
   } = {},
 ) {
   const state = {
@@ -154,6 +162,12 @@ function mockBackend(
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
         });
+      },
+      resolveGuildInvite: (req) => {
+        opts.inviteCodes?.push(req.inviteCode);
+        if (opts.inviteError) throw new ConnectError(opts.inviteError.message, opts.inviteError.code);
+        const r = opts.inviteResolve ?? { guildId: "111", guildName: "The Keep", voiceChannels: [] };
+        return create(ResolveGuildInviteResponseSchema, r);
       },
     });
   });
@@ -481,6 +495,128 @@ describe("Configuration", () => {
     );
     // A rejected paste's hint must not linger after a successful one.
     expect(screen.queryByText(/couldn't read that link/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Configuration invite picker (#105)", () => {
+  it("resolves a pasted invite to the guild's voice channels, sending the bare code", async () => {
+    const inviteCodes: string[] = [];
+    renderScreen(
+      mockBackend({
+        inviteCodes,
+        inviteResolve: {
+          guildId: "111",
+          guildName: "The Keep",
+          voiceChannels: [
+            { id: "900", name: "War Room" },
+            { id: "901", name: "Tavern" },
+          ],
+        },
+      }),
+    );
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, { target: { value: "https://discord.gg/abc123" } });
+
+    // The BARE code crosses the wire — the SPA extracted it, not the whole URL.
+    await waitFor(() => expect(inviteCodes).toEqual(["abc123"]));
+
+    // The guild header + exactly the returned voice channels (name + snowflake).
+    expect(await screen.findByText("The Keep")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /War Room/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tavern/ })).toBeInTheDocument();
+    expect(screen.getByText("900")).toBeInTheDocument();
+  });
+
+  it("fills both ID fields from a picked channel and persists them on Save", async () => {
+    const discordSaves: SaveDiscordSettingsRequest[] = [];
+    renderScreen(
+      mockBackend({
+        discordSaves,
+        inviteResolve: {
+          guildId: "472093001100472093",
+          guildName: "The Keep",
+          voiceChannels: [{ id: "987654321098765432", name: "War Room" }],
+        },
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
+      target: { value: "discord.gg/abc123" },
+    });
+    // Pick the channel from the resolved picker.
+    fireEvent.click(await screen.findByRole("button", { name: /War Room/ }));
+
+    // Both fields fill from the RESOLVED guild + the PICKED channel.
+    expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe("472093001100472093");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe(
+      "987654321098765432",
+    );
+
+    // Save carries BOTH exact snowflakes in their own wire fields (a swap would
+    // still round-trip through the display, so pin the exact field).
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+    await waitFor(() => expect(discordSaves).toHaveLength(1));
+    expect(discordSaves[0].guildId).toBe("472093001100472093");
+    expect(discordSaves[0].voiceChannelId).toBe("987654321098765432");
+  });
+
+  it("renders a precondition failure verbatim with an add-bot hint, leaving fields unchanged", async () => {
+    renderScreen(
+      mockBackend({
+        inviteError: { code: Code.FailedPrecondition, message: "the Bot is not a member of that server" },
+      }),
+    );
+
+    const guild = await screen.findByLabelText("Guild ID");
+    fireEvent.change(guild, { target: { value: "existing-guild" } });
+
+    fireEvent.change(screen.getByLabelText(/paste a discord link/i), {
+      target: { value: "discord.gg/abc123" },
+    });
+
+    // The server message renders VERBATIM — no-token vs not-a-member share the
+    // FailedPrecondition code and differ only by this message.
+    expect(await screen.findByText("the Bot is not a member of that server")).toBeInTheDocument();
+    // …plus the hint pointing back at the Add-Glyphoxa action above.
+    expect(screen.getByText(/then paste the invite again/i)).toBeInTheDocument();
+
+    // A failed resolve touches nothing the operator already had.
+    expect((guild as HTMLInputElement).value).toBe("existing-guild");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+  });
+
+  it("surfaces an invalid/expired invite inline, leaving fields unchanged", async () => {
+    renderScreen(
+      mockBackend({
+        inviteError: { code: Code.NotFound, message: "invalid or expired invite" },
+      }),
+    );
+
+    const guild = await screen.findByLabelText("Guild ID");
+    fireEvent.change(guild, { target: { value: "existing-guild" } });
+
+    fireEvent.change(screen.getByLabelText(/paste a discord link/i), {
+      target: { value: "discord.gg/gone" },
+    });
+
+    expect(await screen.findByText(/invalid or expired/i)).toBeInTheDocument();
+    expect((guild as HTMLInputElement).value).toBe("existing-guild");
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+  });
+
+  it("shows an empty-state line when the resolved guild has no voice channels", async () => {
+    renderScreen(
+      mockBackend({
+        inviteResolve: { guildId: "111", guildName: "The Keep", voiceChannels: [] },
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
+      target: { value: "discord.gg/abc123" },
+    });
+
+    expect(await screen.findByText(/no voice channels in the keep/i)).toBeInTheDocument();
   });
 });
 

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw, Link as LinkIcon } from "lucide-react";
+import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-react";
 
 import {
   CampaignService,
@@ -17,8 +17,8 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Input } from "@/components/ui/Input";
 import { Combobox } from "@/components/ui/Combobox";
 import { Button } from "@/components/ui/Button";
-import { parseChannelLink } from "@/lib/discordLink";
 import { AddBotLink } from "./AddBotLink";
+import { DiscordLinkAutofill } from "./DiscordLinkAutofill";
 
 import "./configuration.css";
 
@@ -98,28 +98,13 @@ export function Configuration() {
     setVoiceChannelId(v);
   };
 
-  // "Paste a Discord link" autofill (#101): a voice channel's Copy-Link carries
-  // both snowflakes, so a well-formed paste fills the two ID fields purely
-  // client-side (parseChannelLink issues no network call) and marks them dirty so
-  // Save picks the values up. A paste that isn't a channel deep-link leaves the
-  // fields untouched and surfaces an inline hint.
-  const [channelLink, setChannelLink] = useState("");
-  const [linkError, setLinkError] = useState<string | null>(null);
-  const pasteChannelLink = (v: string) => {
-    setChannelLink(v);
-    if (!v.trim()) {
-      setLinkError(null);
-      return;
-    }
-    const parsed = parseChannelLink(v);
-    if (!parsed) {
-      setLinkError("Couldn't read that link — paste a Discord channel link.");
-      return;
-    }
-    idsDirty.current = true;
-    setGuildId(parsed.guildId);
-    setVoiceChannelId(parsed.channelId);
-    setLinkError(null);
+  // "Paste a Discord link" autofill (#101/#105): a channel Copy-Link fills both
+  // IDs locally; an invite link resolves server-side to a voice-channel picker.
+  // Either fill goes through the dirty-tracking edit path so a config refetch
+  // can't clobber it (raw setState would), and Save picks the values up.
+  const fillDiscordIds = (g: string, c: string) => {
+    editGuildId(g);
+    editVoiceChannelId(c);
   };
 
   return (
@@ -198,15 +183,7 @@ export function Configuration() {
             // even while the config load is still resolving (#142).
             onSave={(secret) => saveDiscord.mutateAsync({ botToken: secret })}
           />
-          <Input
-            label="Paste a Discord link"
-            placeholder="https://discord.com/channels/…"
-            icon={<LinkIcon size={15} />}
-            hint="Right-click a voice channel → Copy Link to fill both IDs at once."
-            error={linkError}
-            value={channelLink}
-            onChange={(e) => pasteChannelLink(e.target.value)}
-          />
+          <DiscordLinkAutofill onFill={fillDiscordIds} />
           <div className="gx-discord__ids">
             <Input
               label="Guild ID"

--- a/web/src/screens/configuration/DiscordLinkAutofill.tsx
+++ b/web/src/screens/configuration/DiscordLinkAutofill.tsx
@@ -1,0 +1,114 @@
+import { useState, type ReactNode } from "react";
+import { useMutation } from "@connectrpc/connect-query";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { Link as LinkIcon } from "lucide-react";
+
+import {
+  ProviderService,
+  type ResolveGuildInviteResponse,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Input } from "@/components/ui/Input";
+import { parseDiscordLink } from "@/lib/discordLink";
+import { InviteChannelPicker } from "./InviteChannelPicker";
+
+// DiscordLinkAutofill — the Configuration Discord card's "Paste a Discord link"
+// field (#101/#105, ADR-0047). It parses the paste client-side (no network) and
+// takes one of two paths:
+//   - a channel deep-link carries BOTH snowflakes, so it fills the two ID fields
+//     directly via onFill;
+//   - an invite link carries only a code, which it resolves server-side
+//     (ResolveGuildInvite, with the decrypted Bot token) to the guild's voice
+//     channels, then renders a picker; picking a channel fills the IDs via onFill.
+// onFill MUST be the Configuration screen's dirty-tracking edit path — a raw
+// setState would let a config refetch clobber the fill. A failed resolve leaves
+// the fields and any previously-resolved picker untouched.
+
+// ADD_BOT_HINT points a not-a-member / no-token precondition failure back at the
+// Add-Glyphoxa action; the invite can only resolve once the Bot is in the guild.
+const ADD_BOT_HINT = "Use the Add Glyphoxa to your server button above, then paste the invite again.";
+
+export function DiscordLinkAutofill({
+  onFill,
+}: {
+  onFill: (guildId: string, channelId: string) => void;
+}) {
+  const [link, setLink] = useState("");
+  const [linkError, setLinkError] = useState<ReactNode>(null);
+  // The picker is held in local state, not read off the mutation's `data`: a
+  // later failed resolve must leave the previous picker standing (ADR-0047), and
+  // react-query clears `data` on the next mutate. onSuccess is the only writer.
+  const [picker, setPicker] = useState<ResolveGuildInviteResponse | null>(null);
+
+  const resolve = useMutation(ProviderService.method.resolveGuildInvite, {
+    onSuccess: (res) => {
+      setPicker(res);
+      setLinkError(null);
+    },
+    onError: (err) => setLinkError(inviteErrorMessage(err)),
+  });
+
+  const onPaste = (value: string) => {
+    setLink(value);
+    if (!value.trim()) {
+      setLinkError(null);
+      return;
+    }
+    const parsed = parseDiscordLink(value);
+    if (!parsed) {
+      setLinkError("Couldn't read that link — paste a Discord channel or invite link.");
+      return;
+    }
+    if (parsed.kind === "channel") {
+      // Self-describing: both ids are in the URL, fill locally with no round-trip.
+      setLinkError(null);
+      onFill(parsed.guildId, parsed.channelId);
+      return;
+    }
+    // Invite: only the code is known; the guild + channels resolve server-side.
+    setLinkError(null);
+    resolve.mutate({ inviteCode: parsed.code });
+  };
+
+  return (
+    <div className="gx-discord__link">
+      <Input
+        label="Paste a Discord link"
+        placeholder="https://discord.com/channels/… or discord.gg/…"
+        icon={<LinkIcon size={15} />}
+        hint="Paste a channel link to fill both IDs, or an invite link to pick a voice channel."
+        error={linkError}
+        value={link}
+        onChange={(e) => onPaste(e.target.value)}
+      />
+      {resolve.isPending && <p className="gx-discord__resolving">Resolving invite…</p>}
+      {picker && (
+        <InviteChannelPicker
+          guildName={picker.guildName}
+          channels={picker.voiceChannels}
+          onPick={(channelId) => onFill(picker.guildId, channelId)}
+        />
+      )}
+    </div>
+  );
+}
+
+// inviteErrorMessage maps a ResolveGuildInvite failure onto the inline message.
+// NotFound is a plain invalid/expired line; FailedPrecondition renders the SERVER
+// message verbatim (no-token vs not-a-member share the code and differ only by
+// message, ADR-0047) plus the add-bot hint.
+function inviteErrorMessage(err: unknown): ReactNode {
+  const code = err instanceof ConnectError ? err.code : undefined;
+  const raw =
+    err instanceof ConnectError ? err.rawMessage : err instanceof Error ? err.message : String(err);
+  if (code === Code.NotFound) {
+    return "That invite looks invalid or expired.";
+  }
+  if (code === Code.FailedPrecondition) {
+    return (
+      <>
+        <span>{raw}</span> <span>{ADD_BOT_HINT}</span>
+      </>
+    );
+  }
+  return "Couldn't resolve that invite. Please try again.";
+}

--- a/web/src/screens/configuration/InviteChannelPicker.tsx
+++ b/web/src/screens/configuration/InviteChannelPicker.tsx
@@ -1,0 +1,49 @@
+import { Hash } from "lucide-react";
+
+import type { VoiceChannel } from "@gen/glyphoxa/management/v1/management_pb";
+
+// InviteChannelPicker — the list of voice channels ResolveGuildInvite returned
+// for a pasted invite (#105, ADR-0047). It shows the resolved guild's name as a
+// header and one clickable row per voice channel (its name + snowflake); picking
+// a row fills the Guild ID + Voice channel ID fields via onPick. An empty list
+// (a guild with no voice channels) renders an explanatory line instead of rows.
+
+export function InviteChannelPicker({
+  guildName,
+  channels,
+  onPick,
+}: {
+  guildName: string;
+  channels: VoiceChannel[];
+  onPick: (channelId: string) => void;
+}) {
+  return (
+    <div className="gx-invite-picker">
+      <div className="gx-invite-picker__header">
+        <span className="gx-overline">Voice channels in</span>
+        <span className="gx-invite-picker__guild">{guildName}</span>
+      </div>
+      {channels.length === 0 ? (
+        <p className="gx-invite-picker__empty">No voice channels in {guildName}.</p>
+      ) : (
+        <ul className="gx-invite-picker__list">
+          {channels.map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                className="gx-invite-picker__row"
+                onClick={() => onPick(c.id)}
+              >
+                <span className="gx-invite-picker__icon">
+                  <Hash size={15} />
+                </span>
+                <span className="gx-invite-picker__name">{c.name}</span>
+                <span className="gx-invite-picker__id">{c.id}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -115,3 +115,90 @@
   align-items: center;
   gap: 8px;
 }
+
+/* "Paste a Discord link" autofill (#101/#105): the paste field plus, for an
+   invite, the resolving note and the voice-channel picker beneath it. */
+.gx-discord__link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.gx-discord__resolving {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
+/* Invite channel picker (#105): the resolved guild's voice channels as clickable
+   rows; picking one fills both ID fields. */
+.gx-invite-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+}
+
+.gx-invite-picker__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gx-invite-picker__guild {
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+}
+
+.gx-invite-picker__empty {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+  margin: 0;
+}
+
+.gx-invite-picker__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gx-invite-picker__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.gx-invite-picker__row:hover {
+  background: var(--surface-card-hover);
+  border-color: var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.gx-invite-picker__icon {
+  display: inline-flex;
+  color: var(--text-subtle);
+}
+
+.gx-invite-picker__name {
+  flex: 1;
+  font-size: var(--body-sm);
+}
+
+.gx-invite-picker__id {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--text-subtle);
+}


### PR DESCRIPTION
Closes #105

Implements E7's invite resolver: paste a Discord invite link, resolve it to the
Guild server-side with the decrypted Bot token, and pick a voice channel from a
picker that fills the Guild ID + Voice channel ID fields (the existing Save
persists them). Built per ADR-0047.

## What ships
- **proto** — `ResolveGuildInvite` (NO_SIDE_EFFECTS) on `ProviderService` +
  `ResolveGuildInviteRequest` / `VoiceChannel` / `ResolveGuildInviteResponse`.
  The SPA sends a **bare** invite code; the URL never crosses the wire.
- **internal/discordinvite** — plain `net/http` resolver mirroring
  `internal/discordtag` (no disgo rest client → no per-call goroutine leak),
  Bot auth + DiscordBot UA, 15s timeout, base-URL `export_test` seam.
  `GET /invites/{code}` → guild (404 / guild-less → `ErrNotFound`);
  `GET /guilds/{id}/channels` → keep type-2 `GUILD_VOICE` sorted by position
  then name (403/404 → `ErrNoAccess`). Empty token → error with **zero** HTTP
  calls; other non-200 → generic (never the sentinels).
- **internal/rpc** — `ProviderServer.ResolveGuildInvite`: tenant → validate
  `^[A-Za-z0-9-]{2,64}$` + path-escape → `resolveBotToken` (decrypts the saved
  deployment token, mirroring `VoiceServer`) → resolver seam. No token →
  `FailedPrecondition`; `ErrNotFound` → `NotFound`; `ErrNoAccess` →
  `FailedPrecondition` ("not a member"); opaque → `Internal`.
- **web** — `parseDiscordLink` union (channel checked first, invite =
  `discord.gg/{code}` or `discord(app).com/invite/{code}`, same tolerances).
  New `DiscordLinkAutofill` (extracted paste field) + `InviteChannelPicker`.
  A channel link fills IDs locally; an invite resolves and renders the picker,
  whose pick fills both IDs via the dirty-tracking edit path. `NotFound` →
  invalid/expired inline; `FailedPrecondition` → server message **verbatim** +
  add-bot hint; failures leave fields and any prior picker untouched.

## Note on the plan
The architect plan assumed a `DiscordLinkAutofill` component already existed on
main and said "Configuration.tsx: ZERO changes". In reality #101 shipped the
paste logic **inline** in `Configuration.tsx`, so ZERO changes was impossible. I
extracted that inline block into the named `DiscordLinkAutofill` component (the
minimal, mechanical change) and wired it back via an `onFill` prop — honoring the
plan's intent that all new UI lives in `DiscordLinkAutofill`/`InviteChannelPicker`.

## Tests (all TDD red→green)
- `internal/discordinvite`: 6 tests — happy path (filter+sort+map, auth/UA/path),
  invite 404, guild-less invite, channels 403/404, empty-token no-network,
  upstream 500 generic.
- `internal/rpc` (package rpc, seam-override): 7 tests — decrypted-token+mapping,
  no-token/env → FP (seam not called), nil-cipher → FP, sentinel→code mapping,
  bad codes → InvalidArgument, no tenant → Unauthenticated.
- web `discordLink`: invite variants + channel-first + bare-host null.
- web `Configuration` (mockBackend `resolveGuildInvite`): resolve→picker (bare
  code), pick→fill→Save (both snowflakes), FP verbatim+hint, NotFound inline,
  empty-state.

Local: `buf lint`/`breaking` clean, `make proto`, `go build/vet/test -race`,
golangci-lint 0 issues, web `tsc`/135 vitest/`vite build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)