### PR TITLE
fix(#356): campaign-scope bare-id READS (ListToolGrants, UpdateAgent voice pre-read)

### DIFF
--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -65,7 +65,7 @@ type campaignStore interface {
 	DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error
 	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
 	DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error
-	NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
+	NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
 	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
 	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
 	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)

--- a/internal/rpc/campaign_crud.go
+++ b/internal/rpc/campaign_crud.go
@@ -125,17 +125,6 @@ func (s *CampaignServer) UpdateAgent(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
 	}
 
-	// Read the current row so applyVoiceSelection can preserve the persisted voice
-	// tuning the editor never sees (ProviderID/Language/Settings); GetAgent also
-	// gives the authoritative NotFound before the write (#224).
-	existing, err := s.store.GetAgent(ctx, id)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
-		}
-		slog.Default().Error("UpdateAgent: read existing agent failed", "agent_id", id, "err", err)
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
-	}
 	// Resolve the active campaign the SAME live-first way the roster/create paths do
 	// (#222/#229) — its language seeds a first-save voice default (#224). Reusing the
 	// unified resolver avoids a second, divergent campaign-resolution path.
@@ -146,6 +135,25 @@ func (s *CampaignServer) UpdateAgent(
 		}
 		slog.Default().Error("UpdateAgent: get active campaign failed", "agent_id", id, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	// Read the current row so applyVoiceSelection can preserve the persisted voice
+	// tuning the editor never sees (ProviderID/Language/Settings); GetAgent also
+	// gives the authoritative NotFound before the write (#224). The pre-read is
+	// SCOPED to the resolved active campaign (#356): an Agent in another campaign
+	// reads back as CodeNotFound before its voice can ever reach the response — the
+	// scoped store UPDATE would refuse it anyway (#353/#342), but the pre-read must
+	// not leak cross-campaign voice tuning in the meantime.
+	existing, err := s.store.GetAgent(ctx, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("UpdateAgent: read existing agent failed", "agent_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if existing.CampaignID != c.ID {
+		// The Agent is in another Campaign — invisible to this operator's session.
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
 	}
 
 	m := req.Msg

--- a/internal/rpc/campaign_crud_integration_test.go
+++ b/internal/rpc/campaign_crud_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -21,6 +22,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 )
 
 // TestUpdateAgent_CrossCampaign_Integration is #356: the load-bearing GetAgent
@@ -43,8 +45,13 @@ func TestUpdateAgent_CrossCampaign_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCampaign B: %v", err)
 	}
+	// Seed a tuned voice so the load-bearing vector (voice bytes) is non-trivial.
+	voiceB, err := storage.VoiceToJSON(ttseleven.DefaultVoice("secret-voice", "en"))
+	if err != nil {
+		t.Fatalf("VoiceToJSON: %v", err)
+	}
 	npcBID, err := store.CreateAgent(ctx, storage.NewAgent{
-		CampaignID: campaignB, Role: storage.AgentRoleCharacter, Name: "Bandit", Persona: "Lurks.",
+		CampaignID: campaignB, Role: storage.AgentRoleCharacter, Name: "Bandit", Persona: "Lurks.", Voice: voiceB,
 	})
 	if err != nil {
 		t.Fatalf("CreateAgent B: %v", err)
@@ -70,14 +77,15 @@ func TestUpdateAgent_CrossCampaign_Integration(t *testing.T) {
 		t.Fatalf("cross-campaign UpdateAgent code = %v, want NotFound", got)
 	}
 
-	// B's NPC is unchanged — no cross-campaign write landed.
+	// B's NPC is byte-for-byte unchanged — no cross-campaign write landed. Compare
+	// the WHOLE struct (incl. Voice bytes, the load-bearing vector in this fix), not
+	// just the edited fields.
 	after, err := store.GetAgent(ctx, npcBID)
 	if err != nil {
 		t.Fatalf("GetAgent B after: %v", err)
 	}
-	if after.Name != before.Name || after.Persona != before.Persona {
-		t.Errorf("cross-campaign UpdateAgent mutated B's NPC: before %q/%q, after %q/%q",
-			before.Name, before.Persona, after.Name, after.Persona)
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("cross-campaign UpdateAgent mutated B's NPC:\n before %+v\n after  %+v", before, after)
 	}
 }
 

--- a/internal/rpc/campaign_crud_integration_test.go
+++ b/internal/rpc/campaign_crud_integration_test.go
@@ -20,7 +20,66 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
+
+// TestUpdateAgent_CrossCampaign_Integration is #356: the load-bearing GetAgent
+// pre-read (kept for voice preservation) is scoped to the active campaign. With a
+// live Voice Session pinning the active campaign to A, an operator cannot update —
+// or read the voice of — campaign B's NPC by id: UpdateAgent is CodeNotFound
+// before any write, and B's NPC is left byte-for-byte untouched.
+func TestUpdateAgent_CrossCampaign_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignA := seedStore(t, dsn)
+	ctx := context.Background()
+
+	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	npcBID, err := store.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignB, Role: storage.AgentRoleCharacter, Name: "Bandit", Persona: "Lurks.",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent B: %v", err)
+	}
+	before, err := store.GetAgent(ctx, npcBID)
+	if err != nil {
+		t.Fatalf("GetAgent B before: %v", err)
+	}
+
+	// Pin the active campaign to A via a live Voice Session, then mount the server.
+	srv := rpc.NewCampaignServer(store)
+	srv.SetSessions(liveMgr(campaignA))
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler())
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, s.URL, connect.WithProtoJSON())
+
+	_, err = client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{
+		Id: npcBID.String(), Name: "Hijacked", Persona: "Rewritten.",
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("cross-campaign UpdateAgent code = %v, want NotFound", got)
+	}
+
+	// B's NPC is unchanged — no cross-campaign write landed.
+	after, err := store.GetAgent(ctx, npcBID)
+	if err != nil {
+		t.Fatalf("GetAgent B after: %v", err)
+	}
+	if after.Name != before.Name || after.Persona != before.Persona {
+		t.Errorf("cross-campaign UpdateAgent mutated B's NPC: before %q/%q, after %q/%q",
+			before.Name, before.Persona, after.Name, after.Persona)
+	}
+}
 
 func TestCampaignCRUD_Integration(t *testing.T) {
 	dsn := startPostgres(t)

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -887,7 +887,8 @@ func TestUpdateAgent_HappyPathRoundTrips(t *testing.T) {
 func TestUpdateAgent_PreservesExistingVoiceTuning(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	store.campaign = storage.Campaign{ID: uuid.New(), Language: "de"}
+	campID := uuid.New()
+	store.campaign = storage.Campaign{ID: campID, Language: "de"}
 	id := uuid.New()
 
 	tuned := ttseleven.DefaultVoice("v1", "en")
@@ -896,7 +897,7 @@ func TestUpdateAgent_PreservesExistingVoiceTuning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("VoiceToJSON: %v", err)
 	}
-	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old", Voice: blob}
+	store.agents[id] = storage.Agent{ID: id, CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "Old", Voice: blob}
 	client := crudClient(t, store)
 
 	// Same id: the persisted bytes must be byte-identical afterward.
@@ -919,6 +920,42 @@ func TestUpdateAgent_PreservesExistingVoiceTuning(t *testing.T) {
 	}
 	if after.VoiceID != "v2" || after.ProviderID != ttseleven.ProviderID || len(after.Settings) == 0 {
 		t.Errorf("voice change dropped tuning: %+v", after)
+	}
+}
+
+// TestUpdateAgent_CrossCampaignPreReadIsNotFound is #356: the load-bearing
+// pre-read (GetAgent, kept for voice preservation) must not leak across
+// campaigns. An operator whose active campaign is A cannot update — or read the
+// voice of — an Agent that belongs to campaign B by id: the pre-read is scoped to
+// the active campaign, so a mismatch is CodeNotFound before any write, with the
+// same ErrNotFound discipline as the scoped store UPDATE (#353).
+func TestUpdateAgent_CrossCampaignPreReadIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	// The Agent exists, but in ANOTHER campaign, with a tuned voice that must not leak.
+	foreignAgent := uuid.New()
+	tuned, err := storage.VoiceToJSON(ttseleven.DefaultVoice("secret", "en"))
+	if err != nil {
+		t.Fatalf("VoiceToJSON: %v", err)
+	}
+	store.agents[foreignAgent] = storage.Agent{
+		ID: foreignAgent, CampaignID: uuid.New(), Role: storage.AgentRoleCharacter, Voice: tuned,
+	}
+	client := crudClient(t, store)
+
+	resp, err := client.UpdateAgent(context.Background(),
+		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: foreignAgent.String(), Name: "Hijack"}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (cross-campaign agent)", got)
+	}
+	if resp != nil {
+		t.Error("cross-campaign UpdateAgent must not return an agent payload")
+	}
+	// No write reached the store scoped to the active campaign.
+	if store.updateAgentCampaign == activeID {
+		t.Error("cross-campaign UpdateAgent leaked a write to the active campaign")
 	}
 }
 
@@ -982,7 +1019,7 @@ func TestUpdateAgent_ScopesToActiveCampaign(t *testing.T) {
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
-	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old"}
+	store.agents[id] = storage.Agent{ID: id, CampaignID: activeID, Role: storage.AgentRoleCharacter, Name: "Old"}
 	client := crudClient(t, store)
 
 	if _, err := client.UpdateAgent(context.Background(),

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -113,9 +113,12 @@ type fakeCampaignStore struct {
 	edgesOut      []storage.KGEdgeWithNodes
 	edgesIn       []storage.KGEdgeWithNodes
 	nodeEdgesErr  error
-	setAgentCalls []setAgentCall
-	setAgentNode  storage.KGNode
-	setAgentErr   error
+	// nodeEdgesCampaign records the campaign id ListNodeEdges resolved (#356), so a
+	// unit test can assert the read was scoped to the active campaign.
+	nodeEdgesCampaign uuid.UUID
+	setAgentCalls     []setAgentCall
+	setAgentNode      storage.KGNode
+	setAgentErr       error
 	// deleteEdgeCampaign/setAgentCampaign record the campaign id the Edge-delete /
 	// voiced-by link were scoped to (#342), so a unit test can assert the handler
 	// passed the resolved active campaign down.
@@ -411,7 +414,8 @@ func (f *fakeCampaignStore) DeleteEdge(_ context.Context, campaignID, _ uuid.UUI
 	return f.edgeDeleteErr
 }
 
-func (f *fakeCampaignStore) NodeEdges(_ context.Context, _ uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
+func (f *fakeCampaignStore) NodeEdges(_ context.Context, campaignID, _ uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
+	f.nodeEdgesCampaign = campaignID
 	return f.edgesOut, f.edgesIn, f.nodeEdgesErr
 }
 
@@ -953,9 +957,11 @@ func TestUpdateAgent_CrossCampaignPreReadIsNotFound(t *testing.T) {
 	if resp != nil {
 		t.Error("cross-campaign UpdateAgent must not return an agent payload")
 	}
-	// No write reached the store scoped to the active campaign.
-	if store.updateAgentCampaign == activeID {
-		t.Error("cross-campaign UpdateAgent leaked a write to the active campaign")
+	// No write reached the store at all — updateAgentCampaign stays its zero value
+	// (the fake's UpdateAgent never ran). A regression writing with CampaignID=nil
+	// or the foreign id would also be caught (must be exactly uuid.Nil).
+	if store.updateAgentCampaign != uuid.Nil {
+		t.Errorf("cross-campaign UpdateAgent leaked a write scoped to %s, want no write", store.updateAgentCampaign)
 	}
 }
 

--- a/internal/rpc/campaign_grant.go
+++ b/internal/rpc/campaign_grant.go
@@ -35,10 +35,21 @@ func (s *CampaignServer) ListToolGrants(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
 	}
-	// Pre-check the Agent exists so a stale tab (Agent deleted elsewhere) reads a
-	// clean CodeNotFound instead of a fabricated full-catalog-ungranted list
-	// (issue #215) — the sibling CRUD missing-Agent mapping (campaign_crud.go).
-	if err := s.requireAgent(ctx, agentID); err != nil {
+	// Resolve the active campaign and require the Agent to belong to it (#356): the
+	// list is keyed on agent_id alone, so without this an operator on campaign A
+	// could READ campaign B's Agent grant configs by id. The scoped check refuses a
+	// cross-campaign (or deleted, issue #215) target as CodeNotFound — a clean
+	// missing-Agent instead of a fabricated full-catalog-ungranted list — mirroring
+	// the sibling UpdateToolGrant write guard.
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ListToolGrants: get active campaign failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if err := s.requireAgentInCampaign(ctx, c.ID, agentID); err != nil {
 		return nil, err
 	}
 
@@ -129,27 +140,13 @@ func (s *CampaignServer) UpdateToolGrant(
 	return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 }
 
-// requireAgent maps a missing Agent to CodeNotFound (any other lookup failure to
-// CodeInternal) so both grant handlers reject a stale-tab agent_id up front
-// rather than persist against — or fabricate a catalog for — an Agent the FK no
-// longer has (issue #215). Identical shape to the sibling CRUD mutations.
-func (s *CampaignServer) requireAgent(ctx context.Context, agentID uuid.UUID) error {
-	if _, err := s.store.GetAgent(ctx, agentID); err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
-		}
-		slog.Default().Error("tool grant: agent lookup failed", "agent_id", agentID, "err", err)
-		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
-	}
-	return nil
-}
-
-// requireAgentInCampaign is requireAgent scoped to an owning Campaign (#342): the
-// Agent must both exist AND belong to campaignID, else CodeNotFound. Agents never
-// move between Campaigns (campaign_id is immutable), so the read-then-compare is
-// race-free — it verifies ownership before a Tool Grant mutation keyed on agent_id
-// alone can reach another campaign's Agent. Any other lookup failure is
-// CodeInternal.
+// requireAgentInCampaign requires an Agent both to exist AND belong to
+// campaignID, else CodeNotFound (a missing Agent maps the same way, issue #215).
+// Agents never move between Campaigns (campaign_id is immutable), so the
+// read-then-compare is race-free — it verifies ownership before a Tool Grant read
+// or mutation keyed on agent_id alone can reach another campaign's Agent. Any
+// other lookup failure is CodeInternal. Shared by ListToolGrants (#356) and
+// UpdateToolGrant (#342).
 func (s *CampaignServer) requireAgentInCampaign(ctx context.Context, campaignID, agentID uuid.UUID) error {
 	a, err := s.store.GetAgent(ctx, agentID)
 	if err != nil {

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -218,6 +218,47 @@ func TestToolGrants_CrossCampaign_Integration(t *testing.T) {
 	}
 }
 
+// TestListToolGrants_CrossCampaign_Integration is #356: the READ is scoped too.
+// With a live Voice Session pinning the active campaign to A, an operator must not
+// be able to READ campaign B's Butler grant configs by id — ListToolGrants is
+// CodeNotFound, not a leaked catalog of B's grants.
+func TestListToolGrants_CrossCampaign_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignA := seedStore(t, dsn) // A + its auto-Butler (seeded dice grant)
+	ctx := context.Background()
+
+	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	butlerB, err := store.GetButler(ctx, campaignB)
+	if err != nil {
+		t.Fatalf("GetButler B: %v", err)
+	}
+
+	// Pin the active campaign to A via a live Voice Session, then mount the server.
+	srv := rpc.NewCampaignServer(store)
+	srv.SetSessions(liveMgr(campaignA))
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler())
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, s.URL, connect.WithProtoJSON())
+
+	_, err = client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{
+		AgentId: butlerB.ID.String(),
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("cross-campaign ListToolGrants code = %v, want NotFound", got)
+	}
+}
+
 // listGrants is a small helper that lists an Agent's grant states or fails the test.
 func listGrants(t *testing.T, client managementv1connect.CampaignServiceClient, agentID string) []*managementv1.ToolGrant {
 	t.Helper()

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -137,6 +137,43 @@ func TestUpdateToolGrant_NoActiveCampaignIsNotFound(t *testing.T) {
 	}
 }
 
+// TestListToolGrants_CrossCampaignIsNotFound is #356: a READ is scoped too. An
+// operator whose active campaign is A cannot read the grant config of an Agent
+// that belongs to campaign B by id — the list requires the Agent to be in the
+// active campaign, so a mismatch is CodeNotFound, not a leaked catalog.
+func TestListToolGrants_CrossCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	// The Agent exists, but in ANOTHER campaign.
+	foreignAgent := uuid.New()
+	store.agents[foreignAgent] = storage.Agent{ID: foreignAgent, CampaignID: uuid.New()}
+	client := crudClient(t, store)
+
+	_, err := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: foreignAgent.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (cross-campaign agent)", got)
+	}
+}
+
+// TestListToolGrants_NoActiveCampaignIsNotFound is #356: without an active
+// campaign the read cannot resolve an owning campaign and is CodeNotFound.
+func TestListToolGrants_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	agentID := registerAgent(store)
+	client := crudClient(t, store)
+
+	_, err := client.ListToolGrants(context.Background(),
+		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (no active campaign)", got)
+	}
+}
+
 func TestListToolGrants_InvalidAgentID(t *testing.T) {
 	t.Parallel()
 	client := crudClient(t, newFakeStore())

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -117,7 +117,7 @@ func (fakeReader) CreateEdge(context.Context, storage.NewKGEdge) (storage.KGEdge
 func (fakeReader) DeleteEdge(context.Context, uuid.UUID, uuid.UUID) error {
 	return nil
 }
-func (fakeReader) NodeEdges(context.Context, uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
+func (fakeReader) NodeEdges(context.Context, uuid.UUID, uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
 	return nil, nil, nil
 }
 func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.UUID, uuid.NullUUID) (storage.KGNode, error) {

--- a/internal/rpc/kg_edge.go
+++ b/internal/rpc/kg_edge.go
@@ -102,7 +102,11 @@ func (s *CampaignServer) DeleteEdge(
 
 // ListNodeEdges returns a Node's incident Edges split into outgoing and incoming
 // lists, each with joined endpoint name/type. An unparsable id is
-// CodeInvalidArgument; a storage failure is CodeInternal.
+// CodeInvalidArgument. The read is scoped to the active campaign (#356): a Node in
+// another campaign — or a missing Node — is CodeNotFound before any edge data (or
+// joined endpoint name, incl. gm_private ones) is returned, leaking neither the
+// KG nor an existence oracle. No active campaign is CodeNotFound; a storage
+// failure is CodeInternal.
 func (s *CampaignServer) ListNodeEdges(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListNodeEdgesRequest],
@@ -111,8 +115,19 @@ func (s *CampaignServer) ListNodeEdges(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid node id"))
 	}
-	outgoing, incoming, err := s.store.NodeEdges(ctx, nodeID)
+	c, err := s.activeCampaign(ctx)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ListNodeEdges: get active campaign failed", "node_id", nodeID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	outgoing, incoming, err := s.store.NodeEdges(ctx, c.ID, nodeID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("node not found"))
+		}
 		slog.Default().Error("ListNodeEdges: store read failed", "node_id", nodeID, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}

--- a/internal/rpc/kg_edge_integration_test.go
+++ b/internal/rpc/kg_edge_integration_test.go
@@ -22,6 +22,58 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
+// TestListNodeEdges_CrossCampaign_Integration is #356: the KG read is scoped. With
+// a live Voice Session pinning the active campaign to A, an operator must not be
+// able to READ campaign B's Node incident edges by id — ListNodeEdges is
+// CodeNotFound, leaking neither B's edges nor its joined endpoint names nor an
+// existence oracle, even though B's Node has a real incident Edge.
+func TestListNodeEdges_CrossCampaign_Integration(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignA := seedStore(t, dsn)
+	ctx := context.Background()
+
+	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
+	if err != nil {
+		t.Fatalf("GetActiveCampaign: %v", err)
+	}
+	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	// B's Node with a real incident Edge (so an unscoped read would return data).
+	bChar, err := store.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignB, Type: storage.KGNodeCharacter, Name: "Secret Aldric"})
+	if err != nil {
+		t.Fatalf("CreateNode B char: %v", err)
+	}
+	bLoc, err := store.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignB, Type: storage.KGNodeLocation, Name: "Secret Keep"})
+	if err != nil {
+		t.Fatalf("CreateNode B loc: %v", err)
+	}
+	if _, err := store.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignB, FromNodeID: bChar.ID, ToNodeID: bLoc.ID, Type: storage.KGEdgeResidesIn,
+	}); err != nil {
+		t.Fatalf("CreateEdge B: %v", err)
+	}
+
+	// Pin the active campaign to A via a live Voice Session, then mount the server.
+	server := rpc.NewCampaignServer(store)
+	server.SetSessions(liveMgr(campaignA))
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+
+	_, err = client.ListNodeEdges(ctx, connect.NewRequest(&managementv1.ListNodeEdgesRequest{
+		NodeId: bChar.ID.String(),
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Fatalf("cross-campaign ListNodeEdges code = %v, want NotFound", got)
+	}
+}
+
 func TestKGEdge_Integration(t *testing.T) {
 	dsn := startPostgres(t)
 	store, campaignID := seedStore(t, dsn)

--- a/internal/rpc/kg_edge_test.go
+++ b/internal/rpc/kg_edge_test.go
@@ -233,6 +233,57 @@ func TestListNodeEdges_SplitsAndJoins(t *testing.T) {
 	}
 }
 
+// TestListNodeEdges_ScopesToActiveCampaign is #356: the read resolves the active
+// campaign and passes its id to the store, so the anchor Node's ownership is
+// verified there — another campaign's Node is never listable through this session.
+func TestListNodeEdges_ScopesToActiveCampaign(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	activeID := uuid.New()
+	store.campaign = storage.Campaign{ID: activeID}
+	client := crudClient(t, store)
+
+	if _, err := client.ListNodeEdges(context.Background(),
+		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()})); err != nil {
+		t.Fatalf("ListNodeEdges: %v", err)
+	}
+	if store.nodeEdgesCampaign != activeID {
+		t.Errorf("NodeEdges scoped to %s, want active %s", store.nodeEdgesCampaign, activeID)
+	}
+}
+
+// TestListNodeEdges_CrossCampaignIsNotFound is #356: a Node in another campaign is
+// invisible — the store refuses it as ErrNotFound and the handler surfaces
+// CodeNotFound, never a leaked edge list or an existence oracle.
+func TestListNodeEdges_CrossCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.nodeEdgesErr = storage.ErrNotFound // the scoped store refuses a foreign anchor
+	client := crudClient(t, store)
+
+	_, err := client.ListNodeEdges(context.Background(),
+		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (cross-campaign node)", got)
+	}
+}
+
+// TestListNodeEdges_NoActiveCampaignIsNotFound is #356: without an active campaign
+// the read cannot resolve an owning campaign and is CodeNotFound.
+func TestListNodeEdges_NoActiveCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+
+	_, err := client.ListNodeEdges(context.Background(),
+		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound (no active campaign)", got)
+	}
+}
+
 func TestListNodeEdges_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
 	client := crudClient(t, newFakeStore())

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -229,7 +229,28 @@ func (s *Store) DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error 
 // (from_node_id = nodeID) and incoming (to_node_id = nodeID) — each joined to both
 // endpoints' name/type so the Campaign screen renders without an N+1. One query
 // fetches both directions (ordered created_at, id); the split is done in Go.
-func (s *Store) NodeEdges(ctx context.Context, nodeID uuid.UUID) (outgoing, incoming []KGEdgeWithNodes, err error) {
+//
+// The read is scoped to the owning Campaign (#356): the anchor Node must belong to
+// campaignID, else ErrNotFound — a Node in another Campaign is invisible, leaking
+// neither its edges nor its joined endpoint names (incl. gm_private ones) nor an
+// existence oracle. A truly-missing Node id is the same ErrNotFound. Same
+// no-oracle discipline as the cross-campaign DeleteEdge/SetNodeAgent refusals.
+func (s *Store) NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []KGEdgeWithNodes, err error) {
+	// Confirm the anchor Node belongs to this Campaign before returning any edge
+	// data — this is what turns a cross-campaign (or missing) Node into ErrNotFound
+	// instead of a silently-empty list that would still confirm the id parses.
+	var exists bool
+	if err := s.db.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM kg_node WHERE id = $1 AND campaign_id = $2)`,
+		nodeID, campaignID).Scan(&exists); err != nil {
+		return nil, nil, fmt.Errorf("storage: node edges %s: anchor lookup: %w", nodeID, err)
+	}
+	if !exists {
+		return nil, nil, ErrNotFound
+	}
+
+	// Edges are same-campaign by construction (CreateEdge enforces it), so filtering
+	// the anchor by campaign above is sufficient; the WHERE below stays direction-only.
 	rows, err := s.db.Query(ctx,
 		`SELECT e.id, e.campaign_id, e.from_node_id, e.to_node_id, e.edge_type, e.created_at,
 		        fn.name, fn.node_type, tn.name, tn.node_type

--- a/internal/storage/kg_edge_test.go
+++ b/internal/storage/kg_edge_test.go
@@ -126,7 +126,7 @@ func TestNodeEdgesAndDelete(t *testing.T) {
 		t.Fatalf("CreateEdge incoming: %v", err)
 	}
 
-	outgoing, incoming, err := st.NodeEdges(ctx, aldric.ID)
+	outgoing, incoming, err := st.NodeEdges(ctx, campaignID, aldric.ID)
 	if err != nil {
 		t.Fatalf("NodeEdges: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestNodeEdgesAndDelete(t *testing.T) {
 	if err := st.DeleteEdge(ctx, campaignID, out.ID); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("second DeleteEdge err = %v, want ErrNotFound", err)
 	}
-	outgoing, incoming, err = st.NodeEdges(ctx, aldric.ID)
+	outgoing, incoming, err = st.NodeEdges(ctx, campaignID, aldric.ID)
 	if err != nil {
 		t.Fatalf("NodeEdges after delete: %v", err)
 	}
@@ -162,12 +162,50 @@ func TestNodeEdgesAndDelete(t *testing.T) {
 	if err := st.DeleteNode(ctx, campaignID, aldric.ID); err != nil {
 		t.Fatalf("DeleteNode: %v", err)
 	}
-	outC, inC, err := st.NodeEdges(ctx, cyra.ID)
+	outC, inC, err := st.NodeEdges(ctx, campaignID, cyra.ID)
 	if err != nil {
 		t.Fatalf("NodeEdges cyra: %v", err)
 	}
 	if len(outC) != 0 || len(inC) != 0 {
 		t.Errorf("deleting a Node did not cascade its edges: %d out / %d in", len(outC), len(inC))
+	}
+}
+
+// TestNodeEdgesCrossCampaignRefused is #356: NodeEdges is campaign-scoped. A Node
+// that belongs to another Campaign is invisible — asking for its incident Edges
+// yields ErrNotFound (no edge data, no joined endpoint names, no existence oracle),
+// exactly the same discipline as the cross-campaign DeleteEdge/SetNodeAgent refusals.
+// A missing Node id is indistinguishable (also ErrNotFound).
+func TestNodeEdgesCrossCampaignRefused(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A second campaign B in the same tenant, owning a Node with a real incident Edge.
+	campaignB, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID, Name: "Other", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	bChar := mkNode(t, st, campaignB, storage.KGNodeCharacter, "Secret Aldric")
+	bLoc := mkNode(t, st, campaignB, storage.KGNodeLocation, "Secret Keep")
+	if _, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignB, FromNodeID: bChar.ID, ToNodeID: bLoc.ID, Type: storage.KGEdgeResidesIn,
+	}); err != nil {
+		t.Fatalf("CreateEdge B: %v", err)
+	}
+
+	// Reading B's node while scoped to campaign A must leak nothing.
+	_, _, err = st.NodeEdges(ctx, campaignID, bChar.ID)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("cross-campaign NodeEdges err = %v, want ErrNotFound", err)
+	}
+
+	// A truly-missing node id is the same ErrNotFound (no oracle).
+	if _, _, err := st.NodeEdges(ctx, campaignID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("missing-node NodeEdges err = %v, want ErrNotFound", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #342 (PR #353, which campaign-scoped every bare-id *mutation*). This closes the read-side residuals.

## What changed

**1. `ListToolGrants` (`internal/rpc/campaign_grant.go`)** — an operator on active campaign A could READ campaign B's Agent grant configs by id. The bare-id `requireAgent` pre-check is replaced by the campaign-scoped `requireAgentInCampaign` (the exact guard `UpdateToolGrant` already uses): resolve the active campaign first, then a cross-campaign or missing Agent is `CodeNotFound`. Dead `requireAgent` helper removed.

**2. `UpdateAgent` voice pre-read (`internal/rpc/campaign_crud.go`)** — the load-bearing `GetAgent` pre-read (kept for #224 voice preservation) ran bare-id *before* campaign resolution, so campaign B's Agent voice could be read cross-campaign even though the scoped store UPDATE (#353) refused the write. Now the active campaign resolves first and an out-of-campaign pre-read is rejected `CodeNotFound` before its voice reaches the response. Voice-preservation behavior unchanged.

**3. `ListNodeEdges` (`internal/rpc/kg_edge.go` + `internal/storage/kg_edge.go`)** — *added after reviewer caught a third bare-id read of this class.* The handler resolved no active campaign and storage `NodeEdges` had no `campaign_id` filter, so an operator on campaign A could READ campaign B's node incident edges by id — leaking joined endpoint names (incl. `gm_private` node names) and an existence oracle. `NodeEdges` now takes `campaignID` and verifies the anchor node belongs to it (else `ErrNotFound`, indistinguishable from a missing node — no oracle); the handler resolves the active campaign first and maps `ErrNotFound` to `CodeNotFound`. Same discipline as #353.

Same `ErrNotFound` discipline as #353 throughout.

## Storage symmetry (item 3 of the issue) — deliberately NOT changed

The issue notes `UpsertToolGrant`/`DeleteToolGrant` remain unscoped at storage, ownership enforced only at the RPC guard, and says to *consider* pushing scoping into storage "for symmetry." Per #342's decision (verify ownership server-side at the RPC guard), and since the issue text only suggests rather than requires it, storage stays RPC-guarded. No behavior gap today: every caller is the RPC guard. Left as a future consideration if a non-RPC caller ever appears. (Note: `NodeEdges` scoping in fix 3 *does* push into storage, because a KG read has no natural RPC-side ownership check without a redundant node fetch — the anchor-existence check lives where the join does.)

## Completeness — re-grepped ALL of `internal/rpc` (corrected claim)

The original PR grepped only `campaign_*.go`; that claim was too narrow (it missed `kg_edge.go`). Re-grepped every handler file in `internal/rpc` for bare-id reads that take a request id and read without campaign/tenant scoping:

- `campaign_crud.go` GetAgent read-back (CreateAgent) and `campaign_management.go` GetCampaign read-back — read server-created ids, not attacker-supplied; not leaks.
- `campaign_management.go` SetActiveCampaign `GetCampaign(id)` — campaign-level *selection* among the operator's own campaigns, not a per-campaign-scoped resource; tenant isolation is a separate single-operator concern (ADR-0039), out of #356's scope.
- `session.go` GenerateRecap `GetVoiceSession(id)` — already read-then-compares `vs.CampaignID != campaignID` and returns a static NotFound (no oracle); guarded.
- `provider.go` / `voice.go` reads are tenant-scoped; `session.go` transcript/session lists pass `campaignID`.

`ListNodeEdges` was the only unguarded bare-id read of the #342/#356 class. Now fixed.

## Tests (TDD red→green)

Storage (`internal/storage/kg_edge_test.go`, live Postgres):
- `TestNodeEdgesCrossCampaignRefused` (cross-campaign + missing node both `ErrNotFound`; existing `TestNodeEdgesAndDelete` updated to the scoped signature)

Unit (`campaign_grant_test.go`, `campaign_crud_test.go`, `kg_edge_test.go`):
- `TestListToolGrants_CrossCampaignIsNotFound`, `TestListToolGrants_NoActiveCampaignIsNotFound`
- `TestUpdateAgent_CrossCampaignPreReadIsNotFound` (asserts no leaked payload + **no write at all** — `updateAgentCampaign == uuid.Nil`)
- `TestListNodeEdges_ScopesToActiveCampaign`, `TestListNodeEdges_CrossCampaignIsNotFound`, `TestListNodeEdges_NoActiveCampaignIsNotFound`

Integration (live Postgres, two-campaign + live-session pin):
- `TestListToolGrants_CrossCampaign_Integration`
- `TestUpdateAgent_CrossCampaign_Integration` (seeds a tuned voice on B's NPC; asserts the **whole** `storage.Agent` incl. Voice bytes is unchanged via `reflect.DeepEqual`)
- `TestListNodeEdges_CrossCampaign_Integration` (B's node has a real incident edge; read while active on A is `CodeNotFound`)

9 new tests. Existing `TestUpdateAgent_ScopesToActiveCampaign` / `TestUpdateAgent_PreservesExistingVoiceTuning` seed rows updated to give the Agent a matching `CampaignID` now the pre-read is scoped.

Full `internal/...` unit suite green; storage + rpc cross-campaign integration tests green against testcontainers Postgres; `golangci-lint` clean; gofmt clean.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)