### PR TITLE
fix: surface a persistent current-session snapshot failure (post-#326 residual)

### DIFF
--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -357,6 +357,36 @@ describe("Session live transcript (#73)", () => {
     expect(await screen.findByText("recovered live line")).toBeInTheDocument();
   });
 
+  it("surfaces an error (not the silent empty state) when the live session's snapshot fails persistently", async () => {
+    // The live/current snapshot 500s on EVERY attempt: the retry budget (retry:2)
+    // absorbs transients, but a failure that outlasts it must surface — the #326
+    // accepted-residual was this case stranding the screen on "Listening…",
+    // masquerading as no-data.
+    globalThis.fetch = (async () => new Response("boom", { status: 500 })) as typeof fetch;
+
+    render(
+      <Providers transport={liveTransport()} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+
+    // Retries exhaust (1s + 2s backoff) → the inline error replaces the empty state.
+    expect(await screen.findByTestId("snapshot-error", {}, { timeout: 8000 })).toBeInTheDocument();
+    expect(screen.queryByText(/transcript lines will appear here/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/start a session to capture/i)).not.toBeInTheDocument();
+    // The toast fired too — same convention as the past-session surface, with the
+    // current-session wording.
+    await waitFor(() =>
+      expect(
+        vi.mocked(toast.error).mock.calls.some(([m]) => /couldn't load the session transcript/i.test(String(m))),
+      ).toBe(true),
+    );
+    // The stream never opened (it is gated on snapshot success) — the error card
+    // is the operator's signal, not a dead "Listening…".
+    expect(MockEventSource.last()).toBeUndefined();
+  }, 15000);
+
   it("seeds from the snapshot then renders streamed lines + typing dots", async () => {
     // Snapshot: live + listening, no lines yet.
     globalThis.fetch = (async () =>

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -303,17 +303,22 @@ export function Session() {
     setPendingJump({ sessionId, lineId });
   };
 
-  // Failed past-session snapshot (#270 finding 4): a browse whose DB-backed snapshot
-  // fetch errors must NOT masquerade as the empty "start a session" state — that
-  // reads as a lost archive. Surface it: a toast once + an inline error in the
-  // transcript card. Only while viewing a PAST session (a live session's own
-  // failures are the #123 connection surface).
-  const pastSnapshotFailed = viewingPast && transcript.snapshotFailed;
+  // Failed transcript snapshot (#270 finding 4, extended to the current session):
+  // a DB-backed snapshot fetch that errors must NOT masquerade as the empty state —
+  // "start a session" reads as a lost archive, "Listening…" as a mute table. A past
+  // session fails fast (retry:false); the current one lands here only after the
+  // retry budget absorbed transient blips (useSessionEvents retry policy). Surface
+  // it either way: a toast once + an inline error in the transcript card.
+  const snapshotFailed = transcript.snapshotFailed;
   useEffect(() => {
-    if (pastSnapshotFailed) {
-      toast.error("Couldn't load that session's transcript. It may be unavailable — try again.");
+    if (snapshotFailed) {
+      toast.error(
+        viewingPast
+          ? "Couldn't load that session's transcript. It may be unavailable — try again."
+          : "Couldn't load the session transcript. It may be unavailable — reload to try again.",
+      );
     }
-  }, [pastSnapshotFailed]);
+  }, [snapshotFailed, viewingPast]);
 
   return (
     <div className="gx-session">
@@ -405,9 +410,11 @@ export function Session() {
         )}
         <TranscriptSearch onOpen={openHit} />
         <Card>
-          {pastSnapshotFailed ? (
+          {snapshotFailed ? (
             <p className="gx-session__transcript-empty" role="alert" data-testid="snapshot-error">
-              Couldn't load this session's transcript. It may be unavailable — pick another session or try again.
+              {viewingPast
+                ? "Couldn't load this session's transcript. It may be unavailable — pick another session or try again."
+                : "Couldn't load the session transcript. It may be unavailable — reload to try again."}
             </p>
           ) : !hasLines && !showTyping ? (
             <p className="gx-session__transcript-empty">

--- a/web/src/screens/session/useSessionEvents.ts
+++ b/web/src/screens/session/useSessionEvents.ts
@@ -65,8 +65,9 @@ function upsertLine(prev: Transcript | undefined, line: TranscriptLine): Transcr
 
 // SessionTranscript is the cached Transcript plus a transport signal the screen
 // needs but the cache must not carry: snapshotFailed is true when the DB-backed
-// snapshot fetch failed, so a picked past session can surface an error instead of
-// masquerading as the empty "start a session" state (#270).
+// snapshot fetch failed with nothing cached, so the screen — a picked past session
+// AND the current/live one — can surface an error instead of masquerading as the
+// empty "start a session" / "Listening…" state (#270).
 export type SessionTranscript = Transcript & { snapshotFailed: boolean };
 
 export function useSessionEvents(
@@ -101,7 +102,8 @@ export function useSessionEvents(
     // behind backoff. For the CURRENT/live session, KEEP retries so a transient 500
     // is absorbed — else isSuccess never flips, the SSE tail never opens, and the
     // live screen is stuck on "Listening…" forever (staleTime Infinity, no refocus
-    // refetch). A reopen resync or manual re-pick re-fetches either way.
+    // refetch); a failure that outlasts the budget surfaces the same snapshot
+    // error. A reopen resync or manual re-pick re-fetches either way.
     retry: viewingPast ? false : 2,
     queryFn: async () => {
       const res = await fetch(`/api/v1/sessions/${sessionId}`, { credentials: "same-origin" });
@@ -183,9 +185,10 @@ export function useSessionEvents(
   }, [active, sessionId, isSuccess, queryClient, patchOne, patchSpendCap]);
 
   // snapshotFailed only counts for a session that exists — a null id is the
-  // never-run state, not a failure. The screen surfaces it only while browsing a
-  // PAST session (a live session's own failures are the #123 connection surface).
-  return { ...(data ?? EMPTY), snapshotFailed: haveSession && isError };
+  // never-run state, not a failure — and only when the snapshot NEVER landed (no
+  // cached data): a failed resync refetch keeps rendering the retained lines
+  // instead of swapping a visible transcript for an error card.
+  return { ...(data ?? EMPTY), snapshotFailed: haveSession && isError && !data };
 }
 
 // formatClock renders an RFC3339 instant as zero-padded HH:MM:SS (the design's


### PR DESCRIPTION
## What

PR #326 added an error surface (toast + inline `snapshot-error`) when a **past** session's transcript snapshot fetch (`GET /api/v1/sessions/{id}`) fails — but a **persistent** failure on the **current/live** session (after the `retry: 2` budget absorbed transients) still rendered the silent empty state ("Start a session to capture…" / "Listening…"), masquerading as no-data. This was flagged as accepted-residual in #326's review; this PR closes it.

## How

- `Session.tsx`: drop the `viewingPast &&` gate on `snapshotFailed` — the same toast-once + inline-error convention now covers the current session, with current-session wording ("reload to try again" instead of "pick another session").
- `useSessionEvents.ts`: scope `snapshotFailed` to "the snapshot **never landed**" (`isError && !data`). A failed **resync** refetch (SSE reconnect / reopen-after-browse) retains cached lines, and swapping a visible transcript for an error card would be worse than stale lines — the surface targets exactly the masquerading-as-empty case.
- Comments updated where they claimed the surface is past-only.

## Test

New vitest in the `Session live transcript (#73)` describe, following the existing mock-transport + `MockEventSource` pattern: live session, snapshot 500s on **every** attempt → retries exhaust → inline `snapshot-error` renders (neither empty-state string does), the toast fires with the current-session wording, and no EventSource ever opens (stream is gated on snapshot success).

Full web suite: 202/202 green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)