### PR TITLE
feat(#278): persist speaker identity on Transcript Lines and Chunks

### DIFF
--- a/internal/storage/migrations/00020_transcript_line_speaker.sql
+++ b/internal/storage/migrations/00020_transcript_line_speaker.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Persist speaker identity on transcript Lines (#278, E4, ADR-0050). The Speaker
+-- Lanes (#277) attribute each human STTFinal to a Discord User; ADR-0040's line
+-- grain records who said each Line so replay/search can attribute it (#281).
+-- NULLABLE: an unattributed utterance (empty SpeakerID) persists NULL, so the
+-- pre-#278 anonymous behavior is byte-identical. NO index — no query filters on
+-- it yet (the column is written now, consumed by #281 later).
+ALTER TABLE transcript_line ADD COLUMN speaker_discord_user_id text;
+
+-- +goose Down
+
+ALTER TABLE transcript_line DROP COLUMN speaker_discord_user_id;

--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -29,16 +29,30 @@ type TranscriptLine struct {
 	Kind           string
 	TS             time.Time
 	Text           string
+	// SpeakerDiscordUserID is the Discord snowflake of the human who spoke this Line
+	// (#278, ADR-0050), or "" for an unattributed utterance / an Agent reply. It
+	// round-trips "" ↔ NULL: NULLIF on write, COALESCE on scan.
+	SpeakerDiscordUserID string
 }
 
+// transcriptLineInsertColumns are the plain column names for INSERT; the SELECT
+// list (transcriptLineColumns) mirrors them but COALESCEs speaker_discord_user_id
+// to "". BOTH are ORDER-COUPLED with scanTranscriptLine and the INSERT VALUES list
+// — update all together. speaker_discord_user_id is NULLIF'd to NULL on write and
+// COALESCEd to "" on read ("" ↔ NULL round-trip for an unattributed utterance).
+const transcriptLineInsertColumns = `
+	voice_session_id, campaign_id, line_id, seq, who, tag, kind, ts, text,
+	speaker_discord_user_id`
+
 const transcriptLineColumns = `
-	voice_session_id, campaign_id, line_id, seq, who, tag, kind, ts, text`
+	voice_session_id, campaign_id, line_id, seq, who, tag, kind, ts, text,
+	COALESCE(speaker_discord_user_id, '')`
 
 func scanTranscriptLine(row pgx.Row) (TranscriptLine, error) {
 	var l TranscriptLine
 	err := row.Scan(
 		&l.VoiceSessionID, &l.CampaignID, &l.LineID, &l.Seq,
-		&l.Who, &l.Tag, &l.Kind, &l.TS, &l.Text,
+		&l.Who, &l.Tag, &l.Kind, &l.TS, &l.Text, &l.SpeakerDiscordUserID,
 	)
 	return l, err
 }
@@ -52,14 +66,15 @@ func scanTranscriptLine(row pgx.Row) (TranscriptLine, error) {
 // interleaved line landed between a reply's sentences.
 func (s *Store) UpsertTranscriptLine(ctx context.Context, l TranscriptLine) error {
 	_, err := s.db.Exec(ctx,
-		`INSERT INTO transcript_line (`+transcriptLineColumns+`)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`INSERT INTO transcript_line (`+transcriptLineInsertColumns+`)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULLIF($10, ''))
 		 ON CONFLICT (voice_session_id, line_id) DO UPDATE
 		    SET who = EXCLUDED.who, tag = EXCLUDED.tag,
 		        kind = EXCLUDED.kind, ts = EXCLUDED.ts, text = EXCLUDED.text,
+		        speaker_discord_user_id = EXCLUDED.speaker_discord_user_id,
 		        updated_at = now()`,
 		l.VoiceSessionID, l.CampaignID, l.LineID, l.Seq,
-		l.Who, l.Tag, l.Kind, l.TS, l.Text)
+		l.Who, l.Tag, l.Kind, l.TS, l.Text, l.SpeakerDiscordUserID)
 	if err != nil {
 		return fmt.Errorf("storage: upsert transcript line %s/%s: %w", l.VoiceSessionID, l.LineID, err)
 	}

--- a/internal/storage/transcript_line_test.go
+++ b/internal/storage/transcript_line_test.go
@@ -156,3 +156,66 @@ func TestTranscriptLineCascade(t *testing.T) {
 		t.Errorf("count after cascade = %d, %v; want 0, nil", n, err)
 	}
 }
+
+// TestTranscriptLineSpeakerID is #278 (E4, ADR-0050): a SpeakerID-bearing human
+// Line persists the Discord snowflake per row, while an unattributed utterance
+// (empty SpeakerID) persists NULL — asserted via direct SQL — and scans back as
+// "" ("" ↔ NULL round-trip, so the empty case is byte-identical to old behavior).
+func TestTranscriptLineSpeakerID(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	ts := time.Date(2026, 7, 9, 18, 0, 0, 0, time.UTC)
+
+	// An attributed human line and an unattributed one (empty SpeakerID).
+	lines := []storage.TranscriptLine{
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "u:1", Seq: 1, Who: "Player / DM", Kind: "player", TS: ts, Text: "Hello", SpeakerDiscordUserID: "111222333"},
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "u:2", Seq: 2, Who: "Player / DM", Kind: "player", TS: ts, Text: "Silent", SpeakerDiscordUserID: ""},
+	}
+	for _, l := range lines {
+		if err := st.UpsertTranscriptLine(ctx, l); err != nil {
+			t.Fatalf("UpsertTranscriptLine %s: %v", l.LineID, err)
+		}
+	}
+
+	// Direct SQL: the attributed row stores the snowflake, the empty one stores NULL.
+	var attributed string
+	if err := pool.QueryRow(ctx,
+		`SELECT speaker_discord_user_id FROM transcript_line WHERE voice_session_id=$1 AND line_id='u:1'`, vs.ID).
+		Scan(&attributed); err != nil {
+		t.Fatalf("select u:1 speaker: %v", err)
+	}
+	if attributed != "111222333" {
+		t.Errorf("u:1 speaker_discord_user_id = %q, want 111222333", attributed)
+	}
+	var isNull bool
+	if err := pool.QueryRow(ctx,
+		`SELECT speaker_discord_user_id IS NULL FROM transcript_line WHERE voice_session_id=$1 AND line_id='u:2'`, vs.ID).
+		Scan(&isNull); err != nil {
+		t.Fatalf("select u:2 null-check: %v", err)
+	}
+	if !isNull {
+		t.Errorf("empty SpeakerID must persist NULL, got non-null")
+	}
+
+	// Scan round-trips: "" for the unattributed row, the snowflake for the other.
+	got, err := st.ListTranscriptLines(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("list len = %d, want 2", len(got))
+	}
+	if got[0].SpeakerDiscordUserID != "111222333" {
+		t.Errorf("line[0].SpeakerDiscordUserID = %q, want 111222333", got[0].SpeakerDiscordUserID)
+	}
+	if got[1].SpeakerDiscordUserID != "" {
+		t.Errorf("line[1].SpeakerDiscordUserID = %q, want \"\" (NULL round-trips to empty)", got[1].SpeakerDiscordUserID)
+	}
+}

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -101,7 +101,13 @@ type openChunk struct {
 	turnIDs    []string     // Agent turns whose line lives in this chunk (detached on close)
 	agents     []uuid.UUID  // participated Agent ids, first-seen order
 	agentSeen  map[uuid.UUID]struct{}
-	timer      *time.Timer
+	// speakers is the distinct Discord snowflakes of the humans who spoke in this
+	// chunk (#278), collected EAGERLY at appendHuman — the STTFinal events are gone
+	// by closeChunk. First-seen order; an empty SpeakerID (unattributed) is never
+	// added. speakerSeen dedups.
+	speakers    []string
+	speakerSeen map[string]struct{}
+	timer       *time.Timer
 }
 
 // Chunker projects bus events into Transcript Chunks and writes them async. Safe
@@ -228,8 +234,24 @@ func (c *Chunker) rollover(vs storage.VoiceSession) {
 func (c *Chunker) appendHuman(ev voiceevent.STTFinal) {
 	oc := c.ensureOpen(ev.At)
 	oc.entries = append(oc.entries, &chunkLine{text: "Player / DM: " + ev.Text})
+	c.recordSpeaker(oc, ev.SpeakerID)
 	oc.count++
 	c.afterAppend(oc)
+}
+
+// recordSpeaker adds a human utterance's Speaker Lane snowflake to the chunk's
+// distinct speaker set (deduped, first-seen order), collected eagerly since the
+// event is gone by close (#278). An empty SpeakerID (unattributed, ADR-0050) is
+// never added.
+func (c *Chunker) recordSpeaker(oc *openChunk, speakerID string) {
+	if speakerID == "" {
+		return
+	}
+	if _, ok := oc.speakerSeen[speakerID]; ok {
+		return
+	}
+	oc.speakerSeen[speakerID] = struct{}{}
+	oc.speakers = append(oc.speakers, speakerID)
 }
 
 // bufferAgentSentence records one DISPATCHED sentence. TTSInvoked is a dispatch
@@ -320,9 +342,10 @@ func (c *Chunker) recordAgent(oc *openChunk, target voiceevent.AddressTarget) {
 func (c *Chunker) ensureOpen(at time.Time) *openChunk {
 	if c.open == nil {
 		oc := &openChunk{
-			startedAt:  at,
-			openedWall: time.Now(),
-			agentSeen:  map[uuid.UUID]struct{}{},
+			startedAt:   at,
+			openedWall:  time.Now(),
+			agentSeen:   map[uuid.UUID]struct{}{},
+			speakerSeen: map[string]struct{}{},
 		}
 		oc.timer = time.AfterFunc(c.window, func() { c.onTimer(oc) })
 		c.open = oc
@@ -382,11 +405,15 @@ func (c *Chunker) closeChunk(oc *openChunk) {
 	for i, e := range oc.entries {
 		texts[i] = e.text
 	}
+	speakers := oc.speakers
+	if speakers == nil {
+		speakers = []string{} // scan contract: non-nil empty when no attributed speaker
+	}
 	chunk := storage.TranscriptChunk{
 		CampaignID:            c.activeCampaignID,
 		VoiceSessionID:        c.activeUUID,
 		Content:               strings.Join(texts, "\n"),
-		SpeakerDiscordUserIDs: []string{},
+		SpeakerDiscordUserIDs: speakers,
 		ParticipatedAgentIDs:  oc.agents,
 		StartedAt:             oc.startedAt,
 	}

--- a/internal/transcript/chunker_test.go
+++ b/internal/transcript/chunker_test.go
@@ -274,6 +274,89 @@ func TestChunker_AgentReplyCoalesces(t *testing.T) {
 	}
 }
 
+// TestChunker_ChunkCarriesDistinctSpeakerSet is #278: a chunk whose human
+// utterances came from two Speaker Lanes carries the DISTINCT speaker set (deduped,
+// first-seen order), collected eagerly at append time (the events are gone by
+// flush). An agent-only chunk keeps an empty set.
+func TestChunker_ChunkCarriesDistinctSpeakerSet(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+
+	// Two lanes, one repeats — the set dedups to [111, 222] in first-seen order.
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "a", TurnID: "t", SpeakerID: "111"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "b", TurnID: "t", SpeakerID: "222"})
+	bus.Publish(voiceevent.STTFinal{At: at(3), Text: "c", TurnID: "t", SpeakerID: "111"})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 {
+		t.Fatalf("inserts = %d, want 1", len(got))
+	}
+	if want := []string{"111", "222"}; !equalStrs(got[0].SpeakerDiscordUserIDs, want) {
+		t.Errorf("speakers = %v, want %v (distinct, first-seen order)", got[0].SpeakerDiscordUserIDs, want)
+	}
+}
+
+// TestChunker_AgentOnlyChunkHasNoSpeakers is #278: an agent-only chunk carries an
+// empty (non-nil) speaker set — unchanged from the pre-#278 anonymous behaviour.
+func TestChunker_AgentOnlyChunkHasNoSpeakers(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+	agentID := uuid.New()
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: agentID.String(), AgentRole: "character", Name: "Bart"},
+	})
+	agentReply(bus, "t1", "Well met.", at(2))
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 {
+		t.Fatalf("inserts = %d, want 1", len(got))
+	}
+	if len(got[0].SpeakerDiscordUserIDs) != 0 {
+		t.Errorf("speakers = %v, want empty (agent-only chunk)", got[0].SpeakerDiscordUserIDs)
+	}
+	if got[0].SpeakerDiscordUserIDs == nil {
+		t.Errorf("speakers is nil, want non-nil empty slice (scan contract)")
+	}
+}
+
+// TestChunker_UnattributedUtteranceAbsentFromSpeakerSet is #278: an unattributed
+// utterance (empty SpeakerID) is NEVER added to the chunk's speaker set.
+func TestChunker_UnattributedUtteranceAbsentFromSpeakerSet(t *testing.T) {
+	store := &fakeChunkStore{}
+	bus, fs, c := newChunker(t, store, nil, ChunkerConfig{})
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "named", TurnID: "t", SpeakerID: "111"})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "anon", TurnID: "t"}) // empty SpeakerID
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if want := []string{"111"}; !equalStrs(got[0].SpeakerDiscordUserIDs, want) {
+		t.Errorf("speakers = %v, want %v (empty SpeakerID excluded)", got[0].SpeakerDiscordUserIDs, want)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestChunker_DispatchedButNotDeliveredIsIgnored is #104 + ADR-0012: TTSInvoked is
 // a dispatch attempt, not delivery. A sentence dispatched but never delivered (no
 // FirstAudio — e.g. a Synthesize start-error) leaves the chunk unchanged and the

--- a/internal/transcript/persist.go
+++ b/internal/transcript/persist.go
@@ -56,15 +56,16 @@ func (r *Relay) persist(l Line, seq uint64) {
 		return
 	}
 	op := writeOp{line: &storage.TranscriptLine{
-		VoiceSessionID: r.activeUUID,
-		CampaignID:     r.activeCampaignID,
-		LineID:         l.ID,
-		Seq:            int64(seq), //nolint:gosec // seq is a small monotonic counter
-		Who:            l.Who,
-		Tag:            l.Tag,
-		Kind:           string(l.Kind),
-		TS:             l.TS,
-		Text:           l.Text,
+		VoiceSessionID:       r.activeUUID,
+		CampaignID:           r.activeCampaignID,
+		LineID:               l.ID,
+		Seq:                  int64(seq), //nolint:gosec // seq is a small monotonic counter
+		Who:                  l.Who,
+		Tag:                  l.Tag,
+		Kind:                 string(l.Kind),
+		TS:                   l.TS,
+		Text:                 l.Text,
+		SpeakerDiscordUserID: l.SpeakerID, // #278: "" (unattributed / Agent) → NULLIF → NULL in storage
 	}}
 	select {
 	case r.writeCh <- op:

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -95,6 +95,12 @@ type Line struct {
 	Kind Kind      `json:"kind"`
 	TS   time.Time `json:"ts"`
 	Text string    `json:"text"`
+	// SpeakerID is the Discord snowflake of the human who spoke this Line (#278,
+	// ADR-0050), threaded from STTFinal for persistence + later attribution (#281).
+	// Empty for an unattributed utterance or an Agent reply; the omitempty keeps the
+	// live-view wire byte-identical for the anonymous path. RENDERING is untouched —
+	// who/Kind still reflect the anonymous lane until #281 consumes this.
+	SpeakerID string `json:"speaker_id,omitempty"`
 }
 
 // Typing is the "is speaking" / "listening" indicator the SPA renders as the
@@ -291,11 +297,12 @@ func (r *Relay) project(e voiceevent.Event) {
 		// (ADR-0039: raw STT carries no speaker id).
 		r.humanSeq++
 		r.emitLine(Line{
-			ID:   "u:" + strconv.FormatUint(r.humanSeq, 10),
-			Who:  "Player / DM",
-			Kind: KindPlayer,
-			TS:   ev.At,
-			Text: ev.Text,
+			ID:        "u:" + strconv.FormatUint(r.humanSeq, 10),
+			Who:       "Player / DM",
+			Kind:      KindPlayer,
+			TS:        ev.At,
+			Text:      ev.Text,
+			SpeakerID: ev.SpeakerID, // #278: thread the Speaker Lane's snowflake through; rendering unchanged
 		})
 	case voiceevent.AddressRouted:
 		// Records WHO answers this turn; no line yet (no text).

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -85,6 +85,66 @@ func TestProjection_LinesAndOrder(t *testing.T) {
 	}
 }
 
+// TestProjection_SpeakerID is #278: an STTFinal carrying a SpeakerID projects a
+// human Line stamped with that snowflake AND tees it onto the persisted op — while
+// the rendering (who / Kind / Tag) is UNTOUCHED ("Player / DM", player, no pill):
+// attribution is #281's slice, this only threads the id through.
+func TestProjection_SpeakerID(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(bus, fs, store, nil)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hello", TurnID: "t1", SpeakerID: "111"})
+
+	v := r.View(fs.id.String())
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want 1: %+v", len(v.Lines), v.Lines)
+	}
+	l := v.Lines[0]
+	if l.SpeakerID != "111" {
+		t.Errorf("Line.SpeakerID = %q, want 111", l.SpeakerID)
+	}
+	// Rendering untouched — attribution is #281, not this slice.
+	if l.Who != "Player / DM" || l.Kind != KindPlayer || l.Tag != "" {
+		t.Errorf("rendering changed: who=%q kind=%q tag=%q, want Player / DM / player / \"\"", l.Who, l.Kind, l.Tag)
+	}
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got, _ := store.ListTranscriptLines(context.Background(), fs.id)
+	if len(got) != 1 {
+		t.Fatalf("persisted %d lines, want 1", len(got))
+	}
+	if got[0].SpeakerDiscordUserID != "111" {
+		t.Errorf("persisted SpeakerDiscordUserID = %q, want 111", got[0].SpeakerDiscordUserID)
+	}
+}
+
+// TestProjection_EmptySpeakerID is #278: an unattributed STTFinal (empty SpeakerID)
+// leaves Line.SpeakerID "" and persists it empty — the pre-#278 anonymous path,
+// byte-identical.
+func TestProjection_EmptySpeakerID(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(bus, fs, store, nil)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Silent", TurnID: "t1"})
+
+	if l := r.View(fs.id.String()).Lines[0]; l.SpeakerID != "" {
+		t.Errorf("Line.SpeakerID = %q, want \"\" (unattributed)", l.SpeakerID)
+	}
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got, _ := store.ListTranscriptLines(context.Background(), fs.id)
+	if got[0].SpeakerDiscordUserID != "" {
+		t.Errorf("persisted SpeakerDiscordUserID = %q, want \"\"", got[0].SpeakerDiscordUserID)
+	}
+}
+
 // TestProjection_MuteFrame pins the mute relay (#211): a MuteChanged projects a
 // "mute" frame carrying agent_id + muted, and the frame rides the ring so a
 // Last-Event-ID reconnect replays it (no snapshot change — the reload truth is


### PR DESCRIPTION
Closes #278

## What

E4 slice: thread the Speaker Lane's Discord snowflake (from #277's `STTFinal.SpeakerID`) through to the two persisted transcript grains, without touching rendering (that is #281).

- **Migration `00020_transcript_line_speaker.sql`** — `ALTER TABLE transcript_line ADD COLUMN speaker_discord_user_id text` (nullable, no index; goose up+down same file). The chunk column `speaker_discord_user_ids` already exists (00001).
- **`storage.TranscriptLine`** gains `SpeakerDiscordUserID`; `NULLIF($n,'')` on write, `COALESCE(...,'')` on scan → `"" ↔ NULL` round-trip so the unattributed path is byte-identical.
- **relay** — `Line.SpeakerID` (`json:"speaker_id,omitempty"`), set from the STTFinal event; teed onto the persisted op. `who`/`Kind`/`Tag` untouched.
- **chunker** — `openChunk` collects the distinct speaker set eagerly at `appendHuman` (events gone by flush), empty SpeakerID never added, `closeChunk` writes it (keeps `[]string{}` when none). Agent-only chunks unchanged.

## AC

- [x] SpeakerID-bearing STTFinals persist the snowflake per human Line
- [x] Chunks carry the distinct speaker set; agent-only chunks unchanged
- [x] Empty SpeakerID persists NULL / absent from the chunk array (asserted via direct SQL)
- [x] Replay/search outputs unchanged (who untouched); async-writer flush barrier still authoritative

## Tests (TDD red→green)

- storage integration: `TestTranscriptLineSpeakerID` — snowflake persists, empty → NULL (direct SQL), scan round-trips `""`
- relay unit: `TestProjection_SpeakerID`, `TestProjection_EmptySpeakerID`
- chunker unit: `TestChunker_ChunkCarriesDistinctSpeakerSet`, `TestChunker_AgentOnlyChunkHasNoSpeakers`, `TestChunker_UnattributedUtteranceAbsentFromSpeakerSet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)