### PR TITLE
feat(#295): /say slash command — GM direct-speech

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -486,6 +486,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			// and the mute view the live loop reads (NewManager wired cfg.Mutes = mgr).
 			presence.MuteCommand(mgr, store),
 			presence.MuteAllCommand(mgr),
+			// /say <text> as:<agent> (#295, ADR-0010): GM puppeteering. The Manager is the
+			// SayControl (its SayAs publishes SpeakRequested on the shared bus, which the
+			// live loop's DirectSpeech reactor renders in the NPC's Voice); store lists the
+			// voiced roster for the resolver + autocomplete.
+			presence.SayCommand(mgr, store),
 		)
 		// Bring the presence up at boot (AC: the commands appear with no Voice
 		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier

--- a/internal/presence/say.go
+++ b/internal/presence/say.go
@@ -1,0 +1,113 @@
+package presence
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/disgoorg/disgo/discord"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// SayControl is the live Voice Session control surface the /say command drives
+// (#295): the active-session snapshot (for the guard + the campaign the
+// autocomplete/resolver list against) and the direct-speech publish. *session.Manager
+// satisfies it structurally — no import, mirroring the mute seam (SessionMuter).
+type SayControl interface {
+	Snapshot() (storage.VoiceSession, bool)
+	// SayAs asks the voiced Character NPC with agentID to speak text verbatim in the
+	// live Voice Session, bypassing Address Detection and the LLM (GM puppeteering,
+	// ADR-0024). It validates the active session + campaign membership atomically and
+	// returns an error (mapped here to the same ephemeral no-session refusal) when the
+	// session ended or the agent is not a voiced NPC of the Active Campaign.
+	SayAs(ctx context.Context, agentID, text string) error
+}
+
+// SayCommand builds the FLAT /say <text> as:<agent> command (ADR-0010: GM-only,
+// requires an active Voice Session). It is the GM's puppet control: the addressed
+// Agent speaks the given text verbatim in the voice channel, bypassing Address
+// Detection and the Agent's own LLM (ADR-0024 — /say is the explicit-target path,
+// so it publishes SpeakRequested, never AddressRouted, and so never wakes the LLM
+// Replier). The `as` option autocompletes the voiced Character NPCs (Name shown,
+// Agent UUID as the value); the handler resolves a picked UUID against the roster,
+// or a typed free-text name/alias, and replies with a clear ephemeral error on
+// no/ambiguous match. A /say with no active Voice Session is refused ephemerally.
+//
+// There is deliberately NO Defer here (mirrors the mute command): the handler does
+// one roster read plus a bus publish — both fast — and always replies ephemerally,
+// so the #335 first-post-Defer EditOriginal routing rule is simply not in play.
+//
+// The Address-Only Butler is excluded from the puppet targets: it is never voiced
+// (ADR-0009/0024), so puppeteering it needs the Butler voicer on-ramp — the
+// #299-blocked follow-up (ButlerVoicer = SayAs(GetButler id)).
+func SayCommand(mgr SayControl, agents AgentLister) Command {
+	return Command{
+		Path:        "say",
+		Description: "Make an NPC speak the given text in the active Voice Session.",
+		GMOnly:      true,
+		Options: []discord.ApplicationCommandOption{
+			discord.ApplicationCommandOptionString{
+				Name:        "text",
+				Description: "What the NPC should say.",
+				Required:    true,
+			},
+			discord.ApplicationCommandOptionString{
+				Name:         "as",
+				Description:  "The NPC to speak as.",
+				Required:     true,
+				Autocomplete: true,
+			},
+		},
+		Autocomplete: func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
+			vs, active := mgr.Snapshot()
+			if !active {
+				return nil, nil // no session: nothing to puppet, offer nothing
+			}
+			roster, err := agents.ListAgents(ctx, vs.CampaignID)
+			if err != nil {
+				return nil, err
+			}
+			_, focused := ac.Focused()
+			prefix := strings.ToLower(strings.TrimSpace(focused))
+			choices := make([]discord.AutocompleteChoice, 0, len(roster))
+			for _, a := range voiced(roster) {
+				if prefix != "" && !strings.HasPrefix(strings.ToLower(a.Name), prefix) {
+					continue
+				}
+				choices = append(choices, discord.AutocompleteChoiceString{Name: a.Name, Value: a.ID.String()})
+				if len(choices) >= maxAutocompleteChoices {
+					break
+				}
+			}
+			return choices, nil
+		},
+		Handle: func(ctx context.Context, ic *Interaction) error {
+			vs, active := mgr.Snapshot()
+			if !active {
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			text, _ := ic.String("text")
+			input, _ := ic.String("as")
+			roster, err := agents.ListAgents(ctx, vs.CampaignID)
+			if err != nil {
+				return fmt.Errorf("presence: list agents for say: %w", err) // unexpected → generic reply
+			}
+			agent, found, ambiguous := resolveAgent(voiced(roster), input)
+			if ambiguous {
+				return ic.ReplyEphemeral(fmt.Sprintf("%q matches more than one Agent — pick one from the list.", strings.TrimSpace(input)))
+			}
+			if !found {
+				return ic.ReplyEphemeral(fmt.Sprintf("No Agent named %q in the Active Campaign.", strings.TrimSpace(input)))
+			}
+			if err := mgr.SayAs(ctx, agent.ID.String(), text); err != nil {
+				// The expected failures are a session ending between the snapshot and the
+				// publish, or the resolved Agent no longer being in the (now-different)
+				// active Campaign; both surface as the same ephemeral guard rather than a
+				// generic error, so a racing Stop / session swap reads cleanly (mirrors mute).
+				return ic.ReplyEphemeral("No Voice Session is active.")
+			}
+			return ic.ReplyEphemeral(fmt.Sprintf("Speaking as %s.", agent.Name))
+		},
+	}
+}

--- a/internal/presence/say_test.go
+++ b/internal/presence/say_test.go
@@ -1,0 +1,179 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeSayer is a SayControl for the /say command tests: it records the SayAs calls
+// and reports whether a session is active.
+type fakeSayer struct {
+	active     bool
+	campaignID uuid.UUID
+	sayErr     error
+	calls      []sayCall
+}
+
+type sayCall struct {
+	agentID string
+	text    string
+}
+
+func (f *fakeSayer) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{CampaignID: f.campaignID}, f.active
+}
+
+func (f *fakeSayer) SayAs(_ context.Context, agentID, text string) error {
+	f.calls = append(f.calls, sayCall{agentID, text})
+	return f.sayErr
+}
+
+func sayIC(resp *fakeResponder, text, as string) *Interaction {
+	return &Interaction{
+		guildID: testGuild,
+		userID:  operatorID,
+		opts:    fakeOpts{s: map[string]string{"text": text, "as": as}},
+		resp:    resp,
+	}
+}
+
+func sayAC(as string) *Autocomplete {
+	return &Autocomplete{
+		guildID: testGuild,
+		userID:  operatorID,
+		data: discord.AutocompleteInteractionData{
+			CommandName: "say",
+			Options: map[string]discord.AutocompleteOption{
+				"as": {
+					Name:    "as",
+					Type:    discord.ApplicationCommandOptionTypeString,
+					Value:   json.RawMessage(`"` + as + `"`),
+					Focused: true,
+				},
+			},
+		},
+	}
+}
+
+// TestSayCommand_IsFlatGMOnlyWithAutocomplete pins the command shape (ADR-0010):
+// a FLAT /say (not grouped), GM-only, a required "text" and a required
+// autocompleting "as" option.
+func TestSayCommand_IsFlatGMOnlyWithAutocomplete(t *testing.T) {
+	cmd := SayCommand(&fakeSayer{}, &fakeLister{})
+	if cmd.Path != "say" || !cmd.GMOnly || cmd.Autocomplete == nil {
+		t.Fatalf("SayCommand shape = {path %q GMOnly %v autocomplete %v}, want GM-only flat /say with autocomplete", cmd.Path, cmd.GMOnly, cmd.Autocomplete != nil)
+	}
+	if len(cmd.Options) != 2 {
+		t.Fatalf("SayCommand has %d options, want 2 (text + as)", len(cmd.Options))
+	}
+}
+
+// TestSayCommand_NoSessionRefused pins the active-session requirement (ADR-0010):
+// with no live Voice Session /say is refused ephemerally and SayAs is never called.
+func TestSayCommand_NoSessionRefused(t *testing.T) {
+	sayer := &fakeSayer{active: false}
+	resp := &fakeResponder{}
+	if err := SayCommand(sayer, &fakeLister{}).Handle(context.Background(), sayIC(resp, "hi", "Bart")); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(sayer.calls) != 0 {
+		t.Fatalf("SayAs called %d times with no session, want 0", len(sayer.calls))
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("no-session reply = %+v, want one ephemeral refusal", resp.replies)
+	}
+}
+
+// TestSayCommand_UnknownAgentRefused pins the resolver error: a name matching no
+// roster Agent is an ephemeral error and SayAs is never called.
+func TestSayCommand_UnknownAgentRefused(t *testing.T) {
+	campaign := uuid.New()
+	sayer := &fakeSayer{active: true, campaignID: campaign}
+	lister := &fakeLister{agents: []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}}}
+	resp := &fakeResponder{}
+	if err := SayCommand(sayer, lister).Handle(context.Background(), sayIC(resp, "hi", "Nobody")); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(sayer.calls) != 0 {
+		t.Fatalf("SayAs called for an unknown agent, want 0 calls")
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("unknown-agent reply = %+v, want one ephemeral error", resp.replies)
+	}
+}
+
+// TestSayCommand_HappyCallsSayAs pins the success path: a resolved voiced NPC is
+// spoken via SayAs(id, text) and the GM gets an ephemeral ack naming the Agent.
+func TestSayCommand_HappyCallsSayAs(t *testing.T) {
+	campaign := uuid.New()
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	sayer := &fakeSayer{active: true, campaignID: campaign}
+	lister := &fakeLister{agents: []storage.Agent{bart}}
+	resp := &fakeResponder{}
+	if err := SayCommand(sayer, lister).Handle(context.Background(), sayIC(resp, "Welcome!", bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(sayer.calls) != 1 || sayer.calls[0].agentID != bart.ID.String() || sayer.calls[0].text != "Welcome!" {
+		t.Fatalf("SayAs calls = %+v, want one {%s, Welcome!}", sayer.calls, bart.ID)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("ack = %+v, want one ephemeral reply", resp.replies)
+	}
+}
+
+// TestSayCommand_SayAsRaceRefused pins the guard on a session ending between the
+// resolve and the publish: SayAs returning an error surfaces the same ephemeral
+// no-session refusal (mirrors the mute command), not a generic failure.
+func TestSayCommand_SayAsRaceRefused(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	sayer := &fakeSayer{active: true, sayErr: context.Canceled}
+	lister := &fakeLister{agents: []storage.Agent{bart}}
+	resp := &fakeResponder{}
+	if err := SayCommand(sayer, lister).Handle(context.Background(), sayIC(resp, "hi", bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+		t.Fatalf("race reply = %+v, want one ephemeral refusal", resp.replies)
+	}
+}
+
+// TestSayCommand_AutocompleteOffersVoicedNPCs pins the autocomplete (mute pattern):
+// it offers the voiced Character NPCs (Name shown, Agent UUID value) and excludes
+// the Address-Only Butler, which /say cannot puppet yet (#299).
+func TestSayCommand_AutocompleteOffersVoicedNPCs(t *testing.T) {
+	campaign := uuid.New()
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Butler"}
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	sayer := &fakeSayer{active: true, campaignID: campaign}
+	lister := &fakeLister{agents: []storage.Agent{butler, bart}}
+
+	choices, err := SayCommand(sayer, lister).Autocomplete(context.Background(), sayAC(""))
+	if err != nil {
+		t.Fatalf("Autocomplete: %v", err)
+	}
+	if len(choices) != 1 {
+		t.Fatalf("choices = %+v, want only the voiced NPC (Butler excluded)", choices)
+	}
+	c, ok := choices[0].(discord.AutocompleteChoiceString)
+	if !ok || c.Name != "Bart" || c.Value != bart.ID.String() {
+		t.Fatalf("choice = %+v, want {Bart, %s}", choices[0], bart.ID)
+	}
+}
+
+// TestSayCommand_AutocompleteIdleOffersNothing pins that with no live session the
+// autocomplete offers nothing (nothing to puppet).
+func TestSayCommand_AutocompleteIdleOffersNothing(t *testing.T) {
+	choices, err := SayCommand(&fakeSayer{active: false}, &fakeLister{}).Autocomplete(context.Background(), sayAC(""))
+	if err != nil {
+		t.Fatalf("Autocomplete: %v", err)
+	}
+	if len(choices) != 0 {
+		t.Fatalf("idle autocomplete = %+v, want none", choices)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -718,6 +718,74 @@ func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) 
 	return ids, nil
 }
 
+// SayAs publishes a GM-puppeteered direct-speech request (#295, ADR-0010): the
+// voiced Character NPC with agentID speaks text verbatim in the live Voice Session.
+// It refuses when idle (ErrNoActiveSession) and rejects an agentID that is not a
+// VOICED Agent of the active session's Campaign — a foreign agent, an unknown id,
+// or the Address-Only Butler (never voiced, ADR-0009/0024; the Butler on-ramp is a
+// #299-blocked follow-up) — with ErrAgentNotInCampaign.
+//
+// Validation and the publish are SESSION-ATOMIC (mirrors SetAgentMute): the active
+// session is captured, its Campaign is listed with m.mu released (the store read may
+// block), then the event is published only if the SAME session is still active — so
+// a session swap between the roster read and the publish can never voice a foreign
+// agent into the new session. It publishes [voiceevent.SpeakRequested] carrying the
+// agent's Target (id + character role + display name), a fresh TurnID, and the text
+// — NOT [voiceevent.AddressRouted], which would trigger the LLM Replier (ADR-0024).
+// The GM mute is deliberately NOT consulted here (puppeteering is a GM override, so
+// a muted NPC still speaks a /say — the DirectSpeech reactor bypasses the mute gate).
+func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
+	m.mu.Lock()
+	as := m.active
+	if as == nil {
+		m.mu.Unlock()
+		return ErrNoActiveSession
+	}
+	campaignID := as.campaignID
+	m.mu.Unlock()
+
+	agents, err := m.store.ListAgents(ctx, campaignID)
+	if err != nil {
+		return fmt.Errorf("session: list agents for say: %w", err)
+	}
+	var target storage.Agent
+	found := false
+	for _, a := range voicedAgents(agents) {
+		if a.ID.String() == agentID {
+			target = a
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrAgentNotInCampaign
+	}
+
+	m.mu.Lock()
+	if m.active != as {
+		// The session ended or rolled over between the roster read and the publish:
+		// abort rather than voice into a different (or no) session.
+		m.mu.Unlock()
+		return ErrNoActiveSession
+	}
+	bus := m.base.Bus
+	m.mu.Unlock()
+
+	if bus != nil {
+		bus.Publish(voiceevent.SpeakRequested{
+			At:     time.Now(),
+			TurnID: voiceevent.NewTurnID(),
+			Target: voiceevent.AddressTarget{
+				AgentID:   agentID,
+				AgentRole: voiceevent.AgentRoleCharacter,
+				Name:      target.Name,
+			},
+			Text: text,
+		})
+	}
+	return nil
+}
+
 // agentInList reports whether agentID (a UUID string) names an Agent in agents.
 func agentInList(agents []storage.Agent, agentID string) bool {
 	for _, a := range agents {

--- a/internal/session/manager_say_test.go
+++ b/internal/session/manager_say_test.go
@@ -1,0 +1,100 @@
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestSayAs_IdleReturnsNoActiveSession pins the active-session requirement (#295,
+// ADR-0010): a /say with no live Voice Session is refused before any roster lookup
+// and publishes nothing.
+func TestSayAs_IdleReturnsNoActiveSession(t *testing.T) {
+	mgr, bus := muteManager(t, newFakeStore())
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SayAs(context.Background(), uuid.NewString(), "hello"); err != session.ErrNoActiveSession {
+		t.Fatalf("SayAs while idle = %v, want ErrNoActiveSession", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("idle SayAs published %d SpeakRequested, want none", len(got))
+	}
+}
+
+// TestSayAs_ForeignAgentRejected pins the campaign-membership guard (#295): an
+// agent not in the active session's voiced roster is refused ErrAgentNotInCampaign
+// and publishes nothing.
+func TestSayAs_ForeignAgentRejected(t *testing.T) {
+	store := newFakeStore()
+	seedAgents(store, 1)
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SayAs(context.Background(), uuid.NewString(), "hello"); err != session.ErrAgentNotInCampaign {
+		t.Fatalf("SayAs with a foreign agent = %v, want ErrAgentNotInCampaign", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("foreign SayAs published %d SpeakRequested, want none", len(got))
+	}
+}
+
+// TestSayAs_ButlerRejected pins the Address-Only Butler exclusion (ADR-0009/0024):
+// the Butler is never voiced, so /say cannot puppet it (the Butler on-ramp is the
+// #299-blocked follow-up); it is refused ErrAgentNotInCampaign.
+func TestSayAs_ButlerRejected(t *testing.T) {
+	store := newFakeStore()
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Butler"}
+	store.agents = []storage.Agent{butler}
+	mgr, _ := muteManager(t, store)
+	startMuteSession(t, mgr)
+
+	if err := mgr.SayAs(context.Background(), butler.ID.String(), "hello"); err != session.ErrAgentNotInCampaign {
+		t.Fatalf("SayAs with the Butler = %v, want ErrAgentNotInCampaign", err)
+	}
+}
+
+// TestSayAs_HappyPublishesSpeakRequested pins the success path (#295): a voiced
+// Character NPC of the active Campaign yields exactly one SpeakRequested carrying
+// the agent's Target (id + character role + display name), a fresh TurnID, and the
+// verbatim text.
+func TestSayAs_HappyPublishesSpeakRequested(t *testing.T) {
+	store := newFakeStore()
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	store.agents = []storage.Agent{bart}
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SayAs(context.Background(), bart.ID.String(), "Welcome, travelers."); err != nil {
+		t.Fatalf("SayAs happy path: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("SayAs published %d SpeakRequested, want 1", len(got))
+	}
+	e := got[0]
+	if e.Target.AgentID != bart.ID.String() {
+		t.Errorf("Target.AgentID = %q, want %q", e.Target.AgentID, bart.ID.String())
+	}
+	if e.Target.AgentRole != voiceevent.AgentRoleCharacter {
+		t.Errorf("Target.AgentRole = %q, want %q", e.Target.AgentRole, voiceevent.AgentRoleCharacter)
+	}
+	if e.Target.Name != "Bart" {
+		t.Errorf("Target.Name = %q, want Bart", e.Target.Name)
+	}
+	if e.Text != "Welcome, travelers." {
+		t.Errorf("Text = %q, want the verbatim /say text", e.Text)
+	}
+	if e.TurnID == "" {
+		t.Error("SpeakRequested carries no TurnID, want a fresh one")
+	}
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -343,6 +343,14 @@ func (r *Relay) project(e voiceevent.Event) {
 		// Records WHO answers this turn; no line yet (no text).
 		t := r.turn(ev.TurnID)
 		t.target = ev.Target
+	case voiceevent.SpeakRequested:
+		// A GM /say (#295): like AddressRouted it records WHO speaks this turn (no line
+		// yet, no text). The Agent's Voice renders the text through the SAME TTSInvoked
+		// path below, so the /say line is assembled and persisted exactly like an LLM
+		// reply (ID "a:<turn>", NPC kind + pill) — no hand-crafted transcript row
+		// (ADR-0012/0040).
+		t := r.turn(ev.TurnID)
+		t.target = ev.Target
 	case voiceevent.TTSInvoked:
 		// One sentence of the Agent's reply — coalesced into the turn's line.
 		t := r.turn(ev.TurnID)

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -1,0 +1,65 @@
+package transcript
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestProjection_SayLineMatchesLLMTurn pins #295 (ADR-0012/0040): a GM /say lands in
+// the transcript through the NORMAL SpeakRequested → TTSInvoked projection — no
+// hand-crafted row — producing a Line byte-identical to an LLM turn's reply (ID
+// "a:<turn>", NPC kind + pill, the Agent's name, the coalesced text).
+func TestProjection_SayLineMatchesLLMTurn(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.SpeakRequested{
+		At: at(1), TurnID: "s1", Text: "Welcome, travelers.",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Welcome, travelers.", Index: 0, TurnID: "s1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want 1: %+v", len(v.Lines), v.Lines)
+	}
+	l := v.Lines[0]
+	if l.ID != "a:s1" {
+		t.Errorf("Line.ID = %q, want a:s1 (the same a:<turn> shape an LLM turn uses)", l.ID)
+	}
+	if l.Who != "Bart" || l.Kind != KindNPC || l.Tag != "NPC" {
+		t.Errorf("say line meta = {who %q kind %q tag %q}, want {Bart npc NPC}", l.Who, l.Kind, l.Tag)
+	}
+	if l.Text != "Welcome, travelers." {
+		t.Errorf("say line text = %q, want the verbatim /say text", l.Text)
+	}
+}
+
+// TestProjection_SayPersistenceTeeFires pins that a /say line is teed onto the
+// durable writer exactly like an LLM reply (ADR-0040) — no special persistence path.
+func TestProjection_SayPersistenceTeeFires(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(bus, fs, store, nil)
+
+	bus.Publish(voiceevent.SpeakRequested{
+		At: at(1), TurnID: "s1", Text: "Aye.",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Aye.", Index: 0, TurnID: "s1"})
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got, _ := store.ListTranscriptLines(context.Background(), fs.id)
+	if len(got) != 1 {
+		t.Fatalf("persisted %d lines, want 1", len(got))
+	}
+	if got[0].LineID != "a:s1" || got[0].Who != "Bart" || got[0].Text != "Aye." {
+		t.Errorf("persisted say line = {id %q who %q text %q}, want {a:s1 Bart Aye.}", got[0].LineID, got[0].Who, got[0].Text)
+	}
+}

--- a/internal/wirenpc/roster.go
+++ b/internal/wirenpc/roster.go
@@ -152,6 +152,22 @@ func (r *Roster) RemoveNPC(agentID string) {
 	r.cast.Remove(agentID) // Cast is independently concurrency-safe; outside r.mu
 }
 
+// Voice returns the TTS Voice of the held NPC with agentID, reporting ok=false when
+// the Roster never held it (or it was removed). It is the /say direct-speech voice
+// lookup (#295, orchestrator.VoiceLookup): the DirectSpeech reactor renders a GM
+// SpeakRequested in the addressed Agent's Voice, and a miss ends the turn rather
+// than voicing a zero Voice. Concurrency-safe: reads the specs map under r.mu, the
+// same lock AddNPC/RemoveNPC mutate it under.
+func (r *Roster) Voice(agentID string) (tts.Voice, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	spec, ok := r.specs[agentID]
+	if !ok {
+		return tts.Voice{}, false
+	}
+	return spec.voice, true
+}
+
 // SetMuted toggles one NPC's mute in the live scene (#211, #225). It is
 // deliberately MATCHER-ONLY and NEVER touches the Cast, so the NPC keeps its SAME
 // [agent.Replier] — and its ADR-0012 delivered-only history — across a mute,

--- a/internal/wirenpc/roster_voice_test.go
+++ b/internal/wirenpc/roster_voice_test.go
@@ -1,0 +1,57 @@
+package wirenpc
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+)
+
+// silentRoster builds a Roster with a silent replier factory (no engine needed) —
+// enough to exercise the spec bookkeeping Roster.Voice reads.
+func silentRoster() *Roster {
+	return newRoster(rosterDeps{replierFor: func(s npcSpec) *agent.Replier {
+		return agent.NewReplier(agent.Config{
+			Persona:     agent.Persona{AgentID: s.agentID, Voice: s.voice},
+			Engine:      scriptEngine{},
+			Synthesizer: &recordingSynth{},
+		})
+	}})
+}
+
+// TestRosterVoice_HeldNPC pins the /say voice lookup (#295): a held NPC's Voice is
+// returned by agentID, so the DirectSpeech reactor renders /say in the right voice.
+func TestRosterVoice_HeldNPC(t *testing.T) {
+	r := silentRoster()
+	r.AddNPC(specFor("bart", "Bart", ""))
+
+	v, ok := r.Voice("bart")
+	if !ok {
+		t.Fatal("Voice(bart) not found, want the held NPC's voice")
+	}
+	if v.VoiceID != "bart" || v.Name != "Bart" {
+		t.Errorf("Voice(bart) = %+v, want the specFor voice", v)
+	}
+}
+
+// TestRosterVoice_UnknownNPC pins the miss: an id the Roster never held reports
+// ok=false (the DirectSpeech reactor then ends the turn rather than panicking).
+func TestRosterVoice_UnknownNPC(t *testing.T) {
+	r := silentRoster()
+	r.AddNPC(specFor("bart", "Bart", ""))
+
+	if _, ok := r.Voice("ghost"); ok {
+		t.Fatal("Voice(ghost) found, want ok=false for an unheld id")
+	}
+}
+
+// TestRosterVoice_RemovedNPC pins that a removed NPC's Voice is gone, so a /say for
+// a just-removed NPC ends cleanly rather than voicing a stale spec.
+func TestRosterVoice_RemovedNPC(t *testing.T) {
+	r := silentRoster()
+	r.AddNPC(specFor("bart", "Bart", ""))
+	r.RemoveNPC("bart")
+
+	if _, ok := r.Voice("bart"); ok {
+		t.Fatal("Voice(bart) found after RemoveNPC, want ok=false")
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -1099,6 +1099,13 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 		// once the session's estimated spend crosses the soft cap. A nil gate is the
 		// feature-off default (no caps configured), so this option is unconditional.
 		orchestrator.WithTurnGate(gate),
+		// GM /say direct speech (#295, ADR-0010): a DirectSpeech reactor renders a
+		// SpeakRequested (the /say slash command) to TTS in the addressed NPC's Voice,
+		// looked up from THIS roster. It shares the barge-in floor (so a human barge
+		// cancels a /say) and the spend gate, but bypasses mute (GM puppeteering). The
+		// session Manager publishes SpeakRequested; the lookup is always wired so /say
+		// works whenever a session is live.
+		orchestrator.WithDirectSpeech(roster.Voice),
 		// Handles failures the reactors fire off the audio loop: the replier's TTS
 		// dispatch and the segmenter's off-loop STT call (#24). The wrapped error
 		// names its stage (orchestrator.TTS.Dispatch / orchestrator.STT.Transcribe).

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -48,6 +48,13 @@ type Conversation struct {
 	// set, Register installs it on the replier, which refuses a route whose new turn
 	// the gate denies (the spend soft cap) beside the mute pre-check.
 	gate TurnGate
+
+	// voiceOf is the /say direct-speech voice lookup ([WithDirectSpeech], #295): nil
+	// = feature off. When set, Register binds a [DirectSpeech] reactor on
+	// SpeakRequested, sharing the barge-in floor (so a barge cancels a /say) and the
+	// turn gate. Deliberately independent of the mute view (GM puppeteering bypasses
+	// mute).
+	voiceOf VoiceLookup
 }
 
 // Option configures a [Conversation] at construction.
@@ -147,6 +154,18 @@ func WithLaneStreamingSTT(f func(speakerID string) *StreamManager, maxLanes int)
 	}
 }
 
+// WithDirectSpeech enables the GM /say direct-speech path (#295, ADR-0010): a
+// [DirectSpeech] reactor renders a [voiceevent.SpeakRequested] to TTS in the Agent's
+// Voice, looked up via voiceOf. It requires a non-nil TTS stage; Register panics
+// otherwise. The reactor shares the barge-in floor built for [WithReply] (so a human
+// barge cancels a /say) and honors [WithTurnGate], but deliberately bypasses the
+// mute view — /say is a GM override. A nil voiceOf is the feature-off default. It is
+// independent of [WithReply]: /say publishes SpeakRequested, never AddressRouted, so
+// it never wakes the LLM Replier (ADR-0024).
+func WithDirectSpeech(voiceOf VoiceLookup) Option {
+	return func(c *Conversation) { c.voiceOf = voiceOf }
+}
+
 // WithErrorHandler sets the [ErrorFunc] used to report failures from stage calls
 // the reactors fire inside bus callbacks (currently the replier's TTS dispatch).
 // Without it such failures are dropped silently.
@@ -228,6 +247,20 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 			}
 		}
 		reactors = append(reactors, replier)
+	}
+	// GM /say direct speech (#295): a DirectSpeech reactor on SpeakRequested, sharing
+	// the barge-in floor (built above for the reply path, so a barge cancels a /say)
+	// and the turn gate. Bound AFTER the replier so a SpeakRequested and an
+	// AddressRouted never contend — they are distinct events on distinct turns. It
+	// requires a TTS stage; nil voiceOf is the feature-off default.
+	if c.voiceOf != nil {
+		if c.tts == nil {
+			panic("orchestrator.Conversation.Register: WithDirectSpeech was set but no TTS stage was provided")
+		}
+		ds := NewDirectSpeech(c.tts, c.voiceOf, c.onError)
+		ds.floor = c.floor // shared with the barge path (nil when barge-in is off)
+		ds.gate = c.gate
+		reactors = append(reactors, ds)
 	}
 	return Bind(ctx, c.bus, reactors...)
 }

--- a/pkg/voice/orchestrator/directspeech.go
+++ b/pkg/voice/orchestrator/directspeech.go
@@ -1,0 +1,138 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// VoiceLookup resolves an Agent's TTS [tts.Voice] for a GM /say (#295), reporting
+// ok=false when the Agent has no resolvable Voice (an unknown id, or a text-only
+// Agent). The [DirectSpeech] reactor renders the /say text with the returned Voice.
+// Production binds it to the wirenpc Roster (Roster.Voice); tests inject a closure.
+type VoiceLookup func(agentID string) (tts.Voice, bool)
+
+// DirectSpeech is the [Reactor] that turns a [voiceevent.SpeakRequested] (a GM
+// `/say <text> as:<agent>`) into a single TTS dispatch in the Agent's Voice — GM
+// puppeteering (ADR-0010, ADR-0024). It is deliberately NOT driven off
+// [voiceevent.AddressRouted]: /say bypasses Address Detection and the LLM Replier
+// entirely, so it must never publish AddressRouted (which would wake the Replier).
+//
+// It mirrors the barge-in [Replier] turn mechanics (ADR-0027): the turn runs on its
+// own goroutine under the SAME shared [Floor], so a human barge yields that floor
+// and cancels the /say playback mid-sentence exactly as it cancels an LLM turn. The
+// resulting [TTSInvoked] / [FirstAudio] / [FirstOpus] carry the request's TurnID, so
+// the transcript relay assembles the /say line through its normal TTSInvoked
+// projection — no hand-crafted transcript row (ADR-0012/0040).
+//
+// Two deliberate divergences from the LLM path:
+//   - The GM mute is BYPASSED: /say is a GM override, so a muted NPC still speaks
+//     (there is no MuteView here, by design).
+//   - The whole text is ONE dispatch (no sentence split), so a long /say pays the
+//     full first-audio latency; accepted for v1.0 (a puppeted line is short).
+//
+// The spend gate is still honored (a session past its soft cap refuses new turns).
+type DirectSpeech struct {
+	tts     *TTS
+	voiceOf VoiceLookup
+	onError ErrorFunc
+
+	// floor, when non-nil, is the SHARED barge-in floor the turn runs under so a
+	// human interruption cancels the /say (ADR-0027). Set by [Conversation.Register]
+	// from the same floor the barge path uses; nil dispatches synchronously (no
+	// barge). Not part of [NewDirectSpeech].
+	floor *Floor
+
+	// gate, when non-nil, is the live turn gate (#130): a session past its soft cap
+	// refuses the /say turn before taking the floor. Set by [Conversation.Register]
+	// from [WithTurnGate]; nil is the feature-off default. Not part of [NewDirectSpeech].
+	gate TurnGate
+}
+
+// NewDirectSpeech wires ttsStage and voiceOf together. Both must be non-nil;
+// passing nil for either panics. onError may be nil (a [TTS.Dispatch] failure is
+// then dropped silently, mirroring [NewReplier]).
+func NewDirectSpeech(ttsStage *TTS, voiceOf VoiceLookup, onError ErrorFunc) *DirectSpeech {
+	if ttsStage == nil {
+		panic("orchestrator.NewDirectSpeech: tts must not be nil")
+	}
+	if voiceOf == nil {
+		panic("orchestrator.NewDirectSpeech: voiceOf must not be nil")
+	}
+	return &DirectSpeech{tts: ttsStage, voiceOf: voiceOf, onError: onError}
+}
+
+// Bind subscribes the reactor to [voiceevent.SpeakRequested] on bus and returns a
+// function that removes the subscription. It implements [Reactor]; bus must be
+// non-nil.
+func (d *DirectSpeech) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func()) {
+	if bus == nil {
+		panic("orchestrator.DirectSpeech.Bind: bus must not be nil")
+	}
+	return voiceevent.On(bus, func(e voiceevent.SpeakRequested) {
+		// Carry the turn correlation id (A3) so the TTS stage and wire tee stamp the
+		// same id on TTSInvoked / FirstAudio — installed before the floor is taken so
+		// both the sync and barge-in branches inherit it, exactly like the Replier.
+		turnCtx := voiceevent.WithTurnID(ctx, e.TurnID)
+
+		// voiceOf miss: the Agent has no resolvable Voice (unknown id / text-only). End
+		// the turn with an error reason rather than panicking on a zero Voice.
+		voice, ok := d.voiceOf(e.Target.AgentID)
+		if !ok {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndProviderError})
+			return
+		}
+
+		// Spend soft cap (#130): refuse a NEW turn before taking the floor. A SINGLE
+		// pre-check is airtight — spend is monotonic. The GM MUTE is deliberately not
+		// consulted here (puppeteering overrides mute).
+		if d.gate != nil && !d.gate.AllowTurn() {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSpendCap})
+			return
+		}
+
+		// No floor wired (voice standalone / bench): dispatch synchronously on the bus
+		// goroutine, mirroring the Replier's no-floor branch.
+		if d.floor == nil {
+			d.dispatch(turnCtx, bus, e, voice)
+			return
+		}
+
+		// Barge-in: take the shared floor and run the turn on its own goroutine so the
+		// inbound loop keeps feeding VAD during playback, and a barge yielding the floor
+		// cancels floorCtx (unwinding TTS + playback). The take carries the target so a
+		// coalesce window only folds same-target re-takes (harmless for /say, which
+		// never over-splits — this just keeps the take/release pairing honest).
+		floorCtx, release, coalesced := d.floor.Take(turnCtx, e.Target.AgentID)
+		if coalesced {
+			release()
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSupersedeCoalesced, Text: e.Text})
+			return
+		}
+		go func() {
+			defer release()
+			d.dispatch(floorCtx, bus, e, voice)
+		}()
+	})
+}
+
+// dispatch renders one /say request's whole text as a single TTS dispatch under ctx.
+// A start error (real synth/provider fault, not a barge cancel) that produced no
+// audio is announced as a tts_error TurnEnded so the metrics subscriber records the
+// precise reason (mirrors the Replier); a barge cutting ctx publishes its own
+// TurnEnded, so it is not double-counted here.
+func (d *DirectSpeech) dispatch(ctx context.Context, bus *voiceevent.Bus, e voiceevent.SpeakRequested, voice tts.Voice) {
+	if ctx.Err() != nil {
+		return
+	}
+	if err := d.tts.Dispatch(ctx, e.Text, voice); err != nil {
+		if d.onError != nil {
+			d.onError(err)
+		}
+		if ctx.Err() == nil {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndTTSError})
+		}
+	}
+}

--- a/pkg/voice/orchestrator/directspeech.go
+++ b/pkg/voice/orchestrator/directspeech.go
@@ -34,6 +34,19 @@ type VoiceLookup func(agentID string) (tts.Voice, bool)
 //     full first-audio latency; accepted for v1.0 (a puppeted line is short).
 //
 // The spend gate is still honored (a session past its soft cap refuses new turns).
+//
+// Known residuals (per plan #295, accepted for v1.0):
+//   - The /say line does NOT enter the target NPC's [Replier] conversation history:
+//     it never runs the Agent loop, so the NPC will not "remember" a puppeted line
+//     on its next LLM turn. The GM is voicing the NPC, not teaching it.
+//   - Silent-success drops: the GM's slash reply acks BEFORE this reactor runs (the
+//     handler does not Defer), so the three no-audio outcomes here — a voiceOf miss,
+//     a spend-cap refusal, and a floor coalesce-fold — end the turn quietly after the
+//     ack. The coalesce fold matters because [Floor.Take]'s window keys on the target
+//     agent id ONLY and the floor is SHARED with the [Replier]: a /say as Bart landing
+//     within the coalesce window of Bart's own in-flight LLM turn is folded into that
+//     turn and never spoken. Rare (a GM /say racing the NPC's own reply); a TurnEnded
+//     records it for the metrics subscriber.
 type DirectSpeech struct {
 	tts     *TTS
 	voiceOf VoiceLookup
@@ -102,9 +115,14 @@ func (d *DirectSpeech) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel fu
 
 		// Barge-in: take the shared floor and run the turn on its own goroutine so the
 		// inbound loop keeps feeding VAD during playback, and a barge yielding the floor
-		// cancels floorCtx (unwinding TTS + playback). The take carries the target so a
-		// coalesce window only folds same-target re-takes (harmless for /say, which
-		// never over-splits — this just keeps the take/release pairing honest).
+		// cancels floorCtx (unwinding TTS + playback). The take carries the target agent
+		// id, which is what [Floor.Take]'s coalesce window keys on (holderAgent only) —
+		// and the floor is SHARED with the [Replier]. So a /say as Bart landing inside
+		// the coalesce window of Bart's own in-flight LLM turn is folded into that turn
+		// and NOT spoken: a silent-success drop after the GM's ack (see the type doc's
+		// residuals). We honor the fold rather than supersede — publishing a TurnEnded
+		// so the metrics subscriber records the dropped segment — because superseding
+		// would cancel the NPC's live LLM reply mid-sentence, a worse outcome.
 		floorCtx, release, coalesced := d.floor.Take(turnCtx, e.Target.AgentID)
 		if coalesced {
 			release()

--- a/pkg/voice/orchestrator/directspeech_test.go
+++ b/pkg/voice/orchestrator/directspeech_test.go
@@ -1,0 +1,229 @@
+package orchestrator_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// recordSynth records each Synthesize request (sentence + voice + the ctx it ran
+// under) and returns a closed, empty channel — the "spoke cleanly" path.
+type recordSynth struct {
+	mu    sync.Mutex
+	reqs  []tts.SynthesizeRequest
+	ctxs  []context.Context
+	block chan struct{} // when non-nil, Synthesize blocks on it (or ctx cancel)
+}
+
+func (s *recordSynth) Synthesize(ctx context.Context, req tts.SynthesizeRequest) (<-chan tts.AudioChunk, error) {
+	s.mu.Lock()
+	s.reqs = append(s.reqs, req)
+	s.ctxs = append(s.ctxs, ctx)
+	block := s.block
+	s.mu.Unlock()
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+		}
+	}
+	ch := make(chan tts.AudioChunk)
+	close(ch)
+	return ch, nil
+}
+
+func (*recordSynth) AudioMarkupPrompt(tts.Voice) string { return "" }
+
+func (s *recordSynth) requests() []tts.SynthesizeRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]tts.SynthesizeRequest(nil), s.reqs...)
+}
+
+// sayTarget is the Character-NPC target a /say request carries.
+func sayTarget(id, name string) voiceevent.AddressTarget {
+	return voiceevent.AddressTarget{AgentID: id, AgentRole: voiceevent.AgentRoleCharacter, Name: name}
+}
+
+// bartVoice is a distinct Voice the lookup returns, so a test proves the reactor
+// synthesized with the LOOKED-UP voice, not a default.
+func bartVoice() tts.Voice {
+	return tts.Voice{ProviderID: "elevenlabs", VoiceID: "bart-vid", Name: "Bart"}
+}
+
+func voiceOf(id string, v tts.Voice) orchestrator.VoiceLookup {
+	return func(agentID string) (tts.Voice, bool) {
+		if agentID == id {
+			return v, true
+		}
+		return tts.Voice{}, false
+	}
+}
+
+// TestDirectSpeech_SpeaksWithLookedUpVoice pins the /say happy path (#295): a
+// SpeakRequested runs one turn on the floor and dispatches the verbatim text to TTS
+// in the Agent's looked-up Voice, publishing TTSInvoked carrying the request's
+// TurnID (so the transcript projection correlates exactly as an LLM turn).
+func TestDirectSpeech_SpeaksWithLookedUpVoice(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{}
+	stage := orchestrator.NewTTS(h.Bus, synth)
+	floor := orchestrator.NewFloor()
+
+	ds := orchestrator.NewDirectSpeech(stage, voiceOf("bart", bartVoice()), nil)
+	ds.SetFloor(floor)
+	t.Cleanup(ds.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "Welcome, travelers."})
+
+	// The turn runs on a goroutine under the floor; wait for the dispatch.
+	waitFor(t, func() bool { return len(synth.requests()) == 1 })
+
+	reqs := synth.requests()
+	if reqs[0].Sentence != "Welcome, travelers." {
+		t.Errorf("Synthesize sentence = %q, want the verbatim /say text", reqs[0].Sentence)
+	}
+	if reqs[0].Voice.VoiceID != "bart-vid" {
+		t.Errorf("Synthesize voice = %+v, want the looked-up Bart voice", reqs[0].Voice)
+	}
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TTSInvoked) bool { return e.TurnID == "Ts" && e.Sentence == "Welcome, travelers." },
+		"tts.invoked carrying the /say TurnID",
+	)
+	// It must NOT wake the LLM Replier — no AddressRouted is ever published (ADR-0024).
+	voicetest.AssertNoEvent[voiceevent.AddressRouted](t, h)
+}
+
+// TestDirectSpeech_BargeCancelsSay pins ADR-0027: a barge (the shared floor being
+// yielded) cancels the in-flight /say playback — the dispatch ctx is cancelled and
+// Synthesize unwinds.
+func TestDirectSpeech_BargeCancelsSay(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{block: make(chan struct{})}
+	stage := orchestrator.NewTTS(h.Bus, synth)
+	floor := orchestrator.NewFloor()
+
+	ds := orchestrator.NewDirectSpeech(stage, voiceOf("bart", bartVoice()), nil)
+	ds.SetFloor(floor)
+	t.Cleanup(ds.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "A long tale…"})
+	waitFor(t, func() bool { return len(synth.requests()) == 1 }) // dispatch in flight on the floor
+
+	// A human barges: the floor is yielded, which cancels the /say turn ctx.
+	if _, yielded := floor.Yield(); !yielded {
+		t.Fatal("the /say turn must hold the shared floor so a barge can cut it")
+	}
+	// Synthesize was blocking on ctx; the cancel must release it.
+	synth.mu.Lock()
+	ctx := synth.ctxs[0]
+	synth.mu.Unlock()
+	waitFor(t, func() bool { return ctx.Err() != nil })
+}
+
+// TestDirectSpeech_SpendCapRefusesTurn pins the spend gate (#130): once the soft cap
+// is crossed the reactor refuses the /say turn before any Dispatch and announces a
+// spend_cap TurnEnded — the same policy stop the LLM replier applies.
+func TestDirectSpeech_SpendCapRefusesTurn(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{}
+	stage := orchestrator.NewTTS(h.Bus, synth)
+	floor := orchestrator.NewFloor()
+
+	ds := orchestrator.NewDirectSpeech(stage, voiceOf("bart", bartVoice()), nil)
+	ds.SetFloor(floor)
+	ds.SetGate(denyGate{})
+	t.Cleanup(ds.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "Blocked."})
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Ts" && e.Reason == voiceevent.TurnEndSpendCap },
+		"turn.ended (spend_cap) for the refused /say",
+	)
+	if len(synth.requests()) != 0 {
+		t.Fatalf("a spend-capped /say dispatched %d times, want 0", len(synth.requests()))
+	}
+	if floor.Active() {
+		t.Fatal("a refused /say must not take the floor")
+	}
+}
+
+// TestDirectSpeech_UnknownVoiceEndsTurn pins the voiceOf miss: an Agent with no
+// resolvable Voice ends the turn with an error reason (never a panic) and never
+// dispatches.
+func TestDirectSpeech_UnknownVoiceEndsTurn(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{}
+	stage := orchestrator.NewTTS(h.Bus, synth)
+	floor := orchestrator.NewFloor()
+
+	ds := orchestrator.NewDirectSpeech(stage, voiceOf("bart", bartVoice()), nil)
+	ds.SetFloor(floor)
+	t.Cleanup(ds.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("ghost", "Ghost"), Text: "Boo."})
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool {
+			return e.TurnID == "Ts" && e.Reason == voiceevent.TurnEndProviderError
+		},
+		"turn.ended (provider_error) for the unknown-voice /say",
+	)
+	if len(synth.requests()) != 0 {
+		t.Fatalf("an unknown-voice /say dispatched %d times, want 0", len(synth.requests()))
+	}
+}
+
+// TestDirectSpeech_MuteBypassed pins the GM-override semantics (#295): a target that
+// is MUTED for the LLM reply path still speaks a /say — the DirectSpeech reactor has
+// no mute gate, by design. Wired through the full Conversation (WithMute in effect)
+// so the pin is behavioral, not just structural.
+func TestDirectSpeech_MuteBypassed(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{}
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{})
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	ttsStage := orchestrator.NewTTS(h.Bus, synth)
+
+	muted := muteSet{"bart": true} // Bart is muted for the LLM/Replier path
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+		orchestrator.WithReplyStream(func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error { return nil }),
+		orchestrator.WithBargeInCoalesce(10*time.Millisecond, 0),
+		orchestrator.WithMute(muted),
+		orchestrator.WithDirectSpeech(voiceOf("bart", bartVoice())),
+	)
+	t.Cleanup(conv.Register(t.Context()))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "I still speak."})
+
+	waitFor(t, func() bool { return len(synth.requests()) == 1 })
+	if got := synth.requests()[0].Sentence; got != "I still speak." {
+		t.Fatalf("muted /say synthesized %q, want the verbatim text — mute must be bypassed", got)
+	}
+}
+
+// denyGate is a TurnGate that always refuses a new turn (the crossed soft cap).
+type denyGate struct{}
+
+func (denyGate) AllowTurn() bool { return false }
+
+// waitFor polls cond up to ~2s, failing the test if it never holds — the standard
+// wait for a turn that runs on the floor's goroutine.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/pkg/voice/orchestrator/directspeech_test.go
+++ b/pkg/voice/orchestrator/directspeech_test.go
@@ -209,6 +209,88 @@ func TestDirectSpeech_MuteBypassed(t *testing.T) {
 	}
 }
 
+// TestDirectSpeech_RegisterSharesBargeFloor pins the PRODUCTION wiring (#295): the
+// DirectSpeech reactor built inside Conversation.Register takes the SAME floor the
+// barge path uses, so /say runs off the publisher goroutine (an async turn — never
+// blocking the Discord interaction handler for the whole synthesis) AND a real floor
+// Yield (the barge reactor's exact mechanism, ADR-0027) cancels it. If the
+// `ds.floor = c.floor` wiring regresses to nil, the floor is never taken (Active()
+// false) and dispatch runs synchronously — this test fails on both counts.
+func TestDirectSpeech_RegisterSharesBargeFloor(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{block: make(chan struct{})}
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{})
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	ttsStage := orchestrator.NewTTS(h.Bus, synth)
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+		orchestrator.WithReplyStream(func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error { return nil }),
+		orchestrator.WithBargeInCoalesce(50*time.Millisecond, 0),
+		orchestrator.WithDirectSpeech(voiceOf("bart", bartVoice())),
+	)
+	t.Cleanup(conv.Register(t.Context()))
+
+	// Publish on a goroutine so a REGRESSION (nil floor → synchronous dispatch on the
+	// publisher goroutine, blocked in the synth) cannot hang the test body: with the
+	// floor wired, Publish returns at once while the turn runs on the floor goroutine.
+	published := make(chan struct{})
+	go func() {
+		h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "A long puppeted line…"})
+		close(published)
+	}()
+	select {
+	case <-published:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish(SpeakRequested) blocked — dispatch is synchronous, so the floor was not taken (Discord handler would block on synthesis)")
+	}
+
+	waitFor(t, func() bool { return len(synth.requests()) == 1 }) // dispatch in flight on the floor
+
+	floor := conv.Floor()
+	if floor == nil || !floor.Active() {
+		t.Fatal("the /say turn did not take the shared barge floor — ds.floor is not wired to c.floor")
+	}
+	turnID, yielded := floor.Yield() // the barge reactor's exact mechanism
+	if !yielded || turnID != "Ts" {
+		t.Fatalf("floor.Yield() = (%q, %v), want the /say turn (\"Ts\", true) — proving /say holds the shared floor", turnID, yielded)
+	}
+
+	synth.mu.Lock()
+	ctx := synth.ctxs[0]
+	synth.mu.Unlock()
+	waitFor(t, func() bool { return ctx.Err() != nil }) // barge cancelled the synth ctx
+}
+
+// TestDirectSpeech_RegisterWiresGate pins the production spend-gate wiring (#295):
+// the DirectSpeech reactor built inside Register honors WithTurnGate. If the
+// `ds.gate = c.gate` wiring regresses, a spend-capped /say would still dispatch —
+// this test (no dispatch, spend_cap TurnEnded) fails.
+func TestDirectSpeech_RegisterWiresGate(t *testing.T) {
+	h := voicetest.New(t)
+	synth := &recordSynth{}
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{})
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	ttsStage := orchestrator.NewTTS(h.Bus, synth)
+
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+		orchestrator.WithReplyStream(func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error { return nil }),
+		orchestrator.WithBargeInCoalesce(50*time.Millisecond, 0),
+		orchestrator.WithTurnGate(denyGate{}),
+		orchestrator.WithDirectSpeech(voiceOf("bart", bartVoice())),
+	)
+	t.Cleanup(conv.Register(t.Context()))
+
+	h.Bus.Publish(voiceevent.SpeakRequested{At: time.Now(), TurnID: "Ts", Target: sayTarget("bart", "Bart"), Text: "Blocked."})
+
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.TurnEnded) bool { return e.TurnID == "Ts" && e.Reason == voiceevent.TurnEndSpendCap },
+		"turn.ended (spend_cap) from the Register-wired gate",
+	)
+	if len(synth.requests()) != 0 {
+		t.Fatalf("a spend-capped /say dispatched %d times — the gate is not wired into Register", len(synth.requests()))
+	}
+}
+
 // denyGate is a TurnGate that always refuses a new turn (the crossed soft cap).
 type denyGate struct{}
 

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -25,6 +25,11 @@ func (r *Replier) SetMutes(v MuteView) { r.mutes = v }
 // Conversation.Register from [WithTurnGate].
 func (r *Replier) SetGate(g TurnGate) { r.gate = g }
 
+// Floor exposes the Conversation's barge-in floor built inside Register, so a test
+// can assert the production wiring actually shares ONE floor across the replier and
+// the DirectSpeech reactor (#295). nil before Register, or when barge-in is off.
+func (c *Conversation) Floor() *Floor { return c.floor }
+
 // SetFloor installs the shared barge-in floor on the DirectSpeech reactor for the
 // /say wiring tests (external test package, #295). Production wiring sets it inside
 // Conversation.Register from the same floor the barge path uses.

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -25,6 +25,16 @@ func (r *Replier) SetMutes(v MuteView) { r.mutes = v }
 // Conversation.Register from [WithTurnGate].
 func (r *Replier) SetGate(g TurnGate) { r.gate = g }
 
+// SetFloor installs the shared barge-in floor on the DirectSpeech reactor for the
+// /say wiring tests (external test package, #295). Production wiring sets it inside
+// Conversation.Register from the same floor the barge path uses.
+func (d *DirectSpeech) SetFloor(floor *Floor) { d.floor = floor }
+
+// SetGate installs the live turn gate on the DirectSpeech reactor for the spend-cap
+// tests (external test package, #295/#130). Production wiring sets it inside
+// Conversation.Register from [WithTurnGate].
+func (d *DirectSpeech) SetGate(g TurnGate) { d.gate = g }
+
 // SetErrorHandler installs onError on the segmenter for the off-loop STT error
 // tests (external test package). Production wiring sets it inside
 // Conversation.Register from [WithErrorHandler].

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -170,6 +170,26 @@ type AddressRouted struct {
 // EventName implements [Event].
 func (AddressRouted) EventName() string { return "address.routed" }
 
+// SpeakRequested marks a GM-puppeteered direct-speech request: the `/say <text>
+// as:<agent>` slash command (ADR-0010, #295) asks an Agent to speak Text verbatim,
+// bypassing Address Detection and the LLM Replier entirely (ADR-0024 — /say is the
+// explicit-target path, so it must NOT publish [AddressRouted], which would trigger
+// the LLM Replier). It is the seam between the session Manager (which validates the
+// active session + agent and publishes this) and the orchestrator's DirectSpeech
+// reactor (which takes the barge-in floor and dispatches Text to TTS in the Agent's
+// Voice). Target names the Agent whose Voice speaks; TurnID is minted at publish so
+// the resulting [TTSInvoked] / [FirstAudio] / [FirstOpus] and the transcript line
+// projection correlate exactly as an LLM turn's do (A3, ADR-0012/0040).
+type SpeakRequested struct {
+	At     time.Time
+	TurnID string
+	Target AddressTarget
+	Text   string
+}
+
+// EventName implements [Event].
+func (SpeakRequested) EventName() string { return "speak.requested" }
+
 // TTSInvoked marks the dispatch of one sentence to the TTS stage.
 //
 // Per ADR-0021's TTS cassette policy the observable contract for TTS is "the


### PR DESCRIPTION
Closes #295.

## What

GM `/say <text> as:<agent>` puppeteers a voiced Character NPC — the NPC speaks the given text verbatim in the live Voice Session, bypassing Address Detection and its own LLM.

## How (contract S5 / PLAN #295, verbatim)

- **New `voiceevent.SpeakRequested`** — the /say seam. The session Manager publishes it, NOT `AddressRouted` (which would wake the LLM Replier, ADR-0024).
- **`session.Manager.SayAs(ctx, agentID, text)`** — validates the active session + voiced-roster membership session-atomically (mirrors `SetAgentMute`), then publishes `SpeakRequested` with the Agent's `AddressTarget` (character role + display name), a fresh `TurnID`, and the text. `ErrNoActiveSession` / `ErrAgentNotInCampaign`.
- **`orchestrator.DirectSpeech` reactor + `WithDirectSpeech(voiceOf)`** — on `SpeakRequested`: `voiceOf` miss → `TurnEnded{provider_error}`; spend gate pre-check (`spend_cap`); takes the **shared barge-in floor** and runs the turn on a goroutine (so a human barge cancels /say playback via the floor ctx, ADR-0027); a single `TTS.Dispatch(ctx, text, voice)` under `WithTurnID`. **Mute is deliberately bypassed** (GM override — pinned by test).
- **`wirenpc.Roster.Voice(agentID)`** — the production `voiceOf`, wired in `buildConversation`.
- **Relay**: `SpeakRequested` records the turn target; the /say line assembles + persists through the **normal TTSInvoked projection** — byte-identical to an LLM turn (`a:<turn>` id, NPC pill), no hand-crafted transcript row (ADR-0012/0040).
- **`presence.SayCommand`** — flat `/say`, GM-only, `text` + autocompleting `as` (mute-command patterns). **No Defer** (one roster read + bus publish, always ephemeral → the #335 EditOriginal rule is not in play; stated in a code comment).

## Tests (TDD, 20 added)

`SayAs` (4) · presence `/say` gates + resolver + autocomplete (7) · DirectSpeech reactor: voice lookup, barge-cancel, spend refusal, unknown-voice, mute-bypass (6) · `Roster.Voice` (3) · relay say-line + persistence tee (2).

## Constraints honored

ADR-0010 (flat GM-only /say, requires active session) · ADR-0024 (explicit-target path — matcher/detector untouched; publishes SpeakRequested, never AddressRouted) · ADR-0027 (barge via shared floor, turn on goroutine like the Replier) · ADR-0012/0040 (line via normal projection).

## Follow-up

Butler puppeteering (`SpeakAsButler = SayAs(GetButler id)`) is filed as #365, **blocked by #299** (Butler joins the live roster).

## Notes

- Append-only additions to `voiceevent/event.go` and `conversation.go` to ease the concurrent #301 ensemble rebase.
- Long /say = one Dispatch (no sentence split) → full first-audio latency; accepted for v1.0, noted in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Residuals (accepted for v1.0, per plan #295)

- **No Replier memory.** A /say line does NOT enter the target NPC's Replier conversation history — the Agent loop never runs, so the NPC will not "remember" a puppeted line on its next LLM turn. The GM voices the NPC, not teaches it.
- **Silent-success drops after the ack.** The slash handler acks before the DirectSpeech reactor runs (no Defer), so three no-audio outcomes end the turn quietly: a `voiceOf` miss, a spend-cap refusal, and a floor coalesce-fold (a /say as Bart landing inside the coalesce window of Bart's own in-flight LLM turn — the shared floor keys coalesce on the target agent id — is folded into that turn and not spoken). Each publishes a `TurnEnded` for the metrics subscriber.
- Long /say = one Dispatch (no sentence split) → full first-audio latency.

## Review round 2

Pinned the production `Register` floor+gate sharing with two Conversation-wired tests (both fail when the `ds.floor`/`ds.gate` assignments are mutated out — verified red). Corrected the coalesce comment. Rebased onto the merged main (includes #363 flake fix).
