### PR TITLE
fix(#245): harden invite autofill — latest-wins, debounce, verbatim FP, log redaction

### DIFF
--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -453,7 +454,10 @@ func (s *ProviderServer) ResolveGuildInvite(
 			return nil, connect.NewError(connect.CodeFailedPrecondition,
 				errors.New("the Bot is not a member of that server"))
 		default:
-			s.log.Error("ResolveGuildInvite: resolve failed", "err", err)
+			// A transport failure wraps *url.Error, whose text embeds the request
+			// URL — and thus the invite code, a join capability (ADR-0047). Scrub
+			// the code before logging; the op + status text still diagnose.
+			s.log.Error("ResolveGuildInvite: resolve failed", "err", redactInviteCode(err, code))
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
 	}
@@ -467,6 +471,18 @@ func (s *ProviderServer) ResolveGuildInvite(
 		GuildName:     resolved.Guild.Name,
 		VoiceChannels: channels,
 	}), nil
+}
+
+// redactInviteCode strips the invite code from an internal-error string bound for
+// the log. Transport failures wrap *url.Error whose text carries the request URL
+// (code included); the code is a join capability that must not land in logs
+// (ADR-0047). The op and status text survive so a failure is still diagnosable.
+// The code is guaranteed ^[A-Za-z0-9-]{2,64}$, so a literal replace is safe.
+func redactInviteCode(err error, code string) string {
+	if code == "" {
+		return err.Error()
+	}
+	return strings.ReplaceAll(err.Error(), code, "[invite-code]")
 }
 
 // GetSpendCaps returns the operator's two per-Tenant spend caps (#130, ADR-0046),

--- a/internal/rpc/provider_invite_test.go
+++ b/internal/rpc/provider_invite_test.go
@@ -1,8 +1,11 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -198,6 +201,41 @@ func TestResolveGuildInvite_SeamErrorMapping(t *testing.T) {
 				t.Errorf("code = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestResolveGuildInvite_InternalError_LogRedactsCode: an opaque resolver error
+// maps to Internal AND its log line must not carry the invite code. Transport
+// failures wrap *url.Error whose text embeds the request URL — and thus the code,
+// a join capability (ADR-0047). The op still logs; only the code is scrubbed.
+func TestResolveGuildInvite_InternalError_LogRedactsCode(t *testing.T) {
+	t.Parallel()
+	store, cipher := savedInviteStore(t)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	srv := NewProviderServer(store, cipher, logger)
+
+	const code = "s3cretJoinCode"
+	// Mimic the *url.Error a live transport failure produces: its text carries the
+	// full request URL, code included.
+	srv.resolveInvite = func(context.Context, string, string) (discordinvite.Resolved, error) {
+		return discordinvite.Resolved{}, fmt.Errorf(
+			"discordinvite: GET /invites: Get %q: dial tcp: i/o timeout",
+			"https://discord.com/api/v10/invites/"+code)
+	}
+
+	_, err := srv.ResolveGuildInvite(tenantCtx(),
+		connect.NewRequest(&managementv1.ResolveGuildInviteRequest{InviteCode: code}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Fatalf("code = %v, want Internal", got)
+	}
+	logged := buf.String()
+	if strings.Contains(logged, code) {
+		t.Errorf("log leaked the invite code %q:\n%s", code, logged)
+	}
+	// Enough survives to diagnose: the operation and the failing REST call.
+	if !strings.Contains(logged, "GET /invites") {
+		t.Errorf("log dropped the diagnostic op, got:\n%s", logged)
 	}
 }
 

--- a/web/src/lib/discordLink.test.ts
+++ b/web/src/lib/discordLink.test.ts
@@ -86,6 +86,22 @@ describe("parseDiscordLink", () => {
     }
   });
 
+  it("skips a leading 'invite' path segment on the discord.gg host", () => {
+    // A share sheet sometimes yields discord.gg/invite/{code}; segment[0] is the
+    // literal 'invite', not the code. The parser must reach past it (or the whole
+    // valid invite gets resolved as the code 'invite' → a false invalid/expired).
+    expect(parseDiscordLink(`https://discord.gg/invite/${INVITE_CODE}`)).toEqual({
+      kind: "invite",
+      code: INVITE_CODE,
+    });
+    expect(parseDiscordLink(`discord.gg/invite/${INVITE_CODE}`)).toEqual({
+      kind: "invite",
+      code: INVITE_CODE,
+    });
+    // A bare discord.gg/invite with no trailing code is not a link.
+    expect(parseDiscordLink("https://discord.gg/invite/")).toBeNull();
+  });
+
   it("returns null for a bare invite host with no code", () => {
     expect(parseDiscordLink("discord.gg/")).toBeNull();
     expect(parseDiscordLink("https://discord.gg/")).toBeNull();

--- a/web/src/lib/discordLink.ts
+++ b/web/src/lib/discordLink.ts
@@ -86,7 +86,9 @@ export function parseInviteCode(input: string): string | null {
 
   let code: string | undefined;
   if (isInviteHost(host)) {
-    code = segments[0];
+    // discord.gg/{code}, but a share sheet may emit discord.gg/invite/{code} —
+    // skip a leading "invite" segment so the code, not the literal "invite", wins.
+    code = segments[0] === "invite" ? segments[1] : segments[0];
   } else if (isDiscordHost(host) && segments[0] === "invite") {
     code = segments[1];
   }

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -83,6 +83,12 @@ function mockBackend(
     // for a pasted invite (#105). inviteError makes it fail instead.
     inviteResolve?: { guildId: string; guildName: string; voiceChannels: { id: string; name: string }[] };
     inviteError?: { code: Code; message: string };
+    // inviteResolver, when set, computes the response PER code (and may return a
+    // pending promise a test releases later) so a test can force a slow resolve
+    // for one invite and a fast one for another — the stale-response race (#245).
+    inviteResolver?: (
+      code: string,
+    ) => Promise<{ guildId: string; guildName: string; voiceChannels: { id: string; name: string }[] }>;
     // inviteCodes captures every ResolveGuildInvite request's code so a test can
     // pin that the SPA sent the BARE code (not the full URL).
     inviteCodes?: string[];
@@ -174,10 +180,12 @@ function mockBackend(
           voiceChannelId: state.voiceChannelId,
         });
       },
-      resolveGuildInvite: (req) => {
+      resolveGuildInvite: async (req) => {
         opts.inviteCodes?.push(req.inviteCode);
         if (opts.inviteError) throw new ConnectError(opts.inviteError.message, opts.inviteError.code);
-        const r = opts.inviteResolve ?? { guildId: "111", guildName: "The Keep", voiceChannels: [] };
+        const r = opts.inviteResolver
+          ? await opts.inviteResolver(req.inviteCode)
+          : (opts.inviteResolve ?? { guildId: "111", guildName: "The Keep", voiceChannels: [] });
         return create(ResolveGuildInviteResponseSchema, r);
       },
       getSpendCaps: () =>
@@ -609,12 +617,99 @@ describe("Configuration invite picker (#105)", () => {
     // The server message renders VERBATIM — no-token vs not-a-member share the
     // FailedPrecondition code and differ only by this message.
     expect(await screen.findByText("the Bot is not a member of that server")).toBeInTheDocument();
-    // …plus the hint pointing back at the Add-Glyphoxa action above.
+    // …plus the hint pointing back at the Add-Glyphoxa action, which renders at
+    // the FOOT of the card (below the Save button) — the direction word must match.
+    expect(screen.getByText(/at the foot of this card/i)).toBeInTheDocument();
     expect(screen.getByText(/then paste the invite again/i)).toBeInTheDocument();
 
     // A failed resolve touches nothing the operator already had.
     expect((guild as HTMLInputElement).value).toBe("existing-guild");
     expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+  });
+
+  it("renders a DISTINCT precondition message verbatim without the add-bot hint (no-token FP)", async () => {
+    // The no-token precondition shares FailedPrecondition with not-a-member but
+    // differs by message. Using a message distinct from the production not-a-member
+    // string pins that the SERVER text is rendered — a hardcoded client message
+    // dies here — and that the add-bot hint (apt only for not-a-member) is absent.
+    renderScreen(
+      mockBackend({
+        inviteError: { code: Code.FailedPrecondition, message: "save the Discord bot token first" },
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText(/paste a discord link/i), {
+      target: { value: "discord.gg/abc123" },
+    });
+
+    expect(await screen.findByText("save the Discord bot token first")).toBeInTheDocument();
+    // The add-bot hint would be wrong guidance here (the token, not the Bot, is
+    // missing), so it must NOT append to this message.
+    expect(screen.queryByText(/then paste the invite again/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/at the foot of this card/i)).not.toBeInTheDocument();
+  });
+
+  it("debounces the invite resolve so typing fires a single resolve, not one per keystroke", async () => {
+    const inviteCodes: string[] = [];
+    renderScreen(
+      mockBackend({
+        inviteCodes,
+        inviteResolve: { guildId: "111", guildName: "The Keep", voiceChannels: [] },
+      }),
+    );
+
+    // Four change events in a burst (as if typing the code). Without a debounce
+    // each fires an authed GET /invites — three of them 404s that burn Discord's
+    // rate budget; with it, only the final value resolves, exactly once.
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    fireEvent.change(paste, { target: { value: "discord.gg/ab" } });
+    fireEvent.change(paste, { target: { value: "discord.gg/abc" } });
+    fireEvent.change(paste, { target: { value: "discord.gg/abcd" } });
+    fireEvent.change(paste, { target: { value: "discord.gg/abc123" } });
+
+    await waitFor(() => expect(inviteCodes).toEqual(["abc123"]));
+    // Let any wrongly-scheduled extra resolve fire — none does.
+    await new Promise((r) => setTimeout(r, 500));
+    expect(inviteCodes).toEqual(["abc123"]);
+  });
+
+  it("ignores a late resolve for a superseded invite (latest-wins)", async () => {
+    // Paste invite A (slow), then invite B (fast). B's picker renders; A's LATE
+    // response must not swap it back — picking a channel then would fill the wrong
+    // guild's snowflake and Save would persist it.
+    let releaseA: (v: {
+      guildId: string;
+      guildName: string;
+      voiceChannels: { id: string; name: string }[];
+    }) => void = () => {};
+    const gateA = new Promise<{
+      guildId: string;
+      guildName: string;
+      voiceChannels: { id: string; name: string }[];
+    }>((res) => {
+      releaseA = res;
+    });
+    const inviteResolver = (code: string) =>
+      code === "slowaaa"
+        ? gateA
+        : Promise.resolve({ guildId: "222", guildName: "Guild B", voiceChannels: [] });
+
+    renderScreen(mockBackend({ inviteResolver }));
+
+    const paste = await screen.findByLabelText(/paste a discord link/i);
+    // A's debounce ticks and A's resolve goes in flight (gated open).
+    fireEvent.change(paste, { target: { value: "discord.gg/slowaaa" } });
+    await new Promise((r) => setTimeout(r, 500));
+
+    // B supersedes A and resolves immediately → B's picker wins.
+    fireEvent.change(paste, { target: { value: "discord.gg/fastbbb" } });
+    expect(await screen.findByText("Guild B")).toBeInTheDocument();
+
+    // A's slow resolve lands late — the guard drops it, the picker stays B.
+    releaseA({ guildId: "111", guildName: "Guild A", voiceChannels: [] });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText("Guild B")).toBeInTheDocument();
+    expect(screen.queryByText("Guild A")).not.toBeInTheDocument();
   });
 
   it("surfaces an invalid/expired invite inline, leaving fields unchanged", async () => {

--- a/web/src/screens/configuration/DiscordLinkAutofill.tsx
+++ b/web/src/screens/configuration/DiscordLinkAutofill.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useMutation } from "@connectrpc/connect-query";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { Link as LinkIcon } from "lucide-react";
@@ -23,9 +23,25 @@ import { InviteChannelPicker } from "./InviteChannelPicker";
 // setState would let a config refetch clobber the fill. A failed resolve leaves
 // the fields and any previously-resolved picker untouched.
 
-// ADD_BOT_HINT points a not-a-member / no-token precondition failure back at the
-// Add-Glyphoxa action; the invite can only resolve once the Bot is in the guild.
-const ADD_BOT_HINT = "Use the Add Glyphoxa to your server button above, then paste the invite again.";
+// ADD_BOT_HINT points a not-a-member precondition failure back at the Add-Glyphoxa
+// action, which renders at the FOOT of this card (below the Save button) — so the
+// direction word must match its placement. It is appended ONLY to the not-a-member
+// message; the no-token precondition ("save the token first") is already complete
+// guidance and adding "add the Bot" there would be wrong (the token, not
+// membership, is what's missing).
+const ADD_BOT_HINT =
+  "Use the Add Glyphoxa to your server button at the foot of this card, then paste the invite again.";
+
+// NOT_A_MEMBER_MARK picks the not-a-member precondition out of the two messages
+// that share the FailedPrecondition code (ADR-0047): only that one earns the
+// add-bot hint. Matched as a substring so minor server rewording still routes it.
+const NOT_A_MEMBER_MARK = /not a member/i;
+
+// RESOLVE_DEBOUNCE_MS delays the authed invite resolve so editing/typing a
+// discord.gg URL does not fire a bot-token GET /invites per keystroke (mostly
+// 404s that burn Discord's rate budget, #245). A single paste settles after one
+// tick; the channel-link fill stays instant (it needs no round-trip).
+const RESOLVE_DEBOUNCE_MS = 400;
 
 export function DiscordLinkAutofill({
   onFill,
@@ -39,34 +55,64 @@ export function DiscordLinkAutofill({
   // react-query clears `data` on the next mutate. onSuccess is the only writer.
   const [picker, setPicker] = useState<ResolveGuildInviteResponse | null>(null);
 
+  // currentCode is the invite code the input parses to RIGHT NOW — null when it
+  // is empty, a channel link, or unparseable. Mutation callbacks land in
+  // completion order, so a slow resolve for a superseded paste can arrive after a
+  // newer one; the callbacks bail unless their request code still matches this
+  // ref (latest-wins, #245). Without it a stale success overwrites a newer picker
+  // (picking then fills the WRONG guild) or wipes a current parse error, and a
+  // stale error paints over a valid picker.
+  const currentCode = useRef<string | null>(null);
+  // debounceTimer holds the pending resolve; every change clears it first, so a
+  // burst of keystrokes collapses to one resolve of the final value (#245).
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(debounceTimer.current), []);
+
   const resolve = useMutation(ProviderService.method.resolveGuildInvite, {
-    onSuccess: (res) => {
+    onSuccess: (res, variables) => {
+      if (variables.inviteCode !== currentCode.current) return; // superseded
       setPicker(res);
       setLinkError(null);
     },
-    onError: (err) => setLinkError(inviteErrorMessage(err)),
+    onError: (err, variables) => {
+      if (variables.inviteCode !== currentCode.current) return; // superseded
+      setLinkError(inviteErrorMessage(err));
+    },
   });
 
   const onPaste = (value: string) => {
     setLink(value);
+    // Every change cancels a still-pending resolve so typing does not fire one
+    // GET /invites per keystroke.
+    clearTimeout(debounceTimer.current);
     if (!value.trim()) {
+      currentCode.current = null;
       setLinkError(null);
       return;
     }
     const parsed = parseDiscordLink(value);
     if (!parsed) {
+      currentCode.current = null;
       setLinkError("Couldn't read that link — paste a Discord channel or invite link.");
       return;
     }
     if (parsed.kind === "channel") {
       // Self-describing: both ids are in the URL, fill locally with no round-trip.
+      currentCode.current = null;
       setLinkError(null);
       onFill(parsed.guildId, parsed.channelId);
       return;
     }
     // Invite: only the code is known; the guild + channels resolve server-side.
+    // currentCode updates NOW (before the debounce) so a still-in-flight earlier
+    // resolve is recognised as superseded when it lands.
+    const code = parsed.code;
+    currentCode.current = code;
     setLinkError(null);
-    resolve.mutate({ inviteCode: parsed.code });
+    debounceTimer.current = setTimeout(
+      () => resolve.mutate({ inviteCode: code }),
+      RESOLVE_DEBOUNCE_MS,
+    );
   };
 
   return (
@@ -95,7 +141,8 @@ export function DiscordLinkAutofill({
 // inviteErrorMessage maps a ResolveGuildInvite failure onto the inline message.
 // NotFound is a plain invalid/expired line; FailedPrecondition renders the SERVER
 // message verbatim (no-token vs not-a-member share the code and differ only by
-// message, ADR-0047) plus the add-bot hint.
+// message, ADR-0047). The add-bot hint is appended ONLY to the not-a-member
+// message — the no-token message stands alone as its own complete guidance.
 function inviteErrorMessage(err: unknown): ReactNode {
   const code = err instanceof ConnectError ? err.code : undefined;
   const raw =
@@ -104,11 +151,14 @@ function inviteErrorMessage(err: unknown): ReactNode {
     return "That invite looks invalid or expired.";
   }
   if (code === Code.FailedPrecondition) {
-    return (
-      <>
-        <span>{raw}</span> <span>{ADD_BOT_HINT}</span>
-      </>
-    );
+    if (NOT_A_MEMBER_MARK.test(raw)) {
+      return (
+        <>
+          <span>{raw}</span> <span>{ADD_BOT_HINT}</span>
+        </>
+      );
+    }
+    return <span>{raw}</span>;
   }
   return "Couldn't resolve that invite. Please try again.";
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the six post-merge reviewer findings on PR #241, all in one focused diff. Closes #245.

- **Stale-response race (latest-wins)** — `DiscordLinkAutofill` tracks the currently-parsed invite code in a ref; `onSuccess`/`onError` bail when the mutation's `variables.inviteCode` no longer matches. A late resolve for a superseded paste can no longer swap the picker (which would fill the WRONG guild snowflake on the next pick), wipe a current parse error, or paint a stale resolve error.
- **Per-keystroke resolve** — the authed invite resolve is debounced ~400ms (timer in a ref, cleared on each change). Typing a `discord.gg` URL no longer fires a bot-token `GET /invites` per intermediate value; the channel-link fill stays instant/local.
- **Verbatim-FP test gap** — `Configuration.test.tsx` gains an FP case with a DISTINCT server message (`"save the Discord bot token first"`) asserting it renders verbatim, killing a hardcoded-client-message mutant.
- **`discord.gg/invite/{code}` mis-parse** — `discordLink.ts` skips a leading `invite` segment on the `discord.gg` host, so `discord.gg/invite/{code}` yields `{code}`, not the literal `"invite"`.
- **Add-bot hint copy** — the hint now points at the Add-Glyphoxa action *at the foot of this card* (it renders after the Save button, not above), and is appended only to the not-a-member message; the no-token precondition renders verbatim without it.
- **Invite code in logs** — `internal/rpc/provider.go` redacts the invite code from the `ResolveGuildInvite` internal-error log; a transport `*url.Error`'s text embeds the request URL and thus the code (a join capability, ADR-0047). Op + status text still diagnose.

## Why is this change needed?

Reviewer-found correctness/security hardening on the merged invite-autofill surface: a completion-order race that could persist the wrong guild, a Discord rate-budget burn on every keystroke, a mutation-survivable test, a valid-invite false-negative, wrong on-screen guidance, and a join-capability leak into logs.

## How was this tested?

TDD throughout — a failing test drove each behavioral fix (discord.gg/invite parse, log redaction, debounce, latest-wins, distinct-message verbatim FP).

- [x] New/updated tests cover the change
- [x] `web` gate locally: `tsc --noEmit` clean, `vite build` ok, full vitest **147 passed**
- [x] Go locally: `go build`/`go vet`/`go test ./internal/rpc/... ./internal/discordinvite/...` ok
- [x] `golangci-lint run` — 0 issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Additional Notes

Followed the repo's established debounce test convention (real timers + await-outlast, per `Session.test.tsx`) rather than fake timers — deterministic here and consistent with the suite. The latest-wins test drives a gated slow resolve (A) then a fast one (B) and asserts A's late success does not replace B's picker.