### PR TITLE
chore: gofmt integration-tagged transcript chunk search test

### DIFF
--- a/internal/storage/transcript_chunk_search_test.go
+++ b/internal/storage/transcript_chunk_search_test.go
@@ -117,11 +117,11 @@ func TestSearchChunksByCampaign_OrdersByCosineAndCapsAtK(t *testing.T) {
 	// exact cosine order below differs from the L2 order — it fails if <=> (cosine)
 	// is ever swapped for <-> (L2), a mutant that every small-norm vector alone
 	// (similar magnitudes → L2 order == cosine order) could not catch.
-	nearest := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(1, 0))    // cos 0
-	big := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(90, 9))       // cos ~0.005, L2 ~89.5
-	near := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.9, 0.1))   // cos ~0.006
-	mid := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.5, 0.5))    // cos ~0.293
-	far := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0, 1))        // cos 1.0
+	nearest := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(1, 0))  // cos 0
+	big := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(90, 9))     // cos ~0.005, L2 ~89.5
+	near := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.9, 0.1)) // cos ~0.006
+	mid := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0.5, 0.5))  // cos ~0.293
+	far := seedSearchChunk(t, st, campaignID, vs.ID, nil, vec768(0, 1))      // cos 1.0
 
 	got, err := st.SearchChunksByCampaign(ctx, campaignID, query, 5)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `internal/storage/transcript_chunk_search_test.go` failed gofmt/goimports (trailing-comment alignment on the `seedSearchChunk` lines), but only under `golangci-lint run --build-tags=integration` — the file is integration-tagged, so the default lint gate never compiled it and the issue went unnoticed. Pre-existing on main, not introduced by PR #325.
- Fixed with `gofmt -w`; formatting-only, no behavior change.

## Verification
- `golangci-lint run --build-tags=integration ./internal/storage/...` → **0 issues**
- `gofmt -l internal/storage/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)