### PR TITLE
fix(#246): invalidate standing presence client on gateway death

### DIFF
--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -98,7 +98,7 @@ func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log
 		log:      log,
 	}
 	p.guildID.Store("")
-	p.build = defaultClientBuilder(reg, log)
+	p.build = defaultClientBuilder(reg, log, p.invalidate)
 	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
 	p.register = restRegister
 	p.closeClient = func(client *bot.Client) { client.Close(context.Background()) }
@@ -225,6 +225,33 @@ func (p *Presence) ClientProvider() wirenpc.ClientProvider {
 	}
 }
 
+// invalidate drops a standing client whose gateway died unexpectedly (#246). The
+// prod builder wires it as the disgo gateway CloseHandlerFunc, which disgo fires
+// ONLY on an unexpected non-reconnectable death (a mid-session close 4004 after
+// the Bot token is revoked, a disallowed-intents close, or an exhausted
+// reconnect) — never on our own client.Close, so a deliberate token-change
+// rebuild does not trip it. Without this the corpse stays in p.client, every
+// Voice Session cycle borrows it via ClientProvider, and the reconnect loop
+// backs off on non-classifiable errors forever instead of ending the session
+// failed (ADR-0043).
+//
+// It runs on disgo's event goroutine, so it must NOT take p.mu (Ensure holds it
+// across seconds of gateway+REST I/O). A CompareAndSwap clears the client only
+// when dead is still the standing one: a token change may have already replaced
+// it, and a late death of a superseded client must not nil the fresh one. The
+// winner closes the corpse to release its REST/voice resources; the next
+// ClientProvider re-runs Ensure, whose OpenGateway surfaces the wrapped 4004 to
+// classifyFatal so the session ends failed with an invalid_bot_token reason.
+func (p *Presence) invalidate(dead *bot.Client, cause error) {
+	if dead == nil {
+		return
+	}
+	if p.client.CompareAndSwap(dead, nil) {
+		p.log.Warn("presence: standing gateway died; invalidating standing client", "err", cause)
+		p.closeClient(dead)
+	}
+}
+
 // Close tears down the standing client. Called after the voice Manager's
 // shutdown so a live session releases the shared client first.
 func (p *Presence) Close() {
@@ -240,16 +267,28 @@ func (p *Presence) Close() {
 // disgo client with the SAME options the per-session voice wiring used (so a
 // shared-client Voice Session keeps its DAVE encryption and voice-state intents,
 // ADR-0006) plus the interaction listeners and async event delivery.
-func defaultClientBuilder(reg *Registry, log *slog.Logger) ClientBuilder {
+func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot.Client, cause error)) ClientBuilder {
 	return func(token string) (*bot.Client, error) {
-		return disgo.New(token,
+		// client is captured by the close handler below; disgo.New assigns it
+		// before any gateway open, so it is non-nil by the time a close can fire.
+		var client *bot.Client
+		var err error
+		client, err = disgo.New(token,
 			bot.WithLogger(log),
 			bot.WithDefaultGateway(),
 			// Guilds + GuildVoiceStates are the minimum for the voice join path
-			// (see wirenpc.connectAndServe); DAVE is wired at construction.
-			bot.WithGatewayConfigOpts(gateway.WithIntents(
-				gateway.IntentGuilds|gateway.IntentGuildVoiceStates,
-			)),
+			// (see wirenpc.connectAndServe); DAVE is wired at construction. The
+			// close handler drops this client from the presence when its gateway
+			// dies unexpectedly (#246) — disgo calls it only on a non-reconnectable
+			// close or an exhausted reconnect, not on our own Close.
+			bot.WithGatewayConfigOpts(
+				gateway.WithIntents(
+					gateway.IntentGuilds|gateway.IntentGuildVoiceStates,
+				),
+				gateway.WithCloseHandler(func(_ gateway.Gateway, cerr error, _ bool) {
+					onDead(client, cerr)
+				}),
+			),
 			gxvoice.DaveOption(),
 			bot.WithEventListenerFunc(reg.HandleCommand),
 			bot.WithEventListenerFunc(reg.HandleAutocomplete),
@@ -257,6 +296,7 @@ func defaultClientBuilder(reg *Registry, log *slog.Logger) ClientBuilder {
 			// the gateway read goroutine and starves voice events (ADR-0010).
 			bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled()),
 		)
+		return client, err
 	}
 }
 

--- a/internal/presence/presence_test.go
+++ b/internal/presence/presence_test.go
@@ -3,10 +3,12 @@ package presence
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/discord"
+	"github.com/gorilla/websocket"
 
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -33,6 +35,144 @@ func mustEnsure(t *testing.T, p *Presence) {
 	t.Helper()
 	if err := p.Ensure(context.Background()); err != nil {
 		t.Fatalf("Ensure: %v", err)
+	}
+}
+
+// seededPresence builds a Presence with fake seams and one saved token so a
+// single Ensure brings the standing client up. Returns the presence and the
+// mutable slices the seams record into.
+func seededPresence(t *testing.T) (p *Presence, builds *[]*bot.Client, closed *[]*bot.Client, openErr *error) {
+	t.Helper()
+	cipher, err := crypto.New(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	ct, err := cipher.Seal([]byte("tok-A"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	store := &fakePresenceStore{dep: storage.DeploymentConfig{
+		GuildID:                   "G1",
+		DiscordBotTokenCiphertext: ct,
+		DiscordBotTokenLast4:      crypto.Last4("tok-A"),
+	}}
+	reg := NewRegistry(NewGate(auth.ParseOperatorAllowlist(""), fixedGuild("")), nil)
+	reg.Register(Command{Path: "roll", Description: "Roll dice"})
+	p = New(store, cipher, reg, "", nil)
+
+	var bs, cs []*bot.Client
+	var oe error
+	p.build = func(string) (*bot.Client, error) {
+		c := &bot.Client{}
+		bs = append(bs, c)
+		return c, nil
+	}
+	p.open = func(context.Context, *bot.Client) error { return oe }
+	p.closeClient = func(c *bot.Client) { cs = append(cs, c) }
+	p.register = func(context.Context, *bot.Client, string, []discord.ApplicationCommandCreate) error { return nil }
+	return p, &bs, &cs, &oe
+}
+
+// TestPresenceInvalidatesClientOnGatewayDeath: when the standing client's
+// gateway dies (disgo close handler fires, e.g. a mid-session 4004 after the Bot
+// token is revoked), the presence drops the corpse — Client returns ErrNoClient
+// and the dead client is closed — so the next Voice Session cycle re-runs Ensure
+// instead of borrowing the dead client forever (#246).
+func TestPresenceInvalidatesClientOnGatewayDeath(t *testing.T) {
+	p, builds, closed, _ := seededPresence(t)
+
+	mustEnsure(t, p)
+	if len(*builds) != 1 {
+		t.Fatalf("builds=%d, want 1", len(*builds))
+	}
+	dead := (*builds)[0]
+	if got, err := p.Client(); err != nil || got != dead {
+		t.Fatalf("Client before death = %v/%v, want the built client", got, err)
+	}
+
+	// Gateway dies unexpectedly.
+	p.invalidate(dead, errors.New("close 4004"))
+
+	if _, err := p.Client(); !errors.Is(err, ErrNoClient) {
+		t.Errorf("Client after death = %v, want ErrNoClient", err)
+	}
+	if len(*closed) != 1 || (*closed)[0] != dead {
+		t.Errorf("dead client not closed: closed=%v", *closed)
+	}
+
+	// The next borrow re-runs Ensure and rebuilds a fresh standing client.
+	cp := p.ClientProvider()
+	c, err := cp(context.Background())
+	if err != nil {
+		t.Fatalf("ClientProvider after death: %v", err)
+	}
+	if len(*builds) != 2 || c != (*builds)[1] {
+		t.Errorf("ClientProvider = %v, want a freshly rebuilt client (builds=%d)", c, len(*builds))
+	}
+}
+
+// TestPresenceInvalidateIgnoresSupersededClient: a late gateway death from an
+// already-replaced client (e.g. the old client after a token-change rebuild)
+// must NOT nil the fresh standing client — invalidate compare-and-swaps on
+// identity (#246).
+func TestPresenceInvalidateIgnoresSupersededClient(t *testing.T) {
+	p, builds, closed, _ := seededPresence(t)
+
+	mustEnsure(t, p)
+	old := (*builds)[0]
+
+	// Token changes → Ensure closes old and builds a fresh standing client.
+	store := p.store.(*fakePresenceStore)
+	ct, err := p.cipher.Seal([]byte("tok-B"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	store.dep.DiscordBotTokenCiphertext = ct
+	store.dep.DiscordBotTokenLast4 = crypto.Last4("tok-B")
+	mustEnsure(t, p)
+	fresh := (*builds)[1]
+	if got, _ := p.Client(); got != fresh {
+		t.Fatalf("Client after token change = %v, want fresh", got)
+	}
+
+	closesBefore := len(*closed)
+	// The superseded old client's gateway dies late — must be a no-op on p.client.
+	p.invalidate(old, errors.New("late close 4004"))
+
+	if got, err := p.Client(); err != nil || got != fresh {
+		t.Errorf("Client after stale death = %v/%v, want fresh unchanged", got, err)
+	}
+	if len(*closed) != closesBefore {
+		t.Errorf("stale invalidate closed a client: closed=%v", *closed)
+	}
+}
+
+// TestPresenceRevokedTokenRebuildSurfaces4004: with a revoked token, the
+// post-death rebuild's OpenGateway returns a wrapped close 4004; ClientProvider
+// surfaces that error to the reconnect loop with the *websocket.CloseError still
+// recoverable via errors.As — the exact shape classifyFatal keys on to end the
+// session failed with invalid_bot_token instead of retrying forever (#246,
+// ADR-0043).
+func TestPresenceRevokedTokenRebuildSurfaces4004(t *testing.T) {
+	p, builds, _, openErr := seededPresence(t)
+
+	mustEnsure(t, p)
+	dead := (*builds)[0]
+
+	// The token is now revoked: any fresh OpenGateway fails with a wrapped 4004.
+	*openErr = fmt.Errorf("presence: open gateway: %w", &websocket.CloseError{
+		Code: 4004, Text: "Authentication failed",
+	})
+	p.invalidate(dead, errors.New("gateway died"))
+
+	cp := p.ClientProvider()
+	_, err := cp(context.Background())
+	if err == nil {
+		t.Fatalf("ClientProvider with revoked token: err=nil, want a surfaced error")
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) || closeErr.Code != 4004 {
+		t.Fatalf("surfaced err = %v, want a recoverable *websocket.CloseError{4004}", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Bot token revoked **mid-session** with a standing shared client: the gateway dies with close 4004, but `p.client` stays non-nil so `ClientProvider` keeps handing out the corpse. Every reconnect cycle borrows the dead client, voice joins fail with non-classifiable ctx-timeout/state errors, and `runWithReconnect` backs off transiently forever — the session row never lands `failed`. Pre-existing edge from PR #240 (#123), outside that AC (start-with-bad-token).

## Fix

Wire a disgo gateway `CloseHandlerFunc` (via `gateway.WithCloseHandler`) that drops the client from the presence when its gateway dies. Verified against disgo v0.19.6: the handler fires **only** on an unexpected non-reconnectable close (4004/4013/4014/4010-4012) or an exhausted reconnect — a user-initiated `client.Close()` sets `g.conn=nil`, the read loop sees `!sameConn` and returns without calling the handler, so a deliberate token-change rebuild does not trip it.

`invalidate` runs on disgo's event goroutine, so it takes **no** `p.mu` (Ensure holds it across seconds of gateway+REST I/O) and compare-and-swaps on client identity — a late death of a superseded client cannot nil the fresh one. The next `ClientProvider` re-runs `Ensure`, whose `OpenGateway` surfaces the wrapped 4004 to `classifyFatal` (ADR-0043), ending the session `failed` with the `invalid_bot_token` reason instead of looping.

## Tests (TDD, 3 added)

- `TestPresenceInvalidatesClientOnGatewayDeath` — death → `Client` returns `ErrNoClient`, corpse closed, next borrow rebuilds.
- `TestPresenceInvalidateIgnoresSupersededClient` — late death of a replaced client is a no-op (CAS on identity).
- `TestPresenceRevokedTokenRebuildSurfaces4004` — post-death rebuild's wrapped 4004 stays recoverable via `errors.As` — the exact shape `classifyFatal` keys on.

Cosmetic ride-alongs noted in the issue (pre-loop errors publishing no `{failed}` SSE frame) skipped to keep the diff focused; `GetSession` poll already covers them.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)