### PR TITLE
fix(#328): deliver-then-commit race — mute/barge no longer commits the cut sentence

### DIFF
--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -387,12 +387,20 @@ func (r *Replier) streamTurn(ctx context.Context, text string, dispatch func(orc
 	var spoken strings.Builder // what actually reached the pump — the history commit
 	voice := r.cfg.Persona.Voice
 
+	// Deliver-then-commit (ADR-0012): dispatch FIRST; a sentence joins the
+	// history commit only once dispatch returns nil, i.e. it was fully
+	// synthesized under a live turn ctx. A dispatch rejected because the turn was
+	// cancelled between the two select-ready branches (mute/barge) must NOT reach
+	// the spoken builder — the room never heard it.
 	emit := func(sentence string) error {
+		if err := dispatch(orchestrator.Reply{Sentence: sentence, Voice: voice}); err != nil {
+			return err
+		}
 		if spoken.Len() > 0 {
 			spoken.WriteByte(' ')
 		}
 		spoken.WriteString(sentence)
-		return dispatch(orchestrator.Reply{Sentence: sentence, Voice: voice})
+		return nil
 	}
 
 	onText := func(delta string) error {
@@ -444,8 +452,14 @@ func (r *Replier) fallbackTurn(ctx context.Context, messages []llm.Message, disp
 	if reply == "" {
 		return nil
 	}
+	// Deliver-then-commit (ADR-0012): dispatch FIRST, commit only once the reply
+	// was delivered. A turn cancelled before the reply drained delivered nothing,
+	// so it must leave no assistant message.
+	if err := dispatch(orchestrator.Reply{Sentence: reply, Voice: r.cfg.Persona.Voice}); err != nil {
+		return err
+	}
 	r.commitSpoken(reply)
-	return dispatch(orchestrator.Reply{Sentence: reply, Voice: r.cfg.Persona.Voice})
+	return nil
 }
 
 // HistorySnapshot returns a copy of the running conversation history (the recent

--- a/pkg/voice/agent/agent_test.go
+++ b/pkg/voice/agent/agent_test.go
@@ -511,6 +511,62 @@ func TestReplyStream_BargeMidStream_CommitsOnlySpoken(t *testing.T) {
 	}
 }
 
+// TestReplyStream_DispatchRejected_NotCommitted pins deliver-then-commit at the
+// emit seam (ADR-0012): a sentence is committed to history only if its dispatch
+// returned nil (delivered). When dispatch rejects sentence #2 (a turn cancelled
+// between the two select-ready branches), only the delivered sentence #1 lands
+// in the committed assistant turn — not the rejected one.
+func TestReplyStream_DispatchRejected_NotCommitted(t *testing.T) {
+	eng := &fakeStreamEngine{deltas: []string{"First. ", "Second. "}}
+	r := streamReplier(t, eng)
+
+	var n int
+	err := r.ReplyStream()(context.Background(), routed("bart", "go"), func(orchestrator.Reply) error {
+		n++
+		if n == 1 {
+			return nil // delivered
+		}
+		return context.Canceled // turn cancelled mid-drain: #2 never delivered
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReplyStream err = %v, want context.Canceled", err)
+	}
+	hist := r.HistorySnapshot()
+	assistant := hist[len(hist)-1]
+	if string(assistant.Role) != "assistant" || strings.TrimSpace(assistant.Text) != "First." {
+		t.Fatalf("committed assistant turn = {%s %q}, want only the delivered sentence \"First.\"", assistant.Role, assistant.Text)
+	}
+}
+
+// batchEngine is a non-streaming [agent.Engine]: it implements Generate but NOT
+// GenerateStream, so ReplyStream falls back to fallbackTurn (the single-completion
+// path).
+type batchEngine struct{ reply string }
+
+func (e batchEngine) Generate(context.Context, []llm.Message) (string, error) {
+	return e.reply, nil
+}
+
+// TestReplyStream_FallbackCancelled_CommitsNothing pins deliver-then-commit on the
+// non-streaming fallback path: if dispatch of the single reply is rejected (the
+// turn was cancelled), nothing was delivered, so NO assistant message is committed
+// (ADR-0012 zero-delivered rule).
+func TestReplyStream_FallbackCancelled_CommitsNothing(t *testing.T) {
+	r := streamReplier(t, batchEngine{reply: "The whole answer."})
+
+	err := r.ReplyStream()(context.Background(), routed("bart", "go"), func(orchestrator.Reply) error {
+		return context.Canceled
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReplyStream err = %v, want context.Canceled", err)
+	}
+	for _, m := range r.HistorySnapshot() {
+		if m.Role == llm.RoleAssistant {
+			t.Fatalf("committed assistant turn %q, want none (nothing delivered)", m.Text)
+		}
+	}
+}
+
 // delayStreamEngine streams sentences with a fixed delay BEFORE each one,
 // modelling the LLM taking perSentence to produce each sentence. Its Generate
 // (the batch path) blocks for ALL sentences before returning, so a batch reply

--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -205,15 +205,17 @@ func TestBargeIn_PerSpeakerWindowNotDisarmedByOther(t *testing.T) {
 	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "B"})
 	h.Bus.Publish(voiceevent.VADSpeechEnd{SpeakerID: "B"}) // only B stopped
 
-	select {
-	case <-turnCtx.Done():
-	case <-time.After(2 * time.Second):
-		t.Fatal("A's sustained interruption must fire the barge; B's speech_end wrongly disarmed A's window")
-	}
-	voicetest.AssertEvent(t, h,
+	// fire() cancels turnCtx BEFORE it publishes BargeDetected, so syncing on
+	// turnCtx.Done() then snapshotting the log races the publish (the sibling flake
+	// this fix targets). WaitEvent polls until the BargeDetected is observed; once
+	// it is, the earlier cancel is guaranteed visible.
+	voicetest.WaitEvent(t, h, 2*time.Second,
 		func(e voiceevent.BargeDetected) bool { return e.SpeakerID == "A" },
-		"barge.detected attributed to speaker A",
+		"barge.detected attributed to speaker A (A's sustained interruption; B's speech_end must not disarm A's window)",
 	)
+	if turnCtx.Err() == nil {
+		t.Fatal("the barge must have cancelled the turn before publishing BargeDetected")
+	}
 }
 
 // TestBargeIn_SameSpeakerSoftOverlapDisarms pins the complement: a speaker's OWN

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -853,9 +853,14 @@ type ReplyFunc func(ctx context.Context, e voiceevent.AddressRouted) []Reply
 // sentence reaches TTS (and audio begins) before the whole completion is
 // generated. dispatch sends one sentence through the TTS stage and blocks until
 // that sentence is synthesized (the serial, one-at-a-time contract the
-// [PlaybackPump] depends on); it returns ctx.Err() if the turn was cancelled, so
-// the producer can stop generating and emitting pending sentences (a mid-stream
-// barge-in now cancels generation itself, not just post-hoc dispatch).
+// [PlaybackPump] depends on).
+//
+// dispatch's return is the deliver-then-commit signal (ADR-0012): a nil return
+// means the sentence was fully synthesized under a live turn ctx — delivered, so
+// the producer may commit it to history. It returns ctx.Err() if the turn was
+// cancelled BEFORE or DURING the sentence's drain (a mid-stream barge/mute cuts
+// the sentence's tail audio before its last frame is forwarded — not delivered),
+// so the producer stops generating AND does not commit that undelivered sentence.
 //
 // ctx is the per-turn context (the barge-in floor's, under [WithBargeIn]); the
 // producer must thread it into its LLM call so a cancel tears generation down.
@@ -1080,6 +1085,15 @@ func (r *Replier) dispatchStream(ctx context.Context, e voiceevent.AddressRouted
 				return ctx.Err()
 			}
 			ttsFailed = true
+			return nil
+		}
+		// Deliver-then-commit re-check (ADR-0012): Dispatch returns nil even when a
+		// barge/mute cancelled the turn DURING the drain — the vendor call succeeded
+		// but the sentence's tail audio was cut before its last frame was forwarded,
+		// so it was NOT delivered. Report the cancel so the producer does not commit
+		// this undelivered sentence.
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/pkg/voice/orchestrator/reactor_test.go
+++ b/pkg/voice/orchestrator/reactor_test.go
@@ -582,6 +582,58 @@ func TestReplier_FloorCleanTurnPublishesNoTurnEnded(t *testing.T) {
 	}
 }
 
+// yieldSynth cancels the active turn (floor.Yield) DURING Synthesize, then hands
+// back an already-closed audio channel — modelling a sentence whose tail audio is
+// cut mid-drain by a barge/mute that lands after Synthesize was accepted but
+// before the last frame is forwarded. The vendor call itself succeeded, so
+// TTS.Dispatch returns nil; the sentence was nonetheless NOT delivered.
+type yieldSynth struct{ floor *orchestrator.Floor }
+
+func (s yieldSynth) Synthesize(_ context.Context, _ tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	s.floor.Yield() // cancel the turn ctx mid-sentence
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (yieldSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+// TestDispatchStream_TurnCutMidDrain_ReportsUndelivered pins the reactor half of
+// deliver-then-commit (ADR-0012): when a turn is cancelled mid-sentence-drain, the
+// dispatch callback handed to the streaming producer must report a non-nil error,
+// so the producer does NOT commit that sentence (its tail was never forwarded).
+// A nil Dispatch return is not enough — the turn ctx may have gone cancelled
+// during the drain, which the dispatch closure must re-check.
+func TestDispatchStream_TurnCutMidDrain_ReportsUndelivered(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	ttsStage := orchestrator.NewTTS(h.Bus, yieldSynth{floor: floor})
+
+	dispErr := make(chan error, 1)
+	reply := func(_ context.Context, _ voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		err := dispatch(orchestrator.Reply{Sentence: "First."})
+		dispErr <- err
+		return err
+	}
+	replier := orchestrator.NewStreamReplier(ttsStage, reply, nil)
+	replier.SetFloor(floor)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.AddressRouted{
+		TurnID: "tcut",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+
+	select {
+	case err := <-dispErr:
+		if err == nil {
+			t.Fatal("dispatch returned nil for a sentence whose tail audio was cut mid-drain — the producer would commit an undelivered sentence (ADR-0012)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the streaming producer never ran")
+	}
+}
+
 // selectiveSynth is a [tts.Synthesizer] that fails Synthesize for sentences in
 // failOn and otherwise returns an already-closed audio channel.
 type selectiveSynth struct {

--- a/pkg/voice/voicetest/harness.go
+++ b/pkg/voice/voicetest/harness.go
@@ -16,6 +16,7 @@ package voicetest
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -87,6 +88,37 @@ func AssertEvent[T voiceevent.Event](t *testing.T, h *Harness, match func(T) boo
 	}
 	t.Fatalf("AssertEvent[%s]: no event matched %q; seen %d events: %v",
 		eventTypeName[T](), desc, len(h.seen), eventNames(h.seen))
+}
+
+// WaitEvent blocks until an observed event of concrete type T satisfies match,
+// or timeout elapses — then fails with the same diagnostics as [AssertEvent]. It
+// polls the observed log every 2ms, so it synchronizes on events published
+// asynchronously (a floor/turn goroutine) without the caller wiring its own
+// subscription. Use it in place of [AssertEvent] whenever the event under test is
+// published from a goroutine the test does not join: AssertEvent reads a snapshot
+// once and races the publisher, WaitEvent does not.
+func WaitEvent[T voiceevent.Event](t *testing.T, h *Harness, timeout time.Duration, match func(T) bool, desc string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		h.mu.Lock()
+		for _, e := range h.seen {
+			if typed, ok := e.(T); ok && match(typed) {
+				h.mu.Unlock()
+				return
+			}
+		}
+		seen := len(h.seen)
+		names := eventNames(h.seen)
+		h.mu.Unlock()
+
+		if time.Now().After(deadline) {
+			t.Fatalf("WaitEvent[%s]: no event matched %q within %s; seen %d events: %v",
+				eventTypeName[T](), desc, timeout, seen, names)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 }
 
 // AssertEventCount fails the test if the number of observed events of concrete

--- a/pkg/voice/voicetest/harness_test.go
+++ b/pkg/voice/voicetest/harness_test.go
@@ -2,6 +2,7 @@ package voicetest_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
@@ -69,6 +70,22 @@ func TestHarness_Events_ReturnsObservedEventsInOrder(t *testing.T) {
 			t.Errorf("event[%d] name = %q, want vad.speech_start", i, e.EventName())
 		}
 	}
+}
+
+func TestHarness_WaitEvent_SeesEventPublishedAfterDelay(t *testing.T) {
+	t.Parallel()
+	h := voicetest.New(t)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		h.Bus.Publish(voiceevent.VADSpeechStart{Probability: 0.91})
+	}()
+
+	voicetest.WaitEvent(t, h,
+		2*time.Second,
+		func(e voiceevent.VADSpeechStart) bool { return e.Probability > 0.8 },
+		"VADSpeechStart with Probability > 0.8 published asynchronously",
+	)
 }
 
 func TestHarness_AssertOrder_PassesOnSubsequence(t *testing.T) {


### PR DESCRIPTION
Closes #328

## Problem
`TestMute_ConversationCutsSpeakingTurnLikeBarge` was flaky: it committed the undelivered `"First. Second."` instead of the delivered `"First."`. Two root causes:

1. **agent.go emit ordering.** `emit` (and `fallbackTurn`) appended the sentence to the `spoken` history builder BEFORE calling `dispatch`. When a mute/barge cancelled the turn between the two select-ready branches (`release` vs `ctx.Done()` in the pausing engine), the next sentence was appended to `spoken` and only THEN rejected by `dispatch` — so the history committed a sentence the room never heard.
2. **reactor.go dispatchStream nil-after-drain.** `TTS.Dispatch` returns `nil` even when a barge/mute cancels the turn DURING the audio drain (vendor call succeeded, tail audio cut before the last frame is forwarded). The dispatch closure treated that `nil` as "delivered".

Sibling flake `TestBargeIn_PerSpeakerWindowNotDisarmedByOther`: `fire()` cancels `turnCtx` BEFORE publishing `BargeDetected`, so syncing on `turnCtx.Done()` then snapshot-`AssertEvent` raced the publish.

## Fix
- **Deliver-then-commit at the emit seam (ADR-0012).** `emit` and `fallbackTurn` now `dispatch` FIRST and commit to history only on a `nil` return. Zero delivered → no assistant message.
- **Post-Dispatch ctx re-check** in `dispatchStream`: after a `nil` `Dispatch`, re-check `ctx.Err()` and return it — a sentence cut mid-drain was not delivered, so the producer stops and does not commit it. `StreamReplyFunc` doc tightened: `nil` == delivered.
- **`voicetest.WaitEvent[T]`**, a polling counterpart to `AssertEvent` for events published from an unjoined goroutine; used to de-flake the barge sibling (WaitEvent then assert the earlier cancel).

No mute-specific branch anywhere — the fix lives at the shared floor-cancel/dispatch path (ADR-0027). No new audio-level assertions (ADR-0021).

## Prod behavior change
A **mid-sentence barge (or mute) no longer commits the cut sentence** to NPC history. This is ADR-0012's stated deliver-then-commit behavior, which the pre-fix ordering violated. The next turn's Hot Context now reflects only what the room actually heard.

## Tests
- RED→GREEN `TestReplyStream_DispatchRejected_NotCommitted` (agent, streaming emit)
- RED→GREEN `TestReplyStream_FallbackCancelled_CommitsNothing` (agent, non-streaming fallback)
- RED→GREEN `TestDispatchStream_TurnCutMidDrain_ReportsUndelivered` (orchestrator, nil-after-drain)
- `TestHarness_WaitEvent_SeesEventPublishedAfterDelay` (voicetest helper)
- De-flaked `TestBargeIn_PerSpeakerWindowNotDisarmedByOther`
- Determinism: `-race -count=500` green on both formerly-flaky tests; formerly-flaky assertions NOT weakened.

## Out of scope — filed as follow-up
Two pre-existing deliver-then-commit residuals on paths this PR did not touch (swallowed TTS start-error commit; batch `Replier.turn` commit-before-dispatch) are filed as #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)