### PR TITLE
fix(#345): guard resolver inflight delete on generation match

### DIFF
--- a/internal/speaker/resolver.go
+++ b/internal/speaker/resolver.go
@@ -145,10 +145,14 @@ func (r *Resolver) fill(k key, gen uint64) {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.inflight, k)
 	if r.gen[k.campaign] != gen {
-		return // invalidated mid-fill; discard the now-stale result
+		// Invalidated mid-fill: the generation was bumped (and this key's marker
+		// cleared) after this fill started. A later Warm may have installed a fresh
+		// marker for the new generation — do NOT delete it, or dedup breaks and a
+		// duplicate fill spawns. Discard this now-stale result and leave the map.
+		return
 	}
+	delete(r.inflight, k)
 	r.cache[k] = entry{name: name, expires: r.now().Add(ttl)}
 }
 

--- a/internal/speaker/resolver_test.go
+++ b/internal/speaker/resolver_test.go
@@ -266,6 +266,59 @@ func TestResolverWarmDedupesConcurrentFills(t *testing.T) {
 	}
 }
 
+// TestResolverStaleFillKeepsFreshInflightMarker guards the dedup race: a fill
+// dispatched on the old generation must not delete the in-flight marker of a
+// fresh fill dispatched after an InvalidateCampaign bumped the generation.
+//
+//	Warm(k) → fill A (gen 0) blocks
+//	InvalidateCampaign → gen 1, inflight cleared
+//	Warm(k) → fill B (gen 1) sets a fresh marker   (simulated directly)
+//	fill A completes → gen check rejects its result; it must NOT delete B's marker
+//	third Warm(k) while B runs → must dedup (no fill C spawned)
+func TestResolverStaleFillKeepsFreshInflightMarker(t *testing.T) {
+	campaign := uuid.New()
+	gate := make(chan struct{})
+	chars := &fakeChars{
+		byKey: map[string]storage.Character{
+			campaign.String() + "/" + kiraUser: {Name: "Kira", CampaignID: campaign, DiscordUserID: kiraUser},
+		},
+		gate: gate,
+	}
+	r := newTestResolver(t, chars, &fakeNamer{}, "")
+	k := key{campaign: campaign, speaker: kiraUser}
+
+	// Fill A is dispatched on generation 0 and parks in the gated lookup — it
+	// cannot reach its fill tail until the test closes the gate below.
+	r.Warm(campaign, kiraUser)
+
+	// A rebind invalidates the campaign (gen → 1, inflight cleared); a fresh Warm
+	// would then start fill B on gen 1. Simulate B's fresh in-flight marker
+	// directly so fill A is the only tracked goroutine (deterministic wg.Wait).
+	r.InvalidateCampaign(campaign)
+	r.mu.Lock()
+	r.inflight[k] = struct{}{}
+	r.mu.Unlock()
+
+	// Release fill A and wait for it (and only it) to finish its fill tail.
+	close(gate)
+	r.wg.Wait()
+
+	r.mu.Lock()
+	_, marker := r.inflight[k]
+	r.mu.Unlock()
+	if !marker {
+		t.Fatal("stale fill A (gen 0) deleted fill B's fresh (gen 1) inflight marker")
+	}
+
+	// With B still in flight, a third Warm for the same key must dedup: no fill C.
+	before := chars.callCount()
+	r.Warm(campaign, kiraUser)
+	r.wg.Wait()
+	if got := chars.callCount(); got != before {
+		t.Fatalf("third Warm spawned fill C: lookups %d → %d, want no new fill while B in flight", before, got)
+	}
+}
+
 func TestResolverLookupNeverDoesIO(t *testing.T) {
 	campaign := uuid.New()
 	chars := &fakeChars{byKey: map[string]storage.Character{}}


### PR DESCRIPTION
## Problem

`speaker.Resolver.fill()` deleted the in-flight dedup marker **unconditionally**, before the generation check:

```
delete(r.inflight, k)
if r.gen[k.campaign] != gen { return }   // stale result rejected — too late
```

Race:

1. `Warm(k)` starts fill A (gen 0).
2. `InvalidateCampaign` clears inflight + bumps generation → gen 1.
3. `Warm(k)` starts fill B (gen 1), installing a fresh marker.
4. Fill A completes: the generation check rejects its stale result **but it already deleted B's marker**.
5. A third `Warm(k)` while B is still running sees no marker → spawns duplicate fill C.

Severity is dedup-weakening only — the generation check already prevents stale data from being cached; this just lets a redundant fill through.

## Fix

Move the `delete` after the generation check so a fill only clears the marker when its generation still matches the current one. A stale fill discards its result and leaves the map untouched.

## Test

`TestResolverStaleFillKeepsFreshInflightMarker` (white-box, `-race`) reproduces the race deterministically: fill A parks on a gated lookup, the campaign is invalidated, a fresh (gen 1) marker is installed, then A is released — the test asserts B's marker survives and a third `Warm` dedups (no fill C). Red before the guard, green after.

ADR-0039 (in-proc direct-method invalidation), ADR-0040 (transcript relay Warms at persist-time).

Closes #345