### PR TITLE
fix(#342): campaign-scope all bare-id Agent/KG/Character mutations

### DIFF
--- a/internal/kgfacts/kgfacts_integration_test.go
+++ b/internal/kgfacts/kgfacts_integration_test.go
@@ -179,7 +179,7 @@ func linkAgent(t *testing.T, st *storage.Store, campID, npcID uuid.UUID, name st
 	if err != nil {
 		t.Fatalf("CreateAgent %q: %v", name, err)
 	}
-	if _, err := st.SetNodeAgent(context.Background(), npcID,
+	if _, err := st.SetNodeAgent(context.Background(), campID, npcID,
 		uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
 		t.Fatalf("SetNodeAgent %q: %v", name, err)
 	}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -58,11 +58,11 @@ type campaignStore interface {
 	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
 	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
 	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
-	DeleteAgent(ctx context.Context, id uuid.UUID) error
+	DeleteAgent(ctx context.Context, campaignID, id uuid.UUID) error
 	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
 	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
 	UpdateNode(ctx context.Context, u storage.KGNodeUpdate) (storage.KGNode, error)
-	DeleteNode(ctx context.Context, id uuid.UUID) error
+	DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error
 	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
 	DeleteEdge(ctx context.Context, id uuid.UUID) error
 	NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
@@ -78,7 +78,7 @@ type campaignStore interface {
 	ListCharacters(ctx context.Context, campaignID uuid.UUID) ([]storage.Character, error)
 	CreateCharacter(ctx context.Context, c storage.NewCharacter) (uuid.UUID, error)
 	UpdateCharacter(ctx context.Context, c storage.CharacterUpdate) (storage.Character, error)
-	DeleteCharacter(ctx context.Context, id uuid.UUID) error
+	DeleteCharacter(ctx context.Context, campaignID, id uuid.UUID) error
 }
 
 // CampaignServer implements managementv1connect.CampaignServiceHandler over a

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -64,9 +64,9 @@ type campaignStore interface {
 	UpdateNode(ctx context.Context, u storage.KGNodeUpdate) (storage.KGNode, error)
 	DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error
 	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
-	DeleteEdge(ctx context.Context, id uuid.UUID) error
+	DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error
 	NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
-	SetNodeAgent(ctx context.Context, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
+	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
 	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
 	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
 	UpsertToolGrant(ctx context.Context, g storage.NewToolGrant) error

--- a/internal/rpc/campaign_crud.go
+++ b/internal/rpc/campaign_crud.go
@@ -151,6 +151,7 @@ func (s *CampaignServer) UpdateAgent(
 	m := req.Msg
 	updated, err := s.store.UpdateAgent(ctx, storage.AgentUpdate{
 		ID:          id,
+		CampaignID:  c.ID,
 		Name:        m.GetName(),
 		Title:       m.GetTitle(),
 		Persona:     m.GetPersona(),
@@ -179,7 +180,20 @@ func (s *CampaignServer) DeleteAgent(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
 	}
 
-	switch err := s.store.DeleteAgent(ctx, id); {
+	// Resolve the active campaign and scope the delete to it (#342): the store's
+	// DELETE matches (id, campaign_id), so an Agent in another campaign is never
+	// removable through this session — it reads back as CodeNotFound, and the Butler
+	// guard still fires for the active campaign's own Butler.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("DeleteAgent: get active campaign failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	switch err := s.store.DeleteAgent(ctx, c.ID, id); {
 	case err == nil:
 		return connect.NewResponse(&managementv1.DeleteAgentResponse{}), nil
 	case errors.Is(err, storage.ErrButlerUndeletable):

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -81,6 +81,11 @@ type fakeCampaignStore struct {
 	updateErr error
 	deleteErr error
 	nextColor int
+	// updateAgentCampaign/deleteAgentCampaign record the campaign id the agent
+	// mutations were scoped to (#342), so a unit test can assert the handler passed
+	// the resolved active campaign down to storage.
+	updateAgentCampaign uuid.UUID
+	deleteAgentCampaign uuid.UUID
 
 	created []storage.NewAgent
 
@@ -92,6 +97,11 @@ type fakeCampaignStore struct {
 	nodeListErr   error
 	nodeUpdateErr error
 	nodeDeleteErr error
+	// updateNodeCampaign/deleteNodeCampaign record the campaign id the KG-Node
+	// mutations were scoped to (#342), so a unit test can assert the handler passed
+	// the resolved active campaign down to storage.
+	updateNodeCampaign uuid.UUID
+	deleteNodeCampaign uuid.UUID
 
 	// KG Edge state (#132): edgesCreated records CreateEdge inputs; edgesOut/edgesIn
 	// back NodeEdges; setAgentCalls records SetNodeAgent inputs; setAgentNode is the
@@ -135,6 +145,11 @@ type fakeCampaignStore struct {
 	charListErr       error
 	charUpdateErr     error
 	charDeleteErr     error
+	// charUpdateCampaign/charDeleteCampaign record the campaign id the Character
+	// mutations were scoped to (#342): the handler resolves the active campaign and
+	// passes it down, so another campaign's Character is never mutable.
+	charUpdateCampaign uuid.UUID
+	charDeleteCampaign uuid.UUID
 }
 
 // setAgentCall records one SetNodeAgent invocation for assertions.
@@ -290,6 +305,7 @@ func (f *fakeCampaignStore) CreateAgent(_ context.Context, a storage.NewAgent) (
 }
 
 func (f *fakeCampaignStore) UpdateAgent(_ context.Context, u storage.AgentUpdate) (storage.Agent, error) {
+	f.updateAgentCampaign = u.CampaignID
 	if f.updateErr != nil {
 		return storage.Agent{}, f.updateErr
 	}
@@ -307,7 +323,8 @@ func (f *fakeCampaignStore) UpdateAgent(_ context.Context, u storage.AgentUpdate
 	return a, nil
 }
 
-func (f *fakeCampaignStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
+func (f *fakeCampaignStore) DeleteAgent(_ context.Context, campaignID, id uuid.UUID) error {
+	f.deleteAgentCampaign = campaignID
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -341,6 +358,7 @@ func (f *fakeCampaignStore) ListNodes(_ context.Context, campaignID uuid.UUID) (
 }
 
 func (f *fakeCampaignStore) UpdateNode(_ context.Context, u storage.KGNodeUpdate) (storage.KGNode, error) {
+	f.updateNodeCampaign = u.CampaignID
 	if f.nodeUpdateErr != nil {
 		return storage.KGNode{}, f.nodeUpdateErr
 	}
@@ -355,7 +373,8 @@ func (f *fakeCampaignStore) UpdateNode(_ context.Context, u storage.KGNodeUpdate
 	return storage.KGNode{}, storage.ErrNotFound
 }
 
-func (f *fakeCampaignStore) DeleteNode(_ context.Context, id uuid.UUID) error {
+func (f *fakeCampaignStore) DeleteNode(_ context.Context, campaignID, id uuid.UUID) error {
+	f.deleteNodeCampaign = campaignID
 	if f.nodeDeleteErr != nil {
 		return f.nodeDeleteErr
 	}
@@ -944,5 +963,62 @@ func TestDeleteAgent_HappyPath(t *testing.T) {
 	}
 	if _, ok := store.agents[id]; ok {
 		t.Error("agent was not removed from the store")
+	}
+}
+
+// TestUpdateAgent_ScopesToActiveCampaign is #342: the handler resolves the active
+// campaign and passes its id down, so the store's UPDATE matches (id, campaign_id)
+// and a cross-campaign write is refused server-side.
+func TestUpdateAgent_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old"}
+	client := crudClient(t, store)
+
+	if _, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: id.String(), Name: "New"})); err != nil {
+		t.Fatalf("UpdateAgent: %v", err)
+	}
+	if store.updateAgentCampaign != activeID {
+		t.Errorf("UpdateAgent scoped to %s, want active %s", store.updateAgentCampaign, activeID)
+	}
+}
+
+// TestDeleteAgent_ScopesToActiveCampaign is #342: the delete is scoped to the
+// resolved active campaign, so another campaign's Agent is never removable.
+func TestDeleteAgent_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	id := uuid.New()
+	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Doomed"}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	if store.deleteAgentCampaign != activeID {
+		t.Errorf("DeleteAgent scoped to %s, want active %s", store.deleteAgentCampaign, activeID)
+	}
+}
+
+// TestDeleteAgent_NoActiveCampaignIsNotFound is #342: with no active campaign the
+// scoped delete cannot resolve an owner and the handler returns CodeNotFound
+// rather than deleting by bare id.
+func TestDeleteAgent_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.DeleteAgent(context.Background(),
+		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
 	}
 }

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -116,6 +116,11 @@ type fakeCampaignStore struct {
 	setAgentCalls []setAgentCall
 	setAgentNode  storage.KGNode
 	setAgentErr   error
+	// deleteEdgeCampaign/setAgentCampaign record the campaign id the Edge-delete /
+	// voiced-by link were scoped to (#342), so a unit test can assert the handler
+	// passed the resolved active campaign down.
+	deleteEdgeCampaign uuid.UUID
+	setAgentCampaign   uuid.UUID
 
 	// KG Node search state (#131): searchResults is returned verbatim so the
 	// handler's 1:1 rank-order mapping is asserted; searchQuery/searchLimit/searchCalls
@@ -401,7 +406,8 @@ func (f *fakeCampaignStore) CreateEdge(_ context.Context, e storage.NewKGEdge) (
 	}, nil
 }
 
-func (f *fakeCampaignStore) DeleteEdge(_ context.Context, _ uuid.UUID) error {
+func (f *fakeCampaignStore) DeleteEdge(_ context.Context, campaignID, _ uuid.UUID) error {
+	f.deleteEdgeCampaign = campaignID
 	return f.edgeDeleteErr
 }
 
@@ -409,7 +415,8 @@ func (f *fakeCampaignStore) NodeEdges(_ context.Context, _ uuid.UUID) ([]storage
 	return f.edgesOut, f.edgesIn, f.nodeEdgesErr
 }
 
-func (f *fakeCampaignStore) SetNodeAgent(_ context.Context, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error) {
+func (f *fakeCampaignStore) SetNodeAgent(_ context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error) {
+	f.setAgentCampaign = campaignID
 	if f.setAgentErr != nil {
 		return storage.KGNode{}, f.setAgentErr
 	}

--- a/internal/rpc/campaign_grant.go
+++ b/internal/rpc/campaign_grant.go
@@ -72,10 +72,20 @@ func (s *CampaignServer) UpdateToolGrant(
 	if !ok {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("unknown tool"))
 	}
-	// Pre-check the Agent exists so granting for a deleted Agent (stale second
-	// tab) is CodeNotFound, not a tool_agent_grant FK violation surfaced as a 500
-	// (issue #215) — mirrors the sibling UpdateAgent/DeleteAgent mapping.
-	if err := s.requireAgent(ctx, agentID); err != nil {
+	// Resolve the active campaign and require the Agent to belong to it (#342): a
+	// Tool Grant write is keyed on agent_id alone, so without this an operator on
+	// campaign A could grant/revoke Tools on campaign B's Agent (incl. B's Butler).
+	// The scoped check refuses a cross-campaign target as CodeNotFound before any
+	// write — and still maps a deleted Agent to CodeNotFound (issue #215).
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("UpdateToolGrant: get active campaign failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if err := s.requireAgentInCampaign(ctx, c.ID, agentID); err != nil {
 		return nil, err
 	}
 
@@ -130,6 +140,28 @@ func (s *CampaignServer) requireAgent(ctx context.Context, agentID uuid.UUID) er
 		}
 		slog.Default().Error("tool grant: agent lookup failed", "agent_id", agentID, "err", err)
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return nil
+}
+
+// requireAgentInCampaign is requireAgent scoped to an owning Campaign (#342): the
+// Agent must both exist AND belong to campaignID, else CodeNotFound. Agents never
+// move between Campaigns (campaign_id is immutable), so the read-then-compare is
+// race-free — it verifies ownership before a Tool Grant mutation keyed on agent_id
+// alone can reach another campaign's Agent. Any other lookup failure is
+// CodeInternal.
+func (s *CampaignServer) requireAgentInCampaign(ctx context.Context, campaignID, agentID uuid.UUID) error {
+	a, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("tool grant: agent lookup failed", "agent_id", agentID, "err", err)
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if a.CampaignID != campaignID {
+		// The Agent is in another Campaign — invisible to this operator's session.
+		return connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
 	}
 	return nil
 }

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -153,6 +153,71 @@ func TestToolGrants_GhostAgent_Integration(t *testing.T) {
 	}
 }
 
+// TestToolGrants_CrossCampaign_Integration is #342: an operator whose active
+// campaign is A must not be able to grant or revoke Tools on campaign B's Agent
+// (incl. B's Butler). With a live Voice Session pinning the active campaign to A,
+// UpdateToolGrant against B's Butler is CodeNotFound in BOTH directions (grant and
+// revoke), and B's seeded grant rows are left untouched.
+func TestToolGrants_CrossCampaign_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignA := seedStore(t, dsn) // A + its auto-Butler (seeded dice grant)
+	ctx := context.Background()
+
+	// A second campaign B under the same tenant, with its own auto-Butler.
+	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	butlerB, err := store.GetButler(ctx, campaignB)
+	if err != nil {
+		t.Fatalf("GetButler B: %v", err)
+	}
+
+	// Pin the active campaign to A via a live Voice Session, then mount the server.
+	srv := rpc.NewCampaignServer(store)
+	srv.SetSessions(liveMgr(campaignA))
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler())
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, s.URL, connect.WithProtoJSON())
+
+	before, err := store.ListToolGrants(ctx, butlerB.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants(butlerB) before: %v", err)
+	}
+
+	// Revoke B's Butler dice while active on A → refused.
+	_, err = client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: butlerB.ID.String(), ToolName: "dice", Granted: false,
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("cross-campaign UpdateToolGrant(revoke) code = %v, want NotFound", got)
+	}
+	// Grant-with-config on B's Butler while active on A → refused.
+	_, err = client.UpdateToolGrant(ctx, connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+		AgentId: butlerB.ID.String(), ToolName: "dice", Granted: true, Config: `{"scope":"all"}`,
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("cross-campaign UpdateToolGrant(grant) code = %v, want NotFound", got)
+	}
+
+	// B's Butler grants are byte-for-byte unchanged — no cross-campaign write landed.
+	after, err := store.ListToolGrants(ctx, butlerB.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants(butlerB) after: %v", err)
+	}
+	if len(before) != len(after) {
+		t.Fatalf("cross-campaign grant write leaked: before %d rows, after %d", len(before), len(after))
+	}
+}
+
 // listGrants is a small helper that lists an Agent's grant states or fails the test.
 func listGrants(t *testing.T, client managementv1connect.CampaignServiceClient, agentID string) []*managementv1.ToolGrant {
 	t.Helper()

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -96,6 +96,47 @@ func TestToolGrant_GhostAgentNotFound(t *testing.T) {
 	}
 }
 
+// TestUpdateToolGrant_CrossCampaignIsNotFound is #342: an operator whose active
+// campaign is A cannot grant/revoke Tools on an Agent that belongs to campaign B —
+// the write path requires the Agent to be in the active campaign, so a mismatch is
+// CodeNotFound and nothing is written.
+func TestUpdateToolGrant_CrossCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	// The Agent exists, but in ANOTHER campaign.
+	foreignAgent := uuid.New()
+	store.agents[foreignAgent] = storage.Agent{ID: foreignAgent, CampaignID: uuid.New()}
+	client := crudClient(t, store)
+
+	_, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: foreignAgent.String(), ToolName: "dice", Granted: true,
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (cross-campaign agent)", got)
+	}
+}
+
+// TestUpdateToolGrant_NoActiveCampaignIsNotFound is #342: without an active
+// campaign the grant write cannot resolve an owning campaign and is CodeNotFound.
+func TestUpdateToolGrant_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	agentID := registerAgent(store)
+	client := crudClient(t, store)
+
+	_, err := client.UpdateToolGrant(context.Background(),
+		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
+			AgentId: agentID.String(), ToolName: "dice", Granted: true,
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (no active campaign)", got)
+	}
+}
+
 func TestListToolGrants_InvalidAgentID(t *testing.T) {
 	t.Parallel()
 	client := crudClient(t, newFakeStore())

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -114,13 +114,13 @@ func (fakeReader) DeleteNode(context.Context, uuid.UUID, uuid.UUID) error {
 func (fakeReader) CreateEdge(context.Context, storage.NewKGEdge) (storage.KGEdge, error) {
 	return storage.KGEdge{}, nil
 }
-func (fakeReader) DeleteEdge(context.Context, uuid.UUID) error {
+func (fakeReader) DeleteEdge(context.Context, uuid.UUID, uuid.UUID) error {
 	return nil
 }
 func (fakeReader) NodeEdges(context.Context, uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
 	return nil, nil, nil
 }
-func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.NullUUID) (storage.KGNode, error) {
+func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.UUID, uuid.NullUUID) (storage.KGNode, error) {
 	return storage.KGNode{}, nil
 }
 func (fakeReader) SearchNodes(context.Context, uuid.UUID, string, int) ([]storage.KGNode, error) {

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -96,7 +96,7 @@ func (fakeReader) CreateAgent(context.Context, storage.NewAgent) (uuid.UUID, err
 func (fakeReader) UpdateAgent(context.Context, storage.AgentUpdate) (storage.Agent, error) {
 	return storage.Agent{}, storage.ErrNotFound
 }
-func (fakeReader) DeleteAgent(context.Context, uuid.UUID) error {
+func (fakeReader) DeleteAgent(context.Context, uuid.UUID, uuid.UUID) error {
 	return nil
 }
 func (fakeReader) CreateNode(context.Context, storage.NewKGNode) (storage.KGNode, error) {
@@ -108,7 +108,7 @@ func (fakeReader) ListNodes(context.Context, uuid.UUID) ([]storage.KGNode, error
 func (fakeReader) UpdateNode(context.Context, storage.KGNodeUpdate) (storage.KGNode, error) {
 	return storage.KGNode{}, nil
 }
-func (fakeReader) DeleteNode(context.Context, uuid.UUID) error {
+func (fakeReader) DeleteNode(context.Context, uuid.UUID, uuid.UUID) error {
 	return nil
 }
 func (fakeReader) CreateEdge(context.Context, storage.NewKGEdge) (storage.KGEdge, error) {
@@ -144,7 +144,7 @@ func (fakeReader) CreateCharacter(context.Context, storage.NewCharacter) (uuid.U
 func (fakeReader) UpdateCharacter(context.Context, storage.CharacterUpdate) (storage.Character, error) {
 	return storage.Character{}, nil
 }
-func (fakeReader) DeleteCharacter(context.Context, uuid.UUID) error {
+func (fakeReader) DeleteCharacter(context.Context, uuid.UUID, uuid.UUID) error {
 	return nil
 }
 

--- a/internal/rpc/character.go
+++ b/internal/rpc/character.go
@@ -119,8 +119,21 @@ func (s *CampaignServer) UpdateCharacter(
 		return nil, err
 	}
 
+	// Resolve the active campaign and scope the write to it (#342): the store's
+	// UPDATE matches (id, campaign_id), so a Character in another campaign is never
+	// mutable through this operator's session — it reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("UpdateCharacter: get active campaign failed", "character_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
 	updated, err := s.store.UpdateCharacter(ctx, storage.CharacterUpdate{
 		ID:            id,
+		CampaignID:    c.ID,
 		Name:          name,
 		Aliases:       m.GetAliases(),
 		DiscordUserID: discordUserID,
@@ -154,15 +167,23 @@ func (s *CampaignServer) DeleteCharacter(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid character id"))
 	}
 
-	switch err := s.store.DeleteCharacter(ctx, id); {
+	// Resolve the active campaign and scope the delete to it (#342): the store's
+	// DELETE matches (id, campaign_id), so another campaign's Character is never
+	// removable through this session — it reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("DeleteCharacter: get active campaign failed", "character_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	switch err := s.store.DeleteCharacter(ctx, c.ID, id); {
 	case err == nil:
 		// The deleted mapping's Discord User now falls back to guild name / generic
-		// label: drop the active campaign's cached resolutions (#281). The delete is
-		// by raw id, so we scope invalidation to the campaign in view (best-effort —
-		// the 5min TTL self-heals if resolution misses).
-		if c, cerr := s.activeCampaign(ctx); cerr == nil {
-			s.invalidateSpeakers(c.ID)
-		}
+		// label: drop the active campaign's cached resolutions (#281).
+		s.invalidateSpeakers(c.ID)
 		return connect.NewResponse(&managementv1.DeleteCharacterResponse{}), nil
 	case errors.Is(err, storage.ErrNotFound):
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("character not found"))

--- a/internal/rpc/character_test.go
+++ b/internal/rpc/character_test.go
@@ -300,6 +300,24 @@ func TestUpdateCharacter_NonSnowflakeIsInvalidArgument(t *testing.T) {
 	}
 }
 
+// TestUpdateCharacter_NoActiveCampaignIsNotFound is #342: UpdateCharacter gained
+// active-campaign resolution to scope the write; with no active campaign it returns
+// CodeNotFound rather than mutating by bare id.
+func TestUpdateCharacter_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.UpdateCharacter(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCharacterRequest{
+			Id: uuid.NewString(), Name: "New", DiscordUserId: "111111111111111111",
+		}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
 // --- DeleteCharacter ---
 
 func TestDeleteCharacter_Removes(t *testing.T) {

--- a/internal/rpc/character_test.go
+++ b/internal/rpc/character_test.go
@@ -35,6 +35,7 @@ func (f *fakeCampaignStore) CreateCharacter(_ context.Context, c storage.NewChar
 }
 
 func (f *fakeCampaignStore) UpdateCharacter(_ context.Context, u storage.CharacterUpdate) (storage.Character, error) {
+	f.charUpdateCampaign = u.CampaignID
 	if f.charUpdateErr != nil {
 		return storage.Character{}, f.charUpdateErr
 	}
@@ -49,7 +50,8 @@ func (f *fakeCampaignStore) UpdateCharacter(_ context.Context, u storage.Charact
 	return storage.Character{}, storage.ErrNotFound
 }
 
-func (f *fakeCampaignStore) DeleteCharacter(_ context.Context, id uuid.UUID) error {
+func (f *fakeCampaignStore) DeleteCharacter(_ context.Context, campaignID, id uuid.UUID) error {
+	f.charDeleteCampaign = campaignID
 	if f.charDeleteErr != nil {
 		return f.charDeleteErr
 	}
@@ -331,6 +333,66 @@ func TestDeleteCharacter_InvalidIdIsInvalidArgument(t *testing.T) {
 func TestDeleteCharacter_UnknownIdIsNotFound(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
+	client := crudClient(t, store)
+
+	_, err := client.DeleteCharacter(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+// TestUpdateCharacter_ScopesToActiveCampaign is #342: the handler resolves the
+// active campaign and passes its id down, so the store's UPDATE matches (id,
+// campaign_id) and a cross-campaign write is refused server-side.
+func TestUpdateCharacter_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	id := uuid.New()
+	store.characters = []storage.Character{
+		{ID: id, CampaignID: activeID, Name: "Old", DiscordUserID: "111111111111111111"},
+	}
+	client := crudClient(t, store)
+
+	if _, err := client.UpdateCharacter(context.Background(),
+		connect.NewRequest(&managementv1.UpdateCharacterRequest{
+			Id: id.String(), Name: "New", DiscordUserId: "111111111111111111",
+		})); err != nil {
+		t.Fatalf("UpdateCharacter: %v", err)
+	}
+	if store.charUpdateCampaign != activeID {
+		t.Errorf("UpdateCharacter scoped to %s, want active %s", store.charUpdateCampaign, activeID)
+	}
+}
+
+// TestDeleteCharacter_ScopesToActiveCampaign is #342: the delete is scoped to the
+// resolved active campaign, so another campaign's Character is never removable.
+func TestDeleteCharacter_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	id := uuid.New()
+	store.characters = []storage.Character{{ID: id, CampaignID: activeID, Name: "Doomed", DiscordUserID: "1"}}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteCharacter(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteCharacter: %v", err)
+	}
+	if store.charDeleteCampaign != activeID {
+		t.Errorf("DeleteCharacter scoped to %s, want active %s", store.charDeleteCampaign, activeID)
+	}
+}
+
+// TestDeleteCharacter_NoActiveCampaignIsNotFound is #342: without an active
+// campaign the scoped delete cannot resolve an owner and returns CodeNotFound.
+func TestDeleteCharacter_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
 	client := crudClient(t, store)
 
 	_, err := client.DeleteCharacter(context.Background(),

--- a/internal/rpc/kg_edge.go
+++ b/internal/rpc/kg_edge.go
@@ -78,7 +78,18 @@ func (s *CampaignServer) DeleteEdge(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid edge id"))
 	}
-	switch err := s.store.DeleteEdge(ctx, id); {
+	// Resolve the active campaign and scope the delete to it (#342): the store's
+	// DELETE matches (id, campaign_id), so an Edge in another campaign is never
+	// removable through this session — it reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("DeleteEdge: get active campaign failed", "edge_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	switch err := s.store.DeleteEdge(ctx, c.ID, id); {
 	case err == nil:
 		return connect.NewResponse(&managementv1.DeleteEdgeResponse{}), nil
 	case errors.Is(err, storage.ErrNotFound):
@@ -134,7 +145,21 @@ func (s *CampaignServer) SetNodeAgent(
 		agentID = uuid.NullUUID{UUID: parsed, Valid: true}
 	}
 
-	updated, err := s.store.SetNodeAgent(ctx, nodeID, agentID)
+	// Resolve the active campaign and scope both the link and the unlink to it
+	// (#342): the store matches the Node's campaign_id against the active campaign,
+	// so another campaign's Node is never re-voiced nor unlinked through this
+	// session — and a link's Agent must also belong to the active campaign. A
+	// cross-campaign Node/Agent reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("SetNodeAgent: get active campaign failed", "node_id", nodeID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	updated, err := s.store.SetNodeAgent(ctx, c.ID, nodeID, agentID)
 	switch {
 	case err == nil:
 		return connect.NewResponse(&managementv1.SetNodeAgentResponse{Node: toProtoNode(updated)}), nil

--- a/internal/rpc/kg_edge_integration_test.go
+++ b/internal/rpc/kg_edge_integration_test.go
@@ -46,8 +46,14 @@ func TestKGEdge_Integration(t *testing.T) {
 		t.Fatalf("CreateAgent: %v", err)
 	}
 
+	// Pin the active campaign to the seeded one for the whole test: it later
+	// creates a SECOND campaign (the cross-campaign endpoint check), which would
+	// otherwise become the most-recent → active and (correctly, #342) scope the
+	// edge delete away from the seeded campaign the edge lives in.
+	server := rpc.NewCampaignServer(store)
+	server.SetSessions(liveMgr(campaignID))
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(store).Handler())
+	mux.Handle(server.Handler())
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	client := managementv1connect.NewCampaignServiceClient(

--- a/internal/rpc/kg_edge_test.go
+++ b/internal/rpc/kg_edge_test.go
@@ -158,6 +158,39 @@ func TestDeleteEdge_NotFoundIsNotFound(t *testing.T) {
 	}
 }
 
+// TestDeleteEdge_ScopesToActiveCampaign is #342: the delete is scoped to the
+// resolved active campaign, so another campaign's Edge is never removable.
+func TestDeleteEdge_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteEdge(context.Background(),
+		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()})); err != nil {
+		t.Fatalf("DeleteEdge: %v", err)
+	}
+	if store.deleteEdgeCampaign != activeID {
+		t.Errorf("DeleteEdge scoped to %s, want active %s", store.deleteEdgeCampaign, activeID)
+	}
+}
+
+// TestDeleteEdge_NoActiveCampaignIsNotFound is #342: without an active campaign the
+// scoped delete cannot resolve an owner and returns CodeNotFound.
+func TestDeleteEdge_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.DeleteEdge(context.Background(),
+		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
 // TestListNodeEdges_SplitsAndJoins is the AC's incident-edge list: outgoing and
 // incoming are returned as SEPARATE lists (strictly directional), each carrying
 // the server-joined endpoint name + type so the UI needs no N+1.
@@ -311,6 +344,43 @@ func TestSetNodeAgent_StorageErrorsMapToCodes(t *testing.T) {
 				t.Errorf("code = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSetNodeAgent_ScopesToActiveCampaign is #342: the handler resolves the active
+// campaign and passes its id down, so the store matches the Node's campaign against
+// it — a cross-campaign link/unlink is refused server-side.
+func TestSetNodeAgent_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	node := uuid.New()
+	agent := uuid.New()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	store.setAgentNode = storage.KGNode{ID: node, Type: storage.KGNodeNPC, Name: "Bart"}
+	client := crudClient(t, store)
+
+	if _, err := client.SetNodeAgent(context.Background(),
+		connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: node.String(), AgentId: agent.String()})); err != nil {
+		t.Fatalf("SetNodeAgent: %v", err)
+	}
+	if store.setAgentCampaign != activeID {
+		t.Errorf("SetNodeAgent scoped to %s, want active %s", store.setAgentCampaign, activeID)
+	}
+}
+
+// TestSetNodeAgent_NoActiveCampaignIsNotFound is #342: without an active campaign
+// the scoped link/unlink cannot resolve an owner and returns CodeNotFound.
+func TestSetNodeAgent_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.SetNodeAgent(context.Background(),
+		connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: uuid.NewString(), AgentId: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
 	}
 }
 

--- a/internal/rpc/kg_node.go
+++ b/internal/rpc/kg_node.go
@@ -102,11 +102,24 @@ func (s *CampaignServer) UpdateNode(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
 	}
 
+	// Resolve the active campaign and scope the write to it (#342): the store's
+	// UPDATE matches (id, campaign_id), so a Node in another campaign is never
+	// mutable through this session — it reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("UpdateNode: get active campaign failed", "node_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
 	updated, err := s.store.UpdateNode(ctx, storage.KGNodeUpdate{
-		ID:        id,
-		Name:      strings.TrimSpace(m.GetName()),
-		Body:      m.GetBody(),
-		GMPrivate: m.GetGmPrivate(),
+		ID:         id,
+		CampaignID: c.ID,
+		Name:       strings.TrimSpace(m.GetName()),
+		Body:       m.GetBody(),
+		GMPrivate:  m.GetGmPrivate(),
 	})
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
@@ -129,7 +142,19 @@ func (s *CampaignServer) DeleteNode(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid node id"))
 	}
 
-	switch err := s.store.DeleteNode(ctx, id); {
+	// Resolve the active campaign and scope the delete to it (#342): the store's
+	// DELETE matches (id, campaign_id), so a Node in another campaign is never
+	// removable through this session — it reads back as CodeNotFound.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("DeleteNode: get active campaign failed", "node_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	switch err := s.store.DeleteNode(ctx, c.ID, id); {
 	case err == nil:
 		return connect.NewResponse(&managementv1.DeleteNodeResponse{}), nil
 	case errors.Is(err, storage.ErrNotFound):

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -260,6 +260,22 @@ func TestUpdateNode_NotFoundIsNotFound(t *testing.T) {
 	}
 }
 
+// TestUpdateNode_NoActiveCampaignIsNotFound is #342: UpdateNode gained
+// active-campaign resolution to scope the write; with no active campaign it returns
+// CodeNotFound rather than mutating by bare id.
+func TestUpdateNode_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
 func TestUpdateNode_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -326,6 +326,62 @@ func TestDeleteNode_StorageErrorIsInternal(t *testing.T) {
 	}
 }
 
+// TestUpdateNode_ScopesToActiveCampaign is #342: the handler resolves the active
+// campaign and passes its id down, so the store's UPDATE matches (id, campaign_id)
+// and a cross-campaign write is refused server-side.
+func TestUpdateNode_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "old"}}
+	client := crudClient(t, store)
+
+	if _, err := client.UpdateNode(context.Background(),
+		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "New"})); err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	if store.updateNodeCampaign != activeID {
+		t.Errorf("UpdateNode scoped to %s, want active %s", store.updateNodeCampaign, activeID)
+	}
+}
+
+// TestDeleteNode_ScopesToActiveCampaign is #342: the delete is scoped to the
+// resolved active campaign, so another campaign's Node is never removable.
+func TestDeleteNode_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "gone soon"}}
+	client := crudClient(t, store)
+
+	if _, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+	if store.deleteNodeCampaign != activeID {
+		t.Errorf("DeleteNode scoped to %s, want active %s", store.deleteNodeCampaign, activeID)
+	}
+}
+
+// TestDeleteNode_NoActiveCampaignIsNotFound is #342: without an active campaign the
+// scoped delete cannot resolve an owner and returns CodeNotFound.
+func TestDeleteNode_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.DeleteNode(context.Background(),
+		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
 func TestSearchNodes_EmptyQueryIsInvalidArgument(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()

--- a/internal/storage/agent_crud_test.go
+++ b/internal/storage/agent_crud_test.go
@@ -57,6 +57,7 @@ func TestCreateUpdateDeleteCharacterAgent(t *testing.T) {
 	// Update the editable fields.
 	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
 		ID:          id,
+		CampaignID:  campaignID,
 		Name:        "Bartholomew",
 		Title:       "Keeper of the Stonehill Inn",
 		Persona:     "Now eloquent and grandiose.",
@@ -87,7 +88,7 @@ func TestCreateUpdateDeleteCharacterAgent(t *testing.T) {
 	}
 
 	// Delete it; it must then be gone.
-	if err := st.DeleteAgent(ctx, id); err != nil {
+	if err := st.DeleteAgent(ctx, campaignID, id); err != nil {
 		t.Fatalf("DeleteAgent: %v", err)
 	}
 	if _, err := st.GetAgent(ctx, id); !errors.Is(err, storage.ErrNotFound) {
@@ -109,7 +110,7 @@ func TestDeleteButlerRejected(t *testing.T) {
 		t.Fatalf("GetButler: %v", err)
 	}
 
-	err = st.DeleteAgent(ctx, butler.ID)
+	err = st.DeleteAgent(ctx, campaignID, butler.ID)
 	if !errors.Is(err, storage.ErrButlerUndeletable) {
 		t.Fatalf("DeleteAgent(butler) = %v, want ErrButlerUndeletable", err)
 	}
@@ -136,6 +137,7 @@ func TestUpdateButlerKeepsAddressOnly(t *testing.T) {
 
 	updated, err := st.UpdateAgent(ctx, storage.AgentUpdate{
 		ID:          butler.ID,
+		CampaignID:  campaignID,
 		Name:        "Glyphoxa the Wise",
 		Title:       "Game Master's Familiar",
 		Persona:     "A patient arcane butler.",
@@ -202,14 +204,73 @@ func TestCreateAgentAssignsStableSpeakerColors(t *testing.T) {
 // mutating store ops (the RPC maps it to CodeNotFound).
 func TestDeleteAndUpdateAgentNotFound(t *testing.T) {
 	dsn := startPostgres(t)
-	pool, _, _ := seedCampaign(t, dsn)
+	pool, _, campaignID := seedCampaign(t, dsn)
 	ctx := context.Background()
 	st := storage.New(pool)
 
-	if err := st.DeleteAgent(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+	if err := st.DeleteAgent(ctx, campaignID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("DeleteAgent(random) = %v, want ErrNotFound", err)
 	}
-	if _, err := st.UpdateAgent(ctx, storage.AgentUpdate{ID: uuid.New(), Name: "Nobody"}); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := st.UpdateAgent(ctx, storage.AgentUpdate{ID: uuid.New(), CampaignID: campaignID, Name: "Nobody"}); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("UpdateAgent(random) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestAgentMutationsAreCampaignScoped is #342: UpdateAgent/DeleteAgent match
+// (id, campaign_id), so passing another Campaign's id refuses the mutation with
+// ErrNotFound and leaves the Agent — and the other Campaign's Butler — untouched.
+func TestAgentMutationsAreCampaignScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	var campaignB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other Table') RETURNING id`,
+		tenantID).Scan(&campaignB); err != nil {
+		t.Fatalf("insert campaign B: %v", err)
+	}
+
+	// A Character in campaign A.
+	id, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignA, Role: storage.AgentRoleCharacter, Name: "Aravel",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent A: %v", err)
+	}
+
+	// Updating it scoped to campaign B must refuse (ErrNotFound) and change nothing.
+	if _, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID: id, CampaignID: campaignB, Name: "Hijacked",
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign UpdateAgent = %v, want ErrNotFound", err)
+	}
+	// Deleting it scoped to campaign B must refuse (ErrNotFound) and leave the row.
+	if err := st.DeleteAgent(ctx, campaignB, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign DeleteAgent = %v, want ErrNotFound", err)
+	}
+
+	// The Agent is intact: still in campaign A with its original name.
+	got, err := st.GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAgent after refused cross-campaign mutations: %v", err)
+	}
+	if got.Name != "Aravel" || got.CampaignID != campaignA {
+		t.Errorf("cross-campaign mutation leaked through: %+v", got)
+	}
+
+	// Campaign B's own Butler is undeletable AND unreachable from campaign A: a
+	// delete of B's Butler scoped to A is a plain ErrNotFound (never a butler-guard
+	// leak), and B's Butler survives.
+	butlerB, err := st.GetButler(ctx, campaignB)
+	if err != nil {
+		t.Fatalf("GetButler B: %v", err)
+	}
+	if err := st.DeleteAgent(ctx, campaignA, butlerB.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign DeleteAgent(butlerB scoped to A) = %v, want ErrNotFound", err)
+	}
+	if _, err := st.GetButler(ctx, campaignB); err != nil {
+		t.Fatalf("campaign B Butler gone after a cross-campaign delete attempt: %v", err)
 	}
 }

--- a/internal/storage/character.go
+++ b/internal/storage/character.go
@@ -45,10 +45,13 @@ type NewCharacter struct {
 
 // CharacterUpdate is the input to UpdateCharacter — a full-field save of the
 // editor fields. DiscordUserID is included so an operator can rebind a Character
-// to a different Discord User (it stays NOT NULL). CampaignID is not here: a
-// Character never moves between Campaigns; the row is addressed by ID alone.
+// to a different Discord User (it stays NOT NULL). CampaignID is the owning
+// Campaign the write is scoped to (#342): the UPDATE matches (id, campaign_id),
+// so a row in another Campaign is invisible and yields ErrNotFound — a Character
+// never moves between Campaigns, and no operator can mutate one they do not own.
 type CharacterUpdate struct {
 	ID            uuid.UUID
+	CampaignID    uuid.UUID
 	Name          string
 	Aliases       []string
 	DiscordUserID string
@@ -90,9 +93,12 @@ func (s *Store) CreateCharacter(ctx context.Context, n NewCharacter) (uuid.UUID,
 }
 
 // UpdateCharacter saves a Character's editor fields (name/aliases/discord_user_id)
-// and returns the updated row, stamping updated_at = now(). Rebinding
-// discord_user_id is a normal field write; a collision with another Character's
-// (campaign, discord_user_id) yields ErrConflict. A missing id yields ErrNotFound.
+// and returns the updated row, stamping updated_at = now(). The write is scoped to
+// (id, campaign_id) (#342), so a Character in another Campaign matches no row and
+// yields ErrNotFound — a cross-campaign mutation is refused server-side without a
+// separate ownership SELECT. Rebinding discord_user_id is a normal field write; a
+// collision with another Character's (campaign, discord_user_id) yields ErrConflict.
+// A missing id yields ErrNotFound.
 func (s *Store) UpdateCharacter(ctx context.Context, u CharacterUpdate) (Character, error) {
 	aliases := u.Aliases
 	if aliases == nil {
@@ -104,9 +110,9 @@ func (s *Store) UpdateCharacter(ctx context.Context, u CharacterUpdate) (Charact
 		    aliases = $3,
 		    discord_user_id = $4,
 		    updated_at = now()
-		  WHERE id = $1
+		  WHERE id = $1 AND campaign_id = $5
 		 RETURNING `+characterColumns,
-		u.ID, u.Name, aliases, u.DiscordUserID)
+		u.ID, u.Name, aliases, u.DiscordUserID, u.CampaignID)
 	updated, err := scanCharacter(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Character{}, ErrNotFound
@@ -120,10 +126,13 @@ func (s *Store) UpdateCharacter(ctx context.Context, u CharacterUpdate) (Charact
 	return updated, nil
 }
 
-// DeleteCharacter removes a Character by id. A missing id yields ErrNotFound so
-// the RPC can distinguish "gone" from "never existed".
-func (s *Store) DeleteCharacter(ctx context.Context, id uuid.UUID) error {
-	tag, err := s.db.Exec(ctx, `DELETE FROM character WHERE id = $1`, id)
+// DeleteCharacter removes a Character by id, scoped to its owning Campaign (#342):
+// the DELETE matches (id, campaign_id), so a Character in another Campaign is not
+// deleted and yields ErrNotFound — a cross-campaign delete is refused server-side.
+// A missing id likewise yields ErrNotFound so the RPC can distinguish "gone" from
+// "never existed".
+func (s *Store) DeleteCharacter(ctx context.Context, campaignID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM character WHERE id = $1 AND campaign_id = $2`, id, campaignID)
 	if err != nil {
 		return fmt.Errorf("storage: delete character %s: %w", id, err)
 	}

--- a/internal/storage/character_test.go
+++ b/internal/storage/character_test.go
@@ -133,6 +133,7 @@ func TestCharacterUpdateRebind(t *testing.T) {
 
 	updated, err := st.UpdateCharacter(ctx, storage.CharacterUpdate{
 		ID:            id,
+		CampaignID:    campaignA,
 		Name:          "New Name",
 		Aliases:       []string{"new", "renamed"},
 		DiscordUserID: "555555555555555555", // rebind to a different Discord User
@@ -151,7 +152,7 @@ func TestCharacterUpdateRebind(t *testing.T) {
 	}
 
 	if _, err := st.UpdateCharacter(ctx, storage.CharacterUpdate{
-		ID: uuid.New(), Name: "Ghost", DiscordUserID: "666666666666666666",
+		ID: uuid.New(), CampaignID: campaignA, Name: "Ghost", DiscordUserID: "666666666666666666",
 	}); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("UpdateCharacter unknown id: got %v, want ErrNotFound", err)
 	}
@@ -171,10 +172,10 @@ func TestCharacterDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCharacter: %v", err)
 	}
-	if err := st.DeleteCharacter(ctx, id); err != nil {
+	if err := st.DeleteCharacter(ctx, campaignA, id); err != nil {
 		t.Fatalf("DeleteCharacter: %v", err)
 	}
-	if err := st.DeleteCharacter(ctx, id); !errors.Is(err, storage.ErrNotFound) {
+	if err := st.DeleteCharacter(ctx, campaignA, id); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("DeleteCharacter twice: got %v, want ErrNotFound", err)
 	}
 
@@ -239,5 +240,91 @@ func TestGetCharacterByDiscordUser(t *testing.T) {
 	}
 	if _, err := st.GetCharacterByDiscordUser(ctx, campaignB, discordID); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("cross-campaign: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestCharacterMutationsAreCampaignScoped is #342: UpdateCharacter/DeleteCharacter
+// match (id, campaign_id), so passing another Campaign's id refuses the mutation
+// with ErrNotFound and leaves the Character untouched.
+func TestCharacterMutationsAreCampaignScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	var campaignB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other Table') RETURNING id`,
+		tenantID).Scan(&campaignB); err != nil {
+		t.Fatalf("insert campaign B: %v", err)
+	}
+
+	id, err := st.CreateCharacter(ctx, storage.NewCharacter{
+		CampaignID: campaignA, Name: "Aravel", DiscordUserID: "111111111111111111",
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter A: %v", err)
+	}
+
+	// Update scoped to campaign B must refuse and change nothing.
+	if _, err := st.UpdateCharacter(ctx, storage.CharacterUpdate{
+		ID: id, CampaignID: campaignB, Name: "Hijacked", DiscordUserID: "222222222222222222",
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign UpdateCharacter = %v, want ErrNotFound", err)
+	}
+	// Delete scoped to campaign B must refuse and leave the row.
+	if err := st.DeleteCharacter(ctx, campaignB, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign DeleteCharacter = %v, want ErrNotFound", err)
+	}
+
+	// The Character is intact under campaign A with its original fields.
+	got, err := st.GetCharacterByDiscordUser(ctx, campaignA, "111111111111111111")
+	if err != nil {
+		t.Fatalf("GetCharacterByDiscordUser after refused cross-campaign mutations: %v", err)
+	}
+	if got.ID != id || got.Name != "Aravel" {
+		t.Errorf("cross-campaign mutation leaked through: %+v", got)
+	}
+}
+
+// TestCharacterRebindConflict is #342 (the review's untested path): rebinding a
+// Character's discord_user_id onto another Character's (campaign, discord_user_id)
+// trips the UNIQUE index (Postgres 23505) and UpdateCharacter maps it to
+// ErrConflict — now proven against a real DB, not just a fake. The first row is
+// left unchanged.
+func TestCharacterRebindConflict(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	const takenID = "111111111111111111"
+	if _, err := st.CreateCharacter(ctx, storage.NewCharacter{
+		CampaignID: campaignA, Name: "Aravel", DiscordUserID: takenID,
+	}); err != nil {
+		t.Fatalf("CreateCharacter first: %v", err)
+	}
+	second, err := st.CreateCharacter(ctx, storage.NewCharacter{
+		CampaignID: campaignA, Name: "Borin", DiscordUserID: "222222222222222222",
+	})
+	if err != nil {
+		t.Fatalf("CreateCharacter second: %v", err)
+	}
+
+	// Rebind the second Character onto the first's Discord User → 23505 → ErrConflict.
+	if _, err := st.UpdateCharacter(ctx, storage.CharacterUpdate{
+		ID: second, CampaignID: campaignA, Name: "Borin", DiscordUserID: takenID,
+	}); !errors.Is(err, storage.ErrConflict) {
+		t.Fatalf("rebind onto a taken Discord User = %v, want ErrConflict", err)
+	}
+
+	// The second Character keeps its original binding; the conflicting write rolled
+	// back cleanly.
+	got, err := st.GetCharacterByDiscordUser(ctx, campaignA, "222222222222222222")
+	if err != nil {
+		t.Fatalf("GetCharacterByDiscordUser after conflict: %v", err)
+	}
+	if got.ID != second {
+		t.Errorf("conflicting rebind changed the row: %+v", got)
 	}
 }

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -210,9 +210,12 @@ func mapEdgeWriteErr(op string, err error) error {
 	return fmt.Errorf("storage: %s: %w", op, err)
 }
 
-// DeleteEdge removes a typed Edge by id. A missing id yields ErrNotFound.
-func (s *Store) DeleteEdge(ctx context.Context, id uuid.UUID) error {
-	tag, err := s.db.Exec(ctx, `DELETE FROM kg_edge WHERE id = $1`, id)
+// DeleteEdge removes a typed Edge by id, scoped to its owning Campaign (#342): the
+// DELETE matches (id, campaign_id), so an Edge in another Campaign is not deleted
+// and yields ErrNotFound — a cross-campaign delete is refused server-side. A
+// missing id likewise yields ErrNotFound.
+func (s *Store) DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM kg_edge WHERE id = $1 AND campaign_id = $2`, id, campaignID)
 	if err != nil {
 		return fmt.Errorf("storage: delete kg edge %s: %w", id, err)
 	}
@@ -261,18 +264,21 @@ func (s *Store) NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, inco
 }
 
 // SetNodeAgent links or unlinks a Node's Character NPC Agent (the "voiced by"
-// link, ADR-0008 amendment). A valid agentID links: a single UPDATE guards the
-// same-Campaign invariant race-free by matching the Node's campaign_id against the
-// Agent's in one statement — a missing or cross-campaign Agent matches no row and
-// yields ErrNotFound; a non-NPC Node trips the DB CHECK (ErrInvalidEdge); an Agent
-// already linked to another Node trips the UNIQUE index (ErrConflict). An invalid
-// agentID unlinks (agent_id = NULL). A missing Node yields ErrNotFound.
-func (s *Store) SetNodeAgent(ctx context.Context, nodeID uuid.UUID, agentID uuid.NullUUID) (KGNode, error) {
+// link, ADR-0008 amendment). Both paths are scoped to the owning Campaign (#342):
+// every UPDATE matches the Node's campaign_id against the caller's campaignID, so a
+// Node in another Campaign is invisible and yields ErrNotFound — a cross-campaign
+// link or unlink is refused server-side. A valid agentID links: the single UPDATE
+// also matches the Node's campaign against the Agent's in one statement, so a
+// missing or cross-campaign Agent matches no row and yields ErrNotFound; a non-NPC
+// Node trips the DB CHECK (ErrInvalidEdge); an Agent already linked to another Node
+// trips the UNIQUE index (ErrConflict). An invalid agentID unlinks (agent_id =
+// NULL). A missing Node yields ErrNotFound.
+func (s *Store) SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (KGNode, error) {
 	if !agentID.Valid {
 		row := s.db.QueryRow(ctx,
 			`UPDATE kg_node SET agent_id = NULL, updated_at = now()
-			  WHERE id = $1
-			 RETURNING `+kgNodeColumns, nodeID)
+			  WHERE id = $1 AND campaign_id = $2
+			 RETURNING `+kgNodeColumns, nodeID, campaignID)
 		n, err := scanKGNode(row)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return KGNode{}, ErrNotFound
@@ -286,12 +292,13 @@ func (s *Store) SetNodeAgent(ctx context.Context, nodeID uuid.UUID, agentID uuid
 	row := s.db.QueryRow(ctx,
 		`UPDATE kg_node SET agent_id = $2, updated_at = now()
 		  WHERE id = $1
+		    AND campaign_id = $3
 		    AND campaign_id = (SELECT campaign_id FROM agents WHERE id = $2)
-		 RETURNING `+kgNodeColumns, nodeID, agentID.UUID)
+		 RETURNING `+kgNodeColumns, nodeID, agentID.UUID, campaignID)
 	n, err := scanKGNode(row)
 	if errors.Is(err, pgx.ErrNoRows) {
-		// No row matched: the Node is missing, or the Agent is missing / in another
-		// Campaign (the subquery yielded no matching campaign_id).
+		// No row matched: the Node is missing / in another Campaign, or the Agent is
+		// missing / in another Campaign (the subquery yielded no matching campaign_id).
 		return KGNode{}, ErrNotFound
 	}
 	if err != nil {

--- a/internal/storage/kg_edge_test.go
+++ b/internal/storage/kg_edge_test.go
@@ -159,7 +159,7 @@ func TestNodeEdgesAndDelete(t *testing.T) {
 	}
 
 	// Deleting Aldric cascades the remaining incident Edge (Cyra knows Aldric).
-	if err := st.DeleteNode(ctx, aldric.ID); err != nil {
+	if err := st.DeleteNode(ctx, campaignID, aldric.ID); err != nil {
 		t.Fatalf("DeleteNode: %v", err)
 	}
 	outC, inC, err := st.NodeEdges(ctx, cyra.ID)
@@ -225,7 +225,7 @@ func TestSetNodeAgent(t *testing.T) {
 	if _, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
 		t.Fatalf("SetNodeAgent relink: %v", err)
 	}
-	if err := st.DeleteAgent(ctx, agentID); err != nil {
+	if err := st.DeleteAgent(ctx, campaignID, agentID); err != nil {
 		t.Fatalf("DeleteAgent: %v", err)
 	}
 	nodes, err := st.ListNodes(ctx, campaignID)

--- a/internal/storage/kg_edge_test.go
+++ b/internal/storage/kg_edge_test.go
@@ -144,10 +144,10 @@ func TestNodeEdgesAndDelete(t *testing.T) {
 	}
 
 	// DeleteEdge removes the outgoing edge; a repeat is ErrNotFound.
-	if err := st.DeleteEdge(ctx, out.ID); err != nil {
+	if err := st.DeleteEdge(ctx, campaignID, out.ID); err != nil {
 		t.Fatalf("DeleteEdge: %v", err)
 	}
-	if err := st.DeleteEdge(ctx, out.ID); !errors.Is(err, storage.ErrNotFound) {
+	if err := st.DeleteEdge(ctx, campaignID, out.ID); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("second DeleteEdge err = %v, want ErrNotFound", err)
 	}
 	outgoing, incoming, err = st.NodeEdges(ctx, aldric.ID)
@@ -193,7 +193,7 @@ func TestSetNodeAgent(t *testing.T) {
 	}
 
 	// Link the NPC Node to the Agent.
-	linked, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{UUID: agentID, Valid: true})
+	linked, err := st.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{UUID: agentID, Valid: true})
 	if err != nil {
 		t.Fatalf("SetNodeAgent link: %v", err)
 	}
@@ -202,18 +202,18 @@ func TestSetNodeAgent(t *testing.T) {
 	}
 
 	// A non-NPC Node cannot carry the link (DB CHECK).
-	if _, err := st.SetNodeAgent(ctx, loc.ID, uuid.NullUUID{UUID: agentID, Valid: true}); !errors.Is(err, storage.ErrInvalidEdge) {
+	if _, err := st.SetNodeAgent(ctx, campaignID, loc.ID, uuid.NullUUID{UUID: agentID, Valid: true}); !errors.Is(err, storage.ErrInvalidEdge) {
 		t.Errorf("link on non-NPC node err = %v, want ErrInvalidEdge", err)
 	}
 
 	// A second NPC Node claiming the same Agent trips the UNIQUE index.
 	npc2 := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart's Twin")
-	if _, err := st.SetNodeAgent(ctx, npc2.ID, uuid.NullUUID{UUID: agentID, Valid: true}); !errors.Is(err, storage.ErrConflict) {
+	if _, err := st.SetNodeAgent(ctx, campaignID, npc2.ID, uuid.NullUUID{UUID: agentID, Valid: true}); !errors.Is(err, storage.ErrConflict) {
 		t.Errorf("second link to same agent err = %v, want ErrConflict", err)
 	}
 
 	// Unlink.
-	unlinked, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{})
+	unlinked, err := st.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{})
 	if err != nil {
 		t.Fatalf("SetNodeAgent unlink: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestSetNodeAgent(t *testing.T) {
 	}
 
 	// Relink, then delete the Agent: the link is SET NULL, the Node survives.
-	if _, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
+	if _, err := st.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
 		t.Fatalf("SetNodeAgent relink: %v", err)
 	}
 	if err := st.DeleteAgent(ctx, campaignID, agentID); err != nil {
@@ -239,7 +239,7 @@ func TestSetNodeAgent(t *testing.T) {
 	}
 
 	// A missing Agent → ErrNotFound.
-	if _, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{UUID: uuid.New(), Valid: true}); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := st.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{UUID: uuid.New(), Valid: true}); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("link to missing agent err = %v, want ErrNotFound", err)
 	}
 
@@ -256,7 +256,104 @@ func TestSetNodeAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAgent foreign: %v", err)
 	}
-	if _, err := st.SetNodeAgent(ctx, npc.ID, uuid.NullUUID{UUID: foreignAgent, Valid: true}); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := st.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{UUID: foreignAgent, Valid: true}); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("link to cross-campaign agent err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteEdgeIsCampaignScoped is #342: DeleteEdge matches (id, campaign_id), so
+// passing another Campaign's id refuses the delete with ErrNotFound and leaves the
+// Edge; the owning Campaign then deletes it.
+func TestDeleteEdgeIsCampaignScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	var campaignB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other Table') RETURNING id`,
+		tenantID).Scan(&campaignB); err != nil {
+		t.Fatalf("insert campaign B: %v", err)
+	}
+
+	from := mkNode(t, st, campaignA, storage.KGNodeCharacter, "Aldric")
+	to := mkNode(t, st, campaignA, storage.KGNodeLocation, "Barrow")
+	edge, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignA, FromNodeID: from.ID, ToNodeID: to.ID, Type: storage.KGEdgeResidesIn,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+
+	// Delete scoped to campaign B must refuse and leave the Edge.
+	if err := st.DeleteEdge(ctx, campaignB, edge.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign DeleteEdge = %v, want ErrNotFound", err)
+	}
+	// The Edge is intact: the owning Campaign deletes it.
+	if err := st.DeleteEdge(ctx, campaignA, edge.ID); err != nil {
+		t.Fatalf("owner DeleteEdge after refused cross-campaign delete: %v", err)
+	}
+}
+
+// TestSetNodeAgentIsCampaignScoped is #342: both the link and the unlink match the
+// Node's campaign_id against the caller's campaign, so passing another Campaign's
+// id refuses either with ErrNotFound and leaves the voiced-by link untouched.
+func TestSetNodeAgentIsCampaignScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	var campaignB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other Table') RETURNING id`,
+		tenantID).Scan(&campaignB); err != nil {
+		t.Fatalf("insert campaign B: %v", err)
+	}
+
+	npc := mkNode(t, st, campaignA, storage.KGNodeNPC, "Bart the Innkeeper")
+	agentA, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignA, Role: storage.AgentRoleCharacter, Name: "Bart",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Cross-campaign LINK refused: the Node is in A, the caller scopes to B.
+	if _, err := st.SetNodeAgent(ctx, campaignB, npc.ID, uuid.NullUUID{UUID: agentA, Valid: true}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign SetNodeAgent link = %v, want ErrNotFound", err)
+	}
+
+	// Legit link under the owning Campaign.
+	linked, err := st.SetNodeAgent(ctx, campaignA, npc.ID, uuid.NullUUID{UUID: agentA, Valid: true})
+	if err != nil {
+		t.Fatalf("owner SetNodeAgent link: %v", err)
+	}
+	if !linked.AgentID.Valid || linked.AgentID.UUID != agentA {
+		t.Fatalf("link not persisted: %+v", linked.AgentID)
+	}
+
+	// Cross-campaign UNLINK refused: the Node is in A, the caller scopes to B.
+	if _, err := st.SetNodeAgent(ctx, campaignB, npc.ID, uuid.NullUUID{}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign SetNodeAgent unlink = %v, want ErrNotFound", err)
+	}
+
+	// The link survived the refused cross-campaign unlink.
+	nodes, err := st.ListNodes(ctx, campaignA)
+	if err != nil {
+		t.Fatalf("ListNodes A: %v", err)
+	}
+	var found bool
+	for _, n := range nodes {
+		if n.ID == npc.ID {
+			found = true
+			if !n.AgentID.Valid || n.AgentID.UUID != agentA {
+				t.Errorf("cross-campaign unlink leaked through: %+v", n.AgentID)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("npc node vanished")
 	}
 }

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -86,18 +86,23 @@ func (s *Store) CreateNode(ctx context.Context, n NewKGNode) (KGNode, error) {
 }
 
 // KGNodeUpdate is the input to UpdateNode — the Knowledge panel's editor fields
-// (#129). It carries no Type (node_type is immutable, ADR-0008) and no CampaignID
-// (a Node never moves between campaigns); the row is addressed by ID alone.
+// (#129). It carries no Type (node_type is immutable, ADR-0008). CampaignID is the
+// owning Campaign the write is scoped to (#342): the UPDATE matches (id,
+// campaign_id), so a Node in another Campaign is invisible and yields ErrNotFound —
+// a Node never moves between campaigns, and cross-campaign mutation is refused.
 type KGNodeUpdate struct {
-	ID        uuid.UUID
-	Name      string
-	Body      string
-	GMPrivate bool
+	ID         uuid.UUID
+	CampaignID uuid.UUID
+	Name       string
+	Body       string
+	GMPrivate  bool
 }
 
 // UpdateNode saves a Knowledge Graph Node's editor fields (name/body/gm_private)
 // and returns the updated row, stamping updated_at = now(). node_type is never
-// touched (immutable, ADR-0008). A missing id yields ErrNotFound.
+// touched (immutable, ADR-0008). The write is scoped to (id, campaign_id) (#342),
+// so a Node in another Campaign matches no row and yields ErrNotFound — a
+// cross-campaign mutation is refused server-side. A missing id yields ErrNotFound.
 func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) {
 	row := s.db.QueryRow(ctx,
 		`UPDATE kg_node SET
@@ -105,9 +110,9 @@ func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) 
 		    body = $3,
 		    gm_private = $4,
 		    updated_at = now()
-		  WHERE id = $1
+		  WHERE id = $1 AND campaign_id = $5
 		 RETURNING `+kgNodeColumns,
-		u.ID, u.Name, u.Body, u.GMPrivate)
+		u.ID, u.Name, u.Body, u.GMPrivate, u.CampaignID)
 	updated, err := scanKGNode(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return KGNode{}, ErrNotFound
@@ -118,10 +123,13 @@ func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) 
 	return updated, nil
 }
 
-// DeleteNode removes a Knowledge Graph Node by id. A missing id yields
-// ErrNotFound so the RPC can distinguish "gone" from "never existed".
-func (s *Store) DeleteNode(ctx context.Context, id uuid.UUID) error {
-	tag, err := s.db.Exec(ctx, `DELETE FROM kg_node WHERE id = $1`, id)
+// DeleteNode removes a Knowledge Graph Node by id, scoped to its owning Campaign
+// (#342): the DELETE matches (id, campaign_id), so a Node in another Campaign is
+// not deleted and yields ErrNotFound — a cross-campaign delete is refused. A
+// missing id likewise yields ErrNotFound so the RPC can distinguish "gone" from
+// "never existed".
+func (s *Store) DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM kg_node WHERE id = $1 AND campaign_id = $2`, id, campaignID)
 	if err != nil {
 		return fmt.Errorf("storage: delete kg node %s: %w", id, err)
 	}

--- a/internal/storage/kg_node_neighbourhood_test.go
+++ b/internal/storage/kg_node_neighbourhood_test.go
@@ -21,7 +21,7 @@ func linkAgent(t *testing.T, st *storage.Store, campaignID, npcID uuid.UUID, nam
 	if err != nil {
 		t.Fatalf("CreateAgent %q: %v", name, err)
 	}
-	if _, err := st.SetNodeAgent(context.Background(), npcID,
+	if _, err := st.SetNodeAgent(context.Background(), campaignID, npcID,
 		uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
 		t.Fatalf("SetNodeAgent %q: %v", name, err)
 	}

--- a/internal/storage/kg_node_test.go
+++ b/internal/storage/kg_node_test.go
@@ -91,7 +91,7 @@ func TestKGNodeUpdate(t *testing.T) {
 	}
 
 	updated, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
-		ID: created.ID, Name: "Old Barrow", Body: "A very haunted mound.", GMPrivate: true,
+		ID: created.ID, CampaignID: campaignID, Name: "Old Barrow", Body: "A very haunted mound.", GMPrivate: true,
 	})
 	if err != nil {
 		t.Fatalf("UpdateNode: %v", err)
@@ -118,7 +118,7 @@ func TestKGNodeUpdate(t *testing.T) {
 		t.Errorf("update did not persist across reload: %+v", nodes)
 	}
 
-	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: uuid.New(), Name: "ghost"}); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: uuid.New(), CampaignID: campaignID, Name: "ghost"}); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("UpdateNode missing id err = %v, want ErrNotFound", err)
 	}
 }
@@ -138,7 +138,7 @@ func TestKGNodeDelete(t *testing.T) {
 		t.Fatalf("CreateNode: %v", err)
 	}
 
-	if err := st.DeleteNode(ctx, created.ID); err != nil {
+	if err := st.DeleteNode(ctx, campaignID, created.ID); err != nil {
 		t.Fatalf("DeleteNode: %v", err)
 	}
 	nodes, err := st.ListNodes(ctx, campaignID)
@@ -149,10 +149,10 @@ func TestKGNodeDelete(t *testing.T) {
 		t.Errorf("node not deleted: %+v", nodes)
 	}
 
-	if err := st.DeleteNode(ctx, created.ID); !errors.Is(err, storage.ErrNotFound) {
+	if err := st.DeleteNode(ctx, campaignID, created.ID); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("second DeleteNode err = %v, want ErrNotFound", err)
 	}
-	if err := st.DeleteNode(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+	if err := st.DeleteNode(ctx, campaignID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("DeleteNode unknown id err = %v, want ErrNotFound", err)
 	}
 }
@@ -181,12 +181,12 @@ func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 
 	// Edit both: flip the Faction to gm_private, leave the Location public.
 	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
-		ID: loc.ID, Name: "Old Harbor", Body: "Ships used to dock here.",
+		ID: loc.ID, CampaignID: campaignID, Name: "Old Harbor", Body: "Ships used to dock here.",
 	}); err != nil {
 		t.Fatalf("UpdateNode location: %v", err)
 	}
 	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
-		ID: fac.ID, Name: "Dockers Guild", Body: "A secret cabal.", GMPrivate: true,
+		ID: fac.ID, CampaignID: campaignID, Name: "Dockers Guild", Body: "A secret cabal.", GMPrivate: true,
 	}); err != nil {
 		t.Fatalf("UpdateNode faction: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 	}
 
 	// Delete the Location; only the (private) Faction remains.
-	if err := st.DeleteNode(ctx, loc.ID); err != nil {
+	if err := st.DeleteNode(ctx, campaignID, loc.ID); err != nil {
 		t.Fatalf("DeleteNode location: %v", err)
 	}
 	all, err := st.ListNodes(ctx, campaignID)
@@ -220,5 +220,49 @@ func TestKGNodeCreateEditDeleteAcrossTypes(t *testing.T) {
 	}
 	if len(all) != 1 || all[0].ID != fac.ID || !all[0].GMPrivate {
 		t.Errorf("after delete want only the private Faction, got %+v", all)
+	}
+}
+
+// TestKGNodeMutationsAreCampaignScoped is #342: UpdateNode/DeleteNode match
+// (id, campaign_id), so passing another Campaign's id refuses the mutation with
+// ErrNotFound and leaves the Node untouched.
+func TestKGNodeMutationsAreCampaignScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	var campaignB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other Table') RETURNING id`,
+		tenantID).Scan(&campaignB); err != nil {
+		t.Fatalf("insert campaign B: %v", err)
+	}
+
+	node, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignA, Type: storage.KGNodeLocation, Name: "Barrow", Body: "A haunted mound.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode A: %v", err)
+	}
+
+	// Update scoped to campaign B must refuse and change nothing.
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{
+		ID: node.ID, CampaignID: campaignB, Name: "Hijacked",
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign UpdateNode = %v, want ErrNotFound", err)
+	}
+	// Delete scoped to campaign B must refuse and leave the row.
+	if err := st.DeleteNode(ctx, campaignB, node.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign DeleteNode = %v, want ErrNotFound", err)
+	}
+
+	// The Node is intact under campaign A with its original name.
+	got, err := st.ListNodes(ctx, campaignA)
+	if err != nil {
+		t.Fatalf("ListNodes A: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != node.ID || got[0].Name != "Barrow" {
+		t.Errorf("cross-campaign mutation leaked through: %+v", got)
 	}
 }

--- a/internal/storage/tool_grant_test.go
+++ b/internal/storage/tool_grant_test.go
@@ -125,7 +125,7 @@ func TestToolGrantRoundTrip(t *testing.T) {
 
 	// Deleting the Agent cascades its grants away (ON DELETE CASCADE) — no
 	// explicit cleanup code.
-	if err := st.DeleteAgent(ctx, charID); err != nil {
+	if err := st.DeleteAgent(ctx, campaignID, charID); err != nil {
 		t.Fatalf("DeleteAgent: %v", err)
 	}
 	cascaded, err := st.ListToolGrants(ctx, charID)

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -219,10 +219,14 @@ func (s *Store) CreateAgent(ctx context.Context, a NewAgent) (uuid.UUID, error) 
 
 // AgentUpdate is the input to UpdateAgent. It carries the editor-editable fields
 // only — the Campaign screen edits name/title/persona/voice/address-only/aliases;
-// agent_role, campaign_id and speaker_color are immutable here. A Butler's
+// agent_role and speaker_color are immutable here. CampaignID is the owning
+// Campaign the write is scoped to (#342): the UPDATE matches (id, campaign_id), so
+// an Agent in another Campaign is invisible and yields ErrNotFound — cross-campaign
+// mutation is refused, and an Agent never moves between Campaigns. A Butler's
 // address_only is force-kept true regardless of AddressOnly (ADR-0009 / ADR-0024).
 type AgentUpdate struct {
 	ID                    uuid.UUID
+	CampaignID            uuid.UUID
 	Name                  string
 	Title                 string
 	Persona               string
@@ -257,10 +261,11 @@ func (s *Store) UpdateAgent(ctx context.Context, a AgentUpdate) (Agent, error) {
 		    address_only = CASE WHEN agent_role = 'butler' THEN true ELSE $8 END,
 		    aliases = $9,
 		    updated_at = now()
-		  WHERE id = $1
+		  WHERE id = $1 AND campaign_id = $10
 		 RETURNING `+agentColumns,
 		a.ID, a.Name, a.Title, a.Persona, voice,
-		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases)
+		a.VoiceProviderConfigID, a.LLMProviderConfigID, a.AddressOnly, aliases,
+		a.CampaignID)
 	updated, err := scanAgent(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Agent{}, ErrNotFound
@@ -271,23 +276,26 @@ func (s *Store) UpdateAgent(ctx context.Context, a AgentUpdate) (Agent, error) {
 	return updated, nil
 }
 
-// DeleteAgent removes a Character NPC by id. Deleting a Butler is rejected with
-// ErrButlerUndeletable (ADR-0009): the guarded DELETE leaves a Butler row
-// untouched, and the wrapping CTE reports whether the id existed and whether it
-// was a Butler in one atomic round-trip — so a missing id yields ErrNotFound and
-// a Butler yields ErrButlerUndeletable, distinct from "deleted nothing".
-func (s *Store) DeleteAgent(ctx context.Context, id uuid.UUID) error {
+// DeleteAgent removes a Character NPC by id, scoped to its owning Campaign (#342):
+// every clause matches (id, campaign_id), so an Agent in another Campaign is
+// invisible — it neither exists nor deletes — and yields ErrNotFound, refusing a
+// cross-campaign delete. Deleting a Butler is rejected with ErrButlerUndeletable
+// (ADR-0009): the guarded DELETE leaves a Butler row untouched, and the wrapping
+// CTE reports whether the id existed in the Campaign and whether it was a Butler in
+// one atomic round-trip — so a missing id yields ErrNotFound and a Butler yields
+// ErrButlerUndeletable, distinct from "deleted nothing".
+func (s *Store) DeleteAgent(ctx context.Context, campaignID, id uuid.UUID) error {
 	var existed, isButler bool
 	err := s.db.QueryRow(ctx,
 		`WITH found AS (
-		     SELECT agent_role FROM agents WHERE id = $1
+		     SELECT agent_role FROM agents WHERE id = $1 AND campaign_id = $2
 		 ), del AS (
-		     DELETE FROM agents WHERE id = $1 AND agent_role <> 'butler' RETURNING 1
+		     DELETE FROM agents WHERE id = $1 AND campaign_id = $2 AND agent_role <> 'butler' RETURNING 1
 		 )
 		 SELECT
 		     EXISTS (SELECT 1 FROM found),
 		     COALESCE((SELECT agent_role = 'butler' FROM found), false)`,
-		id).Scan(&existed, &isButler)
+		id, campaignID).Scan(&existed, &isButler)
 	if err != nil {
 		return fmt.Errorf("storage: delete agent %s: %w", id, err)
 	}


### PR DESCRIPTION
Closes #342

## Problem

`UpdateAgent`/`DeleteAgent`, `UpdateNode`/`DeleteNode`, and `UpdateCharacter`/`DeleteCharacter` matched rows on `WHERE id = $1` alone. Any operator could mutate another campaign's Agent, KG-Node, or Character by id — a cross-campaign write hole that must close before the player tier lands (ADR-0039 single-operator fast-path is pass-through today; ADR-0003 players scoped via their Characters).

## Fix (per orchestrator decision)

- **Storage** mutations take an **explicit owning campaign id** and match `WHERE id = $1 AND campaign_id = $N`. `RowsAffected`/`RETURNING` 0 → `ErrNotFound` — no separate ownership `SELECT`, no N+1.
  - `AgentUpdate`/`CharacterUpdate`/`KGNodeUpdate` gain a `CampaignID` field.
  - `DeleteAgent`/`DeleteCharacter`/`DeleteNode` gain a `campaignID` parameter. `DeleteAgent`'s butler-guard CTE is scoped by campaign in every clause.
- **RPC handlers** resolve the Active Campaign via the existing live-first resolver (`s.activeCampaign`) and pass its id down. `UpdateCharacter`, `DeleteCharacter`, `UpdateNode`, `DeleteNode`, and `DeleteAgent` — which previously never scoped the write — now do; a cross-campaign id reads back as `CodeNotFound`.
- Butler protections (undeletable, `agent_role` + `address_only` pinning in `UpdateAgent`) and the #281 `invalidateSpeakers` hook on Character mutations are preserved.

## Tests (TDD)

- **Storage integration (real Postgres):** per-entity cross-campaign UPDATE + DELETE refusal (`TestAgentMutationsAreCampaignScoped`, `TestCharacterMutationsAreCampaignScoped`, `TestKGNodeMutationsAreCampaignScoped`).
- **Rebind-conflict:** the previously fake-only `23505 → ErrConflict` path on `UpdateCharacter` is now integration-tested (`TestCharacterRebindConflict`).
- **RPC unit:** each handler scopes the mutation to the resolved active campaign, and returns `NotFound` when there is no active campaign.
- All existing storage/rpc tests updated to the new signatures.

Local: `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` (0 issues), storage + rpc integration suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)