### PR TITLE
feat(#268): per-campaign settings editor — name, System, Campaign Language

### DIFF
--- a/internal/rpc/campaign_language.go
+++ b/internal/rpc/campaign_language.go
@@ -1,0 +1,26 @@
+package rpc
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/address"
+)
+
+// ListSupportedLanguages returns the Campaign Language choices: the language
+// codes with a registered phonetic encoder (ADR-0024 EncoderRegistry), sorted.
+// The registry is the sole language-truth source — the SAME source the wirenpc
+// roster reads (internal/wirenpc/roster.go) — so a newly registered encoder
+// appears here automatically and no language is hardcoded outside phonetic.go.
+// It is a pure read over the default registry: no store, no auth scope, and no
+// failure path.
+func (s *CampaignServer) ListSupportedLanguages(
+	_ context.Context,
+	_ *connect.Request[managementv1.ListSupportedLanguagesRequest],
+) (*connect.Response[managementv1.ListSupportedLanguagesResponse], error) {
+	return connect.NewResponse(&managementv1.ListSupportedLanguagesResponse{
+		Languages: address.DefaultEncoders().Languages(),
+	}), nil
+}

--- a/internal/rpc/campaign_language_test.go
+++ b/internal/rpc/campaign_language_test.go
@@ -1,0 +1,38 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestListSupportedLanguages proves the handler reports the Campaign Language
+// choices as the registered phonetic-encoder codes, sorted (ADR-0024). The
+// registry is the sole language-truth source, so the shipped en/de matrix comes
+// back as ["de","en"] with no store read and no auth needed.
+func TestListSupportedLanguages(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.ListSupportedLanguages(context.Background(),
+		connect.NewRequest(&managementv1.ListSupportedLanguagesRequest{}))
+	if err != nil {
+		t.Fatalf("ListSupportedLanguages: %v", err)
+	}
+	got := resp.Msg.GetLanguages()
+	want := []string{"de", "en"}
+	if len(got) != len(want) {
+		t.Fatalf("languages = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("languages = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/rpc/campaign_management_integration_test.go
+++ b/internal/rpc/campaign_management_integration_test.go
@@ -207,6 +207,87 @@ func TestCampaignManagement_Integration(t *testing.T) {
 	}
 }
 
+// TestUpdateCampaignLanguage_LeavesAgentVoiceUntouched pins the #268 decision that
+// a Campaign Language change mutates NOTHING downstream: existing Agents' voice
+// settings stay byte-identical (ADR-0009, #224). The first-save voice seeding
+// (applyVoiceSelection) lives ONLY on the agent-write path (UpdateAgent) and must
+// never fire from UpdateCampaign — this guards against a future re-seed regression
+// that would re-derive every Agent's voice from the new language.
+func TestUpdateCampaignLanguage_LeavesAgentVoiceUntouched(t *testing.T) {
+	dsn := startPostgres(t)
+	store, seededID := seedStore(t, dsn)
+	ctx := context.Background()
+
+	seeded, err := store.GetCampaign(ctx, seededID)
+	if err != nil {
+		t.Fatalf("GetCampaign(seeded): %v", err)
+	}
+	const operator = "operator-268"
+	client := mgmtIntegrationClient(t, store, seeded.TenantID, operator, nil)
+
+	// A fresh campaign in language "en" with its auto-Butler (ADR-0009), made the
+	// durable Active Campaign so the agent-write path resolves it (#222).
+	created, err := client.CreateCampaign(ctx, connect.NewRequest(&managementv1.CreateCampaignRequest{
+		Name: "Voice Guard", System: "dnd5e", Language: "en",
+	}))
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	campID := created.Msg.GetCampaign().GetId()
+	if _, err := client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
+		CampaignId: campID,
+	})); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+
+	butler, err := store.GetButler(ctx, uuid.MustParse(campID))
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+
+	// Give the Butler a concrete voice via the agent-write path — this is where the
+	// language legitimately seeds the first-save voice default (#224).
+	if _, err := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{
+		Id: butler.ID.String(), Name: butler.Name, Title: butler.Title, Persona: butler.Persona,
+		Voice: "voice-en-123", AddressOnly: butler.AddressOnly,
+	})); err != nil {
+		t.Fatalf("UpdateAgent(seed voice): %v", err)
+	}
+	before, err := store.GetAgent(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("GetAgent(before): %v", err)
+	}
+	if len(before.Voice) == 0 {
+		t.Fatalf("precondition: Butler voice not seeded, got %q", string(before.Voice))
+	}
+
+	// The change under test: Campaign Language en -> de.
+	if _, err := client.UpdateCampaign(ctx, connect.NewRequest(&managementv1.UpdateCampaignRequest{
+		Id: campID, Name: "Voice Guard", System: "dnd5e", Language: "de",
+	})); err != nil {
+		t.Fatalf("UpdateCampaign(lang en->de): %v", err)
+	}
+
+	// The language column moved…
+	after, err := store.GetCampaign(ctx, uuid.MustParse(campID))
+	if err != nil {
+		t.Fatalf("GetCampaign(after): %v", err)
+	}
+	if after.Language != "de" {
+		t.Fatalf("campaign language = %q, want de", after.Language)
+	}
+	// …but the Butler's voice blob is byte-identical: a language change mutates no
+	// Agent voice (the #268 decision; applyVoiceSelection stays unused here).
+	agentAfter, err := store.GetAgent(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("GetAgent(after): %v", err)
+	}
+	if string(agentAfter.Voice) != string(before.Voice) {
+		t.Errorf("Butler voice changed on a language edit:\n before = %s\n after  = %s",
+			string(before.Voice), string(agentAfter.Voice))
+	}
+}
+
 // TestSetActiveCampaignLiveFirst_Integration pins the live-first resolution rule
 // (#222, #264) end to end: with a live Voice Session bound to campaign L, a
 // durable selection of a DIFFERENT campaign D is still written (both surfaces in

--- a/pkg/voice/address/phonetic.go
+++ b/pkg/voice/address/phonetic.go
@@ -22,6 +22,7 @@
 package address
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/antzucaro/matchr"
@@ -94,6 +95,19 @@ func (r *EncoderRegistry) Register(lang string, enc Encoder) {
 		return
 	}
 	r.byLang[key] = enc
+}
+
+// Languages returns the registered language codes (normalized primary subtags),
+// sorted ascending. Empty registry -> empty slice. This is the sole language-
+// truth source for the Campaign Language choices (ADR-0024): a newly registered
+// encoder appears here automatically.
+func (r *EncoderRegistry) Languages() []string {
+	langs := make([]string, 0, len(r.byLang))
+	for lang := range r.byLang {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	return langs
 }
 
 // For returns the [Encoder] registered for lang and whether one was found.

--- a/pkg/voice/address/phonetic_test.go
+++ b/pkg/voice/address/phonetic_test.go
@@ -1,6 +1,34 @@
 package address
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// TestEncoderRegistry_Languages proves Languages() reports the registered
+// language codes as sorted, normalized primary subtags — the sole source for the
+// Campaign Language choices (ADR-0024). An empty registry yields an empty slice,
+// a BCP-47 tag registers under its primary subtag, and a nil-unregister drops it.
+func TestEncoderRegistry_Languages(t *testing.T) {
+	if got := NewEncoderRegistry().Languages(); len(got) != 0 {
+		t.Errorf("empty registry Languages() = %v, want empty", got)
+	}
+
+	if got := DefaultEncoders().Languages(); !reflect.DeepEqual(got, []string{"de", "en"}) {
+		t.Errorf("DefaultEncoders().Languages() = %v, want [de en]", got)
+	}
+
+	r := DefaultEncoders()
+	r.Register("fr-FR", EncoderFunc(func(s string) string { return s }))
+	if got := r.Languages(); !reflect.DeepEqual(got, []string{"de", "en", "fr"}) {
+		t.Errorf("after Register(fr-FR): Languages() = %v, want [de en fr]", got)
+	}
+
+	r.Register("en", nil) // unregister
+	if got := r.Languages(); !reflect.DeepEqual(got, []string{"de", "fr"}) {
+		t.Errorf("after unregister en: Languages() = %v, want [de fr]", got)
+	}
+}
 
 // TestNormalizeLang pins the BCP-47 → primary-subtag reduction the registry
 // keys on, so "en", "en-US", and "EN_us" all resolve to one Encoder.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -40,6 +40,12 @@ service CampaignService {
   // State-changing: the auth + CSRF interceptors guard it.
   rpc UpdateCampaign(UpdateCampaignRequest) returns (UpdateCampaignResponse);
 
+  // ListSupportedLanguages returns the Campaign Language choices: the language
+  // codes with a registered phonetic encoder (ADR-0024 EncoderRegistry), sorted.
+  rpc ListSupportedLanguages(ListSupportedLanguagesRequest) returns (ListSupportedLanguagesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
   // SetActiveCampaign records the operator's durable Active Campaign selection —
   // the SAME users.active_campaign_id row `/glyphoxa use` writes, keeping both
   // surfaces in lockstep (#264, migration 00014) — and returns the resulting
@@ -485,6 +491,14 @@ message UpdateCampaignRequest {
 message UpdateCampaignResponse {
   // campaign is the updated campaign.
   Campaign campaign = 1;
+}
+
+message ListSupportedLanguagesRequest {}
+
+message ListSupportedLanguagesResponse {
+  // languages are the registered encoder codes as lowercase primary subtags
+  // (e.g. ["de","en"]), sorted.
+  repeated string languages = 1;
 }
 
 // SetActiveCampaignRequest names the campaign to make the operator's durable

--- a/web/src/components/CampaignSettingsForm.test.tsx
+++ b/web/src/components/CampaignSettingsForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { createRouterTransport } from "@connectrpc/connect";
+import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -20,12 +20,19 @@ type Camp = { id?: string; name?: string; system?: string; language?: string };
 // UpdateCampaign echoes the request so a test can assert exactly what rode the
 // wire. `updated` captures the last UpdateCampaign request.
 function mockBackend(
-  opts: { languages?: string[]; updated?: { req?: Record<string, unknown> }; updateError?: string } = {},
+  opts: {
+    languages?: string[];
+    languagesError?: string;
+    updated?: { req?: Record<string, unknown> };
+    updateError?: string;
+  } = {},
 ) {
   return createRouterTransport(({ service }) => {
     service(CampaignService, {
-      listSupportedLanguages: () =>
-        create(ListSupportedLanguagesResponseSchema, { languages: opts.languages ?? ["de", "en"] }),
+      listSupportedLanguages: () => {
+        if (opts.languagesError) throw new ConnectError(opts.languagesError, Code.Unavailable);
+        return create(ListSupportedLanguagesResponseSchema, { languages: opts.languages ?? ["de", "en"] });
+      },
       updateCampaign: (req) => {
         if (opts.updated) opts.updated.req = { id: req.id, name: req.name, system: req.system, language: req.language };
         return create(UpdateCampaignResponseSchema, {
@@ -97,6 +104,45 @@ describe("CampaignSettingsForm", () => {
     // silently coerce it to a registered language.
     const list = await openLanguageSelect();
     expect(await within(list).findByRole("option", { name: /unsupported/i })).toBeInTheDocument();
+  });
+
+  it("follows the mocked registry, not a hardcoded language list", async () => {
+    // A DISTINCT set the shipped registry never returns: a regression that
+    // hardcodes en/de (and never calls the RPC) would show "de" and miss "xx",
+    // so this pins the SELECT to the RPC answer (ADR-0024, sole truth source).
+    renderForm({ campaign: makeCampaign({ language: "en" }) }, mockBackend({ languages: ["en", "xx"] }));
+
+    const list = await openLanguageSelect();
+    expect(await within(list).findByRole("option", { name: "xx" })).toBeInTheDocument();
+    expect(within(list).getByRole("option", { name: /English \(en\)/ })).toBeInTheDocument();
+    // "de" is registered by the real platform but NOT by this mock — it must be absent.
+    expect(within(list).queryByRole("option", { name: /German \(de\)/ })).not.toBeInTheDocument();
+  });
+
+  it("does not mislabel a stored registered language while the registry is still loading", () => {
+    // Open the SELECT synchronously, before ListSupportedLanguages resolves:
+    // supported is empty for lack of an answer, not because "en" is unregistered,
+    // so the stored value must ride as a plain option — never a false "unsupported".
+    renderForm({ campaign: makeCampaign({ language: "en" }) });
+    fireEvent.keyDown(screen.getByRole("combobox", { name: /language/i }), { key: "Enter" });
+    const list = screen.getByRole("listbox");
+    expect(within(list).queryByRole("option", { name: /unsupported/i })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a registry load failure instead of mislabeling the stored language", async () => {
+    renderForm(
+      { campaign: makeCampaign({ language: "en" }) },
+      mockBackend({ languagesError: "registry offline" }),
+    );
+
+    // The error is shown (not swallowed)…
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/couldn't load the language choices/i);
+    expect(alert).toHaveTextContent(/registry offline/);
+    // …and the stored value is not falsely branded unsupported on a failed load.
+    fireEvent.keyDown(screen.getByRole("combobox", { name: /language/i }), { key: "Enter" });
+    const list = screen.getByRole("listbox");
+    expect(within(list).queryByRole("option", { name: /unsupported/i })).not.toBeInTheDocument();
   });
 
   it("suggests three systems via a datalist", () => {

--- a/web/src/components/CampaignSettingsForm.test.tsx
+++ b/web/src/components/CampaignSettingsForm.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  CampaignService,
+  CampaignSchema,
+  ListSupportedLanguagesResponseSchema,
+  UpdateCampaignResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { CampaignSettingsForm } from "./CampaignSettingsForm";
+
+type Camp = { id?: string; name?: string; system?: string; language?: string };
+
+// A Connect backend for the settings form: ListSupportedLanguages returns the
+// registered encoder codes (the Campaign Language choices, ADR-0024) and
+// UpdateCampaign echoes the request so a test can assert exactly what rode the
+// wire. `updated` captures the last UpdateCampaign request.
+function mockBackend(
+  opts: { languages?: string[]; updated?: { req?: Record<string, unknown> }; updateError?: string } = {},
+) {
+  return createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listSupportedLanguages: () =>
+        create(ListSupportedLanguagesResponseSchema, { languages: opts.languages ?? ["de", "en"] }),
+      updateCampaign: (req) => {
+        if (opts.updated) opts.updated.req = { id: req.id, name: req.name, system: req.system, language: req.language };
+        return create(UpdateCampaignResponseSchema, {
+          campaign: create(CampaignSchema, {
+            id: req.id,
+            name: req.name,
+            system: req.system,
+            language: req.language,
+          }),
+        });
+      },
+    });
+  });
+}
+
+function makeCampaign(c: Camp = {}) {
+  return create(CampaignSchema, {
+    id: c.id ?? "camp-1",
+    name: c.name ?? "The Sunless Citadel",
+    system: c.system ?? "D&D 5e",
+    language: c.language ?? "en",
+  });
+}
+
+function renderForm(
+  props: { campaign?: ReturnType<typeof makeCampaign>; onSaved?: () => void; onCancel?: () => void } = {},
+  transport = mockBackend(),
+) {
+  const onSaved = props.onSaved ?? vi.fn();
+  const onCancel = props.onCancel ?? vi.fn();
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <CampaignSettingsForm campaign={props.campaign ?? makeCampaign()} onSaved={onSaved} onCancel={onCancel} />
+    </Providers>,
+  );
+  return { onSaved, onCancel };
+}
+
+// openLanguageSelect opens the Radix language Select and returns the listbox.
+async function openLanguageSelect() {
+  fireEvent.keyDown(screen.getByRole("combobox", { name: /language/i }), { key: "Enter" });
+  return screen.getByRole("listbox");
+}
+
+describe("CampaignSettingsForm", () => {
+  it("prefills the fields from the campaign prop and shows the Voice Session hint", () => {
+    renderForm({ campaign: makeCampaign({ name: "Curse of Strahd", system: "D&D 5e", language: "en" }) });
+
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Curse of Strahd");
+    expect((screen.getByLabelText("System") as HTMLInputElement).value).toBe("D&D 5e");
+    // The language change deferral notice (mutates nothing now; next Voice Session).
+    expect(screen.getByText(/next Voice Session/i)).toBeInTheDocument();
+  });
+
+  it("offers the registered languages as the language options", async () => {
+    renderForm({ campaign: makeCampaign({ language: "en" }) }, mockBackend({ languages: ["de", "en"] }));
+
+    const list = await openLanguageSelect();
+    // Options are labeled "<English name> (<code>)" — zero hardcoded list. They
+    // arrive async (ListSupportedLanguages resolves after open), so findByRole.
+    expect(await within(list).findByRole("option", { name: /German \(de\)/ })).toBeInTheDocument();
+    expect(within(list).getByRole("option", { name: /English \(en\)/ })).toBeInTheDocument();
+  });
+
+  it("preserves a stored out-of-registry language as an extra option", async () => {
+    renderForm({ campaign: makeCampaign({ language: "fr" }) }, mockBackend({ languages: ["de", "en"] }));
+
+    // fr has no registered encoder, but it must stay selectable so a save can't
+    // silently coerce it to a registered language.
+    const list = await openLanguageSelect();
+    expect(await within(list).findByRole("option", { name: /unsupported/i })).toBeInTheDocument();
+  });
+
+  it("suggests three systems via a datalist", () => {
+    renderForm();
+    const input = screen.getByLabelText("System") as HTMLInputElement;
+    const listId = input.getAttribute("list");
+    expect(listId).toBeTruthy();
+    const datalist = document.getElementById(listId!);
+    const values = Array.from(datalist!.querySelectorAll("option")).map((o) => o.getAttribute("value"));
+    expect(values).toEqual(["D&D 5e", "Pathfinder 2e", "Call of Cthulhu"]);
+  });
+
+  it("disables save when the name is empty or whitespace", () => {
+    renderForm();
+    const save = screen.getByRole("button", { name: /save/i });
+    expect(save).toBeEnabled();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "   " } });
+    expect(save).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "" } });
+    expect(save).toBeDisabled();
+  });
+
+  it("saves the trimmed name plus system and language, then calls onSaved", async () => {
+    const updated: { req?: Record<string, unknown> } = {};
+    const onSaved = vi.fn();
+    renderForm(
+      { campaign: makeCampaign({ id: "camp-9", system: "D&D 5e", language: "en" }), onSaved },
+      mockBackend({ languages: ["de", "en"], updated }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "  Renamed Quest  " } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(updated.req).toEqual({ id: "camp-9", name: "Renamed Quest", system: "D&D 5e", language: "en" });
+  });
+
+  it("calls onCancel when cancel is clicked", () => {
+    const onCancel = vi.fn();
+    renderForm({ onCancel });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/CampaignSettingsForm.tsx
+++ b/web/src/components/CampaignSettingsForm.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { CampaignService, type Campaign } from "@gen/glyphoxa/management/v1/management_pb";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Button } from "@/components/ui/Button";
+import { invalidateActiveCampaignScopedQueries } from "@/lib/campaignCache";
+
+import "./createCampaignForm.css";
+
+// The per-campaign settings editor (#268): edit an existing campaign's name,
+// System, and Campaign Language, rendered in the topbar CampaignSwitcher's edit
+// panel (#266). It mirrors CreateCampaignForm's plain-useState shape (ADR-0017),
+// but the two curated fields diverge per the recorded product decisions:
+//
+//   System   — free text with datalist suggestions (no enum, rides the wire
+//              opaque server-side, ADR-0039). The suggestions are a static
+//              web-side convenience only.
+//   Language — a SELECT constrained to the registered phonetic encoders
+//              (ListSupportedLanguages → ADR-0024 EncoderRegistry, the sole
+//              language-truth source), so a new encoder appears automatically and
+//              no language list is hardcoded in the web tier.
+//
+// A language change mutates NOTHING now — existing Agents' voice settings are
+// untouched (ADR-0009, #224); it takes effect on the next Voice Session, which
+// the static hint under the select states.
+
+const SYSTEM_SUGGESTIONS = ["D&D 5e", "Pathfinder 2e", "Call of Cthulhu"];
+const SYSTEM_DATALIST_ID = "gx-system-suggestions";
+
+// languageLabel renders a code as "<English name> (<code>)" via Intl, falling
+// back to the bare code when the runtime can't name it — so the option list
+// stays readable without a hardcoded language table.
+function languageLabel(code: string): string {
+  try {
+    const name = new Intl.DisplayNames(["en"], { type: "language" }).of(code);
+    return name && name !== code ? `${name} (${code})` : code;
+  } catch {
+    return code;
+  }
+}
+
+export function CampaignSettingsForm({
+  campaign,
+  onSaved,
+  onCancel,
+}: {
+  campaign: Campaign;
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(campaign.name);
+  const [system, setSystem] = useState(campaign.system);
+  const [language, setLanguage] = useState(campaign.language);
+
+  // The Campaign Language choices come solely from the registered encoders.
+  const langQ = useQuery(CampaignService.method.listSupportedLanguages, {});
+  const supported = langQ.data?.languages ?? [];
+
+  const options = supported.map((code) => ({ value: code, label: languageLabel(code) }));
+  // A stored language with no registered encoder still rides here as an extra
+  // option so the SELECT can't silently coerce it to a supported one on save.
+  if (campaign.language && !supported.includes(campaign.language)) {
+    options.push({ value: campaign.language, label: `${languageLabel(campaign.language)} (unsupported)` });
+  }
+
+  // listCampaigns is campaign-INVARIANT (lib/campaignCache.ts), so the sweep
+  // skips it — a name/system edit must invalidate it explicitly or the switcher's
+  // picker keeps showing the stale name/system.
+  const invalidateList = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listCampaigns,
+        cardinality: "finite",
+      }),
+    });
+
+  const update = useMutation(CampaignService.method.updateCampaign, {
+    onSuccess: () => {
+      void invalidateList();
+      void invalidateActiveCampaignScopedQueries(queryClient);
+      onSaved();
+    },
+    onError: (err) => toast.error(`Couldn't save campaign settings: ${err.message}`),
+  });
+
+  const canSubmit = name.trim() !== "" && !update.isPending;
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    // Name is trimmed (the server rejects empty); System/Language ride opaque.
+    update.mutate({ id: campaign.id, name: name.trim(), system, language });
+  };
+
+  return (
+    <form className="gx-campaign-create" onSubmit={submit}>
+      <Input
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="e.g. The Sunless Citadel"
+        disabled={update.isPending}
+        required
+      />
+      <div className="gx-campaign-create__row">
+        <Input
+          label="System"
+          value={system}
+          onChange={(e) => setSystem(e.target.value)}
+          list={SYSTEM_DATALIST_ID}
+          hint="Free-text — e.g. D&D 5e, Pathfinder 2e"
+          disabled={update.isPending}
+        />
+        <datalist id={SYSTEM_DATALIST_ID}>
+          {SYSTEM_SUGGESTIONS.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+        <div className="gx-campaign-create__lang">
+          <Select
+            label="Language"
+            options={options}
+            value={language}
+            onValueChange={setLanguage}
+            disabled={update.isPending}
+          />
+          <span className="gx-field__hint">Takes effect on the next Voice Session.</span>
+        </div>
+      </div>
+      <div className="gx-campaign-create__actions">
+        <Button type="submit" variant="primary" disabled={!canSubmit}>
+          {update.isPending ? "Saving…" : "Save changes"}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={update.isPending}>
+          Cancel
+        </Button>
+        {update.error && (
+          <span className="gx-campaign-create__error" role="alert">
+            Couldn&apos;t save: {update.error.message}
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/CampaignSettingsForm.tsx
+++ b/web/src/components/CampaignSettingsForm.tsx
@@ -59,14 +59,28 @@ export function CampaignSettingsForm({
   const [language, setLanguage] = useState(campaign.language);
 
   // The Campaign Language choices come solely from the registered encoders.
-  const langQ = useQuery(CampaignService.method.listSupportedLanguages, {});
+  // retry:false so a failed load settles into the error hint at once rather than
+  // backing off first — the registry is a cheap in-process read, so a failure is
+  // a real signal to surface, not a transient to hammer through.
+  const langQ = useQuery(CampaignService.method.listSupportedLanguages, {}, { retry: false });
   const supported = langQ.data?.languages ?? [];
 
   const options = supported.map((code) => ({ value: code, label: languageLabel(code) }));
   // A stored language with no registered encoder still rides here as an extra
   // option so the SELECT can't silently coerce it to a supported one on save.
+  // Only claim "(unsupported)" once the registry has actually LOADED — while the
+  // query is pending or has failed, supported is empty for lack of an answer, not
+  // because the stored language is unregistered, so mislabelling it would be a
+  // lie (and a false claim on every transient). Until then the stored value rides
+  // as a plain option so the SELECT still shows the current selection.
   if (campaign.language && !supported.includes(campaign.language)) {
-    options.push({ value: campaign.language, label: `${languageLabel(campaign.language)} (unsupported)` });
+    const registryKnows = langQ.isSuccess;
+    options.push({
+      value: campaign.language,
+      label: registryKnows
+        ? `${languageLabel(campaign.language)} (unsupported)`
+        : languageLabel(campaign.language),
+    });
   }
 
   // listCampaigns is campaign-INVARIANT (lib/campaignCache.ts), so the sweep
@@ -131,6 +145,11 @@ export function CampaignSettingsForm({
             disabled={update.isPending}
           />
           <span className="gx-field__hint">Takes effect on the next Voice Session.</span>
+          {langQ.isError && (
+            <span className="gx-field__hint gx-field__hint--error" role="alert">
+              Couldn&apos;t load the language choices: {langQ.error.message}
+            </span>
+          )}
         </div>
       </div>
       <div className="gx-campaign-create__actions">

--- a/web/src/components/CampaignSwitcher.test.tsx
+++ b/web/src/components/CampaignSwitcher.test.tsx
@@ -39,6 +39,7 @@ function mockBackend(
     calls?: Record<string, number>;
     createError?: string;
     switchError?: string;
+    activeError?: string;
   } = {},
 ) {
   const state = {
@@ -69,6 +70,10 @@ function mockBackend(
       },
       getActiveCampaign: () => {
         bump("getActiveCampaign");
+        // A non-NotFound resolve failure (not first-run): the trigger falls back
+        // to "Select campaign" with no resolved active campaign, so any
+        // active-campaign-gated control (the settings button) must disable.
+        if (opts.activeError) throw new ConnectError(opts.activeError, Code.Internal);
         const a = resolveActive();
         if (!a) throw new ConnectError("no campaign", Code.NotFound);
         return create(GetActiveCampaignResponseSchema, { campaign: create(CampaignSchema, a) });
@@ -409,6 +414,36 @@ describe("CampaignSwitcher", () => {
     expect(screen.getByText(/next Voice Session/i)).toBeInTheDocument();
   });
 
+  it("saves a rename and refreshes the picker list (#268, ADR-0018)", async () => {
+    const calls: Record<string, number> = {};
+    renderSwitcher(
+      mockBackend({
+        campaigns: [{ id: "a", name: "Alpha Quest", system: "D&D 5e", language: "en" }],
+        activeId: "a",
+        calls,
+      }),
+    );
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    await screen.findByRole("group", { name: /campaigns/i });
+    const listedBefore = calls.listCampaigns;
+
+    // Rename via the settings editor, then Save.
+    fireEvent.click(await screen.findByRole("button", { name: /campaign settings/i }));
+    fireEvent.change(await screen.findByLabelText("Name"), { target: { value: "Renamed Quest" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    // The write happened…
+    await waitFor(() => expect(calls.updateCampaign).toBe(1));
+    // …the editor closed back to the list…
+    const group = await screen.findByRole("group", { name: /campaigns/i });
+    // …listCampaigns is campaign-INVARIANT (the switch sweep skips it), so the
+    // save must invalidate it explicitly or the picker keeps the stale name.
+    await waitFor(() => expect(calls.listCampaigns).toBeGreaterThan(listedBefore));
+    expect(await within(group).findByRole("button", { name: /Renamed Quest/ })).toBeInTheDocument();
+    expect(within(group).queryByRole("button", { name: /Alpha Quest/ })).not.toBeInTheDocument();
+  });
+
   it("returns to the list when the settings editor is cancelled (#268)", async () => {
     renderSwitcher(mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeId: "a" }));
     await screen.findByText("Alpha Quest");
@@ -436,7 +471,7 @@ describe("CampaignSwitcher", () => {
     expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
   });
 
-  it("disables the settings action until a campaign resolves (#268)", async () => {
+  it("has no settings action on the first-run create form (#268)", async () => {
     renderSwitcher(mockBackend({ campaigns: [], calls: {} }));
     // First run: the trigger opens straight into create; there's no active
     // campaign to edit, so the settings action never offers a broken edit.
@@ -444,5 +479,15 @@ describe("CampaignSwitcher", () => {
     fireEvent.click(trigger);
     // Create mode has no settings button at all — nothing to edit yet.
     expect(screen.queryByRole("button", { name: /campaign settings/i })).not.toBeInTheDocument();
+  });
+
+  it("disables the settings action when no active campaign resolves (#268)", async () => {
+    // Campaigns exist but resolution FAILS (non-NotFound): the list still opens,
+    // and the settings button renders — but disabled, since there is no resolved
+    // Active Campaign to seed the editor with.
+    renderSwitcher(mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeError: "resolver down" }));
+    fireEvent.click(await screen.findByTestId("campaign-switcher-trigger"));
+    await screen.findByRole("group", { name: /campaigns/i });
+    expect(await screen.findByRole("button", { name: /campaign settings/i })).toBeDisabled();
   });
 });

--- a/web/src/components/CampaignSwitcher.test.tsx
+++ b/web/src/components/CampaignSwitcher.test.tsx
@@ -15,6 +15,8 @@ import {
   SetActiveCampaignResponseSchema,
   CreateCampaignResponseSchema,
   GetSessionResponseSchema,
+  ListSupportedLanguagesResponseSchema,
+  UpdateCampaignResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -91,6 +93,19 @@ function mockBackend(
         const c = { id: `new-${state.next++}`, name: req.name, system: req.system, language: req.language };
         state.campaigns.push(c);
         return create(CreateCampaignResponseSchema, { campaign: create(CampaignSchema, c) });
+      },
+      listSupportedLanguages: () => {
+        bump("listSupportedLanguages");
+        return create(ListSupportedLanguagesResponseSchema, { languages: ["de", "en"] });
+      },
+      updateCampaign: (req) => {
+        bump("updateCampaign");
+        const c = state.campaigns.find((x) => x.id === req.id);
+        if (!c) throw new ConnectError("unknown campaign", Code.NotFound);
+        c.name = req.name;
+        c.system = req.system;
+        c.language = req.language;
+        return create(UpdateCampaignResponseSchema, { campaign: create(CampaignSchema, c) });
       },
     });
     service(SessionService, {
@@ -373,5 +388,61 @@ describe("CampaignSwitcher", () => {
     fireEvent.click(screen.getByRole("button", { name: /retry activation/i }));
     await waitFor(() => expect(calls.setActiveCampaign).toBe(2));
     expect(calls.createCampaign).toBe(1);
+  });
+
+  it("opens the settings editor seeded with the active campaign (#268)", async () => {
+    renderSwitcher(
+      mockBackend({
+        campaigns: [{ id: "a", name: "Alpha Quest", system: "D&D 5e", language: "en" }],
+        activeId: "a",
+      }),
+    );
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    await screen.findByRole("group", { name: /campaigns/i });
+
+    // The list footer offers a "Campaign settings" action; it opens the edit form
+    // seeded from the resolved Active Campaign.
+    fireEvent.click(await screen.findByRole("button", { name: /campaign settings/i }));
+    expect(((await screen.findByLabelText("Name")) as HTMLInputElement).value).toBe("Alpha Quest");
+    expect((screen.getByLabelText("System") as HTMLInputElement).value).toBe("D&D 5e");
+    expect(screen.getByText(/next Voice Session/i)).toBeInTheDocument();
+  });
+
+  it("returns to the list when the settings editor is cancelled (#268)", async () => {
+    renderSwitcher(mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeId: "a" }));
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    fireEvent.click(await screen.findByRole("button", { name: /campaign settings/i }));
+    await screen.findByLabelText("Name");
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    // Back to the campaign list; the edit form is gone.
+    expect(await screen.findByRole("group", { name: /campaigns/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+  });
+
+  it("resets to the list view after the settings editor is left open and the panel is reopened (#268)", async () => {
+    renderSwitcher(mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeId: "a" }));
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    fireEvent.click(await screen.findByRole("button", { name: /campaign settings/i }));
+    await screen.findByLabelText("Name");
+
+    // Close and reopen: the panel is a single state, so it can't reopen onto the
+    // stale edit form.
+    openPanel(); // closes
+    openPanel(); // reopens
+    expect(await screen.findByRole("group", { name: /campaigns/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+  });
+
+  it("disables the settings action until a campaign resolves (#268)", async () => {
+    renderSwitcher(mockBackend({ campaigns: [], calls: {} }));
+    // First run: the trigger opens straight into create; there's no active
+    // campaign to edit, so the settings action never offers a broken edit.
+    const trigger = await screen.findByRole("button", { name: /create your first campaign/i });
+    fireEvent.click(trigger);
+    // Create mode has no settings button at all — nothing to edit yet.
+    expect(screen.queryByRole("button", { name: /campaign settings/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/CampaignSwitcher.tsx
+++ b/web/src/components/CampaignSwitcher.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Check, ChevronDown, Plus, Swords } from "lucide-react";
+import { Check, ChevronDown, Plus, Settings, Swords } from "lucide-react";
 
 import { CampaignService, SessionService } from "@gen/glyphoxa/management/v1/management_pb";
 import {
@@ -12,6 +12,7 @@ import {
 import { isNotFound } from "@/lib/connectError";
 import { usePopoverDismiss } from "@/components/ui/usePopoverDismiss";
 import { CreateCampaignForm, useCreateCampaign } from "./CreateCampaignForm";
+import { CampaignSettingsForm } from "./CampaignSettingsForm";
 
 import "./campaignSwitcher.css";
 
@@ -30,7 +31,7 @@ import "./campaignSwitcher.css";
 
 // The panel is a single three-value state, so "which view" and "is it open" can
 // never desync — a stale create form can't survive a close/reopen.
-type Panel = "closed" | "list" | "create";
+type Panel = "closed" | "list" | "create" | "edit";
 
 export function CampaignSwitcher() {
   const queryClient = useQueryClient();
@@ -170,6 +171,18 @@ export function CampaignSwitcher() {
                 onCancel={firstRun ? undefined : () => setPanel("list")}
               />
             </div>
+          ) : panel === "edit" && activeCampaign ? (
+            // The per-campaign settings editor (#268), seeded from the resolved
+            // Active Campaign. It shares the create form's classes and, like a
+            // create, returns to the list on save or cancel.
+            <div className="gx-campaign-switcher__create">
+              <div className="gx-campaign-switcher__create-head">Campaign settings</div>
+              <CampaignSettingsForm
+                campaign={activeCampaign}
+                onSaved={() => setPanel("list")}
+                onCancel={() => setPanel("list")}
+              />
+            </div>
           ) : (
             <>
               {/* A labelled group of plain buttons (not a role=listbox): a short,
@@ -215,6 +228,18 @@ export function CampaignSwitcher() {
 
               <button type="button" className="gx-campaign-switcher__new" onClick={enterCreate}>
                 <Plus size={15} /> New campaign
+              </button>
+
+              {/* Edit the resolved Active Campaign's name / System / Language
+                  (#268). Disabled until a campaign resolves — there is nothing to
+                  edit before one exists (first run opens straight into create). */}
+              <button
+                type="button"
+                className="gx-campaign-switcher__new"
+                onClick={() => setPanel("edit")}
+                disabled={!activeCampaign}
+              >
+                <Settings size={15} /> Campaign settings
               </button>
             </>
           )}

--- a/web/src/components/createCampaignForm.css
+++ b/web/src/components/createCampaignForm.css
@@ -23,3 +23,10 @@
   font-weight: var(--weight-semibold);
   color: var(--status-danger);
 }
+/* The Campaign Language cell (#268) stacks its SELECT over the "next Voice
+ * Session" deferral hint, matching the Input's label/field/hint rhythm. */
+.gx-campaign-create__lang {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}


### PR DESCRIPTION
Closes #268

## What

Per-campaign settings editor for **name**, **System**, and **Campaign Language**, rendered from the AppShell topbar campaign switcher (placement per #266) — no new nav screen.

## Recorded product decisions honored (fixed)

1. **System = free text + datalist** suggestions (`D&D 5e`, `Pathfinder 2e`, `Call of Cthulhu`). No enum, no migration; rides the wire opaque server-side (ADR-0039).
2. **Campaign Language = a SELECT** constrained to the registered phonetic encoders, sourced from `ListSupportedLanguages` → `address.EncoderRegistry` (ADR-0024, the sole language-truth source) so new encoders appear automatically. No free text. A stored out-of-registry language is preserved as an extra `(unsupported)` option so save can't silently coerce it.
3. **Language change mutates nothing** — existing Agents' voice settings untouched (ADR-0009, #224 `applyVoiceSelection` unchanged). UI surfaces the established "Takes effect on the next Voice Session." notice.

## Changes

- **proto**: `CampaignService.ListSupportedLanguages` RPC (NO_SIDE_EFFECTS) + its 2 messages, at the #268 anchors only.
- **Go**: `EncoderRegistry.Languages()` (sorted registered primary subtags) in `pkg/voice/address/phonetic.go`; `internal/rpc/campaign_language.go` handler returning `address.DefaultEncoders().Languages()` — same source the wirenpc roster reads, no store, no auth scope, no error path.
- **web**: new `CampaignSettingsForm.tsx` (plain useState, reuses `gx-campaign-create` classes, ADR-0017); `CampaignSwitcher.tsx` gains a `Panel="edit"` branch + a "Campaign settings" footer button (disabled until a campaign resolves). Save invalidates the campaign-INVARIANT `listCampaigns` key + the active-campaign sweep (ADR-0018).

## Test coverage (TDD, red→green)

- `pkg/voice/address/phonetic_test.go`: `Languages()` — empty registry, default `[de en]`, register `fr-FR` → contains `fr`, nil-unregister drops it. (+1 test)
- `internal/rpc/campaign_language_test.go`: handler returns `[de en]` sorted, no auth/store. (+1 test)
- `web/.../CampaignSettingsForm.test.tsx`: prefill from prop; language options from mocked `ListSupportedLanguages`; out-of-registry language preserved; 3 system datalist suggestions; empty/whitespace name disables save; save sends `{id, name trimmed, system, language}` and calls `onSaved`; Voice Session hint present; cancel. (+7 tests)
- `web/.../CampaignSwitcher.test.tsx`: settings button opens edit seeded with active campaign; cancel → list; close/reopen resets to list; disabled on first run. (+4 tests)

Local: Go build/vet/test + golangci-lint clean; web `tsc --noEmit` + full vitest (180) + `vite build` green; integration-tagged rpc tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)