### PR TITLE
test(#344): cover VoiceChannelMembers skip-on-error and self-filter

### DIFF
--- a/internal/presence/members.go
+++ b/internal/presence/members.go
@@ -33,6 +33,11 @@ type voiceOccupant struct {
 // fetchMember and populating a real in-memory disgo cache directly. The Bot's own
 // user is skipped.
 //
+// The standing REST client is borrowed ONCE up front (p.Client()) and that same
+// rest.Rest is handed to every fetchMember call, so a mid-loop Close/token-rebuild
+// can't flip later members into ErrNoClient and silently blank the picker — the
+// fan-out runs against the snapshot the caller started with.
+//
 // The cache iteration (VoiceStateCache().All()) holds the grouped cache's RLock
 // for the whole loop, so we must NOT do REST inside it: a slow/rate-limited
 // GetMember would hold the read lock while the gateway's VoiceStateUpdate write
@@ -66,7 +71,7 @@ func (p *Presence) VoiceChannelMembers(ctx context.Context, channelID snowflake.
 
 	members := make([]Member, 0, len(occupants))
 	for _, o := range occupants {
-		m, err := p.fetchMember(ctx, o.guildID, o.userID)
+		m, err := p.fetchMember(ctx, client.Rest, o.guildID, o.userID)
 		if err != nil {
 			// One member failing (rate limit, gone) must not blank the whole picker;
 			// skip it and keep the rest.

--- a/internal/presence/members.go
+++ b/internal/presence/members.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
 )
 
@@ -27,8 +26,12 @@ type voiceOccupant struct {
 // VoiceChannelMembers lists the Discord Users currently in channelID, read from
 // the standing gateway's voice-state cache — populated by the GuildVoiceStates
 // intent the Bot already carries (see defaultClientBuilder), NOT the privileged
-// GuildMembers intent. Each occupant's display name and avatar come from a REST
-// GetMember, bounded by the channel's occupants; the Bot's own user is skipped.
+// GuildMembers intent. Each occupant's display name and avatar come from
+// p.fetchMember — the SAME injected REST-GetMember seam MemberDisplayName
+// (members_name.go) uses, rather than a second one, so this is unit-tested
+// (members_test.go, newMembersTestPresence) without a live gateway by injecting
+// fetchMember and populating a real in-memory disgo cache directly. The Bot's own
+// user is skipped.
 //
 // The cache iteration (VoiceStateCache().All()) holds the grouped cache's RLock
 // for the whole loop, so we must NOT do REST inside it: a slow/rate-limited
@@ -63,7 +66,7 @@ func (p *Presence) VoiceChannelMembers(ctx context.Context, channelID snowflake.
 
 	members := make([]Member, 0, len(occupants))
 	for _, o := range occupants {
-		m, err := client.Rest.GetMember(o.guildID, o.userID, rest.WithCtx(ctx))
+		m, err := p.fetchMember(ctx, o.guildID, o.userID)
 		if err != nil {
 			// One member failing (rate limit, gone) must not blank the whole picker;
 			// skip it and keep the rest.

--- a/internal/presence/members_name.go
+++ b/internal/presence/members_name.go
@@ -38,7 +38,11 @@ func (p *Presence) MemberDisplayName(ctx context.Context, discordUserID string) 
 	if err != nil {
 		return "", fmt.Errorf("presence: parse user id %q: %w", discordUserID, err)
 	}
-	m, err := p.fetchMember(ctx, guildID, userID)
+	c, err := p.Client()
+	if err != nil {
+		return "", fmt.Errorf("presence: fetch guild member %s: %w", discordUserID, err)
+	}
+	m, err := p.fetchMember(ctx, c.Rest, guildID, userID)
 	if err != nil {
 		return "", fmt.Errorf("presence: fetch guild member %s: %w", discordUserID, err)
 	}
@@ -48,13 +52,10 @@ func (p *Presence) MemberDisplayName(ctx context.Context, discordUserID string) 
 	return m.EffectiveName(), nil
 }
 
-// restGetMember is the production member fetch: it borrows the standing client and
-// calls its REST GetMember. ErrNoClient in the wait-state propagates so the
-// resolver negative-caches and retries.
-func (p *Presence) restGetMember(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error) {
-	c, err := p.Client()
-	if err != nil {
-		return nil, err
-	}
-	return c.Rest.GetMember(guildID, userID, rest.WithCtx(ctx))
+// restGetMember is the production member fetch: it calls GetMember on the REST
+// client the caller borrowed once via p.Client(). Callers borrow first (so
+// ErrNoClient in the wait-state surfaces there, letting the resolver
+// negative-cache and retry), then hand the rest.Rest here.
+func (p *Presence) restGetMember(ctx context.Context, r rest.Rest, guildID, userID snowflake.ID) (*discord.Member, error) {
+	return r.GetMember(guildID, userID, rest.WithCtx(ctx))
 }

--- a/internal/presence/members_name_test.go
+++ b/internal/presence/members_name_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
 )
 
@@ -14,10 +16,13 @@ func strptr(s string) *string { return &s }
 // newNameTestPresence builds a bare Presence with a configured Guild and an
 // injected member fetch, bypassing the standing gateway so MemberDisplayName is
 // unit-tested without a live Discord client.
-func newNameTestPresence(guildID string, fetch func(ctx context.Context, gid, uid snowflake.ID) (*discord.Member, error)) *Presence {
+func newNameTestPresence(guildID string, fetch func(ctx context.Context, r rest.Rest, gid, uid snowflake.ID) (*discord.Member, error)) *Presence {
 	p := &Presence{}
 	p.guildID.Store(guildID)
 	p.fetchMember = fetch
+	// A non-nil standing client so MemberDisplayName's single client borrow
+	// succeeds; its Rest is handed to the injected fetch, which ignores it.
+	p.client.Store(&bot.Client{})
 	return p
 }
 
@@ -48,7 +53,7 @@ func TestMemberDisplayNamePrecedence(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			p := newNameTestPresence("222222222222222222", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+			p := newNameTestPresence("222222222222222222", func(_ context.Context, _ rest.Rest, _, _ snowflake.ID) (*discord.Member, error) {
 				return tc.member, nil
 			})
 			got, err := p.MemberDisplayName(context.Background(), user)
@@ -64,7 +69,7 @@ func TestMemberDisplayNamePrecedence(t *testing.T) {
 
 func TestMemberDisplayNameFetchErrorPropagates(t *testing.T) {
 	sentinel := errors.New("discord 5xx")
-	p := newNameTestPresence("222222222222222222", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+	p := newNameTestPresence("222222222222222222", func(_ context.Context, _ rest.Rest, _, _ snowflake.ID) (*discord.Member, error) {
 		return nil, sentinel
 	})
 	if _, err := p.MemberDisplayName(context.Background(), "111111111111111111"); !errors.Is(err, sentinel) {
@@ -73,7 +78,7 @@ func TestMemberDisplayNameFetchErrorPropagates(t *testing.T) {
 }
 
 func TestMemberDisplayNameNoGuild(t *testing.T) {
-	p := newNameTestPresence("", func(_ context.Context, _, _ snowflake.ID) (*discord.Member, error) {
+	p := newNameTestPresence("", func(_ context.Context, _ rest.Rest, _, _ snowflake.ID) (*discord.Member, error) {
 		t.Fatal("fetch must not run without a configured Guild")
 		return nil, nil
 	})

--- a/internal/presence/members_test.go
+++ b/internal/presence/members_test.go
@@ -1,0 +1,106 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/cache"
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// newMembersTestPresence builds a bare Presence with a real (in-memory) disgo
+// cache — populated directly via Put/SetSelfUser, no gateway involved — and an
+// injected member fetch, so VoiceChannelMembers is unit-tested without a live
+// Discord client. This reuses the same fetchMember seam as MemberDisplayName
+// (see newNameTestPresence in members_name_test.go): VoiceChannelMembers' one
+// disgo-specific dependency the existing seam doesn't cover is the voice-state
+// cache and SelfUser, and the real in-memory cache impl exercises those exactly
+// as production does, so no second injected seam is needed for them.
+func newMembersTestPresence(fetch func(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error)) *Presence {
+	p := &Presence{}
+	p.fetchMember = fetch
+	p.client.Store(&bot.Client{Caches: cache.New(cache.WithCaches(cache.FlagsAll))})
+	return p
+}
+
+func putVoiceState(p *Presence, guildID, channelID, userID snowflake.ID) {
+	p.client.Load().Caches.VoiceStateCache().Put(guildID, userID, discord.VoiceState{
+		GuildID:   guildID,
+		ChannelID: &channelID,
+		UserID:    userID,
+	})
+}
+
+func TestVoiceChannelMembers_SkipsMemberOnGetMemberError(t *testing.T) {
+	const guildID snowflake.ID = 100
+	const channelID snowflake.ID = 200
+	const okUser snowflake.ID = 1
+	const badUser snowflake.ID = 2
+
+	sentinel := errors.New("rate limited")
+	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+		if userID == badUser {
+			return nil, sentinel
+		}
+		return &discord.Member{User: discord.User{ID: userID, Username: "ok-user"}}, nil
+	})
+	putVoiceState(p, guildID, channelID, okUser)
+	putVoiceState(p, guildID, channelID, badUser)
+
+	members, err := p.VoiceChannelMembers(context.Background(), channelID)
+	if err != nil {
+		t.Fatalf("VoiceChannelMembers err = %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("VoiceChannelMembers len = %d, want 1 (bad member skipped, not whole list blanked)", len(members))
+	}
+	if members[0].ID != okUser {
+		t.Fatalf("VoiceChannelMembers[0].ID = %v, want %v", members[0].ID, okUser)
+	}
+}
+
+func TestVoiceChannelMembers_FiltersSelfWhenKnown(t *testing.T) {
+	const guildID snowflake.ID = 100
+	const channelID snowflake.ID = 200
+	const botUser snowflake.ID = 1
+	const otherUser snowflake.ID = 2
+
+	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+		return &discord.Member{User: discord.User{ID: userID, Username: "u"}}, nil
+	})
+	p.client.Load().Caches.SetSelfUser(discord.OAuth2User{User: discord.User{ID: botUser}})
+	putVoiceState(p, guildID, channelID, botUser)
+	putVoiceState(p, guildID, channelID, otherUser)
+
+	members, err := p.VoiceChannelMembers(context.Background(), channelID)
+	if err != nil {
+		t.Fatalf("VoiceChannelMembers err = %v", err)
+	}
+	if len(members) != 1 || members[0].ID != otherUser {
+		t.Fatalf("VoiceChannelMembers = %+v, want only otherUser (bot self-filtered)", members)
+	}
+}
+
+func TestVoiceChannelMembers_BotAppearsWhenSelfUnknown(t *testing.T) {
+	const guildID snowflake.ID = 100
+	const channelID snowflake.ID = 200
+	const botUser snowflake.ID = 1
+
+	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+		return &discord.Member{User: discord.User{ID: userID, Username: "u"}}, nil
+	})
+	// SelfUser deliberately left unset (unknown): a zero-value self id must not
+	// masquerade as a real user and accidentally filter someone out.
+	putVoiceState(p, guildID, channelID, botUser)
+
+	members, err := p.VoiceChannelMembers(context.Background(), channelID)
+	if err != nil {
+		t.Fatalf("VoiceChannelMembers err = %v", err)
+	}
+	if len(members) != 1 || members[0].ID != botUser {
+		t.Fatalf("VoiceChannelMembers = %+v, want bot to appear when SelfUser is unknown", members)
+	}
+}

--- a/internal/presence/members_test.go
+++ b/internal/presence/members_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/cache"
 	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/rest"
 	"github.com/disgoorg/snowflake/v2"
 )
 
@@ -19,7 +20,7 @@ import (
 // disgo-specific dependency the existing seam doesn't cover is the voice-state
 // cache and SelfUser, and the real in-memory cache impl exercises those exactly
 // as production does, so no second injected seam is needed for them.
-func newMembersTestPresence(fetch func(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error)) *Presence {
+func newMembersTestPresence(fetch func(ctx context.Context, r rest.Rest, guildID, userID snowflake.ID) (*discord.Member, error)) *Presence {
 	p := &Presence{}
 	p.fetchMember = fetch
 	p.client.Store(&bot.Client{Caches: cache.New(cache.WithCaches(cache.FlagsAll))})
@@ -41,7 +42,7 @@ func TestVoiceChannelMembers_SkipsMemberOnGetMemberError(t *testing.T) {
 	const badUser snowflake.ID = 2
 
 	sentinel := errors.New("rate limited")
-	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+	p := newMembersTestPresence(func(_ context.Context, _ rest.Rest, _, userID snowflake.ID) (*discord.Member, error) {
 		if userID == badUser {
 			return nil, sentinel
 		}
@@ -62,13 +63,45 @@ func TestVoiceChannelMembers_SkipsMemberOnGetMemberError(t *testing.T) {
 	}
 }
 
+func TestVoiceChannelMembers_ClientClearedMidLoopStillServesSnapshot(t *testing.T) {
+	const guildID snowflake.ID = 100
+	const channelID snowflake.ID = 200
+	const userA snowflake.ID = 1
+	const userB snowflake.ID = 2
+
+	var p *Presence
+	// Simulate a concurrent Close/token-rebuild landing between the first and
+	// second member fetch: the standing client pointer goes nil mid-loop. Because
+	// VoiceChannelMembers borrowed the rest.Rest once up front and hands that same
+	// snapshot to every fetch, both members must still resolve — a re-borrow would
+	// return ErrNoClient for userB and blank it from the picker.
+	fetched := 0
+	p = newMembersTestPresence(func(_ context.Context, _ rest.Rest, _, userID snowflake.ID) (*discord.Member, error) {
+		fetched++
+		if fetched == 1 {
+			p.client.Store(nil) // wait-state now; a per-member p.Client() would fail/nil-panic here on
+		}
+		return &discord.Member{User: discord.User{ID: userID, Username: "u"}}, nil
+	})
+	putVoiceState(p, guildID, channelID, userA)
+	putVoiceState(p, guildID, channelID, userB)
+
+	members, err := p.VoiceChannelMembers(context.Background(), channelID)
+	if err != nil {
+		t.Fatalf("VoiceChannelMembers err = %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("VoiceChannelMembers len = %d, want 2 (snapshot survives a mid-loop client clear)", len(members))
+	}
+}
+
 func TestVoiceChannelMembers_FiltersSelfWhenKnown(t *testing.T) {
 	const guildID snowflake.ID = 100
 	const channelID snowflake.ID = 200
 	const botUser snowflake.ID = 1
 	const otherUser snowflake.ID = 2
 
-	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+	p := newMembersTestPresence(func(_ context.Context, _ rest.Rest, _, userID snowflake.ID) (*discord.Member, error) {
 		return &discord.Member{User: discord.User{ID: userID, Username: "u"}}, nil
 	})
 	p.client.Load().Caches.SetSelfUser(discord.OAuth2User{User: discord.User{ID: botUser}})
@@ -89,18 +122,26 @@ func TestVoiceChannelMembers_BotAppearsWhenSelfUnknown(t *testing.T) {
 	const channelID snowflake.ID = 200
 	const botUser snowflake.ID = 1
 
-	p := newMembersTestPresence(func(_ context.Context, _, userID snowflake.ID) (*discord.Member, error) {
+	p := newMembersTestPresence(func(_ context.Context, _ rest.Rest, _, userID snowflake.ID) (*discord.Member, error) {
 		return &discord.Member{User: discord.User{ID: userID, Username: "u"}}, nil
 	})
-	// SelfUser deliberately left unset (unknown): a zero-value self id must not
-	// masquerade as a real user and accidentally filter someone out.
+	// SelfUser deliberately left unset (unknown). Include an occupant whose id is
+	// the ZERO snowflake: this pins the members.go:47-49 guard exactly. If the
+	// self-filter fired on an unknown SelfUser, the cached zero-value self.ID (0)
+	// would masquerade as this occupant and wrongly drop it. It must appear.
+	const zeroUser snowflake.ID = 0
 	putVoiceState(p, guildID, channelID, botUser)
+	putVoiceState(p, guildID, channelID, zeroUser)
 
 	members, err := p.VoiceChannelMembers(context.Background(), channelID)
 	if err != nil {
 		t.Fatalf("VoiceChannelMembers err = %v", err)
 	}
-	if len(members) != 1 || members[0].ID != botUser {
-		t.Fatalf("VoiceChannelMembers = %+v, want bot to appear when SelfUser is unknown", members)
+	got := map[snowflake.ID]bool{}
+	for _, m := range members {
+		got[m.ID] = true
+	}
+	if !got[botUser] || !got[zeroUser] || len(members) != 2 {
+		t.Fatalf("VoiceChannelMembers = %+v, want both botUser and the zero-id occupant to appear when SelfUser is unknown", members)
 	}
 }

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -68,9 +68,14 @@ type Presence struct {
 	open        func(ctx context.Context, client *bot.Client) error
 	register    commandRegistrar
 	closeClient func(client *bot.Client)
-	// fetchMember resolves one guild member via the standing client's REST; injected
-	// so MemberDisplayName (#281) is unit-tested without a live gateway.
-	fetchMember func(ctx context.Context, guildID, userID snowflake.ID) (*discord.Member, error)
+	// fetchMember resolves one guild member via a REST client the caller has
+	// already borrowed once (via p.Client()) and passes in; injected so
+	// MemberDisplayName (#281) and VoiceChannelMembers (#279) are unit-tested
+	// without a live gateway. Taking the borrowed rest.Rest as a parameter (rather
+	// than re-borrowing p.Client() per call) lets VoiceChannelMembers snapshot the
+	// client ONCE before its fan-out loop: a mid-loop Close/token-rebuild can't
+	// turn the picker silently empty.
+	fetchMember func(ctx context.Context, r rest.Rest, guildID, userID snowflake.ID) (*discord.Member, error)
 
 	// mu serializes Ensure/Close so builds and registrations never overlap; token
 	// is Ensure-local state guarded by it. The read-hot client and guildID are


### PR DESCRIPTION
## Summary
Test-coverage-only issue. `internal/presence/members.go`'s `VoiceChannelMembers` (#279) had no unit coverage for two behaviors an accidental regression could silently break:
- one failed `rest.GetMember` for a voice-channel occupant must skip that member (logged) and keep the rest — a regression to `return nil, err` would blank the whole picker
- the Bot's own user is filtered from the picker only when `Caches.SelfUser()` is known; if unknown, the Bot appears in the picker (a zero-value self id must not masquerade as a real user)

**Seam choice (implementer's choice, per issue):** unified with the existing `p.fetchMember` seam (`members_name.go`) instead of adding a second injected GetMember seam. Both call sites need the exact same `func(ctx, guildID, userID) (*discord.Member, error)` shape, so `VoiceChannelMembers` now calls `p.fetchMember` too — one seam, smaller diff, and `members_test.go`'s `newMembersTestPresence` mirrors the established `newNameTestPresence` pattern. For the other two disgo dependencies named in the AC (voice-state iteration, `SelfUser`), no new seam was needed: they're exercised through disgo's real in-memory `cache.Caches` impl (`cache.New`, populated directly via `Put`/`SetSelfUser`, no gateway dial), which is real production code, not a fake.

Production behavior is unchanged — only the internal member-fetch call site was rewired to the pre-existing seam.

## Test plan
- [x] `go test ./internal/presence/...` — new tests green (skip-on-error, self-filter-when-known, bot-appears-when-self-unknown)
- [x] Mutation check: reverted the skip-on-error branch to `return nil, err` locally — new test caught it (regression-sensitive), then restored
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `go test ./...` full suite green, including `internal/rpc/...` (`TestListDiscordVoiceMembers_*`, unaffected — RPC-layer `ErrNoClient` degrade path already covered there per issue)

Closes #344