### PR TITLE
fix(#248): zero-line live session snapshot crashes the Session screen

### DIFF
--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -496,11 +496,18 @@ func (r *Relay) View(id string) View {
 		return View{Lines: []Line{}, Status: "idle", Typing: Typing{}}
 	}
 	return View{
-		Lines:      append([]Line(nil), r.lines...),
+		Lines:      copyLines(r.lines),
 		Status:     "live",
 		Typing:     r.typing,
 		Connection: r.connection,
 	}
+}
+
+// copyLines snapshots the ring's lines as a NON-NIL slice: the wire contract for
+// View.Lines is a JSON array, never null — a zero-line live session must serve
+// "lines":[] or the screen's .length read crashes (#248).
+func copyLines(lines []Line) []Line {
+	return append(make([]Line, 0, len(lines)), lines...)
 }
 
 // snapshot returns the initial-state View for id: the in-memory live state when id
@@ -511,7 +518,7 @@ func (r *Relay) snapshot(ctx context.Context, id string) View {
 	r.mu.Lock()
 	live := r.currentSessionID() == id && id == r.activeID
 	if live {
-		v := View{Lines: append([]Line(nil), r.lines...), Status: "live", Typing: r.typing, Connection: r.connection}
+		v := View{Lines: copyLines(r.lines), Status: "live", Typing: r.typing, Connection: r.connection}
 		r.mu.Unlock()
 		return v
 	}

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -552,5 +553,20 @@ func TestDropWhenIdle(t *testing.T) {
 	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "ignored", TurnID: "t1"})
 	if got := r.Frames(fs.id.String(), 0); got != nil {
 		t.Errorf("idle relay buffered %d frames", len(got))
+	}
+}
+
+// TestView_ZeroLinesMarshalsEmptyArray is #248: a live session that has produced
+// no transcript lines yet must serve "lines":[] — never null — because the
+// Session screen reads lines.length straight off the snapshot JSON.
+func TestView_ZeroLinesMarshalsEmptyArray(t *testing.T) {
+	_, r, _, id := liveRelay(t)
+
+	b, err := json.Marshal(r.View(id))
+	if err != nil {
+		t.Fatalf("marshal View: %v", err)
+	}
+	if !strings.Contains(string(b), `"lines":[]`) {
+		t.Errorf("zero-line live View marshals %s, want \"lines\":[]", b)
 	}
 }

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -783,3 +783,29 @@ describe("Session spend cap (#130)", () => {
     expect(screen.queryByTestId("spend-cap")).not.toBeInTheDocument();
   });
 });
+
+describe("Session zero-line live snapshot (#248)", () => {
+  it("survives a snapshot with null lines and renders the live badge", async () => {
+    // The pre-#248 relay (or any older server) serves "lines":null for a live
+    // session with no transcript yet; the screen must normalize it, not crash
+    // into the error boundary on lines.length.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          lines: null,
+          status: "live",
+          typing: { active: true, label: "Listening to the table…" },
+          connection: "connected",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -85,7 +85,11 @@ export function useSessionEvents(sessionId: string | undefined, active: boolean)
     queryFn: async () => {
       const res = await fetch(`/api/v1/sessions/${sessionId}`, { credentials: "same-origin" });
       if (!res.ok) throw new Error(`session snapshot failed: ${res.status}`);
-      return (await res.json()) as Transcript;
+      // Normalize lines defensively: a zero-line snapshot must never surface as
+      // null or the screen's .length reads crash (#248) — the server contract is
+      // "lines":[], but the screen should survive an older/other server too.
+      const t = (await res.json()) as Transcript;
+      return { ...t, lines: t.lines ?? [] };
     },
   });
 


### PR DESCRIPTION
Found in the 2026-07-07 live browser pass: clicking Start session on a fresh session crashed the screen (`TypeError: Cannot read properties of null (reading 'length')`) because `GET /api/v1/sessions/{id}` served `"lines":null` for a live zero-line session.

- relay: `View`/live `snapshot` build `Lines` via a non-nil copy — the wire contract is a JSON array, never null
- web: the snapshot `queryFn` normalizes `lines ?? []` defensively
- regression tests: Go marshal test (`"lines":[]`), web test (null-lines snapshot renders the Live badge instead of the error boundary)

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)