### PR TITLE
chore: update repo self-references after the rename to MrWong99/Glyphoxa

### DIFF
--- a/.github/workflows/bench-live.yml
+++ b/.github/workflows/bench-live.yml
@@ -25,7 +25,7 @@ jobs:
     # Skip silently on forks without the secrets configured, mirroring
     # record-live.yml — avoids a red run on every fork. The real key gate is the
     # t.Fatalf in TestBench_LiveSLO when a key env is empty.
-    if: github.repository == 'MrWong99/Glyphoxa_v2'
+    if: github.repository == 'MrWong99/Glyphoxa'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/llm-ttft-live.yml
+++ b/.github/workflows/llm-ttft-live.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     # Skip silently on forks without the secret, mirroring bench-live.yml. The
     # real key gate is the t.Skip in the test when GROQ_API_KEY is empty.
-    if: github.repository == 'MrWong99/Glyphoxa_v2'
+    if: github.repository == 'MrWong99/Glyphoxa'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/record-live.yml
+++ b/.github/workflows/record-live.yml
@@ -28,7 +28,7 @@ jobs:
     # configured. Avoids surfacing as a failed run on every PR sync from a
     # fork. The actual key gate happens at job start; this just keeps the
     # noise level low.
-    if: github.repository == 'MrWong99/Glyphoxa_v2'
+    if: github.repository == 'MrWong99/Glyphoxa'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -24,7 +24,7 @@ jobs:
     name: build + push image to ghcr
     runs-on: ubuntu-latest
     # Don't attempt to publish from forks (no package write, no intent).
-    if: github.repository == 'MrWong99/Glyphoxa_v2'
+    if: github.repository == 'MrWong99/Glyphoxa'
     steps:
       - uses: actions/checkout@v7
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Issue tracker
 
-GitHub Issues on `MrWong99/Glyphoxa_v2` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub Issues on `MrWong99/Glyphoxa` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/deploy/charts/glyphoxa/Chart.yaml
+++ b/deploy/charts/glyphoxa/Chart.yaml
@@ -23,4 +23,4 @@ keywords:
   - migrations
 
 sources:
-  - https://github.com/MrWong99/Glyphoxa_v2
+  - https://github.com/MrWong99/Glyphoxa

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues on `MrWong99/Glyphoxa_v2`. Use the `gh` CLI for all operations.
+Issues and PRDs for this repo live as GitHub issues on `MrWong99/Glyphoxa`. Use the `gh` CLI for all operations.
 
 ## Conventions
 

--- a/docs/sprints/sprint2-planning/latency.md
+++ b/docs/sprints/sprint2-planning/latency.md
@@ -1,6 +1,6 @@
 # Sprint 2 Planning — Voice-Loop Latency Diagnosis & Benchmark Plan
 
-**Task:** #2 · **Author:** `latency` · **Scope:** read-only analysis of `Glyphoxa_v2` voice loop. No production code changed.
+**Task:** #2 · **Author:** `latency` · **Scope:** read-only analysis of `Glyphoxa` voice loop. No production code changed.
 
 **Symptom:** "Bart antwortet manchmal sehr spät" — *sometimes* very late responses. The operative word is **manchmal**: this is a **tail-latency / variance** problem, not a uniformly slow loop. The diagnosis below separates causes that explain the *intermittency* from causes that merely inflate the *baseline* every turn.
 

--- a/internal/discordinvite/discordinvite.go
+++ b/internal/discordinvite/discordinvite.go
@@ -31,7 +31,7 @@ const liveAPIBaseURL = "https://discord.com/api/v10"
 
 // userAgent is the DiscordBot form Discord requires of bot REST callers, matching
 // internal/discordtag.
-const userAgent = "DiscordBot (https://github.com/MrWong99/Glyphoxa_v2, v2)"
+const userAgent = "DiscordBot (https://github.com/MrWong99/Glyphoxa, v2)"
 
 // guildVoiceType is Discord's channel type for a standard voice channel
 // (GUILD_VOICE). Text (0), category (4), and stage (13) are excluded (ADR-0047).

--- a/internal/discordtag/discordtag.go
+++ b/internal/discordtag/discordtag.go
@@ -68,7 +68,7 @@ func resolve(ctx context.Context, token, baseURL string, log *slog.Logger) (stri
 	}
 	req.Header.Set("Authorization", "Bot "+token)
 	// Discord requires bots to identify with the DiscordBot User-Agent form.
-	req.Header.Set("User-Agent", "DiscordBot (https://github.com/MrWong99/Glyphoxa_v2, v2)")
+	req.Header.Set("User-Agent", "DiscordBot (https://github.com/MrWong99/Glyphoxa, v2)")
 
 	resp, err := selfUserClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## What

Executes the in-repo half of #258's rename decision (the GitHub renames themselves are done: v1 → `MrWong99/Glyphoxa-v1`, this repo → `MrWong99/Glyphoxa`).

- **Workflow guards** (`release-image`, `bench-live`, `llm-ttft-live`, `record-live`): `if: github.repository == 'MrWong99/Glyphoxa_v2'` → `'MrWong99/Glyphoxa'` — without this, releases and live benches silently stop running on the renamed repo.
- Discord **User-Agent URLs** in `internal/discordtag` + `internal/discordinvite` (tests assert only the `DiscordBot ` prefix; both packages green).
- `CLAUDE.md`, `docs/agents/issue-tracker.md`, `deploy/charts/glyphoxa/Chart.yaml` sources URL, `docs/sprints/sprint2-planning/latency.md`.

`go.mod` already declared `github.com/MrWong99/Glyphoxa` — no import churn anywhere.

## Note for releases

First v2 release tag must be **≥ v0.2.0** (v1 burned `v0.0.1`–`v0.1.2` on the Go module proxy under this module path) and must stay below `v2.0.0` (which would require a `/v2` module suffix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)