### PR TITLE
[E6] Per-session spend cap: stop Agent turns when a session exceeds its budget (#130)

### DIFF
--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -163,6 +163,10 @@ const (
 	// ReasonBarge (human interruption), so a mute does not collapse into
 	// no_first_audio.
 	ReasonMute TurnReason = "mute"
+	// ReasonSpendCap: the session's estimated spend crossed the soft cap, so the
+	// replier refused this NEW turn before it opened (#130) — a deliberate policy
+	// stop, distinct from a fault or a barge.
+	ReasonSpendCap TurnReason = "spend_cap"
 )
 
 // StageRecorder records the orchestrator's per-stage / per-turn latency

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -315,6 +315,8 @@ func turnEndOutcome(r voiceevent.TurnEndReason) (TurnOutcome, TurnReason, string
 		return TurnAbandoned, ReasonBarge, "abandoned"
 	case voiceevent.TurnEndMute:
 		return TurnAbandoned, ReasonMute, "abandoned"
+	case voiceevent.TurnEndSpendCap:
+		return TurnAbandoned, ReasonSpendCap, "abandoned"
 	case voiceevent.TurnEndTTSError:
 		return TurnAbandoned, ReasonTTSError, "abandoned"
 	case voiceevent.TurnEndProviderError:

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -363,6 +363,7 @@ func TestStageSubscriberTurnEndedReasons(t *testing.T) {
 		{"tts_error", voiceevent.TurnEndTTSError, TurnAbandoned, ReasonTTSError},
 		{"provider_error", voiceevent.TurnEndProviderError, TurnAbandoned, ReasonProviderError},
 		{"mute", voiceevent.TurnEndMute, TurnAbandoned, ReasonMute},
+		{"spend_cap", voiceevent.TurnEndSpendCap, TurnAbandoned, ReasonSpendCap},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/observe/usage.go
+++ b/internal/observe/usage.go
@@ -1,0 +1,52 @@
+package observe
+
+import "time"
+
+// UsageSink is the narrow provider-usage surface a second consumer taps off the
+// [StageRecorder] (#130, ADR-0046): the three usage capture points #127 already
+// records (ADR-0045). The per-session spend meter (internal/spend) implements it;
+// [TeeUsage] fans the recorder's usage calls out to it alongside the Prometheus
+// adapter, so metering the spend meter costs the pipeline nothing new.
+//
+// The methods mirror [StageRecorder]'s usage trio EXACTLY (including the LLM model
+// param the Prometheus adapter drops but the spend meter prices on), so a
+// StageRecorder value satisfies UsageSink for the fan-out.
+type UsageSink interface {
+	LLMTokens(provider Provider, model string, inputTokens, outputTokens int)
+	TTSCharacters(provider Provider, chars int)
+	STTAudioSeconds(provider Provider, d time.Duration)
+}
+
+// TeeUsage returns a [StageRecorder] that forwards every call to base and ALSO
+// fans the three [UsageSink] usage methods out to sink. Non-usage methods (the
+// latency histograms, provider counters, turn outcomes) reach base ONLY — sink
+// sees usage and nothing else. base stays the authoritative production recorder;
+// the tee wraps it, never replaces it, so wiring the meter cannot drop a metric.
+//
+// It embeds base so every StageRecorder method not overridden below passes straight
+// through; only the usage trio is intercepted.
+func TeeUsage(base StageRecorder, sink UsageSink) StageRecorder {
+	return teeRecorder{StageRecorder: base, sink: sink}
+}
+
+// teeRecorder is [TeeUsage]'s value: base handles everything, and the three
+// overrides additionally forward usage to sink.
+type teeRecorder struct {
+	StageRecorder
+	sink UsageSink
+}
+
+func (t teeRecorder) LLMTokens(provider Provider, model string, inputTokens, outputTokens int) {
+	t.StageRecorder.LLMTokens(provider, model, inputTokens, outputTokens)
+	t.sink.LLMTokens(provider, model, inputTokens, outputTokens)
+}
+
+func (t teeRecorder) TTSCharacters(provider Provider, chars int) {
+	t.StageRecorder.TTSCharacters(provider, chars)
+	t.sink.TTSCharacters(provider, chars)
+}
+
+func (t teeRecorder) STTAudioSeconds(provider Provider, d time.Duration) {
+	t.StageRecorder.STTAudioSeconds(provider, d)
+	t.sink.STTAudioSeconds(provider, d)
+}

--- a/internal/observe/usage_test.go
+++ b/internal/observe/usage_test.go
@@ -1,0 +1,56 @@
+package observe
+
+import (
+	"testing"
+	"time"
+)
+
+// baseSpy is a StageRecorder that records only the calls this test cares about:
+// the usage trio (to prove they still reach base) and one non-usage method (to
+// prove non-usage calls reach base and are NOT duplicated to the sink).
+type baseSpy struct {
+	Discard
+	llm    int
+	tts    int
+	stt    int
+	rounds int
+}
+
+func (b *baseSpy) LLMTokens(Provider, string, int, int) { b.llm++ }
+func (b *baseSpy) TTSCharacters(Provider, int)          { b.tts++ }
+func (b *baseSpy) STTAudioSeconds(Provider, time.Duration) {
+	b.stt++
+}
+func (b *baseSpy) LLMRound(Provider, int, bool, time.Duration) { b.rounds++ }
+
+// sinkSpy records the usage fan-out.
+type sinkSpy struct {
+	llm, tts, stt int
+}
+
+func (s *sinkSpy) LLMTokens(Provider, string, int, int)    { s.llm++ }
+func (s *sinkSpy) TTSCharacters(Provider, int)             { s.tts++ }
+func (s *sinkSpy) STTAudioSeconds(Provider, time.Duration) { s.stt++ }
+
+// TestTeeUsageFansOutUsageOnly proves the tee forwards the three usage methods to
+// BOTH base and sink, while a non-usage method reaches base ONLY.
+func TestTeeUsageFansOutUsageOnly(t *testing.T) {
+	base := &baseSpy{}
+	sink := &sinkSpy{}
+	rec := TeeUsage(base, sink)
+
+	rec.LLMTokens(ProviderGroq, "m", 1, 2)
+	rec.TTSCharacters(ProviderElevenLabs, 10)
+	rec.STTAudioSeconds(ProviderElevenLabs, time.Second)
+	rec.LLMRound(ProviderGroq, 0, false, time.Second) // non-usage: base only
+
+	if base.llm != 1 || base.tts != 1 || base.stt != 1 {
+		t.Fatalf("base usage counts = llm:%d tts:%d stt:%d, want 1/1/1", base.llm, base.tts, base.stt)
+	}
+	if base.rounds != 1 {
+		t.Fatalf("base LLMRound = %d, want 1 (non-usage passes through)", base.rounds)
+	}
+	if sink.llm != 1 || sink.tts != 1 || sink.stt != 1 {
+		t.Fatalf("sink usage counts = llm:%d tts:%d stt:%d, want 1/1/1", sink.llm, sink.tts, sink.stt)
+	}
+}

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -42,6 +42,10 @@ type providerStore interface {
 	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
 	SaveDiscordBotToken(ctx context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (storage.DeploymentConfig, error)
 	SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error)
+	// GetTenantSpendCaps / SetTenantSpendCaps back the per-Tenant spend caps
+	// Configuration surface (#130, ADR-0046).
+	GetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID) (storage.SpendCaps, error)
+	SetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID, caps storage.SpendCaps) error
 }
 
 // byokSlot is one Bring-Your-Own-Key provider the Configuration screen saves. A
@@ -463,6 +467,69 @@ func (s *ProviderServer) ResolveGuildInvite(
 		GuildName:     resolved.Guild.Name,
 		VoiceChannels: channels,
 	}), nil
+}
+
+// GetSpendCaps returns the operator's two per-Tenant spend caps (#130, ADR-0046),
+// each absent when unset. A missing tenant row is the no-caps default (both unset),
+// not an error. A read (NO_SIDE_EFFECTS).
+func (s *ProviderServer) GetSpendCaps(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetSpendCapsRequest],
+) (*connect.Response[managementv1.GetSpendCapsResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	caps, err := s.store.GetTenantSpendCaps(ctx, tenantID)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		s.log.Error("GetSpendCaps: store read failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.GetSpendCapsResponse{Caps: toProtoSpendCaps(caps)}), nil
+}
+
+// SetSpendCaps stores the operator's two per-Tenant spend caps (#130). An omitted
+// field clears that cap; a negative value is InvalidArgument, and both-set requires
+// hard >= soft (InvalidArgument). Caps snapshot at the NEXT Voice Session start.
+func (s *ProviderServer) SetSpendCaps(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetSpendCapsRequest],
+) (*connect.Response[managementv1.SetSpendCapsResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var caps storage.SpendCaps
+	if v := req.Msg.SoftUsd; v != nil {
+		if *v < 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("soft cap must not be negative"))
+		}
+		soft := *v
+		caps.SoftUSD = &soft
+	}
+	if v := req.Msg.HardUsd; v != nil {
+		if *v < 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("hard cap must not be negative"))
+		}
+		hard := *v
+		caps.HardUSD = &hard
+	}
+	if caps.SoftUSD != nil && caps.HardUSD != nil && *caps.HardUSD < *caps.SoftUSD {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("hard cap must be greater than or equal to the soft cap"))
+	}
+
+	if err := s.store.SetTenantSpendCaps(ctx, tenantID, caps); err != nil {
+		s.log.Error("SetSpendCaps: store write failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.SetSpendCapsResponse{Caps: toProtoSpendCaps(caps)}), nil
+}
+
+// toProtoSpendCaps maps storage caps onto the wire view: a nil pointer stays absent
+// (no presence), so the screen distinguishes "unset" from "0".
+func toProtoSpendCaps(c storage.SpendCaps) *managementv1.SpendCaps {
+	return &managementv1.SpendCaps{SoftUsd: c.SoftUSD, HardUsd: c.HardUSD}
 }
 
 // resolveBotToken resolves the deployment Bot token for ResolveGuildInvite,

--- a/internal/rpc/provider_invite_test.go
+++ b/internal/rpc/provider_invite_test.go
@@ -51,6 +51,14 @@ func (f *fakeInviteStore) SaveDiscordChannels(context.Context, uuid.UUID, string
 	return storage.DeploymentConfig{}, nil
 }
 
+func (f *fakeInviteStore) GetTenantSpendCaps(context.Context, uuid.UUID) (storage.SpendCaps, error) {
+	return storage.SpendCaps{}, nil
+}
+
+func (f *fakeInviteStore) SetTenantSpendCaps(context.Context, uuid.UUID, storage.SpendCaps) error {
+	return nil
+}
+
 // savedInviteStore builds a store holding a real Bot token sealed under a fresh
 // cipher, returning both so the test decrypts the token the handler passes to
 // the seam.

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -26,6 +26,8 @@ type fakeProviderStore struct {
 	configs map[string]storage.ProviderConfig // key: component|provider
 	dep     *storage.DeploymentConfig
 	tick    int
+	caps    storage.SpendCaps // per-Tenant spend caps (#130)
+	capsSet bool
 }
 
 func newFakeProviderStore() *fakeProviderStore {
@@ -98,6 +100,19 @@ func (f *fakeProviderStore) SaveDiscordChannels(_ context.Context, tenantID uuid
 	f.dep.VoiceChannelID = voiceChannelID
 	f.dep.UpdatedAt = f.now()
 	return *f.dep, nil
+}
+
+func (f *fakeProviderStore) GetTenantSpendCaps(context.Context, uuid.UUID) (storage.SpendCaps, error) {
+	if !f.capsSet {
+		return storage.SpendCaps{}, nil
+	}
+	return f.caps, nil
+}
+
+func (f *fakeProviderStore) SetTenantSpendCaps(_ context.Context, _ uuid.UUID, caps storage.SpendCaps) error {
+	f.caps = caps
+	f.capsSet = true
+	return nil
 }
 
 func testCipher(t *testing.T) *crypto.Cipher {

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -33,6 +34,10 @@ type SessionManager interface {
 	SetAllMute(ctx context.Context, muted bool) ([]string, error)
 	// MutedAgentIDs is the reload truth (AC5): the muted set while active, nil idle.
 	MutedAgentIDs() []string
+	// Spend snapshots the active session's spend meter (#130, ADR-0046): estimated
+	// USD + cap state, the reload truth for the Session screen's spend-cap badge. The
+	// zero Status when idle or no caps are configured.
+	Spend() spend.Status
 }
 
 // SessionStore is the narrow storage surface SessionServer needs: the operator's
@@ -95,10 +100,15 @@ func (s *SessionServer) GetSession(
 	_ *connect.Request[managementv1.GetSessionRequest],
 ) (*connect.Response[managementv1.GetSessionResponse], error) {
 	if vs, active := s.mgr.Snapshot(); active {
+		// Spend-cap reload truth while live (#130): the badge reads the meter state +
+		// estimated spend the same way muted_agent_ids reads the mute set (AC5).
+		sp := s.mgr.Spend()
 		return connect.NewResponse(&managementv1.GetSessionResponse{
-			Session:       toProtoVoiceSession(vs),
-			Active:        true,
-			MutedAgentIds: s.mgr.MutedAgentIDs(), // reload truth while live (AC5)
+			Session:           toProtoVoiceSession(vs),
+			Active:            true,
+			MutedAgentIds:     s.mgr.MutedAgentIDs(), // reload truth while live (AC5)
+			SpendCapState:     string(sp.State),
+			EstimatedSpendUsd: sp.EstimatedUSD,
 		}), nil
 	}
 

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -32,6 +33,7 @@ type fakeSessionManager struct {
 	muted            map[string]struct{}
 	rosterIDs        []string // ids SetAllMute mutes (the campaign roster the real Manager lists)
 	campaignAgentIDs []string // ids SetAgentMute accepts; others → ErrAgentNotInCampaign (Manager validates now)
+	spend            spend.Status // the live meter snapshot GetSession surfaces (#130)
 }
 
 func (f *fakeSessionManager) Start(_ context.Context, _, campaignID uuid.UUID) (storage.VoiceSession, error) {
@@ -129,6 +131,12 @@ func (f *fakeSessionManager) MutedAgentIDs() []string {
 		return nil
 	}
 	return f.mutedIDsLocked()
+}
+
+func (f *fakeSessionManager) Spend() spend.Status {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.spend
 }
 
 func (f *fakeSessionManager) mutedIDsLocked() []string {

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -31,8 +31,8 @@ type fakeSessionManager struct {
 	stopErr          error
 	startCalls       int
 	muted            map[string]struct{}
-	rosterIDs        []string // ids SetAllMute mutes (the campaign roster the real Manager lists)
-	campaignAgentIDs []string // ids SetAgentMute accepts; others → ErrAgentNotInCampaign (Manager validates now)
+	rosterIDs        []string     // ids SetAllMute mutes (the campaign roster the real Manager lists)
+	campaignAgentIDs []string     // ids SetAgentMute accepts; others → ErrAgentNotInCampaign (Manager validates now)
 	spend            spend.Status // the live meter snapshot GetSession surfaces (#130)
 }
 

--- a/internal/rpc/spend_test.go
+++ b/internal/rpc/spend_test.go
@@ -1,0 +1,115 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func dptr(v float64) *float64 { return &v }
+
+// TestSpendCaps_SetGetRoundTrip pins the Set→Get round-trip: both caps set, then
+// clearing one back to unset (#130, ADR-0046). Absence (no field presence) is
+// distinct from 0.
+func TestSpendCaps_SetGetRoundTrip(t *testing.T) {
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	ctx := context.Background()
+
+	// Default: neither cap.
+	got, err := client.GetSpendCaps(ctx, connect.NewRequest(&managementv1.GetSpendCapsRequest{}))
+	if err != nil {
+		t.Fatalf("GetSpendCaps default: %v", err)
+	}
+	if got.Msg.GetCaps().SoftUsd != nil || got.Msg.GetCaps().HardUsd != nil {
+		t.Fatalf("default caps = %+v, want both absent", got.Msg.GetCaps())
+	}
+
+	// Set both.
+	set, err := client.SetSpendCaps(ctx, connect.NewRequest(&managementv1.SetSpendCapsRequest{
+		SoftUsd: dptr(5), HardUsd: dptr(10),
+	}))
+	if err != nil {
+		t.Fatalf("SetSpendCaps both: %v", err)
+	}
+	if set.Msg.GetCaps().GetSoftUsd() != 5 || set.Msg.GetCaps().GetHardUsd() != 10 {
+		t.Fatalf("set echo = %+v, want soft=5 hard=10", set.Msg.GetCaps())
+	}
+
+	got, err = client.GetSpendCaps(ctx, connect.NewRequest(&managementv1.GetSpendCapsRequest{}))
+	if err != nil {
+		t.Fatalf("GetSpendCaps after set: %v", err)
+	}
+	if got.Msg.GetCaps().GetSoftUsd() != 5 || got.Msg.GetCaps().GetHardUsd() != 10 {
+		t.Fatalf("caps after set = %+v, want soft=5 hard=10", got.Msg.GetCaps())
+	}
+
+	// Clear soft (omit it), keep hard.
+	if _, err := client.SetSpendCaps(ctx, connect.NewRequest(&managementv1.SetSpendCapsRequest{HardUsd: dptr(10)})); err != nil {
+		t.Fatalf("SetSpendCaps clear soft: %v", err)
+	}
+	got, _ = client.GetSpendCaps(ctx, connect.NewRequest(&managementv1.GetSpendCapsRequest{}))
+	if got.Msg.GetCaps().SoftUsd != nil {
+		t.Fatalf("soft after clear = %v, want absent", got.Msg.GetCaps().GetSoftUsd())
+	}
+	if got.Msg.GetCaps().GetHardUsd() != 10 {
+		t.Fatalf("hard after clearing soft = %v, want 10", got.Msg.GetCaps().GetHardUsd())
+	}
+}
+
+// TestSpendCaps_Validation pins the two InvalidArgument rules: a negative value and
+// hard < soft (#130).
+func TestSpendCaps_Validation(t *testing.T) {
+	client, _ := newProviderClient(t, newFakeProviderStore(), testCipher(t))
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		req  *managementv1.SetSpendCapsRequest
+	}{
+		{"negative soft", &managementv1.SetSpendCapsRequest{SoftUsd: dptr(-1)}},
+		{"negative hard", &managementv1.SetSpendCapsRequest{HardUsd: dptr(-0.5)}},
+		{"hard below soft", &managementv1.SetSpendCapsRequest{SoftUsd: dptr(10), HardUsd: dptr(5)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.SetSpendCaps(ctx, connect.NewRequest(tc.req))
+			if connect.CodeOf(err) != connect.CodeInvalidArgument {
+				t.Fatalf("err = %v, want InvalidArgument", err)
+			}
+		})
+	}
+
+	// Equal is allowed (hard >= soft).
+	if _, err := client.SetSpendCaps(ctx, connect.NewRequest(&managementv1.SetSpendCapsRequest{SoftUsd: dptr(5), HardUsd: dptr(5)})); err != nil {
+		t.Fatalf("hard == soft must be allowed, got %v", err)
+	}
+}
+
+// TestGetSession_CarriesSpendState pins that a live session's GetSession surfaces
+// the meter's spend-cap state + estimated spend (#130, the reload truth for the
+// Session screen badge).
+func TestGetSession_CarriesSpendState(t *testing.T) {
+	mgr := &fakeSessionManager{
+		active:  true,
+		current: storage.VoiceSession{ID: uuid.New(), Status: storage.VoiceSessionRunning},
+		spend:   spend.Status{State: spend.CapSoft, EstimatedUSD: 7.5},
+	}
+	client := newSessionClient(t, mgr, &fakeSessionStore{})
+
+	resp, err := client.GetSession(context.Background(), connect.NewRequest(&managementv1.GetSessionRequest{}))
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if resp.Msg.GetSpendCapState() != "soft" {
+		t.Fatalf("spend_cap_state = %q, want soft", resp.Msg.GetSpendCapState())
+	}
+	if resp.Msg.GetEstimatedSpendUsd() != 7.5 {
+		t.Fatalf("estimated_spend_usd = %v, want 7.5", resp.Msg.GetEstimatedSpendUsd())
+	}
+}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -779,6 +779,14 @@ func (stubProviderStore) SaveDiscordChannels(_ context.Context, _ uuid.UUID, gui
 	return storage.DeploymentConfig{GuildID: guildID, VoiceChannelID: voiceChannelID}, nil
 }
 
+func (stubProviderStore) GetTenantSpendCaps(context.Context, uuid.UUID) (storage.SpendCaps, error) {
+	return storage.SpendCaps{}, nil
+}
+
+func (stubProviderStore) SetTenantSpendCaps(context.Context, uuid.UUID, storage.SpendCaps) error {
+	return nil
+}
+
 // ptr returns a pointer to v, for proto3 optional scalar fields.
 func ptr[T any](v T) *T { return &v }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
@@ -79,6 +81,10 @@ type Store interface {
 	// ListAgents returns the Active Campaign's roster (Butler + Character NPCs) so
 	// mute-all (#211) can target EVERY Agent, not just the voiced wirenpc Roster.
 	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	// GetTenantSpendCaps returns the Tenant's soft/hard spend caps (#130, ADR-0046),
+	// snapshot at Start to build the session's spend meter. ErrNotFound (no tenant
+	// row) is treated as no caps configured — today's behavior.
+	GetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID) (storage.SpendCaps, error)
 }
 
 // TranscriptFinalizer drains the live transcript's writer queue for a session and
@@ -126,7 +132,23 @@ type activeSession struct {
 	// Agents unmuted (AC5) — there is NO DB column and NO migration; the set dies
 	// with the session. Guarded by Manager.mu.
 	muted map[string]struct{}
+
+	// meter is the session's spend meter (#130, ADR-0046), non-nil only when the
+	// Tenant configured at least one cap at Start. It is the cfg.Gate and rides the
+	// teed StageMetrics, and backs Manager.Spend(). Dies with the session.
+	meter *spend.Meter
+	// endReasonOverride records a deliberate policy end_reason for a session that
+	// ended cleanly (status 'ended') rather than by a fault — set by the hard-cap
+	// trip before it cancels the run ctx (#130). runLoop reads it under Manager.mu
+	// and stamps it onto the clean-close write. Empty for an ordinary stop.
+	endReasonOverride string
 }
+
+// spendHardReason is the end_reason a hard-cap-ended session records: an 'ended'
+// row (a deliberate policy stop, ADR-0046 — NOT 'failed', which is reserved for
+// faults) carrying WHY it stopped. Prefix 'spend_cap_hard' mirrors the classified
+// prefixes #123 uses so the Session screen renders a readable cause.
+const spendHardReason = "spend_cap_hard: estimated spend crossed the hard cap"
 
 // Manager owns at most one live voice session at a time (the single-active
 // guard). It is safe for concurrent use.
@@ -287,6 +309,15 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		return storage.VoiceSession{}, fmt.Errorf("session: create voice session: %w", err)
 	}
 
+	// Snapshot the Tenant's spend caps for this session (#130, ADR-0046): a
+	// mid-session edit applies to the NEXT session, never this one. A missing tenant
+	// row (ErrNotFound) is no caps; any other error fails Start before a row is left
+	// stuck, mirroring the deployment-config precondition above.
+	storeCaps, err := m.store.GetTenantSpendCaps(ctx, tenantID)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, fmt.Errorf("session: load spend caps: %w", err)
+	}
+
 	cfg := m.base
 	cfg.Token = token
 	cfg.Guild = dep.GuildID
@@ -302,9 +333,83 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		done:       make(chan struct{}),
 		muted:      map[string]struct{}{}, // fresh: every new session starts all-unmuted (AC5)
 	}
+
+	// Spend meter (#130, ADR-0046): only when the Tenant configured at least one
+	// cap. It rides the EXISTING recorder config copy — the tee wraps cfg's
+	// StageMetrics, so the meter reads the same usage calls #127 records with ZERO
+	// new pipeline plumbing — and is the turn gate. No caps ⇒ nil meter, no tee, no
+	// gate: byte-for-byte today's behavior.
+	if caps := (spend.Caps{SoftUSD: storeCaps.SoftUSD, HardUSD: storeCaps.HardUSD}); caps.SoftUSD != nil || caps.HardUSD != nil {
+		meter := spend.NewMeter(caps, m.log, m.softCapTrip(as), m.hardCapTrip(as))
+		base := cfg.StageMetrics
+		if base == nil {
+			base = observe.Discard{}
+		}
+		cfg.StageMetrics = observe.TeeUsage(base, meter)
+		cfg.Gate = meter
+		as.meter = meter
+	}
+
 	m.active = as
 	go m.runLoop(runCtx, as, cfg)
 	return vs, nil
+}
+
+// softCapTrip returns the meter's onSoft callback for session as: publish
+// SpendCapReached{soft} on the shared bus (#130). The soft cap refuses NEW turns at
+// the replier gate (the meter's AllowTurn already reports false by the time this
+// fires); this callback only surfaces the state to the Session screen. It runs on
+// the pipeline goroutine that recorded the crossing usage, never under Manager.mu,
+// so publishing (the relay takes its own lock) can't deadlock.
+func (m *Manager) softCapTrip(as *activeSession) func() {
+	return func() {
+		if m.base.Bus != nil {
+			m.base.Bus.Publish(voiceevent.SpendCapReached{At: time.Now(), Level: voiceevent.SpendCapSoft})
+		}
+	}
+}
+
+// hardCapTrip returns the meter's onHard callback for session as: end the session
+// itself cleanly (#130, ADR-0046). It runs on a FRESH goroutine (the #211
+// lock-order pattern): the meter fires it outside its own mutex, but it must take
+// Manager.mu to record the deliberate end_reason override, then publish + cancel
+// OUTSIDE Manager.mu — the relay's SpendCapReached handler calls Snapshot (Manager.mu),
+// so publishing under the lock would deadlock. Guarded by m.active == as so a trip
+// arriving after the session already rolled over is a no-op.
+func (m *Manager) hardCapTrip(as *activeSession) func() {
+	return func() {
+		go func() {
+			m.mu.Lock()
+			if m.active != as {
+				m.mu.Unlock()
+				return // this session already ended / rolled over
+			}
+			as.endReasonOverride = spendHardReason
+			cancel := as.cancel
+			bus := m.base.Bus
+			m.mu.Unlock()
+
+			if bus != nil {
+				bus.Publish(voiceevent.SpendCapReached{At: time.Now(), Level: voiceevent.SpendCapHard})
+			}
+			// Cancel the run ctx: runLoop then closes the row via the CLEAN path
+			// (ctx.Err() != nil ⇒ not 'failed') and stamps the endReasonOverride —
+			// 'ended' + spend_cap_hard reason, a deliberate policy stop.
+			cancel()
+		}()
+	}
+}
+
+// Spend returns a snapshot of the active session's spend meter (#130): estimated
+// USD, cap state, and configured caps. Idle, or a session with no caps configured,
+// reports the zero Status (no state, zero spend) — the feature-off surface.
+func (m *Manager) Spend() spend.Status {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil || m.active.meter == nil {
+		return spend.Status{}
+	}
+	return m.active.meter.Status()
 }
 
 // runLoop runs the voice loop to completion (cancel or self-exit), then writes
@@ -360,15 +465,28 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		chunkCancel()
 	}
 
+	// A hard-cap trip records a deliberate end_reason override before it cancels the
+	// run ctx (#130): the cancel makes ctx.Err() non-nil, so the clean path below
+	// runs (status 'ended', NOT 'failed' — a policy stop is not a fault, ADR-0046),
+	// but the row still records WHY it stopped. Read under Manager.mu (the trip
+	// writes it there) so the race detector sees the synchronization.
+	m.mu.Lock()
+	override := as.endReasonOverride
+	m.mu.Unlock()
+
 	// A FRESH deadline for the terminal write, regardless of what Finalize consumed
 	// (#143): the row landing terminal is the invariant that matters. One
-	// CloseVoiceSession stamps 'failed' + the readable reason, or 'ended' + NULL for
-	// a clean stop — the single write preserves #143's end-write atomicity.
+	// CloseVoiceSession stamps 'failed' + the readable reason, 'ended' + the policy
+	// override reason (hard cap), or 'ended' + NULL for a clean stop — the single
+	// write preserves #143's end-write atomicity.
 	status := storage.VoiceSessionEnded
 	var endReason *string
 	if failed {
 		status = storage.VoiceSessionFailed
 		reason := failureReason(loopErr)
+		endReason = &reason
+	} else if override != "" {
+		reason := override
 		endReason = &reason
 	}
 	endCtx, cancel := context.WithTimeout(base, m.endTimeout)

--- a/internal/session/manager_spend_test.go
+++ b/internal/session/manager_spend_test.go
@@ -1,0 +1,271 @@
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+func fp(v float64) *float64 { return &v }
+
+// reRunner is a LoopRunner safe to invoke more than once (the hard-cap test starts
+// a second session after the first self-ends): it signals the first run via
+// started (once), captures each run's cfg, and blocks every run until its ctx is
+// cancelled.
+type reRunner struct {
+	started chan struct{}
+	once    sync.Once
+	mu      sync.Mutex
+	gotCfg  wirenpc.Config
+	cancels int
+}
+
+func newReRunner() *reRunner { return &reRunner{started: make(chan struct{})} }
+
+func (r *reRunner) run(ctx context.Context, cfg wirenpc.Config) error {
+	r.mu.Lock()
+	r.gotCfg = cfg
+	r.mu.Unlock()
+	r.once.Do(func() { close(r.started) })
+	<-ctx.Done()
+	r.mu.Lock()
+	r.cancels++
+	r.mu.Unlock()
+	return ctx.Err()
+}
+
+func (r *reRunner) cfg() wirenpc.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gotCfg
+}
+
+func (r *reRunner) wasCancelled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cancels > 0
+}
+
+// usageSpy is a StageRecorder that counts the LLMTokens fan-out, so a test can
+// prove the meter TEE wraps (does not replace) the base production recorder.
+type usageSpy struct {
+	observe.Discard
+	mu  sync.Mutex
+	llm int
+}
+
+func (s *usageSpy) LLMTokens(observe.Provider, string, int, int) {
+	s.mu.Lock()
+	s.llm++
+	s.mu.Unlock()
+}
+
+func (s *usageSpy) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.llm
+}
+
+// spendManager builds a Manager whose base config carries a bus + the usage spy,
+// so the spend tests can drive usage through the captured cfg and observe both the
+// meter and the passed-through base recorder.
+func spendManager(t *testing.T, store session.Store, run session.LoopRunner, bus *voiceevent.Bus, spy observe.StageRecorder) *session.Manager {
+	t.Helper()
+	return session.NewManager(store, run,
+		wirenpc.Config{Token: "test-token", Bus: bus, StageMetrics: spy}, nil,
+		slog.New(slog.DiscardHandler), true)
+}
+
+// collectSpendCaps subscribes a collector for SpendCapReached events on bus.
+func collectSpendCaps(bus *voiceevent.Bus) (get func() []voiceevent.SpendCapReached) {
+	var mu sync.Mutex
+	var got []voiceevent.SpendCapReached
+	voiceevent.On(bus, func(e voiceevent.SpendCapReached) {
+		mu.Lock()
+		got = append(got, e)
+		mu.Unlock()
+	})
+	return func() []voiceevent.SpendCapReached {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]voiceevent.SpendCapReached(nil), got...)
+	}
+}
+
+// bigGroqLLM drives one large priced LLM usage call through rec (1M+1M groq tokens
+// ≈ $1.38), enough to cross a sub-dollar cap in one or two calls.
+func bigGroqLLM(rec observe.StageRecorder) {
+	rec.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+}
+
+// TestStart_NoCaps_ByteForByteToday pins the feature-off default: with neither cap
+// set the session gets NO gate and its StageMetrics is the base recorder untouched
+// — today's behavior. Spend() reports the zero Status.
+func TestStart_NoCaps_ByteForByteToday(t *testing.T) {
+	store := newFakeStore() // default caps: both nil
+	runner := newReRunner()
+	spy := &usageSpy{}
+	mgr := spendManager(t, store, runner.run, voiceevent.NewBus(), spy)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-runner.started
+	cfg := runner.cfg()
+
+	if cfg.Gate != nil {
+		t.Fatal("no caps configured: cfg.Gate must be nil (feature off)")
+	}
+	if cfg.StageMetrics != observe.StageRecorder(spy) {
+		t.Fatal("no caps configured: cfg.StageMetrics must be the base recorder, untouched (no tee)")
+	}
+	if s := mgr.Spend(); s.State != spend.CapNone || s.EstimatedUSD != 0 {
+		t.Fatalf("Spend() with no caps = %+v, want zero Status", s)
+	}
+	mgr.Shutdown()
+}
+
+// TestStart_WithCaps_GatesAndTees pins step 7: a configured cap gives the session a
+// gate AND a teed recorder; driving a usage call crosses the soft cap, so the gate
+// refuses new turns, the base recorder still saw the call (tee, not replace), and
+// Spend() reflects the same accumulator.
+func TestStart_WithCaps_GatesAndTees(t *testing.T) {
+	store := newFakeStore()
+	store.caps = storage.SpendCaps{SoftUSD: fp(1.0)} // soft-only
+	runner := newReRunner()
+	spy := &usageSpy{}
+	mgr := spendManager(t, store, runner.run, voiceevent.NewBus(), spy)
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-runner.started
+	cfg := runner.cfg()
+
+	if cfg.Gate == nil {
+		t.Fatal("a configured cap must give the session a turn gate")
+	}
+	if cfg.Gate.AllowTurn() != true {
+		t.Fatal("gate must allow turns before any spend")
+	}
+
+	// Drive usage through the SESSION recorder (as the pipeline would): the tee
+	// forwards to both the base spy and the meter.
+	bigGroqLLM(cfg.StageMetrics)
+
+	if cfg.Gate.AllowTurn() != false {
+		t.Fatal("gate must refuse new turns after crossing the soft cap")
+	}
+	if spy.count() != 1 {
+		t.Fatalf("base recorder LLMTokens count = %d, want 1 (tee must wrap, not replace, the base)", spy.count())
+	}
+	if s := mgr.Spend(); s.State != spend.CapSoft || s.EstimatedUSD <= 0 {
+		t.Fatalf("Spend() after crossing soft = %+v, want soft state + positive estimate", s)
+	}
+	mgr.Shutdown()
+}
+
+// TestSoftCap_SessionKeepsRunning pins step 9: crossing the soft cap publishes
+// SpendCapReached{soft}, but the session stays live (soft never ends it) and
+// Spend() reports the soft state.
+func TestSoftCap_SessionKeepsRunning(t *testing.T) {
+	store := newFakeStore()
+	store.caps = storage.SpendCaps{SoftUSD: fp(1.0)}
+	runner := newReRunner()
+	bus := voiceevent.NewBus()
+	events := collectSpendCaps(bus)
+	mgr := spendManager(t, store, runner.run, bus, &usageSpy{})
+
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-runner.started
+	bigGroqLLM(runner.cfg().StageMetrics)
+
+	evs := events()
+	if len(evs) != 1 || evs[0].Level != voiceevent.SpendCapSoft {
+		t.Fatalf("published spend-cap events = %+v, want one soft", evs)
+	}
+	if _, active := mgr.Snapshot(); !active {
+		t.Fatal("soft cap must NOT end the session")
+	}
+	if runner.wasCancelled() {
+		t.Fatal("soft cap must not cancel the run ctx")
+	}
+	if s := mgr.Spend(); s.State != spend.CapSoft {
+		t.Fatalf("Spend().State = %q, want soft", s.State)
+	}
+	mgr.Shutdown()
+}
+
+// TestHardCap_EndsSessionCleanly pins step 8: crossing the hard cap cancels the run
+// ctx, closes the row with status ENDED (a policy stop, not failed) + the
+// spend_cap_hard reason, publishes SpendCapReached{hard} while the session is still
+// active, frees the single-active guard, and lets the next Start succeed.
+func TestHardCap_EndsSessionCleanly(t *testing.T) {
+	store := newFakeStore()
+	store.caps = storage.SpendCaps{HardUSD: fp(1.0)}
+	runner := newReRunner()
+	bus := voiceevent.NewBus()
+	events := collectSpendCaps(bus)
+	mgr := spendManager(t, store, runner.run, bus, &usageSpy{})
+
+	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-runner.started
+
+	// Cross the hard cap through the session recorder — this fires onHard.
+	bigGroqLLM(runner.cfg().StageMetrics)
+
+	// The hard-cap trip cancels the run ctx on a goroutine; wait for the session to
+	// end (the guard frees).
+	waitInactive(t, mgr)
+
+	// The row closed ENDED (not failed) with the spend_cap_hard reason.
+	closed := store.session(vs.ID)
+	if closed.Status != storage.VoiceSessionEnded {
+		t.Fatalf("hard-cap row status = %q, want ended (a policy stop is not a fault)", closed.Status)
+	}
+	if closed.EndReason == nil || *closed.EndReason != "spend_cap_hard: estimated spend crossed the hard cap" {
+		t.Fatalf("hard-cap end_reason = %v, want the spend_cap_hard reason", closed.EndReason)
+	}
+	if evs := events(); len(evs) != 1 || evs[0].Level != voiceevent.SpendCapHard {
+		t.Fatalf("published spend-cap events = %+v, want one hard", evs)
+	}
+	if !runner.wasCancelled() {
+		t.Fatal("hard cap must cancel the run ctx")
+	}
+
+	// Guard freed: the SAME manager accepts a new Start (the reRunner tolerates the
+	// second run without re-signalling started).
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("second Start after hard-cap end must succeed, got %v", err)
+	}
+	mgr.Shutdown()
+}
+
+// waitInactive polls until the manager reports no active session, or fails.
+func waitInactive(t *testing.T, mgr *session.Manager) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, active := mgr.Snapshot(); !active {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("session did not end within the deadline after the hard cap")
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -34,6 +34,8 @@ type fakeStore struct {
 	tick       int
 	endErr     error           // injected EndVoiceSession failure (#143 Defect A)
 	agents     []storage.Agent // the Active Campaign's roster for ListAgents (#211 mute-all)
+	caps       storage.SpendCaps
+	capsErr    error // injected GetTenantSpendCaps failure (#130)
 }
 
 func newFakeStore() *fakeStore {
@@ -132,10 +134,29 @@ func (f *fakeStore) ListAgents(_ context.Context, _ uuid.UUID) ([]storage.Agent,
 	return append([]storage.Agent(nil), f.agents...), nil
 }
 
+// GetTenantSpendCaps serves the canned per-Tenant spend caps snapshot at Start
+// (#130). Default: both nil (no caps → today's behavior).
+func (f *fakeStore) GetTenantSpendCaps(_ context.Context, _ uuid.UUID) (storage.SpendCaps, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.capsErr != nil {
+		return storage.SpendCaps{}, f.capsErr
+	}
+	return f.caps, nil
+}
+
 func (f *fakeStore) counts() (created, ended int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.created, f.ended
+}
+
+// session returns the recorded voice_sessions row by id (the terminal state after
+// a close), for the spend-cap end-reason assertions (#130).
+func (f *fakeStore) session(id uuid.UUID) storage.VoiceSession {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sessions[id]
 }
 
 // blockingRunner is a fake loop runner that records the cfg it ran with and the

--- a/internal/spend/meter.go
+++ b/internal/spend/meter.go
@@ -1,0 +1,201 @@
+// Package spend is the per-Voice-Session spend meter (#130, ADR-0046): a small
+// in-memory accumulator that estimates a session's provider cost from the same
+// usage capture points #127 already records ([observe.UsageSink]) and enforces two
+// independently opt-in per-Tenant caps.
+//
+// It deliberately holds session-local state, NOT a Prometheus series: ADR-0032
+// forbids per-session metric labels, and the cap needs an authoritative running
+// total, not a sampled counter. The [Meter] is teed alongside the production
+// StageRecorder ([observe.TeeUsage]) so recording usage is unchanged; the meter is
+// the second reader.
+//
+// Every USD figure it produces is an ESTIMATE (see prices.go): plausible enough to
+// enforce an operator cap, never a billed amount.
+package spend
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// Caps are the two independently opt-in per-Tenant thresholds (USD). Either may be
+// nil (that cap is off). When both are set the RPC enforces HardUSD >= SoftUSD;
+// neither set means the meter never gates (today's behavior).
+type Caps struct {
+	SoftUSD *float64
+	HardUSD *float64
+}
+
+// CapState is which cap (if any) a session has crossed.
+type CapState string
+
+const (
+	// CapNone: under every configured cap (or no caps) — turns proceed normally.
+	CapNone CapState = ""
+	// CapSoft: the soft cap is crossed — the replier refuses NEW turns, in-flight
+	// turns finish, transcription continues, the Session screen shows the state.
+	CapSoft CapState = "soft"
+	// CapHard: the hard cap is crossed — the session ends itself cleanly (a
+	// deliberate policy stop, ADR-0046). Terminal; supersedes soft.
+	CapHard CapState = "hard"
+)
+
+// Status is a snapshot of the meter for the RPC / Session screen. EstimatedUSD is
+// labelled an estimate everywhere it surfaces.
+type Status struct {
+	EstimatedUSD float64
+	State        CapState
+	Caps         Caps
+}
+
+// Meter accumulates a Voice Session's estimated spend and evaluates the soft/hard
+// caps. It implements [observe.UsageSink] so it can be teed alongside the
+// production recorder. ONE mutex guards the running total, the state, and the
+// warn-dedup set: the arithmetic plus a threshold-callback decision under one small
+// lock is simpler to reason about than a lock-free scheme, and the hot path (a few
+// float adds per turn) is nowhere near contended.
+type Meter struct {
+	log    *slog.Logger
+	onSoft func()
+	onHard func()
+
+	mu       sync.Mutex
+	totalUSD float64
+	state    CapState
+	caps     Caps
+	warned   map[string]struct{} // price keys already warned-about (dedup)
+
+	// Each callback fires at most once for the session's life. Belt-and-suspenders
+	// with the state guard, and matches the ADR-0046 contract; the Do runs OUTSIDE
+	// the mutex so a callback (which may publish an event or spawn a goroutine)
+	// never runs under the accumulator lock.
+	softOnce sync.Once
+	hardOnce sync.Once
+}
+
+// NewMeter builds a meter for caps. log receives the unknown-price warn-once (nil
+// discards). onSoft/onHard are the cap-crossed callbacks (nil is a no-op); each
+// fires at most once, outside the mutex, and MUST NOT block — the session Manager
+// wires them to a bus publish and a context cancel.
+func NewMeter(caps Caps, log *slog.Logger, onSoft, onHard func()) *Meter {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	if onSoft == nil {
+		onSoft = func() {}
+	}
+	if onHard == nil {
+		onHard = func() {}
+	}
+	return &Meter{
+		log:    log,
+		onSoft: onSoft,
+		onHard: onHard,
+		caps:   caps,
+		warned: map[string]struct{}{},
+	}
+}
+
+// LLMTokens folds one completion's estimated token cost into the accumulator
+// (implements [observe.UsageSink]). An unknown (provider, model) uses the
+// conservative default and warns once.
+func (m *Meter) LLMTokens(provider observe.Provider, model string, inputTokens, outputTokens int) {
+	usd, known := llmCostUSD(provider, model, inputTokens, outputTokens)
+	if !known {
+		m.warnUnknown("llm", string(provider), model)
+	}
+	m.add(usd)
+}
+
+// TTSCharacters folds one synthesis's estimated character cost into the
+// accumulator (implements [observe.UsageSink]).
+func (m *Meter) TTSCharacters(provider observe.Provider, chars int) {
+	usd, known := ttsCostUSD(provider, chars)
+	if !known {
+		m.warnUnknown("tts", string(provider), "")
+	}
+	m.add(usd)
+}
+
+// STTAudioSeconds folds one recognition's estimated audio-duration cost into the
+// accumulator (implements [observe.UsageSink]).
+func (m *Meter) STTAudioSeconds(provider observe.Provider, d time.Duration) {
+	usd, known := sttCostUSD(provider, d)
+	if !known {
+		m.warnUnknown("stt", string(provider), "")
+	}
+	m.add(usd)
+}
+
+// AllowTurn reports whether a NEW Agent turn may start: true only while no cap is
+// crossed. Spend is monotonic, so this is a single authoritative pre-check — once
+// false it never returns true again for the session.
+func (m *Meter) AllowTurn() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state == CapNone
+}
+
+// Status returns the estimated spend, cap state, and configured caps.
+func (m *Meter) Status() Status {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return Status{EstimatedUSD: m.totalUSD, State: m.state, Caps: m.caps}
+}
+
+// add records usd against the total, evaluates the caps under the lock, then fires
+// any newly-due callback OUTSIDE the lock (each at most once).
+func (m *Meter) add(usd float64) {
+	m.mu.Lock()
+	m.totalUSD += usd
+	fireSoft, fireHard := m.evalLocked()
+	m.mu.Unlock()
+
+	// Fire outside the mutex; the callbacks must never block or re-enter the meter.
+	if fireHard {
+		m.hardOnce.Do(m.onHard)
+	}
+	if fireSoft {
+		m.softOnce.Do(m.onSoft)
+	}
+}
+
+// evalLocked advances the cap state at most one level per call and reports which
+// callback newly became due. Hard supersedes soft: a single add that jumps past
+// both caps transitions straight to hard and fires only onHard (the session ends
+// immediately, so the soft badge would be moot). Caller holds m.mu.
+func (m *Meter) evalLocked() (fireSoft, fireHard bool) {
+	switch {
+	case m.caps.HardUSD != nil && m.totalUSD >= *m.caps.HardUSD && m.state != CapHard:
+		m.state = CapHard
+		return false, true
+	case m.caps.SoftUSD != nil && m.totalUSD >= *m.caps.SoftUSD && m.state == CapNone:
+		m.state = CapSoft
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+// warnUnknown logs the conservative-default fallback for an unpriced key exactly
+// once per distinct (component, provider, model), so a live run with an unpriced
+// model does not flood the log every turn.
+func (m *Meter) warnUnknown(component, provider, model string) {
+	key := component + "\x00" + provider + "\x00" + model
+	m.mu.Lock()
+	_, seen := m.warned[key]
+	if !seen {
+		m.warned[key] = struct{}{}
+	}
+	m.mu.Unlock()
+	if seen {
+		return
+	}
+	m.log.Warn("spend: no price for provider/model; using a conservative estimate default (ADR-0046)",
+		"component", component, "provider", provider, "model", model)
+}
+
+var _ observe.UsageSink = (*Meter)(nil)

--- a/internal/spend/meter_test.go
+++ b/internal/spend/meter_test.go
@@ -1,0 +1,152 @@
+package spend
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+func f64(v float64) *float64 { return &v }
+
+// approx compares two USD figures with a cent-scale tolerance so floating point
+// accumulation never fails an otherwise-correct expectation.
+func approx(t *testing.T, got, want float64) {
+	t.Helper()
+	if diff := got - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("estimated USD = %.12f, want %.12f", got, want)
+	}
+}
+
+// TestMeterKnownLLMPrice pins the known (groq, llama-3.3-70b-versatile) rate: the
+// estimate is the per-direction token count times the code-const per-1M rate.
+func TestMeterKnownLLMPrice(t *testing.T) {
+	m := NewMeter(Caps{}, nil, nil, nil)
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+	want := llmPrices[llmKey{observe.ProviderGroq, "llama-3.3-70b-versatile"}]
+	approx(t, m.Status().EstimatedUSD, want.inputPerMTok+want.outputPerMTok)
+}
+
+// TestMeterUnknownModelWarnsOnce uses a model with no price entry: it falls back
+// to the conservative default AND logs exactly one warning even across repeats.
+func TestMeterUnknownModelWarnsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	m := NewMeter(Caps{}, log, nil, nil)
+
+	m.LLMTokens(observe.ProviderGroq, "mystery-model", 1_000_000, 0)
+	m.LLMTokens(observe.ProviderGroq, "mystery-model", 1_000_000, 0)
+
+	// Conservative default rate applied twice (input only).
+	approx(t, m.Status().EstimatedUSD, 2*defaultLLMInputPerMTok)
+
+	if n := strings.Count(buf.String(), "no price"); n != 1 {
+		t.Fatalf("unknown-model warnings = %d, want exactly 1\nlog:\n%s", n, buf.String())
+	}
+}
+
+// TestMeterTTSAndSTTAccumulate proves the TTS-character and STT-audio-second
+// capture points both fold into the same accumulator.
+func TestMeterTTSAndSTTAccumulate(t *testing.T) {
+	m := NewMeter(Caps{}, nil, nil, nil)
+	m.TTSCharacters(observe.ProviderElevenLabs, 1000)
+	m.STTAudioSeconds(observe.ProviderElevenLabs, time.Hour)
+	want := ttsPricePer1kChars[observe.ProviderElevenLabs] + sttPricePerHour[observe.ProviderElevenLabs]
+	approx(t, m.Status().EstimatedUSD, want)
+}
+
+// TestMeterSoftCapTripsOnce: a soft-only cap flips state to soft, fires onSoft
+// exactly once, and refuses new turns thereafter — in-flight semantics live at
+// the replier, the meter only reports the gate.
+func TestMeterSoftCapTripsOnce(t *testing.T) {
+	var softN, hardN int
+	m := NewMeter(Caps{SoftUSD: f64(1.0)}, nil, func() { softN++ }, func() { hardN++ })
+
+	if !m.AllowTurn() {
+		t.Fatal("AllowTurn false before any spend")
+	}
+	// Cross the soft cap with an STT second priced above $1 via the default? Use a
+	// known priced call sized to cross 1 USD: 1M+1M groq tokens > $1.
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+
+	if m.AllowTurn() {
+		t.Fatal("AllowTurn true after crossing the soft cap")
+	}
+	if got := m.Status().State; got != CapSoft {
+		t.Fatalf("state = %q, want soft", got)
+	}
+	if softN != 1 {
+		t.Fatalf("onSoft fired %d times, want 1", softN)
+	}
+	if hardN != 0 {
+		t.Fatalf("onHard fired %d times, want 0 (no hard cap set)", hardN)
+	}
+}
+
+// TestMeterHardCapTripsOnce: a hard-only cap flips state to hard and fires onHard
+// once.
+func TestMeterHardCapTripsOnce(t *testing.T) {
+	var softN, hardN int
+	m := NewMeter(Caps{HardUSD: f64(0.5)}, nil, func() { softN++ }, func() { hardN++ })
+
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+	// Idempotent: further spend does not re-fire.
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000)
+
+	if m.AllowTurn() {
+		t.Fatal("AllowTurn true after crossing the hard cap")
+	}
+	if got := m.Status().State; got != CapHard {
+		t.Fatalf("state = %q, want hard", got)
+	}
+	if hardN != 1 {
+		t.Fatalf("onHard fired %d times, want 1", hardN)
+	}
+	if softN != 0 {
+		t.Fatalf("onSoft fired %d times, want 0 (no soft cap set)", softN)
+	}
+}
+
+// TestMeterBothCapsGradual: soft then hard fire in order as spend climbs past each.
+func TestMeterBothCapsGradual(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	rec := func(s string) func() { return func() { mu.Lock(); order = append(order, s); mu.Unlock() } }
+	m := NewMeter(Caps{SoftUSD: f64(1.0), HardUSD: f64(2.5)}, nil, rec("soft"), rec("hard"))
+
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000) // ~1.38
+	if got := m.Status().State; got != CapSoft {
+		t.Fatalf("after first add state = %q, want soft", got)
+	}
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 1_000_000, 1_000_000) // ~2.76 > 2.5
+	if got := m.Status().State; got != CapHard {
+		t.Fatalf("after second add state = %q, want hard", got)
+	}
+	if strings.Join(order, ",") != "soft,hard" {
+		t.Fatalf("callback order = %v, want [soft hard]", order)
+	}
+}
+
+// TestMeterNoCapsNeverTrips: with neither cap set the meter accumulates but never
+// gates or fires — today's behavior.
+func TestMeterNoCapsNeverTrips(t *testing.T) {
+	var fired int
+	m := NewMeter(Caps{}, nil, func() { fired++ }, func() { fired++ })
+	m.LLMTokens(observe.ProviderGroq, "llama-3.3-70b-versatile", 10_000_000, 10_000_000)
+	if !m.AllowTurn() {
+		t.Fatal("AllowTurn false with no caps set")
+	}
+	if m.Status().State != CapNone {
+		t.Fatalf("state = %q, want none", m.Status().State)
+	}
+	if fired != 0 {
+		t.Fatalf("callbacks fired %d times with no caps, want 0", fired)
+	}
+}
+
+var _ observe.UsageSink = (*Meter)(nil)

--- a/internal/spend/prices.go
+++ b/internal/spend/prices.go
@@ -1,0 +1,99 @@
+package spend
+
+import (
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// Prices for the per-session spend meter (ADR-0046). EVERY figure here is an
+// ESTIMATE, not a billed amount: vendor pricing is plan/tier/region dependent and
+// changes without notice, so these code constants only approximate the true cost.
+// They exist to answer "roughly how much has this Voice Session spent" well enough
+// to enforce an operator-set cap — never to reconcile an invoice. A DB/config
+// price surface is deferred until someone needs to edit prices without a deploy.
+//
+// Keyed by (component, provider, model) where the model actually distinguishes a
+// price (LLM); TTS and STT are keyed by provider alone because their usage capture
+// points (ADR-0045) carry no model. An unknown key falls back to a deliberately
+// CONSERVATIVE (high) default so a missing entry over-estimates — a cap trips
+// early rather than letting an unpriced provider run unbounded — plus a warn-once.
+
+// llmKey identifies an LLM price row: Groq prices input and output tokens
+// differently, and different models carry different rates.
+type llmKey struct {
+	provider observe.Provider
+	model    string
+}
+
+// llmRate is a per-1,000,000-token price split by direction (USD).
+type llmRate struct {
+	inputPerMTok  float64
+	outputPerMTok float64
+}
+
+// llmPrices are the known per-1M-token LLM rates. ESTIMATES.
+var llmPrices = map[llmKey]llmRate{
+	// Groq Llama 3.3 70B Versatile — Groq public API pricing, captured 2026-07-07:
+	// $0.59 / 1M input tokens, $0.79 / 1M output tokens. ESTIMATE (tier-dependent).
+	{observe.ProviderGroq, "llama-3.3-70b-versatile"}: {inputPerMTok: 0.59, outputPerMTok: 0.79},
+}
+
+// ttsPricePer1kChars are the known per-1000-character TTS rates (USD). ElevenLabs
+// bills submitted characters. ESTIMATES.
+var ttsPricePer1kChars = map[observe.Provider]float64{
+	// ElevenLabs standard multilingual voices — plan-dependent credit cost mapped
+	// to USD, captured 2026-07-07: ~$0.30 / 1000 characters. ESTIMATE.
+	observe.ProviderElevenLabs: 0.30,
+}
+
+// sttPricePerHour are the known per-audio-hour STT rates (USD). ESTIMATES.
+var sttPricePerHour = map[observe.Provider]float64{
+	// ElevenLabs Scribe speech-to-text — published pricing, captured 2026-07-07:
+	// ~$0.40 / audio-hour. ESTIMATE.
+	observe.ProviderElevenLabs: 0.40,
+}
+
+// Conservative fallbacks for an unknown price key: high enough that an unpriced
+// provider/model over-estimates rather than running unbounded under a cap. All
+// ESTIMATES.
+const (
+	// defaultLLMInputPerMTok / defaultLLMOutputPerMTok: a frontier-model-class
+	// ceiling ($5 in / $15 out per 1M) so an unrecognised LLM is never cheap.
+	defaultLLMInputPerMTok  = 5.00
+	defaultLLMOutputPerMTok = 15.00
+	// defaultTTSPer1kChars: above the known ElevenLabs estimate.
+	defaultTTSPer1kChars = 0.50
+	// defaultSTTPerHour: above the known Scribe estimate.
+	defaultSTTPerHour = 1.00
+)
+
+// llmCostUSD estimates the USD cost of one completion's tokens. known is false
+// when the (provider, model) key had no entry and the conservative default was
+// used (the caller warns once).
+func llmCostUSD(provider observe.Provider, model string, inputTokens, outputTokens int) (usd float64, known bool) {
+	r, ok := llmPrices[llmKey{provider, model}]
+	if !ok {
+		r = llmRate{inputPerMTok: defaultLLMInputPerMTok, outputPerMTok: defaultLLMOutputPerMTok}
+	}
+	usd = float64(inputTokens)/1e6*r.inputPerMTok + float64(outputTokens)/1e6*r.outputPerMTok
+	return usd, ok
+}
+
+// ttsCostUSD estimates the USD cost of chars submitted to a TTS synthesizer.
+func ttsCostUSD(provider observe.Provider, chars int) (usd float64, known bool) {
+	p, ok := ttsPricePer1kChars[provider]
+	if !ok {
+		p = defaultTTSPer1kChars
+	}
+	return float64(chars) / 1000 * p, ok
+}
+
+// sttCostUSD estimates the USD cost of audio submitted to an STT recognizer.
+func sttCostUSD(provider observe.Provider, d time.Duration) (usd float64, known bool) {
+	p, ok := sttPricePerHour[provider]
+	if !ok {
+		p = defaultSTTPerHour
+	}
+	return d.Hours() * p, ok
+}

--- a/internal/storage/migrations/00017_tenant_spend_caps.sql
+++ b/internal/storage/migrations/00017_tenant_spend_caps.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+-- Per-Tenant spend caps (#130, ADR-0046): two independently opt-in USD thresholds
+-- that stop a Voice Session's Agent turns once its estimated spend crosses them.
+-- Both NULL by default → today's behavior (no cap). Either alone is valid; when
+-- both are set the RPC enforces hard >= soft. double precision holds a currency
+-- estimate — an approximate figure, never a billed amount (ADR-0046).
+ALTER TABLE tenant
+    ADD COLUMN spend_cap_soft_usd double precision,
+    ADD COLUMN spend_cap_hard_usd double precision;
+
+-- +goose Down
+
+ALTER TABLE tenant
+    DROP COLUMN spend_cap_soft_usd,
+    DROP COLUMN spend_cap_hard_usd;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -29,10 +29,24 @@ const (
 
 // Tenant is the top-level isolation boundary.
 type Tenant struct {
-	ID        uuid.UUID
-	Name      string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID   uuid.UUID
+	Name string
+	// SpendCapSoftUSD / SpendCapHardUSD are the two independently opt-in per-Tenant
+	// spend caps (#130, ADR-0046): nil = that cap is off. They gate a Voice Session's
+	// estimated spend (an approximate figure, never a billed amount).
+	SpendCapSoftUSD *float64
+	SpendCapHardUSD *float64
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// SpendCaps is the get/set DTO for a Tenant's two spend caps (#130, ADR-0046),
+// each nil when that cap is unset. It is the storage-layer value the session
+// Manager maps onto its meter and the RPC round-trips; keeping it distinct from
+// spend.Caps keeps storage free of a spend-package import.
+type SpendCaps struct {
+	SoftUSD *float64
+	HardUSD *float64
 }
 
 // Campaign is a persistent TTRPG game owned by a Tenant and GM'd by one Member.

--- a/internal/storage/spend.go
+++ b/internal/storage/spend.go
@@ -1,0 +1,51 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Per-Tenant spend caps (#130, ADR-0046): the two nullable USD thresholds on the
+// tenant row that stop a Voice Session's Agent turns once its estimated spend
+// crosses them. Both NULL is the no-cap default. Reads and writes live together
+// because they are one small cohesive feature.
+
+// GetTenantSpendCaps loads a Tenant's soft/hard spend caps, each nil when that cap
+// is unset. ErrNotFound when no tenant row exists for the id — distinct from a
+// tenant that exists with both caps NULL (which returns a zero-value SpendCaps).
+func (s *Store) GetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID) (SpendCaps, error) {
+	var caps SpendCaps
+	err := s.db.QueryRow(ctx,
+		`SELECT spend_cap_soft_usd, spend_cap_hard_usd FROM tenant WHERE id = $1`, tenantID).
+		Scan(&caps.SoftUSD, &caps.HardUSD)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return SpendCaps{}, ErrNotFound
+	}
+	if err != nil {
+		return SpendCaps{}, fmt.Errorf("storage: get spend caps for tenant %s: %w", tenantID, err)
+	}
+	return caps, nil
+}
+
+// SetTenantSpendCaps writes a Tenant's soft/hard spend caps, storing NULL for a nil
+// pointer (that cap cleared). It does NOT enforce hard >= soft — that validation is
+// the RPC's (InvalidArgument), leaving storage a faithful persistence layer.
+// ErrNotFound when the tenant row does not exist.
+func (s *Store) SetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID, caps SpendCaps) error {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE tenant
+		    SET spend_cap_soft_usd = $2, spend_cap_hard_usd = $3, updated_at = now()
+		  WHERE id = $1`,
+		tenantID, caps.SoftUSD, caps.HardUSD)
+	if err != nil {
+		return fmt.Errorf("storage: set spend caps for tenant %s: %w", tenantID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/spend_test.go
+++ b/internal/storage/spend_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func fp(v float64) *float64 { return &v }
+
+// TestTenantSpendCapsRoundTrip proves the caps default to NULL, round-trip both
+// set, and can be individually cleared back to NULL (#130, ADR-0046). The
+// migration applying is implicit — the columns must exist for the queries to run.
+func TestTenantSpendCapsRoundTrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Default: a freshly-seeded tenant has neither cap.
+	got, err := st.GetTenantSpendCaps(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get default caps: %v", err)
+	}
+	if got.SoftUSD != nil || got.HardUSD != nil {
+		t.Fatalf("default caps = %+v, want both nil", got)
+	}
+
+	// Set both.
+	if err := st.SetTenantSpendCaps(ctx, tenantID, storage.SpendCaps{SoftUSD: fp(5), HardUSD: fp(10)}); err != nil {
+		t.Fatalf("set both caps: %v", err)
+	}
+	got, err = st.GetTenantSpendCaps(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get after set both: %v", err)
+	}
+	if got.SoftUSD == nil || *got.SoftUSD != 5 || got.HardUSD == nil || *got.HardUSD != 10 {
+		t.Fatalf("caps after set both = %+v, want soft=5 hard=10", got)
+	}
+
+	// Clear soft, keep hard (a nil pointer stores NULL).
+	if err := st.SetTenantSpendCaps(ctx, tenantID, storage.SpendCaps{SoftUSD: nil, HardUSD: fp(10)}); err != nil {
+		t.Fatalf("clear soft: %v", err)
+	}
+	got, err = st.GetTenantSpendCaps(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get after clear soft: %v", err)
+	}
+	if got.SoftUSD != nil {
+		t.Fatalf("soft after clear = %v, want nil", *got.SoftUSD)
+	}
+	if got.HardUSD == nil || *got.HardUSD != 10 {
+		t.Fatalf("hard after clear soft = %+v, want 10", got.HardUSD)
+	}
+
+	// Clear both back to NULL.
+	if err := st.SetTenantSpendCaps(ctx, tenantID, storage.SpendCaps{}); err != nil {
+		t.Fatalf("clear both: %v", err)
+	}
+	got, _ = st.GetTenantSpendCaps(ctx, tenantID)
+	if got.SoftUSD != nil || got.HardUSD != nil {
+		t.Fatalf("caps after clear both = %+v, want both nil", got)
+	}
+}
+
+// TestTenantSpendCapsUnknownTenant proves a missing tenant is ErrNotFound on both
+// get and set — never a silent success.
+func TestTenantSpendCapsUnknownTenant(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.GetTenantSpendCaps(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("get unknown tenant err = %v, want ErrNotFound", err)
+	}
+	if err := st.SetTenantSpendCaps(ctx, uuid.New(), storage.SpendCaps{SoftUSD: fp(1)}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("set unknown tenant err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -119,6 +119,14 @@ type muteFrame struct {
 	Muted   bool   `json:"muted"`
 }
 
+// spendcapFrame is the payload of a "spendcap" SSE frame (#130): the session's
+// estimated spend crossed a cap, so the Session screen renders the spend-cap-reached
+// state without a reload. Deliberately minimal (which cap) — the authoritative
+// current state + estimated spend is GetSession (spend_cap_state / estimated_spend_usd).
+type spendcapFrame struct {
+	Level string `json:"level"`
+}
+
 // connectionFrame is the payload of a "connection" SSE frame (#123): the Voice
 // Session's gateway connection state (connecting/connected/failed) and, on a fatal
 // failure, the readable reason. The Session screen flips its badge from this live;
@@ -335,6 +343,13 @@ func (r *Relay) project(e voiceevent.Event) {
 		// ring for Last-Event-ID replay; there is NO transcript-line change and NO
 		// snapshot change — a mid-session reload reads the true state from GetSession.
 		r.emit(Frame{Event: "mute", Data: mustJSON(muteFrame{AgentID: ev.AgentID, Muted: ev.Muted})})
+	case voiceevent.SpendCapReached:
+		// The session's estimated spend crossed a cap (#130): forward a "spendcap"
+		// frame so the Session screen shows the spend-cap-reached state live. It rides
+		// the ring for Last-Event-ID replay; there is NO transcript-line change — a
+		// mid-session reload reads the authoritative state + estimate from GetSession
+		// (spend_cap_state / estimated_spend_usd).
+		r.emit(Frame{Event: "spendcap", Data: mustJSON(spendcapFrame{Level: string(ev.Level)})})
 	case voiceevent.ConnectionStateChanged:
 		// The gateway connection state moved (#123): forward a "connection" frame so
 		// the Session screen flips connecting→connected, or to failed with its reason,

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -134,6 +134,37 @@ func TestProjection_MuteFrame(t *testing.T) {
 	}
 }
 
+// TestProjection_SpendCapFrame pins the spend-cap relay (#130): a SpendCapReached
+// projects a "spendcap" frame carrying the level, the frame rides the ring for a
+// Last-Event-ID reconnect, and it does NOT change the transcript snapshot lines
+// (the reload truth is GetSession).
+func TestProjection_SpendCapFrame(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.SpendCapReached{At: at(1), Level: voiceevent.SpendCapSoft})
+	bus.Publish(voiceevent.SpendCapReached{At: at(2), Level: voiceevent.SpendCapHard})
+
+	frames := r.Frames(id, 0)
+	var levels []string
+	for _, f := range frames {
+		if f.Event != "spendcap" {
+			continue
+		}
+		var p spendcapFrame
+		if err := json.Unmarshal(f.Data, &p); err != nil {
+			t.Fatalf("spendcap frame payload: %v", err)
+		}
+		levels = append(levels, p.Level)
+	}
+	if len(levels) != 2 || levels[0] != "soft" || levels[1] != "hard" {
+		t.Fatalf("spendcap frame levels = %v, want [soft hard]", levels)
+	}
+
+	if v := r.View(id); len(v.Lines) != 0 {
+		t.Fatalf("spendcap frame added %d transcript lines, want 0 (reload truth is GetSession)", len(v.Lines))
+	}
+}
+
 // connFrame is the decoded payload of a "connection" SSE frame.
 type connFrame struct {
 	State  string `json:"state"`

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -651,7 +651,6 @@ func TestSeedIdempotent(t *testing.T) {
 	}
 }
 
-
 // TestResolveNPCModel_BoundConfigOutranksTenantFallback pins the precedence
 // pure-functionally (#227 review finding): a resolver that ignored the bound
 // config and always returned the tenant fallback would pass the DB-backed

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -166,7 +166,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestLoadedNPC_DerivesTruncationAliases(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -362,6 +362,15 @@ type Config struct {
 	// mutes) → buildConversation (orchestrator.WithMute). nil is the feature-off
 	// default: voice standalone / the benchmark are byte-for-byte unchanged.
 	Mutes orchestrator.MuteView
+
+	// Gate is the live turn gate (#130, ADR-0046): the session Manager's spend meter
+	// satisfies it (AllowTurn() false once the soft cap is crossed), and Start sets
+	// it on the per-session config copy so buildConversation wires it via
+	// orchestrator.WithTurnGate. It flows straight into the replier's pre-Take gate,
+	// beside the mute check. nil is the feature-off default: no caps configured, so
+	// voice standalone / the benchmark / an uncapped session are byte-for-byte
+	// unchanged.
+	Gate orchestrator.TurnGate
 }
 
 // RunFromDB loads the seeded Character NPCs from Postgres (via the task-#8
@@ -694,7 +703,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes)
+	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes, cfg.Gate)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -852,7 +861,7 @@ func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView)
 	return unsub
 }
 
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView, gate orchestrator.TurnGate) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -966,6 +975,10 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		// speaking Agent is muted. A nil view is the feature-off default (voice
 		// standalone / bench), so this option is unconditional.
 		orchestrator.WithMute(mutes),
+		// Per-session spend soft cap (#130, ADR-0046): the replier refuses a NEW turn
+		// once the session's estimated spend crosses the soft cap. A nil gate is the
+		// feature-off default (no caps configured), so this option is unconditional.
+		orchestrator.WithTurnGate(gate),
 		// Handles failures the reactors fire off the audio loop: the replier's TTS
 		// dispatch and the segmenter's off-loop STT call (#24). The wrapped error
 		// names its stage (orchestrator.TTS.Dispatch / orchestrator.STT.Transcribe).

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -43,6 +43,11 @@ type Conversation struct {
 	// Register gates the replier's routes on it and — when barge-in built the floor
 	// — binds a [MuteCut] reactor beside [BargeIn].
 	mutes MuteView
+
+	// gate is the live turn gate ([WithTurnGate], #130): nil = feature off. When
+	// set, Register installs it on the replier, which refuses a route whose new turn
+	// the gate denies (the spend soft cap) beside the mute pre-check.
+	gate TurnGate
 }
 
 // Option configures a [Conversation] at construction.
@@ -173,6 +178,10 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 		// before taking the floor, so an addressed-but-muted Agent opens no turn.
 		// Independent of barge-in; nil is the feature-off default.
 		replier.mutes = c.mutes
+		// Live turn gate (#130): the replier refuses a NEW turn once the session's
+		// estimated spend crosses the soft cap. Independent of barge-in and mute; nil
+		// is the feature-off default.
+		replier.gate = c.gate
 		if c.bargeEnabled {
 			// Barge-in mode: the replier runs turns on the floor, and the BargeIn
 			// reactor yields it on a human interruption. Bind BargeIn before the

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -20,6 +20,11 @@ func (r *Replier) SetFloor(floor *Floor) { r.floor = floor }
 // Conversation.Register from [WithMute].
 func (r *Replier) SetMutes(v MuteView) { r.mutes = v }
 
+// SetGate installs the live turn gate on the replier for the spend-cap gate tests
+// (external test package, #130). Production wiring sets r.gate inside
+// Conversation.Register from [WithTurnGate].
+func (r *Replier) SetGate(g TurnGate) { r.gate = g }
+
 // SetErrorHandler installs onError on the segmenter for the off-loop STT error
 // tests (external test package). Production wiring sets it inside
 // Conversation.Register from [WithErrorHandler].

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -479,6 +479,14 @@ type Replier struct {
 	// TTS, no transcript line, and it can never supersede whoever holds the floor
 	// (AC3). Set only via the orchestrator wiring; not part of [NewReplier].
 	mutes MuteView
+
+	// gate, when non-nil, is the live turn gate (#130, [WithTurnGate]): once the
+	// session's estimated spend crosses the soft cap it refuses a NEW turn before
+	// the floor is taken — exactly like a muted route, but for the whole session. A
+	// SINGLE pre-check suffices (spend is monotonic, so no post-Take re-check like
+	// the mute race closure). Set only via the orchestrator wiring; not part of
+	// [NewReplier].
+	gate TurnGate
 }
 
 // NewReplier wires ttsStage and reply together. Both must be non-nil; passing
@@ -551,6 +559,17 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 		// the metrics subscriber records the precise cause.
 		if r.mutes != nil && r.mutes.Muted(e.Target.AgentID) {
 			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndMute})
+			return
+		}
+		// Spend soft cap (#130, AC3): once the session's estimated spend crosses the
+		// soft cap the gate refuses a NEW turn — discard the route BEFORE taking the
+		// floor, so no floor churn, no LLM call, no TTS, no transcript line, and it
+		// never supersedes whoever holds the floor. A SINGLE pre-check is airtight:
+		// spend is monotonic, so unlike mute the gate can never flip back to allowed
+		// between here and the Take. Announce a spend_cap-reason TurnEnded for the
+		// routed TurnID so the metrics subscriber records the precise cause.
+		if r.gate != nil && !r.gate.AllowTurn() {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSpendCap})
 			return
 		}
 		// Barge-in: take the floor and run the turn on its own goroutine so the

--- a/pkg/voice/orchestrator/turngate.go
+++ b/pkg/voice/orchestrator/turngate.go
@@ -1,0 +1,25 @@
+package orchestrator
+
+// TurnGate is the live authoritative check of whether a NEW Agent turn may start
+// (#130, ADR-0046). The per-session spend meter satisfies it: once the session's
+// estimated spend crosses its soft cap, [TurnGate.AllowTurn] returns false and the
+// [Replier] refuses new turns before taking the floor — in-flight turns finish and
+// transcription is untouched (the gate lives at the replier, not the segmenter).
+//
+// It mirrors [MuteView]'s posture: the orchestrator keeps no spend state of its own
+// and asks this view per route. A nil gate is the feature-off default.
+type TurnGate interface {
+	// AllowTurn reports whether a new turn may open. Spend is monotonic, so a false
+	// result is permanent for the session — the replier needs a single pre-check, no
+	// post-Take re-check (unlike the mute view, which can flip mid-turn).
+	AllowTurn() bool
+}
+
+// WithTurnGate wires the live turn gate into the conversation (#130). Register
+// stores it on the [Replier], which refuses a route whose new turn the gate denies
+// (beside the mute pre-check) before the floor is taken. A nil gate is the
+// feature-off default — voice standalone / the benchmark are byte-for-byte
+// unchanged.
+func WithTurnGate(g TurnGate) Option {
+	return func(c *Conversation) { c.gate = g }
+}

--- a/pkg/voice/orchestrator/turngate_test.go
+++ b/pkg/voice/orchestrator/turngate_test.go
@@ -1,0 +1,128 @@
+package orchestrator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// gate is a fixed [orchestrator.TurnGate] for the spend-cap gate tests.
+type gate bool
+
+func (g gate) AllowTurn() bool { return bool(g) }
+
+// TestReplier_SpendCapRefusesNewTurn pins the spend-cap pre-check (#130, AC3): a
+// gate that refuses discards the route BEFORE Floor.Take, so it opens no turn (its
+// producer never runs) and never disturbs whoever holds the floor — a
+// TurnEnded(spend_cap) for the routed TurnID is announced.
+func TestReplier_SpendCapRefusesNewTurn(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	ran := make(chan string, 2)
+	reply := func(_ context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		ran <- e.TurnID
+		return nil
+	}
+
+	floor := orchestrator.NewFloor()
+	// Greta is already speaking (holds the floor) — the refused route must not touch it.
+	gretaParent := voiceevent.WithTurnID(context.Background(), "Tgreta")
+	gretaCtx, gretaRelease, _ := floor.Take(gretaParent, "greta")
+	defer gretaRelease()
+
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	replier.SetGate(gate(false)) // over budget: refuse new turns
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Tbart", Text: "Bart, a room",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case id := <-ran:
+		t.Fatalf("a spend-capped turn's producer ran for %q — the route must be discarded before Floor.Take", id)
+	case <-time.After(100 * time.Millisecond):
+		// Correct: no producer for the refused route.
+	}
+	if gretaCtx.Err() != nil {
+		t.Fatal("a spend-cap refusal must not disturb the Agent holding the floor")
+	}
+	if !floor.Active() {
+		t.Fatal("Greta must keep the floor after a spend-capped route was discarded")
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Tbart" && e.Reason == voiceevent.TurnEndSpendCap },
+		"turn.ended (spend_cap) for the discarded route",
+	)
+}
+
+// TestReplier_SpendCapAllowsUnderBudget proves a gate that allows lets the turn
+// proceed: its producer runs.
+func TestReplier_SpendCapAllowsUnderBudget(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	ran := make(chan string, 2)
+	reply := func(_ context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		ran <- e.TurnID
+		return nil
+	}
+
+	floor := orchestrator.NewFloor()
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	replier.SetGate(gate(true)) // under budget
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Tok", Text: "Bart, a room",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case id := <-ran:
+		if id != "Tok" {
+			t.Fatalf("producer ran for %q, want Tok", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("an under-budget turn's producer must run")
+	}
+}
+
+// TestReplier_NilGateUntouched proves a nil gate is the feature-off default: the
+// turn proceeds exactly as before, byte-for-byte.
+func TestReplier_NilGateUntouched(t *testing.T) {
+	h := voicetest.New(t)
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	ran := make(chan string, 2)
+	reply := func(_ context.Context, e voiceevent.AddressRouted, _ func(orchestrator.Reply) error) error {
+		ran <- e.TurnID
+		return nil
+	}
+
+	floor := orchestrator.NewFloor()
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	// No gate set (nil) — feature off.
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "Tnil", Text: "Bart, a room",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case <-ran:
+		// Correct: proceeds with no gate.
+	case <-time.After(time.Second):
+		t.Fatal("with no gate the turn must proceed")
+	}
+}

--- a/pkg/voice/orchestrator/turngate_test.go
+++ b/pkg/voice/orchestrator/turngate_test.go
@@ -58,7 +58,9 @@ func TestReplier_SpendCapRefusesNewTurn(t *testing.T) {
 		t.Fatal("Greta must keep the floor after a spend-capped route was discarded")
 	}
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Tbart" && e.Reason == voiceevent.TurnEndSpendCap },
+		func(e voiceevent.TurnEnded) bool {
+			return e.TurnID == "Tbart" && e.Reason == voiceevent.TurnEndSpendCap
+		},
 		"turn.ended (spend_cap) for the discarded route",
 	)
 }

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -232,6 +232,11 @@ const (
 	// commit exactly as a barge would (delivered-sentences-only, ADR-0012), but the
 	// cause is a mute, never a barge.
 	TurnEndMute TurnEndReason = "mute"
+	// TurnEndSpendCap: the session's estimated spend crossed its soft cap, so the
+	// replier refused a NEW turn before taking the floor (#130, ADR-0046). Like
+	// [TurnEndMute] it is a deliberate policy stop, not a barge or a fault — the turn
+	// opened no floor, ran no producer, and produced no audio.
+	TurnEndSpendCap TurnEndReason = "spend_cap"
 )
 
 // TurnEnded marks a turn that ended for a known reason — distinct from a turn
@@ -290,6 +295,36 @@ type MuteChanged struct {
 
 // EventName implements [Event].
 func (MuteChanged) EventName() string { return "mute.changed" }
+
+// SpendCapLevel names which per-session spend cap a [SpendCapReached] announces
+// (#130, ADR-0046): the soft cap (refuse new turns) or the hard cap (end the
+// session). It is a bounded enum, DISTINCT from the [TurnEndReason] a refused turn
+// carries — this event is about the session-level cap crossing, not one turn.
+type SpendCapLevel string
+
+const (
+	// SpendCapSoft: the soft cap was crossed — the Session screen shows the
+	// spend-cap-reached state; new Agent turns are refused, in-flight ones finish.
+	SpendCapSoft SpendCapLevel = "soft"
+	// SpendCapHard: the hard cap was crossed — the session is ending itself cleanly.
+	SpendCapHard SpendCapLevel = "hard"
+)
+
+// SpendCapReached marks the moment a live Voice Session's estimated spend crossed
+// one of its per-Tenant caps (#130, ADR-0046). The session Manager publishes it
+// from the spend meter's once-firing callback AFTER it has taken effect (the gate
+// already refuses new turns for soft; the session is already ending for hard), so a
+// subscriber reacting to it sees a consistent state. The SSE relay forwards it as a
+// `spendcap` frame so the Session screen renders which cap tripped and the
+// (estimated) spend; the terminal reload truth for a hard-capped session is
+// GetSession (status + end_reason).
+type SpendCapReached struct {
+	At    time.Time
+	Level SpendCapLevel
+}
+
+// EventName implements [Event].
+func (SpendCapReached) EventName() string { return "spend.cap_reached" }
 
 // ConnectionState is the Voice Session's Discord gateway connection lifecycle as
 // seen by the web Session screen (#123, ADR-0020). It is a coarse UI/telemetry

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -587,6 +587,51 @@ service ProviderService {
   rpc ResolveGuildInvite(ResolveGuildInviteRequest) returns (ResolveGuildInviteResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // GetSpendCaps returns the operator's two per-Tenant spend caps (#130,
+  // ADR-0046): the soft and hard USD thresholds, each absent when unset. It is a
+  // read (NO_SIDE_EFFECTS), so the CSRF check is skipped.
+  rpc GetSpendCaps(GetSpendCapsRequest) returns (GetSpendCapsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // SetSpendCaps stores the operator's two per-Tenant spend caps (#130): each
+  // omitted field clears that cap. A negative value is rejected with
+  // InvalidArgument, and when both are set hard must be >= soft (else
+  // InvalidArgument). Caps snapshot at the NEXT Voice Session start — a mid-session
+  // edit never changes the running session. State-changing: auth + CSRF guard it.
+  rpc SetSpendCaps(SetSpendCapsRequest) returns (SetSpendCapsResponse);
+}
+
+// SpendCaps is the wire view of a Tenant's two spend caps (#130, ADR-0046). Each
+// field is absent (no presence) when that cap is unset; both figures are USD
+// ESTIMATES, never billed amounts.
+message SpendCaps {
+  // soft_usd refuses NEW Agent turns once estimated spend crosses it (in-flight
+  // turns finish, transcription continues). Absent when unset.
+  optional double soft_usd = 1;
+  // hard_usd ends the Voice Session cleanly once estimated spend crosses it. Absent
+  // when unset. When both are set, hard_usd >= soft_usd (enforced at SetSpendCaps).
+  optional double hard_usd = 2;
+}
+
+// GetSpendCapsRequest is the (empty) request; the tenant is resolved server-side.
+message GetSpendCapsRequest {}
+
+// GetSpendCapsResponse carries the operator's current caps.
+message GetSpendCapsResponse {
+  SpendCaps caps = 1;
+}
+
+// SetSpendCapsRequest carries the caps to store; an omitted field clears that cap.
+message SetSpendCapsRequest {
+  // soft_usd / hard_usd: present to set, absent to clear. Negative is rejected;
+  // both present requires hard_usd >= soft_usd.
+  optional double soft_usd = 1;
+  optional double hard_usd = 2;
+}
+
+// SetSpendCapsResponse echoes the stored caps after the save.
+message SetSpendCapsResponse {
+  SpendCaps caps = 1;
 }
 
 // ProviderCredential is the WRITE-ONLY view of a saved secret: never its value,
@@ -827,6 +872,15 @@ message GetSessionResponse {
   // Voice Session is active — the reload truth for a mid-session page reload
   // (AC5). Empty when idle (a new session starts all-unmuted).
   repeated string muted_agent_ids = 3;
+  // spend_cap_state is the live session's spend-cap state (#130, ADR-0046): "soft"
+  // once the soft cap is crossed (new turns refused), "hard" once the hard cap is
+  // crossed (the session is ending), "" otherwise. Set only while active; the
+  // reload truth for the Session screen's spend-cap-reached badge.
+  string spend_cap_state = 4;
+  // estimated_spend_usd is the live session's accumulated spend ESTIMATE in USD
+  // (#130) — an approximate figure the screen labels "estimated", never a billed
+  // amount. 0 when idle or no caps are configured.
+  double estimated_spend_usd = 5;
 }
 
 // SetAgentMuteRequest toggles one Agent's mute in the live Voice Session (#211).

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -18,8 +18,12 @@ import {
   ProviderHealthSchema,
   ListModelsResponseSchema,
   ResolveGuildInviteResponseSchema,
+  GetSpendCapsResponseSchema,
+  SetSpendCapsResponseSchema,
+  SpendCapsSchema,
   type ProviderHealth,
   type SaveDiscordSettingsRequest,
+  type SetSpendCapsRequest,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -82,6 +86,11 @@ function mockBackend(
     // inviteCodes captures every ResolveGuildInvite request's code so a test can
     // pin that the SPA sent the BARE code (not the full URL).
     inviteCodes?: string[];
+    // spendCaps seeds the stored per-Tenant spend caps GetSpendCaps returns (#130);
+    // spendSaves captures every SetSpendCaps request so a test can pin the wire
+    // shape (a blank field must be omitted, i.e. undefined = cleared).
+    spendCaps?: { softUsd?: number; hardUsd?: number };
+    spendSaves?: SetSpendCapsRequest[];
   } = {},
 ) {
   const state = {
@@ -91,6 +100,8 @@ function mockBackend(
     discord: opts.saved?.discord,
     guildId: "",
     voiceChannelId: "",
+    spendSoft: opts.spendCaps?.softUsd,
+    spendHard: opts.spendCaps?.hardUsd,
   };
   return createRouterTransport(({ service }) => {
     service(VoiceService, {
@@ -168,6 +179,26 @@ function mockBackend(
         if (opts.inviteError) throw new ConnectError(opts.inviteError.message, opts.inviteError.code);
         const r = opts.inviteResolve ?? { guildId: "111", guildName: "The Keep", voiceChannels: [] };
         return create(ResolveGuildInviteResponseSchema, r);
+      },
+      getSpendCaps: () =>
+        create(GetSpendCapsResponseSchema, {
+          caps: create(SpendCapsSchema, { softUsd: state.spendSoft, hardUsd: state.spendHard }),
+        }),
+      setSpendCaps: (req) => {
+        opts.spendSaves?.push(req);
+        // Mirror the server (#130): negative or hard < soft is rejected; an omitted
+        // field clears that cap.
+        if ((req.softUsd ?? 0) < 0 || (req.hardUsd ?? 0) < 0) {
+          throw new ConnectError("cap must not be negative", Code.InvalidArgument);
+        }
+        if (req.softUsd !== undefined && req.hardUsd !== undefined && req.hardUsd < req.softUsd) {
+          throw new ConnectError("hard cap must be >= soft cap", Code.InvalidArgument);
+        }
+        state.spendSoft = req.softUsd;
+        state.spendHard = req.hardUsd;
+        return create(SetSpendCapsResponseSchema, {
+          caps: create(SpendCapsSchema, { softUsd: state.spendSoft, hardUsd: state.spendHard }),
+        });
       },
     });
   });
@@ -663,5 +694,37 @@ describe("Configuration model entry (#227)", () => {
     renderScreen(mockBackend({ saved: { groq: "eeee" } }));
     await screen.findByRole("button", { name: "Groq model" });
     expect(screen.queryByRole("button", { name: "Save model" })).not.toBeInTheDocument();
+  });
+});
+
+describe("Configuration spend caps (#130)", () => {
+  it("seeds the inputs from stored caps and saves edits (blank field clears)", async () => {
+    const spendSaves: SetSpendCapsRequest[] = [];
+    renderScreen(mockBackend({ spendCaps: { softUsd: 5, hardUsd: 10 }, spendSaves }));
+
+    const soft = (await screen.findByLabelText("Soft cap (USD)")) as HTMLInputElement;
+    const hard = screen.getByLabelText("Hard cap (USD)") as HTMLInputElement;
+    await waitFor(() => expect(soft.value).toBe("5"));
+    expect(hard.value).toBe("10");
+
+    // Raise the soft cap and clear the hard cap.
+    fireEvent.change(soft, { target: { value: "7" } });
+    fireEvent.change(hard, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /save spend caps/i }));
+
+    await waitFor(() => expect(spendSaves).toHaveLength(1));
+    // A blank field is omitted (undefined) so the server clears it; 7 is sent.
+    expect(spendSaves[0].softUsd).toBe(7);
+    expect(spendSaves[0].hardUsd).toBeUndefined();
+  });
+
+  it("surfaces a server rejection (hard < soft) inline", async () => {
+    renderScreen(mockBackend({ spendSaves: [] }));
+
+    fireEvent.change(await screen.findByLabelText("Soft cap (USD)"), { target: { value: "10" } });
+    fireEvent.change(screen.getByLabelText("Hard cap (USD)"), { target: { value: "5" } });
+    fireEvent.click(screen.getByRole("button", { name: /save spend caps/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't save/i);
   });
 });

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -230,14 +230,100 @@ export function Configuration() {
         </div>
       </Card>
 
-      {/* Session defaults — inert placeholders ("coming soon") */}
-      <h2 className="gx-section-title">Session defaults</h2>
-      <Card>
-        <div className="gx-defaults__body">
-          <span className="gx-coming-soon">Coming soon</span>
-        </div>
-      </Card>
+      {/* Per-session spend caps (#130, ADR-0046) */}
+      <h2 className="gx-section-title">Spend caps</h2>
+      <SpendCapsCard />
     </div>
+  );
+}
+
+// SpendCapsCard is the minimal soft/hard per-session spend-cap editor (#130,
+// ADR-0046): two USD inputs, blank = that cap unset. A soft cap refuses new Agent
+// turns once estimated spend crosses it (in-flight replies finish); a hard cap ends
+// the session. Both figures are ESTIMATES. The server validates (negative or
+// hard < soft => rejected) and caps snapshot at the NEXT session start. The `dirty`
+// ref guards the seed so a slow load / post-save refetch can't clobber typing.
+function SpendCapsCard() {
+  const queryClient = useQueryClient();
+  const capsQuery = useQuery(ProviderService.method.getSpendCaps, {});
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({ schema: ProviderService.method.getSpendCaps, cardinality: "finite" }),
+    });
+  const save = useMutation(ProviderService.method.setSpendCaps, { onSuccess: invalidate });
+
+  const [soft, setSoft] = useState("");
+  const [hard, setHard] = useState("");
+  const dirty = useRef(false);
+  useEffect(() => {
+    if (capsQuery.data && !dirty.current) {
+      const caps = capsQuery.data.caps;
+      setSoft(caps?.softUsd != null ? String(caps.softUsd) : "");
+      setHard(caps?.hardUsd != null ? String(caps.hardUsd) : "");
+    }
+  }, [capsQuery.data]);
+  const editSoft = (v: string) => {
+    dirty.current = true;
+    setSoft(v);
+  };
+  const editHard = (v: string) => {
+    dirty.current = true;
+    setHard(v);
+  };
+
+  // A blank field is "unset" (omit it, presence-absent → clear); anything else is
+  // sent as-is and the server enforces non-negative + hard >= soft.
+  const parse = (v: string): number | undefined => {
+    const t = v.trim();
+    return t === "" ? undefined : Number(t);
+  };
+
+  return (
+    <Card>
+      <div className="gx-spendcaps">
+        <p className="gx-spendcaps__lede">
+          Stop a Voice Session when its estimated provider spend crosses a limit. Figures are estimates,
+          not billed amounts. Leave a field blank to disable that cap; changes apply to the next session.
+        </p>
+        <div className="gx-spendcaps__inputs">
+          <Input
+            label="Soft cap (USD)"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="e.g. 5.00"
+            hint="No new Agent turns once crossed; in-flight replies finish."
+            value={soft}
+            onChange={(e) => editSoft(e.target.value)}
+          />
+          <Input
+            label="Hard cap (USD)"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="e.g. 10.00"
+            hint="Ends the session cleanly. Must be ≥ the soft cap."
+            value={hard}
+            onChange={(e) => editHard(e.target.value)}
+          />
+        </div>
+        <div className="gx-spendcaps__save">
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={save.isPending}
+            onClick={() => save.mutate({ softUsd: parse(soft), hardUsd: parse(hard) })}
+          >
+            Save spend caps
+          </Button>
+          {save.isError && (
+            <span className="gx-spendcaps__error" role="alert">
+              Couldn&apos;t save: {save.error.message}
+            </span>
+          )}
+        </div>
+      </div>
+    </Card>
   );
 }
 

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -73,6 +73,39 @@
   color: var(--status-danger);
 }
 
+/* Per-session spend caps editor (#130, ADR-0046): a short lede, two USD inputs
+ * side by side, and a right-aligned Save row mirroring the Discord IDs form. */
+.gx-spendcaps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.gx-spendcaps__lede {
+  margin: 0;
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+}
+
+.gx-spendcaps__inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+}
+
+.gx-spendcaps__save {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.gx-spendcaps__error {
+  font-size: var(--body-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--status-danger);
+}
+
 /* "Add Glyphoxa to your server" bot-authorization action (#110): a separate,
  * prerequisite step from saving the IDs, sits at the foot of the Discord card
  * above a top divider so the distinction reads. */

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -709,3 +709,77 @@ describe("Session transcript search (#120)", () => {
     );
   });
 });
+
+// spendCapTransport reports a live session whose spend meter has crossed a cap,
+// so GetSession carries the spend-cap state + estimated spend (#130).
+function spendCapTransport(state: string, estimatedSpendUsd: number) {
+  const current = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "running",
+    startedAt: timestampFromDate(new Date()),
+  });
+  return createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () =>
+        create(GetSessionResponseSchema, {
+          session: current,
+          active: true,
+          spendCapState: state,
+          estimatedSpendUsd,
+        }),
+      startSession: () => create(StartSessionResponseSchema, { session: current }),
+      stopSession: () => create(StopSessionResponseSchema, { session: current }),
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+}
+
+describe("Session spend cap (#130)", () => {
+  beforeEach(() => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ lines: [], status: "live", typing: { active: true, label: "Listening to the table…" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+  });
+
+  it("renders the soft spend-cap badge with the estimated spend, labelled estimated", async () => {
+    render(
+      <Providers transport={spendCapTransport("soft", 3.21)} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    const badge = await screen.findByTestId("spend-cap");
+    expect(badge).toHaveTextContent(/soft spend cap reached/i);
+    expect(badge).toHaveTextContent(/no new agent turns/i);
+    expect(badge).toHaveTextContent("$3.21");
+    expect(badge).toHaveTextContent(/estimated/i);
+  });
+
+  it("renders the hard spend-cap badge when the hard cap is crossed", async () => {
+    render(
+      <Providers transport={spendCapTransport("hard", 10)} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    const badge = await screen.findByTestId("spend-cap");
+    expect(badge).toHaveTextContent(/hard spend cap reached/i);
+    expect(badge).toHaveTextContent("$10.00");
+  });
+
+  it("shows no spend-cap badge when no cap is crossed", async () => {
+    render(
+      <Providers transport={spendCapTransport("", 1.5)} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+    expect(screen.queryByTestId("spend-cap")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -88,6 +88,12 @@ function connectionLabel(state: string | undefined): string | null {
   }
 }
 
+// formatUsd renders a USD estimate as $X.XX (#130). Always paired with an
+// "(estimated)" label at the call site — it is an approximate figure, not a bill.
+function formatUsd(usd: number): string {
+  return `$${usd.toFixed(2)}`;
+}
+
 // lastSummary renders the idle "Last session ended …" line from an ended session.
 function lastSummary(session: VoiceSession): string {
   const endedMs = tsMs(session.endedAt);
@@ -114,6 +120,13 @@ export function Session() {
 
   const active = data?.active ?? false;
   const session = data?.session;
+
+  // Spend-cap-reached state (#130, ADR-0046): the live reload truth is GetSession
+  // (spend_cap_state + estimated_spend_usd); the SSE "spendcap" frame patches the
+  // same cache so it appears without waiting for the interval refetch. Every
+  // surfaced figure is labelled an ESTIMATE.
+  const spendCapState = active ? data?.spendCapState : undefined;
+  const estimatedSpendUsd = data?.estimatedSpendUsd ?? 0;
 
   const invalidate = () =>
     queryClient.invalidateQueries({
@@ -240,6 +253,15 @@ export function Session() {
       {failed && (
         <div className="gx-session__failed" role="alert" data-testid="connection-failed">
           {failureReason ? `Voice connection failed: ${failureReason}` : "Voice connection failed."}
+        </div>
+      )}
+
+      {(spendCapState === "soft" || spendCapState === "hard") && (
+        <div className="gx-session__spendcap" role="alert" data-testid="spend-cap">
+          {spendCapState === "hard"
+            ? "Hard spend cap reached — the session is ending."
+            : "Soft spend cap reached — no new Agent turns (in-flight replies finish)."}{" "}
+          Estimated spend {formatUsd(estimatedSpendUsd)} (estimated).
         </div>
       )}
 

--- a/web/src/screens/session/muteCache.ts
+++ b/web/src/screens/session/muteCache.ts
@@ -49,5 +49,18 @@ export function useMuteCache() {
     [queryClient, key],
   );
 
-  return { replace, patchOne };
+  // patchSpendCap flips the live spend-cap state on the same getSession cache from
+  // an SSE "spendcap" frame (#130), so the Session screen shows the
+  // spend-cap-reached state instantly. The interval getSession refetch reconciles
+  // the exact state AND the estimated_spend_usd figure the frame does not carry, so
+  // this is an instant-update optimisation over the authoritative reload truth.
+  const patchSpendCap = useCallback(
+    (level: string) =>
+      queryClient.setQueryData<GetSessionResponse>(key, (prev) =>
+        prev ? { ...prev, spendCapState: level } : prev,
+      ),
+    [queryClient, key],
+  );
+
+  return { replace, patchOne, patchSpendCap };
 }

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -226,6 +226,18 @@
   font-size: 0.875rem;
 }
 
+/* Spend-cap-reached banner (#130, ADR-0046): a warning tone, distinct from the
+ * danger failure banner — a soft cap is a deliberate limit, not a fault. */
+.gx-session__spendcap {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--warning, #a86800);
+  background: color-mix(in srgb, var(--warning, #a86800) 12%, transparent);
+  color: var(--warning, #a86800);
+  font-size: 0.875rem;
+}
+
 .gx-session__transcript {
   margin-top: var(--spacing-xl);
 }

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -68,7 +68,7 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
   // The SSE "mute" frame patches the SHARED getSession cache (not the transcript
   // cache), so the Voice panel reflects a mute from EITHER surface without a
   // reload (#211, AC5). patchOne is referentially stable, so it is a safe effect dep.
-  const { patchOne } = useMuteCache();
+  const { patchOne, patchSpendCap } = useMuteCache();
   // Fetch the snapshot for ANY session that exists — live OR ended. A reload of
   // an ended session replays its persisted history from the DB-backed snapshot
   // (#74); the live stream below only opens while the session is active.
@@ -123,6 +123,14 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
       const m = JSON.parse((e as MessageEvent).data) as { agent_id: string; muted: boolean };
       patchOne(m.agent_id, m.muted);
     });
+    es.addEventListener("spendcap", (e) => {
+      // The session's estimated spend crossed a cap (#130): flip the spend-cap
+      // state on the shared getSession cache so the Session screen shows the
+      // spend-cap-reached badge immediately; the interval refetch fills in the
+      // estimated spend the frame does not carry.
+      const s = JSON.parse((e as MessageEvent).data) as { level: string };
+      patchSpendCap(s.level);
+    });
     es.addEventListener("connection", (e) => {
       // The gateway connection state moved (#123): reflect connecting → connected
       // live, or failed with its readable reason — no page reload.
@@ -135,7 +143,7 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
     });
 
     return () => es.close();
-  }, [active, sessionId, isSuccess, queryClient, patchOne]);
+  }, [active, sessionId, isSuccess, queryClient, patchOne, patchSpendCap]);
 
   return data ?? EMPTY;
 }


### PR DESCRIPTION
Closes #130

## What

Per-session spend cap (E6, ADR-0046): a Voice Session estimates its provider spend from #127's usage capture points and enforces two independently opt-in per-Tenant caps.

- **Soft cap** — refuse NEW Agent turns (in-flight replies finish, transcription continues), show a spend-cap-reached badge.
- **Hard cap** — end the session itself cleanly (status `ended` + `spend_cap_hard` reason — a policy stop, not a fault).

Either alone is valid; both ⇒ hard ≥ soft; neither ⇒ byte-for-byte today's behavior.

## How (per the architect plan)

- `internal/spend.Meter` implements `observe.UsageSink`, one mutex over `totalUSD`+state, once-firing `onSoft`/`onHard` callbacks fired outside the lock. Prices are code consts (`prices.go`), keyed `(component, provider, model)`, each an **estimate** with a source comment + date; unknown key → conservative documented default + warn-once.
- `observe.TeeUsage(base, sink)` fans the three usage methods out to the meter alongside the production recorder (usage → both, everything else → base only).
- `orchestrator.TurnGate` / `WithTurnGate`: the Replier refuses a new turn before `Floor.Take` (single pre-check beside the mute check — spend is monotonic) and publishes `TurnEnded{spend_cap}`; the metrics subscriber maps it to `TurnOutcome(abandoned, spend_cap)`.
- `session.Manager.Start` snapshots the Tenant caps, builds the meter, tees it onto the existing recorder config copy (zero new pipeline plumbing) and wires it as `cfg.Gate`. `softCapTrip` publishes `SpendCapReached{soft}`; `hardCapTrip` (fresh goroutine, #211 lock-order) records a `spend_cap_hard` end-reason override, publishes `SpendCapReached{hard}` outside `Manager.mu`, and cancels the run ctx — `runLoop` closes the row `ended` + the reason. `Manager.Spend()` snapshots the meter.
- storage: nullable `spend_cap_soft_usd`/`spend_cap_hard_usd` on `tenant` (migration 00017) + `Get/SetTenantSpendCaps`.
- proto/rpc: `GetSpendCaps`/`SetSpendCaps` (negative & hard<soft → InvalidArgument; omitted field clears); `GetSessionResponse` gains `spend_cap_state` + `estimated_spend_usd`.
- relay: `SpendCapReached` → `spendcap` SSE frame.
- web: Session screen spend-cap badge (which cap + estimated spend, labelled *estimated*); Configuration soft/hard USD cap inputs (blank = unset).

## Tests (TDD, red→green per slice)

Meter pricing/thresholds (`-race`), TeeUsage fan-out, Replier gate, subscriber mapping, storage round-trip incl. NULLs (integration, real Postgres), Manager gate+tee+soft+hard, rpc validation + round-trip + GetSession fields, relay frame, web Session badge + Configuration inputs. Full Go suite, web suite (143), and touched-package golangci-lint all green locally; `buf lint` + `buf breaking` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
