### PR TITLE
feat(#264): CampaignService management RPCs (List/Create/Update/SetActive)

### DIFF
--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -23,9 +23,9 @@ import (
 )
 
 // campaignStore is the narrow storage surface CampaignServer needs — the active
-// campaign read plus the roster reads and the agent CRUD writes (#71).
-// *storage.Store satisfies it, so handlers can be driven by a fake in unit tests
-// and the real store in integration tests.
+// campaign read, the roster reads and agent CRUD writes (#71), and the campaign
+// management reads/writes (#264). *storage.Store satisfies it, so handlers can be
+// driven by a fake in unit tests and the real store in integration tests.
 type campaignStore interface {
 	// GetActiveCampaignForUser + GetActiveCampaign are the profile-first resolution
 	// (durable /glyphoxa use selection → most-recent fallback) the header + CRUD +

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -37,6 +37,14 @@ type campaignStore interface {
 	// than the profile default. UpdateAgent also uses it to read the owning
 	// campaign's language for a first-save voice default (#224).
 	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	// ListCampaigns/CreateCampaign/UpdateCampaign/SetActiveCampaign back the
+	// campaign management RPCs (#264): the name-ordered picker list, the tenant-
+	// scoped create (auto-Butler fires), the opaque name/system/language write, and
+	// the durable /glyphoxa use selection shared with the slash-command surface.
+	ListCampaigns(ctx context.Context) ([]storage.Campaign, error)
+	CreateCampaign(ctx context.Context, c storage.NewCampaign) (uuid.UUID, error)
+	UpdateCampaign(ctx context.Context, c storage.CampaignUpdate) (storage.Campaign, error)
+	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
 	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
 	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -124,7 +124,10 @@ type setActiveCall struct {
 }
 
 func newFakeStore() *fakeCampaignStore {
-	return &fakeCampaignStore{agents: map[uuid.UUID]storage.Agent{}}
+	return &fakeCampaignStore{
+		agents:        map[uuid.UUID]storage.Agent{},
+		campaignsByID: map[uuid.UUID]storage.Campaign{},
+	}
 }
 
 func (f *fakeCampaignStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
@@ -162,9 +165,6 @@ func (f *fakeCampaignStore) CreateCampaign(_ context.Context, c storage.NewCampa
 	}
 	f.createdCampaigns = append(f.createdCampaigns, c)
 	id := uuid.New()
-	if f.campaignsByID == nil {
-		f.campaignsByID = map[uuid.UUID]storage.Campaign{}
-	}
 	// Land the row so CreateCampaign's read-back (GetCampaign) resolves it.
 	f.campaignsByID[id] = storage.Campaign{
 		ID:       id,

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -43,6 +43,20 @@ type fakeCampaignStore struct {
 	// (#222); getCampaignErr forces its failure path.
 	campaignsByID  map[uuid.UUID]storage.Campaign
 	getCampaignErr error
+
+	// Campaign management state (#264): campaignList backs ListCampaigns;
+	// createdCampaigns records CreateCampaign inputs (created rows also land in
+	// campaignsByID so a read-back resolves); updatedCampaigns records
+	// UpdateCampaign inputs; setActiveCalls records SetActiveCampaign inputs. The
+	// *Err hooks force each failure path.
+	campaignList      []storage.Campaign
+	listCampaignErr   error
+	createdCampaigns  []storage.NewCampaign
+	createCampaignErr error
+	updatedCampaigns  []storage.CampaignUpdate
+	updateCampaignErr error
+	setActiveCalls    []setActiveCall
+	setActiveErr      error
 	// listNodesCampaign/searchNodesCampaign record the campaign id ListNodes /
 	// SearchNodes resolved so the scope precedence can be asserted (#222).
 	listNodesCampaign   uuid.UUID
@@ -103,6 +117,12 @@ type setAgentCall struct {
 	agentID uuid.NullUUID
 }
 
+// setActiveCall records one SetActiveCampaign invocation for assertions (#264).
+type setActiveCall struct {
+	discordUserID string
+	campaignID    uuid.UUID
+}
+
 func newFakeStore() *fakeCampaignStore {
 	return &fakeCampaignStore{agents: map[uuid.UUID]storage.Agent{}}
 }
@@ -130,6 +150,54 @@ func (f *fakeCampaignStore) GetCampaign(_ context.Context, id uuid.UUID) (storag
 		return storage.Campaign{}, storage.ErrNotFound
 	}
 	return c, nil
+}
+
+func (f *fakeCampaignStore) ListCampaigns(context.Context) ([]storage.Campaign, error) {
+	return f.campaignList, f.listCampaignErr
+}
+
+func (f *fakeCampaignStore) CreateCampaign(_ context.Context, c storage.NewCampaign) (uuid.UUID, error) {
+	if f.createCampaignErr != nil {
+		return uuid.Nil, f.createCampaignErr
+	}
+	f.createdCampaigns = append(f.createdCampaigns, c)
+	id := uuid.New()
+	if f.campaignsByID == nil {
+		f.campaignsByID = map[uuid.UUID]storage.Campaign{}
+	}
+	// Land the row so CreateCampaign's read-back (GetCampaign) resolves it.
+	f.campaignsByID[id] = storage.Campaign{
+		ID:       id,
+		TenantID: c.TenantID,
+		Name:     c.Name,
+		System:   c.System,
+		Language: c.Language,
+	}
+	return id, nil
+}
+
+func (f *fakeCampaignStore) UpdateCampaign(_ context.Context, c storage.CampaignUpdate) (storage.Campaign, error) {
+	if f.updateCampaignErr != nil {
+		return storage.Campaign{}, f.updateCampaignErr
+	}
+	f.updatedCampaigns = append(f.updatedCampaigns, c)
+	existing, ok := f.campaignsByID[c.ID]
+	if !ok {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	existing.Name = c.Name
+	existing.System = c.System
+	existing.Language = c.Language
+	f.campaignsByID[c.ID] = existing
+	return existing, nil
+}
+
+func (f *fakeCampaignStore) SetActiveCampaign(_ context.Context, discordUserID string, campaignID uuid.UUID) error {
+	if f.setActiveErr != nil {
+		return f.setActiveErr
+	}
+	f.setActiveCalls = append(f.setActiveCalls, setActiveCall{discordUserID: discordUserID, campaignID: campaignID})
+	return nil
 }
 
 func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {

--- a/internal/rpc/campaign_management.go
+++ b/internal/rpc/campaign_management.go
@@ -1,0 +1,169 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Campaign management handlers (#264, Epic 2/8) on CampaignServer: list, create,
+// update, and durable-select the operator's campaigns. They follow the same error
+// mapping the agent CRUD uses (ErrNotFound→CodeNotFound, empty name→
+// CodeInvalidArgument, generic CodeInternal with a server-side slog). Reads are
+// NO_SIDE_EFFECTS; mutations are CSRF-guarded by the interceptor stack.
+
+// ListCampaigns returns the operator's campaigns in name order (the store's stable
+// name-then-id ordering). A storage failure is CodeInternal.
+func (s *CampaignServer) ListCampaigns(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListCampaignsRequest],
+) (*connect.Response[managementv1.ListCampaignsResponse], error) {
+	campaigns, err := s.store.ListCampaigns(ctx)
+	if err != nil {
+		slog.Default().Error("ListCampaigns: store list failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := make([]*managementv1.Campaign, 0, len(campaigns))
+	for _, c := range campaigns {
+		out = append(out, toProtoCampaign(c))
+	}
+	return connect.NewResponse(&managementv1.ListCampaignsResponse{Campaigns: out}), nil
+}
+
+// CreateCampaign creates a campaign in the operator's tenant and returns it. name
+// is required (empty is CodeInvalidArgument); system/language are optional
+// free-text stored verbatim. The tenant is resolved server-side from the auth
+// interceptor's context (ADR-0039), never a client-supplied id. The ADR-0009
+// auto-Butler trigger fires on the insert, so the new campaign gets its Butler
+// (with the dice grant) as a database invariant. The created row is read back so
+// the response carries the server-assigned id and timestamps.
+func (s *CampaignServer) CreateCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.CreateCampaignRequest],
+) (*connect.Response[managementv1.CreateCampaignResponse], error) {
+	m := req.Msg
+	name := strings.TrimSpace(m.GetName())
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+
+	tenantID, ok := auth.TenantID(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no tenant in context"))
+	}
+
+	id, err := s.store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID,
+		Name:     name,
+		System:   m.GetSystem(),
+		Language: m.GetLanguage(),
+	})
+	if err != nil {
+		slog.Default().Error("CreateCampaign: store create failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Read the row back so the response carries the canonical persisted shape
+	// (server-assigned id, created_at/updated_at), mirroring CreateAgent.
+	created, err := s.store.GetCampaign(ctx, id)
+	if err != nil {
+		slog.Default().Error("CreateCampaign: read-back failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.CreateCampaignResponse{Campaign: toProtoCampaign(created)}), nil
+}
+
+// UpdateCampaign writes a campaign's name/system/language and returns the updated
+// row. id is required (unparsable is CodeInvalidArgument) and name must be
+// non-empty (CodeInvalidArgument). System/Language are written opaquely, exactly
+// as stored today — no validation, no vocabulary curation (that is the settings
+// editor slice's call). An unknown id is CodeNotFound.
+func (s *CampaignServer) UpdateCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateCampaignRequest],
+) (*connect.Response[managementv1.UpdateCampaignResponse], error) {
+	m := req.Msg
+	id, err := uuid.Parse(m.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid campaign id"))
+	}
+	name := strings.TrimSpace(m.GetName())
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+
+	updated, err := s.store.UpdateCampaign(ctx, storage.CampaignUpdate{
+		ID:       id,
+		Name:     name,
+		System:   m.GetSystem(),
+		Language: m.GetLanguage(),
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		}
+		slog.Default().Error("UpdateCampaign: store update failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UpdateCampaignResponse{Campaign: toProtoCampaign(updated)}), nil
+}
+
+// SetActiveCampaign records the operator's durable Active Campaign selection and
+// returns the resulting resolved Active Campaign. The campaign_id is validated via
+// GetCampaign first (an unparsable id is CodeInvalidArgument; an unknown id is
+// CodeNotFound) so a bogus selection is never persisted. The selection is written
+// to users.active_campaign_id keyed on the operator's DiscordUserID — the IDENTICAL
+// row `/glyphoxa use` writes (migration 00014), keeping both surfaces in lockstep.
+// The resolved campaign is read back through the shared live-first policy, so while
+// a Voice Session is live its campaign still wins (#222) and the returned campaign
+// may differ from the one just selected.
+func (s *CampaignServer) SetActiveCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetActiveCampaignRequest],
+) (*connect.Response[managementv1.SetActiveCampaignResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetCampaignId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid campaign id"))
+	}
+
+	u, ok := auth.CurrentUser(ctx)
+	if !ok || u.DiscordUserID == "" {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no operator in context"))
+	}
+
+	// Validate the target exists before persisting the pointer — an unknown id is
+	// a client error (CodeNotFound), never a silently-stored dangling selection.
+	if _, err := s.store.GetCampaign(ctx, id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		}
+		slog.Default().Error("SetActiveCampaign: validate campaign failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	if err := s.store.SetActiveCampaign(ctx, u.DiscordUserID, id); err != nil {
+		slog.Default().Error("SetActiveCampaign: store write failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Return the resolved Active Campaign via the one shared live-first policy, so
+	// this surface agrees with GetActiveCampaign/GetCampaignRoster/ListNodes (#222).
+	resolved, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("SetActiveCampaign: resolve active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.SetActiveCampaignResponse{Campaign: toProtoCampaign(resolved)}), nil
+}

--- a/internal/rpc/campaign_management.go
+++ b/internal/rpc/campaign_management.go
@@ -151,6 +151,12 @@ func (s *CampaignServer) SetActiveCampaign(
 	}
 
 	if err := s.store.SetActiveCampaign(ctx, u.DiscordUserID, id); err != nil {
+		// The write re-checks existence via the active_campaign_id FK, so a campaign
+		// deleted between the validation above and this write is still CodeNotFound,
+		// never a stored dangling pointer or a misleading CodeInternal.
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		}
 		slog.Default().Error("SetActiveCampaign: store write failed", "campaign_id", id, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}

--- a/internal/rpc/campaign_management_integration_test.go
+++ b/internal/rpc/campaign_management_integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+
+// This drives the CampaignService management RPCs (#264) end to end over
+// Connect-JSON against a real *storage.Store (testcontainers Postgres): list,
+// create (auto-Butler + dice grant invariant, ADR-0009), the opaque
+// name/system/language update, and the durable Active Campaign selection shared
+// with `/glyphoxa use` (migration 00014), including the live-first resolution
+// rule (#222). Tag-isolated behind `integration`; reuses startPostgres/seedStore
+// from campaign_integration_test.go.
+
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// mgmtIntegrationClient mounts a CampaignServer over a real store behind an
+// interceptor that injects the resolved tenant + operator (ADR-0039), optionally
+// wiring a live Voice Session source so the live-first rule can be exercised.
+func mgmtIntegrationClient(t *testing.T, store *storage.Store, tenantID uuid.UUID, discordUserID string, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	srv := rpc.NewCampaignServer(store)
+	if sessions != nil {
+		srv.SetSessions(sessions)
+	}
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx = auth.WithTenant(ctx, tenantID)
+			ctx = auth.WithUser(ctx, storage.User{ID: uuid.New(), DiscordUserID: discordUserID})
+			return next(ctx, req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, s.URL, connect.WithProtoJSON(),
+	)
+}
+
+func TestCampaignManagement_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, seededID := seedStore(t, dsn) // seeds a "Lost Mine" campaign (+ its auto-Butler)
+	ctx := context.Background()
+
+	// The tenant is the seeded campaign's; the management RPCs resolve it from the
+	// context, so inject it (and an operator) via the interceptor.
+	seeded, err := store.GetCampaign(ctx, seededID)
+	if err != nil {
+		t.Fatalf("GetCampaign(seeded): %v", err)
+	}
+	const operator = "operator-264"
+	client := mgmtIntegrationClient(t, store, seeded.TenantID, operator, nil)
+
+	// --- Create two campaigns; the tenant comes from the context, never the wire.
+	created1, err := client.CreateCampaign(ctx, connect.NewRequest(&managementv1.CreateCampaignRequest{
+		Name: "Zeta Reach", System: "pf2e", Language: "de",
+	}))
+	if err != nil {
+		t.Fatalf("CreateCampaign(Zeta): %v", err)
+	}
+	zeta := created1.Msg.GetCampaign()
+	if zeta.GetName() != "Zeta Reach" || zeta.GetSystem() != "pf2e" || zeta.GetLanguage() != "de" {
+		t.Errorf("created Zeta fields wrong: %+v", zeta)
+	}
+	if zeta.GetTenantId() != seeded.TenantID.String() {
+		t.Errorf("created Zeta tenant = %q, want the server-resolved %q", zeta.GetTenantId(), seeded.TenantID)
+	}
+
+	created2, err := client.CreateCampaign(ctx, connect.NewRequest(&managementv1.CreateCampaignRequest{
+		Name: "Alpha Quest",
+	}))
+	if err != nil {
+		t.Fatalf("CreateCampaign(Alpha): %v", err)
+	}
+	alpha := created2.Msg.GetCampaign()
+
+	// --- Create fires the ADR-0009 auto-Butler trigger: the new campaign has
+	// exactly one Butler, and it carries the dice grant (migration 00013).
+	butler, err := store.GetButler(ctx, uuid.MustParse(zeta.GetId()))
+	if err != nil {
+		t.Fatalf("auto-Butler missing for created campaign: %v", err)
+	}
+	if butler.Role != storage.AgentRoleButler || !butler.AddressOnly {
+		t.Errorf("auto-Butler wrong: %+v", butler)
+	}
+	grants, err := store.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants(butler): %v", err)
+	}
+	if len(grants) != 1 || grants[0].ToolName != "dice" {
+		t.Errorf("auto-Butler grants = %+v, want exactly one dice grant", grants)
+	}
+
+	// --- List returns every campaign name-ordered: Alpha Quest, Lost Mine, Zeta Reach.
+	list, err := client.ListCampaigns(ctx, connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	names := make([]string, 0, len(list.Msg.GetCampaigns()))
+	for _, c := range list.Msg.GetCampaigns() {
+		names = append(names, c.GetName())
+	}
+	want := []string{"Alpha Quest", "Lost Mine", "Zeta Reach"}
+	if len(names) != len(want) {
+		t.Fatalf("ListCampaigns = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("ListCampaigns order = %v, want %v", names, want)
+		}
+	}
+
+	// --- Update writes the three columns opaquely (arbitrary free-text accepted).
+	const opaqueSystem = "Homebrew: 3d6-in-order ⚔️"
+	const opaqueLang = "Middle Draconic (invented)"
+	upd, err := client.UpdateCampaign(ctx, connect.NewRequest(&managementv1.UpdateCampaignRequest{
+		Id: zeta.GetId(), Name: "Zeta Reach II", System: opaqueSystem, Language: opaqueLang,
+	}))
+	if err != nil {
+		t.Fatalf("UpdateCampaign: %v", err)
+	}
+	if upd.Msg.GetCampaign().GetName() != "Zeta Reach II" ||
+		upd.Msg.GetCampaign().GetSystem() != opaqueSystem ||
+		upd.Msg.GetCampaign().GetLanguage() != opaqueLang {
+		t.Errorf("update did not write opaquely: %+v", upd.Msg.GetCampaign())
+	}
+	// The write persists — a re-read reflects it.
+	reread, err := store.GetCampaign(ctx, uuid.MustParse(zeta.GetId()))
+	if err != nil || reread.System != opaqueSystem {
+		t.Errorf("re-read after update = %+v, %v", reread, err)
+	}
+	// An unknown id is CodeNotFound.
+	_, err = client.UpdateCampaign(ctx, connect.NewRequest(&managementv1.UpdateCampaignRequest{
+		Id: uuid.New().String(), Name: "ghost",
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("UpdateCampaign(unknown) code = %v, want NotFound", got)
+	}
+
+	// --- SetActiveCampaign to Alpha; with no live session the resolved Active
+	// Campaign flips to it across the header, roster, and node reads.
+	setResp, err := client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
+		CampaignId: alpha.GetId(),
+	}))
+	if err != nil {
+		t.Fatalf("SetActiveCampaign(Alpha): %v", err)
+	}
+	if setResp.Msg.GetCampaign().GetId() != alpha.GetId() {
+		t.Errorf("SetActiveCampaign resolved = %s, want Alpha %s", setResp.Msg.GetCampaign().GetId(), alpha.GetId())
+	}
+
+	active, err := client.GetActiveCampaign(ctx, connect.NewRequest(&managementv1.GetActiveCampaignRequest{}))
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	if active.Msg.GetCampaign().GetId() != alpha.GetId() {
+		t.Errorf("GetActiveCampaign = %s, want the selected Alpha %s (not the newest)", active.Msg.GetCampaign().GetId(), alpha.GetId())
+	}
+	roster, err := client.GetCampaignRoster(ctx, connect.NewRequest(&managementv1.GetCampaignRosterRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignRoster: %v", err)
+	}
+	if roster.Msg.GetCampaign().GetId() != alpha.GetId() {
+		t.Errorf("GetCampaignRoster = %s, want Alpha %s", roster.Msg.GetCampaign().GetId(), alpha.GetId())
+	}
+	// ListNodes resolves the same selection: an entry created now lands in Alpha
+	// and lists back, proving the read scoped to the durable selection.
+	if _, err := client.CreateNode(ctx, connect.NewRequest(&managementv1.CreateNodeRequest{
+		NodeType: managementv1.NodeType_NODE_TYPE_NOTE, Name: "Alpha-scoped note",
+	})); err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	nodes, err := client.ListNodes(ctx, connect.NewRequest(&managementv1.ListNodesRequest{}))
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes.Msg.GetNodes()) != 1 || nodes.Msg.GetNodes()[0].GetName() != "Alpha-scoped note" {
+		t.Errorf("ListNodes did not resolve the Alpha selection: %+v", nodes.Msg.GetNodes())
+	}
+	// The durable selection is the SAME row /glyphoxa use reads — both surfaces in
+	// lockstep (migration 00014).
+	forUser, err := store.GetActiveCampaignForUser(ctx, operator)
+	if err != nil || forUser.ID.String() != alpha.GetId() {
+		t.Errorf("GetActiveCampaignForUser = %+v, %v, want Alpha %s", forUser, err, alpha.GetId())
+	}
+
+	// An unknown campaign_id is CodeNotFound and persists nothing.
+	_, err = client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
+		CampaignId: uuid.New().String(),
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("SetActiveCampaign(unknown) code = %v, want NotFound", got)
+	}
+}
+
+// TestSetActiveCampaignLiveFirst_Integration pins the live-first resolution rule
+// (#222, #264) end to end: with a live Voice Session bound to campaign L, a
+// durable selection of a DIFFERENT campaign D is still written (both surfaces in
+// lockstep) but the resolved Active Campaign is L — the live session wins.
+func TestSetActiveCampaignLiveFirst_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, liveID := seedStore(t, dsn) // "Lost Mine" is the live campaign L
+	ctx := context.Background()
+
+	seeded, err := store.GetCampaign(ctx, liveID)
+	if err != nil {
+		t.Fatalf("GetCampaign(seeded): %v", err)
+	}
+	// A second campaign D in the same tenant to durably select.
+	durableID, err := store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: seeded.TenantID, Name: "Durable D", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign(D): %v", err)
+	}
+
+	// A live session bound to L.
+	client := mgmtIntegrationClient(t, store, seeded.TenantID, "operator-live", liveMgr(liveID))
+
+	setResp, err := client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
+		CampaignId: durableID.String(),
+	}))
+	if err != nil {
+		t.Fatalf("SetActiveCampaign(D): %v", err)
+	}
+	// Resolved Active Campaign is the LIVE one, not the just-selected D.
+	if got := setResp.Msg.GetCampaign().GetId(); got != liveID.String() {
+		t.Errorf("resolved = %s, want the LIVE campaign %s (not the selected %s)", got, liveID, durableID)
+	}
+	// ...but the durable selection D was still written (lockstep with /glyphoxa use).
+	forUser, err := store.GetActiveCampaignForUser(ctx, "operator-live")
+	if err != nil || forUser.ID != durableID {
+		t.Errorf("durable selection = %+v, %v, want D %s", forUser, err, durableID)
+	}
+}

--- a/internal/rpc/campaign_management_test.go
+++ b/internal/rpc/campaign_management_test.go
@@ -1,0 +1,350 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+
+	"net/http"
+	"net/http/httptest"
+)
+
+// mgmtClient stands up the CampaignService handler with an injected operator +
+// tenant (the auth interceptor stack's resolved principal, ADR-0039) and an
+// optional live Voice Session source, returning a Connect-JSON client. The
+// management RPCs (#264) need both: CreateCampaign resolves the tenant, and
+// SetActiveCampaign resolves the operator's DiscordUserID.
+func mgmtClient(t *testing.T, store *fakeCampaignStore, user storage.User, tenantID uuid.UUID, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	srv := rpc.NewCampaignServer(store)
+	if sessions != nil {
+		srv.SetSessions(sessions)
+	}
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if user.DiscordUserID != "" {
+				ctx = auth.WithUser(ctx, user)
+			}
+			if tenantID != uuid.Nil {
+				ctx = auth.WithTenant(ctx, tenantID)
+			}
+			return next(ctx, req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, s.URL, connect.WithProtoJSON(),
+	)
+}
+
+func TestListCampaigns_NameOrdered(t *testing.T) {
+	t.Parallel()
+	// The store already returns name-ordered rows (ListCampaigns SQL); the handler
+	// maps them 1:1, so assert the order is preserved onto the wire.
+	store := newFakeStore()
+	store.campaignList = []storage.Campaign{
+		{ID: uuid.New(), TenantID: uuid.New(), Name: "Alpha Quest", System: "dnd5e", Language: "en"},
+		{ID: uuid.New(), TenantID: uuid.New(), Name: "Lost Mine", System: "pf2e", Language: "de"},
+	}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.ListCampaigns(context.Background(),
+		connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	got := resp.Msg.GetCampaigns()
+	if len(got) != 2 {
+		t.Fatalf("campaigns len = %d, want 2", len(got))
+	}
+	if got[0].GetName() != "Alpha Quest" || got[1].GetName() != "Lost Mine" {
+		t.Errorf("order not preserved: %q, %q", got[0].GetName(), got[1].GetName())
+	}
+	if got[1].GetSystem() != "pf2e" || got[1].GetLanguage() != "de" {
+		t.Errorf("fields not mapped: %+v", got[1])
+	}
+}
+
+func TestListCampaigns_Empty(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.ListCampaigns(context.Background(),
+		connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if got := len(resp.Msg.GetCampaigns()); got != 0 {
+		t.Errorf("campaigns len = %d, want 0", got)
+	}
+}
+
+func TestListCampaigns_Internal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.listCampaignErr = errAny
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.ListCampaigns(context.Background(),
+		connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestCreateCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	tenantID := uuid.New()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, tenantID, nil)
+
+	resp, err := client.CreateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.CreateCampaignRequest{
+			Name: "New Campaign", System: "dnd5e", Language: "en",
+		}))
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	c := resp.Msg.GetCampaign()
+	if c.GetName() != "New Campaign" || c.GetSystem() != "dnd5e" || c.GetLanguage() != "en" {
+		t.Errorf("fields not mapped: %+v", c)
+	}
+	if c.GetTenantId() != tenantID.String() {
+		t.Errorf("tenant_id = %q, want the server-resolved %q", c.GetTenantId(), tenantID)
+	}
+	// The tenant must come from the context, never the request — assert the store
+	// was asked to create under the resolved tenant.
+	if len(store.createdCampaigns) != 1 || store.createdCampaigns[0].TenantID != tenantID {
+		t.Errorf("store create tenant = %+v, want %s", store.createdCampaigns, tenantID)
+	}
+	if store.createdCampaigns[0].Name != "New Campaign" {
+		t.Errorf("store create name = %q", store.createdCampaigns[0].Name)
+	}
+}
+
+func TestCreateCampaign_EmptyNameInvalid(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	// Whitespace-only is treated as empty (trimmed), like CreateNode.
+	_, err := client.CreateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.CreateCampaignRequest{Name: "   "}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+	if len(store.createdCampaigns) != 0 {
+		t.Errorf("store should not have been asked to create: %+v", store.createdCampaigns)
+	}
+}
+
+func TestCreateCampaign_NoTenantUnauthenticated(t *testing.T) {
+	t.Parallel()
+	// No tenant injected → the handler treats it as unauthenticated.
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.Nil, nil)
+
+	_, err := client.CreateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.CreateCampaignRequest{Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", got)
+	}
+}
+
+func TestCreateCampaign_Internal(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.createCampaignErr = errAny
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.CreateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.CreateCampaignRequest{Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInternal {
+		t.Errorf("code = %v, want Internal", got)
+	}
+}
+
+func TestUpdateCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.campaignsByID = map[uuid.UUID]storage.Campaign{
+		id: {ID: id, TenantID: uuid.New(), Name: "Old", System: "old-sys", Language: "en"},
+	}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.UpdateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCampaignRequest{
+			Id: id.String(), Name: "Renamed", System: "dnd5e", Language: "de",
+		}))
+	if err != nil {
+		t.Fatalf("UpdateCampaign: %v", err)
+	}
+	c := resp.Msg.GetCampaign()
+	if c.GetName() != "Renamed" || c.GetSystem() != "dnd5e" || c.GetLanguage() != "de" {
+		t.Errorf("update not applied: %+v", c)
+	}
+	// System/Language written opaquely — verbatim, no validation/curation.
+	if len(store.updatedCampaigns) != 1 {
+		t.Fatalf("store updates = %d, want 1", len(store.updatedCampaigns))
+	}
+	u := store.updatedCampaigns[0]
+	if u.System != "dnd5e" || u.Language != "de" || u.Name != "Renamed" {
+		t.Errorf("store update not opaque round-trip: %+v", u)
+	}
+}
+
+// TestUpdateCampaign_OpaqueFreeText pins the #264 opacity rule: an arbitrary,
+// non-vocabulary system/language string reaches storage verbatim — no validation
+// rejects it (curation is the settings-editor slice's call).
+func TestUpdateCampaign_OpaqueFreeText(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.campaignsByID = map[uuid.UUID]storage.Campaign{id: {ID: id, Name: "Old"}}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	const gibberishSystem = "Homebrew: 3d6-in-order ⚔️"
+	const gibberishLang = "Middle Draconic (made up)"
+	resp, err := client.UpdateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCampaignRequest{
+			Id: id.String(), Name: "Kept", System: gibberishSystem, Language: gibberishLang,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateCampaign: %v", err)
+	}
+	if resp.Msg.GetCampaign().GetSystem() != gibberishSystem || resp.Msg.GetCampaign().GetLanguage() != gibberishLang {
+		t.Errorf("opaque strings not preserved: %+v", resp.Msg.GetCampaign())
+	}
+}
+
+func TestUpdateCampaign_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.UpdateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: "not-a-uuid", Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateCampaign_EmptyNameInvalid(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.UpdateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: uuid.New().String(), Name: "  "}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestUpdateCampaign_UnknownIDNotFound(t *testing.T) {
+	t.Parallel()
+	// campaignsByID is empty, so UpdateCampaign returns ErrNotFound.
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.UpdateCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: uuid.New().String(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+func TestSetActiveCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	target := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Target"}
+	store.campaignsByID = map[uuid.UUID]storage.Campaign{target.ID: target}
+	// No live session and no durable selection lookup wired: the resolved read
+	// falls through to the durable selection, which the fake returns from forUser.
+	store.forUser = target
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "operator-42"}, uuid.New(), nil)
+
+	resp, err := client.SetActiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: target.ID.String()}))
+	if err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	if got := resp.Msg.GetCampaign().GetId(); got != target.ID.String() {
+		t.Errorf("resolved campaign = %s, want %s", got, target.ID)
+	}
+	// The selection is keyed on the operator's DiscordUserID — the SAME row
+	// /glyphoxa use writes (migration 00014).
+	if len(store.setActiveCalls) != 1 {
+		t.Fatalf("SetActiveCampaign calls = %d, want 1", len(store.setActiveCalls))
+	}
+	call := store.setActiveCalls[0]
+	if call.discordUserID != "operator-42" || call.campaignID != target.ID {
+		t.Errorf("durable write = %+v, want {operator-42 %s}", call, target.ID)
+	}
+}
+
+func TestSetActiveCampaign_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.SetActiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestSetActiveCampaign_UnknownIDNotFound(t *testing.T) {
+	t.Parallel()
+	// campaignsByID is empty → the pre-write GetCampaign validation returns
+	// ErrNotFound, and the selection is never persisted.
+	store := newFakeStore()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.SetActiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+	if len(store.setActiveCalls) != 0 {
+		t.Errorf("unknown id must not persist a selection: %+v", store.setActiveCalls)
+	}
+}
+
+// TestSetActiveCampaignLiveFirstWins pins the live-first resolution rule (#222,
+// #264): setting a durable selection (D) while a Voice Session is live (bound to
+// L) returns the LIVE campaign, not the one just selected — the durable write
+// still happens (both surfaces stay in lockstep), but the resolved Active Campaign
+// honors the live session.
+func TestSetActiveCampaignLiveFirstWins(t *testing.T) {
+	t.Parallel()
+	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
+	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
+	store := newFakeStore()
+	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live, durable.ID: durable}
+	store.forUser = durable // the durable selection, were live-first not in force
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live.ID))
+
+	resp, err := client.SetActiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: durable.ID.String()}))
+	if err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	// The durable selection was still written (lockstep with /glyphoxa use)...
+	if len(store.setActiveCalls) != 1 || store.setActiveCalls[0].campaignID != durable.ID {
+		t.Errorf("durable selection not written: %+v", store.setActiveCalls)
+	}
+	// ...but the resolved Active Campaign is the LIVE session's, not D.
+	if got := resp.Msg.GetCampaign().GetId(); got != live.ID.String() {
+		t.Errorf("resolved campaign = %s, want the LIVE session campaign %s (not the just-selected %s)",
+			got, live.ID, durable.ID)
+	}
+}

--- a/internal/rpc/campaign_management_test.go
+++ b/internal/rpc/campaign_management_test.go
@@ -2,6 +2,8 @@ package rpc_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -12,9 +14,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
-
-	"net/http"
-	"net/http/httptest"
 )
 
 // mgmtClient stands up the CampaignService handler with an injected operator +

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -46,6 +46,22 @@ func (f fakeReader) GetCampaign(context.Context, uuid.UUID) (storage.Campaign, e
 	return f.campaign, f.err
 }
 
+// The campaign management half of campaignStore (#264) is unused by the
+// GetActiveCampaign tests; stub it so fakeReader still satisfies the widened
+// interface. The management handlers exercise it via fakeCampaignStore.
+func (fakeReader) ListCampaigns(context.Context) ([]storage.Campaign, error) {
+	return nil, nil
+}
+func (fakeReader) CreateCampaign(context.Context, storage.NewCampaign) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+func (fakeReader) UpdateCampaign(context.Context, storage.CampaignUpdate) (storage.Campaign, error) {
+	return storage.Campaign{}, nil
+}
+func (fakeReader) SetActiveCampaign(context.Context, string, uuid.UUID) error {
+	return nil
+}
+
 // The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
 // tests; stub it so fakeReader still satisfies the widened interface. The CRUD
 // handlers have their own fake (campaign_crud_test.go).

--- a/internal/storage/active_campaign_test.go
+++ b/internal/storage/active_campaign_test.go
@@ -182,3 +182,41 @@ func TestListAndGetCampaign(t *testing.T) {
 		t.Errorf("GetCampaign(random) = %v, want ErrNotFound", err)
 	}
 }
+
+// TestUpdateCampaign covers the #264 write against a real Postgres: name/system/
+// language are written verbatim (opaque free-text), updated_at is bumped, and an
+// unknown id is ErrNotFound.
+func TestUpdateCampaign(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, first := seedCampaign(t, dsn) // seeded: name "Lost Mine", system dnd5e, language en
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	before, err := st.GetCampaign(ctx, first)
+	if err != nil {
+		t.Fatalf("GetCampaign(before): %v", err)
+	}
+
+	updated, err := st.UpdateCampaign(ctx, storage.CampaignUpdate{
+		ID: first, Name: "Renamed Quest", System: "Homebrew: 3d6 ⚔️", Language: "Draconic (made up)",
+	})
+	if err != nil {
+		t.Fatalf("UpdateCampaign: %v", err)
+	}
+	if updated.Name != "Renamed Quest" || updated.System != "Homebrew: 3d6 ⚔️" || updated.Language != "Draconic (made up)" {
+		t.Errorf("update did not write the opaque fields verbatim: %+v", updated)
+	}
+	if !updated.UpdatedAt.After(before.UpdatedAt) {
+		t.Errorf("updated_at not bumped: before %v, after %v", before.UpdatedAt, updated.UpdatedAt)
+	}
+	// The write persists — a fresh read reflects it.
+	reread, err := st.GetCampaign(ctx, first)
+	if err != nil || reread.Name != "Renamed Quest" || reread.System != "Homebrew: 3d6 ⚔️" {
+		t.Errorf("re-read after update = %+v, %v", reread, err)
+	}
+
+	// An unknown id is ErrNotFound (the RPC layer maps it to CodeNotFound).
+	if _, err := st.UpdateCampaign(ctx, storage.CampaignUpdate{ID: uuid.New(), Name: "x"}); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("UpdateCampaign(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -82,7 +82,10 @@ func (s *Store) GetUserByDiscordID(ctx context.Context, discordUserID string) (U
 // ADR-0009) on the users row keyed by Discord snowflake. It UPSERTS the row so a
 // GM who drives the slash-command surface before ever logging into the web tier
 // still gets a persisted selection; a later OAuth login refreshes the display
-// fields (UpsertUser) and preserves this selection. Idempotent.
+// fields (UpsertUser) and preserves this selection. Idempotent. A campaignID that
+// no longer exists trips the active_campaign_id FK (23503) and yields ErrNotFound
+// — the write can never store a dangling pointer, even if the campaign vanishes
+// between a caller's existence check and this write.
 func (s *Store) SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error {
 	_, err := s.db.Exec(ctx,
 		`INSERT INTO users (discord_user_id, active_campaign_id)
@@ -90,6 +93,9 @@ func (s *Store) SetActiveCampaign(ctx context.Context, discordUserID string, cam
 		 ON CONFLICT (discord_user_id) DO UPDATE
 		   SET active_campaign_id = EXCLUDED.active_campaign_id, updated_at = now()`,
 		discordUserID, campaignID)
+	if code, ok := pgErrCode(err); ok && code == "23503" { // foreign_key_violation
+		return ErrNotFound
+	}
 	if err != nil {
 		return fmt.Errorf("storage: set active campaign for %q: %w", discordUserID, err)
 	}

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -49,6 +49,40 @@ func (s *Store) CreateCampaign(ctx context.Context, c NewCampaign) (uuid.UUID, e
 	return id, nil
 }
 
+// CampaignUpdate is the input to UpdateCampaign. It carries the operator-editable
+// fields only — name/system/language; tenant_id, gm_member_id and the timestamps
+// are not settable here. System/Language are written verbatim as opaque free-text
+// strings (no validation at this layer), mirroring how they are stored on create.
+type CampaignUpdate struct {
+	ID       uuid.UUID
+	Name     string
+	System   string
+	Language string
+}
+
+// UpdateCampaign writes a campaign's name/system/language and bumps updated_at,
+// returning the updated row. A missing id yields ErrNotFound (the RPC layer maps
+// it to Connect CodeNotFound).
+func (s *Store) UpdateCampaign(ctx context.Context, c CampaignUpdate) (Campaign, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE campaign SET
+		    name = $2,
+		    system = $3,
+		    language = $4,
+		    updated_at = now()
+		  WHERE id = $1
+		 RETURNING `+campaignColumns,
+		c.ID, c.Name, c.System, c.Language)
+	updated, err := scanCampaign(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Campaign{}, ErrNotFound
+	}
+	if err != nil {
+		return Campaign{}, fmt.Errorf("storage: update campaign %s: %w", c.ID, err)
+	}
+	return updated, nil
+}
+
 // NewProviderConfig is the input to CreateProviderConfig. CredentialsCiphertext
 // is the AES-GCM-sealed credential (see internal/storage/crypto); for the
 // self-host voice path the real key lives in the OS keyring and this carries a

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -62,7 +62,9 @@ type CampaignUpdate struct {
 
 // UpdateCampaign writes a campaign's name/system/language and bumps updated_at,
 // returning the updated row. A missing id yields ErrNotFound (the RPC layer maps
-// it to Connect CodeNotFound).
+// it to Connect CodeNotFound). Like the other campaign reads/writes it is scoped
+// by id alone — single-operator today; tenant scoping fills in behind the
+// X-Tenant-Id pass-through later (ADR-0039).
 func (s *Store) UpdateCampaign(ctx context.Context, c CampaignUpdate) (Campaign, error) {
 	row := s.db.QueryRow(ctx,
 		`UPDATE campaign SET

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -13,8 +13,10 @@ option go_package = "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1;man
 // single-operator self-host (ADR-0039) it resolves the sole seeded tenant; the
 // X-Tenant-Id pass-through that scopes multi-tenant reads fills in later.
 service CampaignService {
-  // GetActiveCampaign returns the most-recently-created campaign for the
-  // operator. It fails with CodeNotFound when no campaign exists.
+  // GetActiveCampaign returns the operator's resolved Active Campaign: the live
+  // Voice Session's campaign when one is running, else the durable selection
+  // written by SetActiveCampaign / `/glyphoxa use`, else the most-recently-created
+  // campaign (#222). It fails with CodeNotFound when no campaign exists.
   rpc GetActiveCampaign(GetActiveCampaignRequest) returns (GetActiveCampaignResponse);
 
   // ListCampaigns returns the operator's campaigns in name order (#264). It backs
@@ -432,7 +434,8 @@ message GetActiveCampaignRequest {}
 
 // GetActiveCampaignResponse carries the resolved active campaign.
 message GetActiveCampaignResponse {
-  // campaign is the most-recently-created campaign for the operator.
+  // campaign is the operator's resolved Active Campaign (live Voice Session's
+  // campaign → durable selection → most-recently-created fallback).
   Campaign campaign = 1;
 }
 

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -17,6 +17,37 @@ service CampaignService {
   // operator. It fails with CodeNotFound when no campaign exists.
   rpc GetActiveCampaign(GetActiveCampaignRequest) returns (GetActiveCampaignResponse);
 
+  // ListCampaigns returns the operator's campaigns in name order (#264). It backs
+  // the web UI's campaign picker. It is a read (NO_SIDE_EFFECTS), so the CSRF
+  // check is exempt.
+  rpc ListCampaigns(ListCampaignsRequest) returns (ListCampaignsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // CreateCampaign creates a campaign and returns it (#264). name is required
+  // (empty is CodeInvalidArgument); system/language are optional free-text. The
+  // tenant is resolved server-side (ADR-0039), and the ADR-0009 auto-Butler
+  // trigger fires so the new campaign has its Butler with the dice grant.
+  // State-changing: the auth + CSRF interceptors guard it.
+  rpc CreateCampaign(CreateCampaignRequest) returns (CreateCampaignResponse);
+
+  // UpdateCampaign writes a campaign's name/system/language and returns the
+  // updated campaign (#264). id is required; an unknown id is CodeNotFound and an
+  // empty name is CodeInvalidArgument. system/language are stored as opaque
+  // free-text strings (no validation) and take effect on the next Voice Session.
+  // State-changing: the auth + CSRF interceptors guard it.
+  rpc UpdateCampaign(UpdateCampaignRequest) returns (UpdateCampaignResponse);
+
+  // SetActiveCampaign records the operator's durable Active Campaign selection —
+  // the SAME users.active_campaign_id row `/glyphoxa use` writes, keeping both
+  // surfaces in lockstep (#264, migration 00014) — and returns the resulting
+  // resolved Active Campaign. campaign_id is validated first; an unknown id is
+  // CodeNotFound. The live-first resolution rule is untouched: while a Voice
+  // Session is live its campaign still wins, so the returned campaign may differ
+  // from the one just selected. State-changing: the auth + CSRF interceptors
+  // guard it.
+  rpc SetActiveCampaign(SetActiveCampaignRequest) returns (SetActiveCampaignResponse);
+
   // GetCampaignRoster returns the active campaign together with its ordered
   // roster — the Butler first, then the Character NPCs — each carrying a stable
   // speaker-colour slot (#71). It is a read (NO_SIDE_EFFECTS), so the CSRF check
@@ -402,6 +433,69 @@ message GetActiveCampaignRequest {}
 // GetActiveCampaignResponse carries the resolved active campaign.
 message GetActiveCampaignResponse {
   // campaign is the most-recently-created campaign for the operator.
+  Campaign campaign = 1;
+}
+
+// ListCampaignsRequest is the (empty) request; the operator's campaigns are
+// resolved server-side (single operator, ADR-0039).
+message ListCampaignsRequest {}
+
+// ListCampaignsResponse carries the operator's campaigns in name order.
+message ListCampaignsResponse {
+  // campaigns are the operator's campaigns, name-ordered.
+  repeated Campaign campaigns = 1;
+}
+
+// CreateCampaignRequest is the "New campaign" payload. The tenant is resolved
+// server-side (single operator, ADR-0039).
+message CreateCampaignRequest {
+  // name is the campaign title; empty is rejected with CodeInvalidArgument.
+  string name = 1;
+  // system is the tabletop ruleset (e.g. "D&D 5e"); optional free-text.
+  string system = 2;
+  // language is the BCP-47 tag the campaign runs in (e.g. "en"); optional
+  // free-text.
+  string language = 3;
+}
+
+// CreateCampaignResponse carries the created campaign (its auto-Butler is created
+// as a side effect, ADR-0009).
+message CreateCampaignResponse {
+  // campaign is the newly created campaign.
+  Campaign campaign = 1;
+}
+
+// UpdateCampaignRequest carries a campaign's editable fields. system/language are
+// stored opaquely (no validation) and take effect on the next Voice Session.
+message UpdateCampaignRequest {
+  // id is the campaign to update; an unknown id fails with CodeNotFound.
+  string id = 1;
+  // name is the campaign title; empty is rejected with CodeInvalidArgument.
+  string name = 2;
+  // system is the tabletop ruleset; optional free-text, stored opaquely.
+  string system = 3;
+  // language is the BCP-47 tag; optional free-text, stored opaquely.
+  string language = 4;
+}
+
+// UpdateCampaignResponse carries the updated campaign.
+message UpdateCampaignResponse {
+  // campaign is the updated campaign.
+  Campaign campaign = 1;
+}
+
+// SetActiveCampaignRequest names the campaign to make the operator's durable
+// Active Campaign selection (#264).
+message SetActiveCampaignRequest {
+  // campaign_id is the campaign to select; an unknown id fails with CodeNotFound.
+  string campaign_id = 1;
+}
+
+// SetActiveCampaignResponse carries the resulting resolved Active Campaign. The
+// live-first rule still applies, so while a Voice Session is live this is that
+// session's campaign, not necessarily the one just selected.
+message SetActiveCampaignResponse {
+  // campaign is the resolved Active Campaign after the selection.
   Campaign campaign = 1;
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds four RPCs to `CampaignService` and implements them on `rpc.CampaignServer`, following the existing `internal/rpc/campaign_crud.go` patterns:

- **ListCampaigns** — name-ordered campaigns via `storage.ListCampaigns` (read, `NO_SIDE_EFFECTS`).
- **CreateCampaign** — name required, optional system/language; the tenant is resolved server-side (ADR-0039), and the ADR-0009 auto-Butler trigger fires so the new campaign gets its Butler with the dice grant.
- **UpdateCampaign** — id required; writes name/system/language via new `storage.UpdateCampaign` (`UPDATE … SET … , updated_at = now() RETURNING`). System/Language are written as **opaque free-text strings, no validation** (curation is the settings-editor slice's decision); unknown id → `CodeNotFound`.
- **SetActiveCampaign** — validates `campaign_id` via `storage.GetCampaign` (unknown → `CodeNotFound`), then `storage.SetActiveCampaign` keyed on the operator's `DiscordUserID` from `auth.CurrentUser(ctx)` — the identical `users.active_campaign_id` row `/glyphoxa use` writes (migration 00014), keeping both surfaces in lockstep. Returns the resolved Active Campaign through the shared live-first policy.

The proto carries the correct idempotency annotations (`ListCampaigns` is `NO_SIDE_EFFECTS`; the three mutations are CSRF-guarded). Error mapping mirrors the agent CRUD: `ErrNotFound → CodeNotFound`, empty name → `CodeInvalidArgument`, generic `CodeInternal` with a server-side `slog`.

Closes #264.

## Why is this change needed?

Part of #251 ("Campaign selection & management in the web UI", Epic 2/8). The web UI needs to list, create, edit, and switch the operator's active campaign; these RPCs back that screen while keeping the durable selection in lockstep with the `/glyphoxa use` slash-command surface.

## How was this tested?

- **Unit tests** (fake store) for all four RPCs: name-ordered listing, empty listing, tenant-from-context create, empty-name/invalid-id/unknown-id rejections, opaque free-text update round-trip, durable-write keying, and a **live-first-wins** pin (durable selection set while a fake live session points elsewhere → live campaign still resolves).
- **Storage integration test** for `UpdateCampaign` (opaque verbatim write, `updated_at` bump, unknown id → `ErrNotFound`).
- **RPC integration test** mirroring `campaign_crud_integration_test.go`: asserts the auto-Butler + single dice grant on create, name-ordered `ListCampaigns`, the opaque update, the Active-Campaign flip across `GetActiveCampaign`/`GetCampaignRoster`/`ListNodes` with no live session, and the live-first rule end to end.
- `go build ./...`, `go vet` (default + `-tags integration`), and `gofmt` are clean. Integration tests are tag-isolated (`integration`) and skip loudly without Docker; unit tests for `internal/rpc` and `internal/storage` pass.

- [x] New/updated tests cover the change
- [ ] `make check` passes (unrelated ONNX-runtime download tests fail in this network-restricted env; `internal/rpc` and `internal/storage` pass)
- [x] Manual verification via the integration test's end-to-end curl-equivalent flow (create two campaigns, list, set the second active, watch `GetActiveCampaign` flip, confirm `/glyphoxa use`'s row reads the same selection)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

`gen/` is gitignored (ADR-0039) — regenerated in CI/Docker via `buf generate` — so only the `.proto` change is committed; run `make proto` locally to regenerate the stubs. The live-first resolution rule (#222) is intentionally untouched: `SetActiveCampaign` writes the durable selection but returns whatever the shared resolver yields, so a live session's campaign still wins on every surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUfLwV25vjNzQCgjpc3BsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUfLwV25vjNzQCgjpc3BsQ)_