### PR TITLE
feat(#296): [E7] knowledge Tools — transcript_search & kg_query read-only built-ins

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/jobs"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/recall"
@@ -592,6 +593,18 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// the feature on keyless deployments. It owns no goroutine/subscription, so
 	// there is nothing to Close.
 	mgr.SetFacts(kgfacts.New(store, mgr, metrics, log, kgfacts.Config{}))
+
+	// Knowledge Tools' read sources (#296, S1): the storage-backed adapter behind
+	// the read-only transcript_search and kg_query built-ins. UNCONDITIONAL — like
+	// KG-facts recall it needs only the process store + the session Manager (for the
+	// active Campaign), no embeddings provider — so a keyless deployment still lets a
+	// granted NPC recall the transcript and its own Node neighbourhood. It flows onto
+	// the base voice config every session copies; in web-only mode the Manager starts
+	// no sessions, so the Tools stay dormant. SearchFacts drops gm_private (ADR-0008).
+	mgr.SetToolDeps(tool.Deps{
+		Transcripts: knowledge.New(store, mgr),
+		KG:          knowledge.New(store, mgr),
+	})
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -218,6 +218,14 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 	}
 	cfg.CampaignID = active.ID
 
+	// Standalone voice mode wires no knowledge-Tool sources (cfg.ToolDeps stays
+	// zero): the transcript_search / kg_query built-ins are still registered and
+	// grantable, but a call reports "unavailable in this mode" rather than reading
+	// the DB (#296). Only the web/all boot builds the adapter (over the session
+	// Manager). Log it once so an operator who granted an NPC a knowledge Tool and
+	// runs a pure `-mode voice` node knows why it stays silent.
+	log.Info("standalone voice mode: knowledge Tools (transcript_search, kg_query) are unavailable; run -mode all or web to enable them")
+
 	return wirenpc.RunFromDB(ctx, cfg, pool, cipher)
 }
 
@@ -601,9 +609,10 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// granted NPC recall the transcript and its own Node neighbourhood. It flows onto
 	// the base voice config every session copies; in web-only mode the Manager starts
 	// no sessions, so the Tools stay dormant. SearchFacts drops gm_private (ADR-0008).
+	knowledgeAdapter := knowledge.New(store, mgr)
 	mgr.SetToolDeps(tool.Deps{
-		Transcripts: knowledge.New(store, mgr),
-		KG:          knowledge.New(store, mgr),
+		Transcripts: knowledgeAdapter,
+		KG:          knowledgeAdapter,
 	})
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -1,0 +1,191 @@
+// Package knowledge is the storage-backed adapter behind the read-only knowledge
+// Tools (#296, S1): it wraps internal/storage's retrieval paths in the neutral,
+// storage-free interfaces pkg/tool declares (tool.TranscriptSearcher,
+// tool.KGReader), so pkg/tool never imports internal/storage. That import edge
+// would be a cycle — storage already imports pkg/tool (the grant editor lists the
+// Registry) — which is exactly why the seam is inverted here: the sources are
+// injected as narrow interfaces and this package is the production wiring.
+//
+// It mirrors the kgfacts pattern (internal/kgfacts): a Store for the reads plus a
+// Sessions source for the active Campaign, with "no active session → error" so a
+// Tool called outside a live turn reports it cleanly rather than reading nothing.
+// The load-bearing invariant is SearchFacts DROPPING gm_private rows:
+// storage.SearchNodes is the GM-facing wiki search and does NOT filter them
+// (ADR-0008), so an unfiltered pass would leak a GM secret into an NPC's prompt.
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// ErrNoActiveSession is returned by the campaign-scoped reads when no Voice
+// Session is live: the active session is what resolves the Campaign to scope to,
+// so without one there is nothing to search. The Tool handler surfaces it as an
+// error result the LLM can read ("knowledge is unavailable right now"), never a
+// panic or a silent empty read against the wrong Campaign.
+var ErrNoActiveSession = errors.New("knowledge: no active voice session")
+
+// Store is the narrow set of storage reads the adapter needs. *storage.Store
+// satisfies it. Kept local (not the whole *storage.Store) so the adapter's
+// contract is explicit and unit-fakeable.
+type Store interface {
+	// SearchNodes is the GM-facing KG wiki search — it INCLUDES gm_private Nodes,
+	// so SearchFacts must filter them before they reach a prompt.
+	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+	// SearchTranscriptLines is the campaign-scoped transcript search (#120).
+	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
+	// AgentNodeFacts is the Agent's own edge-aware neighbourhood, already
+	// gm_private-filtered (#133).
+	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
+}
+
+// Sessions reports the active Voice Session (for its Campaign). *session.Manager
+// satisfies it via Snapshot, the same shape kgfacts depends on; defined locally
+// so this package does not import session.
+type Sessions interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// Adapter implements both tool.TranscriptSearcher and tool.KGReader over a
+// storage Store and the active-session source. Safe for concurrent use (its deps
+// are). Build it once at web boot and set it on the session Manager's base config.
+type Adapter struct {
+	store    Store
+	sessions Sessions
+}
+
+// New builds the adapter. Both deps must be non-nil — they are wiring
+// requirements, so a nil is a boot bug, not a runtime condition.
+func New(store Store, sessions Sessions) *Adapter {
+	if store == nil || sessions == nil {
+		panic("knowledge: New: nil store or sessions")
+	}
+	return &Adapter{store: store, sessions: sessions}
+}
+
+// activeCampaign resolves the Campaign the live session scopes reads to, or
+// ErrNoActiveSession when idle.
+func (a *Adapter) activeCampaign() (uuid.UUID, error) {
+	s, ok := a.sessions.Snapshot()
+	if !ok {
+		return uuid.Nil, ErrNoActiveSession
+	}
+	return s.CampaignID, nil
+}
+
+// SearchTranscript implements [tool.TranscriptSearcher]. It searches the active
+// Campaign's persisted transcript (#120) and projects each Line into a
+// storage-free [tool.TranscriptHit]. The Campaign comes from the active session,
+// never the caller, so the search can never cross Campaigns. No session yields
+// ErrNoActiveSession.
+func (a *Adapter) SearchTranscript(ctx context.Context, query string, limit int) ([]tool.TranscriptHit, error) {
+	campaignID, err := a.activeCampaign()
+	if err != nil {
+		return nil, err
+	}
+	lines, err := a.store.SearchTranscriptLines(ctx, campaignID, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("knowledge: search transcript: %w", err)
+	}
+	hits := make([]tool.TranscriptHit, 0, len(lines))
+	for _, l := range lines {
+		hits = append(hits, tool.TranscriptHit{
+			Who:  l.Who,
+			Kind: l.Kind,
+			Text: l.Text,
+			At:   l.TS,
+		})
+	}
+	return hits, nil
+}
+
+// OwnNodeFacts implements [tool.KGReader]. It returns the Agent's own linked Node
+// plus its single-hop neighbourhood (#133), already gm_private-filtered and
+// edge-aware by storage. The agentID is the caller identity threaded from the
+// turn ctx (never the LLM args); an empty or unparseable id has no neighbourhood
+// to scope to and yields no facts (never a wider fallback).
+func (a *Adapter) OwnNodeFacts(ctx context.Context, agentID string) ([]tool.KGFact, error) {
+	aid, err := uuid.Parse(agentID)
+	if err != nil || aid == uuid.Nil {
+		return nil, nil
+	}
+	nodes, err := a.store.AgentNodeFacts(ctx, aid)
+	if err != nil {
+		return nil, fmt.Errorf("knowledge: own node facts: %w", err)
+	}
+	return toFacts(nodes), nil
+}
+
+// SearchFacts implements [tool.KGReader]. It runs the campaign-wide KG search for
+// the Butler's grant, then DROPS every gm_private Node — the load-bearing
+// ADR-0008 filter: storage.SearchNodes is GM-facing and does not filter, so an
+// unfiltered result would leak a GM secret into an NPC's prompt. No session
+// yields ErrNoActiveSession.
+func (a *Adapter) SearchFacts(ctx context.Context, query string, limit int) ([]tool.KGFact, error) {
+	campaignID, err := a.activeCampaign()
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := a.store.SearchNodes(ctx, campaignID, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("knowledge: search facts: %w", err)
+	}
+	public := nodes[:0:0]
+	for _, n := range nodes {
+		if n.GMPrivate {
+			continue // NEVER surface a GM-private Node to a prompt (ADR-0008).
+		}
+		public = append(public, n)
+	}
+	return toFacts(public), nil
+}
+
+// toFacts projects storage Nodes into storage-free [tool.KGFact]s, mapping the
+// Node type onto its GM-facing label here (so pkg/tool needs no storage enum).
+func toFacts(nodes []storage.KGNode) []tool.KGFact {
+	out := make([]tool.KGFact, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, tool.KGFact{
+			Name: n.Name,
+			Type: typeLabel(n.Type),
+			Body: n.Body,
+		})
+	}
+	return out
+}
+
+// typeLabel maps a Node type onto its GM-facing label, mirroring kgfacts. An
+// unknown type falls back to "Note" (the DB enum keeps this exhaustive).
+func typeLabel(t storage.KGNodeType) string {
+	switch t {
+	case storage.KGNodeCharacter:
+		return "Character"
+	case storage.KGNodeNPC:
+		return "NPC"
+	case storage.KGNodeLocation:
+		return "Location"
+	case storage.KGNodeFaction:
+		return "Faction"
+	case storage.KGNodeItem:
+		return "Item"
+	case storage.KGNodePlotThread:
+		return "Plot thread"
+	case storage.KGNodeNote:
+		return "Note"
+	default:
+		return "Note"
+	}
+}
+
+// Compile-time assertions that the adapter satisfies the tool seams.
+var (
+	_ tool.TranscriptSearcher = (*Adapter)(nil)
+	_ tool.KGReader           = (*Adapter)(nil)
+)

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -36,9 +36,10 @@ var ErrNoActiveSession = errors.New("knowledge: no active voice session")
 // satisfies it. Kept local (not the whole *storage.Store) so the adapter's
 // contract is explicit and unit-fakeable.
 type Store interface {
-	// SearchNodes is the GM-facing KG wiki search — it INCLUDES gm_private Nodes,
-	// so SearchFacts must filter them before they reach a prompt.
-	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+	// SearchPublicNodes is the prompt-facing KG search: gm_private Nodes are
+	// EXCLUDED in the query (before the LIMIT), so a GM-only Node never reaches a
+	// prompt and a public match is not starved by top-ranked private hits (ADR-0008).
+	SearchPublicNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
 	// SearchTranscriptLines is the campaign-scoped transcript search (#120).
 	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
 	// AgentNodeFacts is the Agent's own edge-aware neighbourhood, already
@@ -124,27 +125,21 @@ func (a *Adapter) OwnNodeFacts(ctx context.Context, agentID string) ([]tool.KGFa
 }
 
 // SearchFacts implements [tool.KGReader]. It runs the campaign-wide KG search for
-// the Butler's grant, then DROPS every gm_private Node — the load-bearing
-// ADR-0008 filter: storage.SearchNodes is GM-facing and does not filter, so an
-// unfiltered result would leak a GM secret into an NPC's prompt. No session
-// yields ErrNoActiveSession.
+// the Butler's grant over SearchPublicNodes, which EXCLUDES gm_private Nodes in
+// the query itself — the load-bearing ADR-0008 guard. The exclusion must be in
+// the query, not a post-fetch Go filter: filtering after the SQL LIMIT would drop
+// the top-N ranked hits when they are all gm_private and starve a public match
+// ranked just past the limit. No session yields ErrNoActiveSession.
 func (a *Adapter) SearchFacts(ctx context.Context, query string, limit int) ([]tool.KGFact, error) {
 	campaignID, err := a.activeCampaign()
 	if err != nil {
 		return nil, err
 	}
-	nodes, err := a.store.SearchNodes(ctx, campaignID, query, limit)
+	nodes, err := a.store.SearchPublicNodes(ctx, campaignID, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("knowledge: search facts: %w", err)
 	}
-	public := nodes[:0:0]
-	for _, n := range nodes {
-		if n.GMPrivate {
-			continue // NEVER surface a GM-private Node to a prompt (ADR-0008).
-		}
-		public = append(public, n)
-	}
-	return toFacts(public), nil
+	return toFacts(nodes), nil
 }
 
 // toFacts projects storage Nodes into storage-free [tool.KGFact]s, mapping the

--- a/internal/knowledge/knowledge_integration_test.go
+++ b/internal/knowledge/knowledge_integration_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+
+// Drives the #296 knowledge adapter against a real Postgres (testcontainers):
+// storage's real SearchNodes / SearchTranscriptLines behind the neutral tool
+// seams, proving the load-bearing gm_private DROP (SearchNodes returns private
+// Nodes; SearchFacts must not), the campaign-scoping from the active session, and
+// the no-session error. Tag-isolated behind `integration` (ADR-0033).
+
+package knowledge_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("GLYPHOXA_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?). err: %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+func seedCampaign(t *testing.T, dsn string) (*storage.Store, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var tenantID, campaignID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenant (name) VALUES ('Acme TTRPG') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Lost Mine', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaignID); err != nil {
+		t.Fatalf("insert campaign: %v", err)
+	}
+	return storage.New(pool), campaignID
+}
+
+// staticSession is a knowledge.Sessions returning a fixed active session (or
+// none), standing in for the live *session.Manager.
+type staticSession struct {
+	sess storage.VoiceSession
+	live bool
+}
+
+func (s staticSession) Snapshot() (storage.VoiceSession, bool) { return s.sess, s.live }
+
+func TestAdapter_SearchFactsDropsGMPrivate_RealDB(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+
+	// A public and a gm_private Node that both match the search term.
+	if _, err := store.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Duke Aldric", Body: "rules the city openly",
+	}); err != nil {
+		t.Fatalf("create public node: %v", err)
+	}
+	if _, err := store.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "Duke's Shadow Cabal", Body: "GM eyes only", GMPrivate: true,
+	}); err != nil {
+		t.Fatalf("create private node: %v", err)
+	}
+
+	adapter := knowledge.New(store, staticSession{sess: storage.VoiceSession{CampaignID: campaignID}, live: true})
+
+	facts, err := adapter.SearchFacts(ctx, "duke", 10)
+	if err != nil {
+		t.Fatalf("SearchFacts: %v", err)
+	}
+	for _, f := range facts {
+		if f.Name == "Duke's Shadow Cabal" {
+			t.Fatalf("gm_private Node leaked through SearchFacts: %+v", facts)
+		}
+	}
+	if len(facts) != 1 || facts[0].Name != "Duke Aldric" {
+		t.Fatalf("facts = %+v, want only the public Duke Aldric", facts)
+	}
+}
+
+func TestAdapter_SearchTranscriptCampaignScoped_RealDB(t *testing.T) {
+	dsn := startPostgres(t)
+	store, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+
+	sess, err := store.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("create voice session: %v", err)
+	}
+	if err := store.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: sess.ID, CampaignID: campaignID, LineID: "l1", Seq: 1,
+		Who: "Bart", Kind: "npc", TS: time.Now(), Text: "I remember your promise, traveler.",
+	}); err != nil {
+		t.Fatalf("upsert transcript line: %v", err)
+	}
+
+	adapter := knowledge.New(store, staticSession{sess: sess, live: true})
+
+	hits, err := adapter.SearchTranscript(ctx, "promise", 10)
+	if err != nil {
+		t.Fatalf("SearchTranscript: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Who != "Bart" || hits[0].Kind != "npc" {
+		t.Fatalf("hits = %+v, want the one Bart line", hits)
+	}
+
+	// No active session → the campaign-scoped reads error, never read cross-campaign.
+	idle := knowledge.New(store, staticSession{live: false})
+	if _, err := idle.SearchTranscript(ctx, "promise", 10); !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("SearchTranscript idle = %v, want ErrNoActiveSession", err)
+	}
+	if _, err := idle.SearchFacts(ctx, "duke", 10); !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("SearchFacts idle = %v, want ErrNoActiveSession", err)
+	}
+}

--- a/internal/knowledge/knowledge_integration_test.go
+++ b/internal/knowledge/knowledge_integration_test.go
@@ -100,31 +100,41 @@ func TestAdapter_SearchFactsDropsGMPrivate_RealDB(t *testing.T) {
 	store, campaignID := seedCampaign(t, dsn)
 	ctx := context.Background()
 
-	// A public and a gm_private Node that both match the search term.
+	// FIVE gm_private Nodes that all match the term, plus ONE public match. All six
+	// rank on "duke"; the private ones are inserted LAST so — newest-first within
+	// equal ts_rank — they sort ABOVE the public one. With a LIMIT of 1, a post-fetch
+	// Go filter would fetch only the top private row and return NOTHING, starving the
+	// public match ranked past the limit (the reviewer's finding). The query-level
+	// exclusion (SearchPublicNodes) must still surface the public Node.
 	if _, err := store.CreateNode(ctx, storage.NewKGNode{
 		CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Duke Aldric", Body: "rules the city openly",
 	}); err != nil {
 		t.Fatalf("create public node: %v", err)
 	}
-	if _, err := store.CreateNode(ctx, storage.NewKGNode{
-		CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "Duke's Shadow Cabal", Body: "GM eyes only", GMPrivate: true,
-	}); err != nil {
-		t.Fatalf("create private node: %v", err)
+	for i := 0; i < 5; i++ {
+		if _, err := store.CreateNode(ctx, storage.NewKGNode{
+			CampaignID: campaignID, Type: storage.KGNodeFaction,
+			Name: "Duke Shadow Cabal", Body: "GM eyes only duke secret", GMPrivate: true,
+		}); err != nil {
+			t.Fatalf("create private node %d: %v", i, err)
+		}
 	}
 
 	adapter := knowledge.New(store, staticSession{sess: storage.VoiceSession{CampaignID: campaignID}, live: true})
 
-	facts, err := adapter.SearchFacts(ctx, "duke", 10)
+	// LIMIT 1 is the discriminating case: the private rows out-rank the public one,
+	// so only a BEFORE-LIMIT exclusion can return the public fact.
+	facts, err := adapter.SearchFacts(ctx, "duke", 1)
 	if err != nil {
 		t.Fatalf("SearchFacts: %v", err)
 	}
+	if len(facts) != 1 || facts[0].Name != "Duke Aldric" {
+		t.Fatalf("facts = %+v, want the public Duke Aldric — private hits above the LIMIT must not starve it", facts)
+	}
 	for _, f := range facts {
-		if f.Name == "Duke's Shadow Cabal" {
+		if f.Name == "Duke Shadow Cabal" {
 			t.Fatalf("gm_private Node leaked through SearchFacts: %+v", facts)
 		}
-	}
-	if len(facts) != 1 || facts[0].Name != "Duke Aldric" {
-		t.Fatalf("facts = %+v, want only the public Duke Aldric", facts)
 	}
 }
 

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 // fakeStore is a scripted knowledge.Store: it records the campaign/agent it was
-// scoped to and replays fixed rows, so the adapter's session-scoping and
-// gm_private filter are pinned without a DB.
+// scoped to and replays fixed rows. The gm_private EXCLUSION lives in the SQL of
+// SearchPublicNodes (proven against a real DB in the integration test); here the
+// fake stands in for that already-filtered result, so these unit tests pin the
+// adapter's scoping/routing without a DB.
 type fakeStore struct {
-	nodes        []storage.KGNode // SearchNodes result (GM-facing, unfiltered)
+	nodes        []storage.KGNode // SearchPublicNodes result (already gm_private-filtered by SQL)
 	agentNodes   []storage.KGNode // AgentNodeFacts result
 	lines        []storage.TranscriptLine
 	gotNodeCID   uuid.UUID
@@ -24,7 +26,7 @@ type fakeStore struct {
 	agentQueried bool
 }
 
-func (f *fakeStore) SearchNodes(_ context.Context, cid uuid.UUID, _ string, _ int) ([]storage.KGNode, error) {
+func (f *fakeStore) SearchPublicNodes(_ context.Context, cid uuid.UUID, _ string, _ int) ([]storage.KGNode, error) {
 	f.gotNodeCID = cid
 	return f.nodes, nil
 }
@@ -50,14 +52,15 @@ func liveSession(campaignID uuid.UUID) fakeSessions {
 	return fakeSessions{sess: storage.VoiceSession{CampaignID: campaignID}, live: true}
 }
 
-// TestSearchFactsDropsGMPrivate is the load-bearing ADR-0008 pin: SearchNodes is
-// GM-facing (returns gm_private Nodes), so the adapter MUST drop them before they
-// reach an NPC prompt.
-func TestSearchFactsDropsGMPrivate(t *testing.T) {
+// TestSearchFactsUsesPublicSearchScoped pins that SearchFacts routes through the
+// gm_private-EXCLUDING search (SearchPublicNodes), scoped to the active session's
+// Campaign, and maps the rows into facts. The actual gm_private exclusion is a SQL
+// property proven in the integration test (a post-fetch Go filter would starve a
+// public match past the LIMIT — the reviewer's finding).
+func TestSearchFactsUsesPublicSearchScoped(t *testing.T) {
 	cid := uuid.New()
 	store := &fakeStore{nodes: []storage.KGNode{
-		{Name: "Public Duke", Type: storage.KGNodeNPC, Body: "rules openly", GMPrivate: false},
-		{Name: "Secret Cabal", Type: storage.KGNodeFaction, Body: "GM eyes only", GMPrivate: true},
+		{Name: "Public Duke", Type: storage.KGNodeNPC, Body: "rules openly"},
 	}}
 	adapter := knowledge.New(store, liveSession(cid))
 
@@ -66,13 +69,10 @@ func TestSearchFactsDropsGMPrivate(t *testing.T) {
 		t.Fatalf("SearchFacts: %v", err)
 	}
 	if store.gotNodeCID != cid {
-		t.Errorf("SearchNodes scoped to %v, want active session's campaign %v", store.gotNodeCID, cid)
+		t.Errorf("SearchPublicNodes scoped to %v, want active session's campaign %v", store.gotNodeCID, cid)
 	}
-	if len(facts) != 1 || facts[0].Name != "Public Duke" {
-		t.Fatalf("facts = %+v, want only the public Node (gm_private dropped)", facts)
-	}
-	if facts[0].Type != "NPC" {
-		t.Errorf("type label = %q, want NPC", facts[0].Type)
+	if len(facts) != 1 || facts[0].Name != "Public Duke" || facts[0].Type != "NPC" {
+		t.Fatalf("facts = %+v, want the mapped public Duke (NPC)", facts)
 	}
 }
 

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -1,0 +1,146 @@
+package knowledge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeStore is a scripted knowledge.Store: it records the campaign/agent it was
+// scoped to and replays fixed rows, so the adapter's session-scoping and
+// gm_private filter are pinned without a DB.
+type fakeStore struct {
+	nodes        []storage.KGNode // SearchNodes result (GM-facing, unfiltered)
+	agentNodes   []storage.KGNode // AgentNodeFacts result
+	lines        []storage.TranscriptLine
+	gotNodeCID   uuid.UUID
+	gotLineCID   uuid.UUID
+	gotAgentID   uuid.UUID
+	agentQueried bool
+}
+
+func (f *fakeStore) SearchNodes(_ context.Context, cid uuid.UUID, _ string, _ int) ([]storage.KGNode, error) {
+	f.gotNodeCID = cid
+	return f.nodes, nil
+}
+func (f *fakeStore) SearchTranscriptLines(_ context.Context, cid uuid.UUID, _ string, _ int) ([]storage.TranscriptLine, error) {
+	f.gotLineCID = cid
+	return f.lines, nil
+}
+func (f *fakeStore) AgentNodeFacts(_ context.Context, aid uuid.UUID) ([]storage.KGNode, error) {
+	f.agentQueried = true
+	f.gotAgentID = aid
+	return f.agentNodes, nil
+}
+
+// fakeSessions is a scripted active-session source.
+type fakeSessions struct {
+	sess storage.VoiceSession
+	live bool
+}
+
+func (f fakeSessions) Snapshot() (storage.VoiceSession, bool) { return f.sess, f.live }
+
+func liveSession(campaignID uuid.UUID) fakeSessions {
+	return fakeSessions{sess: storage.VoiceSession{CampaignID: campaignID}, live: true}
+}
+
+// TestSearchFactsDropsGMPrivate is the load-bearing ADR-0008 pin: SearchNodes is
+// GM-facing (returns gm_private Nodes), so the adapter MUST drop them before they
+// reach an NPC prompt.
+func TestSearchFactsDropsGMPrivate(t *testing.T) {
+	cid := uuid.New()
+	store := &fakeStore{nodes: []storage.KGNode{
+		{Name: "Public Duke", Type: storage.KGNodeNPC, Body: "rules openly", GMPrivate: false},
+		{Name: "Secret Cabal", Type: storage.KGNodeFaction, Body: "GM eyes only", GMPrivate: true},
+	}}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	facts, err := adapter.SearchFacts(context.Background(), "duke", 5)
+	if err != nil {
+		t.Fatalf("SearchFacts: %v", err)
+	}
+	if store.gotNodeCID != cid {
+		t.Errorf("SearchNodes scoped to %v, want active session's campaign %v", store.gotNodeCID, cid)
+	}
+	if len(facts) != 1 || facts[0].Name != "Public Duke" {
+		t.Fatalf("facts = %+v, want only the public Node (gm_private dropped)", facts)
+	}
+	if facts[0].Type != "NPC" {
+		t.Errorf("type label = %q, want NPC", facts[0].Type)
+	}
+}
+
+// TestSearchFactsNoSessionErrors pins the no-active-session error path.
+func TestSearchFactsNoSessionErrors(t *testing.T) {
+	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	if _, err := adapter.SearchFacts(context.Background(), "x", 5); !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("SearchFacts with no session = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestSearchTranscriptCampaignScoped pins the transcript search is scoped to the
+// active session's Campaign and no session errors.
+func TestSearchTranscriptCampaignScoped(t *testing.T) {
+	cid := uuid.New()
+	store := &fakeStore{lines: []storage.TranscriptLine{
+		{Who: "Bart", Kind: "npc", Text: "I remember."},
+	}}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	hits, err := adapter.SearchTranscript(context.Background(), "remember", 5)
+	if err != nil {
+		t.Fatalf("SearchTranscript: %v", err)
+	}
+	if store.gotLineCID != cid {
+		t.Errorf("transcript search scoped to %v, want %v", store.gotLineCID, cid)
+	}
+	if len(hits) != 1 || hits[0].Who != "Bart" || hits[0].Kind != "npc" {
+		t.Errorf("hits = %+v, want the one Bart line", hits)
+	}
+
+	idle := knowledge.New(store, fakeSessions{live: false})
+	if _, err := idle.SearchTranscript(context.Background(), "x", 5); !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("SearchTranscript with no session = %v, want ErrNoActiveSession", err)
+	}
+}
+
+// TestOwnNodeFactsResolvesAgent pins that OwnNodeFacts keys the read by the
+// caller's agent id (not a campaign), and an empty/invalid id has no
+// neighbourhood — it reads nothing rather than falling back to a wider scope.
+func TestOwnNodeFactsResolvesAgent(t *testing.T) {
+	aid := uuid.New()
+	store := &fakeStore{agentNodes: []storage.KGNode{
+		{Name: "Mara", Type: storage.KGNodeCharacter, Body: "owes you"},
+	}}
+	adapter := knowledge.New(store, liveSession(uuid.New()))
+
+	facts, err := adapter.OwnNodeFacts(context.Background(), aid.String())
+	if err != nil {
+		t.Fatalf("OwnNodeFacts: %v", err)
+	}
+	if store.gotAgentID != aid {
+		t.Errorf("AgentNodeFacts keyed by %v, want caller %v", store.gotAgentID, aid)
+	}
+	if len(facts) != 1 || facts[0].Name != "Mara" || facts[0].Type != "Character" {
+		t.Errorf("facts = %+v, want the Mara Character fact", facts)
+	}
+
+	// Empty caller id → no neighbourhood, no store read, no error.
+	store.agentQueried = false
+	empty, err := adapter.OwnNodeFacts(context.Background(), "")
+	if err != nil {
+		t.Fatalf("OwnNodeFacts(empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty caller should yield no facts, got %+v", empty)
+	}
+	if store.agentQueried {
+		t.Error("empty caller must not hit the store")
+	}
+}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -118,7 +118,7 @@ type SpeakerInvalidator interface {
 // (ADR-0028), so the grants a GM can toggle are exactly the Tools a Voice Session
 // runs; nothing external configures it.
 func NewCampaignServer(s campaignStore) *CampaignServer {
-	return &CampaignServer{store: s, tools: tool.BuiltinRegistry()}
+	return &CampaignServer{store: s, tools: tool.BuiltinRegistry(tool.Deps{})}
 }
 
 // compile-time assertion that CampaignServer satisfies the generated handler.

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -50,8 +50,11 @@ func TestToolGrants_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListToolGrants(butler): %v", err)
 	}
-	if g := butlerGrants.Msg.GetGrants(); len(g) != 1 || g[0].GetToolName() != "dice" || !g[0].GetGranted() {
-		t.Fatalf("butler grants = %+v, want dice granted (seeded)", g)
+	// The catalog now lists every built-in (dice + the #296 knowledge Tools); assert
+	// by the GRANTED set, not by catalog index — the auto-Butler is seeded with dice
+	// only (migration 00013), the rest listed present-but-off.
+	if granted := grantedNames(butlerGrants.Msg.GetGrants()); len(granted) != 1 || granted[0] != "dice" {
+		t.Fatalf("butler granted = %v, want [dice] (seeded); full catalog = %+v", granted, butlerGrants.Msg.GetGrants())
 	}
 
 	// A fresh Character NPC has no grants → dice listed but off.

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -253,7 +253,7 @@ func hydratedDeclarations(t *testing.T, store *storage.Store, agentID uuid.UUID)
 		t.Fatalf("hydrate: ListToolGrants(%s): %v", agentID, err)
 	}
 	grants := storage.GrantsFromRows(rows)
-	decls := tool.NewGrantSet(tool.BuiltinRegistry(), grants...).Declarations()
+	decls := tool.NewGrantSet(tool.BuiltinRegistry(tool.Deps{}), grants...).Declarations()
 	names := make([]string, len(decls))
 	for i, d := range decls {
 		names[i] = d.Name

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -26,33 +26,50 @@ func registerAgent(store *fakeCampaignStore) uuid.UUID {
 }
 
 // TestListToolGrants_CatalogWithState is the AC1 bar over the handler: the list
-// shows EVERY built-in Tool (dice today) with the Agent's current grant state.
-// An ungranted Agent sees dice present-but-off; granting flips it on. Because the
-// catalog is the built-in Registry, an Agent with no rows still lists dice.
+// shows EVERY built-in Tool with the Agent's current grant state. The catalog is
+// the built-in Registry (Name-sorted): dice + the two knowledge Tools kg_query
+// and transcript_search (#296). An ungranted Agent sees them present-but-off;
+// granting flips one on. kg_query advertises scope support (own_node vs
+// campaign, ADR-0029) so the grant editor renders its scope UI; dice and
+// transcript_search do not.
 func TestListToolGrants_CatalogWithState(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	agentID := registerAgent(store)
 	client := crudClient(t, store)
 
-	// No grant rows: dice is listed but not granted, and advertises no scope.
+	// No grant rows: every built-in is listed but not granted.
 	resp, err := client.ListToolGrants(context.Background(),
 		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
 	if err != nil {
 		t.Fatalf("ListToolGrants: %v", err)
 	}
 	grants := resp.Msg.GetGrants()
-	if len(grants) != 1 || grants[0].GetToolName() != "dice" {
-		t.Fatalf("catalog = %+v, want exactly [dice]", grants)
+	wantNames := []string{"dice", "kg_query", "transcript_search"} // Name-sorted catalog
+	if len(grants) != len(wantNames) {
+		t.Fatalf("catalog = %+v, want %v", grants, wantNames)
 	}
-	if grants[0].GetGranted() {
-		t.Error("dice should be ungranted for a fresh Agent")
+	scopeByName := map[string]bool{}
+	for i, g := range grants {
+		if g.GetToolName() != wantNames[i] {
+			t.Errorf("catalog[%d] = %q, want %q", i, g.GetToolName(), wantNames[i])
+		}
+		if g.GetGranted() {
+			t.Errorf("%s should be ungranted for a fresh Agent", g.GetToolName())
+		}
+		if g.GetDescription() == "" {
+			t.Errorf("%s entry should carry the Tool description as hint text", g.GetToolName())
+		}
+		scopeByName[g.GetToolName()] = g.GetSupportsScope()
 	}
-	if grants[0].GetSupportsScope() {
+	if !scopeByName["kg_query"] {
+		t.Error("kg_query must advertise scope support (ADR-0029 own_node vs campaign)")
+	}
+	if scopeByName["dice"] {
 		t.Error("dice must not advertise scope support")
 	}
-	if grants[0].GetDescription() == "" {
-		t.Error("dice entry should carry the Tool description as hint text")
+	if scopeByName["transcript_search"] {
+		t.Error("transcript_search must not advertise scope support (campaign-scoped for all)")
 	}
 
 	// Grant dice, then it lists as granted.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -241,6 +242,19 @@ func (m *Manager) SetMemory(r agent.MemoryRecaller) {
 // start, so no lock is needed. nil leaves facts off (the prompt stays byte-identical).
 func (m *Manager) SetFacts(f agent.FactsRecaller) {
 	m.base.Facts = f
+}
+
+// SetToolDeps wires the built-in knowledge Tools' read sources onto the base
+// voice config every manager-started session copies (#296, S1): the adapter
+// backing transcript_search and kg_query. Like SetFacts it flows through Start →
+// RunFromDB → connectAndServe → buildConversation → tool.BuiltinRegistry, so a
+// live NPC granted a knowledge Tool actually reaches the DB. The adapter needs
+// the Manager as its active-session source, so the Manager is built first and the
+// deps back-wired before any session starts — no lock needed. The zero value
+// leaves the Tools registered but unavailable at Execute (the prompt/loop still
+// behave, the model just gets an "unavailable" tool result).
+func (m *Manager) SetToolDeps(d tool.Deps) {
+	m.base.ToolDeps = d
 }
 
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no

--- a/internal/storage/kg_node_search.go
+++ b/internal/storage/kg_node_search.go
@@ -40,14 +40,37 @@ func BuildTSQuery(q string) string {
 // gm_private Nodes are INCLUDED (GM-facing search). An empty BuildTSQuery result
 // yields (nil, nil) — no matches, not an error.
 func (s *Store) SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]KGNode, error) {
+	return s.searchNodes(ctx, campaignID, query, limit, false)
+}
+
+// SearchPublicNodes is SearchNodes with gm_private Nodes EXCLUDED IN THE QUERY —
+// the prompt-facing knowledge search (#296). The exclusion is pushed into the
+// WHERE clause so it applies BEFORE the LIMIT: a post-fetch filter in Go would
+// drop the top-N ranked hits if they were all gm_private and starve a public
+// match ranked N+1. This is the load-bearing ADR-0008 guard for the kg_query
+// Tool — a GM-only Node must never reach an NPC's prompt. Existing GM-facing
+// callers keep SearchNodes (the wiki search shows private Nodes to the GM).
+func (s *Store) SearchPublicNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]KGNode, error) {
+	return s.searchNodes(ctx, campaignID, query, limit, true)
+}
+
+// searchNodes is the shared body of SearchNodes / SearchPublicNodes: publicOnly
+// pushes an `AND NOT gm_private` into the ranked, LIMITed query so the exclusion
+// precedes the LIMIT (never a post-fetch trim). An empty BuildTSQuery result
+// yields (nil, nil).
+func (s *Store) searchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int, publicOnly bool) ([]KGNode, error) {
 	tsq := BuildTSQuery(query)
 	if tsq == "" {
 		return nil, nil
 	}
+	privacy := ""
+	if publicOnly {
+		privacy = " AND NOT gm_private"
+	}
 	rows, err := s.db.Query(ctx,
 		`SELECT `+kgNodeColumns+`
 		   FROM kg_node, to_tsquery('simple', $2) q
-		  WHERE campaign_id = $1 AND fts @@ q
+		  WHERE campaign_id = $1 AND fts @@ q`+privacy+`
 		  ORDER BY ts_rank(fts, q) DESC, updated_at DESC, id
 		  LIMIT $3`, campaignID, tsq, limit)
 	if err != nil {

--- a/internal/storage/kg_node_search_test.go
+++ b/internal/storage/kg_node_search_test.go
@@ -184,3 +184,50 @@ func TestSearchNodes_UsesFtsIndex(t *testing.T) {
 		t.Errorf("query plan does not use the fts GIN index (substring scan?):\n%s", plan.String())
 	}
 }
+
+// TestSearchPublicNodes_ExcludesPrivateBeforeLimit is the #296 ADR-0008 pin: the
+// prompt-facing search must exclude gm_private Nodes IN THE QUERY, before the
+// LIMIT — a post-fetch filter would drop the top-N ranked rows when they are all
+// gm_private and starve a public match ranked just past the limit. Five private
+// hits are inserted AFTER the sole public one so, newest-first within equal rank,
+// they sort above it; with LIMIT 1 only a before-limit exclusion returns the
+// public Node. SearchNodes (GM-facing) still returns the private rows.
+func TestSearchPublicNodes_ExcludesPrivateBeforeLimit(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	pub, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Duke Aldric", Body: "rules openly duke",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode public: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := st.CreateNode(ctx, storage.NewKGNode{
+			CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "Duke Cabal", Body: "duke secret", GMPrivate: true,
+		}); err != nil {
+			t.Fatalf("CreateNode private %d: %v", i, err)
+		}
+	}
+
+	// LIMIT 1: the private rows out-rank the public one, so a before-limit exclusion
+	// is the only way the public Node survives.
+	pubOnly, err := st.SearchPublicNodes(ctx, campaignID, "duke", 1)
+	if err != nil {
+		t.Fatalf("SearchPublicNodes: %v", err)
+	}
+	if len(pubOnly) != 1 || pubOnly[0].ID != pub.ID {
+		t.Fatalf("SearchPublicNodes(limit 1) = %v, want the public Duke Aldric — private hits above the limit must not starve it", searchNames(pubOnly))
+	}
+
+	// GM-facing SearchNodes still surfaces the private rows.
+	all, err := st.SearchNodes(ctx, campaignID, "duke", 50)
+	if err != nil {
+		t.Fatalf("SearchNodes: %v", err)
+	}
+	if len(all) != 6 {
+		t.Errorf("SearchNodes(GM) = %d matches, want 6 (1 public + 5 private)", len(all))
+	}
+}

--- a/internal/storage/tool_grant_mapping_test.go
+++ b/internal/storage/tool_grant_mapping_test.go
@@ -59,7 +59,7 @@ func TestGrantsFromRows_PreservesConfig(t *testing.T) {
 // grant RPC's AC4 test asserts through this same function.
 func TestGrantsFromRows_HydratesDeclarations(t *testing.T) {
 	grants := storage.GrantsFromRows([]storage.ToolGrant{{ToolName: "dice"}})
-	decls := tool.NewGrantSet(tool.BuiltinRegistry(), grants...).Declarations()
+	decls := tool.NewGrantSet(tool.BuiltinRegistry(tool.Deps{}), grants...).Declarations()
 	if len(decls) != 1 || decls[0].Name != "dice" {
 		t.Fatalf("declared %+v, want exactly [dice]", decls)
 	}

--- a/internal/wirenpc/agentspec_test.go
+++ b/internal/wirenpc/agentspec_test.go
@@ -167,7 +167,7 @@ func TestSeedThenLoadEquivalence(t *testing.T) {
 	// assert it succeeds, and that the matcher routes a named utterance to the
 	// loaded Agent's identity (so the Persona the reply loop answers for and the
 	// Address Detection target agree — the chain that makes the NPC speak).
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation from DB-loaded NPC: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLoadSeededNPCs_LoadsAllCharacterAgents(t *testing.T) {
 
 	// The two NPCs must assemble into a Roster that routes each by name to its own
 	// identity — the end-to-end multi-NPC acceptance bar.
-	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(), slog.New(slog.NewTextHandler(io.Discard, nil)), specs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation from 2 DB NPCs: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestCampaignLanguageDrivesMatcherPhonetics(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestLoadedNPC_DerivesTruncationAliases(t *testing.T) {
 
 	conv, roster, cleanup, err := buildConversation(voiceevent.NewBus(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), specs, loadedCampaign.Language,
-		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	npcs := []npcSpec{hardcodedNPC()}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+	conv1, _, cleanup1, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("first buildConversation: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestBuildConversation_CleanupDoesNotDestroyEngine(t *testing.T) {
 	}
 	cleanup1() // end of reconnect cycle 1
 
-	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil)
+	conv2, _, cleanup2, err := buildConversation(voiceevent.NewBus(), log, npcs, "", ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("second buildConversation after cleanup: %v — cleanup destroyed the shared ONNX env?", err)
 	}
@@ -524,7 +524,7 @@ func TestBuildConversation_ThreadsGMSpeakerIntoButlerGate(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	gmSpeaker := func(id string) bool { return id == "gm-1" }
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log, []npcSpec{hardcodedNPC()}, "",
-		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, gmSpeaker)
+		ttseleven.New(""), nil, providerKeys{}, "", false, nil, nil, nil, nil, gmSpeaker, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation with GMSpeaker: %v", err)
 	}

--- a/internal/wirenpc/credentials_fanout_integration_test.go
+++ b/internal/wirenpc/credentials_fanout_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	stteleven "github.com/MrWong99/Glyphoxa/pkg/voice/stt/elevenlabs"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
@@ -47,7 +48,7 @@ func TestBuildConversation_RoutesEachKeyToItsAdapter(t *testing.T) {
 	keys := providerKeys{llm: "L-llm-key", stt: "S-stt-key", tts: "T-tts-key"}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, "", false, nil, nil, nil, nil, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, keys, "", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestBuildConversation_DispatchesOffProviderID(t *testing.T) {
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, _, cleanup, err := buildConversation(voiceevent.NewBus(), log,
-		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, providerKeys{}, "anthropic", false, nil, nil, nil, nil, nil)
+		[]npcSpec{hardcodedNPC()}, "", ttseleven.New(""), nil, providerKeys{}, "anthropic", false, nil, nil, nil, nil, nil, tool.Deps{})
 	if err != nil {
 		t.Fatalf("buildConversation: %v", err)
 	}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -390,6 +390,16 @@ type Config struct {
 	// unchanged.
 	Gate orchestrator.TurnGate
 
+	// ToolDeps injects the built-in knowledge Tools' read sources (S1, #296): the
+	// transcript-search and KG-query retrieval paths the tool-use loop calls. The
+	// web tier builds the internal/knowledge adapter over the process store +
+	// session Manager and sets it on the session Manager's base config; it flows
+	// through connectAndServe → buildConversation → tool.BuiltinRegistry(cfg.ToolDeps),
+	// so a live NPC granted kg_query/transcript_search actually reaches the DB. The
+	// zero value (voice/bench standalone) registers the Tools but reports them
+	// unavailable at Execute — the loop feeds that back and continues, never panics.
+	ToolDeps tool.Deps
+
 	// GMSpeaker reports whether a Discord SpeakerID belongs to a Game Master —
 	// operator-allowlist membership per ADR-0050/ADR-0041, the deterministic GM
 	// identity with no per-session binding. When non-nil it arms the Butler
@@ -746,7 +756,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	defer stageSub.Subscribe(bus)()
 	stageSub.Start(cycleCtx)
 
-	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.llmProviderID, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes, cfg.Gate, cfg.GMSpeaker)
+	conv, roster, cleanup, err := buildConversation(bus, log, cfg.npcs, cfg.language, teeSynth, cfg.StageMetrics, cfg.keys, cfg.llmProviderID, cfg.STTStreaming, cfg.Memory, cfg.Facts, cfg.Mutes, cfg.Gate, cfg.GMSpeaker, cfg.ToolDeps)
 	if err != nil {
 		return fmt.Errorf("wirenpc: build pipeline: %w", err)
 	}
@@ -934,7 +944,7 @@ func wireMutes(bus *voiceevent.Bus, roster *Roster, mutes orchestrator.MuteView)
 	return unsub
 }
 
-func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, llmProviderID string, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView, gate orchestrator.TurnGate, gmSpeaker func(speakerID string) bool) (*orchestrator.Conversation, *Roster, func(), error) {
+func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, language string, synth tts.Synthesizer, stageMetrics observe.StageRecorder, keys providerKeys, llmProviderID string, streaming bool, memory agent.MemoryRecaller, facts agent.FactsRecaller, mutes orchestrator.MuteView, gate orchestrator.TurnGate, gmSpeaker func(speakerID string) bool, toolDeps tool.Deps) (*orchestrator.Conversation, *Roster, func(), error) {
 	if stageMetrics == nil {
 		stageMetrics = observe.Discard{}
 	}
@@ -1045,7 +1055,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("wirenpc: build LLM provider: %w", err)
 	}
-	reg := tool.BuiltinRegistry()
+	reg := tool.BuiltinRegistry(toolDeps)
 	engineFor := engineFactory(provider, reg, language, stageMetrics, llmProviderLabel(llmProviderID), retryPolicy)
 
 	// Assemble the initial roster: each AddNPC registers the NPC's routing Agent
@@ -1124,7 +1134,7 @@ func buildConversation(bus *voiceevent.Bus, log *slog.Logger, npcs []npcSpec, la
 // the spend price lookup, so a non-Groq adapter is not mispriced as groq.
 func engineFactory(provider llm.Provider, reg *tool.Registry, language string, stageMetrics observe.StageRecorder, provName observe.Provider, retryPolicy retry.Policy) func(npcSpec) agent.Engine {
 	return func(spec npcSpec) agent.Engine {
-		return agenttool.NewEngine(provider, tool.NewGrantSet(reg, spec.grants...), spec.model, 0, 0,
+		return agenttool.NewEngine(provider, tool.NewGrantSet(reg, spec.grants...), spec.agentID, spec.model, 0, 0,
 			// The per-round LLM spans (A3) and the spend price lookup are labelled with
 			// the actual provider (#272). The no-op recorder keeps the keyless path
 			// silent; the live binary / benchmark inject a real one.

--- a/pkg/tool/builtins.go
+++ b/pkg/tool/builtins.go
@@ -1,16 +1,23 @@
 package tool
 
-// BuiltinRegistry returns a Registry holding every built-in Tool v1.0 ships
-// (ADR-0028: exactly one, `dice`). It is the single source of truth for "which
-// Tools exist" — the live voice loop (wirenpc), the benchmark rig, and the grant
-// editor RPC (#117) all build from it, so the Tools an operator can toggle on the
-// Campaign screen are exactly the Tools a Voice Session can actually run. When a
-// new built-in lands it is registered here once and appears everywhere.
+// BuiltinRegistry returns a Registry holding every built-in Tool (ADR-0028):
+// `dice`, plus the two read-only knowledge Tools `transcript_search` and
+// `kg_query` (#296). It is the single source of truth for "which Tools exist" —
+// the live voice loop (wirenpc), the benchmark rig, and the grant editor RPC
+// (#117) all build from it, so the Tools an operator can toggle on the Campaign
+// screen are exactly the Tools a Voice Session can actually run. When a new
+// built-in lands it is registered here once and appears everywhere.
 //
-// dice is registered with a non-deterministic production roller; tests that need
-// a pinned roll construct their own Registry with [NewDiceWithRand].
-func BuiltinRegistry() *Registry {
+// deps injects the knowledge Tools' read sources (S1). A nil source leaves the
+// Tool REGISTERED — the grant editor's catalog is identical in every mode — but
+// its Execute reports it is unavailable, so a mode with no live retrieval (the
+// standalone bench, the grant-editor RPC) still lists the full Tool set without
+// panicking. dice is registered with a non-deterministic production roller; tests
+// that need a pinned roll construct their own Registry with [NewDiceWithRand].
+func BuiltinRegistry(deps Deps) *Registry {
 	r := NewRegistry()
 	r.MustRegister(NewDice())
+	r.MustRegister(NewTranscriptSearch(deps.Transcripts))
+	r.MustRegister(NewKGQuery(deps.KG))
 	return r
 }

--- a/pkg/tool/builtins_test.go
+++ b/pkg/tool/builtins_test.go
@@ -1,0 +1,76 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestBuiltinRegistryRegistersKnowledgeTools pins that the built-in catalog is
+// dice + the two read-only knowledge Tools (#296), regardless of whether their
+// sources are wired — the grant editor's Tool list must be identical in every
+// mode, so a GM toggling grants on the Campaign screen sees the same catalog the
+// live session runs.
+func TestBuiltinRegistryRegistersKnowledgeTools(t *testing.T) {
+	reg := BuiltinRegistry(Deps{})
+	want := []string{"dice", "kg_query", "transcript_search"} // Tools() is Name-sorted
+	got := reg.Tools()
+	if len(got) != len(want) {
+		t.Fatalf("registered %d tools, want %d: %+v", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i].Name() != name {
+			t.Errorf("tool[%d] = %q, want %q", i, got[i].Name(), name)
+		}
+	}
+}
+
+// TestKnowledgeToolsAreReadOnly pins ADR-0030: both knowledge Tools are read-only
+// so the loop runs them inline (never the refused side-effecting path).
+func TestKnowledgeToolsAreReadOnly(t *testing.T) {
+	reg := BuiltinRegistry(Deps{})
+	for _, name := range []string{"transcript_search", "kg_query"} {
+		tl, ok := reg.Get(name)
+		if !ok {
+			t.Fatalf("%s not registered", name)
+		}
+		if !tl.ReadOnly() {
+			t.Errorf("%s must be read-only (ADR-0030 inline execution)", name)
+		}
+	}
+}
+
+// TestKQQuerySupportsScope pins that kg_query exposes a scope editor (its NPC
+// grant narrows to own_node vs the Butler's campaign) while transcript_search
+// does not (campaign-scoped for everyone, no per-grant narrowing).
+func TestKnowledgeToolsScopeDeclarations(t *testing.T) {
+	reg := BuiltinRegistry(Deps{})
+	kg, _ := reg.Get("kg_query")
+	if !kg.SupportsScope() {
+		t.Error("kg_query must support a scope (ADR-0029 own_node vs campaign)")
+	}
+	ts, _ := reg.Get("transcript_search")
+	if ts.SupportsScope() {
+		t.Error("transcript_search carries no per-grant scope")
+	}
+}
+
+// TestNilSourceToolsReportUnavailable pins that with a zero Deps the Tools are
+// still registered but their Execute returns an error result (fed back to the
+// model, not a panic) — the standalone bench and grant-editor RPC path.
+func TestNilSourceToolsReportUnavailable(t *testing.T) {
+	reg := BuiltinRegistry(Deps{})
+	args := json.RawMessage(`{"query":"anything"}`)
+	for _, name := range []string{"transcript_search", "kg_query"} {
+		tl, _ := reg.Get(name)
+		out, err := tl.Execute(context.Background(), args, nil)
+		if err == nil {
+			t.Errorf("%s with nil source should error, got %q", name, out)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unavailable") {
+			t.Errorf("%s nil-source error = %q, want it to mention unavailable", name, err)
+		}
+	}
+}

--- a/pkg/tool/caller.go
+++ b/pkg/tool/caller.go
@@ -1,0 +1,26 @@
+package tool
+
+import "context"
+
+// callerKey is the unexported ctx key the caller identity travels under, so no
+// other package can collide with or forge it.
+type callerKey struct{}
+
+// WithCaller stamps the calling Agent's id onto ctx so a scope-narrowing Tool
+// handler can resolve the caller WITHOUT trusting the LLM's args (S2, ADR-0029).
+// It is set ONCE per turn, in the agenttool Engine's Generate/GenerateStream
+// path, from the Agent's own spec — the model never supplies it, so an
+// own_node-scoped kg_query reads exactly the caller's neighbourhood and cannot
+// be widened by clever arguments.
+func WithCaller(ctx context.Context, agentID string) context.Context {
+	return context.WithValue(ctx, callerKey{}, agentID)
+}
+
+// CallerID returns the Agent id stamped by [WithCaller], or "" if none is set
+// (an unstamped ctx — a standalone bench turn, or a Persona with no persisted
+// id). A handler that needs own-node scope treats "" as "no neighbourhood to
+// scope to" and yields an empty result rather than falling back to a wider read.
+func CallerID(ctx context.Context) string {
+	id, _ := ctx.Value(callerKey{}).(string)
+	return id
+}

--- a/pkg/tool/deps.go
+++ b/pkg/tool/deps.go
@@ -1,0 +1,75 @@
+package tool
+
+import (
+	"context"
+	"time"
+)
+
+// Deps carries the injected read sources the built-in knowledge Tools need
+// (S1, #296). It exists so pkg/tool stays free of an internal/storage import:
+// storage already imports pkg/tool (the grant editor lists the Registry), so a
+// reverse edge would be an import cycle. Instead the retrieval paths are handed
+// in through these narrow, storage-free interfaces, satisfied by the adapter in
+// internal/knowledge.
+//
+// Every field is optional. A nil source means the Tool is still REGISTERED (so
+// the grant editor's catalog is identical in every mode) but its Execute returns
+// an "unavailable in this mode" error result rather than a nil-pointer panic —
+// the standalone voice bench and the grant-editor RPC build a zero Deps and
+// still surface the full Tool list. The live web boot fills the fields.
+type Deps struct {
+	// Transcripts backs transcript_search. nil ⇒ the Tool is registered but its
+	// Execute reports it is unavailable.
+	Transcripts TranscriptSearcher
+	// KG backs kg_query. nil ⇒ the Tool is registered but its Execute reports it
+	// is unavailable.
+	KG KGReader
+}
+
+// TranscriptHit is one persisted transcript Line the knowledge adapter surfaces
+// to transcript_search — a storage-free projection so pkg/tool never sees a
+// storage type. Who is the speaker's display name, Kind the line kind (human
+// utterance vs Agent reply), Text the spoken words, At the wall-clock time.
+type TranscriptHit struct {
+	Who  string
+	Kind string
+	Text string
+	At   time.Time
+}
+
+// TranscriptSearcher is the narrow read transcript_search needs: a relevance
+// search over the active Campaign's persisted transcript. The Campaign is
+// resolved INSIDE the adapter from the active Voice Session (never passed by the
+// LLM), so the model cannot search another Campaign's transcript. A limit ≤ 0 is
+// the adapter's default. *knowledge.Store satisfies it.
+type TranscriptSearcher interface {
+	SearchTranscript(ctx context.Context, query string, limit int) ([]TranscriptHit, error)
+}
+
+// KGFact is one Knowledge Graph fact the adapter surfaces to kg_query — a
+// storage-free projection. Type is the GM-facing label ("Character", "Location",
+// …), already mapped by the adapter so pkg/tool needs no storage enum. Body is
+// the Node's prose.
+type KGFact struct {
+	Name string
+	Type string
+	Body string
+}
+
+// KGReader is the narrow read kg_query needs, in two scopes (S1/S3, ADR-0029):
+//
+//   - OwnNodeFacts returns one Agent's own linked Node plus its single-hop
+//     neighbourhood, already gm_private-filtered and edge-aware (it wraps
+//     storage.AgentNodeFacts). It is the least-privilege scope an NPC's grant
+//     narrows to — the handler resolves the agentID from the caller identity, not
+//     the LLM's args.
+//   - SearchFacts is the campaign-wide relevance search the Butler's grant uses.
+//     The adapter MUST drop gm_private rows: storage.SearchNodes is GM-facing and
+//     does NOT filter them, so an unfiltered pass would leak GM secrets into an
+//     NPC prompt (ADR-0008, the load-bearing filter).
+//
+// *knowledge.Store satisfies it.
+type KGReader interface {
+	OwnNodeFacts(ctx context.Context, agentID string) ([]KGFact, error)
+	SearchFacts(ctx context.Context, query string, limit int) ([]KGFact, error)
+}

--- a/pkg/tool/kg_query.go
+++ b/pkg/tool/kg_query.go
@@ -1,0 +1,222 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// MaxKGFactBodyRunes caps one rendered KG fact's body length, in runes (mirrors
+// kgfacts.MaxFactChars). The whole result is still bounded by MaxToolResultChars.
+const MaxKGFactBodyRunes = 500
+
+// MaxKGNameRunes caps a fact's Node-name length, in runes (mirrors
+// kgfacts.MaxNameChars): without it a single pathological name could push the
+// first block past the whole-result budget and, since the budget stop is a
+// deterministic prefix, silently drop every fact.
+const MaxKGNameRunes = 200
+
+// Scope config values (S3, ADR-0029). The grant's jsonb config is {"scope":…};
+// the direction sets the default when the config is absent.
+const (
+	scopeOwnNode  = "own_node"
+	scopeCampaign = "campaign"
+)
+
+// scopeConfig is the decoded per-grant scope (S3). A grant with no config leaves
+// Scope "", and the handler applies the direction's default.
+type scopeConfig struct {
+	Scope string `json:"scope"`
+}
+
+// parseScope decodes the per-grant config into a scope string. The config
+// arrives from a hydrated tool_agent_grant jsonb row as json.RawMessage (or nil
+// for an unscoped grant); a []byte or string is accepted defensively. An empty
+// or absent config yields "" so the caller applies its direction default. A
+// present-but-unknown scope value is an error — a misconfigured grant must fail
+// loudly, not silently widen.
+func parseScope(grantConfig any) (string, error) {
+	var raw []byte
+	switch c := grantConfig.(type) {
+	case nil:
+		return "", nil
+	case json.RawMessage:
+		raw = c
+	case []byte:
+		raw = c
+	case string:
+		raw = []byte(c)
+	default:
+		return "", fmt.Errorf("unrecognized grant config type %T", grantConfig)
+	}
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var sc scopeConfig
+	if err := json.Unmarshal(raw, &sc); err != nil {
+		return "", fmt.Errorf("invalid scope config: %w", err)
+	}
+	switch sc.Scope {
+	case "", scopeOwnNode, scopeCampaign:
+		return sc.Scope, nil
+	default:
+		return "", fmt.Errorf("unknown scope %q", sc.Scope)
+	}
+}
+
+// KGQuery is the read-only kg_query built-in (#296): a lookup over the Knowledge
+// Graph's Node read paths (ADR-0008). It is the canonical ADR-0029 scope-narrowing
+// example — the SAME registered Tool reads a different slice per Agent purely via
+// the grant config, enforced HERE in the handler, never by the LLM:
+//
+//   - own_node (the default for a Character NPC's grant): only the caller's own
+//     linked Node and its single-hop neighbourhood, gm_private already filtered.
+//     The caller is read from the turn ctx ([CallerID]), NOT the LLM's args — so
+//     no crafted argument can widen the NPC to another Node's neighbourhood.
+//   - campaign (the Butler's grant): a relevance search across the whole
+//     Campaign's public Nodes.
+//
+// nil grant config defaults to campaign for this read direction (S3): a read is
+// gm_private-filtered either way, so the wider default is safe; a write Tool
+// fails closed to own_node instead. A nil source reports unavailable at Execute.
+type KGQuery struct {
+	src KGReader
+}
+
+// NewKGQuery builds the Tool over src. A nil src registers the Tool but reports
+// unavailable at Execute time.
+func NewKGQuery(src KGReader) *KGQuery {
+	return &KGQuery{src: src}
+}
+
+// Name implements [Tool].
+func (*KGQuery) Name() string { return "kg_query" }
+
+// Description implements [Tool].
+func (*KGQuery) Description() string {
+	return "Look up what you know about the world: people, places, factions, items and plot threads. " +
+		"Use it to recall facts before answering."
+}
+
+// InputSchema implements [Tool]. It shares the query/limit schema with
+// transcript_search; the scope is NEVER an argument (it lives in the grant).
+func (*KGQuery) InputSchema() json.RawMessage { return searchInputSchema }
+
+// ReadOnly implements [Tool]: a KG lookup mutates no state (ADR-0030).
+func (*KGQuery) ReadOnly() bool { return true }
+
+// SupportsScope implements [Tool]: kg_query's authority is narrowed per Agent via
+// the grant config (own_node vs campaign), so the grant editor renders its scope
+// UI (ADR-0029).
+func (*KGQuery) SupportsScope() bool { return true }
+
+// Execute implements [Tool]. It resolves the effective scope from grantConfig
+// (never the args), reads the corresponding KG slice, and renders the facts for
+// the prompt. own_node reads the CALLER's neighbourhood ([CallerID]) filtered to
+// the query terms; campaign runs the relevance search. A nil source yields the
+// unavailable error; no facts yields a friendly "none" line, not an error.
+func (kq *KGQuery) Execute(ctx context.Context, args json.RawMessage, grantConfig any) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if kq.src == nil {
+		return "", fmt.Errorf("kg_query: knowledge graph is unavailable in this mode")
+	}
+	var a searchArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("kg_query: invalid arguments: %w", err)
+	}
+	if strings.TrimSpace(a.Query) == "" {
+		return "", fmt.Errorf("kg_query: query must not be empty")
+	}
+
+	scope, err := parseScope(grantConfig)
+	if err != nil {
+		return "", fmt.Errorf("kg_query: %w", err)
+	}
+	if scope == "" {
+		scope = scopeCampaign // read direction default (S3): reads are gm_private-filtered
+	}
+
+	var facts []KGFact
+	switch scope {
+	case scopeOwnNode:
+		// Own-node scope is the caller's neighbourhood, resolved from the turn ctx —
+		// never the LLM args, so crafted arguments cannot widen it. An unstamped ctx
+		// (CallerID "") has no neighbourhood to scope to and reads nothing.
+		facts, err = kq.src.OwnNodeFacts(ctx, CallerID(ctx))
+		if err != nil {
+			return "", fmt.Errorf("kg_query: %w", err)
+		}
+		facts = filterByQuery(facts, a.Query)
+	default: // scopeCampaign
+		facts, err = kq.src.SearchFacts(ctx, a.Query, clampedLimit(a.Limit))
+		if err != nil {
+			return "", fmt.Errorf("kg_query: %w", err)
+		}
+	}
+	return renderKGFacts(facts), nil
+}
+
+// filterByQuery narrows own-node facts to those whose Name or Body contains any
+// of the query's terms (case-insensitive), so an own_node kg_query answers the
+// question asked rather than dumping the whole neighbourhood. A query with no
+// alphanumeric terms matches everything (the neighbourhood is already tiny and
+// caller-scoped).
+func filterByQuery(facts []KGFact, query string) []KGFact {
+	terms := strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !isAlnum(r)
+	})
+	if len(terms) == 0 {
+		return facts
+	}
+	out := facts[:0:0]
+	for _, f := range facts {
+		hay := strings.ToLower(f.Name + " " + f.Body)
+		for _, term := range terms {
+			if strings.Contains(hay, term) {
+				out = append(out, f)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func isAlnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+}
+
+// renderKGFacts projects facts into "### Name (Type)\nBody" blocks, each body
+// rune-truncated to MaxKGFactBodyRunes, the whole result bounded to
+// MaxToolResultChars with a deterministic prefix-stop. An empty set renders the
+// "none" line.
+func renderKGFacts(facts []KGFact) string {
+	if len(facts) == 0 {
+		return "no matching knowledge"
+	}
+	var b strings.Builder
+	n := 0
+	for _, f := range facts {
+		head := fmt.Sprintf("### %s (%s)", truncateRunes(f.Name, MaxKGNameRunes), f.Type)
+		body := truncateRunes(strings.TrimSpace(f.Body), MaxKGFactBodyRunes)
+		block := head
+		if body != "" {
+			block = head + "\n" + body
+		}
+		add := block
+		if n > 0 {
+			add = "\n\n" + block
+		}
+		if b.Len()+len(add) > MaxToolResultChars {
+			break
+		}
+		b.WriteString(add)
+		n++
+	}
+	if n == 0 {
+		return "no matching knowledge"
+	}
+	return b.String()
+}

--- a/pkg/tool/kg_query.go
+++ b/pkg/tool/kg_query.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // MaxKGFactBodyRunes caps one rendered KG fact's body length, in runes (mirrors
@@ -166,7 +168,7 @@ func (kq *KGQuery) Execute(ctx context.Context, args json.RawMessage, grantConfi
 // caller-scoped).
 func filterByQuery(facts []KGFact, query string) []KGFact {
 	terms := strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
-		return !isAlnum(r)
+		return !isWordRune(r)
 	})
 	if len(terms) == 0 {
 		return facts
@@ -184,19 +186,27 @@ func filterByQuery(facts []KGFact, query string) []KGFact {
 	return out
 }
 
-func isAlnum(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+// isWordRune reports whether r is part of a query term. It is Unicode-aware
+// (unicode.IsLetter/IsDigit), not ASCII-only: German is the primary live
+// deployment, so "Würfel" must tokenize as one term and "Öl" / CJK queries must
+// not degrade to zero terms (which would dump the whole neighbourhood).
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 // renderKGFacts projects facts into "### Name (Type)\nBody" blocks, each body
-// rune-truncated to MaxKGFactBodyRunes, the whole result bounded to
-// MaxToolResultChars with a deterministic prefix-stop. An empty set renders the
-// "none" line.
+// rune-truncated to MaxKGFactBodyRunes and each name to MaxKGNameRunes, the whole
+// result bounded to MaxToolResultChars — counted in RUNES to match the per-item
+// rune caps (a byte count would let a multibyte-heavy fact overrun, or worse blow
+// the whole budget on the FIRST block and render a real match as "none"). The
+// first block is ALWAYS emitted (its capped runes never exceed the budget), then
+// a deterministic prefix-stop drops the rest. An empty set renders "none".
 func renderKGFacts(facts []KGFact) string {
 	if len(facts) == 0 {
 		return "no matching knowledge"
 	}
 	var b strings.Builder
+	runes := 0
 	n := 0
 	for _, f := range facts {
 		head := fmt.Sprintf("### %s (%s)", truncateRunes(f.Name, MaxKGNameRunes), f.Type)
@@ -209,14 +219,13 @@ func renderKGFacts(facts []KGFact) string {
 		if n > 0 {
 			add = "\n\n" + block
 		}
-		if b.Len()+len(add) > MaxToolResultChars {
-			break
+		addRunes := utf8.RuneCountInString(add)
+		if n > 0 && runes+addRunes > MaxToolResultChars {
+			break // budget reached; the first block is always kept.
 		}
 		b.WriteString(add)
+		runes += addRunes
 		n++
-	}
-	if n == 0 {
-		return "no matching knowledge"
 	}
 	return b.String()
 }

--- a/pkg/tool/kg_query_test.go
+++ b/pkg/tool/kg_query_test.go
@@ -1,0 +1,159 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// fakeKG is a scripted KGReader recording which scope method ran and with what
+// caller/query, so the handler's scope enforcement is pinned without a DB.
+type fakeKG struct {
+	ownFacts    []KGFact
+	searchFacts []KGFact
+	err         error
+
+	ownCalled    bool
+	ownAgentID   string
+	searchCalled bool
+	searchQuery  string
+	searchLimit  int
+}
+
+func (f *fakeKG) OwnNodeFacts(_ context.Context, agentID string) ([]KGFact, error) {
+	f.ownCalled = true
+	f.ownAgentID = agentID
+	return f.ownFacts, f.err
+}
+
+func (f *fakeKG) SearchFacts(_ context.Context, query string, limit int) ([]KGFact, error) {
+	f.searchCalled = true
+	f.searchQuery = query
+	f.searchLimit = limit
+	return f.searchFacts, f.err
+}
+
+func TestKGQueryOwnNodeUsesCallerNeighbourhood(t *testing.T) {
+	src := &fakeKG{ownFacts: []KGFact{
+		{Name: "Mara", Type: "Character", Body: "You promised Mara a favour."},
+		{Name: "Docks", Type: "Location", Body: "Where you met."},
+	}}
+	tool := NewKGQuery(src)
+	ctx := WithCaller(context.Background(), "agent-42")
+	cfg := json.RawMessage(`{"scope":"own_node"}`)
+
+	out, err := tool.Execute(ctx, json.RawMessage(`{"query":"Mara"}`), cfg)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !src.ownCalled {
+		t.Fatal("own_node scope must read OwnNodeFacts")
+	}
+	if src.searchCalled {
+		t.Fatal("own_node scope must NOT reach the campaign SearchFacts")
+	}
+	if src.ownAgentID != "agent-42" {
+		t.Errorf("OwnNodeFacts agentID = %q, want the caller identity agent-42", src.ownAgentID)
+	}
+	// Query-term filter keeps only the Mara fact.
+	if !strings.Contains(out, "Mara") || strings.Contains(out, "Docks") {
+		t.Errorf("own_node result should be query-filtered to Mara: %q", out)
+	}
+}
+
+// TestKGQueryOwnNodeCannotBeWidenedByArgs pins the ADR-0029 security property:
+// the LLM cannot escape its own_node scope by crafting arguments — the scope and
+// the caller both come from the grant/ctx, never the args, so a hostile "about"
+// or a foreign agent id in the args is ignored.
+func TestKGQueryOwnNodeCannotBeWidenedByArgs(t *testing.T) {
+	src := &fakeKG{ownFacts: []KGFact{{Name: "Mine", Type: "Note", Body: "only mine"}}}
+	ctx := WithCaller(context.Background(), "agent-self")
+	cfg := json.RawMessage(`{"scope":"own_node"}`)
+
+	// Args try to smuggle another agent id and a campaign scope — both must be inert.
+	args := json.RawMessage(`{"query":"mine","agent_id":"agent-victim","scope":"campaign"}`)
+	if _, err := NewKGQuery(src).Execute(ctx, args, cfg); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if src.searchCalled {
+		t.Fatal("crafted args must not widen own_node to campaign SearchFacts")
+	}
+	if src.ownAgentID != "agent-self" {
+		t.Errorf("caller stayed %q — a smuggled agent_id must be ignored", src.ownAgentID)
+	}
+}
+
+// TestKGQueryNilConfigDefaultsCampaign pins S3: a grant with no scope config
+// reads campaign-wide (reads are gm_private-filtered, so the wider default is
+// safe) via SearchFacts, not OwnNodeFacts.
+func TestKGQueryNilConfigDefaultsCampaign(t *testing.T) {
+	src := &fakeKG{searchFacts: []KGFact{{Name: "The Duke", Type: "NPC", Body: "Rules the city."}}}
+	tool := NewKGQuery(src)
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"duke","limit":3}`), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !src.searchCalled {
+		t.Fatal("nil config must default to the campaign SearchFacts read")
+	}
+	if src.ownCalled {
+		t.Fatal("nil config must NOT read OwnNodeFacts")
+	}
+	if src.searchQuery != "duke" || src.searchLimit != 3 {
+		t.Errorf("SearchFacts got (%q,%d), want (duke,3)", src.searchQuery, src.searchLimit)
+	}
+	if !strings.Contains(out, "### The Duke (NPC)") {
+		t.Errorf("render should carry the fact header: %q", out)
+	}
+}
+
+func TestKGQueryExplicitCampaignScope(t *testing.T) {
+	src := &fakeKG{searchFacts: []KGFact{{Name: "X", Type: "Note", Body: "y"}}}
+	cfg := json.RawMessage(`{"scope":"campaign"}`)
+	if _, err := NewKGQuery(src).Execute(context.Background(), json.RawMessage(`{"query":"x"}`), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !src.searchCalled || src.ownCalled {
+		t.Error("explicit campaign scope must read SearchFacts")
+	}
+}
+
+func TestKGQueryUnknownScopeErrors(t *testing.T) {
+	cfg := json.RawMessage(`{"scope":"everything"}`)
+	_, err := NewKGQuery(&fakeKG{}).Execute(context.Background(), json.RawMessage(`{"query":"x"}`), cfg)
+	if err == nil {
+		t.Fatal("an unknown scope must fail loudly, not widen silently")
+	}
+}
+
+func TestKGQueryBoundsAndTruncates(t *testing.T) {
+	long := strings.Repeat("z", MaxKGFactBodyRunes*2)
+	facts := make([]KGFact, 10)
+	for i := range facts {
+		facts[i] = KGFact{Name: "N", Type: "Note", Body: long}
+	}
+	out, err := NewKGQuery(&fakeKG{searchFacts: facts}).Execute(
+		context.Background(), json.RawMessage(`{"query":"z"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) > MaxToolResultChars {
+		t.Errorf("result %d chars exceeds budget %d", len(out), MaxToolResultChars)
+	}
+	if !strings.Contains(out, "…") {
+		t.Error("an overlong body should be truncated with an ellipsis")
+	}
+}
+
+func TestKGQueryEmpty(t *testing.T) {
+	out, err := NewKGQuery(&fakeKG{}).Execute(
+		context.Background(), json.RawMessage(`{"query":"nothing"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "no matching knowledge" {
+		t.Errorf("empty = %q", out)
+	}
+}

--- a/pkg/tool/kg_query_test.go
+++ b/pkg/tool/kg_query_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // fakeKG is a scripted KGReader recording which scope method ran and with what
@@ -155,5 +156,49 @@ func TestKGQueryEmpty(t *testing.T) {
 	}
 	if out != "no matching knowledge" {
 		t.Errorf("empty = %q", out)
+	}
+}
+
+// TestKGQueryMultibyteFactRenders pins the reviewer's finding: a multibyte-heavy
+// (CJK) fact must render (truncated) rather than collapse to "no matching
+// knowledge". A byte-counted budget on the first block blew past 2000 before
+// anything was written; the budget is counted in runes and the first block is
+// always emitted.
+func TestKGQueryMultibyteFactRenders(t *testing.T) {
+	body := strings.Repeat("我", 800) // 800 CJK runes = 2400 bytes > 2000-byte budget
+	src := &fakeKG{searchFacts: []KGFact{{Name: "龍", Type: "NPC", Body: body}}}
+	out, err := NewKGQuery(src).Execute(context.Background(), json.RawMessage(`{"query":"dragon"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "no matching knowledge" {
+		t.Fatal("a CJK-heavy match rendered as 'none' — budget must count runes, not bytes")
+	}
+	if !strings.Contains(out, "### 龍 (NPC)") {
+		t.Errorf("fact header missing: %q", out[:min(60, len(out))])
+	}
+	if utf8.RuneCountInString(out) > MaxToolResultChars {
+		t.Errorf("result %d runes exceeds budget %d", utf8.RuneCountInString(out), MaxToolResultChars)
+	}
+}
+
+// TestFilterByQueryUnicodeTerms pins finding #3: query tokenizing is Unicode-aware
+// so German umlaut and CJK queries filter instead of dumping the whole
+// neighbourhood.
+func TestKGQueryOwnNodeUnicodeQueryFilters(t *testing.T) {
+	src := &fakeKG{ownFacts: []KGFact{
+		{Name: "Würfel des Schicksals", Type: "Item", Body: "ein magischer Würfel"},
+		{Name: "Schwert", Type: "Item", Body: "eine Klinge"},
+	}}
+	ctx := WithCaller(context.Background(), "a1")
+	out, err := NewKGQuery(src).Execute(ctx, json.RawMessage(`{"query":"Würfel"}`), json.RawMessage(`{"scope":"own_node"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Würfel des Schicksals") {
+		t.Errorf("umlaut query should match the Würfel fact: %q", out)
+	}
+	if strings.Contains(out, "Schwert") {
+		t.Errorf("umlaut query should NOT dump unrelated facts (ASCII tokenizer bug): %q", out)
 	}
 }

--- a/pkg/tool/knowledge_loop_test.go
+++ b/pkg/tool/knowledge_loop_test.go
@@ -1,0 +1,90 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestLoopRunsKnowledgeToolsInline is the ADR-0021/ADR-0030 pin for the two new
+// built-ins: granted kg_query and transcript_search execute INLINE inside the
+// tool-use loop (they are read-only, so the loop never refuses them), and their
+// rendered results are fed back to the model as tool-role messages. It drives the
+// loop with a scripted provider over fake sources — the framework's cassette.
+func TestLoopRunsKnowledgeToolsInline(t *testing.T) {
+	kg := &fakeKG{searchFacts: []KGFact{{Name: "The Duke", Type: "NPC", Body: "rules the city"}}}
+	ts := &fakeTranscript{hits: []TranscriptHit{{Who: "GM", Kind: "human", Text: "you promised the Duke a favour"}}}
+	reg := BuiltinRegistry(Deps{KG: kg, Transcripts: ts})
+	gs := NewGrantSet(reg,
+		Grant{ToolName: "kg_query"},          // nil config → campaign scope
+		Grant{ToolName: "transcript_search"}, // no scope
+	)
+
+	p := &scriptedProvider{
+		t: t,
+		steps: []scriptStep{
+			// Round 1: the model recalls from the KG.
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c1", Name: "kg_query", Input: json.RawMessage(`{"query":"duke"}`)},
+			}}},
+			// Round 2: then searches the transcript.
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c2", Name: "transcript_search", Input: json.RawMessage(`{"query":"promise"}`)},
+			}}},
+			// Round 3: answers with both recalled.
+			{reply: AssistantMessage{Text: "Yes — you promised the Duke a favour."}},
+		},
+	}
+	loop := NewLoop(p, gs)
+
+	final, err := loop.Run(context.Background(), []Message{
+		{Role: RoleSystem, Text: "You are Bart."},
+		{Role: RoleUser, Text: "Do you remember what I promised?"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if final != "Yes — you promised the Duke a favour." {
+		t.Errorf("final = %q", final)
+	}
+	if !kg.searchCalled {
+		t.Error("kg_query should have hit the campaign SearchFacts source")
+	}
+	if ts.callCount != 1 {
+		t.Errorf("transcript_search called the source %d times, want 1", ts.callCount)
+	}
+
+	// The kg_query result must have been fed back as a non-error tool-role message.
+	kgResult := findToolResult(t, p.seenMessages, "c1")
+	if kgResult.IsError {
+		t.Errorf("kg_query fed back as error (was it refused as side-effecting?): %q", kgResult.Content)
+	}
+	if !strings.Contains(kgResult.Content, "### The Duke (NPC)") {
+		t.Errorf("kg_query result not rendered for the prompt: %q", kgResult.Content)
+	}
+	tsResult := findToolResult(t, p.seenMessages, "c2")
+	if tsResult.IsError || !strings.Contains(tsResult.Content, "promised the Duke") {
+		t.Errorf("transcript_search result = %+v", tsResult)
+	}
+}
+
+// findToolResult scans the messages the provider saw for the tool-role result
+// keyed to callID.
+func findToolResult(t *testing.T, seen [][]Message, callID string) ToolResult {
+	t.Helper()
+	for _, msgs := range seen {
+		for _, m := range msgs {
+			if m.Role != RoleTool {
+				continue
+			}
+			for _, tr := range m.ToolResults {
+				if tr.CallID == callID {
+					return tr
+				}
+			}
+		}
+	}
+	t.Fatalf("no tool result for call %q was ever fed back", callID)
+	return ToolResult{}
+}

--- a/pkg/tool/registry_test.go
+++ b/pkg/tool/registry_test.go
@@ -62,19 +62,16 @@ func TestRegistryToolsSorted(t *testing.T) {
 	}
 }
 
-// TestBuiltinRegistryIsDiceOnly: the shared built-in set is exactly [dice] and it
-// is a plain on/off grant (no scope editor). This is the source the grant editor
-// and the live loop both build from — they must agree on the available Tools.
-func TestBuiltinRegistryIsDiceOnly(t *testing.T) {
-	tools := BuiltinRegistry().Tools()
-	if len(tools) != 1 || tools[0].Name() != "dice" {
-		t.Fatalf("BuiltinRegistry Tools = %+v, want exactly [dice]", tools)
+// TestBuiltinRegistryHasDice: dice remains a registered, plain on/off grant (no
+// scope editor). The full catalog (dice + the knowledge Tools) is pinned in
+// builtins_test.go; this guards dice's grant shape specifically.
+func TestBuiltinRegistryHasDice(t *testing.T) {
+	dice, ok := BuiltinRegistry(Deps{}).Get("dice")
+	if !ok {
+		t.Fatal("BuiltinRegistry must have dice registered")
 	}
-	if tools[0].SupportsScope() {
+	if dice.SupportsScope() {
 		t.Error("dice must not advertise scope support (it carries no per-grant config)")
-	}
-	if _, ok := BuiltinRegistry().Get("dice"); !ok {
-		t.Error("BuiltinRegistry must have dice registered")
 	}
 }
 

--- a/pkg/tool/transcript_search.go
+++ b/pkg/tool/transcript_search.go
@@ -1,0 +1,177 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Result budgets shared by the knowledge Tools (#296), mirroring the kgfacts
+// discipline (internal/kgfacts): a hard ceiling on the whole result plus a
+// per-item cap so no single oversized row blows the prompt budget. Pinned as
+// consts, not magic numbers, so the bound is one edit away and testable.
+const (
+	// MaxToolResultChars bounds a knowledge Tool's whole rendered result. A
+	// tool-role message is prompt-injected verbatim, so this keeps one tool call
+	// from dominating the next generation's context regardless of DB size.
+	MaxToolResultChars = 2000
+	// MaxTranscriptLineRunes caps one rendered transcript line's spoken text, in
+	// runes (rune-safe truncation, never a split codepoint).
+	MaxTranscriptLineRunes = 300
+	// DefaultSearchLimit is the row cap when the LLM omits "limit".
+	DefaultSearchLimit = 5
+	// MaxSearchLimit is the hard ceiling on "limit"; a larger request is clamped,
+	// re-validated in the handler because the schema is advisory (ADR-0029).
+	MaxSearchLimit = 10
+)
+
+// searchArgs is the shared decoded shape of the knowledge Tools' LLM args: a
+// free-text query and an optional row limit. Both Tools declare the same schema.
+type searchArgs struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit"`
+}
+
+// clampedLimit resolves the requested row limit against the defaults/ceiling.
+// The schema is advisory; the model can emit anything, so the bound is enforced
+// here (ADR-0029: never trust the model to honour constraints).
+func clampedLimit(requested int) int {
+	if requested <= 0 {
+		return DefaultSearchLimit
+	}
+	if requested > MaxSearchLimit {
+		return MaxSearchLimit
+	}
+	return requested
+}
+
+// searchInputSchema is the JSON Schema both knowledge Tools declare to the LLM.
+var searchInputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "The words to search for."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "description": "Maximum number of results to return (default 5)."
+    }
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}`)
+
+// TranscriptSearch is the read-only transcript_search built-in (#296): a
+// relevance search over the active Campaign's persisted transcript (ADR-0011
+// tsvector path), campaign-scoped inside the adapter. It executes inline
+// (ReadOnly) — the model needs the recalled lines to keep talking ("earlier you
+// promised…"). It carries no per-grant scope: every Agent that holds the grant
+// searches its own Campaign's transcript, no narrowing (SupportsScope false).
+//
+// A nil source means the Tool is registered but transcript retrieval is not
+// wired in this mode; Execute then reports it is unavailable rather than panic.
+type TranscriptSearch struct {
+	src TranscriptSearcher
+}
+
+// NewTranscriptSearch builds the Tool over src. A nil src is allowed — the Tool
+// registers but reports unavailable at Execute time (the standalone bench path).
+func NewTranscriptSearch(src TranscriptSearcher) *TranscriptSearch {
+	return &TranscriptSearch{src: src}
+}
+
+// Name implements [Tool].
+func (*TranscriptSearch) Name() string { return "transcript_search" }
+
+// Description implements [Tool].
+func (*TranscriptSearch) Description() string {
+	return "Search the transcript of this campaign's past sessions for what was said. " +
+		"Use it to recall earlier conversations, promises, or events."
+}
+
+// InputSchema implements [Tool].
+func (*TranscriptSearch) InputSchema() json.RawMessage { return searchInputSchema }
+
+// ReadOnly implements [Tool]: a transcript search mutates no state (ADR-0030).
+func (*TranscriptSearch) ReadOnly() bool { return true }
+
+// SupportsScope implements [Tool]: transcript_search is campaign-scoped for
+// everyone (the Campaign comes from the active session, not a grant), so it
+// carries no narrowing config.
+func (*TranscriptSearch) SupportsScope() bool { return false }
+
+// Execute implements [Tool]. It searches the active Campaign's transcript for
+// the query and renders the matches as numbered lines the LLM can read back. The
+// Campaign is resolved inside the adapter (from the active session), never from
+// the args — the model cannot search another Campaign. grantConfig is ignored
+// (no scope). A nil source yields the unavailable error; no matches yields a
+// friendly "none" line, not an error.
+func (ts *TranscriptSearch) Execute(ctx context.Context, args json.RawMessage, _ any) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if ts.src == nil {
+		return "", fmt.Errorf("transcript_search: transcript retrieval is unavailable in this mode")
+	}
+	var a searchArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("transcript_search: invalid arguments: %w", err)
+	}
+	if strings.TrimSpace(a.Query) == "" {
+		return "", fmt.Errorf("transcript_search: query must not be empty")
+	}
+
+	hits, err := ts.src.SearchTranscript(ctx, a.Query, clampedLimit(a.Limit))
+	if err != nil {
+		return "", fmt.Errorf("transcript_search: %w", err)
+	}
+	return renderTranscriptHits(hits), nil
+}
+
+// renderTranscriptHits projects hits into numbered lines "N. [kind] who: text",
+// each line's text rune-truncated to MaxTranscriptLineRunes, the whole result
+// bounded to MaxToolResultChars with a deterministic prefix-stop (a line that
+// would overrun the budget, and every line after it, is dropped rather than the
+// block skip-scanned). An empty set renders the "none" line.
+func renderTranscriptHits(hits []TranscriptHit) string {
+	if len(hits) == 0 {
+		return "no matching transcript lines"
+	}
+	var b strings.Builder
+	n := 0
+	for _, h := range hits {
+		line := fmt.Sprintf("%d. [%s] %s: %s", n+1, h.Kind, h.Who, truncateRunes(h.Text, MaxTranscriptLineRunes))
+		add := line
+		if n > 0 {
+			add = "\n" + line
+		}
+		if b.Len()+len(add) > MaxToolResultChars {
+			break
+		}
+		b.WriteString(add)
+		n++
+	}
+	if n == 0 {
+		// The very first line already exceeds the budget: emit its truncated form
+		// alone rather than the "none" line, so the caller still gets a result.
+		return "no matching transcript lines"
+	}
+	return b.String()
+}
+
+// truncateRunes trims s to at most max runes, appending an ellipsis when it cut —
+// rune-safe so a multibyte character is never split (mirrors kgfacts).
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}

--- a/pkg/tool/transcript_search.go
+++ b/pkg/tool/transcript_search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Result budgets shared by the knowledge Tools (#296), mirroring the kgfacts
@@ -134,14 +135,18 @@ func (ts *TranscriptSearch) Execute(ctx context.Context, args json.RawMessage, _
 
 // renderTranscriptHits projects hits into numbered lines "N. [kind] who: text",
 // each line's text rune-truncated to MaxTranscriptLineRunes, the whole result
-// bounded to MaxToolResultChars with a deterministic prefix-stop (a line that
-// would overrun the budget, and every line after it, is dropped rather than the
-// block skip-scanned). An empty set renders the "none" line.
+// bounded to MaxToolResultChars — counted in RUNES to match the per-line rune cap
+// (a byte count would let a multibyte-heavy result overrun the budget) — with a
+// deterministic prefix-stop: a line that would overrun the budget, and every line
+// after it, is dropped rather than the block skip-scanned. The FIRST line is
+// ALWAYS emitted (one line's runes never exceed the budget), so a real match is
+// never rendered as the "none" line. An empty set renders "none".
 func renderTranscriptHits(hits []TranscriptHit) string {
 	if len(hits) == 0 {
 		return "no matching transcript lines"
 	}
 	var b strings.Builder
+	runes := 0
 	n := 0
 	for _, h := range hits {
 		line := fmt.Sprintf("%d. [%s] %s: %s", n+1, h.Kind, h.Who, truncateRunes(h.Text, MaxTranscriptLineRunes))
@@ -149,16 +154,13 @@ func renderTranscriptHits(hits []TranscriptHit) string {
 		if n > 0 {
 			add = "\n" + line
 		}
-		if b.Len()+len(add) > MaxToolResultChars {
-			break
+		addRunes := utf8.RuneCountInString(add)
+		if n > 0 && runes+addRunes > MaxToolResultChars {
+			break // budget reached; the first line is always kept.
 		}
 		b.WriteString(add)
+		runes += addRunes
 		n++
-	}
-	if n == 0 {
-		// The very first line already exceeds the budget: emit its truncated form
-		// alone rather than the "none" line, so the caller still gets a result.
-		return "no matching transcript lines"
 	}
 	return b.String()
 }

--- a/pkg/tool/transcript_search_test.go
+++ b/pkg/tool/transcript_search_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // fakeTranscript is a scripted TranscriptSearcher: it records the query/limit it
@@ -101,5 +102,27 @@ func TestTranscriptSearchEmpty(t *testing.T) {
 	}
 	if out != "no matching transcript lines" {
 		t.Errorf("empty search = %q", out)
+	}
+}
+
+// TestTranscriptSearchMultibyteBudget pins the reviewer's finding class: a result
+// of multibyte-heavy lines stays within MaxToolResultChars counted in RUNES, and
+// the first line always renders (never collapses to "none").
+func TestTranscriptSearchMultibyteBudget(t *testing.T) {
+	line := strings.Repeat("我", MaxTranscriptLineRunes) // full-width, 3 bytes each
+	hits := make([]TranscriptHit, 10)
+	for i := range hits {
+		hits[i] = TranscriptHit{Who: "話者", Kind: "npc", Text: line}
+	}
+	out, err := NewTranscriptSearch(&fakeTranscript{hits: hits}).Execute(
+		context.Background(), json.RawMessage(`{"query":"x"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "no matching transcript lines" {
+		t.Fatal("CJK hits rendered as 'none' — first line must always emit")
+	}
+	if utf8.RuneCountInString(out) > MaxToolResultChars {
+		t.Errorf("result %d runes exceeds budget %d", utf8.RuneCountInString(out), MaxToolResultChars)
 	}
 }

--- a/pkg/tool/transcript_search_test.go
+++ b/pkg/tool/transcript_search_test.go
@@ -1,0 +1,105 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeTranscript is a scripted TranscriptSearcher: it records the query/limit it
+// was handed and replays a fixed hit set, so the handler's clamping and the
+// campaign-inside-adapter contract are pinned without a DB.
+type fakeTranscript struct {
+	hits      []TranscriptHit
+	err       error
+	gotQuery  string
+	gotLimit  int
+	callCount int
+}
+
+func (f *fakeTranscript) SearchTranscript(_ context.Context, query string, limit int) ([]TranscriptHit, error) {
+	f.callCount++
+	f.gotQuery = query
+	f.gotLimit = limit
+	return f.hits, f.err
+}
+
+func TestTranscriptSearchRendersNumberedLines(t *testing.T) {
+	at := time.Date(2026, 7, 10, 20, 0, 0, 0, time.UTC)
+	src := &fakeTranscript{hits: []TranscriptHit{
+		{Who: "Bart", Kind: "npc", Text: "I will remember your promise.", At: at},
+		{Who: "GM", Kind: "human", Text: "You owe me a favour.", At: at},
+	}}
+	tool := NewTranscriptSearch(src)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"promise"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := "1. [npc] Bart: I will remember your promise.\n2. [human] GM: You owe me a favour."
+	if out != want {
+		t.Errorf("render =\n%q\nwant\n%q", out, want)
+	}
+}
+
+func TestTranscriptSearchDefaultsAndClampsLimit(t *testing.T) {
+	src := &fakeTranscript{}
+	tool := NewTranscriptSearch(src)
+
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"x"}`), nil); err != nil {
+		t.Fatal(err)
+	}
+	if src.gotLimit != DefaultSearchLimit {
+		t.Errorf("omitted limit → %d, want default %d", src.gotLimit, DefaultSearchLimit)
+	}
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"x","limit":999}`), nil); err != nil {
+		t.Fatal(err)
+	}
+	if src.gotLimit != MaxSearchLimit {
+		t.Errorf("oversized limit → %d, want clamp to %d", src.gotLimit, MaxSearchLimit)
+	}
+}
+
+func TestTranscriptSearchTruncatesLongLine(t *testing.T) {
+	long := strings.Repeat("word ", 200) // ~1000 runes
+	src := &fakeTranscript{hits: []TranscriptHit{{Who: "Bart", Kind: "npc", Text: long}}}
+	out, err := NewTranscriptSearch(src).Execute(context.Background(), json.RawMessage(`{"query":"x"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(out, "…") {
+		t.Errorf("a truncated line should end in an ellipsis: %q", out)
+	}
+	if len([]rune(out)) > MaxTranscriptLineRunes+40 { // + the "1. [npc] Bart: " prefix
+		t.Errorf("line not truncated to ~%d runes: %d", MaxTranscriptLineRunes, len([]rune(out)))
+	}
+}
+
+func TestTranscriptSearchBoundsWholeResult(t *testing.T) {
+	// Ten max-length lines would blow 2000 chars; the result must stay bounded.
+	hits := make([]TranscriptHit, 10)
+	line := strings.Repeat("x", MaxTranscriptLineRunes)
+	for i := range hits {
+		hits[i] = TranscriptHit{Who: "W", Kind: "npc", Text: line}
+	}
+	out, err := NewTranscriptSearch(&fakeTranscript{hits: hits}).Execute(
+		context.Background(), json.RawMessage(`{"query":"x"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) > MaxToolResultChars {
+		t.Errorf("result %d chars exceeds budget %d", len(out), MaxToolResultChars)
+	}
+}
+
+func TestTranscriptSearchEmpty(t *testing.T) {
+	out, err := NewTranscriptSearch(&fakeTranscript{}).Execute(
+		context.Background(), json.RawMessage(`{"query":"nothing"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "no matching transcript lines" {
+		t.Errorf("empty search = %q", out)
+	}
+}

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -261,6 +261,15 @@ type Engine struct {
 	full  *tool.Loop // every granted Tool declared
 	gated *tool.Loop // grants minus the dice Tool
 
+	// agentID is this Agent's stable identity, stamped onto the turn ctx once per
+	// Generate/GenerateStream via [tool.WithCaller] (S2, #296). A scope-narrowing
+	// Tool handler (kg_query own_node) reads it back with [tool.CallerID] to scope
+	// the read to THIS Agent's neighbourhood — the caller comes from here, never
+	// the LLM's args, so the model cannot widen its scope. "" (a standalone bench
+	// Agent, or a Persona with no persisted id) stamps an empty caller, which an
+	// own-node handler treats as "no neighbourhood" rather than a wider fallback.
+	agentID string
+
 	// language is the gate language the dice keyword set is selected by (#226):
 	// the Campaign Language, subtag-normalized via [gateLanguage] once at
 	// construction ([WithLanguage]), so an arbitrary campaign string is parsed
@@ -347,7 +356,7 @@ func WithLanguage(lang string) EngineOption {
 // otherwise) — they are wiring requirements. maxRounds caps tool-call rounds;
 // zero uses [tool.DefaultMaxRounds]. Pass [WithMetrics] to enable the A3 per-
 // round instrumentation; without it the adapter records nothing.
-func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTokens, maxRounds int, opts ...EngineOption) *Engine {
+func NewEngine(provider llm.Provider, grants *tool.GrantSet, agentID, model string, maxTokens, maxRounds int, opts ...EngineOption) *Engine {
 	cfg := engineConfig{rec: observe.Discard{}}
 	for _, o := range opts {
 		o(&cfg)
@@ -371,6 +380,7 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 	return &Engine{
 		full:     newLoop(grants),
 		gated:    newLoop(grants.Without(diceToolName)),
+		agentID:  agentID,
 		language: cfg.language,
 		rec:      cfg.rec,
 		provName: cfg.provName,
@@ -383,6 +393,9 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, model string, maxTo
 // for this turn and never share state with a concurrent turn (barge-in).
 func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, error) {
 	start := time.Now()
+	// Stamp the caller identity once per turn (S2): a scope-narrowing Tool handler
+	// resolves the Agent from ctx, never the LLM args.
+	ctx = tool.WithCaller(ctx, e.agentID)
 	out, err := e.loopFor(messages).Run(withRoundCounter(ctx), toToolMessages(messages))
 	// #125: one full-turn span per Generate, spanning every round, recorded on the
 	// success AND error path so a turn that fails mid-loop is still measured.
@@ -398,6 +411,8 @@ func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, 
 // identically on the streaming production path. Returns the full final text.
 func (e *Engine) GenerateStream(ctx context.Context, messages []llm.Message, onText func(delta string) error) (string, error) {
 	start := time.Now()
+	// Stamp the caller identity once per turn (S2), identical to Generate.
+	ctx = tool.WithCaller(ctx, e.agentID)
 	out, err := e.loopFor(messages).RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
 	// #125: the streaming production path records the same one-per-turn LLMTurn span
 	// Generate does, on success and error alike.

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -119,7 +119,7 @@ func TestEngine_ToolUseRoundTrip_RunsDiceAndReturnsFinalText(t *testing.T) {
 		{text: "You rolled well, traveler.", stop: "end_turn"},
 	}}
 
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0)
 	got, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart."},
 		{Role: llm.RoleUser, Text: "Roll a d20 for me."},
@@ -265,7 +265,7 @@ func TestEngine_LLMRoundSpans_IndexAndToolCallPerRound(t *testing.T) {
 		{text: "You rolled well, traveler.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderAnthropic))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
@@ -303,7 +303,7 @@ func TestEngine_LLMRoundSpans_IndexResetsPerTurn(t *testing.T) {
 		{text: "Second answer.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "claude-test", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGemini))
 
 	for i := 0; i < 2; i++ {
@@ -371,7 +371,7 @@ func TestEngine_Generate_RetriesTransientStartError(t *testing.T) {
 		answer:       "Aye, traveler.",
 	}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "m", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq),
 		agenttool.WithRetry(instantAgentRetry()))
 
@@ -412,7 +412,7 @@ func TestEngine_Generate_NonRetryableStartErrorFailsFast(t *testing.T) {
 		t.Error("a non-retryable 400 must not sleep")
 		return nil
 	}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "m", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq),
 		agenttool.WithRetry(p))
 
@@ -442,7 +442,7 @@ func TestEngine_LLMTurn_OneSpanPerTurnAcrossRounds(t *testing.T) {
 		{text: "You rolled well, traveler.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
@@ -473,7 +473,7 @@ func TestEngine_GenerateStream_RecordsOneLLMTurn(t *testing.T) {
 		{text: "You rolled well, traveler.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	if _, err := eng.GenerateStream(context.Background(),
@@ -493,7 +493,7 @@ func TestEngine_GenerateStream_RecordsOneLLMTurn(t *testing.T) {
 // just successful ones (otherwise a provider outage silently drops the samples).
 func TestEngine_LLMTurn_RecordsOnError(t *testing.T) {
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(errorEventProvider{}, tool.NewGrantSet(tool.NewRegistry()), "m", 0, 0,
+	eng := agenttool.NewEngine(errorEventProvider{}, tool.NewGrantSet(tool.NewRegistry()), "", "m", 0, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
@@ -516,7 +516,7 @@ func TestEngine_GenerateStream_ForwardsFinalTextAndKeepsMetrics(t *testing.T) {
 		{text: "You rolled well, traveler.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGemini))
 
 	var streamed strings.Builder
@@ -557,7 +557,7 @@ func TestEngine_GenerateStream_ForwardsFinalTextAndKeepsMetrics(t *testing.T) {
 // asserting the single forward equals the full answer for a no-tool turn.)
 func TestEngine_GenerateStream_NoToolTurnStreamsAnswer(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{{text: "Welcome to the inn.", stop: "end_turn"}}}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "claude-test", 256, 0)
 
 	var got strings.Builder
 	full, err := eng.GenerateStream(context.Background(),
@@ -582,7 +582,7 @@ func TestEngine_NoTools_SingleGenerationReturnsText(t *testing.T) {
 	}}
 	emptyGrants := tool.NewGrantSet(tool.NewRegistry())
 
-	eng := agenttool.NewEngine(prov, emptyGrants, "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, emptyGrants, "", "claude-test", 256, 0)
 	got, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "Hello."},
 	})
@@ -605,7 +605,7 @@ func TestEngine_DiceGate_PlainTurnOffersNoDiceAndIsSingleRound(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{
 		{text: "Ale's a copper, traveler.", stop: "end_turn"},
 	}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0)
 
 	got, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart."},
@@ -634,7 +634,7 @@ func TestEngine_DiceGate_KeywordIntentOffersDice(t *testing.T) {
 		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
 		{text: "You steady your nerves.", stop: "end_turn"},
 	}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0)
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "Make a saving throw against the poison."},
@@ -655,7 +655,7 @@ func TestEngine_DiceGate_KeywordIntentOffersDice(t *testing.T) {
 // declared on a later plain turn.
 func TestEngine_DiceGate_HistoryDiceDoesNotArmCurrentTurn(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{{text: "Right this way.", stop: "end_turn"}}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0)
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "Roll a d20."},                // older turn: had dice intent
@@ -679,7 +679,7 @@ func TestEngine_DiceGate_GermanUtteranceOffersDiceWithLanguage(t *testing.T) {
 		{calls: []llm.ToolCall{{ID: "toolu_1", Name: "dice", Input: json.RawMessage(`{"count":2,"sides":6}`)}}, stop: "tool_use"},
 		{text: "Eine Vier und eine Zwei.", stop: "end_turn"},
 	}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithLanguage("de-DE"))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
@@ -701,7 +701,7 @@ func TestEngine_DiceGate_GermanUtteranceOffersDiceWithLanguage(t *testing.T) {
 // the gate, so a plain German turn stays a single dice-less round.
 func TestEngine_DiceGate_GermanPlainTurnGatedWithLanguage(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{{text: "Es war einmal…", stop: "end_turn"}}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0,
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0,
 		agenttool.WithLanguage("de"))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
@@ -721,7 +721,7 @@ func TestEngine_DiceGate_GermanPlainTurnGatedWithLanguage(t *testing.T) {
 // utterance is gated out — reproducing the live false negative.
 func TestEngine_DiceGate_GermanUtteranceWithoutLanguageStaysEnglish(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{{text: "role-played roll", stop: "end_turn"}}}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "claude-test", 256, 0)
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleUser, Text: "Bart, benutze dein Würfelwerkzeug und würfle zwei sechsseitige Würfel."},
@@ -741,7 +741,7 @@ func TestEngine_AsAgentEngine_DrivesReplier(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{
 		{text: "Aye, two rooms upstairs.", stop: "end_turn"},
 	}}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "claude-test", 256, 0)
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "claude-test", 256, 0)
 
 	r := agent.NewReplier(agent.Config{
 		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart."},
@@ -776,7 +776,7 @@ func (truncatingProvider) Complete(context.Context, llm.Request) (<-chan llm.Str
 func TestEngine_TruncatedStream_ReturnsError(t *testing.T) {
 	reg := tool.NewRegistry()
 	grants := tool.NewGrantSet(reg)
-	eng := agenttool.NewEngine(truncatingProvider{}, grants, "m", 0, 0)
+	eng := agenttool.NewEngine(truncatingProvider{}, grants, "", "m", 0, 0)
 
 	_, err := eng.Generate(t.Context(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
 	if err == nil || !strings.Contains(err.Error(), "without done") {
@@ -812,7 +812,7 @@ func TestEngine_StartError_ClassifiesOutcomeLikeStages(t *testing.T) {
 
 	t.Run("barge cancel is canceled, not a fault", func(t *testing.T) {
 		rec := &recordingStage{}
-		eng := agenttool.NewEngine(bargeStartProvider{}, empty, "m", 0, 0,
+		eng := agenttool.NewEngine(bargeStartProvider{}, empty, "", "m", 0, 0,
 			agenttool.WithMetrics(rec, observe.ProviderGroq))
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan error, 1)
@@ -842,7 +842,7 @@ func TestEngine_StartError_ClassifiesOutcomeLikeStages(t *testing.T) {
 
 	t.Run("live-ctx start failure is error + fault", func(t *testing.T) {
 		rec := &recordingStage{}
-		eng := agenttool.NewEngine(startErrProvider{}, empty, "m", 0, 0,
+		eng := agenttool.NewEngine(startErrProvider{}, empty, "", "m", 0, 0,
 			agenttool.WithMetrics(rec, observe.ProviderGroq))
 		if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
 			t.Fatal("Generate returned nil on a start failure")
@@ -899,7 +899,7 @@ func (p usageProvider) Complete(context.Context, llm.Request) (<-chan llm.Stream
 func TestEngine_Usage_RecordsProviderReportedTokensAndModel(t *testing.T) {
 	prov := usageProvider{text: "Aye, traveler.", usage: &llm.Usage{InputTokens: 100, OutputTokens: 50}}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "claude-test-model", 256, 0,
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "claude-test-model", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Hello."}}); err != nil {
@@ -924,7 +924,7 @@ func TestEngine_Usage_RecordsProviderReportedTokensAndModel(t *testing.T) {
 func TestEngine_Usage_EstimatesWhenProviderReportsNone(t *testing.T) {
 	prov := usageProvider{text: "abcdefghijkl"} // 12 runes, no usage reported
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+	eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "m", 256, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGemini))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Hello."}}); err != nil {
@@ -945,7 +945,7 @@ func TestEngine_Usage_EstimatesWhenProviderReportsNone(t *testing.T) {
 // starts (a start error) records NO usage — there was no completion to meter.
 func TestEngine_Usage_StartErrorRecordsNoTokens(t *testing.T) {
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(startErrProvider{}, tool.NewGrantSet(tool.NewRegistry()), "m", 0, 0,
+	eng := agenttool.NewEngine(startErrProvider{}, tool.NewGrantSet(tool.NewRegistry()), "", "m", 0, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}}); err == nil {
@@ -963,7 +963,7 @@ func TestEngine_Usage_BargeRecordsReportedUsageOnlyIfSeen(t *testing.T) {
 	t.Run("usage already seen → recorded", func(t *testing.T) {
 		prov := usageProvider{text: "partial answer", usage: &llm.Usage{InputTokens: 30, OutputTokens: 5}, usageFirst: true}
 		rec := &recordingStage{}
-		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "m", 256, 0,
 			agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 		_, err := eng.GenerateStream(context.Background(),
@@ -982,7 +982,7 @@ func TestEngine_Usage_BargeRecordsReportedUsageOnlyIfSeen(t *testing.T) {
 	t.Run("no usage yet → nothing", func(t *testing.T) {
 		prov := usageProvider{text: "partial answer"} // no usage before the barge
 		rec := &recordingStage{}
-		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "m", 256, 0,
+		eng := agenttool.NewEngine(prov, tool.NewGrantSet(tool.NewRegistry()), "", "m", 256, 0,
 			agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 		_, err := eng.GenerateStream(context.Background(),
@@ -1013,10 +1013,49 @@ func (errorEventProvider) Complete(context.Context, llm.Request) (<-chan llm.Str
 func TestEngine_EventError_PropagatesAsError(t *testing.T) {
 	reg := tool.NewRegistry()
 	grants := tool.NewGrantSet(reg)
-	eng := agenttool.NewEngine(errorEventProvider{}, grants, "m", 0, 0)
+	eng := agenttool.NewEngine(errorEventProvider{}, grants, "", "m", 0, 0)
 
 	_, err := eng.Generate(t.Context(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
 	if err == nil || !strings.Contains(err.Error(), "connection reset") {
 		t.Fatalf("Generate on EventError = %v, want the provider's error", err)
+	}
+}
+
+// callerCaptureTool is a read-only, scope-supporting Tool that records the
+// [tool.CallerID] present in ctx at Execute time. It lets the bridge tests pin
+// that the Engine stamps the Agent identity onto the turn ctx once (S2, #296),
+// so a scope-narrowing handler resolves the caller from ctx, never the args.
+type callerCaptureTool struct{ got *string }
+
+func (callerCaptureTool) Name() string                 { return "capture" }
+func (callerCaptureTool) Description() string          { return "capture caller" }
+func (callerCaptureTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (callerCaptureTool) ReadOnly() bool               { return true }
+func (callerCaptureTool) SupportsScope() bool          { return true }
+func (c callerCaptureTool) Execute(ctx context.Context, _ json.RawMessage, _ any) (string, error) {
+	*c.got = tool.CallerID(ctx)
+	return "ok", nil
+}
+
+// TestEngine_StampsCallerIdentity pins that NewEngine's agentID reaches the Tool
+// handler via ctx: a granted Tool executed inside the loop sees CallerID equal to
+// the Agent id the Engine was built with (S2). This is what keeps an own_node
+// kg_query scoped to the calling NPC and un-widenable by crafted args.
+func TestEngine_StampsCallerIdentity(t *testing.T) {
+	var seen string
+	reg := tool.NewRegistry()
+	reg.MustRegister(callerCaptureTool{got: &seen})
+	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "capture"})
+
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "c1", Name: "capture", Input: json.RawMessage(`{}`)}}, stop: "tool_use"},
+		{text: "done", stop: "end_turn"},
+	}}
+	eng := agenttool.NewEngine(prov, grants, "agent-bart", "m", 0, 0)
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "recall"}}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if seen != "agent-bart" {
+		t.Errorf("handler saw CallerID %q, want the Engine's agentID agent-bart", seen)
 	}
 }

--- a/pkg/voice/voicebench/rig.go
+++ b/pkg/voice/voicebench/rig.go
@@ -64,9 +64,9 @@ func BuildConversation(cfg RigConfig) *orchestrator.Conversation {
 		rec = observe.Discard{}
 	}
 
-	reg := tool.BuiltinRegistry()
+	reg := tool.BuiltinRegistry(tool.Deps{})
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
-	engine := agenttool.NewEngine(cfg.Provider, grants, "", 0, 0,
+	engine := agenttool.NewEngine(cfg.Provider, grants, "", "", 0, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq))
 
 	replier := agent.NewReplier(agent.Config{

--- a/pkg/voice/voicecassette/llm_test.go
+++ b/pkg/voice/voicecassette/llm_test.go
@@ -81,7 +81,7 @@ func TestLoadLLM_ToolUseLoop_ReplaysDiceRoundTrip(t *testing.T) {
 	reg.MustRegister(tool.NewDiceWithRand(rand.New(rand.NewPCG(42, 99)))) // same seed as the fixture
 	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "dice"})
 
-	eng := agenttool.NewEngine(prov, grants, "llama-3.3-70b-versatile", 256, 0)
+	eng := agenttool.NewEngine(prov, grants, "", "llama-3.3-70b-versatile", 256, 0)
 	got, err := eng.Generate(context.Background(), []llm.Message{
 		{Role: llm.RoleSystem, Text: "You are Bart, the innkeeper.\n\nSpeak plainly."},
 		{Role: llm.RoleUser, Text: "Roll a d20 for my luck."},


### PR DESCRIPTION
Closes #296

## What
Wrap the shipped retrieval paths as two ADR-0028 built-in Tools, grantable per-Agent with ADR-0029 scope narrowing, registered beside `dice`. Implements the E7 shared contract S1/S2/S3 (this PR owns that surface; #295/#299/#300 build on it).

- **pkg/tool** — neutral `Deps` injection (S1): `TranscriptSearcher` / `KGReader` + storage-free `TranscriptHit`/`KGFact` types, so `pkg/tool` never imports `internal/storage` (the cycle guard — storage already imports pkg/tool). `WithCaller`/`CallerID` turn-ctx identity (S2). Scope JSON `{"scope":"own_node"|"campaign"}` with read-direction default = campaign (S3). `transcript_search` (ReadOnly, no scope) and `kg_query` (ReadOnly, own_node|campaign). `BuiltinRegistry(Deps)` — a nil source leaves the Tool registered but its Execute reports unavailable (bench/RPC catalog stays identical in every mode).
- **internal/knowledge** — new storage adapter behind the seams. `SearchFacts` **DROPS gm_private rows** (storage.SearchNodes is GM-facing and does not filter — ADR-0008 leak guard); campaign-scoped from the active session (no session → error); `OwnNodeFacts` wraps `AgentNodeFacts` keyed by the caller identity.
- **agenttool.NewEngine** gains `agentID`, stamps `WithCaller` once per turn — own_node scope resolves from ctx, never the LLM args, so crafted args can't widen it.
- **Wiring** — `wirenpc.Config.ToolDeps` → `buildConversation` → `BuiltinRegistry`; `session.Manager.SetToolDeps`; `cmd/glyphoxa` builds the adapter over the process store + Manager. The 3 `BuiltinRegistry` call sites updated (rpc/voicebench pass `tool.Deps{}`).

## Budgets
2000 chars/tool result, per-item rune truncation (kg body ≤500, name ≤200; transcript line ≤300) — pinned as consts, mirroring `internal/kgfacts`.

## Acceptance criteria
- [x] Both Tools registered, grantable, visible in the grant editor with scope JSON (kg_query `supports_scope=true` via existing `campaign_grant.go` plumb)
- [x] Scope enforcement pinned: own_node kg_query cannot read another Node's neighbourhood, un-widenable by args
- [x] Tool-loop integration covered by cassette-style tests (ADR-0021)
- [x] Read-only classification correct (loop runs them inline, never refuses)
- [x] Result size bounded and formatted for prompt consumption

## Tests
~20 tests added across pkg/tool (registry/render/truncate/scope/loop), internal/knowledge (unit + Docker pgtest: gm_private drop, campaign-scoping, no-session error), pkg/voice/agenttool (engine stamps caller), internal/rpc (grant editor lists all three, kg_query scope). Full `go test ./...` green; `golangci-lint run ./...` 0 issues; integration-tagged build+vet clean; knowledge pgtest passed against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)