### PR TITLE
feat(#269): campaign archive/delete lifecycle

### DIFF
--- a/internal/presence/session_commands_archive_integration_test.go
+++ b/internal/presence/session_commands_archive_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+// Proves the `/glyphoxa use` surface excludes archived campaigns against a real
+// Postgres (#269, decided on #265). The exclusion is transitive — UseCommand's
+// autocomplete + free-text match both read store.ListCampaigns, which filters
+// archived rows — so this pins it at the presence layer: a future change that
+// swapped the source for an archive-inclusive read would re-expose archived
+// campaigns and this test would catch it. Tag-isolated behind `integration`.
+
+package presence
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/disgoorg/disgo/discord"
+)
+
+// startArchivePostgres spins up a pgvector Postgres, migrates up, and returns a
+// Store. It skips (not fails) when Docker is unavailable, mirroring the storage
+// harness so a Docker-free `go test ./...` never hard-fails.
+func startArchivePostgres(t *testing.T) *storage.Store {
+	t.Helper()
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, "pgvector/pgvector:pg17",
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start the container (is Docker running?): %v", err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return storage.New(pool)
+}
+
+func TestUseCommandExcludesArchivedCampaign(t *testing.T) {
+	st := startArchivePostgres(t)
+	ctx := context.Background()
+
+	tenantID, err := st.CreateTenant(ctx, "Acme TTRPG")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	activeID, err := st.CreateCampaign(ctx, storage.NewCampaign{TenantID: tenantID, Name: "Active Quest", System: "dnd5e", Language: "en"})
+	if err != nil {
+		t.Fatalf("CreateCampaign(active): %v", err)
+	}
+	archivedID, err := st.CreateCampaign(ctx, storage.NewCampaign{TenantID: tenantID, Name: "Zombie Vault", System: "dnd5e", Language: "en"})
+	if err != nil {
+		t.Fatalf("CreateCampaign(archived): %v", err)
+	}
+	if _, err := st.ArchiveCampaign(ctx, archivedID); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+
+	cmd := UseCommand(st)
+
+	// --- Autocomplete must NOT offer the archived campaign (empty typed = all).
+	ac := &Autocomplete{
+		guildID: testGuild,
+		userID:  operatorID,
+		data: discord.AutocompleteInteractionData{
+			CommandName: "glyphoxa use",
+			Options: map[string]discord.AutocompleteOption{
+				"campaign": {Name: "campaign", Type: discord.ApplicationCommandOptionTypeString, Focused: true},
+			},
+		},
+	}
+	choices, err := cmd.Autocomplete(ctx, ac)
+	if err != nil {
+		t.Fatalf("autocomplete: %v", err)
+	}
+	names := make(map[string]bool, len(choices))
+	for _, ch := range choices {
+		names[ch.ChoiceName()] = true
+	}
+	if !names["Active Quest"] {
+		t.Errorf("autocomplete missing the active campaign: %v", names)
+	}
+	if names["Zombie Vault"] {
+		t.Errorf("autocomplete leaked the ARCHIVED campaign %q: %v", "Zombie Vault", names)
+	}
+
+	// --- Free-text match can't resolve the archived campaign either (same
+	// archive-excluding source): neither its name nor its id resolves.
+	list, err := st.ListCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if _, ok := matchCampaign(list, "Zombie Vault"); ok {
+		t.Errorf("free-text name resolved an archived campaign, want not-found")
+	}
+	if _, ok := matchCampaign(list, archivedID.String()); ok {
+		t.Errorf("free-text id resolved an archived campaign, want not-found")
+	}
+	// Sanity: the active one still resolves by name.
+	if c, ok := matchCampaign(list, "Active Quest"); !ok || c.ID != activeID {
+		t.Errorf("active campaign no longer resolves: ok=%v", ok)
+	}
+}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -45,6 +45,14 @@ type campaignStore interface {
 	CreateCampaign(ctx context.Context, c storage.NewCampaign) (uuid.UUID, error)
 	UpdateCampaign(ctx context.Context, c storage.CampaignUpdate) (storage.Campaign, error)
 	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
+	// The campaign archive lifecycle (#269): ListAllCampaigns is the archive-
+	// inclusive list the include_archived flag routes to; Archive/Unarchive/Delete
+	// are the lifecycle writes. Delete cascades in one statement; Archive clears any
+	// durable selection pointing at the campaign.
+	ListAllCampaigns(ctx context.Context) ([]storage.Campaign, error)
+	ArchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	UnarchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	DeleteCampaign(ctx context.Context, id uuid.UUID) error
 	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
 	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
@@ -140,7 +148,7 @@ func (s *CampaignServer) GetActiveCampaign(
 // nullable GMMemberID is intentionally not mapped — it is not part of the
 // management.v1 Campaign message (SEAM #6).
 func toProtoCampaign(c storage.Campaign) *managementv1.Campaign {
-	return &managementv1.Campaign{
+	pb := &managementv1.Campaign{
 		Id:        c.ID.String(),
 		TenantId:  c.TenantID.String(),
 		Name:      c.Name,
@@ -149,6 +157,12 @@ func toProtoCampaign(c storage.Campaign) *managementv1.Campaign {
 		CreatedAt: timestamppb.New(c.CreatedAt),
 		UpdatedAt: timestamppb.New(c.UpdatedAt),
 	}
+	// archived_at is left unset (nil) for an active campaign so the wire "unset =
+	// active" contract holds; set only when the campaign is archived (#269).
+	if c.ArchivedAt != nil {
+		pb.ArchivedAt = timestamppb.New(*c.ArchivedAt)
+	}
+	return pb
 }
 
 // Handler builds the Connect HTTP handler for CampaignService and returns the

--- a/internal/rpc/campaign_archive.go
+++ b/internal/rpc/campaign_archive.go
@@ -1,0 +1,125 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Campaign archive/delete lifecycle handlers (#269, decided on #265) on
+// CampaignServer. Archive is the primary flow; hard delete is only for
+// already-archived campaigns. Archive and Delete refuse the campaign backing the
+// LIVE Voice Session (the same in-process liveCampaign truth resolveActiveCampaign
+// consults, ADR-0039 — no second session-truth source). Error mapping mirrors the
+// campaign management handlers: ErrNotFound→CodeNotFound, ErrNotArchived→
+// CodeFailedPrecondition, an unparsable id→CodeInvalidArgument, generic
+// CodeInternal with a server-side slog.
+
+// liveGuard refuses an operation on the campaign backing the LIVE Voice Session
+// (#265): the campaign that is currently voicing can be neither archived nor
+// deleted out from under it. It consults the SAME liveCampaign closure
+// resolveActiveCampaign uses, so there is one source of session truth (ADR-0039).
+// It returns nil when no session is live, the source is unwired (keyless tests),
+// or a DIFFERENT campaign is live. Note the inherent TOCTOU: liveCampaign is
+// in-process manager state and a session could end (or start) in the millisecond
+// after this check — accepted for the single-operator web tier, where the window
+// is negligible and the DB cascade is still safe either way.
+func (s *CampaignServer) liveGuard(id uuid.UUID, verb string) error {
+	if s.liveCampaign == nil {
+		return nil
+	}
+	if lid, active := s.liveCampaign(); active && lid == id {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("campaign backs the live Voice Session and cannot be "+verb+" while it runs"))
+	}
+	return nil
+}
+
+// ArchiveCampaign archives a campaign so it drops out of the list, the /glyphoxa
+// use autocomplete, and the Active-Campaign resolution, and can no longer start a
+// Voice Session (#269). It refuses the live session's campaign
+// (CodeFailedPrecondition) and an unknown id (CodeNotFound); the store write is
+// idempotent, so re-archiving is a no-op returning the same campaign.
+func (s *CampaignServer) ArchiveCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.ArchiveCampaignRequest],
+) (*connect.Response[managementv1.ArchiveCampaignResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid campaign id"))
+	}
+	if err := s.liveGuard(id, "archived"); err != nil {
+		return nil, err
+	}
+
+	c, err := s.store.ArchiveCampaign(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		}
+		slog.Default().Error("ArchiveCampaign: store archive failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.ArchiveCampaignResponse{Campaign: toProtoCampaign(c)}), nil
+}
+
+// UnarchiveCampaign returns an archived campaign to the active set (#269). There
+// is no live-guard: a live session's campaign is never archived, so it can never
+// be a target here. An unknown id is CodeNotFound.
+func (s *CampaignServer) UnarchiveCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.UnarchiveCampaignRequest],
+) (*connect.Response[managementv1.UnarchiveCampaignResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid campaign id"))
+	}
+
+	c, err := s.store.UnarchiveCampaign(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		}
+		slog.Default().Error("UnarchiveCampaign: store unarchive failed", "campaign_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UnarchiveCampaignResponse{Campaign: toProtoCampaign(c)}), nil
+}
+
+// DeleteCampaign permanently removes an already-archived campaign and everything
+// cascading from it (#269). It refuses the live session's campaign
+// (CodeFailedPrecondition), a non-archived campaign (CodeFailedPrecondition —
+// archive first), and an unknown id (CodeNotFound). The re-typed name confirmation
+// is a UI-only guard (the request carries only the id); the server precondition is
+// purely "already archived".
+func (s *CampaignServer) DeleteCampaign(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteCampaignRequest],
+) (*connect.Response[managementv1.DeleteCampaignResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid campaign id"))
+	}
+	if err := s.liveGuard(id, "deleted"); err != nil {
+		return nil, err
+	}
+
+	if err := s.store.DeleteCampaign(ctx, id); err != nil {
+		switch {
+		case errors.Is(err, storage.ErrNotFound):
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
+		case errors.Is(err, storage.ErrNotArchived):
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("campaign must be archived before deletion"))
+		default:
+			slog.Default().Error("DeleteCampaign: store delete failed", "campaign_id", id, "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+	return connect.NewResponse(&managementv1.DeleteCampaignResponse{}), nil
+}

--- a/internal/rpc/campaign_archive_integration_test.go
+++ b/internal/rpc/campaign_archive_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+// End-to-end archive/delete lifecycle (#269) over Connect-JSON against a real
+// *storage.Store (testcontainers Postgres). Proves the two structural
+// consequences of the archive filter that a fake store cannot: archiving the
+// resolved Active Campaign makes GetActiveCampaign fall to the next campaign (or
+// NotFound when none is left), and StartSession refuses when the only campaign is
+// archived — so an archived campaign can never back a Voice Session. Tag-isolated
+// behind `integration`; reuses startPostgres/seedStore + the session test helpers.
+
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestArchiveThenResolveNext: archiving the resolved Active Campaign drops it from
+// resolution, so GetActiveCampaign falls to the next campaign; archiving that one
+// too leaves nothing and GetActiveCampaign is NotFound. Unarchiving brings it back.
+func TestArchiveThenResolveNext(t *testing.T) {
+	dsn := startPostgres(t)
+	store, firstID := seedStore(t, dsn) // "Lost Mine"
+	ctx := context.Background()
+
+	seeded, err := store.GetCampaign(ctx, firstID)
+	if err != nil {
+		t.Fatalf("GetCampaign(seeded): %v", err)
+	}
+	const operator = "operator-269"
+	client := mgmtIntegrationClient(t, store, seeded.TenantID, operator, nil)
+
+	// A second, newer campaign becomes the most-recent resolution.
+	created, err := client.CreateCampaign(ctx, connect.NewRequest(&managementv1.CreateCampaignRequest{Name: "Newer Quest"}))
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	newer := created.Msg.GetCampaign()
+
+	// GetActiveCampaign resolves the newer one (most-recent fallback).
+	active, err := client.GetActiveCampaign(ctx, connect.NewRequest(&managementv1.GetActiveCampaignRequest{}))
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	if active.Msg.GetCampaign().GetId() != newer.GetId() {
+		t.Fatalf("active = %s, want the newer campaign %s", active.Msg.GetCampaign().GetId(), newer.GetId())
+	}
+
+	// Archive the newer (active) one → resolution falls to the seeded campaign.
+	if _, err := client.ArchiveCampaign(ctx, connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: newer.GetId()})); err != nil {
+		t.Fatalf("ArchiveCampaign(newer): %v", err)
+	}
+	active, err = client.GetActiveCampaign(ctx, connect.NewRequest(&managementv1.GetActiveCampaignRequest{}))
+	if err != nil {
+		t.Fatalf("GetActiveCampaign after archive: %v", err)
+	}
+	if active.Msg.GetCampaign().GetId() != firstID.String() {
+		t.Errorf("active after archive = %s, want the seeded campaign %s", active.Msg.GetCampaign().GetId(), firstID)
+	}
+
+	// The default list excludes the archived one; include_archived surfaces it.
+	list, err := client.ListCampaigns(ctx, connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if len(list.Msg.GetCampaigns()) != 1 || list.Msg.GetCampaigns()[0].GetId() != firstID.String() {
+		t.Errorf("default list = %+v, want only the seeded campaign", list.Msg.GetCampaigns())
+	}
+	all, err := client.ListCampaigns(ctx, connect.NewRequest(&managementv1.ListCampaignsRequest{IncludeArchived: true}))
+	if err != nil {
+		t.Fatalf("ListCampaigns(include_archived): %v", err)
+	}
+	if len(all.Msg.GetCampaigns()) != 2 {
+		t.Errorf("include_archived list len = %d, want 2", len(all.Msg.GetCampaigns()))
+	}
+
+	// Archive the seeded one too → nothing resolves.
+	if _, err := client.ArchiveCampaign(ctx, connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: firstID.String()})); err != nil {
+		t.Fatalf("ArchiveCampaign(seeded): %v", err)
+	}
+	if _, err := client.GetActiveCampaign(ctx, connect.NewRequest(&managementv1.GetActiveCampaignRequest{})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("GetActiveCampaign with all archived = %v, want CodeNotFound", err)
+	}
+
+	// Unarchive the seeded one → it resolves again.
+	if _, err := client.UnarchiveCampaign(ctx, connect.NewRequest(&managementv1.UnarchiveCampaignRequest{Id: firstID.String()})); err != nil {
+		t.Fatalf("UnarchiveCampaign(seeded): %v", err)
+	}
+	active, err = client.GetActiveCampaign(ctx, connect.NewRequest(&managementv1.GetActiveCampaignRequest{}))
+	if err != nil || active.Msg.GetCampaign().GetId() != firstID.String() {
+		t.Errorf("active after unarchive = %+v, %v; want the seeded campaign %s", active.Msg.GetCampaign(), err, firstID)
+	}
+}
+
+// TestStartSessionRefusedWhenOnlyCampaignArchived proves the archived-can't-start
+// guard structurally (#265): with the only campaign archived, StartSession's
+// server-side campaign resolution finds nothing, so it fails with the same
+// CodeFailedPrecondition "no active campaign" a truly empty install returns — the
+// manager is never even asked to Start.
+func TestStartSessionRefusedWhenOnlyCampaignArchived(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignID := seedStore(t, dsn)
+	ctx := context.Background()
+
+	// Archive the sole campaign directly.
+	if _, err := store.ArchiveCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+
+	mgr := &fakeSessionManager{}
+	tenantID := uuid.New()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx = auth.WithTenant(ctx, tenantID)
+			ctx = auth.WithUser(ctx, storage.User{ID: uuid.New(), DiscordUserID: "operator-269"})
+			return next(ctx, req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(mgr, store, nil).Handler(connect.WithInterceptors(inject)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	_, err := client.StartSession(ctx, connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("StartSession with only-archived campaign = %v, want CodeFailedPrecondition", err)
+	}
+	if mgr.startCalls != 0 {
+		t.Errorf("manager Start was called %d times, want 0 (resolution refused before Start)", mgr.startCalls)
+	}
+}

--- a/internal/rpc/campaign_archive_test.go
+++ b/internal/rpc/campaign_archive_test.go
@@ -1,0 +1,264 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestArchiveCampaign_HappyPath: a valid, non-live campaign archives and the
+// archived_at timestamp maps onto the wire.
+func TestArchiveCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	archivedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	store.archiveResult = storage.Campaign{ID: id, TenantID: uuid.New(), Name: "Old One", ArchivedAt: &archivedAt}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.ArchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: id.String()}))
+	if err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	if len(store.archiveCalls) != 1 || store.archiveCalls[0] != id {
+		t.Errorf("archive calls = %+v, want [%s]", store.archiveCalls, id)
+	}
+	if got := resp.Msg.GetCampaign().GetArchivedAt().AsTime(); !got.Equal(archivedAt) {
+		t.Errorf("archived_at on wire = %v, want %v", got, archivedAt)
+	}
+}
+
+func TestArchiveCampaign_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.ArchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+func TestArchiveCampaign_UnknownIDNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.archiveErr = storage.ErrNotFound
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.ArchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+// TestArchiveCampaign_LiveSessionRefused: the campaign backing the LIVE Voice
+// Session cannot be archived out from under it (#265).
+func TestArchiveCampaign_LiveSessionRefused(t *testing.T) {
+	t.Parallel()
+	live := uuid.New()
+	store := newFakeStore()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+
+	_, err := client.ArchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: live.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	// The store must never be asked to archive the live campaign.
+	if len(store.archiveCalls) != 0 {
+		t.Errorf("live campaign must not reach the store: %+v", store.archiveCalls)
+	}
+}
+
+// TestArchiveCampaign_OtherCampaignWhileLiveAllowed: a DIFFERENT campaign than the
+// live one archives fine — the guard is scoped to the live campaign only.
+func TestArchiveCampaign_OtherCampaignWhileLiveAllowed(t *testing.T) {
+	t.Parallel()
+	live := uuid.New()
+	other := uuid.New()
+	store := newFakeStore()
+	store.archiveResult = storage.Campaign{ID: other, Name: "Other"}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+
+	if _, err := client.ArchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: other.String()})); err != nil {
+		t.Fatalf("archiving a non-live campaign while live: %v", err)
+	}
+	if len(store.archiveCalls) != 1 || store.archiveCalls[0] != other {
+		t.Errorf("archive calls = %+v, want [%s]", store.archiveCalls, other)
+	}
+}
+
+// TestUnarchiveCampaign_HappyPath: unarchive returns the reactivated campaign
+// (archived_at unset) with no live-guard.
+func TestUnarchiveCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	store.unarchiveResult = storage.Campaign{ID: id, Name: "Back"}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	resp, err := client.UnarchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UnarchiveCampaignRequest{Id: id.String()}))
+	if err != nil {
+		t.Fatalf("UnarchiveCampaign: %v", err)
+	}
+	if resp.Msg.GetCampaign().GetArchivedAt() != nil {
+		t.Errorf("archived_at should be unset after unarchive: %+v", resp.Msg.GetCampaign())
+	}
+	if len(store.unarchiveCalls) != 1 || store.unarchiveCalls[0] != id {
+		t.Errorf("unarchive calls = %+v, want [%s]", store.unarchiveCalls, id)
+	}
+}
+
+func TestUnarchiveCampaign_UnknownIDNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.unarchiveErr = storage.ErrNotFound
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.UnarchiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.UnarchiveCampaignRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+// TestDeleteCampaign_HappyPath: a valid, archived, non-live campaign deletes.
+func TestDeleteCampaign_HappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	if _, err := client.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteCampaign: %v", err)
+	}
+	if len(store.deleteCalls) != 1 || store.deleteCalls[0] != id {
+		t.Errorf("delete calls = %+v, want [%s]", store.deleteCalls, id)
+	}
+}
+
+func TestDeleteCampaign_InvalidID(t *testing.T) {
+	t.Parallel()
+	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: "nope"}))
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+// TestDeleteCampaign_NotArchivedRefused: a non-archived campaign is refused with
+// FailedPrecondition (archive first, #265).
+func TestDeleteCampaign_NotArchivedRefused(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.deleteCampaignErr = storage.ErrNotArchived
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+}
+
+func TestDeleteCampaign_UnknownIDNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.deleteCampaignErr = storage.ErrNotFound
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	_, err := client.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+// TestDeleteCampaign_LiveSessionRefused: the live session's campaign cannot be
+// deleted (#265) — refused before it reaches the store.
+func TestDeleteCampaign_LiveSessionRefused(t *testing.T) {
+	t.Parallel()
+	live := uuid.New()
+	store := newFakeStore()
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+
+	_, err := client.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: live.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	if len(store.deleteCalls) != 0 {
+		t.Errorf("live campaign must not reach the store: %+v", store.deleteCalls)
+	}
+}
+
+// TestListCampaigns_IncludeArchivedRouting pins the include_archived flag routing
+// (#269): true → ListAllCampaigns (archive-inclusive), false → ListCampaigns
+// (active only), and an archived campaign's archived_at maps onto the wire.
+func TestListCampaigns_IncludeArchivedRouting(t *testing.T) {
+	t.Parallel()
+	archivedAt := time.Date(2026, 7, 9, 8, 0, 0, 0, time.UTC)
+	store := newFakeStore()
+	store.campaignList = []storage.Campaign{{ID: uuid.New(), Name: "Active"}}
+	store.allCampaignList = []storage.Campaign{
+		{ID: uuid.New(), Name: "Active"},
+		{ID: uuid.New(), Name: "Archived", ArchivedAt: &archivedAt},
+	}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	// Default (false) → active only.
+	activeResp, err := client.ListCampaigns(context.Background(),
+		connect.NewRequest(&managementv1.ListCampaignsRequest{}))
+	if err != nil {
+		t.Fatalf("ListCampaigns(default): %v", err)
+	}
+	if len(activeResp.Msg.GetCampaigns()) != 1 {
+		t.Errorf("default list len = %d, want 1 (active only)", len(activeResp.Msg.GetCampaigns()))
+	}
+
+	// include_archived=true → archive-inclusive, and archived_at is on the wire.
+	allResp, err := client.ListCampaigns(context.Background(),
+		connect.NewRequest(&managementv1.ListCampaignsRequest{IncludeArchived: true}))
+	if err != nil {
+		t.Fatalf("ListCampaigns(include_archived): %v", err)
+	}
+	got := allResp.Msg.GetCampaigns()
+	if len(got) != 2 {
+		t.Fatalf("archive-inclusive list len = %d, want 2", len(got))
+	}
+	if got[0].GetArchivedAt() != nil {
+		t.Errorf("active campaign archived_at should be unset: %+v", got[0])
+	}
+	if got[1].GetArchivedAt() == nil || !got[1].GetArchivedAt().AsTime().Equal(archivedAt) {
+		t.Errorf("archived campaign archived_at = %v, want %v", got[1].GetArchivedAt(), archivedAt)
+	}
+}
+
+// TestSetActiveCampaign_ArchivedRefused: selecting an archived campaign as the
+// Active Campaign is refused (#269) — it is excluded from resolution, so the
+// selection would silently resolve to a different campaign.
+func TestSetActiveCampaign_ArchivedRefused(t *testing.T) {
+	t.Parallel()
+	archivedAt := time.Date(2026, 7, 9, 8, 0, 0, 0, time.UTC)
+	id := uuid.New()
+	store := newFakeStore()
+	store.campaignsByID = map[uuid.UUID]storage.Campaign{id: {ID: id, Name: "Archived", ArchivedAt: &archivedAt}}
+	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+
+	_, err := client.SetActiveCampaign(context.Background(),
+		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: id.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	// The archived target must never be persisted as a selection.
+	if len(store.setActiveCalls) != 0 {
+		t.Errorf("archived target must not persist a selection: %+v", store.setActiveCalls)
+	}
+}

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -57,6 +57,20 @@ type fakeCampaignStore struct {
 	updateCampaignErr error
 	setActiveCalls    []setActiveCall
 	setActiveErr      error
+	// Archive lifecycle state (#269): allCampaignList backs ListAllCampaigns;
+	// archiveCalls/unarchiveCalls/deleteCalls record the ids each handler passed;
+	// the *Result campaigns are returned on the happy path, and the *Err hooks force
+	// each failure path (e.g. storage.ErrNotFound, storage.ErrNotArchived).
+	allCampaignList   []storage.Campaign
+	listAllErr        error
+	archiveCalls      []uuid.UUID
+	archiveResult     storage.Campaign
+	archiveErr        error
+	unarchiveCalls    []uuid.UUID
+	unarchiveResult   storage.Campaign
+	unarchiveErr      error
+	deleteCalls       []uuid.UUID
+	deleteCampaignErr error
 	// listNodesCampaign/searchNodesCampaign record the campaign id ListNodes /
 	// SearchNodes resolved so the scope precedence can be asserted (#222).
 	listNodesCampaign   uuid.UUID
@@ -198,6 +212,31 @@ func (f *fakeCampaignStore) SetActiveCampaign(_ context.Context, discordUserID s
 	}
 	f.setActiveCalls = append(f.setActiveCalls, setActiveCall{discordUserID: discordUserID, campaignID: campaignID})
 	return nil
+}
+
+func (f *fakeCampaignStore) ListAllCampaigns(context.Context) ([]storage.Campaign, error) {
+	return f.allCampaignList, f.listAllErr
+}
+
+func (f *fakeCampaignStore) ArchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	f.archiveCalls = append(f.archiveCalls, id)
+	if f.archiveErr != nil {
+		return storage.Campaign{}, f.archiveErr
+	}
+	return f.archiveResult, nil
+}
+
+func (f *fakeCampaignStore) UnarchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	f.unarchiveCalls = append(f.unarchiveCalls, id)
+	if f.unarchiveErr != nil {
+		return storage.Campaign{}, f.unarchiveErr
+	}
+	return f.unarchiveResult, nil
+}
+
+func (f *fakeCampaignStore) DeleteCampaign(_ context.Context, id uuid.UUID) error {
+	f.deleteCalls = append(f.deleteCalls, id)
+	return f.deleteCampaignErr
 }
 
 func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {

--- a/internal/rpc/campaign_management.go
+++ b/internal/rpc/campaign_management.go
@@ -21,12 +21,18 @@ import (
 // NO_SIDE_EFFECTS; mutations are CSRF-guarded by the interceptor stack.
 
 // ListCampaigns returns the operator's campaigns in name order (the store's stable
-// name-then-id ordering). A storage failure is CodeInternal.
+// name-then-id ordering). By default only ACTIVE campaigns are returned; when
+// include_archived is set the archived ones are included too — the archive-
+// management panel's view (#269). A storage failure is CodeInternal.
 func (s *CampaignServer) ListCampaigns(
 	ctx context.Context,
-	_ *connect.Request[managementv1.ListCampaignsRequest],
+	req *connect.Request[managementv1.ListCampaignsRequest],
 ) (*connect.Response[managementv1.ListCampaignsResponse], error) {
-	campaigns, err := s.store.ListCampaigns(ctx)
+	list := s.store.ListCampaigns
+	if req.Msg.GetIncludeArchived() {
+		list = s.store.ListAllCampaigns
+	}
+	campaigns, err := list(ctx)
 	if err != nil {
 		slog.Default().Error("ListCampaigns: store list failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
@@ -142,12 +148,19 @@ func (s *CampaignServer) SetActiveCampaign(
 
 	// Validate the target exists before persisting the pointer — an unknown id is
 	// a client error (CodeNotFound), never a silently-stored dangling selection.
-	if _, err := s.store.GetCampaign(ctx, id); err != nil {
+	target, err := s.store.GetCampaign(ctx, id)
+	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
 		}
 		slog.Default().Error("SetActiveCampaign: validate campaign failed", "campaign_id", id, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	// An archived campaign cannot be the Active Campaign (#269): it is excluded from
+	// every resolution surface, so selecting it would resolve to a DIFFERENT campaign
+	// (the fallback) — refuse up front with a clear precondition failure instead.
+	if target.ArchivedAt != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("campaign is archived"))
 	}
 
 	if err := s.store.SetActiveCampaign(ctx, u.DiscordUserID, id); err != nil {

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -62,6 +62,22 @@ func (fakeReader) SetActiveCampaign(context.Context, string, uuid.UUID) error {
 	return nil
 }
 
+// The archive lifecycle half of campaignStore (#269) is unused by the
+// GetActiveCampaign tests; stub it so fakeReader still satisfies the widened
+// interface. The archive handlers exercise it via fakeCampaignStore.
+func (fakeReader) ListAllCampaigns(context.Context) ([]storage.Campaign, error) {
+	return nil, nil
+}
+func (fakeReader) ArchiveCampaign(context.Context, uuid.UUID) (storage.Campaign, error) {
+	return storage.Campaign{}, nil
+}
+func (fakeReader) UnarchiveCampaign(context.Context, uuid.UUID) (storage.Campaign, error) {
+	return storage.Campaign{}, nil
+}
+func (fakeReader) DeleteCampaign(context.Context, uuid.UUID) error {
+	return nil
+}
+
 // The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
 // tests; stub it so fakeReader still satisfies the widened interface. The CRUD
 // handlers have their own fake (campaign_crud_test.go).

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -105,16 +105,19 @@ func (s *Store) SetActiveCampaign(ctx context.Context, discordUserID string, cam
 // GetActiveCampaignForUser returns the Campaign the operator selected via
 // /glyphoxa use (#108, ADR-0009 step 2), joining the users row's
 // active_campaign_id to campaign. ErrNotFound when the operator has no row, has
-// made no selection, or the chosen campaign has since been deleted (the FK's ON
-// DELETE SET NULL nulled the pointer) — the caller then falls through to the
+// made no selection, the chosen campaign has since been deleted (the FK's ON
+// DELETE SET NULL nulled the pointer), or the chosen campaign is now archived
+// (#269: an archived durable selection is treated as absent, so the caller falls
+// through to the GetActiveCampaign fallback — which also skips archived — exactly
+// as it does for a deleted one). The caller then falls through to the
 // GetActiveCampaign fallback (step 3). The columns are qualified to `c` because
 // users and campaign share id/name/created_at/updated_at.
 func (s *Store) GetActiveCampaignForUser(ctx context.Context, discordUserID string) (Campaign, error) {
 	row := s.db.QueryRow(ctx,
 		`SELECT c.id, c.tenant_id, c.gm_member_id, c.name, c.system, c.language,
-		        c.created_at, c.updated_at
+		        c.created_at, c.updated_at, c.archived_at
 		   FROM users u JOIN campaign c ON c.id = u.active_campaign_id
-		  WHERE u.discord_user_id = $1`, discordUserID)
+		  WHERE u.discord_user_id = $1 AND c.archived_at IS NULL`, discordUserID)
 	c, err := scanCampaign(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Campaign{}, ErrNotFound

--- a/internal/storage/campaign_archive.go
+++ b/internal/storage/campaign_archive.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrNotArchived is returned by DeleteCampaign when the target campaign exists
+// but is not archived: the hard delete is refused until the campaign has been
+// archived first (#269, decided on #265). The RPC layer maps it to Connect
+// CodeFailedPrecondition.
+var ErrNotArchived = errors.New("storage: campaign not archived")
+
+// ListAllCampaigns returns every Campaign — active AND archived — ordered by name
+// (then id for a stable tie-break). It backs the archive-management panel's
+// include_archived read (#269); the default list surfaces (ListCampaigns, the
+// /glyphoxa use autocomplete) stay archive-excluding. Single-operator today, so
+// it is unscoped, mirroring ListCampaigns; tenant scoping fills in behind the
+// X-Tenant-Id pass-through later (ADR-0039).
+func (s *Store) ListAllCampaigns(ctx context.Context) ([]Campaign, error) {
+	rows, err := s.db.Query(ctx, `SELECT `+campaignColumns+` FROM campaign ORDER BY name, id`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list all campaigns: %w", err)
+	}
+	defer rows.Close()
+	var out []Campaign
+	for rows.Next() {
+		c, err := scanCampaign(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan campaign: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list all campaigns: %w", err)
+	}
+	return out, nil
+}
+
+// ArchiveCampaign marks a campaign archived and returns the updated row (#269).
+// It is idempotent: COALESCE(archived_at, now()) keeps an already-archived
+// campaign's original timestamp (the audit trail of WHEN it was first archived),
+// so a re-archive is a no-op on the timestamp. In the same transaction it clears
+// users.active_campaign_id for every operator whose durable /glyphoxa use
+// selection pointed at this campaign — the decided "archived durable selection is
+// treated as absent" (#265): the slash surface then falls to its /use hint and
+// the web tier to its most-recent fallback, neither of which resolves an archived
+// campaign. A missing id yields ErrNotFound.
+func (s *Store) ArchiveCampaign(ctx context.Context, id uuid.UUID) (Campaign, error) {
+	var c Campaign
+	err := s.InTx(ctx, func(tx *Store) error {
+		row := tx.db.QueryRow(ctx,
+			`UPDATE campaign
+			    SET archived_at = COALESCE(archived_at, now()), updated_at = now()
+			  WHERE id = $1
+			 RETURNING `+campaignColumns, id)
+		got, err := scanCampaign(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("storage: archive campaign %s: %w", id, err)
+		}
+		// Treat an archived durable selection as absent (#265): null every operator
+		// pointer at this campaign so resolution falls back cleanly.
+		if _, err := tx.db.Exec(ctx,
+			`UPDATE users SET active_campaign_id = NULL, updated_at = now()
+			  WHERE active_campaign_id = $1`, id); err != nil {
+			return fmt.Errorf("storage: clear active selections for archived campaign %s: %w", id, err)
+		}
+		c = got
+		return nil
+	})
+	if err != nil {
+		return Campaign{}, err
+	}
+	return c, nil
+}
+
+// UnarchiveCampaign clears a campaign's archived_at, returning it to the active
+// set, and returns the updated row (#269). A missing id yields ErrNotFound.
+// Un-archiving does not restore any operator's cleared durable selection (that
+// pointer was nulled on archive) — the campaign simply becomes selectable again.
+func (s *Store) UnarchiveCampaign(ctx context.Context, id uuid.UUID) (Campaign, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE campaign SET archived_at = NULL, updated_at = now()
+		  WHERE id = $1
+		 RETURNING `+campaignColumns, id)
+	c, err := scanCampaign(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Campaign{}, ErrNotFound
+	}
+	if err != nil {
+		return Campaign{}, fmt.Errorf("storage: unarchive campaign %s: %w", id, err)
+	}
+	return c, nil
+}
+
+// DeleteCampaign permanently removes an ALREADY-ARCHIVED campaign (#269). The
+// single DELETE cascades to everything owned by the campaign — Agents (and their
+// Tool Grants), Knowledge Graph Nodes/Edges, Voice Sessions (and their Transcript
+// Lines), and Transcript Chunks — via the ON DELETE CASCADE foreign keys the
+// schema already declares (00001 agents/transcript_chunk, 00006 voice_sessions,
+// 00007 transcript_line, 00010 kg_node, 00012 kg_edge, 00013 tool_agent_grant);
+// users.active_campaign_id is nulled via its ON DELETE SET NULL (00014). The
+// Butler is removed through the agents CASCADE, deliberately NOT through
+// DeleteAgent's butler guard (ADR-0009): a campaign delete takes its Butler with
+// it. The WHERE archived_at IS NOT NULL clause makes the delete refuse a
+// non-archived campaign; when no row is affected, GetCampaign disambiguates a
+// missing campaign (ErrNotFound) from a live one (ErrNotArchived). This is
+// irrecoverable removal of play history including transcript PII — no soft-delete
+// retention window (#265).
+func (s *Store) DeleteCampaign(ctx context.Context, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx,
+		`DELETE FROM campaign WHERE id = $1 AND archived_at IS NOT NULL`, id)
+	if err != nil {
+		return fmt.Errorf("storage: delete campaign %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Nothing deleted: either the campaign does not exist, or it exists but is
+		// not archived. Disambiguate so the RPC layer can map each to its own code.
+		if _, gerr := s.GetCampaign(ctx, id); errors.Is(gerr, ErrNotFound) {
+			return ErrNotFound
+		} else if gerr != nil {
+			return gerr
+		}
+		return ErrNotArchived
+	}
+	return nil
+}

--- a/internal/storage/campaign_archive_test.go
+++ b/internal/storage/campaign_archive_test.go
@@ -1,0 +1,278 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestArchiveCampaign proves the archive write against a real Postgres (#269):
+// archived_at is stamped ~now, every operator's durable selection pointing at the
+// campaign is cleared (the "archived durable selection is treated as absent"
+// decision, #265), and a re-archive keeps the ORIGINAL timestamp (COALESCE
+// idempotence — the audit trail of when it was first archived).
+func TestArchiveCampaign(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// An operator has this campaign as their durable /glyphoxa use selection.
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, campaignID); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+
+	before := time.Now()
+	archived, err := st.ArchiveCampaign(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	if archived.ArchivedAt == nil {
+		t.Fatalf("archived_at not set after archive")
+	}
+	if archived.ArchivedAt.Before(before.Add(-time.Minute)) || archived.ArchivedAt.After(time.Now().Add(time.Minute)) {
+		t.Errorf("archived_at = %v, want ~now", archived.ArchivedAt)
+	}
+
+	// The durable selection pointing at the archived campaign was cleared.
+	if _, err := st.GetActiveCampaignForUser(ctx, gmSnowflake); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("durable selection after archive = %v, want ErrNotFound (cleared)", err)
+	}
+
+	// Re-archiving keeps the original timestamp (COALESCE idempotence).
+	firstTS := *archived.ArchivedAt
+	rearchived, err := st.ArchiveCampaign(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ArchiveCampaign (re-archive): %v", err)
+	}
+	if rearchived.ArchivedAt == nil || !rearchived.ArchivedAt.Equal(firstTS) {
+		t.Errorf("re-archive timestamp = %v, want the original %v (idempotent)", rearchived.ArchivedAt, firstTS)
+	}
+
+	// An unknown id is ErrNotFound.
+	if _, err := st.ArchiveCampaign(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("ArchiveCampaign(random) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestArchivedExcludedFromResolution pins the exclusion decisions (#265): an
+// archived campaign drops out of ListCampaigns (and therefore the /glyphoxa use
+// autocomplete, which shares the query), stays in ListAllCampaigns, and is skipped
+// by the GetActiveCampaign most-recent fallback — so an only-archived DB resolves
+// to ErrNotFound.
+func TestArchivedExcludedFromResolution(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, first := seedCampaign(t, dsn) // "Lost Mine"
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	second := insertCampaign(t, st, tenantID, "Alpha Quest")
+
+	// Archive the most-recently-created one; it must leave the default list but
+	// stay in the archive-inclusive list.
+	if _, err := st.ArchiveCampaign(ctx, second); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+
+	active, err := st.ListCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != first {
+		t.Errorf("ListCampaigns = %+v, want only the active campaign %s", active, first)
+	}
+
+	all, err := st.ListAllCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListAllCampaigns: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("ListAllCampaigns len = %d, want 2 (active + archived)", len(all))
+	}
+
+	// The most-recent fallback skips the archived campaign → resolves the active one.
+	def, err := st.GetActiveCampaign(ctx)
+	if err != nil || def.ID != first {
+		t.Errorf("GetActiveCampaign = %s, %v; want the active campaign %s (archived skipped)", def.ID, err, first)
+	}
+
+	// Archive the last active campaign too → nothing resolves.
+	if _, err := st.ArchiveCampaign(ctx, first); err != nil {
+		t.Fatalf("ArchiveCampaign(first): %v", err)
+	}
+	if _, err := st.GetActiveCampaign(ctx); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetActiveCampaign with only archived = %v, want ErrNotFound", err)
+	}
+}
+
+// TestGetActiveCampaignForUserNeverReturnsArchived proves the durable selection
+// read excludes an archived target (#269): even a still-set pointer at an archived
+// campaign resolves to ErrNotFound so the caller falls to the fallback.
+func TestGetActiveCampaignForUserNeverReturnsArchived(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := st.SetActiveCampaign(ctx, gmSnowflake, campaignID); err != nil {
+		t.Fatalf("SetActiveCampaign: %v", err)
+	}
+	// Archive directly via SQL so the pointer is NOT cleared (isolating the read's
+	// own archived filter from ArchiveCampaign's pointer-clearing).
+	if _, err := pool.Exec(ctx, `UPDATE campaign SET archived_at = now() WHERE id = $1`, campaignID); err != nil {
+		t.Fatalf("archive via SQL: %v", err)
+	}
+	if _, err := st.GetActiveCampaignForUser(ctx, gmSnowflake); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetActiveCampaignForUser with archived target = %v, want ErrNotFound", err)
+	}
+}
+
+// TestUnarchiveCampaign proves the reverse: clearing archived_at returns the
+// campaign to ListCampaigns (#269).
+func TestUnarchiveCampaign(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.ArchiveCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	if got, _ := st.ListCampaigns(ctx); len(got) != 0 {
+		t.Fatalf("after archive, ListCampaigns len = %d, want 0", len(got))
+	}
+
+	un, err := st.UnarchiveCampaign(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("UnarchiveCampaign: %v", err)
+	}
+	if un.ArchivedAt != nil {
+		t.Errorf("archived_at = %v after unarchive, want nil", un.ArchivedAt)
+	}
+	got, err := st.ListCampaigns(ctx)
+	if err != nil || len(got) != 1 || got[0].ID != campaignID {
+		t.Errorf("after unarchive, ListCampaigns = %+v, %v; want the reactivated campaign", got, err)
+	}
+
+	// An unknown id is ErrNotFound.
+	if _, err := st.UnarchiveCampaign(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("UnarchiveCampaign(random) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteCampaignCascade proves the hard delete of an archived campaign cascades
+// through the entire owned graph (#269): campaign + Agents + Tool Grants + KG
+// Nodes/Edges + Voice Sessions + Transcript Lines + Transcript Chunks all vanish in
+// one DELETE. A non-archived campaign is refused with ErrNotArchived (its row
+// survives); an unknown id is ErrNotFound.
+func TestDeleteCampaignCascade(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Seed one of every child so the cascade chain is proven, not assumed.
+	// Butler is auto-created by the trigger; add a Character NPC + a Tool Grant.
+	var charID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO agents (campaign_id, agent_role, name, address_only)
+		 VALUES ($1, 'character', 'Bart', false) RETURNING id`, campaignID).Scan(&charID); err != nil {
+		t.Fatalf("insert character: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO tool_agent_grant (agent_id, tool_name) VALUES ($1, 'dice')`, charID); err != nil {
+		t.Fatalf("insert tool grant: %v", err)
+	}
+
+	// KG: two nodes + an edge between them.
+	var nodeA, nodeB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO kg_node (campaign_id, node_type, name) VALUES ($1, 'npc', 'Goblin') RETURNING id`,
+		campaignID).Scan(&nodeA); err != nil {
+		t.Fatalf("insert node A: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO kg_node (campaign_id, node_type, name) VALUES ($1, 'location', 'Cave') RETURNING id`,
+		campaignID).Scan(&nodeB); err != nil {
+		t.Fatalf("insert node B: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kg_edge (campaign_id, from_node_id, to_node_id, edge_type)
+		 VALUES ($1, $2, $3, 'resides_in')`, campaignID, nodeA, nodeB); err != nil {
+		t.Fatalf("insert edge: %v", err)
+	}
+
+	// Voice Session + a Transcript Line under it.
+	var sessionID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO voice_sessions (campaign_id, status) VALUES ($1, 'ended') RETURNING id`,
+		campaignID).Scan(&sessionID); err != nil {
+		t.Fatalf("insert voice session: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO transcript_line (voice_session_id, campaign_id, line_id, seq, who, kind, ts, text)
+		 VALUES ($1, $2, 'u:1', 1, 'Player', 'player', now(), 'hello there')`,
+		sessionID, campaignID); err != nil {
+		t.Fatalf("insert transcript line: %v", err)
+	}
+
+	// Transcript Chunk (campaign-scoped).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO transcript_chunk (campaign_id, voice_session_id, content)
+		 VALUES ($1, $2, 'chunk content')`, campaignID, sessionID); err != nil {
+		t.Fatalf("insert transcript chunk: %v", err)
+	}
+
+	// Delete before archiving is refused; the row survives.
+	if err := st.DeleteCampaign(ctx, campaignID); !errors.Is(err, storage.ErrNotArchived) {
+		t.Fatalf("DeleteCampaign(non-archived) = %v, want ErrNotArchived", err)
+	}
+	if _, err := st.GetCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("campaign should survive a refused delete: %v", err)
+	}
+
+	// Archive, then hard-delete for real.
+	if _, err := st.ArchiveCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	if err := st.DeleteCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("DeleteCampaign(archived): %v", err)
+	}
+
+	// Every child is gone via the FK cascade chain.
+	for _, tc := range []struct {
+		name  string
+		query string
+		arg   any
+	}{
+		{"campaign", `SELECT count(*) FROM campaign WHERE id = $1`, campaignID},
+		{"agents", `SELECT count(*) FROM agents WHERE campaign_id = $1`, campaignID},
+		{"tool_agent_grant", `SELECT count(*) FROM tool_agent_grant WHERE agent_id = $1`, charID},
+		{"kg_node", `SELECT count(*) FROM kg_node WHERE campaign_id = $1`, campaignID},
+		{"kg_edge", `SELECT count(*) FROM kg_edge WHERE campaign_id = $1`, campaignID},
+		{"voice_sessions", `SELECT count(*) FROM voice_sessions WHERE campaign_id = $1`, campaignID},
+		{"transcript_line", `SELECT count(*) FROM transcript_line WHERE campaign_id = $1`, campaignID},
+		{"transcript_chunk", `SELECT count(*) FROM transcript_chunk WHERE campaign_id = $1`, campaignID},
+	} {
+		var n int
+		if err := pool.QueryRow(ctx, tc.query, tc.arg).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", tc.name, err)
+		}
+		if n != 0 {
+			t.Errorf("%s rows after cascade delete = %d, want 0", tc.name, n)
+		}
+	}
+	_ = tenantID
+
+	// An unknown id is ErrNotFound.
+	if err := st.DeleteCampaign(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("DeleteCampaign(random) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/migrations/00018_campaign_archive.sql
+++ b/internal/storage/migrations/00018_campaign_archive.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+-- Campaign archive lifecycle (#269, decided on #265). archived_at is a nullable
+-- timestamp, not a boolean: NULL = active, a non-NULL value = the moment the
+-- campaign was archived (an audit trail the boolean would throw away). Archived
+-- campaigns are excluded from ListCampaigns, the /glyphoxa use autocomplete, and
+-- the GetActiveCampaign most-recent fallback, and can neither start a Voice
+-- Session nor be the resolved Active Campaign. No index: a single operator has a
+-- handful of campaigns, so the WHERE archived_at IS NULL filter is a trivial scan.
+ALTER TABLE campaign ADD COLUMN archived_at timestamptz;
+
+-- +goose Down
+
+ALTER TABLE campaign DROP COLUMN archived_at;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -61,6 +61,12 @@ type Campaign struct {
 	Language   string
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+	// ArchivedAt is when the campaign was archived (#269), or nil when active.
+	// Archived campaigns are excluded from ListCampaigns, the /glyphoxa use
+	// autocomplete, and the GetActiveCampaign most-recent fallback, and cannot back
+	// a Voice Session. Appended LAST in campaignColumns/scanCampaign (column-order
+	// coupling), so any new column follows it in both places.
+	ArchivedAt *time.Time
 }
 
 // ProviderConfig is a Tenant-scoped, encrypted BYOK credential record binding a

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -65,13 +65,13 @@ func (s *Store) InTx(ctx context.Context, fn func(*Store) error) error {
 
 const campaignColumns = `
 	id, tenant_id, gm_member_id, name, system, language,
-	created_at, updated_at`
+	created_at, updated_at, archived_at`
 
 func scanCampaign(row pgx.Row) (Campaign, error) {
 	var c Campaign
 	err := row.Scan(
 		&c.ID, &c.TenantID, &c.GMMemberID, &c.Name, &c.System, &c.Language,
-		&c.CreatedAt, &c.UpdatedAt,
+		&c.CreatedAt, &c.UpdatedAt, &c.ArchivedAt,
 	)
 	return c, err
 }
@@ -80,11 +80,15 @@ func scanCampaign(row pgx.Row) (Campaign, error) {
 // one. Glyphoxa is single-operator today (one Tenant), so the global latest is
 // the sole Tenant's latest. Tenant scoping fills in behind the X-Tenant-Id
 // pass-through later (ADR-0039), at which point this gains a WHERE tenant_id = $1.
-// No campaign yields ErrNotFound (the RPC layer maps it to Connect CodeNotFound).
+// Archived campaigns are excluded from this fallback (#269): an only-archived DB
+// resolves to ErrNotFound, so an archived campaign can never be the implicit
+// Active Campaign nor start a Voice Session. No campaign yields ErrNotFound (the
+// RPC layer maps it to Connect CodeNotFound).
 func (s *Store) GetActiveCampaign(ctx context.Context) (Campaign, error) {
 	row := s.db.QueryRow(ctx,
 		`SELECT `+campaignColumns+`
 		   FROM campaign
+		  WHERE archived_at IS NULL
 		  ORDER BY created_at DESC, id DESC
 		  LIMIT 1`)
 	c, err := scanCampaign(row)
@@ -112,12 +116,14 @@ func (s *Store) GetCampaign(ctx context.Context, id uuid.UUID) (Campaign, error)
 	return c, nil
 }
 
-// ListCampaigns returns every Campaign ordered by name (then id for a stable
-// tie-break) — the /glyphoxa use autocomplete source (#108). Single-operator
-// today, so it is unscoped, mirroring GetActiveCampaign; tenant scoping fills in
-// behind the X-Tenant-Id pass-through later (ADR-0039).
+// ListCampaigns returns every ACTIVE Campaign ordered by name (then id for a
+// stable tie-break) — the /glyphoxa use autocomplete source (#108). Archived
+// campaigns are excluded (#269): the autocomplete inherits that filter with no
+// code change of its own. Single-operator today, so it is unscoped, mirroring
+// GetActiveCampaign; tenant scoping fills in behind the X-Tenant-Id pass-through
+// later (ADR-0039). See ListAllCampaigns for the archive-inclusive read.
 func (s *Store) ListCampaigns(ctx context.Context) ([]Campaign, error) {
-	rows, err := s.db.Query(ctx, `SELECT `+campaignColumns+` FROM campaign ORDER BY name, id`)
+	rows, err := s.db.Query(ctx, `SELECT `+campaignColumns+` FROM campaign WHERE archived_at IS NULL ORDER BY name, id`)
 	if err != nil {
 		return nil, fmt.Errorf("storage: list campaigns: %w", err)
 	}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -147,6 +147,28 @@ service CampaignService {
   // unregistered tool_name is CodeInvalidArgument. State-changing: the auth + CSRF
   // interceptors guard it exactly like the other CampaignService mutations.
   rpc UpdateToolGrant(UpdateToolGrantRequest) returns (UpdateToolGrantResponse);
+
+  // ArchiveCampaign archives a campaign (#269): it is excluded from
+  // ListCampaigns, the /glyphoxa use autocomplete, and the Active-Campaign
+  // fallback, and can no longer start a Voice Session. Archive is idempotent. The
+  // campaign backing the LIVE Voice Session cannot be archived
+  // (CodeFailedPrecondition); an unknown id is CodeNotFound. State-changing: the
+  // auth + CSRF interceptors guard it.
+  rpc ArchiveCampaign(ArchiveCampaignRequest) returns (ArchiveCampaignResponse);
+
+  // UnarchiveCampaign clears a campaign's archived state, returning it to the
+  // active set (#269). An unknown id is CodeNotFound. State-changing: the auth +
+  // CSRF interceptors guard it.
+  rpc UnarchiveCampaign(UnarchiveCampaignRequest) returns (UnarchiveCampaignResponse);
+
+  // DeleteCampaign permanently removes an ALREADY-ARCHIVED campaign and cascades
+  // to its Agents, Knowledge Graph, transcripts, and Voice Sessions (#269). A
+  // non-archived campaign is refused with CodeFailedPrecondition (archive first);
+  // the campaign backing the LIVE Voice Session cannot be deleted
+  // (CodeFailedPrecondition); an unknown id is CodeNotFound. Irreversible — the
+  // web UI gates it behind a re-typed campaign name. State-changing: the auth +
+  // CSRF interceptors guard it.
+  rpc DeleteCampaign(DeleteCampaignRequest) returns (DeleteCampaignResponse);
 }
 
 // ToolGrant is one built-in Tool's availability and grant state for a single
@@ -426,6 +448,11 @@ message Campaign {
   google.protobuf.Timestamp created_at = 6;
   // updated_at is when the campaign was last modified.
   google.protobuf.Timestamp updated_at = 7;
+  // archived_at is when the campaign was archived (#269); unset means active. An
+  // archived campaign is excluded from the default list, the /glyphoxa use
+  // autocomplete, and the Active-Campaign fallback, and cannot start a Voice
+  // Session.
+  google.protobuf.Timestamp archived_at = 8;
 }
 
 // GetActiveCampaignRequest is the (empty) request for GetActiveCampaign; the
@@ -439,9 +466,13 @@ message GetActiveCampaignResponse {
   Campaign campaign = 1;
 }
 
-// ListCampaignsRequest is the (empty) request; the operator's campaigns are
+// ListCampaignsRequest carries the archive filter; the operator's campaigns are
 // resolved server-side (single operator, ADR-0039).
-message ListCampaignsRequest {}
+message ListCampaignsRequest {
+  // include_archived returns archived campaigns alongside active ones when true
+  // (the archive-management panel, #269). Default false = active campaigns only.
+  bool include_archived = 1;
+}
 
 // ListCampaignsResponse carries the operator's campaigns in name order.
 message ListCampaignsResponse {
@@ -501,6 +532,43 @@ message SetActiveCampaignResponse {
   // campaign is the resolved Active Campaign after the selection.
   Campaign campaign = 1;
 }
+
+// ArchiveCampaignRequest names the campaign to archive (#269).
+message ArchiveCampaignRequest {
+  // id is the campaign to archive; an unknown id fails with CodeNotFound.
+  string id = 1;
+}
+
+// ArchiveCampaignResponse carries the archived campaign (archived_at set).
+message ArchiveCampaignResponse {
+  // campaign is the archived campaign.
+  Campaign campaign = 1;
+}
+
+// UnarchiveCampaignRequest names the campaign to unarchive (#269).
+message UnarchiveCampaignRequest {
+  // id is the campaign to unarchive; an unknown id fails with CodeNotFound.
+  string id = 1;
+}
+
+// UnarchiveCampaignResponse carries the reactivated campaign (archived_at unset).
+message UnarchiveCampaignResponse {
+  // campaign is the reactivated campaign.
+  Campaign campaign = 1;
+}
+
+// DeleteCampaignRequest names the already-archived campaign to permanently
+// delete (#269). It carries the id only: the delete is gated server-side by the
+// archived precondition, and the re-typed name confirmation is a UI-only guard.
+message DeleteCampaignRequest {
+  // id is the campaign to delete; it must already be archived
+  // (CodeFailedPrecondition otherwise) and an unknown id fails with CodeNotFound.
+  string id = 1;
+}
+
+// DeleteCampaignResponse is empty: a successful delete removes the campaign and
+// everything cascading from it.
+message DeleteCampaignResponse {}
 
 // AuthService exposes the operator's authenticated identity to the SPA boot
 // flow (ADR-0016 / ADR-0039). The session itself is issued by the net/http

--- a/web/src/components/CampaignRowActions.test.tsx
+++ b/web/src/components/CampaignRowActions.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { useQuery } from "@connectrpc/connect-query";
+
+import {
+  CampaignService,
+  ListCampaignsResponseSchema,
+  ArchiveCampaignResponseSchema,
+  UnarchiveCampaignResponseSchema,
+  DeleteCampaignResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { CampaignRowActions } from "./CampaignRowActions";
+
+// A minimal Connect backend recording each lifecycle call so the tests assert the
+// right RPC fired. ListCampaigns is served so the post-mutation invalidation has a
+// key to refetch (a ListProbe observes it).
+function mockBackend(calls: Record<string, number> = {}) {
+  const bump = (m: string) => {
+    calls[m] = (calls[m] ?? 0) + 1;
+  };
+  return createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listCampaigns: () => {
+        bump("listCampaigns");
+        return create(ListCampaignsResponseSchema, { campaigns: [] });
+      },
+      archiveCampaign: () => {
+        bump("archiveCampaign");
+        return create(ArchiveCampaignResponseSchema, {});
+      },
+      unarchiveCampaign: () => {
+        bump("unarchiveCampaign");
+        return create(UnarchiveCampaignResponseSchema, {});
+      },
+      deleteCampaign: () => {
+        bump("deleteCampaign");
+        return create(DeleteCampaignResponseSchema, {});
+      },
+    });
+  });
+}
+
+// ListProbe observes the listCampaigns cache so a mutation's invalidation
+// (refetch) is provable from the screen's side.
+function ListProbe() {
+  const { data } = useQuery(CampaignService.method.listCampaigns, {});
+  return <div data-testid="list-probe">{data ? "loaded" : "…"}</div>;
+}
+
+function renderActions(campaign: { id: string; name: string; archived: boolean }, calls?: Record<string, number>) {
+  return render(
+    <Providers transport={mockBackend(calls)} queryClient={makeQueryClient()}>
+      <CampaignRowActions campaign={campaign} />
+      <ListProbe />
+    </Providers>,
+  );
+}
+
+const openMenu = () => fireEvent.click(screen.getByRole("button", { name: /Campaign actions/i }));
+
+describe("CampaignRowActions", () => {
+  it("an active row offers only Archive", () => {
+    renderActions({ id: "a", name: "Alpha Quest", archived: false });
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /^Archive$/ })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Unarchive/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Delete/ })).not.toBeInTheDocument();
+  });
+
+  it("an archived row offers Unarchive and Delete", () => {
+    renderActions({ id: "a", name: "Alpha Quest", archived: true });
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /Unarchive/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Delete/ })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /^Archive$/ })).not.toBeInTheDocument();
+  });
+
+  it("archiving an active campaign fires archiveCampaign and refreshes the list", async () => {
+    const calls: Record<string, number> = {};
+    renderActions({ id: "a", name: "Alpha Quest", archived: false }, calls);
+    await waitFor(() => expect(calls.listCampaigns).toBeGreaterThanOrEqual(1));
+    const listBefore = calls.listCampaigns;
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Archive$/ }));
+
+    await waitFor(() => expect(calls.archiveCampaign).toBe(1));
+    // The list refetched (invalidation) so the row moves between groups.
+    await waitFor(() => expect(calls.listCampaigns).toBeGreaterThan(listBefore));
+  });
+
+  it("unarchiving an archived campaign fires unarchiveCampaign", async () => {
+    const calls: Record<string, number> = {};
+    renderActions({ id: "a", name: "Alpha Quest", archived: true }, calls);
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Unarchive/ }));
+    await waitFor(() => expect(calls.unarchiveCampaign).toBe(1));
+  });
+
+  it("delete requires the re-typed campaign name before it fires", async () => {
+    const calls: Record<string, number> = {};
+    renderActions({ id: "a", name: "Lost Mine", archived: true }, calls);
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Delete/ }));
+
+    // The confirm dialog opens with the delete button disabled until the exact
+    // name is typed.
+    const confirm = await screen.findByRole("button", { name: "Delete campaign" });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(calls.deleteCampaign ?? 0).toBe(0);
+
+    fireEvent.change(screen.getByTestId("confirm-text-input"), { target: { value: "Lost Mine" } });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+    await waitFor(() => expect(calls.deleteCampaign).toBe(1));
+  });
+});

--- a/web/src/components/CampaignRowActions.tsx
+++ b/web/src/components/CampaignRowActions.tsx
@@ -1,0 +1,145 @@
+import { useRef, useState } from "react";
+import { useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Archive, ArchiveRestore, MoreHorizontal, Trash2 } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import { invalidateActiveCampaignScopedQueries } from "@/lib/campaignCache";
+import { usePopoverDismiss } from "@/components/ui/usePopoverDismiss";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+import "./campaignRowActions.css";
+
+// CampaignRowActions — the per-row lifecycle menu in the campaign switcher's
+// archive-management view (#269, placement #266). An ACTIVE row offers "Archive";
+// an ARCHIVED row offers "Unarchive" and "Delete…". Archive is the primary flow;
+// hard delete is only reachable on an already-archived campaign and is gated
+// behind a re-typed campaign name in a ConfirmDialog (irreversible — it cascades
+// to the campaign's Agents, Knowledge Graph, transcripts, and Voice Sessions).
+//
+// Every mutation, on success, refreshes the campaign list (all include_archived
+// inputs) so the row moves between the active/archived groups, and runs the
+// Active-Campaign sweep so a screen scoped to a just-archived/deleted campaign
+// follows resolution without a reload. Failures surface as a toast; the live
+// Voice Session's campaign is refused SERVER-SIDE (CodeFailedPrecondition), shown
+// via that toast.
+
+type CampaignRow = { id: string; name: string; archived: boolean };
+
+export function CampaignRowActions({ campaign }: { campaign: CampaignRow }) {
+  const queryClient = useQueryClient();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  usePopoverDismiss(wrapRef, menuOpen, () => setMenuOpen(false));
+
+  // Invalidate the campaign list across every include_archived input (the key is
+  // omitted so React Query matches all listCampaigns entries by prefix), plus the
+  // Active-Campaign scoped sweep so a screen on the affected campaign re-resolves.
+  const refreshAfterChange = () => {
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listCampaigns,
+        cardinality: "finite",
+      }),
+    });
+    void invalidateActiveCampaignScopedQueries(queryClient);
+  };
+
+  const archive = useMutation(CampaignService.method.archiveCampaign, {
+    onSuccess: () => {
+      setMenuOpen(false);
+      refreshAfterChange();
+    },
+    onError: (err) => toast.error(`Couldn't archive campaign: ${err.message}`),
+  });
+
+  const unarchive = useMutation(CampaignService.method.unarchiveCampaign, {
+    onSuccess: () => {
+      setMenuOpen(false);
+      refreshAfterChange();
+    },
+    onError: (err) => toast.error(`Couldn't unarchive campaign: ${err.message}`),
+  });
+
+  const del = useMutation(CampaignService.method.deleteCampaign, {
+    onSuccess: () => {
+      setConfirmOpen(false);
+      setMenuOpen(false);
+      refreshAfterChange();
+    },
+    onError: (err) => toast.error(`Couldn't delete campaign: ${err.message}`),
+  });
+
+  return (
+    <div className="gx-campaign-row-actions" ref={wrapRef}>
+      <button
+        type="button"
+        className="gx-campaign-row-actions__trigger"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        // The label is name-free so it never collides with the sibling switch
+        // button's accessible name (which carries the campaign name); the campaign
+        // is identified by the row it sits in, and by the menu items + confirm
+        // dialog once opened.
+        aria-label="Campaign actions"
+        title={`Actions for ${campaign.name}`}
+        onClick={() => setMenuOpen((o) => !o)}
+      >
+        <MoreHorizontal size={15} />
+      </button>
+
+      {menuOpen && (
+        <div className="gx-select__content gx-campaign-row-actions__menu" role="menu">
+          {campaign.archived ? (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                className="gx-select__item"
+                disabled={unarchive.isPending}
+                onClick={() => unarchive.mutate({ id: campaign.id })}
+              >
+                <ArchiveRestore size={14} /> Unarchive
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="gx-select__item gx-select__item--danger"
+                onClick={() => {
+                  setMenuOpen(false);
+                  setConfirmOpen(true);
+                }}
+              >
+                <Trash2 size={14} /> Delete…
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              role="menuitem"
+              className="gx-select__item"
+              disabled={archive.isPending}
+              onClick={() => archive.mutate({ id: campaign.id })}
+            >
+              <Archive size={14} /> Archive
+            </button>
+          )}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={`Delete “${campaign.name}”?`}
+        description="This permanently deletes the campaign and all of its Agents, Knowledge Graph, transcripts, and Voice Sessions. This cannot be undone."
+        confirmLabel="Delete campaign"
+        confirmText={campaign.name}
+        confirmTextLabel={`Type the campaign name to confirm`}
+        confirmDisabled={del.isPending}
+        onConfirm={() => del.mutate({ id: campaign.id })}
+      />
+    </div>
+  );
+}

--- a/web/src/components/CampaignSwitcher.test.tsx
+++ b/web/src/components/CampaignSwitcher.test.tsx
@@ -416,6 +416,46 @@ describe("CampaignSwitcher", () => {
     await waitFor(() => expect(calls.archiveCampaign).toBe(1));
   });
 
+  it("deletes an archived campaign THROUGH the open panel without the dismiss hook tearing it down mid-flow", async () => {
+    const calls: Record<string, number> = {};
+    renderSwitcher(
+      mockBackend({
+        campaigns: [
+          { id: "a", name: "Alpha Quest" },
+          { id: "z", name: "Zombie Vault", archived: true },
+        ],
+        activeId: "a",
+        calls,
+      }),
+    );
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    fireEvent.click(screen.getByRole("button", { name: /show archived/i }));
+
+    const list = await screen.findByRole("group", { name: /campaigns/i });
+    const row = (await within(list).findByText("Zombie Vault")).closest("li")!;
+    fireEvent.click(within(row).getByRole("button", { name: /Campaign actions/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Delete/ }));
+
+    // The confirm dialog is up. Interacting inside it fires mousedown on nodes
+    // that live OUTSIDE the panel's ref (Radix portal). The dismiss hook must NOT
+    // treat that as an outside click and tear the panel (and this dialog) down.
+    const dialog = await screen.findByRole("alertdialog");
+    const input = within(dialog).getByTestId("confirm-text-input");
+    fireEvent.mouseDown(input);
+
+    // Panel + dialog both survived the mousedown. The panel is aria-hidden by the
+    // modal (hidden:true), but crucially still MOUNTED — the bug tore it (and this
+    // dialog) out of the DOM entirely, which query would then fail.
+    expect(screen.getByRole("group", { name: /campaigns/i, hidden: true })).toBeInTheDocument();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    // Type the exact name and confirm — the delete fires.
+    fireEvent.change(input, { target: { value: "Zombie Vault" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete campaign" }));
+    await waitFor(() => expect(calls.deleteCampaign).toBe(1));
+  });
+
   it("retries only activation (no duplicate create) when the create succeeds but activation fails", async () => {
     const calls: Record<string, number> = {};
     renderSwitcher(

--- a/web/src/components/CampaignSwitcher.test.tsx
+++ b/web/src/components/CampaignSwitcher.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { useQuery } from "@connectrpc/connect-query";
 
 import {
@@ -14,13 +15,16 @@ import {
   GetCampaignRosterResponseSchema,
   SetActiveCampaignResponseSchema,
   CreateCampaignResponseSchema,
+  ArchiveCampaignResponseSchema,
+  UnarchiveCampaignResponseSchema,
+  DeleteCampaignResponseSchema,
   GetSessionResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { CampaignSwitcher } from "./CampaignSwitcher";
 
-type Camp = { id: string; name: string; system?: string; language?: string };
+type Camp = { id: string; name: string; system?: string; language?: string; archived?: boolean };
 
 // A stateful Connect backend for the switcher: ListCampaigns reflects creates,
 // SetActiveCampaign moves the durable selection, and GetActiveCampaign/roster
@@ -45,6 +49,8 @@ function mockBackend(
       name: c.name,
       system: c.system ?? "",
       language: c.language ?? "",
+      // archived campaigns carry an archivedAt timestamp on the wire (#269).
+      archivedAt: c.archived ? timestampFromDate(new Date("2026-07-09T00:00:00Z")) : undefined,
     })),
     activeId: opts.activeId,
     next: 1,
@@ -52,18 +58,38 @@ function mockBackend(
   const bump = (m: string) => {
     if (opts.calls) opts.calls[m] = (opts.calls[m] ?? 0) + 1;
   };
+  const isArchived = (c: { archivedAt?: unknown }) => c.archivedAt !== undefined;
   const resolveActive = () => {
-    if (state.campaigns.length === 0) return undefined;
-    return state.campaigns.find((c) => c.id === state.activeId) ?? state.campaigns[state.campaigns.length - 1];
+    const active = state.campaigns.filter((c) => !isArchived(c));
+    if (active.length === 0) return undefined;
+    return active.find((c) => c.id === state.activeId) ?? active[active.length - 1];
   };
 
   return createRouterTransport(({ service }) => {
     service(CampaignService, {
-      listCampaigns: () => {
+      listCampaigns: (req) => {
         bump("listCampaigns");
+        const rows = req.includeArchived ? state.campaigns : state.campaigns.filter((c) => !isArchived(c));
         return create(ListCampaignsResponseSchema, {
-          campaigns: state.campaigns.map((c) => create(CampaignSchema, c)),
+          campaigns: rows.map((c) => create(CampaignSchema, c)),
         });
+      },
+      archiveCampaign: (req) => {
+        bump("archiveCampaign");
+        const c = state.campaigns.find((x) => x.id === req.id);
+        if (c) c.archivedAt = timestampFromDate(new Date("2026-07-09T00:00:00Z"));
+        return create(ArchiveCampaignResponseSchema, { campaign: c && create(CampaignSchema, c) });
+      },
+      unarchiveCampaign: (req) => {
+        bump("unarchiveCampaign");
+        const c = state.campaigns.find((x) => x.id === req.id);
+        if (c) c.archivedAt = undefined;
+        return create(UnarchiveCampaignResponseSchema, { campaign: c && create(CampaignSchema, c) });
+      },
+      deleteCampaign: (req) => {
+        bump("deleteCampaign");
+        state.campaigns = state.campaigns.filter((x) => x.id !== req.id);
+        return create(DeleteCampaignResponseSchema, {});
       },
       getActiveCampaign: () => {
         bump("getActiveCampaign");
@@ -88,7 +114,7 @@ function mockBackend(
       createCampaign: (req) => {
         bump("createCampaign");
         if (opts.createError) throw new ConnectError(opts.createError, Code.Internal);
-        const c = { id: `new-${state.next++}`, name: req.name, system: req.system, language: req.language };
+        const c = { id: `new-${state.next++}`, name: req.name, system: req.system, language: req.language, archivedAt: undefined };
         state.campaigns.push(c);
         return create(CreateCampaignResponseSchema, { campaign: create(CampaignSchema, c) });
       },
@@ -338,6 +364,56 @@ describe("CampaignSwitcher", () => {
     // the long-lived switcher, so re-entering create mode resets them.
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("");
+  });
+
+  it("toggles the archived campaigns into the list via Show archived", async () => {
+    const calls: Record<string, number> = {};
+    renderSwitcher(
+      mockBackend({
+        campaigns: [
+          { id: "a", name: "Alpha Quest" },
+          { id: "z", name: "Zombie Vault", archived: true },
+        ],
+        activeId: "a",
+        calls,
+      }),
+    );
+    await screen.findByText("Alpha Quest");
+    openPanel();
+
+    // Default: only the active campaign shows; the archived one is hidden.
+    const list = await screen.findByRole("group", { name: /campaigns/i });
+    await within(list).findByRole("button", { name: /Alpha Quest/ });
+    expect(within(list).queryByText("Zombie Vault")).not.toBeInTheDocument();
+
+    // Show archived → the request flips includeArchived, the archived row appears
+    // with an "Archived" badge and its switch button disabled.
+    fireEvent.click(screen.getByRole("button", { name: /show archived/i }));
+    await waitFor(() => expect(within(list).queryByText("Zombie Vault")).toBeInTheDocument());
+    const archivedRow = within(list).getByText("Zombie Vault").closest("li")!;
+    expect(within(archivedRow).getByText("Archived")).toBeInTheDocument();
+    // The switch button of the archived row is disabled (can't be made active).
+    expect(within(archivedRow).getByRole("button", { name: /Zombie Vault/ })).toBeDisabled();
+
+    // Hide again → the archived row is gone.
+    fireEvent.click(screen.getByRole("button", { name: /hide archived/i }));
+    await waitFor(() => expect(within(list).queryByText("Zombie Vault")).not.toBeInTheDocument());
+  });
+
+  it("archives an active campaign from its row menu", async () => {
+    const calls: Record<string, number> = {};
+    renderSwitcher(
+      mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeId: "a", calls }),
+    );
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    const list = await screen.findByRole("group", { name: /campaigns/i });
+    const row = (await within(list).findByText("Alpha Quest")).closest("li")!;
+
+    // Open the row's action menu and archive.
+    fireEvent.click(within(row).getByRole("button", { name: /Campaign actions/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^Archive$/ }));
+    await waitFor(() => expect(calls.archiveCampaign).toBe(1));
   });
 
   it("retries only activation (no duplicate create) when the create succeeds but activation fails", async () => {

--- a/web/src/components/CampaignSwitcher.tsx
+++ b/web/src/components/CampaignSwitcher.tsx
@@ -11,14 +11,17 @@ import {
 } from "@/lib/campaignCache";
 import { isNotFound } from "@/lib/connectError";
 import { usePopoverDismiss } from "@/components/ui/usePopoverDismiss";
+import { Badge } from "@/components/ui/Badge";
+import { CampaignRowActions } from "./CampaignRowActions";
 import { CreateCampaignForm, useCreateCampaign } from "./CreateCampaignForm";
 
 import "./campaignSwitcher.css";
 
 // The Active-Campaign switcher (#267), placement decided in #266 (option a): a
 // topbar control visible on every screen, showing the resolved Active Campaign
-// and opening a panel to switch between campaigns or create a new one. Rename /
-// archive / delete are out of scope here (#268 / #265).
+// and opening a panel to switch between campaigns or create a new one. Per-row
+// archive / unarchive / delete land via CampaignRowActions and the "Show
+// archived" toggle (#269); rename lives in the settings editor (#268).
 //
 // Switching writes the durable selection (SetActiveCampaign) and runs the
 // Active-Campaign cache sweep so every campaign-scoped screen follows without a
@@ -57,10 +60,21 @@ export function CampaignSwitcher() {
   // call-to-action that opens straight into the create form.
   const firstRun = activeQ.isError && isNotFound(activeQ.error);
 
+  // The archive-management view (#269): "Show archived" folds the archived
+  // campaigns into the list so they can be unarchived or permanently deleted. Off
+  // by default — the common case is switching between active campaigns.
+  const [showArchived, setShowArchived] = useState(false);
+
   // The campaign list renders only inside the open panel, so it isn't fetched
   // from every screen on boot/focus — the query wakes when the panel opens (a
-  // create's invalidation just marks it stale for the next open).
-  const listQ = useQuery(CampaignService.method.listCampaigns, {}, { enabled: open });
+  // create's invalidation just marks it stale for the next open). includeArchived
+  // is part of the request, so toggling it fetches the archive-inclusive list under
+  // its own cache key (#269).
+  const listQ = useQuery(
+    CampaignService.method.listCampaigns,
+    { includeArchived: showArchived },
+    { enabled: open },
+  );
   const campaigns = listQ.data?.campaigns ?? [];
 
   // The live-Voice-Session notice needs Voice Session state only while the panel is
@@ -180,14 +194,18 @@ export function CampaignSwitcher() {
               <ul className="gx-campaign-switcher__list" role="group" aria-label="Campaigns">
                 {campaigns.map((c) => {
                   const isActive = c.id === activeId;
+                  // An archived campaign can't be switched to (it is excluded from
+                  // resolution, #269); its row shows the badge + the lifecycle menu
+                  // and its select button is disabled.
+                  const isArchived = c.archivedAt !== undefined;
                   return (
-                    <li key={c.id}>
+                    <li key={c.id} className="gx-campaign-switcher__row" data-archived={isArchived || undefined}>
                       <button
                         type="button"
                         aria-current={isActive || undefined}
                         className="gx-select__item gx-campaign-switcher__item"
                         data-active={isActive || undefined}
-                        disabled={switching}
+                        disabled={switching || isArchived}
                         onClick={() =>
                           isActive ? close() : setActive.mutate({ campaignId: c.id })
                         }
@@ -198,8 +216,14 @@ export function CampaignSwitcher() {
                             <span className="gx-campaign-switcher__item-system">{c.system}</span>
                           )}
                         </span>
+                        {isArchived && (
+                          <Badge variant="neutral" size="sm">
+                            Archived
+                          </Badge>
+                        )}
                         {isActive && <Check size={14} />}
                       </button>
+                      <CampaignRowActions campaign={{ id: c.id, name: c.name, archived: isArchived }} />
                     </li>
                   );
                 })}
@@ -215,6 +239,17 @@ export function CampaignSwitcher() {
 
               <button type="button" className="gx-campaign-switcher__new" onClick={enterCreate}>
                 <Plus size={15} /> New campaign
+              </button>
+
+              {/* Show-archived toggle (#269): folds archived campaigns into the
+                  list so they can be unarchived or permanently deleted. */}
+              <button
+                type="button"
+                className="gx-campaign-switcher__show-archived"
+                aria-pressed={showArchived}
+                onClick={() => setShowArchived((v) => !v)}
+              >
+                {showArchived ? "Hide archived" : "Show archived"}
               </button>
             </>
           )}

--- a/web/src/components/campaignRowActions.css
+++ b/web/src/components/campaignRowActions.css
@@ -1,0 +1,70 @@
+/* Per-row campaign lifecycle menu (#269) — a kebab trigger opening a small
+ * archive/unarchive/delete menu. Reuses the .gx-select__content popover +
+ * .gx-select__item row vocabulary from the switcher.
+ */
+
+.gx-campaign-row-actions {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.gx-campaign-row-actions__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.gx-campaign-row-actions__trigger:hover {
+  background: rgba(144, 89, 255, 0.12);
+  color: var(--text-default);
+}
+.gx-campaign-row-actions__trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.gx-campaign-row-actions__menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  right: 0;
+  z-index: 20;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--spacing-xs);
+}
+.gx-campaign-row-actions__menu .gx-select__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-default);
+  font-family: var(--font-base);
+  font-size: var(--body-sm);
+  padding: 6px 8px;
+  border-radius: var(--radius-xs);
+}
+.gx-campaign-row-actions__menu .gx-select__item:hover:not(:disabled) {
+  background: rgba(144, 89, 255, 0.12);
+}
+.gx-campaign-row-actions__menu .gx-select__item:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.gx-campaign-row-actions__menu .gx-select__item--danger {
+  color: var(--danger, #e5484d);
+}
+.gx-campaign-row-actions__menu .gx-select__item--danger:hover:not(:disabled) {
+  background: rgba(229, 72, 77, 0.12);
+}

--- a/web/src/components/campaignSwitcher.css
+++ b/web/src/components/campaignSwitcher.css
@@ -101,6 +101,20 @@
   gap: 2px;
 }
 
+/* Row (#269) — the switch button plus its per-row lifecycle menu on one line. */
+.gx-campaign-switcher__row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.gx-campaign-switcher__row > .gx-campaign-switcher__item {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.gx-campaign-switcher__row[data-archived] .gx-campaign-switcher__item-name {
+  color: var(--text-muted);
+}
+
 .gx-campaign-switcher__item {
   display: flex;
   align-items: center;
@@ -173,6 +187,26 @@
 }
 .gx-campaign-switcher__new:hover {
   background: rgba(144, 89, 255, 0.1);
+}
+
+/* Show/Hide archived toggle (#269) — a quiet footer control below "New campaign". */
+.gx-campaign-switcher__show-archived {
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-subtle);
+  font-family: var(--font-base);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.gx-campaign-switcher__show-archived:hover {
+  color: var(--text-muted);
+  background: rgba(144, 89, 255, 0.06);
+}
+.gx-campaign-switcher__show-archived[aria-pressed="true"] {
+  color: var(--text-muted);
 }
 
 .gx-campaign-switcher__create {

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -123,6 +124,67 @@ describe("ConfirmDialog", () => {
       String(c[0]).includes("Function components cannot be given refs"),
     );
     expect(refWarnings).toHaveLength(0);
+  });
+
+  it("with confirmText, keeps confirm disabled until the exact string is typed", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete campaign?"
+        confirmLabel="Delete campaign"
+        confirmText="Lost Mine"
+        onConfirm={onConfirm}
+      />,
+    );
+    const confirm = screen.getByRole("button", { name: "Delete campaign" });
+    // Disabled until the name matches — a click does nothing.
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    const input = screen.getByTestId("confirm-text-input");
+    // A near-miss stays disabled.
+    fireEvent.change(input, { target: { value: "Lost Min" } });
+    expect(confirm).toBeDisabled();
+    // Exact match enables it.
+    fireEvent.change(input, { target: { value: "Lost Mine" } });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the typed confirmation when the dialog closes and reopens", () => {
+    const onConfirm = vi.fn();
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>reopen</button>
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Delete campaign?"
+            confirmLabel="Delete campaign"
+            confirmText="Lost Mine"
+            onConfirm={onConfirm}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    // Type the exact name so confirm is enabled.
+    fireEvent.change(screen.getByTestId("confirm-text-input"), { target: { value: "Lost Mine" } });
+    expect(screen.getByRole("button", { name: "Delete campaign" })).toBeEnabled();
+
+    // Cancel (closes), then reopen: the field is empty and confirm is disabled
+    // again — a prior match must not carry over.
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reopen/i }));
+    expect((screen.getByTestId("confirm-text-input") as HTMLInputElement).value).toBe("");
+    expect(screen.getByRole("button", { name: "Delete campaign" })).toBeDisabled();
   });
 
   it("moves initial focus onto the Cancel button (AlertDialog contract)", async () => {

--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -187,6 +187,42 @@ describe("ConfirmDialog", () => {
     expect(screen.getByRole("button", { name: "Delete campaign" })).toBeDisabled();
   });
 
+  it("resets the typed confirmation on a PROGRAMMATIC close (bypassing onOpenChange)", () => {
+    // The caller closes the dialog itself (e.g. a delete's onSuccess flips `open`
+    // to false) — that never flows through Radix onOpenChange, so the reset must
+    // be keyed on `open`, not that callback.
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen(false)}>programmatic close</button>
+          <button onClick={() => setOpen(true)}>reopen</button>
+          <ConfirmDialog
+            open={open}
+            onOpenChange={setOpen}
+            title="Delete campaign?"
+            confirmLabel="Delete campaign"
+            confirmText="Lost Mine"
+            onConfirm={() => {}}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+
+    fireEvent.change(screen.getByTestId("confirm-text-input"), { target: { value: "Lost Mine" } });
+    expect(screen.getByRole("button", { name: "Delete campaign" })).toBeEnabled();
+
+    // Close programmatically (not via Cancel/Escape), then reopen: field empty,
+    // confirm disabled — the effect-based reset covered the non-onOpenChange path.
+    // The harness buttons sit behind the modal (aria-hidden), so query them with
+    // hidden:true.
+    fireEvent.click(screen.getByRole("button", { name: /programmatic close/i, hidden: true }));
+    fireEvent.click(screen.getByRole("button", { name: /reopen/i }));
+    expect((screen.getByTestId("confirm-text-input") as HTMLInputElement).value).toBe("");
+    expect(screen.getByRole("button", { name: "Delete campaign" })).toBeDisabled();
+  });
+
   it("moves initial focus onto the Cancel button (AlertDialog contract)", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const trigger = document.createElement("button");

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import * as RAlert from "@radix-ui/react-alert-dialog";
 
 import { Button } from "./Button";
@@ -46,18 +46,21 @@ export function ConfirmDialog({
 }) {
   const [typed, setTyped] = useState("");
 
-  // Reset the typed value on every close so a reopened dialog starts empty — a
-  // stale match must never let the next open confirm without a fresh re-type.
-  const handleOpenChange = (next: boolean) => {
-    if (!next) setTyped("");
-    onOpenChange(next);
-  };
+  // Reset the typed value whenever the dialog is closed — keyed on `open` rather
+  // than the Radix onOpenChange callback so it fires for BOTH close paths: the
+  // native Cancel/Escape (which flows through onOpenChange) AND a programmatic
+  // close by the caller (e.g. a delete's onSuccess flipping `open` to false,
+  // which bypasses onOpenChange). Either way a reopened dialog starts empty, so a
+  // stale match can't let the next open confirm without a fresh re-type.
+  useEffect(() => {
+    if (!open) setTyped("");
+  }, [open]);
 
   const typedGateOpen = confirmText === undefined || typed === confirmText;
   const disabled = confirmDisabled || !typedGateOpen;
 
   return (
-    <RAlert.Root open={open} onOpenChange={handleOpenChange}>
+    <RAlert.Root open={open} onOpenChange={onOpenChange}>
       <RAlert.Portal>
         <RAlert.Overlay className="gx-confirm__overlay" />
         {/* Radix auto-wires aria-describedby to the Description below when present. */}

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import * as RAlert from "@radix-ui/react-alert-dialog";
 
 import { Button } from "./Button";
+import { Input } from "./Input";
 
 // ConfirmDialog — a modal confirmation gate on a Radix AlertDialog (ADR-0017:
 // Radix backs the accessibility-heavy primitives). Built for destructive actions
@@ -10,6 +11,11 @@ import { Button } from "./Button";
 // state in `onOpenChange`. AlertDialog's native behaviour supplies the rest —
 // Escape and Cancel dismiss without confirming, focus is trapped, and the
 // overlay does NOT close on click (a mis-click can't destroy data).
+//
+// For irreversible deletes (#269 campaign hard-delete) pass `confirmText`: the
+// dialog then renders a text field and keeps confirm disabled until the operator
+// re-types that exact string (e.g. the campaign name). The typed value resets
+// whenever the dialog closes, so a reopened dialog never inherits a prior entry.
 
 export function ConfirmDialog({
   open,
@@ -21,6 +27,8 @@ export function ConfirmDialog({
   onConfirm,
   confirmDisabled = false,
   destructive = true,
+  confirmText,
+  confirmTextLabel,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -31,9 +39,25 @@ export function ConfirmDialog({
   onConfirm: () => void;
   confirmDisabled?: boolean;
   destructive?: boolean;
+  // confirmText, when set, gates confirm behind an exact re-typed match (#269).
+  confirmText?: string;
+  // confirmTextLabel labels the confirmation field; defaults to a generic prompt.
+  confirmTextLabel?: ReactNode;
 }) {
+  const [typed, setTyped] = useState("");
+
+  // Reset the typed value on every close so a reopened dialog starts empty — a
+  // stale match must never let the next open confirm without a fresh re-type.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setTyped("");
+    onOpenChange(next);
+  };
+
+  const typedGateOpen = confirmText === undefined || typed === confirmText;
+  const disabled = confirmDisabled || !typedGateOpen;
+
   return (
-    <RAlert.Root open={open} onOpenChange={onOpenChange}>
+    <RAlert.Root open={open} onOpenChange={handleOpenChange}>
       <RAlert.Portal>
         <RAlert.Overlay className="gx-confirm__overlay" />
         {/* Radix auto-wires aria-describedby to the Description below when present. */}
@@ -41,6 +65,16 @@ export function ConfirmDialog({
           <RAlert.Title className="gx-confirm__title">{title}</RAlert.Title>
           {description && (
             <RAlert.Description className="gx-confirm__desc">{description}</RAlert.Description>
+          )}
+          {confirmText !== undefined && (
+            <Input
+              label={confirmTextLabel ?? `Type “${confirmText}” to confirm`}
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              autoComplete="off"
+              autoFocus
+              data-testid="confirm-text-input"
+            />
           )}
           <div className="gx-confirm__actions">
             <RAlert.Cancel asChild>
@@ -50,7 +84,7 @@ export function ConfirmDialog({
               <Button
                 variant={destructive ? "danger" : "primary"}
                 onClick={onConfirm}
-                disabled={confirmDisabled}
+                disabled={disabled}
               >
                 {confirmLabel}
               </Button>

--- a/web/src/components/ui/usePopoverDismiss.ts
+++ b/web/src/components/ui/usePopoverDismiss.ts
@@ -1,10 +1,24 @@
 import { useEffect, useRef, type RefObject } from "react";
 
+// radixModalOpen reports whether a Radix modal layer (AlertDialog / Dialog) is
+// currently mounted. Those layers render through a Portal onto document.body —
+// OUTSIDE any popover's anchor ref — and own their own dismissal (Escape closes
+// the dialog; a mis-click on the overlay does not destroy data). A popover that
+// spawns such a dialog (e.g. the campaign switcher's delete ConfirmDialog) must
+// SUSPEND its own outside-mousedown / Escape dismissal while the dialog is up:
+// otherwise the first mousedown inside the portalled dialog reads as "outside the
+// anchor", the popover closes, and the dialog unmounts mid-interaction before its
+// action can fire (#269).
+function radixModalOpen(): boolean {
+  return document.querySelector('[role="alertdialog"], [role="dialog"]') !== null;
+}
+
 // usePopoverDismiss closes a lightweight (non-Radix) popover the way a native
 // select would: a mousedown outside the anchor element or an Escape keypress
 // calls onClose. Extracted from the Combobox popover (#88 slice 2) when the
 // CampaignSwitcher grew an identical copy (#267), so dismissal fixes (touch /
-// pointer events, stacked popovers, focus handling) land in one place.
+// pointer events, stacked popovers, focus handling) land in one place. While a
+// Radix modal layer is open it defers to that layer (see radixModalOpen).
 export function usePopoverDismiss(
   ref: RefObject<HTMLElement | null>,
   open: boolean,
@@ -20,10 +34,16 @@ export function usePopoverDismiss(
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
+      // A Radix dialog spawned from inside this popover portals outside the anchor;
+      // let it own dismissal rather than closing the popover out from under it.
+      if (radixModalOpen()) return;
       if (ref.current && !ref.current.contains(e.target as Node)) onCloseRef.current();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCloseRef.current();
+      if (e.key === "Escape") {
+        if (radixModalOpen()) return; // the dialog's own Escape handler closes it
+        onCloseRef.current();
+      }
     };
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);


### PR DESCRIPTION
Closes #269

## Lifecycle behavior (per #265, verbatim)
- **Archive is primary; hard delete only on already-archived campaigns.** New nullable `archived_at timestamptz` column via goose migration `00018` (ADR-0031).
- **Archived excluded everywhere.** `ListCampaigns`, the `/glyphoxa use` autocomplete (inherits the same query — zero code change), and the `GetActiveCampaign` most-recent fallback all filter `archived_at IS NULL`. `GetActiveCampaignForUser` also excludes an archived durable selection → treated as absent → normal fallback. `include_archived` on `ListCampaignsRequest` exposes them for the panel (`ListAllCampaigns`).
- **Un-archive exists.**
- **Archived can't start a Voice Session** — proven *structurally*: an only-archived DB resolves to `ErrNotFound`, so `StartSession` fails `CodeFailedPrecondition "no active campaign"` (no extra guard code).
- **Live Voice Session's campaign can be neither archived nor deleted** — refused with `CodeFailedPrecondition` via the SAME `liveCampaign` closure `resolveActiveCampaign` uses (ADR-0039, one session-truth source).
- **`SetActiveCampaign` on an archived target** → `CodeFailedPrecondition` (would otherwise resolve to a different campaign).
- **Archive clears `users.active_campaign_id`** for pointers at the campaign (idempotent `COALESCE` keeps the original archive timestamp).
- **Hard delete = single cascading `DELETE`** gated on `archived_at IS NOT NULL`; `ErrNotArchived` vs `ErrNotFound` disambiguated via `GetCampaign`.

## Cascade proof
`DeleteCampaign` is ONE `DELETE FROM campaign` relying on the schema's existing `ON DELETE CASCADE`/`SET NULL` FKs (verified in the migrations): agents (00001) → tool_agent_grant (00013); transcript_chunk (00001); voice_sessions (00006) → transcript_line (00007); kg_node (00010) → kg_edge (00012); users.active_campaign_id `SET NULL` (00014). The Butler goes via the agents CASCADE, deliberately NOT through `DeleteAgent`'s butler guard (ADR-0009). An integration test seeds one of every child and asserts all rows vanish. Irrecoverable removal of play history incl. transcript PII — no soft-delete window (#265).

## UI (placement #266, ADR-0017/0018)
- `ConfirmDialog` extended with an optional `confirmText` typed-confirmation on the Radix AlertDialog primitive (resets on close); backward-compatible.
- `CampaignRowActions` — per-row overflow menu: active → Archive; archived → Unarchive + Delete… (delete gated behind the re-typed campaign name).
- `CampaignSwitcher` gains a **Show archived** toggle (flips `include_archived`); archived rows render an *Archived* badge with the switch disabled. Mutations invalidate the `listCampaigns` key + run the Active-Campaign sweep (connect-query + QueryClient invalidation only, ADR-0018).

## Tests added
- **storage** (5 integration): archive idempotence + selection clearing; exclusion from list/autocomplete/fallback; `GetActiveCampaignForUser` never returns archived; unarchive; full cascade + `ErrNotArchived`/`ErrNotFound`.
- **rpc** (16 unit + 2 integration): live-guard refusal (archive+delete), non-archived delete, unknown id, bad uuid, happy paths, `include_archived` routing + `archived_at` wire mapping, archived `SetActiveCampaign`; archive-falls-out-of-resolution + archived-can't-start.
- **web** (10): `ConfirmDialog` typed-confirm gate + reset regression; `CampaignRowActions` menu-per-state + delete flow; `CampaignSwitcher` Show-archived toggle + archived-row badge/disabled + archive-from-menu.

Shared-surface ownership respected: only the archive RPCs/fields in `management.proto` and the list-row region + Show-archived toggle in `CampaignSwitcher.tsx` (#268's Panel union / settings footer untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)