### PR TITLE
fix(#343): Segmenter closed flag stops Feed resurrecting reaped lanes

### DIFF
--- a/pkg/voice/orchestrator/lanes_test.go
+++ b/pkg/voice/orchestrator/lanes_test.go
@@ -1,6 +1,7 @@
 package orchestrator_test
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/stt"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -578,30 +580,152 @@ func TestSegmenter_TeardownRaceWithFeed(t *testing.T) {
 	seg.SetLaneVADFactory(factory)
 	cancel := seg.Bind(t.Context(), bus)
 
+	// The ONE audio loop drives every Process call (Process is single-caller by
+	// contract — two goroutines driving a lane VAD would be a spurious data race, not
+	// #343). Determinism without a second caller: the loop closes `opened` once both
+	// lanes exist and it is mid-flight (so cancel is guaranteed to race a running Feed),
+	// then, once `torn` signals teardown has been requested, it runs a FIXED batch of
+	// post-teardown Feeds — guaranteed to exercise resurrection, unlike a bare Sleep
+	// that can lose to the loop finishing first (false green on the old code).
+	opened := make(chan struct{})
+	torn := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Voiced-only frames keep every lane listening (no flush → no jobs send that
-		// could race the teardown's close(jobs)); the point is the concurrent lane
-		// map + close-func access, which must stay mu-guarded, AND that Feed does not
-		// re-open a lane once teardown has flipped `closed`.
-		for i := 0; i < 500; i++ {
+		// Voiced-only frames keep every lane listening (no flush → no jobs send here);
+		// the point is the concurrent lane map + close-func access, which must stay
+		// mu-guarded, AND that Feed does not re-open a lane once teardown flipped closed.
+		for i := 0; ; i++ {
+			if i == 250 {
+				close(opened)
+			}
 			_ = seg.Process(laneFrame(t, "A", 100))
 			_ = seg.Process(laneFrame(t, "B", 200))
+			select {
+			case <-torn:
+				// Teardown requested: do a fixed batch of GUARANTEED post-teardown Feeds,
+				// which must funnel to the default lane and open no new lane, then stop.
+				for j := 0; j < 100; j++ {
+					_ = seg.Process(laneFrame(t, "A", 100))
+					_ = seg.Process(laneFrame(t, "B", 200))
+				}
+				return
+			default:
+			}
 		}
 	}()
-	time.Sleep(time.Millisecond) // let the loop open the lanes
-	cancel()                     // teardown while Feed is still running
+	<-opened
+	cancel()    // teardown while Feed is still running (concurrent map/close-func access)
+	close(torn) // release the loop into its guaranteed post-teardown batch
 	wg.Wait()
 
 	if got := seg.LaneCount(); got != 1 {
-		t.Errorf("lane count after teardown = %d, want 1 (a still-running Feed resurrected a reaped lane)", got)
+		t.Errorf("lane count after teardown = %d, want 1 (a Feed after teardown resurrected a reaped lane)", got)
 	}
 	cmu.Lock()
 	gotCreates, gotCloses := creates, closes
 	cmu.Unlock()
 	if gotCreates != gotCloses {
 		t.Errorf("lane VADs created = %d but closed = %d — a resurrected lane leaked its ONNX session", gotCreates, gotCloses)
+	}
+}
+
+// gateRecognizer blocks the transcription worker inside Transcribe until the test
+// cancels the bind ctx. With the worker stalled, a flooding feeder fills the buffered
+// jobs channel and then PARKS on its send — so a live `jobs <- job` is deterministically
+// in flight when teardown runs (the exact state that makes #343 residual 2 observable).
+// It closes `entered` on the first call so the test knows the worker is stalled; every
+// later call (the queue draining after ctx cancel) returns at once.
+type gateRecognizer struct {
+	once    sync.Once
+	entered chan struct{}
+}
+
+func (r *gateRecognizer) Transcribe(ctx context.Context, _ []audio.Frame) (stt.Transcript, error) {
+	r.once.Do(func() { close(r.entered) })
+	<-ctx.Done()
+	return stt.Transcript{}, ctx.Err()
+}
+
+// TestSegmenter_TeardownRaceWithFlush is #343 residual 2: a Feed that FLUSHES (an
+// unvoiced frame ends an utterance → dispatchTranscription enqueues a job) runs
+// concurrently with Bind's teardown. A dispatch reads the live jobs channel under mu,
+// unlocks, then sends OUTSIDE the lock; if teardown closes the channel in that window the
+// send panics ("send on closed channel"). The gate recognizer stalls the worker so the
+// feeder is DETERMINISTICALLY parked on a send when teardown runs: on the broken guard
+// the parked send panics on close(jobs); the pending-senders barrier (senders WaitGroup
+// drained before close) instead lets that send finish first. Releasing the bind ctx then
+// drains the queue, so the barrier completes rather than deadlocking. Run under `-race`.
+func TestSegmenter_TeardownRaceWithFlush(t *testing.T) {
+	bus := voiceevent.NewBus()
+	rec := &gateRecognizer{entered: make(chan struct{})}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := orchestrator.NewSegmenter(orchestrator.NewVAD(bus, &contentVAD{}), orchestrator.NewSTT(bus, rec))
+	seg.SetLaneVADFactory(factory)
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+	cancel := seg.Bind(ctx, bus)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// voiced then unvoiced per iteration: the unvoiced frame ends the utterance and
+		// drives dispatchTranscription → a jobs send. The worker is stalled, so after the
+		// buffered queue (64 deep) fills this send parks — live when teardown closes it.
+		for i := 0; i < 200; i++ {
+			_ = seg.Process(laneFrame(t, "A", 100))
+			_ = seg.Process(laneFrame(t, "A", 0))
+		}
+	}()
+
+	<-rec.entered                     // the worker is stalled on the first job
+	time.Sleep(20 * time.Millisecond) // the feeder floods, fills the queue, and parks on a send
+
+	teardownDone := make(chan struct{})
+	go func() {
+		defer close(teardownDone)
+		cancel() // broken guard: close(jobs) panics the parked send; barrier: waits it out
+	}()
+	time.Sleep(20 * time.Millisecond) // let teardown reach close(jobs) / the senders barrier
+	ctxCancel()                       // release the worker → queue drains → the parked send completes
+	wg.Wait()
+	<-teardownDone
+}
+
+// TestSegmenter_ReBindOpensLanesAgain is #343 finding 3: Bind's teardown flips the
+// terminal `closed` flag, so Bind must CLEAR it (alongside the fresh jobs/ctx/bus) or a
+// re-Bound Segmenter is silently crippled — every frame funnels to the default lane and
+// STT runs inline on the audio loop. After a full Bind → teardown → Bind cycle a new
+// speaker must still open its own Speaker Lane.
+func TestSegmenter_ReBindOpensLanesAgain(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var finals []voiceevent.STTFinal
+	voiceevent.On(bus, func(e voiceevent.STTFinal) { finals = append(finals, e) })
+	rec := &recordingRecognizer{}
+	closes := 0
+	factory, _ := laneVADFactory(bus, &closes, nil)
+	seg := orchestrator.NewSegmenter(orchestrator.NewVAD(bus, &contentVAD{}), orchestrator.NewSTT(bus, rec))
+	seg.SetLaneVADFactory(factory)
+
+	// First lifetime: bind then tear all the way down (flips closed).
+	cancel := seg.Bind(t.Context(), bus)
+	cancel()
+
+	// Second lifetime: a re-Bound segmenter must behave like a fresh one.
+	t.Cleanup(seg.Bind(t.Context(), bus))
+	processFrames(t, seg, laneFrame(t, "A", 100), laneFrame(t, "A", 0))
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := seg.LaneCount(); got != 2 {
+		t.Errorf("lane count after re-Bind = %d, want 2 (default + A) — closed was not reset, so A funneled to default", got)
+	}
+	if len(finals) != 1 || finals[0].SpeakerID != "A" {
+		t.Errorf("STTFinals = %+v, want one attributed to A (re-Bound segmenter opened A's lane)", finals)
 	}
 }

--- a/pkg/voice/orchestrator/lanes_test.go
+++ b/pkg/voice/orchestrator/lanes_test.go
@@ -550,15 +550,30 @@ func TestSegmenter_FlushDrainsAllLanes(t *testing.T) {
 	}
 }
 
-// TestSegmenter_TeardownRaceWithFeed is finding 6: Bind's teardown runs concurrently
-// with an audio loop still calling Feed. Lane cancel/close funcs are captured and
-// nulled UNDER mu (and the lane dropped) in both teardown and reap, so no lane is
-// double-closed and no field is touched unlocked. Run under `go test -race`.
+// TestSegmenter_TeardownRaceWithFeed is finding 6 + #343: Bind's teardown runs
+// concurrently with an audio loop still calling Feed. Lane cancel/close funcs are
+// captured and nulled UNDER mu (and the lane dropped) in both teardown and reap, so no
+// lane is double-closed and no field is touched unlocked. Beyond the data-race, the
+// teardown must set a terminal `closed` flag FIRST (same defect class as the fixed #157
+// Manager closed flag): once teardown has begun, a still-running Feed must NOT resurrect
+// a reaped lane — laneFor sees closed and funnels to the default lane, so every
+// factory-built lane's ONNX session is closed exactly once (creates == closes) and no
+// non-default lane survives (LaneCount == 1). Run under `go test -race`.
 func TestSegmenter_TeardownRaceWithFeed(t *testing.T) {
 	bus := voiceevent.NewBus()
 	rec := &recordingRecognizer{}
-	closes := 0
-	factory, _ := laneVADFactory(bus, &closes, nil)
+
+	// Count factory-built VADs created vs closed: a resurrected lane created AFTER
+	// teardown would never be closed (leaked ONNX inferencer), so creates > closes.
+	var cmu sync.Mutex
+	creates, closes := 0, 0
+	factory := orchestrator.LaneVADFactory(func() (*orchestrator.VAD, func(), error) {
+		cmu.Lock()
+		creates++
+		cmu.Unlock()
+		v := orchestrator.NewVAD(bus, &contentVAD{})
+		return v, func() { cmu.Lock(); closes++; cmu.Unlock() }, nil
+	})
 	seg := orchestrator.NewSegmenter(orchestrator.NewVAD(bus, &contentVAD{}), orchestrator.NewSTT(bus, rec))
 	seg.SetLaneVADFactory(factory)
 	cancel := seg.Bind(t.Context(), bus)
@@ -569,7 +584,8 @@ func TestSegmenter_TeardownRaceWithFeed(t *testing.T) {
 		defer wg.Done()
 		// Voiced-only frames keep every lane listening (no flush → no jobs send that
 		// could race the teardown's close(jobs)); the point is the concurrent lane
-		// map + close-func access, which must stay mu-guarded.
+		// map + close-func access, which must stay mu-guarded, AND that Feed does not
+		// re-open a lane once teardown has flipped `closed`.
 		for i := 0; i < 500; i++ {
 			_ = seg.Process(laneFrame(t, "A", 100))
 			_ = seg.Process(laneFrame(t, "B", 200))
@@ -578,4 +594,14 @@ func TestSegmenter_TeardownRaceWithFeed(t *testing.T) {
 	time.Sleep(time.Millisecond) // let the loop open the lanes
 	cancel()                     // teardown while Feed is still running
 	wg.Wait()
+
+	if got := seg.LaneCount(); got != 1 {
+		t.Errorf("lane count after teardown = %d, want 1 (a still-running Feed resurrected a reaped lane)", got)
+	}
+	cmu.Lock()
+	gotCreates, gotCloses := creates, closes
+	cmu.Unlock()
+	if gotCreates != gotCloses {
+		t.Errorf("lane VADs created = %d but closed = %d — a resurrected lane leaked its ONNX session", gotCreates, gotCloses)
+	}
 }

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -112,8 +112,15 @@ type Segmenter struct {
 	sweepCalls  int
 	sweepEvery  int // reap-sweep cadence in Process calls; [laneReapSweepEvery] in prod
 
-	mu  sync.Mutex
-	bus *voiceevent.Bus
+	mu sync.Mutex
+	// closed is the terminal teardown flag (same defect class as the #157 Manager
+	// closed flag). Bind's returned cancel sets it FIRST under mu; laneFor and
+	// dispatchTranscription check it. Once set, a still-running Process (an audio loop
+	// that has not yet stopped) can no longer resurrect a reaped lane — its frames
+	// funnel to the default lane — so every factory-built lane's ONNX session is closed
+	// exactly once by teardown and none leaks (#343).
+	closed bool
+	bus    *voiceevent.Bus
 	// ctx is the context handed to STT.Transcribe when a segment flushes and to each
 	// per-lane stream's maintainer. It is the conversation's lifetime context,
 	// captured at Bind and cleared by the returned cancel; storing it lets Process
@@ -346,6 +353,10 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 			closeVAD     func()
 		}
 		s.mu.Lock()
+		// Flip the terminal flag FIRST (mirrors #157: Shutdown sets closed before it
+		// unwinds), so a Process racing this teardown sees closed in laneFor and cannot
+		// re-open a lane we are about to close — no resurrection, no leaked ONNX session.
+		s.closed = true
 		tds := make([]teardown, 0, len(s.lanes))
 		for id, ln := range s.lanes {
 			tds = append(tds, teardown{streamCancel: ln.streamCancel, closeVAD: ln.closeVAD})
@@ -515,8 +526,10 @@ func (s *Segmenter) laneFor(sp string) (*lane, error) {
 	defer s.mu.Unlock()
 	// A speaker whose factory already failed once is degraded for the session: skip
 	// the retry AND the repeat onError (finding 3 — the factory was retried and
-	// onError fired ~31×/s before this).
-	if sp == "" || s.laneVADFactory == nil || s.degraded[sp] {
+	// onError fired ~31×/s before this). Once teardown has flipped closed, funnel to
+	// the default lane too — a stopping audio loop must not resurrect a reaped lane and
+	// leak a fresh ONNX session teardown will never close (#343).
+	if sp == "" || s.laneVADFactory == nil || s.degraded[sp] || s.closed {
 		return s.lanes[""], nil
 	}
 	if ln, ok := s.lanes[sp]; ok {
@@ -664,6 +677,11 @@ func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame
 	}
 	s.mu.Lock()
 	jobs := s.jobs
+	if s.closed {
+		// Teardown has begun (it closes the jobs channel outside the lock): never send
+		// on it (#343, same closed-flag guard as #157) — fall to the inline transcribe.
+		jobs = nil
+	}
 	s.mu.Unlock()
 	if jobs == nil {
 		// Not bound (or already torn down): transcribe inline so a late flush still

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -89,6 +89,12 @@ type Segmenter struct {
 	// itself so Bind's cancel can stop it.
 	inflight sync.WaitGroup
 	worker   sync.WaitGroup
+	// senders counts dispatchTranscription calls that have committed to a jobs send —
+	// incremented under mu (only when NOT closed), Done after the send returns. Bind's
+	// teardown flips closed under mu (blocking any new sender), then waits senders to
+	// zero BEFORE close(jobs), so no goroutine can send on the closed channel (#343
+	// residual 2 — the panic race the bare closed flag did not cover).
+	senders sync.WaitGroup
 
 	// laneVADFactory builds a fresh per-Speaker-Lane VAD on first frame from a new
 	// speaker (ADR-0050). Nil = single-lane forever: every frame funnels to the
@@ -265,6 +271,11 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 		panic("orchestrator.Segmenter.Bind: bus must not be nil")
 	}
 	s.mu.Lock()
+	// Bind is re-usable: clear the terminal flag a prior teardown set, alongside the
+	// other fresh-per-lifetime state (jobs/ctx/bus). Without this a re-Bound Segmenter
+	// would silently funnel every frame to the default lane and transcribe inline on the
+	// audio loop (#343 finding 3).
+	s.closed = false
 	s.ctx = ctx
 	s.bus = bus
 	jobs := make(chan transcribeJob, transcribeQueueDepth)
@@ -379,6 +390,11 @@ func (s *Segmenter) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func(
 				td.closeVAD()
 			}
 		}
+		// Wait for every dispatch that enlisted as a sender (under mu, before closed was
+		// set) to finish its send, THEN close — so close(jobs) can never race a live
+		// `jobs <- job` into a panic (#343 residual 2). New dispatches see closed and go
+		// inline, so this barrier drains a bounded, non-growing set.
+		s.senders.Wait()
 		// Closing the queue lets the worker drain any still-buffered jobs and exit;
 		// in the normal path Flush already emptied it, so this just stops the worker.
 		close(jobs)
@@ -675,22 +691,25 @@ func (s *Segmenter) dispatchTranscription(ctx context.Context, seg []audio.Frame
 		speakerID:    speakerID,
 		stream:       stream,
 	}
+	// Decide-and-enlist under mu: if teardown has begun (closed) or we were never bound
+	// (jobs nil), transcribe inline; otherwise register as a pending sender BEFORE
+	// releasing the lock, so teardown's senders.Wait() cannot race past us to close the
+	// channel we are about to send on (#343 residual 2). The Add MUST be under the same
+	// lock that sets closed, or the barrier has a hole.
 	s.mu.Lock()
 	jobs := s.jobs
-	if s.closed {
-		// Teardown has begun (it closes the jobs channel outside the lock): never send
-		// on it (#343, same closed-flag guard as #157) — fall to the inline transcribe.
-		jobs = nil
-	}
-	s.mu.Unlock()
-	if jobs == nil {
-		// Not bound (or already torn down): transcribe inline so a late flush still
-		// completes rather than dropping the utterance.
+	if s.closed || jobs == nil {
+		s.mu.Unlock()
+		// Not bound, or teardown in progress: transcribe inline so a late flush still
+		// completes rather than dropping the utterance (or panicking on a closing chan).
 		if err := s.transcribe(job); err != nil && s.onError != nil {
 			s.onError(err)
 		}
 		return
 	}
+	s.senders.Add(1)
+	s.mu.Unlock()
+	defer s.senders.Done()
 	s.inflight.Add(1)
 	jobs <- job
 }


### PR DESCRIPTION
## What

Same defect class as the fixed #157 Manager `closed` flag. A `Segmenter.Bind` teardown racing a still-running `Process` (an audio loop that has not yet stopped) could re-open a lane `laneFor` had just reaped — resurrecting a non-default lane in the map and leaking a fresh ONNX session that teardown would never close.

## Fix (mirrors #157)

- Add `closed bool` under `mu` on `Segmenter`.
- Bind's returned cancel sets `closed = true` **first**, under `mu`, before capturing/nulling lane funcs.
- `laneFor` checks `closed` → funnels the frame to the default lane instead of building a new one.
- `dispatchTranscription` checks `closed` → transcribes inline rather than sending on the closing `jobs` channel.

## Test

Extended `TestSegmenter_TeardownRaceWithFeed` to assert, after the teardown/Feed race:
- no lane resurrection (`LaneCount() == 1`)
- no ONNX leak (`creates == closes` on the factory-built VADs)

Red before the fix (`LaneCount 3`, `created 4 / closed 2`), green after. Package passes `go test -race`, `go vet`, `golangci-lint` clean.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)