### PR TITLE
feat(#274): [E3] Web recap — GenerateRecap RPC + Recap button on the Session screen

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/recall"
+	"github.com/MrWong99/Glyphoxa/internal/recap"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
@@ -505,7 +506,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			}
 		}
 	}
-	mounts := managementMounts(store, cipher, log, mgr, relay, presenceRefresh)
+	mounts := managementMounts(store, cipher, metrics, log, mgr, relay, presenceRefresh)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -566,7 +567,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
 // Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, presenceRefresh func()) []web.Mount {
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, presenceRefresh func()) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses
@@ -622,7 +623,13 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, log *slog.Log
 	providerSrv.SetDiscordApplicationID(clientID)
 	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
-	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, log).Handler(stack.HandlerOptions()...)
+	// The recap engine regenerates Butler-flavoured Session recaps on demand
+	// (#272/#274, gate #271: never persisted). It spends provider money per call
+	// and meters usage, so SessionService.GenerateRecap is CSRF-guarded like a
+	// mutation. NOTE (#273 sibling): when the slash-command branch lands it owns a
+	// single recap.NewEngine construction — collapse this into that one instance.
+	recapEngine := recap.NewEngine(store, cipher, metrics, log)
+	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, recapEngine, log).Handler(stack.HandlerOptions()...)
 
 	return []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),

--- a/internal/rpc/campaign_archive_integration_test.go
+++ b/internal/rpc/campaign_archive_integration_test.go
@@ -128,7 +128,7 @@ func TestStartSessionRefusedWhenOnlyCampaignArchived(t *testing.T) {
 		}
 	})
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(mgr, store, nil).Handler(connect.WithInterceptors(inject)))
+	mux.Handle(rpc.NewSessionServer(mgr, store, nil, nil).Handler(connect.WithInterceptors(inject)))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -14,6 +14,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/recap"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -52,6 +53,18 @@ type SessionStore interface {
 	GetLatestVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error)
 	ListVoiceSessions(ctx context.Context, campaignID uuid.UUID, limit int) ([]storage.VoiceSession, error)
 	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
+	// GetVoiceSession loads one Voice Session by id for the GenerateRecap ownership
+	// check (#274): the resolved Active Campaign must own every requested id, else
+	// CodeNotFound (existence never leaked). storage.ErrNotFound for a missing id.
+	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
+}
+
+// RecapEngine regenerates a Butler-flavoured Recap over the given Voice Sessions
+// (#272/#274). *recap.Engine satisfies it; tests inject a fake. It NEVER persists
+// (gate #271) and spends provider money per call, so GenerateRecap is guarded like
+// a mutation (ADR-0039).
+type RecapEngine interface {
+	Recap(ctx context.Context, sessionIDs []uuid.UUID) (recap.Result, error)
 }
 
 // searchTranscriptLimit caps a transcript search result set (#120). It is a fixed
@@ -68,19 +81,20 @@ const listSessionsLimit = 50
 // SessionStore: Start/Stop drive the in-process loop, GetSession reports the live
 // or last session.
 type SessionServer struct {
-	mgr   SessionManager
-	store SessionStore
-	log   *slog.Logger
+	mgr      SessionManager
+	store    SessionStore
+	recapper RecapEngine
+	log      *slog.Logger
 }
 
 var _ managementv1connect.SessionServiceHandler = (*SessionServer)(nil)
 
-// NewSessionServer wraps the manager + store in a SessionServer.
-func NewSessionServer(mgr SessionManager, store SessionStore, log *slog.Logger) *SessionServer {
+// NewSessionServer wraps the manager + store + recap engine in a SessionServer.
+func NewSessionServer(mgr SessionManager, store SessionStore, recapper RecapEngine, log *slog.Logger) *SessionServer {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &SessionServer{mgr: mgr, store: store, log: log}
+	return &SessionServer{mgr: mgr, store: store, recapper: recapper, log: log}
 }
 
 // Handler builds the Connect HTTP handler for SessionService and returns its
@@ -362,6 +376,81 @@ func (s *SessionServer) ListSessions(
 		out = append(out, toProtoVoiceSession(vs))
 	}
 	return connect.NewResponse(&managementv1.ListSessionsResponse{Sessions: out}), nil
+}
+
+// GenerateRecap regenerates a Butler-flavoured Recap over the requested Voice
+// Sessions (#274, gate #271: never persisted). The Campaign is resolved
+// server-side via the SAME searchCampaign policy the reads use (live Voice
+// Session first, else the profile-first durable selection / most-recent fallback)
+// — no Active Campaign is CodeFailedPrecondition. Every session_id MUST belong to
+// that resolved Campaign: an unparsable id, a storage.ErrNotFound, or a session
+// whose CampaignID differs is CodeNotFound — the SAME never-leak-existence posture
+// as SetAgentMute, so a probe can't learn whether a foreign id exists. Empty
+// session_ids is CodeInvalidArgument. Recapping a RUNNING session is allowed: its
+// Lines already exist and the snapshot simply grows, so the recap covers the
+// transcript as of the call. recap.ErrNoTranscript (nothing to summarize) is
+// CodeFailedPrecondition; any other engine error is logged and returned as a
+// static CodeInternal. State-changing (spends money): auth + CSRF guard it.
+func (s *SessionServer) GenerateRecap(
+	ctx context.Context,
+	req *connect.Request[managementv1.GenerateRecapRequest],
+) (*connect.Response[managementv1.GenerateRecapResponse], error) {
+	rawIDs := req.Msg.GetSessionIds()
+	if len(rawIDs) == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("at least one session id is required"))
+	}
+
+	// A foreign/unknown/unparsable id names no session in the Active Campaign — one
+	// static NotFound for all three, so existence is never leaked (mirrors SetAgentMute).
+	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such session in the Active Campaign"))
+
+	campaignID, ok, err := s.searchCampaign(ctx)
+	if err != nil {
+		s.log.Error("GenerateRecap: resolve active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if !ok {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active campaign"))
+	}
+
+	sessionIDs := make([]uuid.UUID, 0, len(rawIDs))
+	for _, raw := range rawIDs {
+		id, perr := uuid.Parse(raw)
+		if perr != nil {
+			return nil, notFound // a non-UUID id names no session
+		}
+		vs, gerr := s.store.GetVoiceSession(ctx, id)
+		if errors.Is(gerr, storage.ErrNotFound) {
+			return nil, notFound
+		}
+		if gerr != nil {
+			s.log.Error("GenerateRecap: load voice session failed", "err", gerr)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		if vs.CampaignID != campaignID {
+			return nil, notFound // cross-campaign id: never leak that it exists
+		}
+		sessionIDs = append(sessionIDs, id)
+	}
+
+	res, err := s.recapper.Recap(ctx, sessionIDs)
+	if errors.Is(err, recap.ErrNoTranscript) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no transcript to summarize"))
+	}
+	if err != nil {
+		s.log.Error("GenerateRecap: recap engine failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	outIDs := make([]string, len(res.SessionIDs))
+	for i, id := range res.SessionIDs {
+		outIDs[i] = id.String()
+	}
+	return connect.NewResponse(&managementv1.GenerateRecapResponse{
+		Text:       res.Text,
+		SessionIds: outIDs,
+		Windowed:   res.Windowed,
+	}), nil
 }
 
 // searchCampaign resolves the campaign the web transcript search scopes to: the

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -77,6 +77,11 @@ const searchTranscriptLimit = 50
 // tier (ADR-0039); the client sends no limit.
 const listSessionsLimit = 50
 
+// maxRecapSessions caps how many Voice Sessions one GenerateRecap may span (#274).
+// The web recaps a single session; the cap is a spend guardrail (each session is a
+// money-spending LLM call, gate #271), set well above any realistic pick.
+const maxRecapSessions = 20
+
 // SessionServer implements the Connect SessionService over a SessionManager +
 // SessionStore: Start/Stop drive the in-process loop, GetSession reports the live
 // or last session.
@@ -388,9 +393,11 @@ func (s *SessionServer) ListSessions(
 // as SetAgentMute, so a probe can't learn whether a foreign id exists. Empty
 // session_ids is CodeInvalidArgument. Recapping a RUNNING session is allowed: its
 // Lines already exist and the snapshot simply grows, so the recap covers the
-// transcript as of the call. recap.ErrNoTranscript (nothing to summarize) is
+// transcript as of the call. recap.ErrNoTranscript (nothing to summarize) and
+// recap.ErrTranscriptTooLong (a retry can never succeed) are both static
 // CodeFailedPrecondition; any other engine error is logged and returned as a
-// static CodeInternal. State-changing (spends money): auth + CSRF guard it.
+// static CodeInternal. An over-cap session_ids count is CodeInvalidArgument (a
+// spend guardrail). State-changing (spends money): auth + CSRF guard it.
 func (s *SessionServer) GenerateRecap(
 	ctx context.Context,
 	req *connect.Request[managementv1.GenerateRecapRequest],
@@ -398,6 +405,12 @@ func (s *SessionServer) GenerateRecap(
 	rawIDs := req.Msg.GetSessionIds()
 	if len(rawIDs) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("at least one session id is required"))
+	}
+	// Belt-and-braces spend guard (gate #271): the web sends one id; an unreasonable
+	// count would fan out that many money-spending LLM calls. Cap it well above any
+	// realistic pick.
+	if len(rawIDs) > maxRecapSessions {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("too many session ids to recap at once"))
 	}
 
 	// A foreign/unknown/unparsable id names no session in the Active Campaign — one
@@ -436,6 +449,11 @@ func (s *SessionServer) GenerateRecap(
 	res, err := s.recapper.Recap(ctx, sessionIDs)
 	if errors.Is(err, recap.ErrNoTranscript) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no transcript to summarize"))
+	}
+	if errors.Is(err, recap.ErrTranscriptTooLong) {
+		// Deterministic + operator-meaningful (a retry can never succeed): a precondition,
+		// not an internal fault. Name the condition without echoing internals.
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("transcript too long to recap"))
 	}
 	if err != nil {
 		s.log.Error("GenerateRecap: recap engine failed", "err", err)

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -2,9 +2,11 @@ package rpc_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +17,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/recap"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
@@ -175,6 +178,9 @@ type fakeSessionStore struct {
 	listCampaign    uuid.UUID // the campaign id the handler passed to ListVoiceSessions (#270)
 	listLimit       int       // the limit the handler passed (the fixed server policy)
 	listSessionCall int
+
+	voiceSessions map[uuid.UUID]storage.VoiceSession // GenerateRecap ownership lookups (#274)
+	getVoiceErr   error                              // forced non-NotFound error for GetVoiceSession
 }
 
 func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
@@ -233,6 +239,54 @@ func (f *fakeSessionStore) ListVoiceSessions(_ context.Context, campaignID uuid.
 	return f.listSessions, nil
 }
 
+func (f *fakeSessionStore) GetVoiceSession(_ context.Context, id uuid.UUID) (storage.VoiceSession, error) {
+	if f.getVoiceErr != nil {
+		return storage.VoiceSession{}, f.getVoiceErr
+	}
+	vs, ok := f.voiceSessions[id]
+	if !ok {
+		return storage.VoiceSession{}, storage.ErrNotFound
+	}
+	return vs, nil
+}
+
+// fakeRecapEngine records the ids it is asked to recap and returns a canned
+// result or error, so the GenerateRecap handler's wiring + error mapping are
+// tested without an LLM.
+type fakeRecapEngine struct {
+	gotIDs []uuid.UUID
+	calls  int
+	result recap.Result
+	err    error
+}
+
+func (f *fakeRecapEngine) Recap(_ context.Context, ids []uuid.UUID) (recap.Result, error) {
+	f.calls++
+	f.gotIDs = ids
+	if f.err != nil {
+		return recap.Result{}, f.err
+	}
+	return f.result, nil
+}
+
+// newRecapClient mounts a SessionServer with an injected recap engine + an
+// authenticated operator, for the GenerateRecap tests.
+func newRecapClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore, recapper rpc.RecapEngine) managementv1connect.SessionServiceClient {
+	t.Helper()
+	tenantID := uuid.New()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx = auth.WithTenant(ctx, tenantID)
+			return next(ctx, req)
+		}
+	})
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(mgr, store, recapper, nil).Handler(connect.WithInterceptors(inject)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
 func newSessionClient(t *testing.T, mgr rpc.SessionManager, store rpc.SessionStore) managementv1connect.SessionServiceClient {
 	return newSessionClientAs(t, mgr, store, storage.User{})
 }
@@ -253,7 +307,7 @@ func newSessionClientAs(t *testing.T, mgr rpc.SessionManager, store rpc.SessionS
 		}
 	})
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(mgr, store, nil).Handler(connect.WithInterceptors(inject)))
+	mux.Handle(rpc.NewSessionServer(mgr, store, nil, nil).Handler(connect.WithInterceptors(inject)))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
@@ -467,7 +521,7 @@ func TestGetSession_CarriesMutedAgentIds(t *testing.T) {
 func TestSessionMute_CSRFGuardsMutationNotRead(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil).Handler(
 		connect.WithInterceptors(auth.NewCSRFInterceptor()),
 	))
 	srv := httptest.NewServer(mux)
@@ -583,7 +637,7 @@ func TestListSessions_NoCampaignReturnsEmpty(t *testing.T) {
 func TestListSessions_CSRFExemptAsRead(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil).Handler(
 		connect.WithInterceptors(auth.NewCSRFInterceptor()),
 	))
 	srv := httptest.NewServer(mux)
@@ -968,7 +1022,7 @@ func TestSearchTranscriptNoCampaignReturnsEmpty(t *testing.T) {
 func TestSearchTranscriptAuthGatesLikeSiblings(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil).Handler(
 		connect.WithInterceptors(auth.NewAuthInterceptor(denyAuth{})),
 	))
 	srv := httptest.NewServer(mux)
@@ -992,7 +1046,7 @@ func TestSearchTranscriptAuthGatesLikeSiblings(t *testing.T) {
 func TestSearchTranscriptCSRFExemptAsRead(t *testing.T) {
 	t.Parallel()
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil).Handler(
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil).Handler(
 		connect.WithInterceptors(auth.NewCSRFInterceptor()),
 	))
 	srv := httptest.NewServer(mux)
@@ -1008,5 +1062,224 @@ func TestSearchTranscriptCSRFExemptAsRead(t *testing.T) {
 	// The read is exempt — no token still reaches the handler.
 	if _, err := client.SearchTranscriptLines(ctx, connect.NewRequest(&managementv1.SearchTranscriptLinesRequest{Query: "dragon"})); connect.CodeOf(err) == connect.CodePermissionDenied {
 		t.Error("SearchTranscriptLines must be CSRF-exempt (NO_SIDE_EFFECTS read)")
+	}
+}
+
+// recapStore returns a fake store whose Active Campaign owns the given sessions,
+// so a GenerateRecap over those ids passes the ownership check.
+func recapStore(campaignID uuid.UUID, sessions ...storage.VoiceSession) *fakeSessionStore {
+	m := make(map[uuid.UUID]storage.VoiceSession, len(sessions))
+	for _, vs := range sessions {
+		m[vs.ID] = vs
+	}
+	return &fakeSessionStore{
+		campaign:      storage.Campaign{ID: campaignID, Name: "Sunless Citadel"},
+		latestErr:     storage.ErrNotFound,
+		voiceSessions: m,
+	}
+}
+
+// TestGenerateRecap_EmptyIDsIsInvalidArgument: no session ids is
+// CodeInvalidArgument and never reaches the engine.
+func TestGenerateRecap_EmptyIDsIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	engine := &fakeRecapEngine{}
+	client := newRecapClient(t, &fakeSessionManager{}, recapStore(uuid.New()), engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: nil}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("empty ids code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times for empty ids, want 0", engine.calls)
+	}
+}
+
+// TestGenerateRecap_UnparsableIDIsNotFound: a non-UUID id names no session and is
+// CodeNotFound (never reaching the engine) — the never-leak-existence posture.
+func TestGenerateRecap_UnparsableIDIsNotFound(t *testing.T) {
+	t.Parallel()
+	engine := &fakeRecapEngine{}
+	client := newRecapClient(t, &fakeSessionManager{}, recapStore(uuid.New()), engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{"not-a-uuid"}}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("unparsable id code = %v, want NotFound", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times for unparsable id, want 0", engine.calls)
+	}
+}
+
+// TestGenerateRecap_ForeignCampaignIDIsNotFound: a session that exists but belongs
+// to another Campaign is CodeNotFound — existence is never leaked, and the engine
+// is never asked to cross campaigns (AC1).
+func TestGenerateRecap_ForeignCampaignIDIsNotFound(t *testing.T) {
+	t.Parallel()
+	activeCampaign := uuid.New()
+	foreign := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New(), Status: storage.VoiceSessionEnded}
+	store := recapStore(activeCampaign, foreign) // exists in the store, but owned by another campaign
+	engine := &fakeRecapEngine{}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{foreign.ID.String()}}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("foreign-campaign id code = %v, want NotFound", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times for foreign id, want 0", engine.calls)
+	}
+}
+
+// TestGenerateRecap_MissingIDIsNotFound: a well-formed id that no session matches
+// (storage.ErrNotFound) is CodeNotFound.
+func TestGenerateRecap_MissingIDIsNotFound(t *testing.T) {
+	t.Parallel()
+	engine := &fakeRecapEngine{}
+	client := newRecapClient(t, &fakeSessionManager{}, recapStore(uuid.New()), engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{uuid.NewString()}}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("missing id code = %v, want NotFound", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times for missing id, want 0", engine.calls)
+	}
+}
+
+// TestGenerateRecap_NoActiveCampaignIsFailedPrecondition: with no live session and
+// no Active Campaign, GenerateRecap is CodeFailedPrecondition — there is no
+// campaign to scope ownership to.
+func TestGenerateRecap_NoActiveCampaignIsFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	store := &fakeSessionStore{campaignErr: storage.ErrNotFound}
+	engine := &fakeRecapEngine{}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{uuid.NewString()}}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("no-campaign code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times with no campaign, want 0", engine.calls)
+	}
+}
+
+// TestGenerateRecap_HappyPath: the handler resolves the Active Campaign, checks
+// every id's ownership, calls the engine with the parsed UUIDs, and maps the
+// Result onto the wire (text / session_ids / windowed).
+func TestGenerateRecap_HappyPath(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	s1 := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionEnded}
+	s2 := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionEnded}
+	store := recapStore(campaignID, s1, s2)
+	engine := &fakeRecapEngine{result: recap.Result{
+		Text:       "The party bested the goblin warren.",
+		SessionIDs: []uuid.UUID{s1.ID, s2.ID},
+		Windowed:   true,
+	}}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	resp, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{s1.ID.String(), s2.ID.String()}}))
+	if err != nil {
+		t.Fatalf("GenerateRecap: %v", err)
+	}
+	if len(engine.gotIDs) != 2 || engine.gotIDs[0] != s1.ID || engine.gotIDs[1] != s2.ID {
+		t.Errorf("engine got ids %v, want the parsed UUIDs [%s %s]", engine.gotIDs, s1.ID, s2.ID)
+	}
+	if resp.Msg.GetText() != "The party bested the goblin warren." {
+		t.Errorf("text = %q, want the engine's recap prose", resp.Msg.GetText())
+	}
+	if got := resp.Msg.GetSessionIds(); len(got) != 2 || got[0] != s1.ID.String() || got[1] != s2.ID.String() {
+		t.Errorf("session_ids = %v, want [%s %s]", got, s1.ID, s2.ID)
+	}
+	if !resp.Msg.GetWindowed() {
+		t.Error("windowed = false, want true (mapped from the Result)")
+	}
+}
+
+// TestGenerateRecap_NoTranscriptIsFailedPrecondition: recap.ErrNoTranscript
+// (nothing to summarize) maps to CodeFailedPrecondition, not Internal.
+func TestGenerateRecap_NoTranscriptIsFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionEnded}
+	store := recapStore(campaignID, vs)
+	engine := &fakeRecapEngine{err: recap.ErrNoTranscript}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{vs.ID.String()}}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("no-transcript code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestGenerateRecap_EngineErrorIsInternal: any other engine failure is a logged,
+// static CodeInternal — the underlying error is never echoed to the client.
+func TestGenerateRecap_EngineErrorIsInternal(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionEnded}
+	store := recapStore(campaignID, vs)
+	engine := &fakeRecapEngine{err: errors.New("groq: 500 upstream boom")}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{vs.ID.String()}}))
+	if connect.CodeOf(err) != connect.CodeInternal {
+		t.Errorf("engine-error code = %v, want Internal", connect.CodeOf(err))
+	}
+	if err != nil && strings.Contains(err.Error(), "boom") {
+		t.Errorf("error message %q leaks the underlying engine error", err.Error())
+	}
+}
+
+// TestGenerateRecap_RunningSessionAllowed pins the documented policy: a RUNNING
+// Voice Session may be recapped (its Lines exist; the snapshot grows). The live
+// session's campaign scopes ownership, and the engine is called with its id.
+func TestGenerateRecap_RunningSessionAllowed(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	running := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionRunning}
+	store := recapStore(campaignID, running)
+	mgr := &fakeSessionManager{active: true, current: running}
+	engine := &fakeRecapEngine{result: recap.Result{Text: "so far…", SessionIDs: []uuid.UUID{running.ID}}}
+	client := newRecapClient(t, mgr, store, engine)
+
+	if _, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{running.ID.String()}})); err != nil {
+		t.Fatalf("GenerateRecap of running session: %v", err)
+	}
+	if len(engine.gotIDs) != 1 || engine.gotIDs[0] != running.ID {
+		t.Errorf("engine got %v, want the running session id %s", engine.gotIDs, running.ID)
+	}
+}
+
+// TestGenerateRecap_CSRFGuardsAsMutation pins the ADR-0039 posture: GenerateRecap
+// spends provider money, so it is deliberately NOT NO_SIDE_EFFECTS — with the CSRF
+// interceptor mounted and no double-submit token it is PermissionDenied, exactly
+// like StartSession.
+func TestGenerateRecap_CSRFGuardsAsMutation(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.Handle(rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), &fakeRecapEngine{}, nil).Handler(
+		connect.WithInterceptors(auth.NewCSRFInterceptor()),
+	))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewSessionServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{uuid.NewString()}}))
+	if got := connect.CodeOf(err); got != connect.CodePermissionDenied {
+		t.Errorf("GenerateRecap code = %v, want PermissionDenied (CSRF-guarded mutation)", got)
 	}
 }

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -181,6 +181,7 @@ type fakeSessionStore struct {
 
 	voiceSessions map[uuid.UUID]storage.VoiceSession // GenerateRecap ownership lookups (#274)
 	getVoiceErr   error                              // forced non-NotFound error for GetVoiceSession
+	getVoiceCalls int                                // GetVoiceSession call count (spend-cap guard test)
 }
 
 func (f *fakeSessionStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
@@ -240,6 +241,7 @@ func (f *fakeSessionStore) ListVoiceSessions(_ context.Context, campaignID uuid.
 }
 
 func (f *fakeSessionStore) GetVoiceSession(_ context.Context, id uuid.UUID) (storage.VoiceSession, error) {
+	f.getVoiceCalls++
 	if f.getVoiceErr != nil {
 		return storage.VoiceSession{}, f.getVoiceErr
 	}
@@ -1219,6 +1221,50 @@ func TestGenerateRecap_NoTranscriptIsFailedPrecondition(t *testing.T) {
 		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{vs.ID.String()}}))
 	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
 		t.Errorf("no-transcript code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestGenerateRecap_TranscriptTooLongIsFailedPrecondition: recap.ErrTranscriptTooLong
+// is deterministic + operator-meaningful (a retry can never succeed), so it maps to
+// CodeFailedPrecondition, not the generic Internal.
+func TestGenerateRecap_TranscriptTooLongIsFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	campaignID := uuid.New()
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionEnded}
+	store := recapStore(campaignID, vs)
+	engine := &fakeRecapEngine{err: recap.ErrTranscriptTooLong}
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: []string{vs.ID.String()}}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("too-long code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+// TestGenerateRecap_TooManyIDsIsInvalidArgument: a request spanning an
+// unreasonable number of sessions is rejected CodeInvalidArgument before any
+// ownership lookup or engine call — a spend guardrail (gate #271).
+func TestGenerateRecap_TooManyIDsIsInvalidArgument(t *testing.T) {
+	t.Parallel()
+	engine := &fakeRecapEngine{}
+	store := recapStore(uuid.New())
+	client := newRecapClient(t, &fakeSessionManager{}, store, engine)
+
+	ids := make([]string, 21) // just over the cap
+	for i := range ids {
+		ids[i] = uuid.NewString()
+	}
+	_, err := client.GenerateRecap(context.Background(),
+		connect.NewRequest(&managementv1.GenerateRecapRequest{SessionIds: ids}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("too-many-ids code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times for over-cap request, want 0", engine.calls)
+	}
+	if store.getVoiceCalls != 0 {
+		t.Errorf("store.GetVoiceSession called %d times for over-cap request, want 0", store.getVoiceCalls)
 	}
 }
 

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -989,6 +989,32 @@ service SessionService {
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // GenerateRecap regenerates a Butler-flavored Recap over the given sessions
+  // (#271: never persisted). Every session_id must belong to the resolved
+  // Active Campaign (cross-campaign/unparsable -> CodeNotFound). Deliberately
+  // NOT NO_SIDE_EFFECTS: each call spends provider money + records usage, so
+  // CSRF + auth guard it like a mutation.
+  rpc GenerateRecap(GenerateRecapRequest) returns (GenerateRecapResponse);
+}
+
+// GenerateRecapRequest carries the Voice Session ids to recap; each must belong
+// to the server-resolved Active Campaign (ADR-0039) — a cross-campaign or
+// unparsable id is CodeNotFound (existence never leaked).
+message GenerateRecapRequest {
+  // session_ids are the Voice Sessions to summarize into one recap.
+  repeated string session_ids = 1;
+}
+
+// GenerateRecapResponse carries the regenerated recap prose, the recapped
+// session ids (chronological), and whether any session took the map-reduce
+// (windowed) path.
+message GenerateRecapResponse {
+  // text is the Butler-flavored recap prose.
+  string text = 1;
+  // session_ids are the recapped sessions in chronological (started_at) order.
+  repeated string session_ids = 2;
+  // windowed reports whether any session was map-reduced over windows.
+  bool windowed = 3;
 }
 
 // ListSessionsRequest is the (empty) request; the Active Campaign is resolved

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -24,6 +24,7 @@ import {
   TranscriptLineMatchSchema,
   SearchTranscriptLinesResponseSchema,
   ListSessionsResponseSchema,
+  GenerateRecapResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -1181,6 +1182,198 @@ describe("Session past-session view across a campaign switch (#270 finding 1)", 
     expect(await screen.findByText("B current line")).toBeInTheDocument();
     expect(screen.queryByText("A archived line")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /back to current session/i })).not.toBeInTheDocument();
+  });
+});
+
+// --- Recap (#274) -----------------------------------------------------------
+
+// recapStartISO is the fixed start instant of the idle ended session the recap
+// tests cover; the result card's label is derived from it (formatStamp).
+const recapStartISO = "2026-07-08T20:15:00Z";
+
+// recapStampLabel replicates the screen's formatStamp for the covered session, so
+// the label assertion is timezone-consistent with the render (both run in this env).
+function recapStampLabel(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// recapTransport serves an IDLE ended session (vs1) plus a configurable
+// GenerateRecap handler, recording the session_ids each call requested. sessions
+// seeds the past-session picker (empty by default).
+function recapTransport(
+  recap: (req: { sessionIds: string[] }) => Promise<ReturnType<typeof create<typeof GenerateRecapResponseSchema>>>,
+  sessions: ReturnType<typeof create<typeof VoiceSessionSchema>>[] = [],
+) {
+  const ended = create(VoiceSessionSchema, {
+    id: "vs1",
+    campaignId: "c1",
+    status: "ended",
+    startedAt: timestampFromDate(new Date(recapStartISO)),
+    endedAt: timestampFromDate(new Date("2026-07-08T21:00:00Z")),
+    lineCount: 12,
+  });
+  const requested: string[][] = [];
+  const transport = createRouterTransport(({ service }) => {
+    service(SessionService, {
+      getSession: () => create(GetSessionResponseSchema, { session: ended, active: false }),
+      listSessions: () => create(ListSessionsResponseSchema, { sessions }),
+      generateRecap: async (req) => {
+        requested.push(req.sessionIds);
+        return await recap(req);
+      },
+    });
+    service(CampaignService, {
+      getActiveCampaign: () =>
+        create(GetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: "c1", name: "The Sunless Citadel" }),
+        }),
+    });
+  });
+  return { transport, requested };
+}
+
+describe("Session recap (#274)", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear();
+    // Idle snapshot for the covered session(s): no lines needed for the recap tests.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ lines: [], status: "idle", typing: { active: false, label: "" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+  });
+
+  it("recaps the latest ended session: pending spinner + disabled, then a labelled result card", async () => {
+    // Gate the recap so the pending state is observable (a real call can take ~2min).
+    let release!: (r: ReturnType<typeof create<typeof GenerateRecapResponseSchema>>) => void;
+    const gate = new Promise<ReturnType<typeof create<typeof GenerateRecapResponseSchema>>>((res) => {
+      release = res;
+    });
+    const { transport, requested } = recapTransport(() => gate);
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    const button = await screen.findByTestId("recap-button");
+    fireEvent.click(button);
+
+    // Pending: spinner shown, button disabled, no result yet.
+    expect(await screen.findByTestId("recap-pending")).toBeInTheDocument();
+    expect(screen.getByTestId("recap-button")).toBeDisabled();
+    expect(screen.queryByTestId("recap-result")).not.toBeInTheDocument();
+
+    // The mutation carried exactly the covered session id.
+    expect(requested).toEqual([["vs1"]]);
+
+    // Resolve → result card with the recap prose, labelled by the covered session's start.
+    await act(async () => {
+      release(create(GenerateRecapResponseSchema, { text: "The party bested the goblin warren.", sessionIds: ["vs1"], windowed: false }));
+    });
+    const result = await screen.findByTestId("recap-result");
+    expect(result).toHaveTextContent("The party bested the goblin warren.");
+    expect(result).toHaveTextContent(recapStampLabel(recapStartISO));
+    expect(screen.queryByTestId("recap-pending")).not.toBeInTheDocument();
+  });
+
+  it("recaps the picked past session (its id, not the current one)", async () => {
+    const older = create(VoiceSessionSchema, {
+      id: "vsOld",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(Date.now() - 5 * 60 * 60 * 1000)),
+      endedAt: timestampFromDate(new Date(Date.now() - 4 * 60 * 60 * 1000)),
+      lineCount: 5,
+    });
+    const latest = create(VoiceSessionSchema, {
+      id: "vs1",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(recapStartISO)),
+      endedAt: timestampFromDate(new Date("2026-07-08T21:00:00Z")),
+      lineCount: 12,
+    });
+    const { transport, requested } = recapTransport(
+      async () => create(GenerateRecapResponseSchema, { text: "Recap of the older delve.", sessionIds: ["vsOld"], windowed: true }),
+      [latest, older],
+    );
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    // Browse the older past session, then recap it.
+    const picker = await screen.findByTestId("session-picker");
+    fireEvent.click(within(picker).getByText(/5 lines/));
+    fireEvent.click(await screen.findByTestId("recap-button"));
+
+    await waitFor(() => expect(requested).toEqual([["vsOld"]]));
+    expect(await screen.findByTestId("recap-result")).toHaveTextContent("Recap of the older delve.");
+  });
+
+  it("surfaces a recap failure as a toast (ADR-0017 sonner), no result card", async () => {
+    const { transport } = recapTransport(async () => {
+      throw new ConnectError("recap: no active campaign", Code.FailedPrecondition);
+    });
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    fireEvent.click(await screen.findByTestId("recap-button"));
+    await waitFor(() =>
+      expect(vi.mocked(toast.error).mock.calls.some(([m]) => /couldn't generate the recap/i.test(String(m)))).toBe(true),
+    );
+    expect(screen.queryByTestId("recap-result")).not.toBeInTheDocument();
+  });
+
+  it("clears a shown recap when the viewed session changes", async () => {
+    const older = create(VoiceSessionSchema, {
+      id: "vsOld",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(Date.now() - 5 * 60 * 60 * 1000)),
+      endedAt: timestampFromDate(new Date(Date.now() - 4 * 60 * 60 * 1000)),
+      lineCount: 5,
+    });
+    const latest = create(VoiceSessionSchema, {
+      id: "vs1",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(recapStartISO)),
+      endedAt: timestampFromDate(new Date("2026-07-08T21:00:00Z")),
+      lineCount: 12,
+    });
+    const { transport } = recapTransport(
+      async () => create(GenerateRecapResponseSchema, { text: "A recap of the current session.", sessionIds: ["vs1"], windowed: false }),
+      [latest, older],
+    );
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    // Recap the default (current) session → result shows.
+    fireEvent.click(await screen.findByTestId("recap-button"));
+    expect(await screen.findByTestId("recap-result")).toBeInTheDocument();
+
+    // Browse a past session → the stale recap is dropped (it labelled the current one).
+    const picker = screen.getByTestId("session-picker");
+    fireEvent.click(within(picker).getByText(/5 lines/));
+    await waitFor(() => expect(screen.queryByTestId("recap-result")).not.toBeInTheDocument());
   });
 });
 

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1375,6 +1375,52 @@ describe("Session recap (#274)", () => {
     fireEvent.click(within(picker).getByText(/5 lines/));
     await waitFor(() => expect(screen.queryByTestId("recap-result")).not.toBeInTheDocument());
   });
+
+  it("does NOT render an in-flight recap that resolves after the session changed", async () => {
+    const older = create(VoiceSessionSchema, {
+      id: "vsOld",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(Date.now() - 5 * 60 * 60 * 1000)),
+      endedAt: timestampFromDate(new Date(Date.now() - 4 * 60 * 60 * 1000)),
+      lineCount: 5,
+    });
+    const latest = create(VoiceSessionSchema, {
+      id: "vs1",
+      campaignId: "c1",
+      status: "ended",
+      startedAt: timestampFromDate(new Date(recapStartISO)),
+      endedAt: timestampFromDate(new Date("2026-07-08T21:00:00Z")),
+      lineCount: 12,
+    });
+    // Gate the recap so it is still in flight when we switch sessions.
+    let release!: (r: ReturnType<typeof create<typeof GenerateRecapResponseSchema>>) => void;
+    const gate = new Promise<ReturnType<typeof create<typeof GenerateRecapResponseSchema>>>((res) => {
+      release = res;
+    });
+    const { transport } = recapTransport(() => gate, [latest, older]);
+
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    // Recap the current (vs1) session; while it is pending, switch to the past one.
+    fireEvent.click(await screen.findByTestId("recap-button"));
+    expect(await screen.findByTestId("recap-pending")).toBeInTheDocument();
+    const picker = screen.getByTestId("session-picker");
+    fireEvent.click(within(picker).getByText(/5 lines/));
+
+    // Now the gated vs1 recap resolves — but vs1 is no longer on screen, so its
+    // result must be discarded, never rendered above vsOld's transcript.
+    await act(async () => {
+      release(create(GenerateRecapResponseSchema, { text: "Stale recap of vs1.", sessionIds: ["vs1"], windowed: false }));
+    });
+    await waitFor(() => expect(screen.queryByTestId("recap-pending")).not.toBeInTheDocument());
+    expect(screen.queryByTestId("recap-result")).not.toBeInTheDocument();
+    expect(screen.queryByText("Stale recap of vs1.")).not.toBeInTheDocument();
+  });
 });
 
 describe("Session zero-line live snapshot (#248)", () => {

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { Play, Square, Search, ScrollText, Loader2 } from "lucide-react";
@@ -333,10 +333,27 @@ export function Session() {
   const generateRecap = useMutation(SessionService.method.generateRecap, {
     onError: (err: Error) => toast.error(`Couldn't generate the recap: ${err.message}`),
   });
+  // The rendered session the operator is looking at RIGHT NOW, tracked in a ref so
+  // the async onSuccess below can compare against it — a ~2min recap may resolve
+  // long after the operator switched sessions.
+  const renderedSessionIdRef = useRef(renderedSessionId);
+  useEffect(() => {
+    renderedSessionIdRef.current = renderedSessionId;
+  }, [renderedSessionId]);
   const runRecap = (vs: VoiceSession) => {
+    const coveredId = vs.id;
     generateRecap.mutate(
-      { sessionIds: [vs.id] },
-      { onSuccess: (res) => setRecapResult({ startedMs: tsMs(vs.startedAt), text: res.text }) },
+      { sessionIds: [coveredId] },
+      {
+        onSuccess: (res) => {
+          // Drop a recap whose covered session is no longer on screen: an in-flight
+          // call that resolves AFTER the operator switched sessions must not render
+          // "session of <old>" above the new session's transcript. The clear-on-change
+          // useEffect can't catch this — onSuccess fires after it already ran.
+          if (renderedSessionIdRef.current !== coveredId) return;
+          setRecapResult({ startedMs: tsMs(vs.startedAt), text: res.text });
+        },
+      },
     );
   };
   // A recap belongs to the session it covered; when the rendered session changes

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
-import { Play, Square, Search } from "lucide-react";
+import { Play, Square, Search, ScrollText, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { timestampMs } from "@bufbuild/protobuf/wkt";
 
@@ -320,6 +320,33 @@ export function Session() {
     }
   }, [snapshotFailed, viewingPast]);
 
+  // Recap (#274, epic #252): the operator regenerates a Butler-flavoured recap of a
+  // Voice Session on demand — GenerateRecap is REGENERATED per call and never
+  // persisted (gate #271), spends provider money (guarded like a mutation), and can
+  // take ~2 min for a long session, so the pending state must survive that whole
+  // wait. The button covers the session ON SCREEN: the idle latest-session card
+  // recaps that ended session; while browsing a past session it recaps THAT viewed
+  // one. The result is a labelled card carrying the covered session's start stamp;
+  // it is cleared whenever the rendered session changes so a stale recap never sits
+  // under a different session. A failure surfaces as a toast (ADR-0017: sonner).
+  const [recapResult, setRecapResult] = useState<{ startedMs: number | null; text: string } | null>(null);
+  const generateRecap = useMutation(SessionService.method.generateRecap, {
+    onError: (err: Error) => toast.error(`Couldn't generate the recap: ${err.message}`),
+  });
+  const runRecap = (vs: VoiceSession) => {
+    generateRecap.mutate(
+      { sessionIds: [vs.id] },
+      { onSuccess: (res) => setRecapResult({ startedMs: tsMs(vs.startedAt), text: res.text }) },
+    );
+  };
+  // A recap belongs to the session it covered; when the rendered session changes
+  // (picker pick or back-to-current) drop it so it never mislabels another session.
+  useEffect(() => setRecapResult(null), [renderedSessionId]);
+
+  // The session the on-screen Recap button covers: the picked past session while
+  // browsing one, else the idle ended latest-session summary.
+  const viewedSession = viewingPast ? pastSessions.find((s) => s.id === viewedId) : undefined;
+
   return (
     <div className="gx-session">
       <div className="gx-session__main">
@@ -392,7 +419,24 @@ export function Session() {
       )}
 
       {!active && session && session.status === "ended" && (
-        <div className="gx-session__last">{lastSummary(session)}</div>
+        <div className="gx-session__last">
+          <span className="gx-session__last-text">{lastSummary(session)}</span>
+          {/* The latest-card Recap covers the idle ended session; hidden while
+              browsing a past one, whose own Recap button lives in the picker view
+              (so only one Recap button is ever on screen). */}
+          {!viewingPast && (
+            <Button
+              variant="secondary"
+              size="sm"
+              iconStart={<ScrollText size={15} />}
+              onClick={() => runRecap(session)}
+              disabled={generateRecap.isPending}
+              data-testid="recap-button"
+            >
+              Recap
+            </Button>
+          )}
+        </div>
       )}
 
       <section className="gx-session__transcript">
@@ -408,6 +452,21 @@ export function Session() {
             onBackToCurrent={() => viewSession(null)}
           />
         )}
+        {viewingPast && viewedSession && (
+          <div className="gx-session__recap-bar">
+            <Button
+              variant="secondary"
+              size="sm"
+              iconStart={<ScrollText size={15} />}
+              onClick={() => runRecap(viewedSession)}
+              disabled={generateRecap.isPending}
+              data-testid="recap-button"
+            >
+              Recap
+            </Button>
+          </div>
+        )}
+        <RecapView pending={generateRecap.isPending} result={recapResult} />
         <TranscriptSearch onOpen={openHit} />
         <Card>
           {snapshotFailed ? (
@@ -508,6 +567,37 @@ function SessionPicker({
         </button>
       )}
     </div>
+  );
+}
+
+// RecapView renders the Recap request's pending + result states (#274). While the
+// GenerateRecap call is in flight it shows a spinner (the button is disabled at the
+// call site) — the call can take ~2 min for a long session, so this pending row
+// must survive the whole wait. On success it shows a card labelled with the covered
+// session's start stamp holding the recap prose. Nothing renders before the first
+// Recap of the current view.
+function RecapView({
+  pending,
+  result,
+}: {
+  pending: boolean;
+  result: { startedMs: number | null; text: string } | null;
+}) {
+  if (pending) {
+    return (
+      <div className="gx-session__recap-pending" role="status" data-testid="recap-pending">
+        <Loader2 size={15} className="gx-spin" aria-hidden="true" />
+        <span>Generating recap…</span>
+      </div>
+    );
+  }
+  if (!result) return null;
+  const label = result.startedMs != null ? formatStamp(new Date(result.startedMs)) : "—";
+  return (
+    <Card className="gx-session__recap" data-testid="recap-result">
+      <div className="gx-session__recap-label">Recap · session of {label}</div>
+      <p className="gx-session__recap-text">{result.text}</p>
+    </Card>
   );
 }
 

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -205,7 +205,8 @@
   font-size: 0.875rem;
 }
 
-/* Subtle inset summary of the prior session, shown only while idle. */
+/* Subtle inset summary of the prior session, shown only while idle. The Recap
+ * button sits at the end of the row (#274). */
 .gx-session__last {
   margin-top: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
@@ -213,6 +214,63 @@
   background: var(--surface-inset);
   color: var(--text-subtle);
   font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.gx-session__last-text {
+  min-width: 0;
+}
+
+/* The Recap control while browsing a past session (#274): a right-aligned bar
+ * above the transcript so the button sits with the picker, not the summary. */
+.gx-session__recap-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--spacing-sm);
+}
+
+/* Recap pending row (#274): a spinner + label that must survive a ~2min LLM call. */
+.gx-session__recap-pending {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  color: var(--text-subtle);
+  font-size: 0.875rem;
+}
+
+/* Recap result card (#274): the regenerated recap, labelled with the covered
+ * session's start stamp. */
+.gx-session__recap {
+  margin-bottom: var(--spacing-md);
+}
+
+.gx-session__recap-label {
+  margin-bottom: var(--spacing-xs);
+  color: var(--text-subtle);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.gx-session__recap-text {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.55;
+}
+
+/* Slow spin for the Loader2 recap spinner. */
+.gx-spin {
+  animation: gx-spin 1s linear infinite;
+}
+
+@keyframes gx-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* A fatal gateway rejection: a prominent, readable failure banner (#123). */


### PR DESCRIPTION
Closes #274. Parent epic #252.

## What

Adds on-demand Recap to the web Session screen: a new `SessionService.GenerateRecap` RPC plus a Recap button on both the idle latest-session card and a picked past session.

### Proto
- `GenerateRecap(GenerateRecapRequest) returns (GenerateRecapResponse)` — deliberately NOT `NO_SIDE_EFFECTS` (each call spends provider money + records usage), so it is CSRF + auth guarded like a mutation (ADR-0039).

### RPC (`internal/rpc/session.go`)
- `RecapEngine` interface (`*recap.Engine` satisfies it) + `SessionStore.GetVoiceSession` for the ownership check; `NewSessionServer` gains a 4th param (mechanical test sweep).
- Campaign resolved server-side via `searchCampaign` (live-first, else durable/most-recent). No Active Campaign → `CodeFailedPrecondition`. Empty ids → `CodeInvalidArgument`. Unparsable / `storage.ErrNotFound` / cross-campaign id → `CodeNotFound` (never leaks existence — mirrors `SetAgentMute`). `recap.ErrNoTranscript` → `CodeFailedPrecondition`; any other engine error → logged + static `CodeInternal`. Recapping a RUNNING session is allowed (documented).
- `cmd/glyphoxa/main.go` constructs `recap.NewEngine` and wires it in. (Note: #273 sibling owns the single engine construction — collapse on their merge.)

### Web (`web/src/screens/session/`)
- Recap button on the idle latest-session card and on a picked past session (recaps the viewed id). Pending spinner + disabled button (LLM call can take ~2min; pending survives). Result card labelled with the covered session's `started_at`. Failure → sonner toast (ADR-0017). Result cleared when the rendered session changes.

## Tests (TDD)
- RPC: 9 new handler tests (empty/unparsable/foreign/missing → codes; no-campaign; happy maps text/session_ids/windowed; ErrNoTranscript; static Internal; running-session allowed; CSRF-guarded).
- Web: 4 new vitest (latest-card pending→labelled result; past-session recaps viewed id; failure toast; cleared on session change). Full web suite 206 green.

Rebased onto latest `main` (includes #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)