### PR TITLE
feat(#287): [E6] internal/bundle types + gzipped-JSON codec

### DIFF
--- a/internal/bundle/codec.go
+++ b/internal/bundle/codec.go
@@ -1,0 +1,114 @@
+package bundle
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// FormatVersion is the current campaign bundle format version (ADR-0053 §7).
+const FormatVersion = 1
+
+// MaxDecodedBytes caps the decompressed JSON size Decode will read, guarding
+// against gzip bombs.
+const MaxDecodedBytes int64 = 256 << 20 // 256 MiB
+
+// decodeLimit is the effective decode cap; a var so tests can shrink it.
+var decodeLimit = MaxDecodedBytes
+
+var (
+	// ErrNewerFormat means the bundle was written by a newer build than this one.
+	ErrNewerFormat = errors.New("bundle format is newer than this build supports")
+	// ErrUnsupportedFormat means the format version has no migration path here.
+	ErrUnsupportedFormat = errors.New("bundle format version is unsupported")
+	// ErrTooLarge means the decompressed bundle exceeded the decode cap.
+	ErrTooLarge = errors.New("bundle exceeds maximum decoded size")
+)
+
+// Encode writes b as gzip-wrapped, indented JSON.
+func Encode(w io.Writer, b *Bundle) error {
+	gz := gzip.NewWriter(w)
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := gz.Write(data); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// Decode reads a bundle, transparently accepting either a gzipped or a plain
+// JSON stream. It enforces the decode-size cap, rejects unknown fields, and
+// checks the format version.
+func Decode(r io.Reader) (*Bundle, error) {
+	br := bufio.NewReader(r)
+	magic, err := br.Peek(2)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	var src io.Reader = br
+	if len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, err := gzip.NewReader(br)
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		src = gz
+	}
+
+	limited := io.LimitReader(src, decodeLimit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > decodeLimit {
+		return nil, ErrTooLarge
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var b Bundle
+	if err := dec.Decode(&b); err != nil {
+		return nil, err
+	}
+
+	if err := CheckVersion(b.FormatVersion); err != nil {
+		return nil, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
+			b.FormatVersion, FormatVersion, err)
+	}
+	return &b, nil
+}
+
+// CheckVersion reports whether v is a supported bundle format version.
+func CheckVersion(v int) error {
+	switch {
+	case v == FormatVersion:
+		return nil
+	case v > FormatVersion:
+		return ErrNewerFormat
+	default:
+		return ErrUnsupportedFormat
+	}
+}
+
+var slugNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Filename returns the canonical bundle filename for a campaign name:
+// "<slug>.glyphoxa.json.gz", where slug is lowercased with runs of non
+// [a-z0-9] collapsed to "-" and trimmed; an empty slug becomes "campaign".
+func Filename(campaignName string) string {
+	slug := slugNonAlnum.ReplaceAllString(strings.ToLower(campaignName), "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		slug = "campaign"
+	}
+	return slug + ".glyphoxa.json.gz"
+}

--- a/internal/bundle/codec.go
+++ b/internal/bundle/codec.go
@@ -73,16 +73,26 @@ func Decode(r io.Reader) (*Bundle, error) {
 		return nil, ErrTooLarge
 	}
 
+	// Lenient version pre-pass: a newer bundle adds fields this build does not
+	// know, so the strict decode below would reject it with a cryptic
+	// unknown-field error. Gate on the version FIRST (ADR-0053 §7: refuse newer
+	// with a clear error) before the strict full decode.
+	var ver struct {
+		FormatVersion int `json:"format_version"`
+	}
+	if err := json.Unmarshal(data, &ver); err != nil {
+		return nil, err
+	}
+	if err := CheckVersion(ver.FormatVersion); err != nil {
+		return nil, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
+			ver.FormatVersion, FormatVersion, err)
+	}
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	var b Bundle
 	if err := dec.Decode(&b); err != nil {
 		return nil, err
-	}
-
-	if err := CheckVersion(b.FormatVersion); err != nil {
-		return nil, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
-			b.FormatVersion, FormatVersion, err)
 	}
 	return &b, nil
 }

--- a/internal/bundle/codec_test.go
+++ b/internal/bundle/codec_test.go
@@ -131,6 +131,21 @@ func TestDecodeNewerVersionMessage(t *testing.T) {
 	}
 }
 
+func TestDecodeNewerVersionWithNewFieldStillRefused(t *testing.T) {
+	// A real v2 bundle adds fields unknown to this v1 build. The version gate
+	// must fire BEFORE strict unknown-field decoding, so an old build tells the
+	// operator "format is newer", not a cryptic unknown-field error.
+	raw := []byte(`{"format_version":2,"exported_at":"2026-07-10T20:00:00Z","new_v2_section":{"x":1},"campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if !errors.Is(err, ErrNewerFormat) {
+		t.Fatalf("want ErrNewerFormat, got %v", err)
+	}
+	msg := err.Error()
+	if !bytes.Contains([]byte(msg), []byte("2")) || !bytes.Contains([]byte(msg), []byte("1")) {
+		t.Fatalf("message must mention both versions, got %q", msg)
+	}
+}
+
 func TestDecodeOlderVersionUnsupported(t *testing.T) {
 	raw := []byte(`{"format_version":0,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
 	_, err := Decode(bytes.NewReader(raw))
@@ -147,6 +162,19 @@ func TestDecodeRejectsUnknownField(t *testing.T) {
 	}
 	if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) || errors.Is(err, ErrTooLarge) {
 		t.Fatalf("unexpected sentinel for unknown field: %v", err)
+	}
+}
+
+func TestDecodeRejectsNestedUnknownField(t *testing.T) {
+	// Secrets would hide inside a nested object (e.g. an agent's provider
+	// binding). DisallowUnknownFields must reject at any depth, not just top level.
+	raw := []byte(`{"format_version":1,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[{"id":"a1","role":"npc","name":"Bob","voice_provider_config_id":"secret"}]}}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if err == nil {
+		t.Fatal("expected nested unknown-field rejection")
+	}
+	if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) || errors.Is(err, ErrTooLarge) {
+		t.Fatalf("unexpected sentinel for nested unknown field: %v", err)
 	}
 }
 

--- a/internal/bundle/codec_test.go
+++ b/internal/bundle/codec_test.go
@@ -1,0 +1,198 @@
+package bundle
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func fullBundle() *Bundle {
+	end := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+	reason := "gm_ended"
+	return &Bundle{
+		FormatVersion: FormatVersion,
+		ExportedAt:    time.Date(2026, 7, 10, 20, 0, 0, 0, time.UTC),
+		Campaign: Campaign{
+			Name:     "The Prancing Pony",
+			System:   "D&D 5e",
+			Language: "de",
+			Agents: []Agent{
+				{
+					ID:          "a1",
+					Role:        "butler",
+					Name:        "Glyphoxa",
+					Title:       "Majordomo",
+					Persona:     "Helpful.",
+					Voice:       json.RawMessage(`{"provider_voice":"barb"}`),
+					AddressOnly: true,
+					Aliases:     []string{"Butler"},
+					Grants: []Grant{
+						{ToolName: "roll_dice", Config: json.RawMessage(`{"max":20}`)},
+					},
+				},
+			},
+			Nodes: []Node{
+				{ID: "n1", Type: "npc", Name: "Barliman", Body: "Innkeeper.", GMPrivate: true, AgentID: "a1"},
+			},
+			Edges: []Edge{
+				{From: "n1", To: "a1", Type: "is"},
+			},
+			Characters: []Character{
+				{Name: "Frodo", Aliases: []string{"Mr. Underhill"}, DiscordUserID: "123"},
+			},
+			History: &History{
+				Sessions: []Session{
+					{
+						ID:        "s1",
+						StartedAt: time.Date(2026, 7, 10, 19, 0, 0, 0, time.UTC),
+						EndedAt:   &end,
+						Status:    "ended",
+						LineCount: 1,
+						EndReason: &reason,
+						Lines: []Line{
+							{LineID: "l1", Seq: 1, Who: "player", Tag: "Frodo", Kind: "speech", TS: end, Text: "Hi", SpeakerDiscordUserID: "123"},
+						},
+						Chunks: []Chunk{
+							{Content: "Hi there", SpeakerDiscordUserIDs: []string{"123"}, ParticipatedAgentIDs: []string{"a1"}, StartedAt: end},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	orig := fullBundle()
+	var buf bytes.Buffer
+	if err := Encode(&buf, orig); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := Decode(&buf)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	// Compare via canonical compact JSON: MarshalIndent reindents embedded
+	// json.RawMessage (Voice, Grant.Config), which is a whitespace-only
+	// difference, so DeepEqual on the raw bytes is too strict.
+	if a, b := compact(t, orig), compact(t, got); a != b {
+		t.Fatalf("round-trip mismatch:\norig=%s\ngot =%s", a, b)
+	}
+}
+
+func compact(t *testing.T, b *Bundle) string {
+	t.Helper()
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func TestDecodeAcceptsPlainJSON(t *testing.T) {
+	orig := fullBundle()
+	raw, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Decode plain JSON: %v", err)
+	}
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatal("plain-JSON decode mismatch")
+	}
+}
+
+func TestCheckVersionErrors(t *testing.T) {
+	if err := CheckVersion(FormatVersion); err != nil {
+		t.Fatalf("current version should be ok, got %v", err)
+	}
+	if err := CheckVersion(FormatVersion + 1); !errors.Is(err, ErrNewerFormat) {
+		t.Fatalf("want ErrNewerFormat, got %v", err)
+	}
+	if err := CheckVersion(0); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("want ErrUnsupportedFormat, got %v", err)
+	}
+}
+
+func TestDecodeNewerVersionMessage(t *testing.T) {
+	raw := []byte(`{"format_version":2,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if !errors.Is(err, ErrNewerFormat) {
+		t.Fatalf("want ErrNewerFormat, got %v", err)
+	}
+	msg := err.Error()
+	if !bytes.Contains([]byte(msg), []byte("2")) || !bytes.Contains([]byte(msg), []byte("1")) {
+		t.Fatalf("message must mention both versions, got %q", msg)
+	}
+}
+
+func TestDecodeOlderVersionUnsupported(t *testing.T) {
+	raw := []byte(`{"format_version":0,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("want ErrUnsupportedFormat, got %v", err)
+	}
+}
+
+func TestDecodeRejectsUnknownField(t *testing.T) {
+	raw := []byte(`{"format_version":1,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]},"secret_ciphertext":"boom"}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if err == nil {
+		t.Fatal("expected unknown-field rejection")
+	}
+	if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) || errors.Is(err, ErrTooLarge) {
+		t.Fatalf("unexpected sentinel for unknown field: %v", err)
+	}
+}
+
+func TestDecodeTooLarge(t *testing.T) {
+	orig := decodeLimit
+	decodeLimit = 32
+	defer func() { decodeLimit = orig }()
+	raw := []byte(`{"format_version":1,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"padpadpadpadpadpad","system":"y","language":"de","agents":[]}}`)
+	_, err := Decode(bytes.NewReader(raw))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("want ErrTooLarge, got %v", err)
+	}
+}
+
+func TestFilenameSlug(t *testing.T) {
+	cases := map[string]string{
+		"The Prancing Pony": "the-prancing-pony.glyphoxa.json.gz",
+		"!!!":               "campaign.glyphoxa.json.gz",
+		"":                  "campaign.glyphoxa.json.gz",
+		"  Hello, World!  ": "hello-world.glyphoxa.json.gz",
+	}
+	for in, want := range cases {
+		if got := Filename(in); got != want {
+			t.Errorf("Filename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDecodeHandWrittenMinimalBundle(t *testing.T) {
+	raw := `{
+  "format_version": 1,
+  "exported_at": "2026-07-10T20:00:00Z",
+  "campaign": {
+    "name": "Tiny",
+    "system": "D&D 5e",
+    "language": "en",
+    "agents": [
+      {"id": "n1", "role": "npc", "name": "Bob"}
+    ]
+  }
+}`
+	b, err := Decode(bytes.NewReader([]byte(raw)))
+	if err != nil {
+		t.Fatalf("Decode hand-written: %v", err)
+	}
+	if b.Campaign.Name != "Tiny" || len(b.Campaign.Agents) != 1 || b.Campaign.Agents[0].ID != "n1" {
+		t.Fatalf("unexpected decode: %+v", b)
+	}
+}

--- a/internal/bundle/types.go
+++ b/internal/bundle/types.go
@@ -1,0 +1,118 @@
+// Package bundle defines the campaign bundle format (ADR-0053): a versioned,
+// gzipped-JSON envelope for exporting and importing a campaign setup.
+//
+// The structs in this file ARE the secrets-exclusion allowlist (ADR-0053 §2):
+// there is deliberately no field for provider_config, deployment_config, users,
+// auth sessions, ciphertext, last4, speaker_color, linked_user_id, embeddings,
+// embedding_model, or provider FK ids. Never add one — the exporter builds a
+// bundle by populating these fields explicitly, never by reflecting over tables.
+//
+// All entity IDs are opaque string ref keys (§4: the exporter writes the source
+// UUID strings; a hand-written bundle may use "n1"). There is no uuid.UUID here.
+package bundle
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Bundle is the top-level envelope written to a .glyphoxa.json.gz file.
+type Bundle struct {
+	FormatVersion int       `json:"format_version"`
+	ExportedAt    time.Time `json:"exported_at"`
+	Campaign      Campaign  `json:"campaign"`
+}
+
+// Campaign is the exported campaign payload. The Butler is included in Agents;
+// more than one Butler agent is invalid.
+type Campaign struct {
+	Name       string      `json:"name"`
+	System     string      `json:"system"`
+	Language   string      `json:"language"`
+	Agents     []Agent     `json:"agents"`
+	Nodes      []Node      `json:"nodes,omitempty"`
+	Edges      []Edge      `json:"edges,omitempty"`
+	Characters []Character `json:"characters,omitempty"`
+	History    *History    `json:"history,omitempty"`
+}
+
+// Agent is an NPC or the Butler. Voice is opaque JSON minus provider bindings.
+type Agent struct {
+	ID          string          `json:"id"`
+	Role        string          `json:"role"`
+	Name        string          `json:"name"`
+	Title       string          `json:"title,omitempty"`
+	Persona     string          `json:"persona,omitempty"`
+	Voice       json.RawMessage `json:"voice,omitempty"`
+	AddressOnly bool            `json:"address_only,omitempty"`
+	Aliases     []string        `json:"aliases,omitempty"`
+	Grants      []Grant         `json:"grants,omitempty"`
+}
+
+// Grant is a tool grant for an agent.
+type Grant struct {
+	ToolName string          `json:"tool_name"`
+	Config   json.RawMessage `json:"config,omitempty"`
+}
+
+// Node is a knowledge-graph node. AgentID links an NPC node to its agent.
+type Node struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Body      string `json:"body,omitempty"`
+	GMPrivate bool   `json:"gm_private,omitempty"`
+	AgentID   string `json:"agent_id,omitempty"`
+}
+
+// Edge is a knowledge-graph edge referencing node ref keys.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Type string `json:"type"`
+}
+
+// Character is a player character. DiscordUserID is kept verbatim (ADR-0053 §6).
+type Character struct {
+	Name          string   `json:"name"`
+	Aliases       []string `json:"aliases,omitempty"`
+	DiscordUserID string   `json:"discord_user_id"`
+}
+
+// History is the flag-gated transcript payload (ADR-0053 §1, default off).
+type History struct {
+	Sessions []Session `json:"sessions"`
+}
+
+// Session is a voice session with its transcript lines and recall chunks.
+type Session struct {
+	ID        string     `json:"id"`
+	StartedAt time.Time  `json:"started_at"`
+	EndedAt   *time.Time `json:"ended_at,omitempty"`
+	Status    string     `json:"status"`
+	LineCount int        `json:"line_count"`
+	EndReason *string    `json:"end_reason,omitempty"`
+	Lines     []Line     `json:"lines,omitempty"`
+	Chunks    []Chunk    `json:"chunks,omitempty"`
+}
+
+// Line is a transcript line.
+type Line struct {
+	LineID               string    `json:"line_id"`
+	Seq                  int64     `json:"seq"`
+	Who                  string    `json:"who"`
+	Tag                  string    `json:"tag,omitempty"`
+	Kind                 string    `json:"kind"`
+	TS                   time.Time `json:"ts"`
+	Text                 string    `json:"text"`
+	SpeakerDiscordUserID string    `json:"speaker_discord_user_id,omitempty"`
+}
+
+// Chunk is a recall chunk. Embeddings are never exported (ADR-0053 §3): there is
+// no embedding or embedding_model field, and there never will be.
+type Chunk struct {
+	Content               string    `json:"content"`
+	SpeakerDiscordUserIDs []string  `json:"speaker_discord_user_ids,omitempty"`
+	ParticipatedAgentIDs  []string  `json:"participated_agent_ids,omitempty"`
+	StartedAt             time.Time `json:"started_at"`
+}


### PR DESCRIPTION
## What

New package `internal/bundle` — the campaign bundle **type skeleton + codec only** (ADR-0053). No storage import, no exporter/importer/HTTP — those land in #288-#294.

ADR accepted (ADR-0053); this delivers the type skeleton AC.

### Types (`types.go`)
Hand-written allowlist structs — **the structs ARE the secrets-exclusion allowlist** (ADR-0053 §2). No field for `provider_config`, `deployment_config`, users/auth sessions, ciphertext, last4, speaker_color, linked_user_id, embeddings/embedding_model, or provider FK ids — ever. All entity IDs are opaque string ref keys (§4): exporter writes source UUID strings, hand-written bundles may use `"n1"`. No `uuid.UUID`. Chunk carries no embedding.

### Codec (`codec.go`)
- `FormatVersion = 1`, `MaxDecodedBytes = 256 MiB` gzip-bomb guard
- `ErrNewerFormat` / `ErrUnsupportedFormat` / `ErrTooLarge`
- `Encode` — gzip-wrapped `MarshalIndent`
- `Decode` — sniffs gzip magic `0x1f8b` via `bufio.Peek`; plain JSON also accepted; `io.LimitReader` cap → `ErrTooLarge`; `DisallowUnknownFields`; version-checks with both versions in the message
- `CheckVersion`, `Filename` (slug → `<slug>.glyphoxa.json.gz`, empty → `campaign`)

## Tests (10, TDD red→green)
Round-trip; plain-JSON accept; newer→`ErrNewerFormat` (both versions in msg); older→`ErrUnsupportedFormat`; `CheckVersion` matrix; unknown-field reject; `MaxDecodedBytes`→`ErrTooLarge`; Filename slugging; hand-written minimal ADR-0053 bundle decodes.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)