### PR TITLE
feat(#290): [E6] campaign bundle exporter + operator-gated download + `glyphoxa export` CLI

### DIFF
--- a/cmd/glyphoxa/export.go
+++ b/cmd/glyphoxa/export.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// RunExport is the `glyphoxa export` subcommand: it serializes one Campaign into
+// a #287 bundle for headless backup/provisioning, mirroring seed.go's env
+// conventions. Usage:
+//
+//	glyphoxa export -campaign <uuid> [-include-history] [-o <file>]
+//
+// Connection string: $GLYPHOXA_DATABASE_URL (or $DATABASE_URL). Unlike seed,
+// export needs NO $GLYPHOXA_SECRET — the exporter reads through the storage
+// allowlist and never decrypts a credential (ADR-0053 §2). Output defaults to
+// stdout; -o writes the gzipped bundle to a file.
+func RunExport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	campaignStr := fs.String("campaign", "", "campaign UUID to export (required)")
+	includeHistory := fs.Bool("include-history", false, "include Voice Session transcripts (default off; backup/migration)")
+	outPath := fs.String("o", "", "output file (default stdout)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Validate the campaign id BEFORE opening the DB so a bad invocation fails fast
+	// with no connection attempt (and the arg-parse unit test needs no Postgres).
+	if *campaignStr == "" {
+		return fmt.Errorf("export: -campaign <uuid> is required")
+	}
+	campaignID, err := uuid.Parse(*campaignStr)
+	if err != nil {
+		return fmt.Errorf("export: -campaign must be a UUID: %w", err)
+	}
+
+	dsn := databaseURL()
+	if dsn == "" {
+		return fmt.Errorf("export: set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL)")
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("export: open db: %w", err)
+	}
+	defer pool.Close()
+
+	b, err := bundle.Export(ctx, storage.New(pool), campaignID, bundle.ExportOptions{
+		IncludeHistory: *includeHistory,
+	})
+	if err != nil {
+		return err
+	}
+
+	var out io.Writer = os.Stdout
+	if *outPath != "" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			return fmt.Errorf("export: create %s: %w", *outPath, err)
+		}
+		defer f.Close()
+		out = f
+	}
+	if err := bundle.Encode(out, b); err != nil {
+		return fmt.Errorf("export: encode bundle: %w", err)
+	}
+	return nil
+}

--- a/cmd/glyphoxa/export_integration_test.go
+++ b/cmd/glyphoxa/export_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// TestRunExportHeadless is TEST 6 (integration): `glyphoxa export` writes a
+// decodable bundle file against a configured DB, with NO $GLYPHOXA_SECRET set —
+// the exporter never decrypts, so a headless backup needs only the DSN.
+func TestRunExportHeadless(t *testing.T) {
+	ctx := context.Background()
+	dsn := startPostgres(t)
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	_ = db.Close()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	cipher, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	if err := wirenpc.SeedNPC(ctx, pool, cipher, nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	st := storage.New(pool)
+	tenant, err := st.FindTenantByName(ctx, wirenpc.SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, wirenpc.SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+
+	// Headless invocation: DSN via env, and $GLYPHOXA_SECRET explicitly absent.
+	t.Setenv("GLYPHOXA_DATABASE_URL", dsn)
+	os.Unsetenv("GLYPHOXA_SECRET")
+	out := filepath.Join(t.TempDir(), "pony.glyphoxa.json.gz")
+
+	if err := RunExport(ctx, []string{"-campaign", campaign.ID.String(), "-o", out}); err != nil {
+		t.Fatalf("RunExport: %v", err)
+	}
+
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open output: %v", err)
+	}
+	defer f.Close()
+	b, err := bundle.Decode(f)
+	if err != nil {
+		t.Fatalf("Decode written file: %v", err)
+	}
+	if b.Campaign.Name != wirenpc.SeedCampaignName {
+		t.Errorf("bundle campaign = %q, want %q", b.Campaign.Name, wirenpc.SeedCampaignName)
+	}
+	var hasBart bool
+	for _, a := range b.Campaign.Agents {
+		if a.Name == "Bart" {
+			hasBart = true
+		}
+	}
+	if !hasBart {
+		t.Errorf("exported bundle missing Bart")
+	}
+}

--- a/cmd/glyphoxa/export_test.go
+++ b/cmd/glyphoxa/export_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestRunExport_MissingCampaign is TEST 6 (arg parse): a missing -campaign fails
+// fast with an actionable error and never touches the DB.
+func TestRunExport_MissingCampaign(t *testing.T) {
+	err := RunExport(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "-campaign") {
+		t.Fatalf("missing -campaign: err=%v, want mention of -campaign", err)
+	}
+}
+
+// TestRunExport_BadCampaignUUID rejects a non-UUID -campaign before opening the DB.
+func TestRunExport_BadCampaignUUID(t *testing.T) {
+	err := RunExport(context.Background(), []string{"-campaign", "not-a-uuid"})
+	if err == nil || !strings.Contains(err.Error(), "UUID") {
+		t.Fatalf("bad uuid: err=%v, want UUID complaint", err)
+	}
+}

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/jobs"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
@@ -78,6 +79,12 @@ func main() {
 			return
 		case "seed":
 			if err := RunSeed(context.Background(), log, os.Args[2:]); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return
+		case "export":
+			if err := RunExport(context.Background(), os.Args[2:]); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
@@ -765,6 +772,13 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 	// RPC (#274) and the /glyphoxa recap slash command (#273) share one instance.
 	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, recapEngine, log).Handler(stack.HandlerOptions()...)
 
+	// The campaign-bundle transport (#290, ADR-0053) is a PLAIN net/http mount
+	// beside the SSE relay, not a Connect service (ADR-0015): a streamed gzip
+	// download does not fit Connect's message model. Operator-only via
+	// auth.RequireSession, the same gate the relay reads (ADR-0041). #291 adds the
+	// POST import mount here next.
+	bundleHandler := &bundle.Handler{Store: store, Log: log}
+
 	return []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),
 		web.APIMount(authPath, authHandler),
@@ -778,6 +792,8 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 		// validates the glyphoxa_session cookie the EventSource/fetch send.
 		{Path: "GET /api/v1/sessions/{id}/events", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeEvents))},
 		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
+		// Campaign bundle export (#290): streamed gzip download, operator-gated.
+		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, http.HandlerFunc(bundleHandler.ServeExport))},
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/internal/bundle/export.go
+++ b/internal/bundle/export.go
@@ -194,6 +194,14 @@ func exportHistory(ctx context.Context, st *storage.Store, campaignID uuid.UUID)
 	}
 	chunksBySession := make(map[uuid.UUID][]Chunk, len(sessions))
 	for _, c := range chunks {
+		// voice_session_id is a nullable column (ADR-0011 SEAM): a chunk not bound to
+		// a Voice Session (uuid.Nil) has no Session to nest under, so it is skipped
+		// from the history payload rather than orphaned under a nil map key. Every
+		// chunk the live pipeline writes carries a session, so this is a defensive
+		// guard, not the normal path.
+		if c.VoiceSessionID == uuid.Nil {
+			continue
+		}
 		participated := make([]string, 0, len(c.ParticipatedAgentIDs))
 		for _, id := range c.ParticipatedAgentIDs {
 			participated = append(participated, id.String())

--- a/internal/bundle/export.go
+++ b/internal/bundle/export.go
@@ -1,0 +1,241 @@
+package bundle
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// ExportOptions controls what an [Export] writes. History (Voice Sessions +
+// their Transcript Lines/Chunks) is flag-gated and default off (ADR-0053 §1):
+// the default export shares/provisions a campaign SETUP; IncludeHistory serves
+// the backup/migration path.
+type ExportOptions struct {
+	IncludeHistory bool
+}
+
+// Export serializes one Campaign into a [Bundle] (ADR-0053). It reads EXCLUSIVELY
+// through the storage layer's allowlisted read paths — GetCampaign, ListAgents,
+// per-agent ListToolGrants, ListNodes, ListEdges, ListCharacters, and (only when
+// opts.IncludeHistory) ListVoiceSessions + ListTranscriptLines +
+// ListTranscriptChunks. It NEVER touches provider_config, deployment_config,
+// users, or auth sessions: the secrets-exclusion property (ADR-0053 §2) holds by
+// construction because the bundle types carry no field for a secret and this
+// function reads no table that stores one.
+//
+// Every entity reference in the produced bundle is the SOURCE row's UUID string
+// (ADR-0053 §4): agent ids, node ids, edge endpoints, and history session/agent
+// refs are all uuid.UUID.String(). The importer mints fresh ids and remaps these.
+//
+// Agent voice round-trips storage.VoiceFromJSON -> VoiceToJSON so the exported
+// voice carries the canonical shape minus provider bindings (the FK
+// voice_provider_config_id is an Agent column this never reads). A voice column
+// that does not parse is a hard error, never a silently dropped voice (#224).
+func Export(ctx context.Context, st *storage.Store, campaignID uuid.UUID, opts ExportOptions) (*Bundle, error) {
+	campaign, err := st.GetCampaign(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: get campaign %s: %w", campaignID, err)
+	}
+
+	agents, err := st.ListAgents(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list agents: %w", err)
+	}
+	bAgents := make([]Agent, 0, len(agents))
+	for _, a := range agents {
+		voice, err := exportVoice(a.Voice)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: export: agent %s voice: %w", a.ID, err)
+		}
+		grants, err := exportGrants(ctx, st, a.ID)
+		if err != nil {
+			return nil, err
+		}
+		bAgents = append(bAgents, Agent{
+			ID:          a.ID.String(),
+			Role:        string(a.Role),
+			Name:        a.Name,
+			Title:       a.Title,
+			Persona:     a.Persona,
+			Voice:       voice,
+			AddressOnly: a.AddressOnly,
+			Aliases:     a.Aliases,
+			Grants:      grants,
+		})
+	}
+
+	nodes, err := st.ListNodes(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list nodes: %w", err)
+	}
+	bNodes := make([]Node, 0, len(nodes))
+	for _, n := range nodes {
+		bn := Node{
+			ID:        n.ID.String(),
+			Type:      string(n.Type),
+			Name:      n.Name,
+			Body:      n.Body,
+			GMPrivate: n.GMPrivate,
+		}
+		if n.AgentID.Valid {
+			bn.AgentID = n.AgentID.UUID.String()
+		}
+		bNodes = append(bNodes, bn)
+	}
+
+	edges, err := st.ListEdges(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list edges: %w", err)
+	}
+	bEdges := make([]Edge, 0, len(edges))
+	for _, e := range edges {
+		bEdges = append(bEdges, Edge{
+			From: e.FromNodeID.String(),
+			To:   e.ToNodeID.String(),
+			Type: string(e.Type),
+		})
+	}
+
+	chars, err := st.ListCharacters(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list characters: %w", err)
+	}
+	bChars := make([]Character, 0, len(chars))
+	for _, c := range chars {
+		bChars = append(bChars, Character{
+			Name:          c.Name,
+			Aliases:       c.Aliases,
+			DiscordUserID: c.DiscordUserID,
+		})
+	}
+
+	var history *History
+	if opts.IncludeHistory {
+		history, err = exportHistory(ctx, st, campaignID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Bundle{
+		FormatVersion: FormatVersion,
+		ExportedAt:    time.Now().UTC(),
+		Campaign: Campaign{
+			Name:       campaign.Name,
+			System:     campaign.System,
+			Language:   campaign.Language,
+			Agents:     bAgents,
+			Nodes:      bNodes,
+			Edges:      bEdges,
+			Characters: bChars,
+			History:    history,
+		},
+	}, nil
+}
+
+// exportGrants reads one Agent's persisted Tool Grants and maps them to bundle
+// grains. Config is carried verbatim (nil when the grant narrows nothing).
+func exportGrants(ctx context.Context, st *storage.Store, agentID uuid.UUID) ([]Grant, error) {
+	rows, err := st.ListToolGrants(ctx, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list grants for agent %s: %w", agentID, err)
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	grants := make([]Grant, 0, len(rows))
+	for _, g := range rows {
+		grants = append(grants, Grant{ToolName: g.ToolName, Config: g.Config})
+	}
+	return grants, nil
+}
+
+// exportVoice round-trips a persisted voice JSONB through the canonical mapper so
+// the bundle carries the normalized shape and never provider bindings. A voice
+// that decodes to the zero Voice — an empty column or the '{}' schema/trigger
+// default — is exported as absent (nil) rather than a noisy all-empty object, so
+// a voiceless Butler round-trips clean. An unparsable column is an error (#224).
+func exportVoice(raw []byte) ([]byte, error) {
+	v, err := storage.VoiceFromJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	if v.ProviderID == "" && v.VoiceID == "" && v.Name == "" && v.Language == "" &&
+		len(v.Settings) == 0 && len(v.Metadata) == 0 {
+		return nil, nil
+	}
+	out, err := storage.VoiceToJSON(v)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// exportHistory reads the flag-gated transcript payload (ADR-0053 §1): every
+// Voice Session of the Campaign with its Transcript Lines (seq order) and its
+// Transcript Chunks grouped by Voice Session. Embeddings are never read
+// (ListTranscriptChunks is called with includeVectors=false, ADR-0053 §3) — the
+// destination re-embeds. ListVoiceSessions has no all-rows overload, so the cap
+// is math.MaxInt32: a backup pulls every session, and no campaign approaches it.
+func exportHistory(ctx context.Context, st *storage.Store, campaignID uuid.UUID) (*History, error) {
+	sessions, err := st.ListVoiceSessions(ctx, campaignID, math.MaxInt32)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list voice sessions: %w", err)
+	}
+
+	chunks, err := st.ListTranscriptChunks(ctx, campaignID, false)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list transcript chunks: %w", err)
+	}
+	chunksBySession := make(map[uuid.UUID][]Chunk, len(sessions))
+	for _, c := range chunks {
+		participated := make([]string, 0, len(c.ParticipatedAgentIDs))
+		for _, id := range c.ParticipatedAgentIDs {
+			participated = append(participated, id.String())
+		}
+		chunksBySession[c.VoiceSessionID] = append(chunksBySession[c.VoiceSessionID], Chunk{
+			Content:               c.Content,
+			SpeakerDiscordUserIDs: c.SpeakerDiscordUserIDs,
+			ParticipatedAgentIDs:  participated,
+			StartedAt:             c.StartedAt,
+		})
+	}
+
+	bSessions := make([]Session, 0, len(sessions))
+	for _, s := range sessions {
+		lines, err := st.ListTranscriptLines(ctx, s.ID)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: export: list transcript lines for session %s: %w", s.ID, err)
+		}
+		bLines := make([]Line, 0, len(lines))
+		for _, l := range lines {
+			bLines = append(bLines, Line{
+				LineID:               l.LineID,
+				Seq:                  l.Seq,
+				Who:                  l.Who,
+				Tag:                  l.Tag,
+				Kind:                 l.Kind,
+				TS:                   l.TS,
+				Text:                 l.Text,
+				SpeakerDiscordUserID: l.SpeakerDiscordUserID,
+			})
+		}
+		bSessions = append(bSessions, Session{
+			ID:        s.ID.String(),
+			StartedAt: s.StartedAt,
+			EndedAt:   s.EndedAt,
+			Status:    string(s.Status),
+			LineCount: s.LineCount,
+			EndReason: s.EndReason,
+			Lines:     bLines,
+			Chunks:    chunksBySession[s.ID],
+		})
+	}
+
+	return &History{Sessions: bSessions}, nil
+}

--- a/internal/bundle/export_test.go
+++ b/internal/bundle/export_test.go
@@ -288,6 +288,69 @@ func TestExportVoiceRoundTrip(t *testing.T) {
 	}
 }
 
+// TestExportHistorySkipsSessionlessChunk pins the contract that a Transcript
+// Chunk with a NULL voice_session_id (the ADR-0011 nullable SEAM — reads back as
+// uuid.Nil) is skipped from the history payload rather than orphaned under a nil
+// map key. The FK forbids a non-null non-existent session, so a raw NULL insert
+// is the only way to reach the guard; no storage writer produces it.
+func TestExportHistorySkipsSessionlessChunk(t *testing.T) {
+	ctx := context.Background()
+	pool := migratedPool(t)
+	if err := wirenpc.SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	st := storage.New(pool)
+	tenant, err := st.FindTenantByName(ctx, wirenpc.SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, wirenpc.SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+	cid := campaign.ID
+
+	vs, err := st.CreateVoiceSession(ctx, cid)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	base := time.Now().UTC()
+	if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: cid, VoiceSessionID: vs.ID, Content: "bound", StartedAt: base,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk bound: %v", err)
+	}
+	// Raw NULL voice_session_id insert — unreachable through the storage writer,
+	// which always binds a session; the FK only forbids a non-null orphan.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO transcript_chunk
+		   (campaign_id, voice_session_id, content, speaker_discord_user_ids, participated_agent_ids, started_at)
+		 VALUES ($1, NULL, $2, '{}', '{}', $3)`,
+		cid, "orphan", base); err != nil {
+		t.Fatalf("raw null-session chunk insert: %v", err)
+	}
+
+	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if b.Campaign.History == nil || len(b.Campaign.History.Sessions) != 1 {
+		t.Fatalf("history sessions = %+v, want 1", b.Campaign.History)
+	}
+	var total int
+	for _, s := range b.Campaign.History.Sessions {
+		for _, c := range s.Chunks {
+			total++
+			if c.Content == "orphan" {
+				t.Errorf("sessionless chunk leaked into history")
+			}
+		}
+	}
+	if total != 1 {
+		t.Errorf("exported chunks = %d, want 1 (orphan skipped)", total)
+	}
+}
+
 func hasGrant(gs []bundle.Grant, tool string) bool {
 	for _, g := range gs {
 		if g.ToolName == tool {

--- a/internal/bundle/export_test.go
+++ b/internal/bundle/export_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+package bundle_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// seededCampaign runs the demo seed (Butler + Bart + dice grants + provider
+// configs) then adds KG content (a location node, an NPC node linked to Bart, an
+// edge between them) and one PC Character. It returns the store, the campaign id,
+// and Bart's agent id so callers can assert node↔agent links.
+func seededCampaign(t *testing.T) (*storage.Store, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	pool := migratedPool(t)
+	if err := wirenpc.SeedNPC(ctx, pool, testCipher(t), nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	st := storage.New(pool)
+
+	tenant, err := st.FindTenantByName(ctx, wirenpc.SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, wirenpc.SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+	cid := campaign.ID
+
+	agents, err := st.ListAgents(ctx, cid)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	var bartID uuid.UUID
+	for _, a := range agents {
+		if a.Role == storage.AgentRoleCharacter && a.Name == "Bart" {
+			bartID = a.ID
+		}
+	}
+	if bartID == uuid.Nil {
+		t.Fatal("seed did not create Bart")
+	}
+
+	loc, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: cid, Type: storage.KGNodeLocation, Name: "The Prancing Pony", Body: "A cozy inn.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode location: %v", err)
+	}
+	npcNode, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: cid, Type: storage.KGNodeNPC, Name: "Barliman", GMPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateNode npc: %v", err)
+	}
+	if _, err := st.SetNodeAgent(ctx, cid, npcNode.ID, uuid.NullUUID{UUID: bartID, Valid: true}); err != nil {
+		t.Fatalf("SetNodeAgent: %v", err)
+	}
+	if _, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: cid, FromNodeID: npcNode.ID, ToNodeID: loc.ID, Type: storage.KGEdgeResidesIn,
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	if _, err := st.CreateCharacter(ctx, storage.NewCharacter{
+		CampaignID: cid, Name: "Frodo", DiscordUserID: "123456789", Aliases: []string{"Mr. Underhill"},
+	}); err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+	return st, cid, bartID
+}
+
+// TestExportDemoCampaign is TEST 1: the seeded demo exports Butler + Bart with
+// dice grants, KG nodes/edges with source-UUID refs, and no History by default.
+func TestExportDemoCampaign(t *testing.T) {
+	ctx := context.Background()
+	st, cid, bartID := seededCampaign(t)
+
+	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	if b.FormatVersion != bundle.FormatVersion {
+		t.Errorf("FormatVersion = %d, want %d", b.FormatVersion, bundle.FormatVersion)
+	}
+	if b.Campaign.History != nil {
+		t.Errorf("default export has History; want nil")
+	}
+	if b.Campaign.Name != wirenpc.SeedCampaignName {
+		t.Errorf("Name = %q, want %q", b.Campaign.Name, wirenpc.SeedCampaignName)
+	}
+
+	var butler, bart *bundle.Agent
+	for i := range b.Campaign.Agents {
+		switch b.Campaign.Agents[i].Role {
+		case "butler":
+			butler = &b.Campaign.Agents[i]
+		case "character":
+			if b.Campaign.Agents[i].Name == "Bart" {
+				bart = &b.Campaign.Agents[i]
+			}
+		}
+	}
+	if butler == nil {
+		t.Fatal("bundle missing Butler agent")
+	}
+	if bart == nil {
+		t.Fatal("bundle missing Bart agent")
+	}
+	if bart.ID != bartID.String() {
+		t.Errorf("Bart ref = %q, want source UUID %q", bart.ID, bartID.String())
+	}
+	if !hasGrant(bart.Grants, "dice") {
+		t.Errorf("Bart missing dice grant, got %+v", bart.Grants)
+	}
+	if !hasGrant(butler.Grants, "dice") {
+		t.Errorf("Butler missing dice grant, got %+v", butler.Grants)
+	}
+
+	// KG: an NPC node linked to Bart, a location node, one edge with UUID refs.
+	nodeIDs := map[string]bool{}
+	var linkedToBart bool
+	for _, n := range b.Campaign.Nodes {
+		if _, err := uuid.Parse(n.ID); err != nil {
+			t.Errorf("node ref %q is not a source UUID", n.ID)
+		}
+		nodeIDs[n.ID] = true
+		if n.AgentID == bartID.String() {
+			linkedToBart = true
+		}
+	}
+	if !linkedToBart {
+		t.Errorf("no node links to Bart's agent id %s", bartID)
+	}
+	if len(b.Campaign.Edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(b.Campaign.Edges))
+	}
+	e := b.Campaign.Edges[0]
+	if !nodeIDs[e.From] || !nodeIDs[e.To] {
+		t.Errorf("edge endpoints %q->%q are not node refs", e.From, e.To)
+	}
+
+	if len(b.Campaign.Characters) != 1 || b.Campaign.Characters[0].Name != "Frodo" {
+		t.Errorf("characters = %+v, want one Frodo", b.Campaign.Characters)
+	}
+}
+
+// TestExportHistoryFlag is TEST 3: IncludeHistory omits/includes transcript
+// sections, sessions nest lines (seq order) and chunks grouped by session, and
+// chunk participated refs are agent UUID strings.
+func TestExportHistoryFlag(t *testing.T) {
+	ctx := context.Background()
+	st, cid, bartID := seededCampaign(t)
+
+	vs, err := st.CreateVoiceSession(ctx, cid)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	// Insert two lines OUT of seq order to prove the export orders by seq.
+	if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs.ID, CampaignID: cid, LineID: "l2", Seq: 2,
+		Who: "Bart", Kind: "agent", TS: base.Add(time.Second), Text: "second",
+	}); err != nil {
+		t.Fatalf("UpsertTranscriptLine l2: %v", err)
+	}
+	if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs.ID, CampaignID: cid, LineID: "l1", Seq: 1,
+		Who: "Frodo", Kind: "human", TS: base, Text: "first", SpeakerDiscordUserID: "123456789",
+	}); err != nil {
+		t.Fatalf("UpsertTranscriptLine l1: %v", err)
+	}
+	if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: cid, VoiceSessionID: vs.ID, Content: "first\nsecond",
+		SpeakerDiscordUserIDs: []string{"123456789"},
+		ParticipatedAgentIDs:  []uuid.UUID{bartID},
+		StartedAt:             base,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+
+	// IncludeHistory=false omits sessions even though transcript rows exist.
+	noHist, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: false})
+	if err != nil {
+		t.Fatalf("Export no-history: %v", err)
+	}
+	if noHist.Campaign.History != nil {
+		t.Errorf("IncludeHistory=false still nested History")
+	}
+
+	hist, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("Export history: %v", err)
+	}
+	if hist.Campaign.History == nil || len(hist.Campaign.History.Sessions) != 1 {
+		t.Fatalf("history sessions = %+v, want 1", hist.Campaign.History)
+	}
+	s := hist.Campaign.History.Sessions[0]
+	if s.ID != vs.ID.String() {
+		t.Errorf("session ref %q, want %q", s.ID, vs.ID)
+	}
+	if len(s.Lines) != 2 || s.Lines[0].LineID != "l1" || s.Lines[1].LineID != "l2" {
+		t.Errorf("lines not in seq order: %+v", s.Lines)
+	}
+	if len(s.Chunks) != 1 {
+		t.Fatalf("chunks = %d, want 1", len(s.Chunks))
+	}
+	if got := s.Chunks[0].ParticipatedAgentIDs; len(got) != 1 || got[0] != bartID.String() {
+		t.Errorf("chunk participated refs = %v, want [%s]", got, bartID)
+	}
+}
+
+// TestExportVoiceRoundTrip is TEST 4: Bart's seeded canonical voice round-trips
+// through VoiceFromJSON, and no provider-config FK id appears in the JSON.
+func TestExportVoiceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st, cid, _ := seededCampaign(t)
+
+	// Collect the provider-config FK ids that must NOT leak into the bundle.
+	agents, err := st.ListAgents(ctx, cid)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	var fkIDs []string
+	var bartVoice []byte
+	for _, a := range agents {
+		if a.VoiceProviderConfigID.Valid {
+			fkIDs = append(fkIDs, a.VoiceProviderConfigID.UUID.String())
+		}
+		if a.LLMProviderConfigID.Valid {
+			fkIDs = append(fkIDs, a.LLMProviderConfigID.UUID.String())
+		}
+		if a.Name == "Bart" {
+			bartVoice = a.Voice
+		}
+	}
+	if len(fkIDs) == 0 {
+		t.Fatal("seed produced no provider FK ids to check exclusion against")
+	}
+
+	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	// Bart's exported voice must decode to the same canonical Voice the column holds.
+	var bart *bundle.Agent
+	for i := range b.Campaign.Agents {
+		if b.Campaign.Agents[i].Name == "Bart" {
+			bart = &b.Campaign.Agents[i]
+		}
+	}
+	if bart == nil || len(bart.Voice) == 0 {
+		t.Fatal("Bart has no exported voice")
+	}
+	wantVoice, err := storage.VoiceFromJSON(bartVoice)
+	if err != nil {
+		t.Fatalf("decode seeded voice: %v", err)
+	}
+	gotVoice, err := storage.VoiceFromJSON(bart.Voice)
+	if err != nil {
+		t.Fatalf("decode exported voice: %v", err)
+	}
+	if gotVoice.ProviderID != wantVoice.ProviderID || gotVoice.VoiceID != wantVoice.VoiceID {
+		t.Errorf("voice round-trip mismatch: got %+v want %+v", gotVoice, wantVoice)
+	}
+
+	raw, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	for _, id := range fkIDs {
+		if bytes.Contains(raw, []byte(id)) {
+			t.Errorf("provider FK id %s leaked into bundle JSON", id)
+		}
+	}
+}
+
+func hasGrant(gs []bundle.Grant, tool string) bool {
+	for _, g := range gs {
+		if g.ToolName == tool {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -1,0 +1,81 @@
+package bundle
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Handler serves the campaign-bundle HTTP transport (ADR-0053 §7): plain
+// net/http endpoints mounted beside the SSE relay, NOT Connect RPCs (ADR-0015) —
+// the bundle is a file a human inspects, and a streamed gzip download / multipart
+// upload do not fit the Connect message-size model. The operator-only auth
+// posture (ADR-0041) is applied at the mount by wrapping in auth.RequireSession;
+// this type invents no auth of its own.
+//
+// #290 owns ServeExport (the GET download); #291 adds ServeImport (the POST
+// upload) to this same type.
+type Handler struct {
+	Store *storage.Store
+	Log   *slog.Logger
+}
+
+// ServeExport streams a campaign bundle download: GET
+// /api/v1/campaigns/{id}/export. The {id} path value must parse as a UUID (400
+// otherwise); an unknown campaign is 404. ?include_history=true nests the
+// transcript payload (ADR-0053 §1, default off). Archived campaigns are
+// exportable — a backup must still capture a campaign after it is archived.
+//
+// The bundle is [Encode]d STRAIGHT to the ResponseWriter (ADR-0048: no
+// blob.Store round-trip — the download never lands in object storage). The
+// filename is the canonical [Filename] for the campaign name.
+func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "invalid campaign id", http.StatusBadRequest)
+		return
+	}
+
+	opts := ExportOptions{IncludeHistory: r.URL.Query().Get("include_history") == "true"}
+
+	// GetCampaign resolves name (for the filename) and existence (404) before any
+	// bytes are written, so a missing campaign is a clean 404 rather than a
+	// half-streamed body. Archived campaigns resolve fine here (backup path).
+	campaign, err := h.Store.GetCampaign(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			http.Error(w, "campaign not found", http.StatusNotFound)
+			return
+		}
+		h.logError("get campaign", err)
+		http.Error(w, "export failed", http.StatusInternalServerError)
+		return
+	}
+
+	b, err := Export(r.Context(), h.Store, id, opts)
+	if err != nil {
+		h.logError("build bundle", err)
+		http.Error(w, "export failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename=%q`, Filename(campaign.Name)))
+	if err := Encode(w, b); err != nil {
+		// Headers (and likely body bytes) are already committed, so this can only be
+		// logged — the client sees a truncated download and retries.
+		h.logError("encode bundle", err)
+	}
+}
+
+func (h *Handler) logError(msg string, err error) {
+	if h.Log != nil {
+		h.Log.Error("bundle: "+msg, "err", err)
+	}
+}

--- a/internal/bundle/handler_test.go
+++ b/internal/bundle/handler_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+package bundle_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// fakeAuthN authenticates exactly one token, so the mount's RequireSession gate
+// can be exercised without a real session row.
+type fakeAuthN struct{ token string }
+
+func (f fakeAuthN) AuthenticateSession(_ context.Context, token string) (storage.User, error) {
+	if token == f.token {
+		return storage.User{ID: uuid.New(), Name: "op", Role: "operator"}, nil
+	}
+	return storage.User{}, storage.ErrNotFound
+}
+
+// exportRoute mounts ServeExport exactly as cmd/glyphoxa/main.go does — behind
+// auth.RequireSession on GET /api/v1/campaigns/{id}/export — so the test drives
+// the guarded route through a real ServeMux.
+func exportRoute(st *storage.Store, token string) http.Handler {
+	h := &bundle.Handler{Store: st}
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/campaigns/{id}/export",
+		auth.RequireSession(fakeAuthN{token: token}, http.HandlerFunc(h.ServeExport)))
+	return mux
+}
+
+func TestServeExport(t *testing.T) {
+	ctx := context.Background()
+	st, cid, _ := seededCampaign(t)
+	const token = "valid-session-token"
+	route := exportRoute(st, token)
+
+	authed := func(method, target string) *http.Request {
+		req := httptest.NewRequest(method, target, nil)
+		req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+		return req
+	}
+
+	t.Run("no cookie is 401", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/campaigns/"+cid.String()+"/export", nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("code=%d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("bad uuid is 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authed(http.MethodGet, "/api/v1/campaigns/not-a-uuid/export"))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("code=%d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("unknown id is 404", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authed(http.MethodGet, "/api/v1/campaigns/"+uuid.New().String()+"/export"))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("code=%d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("200 gzip with filename", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authed(http.MethodGet, "/api/v1/campaigns/"+cid.String()+"/export"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d, want 200", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/gzip" {
+			t.Errorf("Content-Type=%q, want application/gzip", ct)
+		}
+		wantCD := `attachment; filename="` + bundle.Filename(wirenpc.SeedCampaignName) + `"`
+		if cd := rec.Header().Get("Content-Disposition"); cd != wantCD {
+			t.Errorf("Content-Disposition=%q, want %q", cd, wantCD)
+		}
+		b := decodeBody(t, rec)
+		if b.Campaign.History != nil {
+			t.Errorf("default export nested History")
+		}
+	})
+
+	t.Run("include_history honored", func(t *testing.T) {
+		// Add transcript rows so history is non-empty.
+		vs, err := st.CreateVoiceSession(ctx, cid)
+		if err != nil {
+			t.Fatalf("CreateVoiceSession: %v", err)
+		}
+		if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+			VoiceSessionID: vs.ID, CampaignID: cid, LineID: "l1", Seq: 1,
+			Who: "Frodo", Kind: "human", TS: time.Now().UTC(), Text: "hi",
+		}); err != nil {
+			t.Fatalf("UpsertTranscriptLine: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authed(http.MethodGet, "/api/v1/campaigns/"+cid.String()+"/export?include_history=true"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d, want 200", rec.Code)
+		}
+		b := decodeBody(t, rec)
+		if b.Campaign.History == nil || len(b.Campaign.History.Sessions) == 0 {
+			t.Errorf("include_history=true did not nest sessions")
+		}
+	})
+}
+
+// TestServeExportArchivedCampaign proves an archived campaign is still
+// exportable (backup path, ADR-0053 §7).
+func TestServeExportArchivedCampaign(t *testing.T) {
+	ctx := context.Background()
+	st, cid, _ := seededCampaign(t)
+	if _, err := st.ArchiveCampaign(ctx, cid); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	const token = "valid-session-token"
+	route := exportRoute(st, token)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/campaigns/"+cid.String()+"/export", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	route.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("archived export code=%d, want 200", rec.Code)
+	}
+}
+
+func decodeBody(t *testing.T, rec *httptest.ResponseRecorder) *bundle.Bundle {
+	t.Helper()
+	// Decode sniffs the gzip magic and inflates transparently.
+	b, err := bundle.Decode(rec.Body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return b
+}

--- a/internal/bundle/harness_test.go
+++ b/internal/bundle/harness_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+// These tests stand up a real Postgres (testcontainers) and are tag-isolated
+// behind `integration` so a plain `go test ./...` stays Docker-free (ADR-0021 /
+// ADR-0033). Run with `go test -tags=integration ./internal/bundle/...`.
+package bundle_test
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+const pgImage = "pgvector/pgvector:pg17"
+
+// startPostgres spins up a pgvector container and returns its DSN, or skips
+// LOUDLY when Docker is unavailable so a green run can't be mistaken for real DB
+// coverage. GLYPHOXA_TEST_DSN points at an external pgvector Postgres instead.
+func startPostgres(t *testing.T) string {
+	t.Helper()
+	if dsn := os.Getenv("GLYPHOXA_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	ctx := context.Background()
+	container, err := tcpostgres.Run(ctx, pgImage,
+		tcpostgres.WithDatabase("glyphoxa_test"),
+		tcpostgres.WithUsername("glyphoxa"),
+		tcpostgres.WithPassword("glyphoxa"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Skipf("SKIPPED DB TEST — NO POSTGRES: could not start %s (is Docker running?). "+
+			"Set GLYPHOXA_TEST_DSN to an external pgvector Postgres. error: %v", pgImage, err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(container) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	return dsn
+}
+
+// migratedPool returns a migrated pgx pool against a fresh Postgres.
+func migratedPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := startPostgres(t)
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := storage.MigrateUp(context.Background(), db); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	_ = db.Close()
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// testCipher builds a random-key AES-GCM cipher for the seed's sealed placeholders.
+func testCipher(t *testing.T) *crypto.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand key: %v", err)
+	}
+	c, err := crypto.New(key)
+	if err != nil {
+		t.Fatalf("crypto.New: %v", err)
+	}
+	return c
+}

--- a/internal/bundle/secrets_test.go
+++ b/internal/bundle/secrets_test.go
@@ -45,9 +45,14 @@ func TestSecretsExclusionProperty(t *testing.T) {
 
 	// Distinctive marker bytes seeded into the secret tables. The base64 form of
 	// the ciphertext is checked too, since JSON encoding of []byte is base64.
-	const providerMarker = "SUPERSECRETCIPHERTEXT-ab12-marker"
+	// Markers are deliberately NON-hex / NON-digit so they can never collide with
+	// a random UUID's hex runs or a numeric field elsewhere in the plaintext (a
+	// 4-hex last4 like "ab12" would spuriously match ~0.3%/run against the ~8 UUID
+	// strings a bundle carries — this test runs on EVERY PR).
+	const providerMarker = "SUPERSECRETCIPHERTEXT-zqxw-marker"
 	const deployMarker = "DEPLOYMENTBOTTOKENCIPHERTEXT-marker"
-	const last4 = "ab12"
+	const providerLast4 = "zqxw"
+	const deployLast4 = "wqzx"
 
 	provCipher, err := cipher.Seal([]byte(providerMarker))
 	if err != nil {
@@ -59,7 +64,7 @@ func TestSecretsExclusionProperty(t *testing.T) {
 		Provider:              "openai",
 		Model:                 "gpt-4o",
 		CredentialsCiphertext: provCipher,
-		CredentialsLast4:      last4,
+		CredentialsLast4:      providerLast4,
 	}); err != nil {
 		t.Fatalf("CreateProviderConfig: %v", err)
 	}
@@ -67,7 +72,7 @@ func TestSecretsExclusionProperty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seal deploy: %v", err)
 	}
-	if _, err := st.SaveDiscordBotToken(ctx, tenant.ID, deployCipher, "9999"); err != nil {
+	if _, err := st.SaveDiscordBotToken(ctx, tenant.ID, deployCipher, deployLast4); err != nil {
 		t.Fatalf("SaveDiscordBotToken: %v", err)
 	}
 
@@ -95,7 +100,8 @@ func TestSecretsExclusionProperty(t *testing.T) {
 		[]byte(base64.StdEncoding.EncodeToString(deployCipher)),
 		[]byte(providerMarker),
 		[]byte(deployMarker),
-		[]byte(last4),
+		[]byte(providerLast4),
+		[]byte(deployLast4),
 		[]byte("ciphertext"),
 		[]byte("last4"),
 		[]byte("credentials"),

--- a/internal/bundle/secrets_test.go
+++ b/internal/bundle/secrets_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package bundle_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+)
+
+// TestSecretsExclusionProperty is the ADR-0053 §2 named property test: NO secret
+// byte reaches ANY bundle. It seeds a Campaign whose provider_config carries a
+// distinctive real-looking ciphertext + a "ab12" last4, and whose
+// deployment_config holds a distinctive Bot-token ciphertext, then adds
+// transcript history — and asserts the gunzipped bytes of BOTH the history and
+// no-history exports contain none of that key material, nor the schema words a
+// leak would carry. The property holds by construction (Export reads no secret
+// table), so a regression here means someone added a forbidden read or field.
+func TestSecretsExclusionProperty(t *testing.T) {
+	ctx := context.Background()
+	cipher := testCipher(t)
+	pool := migratedPool(t)
+	if err := wirenpc.SeedNPC(ctx, pool, cipher, nil); err != nil {
+		t.Fatalf("SeedNPC: %v", err)
+	}
+	st := storage.New(pool)
+
+	tenant, err := st.FindTenantByName(ctx, wirenpc.SeedTenantName)
+	if err != nil {
+		t.Fatalf("FindTenantByName: %v", err)
+	}
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, wirenpc.SeedCampaignName)
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+	cid := campaign.ID
+
+	// Distinctive marker bytes seeded into the secret tables. The base64 form of
+	// the ciphertext is checked too, since JSON encoding of []byte is base64.
+	const providerMarker = "SUPERSECRETCIPHERTEXT-ab12-marker"
+	const deployMarker = "DEPLOYMENTBOTTOKENCIPHERTEXT-marker"
+	const last4 = "ab12"
+
+	provCipher, err := cipher.Seal([]byte(providerMarker))
+	if err != nil {
+		t.Fatalf("seal provider: %v", err)
+	}
+	if _, err := st.CreateProviderConfig(ctx, storage.NewProviderConfig{
+		TenantID:              tenant.ID,
+		Component:             storage.ComponentLLM,
+		Provider:              "openai",
+		Model:                 "gpt-4o",
+		CredentialsCiphertext: provCipher,
+		CredentialsLast4:      last4,
+	}); err != nil {
+		t.Fatalf("CreateProviderConfig: %v", err)
+	}
+	deployCipher, err := cipher.Seal([]byte(deployMarker))
+	if err != nil {
+		t.Fatalf("seal deploy: %v", err)
+	}
+	if _, err := st.SaveDiscordBotToken(ctx, tenant.ID, deployCipher, "9999"); err != nil {
+		t.Fatalf("SaveDiscordBotToken: %v", err)
+	}
+
+	// Transcript history so the property is checked on a history bundle too.
+	vs, err := st.CreateVoiceSession(ctx, cid)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs.ID, CampaignID: cid, LineID: "l1", Seq: 1,
+		Who: "Frodo", Kind: "human", TS: time.Now().UTC(), Text: "hello",
+	}); err != nil {
+		t.Fatalf("UpsertTranscriptLine: %v", err)
+	}
+	if _, err := st.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: cid, VoiceSessionID: vs.ID, Content: "hello", StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+
+	forbidden := [][]byte{
+		provCipher,
+		[]byte(base64.StdEncoding.EncodeToString(provCipher)),
+		deployCipher,
+		[]byte(base64.StdEncoding.EncodeToString(deployCipher)),
+		[]byte(providerMarker),
+		[]byte(deployMarker),
+		[]byte(last4),
+		[]byte("ciphertext"),
+		[]byte("last4"),
+		[]byte("credentials"),
+		[]byte("deployment_config"),
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts bundle.ExportOptions
+	}{
+		{"no-history", bundle.ExportOptions{}},
+		{"history", bundle.ExportOptions{IncludeHistory: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := bundle.Export(ctx, st, cid, tc.opts)
+			if err != nil {
+				t.Fatalf("Export: %v", err)
+			}
+			var buf bytes.Buffer
+			if err := bundle.Encode(&buf, b); err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			gz, err := gzip.NewReader(&buf)
+			if err != nil {
+				t.Fatalf("gzip reader: %v", err)
+			}
+			plain, err := io.ReadAll(gz)
+			if err != nil {
+				t.Fatalf("gunzip: %v", err)
+			}
+			for _, f := range forbidden {
+				if len(f) == 0 {
+					continue
+				}
+				if bytes.Contains(plain, f) {
+					t.Errorf("bundle leaked forbidden bytes %q", f)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Implements the E6 exporter half of the campaign bundle (ADR-0053), consuming the #287 types/codec and #288 read paths verbatim.

- `internal/bundle/export.go` — `Export(ctx, st, campaignID, ExportOptions)` reads EXCLUSIVELY through the storage allowlist (GetCampaign, ListAgents, per-agent ListToolGrants, ListNodes, ListEdges, ListCharacters; history: ListVoiceSessions(MaxInt32) + ListTranscriptLines + ListTranscriptChunks grouped by session). Voice round-trips `storage.VoiceFromJSON`→`VoiceToJSON` (unparsable = error, zero voice = absent). All refs are source UUID strings. Never touches provider_config / deployment_config / users / sessions.
- `internal/bundle/handler.go` — `Handler.ServeExport`: `GET /api/v1/campaigns/{id}/export`, 400 bad uuid / 404 missing, `?include_history=true`, streams `Encode` straight to the ResponseWriter (no blob.Store), `Content-Disposition` from `bundle.Filename`. Archived campaigns exportable.
- `cmd/glyphoxa/export.go` — `glyphoxa export -campaign <uuid> [-include-history] [-o <file>]`, needs `$GLYPHOXA_DATABASE_URL` but NOT `$GLYPHOXA_SECRET` (exporter never decrypts).
- `cmd/glyphoxa/main.go` — `export` dispatch + `auth.RequireSession`-gated GET mount in `managementMounts` (kept minimal; #291 adds the POST mount in the same spot).

## Secrets exclusion (ADR-0053 d2)

Named property test seeds real-looking provider ciphertext + last4 `ab12` + a deployment Bot-token ciphertext, exports both history and no-history bundles, gunzips, and asserts NONE of the ciphertext / base64(ciphertext) / last4 / `ciphertext` / `last4` / `credentials` / `deployment_config` bytes appear.

## Tests (TDD, per PLAN #290 TEST SEQUENCE)

10 tests added: export integration (demo campaign / history flag / voice round-trip + FK-id exclusion), secrets property (×2 history modes), ServeExport httptest (401/400/404/200+filename/history/archived), CLI arg-parse unit (×2) + headless integration. All green locally incl. `golangci-lint` (0 issues) with and without `-tags=integration`.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)