### PR TITLE
feat(#288): campaign-scoped export read paths for edges + chunks

### DIFF
--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -210,6 +210,37 @@ func mapEdgeWriteErr(op string, err error) error {
 	return fmt.Errorf("storage: %s: %w", op, err)
 }
 
+// ListEdges returns every Edge in a Campaign ordered (created_at, id) — the
+// deterministic read the Campaign Bundle exporter serialises (#288, ADR-0053).
+// It is Campaign-scoped (#342): only rows whose campaign_id matches are returned,
+// so no Edge leaks across Campaigns. An empty Campaign yields an empty slice, not
+// an error. Export is a rare admin read, so this reuses the (campaign_id) filter
+// without a dedicated index (ADR-0053 decision).
+func (s *Store) ListEdges(ctx context.Context, campaignID uuid.UUID) ([]KGEdge, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+kgEdgeColumns+`
+		   FROM kg_edge
+		  WHERE campaign_id = $1
+		  ORDER BY created_at, id`, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list kg edges for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []KGEdge
+	for rows.Next() {
+		e, err := scanKGEdge(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan kg edge: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list kg edges for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}
+
 // DeleteEdge removes a typed Edge by id, scoped to its owning Campaign (#342): the
 // DELETE matches (id, campaign_id), so an Edge in another Campaign is not deleted
 // and yields ErrNotFound — a cross-campaign delete is refused server-side. A

--- a/internal/storage/kg_edge_test.go
+++ b/internal/storage/kg_edge_test.go
@@ -261,6 +261,98 @@ func TestSetNodeAgent(t *testing.T) {
 	}
 }
 
+// TestListEdges is #288: ListEdges returns a Campaign's Edges ordered (created_at,
+// id) for the Bundle exporter; an empty Campaign yields an empty slice, not an
+// error; and it is Campaign-scoped (#342) so a second Campaign's Edges never leak.
+func TestListEdges(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// An empty Campaign lists no Edges (empty slice, not error).
+	edges, err := st.ListEdges(ctx, campaignA)
+	if err != nil {
+		t.Fatalf("ListEdges empty: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Fatalf("ListEdges on empty campaign = %d, want 0", len(edges))
+	}
+
+	// Seed three Edges in A. created_at defaults to now() at insert, so insertion
+	// order is the (created_at, id) order.
+	aldric := mkNode(t, st, campaignA, storage.KGNodeCharacter, "Aldric")
+	barrow := mkNode(t, st, campaignA, storage.KGNodeLocation, "Barrow")
+	cult := mkNode(t, st, campaignA, storage.KGNodeFaction, "The Cult")
+	cyra := mkNode(t, st, campaignA, storage.KGNodeCharacter, "Cyra")
+
+	e1, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignA, FromNodeID: aldric.ID, ToNodeID: barrow.ID, Type: storage.KGEdgeResidesIn,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge e1: %v", err)
+	}
+	e2, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignA, FromNodeID: aldric.ID, ToNodeID: cult.ID, Type: storage.KGEdgeMemberOf,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge e2: %v", err)
+	}
+	e3, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignA, FromNodeID: cyra.ID, ToNodeID: aldric.ID, Type: storage.KGEdgeKnows,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge e3: %v", err)
+	}
+
+	// A second Campaign (same tenant) with its own Edge must never appear in A's list.
+	campaignB, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID, Name: "Other", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	bFrom := mkNode(t, st, campaignB, storage.KGNodeCharacter, "Foreigner")
+	bTo := mkNode(t, st, campaignB, storage.KGNodeLocation, "Foreign Keep")
+	if _, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignB, FromNodeID: bFrom.ID, ToNodeID: bTo.ID, Type: storage.KGEdgeResidesIn,
+	}); err != nil {
+		t.Fatalf("CreateEdge B: %v", err)
+	}
+
+	edges, err = st.ListEdges(ctx, campaignA)
+	if err != nil {
+		t.Fatalf("ListEdges A: %v", err)
+	}
+	if len(edges) != 3 {
+		t.Fatalf("ListEdges A = %d edges, want 3 (no B leakage)", len(edges))
+	}
+	wantIDs := []uuid.UUID{e1.ID, e2.ID, e3.ID}
+	for i, e := range edges {
+		if e.ID != wantIDs[i] {
+			t.Errorf("edge[%d].ID = %s, want %s (created_at, id order)", i, e.ID, wantIDs[i])
+		}
+		if e.CampaignID != campaignA {
+			t.Errorf("edge[%d].CampaignID = %s, want %s (no cross-campaign leak)", i, e.CampaignID, campaignA)
+		}
+	}
+	// Ordering is non-decreasing on created_at.
+	for i := 1; i < len(edges); i++ {
+		if edges[i].CreatedAt.Before(edges[i-1].CreatedAt) {
+			t.Errorf("edges not ordered by created_at at %d", i)
+		}
+	}
+
+	// B lists exactly its own single Edge.
+	bEdges, err := st.ListEdges(ctx, campaignB)
+	if err != nil {
+		t.Fatalf("ListEdges B: %v", err)
+	}
+	if len(bEdges) != 1 {
+		t.Fatalf("ListEdges B = %d, want 1", len(bEdges))
+	}
+}
+
 // TestDeleteEdgeIsCampaignScoped is #342: DeleteEdge matches (id, campaign_id), so
 // passing another Campaign's id refuses the delete with ErrNotFound and leaves the
 // Edge; the owning Campaign then deletes it.

--- a/internal/storage/transcript_chunk.go
+++ b/internal/storage/transcript_chunk.go
@@ -244,6 +244,58 @@ func (s *Store) searchChunks(ctx context.Context, campaignID uuid.UUID, agentID 
 	return out, nil
 }
 
+// ExportChunk is one Transcript Chunk plus its embedding rendered as pgvector's
+// text form ("[...]") for the Campaign Bundle exporter (#288, ADR-0053). Embedding
+// is "" when the row's vector is NULL or when the caller excluded vectors — the
+// default export strips embeddings (ADR-0053 d3), so the destination re-embeds.
+type ExportChunk struct {
+	TranscriptChunk
+	Embedding string
+}
+
+// ListTranscriptChunks returns every Transcript Chunk in a Campaign ordered
+// (created_at, id) — the deterministic read the Campaign Bundle exporter serialises
+// (#288, ADR-0053). It is Campaign-scoped (#342): only matching campaign_id rows
+// are returned, so no Chunk leaks across Campaigns. embedding_model is always
+// selected; the vector is included as its ::text form only when includeVectors is
+// true, else "" (COALESCE handles NULL either way). The exporter passes false
+// (ADR-0053 d3 strips vectors); the flag exists for the backup/migration path.
+// Vectors stay text-form so storage keeps no pgvector-go dependency.
+func (s *Store) ListTranscriptChunks(ctx context.Context, campaignID uuid.UUID, includeVectors bool) ([]ExportChunk, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+transcriptChunkColumns+`,
+		        CASE WHEN $2 THEN COALESCE(embedding::text, '') ELSE '' END AS embedding_text
+		   FROM transcript_chunk
+		  WHERE campaign_id = $1
+		  ORDER BY created_at, id`, campaignID, includeVectors)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list transcript chunks for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []ExportChunk
+	for rows.Next() {
+		var (
+			e    ExportChunk
+			vsID uuid.NullUUID // column nullable (ADR-0011 SEAM); may be NULL
+		)
+		if err := rows.Scan(
+			&e.ID, &e.CampaignID, &vsID, &e.Content,
+			&e.SpeakerDiscordUserIDs, &e.ParticipatedAgentIDs,
+			&e.EmbeddingModel, &e.StartedAt, &e.CreatedAt,
+			&e.Embedding,
+		); err != nil {
+			return nil, fmt.Errorf("storage: scan export chunk: %w", err)
+		}
+		e.VoiceSessionID = vsID.UUID // uuid.Nil when NULL
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list transcript chunks for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}
+
 // GetEmbeddingsProviderConfig returns the most-recently-updated 'embeddings'
 // Provider Config, or ErrNotFound when none is bound. Process-wide (no tenant
 // filter), mirroring GetActiveCampaign's single-operator posture (ADR-0039): the

--- a/internal/storage/transcript_chunk_test.go
+++ b/internal/storage/transcript_chunk_test.go
@@ -4,6 +4,7 @@ package storage_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,5 +124,115 @@ func TestTranscriptChunkPersistence(t *testing.T) {
 	}
 	if chunkRows != 2 {
 		t.Errorf("chunk rows for session = %d, want 2 (both grains persist under one session)", chunkRows)
+	}
+}
+
+// TestListTranscriptChunks is #288: the Campaign Bundle exporter's chunk read. It
+// returns a Campaign's chunks ordered (created_at, id) with embedding_model always
+// populated; with includeVectors=false every Embedding is "" (the default
+// vector-stripping export, ADR-0053 d3); with includeVectors=true an embedded row
+// carries pgvector text form "[...]" while a NULL-embedding row stays ""; and it is
+// Campaign-scoped (#342) so a second Campaign's chunks never leak.
+func TestListTranscriptChunks(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignA)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	startedAt := time.Date(2026, 7, 5, 18, 0, 1, 0, time.UTC)
+
+	// Two chunks in A; embed only the first.
+	id1, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: campaignA, VoiceSessionID: vs.ID, Content: "first", StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("InsertTranscriptChunk 1: %v", err)
+	}
+	id2, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: campaignA, VoiceSessionID: vs.ID, Content: "second", StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("InsertTranscriptChunk 2: %v", err)
+	}
+	vec := make([]float32, 768)
+	vec[0] = 0.25
+	if err := st.SetChunkEmbedding(ctx, id1, vec, "nomic-embed-text"); err != nil {
+		t.Fatalf("SetChunkEmbedding: %v", err)
+	}
+
+	// includeVectors=false: ordered rows, every Embedding "", model stamped on id1.
+	chunks, err := st.ListTranscriptChunks(ctx, campaignA, false)
+	if err != nil {
+		t.Fatalf("ListTranscriptChunks false: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("ListTranscriptChunks false = %d, want 2", len(chunks))
+	}
+	if chunks[0].ID != id1 || chunks[1].ID != id2 {
+		t.Errorf("order = [%s %s], want [%s %s] (created_at, id)", chunks[0].ID, chunks[1].ID, id1, id2)
+	}
+	for i, c := range chunks {
+		if c.Embedding != "" {
+			t.Errorf("chunk[%d].Embedding = %q, want \"\" (vectors stripped when includeVectors=false)", i, c.Embedding)
+		}
+		if c.CampaignID != campaignA {
+			t.Errorf("chunk[%d].CampaignID = %s, want %s", i, c.CampaignID, campaignA)
+		}
+	}
+	if chunks[0].EmbeddingModel != "nomic-embed-text" {
+		t.Errorf("chunk[0].EmbeddingModel = %q, want nomic-embed-text (always selected)", chunks[0].EmbeddingModel)
+	}
+	if chunks[1].EmbeddingModel != "" {
+		t.Errorf("chunk[1].EmbeddingModel = %q, want \"\" (never embedded)", chunks[1].EmbeddingModel)
+	}
+
+	// includeVectors=true: id1 carries its "[...]" vector text; id2 (NULL) stays "".
+	withVec, err := st.ListTranscriptChunks(ctx, campaignA, true)
+	if err != nil {
+		t.Fatalf("ListTranscriptChunks true: %v", err)
+	}
+	if len(withVec) != 2 {
+		t.Fatalf("ListTranscriptChunks true = %d, want 2", len(withVec))
+	}
+	if !strings.HasPrefix(withVec[0].Embedding, "[") || !strings.HasSuffix(withVec[0].Embedding, "]") {
+		t.Errorf("embedded chunk Embedding = %q, want pgvector text form \"[...]\"", withVec[0].Embedding)
+	}
+	if withVec[1].Embedding != "" {
+		t.Errorf("NULL-embedding chunk Embedding = %q, want \"\"", withVec[1].Embedding)
+	}
+
+	// Campaign-scoped: a second Campaign's chunk never leaks into A's list.
+	campaignB, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID, Name: "Other", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign B: %v", err)
+	}
+	vsB, err := st.CreateVoiceSession(ctx, campaignB)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession B: %v", err)
+	}
+	if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: campaignB, VoiceSessionID: vsB.ID, Content: "b-chunk", StartedAt: startedAt,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk B: %v", err)
+	}
+	aAgain, err := st.ListTranscriptChunks(ctx, campaignA, false)
+	if err != nil {
+		t.Fatalf("ListTranscriptChunks A again: %v", err)
+	}
+	if len(aAgain) != 2 {
+		t.Errorf("ListTranscriptChunks A = %d, want 2 (no B leakage)", len(aAgain))
+	}
+	bChunks, err := st.ListTranscriptChunks(ctx, campaignB, false)
+	if err != nil {
+		t.Fatalf("ListTranscriptChunks B: %v", err)
+	}
+	if len(bChunks) != 1 {
+		t.Errorf("ListTranscriptChunks B = %d, want 1", len(bChunks))
 	}
 }


### PR DESCRIPTION
Two campaign-scoped `Store` reads the Campaign Bundle exporter (Epic 6, ADR-0053) serialises, plus testcontainers coverage. No migration, no RPC/bundle code — read-path slice only.

## What

- `ListEdges(ctx, campaignID) ([]KGEdge, error)` — `WHERE campaign_id = $1 ORDER BY created_at, id`.
- `type ExportChunk struct { TranscriptChunk; Embedding string }` — pgvector text form `"[...]"`, `""` when NULL or excluded.
- `ListTranscriptChunks(ctx, campaignID, includeVectors) ([]ExportChunk, error)` — `ORDER BY created_at, id`; `embedding_model` always selected; vector via `CASE WHEN $2 THEN COALESCE(embedding::text,'') ELSE ''`.

Exporter passes `includeVectors=false` (ADR-0053 d3 strips vectors, destination re-embeds); the flag exists for the backup/migration path. Vector stays text-form — no pgvector-go dependency.

## Design notes

- Both filter `campaign_id` (#342 posture) — no cross-campaign leakage (tested both directions).
- No new index: export is a rare admin read (ADR-0053 decision).
- `ListVoiceSessions` (#270) already covers the session read — not duplicated.

## Tests (integration, testcontainers)

- `TestListEdges` — ordered list, empty campaign → empty slice, two-campaign leakage.
- `TestListTranscriptChunks` — false: ordered, `Embedding==""`, model stamped after `SetChunkEmbedding`; true: embedded row `"[...]"`, NULL row `""`; two-campaign leakage.

Both pass locally; `golangci-lint` clean.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)