### PR TITLE
feat(#272): recap engine — one-shot Voice Session summarization

### DIFF
--- a/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
+++ b/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
@@ -17,6 +17,29 @@ Implementing #130 (E6, under the ADR-0004 amendment) required deciding where the
 - **Gating inside the address detector or segmenter** — would silence transcription; the AC requires transcription to continue under a soft cap.
 - **Failed-status rows on hard cap** — the session did exactly what it was configured to do; `failed` is reserved for faults (ADR-0043).
 
+## Amendment (2026-07-09, #272 recap engine)
+
+The cap mechanics above are **live-Voice-Session-only**. The Recap engine
+(`internal/recap`, E3) is an *idle* off-session LLM call — it summarizes a past
+session and does not belong to any running session's meter. Its metering posture
+(gate #271):
+
+- **Metered, never cap-gated.** Each recap builds its own caps-free
+  `spend.NewMeter(spend.Caps{}, …)` teed alongside the production recorder via
+  `observe.TeeUsage`, so usage is priced and the `glyphoxa_voice_llm_tokens_total`
+  series still moves. The engine **never** reads a tenant cap and **never** calls
+  `AllowTurn`: `recap.Store` deliberately omits any spend-cap method, so the code
+  *cannot* gate on a cap. A recap is never refused for spend — the soft/hard-cap
+  consequences here are exclusively the live session's concern.
+- **Usage attributed to the recapped Voice Session id(s).** Beyond the counters,
+  the engine emits one structured `recap: llm usage` log line carrying the
+  `voice_session_ids`, the input/output token totals, and the meter's
+  `EstimatedUSD`, so an operator can attribute recap spend to the session(s) it
+  summarized.
+
+This is additive: the live-session meter, caps, gate, and `SpendCapReached`
+mechanics are unchanged.
+
 ## Relationship to other ADRs
 
 ADR-0004 (amendment is the spec this implements), ADR-0045 (usage capture points), ADR-0043 (close seam + end_reason prefixes), ADR-0032 (no session labels), ADR-0020/0014/0039 (event + SSE + screen surface).

--- a/internal/llmbuild/llmbuild.go
+++ b/internal/llmbuild/llmbuild.go
@@ -1,0 +1,92 @@
+// Package llmbuild constructs an [llm.Provider] from a saved Provider Config
+// (ADR-0004), keyed off the config's provider id rather than a hardwired adapter.
+//
+// It is the shared LLM construction seam the live voice loop (internal/wirenpc)
+// and the Recap engine (internal/recap) both use: the BYOK credential resolution
+// ([ResolveKey], moved verbatim from wirenpc under the hybrid policy ADR-0039) and
+// the provider dispatch ([New], groq/anthropic/gemini keyed off
+// provider_config.provider, groq the default per ADR-0036). [FromConfig] bundles
+// the two for callers that hold a *storage.ProviderConfig.
+package llmbuild
+
+import (
+	"fmt"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/anthropic"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/gemini"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+)
+
+// EnvPlaceholderLast4 marks a provider_config whose real key lives OUTSIDE the DB
+// (the keyring / an *_API_KEY env var), not in credentials_ciphertext. It matches
+// the seed placeholder wirenpc writes; [ResolveKey] reads it as "-> env fallback".
+const EnvPlaceholderLast4 = "env"
+
+// ResolveKey resolves ONE component's API key under the hybrid BYOK policy
+// (ADR-0039), moved verbatim from wirenpc's resolveKey (issue #69):
+//
+//   - cfg == nil, or cfg.CredentialsLast4 == "env" (the seeded placeholder):
+//     no real key in the DB -> "" so the adapter falls back to its env var.
+//   - a real saved key (last4 != "env") but no cipher: a CLEAR error, never a
+//     silent empty key (AC2) — boot without $GLYPHOXA_SECRET cannot quietly
+//     ignore a configured key and degrade to ENV.
+//   - a real saved key the cipher cannot open: a CLEAR error wrapping crypto's.
+//   - otherwise: the decrypted plaintext key.
+//
+// component only labels the error so an operator knows which key failed.
+func ResolveKey(cipher *crypto.Cipher, cfg *storage.ProviderConfig, component storage.Component) (string, error) {
+	if cfg == nil || cfg.CredentialsLast4 == EnvPlaceholderLast4 {
+		return "", nil
+	}
+	if cipher == nil {
+		return "", fmt.Errorf("llmbuild: %s key needs decryption but the credential cipher is unavailable; set $GLYPHOXA_SECRET (ADR-0004)", component)
+	}
+	plaintext, err := cipher.Open(cfg.CredentialsCiphertext)
+	if err != nil {
+		return "", fmt.Errorf("llmbuild: decrypt %s key: %w", component, err)
+	}
+	return string(plaintext), nil
+}
+
+// New builds an [llm.Provider] for providerID with apiKey, keyed off
+// provider_config.provider (ADR-0004). An empty id defaults to Groq (the
+// deployment LLM, ADR-0036); an unrecognised id is a CLEAR error naming it, never
+// a silent hardwired adapter. An empty apiKey lets the adapter fall back to its
+// own *_API_KEY env var at request time (the hybrid policy, ADR-0039).
+func New(providerID, apiKey string) (llm.Provider, error) {
+	switch providerID {
+	case "", groq.ProviderID:
+		return groq.New(apiKey), nil
+	case anthropic.ProviderID:
+		return anthropic.New(apiKey), nil
+	case gemini.ProviderID:
+		return gemini.New(apiKey), nil
+	default:
+		return nil, fmt.Errorf("llmbuild: unknown LLM provider %q (want %q, %q, or %q)", providerID, groq.ProviderID, anthropic.ProviderID, gemini.ProviderID)
+	}
+}
+
+// FromConfig resolves a Provider Config into a live [llm.Provider] plus the model
+// id the caller should request. It is [ResolveKey] (ComponentLLM) followed by
+// [New] keyed off cfg.Provider; the returned model is cfg.Model (empty lets the
+// adapter pick its default per [llm.Request.Model]). A nil cfg resolves to Groq
+// with an empty env-fallback key and an empty model (the deployment default).
+func FromConfig(cipher *crypto.Cipher, cfg *storage.ProviderConfig) (p llm.Provider, model string, err error) {
+	key, err := ResolveKey(cipher, cfg, storage.ComponentLLM)
+	if err != nil {
+		return nil, "", err
+	}
+	providerID := ""
+	if cfg != nil {
+		providerID = cfg.Provider
+		model = cfg.Model
+	}
+	p, err = New(providerID, key)
+	if err != nil {
+		return nil, "", err
+	}
+	return p, model, nil
+}

--- a/internal/llmbuild/llmbuild_test.go
+++ b/internal/llmbuild/llmbuild_test.go
@@ -1,0 +1,161 @@
+package llmbuild
+
+import (
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/anthropic"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/gemini"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+)
+
+func newUnitCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	c, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}
+
+func sealedConfig(t *testing.T, cipher *crypto.Cipher, provider, model, key string) *storage.ProviderConfig {
+	t.Helper()
+	ct, err := cipher.Seal([]byte(key))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return &storage.ProviderConfig{
+		Provider:              provider,
+		Model:                 model,
+		CredentialsCiphertext: ct,
+		CredentialsLast4:      crypto.Last4(key),
+	}
+}
+
+// TestResolveKey is the parity port of wirenpc's credentials_test.go: the moved,
+// exported resolver keeps identical semantics — nil cfg / "env" placeholder -> ""
+// env fallback; a real key without a cipher or that cannot be decrypted is a CLEAR
+// error, never a silent empty key (AC2, ADR-0039/0004).
+func TestResolveKey(t *testing.T) {
+	cipher := newUnitCipher(t)
+	wrong := newUnitCipher(t)
+
+	const realKey = "sk-real-secret-key-1234"
+	sealed := sealedConfig(t, cipher, groq.ProviderID, "", realKey)
+
+	placeholder := sealedConfig(t, cipher, groq.ProviderID, "", "placeholder: real key in keyring")
+	placeholder.CredentialsLast4 = EnvPlaceholderLast4
+
+	tests := []struct {
+		name    string
+		cipher  *crypto.Cipher
+		cfg     *storage.ProviderConfig
+		wantKey string
+		wantErr string
+	}{
+		{name: "nil config -> env fallback", cipher: cipher, cfg: nil, wantKey: ""},
+		{name: "env placeholder -> env fallback", cipher: cipher, cfg: placeholder, wantKey: ""},
+		{name: "real key + cipher -> decrypted", cipher: cipher, cfg: sealed, wantKey: realKey},
+		{name: "real key + nil cipher -> clear error", cipher: nil, cfg: sealed, wantErr: "cipher"},
+		{name: "real key + wrong cipher -> clear error", cipher: wrong, cfg: sealed, wantErr: "decrypt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveKey(tt.cipher, tt.cfg, storage.ComponentLLM)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveKey() error = nil, want error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("ResolveKey() error = %q, want substring %q", err, tt.wantErr)
+				}
+				if got != "" {
+					t.Errorf("ResolveKey() key = %q on error, want empty", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveKey() unexpected error: %v", err)
+			}
+			if got != tt.wantKey {
+				t.Errorf("ResolveKey() = %q, want %q", got, tt.wantKey)
+			}
+		})
+	}
+}
+
+// TestNewDispatch pins provider selection off the provider_config.provider id: the
+// three wired adapters, the empty-id default to Groq (ADR-0036), and a clear error
+// naming an unknown id (never a silent hardwired groq).
+func TestNewDispatch(t *testing.T) {
+	tests := []struct {
+		providerID string
+		wantErr    string
+	}{
+		{providerID: "", wantErr: ""},
+		{providerID: groq.ProviderID, wantErr: ""},
+		{providerID: anthropic.ProviderID, wantErr: ""},
+		{providerID: gemini.ProviderID, wantErr: ""},
+		{providerID: "no-such-provider", wantErr: "no-such-provider"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.providerID, func(t *testing.T) {
+			p, err := New(tt.providerID, "")
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("New(%q) error = nil, want error naming the id", tt.providerID)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("New(%q) error = %q, want substring %q", tt.providerID, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New(%q) unexpected error: %v", tt.providerID, err)
+			}
+			if p == nil {
+				t.Fatalf("New(%q) provider = nil", tt.providerID)
+			}
+		})
+	}
+}
+
+// TestFromConfig proves the config carry: model comes from cfg.Model, a nil cfg
+// resolves to the Groq default with an empty (env-fallback) key and empty model.
+func TestFromConfig(t *testing.T) {
+	cipher := newUnitCipher(t)
+
+	t.Run("nil cfg -> groq default, empty model", func(t *testing.T) {
+		p, model, err := FromConfig(cipher, nil)
+		if err != nil {
+			t.Fatalf("FromConfig(nil): %v", err)
+		}
+		if p == nil {
+			t.Fatal("FromConfig(nil) provider = nil")
+		}
+		if model != "" {
+			t.Errorf("FromConfig(nil) model = %q, want \"\"", model)
+		}
+	})
+
+	t.Run("real cfg carries model", func(t *testing.T) {
+		cfg := sealedConfig(t, cipher, anthropic.ProviderID, "claude-x", "sk-anthropic-key-9999")
+		p, model, err := FromConfig(cipher, cfg)
+		if err != nil {
+			t.Fatalf("FromConfig(cfg): %v", err)
+		}
+		if p == nil {
+			t.Fatal("FromConfig(cfg) provider = nil")
+		}
+		if model != "claude-x" {
+			t.Errorf("FromConfig(cfg) model = %q, want %q", model, "claude-x")
+		}
+	})
+}

--- a/internal/recap/call.go
+++ b/internal/recap/call.go
@@ -52,12 +52,19 @@ func neutralSystemPrompt(language string) string {
 
 // llmCaller drives one recap's LLM completions against a fixed provider/model,
 // metering each via rec and accumulating the token totals for the attribution log.
+//
+// model is the request model (empty lets the adapter pick its default). priceModel
+// is the model the spend sink prices on: it equals model except on the default path,
+// where model is "" but priceModel is groq.DefaultModel, so (groq, "") is never a
+// price-map miss (#272 review). The request model stays "" so the cassette hash and
+// the adapter default are unchanged.
 type llmCaller struct {
-	ctx      context.Context
-	provider llm.Provider
-	model    string
-	label    observe.Provider
-	rec      observe.StageRecorder
+	ctx        context.Context
+	provider   llm.Provider
+	model      string
+	priceModel string
+	label      observe.Provider
+	rec        observe.StageRecorder
 
 	totalIn  int
 	totalOut int
@@ -65,9 +72,12 @@ type llmCaller struct {
 
 // call runs one completion (system + user), drains it to close, and returns the
 // accumulated text. Usage is metered from the provider-reported [llm.EventUsage] or,
-// when none arrives, a documented ceil(chars/4) per-direction estimate — never zero
-// (ADR-0045). An [llm.EventError] or a stream that closes without an [llm.EventDone]
-// fails the call: a truncated recap is never presented as complete.
+// when none arrives on a COMPLETED call, a documented ceil(chars/4) per-direction
+// estimate (ADR-0045). An [llm.EventError] or a stream that closes without an
+// [llm.EventDone] fails the call — a truncated recap is never presented as complete
+// — but any provider-REPORTED usage that already arrived is still metered on those
+// paths (ADR-0045's error rule: a partial turn is metered by what was reported, not
+// by a fabricated estimate — matching agenttool).
 func (c *llmCaller) call(system, user string, maxTokens int) (string, error) {
 	stream, err := c.provider.Complete(c.ctx, llm.Request{
 		Model:     c.model,
@@ -98,9 +108,11 @@ func (c *llmCaller) call(system, user string, maxTokens int) (string, error) {
 		}
 	}
 	if streamErr != nil {
+		c.meterReported(haveUsage, usage)
 		return "", fmt.Errorf("recap: llm stream error: %w", streamErr)
 	}
 	if !done {
+		c.meterReported(haveUsage, usage)
 		if err := c.ctx.Err(); err != nil {
 			return "", err
 		}
@@ -112,17 +124,32 @@ func (c *llmCaller) call(system, user string, maxTokens int) (string, error) {
 	return text, nil
 }
 
-// meter records one completion's token usage: the provider-reported counts, or a
+// meter records a COMPLETED call's token usage: the provider-reported counts, or a
 // ceil(chars/4) per-direction estimate over the sent prompt and received text when
-// none was reported — never zero (ADR-0045). The model rides only to the sink for
-// pricing (ADR-0046); Prometheus drops it (ADR-0032).
+// none was reported. The input estimate is always >0 (the system+user prompt is
+// non-empty); a completed call that returned no text meters out=0, matching
+// agenttool. priceModel rides only to the sink for pricing (ADR-0046); Prometheus
+// drops it (ADR-0032).
 func (c *llmCaller) meter(haveUsage bool, u llm.Usage, sent, received string) {
 	in, out := u.InputTokens, u.OutputTokens
 	if !haveUsage {
 		in = estimateTokens(utf8.RuneCountInString(sent))
 		out = estimateTokens(utf8.RuneCountInString(received))
 	}
-	c.rec.LLMTokens(c.label, c.model, in, out)
+	c.record(in, out)
+}
+
+// meterReported records ONLY provider-reported usage (the error/truncation rule,
+// ADR-0045): a failed or truncated call is metered by what the provider actually
+// reported, never a fabricated estimate.
+func (c *llmCaller) meterReported(haveUsage bool, u llm.Usage) {
+	if haveUsage {
+		c.record(u.InputTokens, u.OutputTokens)
+	}
+}
+
+func (c *llmCaller) record(in, out int) {
+	c.rec.LLMTokens(c.label, c.priceModel, in, out)
 	c.totalIn += in
 	c.totalOut += out
 }

--- a/internal/recap/call.go
+++ b/internal/recap/call.go
@@ -1,0 +1,131 @@
+package recap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// recapInstruction is the Butler-flavoured recap directive appended after the
+// Butler's Persona. Fixed text: the cassette prompt hash (ADR-0021) depends on it.
+const recapInstruction = "You are recapping a past tabletop RPG voice session for the players. " +
+	"Summarize what happened as a single coherent narrative recap in your own voice, " +
+	"preserving the key events, characters, and decisions in the order they occurred. " +
+	"Do not invent details that are not in the transcript."
+
+// neutralInstruction is the map-step directive: a plain factual condensation with no
+// persona, used per window before the Butler-flavoured reduce.
+const neutralInstruction = "Condense the following transcript excerpt into a factual, concise summary. " +
+	"Preserve the key events, characters, names, and decisions in order. " +
+	"Do not add commentary, flavor, or details not present in the excerpt."
+
+// answerLanguageLine, when a Campaign Language is set, pins the output language.
+func answerLanguageLine(language string) string {
+	if language == "" {
+		return ""
+	}
+	return "\n\nAnswer in " + language + "."
+}
+
+// butlerSystemPrompt is the Persona-flavoured system prompt for a single-call recap
+// or the reduce step: Persona + recap instruction + language pin.
+func butlerSystemPrompt(persona, language string) string {
+	var b strings.Builder
+	if persona != "" {
+		b.WriteString(persona)
+		b.WriteString("\n\n")
+	}
+	b.WriteString(recapInstruction)
+	b.WriteString(answerLanguageLine(language))
+	return b.String()
+}
+
+// neutralSystemPrompt is the persona-free factual system prompt for the map step.
+func neutralSystemPrompt(language string) string {
+	return neutralInstruction + answerLanguageLine(language)
+}
+
+// llmCaller drives one recap's LLM completions against a fixed provider/model,
+// metering each via rec and accumulating the token totals for the attribution log.
+type llmCaller struct {
+	ctx      context.Context
+	provider llm.Provider
+	model    string
+	label    observe.Provider
+	rec      observe.StageRecorder
+
+	totalIn  int
+	totalOut int
+}
+
+// call runs one completion (system + user), drains it to close, and returns the
+// accumulated text. Usage is metered from the provider-reported [llm.EventUsage] or,
+// when none arrives, a documented ceil(chars/4) per-direction estimate — never zero
+// (ADR-0045). An [llm.EventError] or a stream that closes without an [llm.EventDone]
+// fails the call: a truncated recap is never presented as complete.
+func (c *llmCaller) call(system, user string, maxTokens int) (string, error) {
+	stream, err := c.provider.Complete(c.ctx, llm.Request{
+		Model:     c.model,
+		MaxTokens: maxTokens,
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Text: system},
+			{Role: llm.RoleUser, Text: user},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("recap: llm complete: %w", err)
+	}
+
+	var sb strings.Builder
+	var usage llm.Usage
+	var haveUsage, done bool
+	var streamErr error
+	for ev := range stream {
+		switch ev.Type {
+		case llm.EventText:
+			sb.WriteString(ev.Text)
+		case llm.EventUsage:
+			usage, haveUsage = ev.Usage, true
+		case llm.EventDone:
+			done = true
+		case llm.EventError:
+			streamErr = errors.New(ev.Err)
+		}
+	}
+	if streamErr != nil {
+		return "", fmt.Errorf("recap: llm stream error: %w", streamErr)
+	}
+	if !done {
+		if err := c.ctx.Err(); err != nil {
+			return "", err
+		}
+		return "", errors.New("recap: completion stream ended without a done event (truncated response)")
+	}
+
+	text := sb.String()
+	c.meter(haveUsage, usage, system+user, text)
+	return text, nil
+}
+
+// meter records one completion's token usage: the provider-reported counts, or a
+// ceil(chars/4) per-direction estimate over the sent prompt and received text when
+// none was reported — never zero (ADR-0045). The model rides only to the sink for
+// pricing (ADR-0046); Prometheus drops it (ADR-0032).
+func (c *llmCaller) meter(haveUsage bool, u llm.Usage, sent, received string) {
+	in, out := u.InputTokens, u.OutputTokens
+	if !haveUsage {
+		in = estimateTokens(utf8.RuneCountInString(sent))
+		out = estimateTokens(utf8.RuneCountInString(received))
+	}
+	c.rec.LLMTokens(c.label, c.model, in, out)
+	c.totalIn += in
+	c.totalOut += out
+}
+
+// estimateTokens is the ceil(chars/4) per-direction token estimate (ADR-0045).
+func estimateTokens(runes int) int { return (runes + 3) / 4 }

--- a/internal/recap/engine_test.go
+++ b/internal/recap/engine_test.go
@@ -254,3 +254,27 @@ func TestEmptyTranscripts(t *testing.T) {
 }
 
 func okFactory(_, _ string) (llm.Provider, error) { return &stubProvider{text: "recap text"}, nil }
+
+// TestDedupSessions: the same session passed twice is recapped — and spent on — once.
+func TestDedupSessions(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	calls := 0
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "recap", capture: func(llm.Request) { calls++ }}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{sid, sid})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("provider calls = %d, want 1 (duplicate session deduped)", calls)
+	}
+	if len(res.SessionIDs) != 1 || res.SessionIDs[0] != sid {
+		t.Errorf("SessionIDs = %v, want [%s] deduped", res.SessionIDs, sid)
+	}
+}

--- a/internal/recap/engine_test.go
+++ b/internal/recap/engine_test.go
@@ -1,0 +1,256 @@
+package recap
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// seedSession adds a campaign (once per campaignID), a Butler, a session, and its
+// lines to the store. Returns the session id.
+func seedSession(s *fakeStore, tenantID, campaignID uuid.UUID, language string, butler storage.Agent, startedAt time.Time, lines []storage.TranscriptLine) uuid.UUID {
+	if _, ok := s.campaigns[campaignID]; !ok {
+		s.campaigns[campaignID] = storage.Campaign{ID: campaignID, TenantID: tenantID, Language: language}
+	}
+	butler.CampaignID = campaignID
+	s.butlers[campaignID] = butler
+	id := uuid.New()
+	s.sessions[id] = storage.VoiceSession{ID: id, CampaignID: campaignID, StartedAt: startedAt}
+	s.lines[id] = lines
+	return id
+}
+
+func sampleLines() []storage.TranscriptLine {
+	return []storage.TranscriptLine{
+		{Seq: 1, Who: "GM", Text: "You enter the tavern."},
+		{Seq: 2, Who: "Bart", Tag: "npc", Text: "Well met, travelers."},
+		{Seq: 3, Who: "Alice", Tag: "player", Text: "We seek the lost relic."},
+	}
+}
+
+// TestProviderResolutionChain pins gate #271's resolution order via the injected
+// factory: the Butler's own config wins; else the Tenant 'llm' config; else the Groq
+// env default (empty id, empty key).
+func TestProviderResolutionChain(t *testing.T) {
+	cipher := newCipher(t)
+	tenantID := uuid.New()
+
+	sealed := func(provider, model, key string) storage.ProviderConfig {
+		ct, err := cipher.Seal([]byte(key))
+		if err != nil {
+			t.Fatalf("seal: %v", err)
+		}
+		return storage.ProviderConfig{
+			ID:                    uuid.New(),
+			TenantID:              tenantID,
+			Component:             storage.ComponentLLM,
+			Provider:              provider,
+			Model:                 model,
+			CredentialsCiphertext: ct,
+			CredentialsLast4:      crypto.Last4(key),
+		}
+	}
+
+	t.Run("butler config wins", func(t *testing.T) {
+		st := newFakeStore()
+		cfg := sealed("anthropic", "claude-x", "sk-butler-key-1111")
+		st.configs[cfg.ID] = cfg
+		// A tenant config also exists — must be ignored in favour of the Butler's.
+		tc := sealed("gemini", "gem-y", "gm-key-2222")
+		st.byComponent[tenantID] = tc
+		butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "The Keeper.", LLMProviderConfigID: uuid.NullUUID{UUID: cfg.ID, Valid: true}}
+		sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+		var gotID, gotKey string
+		factory := func(providerID, apiKey string) (llm.Provider, error) {
+			gotID, gotKey = providerID, apiKey
+			return &stubProvider{text: "A recap."}, nil
+		}
+		eng := NewEngine(st, cipher, observe.Discard{}, nil, WithProviderFactory(factory))
+		if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+			t.Fatalf("Recap: %v", err)
+		}
+		if gotID != "anthropic" {
+			t.Errorf("providerID = %q, want anthropic", gotID)
+		}
+		if gotKey != "sk-butler-key-1111" {
+			t.Errorf("key = %q, want decrypted butler key", gotKey)
+		}
+	})
+
+	t.Run("tenant llm config fallback", func(t *testing.T) {
+		st := newFakeStore()
+		tc := sealed("gemini", "gem-y", "gm-key-3333")
+		st.byComponent[tenantID] = tc
+		butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "The Keeper."}
+		sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+		var gotID, gotKey string
+		factory := func(providerID, apiKey string) (llm.Provider, error) {
+			gotID, gotKey = providerID, apiKey
+			return &stubProvider{text: "A recap."}, nil
+		}
+		eng := NewEngine(st, cipher, observe.Discard{}, nil, WithProviderFactory(factory))
+		if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+			t.Fatalf("Recap: %v", err)
+		}
+		if gotID != "gemini" || gotKey != "gm-key-3333" {
+			t.Errorf("got (%q,%q), want (gemini, gm-key-3333)", gotID, gotKey)
+		}
+	})
+
+	t.Run("no config -> groq env default", func(t *testing.T) {
+		st := newFakeStore()
+		butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "The Keeper."}
+		sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+		var gotID, gotKey string
+		factory := func(providerID, apiKey string) (llm.Provider, error) {
+			gotID, gotKey = providerID, apiKey
+			return &stubProvider{text: "A recap."}, nil
+		}
+		eng := NewEngine(st, cipher, observe.Discard{}, nil, WithProviderFactory(factory))
+		if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+			t.Fatalf("Recap: %v", err)
+		}
+		if gotID != "" || gotKey != "" {
+			t.Errorf("got (%q,%q), want (\"\",\"\") the groq env default", gotID, gotKey)
+		}
+	})
+}
+
+// TestRecapSingleSession proves a short session produces the model's text with
+// Windowed=false, the reported session id, and a system prompt carrying the Butler
+// Persona and the Campaign Language.
+func TestRecapSingleSession(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Wise Butler Persona."}
+	sid := seedSession(st, tenantID, uuid.New(), "German", butler, time.Now(), sampleLines())
+
+	var sysSeen string
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "The party sought a relic.", capture: func(req llm.Request) {
+			sysSeen = req.Messages[0].Text
+		}}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{sid})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if res.Windowed {
+		t.Error("Windowed = true, want false for a short session")
+	}
+	if res.Text != "The party sought a relic." {
+		t.Errorf("Text = %q, want the model output", res.Text)
+	}
+	if len(res.SessionIDs) != 1 || res.SessionIDs[0] != sid {
+		t.Errorf("SessionIDs = %v, want [%s]", res.SessionIDs, sid)
+	}
+	if !strings.Contains(sysSeen, "Wise Butler Persona.") {
+		t.Errorf("system prompt missing Persona: %q", sysSeen)
+	}
+	if !strings.Contains(sysSeen, "German") {
+		t.Errorf("system prompt missing Campaign Language: %q", sysSeen)
+	}
+}
+
+// TestRecapMultiSession joins per-session recaps chronologically with headers, marks
+// Windowed if any session windowed, and reports ids in chronological order.
+func TestRecapMultiSession(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	t0 := time.Date(2026, 1, 2, 15, 4, 0, 0, time.UTC)
+	// Seed the LATER session first to prove chronological sort.
+	later := seedSession(st, tenantID, campaignID, "English", butler, t0.Add(time.Hour), sampleLines())
+	earlier := seedSession(st, tenantID, campaignID, "English", butler, t0, sampleLines())
+
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "session recap"}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{later, earlier})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if res.SessionIDs[0] != earlier || res.SessionIDs[1] != later {
+		t.Errorf("SessionIDs not chronological: %v", res.SessionIDs)
+	}
+	if !strings.Contains(res.Text, "**Session 2026-01-02 15:04 UTC**") {
+		t.Errorf("missing chronological header: %q", res.Text)
+	}
+	// The earlier header must appear before the later one.
+	if strings.Index(res.Text, "15:04 UTC") > strings.Index(res.Text, "16:04 UTC") {
+		t.Errorf("headers out of order: %q", res.Text)
+	}
+}
+
+// TestMixedCampaigns rejects sessions from different campaigns.
+func TestMixedCampaigns(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler}
+	a := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+	b := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "x"}, nil
+	}))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{a, b}); err != ErrMixedCampaigns {
+		t.Fatalf("err = %v, want ErrMixedCampaigns", err)
+	}
+}
+
+// TestEmptyTranscripts: a single empty session and an all-empty multi-set both yield
+// ErrNoTranscript; a mixed set skips the empty one with a note.
+func TestEmptyTranscripts(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+
+	t.Run("single empty -> ErrNoTranscript", func(t *testing.T) {
+		st := newFakeStore()
+		sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), nil)
+		eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(okFactory))
+		if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != ErrNoTranscript {
+			t.Fatalf("err = %v, want ErrNoTranscript", err)
+		}
+	})
+
+	t.Run("all empty -> ErrNoTranscript", func(t *testing.T) {
+		st := newFakeStore()
+		a := seedSession(st, tenantID, campaignID, "English", butler, time.Now(), nil)
+		b := seedSession(st, tenantID, campaignID, "English", butler, time.Now().Add(time.Hour), nil)
+		eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(okFactory))
+		if _, err := eng.Recap(context.Background(), []uuid.UUID{a, b}); err != ErrNoTranscript {
+			t.Fatalf("err = %v, want ErrNoTranscript", err)
+		}
+	})
+
+	t.Run("one empty in multi-set is noted, not dropped", func(t *testing.T) {
+		st := newFakeStore()
+		full := seedSession(st, tenantID, campaignID, "English", butler, time.Now(), sampleLines())
+		empty := seedSession(st, tenantID, campaignID, "English", butler, time.Now().Add(time.Hour), nil)
+		eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(okFactory))
+		res, err := eng.Recap(context.Background(), []uuid.UUID{full, empty})
+		if err != nil {
+			t.Fatalf("Recap: %v", err)
+		}
+		if !strings.Contains(res.Text, "no transcript lines recorded") {
+			t.Errorf("empty session not noted: %q", res.Text)
+		}
+	})
+}
+
+func okFactory(_, _ string) (llm.Provider, error) { return &stubProvider{text: "recap text"}, nil }

--- a/internal/recap/fakes_test.go
+++ b/internal/recap/fakes_test.go
@@ -1,0 +1,146 @@
+package recap
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+func newCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	c, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}
+
+// fakeStore is an in-memory recap.Store for keyless unit tests.
+type fakeStore struct {
+	sessions    map[uuid.UUID]storage.VoiceSession
+	lines       map[uuid.UUID][]storage.TranscriptLine
+	campaigns   map[uuid.UUID]storage.Campaign
+	butlers     map[uuid.UUID]storage.Agent          // keyed by campaignID
+	configs     map[uuid.UUID]storage.ProviderConfig // keyed by config id
+	byComponent map[uuid.UUID]storage.ProviderConfig // keyed by tenantID (llm only)
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		sessions:    map[uuid.UUID]storage.VoiceSession{},
+		lines:       map[uuid.UUID][]storage.TranscriptLine{},
+		campaigns:   map[uuid.UUID]storage.Campaign{},
+		butlers:     map[uuid.UUID]storage.Agent{},
+		configs:     map[uuid.UUID]storage.ProviderConfig{},
+		byComponent: map[uuid.UUID]storage.ProviderConfig{},
+	}
+}
+
+func (s *fakeStore) GetVoiceSession(_ context.Context, id uuid.UUID) (storage.VoiceSession, error) {
+	vs, ok := s.sessions[id]
+	if !ok {
+		return storage.VoiceSession{}, storage.ErrNotFound
+	}
+	return vs, nil
+}
+
+func (s *fakeStore) ListTranscriptLines(_ context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error) {
+	return s.lines[sessionID], nil
+}
+
+func (s *fakeStore) GetCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	c, ok := s.campaigns[id]
+	if !ok {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return c, nil
+}
+
+func (s *fakeStore) GetButler(_ context.Context, campaignID uuid.UUID) (storage.Agent, error) {
+	a, ok := s.butlers[campaignID]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (s *fakeStore) GetProviderConfig(_ context.Context, id uuid.UUID) (storage.ProviderConfig, error) {
+	c, ok := s.configs[id]
+	if !ok {
+		return storage.ProviderConfig{}, storage.ErrNotFound
+	}
+	return c, nil
+}
+
+func (s *fakeStore) GetProviderConfigByComponent(_ context.Context, tenantID uuid.UUID, component storage.Component) (storage.ProviderConfig, error) {
+	if component != storage.ComponentLLM {
+		return storage.ProviderConfig{}, storage.ErrNotFound
+	}
+	c, ok := s.byComponent[tenantID]
+	if !ok {
+		return storage.ProviderConfig{}, storage.ErrNotFound
+	}
+	return c, nil
+}
+
+// stubProvider is a scripted [llm.Provider]: one canned text response, an optional
+// reported usage, an optional mid-stream error, and an optional missing-done to
+// exercise the truncation guard. capture (when set) records each request.
+type stubProvider struct {
+	text    string
+	usage   *llm.Usage
+	errText string
+	noDone  bool
+	capture func(llm.Request)
+}
+
+// capRec is a StageRecorder that records the LLMTokens calls the meter tee forwards.
+type capRec struct {
+	observe.Discard
+	calls []llmTok
+}
+
+type llmTok struct {
+	provider observe.Provider
+	model    string
+	in, out  int
+}
+
+func (r *capRec) LLMTokens(p observe.Provider, model string, in, out int) {
+	r.calls = append(r.calls, llmTok{p, model, in, out})
+}
+
+func (p *stubProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	if p.capture != nil {
+		p.capture(req)
+	}
+	ch := make(chan llm.StreamEvent, 8)
+	go func() {
+		defer close(ch)
+		if p.text != "" {
+			ch <- llm.StreamEvent{Type: llm.EventText, Text: p.text}
+		}
+		if p.errText != "" {
+			ch <- llm.StreamEvent{Type: llm.EventError, Err: p.errText}
+			return
+		}
+		if p.usage != nil {
+			ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: *p.usage}
+		}
+		if !p.noDone {
+			ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+		}
+	}()
+	return ch, nil
+}

--- a/internal/recap/fakes_test.go
+++ b/internal/recap/fakes_test.go
@@ -131,12 +131,14 @@ func (p *stubProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.
 		if p.text != "" {
 			ch <- llm.StreamEvent{Type: llm.EventText, Text: p.text}
 		}
+		// Usage rides before the error/truncation so a failed call can still see the
+		// provider-reported usage that already arrived (ADR-0045 error rule).
+		if p.usage != nil {
+			ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: *p.usage}
+		}
 		if p.errText != "" {
 			ch <- llm.StreamEvent{Type: llm.EventError, Err: p.errText}
 			return
-		}
-		if p.usage != nil {
-			ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: *p.usage}
 		}
 		if !p.noDone {
 			ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}

--- a/internal/recap/metering_test.go
+++ b/internal/recap/metering_test.go
@@ -1,0 +1,116 @@
+package recap
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// TestMeteringReportedUsage: a provider-reported EventUsage is recorded verbatim as
+// LLMTokens on the recapped provider/model.
+func TestMeteringReportedUsage(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	rec := &capRec{}
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "recap", usage: &llm.Usage{InputTokens: 321, OutputTokens: 99}}, nil
+	}
+	eng := NewEngine(st, nil, rec, nil, WithProviderFactory(factory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("LLMTokens calls = %d, want 1", len(rec.calls))
+	}
+	got := rec.calls[0]
+	if got.in != 321 || got.out != 99 {
+		t.Errorf("tokens = (%d,%d), want (321,99) from reported usage", got.in, got.out)
+	}
+	if got.provider != observe.ProviderGroq {
+		t.Errorf("provider label = %q, want groq (default)", got.provider)
+	}
+}
+
+// TestMeteringEstimateNeverZero: with no EventUsage the engine records a ceil(chars/4)
+// estimate per direction, never zero (ADR-0045).
+func TestMeteringEstimateNeverZero(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	rec := &capRec{}
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "a non-empty recap body"}, nil // no usage
+	}
+	eng := NewEngine(st, nil, rec, nil, WithProviderFactory(factory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("LLMTokens calls = %d, want 1", len(rec.calls))
+	}
+	got := rec.calls[0]
+	if got.in <= 0 || got.out <= 0 {
+		t.Errorf("estimate tokens = (%d,%d), want both > 0 (never zero)", got.in, got.out)
+	}
+}
+
+// TestAttributionLog: the post-run log line carries the recapped session id and the
+// estimated USD.
+func TestAttributionLog(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	eng := NewEngine(st, nil, observe.Discard{}, log, WithProviderFactory(func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "recap", usage: &llm.Usage{InputTokens: 10, OutputTokens: 5}}, nil
+	}))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "recap: llm usage") {
+		t.Errorf("missing attribution log line: %q", out)
+	}
+	if !strings.Contains(out, sid.String()) {
+		t.Errorf("attribution log missing session id: %q", out)
+	}
+	if !strings.Contains(out, "estimated_usd") {
+		t.Errorf("attribution log missing estimated_usd: %q", out)
+	}
+}
+
+// TestNeverReadsCaps: the Store surface has no spend-cap method, so a recap cannot
+// read a tenant cap or gate on it (ADR-0046 is live-session-only). This compiles as
+// a structural proof: recap.Store deliberately omits GetTenantSpendCaps, and the
+// engine still recaps normally regardless of any caps configured elsewhere.
+func TestNeverReadsCaps(t *testing.T) {
+	// The interface itself is the assertion — assign the store and confirm no
+	// caps-reading method is required to satisfy recap.Store.
+	var _ Store = newFakeStore()
+
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(okFactory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+		t.Fatalf("Recap must succeed without any cap surface: %v", err)
+	}
+}

--- a/internal/recap/metering_test.go
+++ b/internal/recap/metering_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 )
 
 // TestMeteringReportedUsage: a provider-reported EventUsage is recorded verbatim as
@@ -65,6 +66,85 @@ func TestMeteringEstimateNeverZero(t *testing.T) {
 	got := rec.calls[0]
 	if got.in <= 0 || got.out <= 0 {
 		t.Errorf("estimate tokens = (%d,%d), want both > 0 (never zero)", got.in, got.out)
+	}
+}
+
+// TestMeteringReportedUsageOnError: a call that FAILS mid-stream after the provider
+// already reported usage still meters that reported usage (ADR-0045 error rule) — no
+// fabricated estimate, but no dropped reported usage either.
+func TestMeteringReportedUsageOnError(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	rec := &capRec{}
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "partial", usage: &llm.Usage{InputTokens: 7, OutputTokens: 3}, errText: "boom"}, nil
+	}
+	eng := NewEngine(st, nil, rec, nil, WithProviderFactory(factory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err == nil {
+		t.Fatal("Recap err = nil, want the stream error")
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("LLMTokens calls = %d, want 1 (reported usage on the failed call)", len(rec.calls))
+	}
+	if got := rec.calls[0]; got.in != 7 || got.out != 3 {
+		t.Errorf("metered (%d,%d), want reported (7,3)", got.in, got.out)
+	}
+}
+
+// TestMeteringDefaultPathPricesGroqModel: the default path (no provider config) sends
+// request model "" but prices on groq.DefaultModel, so the spend meter never misses
+// (groq, "") (#272 review).
+func TestMeteringDefaultPathPricesGroqModel(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	rec := &capRec{}
+	var reqModel string
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "recap", capture: func(req llm.Request) { reqModel = req.Model }}, nil
+	}
+	eng := NewEngine(st, nil, rec, nil, WithProviderFactory(factory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if reqModel != "" {
+		t.Errorf("request model = %q, want \"\" (adapter default, cassette-stable)", reqModel)
+	}
+	if len(rec.calls) != 1 || rec.calls[0].model != groq.DefaultModel {
+		t.Errorf("priced model = %q, want groq.DefaultModel %q", rec.calls[0].model, groq.DefaultModel)
+	}
+}
+
+// TestAttributionLogOnFailure: a midway failure still emits the attribution line with
+// ok=false, so metered spend is never orphaned (#272 review).
+func TestAttributionLogOnFailure(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+	eng := NewEngine(st, nil, observe.Discard{}, log, WithProviderFactory(func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "partial", usage: &llm.Usage{InputTokens: 4, OutputTokens: 2}, errText: "boom"}, nil
+	}))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err == nil {
+		t.Fatal("Recap err = nil, want failure")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "recap: llm usage") {
+		t.Errorf("no attribution log on failure: %q", out)
+	}
+	if !strings.Contains(out, "ok=false") {
+		t.Errorf("attribution log missing ok=false: %q", out)
+	}
+	if !strings.Contains(out, sid.String()) {
+		t.Errorf("attribution log missing session id: %q", out)
 	}
 }
 

--- a/internal/recap/recap.go
+++ b/internal/recap/recap.go
@@ -1,0 +1,317 @@
+// Package recap is the one-shot Voice Session summarization service (#272, E3):
+// given one or more Voice Session ids it renders their Transcript Lines (ADR-0040)
+// and asks the campaign's Butler-flavoured LLM to produce a coherent recap. It is a
+// plain service — NO Tool registration (ADR-0028/0029); Epic 7 wraps it later.
+//
+// Decisions (gate #271): the LLM provider is resolved from the Butler's
+// llm_provider_config_id, falling back to the Tenant 'llm' Provider Config, then to
+// the Groq env default (ADR-0036) — via the shared [internal/llmbuild] helper.
+// Recaps are REGENERATED per request and never persisted (no schema touch). A short
+// session is one Butler-flavoured call; an over-budget one is map-reduced over
+// windows of whole Lines. Usage is METERED (attributed to the recapped Voice Session
+// ids via metrics + a structured log) but NEVER cap-gated — recap never reads a
+// tenant cap nor calls AllowTurn (ADR-0046 is live-session-only).
+package recap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+const (
+	// singleCallBudgetChars is the conservative per-session rendered-character ceiling
+	// under which a whole session is recapped in ONE Butler-flavoured call. Above it,
+	// the session is map-reduced over windows (gate #271 long-session strategy).
+	singleCallBudgetChars = 24_000
+	// windowChars caps one map window's rendered characters; windows hold WHOLE Lines.
+	windowChars = 20_000
+	// maxWindows bounds the map fan-out; a transcript needing more fails loudly rather
+	// than launching an unbounded number of calls.
+	maxWindows = 32
+
+	mapMaxTokens    = 512
+	reduceMaxTokens = 1024
+	singleMaxTokens = 1024
+
+	sessionHeaderTimeFormat = "2006-01-02 15:04"
+)
+
+var (
+	// ErrNoTranscript is returned when a single-session recap has no Lines, or every
+	// session in a multi-session recap is empty — there is nothing to summarize.
+	ErrNoTranscript = errors.New("recap: no transcript lines to summarize")
+	// ErrMixedCampaigns is returned when the requested sessions do not all belong to
+	// one Campaign — a recap is scoped to a single campaign's Butler and Language.
+	ErrMixedCampaigns = errors.New("recap: sessions span multiple campaigns")
+	// ErrTranscriptTooLong is returned when a session's transcript needs more than
+	// maxWindows map windows — beyond the bounded single-pass map-reduce.
+	ErrTranscriptTooLong = errors.New("recap: transcript exceeds the maximum window count")
+)
+
+// Store is the read surface the engine needs; *storage.Store satisfies it (all six
+// methods already exist on the concrete store — no wrapper needed).
+type Store interface {
+	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
+	ListTranscriptLines(ctx context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error)
+	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
+	GetProviderConfig(ctx context.Context, id uuid.UUID) (storage.ProviderConfig, error)
+	GetProviderConfigByComponent(ctx context.Context, tenantID uuid.UUID, component storage.Component) (storage.ProviderConfig, error)
+}
+
+// The concrete store satisfies Store with no thin wrappers (#272 contract).
+var _ Store = (*storage.Store)(nil)
+
+// Result is a completed recap. Text is the recap prose; SessionIDs are the recapped
+// sessions in chronological (started_at) order; Windowed reports whether any session
+// took the map-reduce path.
+type Result struct {
+	Text       string
+	SessionIDs []uuid.UUID
+	Windowed   bool
+}
+
+// ProviderFactory builds an [llm.Provider] from a provider id and API key — the
+// cassette seam ([WithProviderFactory]); it defaults to [llmbuild.New].
+type ProviderFactory func(providerID, apiKey string) (llm.Provider, error)
+
+// Engine summarizes Voice Sessions. Construct with [NewEngine].
+type Engine struct {
+	st          Store
+	cipher      *crypto.Cipher
+	metrics     observe.StageRecorder
+	log         *slog.Logger
+	newProvider ProviderFactory
+}
+
+// Option customises an [Engine].
+type Option func(*Engine)
+
+// WithProviderFactory overrides the LLM provider constructor — the cassette seam a
+// deterministic test injects to replay a recorded completion (ADR-0021). The default
+// is [llmbuild.New].
+func WithProviderFactory(f func(providerID, apiKey string) (llm.Provider, error)) Option {
+	return func(e *Engine) { e.newProvider = f }
+}
+
+// NewEngine builds a recap Engine. cipher decrypts a BYOK LLM key (nil is fine for
+// the env/default path); metrics receives usage (nil -> discard); log receives the
+// attribution line (nil -> discard).
+func NewEngine(st Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, opts ...Option) *Engine {
+	e := &Engine{
+		st:          st,
+		cipher:      cipher,
+		metrics:     metrics,
+		log:         log,
+		newProvider: llmbuild.New,
+	}
+	if e.metrics == nil {
+		e.metrics = observe.Discard{}
+	}
+	if e.log == nil {
+		e.log = slog.New(slog.DiscardHandler)
+	}
+	for _, o := range opts {
+		o(e)
+	}
+	return e
+}
+
+// Recap summarizes the given Voice Sessions. The sessions must share one Campaign
+// (else [ErrMixedCampaigns]); they are recapped in chronological order, each
+// independently, and joined with per-session headers when there is more than one. A
+// single empty session — or all-empty in a multi-session set — yields
+// [ErrNoTranscript].
+func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (Result, error) {
+	if len(sessionIDs) == 0 {
+		return Result{}, ErrNoTranscript
+	}
+
+	sessions := make([]storage.VoiceSession, 0, len(sessionIDs))
+	for _, id := range sessionIDs {
+		vs, err := e.st.GetVoiceSession(ctx, id)
+		if err != nil {
+			return Result{}, fmt.Errorf("recap: load voice session %s: %w", id, err)
+		}
+		sessions = append(sessions, vs)
+	}
+
+	campaignID := sessions[0].CampaignID
+	for _, vs := range sessions[1:] {
+		if vs.CampaignID != campaignID {
+			return Result{}, ErrMixedCampaigns
+		}
+	}
+	// Chronological order: multi-session join and the reported SessionIDs both use it.
+	sort.SliceStable(sessions, func(i, j int) bool {
+		return sessions[i].StartedAt.Before(sessions[j].StartedAt)
+	})
+
+	campaign, err := e.st.GetCampaign(ctx, campaignID)
+	if err != nil {
+		return Result{}, fmt.Errorf("recap: load campaign %s: %w", campaignID, err)
+	}
+	butler, err := e.st.GetButler(ctx, campaignID)
+	if err != nil {
+		return Result{}, fmt.Errorf("recap: load butler for campaign %s: %w", campaignID, err)
+	}
+
+	cfg, err := e.resolveLLMConfig(ctx, campaign.TenantID, butler)
+	if err != nil {
+		return Result{}, err
+	}
+	key, err := llmbuild.ResolveKey(e.cipher, cfg, storage.ComponentLLM)
+	if err != nil {
+		return Result{}, err
+	}
+	providerID, model := "", ""
+	if cfg != nil {
+		providerID, model = cfg.Provider, cfg.Model
+	}
+	provider, err := e.newProvider(providerID, key)
+	if err != nil {
+		return Result{}, fmt.Errorf("recap: build llm provider: %w", err)
+	}
+
+	// Metering (gate #271 posture): a caps-free meter teed alongside the production
+	// recorder — usage is recorded and priced, but the meter has NO caps and the
+	// engine never reads one or calls AllowTurn (ADR-0046 is live-session-only).
+	meter := spend.NewMeter(spend.Caps{}, e.log, nil, nil)
+	caller := &llmCaller{
+		ctx:      ctx,
+		provider: provider,
+		model:    model,
+		label:    providerLabel(providerID),
+		rec:      observe.TeeUsage(e.metrics, meter),
+	}
+
+	butlerSys := butlerSystemPrompt(butler.Persona, campaign.Language)
+	neutralSys := neutralSystemPrompt(campaign.Language)
+
+	chronIDs := make([]uuid.UUID, len(sessions))
+	for i, vs := range sessions {
+		chronIDs[i] = vs.ID
+	}
+	multi := len(sessions) > 1
+
+	var parts []string
+	anyWindowed := false
+	produced := false
+	for _, vs := range sessions {
+		lines, err := e.st.ListTranscriptLines(ctx, vs.ID)
+		if err != nil {
+			return Result{}, fmt.Errorf("recap: load transcript for session %s: %w", vs.ID, err)
+		}
+		header := "**Session " + vs.StartedAt.UTC().Format(sessionHeaderTimeFormat) + " UTC**"
+		if len(lines) == 0 {
+			if !multi {
+				return Result{}, ErrNoTranscript
+			}
+			// A zero-line session in a multi-set is skipped with a note, not dropped —
+			// the reader sees the gap rather than a silently missing header.
+			parts = append(parts, header+"\n_(no transcript lines recorded for this session)_")
+			continue
+		}
+		text, windowed, err := e.recapSession(caller, butlerSys, neutralSys, lines)
+		if err != nil {
+			return Result{}, err
+		}
+		produced = true
+		anyWindowed = anyWindowed || windowed
+		if multi {
+			parts = append(parts, header+"\n"+text)
+		} else {
+			parts = append(parts, text)
+		}
+	}
+	if !produced {
+		return Result{}, ErrNoTranscript
+	}
+
+	status := meter.Status()
+	e.log.Info("recap: llm usage",
+		"voice_session_ids", chronIDs,
+		"input_tokens", caller.totalIn,
+		"output_tokens", caller.totalOut,
+		"estimated_usd", status.EstimatedUSD,
+	)
+
+	return Result{
+		Text:       strings.Join(parts, "\n\n"),
+		SessionIDs: chronIDs,
+		Windowed:   anyWindowed,
+	}, nil
+}
+
+// recapSession recaps ONE session's Lines. At or under the single-call budget it is
+// one Butler-flavoured call; above it, a map-reduce: each window of whole Lines is
+// mapped with a NEUTRAL factual prompt, then the ordered partials are reduced by one
+// Butler-flavoured call. Windowed reports which path ran.
+func (e *Engine) recapSession(c *llmCaller, butlerSys, neutralSys string, lines []storage.TranscriptLine) (text string, windowed bool, err error) {
+	rendered := renderLines(lines)
+	if utf8.RuneCountInString(rendered) <= singleCallBudgetChars {
+		text, err = c.call(butlerSys, rendered, singleMaxTokens)
+		return text, false, err
+	}
+
+	windows := splitWindows(lines, windowChars)
+	if len(windows) > maxWindows {
+		return "", false, ErrTranscriptTooLong
+	}
+	partials := make([]string, 0, len(windows))
+	for _, w := range windows {
+		p, err := c.call(neutralSys, renderLines(w), mapMaxTokens)
+		if err != nil {
+			return "", false, err
+		}
+		partials = append(partials, p)
+	}
+	reduced, err := c.call(butlerSys, strings.Join(partials, "\n\n"), reduceMaxTokens)
+	return reduced, true, err
+}
+
+// resolveLLMConfig resolves the LLM Provider Config for the recap (gate #271):
+// the Butler's llm_provider_config_id if set, else the Tenant's 'llm' Provider
+// Config, else nil (the Groq env default, ADR-0036).
+func (e *Engine) resolveLLMConfig(ctx context.Context, tenantID uuid.UUID, butler storage.Agent) (*storage.ProviderConfig, error) {
+	if butler.LLMProviderConfigID.Valid {
+		pc, err := e.st.GetProviderConfig(ctx, butler.LLMProviderConfigID.UUID)
+		if err != nil {
+			return nil, fmt.Errorf("recap: load butler LLM provider config: %w", err)
+		}
+		return &pc, nil
+	}
+	pc, err := e.st.GetProviderConfigByComponent(ctx, tenantID, storage.ComponentLLM)
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, nil // no config -> default Groq + env key
+	case err != nil:
+		return nil, fmt.Errorf("recap: load tenant LLM provider config: %w", err)
+	default:
+		return &pc, nil
+	}
+}
+
+// providerLabel maps a provider_config id to the bounded [observe.Provider] metric
+// label; the empty id (default) is Groq (ADR-0036). The three wired ids equal their
+// observe constants, so the cast is exact.
+func providerLabel(providerID string) observe.Provider {
+	if providerID == "" {
+		return observe.ProviderGroq
+	}
+	return observe.Provider(providerID)
+}

--- a/internal/recap/recap.go
+++ b/internal/recap/recap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 )
 
 const (
@@ -136,7 +137,10 @@ func NewEngine(st Store, cipher *crypto.Cipher, metrics observe.StageRecorder, l
 // independently, and joined with per-session headers when there is more than one. A
 // single empty session — or all-empty in a multi-session set — yields
 // [ErrNoTranscript].
-func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (Result, error) {
+func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (res Result, err error) {
+	// Dedup up front so a caller passing the same session twice (e.g. a sloppy
+	// "last N" list) recaps it — and spends on it — once, not per duplicate.
+	sessionIDs = dedupUUIDs(sessionIDs)
 	if len(sessionIDs) == 0 {
 		return Result{}, ErrNoTranscript
 	}
@@ -186,35 +190,58 @@ func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (Result, err
 	if err != nil {
 		return Result{}, fmt.Errorf("recap: build llm provider: %w", err)
 	}
+	// The default path (providerID "") sends request model "" (adapter fills the
+	// Groq default), but the spend sink must price on a real model, else (groq, "")
+	// misses the price map and warn-spams / inflates the estimate (#272 review).
+	priceModel := model
+	if providerID == "" {
+		priceModel = groq.DefaultModel
+	}
 
 	// Metering (gate #271 posture): a caps-free meter teed alongside the production
 	// recorder — usage is recorded and priced, but the meter has NO caps and the
 	// engine never reads one or calls AllowTurn (ADR-0046 is live-session-only).
 	meter := spend.NewMeter(spend.Caps{}, e.log, nil, nil)
 	caller := &llmCaller{
-		ctx:      ctx,
-		provider: provider,
-		model:    model,
-		label:    providerLabel(providerID),
-		rec:      observe.TeeUsage(e.metrics, meter),
+		ctx:        ctx,
+		provider:   provider,
+		model:      model,
+		priceModel: priceModel,
+		label:      providerLabel(providerID),
+		rec:        observe.TeeUsage(e.metrics, meter),
 	}
-
-	butlerSys := butlerSystemPrompt(butler.Persona, campaign.Language)
-	neutralSys := neutralSystemPrompt(campaign.Language)
 
 	chronIDs := make([]uuid.UUID, len(sessions))
 	for i, vs := range sessions {
 		chronIDs[i] = vs.ID
 	}
+	// Attribute whatever was spent to the recapped session id(s) — on success AND on
+	// a midway failure, so metered tokens are never orphaned (#272 review). Fires
+	// once the meter/caller exist; the earlier provider-resolution errors spent
+	// nothing and have no meter to report.
+	defer func() {
+		status := meter.Status()
+		e.log.Info("recap: llm usage",
+			"voice_session_ids", chronIDs,
+			"input_tokens", caller.totalIn,
+			"output_tokens", caller.totalOut,
+			"estimated_usd", status.EstimatedUSD,
+			"ok", err == nil,
+		)
+	}()
+
+	butlerSys := butlerSystemPrompt(butler.Persona, campaign.Language)
+	neutralSys := neutralSystemPrompt(campaign.Language)
+
 	multi := len(sessions) > 1
 
 	var parts []string
 	anyWindowed := false
 	produced := false
 	for _, vs := range sessions {
-		lines, err := e.st.ListTranscriptLines(ctx, vs.ID)
-		if err != nil {
-			return Result{}, fmt.Errorf("recap: load transcript for session %s: %w", vs.ID, err)
+		lines, lerr := e.st.ListTranscriptLines(ctx, vs.ID)
+		if lerr != nil {
+			return Result{}, fmt.Errorf("recap: load transcript for session %s: %w", vs.ID, lerr)
 		}
 		header := "**Session " + vs.StartedAt.UTC().Format(sessionHeaderTimeFormat) + " UTC**"
 		if len(lines) == 0 {
@@ -241,14 +268,6 @@ func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (Result, err
 	if !produced {
 		return Result{}, ErrNoTranscript
 	}
-
-	status := meter.Status()
-	e.log.Info("recap: llm usage",
-		"voice_session_ids", chronIDs,
-		"input_tokens", caller.totalIn,
-		"output_tokens", caller.totalOut,
-		"estimated_usd", status.EstimatedUSD,
-	)
 
 	return Result{
 		Text:       strings.Join(parts, "\n\n"),
@@ -304,6 +323,20 @@ func (e *Engine) resolveLLMConfig(ctx context.Context, tenantID uuid.UUID, butle
 	default:
 		return &pc, nil
 	}
+}
+
+// dedupUUIDs returns ids with duplicates removed, preserving first-seen order.
+func dedupUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 // providerLabel maps a provider_config id to the bounded [observe.Provider] metric

--- a/internal/recap/recap_cassette_test.go
+++ b/internal/recap/recap_cassette_test.go
@@ -1,0 +1,153 @@
+package recap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
+)
+
+// countingProvider wraps a cassette provider to count Complete calls (the map/reduce
+// fan-out observation) while replaying the recorded exchanges unchanged.
+type countingProvider struct {
+	inner llm.Provider
+	calls *int
+}
+
+func (p countingProvider) Complete(ctx context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	*p.calls++
+	return p.inner.Complete(ctx, req)
+}
+
+const cassetteButlerPersona = "You are Gimble, the wise and slightly weary Butler who chronicles the party's deeds with dry wit."
+
+// singleCassetteLines is the fixed fixture transcript for the single-call cassette.
+// The distinctive proper nouns (Aethelred, Sunstone, crypt) let a tolerant,
+// normalized assertion confirm the recap is about THIS session without pinning exact
+// wording (the model paraphrases).
+func singleCassetteLines() []storage.TranscriptLine {
+	return []storage.TranscriptLine{
+		{Seq: 1, Who: "GM", Text: "The party arrives at the ruined keep of Aethelred as dusk falls."},
+		{Seq: 2, Who: "Bart", Tag: "npc", Text: "Halt! None pass the gate of Aethelred without paying the toll."},
+		{Seq: 3, Who: "Alice", Tag: "player", Text: "We carry the Sunstone relic and seek the buried crypt beneath the keep."},
+		{Seq: 4, Who: "GM", Text: "A cold wind stirs; the crypt door grinds slowly open before them."},
+		{Seq: 5, Who: "Bart", Tag: "npc", Text: "Then your doom is your own, relic-bearers. The dead do not forgive trespass."},
+	}
+}
+
+// TestRecapSingleCassette is the AC1 determinism proof: a seeded session recapped
+// through a cassette-recorded Groq completion (ADR-0021) yields coherent text about
+// this session, Windowed=false, with a system prompt carrying the Butler Persona and
+// the Campaign Language.
+func TestRecapSingleCassette(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: cassetteButlerPersona}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), singleCassetteLines())
+
+	var sysSeen string
+	calls := 0
+	factory := func(_, _ string) (llm.Provider, error) {
+		cass := voicecassette.LoadLLM(t, "llm-recap-single")
+		return countingProvider{inner: capturingProvider{inner: cass, sys: &sysSeen}, calls: &calls}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{sid})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if res.Windowed {
+		t.Error("Windowed = true, want false for a short session")
+	}
+	if calls != 1 {
+		t.Errorf("Complete calls = %d, want 1 (single-call path)", calls)
+	}
+	norm := strings.ToLower(res.Text)
+	if len(strings.TrimSpace(norm)) < 40 {
+		t.Errorf("recap too short to be coherent: %q", res.Text)
+	}
+	salient := []string{"aethelred", "sunstone", "relic", "crypt"}
+	hits := 0
+	for _, s := range salient {
+		if strings.Contains(norm, s) {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("recap does not reference the session (hits=%d): %q", hits, res.Text)
+	}
+	if !strings.Contains(sysSeen, "Gimble") {
+		t.Errorf("system prompt missing Butler Persona: %q", sysSeen)
+	}
+	if !strings.Contains(sysSeen, "English") {
+		t.Errorf("system prompt missing Campaign Language: %q", sysSeen)
+	}
+}
+
+// windowedCassetteLines deterministically generates an over-budget transcript
+// (> singleCallBudgetChars) so the recap map-reduces. Each line's text is distinct so
+// the two window prompts hash differently.
+func windowedCassetteLines() []storage.TranscriptLine {
+	const n = 40
+	lines := make([]storage.TranscriptLine, n)
+	for i := 0; i < n; i++ {
+		who := "GM"
+		if i%2 == 1 {
+			who = "Alice"
+		}
+		sentence := fmt.Sprintf("In chapter %d the heroes explored region %d, bargained with faction %d, and fought the beast of hollow %d. ", i, i, i, i)
+		lines[i] = storage.TranscriptLine{Seq: int64(i + 1), Who: who, Text: strings.Repeat(sentence, 6)}
+	}
+	return lines
+}
+
+// TestRecapWindowedCassette is the oversized-fixture proof: an over-budget session
+// map-reduces through the cassette — two map calls plus one reduce — and reports
+// Windowed=true (ADR-0021 determinism over the long-session strategy).
+func TestRecapWindowedCassette(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: cassetteButlerPersona}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), windowedCassetteLines())
+
+	calls := 0
+	factory := func(_, _ string) (llm.Provider, error) {
+		return countingProvider{inner: voicecassette.LoadLLM(t, "llm-recap-windowed"), calls: &calls}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{sid})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if !res.Windowed {
+		t.Error("Windowed = false, want true for an over-budget session")
+	}
+	if calls != 3 {
+		t.Errorf("Complete calls = %d, want 3 (2 map + 1 reduce)", calls)
+	}
+	if len(strings.TrimSpace(res.Text)) < 40 {
+		t.Errorf("reduced recap too short: %q", res.Text)
+	}
+}
+
+// capturingProvider records the system prompt of the first request it sees, so the
+// cassette test can assert Persona/Language without pinning exact wording.
+type capturingProvider struct {
+	inner llm.Provider
+	sys   *string
+}
+
+func (p capturingProvider) Complete(ctx context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	if *p.sys == "" && len(req.Messages) > 0 {
+		*p.sys = req.Messages[0].Text
+	}
+	return p.inner.Complete(ctx, req)
+}

--- a/internal/recap/render.go
+++ b/internal/recap/render.go
@@ -1,0 +1,66 @@
+package recap
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// renderLine renders one Transcript Line as `Who (Tag): text\n`, with the ` (Tag)`
+// segment omitted when the Line has no Tag (ADR-0040 line grain). This is the exact
+// input the LLM sees, so it is deterministic and cassette-hashable (ADR-0021).
+func renderLine(l storage.TranscriptLine) string {
+	var b strings.Builder
+	b.WriteString(l.Who)
+	if l.Tag != "" {
+		b.WriteString(" (")
+		b.WriteString(l.Tag)
+		b.WriteString(")")
+	}
+	b.WriteString(": ")
+	b.WriteString(l.Text)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderLines concatenates the rendered Lines in the given (seq) order.
+func renderLines(lines []storage.TranscriptLine) string {
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(renderLine(l))
+	}
+	return b.String()
+}
+
+// lineChars is the rendered character (rune) length of one Line — the unit the
+// budget/window thresholds are measured in.
+func lineChars(l storage.TranscriptLine) int {
+	return utf8.RuneCountInString(renderLine(l))
+}
+
+// splitWindows greedily packs consecutive WHOLE Lines into windows each no larger
+// than windowChars rendered characters (ADR-0040 seq order preserved). A single
+// Line longer than windowChars is never split — it forms its own oversized window,
+// so the map step still sees complete Lines. Returns nil for no Lines.
+func splitWindows(lines []storage.TranscriptLine, windowChars int) [][]storage.TranscriptLine {
+	var windows [][]storage.TranscriptLine
+	var cur []storage.TranscriptLine
+	curChars := 0
+	for _, l := range lines {
+		lc := lineChars(l)
+		// Start a new window when the current one is non-empty and adding this Line
+		// would exceed the budget. A lone over-budget Line stays in its own window.
+		if len(cur) > 0 && curChars+lc > windowChars {
+			windows = append(windows, cur)
+			cur = nil
+			curChars = 0
+		}
+		cur = append(cur, l)
+		curChars += lc
+	}
+	if len(cur) > 0 {
+		windows = append(windows, cur)
+	}
+	return windows
+}

--- a/internal/recap/render_test.go
+++ b/internal/recap/render_test.go
@@ -1,0 +1,70 @@
+package recap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func TestRenderLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line storage.TranscriptLine
+		want string
+	}{
+		{name: "with tag", line: storage.TranscriptLine{Who: "Bart", Tag: "npc", Text: "Well met."}, want: "Bart (npc): Well met.\n"},
+		{name: "no tag omits parens", line: storage.TranscriptLine{Who: "GM", Tag: "", Text: "You enter the tavern."}, want: "GM: You enter the tavern.\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := renderLine(tt.line); got != tt.want {
+				t.Errorf("renderLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitWindows(t *testing.T) {
+	// Each rendered line "X: yyyy\n"; make lengths easy to reason about.
+	lines := []storage.TranscriptLine{
+		{Who: "A", Text: "one"},   // "A: one\n" = 7
+		{Who: "B", Text: "two"},   // 7
+		{Who: "C", Text: "three"}, // "C: three\n" = 9
+	}
+
+	t.Run("all fit one window", func(t *testing.T) {
+		w := splitWindows(lines, 1000)
+		if len(w) != 1 {
+			t.Fatalf("got %d windows, want 1", len(w))
+		}
+		if len(w[0]) != 3 {
+			t.Errorf("window has %d lines, want 3", len(w[0]))
+		}
+	})
+
+	t.Run("splits on budget into whole lines", func(t *testing.T) {
+		// Budget 14 fits two 7-char lines but not the third (9).
+		w := splitWindows(lines, 14)
+		if len(w) != 2 {
+			t.Fatalf("got %d windows, want 2", len(w))
+		}
+		if len(w[0]) != 2 || len(w[1]) != 1 {
+			t.Errorf("window sizes = %d,%d; want 2,1", len(w[0]), len(w[1]))
+		}
+	})
+
+	t.Run("oversized single line gets its own window", func(t *testing.T) {
+		big := storage.TranscriptLine{Who: "X", Text: strings.Repeat("z", 100)}
+		w := splitWindows([]storage.TranscriptLine{big}, 10)
+		if len(w) != 1 || len(w[0]) != 1 {
+			t.Fatalf("oversized line: got %d windows, want 1 with 1 line", len(w))
+		}
+	})
+
+	t.Run("no lines -> nil", func(t *testing.T) {
+		if w := splitWindows(nil, 10); w != nil {
+			t.Errorf("splitWindows(nil) = %v, want nil", w)
+		}
+	})
+}

--- a/internal/recap/windowing_test.go
+++ b/internal/recap/windowing_test.go
@@ -1,0 +1,96 @@
+package recap
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+func bigLines(n, chars int) []storage.TranscriptLine {
+	lines := make([]storage.TranscriptLine, n)
+	for i := range lines {
+		lines[i] = storage.TranscriptLine{Seq: int64(i + 1), Who: "GM", Text: strings.Repeat("x", chars)}
+	}
+	return lines
+}
+
+// TestWindowedMapReduce: an over-budget session takes the map-reduce path — N map
+// calls plus one reduce — and reports Windowed=true.
+func TestWindowedMapReduce(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	// 30 lines of ~1000 chars => ~30k rendered > singleCallBudgetChars(24k); windows of
+	// <=20k chars => 2 windows => 2 maps + 1 reduce = 3 calls.
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), bigLines(30, 1000))
+
+	var calls int
+	factory := func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "partial", capture: func(llm.Request) { calls++ }}, nil
+	}
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(factory))
+	res, err := eng.Recap(context.Background(), []uuid.UUID{sid})
+	if err != nil {
+		t.Fatalf("Recap: %v", err)
+	}
+	if !res.Windowed {
+		t.Error("Windowed = false, want true for an over-budget session")
+	}
+	if calls != 3 {
+		t.Errorf("provider calls = %d, want 3 (2 map + 1 reduce)", calls)
+	}
+}
+
+// TestTooManyWindows: a transcript needing more than maxWindows map windows fails
+// loudly rather than fanning out unbounded calls.
+func TestTooManyWindows(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	// 33 lines each longer than windowChars => each is its own window => 33 > maxWindows(32).
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), bigLines(maxWindows+1, windowChars+10))
+
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(okFactory))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err != ErrTranscriptTooLong {
+		t.Fatalf("err = %v, want ErrTranscriptTooLong", err)
+	}
+}
+
+// TestStreamError: a mid-stream EventError fails the recap — never returns truncated
+// text as a complete recap.
+func TestStreamError(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "partial cut off", errText: "boom"}, nil
+	}))
+	_, err := eng.Recap(context.Background(), []uuid.UUID{sid})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want stream error wrapping boom", err)
+	}
+}
+
+// TestTruncatedStream: a stream that closes without EventDone fails the recap.
+func TestTruncatedStream(t *testing.T) {
+	st := newFakeStore()
+	tenantID := uuid.New()
+	butler := storage.Agent{Role: storage.AgentRoleButler, Persona: "Butler."}
+	sid := seedSession(st, tenantID, uuid.New(), "English", butler, time.Now(), sampleLines())
+
+	eng := NewEngine(st, nil, observe.Discard{}, nil, WithProviderFactory(func(_, _ string) (llm.Provider, error) {
+		return &stubProvider{text: "partial", noDone: true}, nil
+	}))
+	if _, err := eng.Recap(context.Background(), []uuid.UUID{sid}); err == nil {
+		t.Fatal("err = nil, want a truncation error for a stream missing EventDone")
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -134,7 +134,11 @@ func (s *Store) GetActiveCampaignForUser(ctx context.Context, discordUserID stri
 // context-free analogue of GetActiveCampaignForUser: it joins any users row
 // carrying a non-null active_campaign_id to a non-archived campaign. Single
 // operator, so at most one such selection is meaningful; a tie breaks on the
-// most-recently-updated users row (the freshest /glyphoxa use). ErrNotFound when
+// most-recently-updated users row — the freshest login-or-selection, NOT strictly
+// the freshest campaign selection: UpsertUser bumps users.updated_at on EVERY OAuth
+// login, not only on SetActiveCampaign, so `ORDER BY u.updated_at` is a login clock,
+// not a selection clock. Acceptable under the single-operator model (ADR-0039),
+// where at most one operator has a durable selection anyway. ErrNotFound when
 // no operator has a durable, non-archived selection (deleted/archived selections
 // are treated as absent, matching GetActiveCampaignForUser), so the caller falls
 // through to the GetActiveCampaign recent fallback.

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -166,7 +166,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestLoadedNPC_DerivesTruncationAliases(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, false, nil, nil, nil, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}

--- a/internal/wirenpc/credentials.go
+++ b/internal/wirenpc/credentials.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 )
@@ -29,29 +30,13 @@ type providerKeys struct {
 }
 
 // resolveKey resolves ONE component's API key under the hybrid BYOK policy
-// (ADR-0039):
+// (ADR-0039).
 //
-//   - cfg == nil, or cfg.CredentialsLast4 == "env" (the seeded placeholder):
-//     no real key in the DB -> "" so the adapter falls back to its env var.
-//   - a real saved key (last4 != "env") but no cipher: a CLEAR error, never a
-//     silent empty key (AC2) — boot without $GLYPHOXA_SECRET cannot quietly
-//     ignore a configured key and degrade to ENV.
-//   - a real saved key the cipher cannot open: a CLEAR error wrapping crypto's.
-//   - otherwise: the decrypted plaintext key.
-//
-// component only labels the error so an operator knows which key failed.
+// It is a one-line delegate to [llmbuild.ResolveKey]: the resolver was moved
+// verbatim into internal/llmbuild (#272) so the Recap engine shares the same BYOK
+// credential resolution as the live voice loop, under identical semantics.
 func resolveKey(cipher *crypto.Cipher, cfg *storage.ProviderConfig, component storage.Component) (string, error) {
-	if cfg == nil || cfg.CredentialsLast4 == credPlaceholderLast4 {
-		return "", nil
-	}
-	if cipher == nil {
-		return "", fmt.Errorf("wirenpc: %s key needs decryption but the credential cipher is unavailable; set $GLYPHOXA_SECRET (ADR-0004)", component)
-	}
-	plaintext, err := cipher.Open(cfg.CredentialsCiphertext)
-	if err != nil {
-		return "", fmt.Errorf("wirenpc: decrypt %s key: %w", component, err)
-	}
-	return string(plaintext), nil
+	return llmbuild.ResolveKey(cipher, cfg, component)
 }
 
 // ResolveDiscordToken resolves the Discord bot token a UI-started session drives

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -63,3 +63,31 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 		t.Errorf("tts adapter got apiKey %q, want %q — keys.tts must reach the TTS adapter", gotTTS, keys.tts)
 	}
 }
+
+// TestBuildConversation_DispatchesOffProviderID is the #272 seam guard: the LLM
+// provider id buildConversation is handed reaches [newLLM] for adapter dispatch. A
+// buildConversation that ignored the param (reverting to hardwired groq) would leave
+// a DB Agent's non-Groq LLM config silently on Groq. It needs a real Silero VAD like
+// the fan-out guard, so it is tag-isolated behind `integration` (ADR-0033).
+func TestBuildConversation_DispatchesOffProviderID(t *testing.T) {
+	origLLM := newLLM
+	t.Cleanup(func() { newLLM = origLLM })
+
+	var gotProviderID string
+	newLLM = func(providerID, apiKey string) (llm.Provider, error) {
+		gotProviderID = providerID
+		return origLLM(providerID, apiKey)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, providerKeys{}, "anthropic", false, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildConversation: %v", err)
+	}
+	defer cleanup()
+
+	if gotProviderID != "anthropic" {
+		t.Errorf("newLLM got providerID %q, want %q — the Agent's LLM provider id must drive adapter dispatch, not a hardwired groq", gotProviderID, "anthropic")
+	}
+}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	stteleven "github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -31,9 +31,9 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	t.Cleanup(func() { newLLM, newSTT, newTTS = origLLM, origSTT, origTTS })
 
 	var gotLLM, gotSTT, gotTTS string
-	newLLM = func(apiKey string, opts ...groq.Option) *groq.Client {
+	newLLM = func(providerID, apiKey string) (llm.Provider, error) {
 		gotLLM = apiKey
-		return origLLM(apiKey, opts...)
+		return origLLM(providerID, apiKey)
 	}
 	newSTT = func(apiKey string, opts ...stteleven.Option) *stteleven.Client {
 		gotSTT = apiKey
@@ -47,7 +47,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, false, nil, nil, nil, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, "", false, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/enginefactory_test.go
+++ b/internal/wirenpc/enginefactory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
@@ -44,10 +45,10 @@ func (p *modelCapturingProvider) lastModel(t *testing.T) string {
 }
 
 // generateOnce drives one Agent turn through an engine so the provider records
-// the request it carried.
-func generateOnce(t *testing.T, spec npcSpec, prov llm.Provider) {
+// the request it carried. rec/provName label the LLM spans (#272).
+func generateOnce(t *testing.T, spec npcSpec, prov llm.Provider, rec observe.StageRecorder, provName observe.Provider) {
 	t.Helper()
-	factory := engineFactory(prov, tool.NewRegistry(), "en", observe.Discard{}, retry.Policy{})
+	factory := engineFactory(prov, tool.NewRegistry(), "en", rec, provName, retry.Policy{})
 	eng := factory(spec)
 	if _, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart."},
@@ -57,13 +58,50 @@ func generateOnce(t *testing.T, spec npcSpec, prov llm.Provider) {
 	}
 }
 
+// labelCapturingRecorder records the provider label the engine tags its LLM spans
+// with, so the metrics-label threading (#272) is asserted without Prometheus.
+type labelCapturingRecorder struct {
+	observe.Discard
+	roundProvider  observe.Provider
+	tokensProvider observe.Provider
+	tokensModel    string
+}
+
+func (r *labelCapturingRecorder) LLMRound(p observe.Provider, _ int, _ bool, _ time.Duration) {
+	r.roundProvider = p
+}
+
+func (r *labelCapturingRecorder) LLMTokens(p observe.Provider, model string, _, _ int) {
+	r.tokensProvider = p
+	r.tokensModel = model
+}
+
 // TestEngineFactory_ThreadsConfiguredModel is the #227 unit pin: the model on the
 // npcSpec (resolved from provider_config) is the model the Groq request carries.
 func TestEngineFactory_ThreadsConfiguredModel(t *testing.T) {
 	prov := &modelCapturingProvider{}
-	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: "meta-llama/llama-4-scout-17b-16e-instruct"}, prov)
+	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: "meta-llama/llama-4-scout-17b-16e-instruct"}, prov, observe.Discard{}, observe.ProviderGroq)
 	if got := prov.lastModel(t); got != "meta-llama/llama-4-scout-17b-16e-instruct" {
 		t.Errorf("request model = %q, want the configured model", got)
+	}
+}
+
+// TestEngineFactory_LabelsMetricsWithProvider is the #272 guard: the provider label
+// engineFactory is built with reaches the LLM span metrics AND the token/price sink,
+// so a non-Groq voice session is not mispriced as groq. Without the threading the
+// engine hardcoded observe.ProviderGroq and this fails.
+func TestEngineFactory_LabelsMetricsWithProvider(t *testing.T) {
+	prov := &modelCapturingProvider{}
+	rec := &labelCapturingRecorder{}
+	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: "claude-x"}, prov, rec, observe.ProviderAnthropic)
+	if rec.roundProvider != observe.ProviderAnthropic {
+		t.Errorf("LLMRound provider = %q, want anthropic", rec.roundProvider)
+	}
+	if rec.tokensProvider != observe.ProviderAnthropic {
+		t.Errorf("LLMTokens provider = %q, want anthropic", rec.tokensProvider)
+	}
+	if rec.tokensModel != "claude-x" {
+		t.Errorf("LLMTokens model = %q, want claude-x", rec.tokensModel)
 	}
 }
 
@@ -73,7 +111,7 @@ func TestEngineFactory_ThreadsConfiguredModel(t *testing.T) {
 // keeps the "empty → provider default" behavior with zero duplicated defaulting.
 func TestEngineFactory_EmptyModelFlowsThrough(t *testing.T) {
 	prov := &modelCapturingProvider{}
-	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: ""}, prov)
+	generateOnce(t, npcSpec{agentID: "bart", name: "Bart", model: ""}, prov, observe.Discard{}, observe.ProviderGroq)
 	if got := prov.lastModel(t); got != "" {
 		t.Errorf("request model = %q, want empty (adapter fills the default)", got)
 	}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -831,6 +831,19 @@ func llmProviderID(cfg *storage.ProviderConfig) string {
 	return cfg.Provider
 }
 
+// llmProviderLabel maps an LLM provider id to its bounded [observe.Provider] metric
+// label (#272): the empty id (env-only / nil config) is Groq (ADR-0036). The wired
+// ids equal their observe constants, so the cast is exact. It keeps the per-round
+// LLM spans AND the spend price lookup keyed to the ACTUAL provider — a non-Groq
+// adapter mislabelled groq would price (groq, claude-model) as a miss and trip caps
+// on the frontier default.
+func llmProviderLabel(providerID string) observe.Provider {
+	if providerID == "" {
+		return observe.ProviderGroq
+	}
+	return observe.Provider(providerID)
+}
+
 // buildConversation assembles the orchestrator reactive pipeline: VAD (Silero)
 // → STT (ElevenLabs) → Address Detection → production Reply (the Agent loop over
 // Groq, with the dice Tool granted via the tool-use loop) → TTS (synth).
@@ -988,7 +1001,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		return nil, nil, nil, fmt.Errorf("wirenpc: build LLM provider: %w", err)
 	}
 	reg := tool.BuiltinRegistry()
-	engineFor := engineFactory(provider, reg, language, stageMetrics, retryPolicy)
+	engineFor := engineFactory(provider, reg, language, stageMetrics, llmProviderLabel(llmProviderID), retryPolicy)
 
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
 	// in the Matcher and its Replier (over a per-NPC engine carrying that NPC's
@@ -1048,15 +1061,16 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 // tenant-level row as fallback — flows verbatim into the request. Empty passes
 // through as "" so the openaicompat adapter fills [groq.DefaultModel]; there is
 // NO defaulting duplicated here (the AC "empty → provider default" is proven at
-// the adapter). language selects the dice gate's keyword set (#226); stageMetrics
-// labels the per-round LLM spans groq (A3).
-func engineFactory(provider llm.Provider, reg *tool.Registry, language string, stageMetrics observe.StageRecorder, retryPolicy retry.Policy) func(npcSpec) agent.Engine {
+// the adapter). language selects the dice gate's keyword set (#226). provName is
+// the ACTUAL LLM provider (#272): it labels the per-round LLM spans (A3) AND keys
+// the spend price lookup, so a non-Groq adapter is not mispriced as groq.
+func engineFactory(provider llm.Provider, reg *tool.Registry, language string, stageMetrics observe.StageRecorder, provName observe.Provider, retryPolicy retry.Policy) func(npcSpec) agent.Engine {
 	return func(spec npcSpec) agent.Engine {
 		return agenttool.NewEngine(provider, tool.NewGrantSet(reg, spec.grants...), spec.model, 0, 0,
-			// Groq is the wired provider (see buildConversation's doc), so the
-			// per-round LLM spans (A3) are labelled groq. The no-op recorder keeps the
-			// keyless path silent; the live binary / benchmark inject a real one.
-			agenttool.WithMetrics(stageMetrics, observe.ProviderGroq),
+			// The per-round LLM spans (A3) and the spend price lookup are labelled with
+			// the actual provider (#272). The no-op recorder keeps the keyless path
+			// silent; the live binary / benchmark inject a real one.
+			agenttool.WithMetrics(stageMetrics, provName),
 			// The dice gate selects its keyword set by Campaign Language (#226), so a
 			// German campaign arms the dice Tool for German roll requests instead of
 			// gating it out and forcing the model to improvise the roll.

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the database/sql "pgx" driver for the goose-backed schema check
 
+	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
@@ -34,7 +35,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agenttool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
-	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/retry"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
@@ -339,6 +339,12 @@ type Config struct {
 	// adapters. An empty key means "adapter ENV fallback", so the zero value (the
 	// env-only Run path) reproduces today's behavior untouched.
 	keys providerKeys
+	// llmProviderID is the primary Agent's LLM Provider Config provider id (#272):
+	// buildConversation dispatches [newLLM] off it so a DB Agent bound to a non-Groq
+	// LLM provider gets that adapter. Empty (the env-only Run path, or a nil LLM
+	// config) resolves to the Groq default (ADR-0036) — byte-identical to the
+	// pre-#272 hardwired constructor.
+	llmProviderID string
 	// language is the Campaign Language (CONTEXT.md) of the campaign the npcs
 	// were loaded from: it selects the Roster matcher's phonetic encoder (#199).
 	// RunFromDB sets it from the campaign row; the env-only Run path leaves it
@@ -444,6 +450,7 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *cryp
 
 	cfg.npcs = npcs
 	cfg.keys = keys
+	cfg.llmProviderID = llmProviderID(primary.LLMConfig)
 	cfg.language = campaign.Language
 	return Run(ctx, cfg)
 }
@@ -726,7 +733,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes, cfg.Gate)
+	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.llmProviderID, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes, cfg.Gate)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -808,10 +815,21 @@ func npcVoice() tts.Voice {
 // would otherwise revert the feature to ENV while every providerKeys{} test
 // stayed green. Production always uses the real constructors.
 var (
-	newLLM = groq.New
+	newLLM = llmbuild.New
 	newSTT = stteleven.New
 	newTTS = ttseleven.New
 )
+
+// llmProviderID reports the provider id of an LLM Provider Config for [newLLM]
+// dispatch (#272). A nil config — the env-only [Run] path, or a DB Agent with no
+// bound LLM config — yields "", which [llmbuild.New] resolves to the Groq default
+// (ADR-0036), keeping the pre-#272 hardwired-groq behaviour byte-identical.
+func llmProviderID(cfg *storage.ProviderConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Provider
+}
 
 // buildConversation assembles the orchestrator reactive pipeline: VAD (Silero)
 // → STT (ElevenLabs) → Address Detection → production Reply (the Agent loop over
@@ -838,13 +856,14 @@ var (
 // registered encoder — including the env-only path's "" — resolves to "en"
 // (see matcherLanguage).
 //
-// All NPCs share ONE Groq tool-engine (one client, the `dice` grant in code —
-// Tool Grants are a #6 table, not yet seeded). The LLM provider is Groq (model
-// llama-3.3-70b-versatile via the OpenAI-compat endpoint). The DB Agent's
-// provider_config provider/model is recorded but adapter selection is not yet
-// driven by it; the wired adapter is Groq for any NPC in this tree. Keyless
-// cassette tests replay the Anthropic adapter behind the same llm.Provider
-// interface.
+// All NPCs share ONE tool-engine (one client, the `dice` grant in code — Tool
+// Grants are a #6 table, not yet seeded). The LLM adapter is dispatched off the
+// primary Agent's provider_config.provider via llmProviderID -> [newLLM]
+// ([llmbuild.New], #272): the seed's groq config (model llama-3.3-70b-versatile via
+// the OpenAI-compat endpoint) and the env-only "" both resolve to Groq (ADR-0036),
+// so this stays byte-identical to the pre-#272 hardwired constructor, while a saved
+// non-Groq LLM config now gets its own adapter. Keyless cassette tests replay the
+// Anthropic adapter behind the same llm.Provider interface.
 //
 // synth is the [tts.Synthesizer] the TTS stage drives. [Run] passes a
 // [wire.TeeSynthesizer] wrapping the real ElevenLabs synthesizer so the
@@ -884,7 +903,7 @@ func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView)
 	return unsub
 }
 
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView, gate orchestrator.TurnGate) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, llmProviderID string, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView, gate orchestrator.TurnGate) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -960,7 +979,14 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// runnable NPC. The Groq client and the Registry are shared across every NPC
 	// — only the GrantSet differs per NPC — so N NPCs reuse one client rather than
 	// each opening their own.
-	provider := newLLM(keys.llm)
+	// Dispatch the LLM adapter off the Agent's Provider Config provider id (#272):
+	// an empty id (env-only path, or a nil LLM config) resolves to the Groq default
+	// (ADR-0036), so the seed's groq config stays byte-identical and the keyless
+	// cassette gate holds. A saved non-Groq provider now gets its own adapter.
+	provider, err := newLLM(llmProviderID, keys.llm)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("wirenpc: build LLM provider: %w", err)
+	}
 	reg := tool.BuiltinRegistry()
 	engineFor := engineFactory(provider, reg, language, stageMetrics, retryPolicy)
 

--- a/tests/voice-cassettes/llm-recap-single.yaml
+++ b/tests/voice-cassettes/llm-recap-single.yaml
@@ -1,0 +1,8 @@
+exchanges:
+    - prompt_hash: 847b9f6a4d3463d9e31412bbf73ed443669fe457e83bbd84abb4385f1bbdc56c
+      text: |-
+        Yes, the party's latest escapade. As the sun dipped below the horizon, casting a dreary dusk over the landscape, our intrepid adventurers arrived at the ruined keep of Aethelred. They were promptly greeted by Bart, a somewhat unwelcoming gatekeeper, who demanded they pay a toll to pass. However, the party was not interested in such frivolities, as they were on a mission to uncover the buried crypt beneath the keep, and they happened to be in possession of the esteemed Sunstone relic.
+
+        In a turn of events that I can only describe as predictably ominous, the party's declaration of their intentions seemed to have an otherworldly effect. A chill wind began to stir, and the crypt door, as if beckoned by some unseen force, slowly creaked open before them. Bart, with a tone that suggested he had witnessed this sort of thing before, ominously warned the party that their fate was now their own to bear, cautioning that the dead are not known for their forgiving nature towards trespassers. And so, with that cheerful sentiment, the party was left to ponder the wisdom of proceeding into the depths of the mysterious and presumably deadly crypt.
+      stop_reason: stop
+notes: Re-recorded against Groq llama-3.3-70b-versatile on 2026-07-09.

--- a/tests/voice-cassettes/llm-recap-windowed.yaml
+++ b/tests/voice-cassettes/llm-recap-windowed.yaml
@@ -1,0 +1,40 @@
+exchanges:
+    - prompt_hash: 1f9c02b03f489d16d647fa4a77626b5d240e30f78112e425f10756e83dfede39
+      text: |-
+        Here is a concise summary of the events:
+
+        The heroes, guided by GM and Alice, went through 30 chapters. In each chapter, they:
+        - Explored a region (numbered from 0 to 30)
+        - Bargained with a faction (numbered from 0 to 30)
+        - Fought the beast of a hollow (numbered from 0 to 30)
+
+        The events were narrated in an alternating pattern between GM and Alice, with GM starting in chapter 0 and Alice starting in chapter 1.
+      stop_reason: stop
+    - prompt_hash: 20ecf47fab57bb181428cd3e87161e70bf629e7b1dc55498a58f8d0221a87a16
+      text: |-
+        Here is a concise summary of the transcript excerpt:
+
+        The heroes' activities are described in the following chapters:
+        - Chapter 31: Explored region 31, bargained with faction 31, and fought the beast of hollow 31.
+        - Chapter 32: Explored region 32, bargained with faction 32, and fought the beast of hollow 32.
+        - Chapter 33: Explored region 33, bargained with faction 33, and fought the beast of hollow 33.
+        - Chapter 34: Explored region 34, bargained with faction 34, and fought the beast of hollow 34.
+        - Chapter 35: Explored region 35, bargained with faction 35, and fought the beast of hollow 35.
+        - Chapter 36: Explored region 36, bargained with faction 36, and fought the beast of hollow 36.
+        - Chapter 37: Explored region 37, bargained with faction 37, and fought the beast of hollow 37.
+        - Chapter 38: Explored region 38, bargained with faction 38, and fought the beast of hollow 38.
+        - Chapter 39: Explored region 39, bargained with faction 39, and fought the beast of hollow 39.
+
+        The speakers are Alice and the GM (Game Master).
+      stop_reason: stop
+    - prompt_hash: dc83366a8f014bd3e02763942feb1b792fbb3ba176d7d427d6d19a6edf5301ff
+      text: |-
+        Another thrilling installment in the annals of our heroes' escapades. As I, Gimble, take up my pen to recount the events of our most recent session, I am reminded of the unrelenting pace at which our brave adventurers forge ahead.
+
+        In the chapters that followed their initial 30 exploits, our heroes found themselves facing an additional nine regions to explore, factions to bargain with, and beasts to vanquish. It began with Chapter 31, where they delved into region 31, negotiated with faction 31, and battled the beast residing within hollow 31. This pattern continued unabated, with each subsequent chapter presenting a new region, faction, and beast to overcome.
+
+        Thus, our heroes progressed through Chapters 32 to 39, exploring regions 32 to 39, engaging in diplomatic efforts with factions 32 to 39, and testing their mettle against the beasts lurking within hollows 32 to 39. Throughout this odyssey, the narrative was expertly woven by the alternating voices of the GM and Alice, each contributing their unique perspective to the unfolding tale.
+
+        As I record these events, I am struck by the unwavering dedication of our heroes, who face each new challenge with unshakeable resolve. And so, their legend grows, as does the chronicle of their deeds, which I am honored to preserve for posterity. Now, if you will excuse me, I must attend to my tea; the recounting of such valorous exploits can be quite taxing.
+      stop_reason: stop
+notes: Re-recorded against Groq llama-3.3-70b-versatile on 2026-07-09.


### PR DESCRIPTION
Closes #272

## What

E3 Recap engine (parent epic #252, gate #271): a one-shot Voice Session summarization service.

### `internal/llmbuild` (NEW)
Shared LLM construction seam for the voice loop and recap:
- `ResolveKey` — moved verbatim from `wirenpc.resolveKey` (exported; same hybrid-BYOK semantics, ADR-0039).
- `New(providerID, apiKey)` — dispatches off `provider_config.provider` (groq/anthropic/gemini; `""`/groq default per ADR-0036; unknown id → clear error). Hardwired `groq.New` is gone.
- `FromConfig` — `ResolveKey` + `New`, carries `cfg.Model`.

`wirenpc.resolveKey` is now a one-line delegate; the `newLLM` seam is `llmbuild.New` and dispatches off the primary Agent's LLM config provider id. The seed's groq config and the env `""` both resolve to Groq, so **the voice path stays byte-identical and the keyless cassette gate holds**. The fanout integration spy adapts to the new signature.

### `internal/recap` (NEW)
- Provider resolution: Butler `llm_provider_config_id` → Tenant `llm` config → nil (groq+env default).
- Input: Transcript Lines in seq order (ADR-0040), rendered `Who (Tag): text`.
- Long-session strategy: ≤24k chars → one Butler-flavoured call; above → map-reduce over windows of whole Lines (neutral map prompt, Butler-flavoured reduce); >32 windows → `ErrTranscriptTooLong`.
- Multi-session ("last N"): chronological, each recapped independently, joined with `**Session <UTC>**` headers; empty session noted, all-empty → `ErrNoTranscript`; mixed campaigns → `ErrMixedCampaigns`.
- **Regenerate per request, never persisted** (gate #271 — no schema/migration).
- Metering (ADR-0045/0046): caps-free meter teed via `observe.TeeUsage`; provider-reported usage or `ceil(chars/4)` estimate (never zero); attributed to the recapped `voice_session_id`(s) via a structured log. **Never cap-gated** — `recap.Store` has no cap surface, so the engine cannot read a tenant cap or call `AllowTurn`.
- Plain service, **no Tool registration** (ADR-0028/0029) — Epic 7 wraps later.

### Docs / incidental
- ADR-0046 amended: idle recap calls are metered, never cap-gated, attributed to the recapped session id.
- `storage/auth.go`: fixed the `GetOperatorActiveCampaign` tie-break comment (login clock, not selection clock — PR #325 review finding). Comment-only, no behavior change.

## Tests
- `llmbuild`: ResolveKey parity, New dispatch, FromConfig model carry.
- `wirenpc`: whole suite green after delegation + seam swap (regression gate).
- `recap`: line rendering + window splitter units; provider resolution chain (fake Store + injected factory capturing providerID/key); **cassette-recorded** single-call (coherent text via tolerant normalized assertion, Persona+Language in prompt, Windowed=false) and oversized map-reduce (2 map + 1 reduce, Windowed=true); multi-session join / mixed-campaign / all-empty errors; metering (reported usage, chars/4 estimate never zero, attribution log, no cap read). Cassettes replay keyless (ADR-0021).

Local `go test -race` + `golangci-lint` green on all touched packages; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)