### PR TITLE
feat(#277): thread SpeakerID through the voice pipeline (N Speaker Lanes)

### DIFF
--- a/internal/wirenpc/streammaxlanes_test.go
+++ b/internal/wirenpc/streammaxlanes_test.go
@@ -1,0 +1,34 @@
+package wirenpc
+
+import "testing"
+
+// TestStreamMaxLanes pins the GLYPHOXA_STT_STREAM_MAX_LANES parsing (finding 7):
+// absent/empty/invalid → the default 4; an explicit "0" is honoured as disabled (0
+// lanes stream); a negative value is invalid → default.
+func TestStreamMaxLanes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  bool
+		val  string
+		want int
+	}{
+		{name: "absent", set: false, want: defaultStreamMaxLanes},
+		{name: "empty", set: true, val: "", want: defaultStreamMaxLanes},
+		{name: "invalid", set: true, val: "abc", want: defaultStreamMaxLanes},
+		{name: "negative", set: true, val: "-2", want: defaultStreamMaxLanes},
+		{name: "zero disables", set: true, val: "0", want: 0},
+		{name: "explicit", set: true, val: "8", want: 8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("GLYPHOXA_STT_STREAM_MAX_LANES", tc.val)
+			} else {
+				t.Setenv("GLYPHOXA_STT_STREAM_MAX_LANES", "")
+				// t.Setenv can't unset; the empty case already covers "unset" semantics.
+			}
+			if got := streamMaxLanes(); got != tc.want {
+				t.Errorf("streamMaxLanes() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -1149,18 +1149,20 @@ func buildStreamManager(recognizer stt.Recognizer, streaming bool, stageMetrics 
 const defaultStreamMaxLanes = 4
 
 // streamMaxLanes reads the per-lane streaming concurrency cap from
-// GLYPHOXA_STT_STREAM_MAX_LANES, falling back to [defaultStreamMaxLanes] when unset,
-// empty, or unparseable (a malformed value must not silently disable streaming).
+// GLYPHOXA_STT_STREAM_MAX_LANES. Absent, empty, or unparseable → [defaultStreamMaxLanes]
+// (a typo must not silently change behaviour). An explicit "0" IS honoured — it
+// disables per-lane streaming (0 lanes stream) while the default lane keeps its own
+// stream; a negative value is invalid and falls back to the default (finding 7).
 func streamMaxLanes() int {
 	v := os.Getenv("GLYPHOXA_STT_STREAM_MAX_LANES")
 	if v == "" {
 		return defaultStreamMaxLanes
 	}
 	n, err := strconv.Atoi(v)
-	if err != nil || n <= 0 {
+	if err != nil || n < 0 {
 		return defaultStreamMaxLanes
 	}
-	return n
+	return n // 0 = explicitly disabled
 }
 
 // buildLaneStreamFactory returns the per-Speaker-Lane [orchestrator.StreamManager]

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -15,6 +15,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/disgoorg/disgo"
@@ -952,8 +954,30 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	// stage cannot read off the Silero session (vad.Session doesn't expose
 	// minSilenceFrames), so compute it here from the same consts the session is
 	// configured with — vadMinSilenceFrames*vadFrameMs (= 384 ms).
+	vadHangover := vadMinSilenceFrames * vadFrameMs * time.Millisecond
 	vadStage := orchestrator.NewVAD(bus, vadSession,
-		orchestrator.WithVADMetrics(stageMetrics, vadMinSilenceFrames*vadFrameMs*time.Millisecond))
+		orchestrator.WithVADMetrics(stageMetrics, vadHangover))
+
+	// Speaker Lanes (ADR-0050): each Discord participant's already-separated frame
+	// stream (codec stamps Frame.UserID) opens its own VAD lane, so utterances are
+	// segmented and attributed per speaker. The lane factory builds a fresh Silero
+	// session PER lane from the SAME process-global engine (NewSession is cheap; the
+	// engine is the ONNX singleton, never re-created) and its close releases that
+	// lane's ONNX inferencer on reap (risk (b)). The default lane keeps vadSession;
+	// the factory builds only the non-default lanes.
+	laneVADFactory := func() (*orchestrator.VAD, func(), error) {
+		sess, err := engine.NewSession(vad.Config{
+			SampleRate:       vadSampleRate,
+			FrameSizeMs:      vadFrameMs,
+			SpeechThreshold:  0.5,
+			SilenceThreshold: 0.35,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("open lane VAD session: %w", err)
+		}
+		v := orchestrator.NewVAD(bus, sess, orchestrator.WithVADMetrics(stageMetrics, vadHangover))
+		return v, func() { _ = sess.Close() }, nil
+	}
 
 	// Bounded transient-error retry (#124, ADR-0044): one shared policy threaded
 	// into all three provider stages (STT, TTS, LLM). Log-only per-attempt detail;
@@ -974,6 +998,11 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		orchestrator.WithTTSMetrics(stageMetrics, observe.ProviderElevenLabs),
 		orchestrator.WithTTSRetry(retryPolicy))
 	streamMgr := buildStreamManager(recognizer, streaming, stageMetrics, log)
+	// Per-lane streaming STT (ADR-0042 × ADR-0050): each Speaker Lane opens its own
+	// stream (stamping its SpeakerID on partials) under a concurrency cap, so
+	// concurrent sockets track concurrent speakers, not channel size. Nil unless
+	// streaming is on AND the adapter streams — the byte-for-byte batch default.
+	laneStreamFactory := buildLaneStreamFactory(recognizer, streaming, stageMetrics)
 
 	// Tool Grants are now DB-backed and hydrated per NPC (#113, ADR-0029): each
 	// NPC carries its own grants (spec.grants — from its tool_agent_grant rows on
@@ -1032,6 +1061,15 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		// batch path, so this option is unconditional — buildStreamManager returns nil
 		// unless GLYPHOXA_STT_STREAMING is set AND the adapter is a StreamingRecognizer.
 		orchestrator.WithStreamingSTT(streamMgr),
+		// Speaker Lanes (ADR-0050): attributed inbound frames open per-speaker VAD
+		// lanes so utterances are segmented and attributed independently. A single
+		// participant still gets one lane transcribed exactly as today; the default
+		// (unattributed) lane carries the silence clock. Unconditional — the factory is
+		// only invoked for a non-empty SpeakerID.
+		orchestrator.WithSpeakerLanes(laneVADFactory),
+		// Per-lane streaming STT under the env cap (ADR-0042 × ADR-0050). A nil factory
+		// (batch default) leaves the lanes batch-only, so this is unconditional.
+		orchestrator.WithLaneStreamingSTT(laneStreamFactory, streamMaxLanes()),
 		// Per-Agent mute (#211): the replier discards a muted addressee's route
 		// before taking the floor, and a MuteCut reactor cuts the floor when the
 		// speaking Agent is muted. A nil view is the feature-off default (voice
@@ -1103,4 +1141,44 @@ func buildStreamManager(recognizer stt.Recognizer, streaming bool, stageMetrics 
 	}
 	return orchestrator.NewStreamManager(sr,
 		orchestrator.WithStreamMetrics(stageMetrics, observe.ProviderElevenLabs))
+}
+
+// defaultStreamMaxLanes caps concurrent per-lane streaming-STT sockets (ADR-0050):
+// concurrent connections equal concurrent speakers, not channel size. Sized for a
+// typical active table; past it a lane transcribes pure batch.
+const defaultStreamMaxLanes = 4
+
+// streamMaxLanes reads the per-lane streaming concurrency cap from
+// GLYPHOXA_STT_STREAM_MAX_LANES, falling back to [defaultStreamMaxLanes] when unset,
+// empty, or unparseable (a malformed value must not silently disable streaming).
+func streamMaxLanes() int {
+	v := os.Getenv("GLYPHOXA_STT_STREAM_MAX_LANES")
+	if v == "" {
+		return defaultStreamMaxLanes
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return defaultStreamMaxLanes
+	}
+	return n
+}
+
+// buildLaneStreamFactory returns the per-Speaker-Lane [orchestrator.StreamManager]
+// factory when streaming is enabled AND the wired recognizer streams, else nil (the
+// batch default). It is the lane analogue of [buildStreamManager]: each lane's
+// manager stamps its SpeakerID on partials (ADR-0050). The provider label is
+// elevenlabs (the only streaming STT adapter in the MVP matrix, ADR-0039).
+func buildLaneStreamFactory(recognizer stt.Recognizer, streaming bool, stageMetrics observe.StageRecorder) func(speakerID string) *orchestrator.StreamManager {
+	if !streaming {
+		return nil
+	}
+	sr, ok := recognizer.(stt.StreamingRecognizer)
+	if !ok {
+		return nil
+	}
+	return func(speakerID string) *orchestrator.StreamManager {
+		return orchestrator.NewStreamManager(sr,
+			orchestrator.WithStreamMetrics(stageMetrics, observe.ProviderElevenLabs),
+			orchestrator.WithStreamSpeakerID(speakerID))
+	}
 }

--- a/pkg/voice/audio/frame.go
+++ b/pkg/voice/audio/frame.go
@@ -22,6 +22,14 @@ type Frame struct {
 	samples    []int16
 	sampleRate int
 	frameMs    int
+	// speaker is the attribution of this frame's audio: a Discord snowflake
+	// string for a frame decoded from one participant's Opus stream, or "" when
+	// the source is unknown (a mixed/silence-clock frame, or a test frame). It is
+	// private so it never widens the Frame construction contract — set only via
+	// [Frame.WithSpeaker] — and it is deliberately NOT part of the audio payload:
+	// [voicecassette.HashFrames] hashes only Samples(), so tagging a frame leaves
+	// cassette fingerprints untouched.
+	speaker string
 }
 
 // NewFrame wraps an existing []int16 slice as a Frame, validating that the
@@ -67,3 +75,21 @@ func (f Frame) SampleRate() int { return f.sampleRate }
 
 // FrameMs returns the frame duration in milliseconds.
 func (f Frame) FrameMs() int { return f.frameMs }
+
+// Speaker returns the frame's attribution — the Discord snowflake string of the
+// participant whose Opus stream it was decoded from, or "" (the zero value) when
+// the source is unattributed: a mixed/silence-clock frame, or a frame built
+// without [Frame.WithSpeaker]. Downstream the [orchestrator.Segmenter] routes an
+// attributed frame to its Speaker Lane and a "" frame to the default lane, so the
+// zero value reproduces today's single-lane behaviour exactly (ADR-0050).
+func (f Frame) Speaker() string { return f.speaker }
+
+// WithSpeaker returns a copy of f attributed to speaker id. It never mutates the
+// receiver (Frames are immutable from the caller's perspective) and shares the
+// same sample storage — only the attribution differs. Passing "" yields an
+// unattributed copy. The codec stamps each decoded frame with its
+// [gxvoice.Frame.UserID] here (ADR-0050).
+func (f Frame) WithSpeaker(id string) Frame {
+	f.speaker = id
+	return f
+}

--- a/pkg/voice/audio/frame_test.go
+++ b/pkg/voice/audio/frame_test.go
@@ -132,3 +132,31 @@ func TestFromPCM16LE_DecodesLittleEndianSignedSamples(t *testing.T) {
 		}
 	}
 }
+
+func TestFrame_WithSpeaker_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	base, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("NewFrame: %v", err)
+	}
+
+	// Zero value is unattributed.
+	if got := base.Speaker(); got != "" {
+		t.Errorf("zero-value Frame.Speaker() = %q, want \"\"", got)
+	}
+
+	tagged := base.WithSpeaker("111")
+	if got := tagged.Speaker(); got != "111" {
+		t.Errorf("Speaker() = %q, want \"111\"", got)
+	}
+	// WithSpeaker returns a copy: the original stays unattributed (immutable).
+	if got := base.Speaker(); got != "" {
+		t.Errorf("original Frame.Speaker() = %q after WithSpeaker, want \"\" (copy, not mutate)", got)
+	}
+	// The copy preserves the audio payload and geometry.
+	if len(tagged.Samples()) != len(base.Samples()) || tagged.SampleRate() != base.SampleRate() || tagged.FrameMs() != base.FrameMs() {
+		t.Errorf("WithSpeaker altered frame geometry: samples=%d rate=%d ms=%d",
+			len(tagged.Samples()), tagged.SampleRate(), tagged.FrameMs())
+	}
+}

--- a/pkg/voice/orchestrator/barge.go
+++ b/pkg/voice/orchestrator/barge.go
@@ -30,20 +30,21 @@ import (
 // Per ADR-0027 an Agent's own TTS never triggers a barge: only inbound
 // participant audio is VAD'd, so every speech_start here is a human's.
 //
-// Multi-speaker caveat: [voiceevent.VADSpeechStart]/[voiceevent.VADSpeechEnd]
-// carry no speaker identity because the current wiring runs ONE VAD session
-// over all participants' interleaved frames — the transitions describe the
-// mix, not a person. The confirm window is therefore only meaningful with the
-// single-active-speaker assumption of the MVP slice; do not tune
-// confirmWindow > 0 for a multi-speaker table until per-participant VAD
-// sessions (ADR-0019, deferred) attribute these events, or one speaker's
-// pause can disarm a window another speaker's interruption armed.
+// Per-speaker confirm windows (ADR-0050): [voiceevent.VADSpeechStart] /
+// [voiceevent.VADSpeechEnd] now carry a SpeakerID (the Speaker Lane the transition
+// came off), so a confirm window is armed and disarmed PER speaker — a speech_end
+// from speaker B no longer disarms the window speaker A's interruption armed (the
+// pre-lane caveat this fixes). Single-lane wiring runs one "" key, so the behaviour
+// is identical to before lanes existed. The fired [voiceevent.BargeDetected] names
+// the barging speaker.
 type BargeIn struct {
 	floor   *Floor
 	confirm time.Duration
 
-	mu      sync.Mutex
-	pending chan struct{} // closed to cancel the armed confirm timer; nil when unarmed
+	mu sync.Mutex
+	// pending maps SpeakerID → the channel closed to cancel that speaker's armed
+	// confirm timer. A key is present only while that speaker's window is armed.
+	pending map[string]chan struct{}
 }
 
 // NewBargeIn builds a barge-in reactor that yields floor after confirmWindow of
@@ -52,7 +53,7 @@ func NewBargeIn(floor *Floor, confirmWindow time.Duration) *BargeIn {
 	if floor == nil {
 		panic("orchestrator.NewBargeIn: floor must not be nil")
 	}
-	return &BargeIn{floor: floor, confirm: confirmWindow}
+	return &BargeIn{floor: floor, confirm: confirmWindow, pending: make(map[string]chan struct{})}
 }
 
 // Bind subscribes the reactor to the VAD speech transitions on bus and returns a
@@ -76,7 +77,7 @@ func (b *BargeIn) Bind(_ context.Context, bus *voiceevent.Bus) (cancel func()) {
 		// The holder is now audible on the wire: arm the barge for this turn.
 		b.floor.MarkSpeaking(e.TurnID)
 	})
-	unsubStart := voiceevent.On(bus, func(voiceevent.VADSpeechStart) {
+	unsubStart := voiceevent.On(bus, func(e voiceevent.VADSpeechStart) {
 		// Only fight for the floor if an Agent is AUDIBLY speaking (ADR-0027);
 		// otherwise this is the user's own utterance — the onset of a new turn, or
 		// the continuation of the one that holds the still-silent floor — and the
@@ -86,32 +87,32 @@ func (b *BargeIn) Bind(_ context.Context, bus *voiceevent.Bus) (cancel func()) {
 			return
 		}
 		if b.confirm <= 0 {
-			b.fire(bus)
+			b.fire(bus, e.SpeakerID)
 			return
 		}
-		b.arm(bus)
+		b.arm(bus, e.SpeakerID)
 	})
-	unsubEnd := voiceevent.On(bus, func(voiceevent.VADSpeechEnd) {
-		b.disarm() // speech ended before the window: soft overlap, no cancel
+	unsubEnd := voiceevent.On(bus, func(e voiceevent.VADSpeechEnd) {
+		b.disarm(e.SpeakerID) // this speaker's speech ended before its window: soft overlap, no cancel
 	})
 
 	return func() {
 		unsubSpeaking()
 		unsubStart()
 		unsubEnd()
-		b.disarm()
+		b.disarmAll()
 	}
 }
 
-// arm starts (or restarts) the confirm-window timer. When it elapses without an
-// intervening speech_end, the barge fires.
-func (b *BargeIn) arm(bus *voiceevent.Bus) {
+// arm starts (or restarts) speaker sp's confirm-window timer. When it elapses
+// without an intervening speech_end from the SAME speaker, the barge fires.
+func (b *BargeIn) arm(bus *voiceevent.Bus, sp string) {
 	done := make(chan struct{})
 	b.mu.Lock()
-	if b.pending != nil {
-		close(b.pending) // supersede a still-armed window
+	if prev := b.pending[sp]; prev != nil {
+		close(prev) // supersede this speaker's still-armed window
 	}
-	b.pending = done
+	b.pending[sp] = done
 	b.mu.Unlock()
 
 	go func() {
@@ -120,40 +121,52 @@ func (b *BargeIn) arm(bus *voiceevent.Bus) {
 		select {
 		case <-t.C:
 			b.mu.Lock()
-			// Only fire if still the armed window (not disarmed/superseded).
-			current := b.pending == done
+			// Only fire if still this speaker's armed window (not disarmed/superseded).
+			current := b.pending[sp] == done
 			if current {
-				b.pending = nil
+				delete(b.pending, sp)
 			}
 			b.mu.Unlock()
 			if current {
-				b.fire(bus)
+				b.fire(bus, sp)
 			}
 		case <-done:
 		}
 	}()
 }
 
-// disarm cancels a pending confirm timer, if any.
-func (b *BargeIn) disarm() {
+// disarm cancels speaker sp's pending confirm timer, if any. Another speaker's
+// armed window is left untouched (ADR-0050).
+func (b *BargeIn) disarm(sp string) {
 	b.mu.Lock()
-	if b.pending != nil {
-		close(b.pending)
-		b.pending = nil
+	if done := b.pending[sp]; done != nil {
+		close(done)
+		delete(b.pending, sp)
+	}
+	b.mu.Unlock()
+}
+
+// disarmAll cancels every pending confirm timer (teardown).
+func (b *BargeIn) disarmAll() {
+	b.mu.Lock()
+	for sp, done := range b.pending {
+		close(done)
+		delete(b.pending, sp)
 	}
 	b.mu.Unlock()
 }
 
 // fire yields the floor and, if a turn was actually cancelled, announces it: the
-// BargeDetected observability signal (ADR-0027) and a TurnEnded carrying the cut
-// turn's TurnID + the barge reason, so the metrics subscriber attributes this
-// turn's death to the barge rather than the coarse no-first-audio catch-all.
-func (b *BargeIn) fire(bus *voiceevent.Bus) {
+// BargeDetected observability signal (ADR-0027) carrying the barging speaker (sp,
+// ADR-0050) and a TurnEnded carrying the cut turn's TurnID + the barge reason, so
+// the metrics subscriber attributes this turn's death to the barge rather than the
+// coarse no-first-audio catch-all.
+func (b *BargeIn) fire(bus *voiceevent.Bus, sp string) {
 	turnID, yielded := b.floor.Yield()
 	if !yielded {
 		return
 	}
 	now := time.Now()
-	bus.Publish(voiceevent.BargeDetected{At: now})
+	bus.Publish(voiceevent.BargeDetected{At: now, SpeakerID: sp})
 	bus.Publish(voiceevent.TurnEnded{At: now, TurnID: turnID, Reason: voiceevent.TurnEndBarge})
 }

--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -183,3 +183,57 @@ func TestBargeIn_ConfirmWindowCrossingCancels(t *testing.T) {
 		t.Fatal("barge must free the floor")
 	}
 }
+
+// TestBargeIn_PerSpeakerWindowNotDisarmedByOther is step 9 (ADR-0050): speaker A's
+// confirm window is armed; speaker B's speech_end arrives inside it. B's speech_end
+// must NOT disarm A's window — A's sustained interruption still fires the barge, and
+// the BargeDetected names A. Under one shared VAD (the pre-lane MVP) B's pause would
+// have disarmed A's window and swallowed the interruption.
+func TestBargeIn_PerSpeakerWindowNotDisarmedByOther(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	t.Cleanup(orchestrator.NewBargeIn(floor, 40*time.Millisecond).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"}) // the Agent is audibly speaking
+
+	// A starts interrupting; B backchannels and stops — B's speech_end must leave A's
+	// window armed.
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "B"})
+	h.Bus.Publish(voiceevent.VADSpeechEnd{SpeakerID: "B"}) // only B stopped
+
+	select {
+	case <-turnCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's sustained interruption must fire the barge; B's speech_end wrongly disarmed A's window")
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.BargeDetected) bool { return e.SpeakerID == "A" },
+		"barge.detected attributed to speaker A",
+	)
+}
+
+// TestBargeIn_SameSpeakerSoftOverlapDisarms pins the complement: a speaker's OWN
+// speech_end inside the window disarms it (a soft-overlap backchannel from that
+// speaker), so no barge fires and the turn survives — the per-speaker analogue of
+// TestBargeIn_SoftOverlapDoesNotCancel.
+func TestBargeIn_SameSpeakerSoftOverlapDisarms(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	t.Cleanup(orchestrator.NewBargeIn(floor, 200*time.Millisecond).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	h.Bus.Publish(voiceevent.VADSpeechEnd{SpeakerID: "A"}) // A's own backchannel ends the window
+
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	if turnCtx.Err() != nil {
+		t.Fatal("a same-speaker soft-overlap backchannel must not cancel the turn")
+	}
+}

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -120,7 +120,31 @@ func WithBargeInCoalesce(confirmWindow, coalesceWindow time.Duration) Option {
 // batch recognizer as the automatic fallback. A nil sm is ZERO behaviour change —
 // the byte-for-byte no-streaming default — so callers can wire it unconditionally.
 func WithStreamingSTT(sm *StreamManager) Option {
-	return func(c *Conversation) { c.seg.stream = sm }
+	return func(c *Conversation) { c.seg.lanes[""].stream = sm }
+}
+
+// WithSpeakerLanes enables per-speaker utterance segmentation (ADR-0050): an
+// attributed frame ([audio.Frame.Speaker] != "") opens a Speaker Lane — a VAD
+// session built by f, fed only that speaker's frames — so each speaker's utterances
+// are transcribed and attributed independently. A nil f (or leaving this option
+// unset) keeps the segmenter single-lane forever, byte-identical to the pre-lane
+// pipeline. The default (unattributed) lane always exists; f builds only the
+// non-default lanes and its close func releases each lane's ONNX session on reap.
+func WithSpeakerLanes(f LaneVADFactory) Option {
+	return func(c *Conversation) { c.seg.laneVADFactory = f }
+}
+
+// WithLaneStreamingSTT wires a per-Speaker-Lane streaming-STT transport (ADR-0042 ×
+// ADR-0050): f builds a [StreamManager] for a lane at its creation, capped at
+// maxLanes concurrent lane streams — past the cap a lane transcribes pure batch, so
+// concurrent sockets track concurrent speakers, not channel size. It complements
+// [WithStreamingSTT] (which wires the default lane's stream); a nil f leaves the
+// non-default lanes batch-only.
+func WithLaneStreamingSTT(f func(speakerID string) *StreamManager, maxLanes int) Option {
+	return func(c *Conversation) {
+		c.seg.laneStreamFactory = f
+		c.seg.maxStreamLanes = maxLanes
+	}
 }
 
 // WithErrorHandler sets the [ErrorFunc] used to report failures from stage calls

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -242,6 +242,18 @@ func (c *Conversation) Feed(frame audio.Frame) error {
 	return c.seg.Process(frame)
 }
 
+// FeedSilence pushes one silence-CLOCK frame (issue #91) into the conversation. It is
+// the sibling of [Conversation.Feed] for the ONE unattributed source that must reach
+// every Speaker Lane: the wire tick branch (a paused speaker's packet gap) routes
+// synthesized silence here so every lane's VAD hangover advances toward its
+// speech_end (ADR-0050's speaker-agnostic silence clock), while real inbound audio —
+// including a not-yet-resolved SSRC — stays on [Conversation.Feed] and its own lane
+// (or the default lane). Distinguishing the two "" sources at source avoids sniffing
+// zero PCM (Opus can legally decode an all-zero frame).
+func (c *Conversation) FeedSilence(frame audio.Frame) error {
+	return c.seg.ProcessSilence(frame)
+}
+
 // Flush transcribes any utterance still buffered because the audio stream ended
 // while speech was active, then waits for every in-flight transcription to finish
 // (see [Segmenter.Flush]). Call it once after the last [Conversation.Feed] — at

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -30,6 +30,35 @@ func (r *Replier) SetGate(g TurnGate) { r.gate = g }
 // Conversation.Register from [WithErrorHandler].
 func (s *Segmenter) SetErrorHandler(fn ErrorFunc) { s.onError = fn }
 
+// SetLaneVADFactory installs the per-Speaker-Lane VAD factory for the lane tests
+// (external test package). Production wiring sets it inside NewConversation from
+// [WithSpeakerLanes].
+func (s *Segmenter) SetLaneVADFactory(f LaneVADFactory) { s.laneVADFactory = f }
+
+// SetLaneStreamFactory installs the per-lane streaming-STT factory and cap for the
+// lane tests (external test package). Production wiring sets it from
+// [WithLaneStreamingSTT].
+func (s *Segmenter) SetLaneStreamFactory(f func(speakerID string) *StreamManager, maxLanes int) {
+	s.laneStreamFactory = f
+	s.maxStreamLanes = maxLanes
+}
+
+// LaneCount reports the number of live lanes (including the default lane), for the
+// reap tests (external test package).
+func (s *Segmenter) LaneCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.lanes)
+}
+
+// SetSweepEvery overrides the reap-sweep cadence (Process calls per sweep) so a
+// reap test triggers a sweep without 1024 frames (external test package).
+func (s *Segmenter) SetSweepEvery(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sweepEvery = n
+}
+
 // WaitStreamUp blocks until the manager has a live session or timeout elapses,
 // reporting whether one came up. Test-only: pipeline tests feed the first
 // utterance only after the eager dial completes, so utterance 1 streams

--- a/pkg/voice/orchestrator/lanes_cassette_test.go
+++ b/pkg/voice/orchestrator/lanes_cassette_test.go
@@ -138,23 +138,65 @@ func TestConversation_TwoSpeakerCassette_DistinctSpeakerIDs(t *testing.T) {
 		t.Fatalf("Flush: %v", err)
 	}
 
-	// Exactly two STTFinals, one per speaker, each matching its clip's ground truth.
-	bySpeaker := map[string]string{}
+	// Group EVERY STTFinal by speaker (finding 4: do not silently collapse dupes into a
+	// map — real Silero legitimately splits a clip with an internal pause into several
+	// segments, so each speaker may yield >1 final; each must still carry ITS speaker's
+	// id, never the other's). Assert: exactly two distinct SpeakerIDs (both attributed,
+	// neither ""), every final attributed to one of them, and the per-speaker CONCATENATED
+	// text matches its clip's ground truth (tolerant word-overlap, the house rule) with
+	// NO cross-contamination from the other speaker's clip — the real attribution proof.
+	joined := map[string][]string{}
+	var total int
 	for _, e := range h.Events() {
-		if f, ok := e.(voiceevent.STTFinal); ok {
-			bySpeaker[f.SpeakerID] = f.Text
+		f, ok := e.(voiceevent.STTFinal)
+		if !ok {
+			continue
 		}
+		total++
+		if f.SpeakerID != speakerHello && f.SpeakerID != speakerBart {
+			t.Errorf("STTFinal carries unexpected SpeakerID %q (want %q or %q)", f.SpeakerID, speakerHello, speakerBart)
+		}
+		joined[f.SpeakerID] = append(joined[f.SpeakerID], f.Text)
 	}
-	if len(bySpeaker) != 2 {
-		t.Fatalf("STTFinals by speaker = %v, want two distinct SpeakerIDs", bySpeaker)
+	if total < 2 {
+		t.Fatalf("STTFinal count = %d, want >= 2 (one utterance per speaker, possibly VAD-split)", total)
 	}
-	assertNormalized(t, bySpeaker[speakerHello], helloUtterance, speakerHello)
-	assertNormalized(t, bySpeaker[speakerBart], bartUtterance, speakerBart)
+	if len(joined) != 2 {
+		t.Fatalf("distinct SpeakerIDs = %v, want exactly two ({%s, %s})", keysOf(joined), speakerHello, speakerBart)
+	}
+	assertSpeakerText(t, joined[speakerHello], helloUtterance, bartUtterance, speakerHello)
+	assertSpeakerText(t, joined[speakerBart], bartUtterance, helloUtterance, speakerBart)
 }
 
-func assertNormalized(t *testing.T, got, want, speaker string) {
+// assertSpeakerText checks that EVERY final attributed to a speaker resolved to its
+// OWN clip's ground truth (normalized), and NONE to the OTHER clip — so a segment
+// mis-routed to the wrong lane (the exact failure Speaker Lanes prevent) fails loudly.
+// The clip-identity fake returns the whole ground-truth transcript per matched
+// segment, so a VAD-split clip yields several finals that each equal the ground truth
+// (asserted per-final rather than concatenated, which would double the text).
+func assertSpeakerText(t *testing.T, parts []string, want, other, speaker string) {
 	t.Helper()
-	if voicetest.NormalizeTranscript(got) != voicetest.NormalizeTranscript(want) {
-		t.Errorf("speaker %s transcript = %q, want (normalized) %q", speaker, got, want)
+	if len(parts) == 0 {
+		t.Errorf("speaker %s produced no STTFinal", speaker)
+		return
 	}
+	wn := voicetest.NormalizeTranscript(want)
+	on := voicetest.NormalizeTranscript(other)
+	for _, p := range parts {
+		gn := voicetest.NormalizeTranscript(p)
+		if gn != wn {
+			t.Errorf("speaker %s final = %q, want (normalized) %q", speaker, gn, wn)
+		}
+		if gn == on {
+			t.Errorf("speaker %s final matched the OTHER clip %q — cross-attribution", speaker, on)
+		}
+	}
+}
+
+func keysOf(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/pkg/voice/orchestrator/lanes_cassette_test.go
+++ b/pkg/voice/orchestrator/lanes_cassette_test.go
@@ -1,0 +1,160 @@
+package orchestrator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad/silero"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// clipRecognizer is a [stt.Recognizer] for the two-speaker lane test: it maps a
+// VAD-segmented utterance back to its SOURCE clip's ground-truth transcript by frame
+// identity (each lane buffers the exact frames the test fed it, so a segment's frames
+// are a contiguous run of one clip's frames). This keeps the assertion on the tolerant
+// house rule — normalized text vs the recorded ground truth — WITHOUT depending on the
+// batch cassettes' whole-clip audio hash, which a real VAD segmentation would not
+// reproduce (the clips were recorded as one Transcribe call, not VAD-segmented).
+type clipRecognizer struct {
+	// frameHash → transcript, one entry per frame of each source clip.
+	byFrame map[string]string
+}
+
+func newClipRecognizer(clips map[string][]audio.Frame) *clipRecognizer {
+	r := &clipRecognizer{byFrame: map[string]string{}}
+	for transcript, frames := range clips {
+		for _, f := range frames {
+			r.byFrame[voicecassette.HashFrames([]audio.Frame{f})] = transcript
+		}
+	}
+	return r
+}
+
+func (r *clipRecognizer) Transcribe(_ context.Context, frames []audio.Frame) (stt.Transcript, error) {
+	// A middle frame is guaranteed inside the clip's voiced body (VAD trims edges).
+	for _, f := range frames {
+		if txt, ok := r.byFrame[voicecassette.HashFrames([]audio.Frame{f})]; ok {
+			return stt.Transcript{Text: txt}, nil
+		}
+	}
+	return stt.Transcript{Text: ""}, nil
+}
+
+// sileroLaneFactory builds a real Silero VAD lane on bus for each Speaker Lane,
+// matching the default lane's configuration (16 kHz / 32 ms, 0.5/0.35 hysteresis).
+func sileroLaneFactory(t *testing.T, bus *voiceevent.Bus) orchestrator.LaneVADFactory {
+	t.Helper()
+	engine, err := silero.New()
+	if err != nil {
+		t.Fatalf("silero.New: %v", err)
+	}
+	cfg := vad.Config{SampleRate: 16000, FrameSizeMs: 32, SpeechThreshold: 0.5, SilenceThreshold: 0.35}
+	return func() (*orchestrator.VAD, func(), error) {
+		sess, err := engine.NewSession(cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		return orchestrator.NewVAD(bus, sess), func() { _ = sess.Close() }, nil
+	}
+}
+
+// clipFrames loads a clip and frames it at the VAD chunk size (512 samples), tagged
+// with speaker.
+func clipFrames(t *testing.T, name, speaker string) []audio.Frame {
+	t.Helper()
+	clip := voicetest.LoadClip(t, name)
+	frames, _ := clip.FramesOf(t, 512)
+	out := make([]audio.Frame, len(frames))
+	for i, f := range frames {
+		out[i] = f.WithSpeaker(speaker)
+	}
+	return out
+}
+
+// TestConversation_TwoSpeakerCassette_DistinctSpeakerIDs is step 12 / AC1: two
+// solo-recorded clips, interleaved frame-by-frame and tagged as two distinct Discord
+// speakers, drive two Speaker Lanes through the full Conversation façade and yield two
+// STTFinals — each carrying its own SpeakerID and its clip's ground-truth transcript
+// (normalized-text match, the tolerant house rule). This is the headline
+// two-speaker-attribution proof of ADR-0050.
+func TestConversation_TwoSpeakerCassette_DistinctSpeakerIDs(t *testing.T) {
+	h := voicetest.New(t)
+
+	const speakerHello, speakerBart = "111", "222"
+	helloFrames := clipFrames(t, "hello-test", speakerHello)
+	bartFrames := clipFrames(t, "bart-test", speakerBart)
+
+	rec := newClipRecognizer(map[string][]audio.Frame{
+		helloUtterance: helloFrames,
+		bartUtterance:  bartFrames,
+	})
+
+	// The default lane's VAD is a real Silero session (it only ever sees the trailing
+	// broadcast silence, never a voiced frame, so it emits nothing).
+	engine, err := silero.New()
+	if err != nil {
+		t.Fatalf("silero.New: %v", err)
+	}
+	defSess, err := engine.NewSession(vad.Config{SampleRate: 16000, FrameSizeMs: 32, SpeechThreshold: 0.5, SilenceThreshold: 0.35})
+	if err != nil {
+		t.Fatalf("engine.NewSession: %v", err)
+	}
+	t.Cleanup(func() { _ = defSess.Close() })
+
+	vadStage := orchestrator.NewVAD(h.Bus, defSess)
+	sttStage := orchestrator.NewSTT(h.Bus, rec)
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil,
+		orchestrator.WithSpeakerLanes(sileroLaneFactory(t, h.Bus)),
+		orchestrator.WithErrorHandler(func(err error) { t.Errorf("stage: %v", err) }),
+	)
+	t.Cleanup(conv.Register(t.Context()))
+
+	// Interleave the two speakers' frames frame-by-frame: the segmenter routes each to
+	// its own lane, so each lane's Silero session reconstructs its clip's contiguous
+	// stream — real cross-talk, correctly separated (ADR-0050).
+	maxLen := len(helloFrames)
+	if len(bartFrames) > maxLen {
+		maxLen = len(bartFrames)
+	}
+	for i := 0; i < maxLen; i++ {
+		if i < len(helloFrames) {
+			if err := conv.Feed(helloFrames[i]); err != nil {
+				t.Fatalf("feed hello %d: %v", i, err)
+			}
+		}
+		if i < len(bartFrames) {
+			if err := conv.Feed(bartFrames[i]); err != nil {
+				t.Fatalf("feed bart %d: %v", i, err)
+			}
+		}
+	}
+	if err := conv.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Exactly two STTFinals, one per speaker, each matching its clip's ground truth.
+	bySpeaker := map[string]string{}
+	for _, e := range h.Events() {
+		if f, ok := e.(voiceevent.STTFinal); ok {
+			bySpeaker[f.SpeakerID] = f.Text
+		}
+	}
+	if len(bySpeaker) != 2 {
+		t.Fatalf("STTFinals by speaker = %v, want two distinct SpeakerIDs", bySpeaker)
+	}
+	assertNormalized(t, bySpeaker[speakerHello], helloUtterance, speakerHello)
+	assertNormalized(t, bySpeaker[speakerBart], bartUtterance, speakerBart)
+}
+
+func assertNormalized(t *testing.T, got, want, speaker string) {
+	t.Helper()
+	if voicetest.NormalizeTranscript(got) != voicetest.NormalizeTranscript(want) {
+		t.Errorf("speaker %s transcript = %q, want (normalized) %q", speaker, got, want)
+	}
+}

--- a/pkg/voice/orchestrator/lanes_test.go
+++ b/pkg/voice/orchestrator/lanes_test.go
@@ -1,0 +1,355 @@
+package orchestrator_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// contentVAD is a [vad.SessionHandle] that segments purely on frame content: a
+// non-silent frame is speech, an all-zero frame is silence. It emits a speech_start
+// on the first voiced frame, speech_continue while voiced, a speech_end on the first
+// silent frame after speech, and silence otherwise — so a test drives each lane's
+// segmentation deterministically by the frames it feeds, one detector per lane.
+type contentVAD struct{ speaking bool }
+
+func (c *contentVAD) ProcessFrame(f audio.Frame) (vad.VADEvent, error) {
+	voiced := false
+	for _, s := range f.Samples() {
+		if s != 0 {
+			voiced = true
+			break
+		}
+	}
+	switch {
+	case voiced && !c.speaking:
+		c.speaking = true
+		return vad.VADEvent{Type: vad.VADSpeechStart}, nil
+	case voiced:
+		return vad.VADEvent{Type: vad.VADSpeechContinue}, nil
+	case c.speaking:
+		c.speaking = false
+		return vad.VADEvent{Type: vad.VADSpeechEnd}, nil
+	default:
+		return vad.VADEvent{Type: vad.VADSilence}, nil
+	}
+}
+
+func (c *contentVAD) Reset()       { c.speaking = false }
+func (c *contentVAD) Close() error { return nil }
+
+// laneFrame builds a 32 ms / 16 kHz frame whose 512 samples all equal value
+// (0 = silence), tagged with speaker. A distinct non-zero value per speaker lets a
+// test prove a lane's segment contains only its own speaker's frames.
+func laneFrame(t *testing.T, speaker string, value int16) audio.Frame {
+	t.Helper()
+	s := make([]int16, 512)
+	for i := range s {
+		s[i] = value
+	}
+	f, err := audio.NewFrame(s, 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f.WithSpeaker(speaker)
+}
+
+// laneVADFactory returns a factory building a contentVAD-backed lane VAD on bus,
+// counting the close funcs invoked (so a reap test proves the ONNX session is
+// released). err, when set, is returned instead — the degraded path.
+func laneVADFactory(bus *voiceevent.Bus, closes *int, err error) (orchestrator.LaneVADFactory, *sync.Mutex) {
+	var mu sync.Mutex
+	return func() (*orchestrator.VAD, func(), error) {
+		if err != nil {
+			return nil, nil, err
+		}
+		v := orchestrator.NewVAD(bus, &contentVAD{})
+		return v, func() { mu.Lock(); *closes++; mu.Unlock() }, nil
+	}, &mu
+}
+
+// newLaneSegmenter wires a lane-enabled segmenter over a default contentVAD and the
+// given recognizer onto a fresh bus, bound for the test's lifetime.
+func newLaneSegmenter(t *testing.T, bus *voiceevent.Bus, rec *recordingRecognizer, factory orchestrator.LaneVADFactory) *orchestrator.Segmenter {
+	t.Helper()
+	vadStage := orchestrator.NewVAD(bus, &contentVAD{})
+	sttStage := orchestrator.NewSTT(bus, rec)
+	seg := orchestrator.NewSegmenter(vadStage, sttStage)
+	seg.SetLaneVADFactory(factory)
+	t.Cleanup(seg.Bind(t.Context(), bus))
+	return seg
+}
+
+func processFrames(t *testing.T, seg *orchestrator.Segmenter, frames ...audio.Frame) {
+	t.Helper()
+	for i, f := range frames {
+		if err := seg.Process(f); err != nil {
+			t.Fatalf("frame %d: Process: %v", i, err)
+		}
+	}
+}
+
+// TestSegmenter_TwoSpeakers_TwoLanesTwoFinals is step 3: speaker A then speaker B
+// open two Speaker Lanes; each utterance is transcribed on its own lane and only its
+// own frames, and the two STTFinals carry distinct SpeakerIDs (ADR-0050).
+func TestSegmenter_TwoSpeakers_TwoLanesTwoFinals(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	// A speaks (value 100) then goes silent (flush), then B speaks (value 200).
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), laneFrame(t, "A", 100), laneFrame(t, "A", 0),
+		laneFrame(t, "B", 200), laneFrame(t, "B", 200), laneFrame(t, "B", 0),
+	)
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := seg.LaneCount(); got != 3 { // default + A + B
+		t.Errorf("lane count = %d, want 3 (default, A, B)", got)
+	}
+	batches := rec.batches()
+	if len(batches) != 2 {
+		t.Fatalf("transcribe calls = %d, want 2 (one per speaker)", len(batches))
+	}
+	// Each batch is 2 voiced frames of a single speaker's value — no cross-lane bleed.
+	for _, b := range batches {
+		if len(b) != 2 {
+			t.Errorf("segment had %d frames, want 2", len(b))
+		}
+		v := b[0].Samples()[0]
+		for _, f := range b {
+			if f.Samples()[0] != v {
+				t.Errorf("segment mixed speaker values (%d and %d) — lanes bled together", v, f.Samples()[0])
+			}
+		}
+	}
+	ids := map[string]bool{}
+	for _, f := range finals {
+		ids[f.SpeakerID] = true
+	}
+	if !ids["A"] || !ids["B"] || len(ids) != 2 {
+		t.Errorf("STTFinal SpeakerIDs = %v, want exactly {A, B}", ids)
+	}
+}
+
+// TestSegmenter_CrossTalk_LanesStayIntact is step 4: A is mid-utterance when B
+// interjects a short overlap; each lane's segment stays intact and correctly
+// attributed (the whole point of per-speaker lanes — cross-talk must not bake a
+// mis-attribution into the Transcript, ADR-0050).
+func TestSegmenter_CrossTalk_LanesStayIntact(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	// A: |----speech----|  with B's short overlap in the middle.
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), // A start
+		laneFrame(t, "A", 100), // A continue
+		laneFrame(t, "B", 200), // B start (overlap)
+		laneFrame(t, "A", 100), // A continue (still speaking)
+		laneFrame(t, "B", 0),   // B end → flush B (1 frame)
+		laneFrame(t, "A", 100), // A continue
+		laneFrame(t, "A", 0),   // A end → flush A (4 frames)
+	)
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	batches := rec.batches()
+	if len(batches) != 2 {
+		t.Fatalf("transcribe calls = %d, want 2 (A + B)", len(batches))
+	}
+	var aLen, bLen int
+	for _, b := range batches {
+		switch b[0].Samples()[0] {
+		case 100:
+			aLen = len(b)
+		case 200:
+			bLen = len(b)
+		}
+		v := b[0].Samples()[0]
+		for _, f := range b {
+			if f.Samples()[0] != v {
+				t.Errorf("cross-talk bled a %d frame into a %d segment", f.Samples()[0], v)
+			}
+		}
+	}
+	if aLen != 4 {
+		t.Errorf("A segment had %d frames, want 4 (its own voiced frames only)", aLen)
+	}
+	if bLen != 1 {
+		t.Errorf("B segment had %d frames, want 1 (its short overlap only)", bLen)
+	}
+	if len(finals) != 2 {
+		t.Errorf("STTFinals = %d, want 2", len(finals))
+	}
+}
+
+// TestSegmenter_EmptySpeakerBroadcasts is step 5: an unattributed ("") frame — the
+// silence clock — broadcasts to every lane, advancing a listening lane's hangover so
+// it endpoints and flushes (ADR-0050's speaker-agnostic silence clock).
+func TestSegmenter_EmptySpeakerBroadcasts(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	// A speaks, then a broadcast SILENCE-clock frame (Speaker "") ends A's utterance.
+	silence, err := audio.NewFrame(make([]int16, 512), 16000, 32) // Speaker() == ""
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	processFrames(t, seg,
+		laneFrame(t, "A", 100),
+		laneFrame(t, "A", 100),
+		silence, // broadcast: advances A's lane hangover → speech_end → flush
+	)
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	batches := rec.batches()
+	if len(batches) != 1 {
+		t.Fatalf("transcribe calls = %d, want 1 (the broadcast silence endpointed A)", len(batches))
+	}
+	if got := len(batches[0]); got != 2 {
+		t.Errorf("A segment had %d frames, want 2 (silence-clock frame endpoints, not buffered)", got)
+	}
+}
+
+// TestSegmenter_LaneIdleReap is step 6: a lane idle past the TTL is reaped — its
+// buffered utterance flushed (not dropped), its VAD close() called — and the default
+// lane is never reaped (ADR-0050 lane lifecycle; risk (b) ONNX release).
+func TestSegmenter_LaneIdleReap(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, cmu := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	now := time.Unix(0, 0)
+	seg.SetLaneReap(50*time.Millisecond, func() time.Time { return now })
+	seg.SetSweepEvery(1) // sweep on every Process call
+
+	// A speaks but never ends (buffered mid-utterance), leaving A's lane open.
+	processFrames(t, seg, laneFrame(t, "A", 100), laneFrame(t, "A", 100))
+	if got := seg.LaneCount(); got != 2 {
+		t.Fatalf("lane count = %d, want 2 (default + A)", got)
+	}
+
+	// Advance the clock past the TTL; a further (unattributed) frame triggers the sweep.
+	now = now.Add(time.Second)
+	silence, _ := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err := seg.Process(silence); err != nil {
+		t.Fatalf("Process (sweep trigger): %v", err)
+	}
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := seg.LaneCount(); got != 1 {
+		t.Errorf("lane count after reap = %d, want 1 (only the default lane survives)", got)
+	}
+	cmu.Lock()
+	gotCloses := closes
+	cmu.Unlock()
+	if gotCloses != 1 {
+		t.Errorf("lane VAD close() called %d times, want 1 (reaped lane's ONNX session released)", gotCloses)
+	}
+	// The reaped lane's buffered utterance was flushed, not dropped.
+	batches := rec.batches()
+	if len(batches) != 1 {
+		t.Fatalf("transcribe calls = %d, want 1 (reaped lane's buffered utterance flushed)", len(batches))
+	}
+	if got := len(batches[0]); got != 2 {
+		t.Errorf("reaped segment had %d frames, want 2 (A's buffered audio)", got)
+	}
+}
+
+// TestSegmenter_FactoryErrorFallsToDefaultLane is step 7: a lane VAD factory error
+// degrades the speaker's frames to the default lane (still transcribed) and reports
+// the error via onError — the audio loop stays up (ADR-0050 risk (c)).
+func TestSegmenter_FactoryErrorFallsToDefaultLane(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, errors.New("silero session exhausted"))
+	seg := newLaneSegmenter(t, bus, rec, factory)
+	var mu sync.Mutex
+	var errs []error
+	seg.SetErrorHandler(func(err error) { mu.Lock(); errs = append(errs, err); mu.Unlock() })
+
+	// A's frames cannot open a lane (factory errors) → they drive the DEFAULT lane's
+	// VAD instead. Feed a full A utterance on the default lane.
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), laneFrame(t, "A", 100), laneFrame(t, "A", 0),
+	)
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := seg.LaneCount(); got != 1 {
+		t.Errorf("lane count = %d, want 1 (no lane opened; frames fell to default)", got)
+	}
+	if len(rec.batches()) != 1 {
+		t.Errorf("transcribe calls = %d, want 1 (degraded but still transcribed)", len(rec.batches()))
+	}
+	mu.Lock()
+	gotErrs := len(errs)
+	mu.Unlock()
+	if gotErrs == 0 {
+		t.Error("factory error was not reported via onError")
+	}
+}
+
+// TestSegmenter_FlushDrainsAllLanes is step 8: Flush drains a still-buffered
+// utterance on every lane (default + each speaker lane), so no mid-utterance lane is
+// lost at end-of-stream.
+func TestSegmenter_FlushDrainsAllLanes(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	// Two speakers, both mid-utterance (never a silent end frame) at end-of-stream.
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), laneFrame(t, "A", 100),
+		laneFrame(t, "B", 200),
+	)
+	if len(rec.batches()) != 0 {
+		t.Fatalf("before Flush: %d transcribe calls, want 0 (both lanes still listening)", len(rec.batches()))
+	}
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if len(rec.batches()) != 2 {
+		t.Fatalf("after Flush: %d transcribe calls, want 2 (both lanes drained)", len(rec.batches()))
+	}
+	ids := map[string]bool{}
+	for _, f := range finals {
+		ids[f.SpeakerID] = true
+	}
+	if !ids["A"] || !ids["B"] {
+		t.Errorf("flushed SpeakerIDs = %v, want both A and B", ids)
+	}
+}

--- a/pkg/voice/orchestrator/lanes_test.go
+++ b/pkg/voice/orchestrator/lanes_test.go
@@ -17,7 +17,14 @@ import (
 // on the first voiced frame, speech_continue while voiced, a speech_end on the first
 // silent frame after speech, and silence otherwise — so a test drives each lane's
 // segmentation deterministically by the frames it feeds, one detector per lane.
-type contentVAD struct{ speaking bool }
+type contentVAD struct {
+	speaking bool
+	// hangover is the number of consecutive silent frames BUFFERED before speech_end
+	// (0 = end on the first silent frame). A non-zero hangover models real Silero: the
+	// silence-clock frames that endpoint an utterance are buffered into it first.
+	hangover int
+	silent   int
+}
 
 func (c *contentVAD) ProcessFrame(f audio.Frame) (vad.VADEvent, error) {
 	voiced := false
@@ -27,21 +34,26 @@ func (c *contentVAD) ProcessFrame(f audio.Frame) (vad.VADEvent, error) {
 			break
 		}
 	}
-	switch {
-	case voiced && !c.speaking:
-		c.speaking = true
-		return vad.VADEvent{Type: vad.VADSpeechStart}, nil
-	case voiced:
+	if voiced {
+		c.silent = 0
+		if !c.speaking {
+			c.speaking = true
+			return vad.VADEvent{Type: vad.VADSpeechStart}, nil
+		}
 		return vad.VADEvent{Type: vad.VADSpeechContinue}, nil
-	case c.speaking:
-		c.speaking = false
-		return vad.VADEvent{Type: vad.VADSpeechEnd}, nil
-	default:
-		return vad.VADEvent{Type: vad.VADSilence}, nil
 	}
+	if c.speaking {
+		c.silent++
+		if c.silent > c.hangover {
+			c.speaking = false
+			return vad.VADEvent{Type: vad.VADSpeechEnd}, nil
+		}
+		return vad.VADEvent{Type: vad.VADSpeechContinue}, nil // buffered during hangover
+	}
+	return vad.VADEvent{Type: vad.VADSilence}, nil
 }
 
-func (c *contentVAD) Reset()       { c.speaking = false }
+func (c *contentVAD) Reset()       { c.speaking = false; c.silent = 0 }
 func (c *contentVAD) Close() error { return nil }
 
 // laneFrame builds a 32 ms / 16 kHz frame whose 512 samples all equal value
@@ -64,12 +76,18 @@ func laneFrame(t *testing.T, speaker string, value int16) audio.Frame {
 // counting the close funcs invoked (so a reap test proves the ONNX session is
 // released). err, when set, is returned instead — the degraded path.
 func laneVADFactory(bus *voiceevent.Bus, closes *int, err error) (orchestrator.LaneVADFactory, *sync.Mutex) {
+	return laneVADFactoryH(bus, closes, err, 0)
+}
+
+// laneVADFactoryH is [laneVADFactory] with a configurable VAD hangover (silent frames
+// buffered before speech_end) — non-zero so a silence-clock frame lands in the segment.
+func laneVADFactoryH(bus *voiceevent.Bus, closes *int, err error, hangover int) (orchestrator.LaneVADFactory, *sync.Mutex) {
 	var mu sync.Mutex
 	return func() (*orchestrator.VAD, func(), error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		v := orchestrator.NewVAD(bus, &contentVAD{})
+		v := orchestrator.NewVAD(bus, &contentVAD{hangover: hangover})
 		return v, func() { mu.Lock(); *closes++; mu.Unlock() }, nil
 	}, &mu
 }
@@ -201,37 +219,136 @@ func TestSegmenter_CrossTalk_LanesStayIntact(t *testing.T) {
 	}
 }
 
-// TestSegmenter_EmptySpeakerBroadcasts is step 5: an unattributed ("") frame — the
-// silence clock — broadcasts to every lane, advancing a listening lane's hangover so
-// it endpoints and flushes (ADR-0050's speaker-agnostic silence clock).
-func TestSegmenter_EmptySpeakerBroadcasts(t *testing.T) {
+func silentFrame(t *testing.T) audio.Frame {
+	t.Helper()
+	f, err := audio.NewFrame(make([]int16, 512), 16000, 32) // Speaker() == ""
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f
+}
+
+// TestSegmenter_ProcessSilenceBroadcastsToAllLanes is step 5 / T3 (revised contract):
+// the silence CLOCK — [Segmenter.ProcessSilence] — reaches EVERY lane, endpointing
+// each listening lane on its own SpeakerID, and the silence frames land in each lane's
+// buffered segment stamped with that lane's id (parity with the pre-lane single-lane
+// path). A VAD hangover of 1 buffers the first silence frame before the second ends it.
+func TestSegmenter_ProcessSilenceBroadcastsToAllLanes(t *testing.T) {
 	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactoryH(bus, &closes, nil, 1) // 1-frame hangover
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	// A and B each mid-utterance (real speech via Process).
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), laneFrame(t, "B", 200),
+	)
+	// Two silence-clock ticks: first buffered into each lane (hangover), second endpoints.
+	if err := seg.ProcessSilence(silentFrame(t)); err != nil {
+		t.Fatalf("ProcessSilence 1: %v", err)
+	}
+	if err := seg.ProcessSilence(silentFrame(t)); err != nil {
+		t.Fatalf("ProcessSilence 2: %v", err)
+	}
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if len(finals) != 2 {
+		t.Fatalf("STTFinals = %d, want 2 (both lanes endpointed by the silence clock)", len(finals))
+	}
+	ids := map[string]bool{}
+	for _, f := range finals {
+		ids[f.SpeakerID] = true
+	}
+	if !ids["A"] || !ids["B"] {
+		t.Errorf("endpointed SpeakerIDs = %v, want both A and B", ids)
+	}
+	// Each segment contains a silence frame stamped with ITS lane's id.
+	batches := rec.batches()
+	if len(batches) != 2 {
+		t.Fatalf("transcribe calls = %d, want 2", len(batches))
+	}
+	for _, b := range batches {
+		laneID := b[0].Speaker()
+		sawSilence := false
+		for _, f := range b {
+			if f.Speaker() != laneID {
+				t.Errorf("segment frame stamped %q, want lane id %q (silence restamped per lane)", f.Speaker(), laneID)
+			}
+			if f.Samples()[0] == 0 {
+				sawSilence = true
+			}
+		}
+		if !sawSilence {
+			t.Errorf("lane %q segment has no buffered silence-clock frame", laneID)
+		}
+	}
+}
+
+// TestSegmenter_VoicedUnknownSpeakerDefaultLaneOnly is T2 / finding 2: a still-voiced
+// frame whose SSRC hasn't resolved (Speaker() == "") goes to the DEFAULT lane ONLY —
+// it never touches an open Speaker Lane (no phantom misattribution) and its STTFinal
+// is unattributed (SpeakerID "" → Butler fail-closed). The open lanes' segments stay
+// clean.
+func TestSegmenter_VoicedUnknownSpeakerDefaultLaneOnly(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
 	rec := &recordingRecognizer{}
 	closes := 0
 	factory, _ := laneVADFactory(bus, &closes, nil)
 	seg := newLaneSegmenter(t, bus, rec, factory)
 
-	// A speaks, then a broadcast SILENCE-clock frame (Speaker "") ends A's utterance.
-	silence, err := audio.NewFrame(make([]int16, 512), 16000, 32) // Speaker() == ""
+	// Open lanes A and B (each a full utterance), then a VOICED unknown-SSRC frame
+	// (Speaker "" but non-zero PCM, value 300) followed by a silent "" frame to end it.
+	voicedUnknown, err := audio.NewFrame(mkSamples(300), 16000, 32) // Speaker() == ""
 	if err != nil {
 		t.Fatalf("audio.NewFrame: %v", err)
 	}
 	processFrames(t, seg,
-		laneFrame(t, "A", 100),
-		laneFrame(t, "A", 100),
-		silence, // broadcast: advances A's lane hangover → speech_end → flush
+		laneFrame(t, "A", 100), laneFrame(t, "A", 0), // A utterance
+		laneFrame(t, "B", 200), laneFrame(t, "B", 0), // B utterance
+		voicedUnknown,  // → default lane only
+		silentFrame(t), // ends the default-lane utterance
 	)
 	if err := seg.Flush(); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
 
-	batches := rec.batches()
-	if len(batches) != 1 {
-		t.Fatalf("transcribe calls = %d, want 1 (the broadcast silence endpointed A)", len(batches))
+	// Three finals: A, B, and the unattributed default-lane one.
+	bySpeaker := map[string]string{}
+	for _, f := range finals {
+		bySpeaker[f.SpeakerID] = "seen"
 	}
-	if got := len(batches[0]); got != 2 {
-		t.Errorf("A segment had %d frames, want 2 (silence-clock frame endpoints, not buffered)", got)
+	if _, ok := bySpeaker[""]; !ok {
+		t.Error("no unattributed STTFinal for the voiced unknown-SSRC frame (default lane)")
 	}
+	if bySpeaker["A"] == "" || bySpeaker["B"] == "" {
+		t.Errorf("SpeakerIDs = %v, want A, B and \"\"", bySpeaker)
+	}
+	// No lane's segment may contain the value-300 unknown frame — it never touched them.
+	for _, b := range rec.batches() {
+		id := b[0].Speaker()
+		if id != "" { // a Speaker Lane
+			for _, f := range b {
+				if f.Samples()[0] == 300 {
+					t.Errorf("lane %q segment contains the voiced unknown-SSRC frame — phantom misattribution", id)
+				}
+			}
+		}
+	}
+}
+
+func mkSamples(v int16) []int16 {
+	s := make([]int16, 512)
+	for i := range s {
+		s[i] = v
+	}
+	return s
 }
 
 // TestSegmenter_LaneIdleReap is step 6: a lane idle past the TTL is reaped — its
@@ -256,8 +373,7 @@ func TestSegmenter_LaneIdleReap(t *testing.T) {
 
 	// Advance the clock past the TTL; a further (unattributed) frame triggers the sweep.
 	now = now.Add(time.Second)
-	silence, _ := audio.NewFrame(make([]int16, 512), 16000, 32)
-	if err := seg.Process(silence); err != nil {
+	if err := seg.Process(silentFrame(t)); err != nil {
 		t.Fatalf("Process (sweep trigger): %v", err)
 	}
 	if err := seg.Flush(); err != nil {
@@ -283,24 +399,101 @@ func TestSegmenter_LaneIdleReap(t *testing.T) {
 	}
 }
 
-// TestSegmenter_FactoryErrorFallsToDefaultLane is step 7: a lane VAD factory error
-// degrades the speaker's frames to the default lane (still transcribed) and reports
-// the error via onError — the audio loop stays up (ADR-0050 risk (c)).
-func TestSegmenter_FactoryErrorFallsToDefaultLane(t *testing.T) {
+// TestSegmenter_LanesReapUnderContinuousSilence is T1 / finding 1 (the high one): a
+// quiet table ticks the silence clock every 32 ms forever. Because processLane no
+// longer refreshes lastSeen (only attributed frames via laneFor do), the lanes MUST
+// still age past the idle TTL and be reaped DESPITE the continuous silence — otherwise
+// each departed speaker's ONNX inferencer and stream slot leak for the session.
+func TestSegmenter_LanesReapUnderContinuousSilence(t *testing.T) {
 	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, cmu := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	now := time.Unix(0, 0)
+	seg.SetLaneReap(500*time.Millisecond, func() time.Time { return now })
+	seg.SetSweepEvery(4) // sweep every 4 ticks, a realistic amortised cadence (not 1)
+
+	// Two speakers speak once each (lanes A, B created; each utterance ended).
+	processFrames(t, seg,
+		laneFrame(t, "A", 100), laneFrame(t, "A", 0),
+		laneFrame(t, "B", 200), laneFrame(t, "B", 0),
+	)
+	if got := seg.LaneCount(); got != 3 {
+		t.Fatalf("lane count = %d, want 3 (default + A + B)", got)
+	}
+
+	// The table goes quiet: only the silence clock ticks, advancing wall time. The
+	// lanes must age out even though ProcessSilence keeps being called.
+	for i := 0; i < 40; i++ {
+		now = now.Add(32 * time.Millisecond) // ~1.28s total, well past the 500ms TTL
+		if err := seg.ProcessSilence(silentFrame(t)); err != nil {
+			t.Fatalf("ProcessSilence %d: %v", i, err)
+		}
+	}
+
+	if got := seg.LaneCount(); got != 1 {
+		t.Errorf("lane count = %d, want 1 — lanes never aged under continuous silence (reap dead in prod)", got)
+	}
+	cmu.Lock()
+	gotCloses := closes
+	cmu.Unlock()
+	if gotCloses != 2 {
+		t.Errorf("lane VAD close() called %d times, want 2 (both departed speakers' ONNX sessions released)", gotCloses)
+	}
+}
+
+// TestSegmenter_SweepFiresFromSilenceOnly is T4: reap runs from ProcessSilence too, so
+// a lane created then followed ONLY by silence ticks (no further attributed frame)
+// still reaps once the clock passes the TTL — idle is exactly when reap must fire.
+func TestSegmenter_SweepFiresFromSilenceOnly(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := newLaneSegmenter(t, bus, rec, factory)
+
+	now := time.Unix(0, 0)
+	seg.SetLaneReap(50*time.Millisecond, func() time.Time { return now })
+	seg.SetSweepEvery(1)
+
+	processFrames(t, seg, laneFrame(t, "A", 100), laneFrame(t, "A", 0))
+	if got := seg.LaneCount(); got != 2 {
+		t.Fatalf("lane count = %d, want 2", got)
+	}
+	now = now.Add(time.Second)
+	if err := seg.ProcessSilence(silentFrame(t)); err != nil { // only silence, no attributed frame
+		t.Fatalf("ProcessSilence: %v", err)
+	}
+	if got := seg.LaneCount(); got != 1 {
+		t.Errorf("lane count = %d, want 1 (reap must fire from ProcessSilence)", got)
+	}
+}
+
+// TestSegmenter_FactoryErrorReportedOnceThenDegrades is step 7 + finding 3: a lane VAD
+// factory error degrades the speaker's frames to the DEFAULT lane (still transcribed,
+// unattributed) and reports the error exactly ONCE — not per frame at ~31/s. Later
+// frames from the same speaker take the memoized degrade path silently (risk (c)).
+func TestSegmenter_FactoryErrorReportedOnceThenDegrades(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
 	rec := &recordingRecognizer{}
 	closes := 0
 	factory, _ := laneVADFactory(bus, &closes, errors.New("silero session exhausted"))
 	seg := newLaneSegmenter(t, bus, rec, factory)
 	var mu sync.Mutex
-	var errs []error
-	seg.SetErrorHandler(func(err error) { mu.Lock(); errs = append(errs, err); mu.Unlock() })
+	errs := 0
+	seg.SetErrorHandler(func(error) { mu.Lock(); errs++; mu.Unlock() })
 
-	// A's frames cannot open a lane (factory errors) → they drive the DEFAULT lane's
-	// VAD instead. Feed a full A utterance on the default lane.
-	processFrames(t, seg,
-		laneFrame(t, "A", 100), laneFrame(t, "A", 100), laneFrame(t, "A", 0),
-	)
+	// A MANY-frame utterance: a per-frame factory retry would fire onError ~20 times.
+	frames := make([]audio.Frame, 0, 21)
+	for i := 0; i < 20; i++ {
+		frames = append(frames, laneFrame(t, "A", 100))
+	}
+	frames = append(frames, laneFrame(t, "A", 0)) // ends the default-lane utterance
+	processFrames(t, seg, frames...)
 	if err := seg.Flush(); err != nil {
 		t.Fatalf("Flush: %v", err)
 	}
@@ -311,11 +504,14 @@ func TestSegmenter_FactoryErrorFallsToDefaultLane(t *testing.T) {
 	if len(rec.batches()) != 1 {
 		t.Errorf("transcribe calls = %d, want 1 (degraded but still transcribed)", len(rec.batches()))
 	}
+	if len(finals) != 1 || finals[0].SpeakerID != "" {
+		t.Errorf("STTFinals = %+v, want one unattributed (SpeakerID \"\") default-lane final", finals)
+	}
 	mu.Lock()
-	gotErrs := len(errs)
+	gotErrs := errs
 	mu.Unlock()
-	if gotErrs == 0 {
-		t.Error("factory error was not reported via onError")
+	if gotErrs != 1 {
+		t.Errorf("factory error reported %d times, want exactly 1 (memoized single-shot degrade)", gotErrs)
 	}
 }
 
@@ -352,4 +548,34 @@ func TestSegmenter_FlushDrainsAllLanes(t *testing.T) {
 	if !ids["A"] || !ids["B"] {
 		t.Errorf("flushed SpeakerIDs = %v, want both A and B", ids)
 	}
+}
+
+// TestSegmenter_TeardownRaceWithFeed is finding 6: Bind's teardown runs concurrently
+// with an audio loop still calling Feed. Lane cancel/close funcs are captured and
+// nulled UNDER mu (and the lane dropped) in both teardown and reap, so no lane is
+// double-closed and no field is touched unlocked. Run under `go test -race`.
+func TestSegmenter_TeardownRaceWithFeed(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := orchestrator.NewSegmenter(orchestrator.NewVAD(bus, &contentVAD{}), orchestrator.NewSTT(bus, rec))
+	seg.SetLaneVADFactory(factory)
+	cancel := seg.Bind(t.Context(), bus)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Voiced-only frames keep every lane listening (no flush → no jobs send that
+		// could race the teardown's close(jobs)); the point is the concurrent lane
+		// map + close-func access, which must stay mu-guarded.
+		for i := 0; i < 500; i++ {
+			_ = seg.Process(laneFrame(t, "A", 100))
+			_ = seg.Process(laneFrame(t, "B", 200))
+		}
+	}()
+	time.Sleep(time.Millisecond) // let the loop open the lanes
+	cancel()                     // teardown while Feed is still running
+	wg.Wait()
 }

--- a/pkg/voice/orchestrator/lanestream_internal_test.go
+++ b/pkg/voice/orchestrator/lanestream_internal_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
@@ -81,4 +82,61 @@ type stubRec struct{}
 
 func (stubRec) Transcribe(_ context.Context, _ []audio.Frame) (stt.Transcript, error) {
 	return stt.Transcript{}, nil
+}
+
+// TestSegmenter_StreamSlotRecycledOnReap is T5: with a per-lane stream cap of 1,
+// speaker A opens the one stream; after A's lane is reaped the slot is freed, so a
+// later speaker C opens a stream instead of falling to batch (reap decrements the
+// concurrency count — reviewer finding 5).
+func TestSegmenter_StreamSlotRecycledOnReap(t *testing.T) {
+	bus := voiceevent.NewBus()
+	seg := NewSegmenter(NewVAD(bus, silentSession{}), NewSTT(bus, stubRec{}))
+	seg.laneVADFactory = func() (*VAD, func(), error) {
+		return NewVAD(bus, silentSession{}), func() {}, nil
+	}
+	seg.laneStreamFactory = func(speakerID string) *StreamManager {
+		return NewStreamManager(&fakeStreamingRecognizer{stream: &fakeStream{}}, WithStreamSpeakerID(speakerID))
+	}
+	seg.maxStreamLanes = 1
+	now := time.Unix(0, 0)
+	seg.SetLaneReap(50*time.Millisecond, func() time.Time { return now })
+	seg.SetSweepEvery(1)
+	t.Cleanup(seg.Bind(t.Context(), bus))
+
+	if err := seg.Process(capTestFrame(t, "A")); err != nil { // A opens the one stream
+		t.Fatalf("Process A: %v", err)
+	}
+	seg.mu.Lock()
+	aStream := seg.lanes["A"].stream != nil
+	seg.mu.Unlock()
+	if !aStream {
+		t.Fatal("lane A has no stream, want one (under cap)")
+	}
+
+	// Reap A: advance past the TTL and tick the silence clock to trigger the sweep.
+	now = now.Add(time.Second)
+	if err := seg.ProcessSilence(capTestFrame(t, "")); err != nil {
+		t.Fatalf("ProcessSilence: %v", err)
+	}
+	seg.mu.Lock()
+	_, aGone := seg.lanes["A"]
+	freed := seg.streamLanes
+	seg.mu.Unlock()
+	if aGone {
+		t.Fatal("lane A was not reaped")
+	}
+	if freed != 0 {
+		t.Fatalf("streamLanes = %d after reap, want 0 (slot freed)", freed)
+	}
+
+	// C now opens a stream — the recycled slot.
+	if err := seg.Process(capTestFrame(t, "C")); err != nil {
+		t.Fatalf("Process C: %v", err)
+	}
+	seg.mu.Lock()
+	cStream := seg.lanes["C"].stream != nil
+	seg.mu.Unlock()
+	if !cStream {
+		t.Error("lane C has no stream — the reaped slot was not recycled (finding 5)")
+	}
 }

--- a/pkg/voice/orchestrator/lanestream_internal_test.go
+++ b/pkg/voice/orchestrator/lanestream_internal_test.go
@@ -44,7 +44,7 @@ func TestSegmenter_LaneStreamCap(t *testing.T) {
 	var factoryCalls int
 	seg.laneStreamFactory = func(speakerID string) *StreamManager {
 		factoryCalls++
-		return NewStreamManager(&fakeStreamingRecognizer{}, WithStreamSpeakerID(speakerID))
+		return NewStreamManager(&fakeStreamingRecognizer{stream: &fakeStream{}}, WithStreamSpeakerID(speakerID))
 	}
 	seg.maxStreamLanes = 1
 	t.Cleanup(seg.Bind(t.Context(), bus))

--- a/pkg/voice/orchestrator/lanestream_internal_test.go
+++ b/pkg/voice/orchestrator/lanestream_internal_test.go
@@ -1,0 +1,84 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// silentSession is a [vad.SessionHandle] that reports silence for every frame — the
+// cap test only needs lanes to be CREATED (which happens on the first frame from a
+// new speaker), not segmented.
+type silentSession struct{}
+
+func (silentSession) ProcessFrame(audio.Frame) (vad.VADEvent, error) {
+	return vad.VADEvent{Type: vad.VADSilence}, nil
+}
+func (silentSession) Reset()       {}
+func (silentSession) Close() error { return nil }
+
+func capTestFrame(t *testing.T, speaker string) audio.Frame {
+	t.Helper()
+	f, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	return f.WithSpeaker(speaker)
+}
+
+// TestSegmenter_LaneStreamCap is step 11 (ADR-0050): with a per-lane stream cap of
+// 1, the first Speaker Lane opens a StreamManager; the second lane exceeds the cap
+// and is pure batch (no stream) — so concurrent sockets track concurrent speakers,
+// not channel size.
+func TestSegmenter_LaneStreamCap(t *testing.T) {
+	bus := voiceevent.NewBus()
+	sttStage := NewSTT(bus, stubRec{})
+	seg := NewSegmenter(NewVAD(bus, silentSession{}), sttStage)
+	seg.laneVADFactory = func() (*VAD, func(), error) {
+		return NewVAD(bus, silentSession{}), func() {}, nil
+	}
+	var factoryCalls int
+	seg.laneStreamFactory = func(speakerID string) *StreamManager {
+		factoryCalls++
+		return NewStreamManager(&fakeStreamingRecognizer{}, WithStreamSpeakerID(speakerID))
+	}
+	seg.maxStreamLanes = 1
+	t.Cleanup(seg.Bind(t.Context(), bus))
+
+	if err := seg.Process(capTestFrame(t, "A")); err != nil { // opens lane A (under cap → stream)
+		t.Fatalf("Process A: %v", err)
+	}
+	if err := seg.Process(capTestFrame(t, "B")); err != nil { // opens lane B (over cap → batch)
+		t.Fatalf("Process B: %v", err)
+	}
+
+	seg.mu.Lock()
+	laneA, laneB := seg.lanes["A"], seg.lanes["B"]
+	streamLanes := seg.streamLanes
+	seg.mu.Unlock()
+
+	if laneA == nil || laneA.stream == nil {
+		t.Error("lane A (first, under cap) has no stream, want one")
+	}
+	if laneB == nil || laneB.stream != nil {
+		t.Error("lane B (over cap) has a stream, want pure batch (nil)")
+	}
+	if factoryCalls != 1 {
+		t.Errorf("lane stream factory called %d times, want 1 (cap honoured)", factoryCalls)
+	}
+	if streamLanes != 1 {
+		t.Errorf("streamLanes = %d, want 1", streamLanes)
+	}
+}
+
+// stubRec is a minimal [stt.Recognizer] for the cap test — its output is never
+// asserted (no utterance is segmented).
+type stubRec struct{}
+
+func (stubRec) Transcribe(_ context.Context, _ []audio.Frame) (stt.Transcript, error) {
+	return stt.Transcript{}, nil
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -67,7 +68,6 @@ type ErrorFunc func(error)
 // This is the bus-driven form of the accumulate-between-VAD-events loop the
 // slice-1 pipeline test used to spell out inline (ADR-0026).
 type Segmenter struct {
-	vad *VAD
 	stt *STT
 
 	// onError surfaces a recognizer error from the transcription worker (see
@@ -77,8 +77,10 @@ type Segmenter struct {
 	// [WithErrorHandler].
 	onError ErrorFunc
 	// jobs carries flushed segments from the audio loop to the single transcription
-	// worker (#24). Created and drained per [Segmenter.Bind] lifetime; buffered
-	// deeply enough that a normal call never backs the audio loop up on the send.
+	// worker (#24). ONE shared serial worker drains every lane's utterances, so STT
+	// cost per utterance is unchanged vs single-lane (ADR-0050). Created and drained
+	// per [Segmenter.Bind] lifetime; buffered deeply enough that a normal call never
+	// backs the audio loop up on the send.
 	jobs chan transcribeJob
 	// inflight counts segments enqueued but not yet transcribed, so
 	// [Segmenter.Flush] can wait for the backlog (incl. the final utterance) to
@@ -88,50 +90,100 @@ type Segmenter struct {
 	inflight sync.WaitGroup
 	worker   sync.WaitGroup
 
-	// stream is the optional streaming-STT transport (ADR-0042, [WithStreamingSTT]).
-	// When non-nil the segmenter mirrors each utterance onto it — pre-roll while
-	// idle, voiced frames while listening, a manual commit at speech-end — and the
-	// worker prefers the committed text, falling back to the batch recognizer on any
-	// failure. Nil is the byte-for-byte no-streaming default: none of the stream
-	// hooks fire and the batch path is untouched.
-	stream *StreamManager
-	// streamCancel stops the stream manager's maintainer; set at Bind (when stream
-	// is non-nil), called from the returned teardown.
-	streamCancel func()
+	// laneVADFactory builds a fresh per-Speaker-Lane VAD on first frame from a new
+	// speaker (ADR-0050). Nil = single-lane forever: every frame funnels to the
+	// default lane, byte-identical to the pre-lane pipeline. Set via
+	// [WithSpeakerLanes].
+	laneVADFactory LaneVADFactory
+	// laneStreamFactory builds a per-lane streaming-STT [StreamManager] at lane
+	// creation, capped at maxStreamLanes concurrent lane streams (past the cap a
+	// lane is pure batch). Nil = no per-lane streaming (the default lane keeps its
+	// own [WithStreamingSTT] manager). Set via [WithLaneStreamingSTT].
+	laneStreamFactory func(speakerID string) *StreamManager
+	maxStreamLanes    int
+	streamLanes       int // live non-default lane streams, for the cap
 
-	mu sync.Mutex
-	// speechEndAt is the [voiceevent.VADSpeechEnd.At] of the most recent
-	// speech-end transition, captured so the flushed utterance's STTFinal can
-	// carry it forward (A3): it anchors the headline response-latency span at the
-	// turn's true speech-end without the metrics subscriber guessing. Zero until
-	// the first speech-end, and for a Flush with no preceding transition.
+	// laneIdleTTL is how long a Speaker Lane may sit unused before the reap sweep
+	// closes it (ADR-0050 "leave OR idle timeout"). nowFn is the injectable clock
+	// the TTL is measured against (real time in prod); both are test-overridable via
+	// [Segmenter.SetLaneReap]. sweepCalls counts Process calls toward the next sweep.
+	laneIdleTTL time.Duration
+	nowFn       func() time.Time
+	sweepCalls  int
+	sweepEvery  int // reap-sweep cadence in Process calls; [laneReapSweepEvery] in prod
+
+	mu  sync.Mutex
+	bus *voiceevent.Bus
+	// ctx is the context handed to STT.Transcribe when a segment flushes and to each
+	// per-lane stream's maintainer. It is the conversation's lifetime context,
+	// captured at Bind and cleared by the returned cancel; storing it lets Process
+	// stay frame-only (ctx-free) so the audio loop reads as a plain range over frames.
+	ctx context.Context
+	// lanes maps SpeakerID → its [lane]. The default lane (key "") is ALWAYS present,
+	// wraps the ctor-supplied *VAD, and is never reaped nor factory-built — it is the
+	// single-lane code path, byte-identical for an unattributed (Speaker()=="") frame.
+	// laneOrder is the non-default lanes in first-seen order, so [Segmenter.Flush]
+	// drains them deterministically after the default lane.
+	lanes     map[string]*lane
+	laneOrder []string
+}
+
+// lane is one Speaker Lane (ADR-0050): a VAD session fed only its speaker's frame
+// stream, emitting per-speaker utterance windows into the shared transcription
+// worker. The default lane (SpeakerID "") wraps the ctor-supplied VAD; every other
+// lane is factory-built on first frame and reaped on idle. All fields are guarded
+// by the [Segmenter]'s mu except vad (driven from the audio loop) and closeVAD.
+type lane struct {
+	id       string // the lane's SpeakerID ("" = default lane)
+	vad      *VAD
+	closeVAD func() // releases the factory-built VAD's ONNX session; nil for the default lane
+
+	listening bool
+	buf       []audio.Frame
+	// speechEndAt is the [voiceevent.VADSpeechEnd.At] of this lane's most recent
+	// speech-end, carried onto the flushed utterance's STTFinal (A3).
 	speechEndAt time.Time
-	// curUtteranceID and pendCommit/pendCommitSentAt carry the current utterance's
-	// streaming state from the VAD callbacks to the flush that enqueues its job. The
-	// id is minted at speech_start (beginUtterance); the commit handle is captured at
-	// speech_end (endUtterance) and consumed by the flush. All guarded by mu.
+	// curUtteranceID / pendCommit / pendCommitSentAt carry this lane's current
+	// utterance's streaming state from the VAD callbacks to the flush (ADR-0042).
 	curUtteranceID   string
 	pendCommit       <-chan stt.CommitResult
 	pendCommitSentAt time.Time
-	// ctx is the context handed to STT.Transcribe when a segment flushes. It is
-	// the conversation's lifetime context, captured at Bind and cleared by the
-	// returned cancel; storing it lets Process stay frame-only (ctx-free) so the
-	// audio loop reads as a plain range over frames.
-	ctx       context.Context
-	listening bool
-	buf       []audio.Frame
+	// stream is this lane's optional streaming-STT transport; nil = pure batch.
+	stream       *StreamManager
+	streamCancel func()
+	// lastSeen is the wall (nowFn) time of the last frame routed to this lane, for
+	// idle-TTL reaping.
+	lastSeen time.Time
 }
 
+// LaneVADFactory builds a fresh Speaker Lane VAD plus its close func (which
+// releases the ONNX session so a reaped lane does not leak an inferencer, ADR-0050
+// risk (b)). It returns an error the [Segmenter] degrades on: the speaker's frames
+// fall back to the default lane rather than dropping.
+type LaneVADFactory func() (v *VAD, close func(), err error)
+
+// defaultLaneIdleTTL is how long a Speaker Lane may sit unused before the reap
+// sweep closes it (ADR-0050 "leave OR idle timeout" — idle subsumes leave). Sized
+// generously so a mid-session pause never reaps an active participant's lane.
+const defaultLaneIdleTTL = 2 * time.Minute
+
+// laneReapSweepEvery is the reap-sweep cadence, counted in [Segmenter.Process]
+// calls — the same amortised-sweep precedent as the codec's pruneEvery, cheap
+// enough to keep the sweep off the hot path's tail.
+const laneReapSweepEvery = 1024
+
 // transcribeJob is one flushed utterance handed to the transcription worker: the
-// segment frames plus the per-segment state STT needs (the lifetime ctx and the
-// turn's speech-end time), snapshotted at enqueue so the worker never reads
-// mutable Segmenter state.
+// segment frames plus the per-segment state STT needs (the lifetime ctx, the turn's
+// speech-end time, and the lane's SpeakerID stamped on the STTFinal), snapshotted at
+// enqueue so the worker never reads mutable Segmenter/lane state.
 //
 // On the streaming path (ADR-0042) it additionally carries the utterance's manual
 // commit handle (nil = pure batch), the moment that commit was sent (for the
-// stt_request span), and the utterance id (stamped on the STTFinal so it joins its
-// partials). The worker prefers the committed text and falls back to the batch
-// recognizer — with these SAME locally-buffered seg frames — on any commit failure.
+// stt_request span), the utterance id (joining the STTFinal to its partials), and
+// the lane's [StreamManager] (whose awaitCommit resolves the commit — carried on the
+// job so a reaped lane's commit still resolves on the shared worker). The worker
+// prefers the committed text and falls back to the batch recognizer — with these
+// SAME locally-buffered seg frames — on any commit failure.
 type transcribeJob struct {
 	ctx          context.Context
 	seg          []audio.Frame
@@ -139,6 +191,8 @@ type transcribeJob struct {
 	commit       <-chan stt.CommitResult
 	commitSentAt time.Time
 	utteranceID  string
+	speakerID    string
+	stream       *StreamManager
 }
 
 // transcribeQueueDepth is the buffer on the worker's job channel. A flush enqueues
@@ -149,7 +203,10 @@ type transcribeJob struct {
 const transcribeQueueDepth = 64
 
 // NewSegmenter wires vad and stt together. Both must be non-nil; passing nil
-// for either panics. The caller owns the wrapped stages.
+// for either panics. The caller owns the wrapped stages. vad becomes the default
+// lane (SpeakerID ""), which is always present and never reaped — so with no
+// [WithSpeakerLanes] factory the segmenter is single-lane, byte-identical to the
+// pre-lane pipeline.
 func NewSegmenter(vad *VAD, stt *STT) *Segmenter {
 	if vad == nil {
 		panic("orchestrator.NewSegmenter: vad must not be nil")
@@ -157,8 +214,32 @@ func NewSegmenter(vad *VAD, stt *STT) *Segmenter {
 	if stt == nil {
 		panic("orchestrator.NewSegmenter: stt must not be nil")
 	}
-	return &Segmenter{vad: vad, stt: stt}
+	return &Segmenter{
+		stt:         stt,
+		laneIdleTTL: defaultLaneIdleTTL,
+		nowFn:       time.Now,
+		sweepEvery:  laneReapSweepEvery,
+		lanes:       map[string]*lane{"": {id: "", vad: vad}},
+	}
 }
+
+// SetLaneReap overrides the idle-TTL and clock the reap sweep uses (test seam;
+// production uses [defaultLaneIdleTTL] and time.Now). A non-positive ttl leaves the
+// default; a nil now leaves the current clock.
+func (s *Segmenter) SetLaneReap(ttl time.Duration, now func() time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ttl > 0 {
+		s.laneIdleTTL = ttl
+	}
+	if now != nil {
+		s.nowFn = now
+	}
+}
+
+// now reads the segmenter's clock (real time in prod, faked in reap tests). Callers
+// must hold mu, or use it where a slightly stale read is harmless.
+func (s *Segmenter) now() time.Time { return s.nowFn() }
 
 // Bind subscribes the segmenter to the VAD speech transitions on bus and records
 // ctx as the context handed to STT.Transcribe on flush. It implements
@@ -172,14 +253,17 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 	}
 	s.mu.Lock()
 	s.ctx = ctx
+	s.bus = bus
 	jobs := make(chan transcribeJob, transcribeQueueDepth)
 	s.jobs = jobs
+	def := s.lanes[""]
 	s.mu.Unlock()
 
-	// Start the streaming transport's maintainer (eager dial) so utterance 1 can
-	// stream; nil stream = no-op (byte-for-byte batch path).
-	if s.stream != nil {
-		s.streamCancel = s.stream.bind(ctx, bus)
+	// Start the default lane's streaming transport (eager dial) so utterance 1 can
+	// stream; a nil stream = no-op (byte-for-byte batch path). Non-default lanes bind
+	// their own stream at lane creation (laneFor).
+	if def.stream != nil {
+		def.streamCancel = def.stream.bind(ctx, bus)
 	}
 
 	// One serial worker drains the queue, so transcriptions stay in speech order.
@@ -192,37 +276,52 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 		}
 	})
 
+	// The speech transitions of EVERY lane's VAD land on this one bus; route each to
+	// its lane by SpeakerID ("" → default lane). A transition for an unknown lane (it
+	// was reaped between the frame and the synchronous publish) is dropped.
 	unsubStart := voiceevent.On(bus, func(start voiceevent.VADSpeechStart) {
 		s.mu.Lock()
-		s.listening = true
+		ln := s.lanes[start.SpeakerID]
+		if ln == nil {
+			s.mu.Unlock()
+			return
+		}
+		ln.listening = true
+		stream := ln.stream
 		s.mu.Unlock()
 		// Mint this utterance's id and, if the stream is up, flush the pre-roll ring —
 		// voiced frames then follow from Process (see [Segmenter.Process]).
-		if s.stream != nil {
-			id := s.stream.beginUtterance(start.At)
+		if stream != nil {
+			id := stream.beginUtterance(start.At)
 			s.mu.Lock()
-			s.curUtteranceID = id
+			ln.curUtteranceID = id
 			s.mu.Unlock()
 		}
 	})
 	unsubEnd := voiceevent.On(bus, func(end voiceevent.VADSpeechEnd) {
 		s.mu.Lock()
-		s.listening = false
+		ln := s.lanes[end.SpeakerID]
+		if ln == nil {
+			s.mu.Unlock()
+			return
+		}
+		ln.listening = false
 		// Remember this turn's true speech-end so the flushed utterance's STTFinal
-		// can carry it (A3); the next Process call after speech ends flushes.
-		s.speechEndAt = end.At
+		// can carry it (A3); the next Process call for this lane flushes.
+		ln.speechEndAt = end.At
+		stream := ln.stream
 		s.mu.Unlock()
 		// Local VAD is the sole endpointing authority (ADR-0042): the manual commit
 		// fires HERE, at the VAD speech-end, never provider-side. The handle is stashed
 		// for the imminent flush to attach to the job.
-		if s.stream != nil {
-			commit, sentAt, ok := s.stream.endUtterance()
+		if stream != nil {
+			commit, sentAt, ok := stream.endUtterance()
 			s.mu.Lock()
 			if ok {
-				s.pendCommit = commit
-				s.pendCommitSentAt = sentAt
+				ln.pendCommit = commit
+				ln.pendCommitSentAt = sentAt
 			} else {
-				s.pendCommit = nil
+				ln.pendCommit = nil
 			}
 			s.mu.Unlock()
 		}
@@ -230,14 +329,26 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 	return func() {
 		unsubStart()
 		unsubEnd()
-		if s.streamCancel != nil {
-			s.streamCancel()
-			s.streamCancel = nil
-		}
+		// Tear down every lane's stream and every FACTORY-built lane's VAD (the ONNX
+		// session — ADR-0050 risk (b)). The default lane's VAD is caller-owned and is
+		// NOT closed here.
 		s.mu.Lock()
+		lanes := make([]*lane, 0, len(s.lanes))
+		for _, ln := range s.lanes {
+			lanes = append(lanes, ln)
+		}
 		s.ctx = nil
 		s.jobs = nil
 		s.mu.Unlock()
+		for _, ln := range lanes {
+			if ln.streamCancel != nil {
+				ln.streamCancel()
+				ln.streamCancel = nil
+			}
+			if ln.closeVAD != nil {
+				ln.closeVAD()
+			}
+		}
 		// Closing the queue lets the worker drain any still-buffered jobs and exit;
 		// in the normal path Flush already emptied it, so this just stops the worker.
 		close(jobs)
@@ -260,50 +371,207 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 // The buffer is cleared synchronously so a failed utterance does not bleed into
 // the next, and a recognizer error surfaces via onError, not this return value.
 func (s *Segmenter) Process(frame audio.Frame) error {
-	if err := s.vad.Process(frame); err != nil {
+	s.reapIdleLanes()
+
+	sp := frame.Speaker()
+	if sp == "" {
+		// Unattributed frame (silence clock, a mixed/test frame): BROADCAST to every
+		// lane so each lane's VAD hangover advances (the silence clock is
+		// speaker-agnostic, ADR-0050) and any listening lane buffers the trailing
+		// audio. With only the default lane present this is exactly the pre-lane path.
+		s.mu.Lock()
+		targets := make([]*lane, 0, len(s.lanes))
+		for _, ln := range s.lanes {
+			targets = append(targets, ln)
+		}
+		s.mu.Unlock()
+		var firstErr error
+		for _, ln := range targets {
+			if err := s.processLane(ln, frame); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+
+	// Attributed frame: route to its Speaker Lane, created on first frame. A nil or
+	// erroring factory degrades to the default lane (still transcribed) and reports
+	// the error once — the audio loop stays up (ADR-0050 risk (c)).
+	ln, err := s.laneFor(sp)
+	if err != nil && s.onError != nil {
+		s.onError(err)
+	}
+	return s.processLane(ln, frame)
+}
+
+// processLane drives one lane's VAD with the frame (re-stamped to the lane's id so
+// the transition routes back to this lane) and accumulates its utterance audio,
+// mirroring [Segmenter.Process]'s original single-lane body per lane. The VAD
+// publishes its transitions synchronously, so ln.listening is up to date by the
+// time this returns from vad.Process.
+func (s *Segmenter) processLane(ln *lane, frame audio.Frame) error {
+	f := frame
+	if f.Speaker() != ln.id {
+		f = f.WithSpeaker(ln.id) // e.g. a broadcast "" frame fed to an attributed lane
+	}
+	if err := ln.vad.Process(f); err != nil {
 		return err
 	}
 
 	s.mu.Lock()
-	if s.listening {
-		s.buf = append(s.buf, frame)
+	ln.lastSeen = s.now()
+	if ln.listening {
+		ln.buf = append(ln.buf, f)
+		stream := ln.stream
 		s.mu.Unlock()
-		// Mirror the voiced frame onto the stream (additive; the local buffer above
-		// stays authoritative for the batch fallback). No-op when no stream is wired.
-		if s.stream != nil {
-			s.stream.send(frame)
+		// Mirror the voiced frame onto the lane's stream (additive; the local buffer
+		// above stays authoritative for the batch fallback). No-op when no stream.
+		if stream != nil {
+			stream.send(f)
 		}
 		return nil
 	}
-	seg := s.buf
-	s.buf = nil
+	seg := ln.buf
+	ln.buf = nil
 	ctx := s.ctx
-	speechEndAt := s.speechEndAt
-	commit := s.pendCommit
-	commitSentAt := s.pendCommitSentAt
-	utteranceID := s.curUtteranceID
-	s.pendCommit = nil
+	speechEndAt := ln.speechEndAt
+	commit := ln.pendCommit
+	commitSentAt := ln.pendCommitSentAt
+	utteranceID := ln.curUtteranceID
+	stream := ln.stream
+	ln.pendCommit = nil
 	s.mu.Unlock()
 
 	// A non-listening frame is pre-speech silence: fill the pre-roll ring (never
 	// streamed until the next utterance begins, so silence is not billed).
-	if s.stream != nil {
-		s.stream.idleFrame(frame)
+	if stream != nil {
+		stream.idleFrame(f)
 	}
-	s.dispatchTranscription(ctx, seg, speechEndAt, commit, commitSentAt, utteranceID)
+	s.dispatchTranscription(ctx, seg, speechEndAt, commit, commitSentAt, utteranceID, ln.id, stream)
 	return nil
+}
+
+// laneFor returns the Speaker Lane a speaker's frames feed, creating it on first
+// sight. With no [WithSpeakerLanes] factory (or a "" speaker) it funnels to the
+// default lane. A factory error — or a panic (ADR-0050 risk (c)) — is returned and
+// the frames degrade to the default lane; the returned *lane is never nil.
+func (s *Segmenter) laneFor(sp string) (*lane, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sp == "" || s.laneVADFactory == nil {
+		return s.lanes[""], nil
+	}
+	if ln, ok := s.lanes[sp]; ok {
+		ln.lastSeen = s.now()
+		return ln, nil
+	}
+	v, closeVAD, err := s.newLaneVAD()
+	if err != nil {
+		return s.lanes[""], err
+	}
+	ln := &lane{id: sp, vad: v, closeVAD: closeVAD, lastSeen: s.now()}
+	// Per-lane streaming under the concurrency cap (ADR-0050): the first maxStreamLanes
+	// lanes open a stream at creation (bound to the conversation ctx, reaped with the
+	// lane); past the cap a lane is pure batch. Only when a factory is wired AND the
+	// conversation is bound (s.ctx set).
+	if s.laneStreamFactory != nil && s.streamLanes < s.maxStreamLanes && s.ctx != nil && s.bus != nil {
+		if sm := s.laneStreamFactory(sp); sm != nil {
+			ln.stream = sm
+			ln.streamCancel = sm.bind(s.ctx, s.bus)
+			s.streamLanes++
+		}
+	}
+	s.lanes[sp] = ln
+	s.laneOrder = append(s.laneOrder, sp)
+	return ln, nil
+}
+
+// newLaneVAD calls the lane VAD factory, converting a panic into an error so a
+// misbehaving factory degrades one speaker to the default lane rather than taking
+// the audio loop down (ADR-0050 risk (c)). Called under mu.
+func (s *Segmenter) newLaneVAD() (v *VAD, closeVAD func(), err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			v, closeVAD, err = nil, nil, fmt.Errorf("orchestrator.Segmenter: lane VAD factory panicked: %v", r)
+		}
+	}()
+	return s.laneVADFactory()
+}
+
+// reapIdleLanes closes every non-default lane idle past laneIdleTTL, on the
+// amortised [laneReapSweepEvery] cadence (ADR-0050 lane lifecycle). A reaped lane's
+// still-buffered utterance is FLUSHED (dispatched, not dropped), its stream cancelled
+// and its VAD's ONNX session closed (risk (b)). The default lane is never reaped.
+func (s *Segmenter) reapIdleLanes() {
+	s.mu.Lock()
+	s.sweepCalls++
+	if s.sweepEvery <= 0 || s.sweepCalls < s.sweepEvery {
+		s.mu.Unlock()
+		return
+	}
+	s.sweepCalls = 0
+	cutoff := s.now().Add(-s.laneIdleTTL)
+	var reap []*lane
+	for id, ln := range s.lanes {
+		if id == "" || !ln.lastSeen.Before(cutoff) {
+			continue
+		}
+		reap = append(reap, ln)
+	}
+	for _, ln := range reap {
+		delete(s.lanes, ln.id)
+		s.removeLaneOrder(ln.id)
+		if ln.stream != nil {
+			s.streamLanes--
+		}
+	}
+	ctx := s.ctx
+	s.mu.Unlock()
+
+	for _, ln := range reap {
+		// Flush a still-buffered utterance so a reaped mid-utterance lane is not lost;
+		// dispatchTranscription is a no-op on an empty buffer.
+		s.mu.Lock()
+		seg := ln.buf
+		ln.buf = nil
+		speechEndAt := ln.speechEndAt
+		commit := ln.pendCommit
+		commitSentAt := ln.pendCommitSentAt
+		utteranceID := ln.curUtteranceID
+		stream := ln.stream
+		ln.pendCommit = nil
+		s.mu.Unlock()
+		s.dispatchTranscription(ctx, seg, speechEndAt, commit, commitSentAt, utteranceID, ln.id, stream)
+		if ln.streamCancel != nil {
+			ln.streamCancel()
+		}
+		if ln.closeVAD != nil {
+			ln.closeVAD()
+		}
+	}
+}
+
+// removeLaneOrder drops id from the first-seen order slice. Called under mu.
+func (s *Segmenter) removeLaneOrder(id string) {
+	for i, v := range s.laneOrder {
+		if v == id {
+			s.laneOrder = append(s.laneOrder[:i], s.laneOrder[i+1:]...)
+			return
+		}
+	}
 }
 
 // dispatchTranscription enqueues a flushed segment for the transcription worker so
 // the audio intake loop is never blocked by the network-bound recognizer call
 // (#24); an empty segment is a no-op. The enqueue is counted on inflight so
 // [Segmenter.Flush] can drain the backlog before teardown. Each segment is owned
-// by the job (Process cleared s.buf before handing it over, so a subsequent append
-// cannot mutate it) and mints its own TurnID at STTFinal (stt.go). The send blocks
+// by the job (processLane cleared the lane's buf before handing it over, so a
+// subsequent append cannot mutate it) and mints its own TurnID at STTFinal (stt.go).
+// The send blocks
 // only if the queue is full (see [transcribeQueueDepth]). A recognizer error is
 // reported by the worker through onError — the side channel that replaces the
 // inline call's return value.
-func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame, speechEndAt time.Time, commit <-chan stt.CommitResult, commitSentAt time.Time, utteranceID string) {
+func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame, speechEndAt time.Time, commit <-chan stt.CommitResult, commitSentAt time.Time, utteranceID, speakerID string, stream *StreamManager) {
 	if len(seg) == 0 {
 		return
 	}
@@ -314,6 +582,8 @@ func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame
 		commit:       commit,
 		commitSentAt: commitSentAt,
 		utteranceID:  utteranceID,
+		speakerID:    speakerID,
+		stream:       stream,
 	}
 	s.mu.Lock()
 	jobs := s.jobs
@@ -347,24 +617,48 @@ func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame
 // via onError, so Flush always returns nil (the error return is retained for the
 // audio loop's call-site symmetry).
 func (s *Segmenter) Flush() error {
+	// Default lane first, then the non-default lanes in first-seen order, so the
+	// end-of-stream drain is deterministic (positional cassette replay relies on
+	// speech order within a lane; across lanes the default lane leads).
 	s.mu.Lock()
-	seg := s.buf
-	s.buf = nil
-	wasListening := s.listening
-	s.listening = false
+	order := append([]string{""}, s.laneOrder...)
+	lanes := make([]*lane, 0, len(order))
+	for _, id := range order {
+		if ln := s.lanes[id]; ln != nil {
+			lanes = append(lanes, ln)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, ln := range lanes {
+		s.flushLane(ln)
+	}
+	s.inflight.Wait()
+	return nil
+}
+
+// flushLane dispatches one lane's still-buffered utterance regardless of whether
+// speech is still active (the end-of-stream counterpart to [Segmenter.processLane]).
+func (s *Segmenter) flushLane(ln *lane) {
+	s.mu.Lock()
+	seg := ln.buf
+	ln.buf = nil
+	wasListening := ln.listening
+	ln.listening = false
 	ctx := s.ctx
-	commit := s.pendCommit
-	commitSentAt := s.pendCommitSentAt
-	utteranceID := s.curUtteranceID
-	s.pendCommit = nil
+	commit := ln.pendCommit
+	commitSentAt := ln.pendCommitSentAt
+	utteranceID := ln.curUtteranceID
+	stream := ln.stream
+	ln.pendCommit = nil
 	s.mu.Unlock()
 
 	// If the stream ended while speech was still active there was no VAD speech-end,
 	// so the open utterance never got its manual commit — request it now (ADR-0042),
 	// or fall to batch if the stream is down. A speech-end already emitted a handle
 	// captured above, so this only fires for a truly mid-utterance end-of-stream.
-	if wasListening && s.stream != nil {
-		if c, sentAt, ok := s.stream.endUtterance(); ok {
+	if wasListening && stream != nil {
+		if c, sentAt, ok := stream.endUtterance(); ok {
 			commit = c
 			commitSentAt = sentAt
 		}
@@ -372,9 +666,7 @@ func (s *Segmenter) Flush() error {
 
 	// A Flush has no speech-end transition (end-of-stream), so it carries the
 	// zero time — the STTFinal's SpeechEndAt is unset for a flushed final turn.
-	s.dispatchTranscription(ctx, seg, time.Time{}, commit, commitSentAt, utteranceID)
-	s.inflight.Wait()
-	return nil
+	s.dispatchTranscription(ctx, seg, time.Time{}, commit, commitSentAt, utteranceID, ln.id, stream)
 }
 
 // transcribe produces one utterance's authoritative STTFinal, carrying the turn's
@@ -399,9 +691,10 @@ func (s *Segmenter) transcribe(job transcribeJob) error {
 	}
 	ctx = withSpeechEndAt(ctx, job.speechEndAt)
 	ctx = withUtteranceID(ctx, job.utteranceID)
+	ctx = withSpeakerID(ctx, job.speakerID)
 
-	if job.commit != nil && s.stream != nil {
-		if t, ok := s.stream.awaitCommit(job.commit, job.commitSentAt); ok {
+	if job.commit != nil && job.stream != nil {
+		if t, ok := job.stream.awaitCommit(job.commit, job.commitSentAt); ok {
 			// Committed text is authoritative: publish it as this utterance's STTFinal
 			// with the SAME TurnID minting the batch path uses.
 			s.stt.PublishFinal(ctx, t)

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -126,6 +126,11 @@ type Segmenter struct {
 	// drains them deterministically after the default lane.
 	lanes     map[string]*lane
 	laneOrder []string
+	// degraded records speakers whose lane VAD factory failed once: their frames fall
+	// to the default lane for the rest of the session and the error is reported ONCE
+	// (not per frame at ~31/s). Single-shot fail-closed — a bounded map keyed by the
+	// session's participants (ADR-0050 risk (c)).
+	degraded map[string]bool
 }
 
 // lane is one Speaker Lane (ADR-0050): a VAD session fed only its speaker's frame
@@ -220,6 +225,7 @@ func NewSegmenter(vad *VAD, stt *STT) *Segmenter {
 		nowFn:       time.Now,
 		sweepEvery:  laneReapSweepEvery,
 		lanes:       map[string]*lane{"": {id: "", vad: vad}},
+		degraded:    map[string]bool{},
 	}
 }
 
@@ -331,22 +337,35 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 		unsubEnd()
 		// Tear down every lane's stream and every FACTORY-built lane's VAD (the ONNX
 		// session — ADR-0050 risk (b)). The default lane's VAD is caller-owned and is
-		// NOT closed here.
-		s.mu.Lock()
-		lanes := make([]*lane, 0, len(s.lanes))
-		for _, ln := range s.lanes {
-			lanes = append(lanes, ln)
+		// NOT closed here. Under mu we CAPTURE each lane's cancel/close funcs, null them,
+		// and drop the non-default lanes from the map — so a concurrent reap sweep (still
+		// on the audio-loop goroutine) can never double-close the same lane (finding 6).
+		// The captured funcs are then invoked outside the lock.
+		type teardown struct {
+			streamCancel func()
+			closeVAD     func()
 		}
+		s.mu.Lock()
+		tds := make([]teardown, 0, len(s.lanes))
+		for id, ln := range s.lanes {
+			tds = append(tds, teardown{streamCancel: ln.streamCancel, closeVAD: ln.closeVAD})
+			ln.streamCancel = nil
+			ln.closeVAD = nil
+			if id != "" {
+				delete(s.lanes, id)
+			}
+		}
+		s.laneOrder = nil
+		s.streamLanes = 0
 		s.ctx = nil
 		s.jobs = nil
 		s.mu.Unlock()
-		for _, ln := range lanes {
-			if ln.streamCancel != nil {
-				ln.streamCancel()
-				ln.streamCancel = nil
+		for _, td := range tds {
+			if td.streamCancel != nil {
+				td.streamCancel()
 			}
-			if ln.closeVAD != nil {
-				ln.closeVAD()
+			if td.closeVAD != nil {
+				td.closeVAD()
 			}
 		}
 		// Closing the queue lets the worker drain any still-buffered jobs and exit;
@@ -375,51 +394,87 @@ func (s *Segmenter) Process(frame audio.Frame) error {
 
 	sp := frame.Speaker()
 	if sp == "" {
-		// Unattributed frame (silence clock, a mixed/test frame): BROADCAST to every
-		// lane so each lane's VAD hangover advances (the silence clock is
-		// speaker-agnostic, ADR-0050) and any listening lane buffers the trailing
-		// audio. With only the default lane present this is exactly the pre-lane path.
+		// Unattributed INBOUND audio (an unresolved SSRC still voiced, a mixed/test
+		// frame): DEFAULT LANE ONLY — byte-identical to the pre-lane single-lane path,
+		// no re-stamp, barge key "" only. It transcribes unattributed
+		// (STTFinal.SpeakerID == "" → Butler fail-closed) and NEVER touches a Speaker
+		// Lane, so a not-yet-resolved speaker can never phantom-misattribute onto
+		// someone else's lane. The silence CLOCK uses [Segmenter.ProcessSilence]
+		// instead — the caller distinguishes the two "" sources at source (ADR-0050).
 		s.mu.Lock()
-		targets := make([]*lane, 0, len(s.lanes))
-		for _, ln := range s.lanes {
-			targets = append(targets, ln)
-		}
+		def := s.lanes[""]
 		s.mu.Unlock()
-		var firstErr error
-		for _, ln := range targets {
-			if err := s.processLane(ln, frame); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
+		return s.processLane(def, frame)
 	}
 
 	// Attributed frame: route to its Speaker Lane, created on first frame. A nil or
-	// erroring factory degrades to the default lane (still transcribed) and reports
-	// the error once — the audio loop stays up (ADR-0050 risk (c)).
+	// (once) erroring factory degrades to the default lane (still transcribed) and
+	// reports the error ONCE — the audio loop stays up (ADR-0050 risk (c)).
 	ln, err := s.laneFor(sp)
 	if err != nil && s.onError != nil {
 		s.onError(err)
 	}
-	return s.processLane(ln, frame)
-}
-
-// processLane drives one lane's VAD with the frame (re-stamped to the lane's id so
-// the transition routes back to this lane) and accumulates its utterance audio,
-// mirroring [Segmenter.Process]'s original single-lane body per lane. The VAD
-// publishes its transitions synchronously, so ln.listening is up to date by the
-// time this returns from vad.Process.
-func (s *Segmenter) processLane(ln *lane, frame audio.Frame) error {
+	// On the degrade path the lane is the default ("") but the frame is still stamped
+	// sp; re-stamp it to the lane's id so its VAD transition routes back to the default
+	// lane (and its STTFinal.SpeakerID is "" → Butler fail-closed). The happy path is a
+	// no-op (frame already == lane id).
 	f := frame
 	if f.Speaker() != ln.id {
-		f = f.WithSpeaker(ln.id) // e.g. a broadcast "" frame fed to an attributed lane
+		f = f.WithSpeaker(ln.id)
 	}
+	return s.processLane(ln, f)
+}
+
+// ProcessSilence feeds one silence-CLOCK frame (issue #91) to EVERY lane so each
+// lane's VAD hangover advances toward its speech_end — the silence clock is
+// speaker-agnostic (ADR-0050). It is the [Segmenter.Process] sibling for the ONE
+// unattributed source that must reach every lane; the caller (the wire tick branch)
+// routes clock frames here and real inbound audio through Process, so the two ""
+// sources are distinguished at source rather than by sniffing zero PCM (Opus can
+// legally decode an all-zero frame). Each lane's copy is re-stamped to that lane's id
+// so the resulting speech_end routes back to it; zero PCM never onsets speech, so a
+// silence frame only ever ADVANCES a listening lane, never opens one. A silence frame
+// DOES enter a listening lane's buffer (parity with the pre-lane single-lane path,
+// where clock frames were buffered). It also drives the reap sweep, so a fully-idle
+// table still ages out departed speakers' lanes.
+func (s *Segmenter) ProcessSilence(frame audio.Frame) error {
+	s.reapIdleLanes()
+
+	s.mu.Lock()
+	order := append([]string{""}, s.laneOrder...)
+	lanes := make([]*lane, 0, len(order))
+	for _, id := range order {
+		if ln := s.lanes[id]; ln != nil {
+			lanes = append(lanes, ln)
+		}
+	}
+	s.mu.Unlock()
+
+	var firstErr error
+	for _, ln := range lanes {
+		f := frame
+		if ln.id != "" {
+			f = frame.WithSpeaker(ln.id)
+		}
+		if err := s.processLane(ln, f); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// processLane drives one lane's VAD with the (already correctly-stamped) frame and
+// accumulates its utterance audio, mirroring the original single-lane body per lane.
+// The VAD publishes its transitions synchronously, so ln.listening is up to date by
+// the time this returns from vad.Process. It does NOT refresh ln.lastSeen: idle-reap
+// aging keys off attributed frames (via [Segmenter.laneFor]) only, so a lane still
+// ages while the speaker-agnostic silence clock ticks (risk: reap dead in prod).
+func (s *Segmenter) processLane(ln *lane, f audio.Frame) error {
 	if err := ln.vad.Process(f); err != nil {
 		return err
 	}
 
 	s.mu.Lock()
-	ln.lastSeen = s.now()
 	if ln.listening {
 		ln.buf = append(ln.buf, f)
 		stream := ln.stream
@@ -458,7 +513,10 @@ func (s *Segmenter) processLane(ln *lane, frame audio.Frame) error {
 func (s *Segmenter) laneFor(sp string) (*lane, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if sp == "" || s.laneVADFactory == nil {
+	// A speaker whose factory already failed once is degraded for the session: skip
+	// the retry AND the repeat onError (finding 3 — the factory was retried and
+	// onError fired ~31×/s before this).
+	if sp == "" || s.laneVADFactory == nil || s.degraded[sp] {
 		return s.lanes[""], nil
 	}
 	if ln, ok := s.lanes[sp]; ok {
@@ -467,6 +525,7 @@ func (s *Segmenter) laneFor(sp string) (*lane, error) {
 	}
 	v, closeVAD, err := s.newLaneVAD()
 	if err != nil {
+		s.degraded[sp] = true // single-shot fail-closed: report once, then default silently
 		return s.lanes[""], err
 	}
 	ln := &lane{id: sp, vad: v, closeVAD: closeVAD, lastSeen: s.now()}
@@ -511,42 +570,60 @@ func (s *Segmenter) reapIdleLanes() {
 	}
 	s.sweepCalls = 0
 	cutoff := s.now().Add(-s.laneIdleTTL)
-	var reap []*lane
+	ctx := s.ctx
+
+	// Snapshot everything a reaped lane needs — the flush state AND its cancel/close
+	// funcs — UNDER the lock, nulling the funcs and dropping the lane, so a concurrent
+	// Bind teardown can never also close it (finding 6). The heavy work (dispatch +
+	// close) then runs outside the lock.
+	type reaped struct {
+		id           string
+		seg          []audio.Frame
+		speechEndAt  time.Time
+		commit       <-chan stt.CommitResult
+		commitSentAt time.Time
+		utteranceID  string
+		stream       *StreamManager
+		streamCancel func()
+		closeVAD     func()
+	}
+	var reap []reaped
 	for id, ln := range s.lanes {
 		if id == "" || !ln.lastSeen.Before(cutoff) {
 			continue
 		}
-		reap = append(reap, ln)
-	}
-	for _, ln := range reap {
-		delete(s.lanes, ln.id)
-		s.removeLaneOrder(ln.id)
+		reap = append(reap, reaped{
+			id:           ln.id,
+			seg:          ln.buf,
+			speechEndAt:  ln.speechEndAt,
+			commit:       ln.pendCommit,
+			commitSentAt: ln.pendCommitSentAt,
+			utteranceID:  ln.curUtteranceID,
+			stream:       ln.stream,
+			streamCancel: ln.streamCancel,
+			closeVAD:     ln.closeVAD,
+		})
+		ln.buf = nil
+		ln.pendCommit = nil
+		ln.streamCancel = nil
+		ln.closeVAD = nil
 		if ln.stream != nil {
 			s.streamLanes--
 		}
+		delete(s.lanes, id)
+		s.removeLaneOrder(id)
 	}
-	ctx := s.ctx
 	s.mu.Unlock()
 
-	for _, ln := range reap {
+	for _, r := range reap {
 		// Flush a still-buffered utterance so a reaped mid-utterance lane is not lost;
 		// dispatchTranscription is a no-op on an empty buffer.
-		s.mu.Lock()
-		seg := ln.buf
-		ln.buf = nil
-		speechEndAt := ln.speechEndAt
-		commit := ln.pendCommit
-		commitSentAt := ln.pendCommitSentAt
-		utteranceID := ln.curUtteranceID
-		stream := ln.stream
-		ln.pendCommit = nil
-		s.mu.Unlock()
-		s.dispatchTranscription(ctx, seg, speechEndAt, commit, commitSentAt, utteranceID, ln.id, stream)
-		if ln.streamCancel != nil {
-			ln.streamCancel()
+		s.dispatchTranscription(ctx, r.seg, r.speechEndAt, r.commit, r.commitSentAt, r.utteranceID, r.id, r.stream)
+		if r.streamCancel != nil {
+			r.streamCancel()
 		}
-		if ln.closeVAD != nil {
-			ln.closeVAD()
+		if r.closeVAD != nil {
+			r.closeVAD()
 		}
 	}
 }

--- a/pkg/voice/orchestrator/stt.go
+++ b/pkg/voice/orchestrator/stt.go
@@ -204,6 +204,7 @@ func (s *STT) PublishFinal(ctx context.Context, t stt.Transcript) {
 		TurnID:      voiceevent.NewTurnID(),
 		SpeechEndAt: speechEndAtFrom(ctx),
 		UtteranceID: utteranceIDFrom(ctx),
+		SpeakerID:   speakerIDFrom(ctx),
 	})
 }
 
@@ -246,5 +247,27 @@ func withUtteranceID(ctx context.Context, id string) context.Context {
 // transcribed without one (the batch path, or a direct Transcribe call).
 func utteranceIDFrom(ctx context.Context) string {
 	id, _ := ctx.Value(utteranceIDKey{}).(string)
+	return id
+}
+
+// speakerIDKey carries the Speaker Lane's id (ADR-0050) from the [Segmenter] to
+// [STT.PublishFinal] without widening the publish signature — pattern-copied from
+// [speechEndAtKey]. Unexported and orchestrator-internal.
+type speakerIDKey struct{}
+
+// withSpeakerID returns ctx carrying the utterance's Speaker Lane id; an empty id
+// (the default/unattributed lane, the single-lane MVP path) leaves ctx unchanged,
+// so [speakerIDFrom] yields "" and STTFinal.SpeakerID stays empty.
+func withSpeakerID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, speakerIDKey{}, id)
+}
+
+// speakerIDFrom recovers the Speaker Lane id stamped on this utterance, or "" for
+// the default lane (or a direct Transcribe call).
+func speakerIDFrom(ctx context.Context) string {
+	id, _ := ctx.Value(speakerIDKey{}).(string)
 	return id
 }

--- a/pkg/voice/orchestrator/sttstream.go
+++ b/pkg/voice/orchestrator/sttstream.go
@@ -40,6 +40,12 @@ type StreamManager struct {
 	metrics  observe.StageRecorder
 	provider observe.Provider
 
+	// speakerID is the Speaker Lane this manager serves (ADR-0050), stamped on every
+	// [voiceevent.STTPartial] it publishes. "" for the default (unattributed) lane —
+	// the single-lane MVP path, unchanged. Set at construction via
+	// [WithStreamSpeakerID].
+	speakerID string
+
 	// sleep/now are the deterministic-test seams, copied from wirenpc.reconnectPolicy:
 	// sleep blocks for d or until ctx is cancelled; now stamps the commit-latency
 	// span and partial timestamps. Production uses real time.
@@ -127,6 +133,14 @@ func WithStreamMetrics(rec observe.StageRecorder, p observe.Provider) StreamMana
 		}
 		m.provider = p
 	}
+}
+
+// WithStreamSpeakerID sets the Speaker Lane id this manager serves (ADR-0050),
+// stamped on every [voiceevent.STTPartial] it publishes. The per-lane stream factory
+// ([WithLaneStreamingSTT]) sets it to the lane's speaker; the default lane leaves it
+// "" (the single-lane MVP path).
+func WithStreamSpeakerID(id string) StreamManagerOption {
+	return func(m *StreamManager) { m.speakerID = id }
 }
 
 // NewStreamManager wires rec as the streaming recognizer. rec must be non-nil;
@@ -451,7 +465,7 @@ func (m *StreamManager) onPartial(text string) {
 	if bus == nil {
 		return
 	}
-	bus.Publish(voiceevent.STTPartial{At: m.now(), Text: text, UtteranceID: id})
+	bus.Publish(voiceevent.STTPartial{At: m.now(), Text: text, UtteranceID: id, SpeakerID: m.speakerID})
 }
 
 // streamFailed records a send/commit failure against session s: the utterance is

--- a/pkg/voice/orchestrator/sttstream_internal_test.go
+++ b/pkg/voice/orchestrator/sttstream_internal_test.go
@@ -625,3 +625,30 @@ func TestStreamManager_BoundedBackoff(t *testing.T) {
 		t.Errorf("only %d dial attempts; want at least %d (one per failed dial)", rec.openCount(), len(want))
 	}
 }
+
+// TestStreamManager_PartialsCarryLaneSpeakerID pins step 11 (ADR-0050): a manager
+// built for a Speaker Lane stamps that lane's SpeakerID on every STTPartial it
+// publishes, so a live-view/speculation consumer can attribute an in-flight
+// hypothesis to its speaker. The default lane leaves it "".
+func TestStreamManager_PartialsCarryLaneSpeakerID(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var partials []voiceevent.STTPartial
+	voiceevent.On(bus, func(e voiceevent.STTPartial) { partials = append(partials, e) })
+
+	m := NewStreamManager(&fakeStreamingRecognizer{}, WithStreamSpeakerID("222"))
+	m.stream = &fakeStream{}
+	m.bus = bus
+
+	m.beginUtterance(time.Now())
+	m.onPartial("he")
+	m.onPartial("hello")
+
+	if len(partials) != 2 {
+		t.Fatalf("published %d partials, want 2", len(partials))
+	}
+	for _, p := range partials {
+		if p.SpeakerID != "222" {
+			t.Errorf("partial SpeakerID = %q, want \"222\"", p.SpeakerID)
+		}
+	}
+}

--- a/pkg/voice/orchestrator/vad.go
+++ b/pkg/voice/orchestrator/vad.go
@@ -87,16 +87,23 @@ func (v *VAD) Process(frame audio.Frame) error {
 	if err != nil {
 		return fmt.Errorf("orchestrator.VAD.Process: %w", err)
 	}
+	// The transition inherits the frame's attribution (ADR-0050): a per-lane VAD is
+	// fed only its speaker's frames, so stamping frame.Speaker() names the lane the
+	// segmenter routes this transition to. An unattributed ("") frame — the default
+	// lane / single-lane MVP path — leaves SpeakerID empty, unchanged.
+	speaker := frame.Speaker()
 	switch evt.Type {
 	case vad.VADSpeechStart:
 		v.bus.Publish(voiceevent.VADSpeechStart{
 			At:          time.Now(),
 			Probability: evt.Probability,
+			SpeakerID:   speaker,
 		})
 	case vad.VADSpeechEnd:
 		v.bus.Publish(voiceevent.VADSpeechEnd{
 			At:          time.Now(),
 			Probability: evt.Probability,
+			SpeakerID:   speaker,
 		})
 		// #125: stamp the fixed end-of-speech detection lag once per speech_end.
 		v.rec.VADHangover(v.hangover)

--- a/pkg/voice/orchestrator/vad_test.go
+++ b/pkg/voice/orchestrator/vad_test.go
@@ -165,3 +165,37 @@ func TestVAD_TwoUtteranceTest_EmitsTwoSpeechStarts(t *testing.T) {
 
 	voicetest.AssertEventCount[voiceevent.VADSpeechStart](t, h, 2)
 }
+
+// TestVAD_StampsSpeakerIDFromFrame pins that the VAD stage stamps each published
+// speech transition with the processed frame's Speaker() (ADR-0050): an attributed
+// frame yields VADSpeechStart/End carrying that SpeakerID, and an unattributed ("")
+// frame leaves the events' SpeakerID empty — the single-lane MVP path unchanged.
+func TestVAD_StampsSpeakerIDFromFrame(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var starts []voiceevent.VADSpeechStart
+	var ends []voiceevent.VADSpeechEnd
+	voiceevent.On(bus, func(e voiceevent.VADSpeechStart) { starts = append(starts, e) })
+	voiceevent.On(bus, func(e voiceevent.VADSpeechEnd) { ends = append(ends, e) })
+
+	stage := orchestrator.NewVAD(bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADSpeechEnd,
+	}})
+
+	base, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	if err := stage.Process(base.WithSpeaker("42")); err != nil { // → speech_start
+		t.Fatalf("Process: %v", err)
+	}
+	if err := stage.Process(base.WithSpeaker("42")); err != nil { // → speech_end
+		t.Fatalf("Process: %v", err)
+	}
+
+	if len(starts) != 1 || starts[0].SpeakerID != "42" {
+		t.Errorf("VADSpeechStart SpeakerID = %+v, want one with \"42\"", starts)
+	}
+	if len(ends) != 1 || ends[0].SpeakerID != "42" {
+		t.Errorf("VADSpeechEnd SpeakerID = %+v, want one with \"42\"", ends)
+	}
+}

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -20,9 +20,15 @@ type Event interface {
 }
 
 // VADSpeechStart marks the onset of an utterance as detected by the VAD stage.
+//
+// SpeakerID is the Discord snowflake string of the participant whose Speaker Lane
+// detected the onset (ADR-0050), or "" when the transition came off the default
+// (unattributed) lane — the single-lane MVP path, byte-identical to before speaker
+// lanes existed. Additive per ADR-0039's stated seam.
 type VADSpeechStart struct {
 	At          time.Time
 	Probability float64
+	SpeakerID   string
 }
 
 // EventName implements [Event].
@@ -31,9 +37,16 @@ func (VADSpeechStart) EventName() string { return "vad.speech_start" }
 // VADSpeechEnd marks the end of an utterance as detected by the VAD stage:
 // the speech-active state has been left because probability stayed below the
 // silence threshold for the configured number of consecutive frames.
+// SpeakerID is the Discord snowflake string of the participant whose Speaker Lane
+// detected the end-of-speech (ADR-0050), or "" for the default lane. NOTE: unlike
+// the ADR-0050 enumeration (VADSpeechStart / STTPartial / STTFinal / BargeDetected),
+// VADSpeechEnd also carries SpeakerID — lane routing of the bus-driven speech
+// transitions needs the speech-end attributed to disarm the right lane's barge
+// window and endpoint the right lane. Additive, in the ADR's spirit.
 type VADSpeechEnd struct {
 	At          time.Time
 	Probability float64
+	SpeakerID   string
 }
 
 // EventName implements [Event].
@@ -63,6 +76,10 @@ type STTPartial struct {
 	// UtteranceID is minted at the local VAD speech_start ([NewUtteranceID]) and
 	// joins this utterance's partials to the [STTFinal] its manual commit yields.
 	UtteranceID string
+	// SpeakerID is the Discord snowflake string of the Speaker Lane this partial's
+	// stream belongs to (ADR-0050), or "" for the default lane. Stamped by the
+	// per-lane [StreamManager] on the partials it publishes.
+	SpeakerID string
 }
 
 // EventName implements [Event].
@@ -92,6 +109,12 @@ type STTFinal struct {
 	// from (ADR-0042), minted at the local VAD speech_start. It is empty on the
 	// batch path (no stream, no partials) — the byte-for-byte no-streaming default.
 	UtteranceID string
+	// SpeakerID is the Discord snowflake string of the Speaker Lane this utterance
+	// was segmented on (ADR-0050) — the attribution Address Detection and the
+	// Transcript inherit. "" for the default (unattributed) lane, the single-lane
+	// MVP path. Stamped by [STT.PublishFinal] on both the batch and streamed-commit
+	// paths.
+	SpeakerID string
 }
 
 // EventName implements [Event].
@@ -266,11 +289,14 @@ func (TurnEnded) EventName() string { return "turn.ended" }
 // It is the observability signal for a yield that actually cancelled an active
 // turn — speech that finds no Agent speaking does not emit it.
 //
-// Per-participant attribution (interrupted_by_user_id) is deferred until the VAD
-// stage republishes per-participant speech events (ADR-0019); this slice runs a
-// single VAD session, so the event carries only the moment of the cut.
+// SpeakerID is the Discord snowflake string of the participant who barged — the
+// Speaker Lane whose confirmed speech reclaimed the floor (ADR-0050). It is ""
+// when the barge came off the default (single, unattributed) lane, the MVP path.
+// With per-speaker lanes the barge window is per-speaker, so this names exactly
+// who interrupted (needed by Epic 8's detector and future floor rules).
 type BargeDetected struct {
-	At time.Time
+	At        time.Time
+	SpeakerID string
 }
 
 // EventName implements [Event].

--- a/pkg/voice/wire/codec/codec.go
+++ b/pkg/voice/wire/codec/codec.go
@@ -185,13 +185,21 @@ func (c *Codec) DecodeInbound(frame gxvoice.Frame) ([]audio.Frame, error) {
 	if len(grouped) == 0 {
 		return nil, nil
 	}
+	// Stamp each decoded frame with its speaker so the segmenter can route it to
+	// that speaker's lane (ADR-0050). GUARD: snowflake.ID(0).String() == "0", not
+	// "" — an unresolved SSRC (zero UserID, audio before the speaking event) must
+	// stay unattributed, so only a non-zero UserID stamps a SpeakerID.
+	var speaker string
+	if frame.UserID != 0 {
+		speaker = frame.UserID.String()
+	}
 	frames := make([]audio.Frame, 0, len(grouped))
 	for _, samples := range grouped {
 		f, err := audio.NewFrame(samples, vadSampleRate, vadFrameMs)
 		if err != nil {
 			return nil, fmt.Errorf("codec: build audio frame: %w", err)
 		}
-		frames = append(frames, f)
+		frames = append(frames, f.WithSpeaker(speaker))
 	}
 	return frames, nil
 }

--- a/pkg/voice/wire/codec/codec_test.go
+++ b/pkg/voice/wire/codec/codec_test.go
@@ -363,3 +363,46 @@ func rms(s []int16) float64 {
 	}
 	return math.Sqrt(sum / float64(len(s)))
 }
+
+// TestDecodeInbound_StampsSpeakerFromUserID pins the ADR-0050 codec stamp: every
+// decoded audio.Frame carries its speaker's Discord snowflake string, so the
+// segmenter can route it to that speaker's lane. A known UserID stamps its
+// String(); the zero UserID (SSRC not yet resolved) MUST stay unattributed ("") —
+// snowflake.ID(0).String() is "0", so a naive stamp would misattribute unknown
+// audio to a bogus "0" speaker.
+func TestDecodeInbound_StampsSpeakerFromUserID(t *testing.T) {
+	packets := encodeOpus(t, sine(48000, 48000, 330), 48000)
+	c := New()
+	user := snowflake.ID(4242)
+
+	var sawAttributed bool
+	for _, pkt := range packets {
+		out, err := c.DecodeInbound(gxvoice.Frame{UserID: user, Opus: pkt})
+		if err != nil {
+			t.Fatalf("DecodeInbound: %v", err)
+		}
+		for _, f := range out {
+			if f.Speaker() != user.String() {
+				t.Fatalf("frame Speaker() = %q, want %q", f.Speaker(), user.String())
+			}
+			sawAttributed = true
+		}
+	}
+	if !sawAttributed {
+		t.Fatal("no attributed frames emitted")
+	}
+
+	// Unknown SSRC (zero UserID) must stay "" — never the literal "0".
+	c2 := New()
+	for _, pkt := range packets {
+		out, err := c2.DecodeInbound(gxvoice.Frame{UserID: 0, Opus: pkt})
+		if err != nil {
+			t.Fatalf("DecodeInbound(zero user): %v", err)
+		}
+		for _, f := range out {
+			if f.Speaker() != "" {
+				t.Fatalf("zero-UserID frame Speaker() = %q, want \"\" (unattributed)", f.Speaker())
+			}
+		}
+	}
+}

--- a/pkg/voice/wire/wire.go
+++ b/pkg/voice/wire/wire.go
@@ -262,8 +262,11 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 				continue
 			}
 			// The speaker stopped and audio has been idle for one frame interval:
-			// advance the VAD with one frame of silence so the utterance endpoints.
-			if err := p.conv.Feed(p.silence); err != nil {
+			// advance the VAD with one frame of silence so the utterance endpoints. This
+			// is the speaker-agnostic silence CLOCK — it must reach EVERY Speaker Lane's
+			// VAD hangover, so it routes through FeedSilence, distinct from the per-speaker
+			// inbound audio on Feed below (ADR-0050).
+			if err := p.conv.FeedSilence(p.silence); err != nil {
 				p.log.Debug("feed silence frame", "err", err)
 			}
 		case frame, ok := <-inbound:


### PR DESCRIPTION
Closes #277

## What

Threads a **SpeakerID** through the whole voice pipeline and turns the segmenter into **N Speaker Lanes** (one per active Discord participant), per **ADR-0050**. Each speaker's already-separated frame stream drives its own Silero VAD lane, so every utterance is segmented and attributed independently; the shared serial STT worker is unchanged (STT cost per utterance identical to single-lane).

## Contract (as designed by the architect — implemented exactly)

- **Wire format**: `SpeakerID` rides `audio.Frame` as a new private field (`Frame.WithSpeaker(id)` / `Frame.Speaker()`, copy-on-write). `voicecassette.HashFrames` hashes only `Samples()`, so **cassette fingerprints are untouched**.
- `codec.DecodeInbound` stamps each decoded frame with `Frame.UserID.String()`, guarding the zero UserID (`snowflake.ID(0).String()=="0"`) so an unresolved SSRC stays unattributed (`""`).
- Additive `SpeakerID` on **five** events: `VADSpeechStart`, `VADSpeechEnd`, `STTPartial`, `STTFinal`, `BargeDetected`.
  - **Note**: `VADSpeechEnd` is *not* in ADR-0050's enumerated list; lane routing of the bus-driven speech transitions needs the speech-end attributed (to disarm the right lane's barge window / endpoint the right lane). Additive, in the ADR's spirit.
- **Segmenter owns a lane map** keyed by SpeakerID. The default lane (`""`) is always present, wraps the ctor-supplied VAD, is never reaped/factory-built → **single-lane path byte-identical** when no `WithSpeakerLanes` factory is set.
- Empty-SpeakerID frames **broadcast to all lanes** (silence clock is speaker-agnostic).
- **Lane lifecycle**: idle reap sweep every 1024 `Process` calls, `laneIdleTTL = 2m`; reap flushes a buffered segment (not dropped), cancels the stream, closes the lane's ONNX session. Leave subsumed by idle TTL.
- **Per-speaker barge windows**: a `speech_end` from one speaker no longer disarms another speaker's armed confirm window; `BargeDetected` names the barging speaker.
- **Per-lane StreamManager** (flag-gated, default OFF): stamps its lane SpeakerID on partials, created at lane creation, capped by `GLYPHOXA_STT_STREAM_MAX_LANES` (default 4); past the cap a lane is pure batch. Default lane keeps `WithStreamingSTT`.
- New options: `WithSpeakerLanes`, `WithLaneStreamingSTT`, `WithStreamSpeakerID`; wired in `wirenpc.buildConversation` (lane VAD factory off the same process-global Silero engine; per-lane stream factory + env cap).

## Risks handled (per architect)

- **(a)** Global silence clock under sustained overlap can delay one lane's trailing-silence endpoint — **accepted residual** (Flush and the next lane-attributed frame both still endpoint; the ADR keeps the silence clock speaker-agnostic).
- **(b)** Per-lane Silero sessions are ONNX inferencers — closed on reap and on teardown (default lane's caller-owned VAD is never closed here).
- **(c)** A lane-VAD factory error **or panic** degrades that speaker to the default lane (still transcribed, `onError` reported) — the audio loop never goes down.
- **(d)** Process publish order preserved: each lane's VAD transitions fire synchronously before that lane's buffer decision.

## Acceptance criteria

- [x] **AC1** two-speaker clip → two `STTFinal`s with distinct SpeakerIDs — `TestConversation_TwoSpeakerCassette_DistinctSpeakerIDs` (two solo clips interleaved as two Discord speakers through two real Silero lanes; normalized-text match vs ground truth, no cassette-hash dependency).
- [x] **AC2** single-speaker byte-identical — full existing suite green; single-lane path is the untouched default-lane code path.
- [x] **AC3** join/leave mid-session — lane created on first frame, reaped on idle TTL (`TestSegmenter_LaneIdleReap`).
- [x] **AC4** soft-overlap / cross-talk attribution — `TestSegmenter_CrossTalk_LanesStayIntact`, `TestBargeIn_PerSpeakerWindowNotDisarmedByOther`, `TestBargeIn_SameSpeakerSoftOverlapDisarms`.
- [x] **AC5** latency SLOs unchanged — `TestBench_CassetteRegression` green against committed baseline (bench rig uses the default lane, so before/after is identical by construction).

## voicebench (AC5) — cassette tier, before == after

| stage | p50 (ms) | p95 (ms) | n |
|---|---|---|---|
| response_latency | 0.1 | 1.3 | 32 |
| address_detect | 0.0 | 0.0 | 32 |
| llm_round | 0.1 | 0.8 | 32 |
| tts_ttfb | 0.0 | 0.0 | 96 |

Regression gate passes against the committed baseline (tolerance 0) — no SLO drift.

## Tests added (13)

Frame round-trip; VAD stamp; codec stamp (+zero-UserID guard); two-lane/two-final; cross-talk; empty-speaker broadcast; idle reap; factory-error degrade; flush-drains-all-lanes; lane-stream cap; per-lane partial SpeakerID; per-speaker barge (×2); two-speaker cassette integration.

## Local gates

`go test -race ./...`, `golangci-lint run ./...`, `go build/vet -tags "opus nolibopusfile" ./...`, the bench regression, and `-tags=record`/`-tags=integration` compiles all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
