### PR TITLE
feat(#285): [E5] blob storage seam — Postgres bytea backend

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -602,6 +602,29 @@ otherwise the adapter's own ENV variable is used. DB-as-sole-source is the state
 end-state. Without `$GLYPHOXA_SECRET` the web tier still boots and reads — only
 *saving* a key fails, loudly (`CodeFailedPrecondition`).
 
+### 6.6 Blob storage seam
+
+Binary payloads — Epic 8 Highlight clips and generated images, later ADR-0011
+audio extracts and export bundles — live behind a small streaming `Store`
+interface in `internal/blob` (ADR-0048): `Put`/`Get`/`Delete`, keyed by the
+tenant-scoped path `t/<tenant_id>/<owner-kind>/<owner-id>/<name>`. The package
+owns both key construction (`Key`) and validation (`ValidateKey`); the tenant
+prefix is mandatory and the backend derives `tenant_id` from the key, so a
+prefix-less key never reaches SQL.
+
+**All ADR-0034 deployment shapes store blobs in Postgres** (`blob` table, bytea,
+`00021_blob.sql`). The Helm shape runs voice and web as separate Deployments with
+no shared filesystem, but every shape already shares Postgres — so a Voice
+Instance writes and a Web Instance serves with zero new configuration, in
+compose, systemd, and Helm alike. A **32 MiB per-blob cap** (a code constant,
+`blob.MaxSize`) enforced at `Put` keeps a bytea backend honest; anything larger
+forces the backend conversation. **S3-compatible storage is the documented growth
+path** behind the same seam — a local-filesystem backend is deliberately not
+built (the Helm split can't reach it without RWX volumes). Deletion goes through
+the seam, not FK cascade: a deterministic `Key()` plus `Delete` is the mechanism
+owning rows use, which survives the backend swap; the owner-side wiring and
+retention semantics are Epic 8 / ADR-0051.
+
 ---
 
 ## 7. Observability and spend
@@ -713,7 +736,7 @@ the architecture question is already answered.
 |-----|----------|-------------------|
 | [0025](adr/0025-ensemble-turns-speculative-lead-reaction.md) | Ensemble Turns: speculative Lead + Cross-talk Reaction | Deferred by [0038](adr/0038-multi-npc-single-target-default-programmatic-roster.md). `MaxTargets` reaches the multi-target set; the turn-taking layer is not built. |
 | [0030](adr/0030-tool-side-effects-deferred-to-turn-commit.md) | Side-effecting Tool intents flush at turn-commit | Not built. `pkg/tool/loop.go` hard-refuses non-read-only Tools. |
-| [0048](adr/0048-blob-storage-seam-postgres-v1.md) | a blob-storage seam package, Postgres bytea backend | No blob package exists; nothing binary is persisted. |
+| [0048](adr/0048-blob-storage-seam-postgres-v1.md) | a blob-storage seam package, Postgres bytea backend | **Shipped** (§6.6): `internal/blob` seam + Postgres bytea backend (`00021_blob.sql`), 32 MiB cap. No consumer wires it yet — owner-side Delete + retention are Epic 8 / ADR-0051. |
 | [0049](adr/0049-background-job-runner.md) | One DB-backed job runner over a job table | No job table exists. `internal/embedworker` stays a bespoke poll loop, as the ADR allows. |
 | [0050](adr/0050-per-speaker-utterance-segmentation.md) | N Speaker Lanes; `SpeakerID` on voice events | No `SpeakerID` anywhere. Human speech is still one anonymous lane (§2.6). |
 | [0051](adr/0051-rollover-tape-consent-retention.md) | Consent-gated 120 s Rollover Tape; Highlights | No audio is persisted. Blocks on 0048 + 0050. |

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -103,10 +103,21 @@ func ValidateKey(key string) (tenantID uuid.UUID, err error) {
 	if perr != nil {
 		return uuid.Nil, ErrInvalidKey
 	}
+	// uuid.Parse tolerates braces/urn/no-dash forms; require the canonical dashed
+	// string so one logical blob has exactly one key. A non-canonical hand-built
+	// key would otherwise become an orphan the E8 delete hook can never
+	// reconstruct via Key().
+	if segs[1] != tenant.String() {
+		return uuid.Nil, ErrInvalidKey
+	}
 	// segs[2] = owner-kind, segs[3] = owner-id, segs[4] = name. Kind and name
 	// must be non-empty; a slash inside either is impossible (it would raise the
-	// segment count above five).
+	// segment count above five). The owner-id gets the same canonical-uuid
+	// discipline as the tenant.
 	if segs[2] == "" || segs[4] == "" {
+		return uuid.Nil, ErrInvalidKey
+	}
+	if owner, oerr := uuid.Parse(segs[3]); oerr != nil || segs[3] != owner.String() {
 		return uuid.Nil, ErrInvalidKey
 	}
 	return tenant, nil

--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -1,0 +1,113 @@
+// Package blob is the object-storage seam (ADR-0048). Binary payloads —
+// Highlight clips, generated images, future audio extracts and export bundles —
+// live behind a small streaming Store interface so the backend can change (v1
+// Postgres bytea → S3 growth path) without touching callers.
+//
+// Keys are tenant-scoped paths — t/<tenant_id>/<owner-kind>/<owner-id>/<name> —
+// and the tenant prefix is MANDATORY: the package owns both construction (Key)
+// and validation (ValidateKey), and the backend derives the tenant_id column
+// FROM the key, so a key without a valid tenant prefix can never reach SQL.
+//
+// Deletion goes through the seam, not FK cascade (ADR-0048): a deterministic
+// Key() plus a seam Delete are the mechanism owning rows use to drop their
+// blobs. Retention semantics are ADR-0051's, not this package's.
+package blob
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MaxSize is the per-blob size cap enforced at Put (ADR-0048: 32 MiB to start).
+// The cap is what keeps a bytea backend honest — anything larger forces the
+// backend conversation instead of silently bloating the DB.
+const MaxSize int64 = 32 << 20
+
+var (
+	// ErrNotFound is returned by Get/Delete semantics where a key is absent.
+	// (Delete is idempotent and returns nil for an absent key; ErrNotFound is
+	// the Get signal.)
+	ErrNotFound = errors.New("blob: not found")
+	// ErrTooLarge is returned by Put when the declared size exceeds MaxSize.
+	ErrTooLarge = errors.New("blob: payload exceeds size cap")
+	// ErrInvalidKey is returned when a key is missing or malformed — no tenant
+	// prefix, non-uuid tenant, wrong segment count, or an empty/slash-bearing
+	// owner-kind or name.
+	ErrInvalidKey = errors.New("blob: invalid key")
+)
+
+// Meta is the stored metadata for a blob, returned alongside its bytes on Get.
+type Meta struct {
+	ContentType string
+	Size        int64
+	CreatedAt   time.Time
+}
+
+// Store is the blob seam. Signatures are streaming even where a backend buffers,
+// so backends can change without touching callers (ADR-0048).
+type Store interface {
+	// Put stores the blob at key, reading EXACTLY size bytes from r. Put on an
+	// existing key is an upsert. size<0 or size>MaxSize, or an invalid key, is
+	// an error before any read.
+	Put(ctx context.Context, key, contentType string, r io.Reader, size int64) error
+	// Get returns the blob's bytes and Meta, or ErrNotFound.
+	Get(ctx context.Context, key string) (io.ReadCloser, Meta, error)
+	// Delete removes the blob at key. Deleting an absent key returns nil
+	// (idempotent).
+	Delete(ctx context.Context, key string) error
+}
+
+// keyPrefix is the mandatory first segment of every key.
+const keyPrefix = "t"
+
+// Key builds the canonical tenant-scoped key
+// t/<tenant_id>/<owner-kind>/<owner-id>/<name>. It is deterministic — the same
+// inputs always yield the same key — so an owning row can reconstruct its blob
+// key for Delete (ADR-0048 lifecycle hook). ownerKind and name must be
+// non-empty and name must not contain a path separator, else ErrInvalidKey.
+func Key(tenantID uuid.UUID, ownerKind string, ownerID uuid.UUID, name string) (string, error) {
+	if ownerKind == "" || strings.Contains(ownerKind, "/") {
+		return "", ErrInvalidKey
+	}
+	if name == "" || strings.Contains(name, "/") {
+		return "", ErrInvalidKey
+	}
+	key := strings.Join([]string{keyPrefix, tenantID.String(), ownerKind, ownerID.String(), name}, "/")
+	// Round-trip through ValidateKey so construction can never emit a key the
+	// backend would reject.
+	if _, err := ValidateKey(key); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// ValidateKey parses a key and returns the tenant id it encodes, or
+// ErrInvalidKey. A valid key is exactly five segments —
+// "t"/<uuid>/<kind>/<owner-id>/<name> — with a parseable tenant uuid and
+// non-empty kind and name. The backend calls this and derives the tenant_id
+// column from the result, so an invalid key never reaches SQL.
+func ValidateKey(key string) (tenantID uuid.UUID, err error) {
+	segs := strings.Split(key, "/")
+	if len(segs) != 5 {
+		return uuid.Nil, ErrInvalidKey
+	}
+	if segs[0] != keyPrefix {
+		return uuid.Nil, ErrInvalidKey
+	}
+	tenant, perr := uuid.Parse(segs[1])
+	if perr != nil {
+		return uuid.Nil, ErrInvalidKey
+	}
+	// segs[2] = owner-kind, segs[3] = owner-id, segs[4] = name. Kind and name
+	// must be non-empty; a slash inside either is impossible (it would raise the
+	// segment count above five).
+	if segs[2] == "" || segs[4] == "" {
+		return uuid.Nil, ErrInvalidKey
+	}
+	return tenant, nil
+}

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -1,0 +1,119 @@
+package blob_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+)
+
+// TestKeyRoundTrip proves Key() builds the canonical tenant-scoped path and that
+// ValidateKey recovers the tenant id from it — the package owns both
+// construction and validation (ADR-0048: the storage layer never accepts a key
+// without a tenant prefix).
+func TestKeyRoundTrip(t *testing.T) {
+	tenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	owner := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	key, err := blob.Key(tenant, "highlight", owner, "clip.opus")
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	want := "t/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/clip.opus"
+	if key != want {
+		t.Fatalf("Key = %q, want %q", key, want)
+	}
+
+	gotTenant, err := blob.ValidateKey(key)
+	if err != nil {
+		t.Fatalf("ValidateKey: %v", err)
+	}
+	if gotTenant != tenant {
+		t.Fatalf("ValidateKey tenant = %s, want %s", gotTenant, tenant)
+	}
+}
+
+// TestKeyRejectsBadOwnerAndName covers construction-side validation: an empty
+// owner-kind or name (or a name with a path separator) can never yield a valid
+// key.
+func TestKeyRejectsBadOwnerAndName(t *testing.T) {
+	tenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	owner := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	cases := map[string]struct {
+		kind, name string
+	}{
+		"empty kind": {"", "clip.opus"},
+		"empty name": {"highlight", ""},
+		"slash name": {"highlight", "sub/clip.opus"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := blob.Key(tenant, tc.kind, owner, tc.name); !errors.Is(err, blob.ErrInvalidKey) {
+				t.Fatalf("Key(%q,%q) err = %v, want ErrInvalidKey", tc.kind, tc.name, err)
+			}
+		})
+	}
+}
+
+// TestValidateKeyRejectsMalformed exercises the validation side directly: a key
+// must be exactly five segments "t"/<uuid>/<kind>/<owner-id>/<name>, kind+name
+// non-empty. Anything else is ErrInvalidKey and must never reach SQL.
+func TestValidateKeyRejectsMalformed(t *testing.T) {
+	cases := map[string]string{
+		"missing t prefix": "x/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/clip.opus",
+		"non-uuid tenant":  "t/not-a-uuid/highlight/22222222-2222-2222-2222-222222222222/clip.opus",
+		"empty kind":       "t/11111111-1111-1111-1111-111111111111//22222222-2222-2222-2222-222222222222/clip.opus",
+		"empty name":       "t/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/",
+		"four segments":    "t/11111111-1111-1111-1111-111111111111/highlight/clip.opus",
+		"six segments":     "t/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/sub/clip.opus",
+	}
+	for name, key := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := blob.ValidateKey(key); !errors.Is(err, blob.ErrInvalidKey) {
+				t.Fatalf("ValidateKey(%q) err = %v, want ErrInvalidKey", key, err)
+			}
+		})
+	}
+}
+
+// TestPutPreChecks proves Put rejects a bad size or a prefix-less key BEFORE it
+// touches the reader or the DB — so a nil pool is enough to observe the guard
+// (ADR-0048: invalid key never reaches SQL; the cap is enforced at Put).
+func TestPutPreChecks(t *testing.T) {
+	tenant := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	owner := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	goodKey, err := blob.Key(tenant, "highlight", owner, "clip.opus")
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+
+	// A nil-pool Postgres must be constructible; the pre-checks fire before any
+	// pool method is called.
+	store := blob.NewPostgres(nil)
+	ctx := context.Background()
+
+	t.Run("over cap", func(t *testing.T) {
+		err := store.Put(ctx, goodKey, "audio/opus", strings.NewReader("x"), blob.MaxSize+1)
+		if !errors.Is(err, blob.ErrTooLarge) {
+			t.Fatalf("Put over cap err = %v, want ErrTooLarge", err)
+		}
+	})
+	t.Run("negative size", func(t *testing.T) {
+		err := store.Put(ctx, goodKey, "audio/opus", strings.NewReader("x"), -1)
+		if err == nil {
+			t.Fatal("Put negative size err = nil, want error")
+		}
+	})
+	t.Run("invalid key", func(t *testing.T) {
+		err := store.Put(ctx, "no-prefix", "audio/opus", bytes.NewReader([]byte("x")), 1)
+		if !errors.Is(err, blob.ErrInvalidKey) {
+			t.Fatalf("Put invalid key err = %v, want ErrInvalidKey", err)
+		}
+	})
+}

--- a/internal/blob/blob_test.go
+++ b/internal/blob/blob_test.go
@@ -72,6 +72,12 @@ func TestValidateKeyRejectsMalformed(t *testing.T) {
 		"empty name":       "t/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/",
 		"four segments":    "t/11111111-1111-1111-1111-111111111111/highlight/clip.opus",
 		"six segments":     "t/11111111-1111-1111-1111-111111111111/highlight/22222222-2222-2222-2222-222222222222/sub/clip.opus",
+		// uuid.Parse tolerates these non-canonical forms; a valid key must carry
+		// the canonical dashed uuid only, so one blob has exactly one key.
+		"braced tenant":   "t/{11111111-1111-1111-1111-111111111111}/highlight/22222222-2222-2222-2222-222222222222/clip.opus",
+		"undashed tenant": "t/11111111111111111111111111111111/highlight/22222222-2222-2222-2222-222222222222/clip.opus",
+		"undashed owner":  "t/11111111-1111-1111-1111-111111111111/highlight/22222222222222222222222222222222/clip.opus",
+		"non-uuid owner":  "t/11111111-1111-1111-1111-111111111111/highlight/not-a-uuid/clip.opus",
 	}
 	for name, key := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/blob/postgres.go
+++ b/internal/blob/postgres.go
@@ -1,0 +1,117 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Postgres is the v1 blob backend: bytea rows in the shared Postgres (ADR-0048).
+// Every ADR-0034 deployment shape already shares Postgres, so a Voice Instance
+// writes and a Web Instance serves with zero new configuration. bytea is scanned
+// straight to []byte via pgx (no large-object API); the MaxSize cap keeps that
+// honest.
+type Postgres struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgres builds a Postgres-backed Store over an existing pool. A nil pool
+// is permitted (the Put pre-checks — size and key validation — run before any
+// pool method is touched), which keeps the guard unit-testable without a DB.
+func NewPostgres(pool *pgxpool.Pool) *Postgres {
+	return &Postgres{pool: pool}
+}
+
+var _ Store = (*Postgres)(nil)
+
+// Put stores the blob, upserting on key conflict (ADR-0048 semantics). It
+// validates size and key BEFORE reading r or touching the DB, then reads
+// EXACTLY size bytes plus one probe byte — a short or over-long stream is an
+// error and no row is written. The tenant_id column is derived from the key.
+func (p *Postgres) Put(ctx context.Context, key, contentType string, r io.Reader, size int64) error {
+	if size < 0 {
+		return fmt.Errorf("blob: negative size %d", size)
+	}
+	if size > MaxSize {
+		return ErrTooLarge
+	}
+	tenantID, err := ValidateKey(key)
+	if err != nil {
+		return err
+	}
+
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		// io.EOF (zero read) or io.ErrUnexpectedEOF (partial) both mean the
+		// stream was shorter than the declared size.
+		return fmt.Errorf("blob: read payload for %s: %w", key, err)
+	}
+	// Probe one more byte: a non-EOF read means the stream was longer than
+	// declared, which we reject rather than silently truncate.
+	var probe [1]byte
+	if _, perr := io.ReadFull(r, probe[:]); perr == nil {
+		return fmt.Errorf("blob: payload for %s exceeds declared size %d", key, size)
+	} else if !errors.Is(perr, io.EOF) {
+		return fmt.Errorf("blob: probe payload for %s: %w", key, perr)
+	}
+
+	_, err = p.pool.Exec(ctx,
+		`INSERT INTO blob (key, tenant_id, content_type, size, bytes)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (key) DO UPDATE SET
+		     tenant_id    = EXCLUDED.tenant_id,
+		     content_type = EXCLUDED.content_type,
+		     size         = EXCLUDED.size,
+		     bytes        = EXCLUDED.bytes,
+		     created_at   = now()`,
+		key, tenantID, contentType, size, buf)
+	if err != nil {
+		return fmt.Errorf("blob: put %s: %w", key, err)
+	}
+	return nil
+}
+
+// Get returns the blob's bytes (buffered into an in-memory ReadCloser) and Meta,
+// or ErrNotFound. An invalid key is ErrInvalidKey and never reaches SQL.
+func (p *Postgres) Get(ctx context.Context, key string) (io.ReadCloser, Meta, error) {
+	if _, err := ValidateKey(key); err != nil {
+		return nil, Meta{}, err
+	}
+	var (
+		contentType string
+		size        int64
+		createdAt   time.Time
+		raw         []byte
+	)
+	err := p.pool.QueryRow(ctx,
+		`SELECT content_type, size, bytes, created_at FROM blob WHERE key = $1`, key).
+		Scan(&contentType, &size, &raw, &createdAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, Meta{}, ErrNotFound
+	}
+	if err != nil {
+		return nil, Meta{}, fmt.Errorf("blob: get %s: %w", key, err)
+	}
+	meta := Meta{ContentType: contentType, Size: size, CreatedAt: createdAt}
+	return io.NopCloser(bytes.NewReader(raw)), meta, nil
+}
+
+// Delete removes the blob at key. Deleting an absent key returns nil
+// (idempotent) — the deterministic Key() plus this Delete are the lifecycle
+// mechanism owning rows use (ADR-0048; wiring is E8's). An invalid key is
+// ErrInvalidKey and never reaches SQL.
+func (p *Postgres) Delete(ctx context.Context, key string) error {
+	if _, err := ValidateKey(key); err != nil {
+		return err
+	}
+	if _, err := p.pool.Exec(ctx, `DELETE FROM blob WHERE key = $1`, key); err != nil {
+		return fmt.Errorf("blob: delete %s: %w", key, err)
+	}
+	return nil
+}

--- a/internal/blob/postgres.go
+++ b/internal/blob/postgres.go
@@ -33,7 +33,9 @@ var _ Store = (*Postgres)(nil)
 // Put stores the blob, upserting on key conflict (ADR-0048 semantics). It
 // validates size and key BEFORE reading r or touching the DB, then reads
 // EXACTLY size bytes plus one probe byte — a short or over-long stream is an
-// error and no row is written. The tenant_id column is derived from the key.
+// error and no row is written. The tenant_id column is derived from the key. An
+// upsert preserves the original created_at (so Meta.CreatedAt is birth time, not
+// last-write time — ADR-0051 retention math depends on it).
 func (p *Postgres) Put(ctx context.Context, key, contentType string, r io.Reader, size int64) error {
 	if size < 0 {
 		return fmt.Errorf("blob: negative size %d", size)
@@ -68,8 +70,7 @@ func (p *Postgres) Put(ctx context.Context, key, contentType string, r io.Reader
 		     tenant_id    = EXCLUDED.tenant_id,
 		     content_type = EXCLUDED.content_type,
 		     size         = EXCLUDED.size,
-		     bytes        = EXCLUDED.bytes,
-		     created_at   = now()`,
+		     bytes        = EXCLUDED.bytes`,
 		key, tenantID, contentType, size, buf)
 	if err != nil {
 		return fmt.Errorf("blob: put %s: %w", key, err)

--- a/internal/blob/postgres_test.go
+++ b/internal/blob/postgres_test.go
@@ -1,0 +1,296 @@
+//go:build integration
+
+// These tests stand up a real Postgres (testcontainers) and are tag-isolated
+// behind `integration` so the default `go test ./...` stays Docker-free and fast
+// (ADR-0021 / ADR-0033). Run them with `go test -tags=integration`. The harness
+// mirrors internal/storage/harness_test.go and internal/rpc — start a pgvector
+// container, migrate up, then exercise the blob Store against a seeded tenant.
+
+package blob_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+// startPostgres spins up a pgvector container and returns its DSN, or skips
+// loudly when Docker is unavailable (a Docker-less `go test` must not hard-fail).
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("GLYPHOXA_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start the %s container "+
+			"(is Docker running?). Set GLYPHOXA_TEST_DSN to an external pgvector "+
+			"Postgres to run these without Docker. underlying error: %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+// newStore migrates the schema up and returns a blob Store plus the raw pool
+// (for row-count assertions the seam deliberately does not expose).
+func newStore(t *testing.T) (*blob.Postgres, *pgxpool.Pool) {
+	t.Helper()
+	dsn := startPostgres(t)
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return blob.NewPostgres(pool), pool
+}
+
+// seedTenant inserts a tenant and returns its id — blob rows FK to tenant(id).
+func seedTenant(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO tenant (name) VALUES ($1) RETURNING id`, name).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	return id
+}
+
+func countBlobs(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM blob`).Scan(&n); err != nil {
+		t.Fatalf("count blobs: %v", err)
+	}
+	return n
+}
+
+func mustKey(t *testing.T, tenant, owner uuid.UUID, name string) string {
+	t.Helper()
+	key, err := blob.Key(tenant, "highlight", owner, name)
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	return key
+}
+
+// TestPutGetRoundTrip stores a blob and reads it back with correct bytes and
+// Meta; an unknown key yields ErrNotFound.
+func TestPutGetRoundTrip(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+	key := mustKey(t, tenant, uuid.New(), "clip.opus")
+
+	payload := []byte("hello blob world")
+	if err := store.Put(ctx, key, "audio/opus", bytes.NewReader(payload), int64(len(payload))); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	rc, meta, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("bytes = %q, want %q", got, payload)
+	}
+	if meta.ContentType != "audio/opus" {
+		t.Errorf("ContentType = %q, want audio/opus", meta.ContentType)
+	}
+	if meta.Size != int64(len(payload)) {
+		t.Errorf("Size = %d, want %d", meta.Size, len(payload))
+	}
+	if meta.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero")
+	}
+
+	missing := mustKey(t, tenant, uuid.New(), "nope.opus")
+	if _, _, err := store.Get(ctx, missing); !errors.Is(err, blob.ErrNotFound) {
+		t.Fatalf("Get unknown err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestPutUpsert proves a second Put at the same key overwrites and leaves a
+// single row.
+func TestPutUpsert(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+	key := mustKey(t, tenant, uuid.New(), "clip.opus")
+
+	if err := store.Put(ctx, key, "text/plain", bytes.NewReader([]byte("first")), 5); err != nil {
+		t.Fatalf("Put first: %v", err)
+	}
+	if err := store.Put(ctx, key, "audio/opus", bytes.NewReader([]byte("second!")), 7); err != nil {
+		t.Fatalf("Put second: %v", err)
+	}
+
+	if n := countBlobs(t, pool); n != 1 {
+		t.Fatalf("row count = %d, want 1 (upsert)", n)
+	}
+	rc, meta, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if string(got) != "second!" || meta.ContentType != "audio/opus" || meta.Size != 7 {
+		t.Fatalf("after upsert got %q/%q/%d, want second!/audio/opus/7", got, meta.ContentType, meta.Size)
+	}
+}
+
+// TestPutSizeMismatch rejects a stream shorter or longer than the declared size,
+// writing no row in either case.
+func TestPutSizeMismatch(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+
+	// Declared longer than actual (short stream).
+	shortKey := mustKey(t, tenant, uuid.New(), "short.bin")
+	if err := store.Put(ctx, shortKey, "application/octet-stream", bytes.NewReader([]byte("abc")), 10); err == nil {
+		t.Fatal("Put short stream err = nil, want error")
+	}
+	// Declared shorter than actual (long stream).
+	longKey := mustKey(t, tenant, uuid.New(), "long.bin")
+	if err := store.Put(ctx, longKey, "application/octet-stream", bytes.NewReader([]byte("abcdefghij")), 3); err == nil {
+		t.Fatal("Put long stream err = nil, want error")
+	}
+
+	if n := countBlobs(t, pool); n != 0 {
+		t.Fatalf("row count = %d, want 0 (no row on size mismatch)", n)
+	}
+}
+
+// TestDeleteIdempotent removes a blob (Get then ErrNotFound) and proves a second
+// Delete of the now-absent key is a no-op nil.
+func TestDeleteIdempotent(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+	key := mustKey(t, tenant, uuid.New(), "clip.opus")
+
+	if err := store.Put(ctx, key, "audio/opus", bytes.NewReader([]byte("data")), 4); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, _, err := store.Get(ctx, key); !errors.Is(err, blob.ErrNotFound) {
+		t.Fatalf("Get after Delete err = %v, want ErrNotFound", err)
+	}
+	if err := store.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete absent err = %v, want nil (idempotent)", err)
+	}
+}
+
+// TestTenantIsolation proves two tenants can hold blobs at the same owner-kind /
+// owner-id / name suffix without colliding, each reading its own bytes — the key
+// carries the tenant, so there is no cross-tenant read. A prefix-less key is
+// rejected before any query.
+func TestTenantIsolation(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenantA := seedTenant(t, pool, "tenant-a")
+	tenantB := seedTenant(t, pool, "tenant-b")
+
+	owner := uuid.New() // same owner id + name on both sides
+	keyA := mustKey(t, tenantA, owner, "clip.opus")
+	keyB := mustKey(t, tenantB, owner, "clip.opus")
+
+	if err := store.Put(ctx, keyA, "audio/opus", bytes.NewReader([]byte("AAA")), 3); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	if err := store.Put(ctx, keyB, "audio/opus", bytes.NewReader([]byte("BBB")), 3); err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+
+	rcA, _, err := store.Get(ctx, keyA)
+	if err != nil {
+		t.Fatalf("Get A: %v", err)
+	}
+	defer rcA.Close()
+	gotA, _ := io.ReadAll(rcA)
+	rcB, _, err := store.Get(ctx, keyB)
+	if err != nil {
+		t.Fatalf("Get B: %v", err)
+	}
+	defer rcB.Close()
+	gotB, _ := io.ReadAll(rcB)
+	if string(gotA) != "AAA" || string(gotB) != "BBB" {
+		t.Fatalf("cross-tenant bleed: A=%q B=%q, want AAA/BBB", gotA, gotB)
+	}
+	if n := countBlobs(t, pool); n != 2 {
+		t.Fatalf("row count = %d, want 2", n)
+	}
+
+	// A key without a tenant prefix never reaches SQL.
+	if err := store.Put(ctx, "no-prefix-key", "audio/opus", bytes.NewReader([]byte("x")), 1); !errors.Is(err, blob.ErrInvalidKey) {
+		t.Fatalf("Put prefix-less err = %v, want ErrInvalidKey", err)
+	}
+}
+
+// TestSizeCapBoundary proves the cap edge: exactly MaxSize succeeds, MaxSize+1 is
+// ErrTooLarge (rejected before any read). One MaxSize buffer only — do not
+// table-drive multiple 32 MiB allocations.
+func TestSizeCapBoundary(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+
+	atCap := bytes.Repeat([]byte{0x7}, int(blob.MaxSize))
+	okKey := mustKey(t, tenant, uuid.New(), "big.bin")
+	if err := store.Put(ctx, okKey, "application/octet-stream", bytes.NewReader(atCap), blob.MaxSize); err != nil {
+		t.Fatalf("Put at cap: %v", err)
+	}
+
+	overKey := mustKey(t, tenant, uuid.New(), "toobig.bin")
+	if err := store.Put(ctx, overKey, "application/octet-stream", bytes.NewReader(atCap), blob.MaxSize+1); !errors.Is(err, blob.ErrTooLarge) {
+		t.Fatalf("Put over cap err = %v, want ErrTooLarge", err)
+	}
+}

--- a/internal/blob/postgres_test.go
+++ b/internal/blob/postgres_test.go
@@ -96,10 +96,15 @@ func seedTenant(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
 	return id
 }
 
-func countBlobs(t *testing.T, pool *pgxpool.Pool) int {
+// countBlobs counts rows for ONE tenant, not the whole table — a global count
+// would break the suite's GLYPHOXA_TEST_DSN shared-DB mode (no truncation
+// between tests → cross-test row bleed). Mirrors the repo pattern
+// (campaign_archive_test.go).
+func countBlobs(t *testing.T, pool *pgxpool.Pool, tenant uuid.UUID) int {
 	t.Helper()
 	var n int
-	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM blob`).Scan(&n); err != nil {
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM blob WHERE tenant_id = $1`, tenant).Scan(&n); err != nil {
 		t.Fatalf("count blobs: %v", err)
 	}
 	return n
@@ -166,11 +171,17 @@ func TestPutUpsert(t *testing.T) {
 	if err := store.Put(ctx, key, "text/plain", bytes.NewReader([]byte("first")), 5); err != nil {
 		t.Fatalf("Put first: %v", err)
 	}
+	_, firstMeta, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get first: %v", err)
+	}
+	// Guarantee wall-clock advances so a now()-stamp on conflict would differ.
+	time.Sleep(10 * time.Millisecond)
 	if err := store.Put(ctx, key, "audio/opus", bytes.NewReader([]byte("second!")), 7); err != nil {
 		t.Fatalf("Put second: %v", err)
 	}
 
-	if n := countBlobs(t, pool); n != 1 {
+	if n := countBlobs(t, pool, tenant); n != 1 {
 		t.Fatalf("row count = %d, want 1 (upsert)", n)
 	}
 	rc, meta, err := store.Get(ctx, key)
@@ -181,6 +192,11 @@ func TestPutUpsert(t *testing.T) {
 	got, _ := io.ReadAll(rc)
 	if string(got) != "second!" || meta.ContentType != "audio/opus" || meta.Size != 7 {
 		t.Fatalf("after upsert got %q/%q/%d, want second!/audio/opus/7", got, meta.ContentType, meta.Size)
+	}
+	// created_at is birth time, not last-write time — ADR-0051 retention math
+	// depends on it, so an upsert must NOT restamp it.
+	if !meta.CreatedAt.Equal(firstMeta.CreatedAt) {
+		t.Fatalf("CreatedAt = %v after upsert, want unchanged %v", meta.CreatedAt, firstMeta.CreatedAt)
 	}
 }
 
@@ -202,7 +218,7 @@ func TestPutSizeMismatch(t *testing.T) {
 		t.Fatal("Put long stream err = nil, want error")
 	}
 
-	if n := countBlobs(t, pool); n != 0 {
+	if n := countBlobs(t, pool, tenant); n != 0 {
 		t.Fatalf("row count = %d, want 0 (no row on size mismatch)", n)
 	}
 }
@@ -265,8 +281,11 @@ func TestTenantIsolation(t *testing.T) {
 	if string(gotA) != "AAA" || string(gotB) != "BBB" {
 		t.Fatalf("cross-tenant bleed: A=%q B=%q, want AAA/BBB", gotA, gotB)
 	}
-	if n := countBlobs(t, pool); n != 2 {
-		t.Fatalf("row count = %d, want 2", n)
+	if n := countBlobs(t, pool, tenantA); n != 1 {
+		t.Fatalf("tenant A row count = %d, want 1", n)
+	}
+	if n := countBlobs(t, pool, tenantB); n != 1 {
+		t.Fatalf("tenant B row count = %d, want 1", n)
 	}
 
 	// A key without a tenant prefix never reaches SQL.

--- a/internal/storage/migrations/00021_blob.sql
+++ b/internal/storage/migrations/00021_blob.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+
+-- blob is the v1 object-storage backend (ADR-0048): binary payloads (Highlight
+-- clips, generated images, future audio extracts / export bundles) as bytea in
+-- the shared Postgres, behind the internal/blob Store seam. Every ADR-0034
+-- deployment shape already shares Postgres, so a Voice Instance writes and a Web
+-- Instance serves with no new configuration; the 32 MiB Put cap (a code
+-- constant) keeps a bytea backend honest.
+--
+-- key is the tenant-scoped path t/<tenant_id>/<owner-kind>/<owner-id>/<name>;
+-- tenant_id is a plain REFERENCES tenant(id) — DELIBERATELY no owner FKs and no
+-- ON DELETE CASCADE. Deletion goes through the seam (blob.Delete), not FK
+-- cascade, because a cascade would only ever work for the Postgres backend; a
+-- hook survives the S3 backend swap (ADR-0048 lifecycle).
+CREATE TABLE blob (
+    key          text PRIMARY KEY,
+    tenant_id    uuid NOT NULL REFERENCES tenant (id),
+    content_type text NOT NULL,
+    size         bigint NOT NULL,
+    bytes        bytea NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX blob_tenant_key_idx ON blob (tenant_id, key);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS blob;


### PR DESCRIPTION
Closes #285

Implements the blob storage seam per ADR-0048 and the architect plan.

## What
- **`internal/blob` Store seam** — `Put`/`Get`/`Delete` over tenant-scoped keys `t/<tenant_id>/<owner-kind>/<owner-id>/<name>`. Package owns both `Key()` (deterministic construction) and `ValidateKey()` (parse + tenant recovery). Backend derives `tenant_id` FROM the key, so a prefix-less/malformed key never reaches SQL.
- **Postgres bytea backend** (`postgres.go`, `var _ Store`). `Put` upserts on key conflict (`ON CONFLICT (key) DO UPDATE`), reads EXACTLY `size` bytes + a probe byte (short/long stream → error, no row), enforces the **32 MiB `MaxSize`** cap *before* any read; `size<0`/invalid key rejected before touching pool (nil-pool constructible). `Get` buffers bytea → `io.NopCloser`. `Delete` idempotent.
- **Migration `00021_blob.sql`** — plain `REFERENCES tenant(id)`, deliberately NO owner FKs / NO cascade. Deletion is a seam hook (deterministic `Key()` + `Delete`), so it survives the documented S3 growth path. (Skipped 00022 for parallel #286.)
- **Docs** — architecture §6.6 (all ADR-0034 shapes store blobs in Postgres, 32 MiB cap, S3 = growth path behind same seam); flipped ADR-0048 row in the design-of-record table to Shipped.

## Scope guardrails (per plan)
No S3 scaffolding, no filesystem backend, no `main.go` change (nothing consumes blob yet), no `storage.Store` methods (blob owns its SQL). Owner-side Delete wiring + retention are E8 / ADR-0051.

## Tests
- **Unit** (`blob_test.go`): Key/ValidateKey round-trip; rejects missing `t/`, non-uuid tenant, empty kind/name, `/` in name, 4/6 segments; Put pre-checks (over-cap → `ErrTooLarge`, negative size, invalid key → `ErrInvalidKey`) on a nil pool.
- **Integration** (`postgres_test.go`, tag `integration`): round-trip + Meta; Get unknown → `ErrNotFound`; upsert (one row, second wins); size mismatch both directions (no row); Delete removes + idempotent; tenant isolation (same suffix, own bytes, prefix-less rejected pre-query); 32 MiB exact succeeds / +1 → `ErrTooLarge`.

All integration tests green against pgvector testcontainer locally; storage migrate up/down reversibility stays green with 00021. `golangci-lint` clean (incl. `--build-tags=integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)