### PR TITLE
[E1] CONTRIBUTING.md corrections + docs/README.md index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,15 @@ you need to get started.
 
 ### Prerequisites
 
-- **Go 1.26+** with CGo enabled
+- **Go 1.26+** with CGo enabled (`CGO_ENABLED=1`)
+- **Node.js 20+ and npm** — the operator console is a Vite/React bundle the Go binary embeds (see the SPA step below)
+- **[buf](https://buf.build/docs/installation)** — the Connect/protobuf stubs under `gen/` are generated, not committed
 - **libopus** — `apt install libopus-dev` (Debian/Ubuntu) · `pacman -S opus` (Arch) · `brew install opus` (macOS)
 - **ONNX Runtime** — shared library from [onnxruntime releases](https://github.com/microsoft/onnxruntime/releases) (for Silero VAD)
+
+The full self-host setup (Postgres/pgvector, the `.env` template, Discord OAuth)
+lives in [docs/configuration.md](docs/configuration.md); the build steps below
+mirror its §3 build order.
 
 ### Build & Test
 
@@ -17,7 +23,15 @@ you need to get started.
 git clone https://github.com/MrWong99/glyphoxa.git
 cd glyphoxa
 
-# Build
+# 1. Generate the protobuf stubs → gen/ (Go + TS). gen/ is gitignored, so this
+#    must run first: the Go build and the SPA both import the generated code.
+make proto
+
+# 2. Build the SPA bundle → internal/spa/dist (go:embed). Must run before
+#    `make build` embeds the console; skipping it embeds a blank placeholder.
+make spa
+
+# 3. Build the binary → bin/glyphoxa
 make build
 
 # Run all tests with race detector
@@ -26,9 +40,32 @@ make test
 # Lint
 make lint
 
-# Full check (lint + vet + test)
+# Full check (fmt + vet + test) — the pre-push gate
 make check
 ```
+
+Order matters: `make proto` → `make spa` → `make build`, exactly as
+[docs/configuration.md](docs/configuration.md) §3 mandates.
+
+#### Audible local runs (voice mode)
+
+The audio codec (libopus) and DAVE/MLS encryption are opt-in native
+dependencies selected by build tags. A default build links stubs — the pipeline
+wires up but the audio loop exits with `wire: audio codec unavailable` on the
+first frame. For an **audible** (and encrypted) live run, install libdave and
+build with the audio tags:
+
+```bash
+make dave-libs   # installs libdave; prints the PKG_CONFIG_PATH / LD_LIBRARY_PATH exports to add
+CGO_ENABLED=1 go build -tags "opus dave nolibopusfile" -o glyphoxa ./cmd/glyphoxa
+```
+
+- `opus` — real Opus↔PCM codec (else the stub: no audio).
+- `dave` — real DAVE/MLS encryption (mandatory on production Discord; else unencrypted).
+- `nolibopusfile` — compiles out the unused libopusfile dependency; **required whenever `opus` is set**.
+
+See [docs/agents/live-npc-run.md](docs/agents/live-npc-run.md) for the full
+`voice`-mode runbook.
 
 ## Development Workflow
 
@@ -66,7 +103,7 @@ Glyphoxa follows standard Go conventions with a few project-specific rules:
 - **Compile-time interface assertions** — `var _ Interface = (*Impl)(nil)`
 - **Mocks** live in `<package>/mock/` subdirectories
 
-For detailed testing patterns, mock conventions, and examples, see the [Testing Guide](docs/testing.md).
+For detailed testing patterns, mock conventions, and examples, see the [Voice Tests guide](docs/devs/voice-tests.md).
 
 ### Concurrency
 
@@ -84,11 +121,10 @@ For detailed testing patterns, mock conventions, and examples, see the [Testing 
 
 ## Architecture
 
-Before contributing a major feature, read the [design documents](docs/design/):
+Before contributing a major feature, read the architecture overview and the ADRs:
 
-- [Architecture](docs/design/01-architecture.md) — system layers and data flow
-- [Providers](docs/design/02-providers.md) — LLM, STT, TTS, Audio interfaces
-- [Roadmap](docs/design/09-roadmap.md) — development phases
+- [Architecture overview](docs/architecture.md) — the current-system overview; every subsystem names the ADR(s) that govern it
+- [Architecture Decision Records](docs/adr/) — the decisions ledger (system layers, provider seams, data flow)
 
 The core principle: **every external dependency sits behind an interface**. Swapping
 providers is a config change, not a rewrite.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# Glyphoxa documentation
+
+Glyphoxa is a multi-tenant TTRPG voice-and-knowledge platform: AI Agents
+(the Butler and Character NPCs) join a Discord **Voice Session**, voice Campaign
+NPCs, and assist the **GM** via Slash Commands and Tools, persisting Transcripts
+and a per-Campaign **Knowledge Graph**.
+
+Domain vocabulary is defined once in [../CONTEXT.md](../CONTEXT.md) and used
+across every doc here. The decisions ledger is [../DESIGN.md](../DESIGN.md).
+
+## Current docs
+
+Start here — these describe the system as it ships today.
+
+- **[architecture.md](architecture.md)** — current-system overview; every
+  subsystem names the ADR(s) that govern it.
+- **[configuration.md](configuration.md)** — self-host setup runbook: every
+  environment variable, the `.env` template, Postgres/pgvector, Discord OAuth,
+  the Operator allowlist, and the build order.
+- **[quickstart-gm.md](quickstart-gm.md)** — GM quickstart: from a fresh clone
+  to a talking Character NPC in a Discord voice channel.
+
+### [adr/](adr/) — Architecture Decision Records
+
+The 53 ADRs (`0001`…`0053`) recording the decisions behind the system, from
+multi-GM self-hosting through the Campaign Bundle format. Where an ADR and the
+shipped tree disagree, `architecture.md` follows the tree and says so.
+
+### [agents/](agents/) — agent & contributor conventions
+
+- **[domain.md](agents/domain.md)** — how the single-context domain docs
+  (`CONTEXT.md` + ADRs) are kept.
+- **[issue-tracker.md](agents/issue-tracker.md)** — GitHub Issues workflow via
+  the `gh` CLI.
+- **[triage-labels.md](agents/triage-labels.md)** — the triage label vocabulary.
+- **[live-npc-run.md](agents/live-npc-run.md)** — developer runbook for the
+  `voice`-mode live NPC, including the `opus`/`dave`/`nolibopusfile` build tags.
+
+### [devs/](devs/) — developer guides
+
+- **[voice-tests.md](devs/voice-tests.md)** — how the voice integration tests
+  exercise the orchestrator stage against a deterministic provider seam.
+
+## Historical
+
+Kept for reference; **not** maintained and not authoritative for the current
+system. Superseded content lives here rather than being deleted.
+
+- **[sprints/](sprints/)** — past sprint plans and planning notes.
+- **[latency-investigation/](latency-investigation/)** — an audio-pipeline
+  latency investigation.
+- **[import/](import/)** — early import/mapping notes
+  (Foundry/Roll20 field mapping).


### PR DESCRIPTION
Slice of epic #250. Two bounded documentation fixes.

## CONTRIBUTING.md
- Fixed dead link: `docs/testing.md` → `docs/devs/voice-tests.md`.
- Replaced the entire nonexistent `docs/design/` block (`[design documents](docs/design/)` + its three children `01-architecture.md`, `02-providers.md`, `09-roadmap.md`) with `docs/architecture.md` (system overview, merged today) and `docs/adr/` (the 53 ADRs). Dropped the roadmap link — roadmap lives in the issue tracker, not docs (#258 policy).
- Added the mandated build order from `docs/configuration.md` §3: `make proto` → `make spa` → `make build`, with the buf proto-generation step and the Node/npm SPA build steps, plus the Node 20+/buf prerequisites.
- Documented `make dave-libs` and the `opus`/`dave`/`nolibopusfile` build tags for audible local `voice`-mode runs, per `docs/agents/live-npc-run.md`.

## docs/README.md (new)
The docs index. Lists every current doc — `configuration.md`, `architecture.md`, `quickstart-gm.md`, `adr/`, `agents/` (all four), `devs/voice-tests.md` — and labels `sprints/`, `latency-investigation/`, and `import/` as historical (labeled, not moved/deleted, per the issue default).

## Verification
- Every relative link in both files resolved by hand (`ls` each target) — CI has no markdown link checker. No dead links remain; `grep -rn '/home/'` is empty.
- Ran the CONTRIBUTING build steps in a fresh worktree: `make proto` (gen/ produced), `make spa` (Vite bundle → internal/spa/dist), `make build` (bin/glyphoxa produced) — all green. `go vet ./...` clean.
- Doc-only change: zero runtime change, no Go/TS source touched, no tests added (TDD loop does not apply). Reverted the tracked placeholder `internal/spa/dist/index.html` that the local SPA build overwrote so the diff is docs-only.

## Note on the root README
Per the task constraint, I did **not** touch `README.md`. It is rewritten by sibling slice #259 (not yet started), which will add the link to `docs/README.md`. The root README does not link `docs/README.md` yet; this PR just creates the target so #259's link resolves when it lands.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)