### PR TITLE
[E6] Provider usage metering: LLM tokens, TTS characters, STT audio-seconds (#127)

### DIFF
--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -68,6 +68,15 @@ type PrometheusRecorder struct {
 	providerCalls  *prometheus.CounterVec // stage, provider, outcome
 	providerErrors *prometheus.CounterVec // stage, provider
 
+	// provider usage (StageRecorder, #127 / ADR-0045): token / character / audio-
+	// second spend per provider. llmTokens splits by a required direction label
+	// (input|output) because Groq prices the two directions differently; model is
+	// NEVER a label (it rides only to the spend meter, ADR-0046). ttsCharacters and
+	// sttAudioSeconds carry the provider label only (ADR-0032 bounds).
+	llmTokens       *prometheus.CounterVec // provider, direction
+	ttsCharacters   *prometheus.CounterVec // provider
+	sttAudioSeconds *prometheus.CounterVec // provider
+
 	// turn lifecycle (StageRecorder): the survivorship counterpart to
 	// response_latency — every turn records one terminal outcome.
 	turnTotal *prometheus.CounterVec // outcome, reason
@@ -199,6 +208,12 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 	r.providerErrors = counterVec("provider_errors_total", "Vendor call errors by stage and provider.", "stage", "provider")
 	r.turnTotal = counterVec("turn_total", "Turns by terminal outcome and reason — the survivorship counterpart to response_latency (which records only turns that reached first audio).", "outcome", "reason")
 
+	// Provider usage meters (#127, ADR-0045). direction is required on llm_tokens
+	// (Groq prices input/output differently); model is never a label (ADR-0032).
+	r.llmTokens = counterVec("llm_tokens_total", "LLM tokens metered by provider and direction (provider-reported, or a ceil(chars/4) estimate when none is reported — never zero).", "provider", "direction")
+	r.ttsCharacters = counterVec("tts_characters_total", "TTS characters (utf8 runes) submitted per provider (billed even if a later barge cuts the audio).", "provider")
+	r.sttAudioSeconds = counterVec("stt_audio_seconds_total", "STT audio seconds submitted per provider (batch clip length, or streamed voiced+pre-roll duration).", "provider")
+
 	r.embeddingBacklog = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace, // process-level, not a voice subsystem metric (ADR-0032)
 		Name:      "embedding_backlog",
@@ -224,6 +239,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
 		r.memoryRecall, r.kgFacts,
+		r.llmTokens, r.ttsCharacters, r.sttAudioSeconds,
 		// Standard runtime collectors so /metrics also reports process/Go health.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
@@ -293,6 +309,26 @@ func (r *PrometheusRecorder) ProviderError(s Stage, p Provider) {
 }
 func (r *PrometheusRecorder) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
 	r.turnTotal.WithLabelValues(string(outcome), string(reason)).Inc()
+}
+
+// LLMTokens records a completion's input/output token usage (#127, ADR-0045). The
+// model argument is DROPPED here — it exists only for the per-model spend meter
+// (ADR-0046); model is never a Prometheus label (ADR-0032). The two directions
+// land on separate series because Groq prices them differently.
+func (r *PrometheusRecorder) LLMTokens(p Provider, _ string, inputTokens, outputTokens int) {
+	r.llmTokens.WithLabelValues(string(p), "input").Add(float64(inputTokens))
+	r.llmTokens.WithLabelValues(string(p), "output").Add(float64(outputTokens))
+}
+
+// TTSCharacters records characters submitted to a TTS synthesizer (#127).
+func (r *PrometheusRecorder) TTSCharacters(p Provider, chars int) {
+	r.ttsCharacters.WithLabelValues(string(p)).Add(float64(chars))
+}
+
+// STTAudioSeconds records audio-seconds submitted to an STT recognizer (#127),
+// exported in the base unit seconds (Prometheus convention).
+func (r *PrometheusRecorder) STTAudioSeconds(p Provider, d time.Duration) {
+	r.sttAudioSeconds.WithLabelValues(string(p)).Add(d.Seconds())
 }
 
 // MemoryRecall counts one NPC memory recall by its bounded outcome (#122,

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -179,6 +179,39 @@ func TestTTSTotalDeliverSpanBucketsAndHelp(t *testing.T) {
 	}
 }
 
+// TestUsageMeters_TokensCharactersAudioSeconds is the #127 AC pin (ADR-0045): the
+// three usage meters expose their series with provider-only bounds — LLM tokens
+// split by a required direction label (Groq prices input/output differently), TTS
+// characters and STT audio-seconds by provider. The model passed to LLMTokens is
+// for the spend meter (ADR-0046) and must NEVER become a Prometheus label
+// (ADR-0032 cardinality).
+func TestUsageMeters_TokensCharactersAudioSeconds(t *testing.T) {
+	rec := NewPrometheusRecorder()
+
+	rec.LLMTokens(ProviderGroq, "llama-3.3-70b-versatile", 100, 50)
+	rec.TTSCharacters(ProviderElevenLabs, 42)
+	rec.STTAudioSeconds(ProviderElevenLabs, 3200*time.Millisecond)
+
+	out := scrape(t, rec)
+
+	wantSeries := []string{
+		`glyphoxa_voice_llm_tokens_total{direction="input",provider="groq"} 100`,
+		`glyphoxa_voice_llm_tokens_total{direction="output",provider="groq"} 50`,
+		`glyphoxa_voice_tts_characters_total{provider="elevenlabs"} 42`,
+		`glyphoxa_voice_stt_audio_seconds_total{provider="elevenlabs"} 3.2`,
+	}
+	for _, want := range wantSeries {
+		if !strings.Contains(out, want) {
+			t.Errorf("scrape missing %q\n%s", want, filterGlyphoxa(out))
+		}
+	}
+
+	// The model rides only to the spend meter; it must not reach a series (ADR-0032).
+	if strings.Contains(out, "llama-3.3-70b-versatile") || strings.Contains(out, "model=") {
+		t.Errorf("model leaked into a series (must never be a label):\n%s", filterGlyphoxa(out))
+	}
+}
+
 func TestSessionGaugeTracksOpenClose(t *testing.T) {
 	rec := NewPrometheusRecorder()
 	rec.SessionOpened("a")

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -242,6 +242,30 @@ type StageRecorder interface {
 	// (glyphoxa_voice_turn_total{outcome,reason}) — WIRED by the bus subscriber
 	// (first_audio on the first FirstAudio per turn, abandoned on a TTL reap).
 	TurnOutcome(outcome TurnOutcome, reason TurnReason)
+
+	// LLMTokens counts one completion's token usage split by direction (#127,
+	// ADR-0045): the provider-reported input/output counts, or a documented
+	// ceil(chars/4) estimate per direction when the provider reports none — never
+	// zero. model is carried for the per-model spend meter (ADR-0046) ONLY; the
+	// Prometheus adapter DROPS it — model is never a label (ADR-0032). direction is
+	// required because Groq prices input and output differently.
+	// (glyphoxa_voice_llm_tokens_total{provider,direction=input|output}) — WIRED by
+	// agenttool.providerAdapter after each Complete drain.
+	LLMTokens(provider Provider, model string, inputTokens, outputTokens int)
+	// TTSCharacters counts the characters (utf8 runes, not bytes) submitted to a
+	// TTS synthesizer (#127, ADR-0045): ElevenLabs bills submitted characters, so a
+	// sentence is counted on an accepted Synthesize even if a later barge cuts its
+	// audio. (glyphoxa_voice_tts_characters_total{provider}) — WIRED by the TTS
+	// stage after a successful Synthesize start.
+	TTSCharacters(provider Provider, chars int)
+	// STTAudioSeconds counts the audio duration submitted to an STT recognizer
+	// (#127, ADR-0045/0042): the batch path bills the submitted clip length, the
+	// streaming path the voiced+pre-roll duration accumulated per utterance and
+	// recorded at end-utterance regardless of commit outcome (audio sent is audio
+	// billed; a batch fallback after a failed commit truthfully double-records,
+	// since both calls billed). (glyphoxa_voice_stt_audio_seconds_total{provider})
+	// — WIRED by the STT batch stage and the StreamManager.
+	STTAudioSeconds(provider Provider, d time.Duration)
 }
 
 // Discard is the no-op StageRecorder used when none is configured, so call sites
@@ -261,6 +285,9 @@ func (Discard) LLMTurn(Provider, time.Duration)             {}
 func (Discard) ProviderCall(Stage, Provider, Outcome)       {}
 func (Discard) ProviderError(Stage, Provider)               {}
 func (Discard) TurnOutcome(TurnOutcome, TurnReason)         {}
+func (Discard) LLMTokens(Provider, string, int, int)        {}
+func (Discard) TTSCharacters(Provider, int)                 {}
+func (Discard) STTAudioSeconds(Provider, time.Duration)     {}
 
 // Static assertion that the no-op satisfies the contract.
 var _ StageRecorder = Discard{}

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -58,6 +58,9 @@ func (r *recordingStage) LLMRound(Provider, int, bool, time.Duration) {}
 func (r *recordingStage) LLMTurn(Provider, time.Duration)             {}
 func (r *recordingStage) ProviderCall(Stage, Provider, Outcome)       {}
 func (r *recordingStage) ProviderError(Stage, Provider)               {}
+func (r *recordingStage) LLMTokens(Provider, string, int, int)        {}
+func (r *recordingStage) TTSCharacters(Provider, int)                 {}
+func (r *recordingStage) STTAudioSeconds(Provider, time.Duration)     {}
 func (r *recordingStage) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"time"
+	"unicode/utf8"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
@@ -150,16 +151,25 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 	var text []byte
 	var done bool
 	var streamErr error
+	// usage/haveUsage stash the provider-reported token accounting from the additive
+	// EventUsage (#127, ADR-0045). It rides a distinct event, not EventDone, and may
+	// arrive before or after done — draining to close (as we do) captures it either
+	// way.
+	var usage llm.Usage
+	var haveUsage bool
 	for ev := range stream {
 		switch ev.Type {
 		case llm.EventText:
 			text = append(text, ev.Text...)
 			if onText != nil {
 				if err := onText(ev.Text); err != nil {
-					// Downstream cancel (barge-in): record the round we did and stop.
+					// Downstream cancel (barge-in): record the round we did and stop. A
+					// barge records the provider-reported usage IF it already arrived, never
+					// an estimate — a partial turn is not metered by guesswork (ADR-0045).
 					out.Text = string(text)
 					a.rec.LLMRound(a.provName, round, len(out.ToolCalls) > 0, time.Since(start))
 					a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
+					a.recordReportedUsage(haveUsage, usage)
 					return out, err
 				}
 			}
@@ -169,6 +179,8 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 				Name:  ev.ToolCall.Name,
 				Input: ev.ToolCall.Input,
 			})
+		case llm.EventUsage:
+			usage, haveUsage = ev.Usage, true
 		case llm.EventDone:
 			done = true
 		case llm.EventError:
@@ -176,9 +188,12 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 		}
 	}
 	if streamErr != nil {
+		// A mid-stream error records reported usage if it arrived, else nothing.
+		a.recordReportedUsage(haveUsage, usage)
 		return tool.AssistantMessage{}, streamErr
 	}
 	if !done {
+		a.recordReportedUsage(haveUsage, usage)
 		if err := ctx.Err(); err != nil {
 			return tool.AssistantMessage{}, err
 		}
@@ -189,7 +204,47 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 	hadToolCall := len(out.ToolCalls) > 0
 	a.rec.LLMRound(a.provName, round, hadToolCall, time.Since(start))
 	a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
+	// A completed round meters its tokens: the provider-reported counts, or a
+	// documented ceil(chars/4) estimate per direction when none was reported — never
+	// zero (AC, ADR-0045). An atomic counter add; it never blocks or fails the turn.
+	a.recordUsage(haveUsage, usage, messages, out.Text)
 	return out, nil
+}
+
+// recordReportedUsage records provider-reported token usage if it arrived, else
+// nothing — the error/barge rule (ADR-0045): a partial or failed turn is metered
+// only by what the provider actually reported, never by a fabricated estimate.
+func (a providerAdapter) recordReportedUsage(have bool, u llm.Usage) {
+	if have {
+		a.rec.LLMTokens(a.provName, a.model, u.InputTokens, u.OutputTokens)
+	}
+}
+
+// recordUsage meters a completed round: the provider-reported counts, or a
+// documented ceil(chars/4) estimate per direction over the sent conversation and
+// the received text when the provider reported none — never zero (AC, ADR-0045).
+// model rides only to the spend meter (ADR-0046); Prometheus drops it.
+func (a providerAdapter) recordUsage(have bool, u llm.Usage, sent []tool.Message, received string) {
+	if have {
+		a.rec.LLMTokens(a.provName, a.model, u.InputTokens, u.OutputTokens)
+		return
+	}
+	a.rec.LLMTokens(a.provName, a.model, estimateTokens(sentRunes(sent)), estimateTokens(utf8.RuneCountInString(received)))
+}
+
+// estimateTokens is the ceil(chars/4) per-direction token estimate (ADR-0045): the
+// classic ~4-characters-per-token heuristic, integer ceil for a non-negative count.
+func estimateTokens(runes int) int { return (runes + 3) / 4 }
+
+// sentRunes sums the prose runes across the sent conversation — the input side of
+// the estimate. It counts message text only (an approximation, as documented on the
+// estimate path); tool-call arguments and results are not separately weighed.
+func sentRunes(msgs []tool.Message) int {
+	total := 0
+	for _, m := range msgs {
+		total += utf8.RuneCountInString(m.Text)
+	}
+	return total
 }
 
 // Engine is the [agent.Engine] that drives the tool-use loop. Build with

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -184,6 +184,7 @@ type recordingStage struct {
 	turns        []observe.Provider // one LLMTurn span per Engine.Generate/GenerateStream
 	outcomes     []observe.Outcome  // every ProviderCall outcome, in order
 	providerErrs int                // ProviderError invocations
+	tokens       []llmTokensRec     // one LLMTokens per drained Complete (reported or estimate)
 }
 
 func (r *recordingStage) LLMRound(p observe.Provider, idx int, hadToolCall bool, _ time.Duration) {
@@ -196,6 +197,25 @@ func (r *recordingStage) LLMTurn(p observe.Provider, _ time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.turns = append(r.turns, p)
+}
+
+// llmTokensRec is one captured LLMTokens call: provider + model + the two counts.
+type llmTokensRec struct {
+	provider observe.Provider
+	model    string
+	in, out  int
+}
+
+func (r *recordingStage) LLMTokens(p observe.Provider, model string, in, out int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tokens = append(r.tokens, llmTokensRec{provider: p, model: model, in: in, out: out})
+}
+
+func (r *recordingStage) tokenSpans() []llmTokensRec {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]llmTokensRec(nil), r.tokens...)
 }
 
 func (r *recordingStage) turnSpans() []observe.Provider {
@@ -833,6 +853,146 @@ func TestEngine_StartError_ClassifiesOutcomeLikeStages(t *testing.T) {
 		}
 		if provErrs != 1 {
 			t.Errorf("provider_errors = %d on a vendor start failure, want 1", provErrs)
+		}
+	})
+}
+
+// usageProvider streams a fixed exact text (no per-word spacing) and, optionally,
+// one provider-reported EventUsage, so the #127 usage-metering tests drive both the
+// reported-usage and estimate-fallback paths deterministically. usageFirst emits
+// the usage BEFORE the text so a barge (onText error on the first delta) can see it.
+// The channel is buffered so a test that bails early (barge) never leaks the
+// producer goroutine.
+type usageProvider struct {
+	text       string
+	usage      *llm.Usage
+	usageFirst bool
+}
+
+func (p usageProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 8)
+	go func() {
+		defer close(ch)
+		emitUsage := func() {
+			if p.usage != nil {
+				ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: *p.usage}
+			}
+		}
+		if p.usageFirst {
+			emitUsage()
+		}
+		if p.text != "" {
+			ch <- llm.StreamEvent{Type: llm.EventText, Text: p.text}
+		}
+		if !p.usageFirst {
+			emitUsage()
+		}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	}()
+	return ch, nil
+}
+
+// TestEngine_Usage_RecordsProviderReportedTokensAndModel pins the #127 happy path
+// (ADR-0045): a completion that reports usage records exactly one LLMTokens with the
+// provider-reported input/output counts, labelled with the injected provider AND the
+// adapter model (the model rides to the spend meter; Prometheus drops it later).
+func TestEngine_Usage_RecordsProviderReportedTokensAndModel(t *testing.T) {
+	prov := usageProvider{text: "Aye, traveler.", usage: &llm.Usage{InputTokens: 100, OutputTokens: 50}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "claude-test-model", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Hello."}}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	toks := rec.tokenSpans()
+	if len(toks) != 1 {
+		t.Fatalf("recorded %d LLMTokens, want exactly 1", len(toks))
+	}
+	want := llmTokensRec{provider: observe.ProviderGroq, model: "claude-test-model", in: 100, out: 50}
+	if toks[0] != want {
+		t.Errorf("LLMTokens = %+v, want %+v (provider-reported counts + adapter model)", toks[0], want)
+	}
+}
+
+// TestEngine_Usage_EstimatesWhenProviderReportsNone pins the AC estimate fallback:
+// a completion with NO EventUsage (an old cassette, a gateway that omits it) records
+// a documented ceil(chars/4) estimate per direction — never zero. Sent text is the
+// one user message ("Hello." = 6 runes → 2); received text is the answer
+// ("abcdefghijkl" = 12 runes → 3).
+func TestEngine_Usage_EstimatesWhenProviderReportsNone(t *testing.T) {
+	prov := usageProvider{text: "abcdefghijkl"} // 12 runes, no usage reported
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGemini))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Hello."}}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	toks := rec.tokenSpans()
+	if len(toks) != 1 {
+		t.Fatalf("recorded %d LLMTokens, want exactly 1 (estimate, never zero)", len(toks))
+	}
+	want := llmTokensRec{provider: observe.ProviderGemini, model: "m", in: 2, out: 3}
+	if toks[0] != want {
+		t.Errorf("estimate = %+v, want %+v (ceil(6/4)=2 in, ceil(12/4)=3 out)", toks[0], want)
+	}
+}
+
+// TestEngine_Usage_StartErrorRecordsNoTokens pins that a completion that never
+// starts (a start error) records NO usage — there was no completion to meter.
+func TestEngine_Usage_StartErrorRecordsNoTokens(t *testing.T) {
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(startErrProvider{}, tool.NewGrantSet(tool.NewRegistry()), "m", 0, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
+		t.Fatal("Generate returned nil on a start failure")
+	}
+	if toks := rec.tokenSpans(); len(toks) != 0 {
+		t.Errorf("recorded %d LLMTokens on a start error, want 0", len(toks))
+	}
+}
+
+// TestEngine_Usage_BargeRecordsReportedUsageOnlyIfSeen pins the barge rule
+// (ADR-0045): a barge (onText error) records the provider-reported usage IF it
+// already arrived, otherwise nothing — a partial turn is never estimated.
+func TestEngine_Usage_BargeRecordsReportedUsageOnlyIfSeen(t *testing.T) {
+	t.Run("usage already seen → recorded", func(t *testing.T) {
+		prov := usageProvider{text: "partial answer", usage: &llm.Usage{InputTokens: 30, OutputTokens: 5}, usageFirst: true}
+		rec := &recordingStage{}
+		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+			agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+		_, err := eng.GenerateStream(context.Background(),
+			[]llm.Message{{Role: llm.RoleUser, Text: "Hello."}},
+			func(string) error { return errors.New("barge") })
+		if err == nil {
+			t.Fatal("GenerateStream returned nil on a barge")
+		}
+		toks := rec.tokenSpans()
+		want := llmTokensRec{provider: observe.ProviderGroq, model: "m", in: 30, out: 5}
+		if len(toks) != 1 || toks[0] != want {
+			t.Errorf("LLMTokens on a barge with usage seen = %+v, want one %+v (reported, not estimated)", toks, want)
+		}
+	})
+
+	t.Run("no usage yet → nothing", func(t *testing.T) {
+		prov := usageProvider{text: "partial answer"} // no usage before the barge
+		rec := &recordingStage{}
+		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+			agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+		_, err := eng.GenerateStream(context.Background(),
+			[]llm.Message{{Role: llm.RoleUser, Text: "Hello."}},
+			func(string) error { return errors.New("barge") })
+		if err == nil {
+			t.Fatal("GenerateStream returned nil on a barge")
+		}
+		if toks := rec.tokenSpans(); len(toks) != 0 {
+			t.Errorf("LLMTokens on a barge with no usage = %+v, want none (never estimate a partial turn)", toks)
 		}
 	})
 }

--- a/pkg/voice/llm/anthropic/anthropic_test.go
+++ b/pkg/voice/llm/anthropic/anthropic_test.go
@@ -126,6 +126,78 @@ func TestComplete_TextStream_AccumulatesDeltas(t *testing.T) {
 	}
 }
 
+// TestComplete_Usage_EmitsOneEventUsageBeforeDone pins the #127 usage decode
+// (ADR-0045): input_tokens is stashed from message_start, output_tokens read from
+// message_delta, and exactly one EventUsage carrying both is emitted BEFORE the
+// terminating EventDone.
+func TestComplete_Usage_EmitsOneEventUsageBeforeDone(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":25,"output_tokens":1}}}`),
+		sse(`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		sse(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`),
+		sse(`{"type":"content_block_stop","index":0}`),
+		sse(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":40}}`),
+		sse(`{"type":"message_stop"}`),
+	)
+	defer srv.Close()
+
+	c := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	events := collect(t, ch)
+	var usageIdx, doneIdx = -1, -1
+	var usageCount int
+	for i, ev := range events {
+		switch ev.Type {
+		case llm.EventUsage:
+			usageCount++
+			usageIdx = i
+			if ev.Usage.InputTokens != 25 || ev.Usage.OutputTokens != 40 {
+				t.Errorf("usage = %+v, want {InputTokens:25, OutputTokens:40}", ev.Usage)
+			}
+		case llm.EventDone:
+			doneIdx = i
+		}
+	}
+	if usageCount != 1 {
+		t.Fatalf("EventUsage count = %d, want exactly 1", usageCount)
+	}
+	if usageIdx > doneIdx {
+		t.Errorf("EventUsage index %d is after EventDone index %d; want usage before done", usageIdx, doneIdx)
+	}
+}
+
+// TestComplete_NoUsage_EmitsNoEventUsage pins that a stream without usage fields
+// (an old cassette, or a gateway that omits them) emits NO EventUsage — the
+// consumer then estimates rather than recording a spurious zero.
+func TestComplete_NoUsage_EmitsNoEventUsage(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"type":"message_start","message":{"id":"msg_1"}}`),
+		sse(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`),
+		sse(`{"type":"message_delta","delta":{"stop_reason":"end_turn"}}`),
+		sse(`{"type":"message_stop"}`),
+	)
+	defer srv.Close()
+
+	c := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	for _, ev := range collect(t, ch) {
+		if ev.Type == llm.EventUsage {
+			t.Errorf("emitted an EventUsage for a usage-free stream: %+v", ev.Usage)
+		}
+	}
+}
+
 // TestComplete_ToolUseStream_DecodesCall pins the tool-use decode (the ADR-0028
 // seam): a content_block_start naming the tool, a run of input_json_delta lines
 // accumulating the arguments, and a content_block_stop produce exactly one

--- a/pkg/voice/llm/anthropic/complete.go
+++ b/pkg/voice/llm/anthropic/complete.go
@@ -273,6 +273,11 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 	}
 	tools := map[int]*pendingTool{}
 
+	// inputTokens is stashed from message_start's usage (Anthropic reports the
+	// prompt tokens there) and combined with message_delta's output_tokens into the
+	// one EventUsage emitted before EventDone (#127, ADR-0045).
+	var inputTokens int
+
 	send := func(ev llm.StreamEvent) bool {
 		select {
 		case <-ctx.Done():
@@ -322,6 +327,11 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 		}
 
 		switch ev.Type {
+		case "message_start":
+			// Stash the prompt-token count; message_delta later carries output_tokens.
+			if ev.Message != nil && ev.Message.Usage != nil {
+				inputTokens = ev.Message.Usage.InputTokens
+			}
 		case "content_block_start":
 			if ev.ContentBlock.Type == "tool_use" {
 				tools[ev.Index] = &pendingTool{id: ev.ContentBlock.ID, name: ev.ContentBlock.Name}
@@ -358,6 +368,18 @@ func streamEvents(ctx context.Context, r io.ReadCloser, ch chan<- llm.StreamEven
 				}
 			}
 		case "message_delta":
+			// Usage rides message_delta (output_tokens); emit ONE EventUsage carrying
+			// the stashed input plus this output, BEFORE EventDone (#127, ADR-0045). A
+			// stream that omits usage (an old cassette) sends nothing here, so the
+			// consumer estimates rather than recording zero.
+			if ev.Usage != nil {
+				if !send(llm.StreamEvent{Type: llm.EventUsage, Usage: llm.Usage{
+					InputTokens:  inputTokens,
+					OutputTokens: ev.Usage.OutputTokens,
+				}}) {
+					return
+				}
+			}
 			if ev.Delta.StopReason != "" {
 				if !send(llm.StreamEvent{Type: llm.EventDone, StopReason: ev.Delta.StopReason}) {
 					return
@@ -390,4 +412,19 @@ type sseEvent struct {
 		PartialJSON string `json:"partial_json"`
 		StopReason  string `json:"stop_reason"`
 	} `json:"delta"`
+	// Message carries the prompt-token usage on message_start; Usage carries the
+	// output-token usage on message_delta (#127). Both are pointers so an absent
+	// usage object (an old cassette, a gateway that omits it) is distinguishable
+	// from a zero count — nil means "no usage reported", not "zero tokens".
+	Message *struct {
+		Usage *usageWire `json:"usage"`
+	} `json:"message"`
+	Usage *usageWire `json:"usage"`
+}
+
+// usageWire is the Anthropic usage object as it appears on message_start
+// (input_tokens) and message_delta (output_tokens).
+type usageWire struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
 }

--- a/pkg/voice/llm/gemini/gemini_test.go
+++ b/pkg/voice/llm/gemini/gemini_test.go
@@ -53,6 +53,31 @@ func captureServer(t *testing.T, capture *atomic.Value) *httptest.Server {
 	}))
 }
 
+// TestComplete_GeminiPreset_OmitsStreamOptions pins the #127 preset gate's
+// negative half (ADR-0045): the Gemini compat endpoint is not verified to honour
+// stream_options, so the preset must NOT send include_usage — a gateway that
+// rejects the field would 400 every turn. Token metering for Gemini falls back to
+// the ceil(chars/4) estimate instead.
+func TestComplete_GeminiPreset_OmitsStreamOptions(t *testing.T) {
+	var capture atomic.Value
+	srv := captureServer(t, &capture)
+	defer srv.Close()
+
+	c := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	drain(ch)
+
+	raw, _ := capture.Load().([]byte)
+	if strings.Contains(string(raw), "stream_options") {
+		t.Errorf("Gemini preset must omit stream_options (unverified endpoint); got %s", raw)
+	}
+}
+
 // TestNew_NoKey_NoEnv_CompleteReturnsMissingKeyError pins the link-time-safety
 // property shared with the anthropic and elevenlabs adapters: New must not panic
 // without an API key; the missing-key error surfaces at the first request and

--- a/pkg/voice/llm/groq/groq.go
+++ b/pkg/voice/llm/groq/groq.go
@@ -84,6 +84,9 @@ func New(apiKey string, opts ...Option) *Client {
 		openaicompat.WithBaseURL(DefaultBaseURL),
 		openaicompat.WithModel(DefaultModel),
 		openaicompat.WithDefaultMaxTokens(DefaultMaxTokens),
+		// Groq honours stream_options.include_usage, so ask for the trailing usage
+		// chunk to meter tokens (#127, ADR-0045).
+		openaicompat.WithIncludeUsage(true),
 	}
 	// Caller options come last so WithBaseURL/WithModel overrides win.
 	return openaicompat.New(append(base, opts...)...)

--- a/pkg/voice/llm/groq/groq_test.go
+++ b/pkg/voice/llm/groq/groq_test.go
@@ -135,6 +135,42 @@ func TestComplete_ModelOverride(t *testing.T) {
 	}
 }
 
+// TestComplete_GroqPreset_RequestsUsage pins the #127 preset gate: Groq honours
+// stream_options, so the preset asks for the trailing usage chunk
+// (include_usage=true on the wire) to meter tokens (ADR-0045).
+func TestComplete_GroqPreset_RequestsUsage(t *testing.T) {
+	var capture atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.Store(readBody(r))
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sse(`{"choices":[{"delta":{},"finish_reason":"stop"}]}`)))
+	}))
+	defer srv.Close()
+
+	c := groq.New("k", groq.WithBaseURL(srv.URL))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	drain(ch)
+
+	raw, _ := capture.Load().([]byte)
+	var body struct {
+		StreamOptions *struct {
+			IncludeUsage *bool `json:"include_usage"`
+		} `json:"stream_options"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("request body not JSON: %v\n%s", err, raw)
+	}
+	if body.StreamOptions == nil || body.StreamOptions.IncludeUsage == nil || !*body.StreamOptions.IncludeUsage {
+		t.Errorf("Groq preset must set stream_options.include_usage=true; got %s", raw)
+	}
+}
+
 // bodyModel extracts the "model" field from a captured request body.
 func bodyModel(t *testing.T, capture atomic.Value) string {
 	t.Helper()

--- a/pkg/voice/llm/llm.go
+++ b/pkg/voice/llm/llm.go
@@ -170,11 +170,30 @@ const (
 	// channel right after. Consumers must treat the accumulated text as
 	// truncated and fail the turn rather than present it as a complete reply.
 	EventError
+
+	// EventUsage carries the provider's token accounting for the completion in
+	// [StreamEvent.Usage] (#127, ADR-0045). It is ADDITIVE (ADR-0021): it is the
+	// last iota so old cassettes never contain it and replay is byte-for-byte
+	// unchanged; a provider that reports no usage emits none and the consumer
+	// estimates rather than recording zero. It is NOT ordered relative to
+	// [EventDone] — Anthropic reports usage just before the stop (message_delta),
+	// OpenAI-compat in a trailing chunk after it — so consumers must drain the
+	// stream to close to see it, exactly as they already must.
+	EventUsage
 )
+
+// Usage is a completion's token accounting, carried on an [EventUsage] (#127,
+// ADR-0045). InputTokens is the prompt tokens, OutputTokens the generated
+// tokens; the two are metered on separate direction series because providers
+// (Groq) price them differently.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
 
 // StreamEvent is one item in a [Provider] completion stream. The active fields
 // depend on Type: Text on [EventText], ToolCall on [EventToolCall], StopReason
-// on [EventDone].
+// on [EventDone], Usage on [EventUsage].
 type StreamEvent struct {
 	Type StreamEventType
 
@@ -190,6 +209,9 @@ type StreamEvent struct {
 	// Err is the failure description on an [EventError]. A string, not an
 	// error, so cassette recordings serialize it faithfully (ADR-0021).
 	Err string
+
+	// Usage is the token accounting on an [EventUsage].
+	Usage Usage
 }
 
 // Provider is the hot-path interface implemented by every LLM provider and by

--- a/pkg/voice/llm/openaicompat/complete.go
+++ b/pkg/voice/llm/openaicompat/complete.go
@@ -81,6 +81,12 @@ func (c *Client) Complete(ctx context.Context, req llm.Request) (<-chan llm.Stre
 	if c.reasoningEffort != "" {
 		params.ReasoningEffort = openai.ReasoningEffort(c.reasoningEffort)
 	}
+	if c.includeUsage {
+		// Ask for the trailing usage chunk (token metering, #127). Preset-gated: a
+		// gateway that rejects stream_options would 400, so only presets that verified
+		// the endpoint honours it turn this on.
+		params.StreamOptions = openai.ChatCompletionStreamOptionsParam{IncludeUsage: openai.Bool(true)}
+	}
 
 	// Non-standard body fields (e.g. Gemini's extra_body thinking_config) ride via
 	// the SDK's JSON-set escape hatch so nested values serialize verbatim.
@@ -289,6 +295,10 @@ func (c *Client) streamEvents(ctx context.Context, stream *ssestream.Stream[open
 	// and its count against maxStreamChunks — so a zero-content chunk flood trips
 	// a specific budget error here long before the transport cap.
 	var totalBytes, totalChunks int
+	// sawUsage guards against emitting more than one EventUsage (#127): only the
+	// trailing chunk carries a non-null usage, but the guard keeps the contract
+	// explicit even if a gateway repeats it.
+	var sawUsage bool
 
 	for stream.Next() {
 		if ctx.Err() != nil {
@@ -302,6 +312,20 @@ func (c *Client) streamEvents(ctx context.Context, stream *ssestream.Stream[open
 		if totalBytes += len(chunk.RawJSON()); totalBytes > maxStreamBytes {
 			fail(fmt.Sprintf("%s: response stream exceeded %d bytes", c.name, maxStreamBytes))
 			return
+		}
+		// Capture usage BEFORE the empty-choices skip below: the trailing usage chunk
+		// (include_usage) arrives with an empty choices array, so the continue guard
+		// would otherwise swallow it silently (#127, ADR-0045). All non-final chunks
+		// carry a null (zero) usage, so a non-zero prompt/completion count is the
+		// signal; emit exactly one EventUsage for it.
+		if u := chunk.Usage; !sawUsage && (u.PromptTokens != 0 || u.CompletionTokens != 0) {
+			sawUsage = true
+			if !send(llm.StreamEvent{Type: llm.EventUsage, Usage: llm.Usage{
+				InputTokens:  int(u.PromptTokens),
+				OutputTokens: int(u.CompletionTokens),
+			}}) {
+				return
+			}
 		}
 		if len(chunk.Choices) == 0 {
 			continue // usage-only or otherwise choice-less trailing chunk

--- a/pkg/voice/llm/openaicompat/openaicompat.go
+++ b/pkg/voice/llm/openaicompat/openaicompat.go
@@ -70,6 +70,12 @@ type Client struct {
 	// via the SDK's JSON-set escape hatch (e.g. Gemini's
 	// extra_body.google.thinking_config). Nil omits them.
 	extraFields map[string]any
+	// includeUsage, when true, sets stream_options.include_usage so the provider
+	// streams a trailing usage chunk for token metering (#127, ADR-0045). It is
+	// preset-gated OFF by default: a gateway that rejects stream_options would 400
+	// every turn, so a preset only turns it on for endpoints known to honour it
+	// (Groq, OpenAI); Gemini leaves it off.
+	includeUsage bool
 
 	oai openai.Client
 }
@@ -89,6 +95,7 @@ type settings struct {
 	maxTokens       int
 	reasoningEffort string
 	extraFields     map[string]any
+	includeUsage    bool
 	httpClient      *http.Client
 }
 
@@ -129,6 +136,13 @@ func WithReasoningEffort(effort string) Option {
 // WithExtraFields sets non-standard top-level request-body fields merged onto
 // every completion (e.g. Gemini's extra_body passthrough). Nil omits them.
 func WithExtraFields(f map[string]any) Option { return func(s *settings) { s.extraFields = f } }
+
+// WithIncludeUsage enables stream_options.include_usage so the provider streams a
+// trailing usage chunk for token metering (#127, ADR-0045). Off by default and
+// preset-gated: only turn it on for endpoints known to honour stream_options
+// (Groq, OpenAI). A gateway that rejects the field would 400 every turn, so
+// Gemini leaves it off until verified.
+func WithIncludeUsage(on bool) Option { return func(s *settings) { s.includeUsage = on } }
 
 // defaultHTTPClient bounds the connection-establishment phases so a black-holed
 // endpoint fails in seconds instead of hanging a turn. No overall Timeout: that
@@ -244,6 +258,7 @@ func New(opts ...Option) *Client {
 		maxTokens:       s.maxTokens,
 		reasoningEffort: s.reasoningEffort,
 		extraFields:     s.extraFields,
+		includeUsage:    s.includeUsage,
 		oai:             openai.NewClient(reqOpts...),
 	}
 }

--- a/pkg/voice/llm/openaicompat/openaicompat_test.go
+++ b/pkg/voice/llm/openaicompat/openaicompat_test.go
@@ -96,6 +96,68 @@ func captureBody(t *testing.T, req llm.Request, opts ...openaicompat.Option) []b
 	return raw
 }
 
+// TestComplete_IncludeUsage_SetsStreamOptionsOnWire pins the #127 preset gate: with
+// WithIncludeUsage the request carries stream_options.include_usage=true (so the
+// trailing usage chunk is emitted); without it the field is omitted entirely — a
+// gateway that rejects stream_options would otherwise 400 every turn (ADR-0045).
+func TestComplete_IncludeUsage_SetsStreamOptionsOnWire(t *testing.T) {
+	req := llm.Request{Messages: []llm.Message{{Role: llm.RoleUser, Text: "hi"}}}
+
+	on := captureBody(t, req, openaicompat.WithIncludeUsage(true))
+	var body struct {
+		StreamOptions *struct {
+			IncludeUsage *bool `json:"include_usage"`
+		} `json:"stream_options"`
+	}
+	if err := json.Unmarshal(on, &body); err != nil {
+		t.Fatalf("request body not JSON: %v\n%s", err, on)
+	}
+	if body.StreamOptions == nil || body.StreamOptions.IncludeUsage == nil || !*body.StreamOptions.IncludeUsage {
+		t.Errorf("with WithIncludeUsage the wire must carry stream_options.include_usage=true; got %s", on)
+	}
+
+	off := captureBody(t, req) // default: no include-usage
+	if strings.Contains(string(off), "stream_options") {
+		t.Errorf("without WithIncludeUsage the wire must omit stream_options entirely; got %s", off)
+	}
+}
+
+// TestComplete_TrailingUsageChunk_EmitsEventUsage is THE hoisted-capture regression
+// trap (#127): the final usage chunk arrives with an empty choices array. The
+// chunk loop's len(choices)==0 continue guard would silently swallow it, so usage
+// must be captured BEFORE that guard. One EventUsage with the reported tokens must
+// reach the consumer.
+func TestComplete_TrailingUsageChunk_EmitsEventUsage(t *testing.T) {
+	srv := sseServer(t, nil,
+		sse(`{"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}`),
+		sse(`{"choices":[{"delta":{},"finish_reason":"stop"}]}`),
+		// Trailing usage chunk: empty choices, non-null usage.
+		sse(`{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`),
+	)
+	defer srv.Close()
+
+	c := newClient(srv.URL, openaicompat.WithIncludeUsage(true))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Text: "Greet me."}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var usageCount int
+	for _, ev := range collect(t, ch) {
+		if ev.Type == llm.EventUsage {
+			usageCount++
+			if ev.Usage.InputTokens != 100 || ev.Usage.OutputTokens != 50 {
+				t.Errorf("usage = %+v, want {InputTokens:100, OutputTokens:50}", ev.Usage)
+			}
+		}
+	}
+	if usageCount != 1 {
+		t.Fatalf("EventUsage count = %d, want exactly 1 (the trailing empty-choices chunk must not be swallowed)", usageCount)
+	}
+}
+
 // TestNew_NoKey_CompleteReturnsMissingKeyError pins the link-time-safety property
 // shared with the anthropic and elevenlabs adapters: New must not panic without
 // an API key; the missing-key error surfaces at the first request and names both

--- a/pkg/voice/orchestrator/metrics_spy_test.go
+++ b/pkg/voice/orchestrator/metrics_spy_test.go
@@ -35,6 +35,16 @@ type metricsSpy struct {
 	vadHangs    []time.Duration
 	calls       []providerCall
 	errs        []providerErr
+
+	// #127 usage meters.
+	sttAudio []time.Duration // STTAudioSeconds durations
+	ttsChars []ttsCharsRec   // TTSCharacters (provider, chars)
+}
+
+// ttsCharsRec is one captured TTSCharacters call.
+type ttsCharsRec struct {
+	provider observe.Provider
+	chars    int
 }
 
 func (s *metricsSpy) STTRequest(p observe.Provider, _ time.Duration) {
@@ -67,6 +77,18 @@ func (s *metricsSpy) ProviderError(stage observe.Stage, p observe.Provider) {
 	s.errs = append(s.errs, providerErr{stage: stage, provider: p})
 }
 
+func (s *metricsSpy) STTAudioSeconds(_ observe.Provider, d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sttAudio = append(s.sttAudio, d)
+}
+
+func (s *metricsSpy) TTSCharacters(p observe.Provider, chars int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ttsChars = append(s.ttsChars, ttsCharsRec{provider: p, chars: chars})
+}
+
 func (s *metricsSpy) snapshot() ([]observe.Provider, []observe.Provider, []time.Duration, []providerCall, []providerErr) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -75,4 +97,18 @@ func (s *metricsSpy) snapshot() ([]observe.Provider, []observe.Provider, []time.
 		append([]time.Duration(nil), s.vadHangs...),
 		append([]providerCall(nil), s.calls...),
 		append([]providerErr(nil), s.errs...)
+}
+
+// audioSeconds returns the captured STTAudioSeconds durations.
+func (s *metricsSpy) audioSeconds() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]time.Duration(nil), s.sttAudio...)
+}
+
+// characters returns the captured TTSCharacters records.
+func (s *metricsSpy) characters() []ttsCharsRec {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]ttsCharsRec(nil), s.ttsChars...)
 }

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -162,8 +162,28 @@ func (s *STT) Transcribe(ctx context.Context, frames []audio.Frame) error {
 		}
 		return fmt.Errorf("orchestrator.STT.Transcribe: %w", err)
 	}
+	// Usage metering (#127, ADR-0045/0042): on success only, bill the submitted audio
+	// length — a failed/hung call above billed nothing. An atomic counter add; it
+	// never blocks or fails the turn.
+	s.rec.STTAudioSeconds(s.provider, framesDuration(frames))
 	s.PublishFinal(ctx, t)
 	return nil
+}
+
+// framesDuration sums the wall-clock span of frames from each Frame's FrameMs — the
+// audio length submitted to the recognizer, which the STT usage meter bills (#127,
+// ADR-0045/0042).
+func framesDuration(frames []audio.Frame) time.Duration {
+	var d time.Duration
+	for _, f := range frames {
+		d += frameDuration(f)
+	}
+	return d
+}
+
+// frameDuration is one Frame's wall-clock span (FrameMs milliseconds).
+func frameDuration(f audio.Frame) time.Duration {
+	return time.Duration(f.FrameMs()) * time.Millisecond
 }
 
 // PublishFinal fans an authoritative [stt.Transcript] out as a

--- a/pkg/voice/orchestrator/stt_test.go
+++ b/pkg/voice/orchestrator/stt_test.go
@@ -168,6 +168,55 @@ func TestSTT_Transcribe_HungRecognizerBudgetNotMultiplied(t *testing.T) {
 	}
 }
 
+// batchFrames builds n 32 ms / 16 kHz PCM frames (512 samples each) for the STT
+// audio-seconds meter tests — n*32ms of submitted audio.
+func batchFrames(t *testing.T, n int) []audio.Frame {
+	t.Helper()
+	out := make([]audio.Frame, n)
+	for i := range out {
+		f, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+		if err != nil {
+			t.Fatalf("audio.NewFrame: %v", err)
+		}
+		out[i] = f
+	}
+	return out
+}
+
+// TestSTT_Transcribe_MetersSubmittedAudioSeconds is the #127 STT AC (ADR-0045/0042):
+// a successful batch Transcribe meters the submitted audio length (N*32ms), and a
+// failed one meters nothing — only audio the recognizer actually consumed is billed.
+func TestSTT_Transcribe_MetersSubmittedAudioSeconds(t *testing.T) {
+	t.Run("success meters N*32ms", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewSTT(h.Bus, stubRecognizer{transcript: stt.Transcript{Text: "roll a d20"}},
+			orchestrator.WithSTTMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Transcribe(context.Background(), batchFrames(t, 5)); err != nil {
+			t.Fatalf("Transcribe: %v", err)
+		}
+		got := spy.audioSeconds()
+		if len(got) != 1 || got[0] != 5*32*time.Millisecond {
+			t.Errorf("stt_audio_seconds = %v, want one 160ms span (5×32ms)", got)
+		}
+	})
+
+	t.Run("failure meters nothing", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewSTT(h.Bus, errorRecognizer{},
+			orchestrator.WithSTTMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Transcribe(context.Background(), batchFrames(t, 5)); err == nil {
+			t.Fatal("Transcribe returned nil on a provider error")
+		}
+		if got := spy.audioSeconds(); len(got) != 0 {
+			t.Errorf("stt_audio_seconds on a failed transcribe = %v, want none (no audio billed)", got)
+		}
+	})
+}
+
 // stubRecognizer is a [stt.Recognizer] that returns a pinned [stt.Transcript]
 // regardless of input. Used to exercise the orchestrator stage's republish
 // contract independently of any real provider or cassette.

--- a/pkg/voice/orchestrator/sttstream.go
+++ b/pkg/voice/orchestrator/sttstream.go
@@ -62,6 +62,10 @@ type StreamManager struct {
 	utterOpen   bool   // between beginUtterance and endUtterance — partials publish only then
 	utterDead   bool   // stream was down at begin, or a send failed → this utterance is batch
 	lastPartial string // last published partial text, for consecutive-duplicate dedupe
+	// streamedDur accumulates the wall-clock duration of frames actually sent to the
+	// live session this utterance (pre-roll flush + voiced), reset at beginUtterance
+	// and metered at endUtterance (#127, ADR-0045/0042): audio sent is audio billed.
+	streamedDur time.Duration
 
 	// ring is the pre-roll buffer of the most recent idle (pre-speech) frames,
 	// streamed as context at beginUtterance. Audio-loop-only (idleFrame/beginUtterance
@@ -309,6 +313,7 @@ func (m *StreamManager) beginUtterance(at time.Time) string {
 	m.curUtterID = id
 	m.utterOpen = true
 	m.lastPartial = ""
+	m.streamedDur = 0 // reset the per-utterance billed-audio accumulator (#127)
 	s := m.stream
 	m.utterDead = s == nil
 	m.mu.Unlock()
@@ -325,8 +330,18 @@ func (m *StreamManager) beginUtterance(at time.Time) string {
 			m.streamFailed(s, err)
 			break
 		}
+		m.addStreamed(f) // pre-roll frame accepted → bill it (#127)
 	}
 	return id
+}
+
+// addStreamed adds one accepted frame's duration to the per-utterance billed-audio
+// accumulator (#127, ADR-0045/0042). Called only after a successful Send, so a frame
+// the provider rejected is never billed.
+func (m *StreamManager) addStreamed(f audio.Frame) {
+	m.mu.Lock()
+	m.streamedDur += frameDuration(f)
+	m.mu.Unlock()
 }
 
 // send streams one voiced frame to the session. On any send error the utterance is
@@ -350,7 +365,9 @@ func (m *StreamManager) send(f audio.Frame) {
 	}
 	if err := s.Send(f); err != nil {
 		m.streamFailed(s, err)
+		return
 	}
+	m.addStreamed(f) // voiced frame accepted → bill it (#127)
 }
 
 // endUtterance closes the utterance. When it streamed live to a healthy session it
@@ -362,7 +379,16 @@ func (m *StreamManager) endUtterance() (commit <-chan stt.CommitResult, sentAt t
 	m.utterOpen = false
 	dead := m.utterDead
 	s := m.stream
+	streamed := m.streamedDur
 	m.mu.Unlock()
+	// Meter the streamed audio once per utterance, regardless of the commit outcome
+	// below (#127, ADR-0045/0042): audio sent is audio billed. A pure-batch utterance
+	// streamed nothing (streamed == 0), so nothing is billed here — the batch path
+	// bills its clip; a fatal mid-utterance death bills only what streamed, and the
+	// batch fallback then bills its own clip (both calls truthfully billed).
+	if streamed > 0 {
+		m.metrics.STTAudioSeconds(m.provider, streamed)
+	}
 	if dead || s == nil {
 		return nil, time.Time{}, false
 	}

--- a/pkg/voice/orchestrator/sttstream_internal_test.go
+++ b/pkg/voice/orchestrator/sttstream_internal_test.go
@@ -107,6 +107,7 @@ type spyStage struct {
 	lastProvider observe.Provider
 	calls        []spyProviderCall
 	errs         int
+	audio        []time.Duration // #127 STTAudioSeconds durations
 }
 
 // spyProviderCall is one captured ProviderCall's bounded labels.
@@ -133,6 +134,18 @@ func (s *spyStage) ProviderError(observe.Stage, observe.Provider) {
 	s.mu.Lock()
 	s.errs++
 	s.mu.Unlock()
+}
+
+func (s *spyStage) STTAudioSeconds(_ observe.Provider, d time.Duration) {
+	s.mu.Lock()
+	s.audio = append(s.audio, d)
+	s.mu.Unlock()
+}
+
+func (s *spyStage) audioSeconds() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]time.Duration(nil), s.audio...)
 }
 
 func (s *spyStage) requests() int {
@@ -200,6 +213,87 @@ func TestStreamManager_BeginSendsPreRollThenLiveFrames(t *testing.T) {
 	}
 	if fs.commitCount() != 1 {
 		t.Errorf("Commit called %d times; want exactly 1", fs.commitCount())
+	}
+}
+
+// TestStreamManager_MetersStreamedAudioSecondsAtEndUtterance is the #127 streaming
+// AC (ADR-0045/0042): endUtterance meters the voiced+pre-roll duration accumulated
+// for the utterance — (P pre-roll + M voiced) × 32ms — recorded once per utterance,
+// regardless of the commit outcome (audio sent is audio billed).
+func TestStreamManager_MetersStreamedAudioSecondsAtEndUtterance(t *testing.T) {
+	spy := &spyStage{}
+	fs := &fakeStream{result: &stt.CommitResult{Transcript: stt.Transcript{Text: "ok"}}}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithPreRoll(2), WithStreamMetrics(spy, observe.ProviderElevenLabs))
+	m.stream = fs
+	m.bus = voiceevent.NewBus()
+
+	m.idleFrame(streamFrame(t, 1))
+	m.idleFrame(streamFrame(t, 2)) // 2 pre-roll frames
+	m.beginUtterance(time.Now())
+	m.send(streamFrame(t, 3))
+	m.send(streamFrame(t, 4))
+	m.send(streamFrame(t, 5)) // 3 voiced frames
+	if _, _, ok := m.endUtterance(); !ok {
+		t.Fatal("endUtterance ok=false on a healthy utterance")
+	}
+
+	got := spy.audioSeconds()
+	if len(got) != 1 || got[0] != 5*32*time.Millisecond {
+		t.Errorf("stt_audio_seconds = %v, want one 160ms span ((2 pre-roll + 3 voiced)×32ms)", got)
+	}
+}
+
+// TestStreamManager_MetersOnlyStreamedAudioWhenUtteranceDies pins the truthful
+// billing on a mid-utterance death (ADR-0045): only the frames the provider actually
+// accepted before the death are billed by the streaming path (the batch fallback then
+// bills its own clip — both calls billed). Here 2 pre-roll frames stream, then a fatal
+// voiced send kills the utterance, so endUtterance meters exactly 2×32ms and returns
+// the batch-fallback signal.
+func TestStreamManager_MetersOnlyStreamedAudioWhenUtteranceDies(t *testing.T) {
+	spy := &spyStage{}
+	fs := &fakeStream{}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithPreRoll(2), WithStreamMetrics(spy, observe.ProviderElevenLabs))
+	m.stream = fs
+	m.bus = voiceevent.NewBus()
+
+	m.idleFrame(streamFrame(t, 1))
+	m.idleFrame(streamFrame(t, 2))
+	m.beginUtterance(time.Now()) // 2 pre-roll frames stream OK (sendErr still nil)
+
+	// The websocket dies before the first voiced frame.
+	fs.mu.Lock()
+	fs.sendErr = &stt.StreamError{Code: stt.CodeTransport, Fatal: true, Err: errors.New("ws dead")}
+	fs.mu.Unlock()
+	m.send(streamFrame(t, 3)) // fails → utterance dead
+
+	if _, _, ok := m.endUtterance(); ok {
+		t.Fatal("endUtterance ok=true after a fatal send; want batch fallback (ok=false)")
+	}
+	got := spy.audioSeconds()
+	if len(got) != 1 || got[0] != 2*32*time.Millisecond {
+		t.Errorf("stt_audio_seconds = %v, want one 64ms span (only the 2 pre-roll frames the provider accepted)", got)
+	}
+}
+
+// TestStreamManager_PureBatchUtteranceMetersNoStreamedAudio pins that an utterance
+// that never streamed (session down at begin) bills nothing on the streaming path —
+// the batch path bills the whole clip instead (no double count when nothing streamed).
+func TestStreamManager_PureBatchUtteranceMetersNoStreamedAudio(t *testing.T) {
+	spy := &spyStage{}
+	m := NewStreamManager(&fakeStreamingRecognizer{},
+		WithPreRoll(2), WithStreamMetrics(spy, observe.ProviderElevenLabs))
+	m.bus = voiceevent.NewBus() // m.stream stays nil: session down at begin
+
+	m.idleFrame(streamFrame(t, 1))
+	m.beginUtterance(time.Now()) // pure batch: nothing streamed
+	m.send(streamFrame(t, 2))    // no-op
+	if _, _, ok := m.endUtterance(); ok {
+		t.Fatal("endUtterance ok=true with no session; want batch (ok=false)")
+	}
+	if got := spy.audioSeconds(); len(got) != 0 {
+		t.Errorf("stt_audio_seconds on a pure-batch utterance = %v, want none (batch path bills it)", got)
 	}
 }
 

--- a/pkg/voice/orchestrator/tts.go
+++ b/pkg/voice/orchestrator/tts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/retry"
@@ -159,6 +160,11 @@ func (s *TTS) Dispatch(ctx context.Context, sentence string, voice tts.Voice) er
 		}
 		return fmt.Errorf("orchestrator.TTS.Dispatch: %w", err)
 	}
+	// Usage metering (#127, ADR-0045): Synthesize accepted the request, so bill the
+	// submitted characters as utf8 runes (ElevenLabs bills submitted characters, not
+	// bytes). Counted here, before the drain, so a later barge cutting the audio still
+	// bills what was submitted. An atomic counter add; it never blocks or fails the turn.
+	s.rec.TTSCharacters(s.provider, utf8.RuneCountInString(sentence))
 	for range ch {
 	}
 	// The channel closed: record the DELIVER span and count the call OK. tts_total is

--- a/pkg/voice/orchestrator/tts_test.go
+++ b/pkg/voice/orchestrator/tts_test.go
@@ -221,6 +221,42 @@ func TestTTS_Dispatch_RecordsProviderCallOutcomes(t *testing.T) {
 	})
 }
 
+// TestTTS_Dispatch_MetersSubmittedCharacters is the #127 TTS AC (ADR-0045): a
+// successful Synthesize start meters the submitted characters counted as utf8 RUNES
+// (not bytes — ElevenLabs bills characters), even if a later barge cuts the audio; a
+// start error meters nothing. "Hällo." is 6 runes but 7 bytes (ä is two bytes).
+func TestTTS_Dispatch_MetersSubmittedCharacters(t *testing.T) {
+	t.Run("successful start meters runes", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewTTS(h.Bus, closedChanSynth{},
+			orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Dispatch(context.Background(), "Hällo.", voicetest.LiveElevenLabsVoice()); err != nil {
+			t.Fatalf("Dispatch: %v", err)
+		}
+		got := spy.characters()
+		want := ttsCharsRec{provider: observe.ProviderElevenLabs, chars: 6}
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("tts_characters = %v, want one %+v (6 runes, not 7 bytes)", got, want)
+		}
+	})
+
+	t.Run("start error meters nothing", func(t *testing.T) {
+		h := voicetest.New(t)
+		spy := &metricsSpy{}
+		stage := orchestrator.NewTTS(h.Bus, startErrSynth{},
+			orchestrator.WithTTSMetrics(spy, observe.ProviderElevenLabs))
+
+		if err := stage.Dispatch(context.Background(), "Hällo.", voicetest.LiveElevenLabsVoice()); err == nil {
+			t.Fatal("Dispatch: expected the synth start error to propagate")
+		}
+		if got := spy.characters(); len(got) != 0 {
+			t.Errorf("tts_characters on a start error = %v, want none (no submission billed)", got)
+		}
+	})
+}
+
 // TestTTS_Dispatch_KeylessRecordsNothing pins the keyless default: an option-less
 // NewTTS never nil-panics on the metric calls — the recorder defaults to
 // observe.Discard, so Dispatch works exactly as before the #125 wiring.

--- a/pkg/voice/voicebench/recorder_tap.go
+++ b/pkg/voice/voicebench/recorder_tap.go
@@ -130,5 +130,11 @@ func (t *recorderTap) STTRequest(_ observe.Provider, d time.Duration) { t.add(St
 // surviving turns, not the outcome mix, so it is a no-op here.
 func (t *recorderTap) TurnOutcome(observe.TurnOutcome, observe.TurnReason) {}
 
+// Usage meters (#127) are a spend signal, not a latency one; the bench does not
+// harvest them, so they are no-ops here (the tap records only latency stages).
+func (t *recorderTap) LLMTokens(observe.Provider, string, int, int)    {}
+func (t *recorderTap) TTSCharacters(observe.Provider, int)             {}
+func (t *recorderTap) STTAudioSeconds(observe.Provider, time.Duration) {}
+
 // compile-time assertion: the tap satisfies the recorder the orchestrator drives.
 var _ observe.StageRecorder = (*recorderTap)(nil)


### PR DESCRIPTION
Closes #127

Captures LLM token, TTS character, and STT audio-second usage into bounded-cardinality counters on the existing `/metrics` surface, per **ADR-0045** (event shape, labels, estimate fallbacks) under the ADR-0004 metering mandate and ADR-0042 STT-duration cost.

## What lands

**New series (ADR-0032 bounds — provider only, model never a label):**
- `glyphoxa_voice_llm_tokens_total{provider,direction=input|output}` — direction required (Groq prices directions differently)
- `glyphoxa_voice_tts_characters_total{provider}`
- `glyphoxa_voice_stt_audio_seconds_total{provider}`

**Usage transport:** a new additive `llm.EventUsage` stream event (last iota, so old cassettes replay byte-for-byte — ADR-0021) carrying `llm.Usage{InputTokens,OutputTokens}`. It rides a distinct event, not a mutated `EventDone`, and may arrive before the stop (Anthropic `message_delta`) or after it (OpenAI trailing chunk); consumers already drain to close.

**Adapters:**
- anthropic: stash `input_tokens` at `message_start`, emit one `EventUsage` before `EventDone`; a usage-free stream emits none.
- openaicompat: `WithIncludeUsage` sets `stream_options.include_usage`; usage captured **before** the empty-choices skip guard (the trailing usage chunk has empty choices — the swallow trap). Groq preset ON, Gemini OFF (unverified endpoint would 400 every turn).

**Capture points (inline atomic adds — never block or fail a turn):**
- agenttool: provider-reported tokens, or a documented `ceil(chars/4)` estimate per direction when none reported — never zero; start-error records nothing; barge/error records reported-only-if-seen.
- STT batch: submitted clip length on success only.
- STT streaming: accepted voiced+pre-roll duration per utterance, metered at end-utterance regardless of commit outcome (a batch fallback truthfully double-records — both calls billed).
- TTS: submitted sentence as utf8 runes after a successful start, counted even if a later barge cuts the audio.

`StageRecorder.LLMTokens` also carries the model for the future spend meter (ADR-0046); the Prometheus adapter drops it.

## Acceptance criteria
- [x] LLM token + TTS character counters advance after an NPC turn, labelled component+provider only
- [x] Exposed on `/metrics`, respect ADR-0032 bounds
- [x] No usage figure → documented estimate (not zero), covered by a test
- [x] Metering adds no hot-path latency, never blocks/fails a turn
- [x] STT audio-seconds metered (scope addition, ADR-0042/0004)

## Tests (TDD red→green)
Prometheus series + model-not-a-label; anthropic usage/no-usage; openaicompat include_usage wire + trailing-chunk capture + gemini omit; agenttool reported/estimate/start-error/barge; STT batch success+failure; STT streaming happy/mid-death/pure-batch; TTS runes+start-error.

Local: full `go test ./...` green, `go vet` clean, `golangci-lint v2.12.2 run` 0 issues, `-race` green on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)