### PR TITLE
feat(#281): [E4] resolve Character names in the transcript relay + unmapped-speaker fallback

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
+	"github.com/MrWong99/Glyphoxa/internal/speaker"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/transcript"
@@ -444,11 +445,26 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		}
 	}
 
+	// The speaker resolver (#281, E4) resolves a Speaker Lane snowflake to its
+	// Character/GM display name for the relay + chunk prefix. It reads Characters
+	// from the store and, for an unmapped speaker, falls back to the Discord guild
+	// display name via the standing presence (web-only replicas have no presence, so
+	// the namer stays a true nil interface — no guild fallback, generic label). GM
+	// is the operator allowlist (ADR-0050/0041). Shared by the relay, chunker, and
+	// the Character CRUD invalidation hook.
+	var speakerNamer speaker.MemberNamer
+	if pres != nil {
+		speakerNamer = pres
+	}
+	speakerResolver := speaker.NewResolver(store, speakerNamer,
+		auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS")), log)
+
 	// The SSE transcript relay (issue #73, ADR-0014 Hop-B) subscribes to the
 	// process bus once and reads the active session from the manager (Snapshot).
 	// The store backs incremental line persistence + replay-on-reload (#74,
 	// ADR-0040); the manager finalizes the relay's writer queue on Stop (below).
 	relay := transcript.NewRelay(eventBus, mgr, store, log)
+	relay.SetResolver(speakerResolver) // #281: resolve who/GM per line (nil-safe, off if unset)
 	// Back-wire the finalizer so Stop drains the relay's writer queue and records
 	// the authoritative line_count (#74). Done after the relay exists because the
 	// relay needs the manager (Snapshot), so the manager is built first.
@@ -462,6 +478,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// line grain (ADR-0040). Voice-standalone mode does not chunk (same posture as
 	// line persistence).
 	chunker := transcript.NewChunker(eventBus, mgr, store, metrics, log, transcript.ChunkerConfig{})
+	chunker.SetResolver(speakerResolver) // #281: resolved name as each human line's chunk prefix
 	mgr.SetChunkFlusher(chunker)
 	// Seed the backlog gauge from the DB at boot so it reads the true count before
 	// the first chunk is written (idempotent Set-from-COUNT, ADR-0032). A read
@@ -549,7 +566,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			return pres.VoiceChannelMembers(ctx, channelID)
 		}
 	}
-	mounts := managementMounts(store, cipher, metrics, log, mgr, relay, recapEngine, presenceRefresh, memberLister)
+	mounts := managementMounts(store, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, presenceRefresh, memberLister)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -610,7 +627,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
 // Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error)) []web.Mount {
+func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error)) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses
@@ -646,6 +663,10 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 	if memberLister != nil {
 		campaignSrv.SetMemberLister(memberLister)
 	}
+	// A Character mutation invalidates the campaign's cached speaker resolutions so
+	// the live relay re-resolves future lines with the new mapping (#281, ADR-0039
+	// in-proc direct-method invalidation).
+	campaignSrv.SetSpeakerInvalidator(speakerResolver)
 	campaignPath, campaignHandler := campaignSrv.Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
 	// VoiceService (#70) serves the live provider data the Configuration +

--- a/internal/presence/members_name.go
+++ b/internal/presence/members_name.go
@@ -1,0 +1,60 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/rest"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// ErrNoGuild is returned by MemberDisplayName while the presence has no configured
+// Guild (the wait-state) — there is no guild to fetch a member from, so the
+// speaker resolver (#281) falls back to its generic label.
+var ErrNoGuild = errors.New("presence: no configured guild for member lookup")
+
+// MemberDisplayName resolves a Discord User snowflake to its display name in the
+// configured Guild, using nick > global name > username precedence (disgo's
+// Member.EffectiveName). It is the unmapped-speaker fallback the transcript
+// resolver consults (#281, recorded decision 2): a speaker with no mapped
+// Character renders as their guild display name. A wait-state (no Guild) or a REST
+// failure returns an error, and the resolver negative-caches it as unresolved.
+//
+// This satisfies speaker.MemberNamer. The fetch is off-bus (the resolver calls it
+// from a Warm goroutine, never a synchronous bus callback), so the REST round-trip
+// here never stalls the voice pipeline.
+func (p *Presence) MemberDisplayName(ctx context.Context, discordUserID string) (string, error) {
+	gid := p.GuildID()
+	if gid == "" {
+		return "", ErrNoGuild
+	}
+	guildID, err := snowflake.Parse(gid)
+	if err != nil {
+		return "", fmt.Errorf("presence: parse guild id %q: %w", gid, err)
+	}
+	userID, err := snowflake.Parse(discordUserID)
+	if err != nil {
+		return "", fmt.Errorf("presence: parse user id %q: %w", discordUserID, err)
+	}
+	m, err := p.fetchMember(ctx, guildID, userID)
+	if err != nil {
+		return "", fmt.Errorf("presence: fetch guild member %s: %w", discordUserID, err)
+	}
+	if m == nil {
+		return "", fmt.Errorf("presence: guild member %s: %w", discordUserID, ErrNoGuild)
+	}
+	return m.EffectiveName(), nil
+}
+
+// restGetMember is the production member fetch: it borrows the standing client and
+// calls its REST GetMember. ErrNoClient in the wait-state propagates so the
+// resolver negative-caches and retries.
+func (p *Presence) restGetMember(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error) {
+	c, err := p.Client()
+	if err != nil {
+		return nil, err
+	}
+	return c.Rest.GetMember(guildID, userID, rest.WithCtx(ctx))
+}

--- a/internal/presence/members_name_test.go
+++ b/internal/presence/members_name_test.go
@@ -1,0 +1,83 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+func strptr(s string) *string { return &s }
+
+// newNameTestPresence builds a bare Presence with a configured Guild and an
+// injected member fetch, bypassing the standing gateway so MemberDisplayName is
+// unit-tested without a live Discord client.
+func newNameTestPresence(guildID string, fetch func(ctx context.Context, gid, uid snowflake.ID) (*discord.Member, error)) *Presence {
+	p := &Presence{}
+	p.guildID.Store(guildID)
+	p.fetchMember = fetch
+	return p
+}
+
+func TestMemberDisplayNamePrecedence(t *testing.T) {
+	const user = "111111111111111111"
+
+	cases := []struct {
+		name   string
+		member *discord.Member
+		want   string
+	}{
+		{
+			name:   "nick wins over global name and username",
+			member: &discord.Member{Nick: strptr("Kira the Bold"), User: discord.User{GlobalName: strptr("Kira G"), Username: "kira_u"}},
+			want:   "Kira the Bold",
+		},
+		{
+			name:   "global name wins when no nick",
+			member: &discord.Member{User: discord.User{GlobalName: strptr("Kira G"), Username: "kira_u"}},
+			want:   "Kira G",
+		},
+		{
+			name:   "username when neither nick nor global name",
+			member: &discord.Member{User: discord.User{Username: "kira_u"}},
+			want:   "kira_u",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newNameTestPresence("222222222222222222", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+				return tc.member, nil
+			})
+			got, err := p.MemberDisplayName(context.Background(), user)
+			if err != nil {
+				t.Fatalf("MemberDisplayName err = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("MemberDisplayName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMemberDisplayNameFetchErrorPropagates(t *testing.T) {
+	sentinel := errors.New("discord 5xx")
+	p := newNameTestPresence("222222222222222222", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+		return nil, sentinel
+	})
+	if _, err := p.MemberDisplayName(context.Background(), "111111111111111111"); !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrapping %v", err, sentinel)
+	}
+}
+
+func TestMemberDisplayNameNoGuild(t *testing.T) {
+	p := newNameTestPresence("", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+		t.Fatal("fetch must not run without a configured Guild")
+		return nil, nil
+	})
+	if _, err := p.MemberDisplayName(context.Background(), "111111111111111111"); err == nil {
+		t.Fatal("MemberDisplayName err = nil, want error in the wait-state (no Guild)")
+	}
+}

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -68,6 +68,9 @@ type Presence struct {
 	open        func(ctx context.Context, client *bot.Client) error
 	register    commandRegistrar
 	closeClient func(client *bot.Client)
+	// fetchMember resolves one guild member via the standing client's REST; injected
+	// so MemberDisplayName (#281) is unit-tested without a live gateway.
+	fetchMember func(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error)
 
 	// mu serializes Ensure/Close so builds and registrations never overlap; token
 	// is Ensure-local state guarded by it. The read-hot client and guildID are
@@ -99,6 +102,7 @@ func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log
 	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
 	p.register = restRegister
 	p.closeClient = func(client *bot.Client) { client.Close(context.Background()) }
+	p.fetchMember = p.restGetMember
 	return p
 }
 

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -99,6 +99,18 @@ type CampaignServer struct {
 	// returns an empty list so the UI falls back to free-text snowflake entry. Set
 	// once at boot before serving, so no lock is needed.
 	memberLister voiceMemberLister
+	// speakerInv drops a campaign's cached speaker→name resolutions after a Character
+	// mutation (#281, ADR-0039 in-proc direct-method invalidation), so the live relay
+	// re-resolves future lines with the new mapping. Nil disables (feature off / no
+	// live resolver); set once at boot before serving.
+	speakerInv SpeakerInvalidator
+}
+
+// SpeakerInvalidator drops a campaign's cached speaker→name resolutions. The live
+// *speaker.Resolver satisfies it; the Character CRUD handlers call it on
+// create/update/delete so a rebind takes effect on the next projected line (#281).
+type SpeakerInvalidator interface {
+	InvalidateCampaign(campaignID uuid.UUID)
 }
 
 // NewCampaignServer wraps a campaignStore (e.g. *storage.Store) in a
@@ -122,6 +134,21 @@ func (s *CampaignServer) SetSessions(src activeSessionSource) {
 	s.liveCampaign = func() (uuid.UUID, bool) {
 		vs, active := src.Snapshot()
 		return vs.CampaignID, active
+	}
+}
+
+// SetSpeakerInvalidator wires the live speaker resolver's campaign invalidation
+// (#281). Called once at boot before serving, so no lock is needed; nil-safe at the
+// call sites (invalidateSpeakers). A nil resolver leaves the hook off.
+func (s *CampaignServer) SetSpeakerInvalidator(inv SpeakerInvalidator) {
+	s.speakerInv = inv
+}
+
+// invalidateSpeakers drops a campaign's cached speaker resolutions after a
+// Character mutation, if a resolver is wired (#281). Nil-safe.
+func (s *CampaignServer) invalidateSpeakers(campaignID uuid.UUID) {
+	if s.speakerInv != nil {
+		s.speakerInv.InvalidateCampaign(campaignID)
 	}
 }
 

--- a/internal/rpc/character.go
+++ b/internal/rpc/character.go
@@ -86,6 +86,9 @@ func (s *CampaignServer) CreateCharacter(
 		slog.Default().Error("CreateCharacter: store create failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
+	// A new speaker→Character mapping: drop the campaign's cached resolutions so the
+	// live relay attributes this Discord User's next line to the new Character (#281).
+	s.invalidateSpeakers(c.ID)
 	return connect.NewResponse(&managementv1.CreateCharacterResponse{
 		Character: &managementv1.Character{
 			Id:            id.String(),
@@ -133,6 +136,9 @@ func (s *CampaignServer) UpdateCharacter(
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
 	}
+	// A rebind or rename changes how this Discord User resolves: drop the campaign's
+	// cached resolutions so the next projected line reflects it (#281).
+	s.invalidateSpeakers(updated.CampaignID)
 	return connect.NewResponse(&managementv1.UpdateCharacterResponse{Character: toProtoCharacter(updated)}), nil
 }
 
@@ -150,6 +156,13 @@ func (s *CampaignServer) DeleteCharacter(
 
 	switch err := s.store.DeleteCharacter(ctx, id); {
 	case err == nil:
+		// The deleted mapping's Discord User now falls back to guild name / generic
+		// label: drop the active campaign's cached resolutions (#281). The delete is
+		// by raw id, so we scope invalidation to the campaign in view (best-effort —
+		// the 5min TTL self-heals if resolution misses).
+		if c, cerr := s.activeCampaign(ctx); cerr == nil {
+			s.invalidateSpeakers(c.ID)
+		}
 		return connect.NewResponse(&managementv1.DeleteCharacterResponse{}), nil
 	case errors.Is(err, storage.ErrNotFound):
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("character not found"))

--- a/internal/rpc/character_invalidate_test.go
+++ b/internal/rpc/character_invalidate_test.go
@@ -1,0 +1,106 @@
+package rpc_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// spyInvalidator records InvalidateCampaign calls so the Character CRUD hook (#281)
+// is assertable.
+type spyInvalidator struct {
+	mu  sync.Mutex
+	ids []uuid.UUID
+}
+
+func (s *spyInvalidator) InvalidateCampaign(id uuid.UUID) {
+	s.mu.Lock()
+	s.ids = append(s.ids, id)
+	s.mu.Unlock()
+}
+
+func (s *spyInvalidator) calls() []uuid.UUID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uuid.UUID(nil), s.ids...)
+}
+
+// TestCharacterMutations_InvalidateSpeakers pins the in-proc invalidation hook
+// (#281, ADR-0039): Create/Update/Delete each drop the campaign's cached speaker
+// resolutions so the live relay re-resolves future lines with the new mapping.
+func TestCharacterMutations_InvalidateSpeakers(t *testing.T) {
+	campaign := storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store := newFakeStore()
+	store.campaign = campaign
+	spy := &spyInvalidator{}
+
+	srv := rpc.NewCampaignServer(store)
+	srv.SetSpeakerInvalidator(spy)
+
+	ctx := context.Background()
+	createResp, err := srv.CreateCharacter(ctx, connect.NewRequest(&managementv1.CreateCharacterRequest{
+		Name:          "Kira",
+		DiscordUserId: "111111111111111111",
+	}))
+	if err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+	if _, err := srv.UpdateCharacter(ctx, connect.NewRequest(&managementv1.UpdateCharacterRequest{
+		Id:            createResp.Msg.GetCharacter().GetId(),
+		Name:          "Kira Reborn",
+		DiscordUserId: "111111111111111111",
+	})); err != nil {
+		t.Fatalf("UpdateCharacter: %v", err)
+	}
+	if _, err := srv.DeleteCharacter(ctx, connect.NewRequest(&managementv1.DeleteCharacterRequest{
+		Id: createResp.Msg.GetCharacter().GetId(),
+	})); err != nil {
+		t.Fatalf("DeleteCharacter: %v", err)
+	}
+
+	got := spy.calls()
+	if len(got) != 3 {
+		t.Fatalf("InvalidateCampaign calls = %d, want 3 (create/update/delete)", len(got))
+	}
+	for i, id := range got {
+		if id != campaign.ID {
+			t.Errorf("call %d invalidated %s, want campaign %s", i, id, campaign.ID)
+		}
+	}
+}
+
+// TestCharacterMutations_NilInvalidatorSafe: with no invalidator wired (feature
+// off / no live resolver) the mutations must not panic.
+func TestCharacterMutations_NilInvalidatorSafe(t *testing.T) {
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	srv := rpc.NewCampaignServer(store) // no SetSpeakerInvalidator
+
+	ctx := context.Background()
+	resp, err := srv.CreateCharacter(ctx, connect.NewRequest(&managementv1.CreateCharacterRequest{
+		Name:          "Kira",
+		DiscordUserId: "111111111111111111",
+	}))
+	if err != nil {
+		t.Fatalf("CreateCharacter with nil invalidator: %v", err)
+	}
+	if _, err := srv.UpdateCharacter(ctx, connect.NewRequest(&managementv1.UpdateCharacterRequest{
+		Id:            resp.Msg.GetCharacter().GetId(),
+		Name:          "Kira Reborn",
+		DiscordUserId: "111111111111111111",
+	})); err != nil {
+		t.Fatalf("UpdateCharacter with nil invalidator: %v", err)
+	}
+	if _, err := srv.DeleteCharacter(ctx, connect.NewRequest(&managementv1.DeleteCharacterRequest{
+		Id: resp.Msg.GetCharacter().GetId(),
+	})); err != nil {
+		t.Fatalf("DeleteCharacter with nil invalidator: %v", err)
+	}
+}

--- a/internal/speaker/resolver.go
+++ b/internal/speaker/resolver.go
@@ -1,0 +1,224 @@
+// Package speaker resolves a Speaker Lane's Discord snowflake to a display name
+// and GM flag for the transcript relay + chunk writer (#281, E4). The two
+// consumers are synchronous bus callbacks that must never block (ADR-0040), so
+// resolution is split: Warm does the DB / Discord I/O asynchronously off the bus
+// and fills a short-TTL cache; Lookup is cache-only and never blocks.
+//
+// The name is a persist-time snapshot (the recorded decision): who is written
+// once at persist time and a later rebind only affects FUTURE lines — replay and
+// search read the persisted who unchanged. Invalidation is an in-proc direct
+// method (ADR-0039), called by the Character CRUD handlers, so a mid-campaign
+// rebind re-resolves the next line without a bus event or polling.
+package speaker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const (
+	// ttlPositive caches a resolved name (Character or guild display) for 5 minutes:
+	// long enough to cover a session's cadence, short enough that a rebind without
+	// an explicit invalidation still self-heals.
+	ttlPositive = 5 * time.Minute
+	// ttlNegative caches an unresolved speaker (fetch error, nil namer, unknown
+	// lookup failure) for 30s only, so a transient Discord blip retries soon.
+	ttlNegative = 30 * time.Second
+	// fillTimeout bounds one asynchronous fill's I/O so a stalled DB or Discord REST
+	// call cannot leak goroutines.
+	fillTimeout = 5 * time.Second
+)
+
+// CharacterLookup is the speaker → Character resolution the resolver needs (#276).
+// *storage.Store satisfies it via GetCharacterByDiscordUser.
+type CharacterLookup interface {
+	GetCharacterByDiscordUser(ctx context.Context, campaignID uuid.UUID, discordUserID string) (storage.Character, error)
+}
+
+// MemberNamer resolves a Discord snowflake to its guild display name — the
+// unmapped-speaker fallback (recorded decision 2). *presence.Presence satisfies
+// it; a nil namer means web-only mode with no guild fallback.
+type MemberNamer interface {
+	MemberDisplayName(ctx context.Context, discordUserID string) (string, error)
+}
+
+// Resolution is the resolved identity for a Speaker Lane snowflake. Name is the
+// Character name when mapped, else the guild display name, else "" (unresolved or
+// a failed fetch — the caller keeps its generic label). GM is allowlist
+// membership, computed inline on every Lookup and never cached, so a grant change
+// takes effect on the next boot's parsed allowlist without a cache flush.
+type Resolution struct {
+	Name string
+	GM   bool
+}
+
+// key identifies a cached name by campaign + speaker snowflake. GM is not part of
+// the key: it is never cached.
+type key struct {
+	campaign uuid.UUID
+	speaker  string
+}
+
+// entry is a cached resolution: name ("" = negative) and its expiry.
+type entry struct {
+	name    string
+	expires time.Time
+}
+
+// Resolver caches speaker → name resolutions. Warm fills asynchronously off the
+// bus; Lookup reads the cache only. Its own mutex is never held across a callback,
+// so a caller may Warm/Lookup from under its own lock without a deadlock.
+type Resolver struct {
+	chars   CharacterLookup
+	members MemberNamer
+	allow   auth.OperatorAllowlist
+	log     *slog.Logger
+	now     func() time.Time
+
+	mu       sync.Mutex
+	cache    map[key]entry
+	inflight map[key]struct{}     // keys with a fill in progress (dedup)
+	gen      map[uuid.UUID]uint64 // per-campaign generation; bumped on InvalidateCampaign
+	wg       sync.WaitGroup       // tracks in-flight fills (test synchronization)
+}
+
+// NewResolver builds a Resolver. members may be nil (web-only mode: no guild
+// fallback). log nil defaults to a discarding logger.
+func NewResolver(chars CharacterLookup, members MemberNamer, allow auth.OperatorAllowlist, log *slog.Logger) *Resolver {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &Resolver{
+		chars:    chars,
+		members:  members,
+		allow:    allow,
+		log:      log,
+		now:      time.Now,
+		cache:    map[key]entry{},
+		inflight: map[key]struct{}{},
+		gen:      map[uuid.UUID]uint64{},
+	}
+}
+
+// Warm asynchronously fills the cache for a speaker so a later Lookup hits. It
+// never blocks: a fresh cache entry or an in-flight fill for the same key is a
+// no-op (dedup), otherwise it dispatches one background fill. An empty speakerID
+// (unattributed lane) is ignored.
+func (r *Resolver) Warm(campaignID uuid.UUID, speakerID string) {
+	if speakerID == "" {
+		return
+	}
+	k := key{campaign: campaignID, speaker: speakerID}
+
+	r.mu.Lock()
+	if e, ok := r.cache[k]; ok && r.now().Before(e.expires) {
+		r.mu.Unlock()
+		return // still fresh
+	}
+	if _, busy := r.inflight[k]; busy {
+		r.mu.Unlock()
+		return // a fill is already running for this key
+	}
+	r.inflight[k] = struct{}{}
+	gen := r.gen[campaignID]
+	r.wg.Add(1)
+	r.mu.Unlock()
+
+	go r.fill(k, gen)
+}
+
+// fill runs one resolution's I/O off the bus and stores the result under the
+// mutex. A result whose campaign generation changed while the fill ran (an
+// InvalidateCampaign landed mid-flight) is dropped so a stale name is never cached.
+func (r *Resolver) fill(k key, gen uint64) {
+	defer r.wg.Done()
+
+	name, ttl := r.resolve(k)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.inflight, k)
+	if r.gen[k.campaign] != gen {
+		return // invalidated mid-fill; discard the now-stale result
+	}
+	r.cache[k] = entry{name: name, expires: r.now().Add(ttl)}
+}
+
+// resolve performs the actual lookup with no lock held: Character name (positive)
+// → guild display name (positive) → "" (negative). An unknown Character-lookup
+// error (not a genuine miss) short-caches negative and does NOT fall through to
+// the guild name — "unknown" is not "unmapped".
+func (r *Resolver) resolve(k key) (string, time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), fillTimeout)
+	defer cancel()
+
+	ch, err := r.chars.GetCharacterByDiscordUser(ctx, k.campaign, k.speaker)
+	switch {
+	case err == nil:
+		return ch.Name, ttlPositive
+	case !errors.Is(err, storage.ErrNotFound):
+		r.log.Warn("speaker: character lookup failed", "err", err, "speaker", k.speaker)
+		return "", ttlNegative
+	}
+
+	// Genuine miss (unmapped speaker): fall back to the Discord guild display name.
+	if r.members == nil {
+		return "", ttlNegative
+	}
+	name, err := r.members.MemberDisplayName(ctx, k.speaker)
+	if err != nil {
+		r.log.Warn("speaker: guild member fetch failed", "err", err, "speaker", k.speaker)
+		return "", ttlNegative
+	}
+	if name == "" {
+		return "", ttlNegative
+	}
+	return name, ttlPositive
+}
+
+// Lookup returns the cached Resolution for a speaker. It NEVER blocks or does I/O:
+// GM is computed inline from the allowlist, and Name is served only from a fresh
+// cache entry (a cold or expired entry yields Name ""). The caller keeps its
+// generic label when Name is "".
+func (r *Resolver) Lookup(campaignID uuid.UUID, speakerID string) Resolution {
+	res := Resolution{GM: r.allow.Contains(speakerID)}
+	if speakerID == "" {
+		return res
+	}
+	r.mu.Lock()
+	if e, ok := r.cache[key{campaign: campaignID, speaker: speakerID}]; ok && r.now().Before(e.expires) {
+		res.Name = e.name
+	}
+	r.mu.Unlock()
+	return res
+}
+
+// InvalidateCampaign drops every cached name for a campaign and bumps its
+// generation, so any fill still in flight discards its result and the next Warm
+// re-queries with the new mapping (ADR-0039 in-proc direct-method invalidation).
+// Called by the Character CRUD handlers after a create/update/delete.
+func (r *Resolver) InvalidateCampaign(campaignID uuid.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.gen[campaignID]++
+	for k := range r.cache {
+		if k.campaign == campaignID {
+			delete(r.cache, k)
+		}
+	}
+	// Clear in-flight markers too so a fresh Warm re-queries immediately rather than
+	// waiting on the now-stale fill (whose result the generation check discards).
+	for k := range r.inflight {
+		if k.campaign == campaignID {
+			delete(r.inflight, k)
+		}
+	}
+}

--- a/internal/speaker/resolver_test.go
+++ b/internal/speaker/resolver_test.go
@@ -1,0 +1,280 @@
+package speaker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeChars is a scripted CharacterLookup: it returns the mapped Character for a
+// (campaign, discordUser) pair, else storage.ErrNotFound, and counts calls.
+type fakeChars struct {
+	mu    sync.Mutex
+	byKey map[string]storage.Character // key = campaign+"/"+discordUser
+	err   error                        // when non-nil, returned for every lookup (a DB failure)
+	gate  chan struct{}                // when non-nil, each lookup blocks on it before returning
+	calls int
+}
+
+func (f *fakeChars) GetCharacterByDiscordUser(_ context.Context, campaignID uuid.UUID, discordUserID string) (storage.Character, error) {
+	if f.gate != nil {
+		<-f.gate
+	}
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.err != nil {
+		return storage.Character{}, f.err
+	}
+	if c, ok := f.byKey[campaignID.String()+"/"+discordUserID]; ok {
+		return c, nil
+	}
+	return storage.Character{}, storage.ErrNotFound
+}
+
+func (f *fakeChars) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// fakeNamer is a scripted MemberNamer: it returns a guild display name per
+// snowflake, else an error, and counts calls.
+type fakeNamer struct {
+	mu     sync.Mutex
+	byUser map[string]string
+	err    error
+	calls  int
+}
+
+func (f *fakeNamer) MemberDisplayName(_ context.Context, discordUserID string) (string, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.err != nil {
+		return "", f.err
+	}
+	if n, ok := f.byUser[discordUserID]; ok {
+		return n, nil
+	}
+	return "", nil // no name known
+}
+
+func (f *fakeNamer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+const (
+	kiraUser = "111111111111111111"
+	gmUser   = "222222222222222222"
+	guestID  = "333333333333333333"
+)
+
+func newTestResolver(t *testing.T, chars CharacterLookup, namer MemberNamer, allowIDs string) *Resolver {
+	t.Helper()
+	return NewResolver(chars, namer, auth.ParseOperatorAllowlist(allowIDs), nil)
+}
+
+func TestResolverWarmThenLookupCharacterName(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{
+		campaign.String() + "/" + kiraUser: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraUser},
+	}}
+	r := newTestResolver(t, chars, &fakeNamer{}, "")
+
+	r.Warm(campaign, kiraUser)
+	r.wg.Wait()
+
+	got := r.Lookup(campaign, kiraUser)
+	if got.Name != "Kira" || got.GM {
+		t.Fatalf("Lookup = %+v, want Name=Kira GM=false", got)
+	}
+	if chars.callCount() != 1 {
+		t.Fatalf("character lookups = %d, want 1", chars.callCount())
+	}
+}
+
+func TestResolverMissFallsBackToGuildName(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{}} // no Character mapped
+	namer := &fakeNamer{byUser: map[string]string{guestID: "GuildGuest"}}
+	r := newTestResolver(t, chars, namer, "")
+
+	r.Warm(campaign, guestID)
+	r.wg.Wait()
+
+	got := r.Lookup(campaign, guestID)
+	if got.Name != "GuildGuest" {
+		t.Fatalf("Lookup.Name = %q, want GuildGuest", got.Name)
+	}
+	if namer.callCount() != 1 {
+		t.Fatalf("namer calls = %d, want 1", namer.callCount())
+	}
+}
+
+func TestResolverNamerErrorNegativeCachedThenExpires(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{}}
+	namer := &fakeNamer{err: errors.New("discord unavailable")}
+	r := newTestResolver(t, chars, namer, "")
+
+	base := time.Now()
+	r.now = func() time.Time { return base }
+
+	r.Warm(campaign, guestID)
+	r.wg.Wait()
+
+	if got := r.Lookup(campaign, guestID); got.Name != "" {
+		t.Fatalf("Lookup.Name = %q, want empty (negative)", got.Name)
+	}
+	// A second Warm within the 30s negative TTL must NOT re-query (cached).
+	r.Warm(campaign, guestID)
+	r.wg.Wait()
+	if namer.callCount() != 1 {
+		t.Fatalf("namer calls = %d, want 1 while negative entry fresh", namer.callCount())
+	}
+
+	// Past the 30s negative TTL, the entry has expired: a fresh Warm re-queries.
+	r.now = func() time.Time { return base.Add(31 * time.Second) }
+	r.Warm(campaign, guestID)
+	r.wg.Wait()
+	if namer.callCount() != 2 {
+		t.Fatalf("namer calls = %d, want 2 after negative TTL expiry", namer.callCount())
+	}
+}
+
+func TestResolverNilNamerNegativeOnMiss(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{}}
+	r := NewResolver(chars, nil, auth.ParseOperatorAllowlist(""), nil) // web-only mode: no guild fallback
+
+	r.Warm(campaign, guestID)
+	r.wg.Wait()
+
+	if got := r.Lookup(campaign, guestID); got.Name != "" {
+		t.Fatalf("Lookup.Name = %q, want empty with nil namer", got.Name)
+	}
+}
+
+func TestResolverGMFlagIndependentOfName(t *testing.T) {
+	campaign := uuid.New()
+	// gmUser is on the allowlist AND maps to a Character; kiraUser maps but is not GM.
+	chars := &fakeChars{byKey: map[string]storage.Character{
+		campaign.String() + "/" + gmUser:   {Name: "Dungeon Master", CampaignID: campaign, DiscordUserID: gmUser},
+		campaign.String() + "/" + kiraUser: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraUser},
+	}}
+	r := newTestResolver(t, chars, &fakeNamer{}, gmUser)
+
+	r.Warm(campaign, gmUser)
+	r.Warm(campaign, kiraUser)
+	r.wg.Wait()
+
+	if got := r.Lookup(campaign, gmUser); !got.GM || got.Name != "Dungeon Master" {
+		t.Fatalf("mapped GM Lookup = %+v, want GM=true Name=Dungeon Master", got)
+	}
+	if got := r.Lookup(campaign, kiraUser); got.GM || got.Name != "Kira" {
+		t.Fatalf("player Lookup = %+v, want GM=false Name=Kira", got)
+	}
+
+	// Unmapped GM: no Character, no guild name — still GM by allowlist membership.
+	unmappedGM := "999999999999999999"
+	r2 := newTestResolver(t, &fakeChars{byKey: map[string]storage.Character{}}, &fakeNamer{}, unmappedGM)
+	if got := r2.Lookup(campaign, unmappedGM); !got.GM {
+		t.Fatalf("unmapped GM Lookup = %+v, want GM=true (allowlist membership, no name needed)", got)
+	}
+}
+
+func TestResolverInvalidateCampaignReQueriesRebind(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{
+		campaign.String() + "/" + kiraUser: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraUser},
+	}}
+	r := newTestResolver(t, chars, &fakeNamer{}, "")
+
+	r.Warm(campaign, kiraUser)
+	r.wg.Wait()
+	if got := r.Lookup(campaign, kiraUser); got.Name != "Kira" {
+		t.Fatalf("pre-rebind Name = %q, want Kira", got.Name)
+	}
+
+	// Operator rebinds the same Discord User to a new Character, then invalidates.
+	chars.mu.Lock()
+	chars.byKey[campaign.String()+"/"+kiraUser] = storage.Character{Name: "Kira Reborn", CampaignID: campaign, DiscordUserID: kiraUser}
+	chars.mu.Unlock()
+
+	// Without invalidation the cached "Kira" would still be served.
+	if got := r.Lookup(campaign, kiraUser); got.Name != "Kira" {
+		t.Fatalf("cached Name = %q, want still Kira before invalidation", got.Name)
+	}
+
+	r.InvalidateCampaign(campaign)
+	if got := r.Lookup(campaign, kiraUser); got.Name != "" {
+		t.Fatalf("post-invalidate Name = %q, want empty (cache dropped)", got.Name)
+	}
+
+	r.Warm(campaign, kiraUser)
+	r.wg.Wait()
+	if got := r.Lookup(campaign, kiraUser); got.Name != "Kira Reborn" {
+		t.Fatalf("post-rebind Name = %q, want Kira Reborn", got.Name)
+	}
+}
+
+func TestResolverWarmDedupesConcurrentFills(t *testing.T) {
+	campaign := uuid.New()
+	gate := make(chan struct{})
+	chars := &fakeChars{
+		byKey: map[string]storage.Character{
+			campaign.String() + "/" + kiraUser: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraUser},
+		},
+		gate: gate,
+	}
+	r := newTestResolver(t, chars, &fakeNamer{}, "")
+
+	// Fire many concurrent Warms for the SAME key while the fake lookup is blocked.
+	const n = 20
+	var start, done sync.WaitGroup
+	start.Add(n)
+	done.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer done.Done()
+			start.Done()
+			r.Warm(campaign, kiraUser)
+		}()
+	}
+	start.Wait()
+	done.Wait() // every Warm has returned; exactly one grabbed the inflight guard
+	// Give the fill goroutine time to block on the gated lookup, then release.
+	time.Sleep(20 * time.Millisecond)
+	close(gate)
+	r.wg.Wait()
+
+	if got := chars.callCount(); got != 1 {
+		t.Fatalf("character lookups = %d, want 1 (deduped)", got)
+	}
+	if got := r.Lookup(campaign, kiraUser); got.Name != "Kira" {
+		t.Fatalf("Lookup.Name = %q, want Kira", got.Name)
+	}
+}
+
+func TestResolverLookupNeverDoesIO(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeChars{byKey: map[string]storage.Character{}}
+	namer := &fakeNamer{byUser: map[string]string{guestID: "GuildGuest"}}
+	r := newTestResolver(t, chars, namer, "")
+
+	// Lookup on a cold cache must not touch the store or namer.
+	_ = r.Lookup(campaign, guestID)
+	if chars.callCount() != 0 || namer.callCount() != 0 {
+		t.Fatalf("Lookup did I/O: chars=%d namer=%d, want 0/0", chars.callCount(), namer.callCount())
+	}
+}

--- a/internal/storage/transcript_chunk.go
+++ b/internal/storage/transcript_chunk.go
@@ -28,7 +28,7 @@ type TranscriptChunk struct {
 	CampaignID            uuid.UUID
 	VoiceSessionID        uuid.UUID   // column nullable; the writer always sets it
 	Content               string      // the chunk's utterances joined "\n"
-	SpeakerDiscordUserIDs []string    // empty in v1.0: anonymous STT lane (ADR-0039)
+	SpeakerDiscordUserIDs []string    // distinct Speaker Lane snowflakes in the chunk (populated since #278/ADR-0050); empty only when all utterances were unattributed
 	ParticipatedAgentIDs  []uuid.UUID // Agents that spoke in the chunk (NPC-knowledge filter)
 	EmbeddingModel        string      // '' until the backfill worker embeds the row (#116)
 	StartedAt             time.Time

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -121,6 +121,8 @@ type Chunker struct {
 	window   time.Duration
 	maxUtt   int
 
+	resolver SpeakerResolver // resolves SpeakerID → name for the line prefix (#281); nil = generic label
+
 	mu               sync.Mutex
 	activeID         string // current session id; "" at process start
 	activeUUID       uuid.UUID
@@ -180,6 +182,16 @@ func NewChunker(bus *voiceevent.Bus, sessions Sessions, store ChunkStore, gauge 
 	return c
 }
 
+// SetResolver wires the speaker resolver (#281) after construction, so existing
+// NewChunker call sites stay byte-identical (nil resolver = generic prefix). Called
+// once at boot before the chunker folds any event; guarded by c.mu so it is safe
+// against the subscribed bus callback.
+func (c *Chunker) SetResolver(res SpeakerResolver) {
+	c.mu.Lock()
+	c.resolver = res
+	c.mu.Unlock()
+}
+
 // project is the bus callback: it attributes the event to the active session
 // (rolling over on a session change, one Snapshot per event like the relay) and
 // folds it into the open chunk. It must not block (the bus delivers
@@ -229,14 +241,32 @@ func (c *Chunker) rollover(vs storage.VoiceSession) {
 	c.turns = map[string]*chunkTurn{}
 }
 
-// appendHuman folds one human utterance (one STTFinal, anonymous lane ADR-0039)
-// into the open chunk and re-checks the close conditions.
+// appendHuman folds one human utterance (one STTFinal, attributed to its Speaker
+// Lane via SpeakerID since #278/ADR-0050) into the open chunk and re-checks the
+// close conditions. The line prefix resolves to the speaker's Character/guild name
+// when available (#281), else the generic "Player / DM".
 func (c *Chunker) appendHuman(ev voiceevent.STTFinal) {
 	oc := c.ensureOpen(ev.At)
-	oc.entries = append(oc.entries, &chunkLine{text: "Player / DM: " + ev.Text})
+	oc.entries = append(oc.entries, &chunkLine{text: c.humanPrefix(ev.SpeakerID) + ": " + ev.Text})
 	c.recordSpeaker(oc, ev.SpeakerID)
 	oc.count++
 	c.afterAppend(oc)
+}
+
+// humanPrefix is the "Who" prefix for a human chunk line (#281): the resolved
+// Character (or guild) name when available, else the generic "Player / DM". It is
+// cache-only (Lookup never blocks) and applies to NEW chunk content only —
+// persisted chunks are immutable (ADR-0011). The relay warms the resolver on
+// VADSpeechStart, so this shared cache is usually populated by the time a line
+// folds. GM lane routing is a live-view concern; chunk content just uses names.
+func (c *Chunker) humanPrefix(speakerID string) string {
+	if c.resolver == nil || speakerID == "" {
+		return "Player / DM"
+	}
+	if name := c.resolver.Lookup(c.activeCampaignID, speakerID).Name; name != "" {
+		return name
+	}
+	return "Player / DM"
 }
 
 // recordSpeaker adds a human utterance's Speaker Lane snowflake to the chunk's

--- a/internal/transcript/chunker_resolve_test.go
+++ b/internal/transcript/chunker_resolve_test.go
@@ -1,0 +1,45 @@
+package transcript
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/speaker"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestChunker_ResolvedNamePrefix: a chunk's human line uses the resolved Character
+// (or guild) name as its prefix; an unresolved speaker keeps the generic
+// "Player / DM:" prefix — NEW chunk content only.
+func TestChunker_ResolvedNamePrefix(t *testing.T) {
+	spy := &spyResolver{lookup: func(_ uuid.UUID, sp string) speaker.Resolution {
+		if sp == kiraSpeaker {
+			return speaker.Resolution{Name: "Kira"}
+		}
+		return speaker.Resolution{} // guestSpeaker unresolved
+	}}
+
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), campaign: uuid.New(), active: true}
+	store := &fakeChunkStore{}
+	c := NewChunker(bus, fs, store, nil, slog.New(slog.DiscardHandler), ChunkerConfig{MaxUtterances: 2})
+	c.SetResolver(spy)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "mapped line", TurnID: "t1", SpeakerID: kiraSpeaker})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "unresolved line", TurnID: "t2", SpeakerID: guestSpeaker})
+
+	if err := c.FlushSession(context.Background(), fs.id); err != nil {
+		t.Fatalf("FlushSession: %v", err)
+	}
+	got := store.all()
+	if len(got) != 1 {
+		t.Fatalf("chunks = %d, want 1", len(got))
+	}
+	want := "Kira: mapped line\nPlayer / DM: unresolved line"
+	if got[0].Content != want {
+		t.Fatalf("content = %q,\nwant %q", got[0].Content, want)
+	}
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -1,8 +1,9 @@
 // Package transcript is the SSE relay (ADR-0014 Hop-B): it bridges the
 // in-process voiceevent.Bus to the browser's live Session screen. It subscribes
 // to the bus ONCE at startup, projects the voice pipeline's events into
-// human-readable transcript lines (ADR-0020 taxonomy, ADR-0039 anonymous human
-// lane), keeps a per-session ~500-event ring buffer for Last-Event-ID replay,
+// human-readable transcript lines (ADR-0020 taxonomy; humans attributed to their
+// Speaker Lane via SpeakerID since ADR-0050, resolved to Character/GM names by
+// #281), keeps a per-session ~500-event ring buffer for Last-Event-ID replay,
 // and serves two endpoints: a Server-Sent-Events live tail and a JSON snapshot.
 //
 // There is no DB write here: line persistence is issue #74. The buffer is the
@@ -20,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/speaker"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -42,9 +44,10 @@ const (
 	listenLabel = "Listening to the table…"
 )
 
-// Kind classifies a transcript line's speaker. Per ADR-0039 the live projection
-// only ever emits player/npc/butler — raw STT has no speaker id, so all humans
-// share the anonymous "player" lane; gm is reserved for future SpeakerID work.
+// Kind classifies a transcript line's speaker. Humans resolve to player or gm from
+// their Speaker Lane's SpeakerID (#281, ADR-0050): a GM-allowlisted snowflake lands
+// in the gm lane, everyone else in player; an unattributed or resolver-off line
+// stays in the anonymous player lane. Agent replies map to npc/butler.
 type Kind string
 
 const (
@@ -56,9 +59,9 @@ const (
 
 // kindFor maps a speaker role to its transcript Kind. role is the
 // AddressTarget.AgentRole ("butler"/"character") for an Agent reply, or one of
-// the human pseudo-roles "gm"/"player" for human STT. The live projection only
-// passes "player" for humans (ADR-0039); "gm" is reserved for future SpeakerID
-// work, so an explicit gm input still maps to gm.
+// the human pseudo-roles "gm"/"player" for human STT. Human lines derive their
+// Kind directly in resolveHuman (#281); this helper serves the Agent-reply path
+// and still maps an explicit "gm"/"player" input for completeness.
 func kindFor(role string) Kind {
 	switch role {
 	case "butler":
@@ -96,10 +99,11 @@ type Line struct {
 	TS   time.Time `json:"ts"`
 	Text string    `json:"text"`
 	// SpeakerID is the Discord snowflake of the human who spoke this Line (#278,
-	// ADR-0050), threaded from STTFinal for persistence + later attribution (#281).
-	// Empty for an unattributed utterance or an Agent reply; the omitempty keeps the
-	// live-view wire byte-identical for the anonymous path. RENDERING is untouched —
-	// who/Kind still reflect the anonymous lane until #281 consumes this.
+	// ADR-0050), threaded from STTFinal for persistence + attribution (#281). Empty
+	// for an unattributed utterance or an Agent reply; the omitempty keeps the
+	// live-view wire byte-identical for the anonymous path. Who/Kind are resolved
+	// from this snowflake at persist time (#281) — a display snapshot, never
+	// re-resolved on replay.
 	SpeakerID string `json:"speaker_id,omitempty"`
 }
 
@@ -172,6 +176,17 @@ type Sessions interface {
 	Snapshot() (storage.VoiceSession, bool)
 }
 
+// SpeakerResolver resolves a Speaker Lane snowflake to a display name + GM flag
+// for the live projection (#281). *speaker.Resolver satisfies it. Warm is the
+// non-blocking async fill the relay calls on VADSpeechStart (~1.7s before STTFinal,
+// so the name is cached by lookup time); Lookup is the cache-only read the
+// synchronous STTFinal branch uses — it NEVER blocks (the bus callback must not).
+// nil disables resolution, keeping the anonymous "Player / DM" lane byte-identical.
+type SpeakerResolver interface {
+	Warm(campaignID uuid.UUID, speakerID string)
+	Lookup(campaignID uuid.UUID, speakerID string) speaker.Resolution
+}
+
 // LineStore is the narrow persistence surface the relay needs (#74, ADR-0040):
 // an incremental UPSERT of each projected Line, a list for replay-on-reload, and
 // the authoritative count for the Stop summary. *storage.Store satisfies it;
@@ -198,7 +213,8 @@ type turn struct {
 // all take the same lock.
 type Relay struct {
 	sessions Sessions
-	store    LineStore // persists projected lines (#74); nil disables persistence
+	store    LineStore       // persists projected lines (#74); nil disables persistence
+	resolver SpeakerResolver // resolves SpeakerID → name/GM (#281); nil = anonymous lane
 	log      *slog.Logger
 
 	mu       sync.Mutex
@@ -264,6 +280,16 @@ func NewRelay(bus *voiceevent.Bus, sessions Sessions, store LineStore, log *slog
 	return r
 }
 
+// SetResolver wires the speaker resolver (#281) after construction, so the many
+// existing NewRelay call sites stay byte-identical (nil resolver = anonymous lane).
+// Called once at boot before the relay serves any event; guarded by r.mu so it is
+// safe against the subscribed bus callback.
+func (r *Relay) SetResolver(res SpeakerResolver) {
+	r.mu.Lock()
+	r.resolver = res
+	r.mu.Unlock()
+}
+
 // project is the bus callback: it attributes the event to the active session,
 // rolling the buffer over on a session change, and folds the event into the
 // transcript. It must not block (the bus delivers synchronously): all sends to
@@ -286,23 +312,32 @@ func (r *Relay) project(e voiceevent.Event) {
 
 	switch ev := e.(type) {
 	case voiceevent.VADSpeechStart:
-		// A human opened their mouth: clear any stale "<NPC> is speaking…" the
+		// A human opened their mouth: warm the speaker resolver NOW (#281) so the
+		// name is cached by the time STTFinal projects the line (~1.7s later, off the
+		// bus). Warm never blocks. Then clear any stale "<NPC> is speaking…" the
 		// moment speech starts (it fires BEFORE STTFinal), instead of waiting for
 		// the next finalized line. Live-validated — a clean turn emits no
 		// TurnEnded, so without this the last agent line keeps the label through
 		// the following silence. Also correct for a barge (human over the Agent).
+		if r.resolver != nil && ev.SpeakerID != "" {
+			r.resolver.Warm(r.activeCampaignID, ev.SpeakerID)
+		}
 		r.setTyping(r.liveTyping())
 	case voiceevent.STTFinal:
-		// A human utterance — one line per STTFinal in the anonymous lane
-		// (ADR-0039: raw STT carries no speaker id).
+		// A human utterance — one line per STTFinal. who/Kind resolve from the
+		// Speaker Lane's snowflake (#281): a mapped Character or guild display name
+		// with the GM lane for allowlisted speakers, falling back to the
+		// byte-identical anonymous "Player / DM" / KindPlayer label when the resolver
+		// is off, the speaker is unattributed, or the name is unresolved.
 		r.humanSeq++
+		who, kind := r.resolveHuman(ev.SpeakerID)
 		r.emitLine(Line{
 			ID:        "u:" + strconv.FormatUint(r.humanSeq, 10),
-			Who:       "Player / DM",
-			Kind:      KindPlayer,
+			Who:       who,
+			Kind:      kind,
 			TS:        ev.At,
 			Text:      ev.Text,
-			SpeakerID: ev.SpeakerID, // #278: thread the Speaker Lane's snowflake through; rendering unchanged
+			SpeakerID: ev.SpeakerID, // #278: thread the Speaker Lane's snowflake through for persistence
 		})
 	case voiceevent.AddressRouted:
 		// Records WHO answers this turn; no line yet (no text).
@@ -579,6 +614,28 @@ func (r *Relay) Frames(id string, afterSeq uint64) []Frame {
 		}
 	}
 	return out
+}
+
+// resolveHuman maps a human utterance's SpeakerID to its rendered who + Kind
+// (#281). With no resolver or an empty SpeakerID it is the pre-#281 anonymous lane
+// exactly ("Player / DM", KindPlayer). Otherwise a cache-only Lookup supplies the
+// name (Character > guild display > "") and the GM flag: an allowlisted speaker
+// lands in the KindGM lane even when unmapped (name falls back to the generic
+// label), and a resolved name replaces the generic label. Caller holds r.mu.
+func (r *Relay) resolveHuman(speakerID string) (string, Kind) {
+	if r.resolver == nil || speakerID == "" {
+		return "Player / DM", KindPlayer
+	}
+	res := r.resolver.Lookup(r.activeCampaignID, speakerID)
+	kind := KindPlayer
+	if res.GM {
+		kind = KindGM
+	}
+	who := "Player / DM"
+	if res.Name != "" {
+		who = res.Name
+	}
+	return who, kind
 }
 
 // nameOr returns name, or def when name is empty.

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -17,12 +17,13 @@ import (
 // fakeSessions is a settable Snapshot source: the relay attributes events and
 // derives status from whatever active session it reports.
 type fakeSessions struct {
-	id     uuid.UUID
-	active bool
+	id       uuid.UUID
+	campaign uuid.UUID
+	active   bool
 }
 
 func (f *fakeSessions) Snapshot() (storage.VoiceSession, bool) {
-	return storage.VoiceSession{ID: f.id}, f.active
+	return storage.VoiceSession{ID: f.id, CampaignID: f.campaign}, f.active
 }
 
 func at(sec int) time.Time {

--- a/internal/transcript/resolve_test.go
+++ b/internal/transcript/resolve_test.go
@@ -1,0 +1,251 @@
+package transcript
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/speaker"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// spyResolver is a settable SpeakerResolver: it records Warm calls and answers
+// Lookup from an injected func, so the relay/chunker projection is tested without
+// the real async cache.
+type spyResolver struct {
+	mu     sync.Mutex
+	warmed []warmCall
+	lookup func(campaignID uuid.UUID, speakerID string) speaker.Resolution
+}
+
+type warmCall struct {
+	campaign uuid.UUID
+	speaker  string
+}
+
+func (s *spyResolver) Warm(campaignID uuid.UUID, speakerID string) {
+	s.mu.Lock()
+	s.warmed = append(s.warmed, warmCall{campaign: campaignID, speaker: speakerID})
+	s.mu.Unlock()
+}
+
+func (s *spyResolver) Lookup(campaignID uuid.UUID, speakerID string) speaker.Resolution {
+	if s.lookup != nil {
+		return s.lookup(campaignID, speakerID)
+	}
+	return speaker.Resolution{}
+}
+
+func (s *spyResolver) warmCalls() []warmCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]warmCall(nil), s.warmed...)
+}
+
+const (
+	kiraSpeaker  = "111111111111111111"
+	gmSpeaker    = "222222222222222222"
+	guestSpeaker = "333333333333333333"
+)
+
+// resolvingRelay wires a relay with a resolver and an active campaign-scoped session.
+func resolvingRelay(t *testing.T, res SpeakerResolver) (*voiceevent.Bus, *Relay, *fakeSessions) {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), campaign: uuid.New(), active: true}
+	r := NewRelay(bus, fs, nil, nil)
+	r.SetResolver(res)
+	return bus, r, fs
+}
+
+// TestResolve_MappedSpeaker: a mapped SpeakerID renders as its Character on the
+// live feed, KindPlayer.
+func TestResolve_MappedSpeaker(t *testing.T) {
+	spy := &spyResolver{lookup: func(_ uuid.UUID, sp string) speaker.Resolution {
+		if sp == kiraSpeaker {
+			return speaker.Resolution{Name: "Kira"}
+		}
+		return speaker.Resolution{}
+	}}
+	bus, r, fs := resolvingRelay(t, spy)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hello", TurnID: "t1", SpeakerID: kiraSpeaker})
+
+	l := r.View(fs.id.String()).Lines[0]
+	if l.Who != "Kira" || l.Kind != KindPlayer {
+		t.Fatalf("mapped line = who %q kind %q, want Kira/player", l.Who, l.Kind)
+	}
+}
+
+// TestResolve_GMLane: a GM-allowlisted snowflake lands in the KindGM lane
+// regardless of Character mapping (mapped GM keeps its Character name; unmapped GM
+// keeps the generic label but still routes to KindGM).
+func TestResolve_GMLane(t *testing.T) {
+	spy := &spyResolver{lookup: func(_ uuid.UUID, sp string) speaker.Resolution {
+		switch sp {
+		case gmSpeaker: // mapped GM
+			return speaker.Resolution{Name: "Dungeon Master", GM: true}
+		case "444444444444444444": // unmapped GM (no name)
+			return speaker.Resolution{GM: true}
+		}
+		return speaker.Resolution{}
+	}}
+	bus, r, fs := resolvingRelay(t, spy)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "As the GM speaks", TurnID: "t1", SpeakerID: gmSpeaker})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "Unmapped GM", TurnID: "t2", SpeakerID: "444444444444444444"})
+
+	lines := r.View(fs.id.String()).Lines
+	mapped := lines[0]
+	if mapped.Kind != KindGM || mapped.Who != "Dungeon Master" {
+		t.Fatalf("mapped GM line = who %q kind %q, want Dungeon Master/gm", mapped.Who, mapped.Kind)
+	}
+	unmapped := lines[1]
+	if unmapped.Kind != KindGM || unmapped.Who != "Player / DM" {
+		t.Fatalf("unmapped GM line = who %q kind %q, want Player / DM/gm", unmapped.Who, unmapped.Kind)
+	}
+}
+
+// TestResolve_UnmappedGuestName: an unmapped speaker whose guild display name
+// resolved renders as that name, KindPlayer.
+func TestResolve_UnmappedGuestName(t *testing.T) {
+	spy := &spyResolver{lookup: func(_ uuid.UUID, sp string) speaker.Resolution {
+		if sp == guestSpeaker {
+			return speaker.Resolution{Name: "GuildGuest"}
+		}
+		return speaker.Resolution{}
+	}}
+	bus, r, fs := resolvingRelay(t, spy)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hi", TurnID: "t1", SpeakerID: guestSpeaker})
+
+	l := r.View(fs.id.String()).Lines[0]
+	if l.Who != "GuildGuest" || l.Kind != KindPlayer {
+		t.Fatalf("unmapped-resolved line = who %q kind %q, want GuildGuest/player", l.Who, l.Kind)
+	}
+}
+
+// TestResolve_UnresolvedAndEmptyByteIdentical: an unresolved SpeakerID (empty
+// Resolution.Name) and an empty SpeakerID both keep the pre-#281 generic
+// "Player / DM" / KindPlayer label — byte-identical to the anonymous path.
+func TestResolve_UnresolvedAndEmptyByteIdentical(t *testing.T) {
+	spy := &spyResolver{lookup: func(_ uuid.UUID, _ string) speaker.Resolution {
+		return speaker.Resolution{} // never resolves
+	}}
+	bus, r, fs := resolvingRelay(t, spy)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "attributed but unresolved", TurnID: "t1", SpeakerID: kiraSpeaker})
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "unattributed", TurnID: "t2"})
+
+	lines := r.View(fs.id.String()).Lines
+	for i, l := range lines {
+		if l.Who != "Player / DM" || l.Kind != KindPlayer || l.Tag != "" {
+			t.Fatalf("line %d = who %q kind %q tag %q, want Player / DM/player/\"\"", i, l.Who, l.Kind, l.Tag)
+		}
+	}
+	// The attributed line still carries its SpeakerID for persistence (#278).
+	if lines[0].SpeakerID != kiraSpeaker {
+		t.Fatalf("line 0 SpeakerID = %q, want %q", lines[0].SpeakerID, kiraSpeaker)
+	}
+}
+
+// TestResolve_WarmOnSpeechStart: a VADSpeechStart carrying a SpeakerID triggers a
+// resolver Warm (~1.7s before STTFinal) so the name is cached by lookup time.
+func TestResolve_WarmOnSpeechStart(t *testing.T) {
+	spy := &spyResolver{}
+	bus, _, fs := resolvingRelay(t, spy)
+
+	bus.Publish(voiceevent.VADSpeechStart{At: at(1), SpeakerID: kiraSpeaker})
+	// An unattributed onset must NOT warm (empty speaker).
+	bus.Publish(voiceevent.VADSpeechStart{At: at(2)})
+
+	got := spy.warmCalls()
+	if len(got) != 1 {
+		t.Fatalf("warm calls = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].speaker != kiraSpeaker || got[0].campaign != fs.campaign {
+		t.Fatalf("warm call = %+v, want speaker %q campaign %s", got[0], kiraSpeaker, fs.campaign)
+	}
+}
+
+// TestResolve_RebindPropagatesToNextLine is the AC mapping-change propagation: a
+// live session's mid-session rebind (Character change → InvalidateCampaign) makes
+// the NEXT line render the new name while prior lines are untouched. Driven
+// end-to-end through the real resolver: warm, line, rebind+invalidate, warm, line.
+func TestResolve_RebindPropagatesToNextLine(t *testing.T) {
+	campaign := uuid.New()
+	chars := &fakeCharLookup{byKey: map[string]storage.Character{
+		campaign.String() + "/" + kiraSpeaker: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraSpeaker},
+	}}
+	res := speaker.NewResolver(chars, nil, auth.ParseOperatorAllowlist(""), nil)
+
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), campaign: campaign, active: true}
+	r := NewRelay(bus, fs, nil, nil)
+	r.SetResolver(res)
+
+	// First utterance: warm (async), wait for the name, then the line renders "Kira".
+	bus.Publish(voiceevent.VADSpeechStart{At: at(1), SpeakerID: kiraSpeaker})
+	waitResolved(t, res, campaign, kiraSpeaker, "Kira")
+	bus.Publish(voiceevent.STTFinal{At: at(2), Text: "first", TurnID: "t1", SpeakerID: kiraSpeaker})
+
+	// Operator rebinds the Discord User to a new Character and invalidates the campaign.
+	chars.set(campaign, kiraSpeaker, storage.Character{Name: "Kira Reborn", CampaignID: campaign, DiscordUserID: kiraSpeaker})
+	res.InvalidateCampaign(campaign)
+
+	// Next utterance: re-warm, wait for the new name, line renders "Kira Reborn".
+	bus.Publish(voiceevent.VADSpeechStart{At: at(3), SpeakerID: kiraSpeaker})
+	waitResolved(t, res, campaign, kiraSpeaker, "Kira Reborn")
+	bus.Publish(voiceevent.STTFinal{At: at(4), Text: "second", TurnID: "t2", SpeakerID: kiraSpeaker})
+
+	lines := r.View(fs.id.String()).Lines
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if lines[0].Who != "Kira" {
+		t.Errorf("prior line who = %q, want Kira (untouched)", lines[0].Who)
+	}
+	if lines[1].Who != "Kira Reborn" {
+		t.Errorf("next line who = %q, want Kira Reborn (rebound)", lines[1].Who)
+	}
+}
+
+// waitResolved polls the resolver's cache-only Lookup until it returns want, so a
+// test can await an async Warm fill without reaching into resolver internals.
+func waitResolved(t *testing.T, res *speaker.Resolver, campaign uuid.UUID, speakerID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if res.Lookup(campaign, speakerID).Name == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("resolver never resolved %q to %q", speakerID, want)
+}
+
+// fakeCharLookup is a mutable CharacterLookup for the end-to-end rebind test.
+type fakeCharLookup struct {
+	mu    sync.Mutex
+	byKey map[string]storage.Character
+}
+
+func (f *fakeCharLookup) GetCharacterByDiscordUser(_ context.Context, campaignID uuid.UUID, discordUserID string) (storage.Character, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if c, ok := f.byKey[campaignID.String()+"/"+discordUserID]; ok {
+		return c, nil
+	}
+	return storage.Character{}, storage.ErrNotFound
+}
+
+func (f *fakeCharLookup) set(campaignID uuid.UUID, discordUserID string, c storage.Character) {
+	f.mu.Lock()
+	f.byKey[campaignID.String()+"/"+discordUserID] = c
+	f.mu.Unlock()
+}


### PR DESCRIPTION
## What

Resolve Character names in the transcript relay + unmapped-speaker fallback (E4). Both binding decisions were recorded on the issue 2026-07-07 and are implemented verbatim:

1. **Persist-time snapshot everywhere** — `who` is a display snapshot written at persist time; a mid-campaign rebind affects only FUTURE lines. Replay/search read the persisted `who` unchanged (no read-time re-resolution).
2. **Unmapped fallback** — Discord guild display name (Bot member fetch); generic `Player / DM` only when it fails. GM-allowlist speakers route to the KindGM lane regardless of mapping.

## How

- **`internal/speaker` (new)** — `Resolver`: `Warm` does the DB / guild-name I/O off the bus and fills a short-TTL cache (5min positive, 30s negative); `Lookup` is cache-only and NEVER blocks (the relay/chunker `project()` are synchronous bus callbacks, ADR-0040). `InvalidateCampaign` is the in-proc direct-method drop (ADR-0039), with a per-campaign generation guard so a fill racing an invalidation discards its stale result. GM is allowlist membership, computed inline and never cached (ADR-0050/0041).
- **`internal/presence/members_name.go` (new)** — `MemberDisplayName` (satisfies `speaker.MemberNamer`): nick > global name > username via disgo `Member.EffectiveName`. Separate file so there is no textual conflict with `VoiceChannelMembers` (#279).
- **Relay** — STTFinal resolves who/Kind from the Speaker Lane snowflake; warms on VADSpeechStart (~1.7s ahead). Byte-identical anonymous `Player / DM` / KindPlayer fallback when the resolver is off, the speaker is unattributed, or the name is unresolved.
- **Chunker** — resolved name as each human line's prefix, NEW chunks only (existing chunks immutable, ADR-0011).
- **`internal/rpc/character.go`** — nil-safe `SpeakerInvalidator` hook on Create/Update/Delete.
- **`cmd/glyphoxa/main.go`** — builds one shared `Resolver` (store + presence guild-name fallback as a true nil interface on web-only replicas + operator allowlist), wired into relay/chunker/CRUD.

Also refreshes three stale `#339`-review comments (`relay`/`chunker` "anonymous lane", chunk `SpeakerDiscordUserIDs` "empty in v1.0") now that SpeakerID is threaded and consumed.

## Tests (TDD, red→green per slice)

- resolver unit: warm→lookup Character name; miss→guild name; namer error→negative-cached 30s→re-query after expiry; nil namer; GM flag independent of name (mapped + unmapped GM); InvalidateCampaign drops cache + rebind re-queries; Warm dedupes concurrent fills; Lookup does no I/O.
- relay: mapped→Character name/player; GM snowflake→KindGM regardless of mapping; unmapped-resolved→guild name; unresolved/empty→`Player / DM` byte-identical; VADSpeechStart triggers Warm; **mid-session rebind + InvalidateCampaign → next line new name, prior lines untouched** (AC mapping-change propagation, driven end-to-end through the real resolver).
- chunker: resolved-name prefix; unresolved keeps `Player / DM:`.
- rpc: Create/Update/Delete call SpeakerInvalidator; nil-safe (no panic when unset).
- presence: `MemberDisplayName` nick > global > username precedence; fetch error propagates; wait-state error.

Existing relay/chunker/rpc tests untouched (resolver wired via `SetResolver`/`SetSpeakerInvalidator`, nil = feature off).

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
