### PR TITLE
fix(ui): tone down the rune highlight — tint, not solid neon

### DIFF
--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -407,7 +407,8 @@
 /* The currently-viewed session's chip: emphasized like the deep-link highlight. */
 .gx-session__picker-item[aria-pressed="true"] {
   background: var(--rune-soft, rgba(120, 160, 255, 0.14));
-  box-shadow: 0 0 0 1px var(--rune, rgba(120, 160, 255, 0.5)) inset;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--rune, #00ddff) 45%, transparent)
+    inset;
 }
 
 .gx-session__picker-back {
@@ -419,7 +420,8 @@
 .gx-line--highlighted {
   background: var(--rune-soft, rgba(120, 160, 255, 0.14));
   border-radius: var(--radius-sm, 4px);
-  box-shadow: 0 0 0 2px var(--rune, rgba(120, 160, 255, 0.5)) inset;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--rune, #00ddff) 45%, transparent)
+    inset;
 }
 
 /* Live transcript list: one row per line — speaker name, optional tag pill,

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -422,6 +422,10 @@
   border-radius: var(--radius-sm, 4px);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--rune, #00ddff) 45%, transparent)
     inset;
+  /* Breathing room between the ring and the text, with a compensating
+   * negative margin so the line stays column-aligned with its neighbors. */
+  padding-inline: var(--spacing-sm, 8px);
+  margin-inline: calc(-1 * var(--spacing-sm, 8px));
 }
 
 /* Live transcript list: one row per line — speaker name, optional tag pill,

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -110,7 +110,10 @@
   --arcane-active: var(--color-violet-60);
   --arcane-ink: var(--color-violet-90);
   --rune: var(--color-blue-20);
-  --rune-soft: var(--color-blue-10);
+  /* Soft = a tint, not a solid: full-strength blue as a background fill
+   * glares against the dark violet surfaces (highlighted transcript lines,
+   * selected session chips). */
+  --rune-soft: color-mix(in srgb, var(--color-blue-20) 12%, transparent);
   --spell: var(--color-blue-40);
   --gold: var(--color-yellow-40);
   --ember: var(--color-orange-50);


### PR DESCRIPTION
## What

User feedback from the 2026-07-10 live validation: the search-hit line highlight (and the selected session chip) rendered as a solid bright-cyan fill that clashes with the dark violet theme.

## Why

`--rune-soft` was defined as full-strength `--color-blue-10` (`#80ebff`) — a solid, not a tint. The session screen's fallback values (`rgba(120,160,255,0.14)`) show the intended softness; the token betrayed it. The inset rings also used full-strength `--rune`.

## How

- `tokens.css`: `--rune-soft` = `color-mix(in srgb, var(--color-blue-20) 12%, transparent)` (house pattern, same as the danger/warning tints in session.css).
- `session.css`: both inset rings (`.gx-line--highlighted`, selected picker chip) softened to 45% via `color-mix`.
- Full-strength `--rune` text/dot uses (speaker names, typing indicator) untouched.

Verified live in Chrome against the running stack: highlight now reads as subtle emphasis, text keeps theme colors. Web suite 207/207 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)