### PR TITLE
feat(#301): [E7] Ensemble Turns pt1 — speculative fan-out + Lead race

### DIFF
--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -199,6 +199,11 @@ func (s *StageSubscriber) onEnsembleRouted(e voiceevent.EnsembleRouted) {
 		t = &turnState{}
 		s.turns[e.TurnID] = t
 	}
+	// TODO(#301): the role label uses Targets[0].AgentRole (the top-scored coalesce
+	// anchor), which may not match the eventually-elected Lead's AgentRole. It is a
+	// metrics label only (ADR-0032 §2.1 — never a per-turn identity), and an
+	// ensemble's candidates share the character role in practice, so the approximation
+	// is harmless; revisit if a mixed-role ensemble (Butler + Character) ever ships.
 	t.role = normalizeRole(e.Targets[0].AgentRole)
 	t.roleKnown = true
 	t.routedAt = e.At

--- a/internal/observe/subscriber.go
+++ b/internal/observe/subscriber.go
@@ -130,6 +130,7 @@ func (s *StageSubscriber) Subscribe(bus *voiceevent.Bus) (unsubscribe func()) {
 	unsubs := []func(){
 		voiceevent.On(bus, s.onSTTFinal),
 		voiceevent.On(bus, s.onAddressRouted),
+		voiceevent.On(bus, s.onEnsembleRouted),
 		voiceevent.On(bus, s.onTTSInvoked),
 		voiceevent.On(bus, s.onFirstAudio),
 		voiceevent.On(bus, s.onFirstOpus),
@@ -177,6 +178,32 @@ func (s *StageSubscriber) onAddressRouted(e voiceevent.AddressRouted) {
 
 	// address_detect = route decision − transcript. Only when we have the
 	// STTFinal anchor (sttFinalAt set); otherwise we can't compute the span.
+	if !t.sttFinalAt.IsZero() {
+		s.rec.AddressDetect(e.At.Sub(t.sttFinalAt))
+	}
+}
+
+// onEnsembleRouted stage-marks an Ensemble Turn's routing decision exactly like
+// onAddressRouted (#301): the ensemble opens ONE turn under its TurnID, so the
+// role (Targets[0], the top-scored/eventual coalesce anchor) and the address_detect
+// span are recorded the same way a single-target route is. The elected Lead speaks
+// under this same TurnID, so its FirstOpus/latency pair against this mark.
+func (s *StageSubscriber) onEnsembleRouted(e voiceevent.EnsembleRouted) {
+	if e.TurnID == "" || len(e.Targets) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.turns[e.TurnID]
+	if t == nil {
+		t = &turnState{}
+		s.turns[e.TurnID] = t
+	}
+	t.role = normalizeRole(e.Targets[0].AgentRole)
+	t.roleKnown = true
+	t.routedAt = e.At
+	t.lastSeen = s.now()
+
 	if !t.sttFinalAt.IsZero() {
 		s.rec.AddressDetect(e.At.Sub(t.sttFinalAt))
 	}

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -539,3 +539,26 @@ func TestStageSubscriberEndToEndPrometheus(t *testing.T) {
 		}
 	}
 }
+
+// TestStageSubscriberEnsembleRoutedStageMark pins #301: an EnsembleRouted stage-marks
+// the turn exactly like an AddressRouted — the role comes from Targets[0] and the
+// address_detect span is recorded, so the Lead's FirstOpus (under the same TurnID)
+// pairs against it.
+func TestStageSubscriberEnsembleRoutedStageMark(t *testing.T) {
+	rec := &recordingStage{}
+	bus := voiceevent.NewBus()
+	NewStageSubscriber(rec).Subscribe(bus)
+
+	bus.Publish(voiceevent.STTFinal{At: base.Add(700 * time.Millisecond), TurnID: "E", SpeechEndAt: base})
+	bus.Publish(voiceevent.EnsembleRouted{At: base.Add(750 * time.Millisecond), TurnID: "E", Targets: []voiceevent.AddressTarget{
+		{AgentRole: "character"}, {AgentRole: "character"},
+	}})
+	bus.Publish(voiceevent.FirstOpus{At: base.Add(1600 * time.Millisecond), TurnID: "E"})
+
+	if len(rec.addressDetect) != 1 || rec.addressDetect[0] != 50*time.Millisecond {
+		t.Fatalf("address_detect = %v, want [50ms] from the EnsembleRouted mark", rec.addressDetect)
+	}
+	if len(rec.responseLat) != 1 || rec.responseLat[0].label != "character" || rec.responseLat[0].d != 1600*time.Millisecond {
+		t.Fatalf("response_latency = %+v, want one [character 1.6s] anchored on the ensemble mark", rec.responseLat)
+	}
+}

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -351,6 +351,14 @@ func (r *Relay) project(e voiceevent.Event) {
 		// (ADR-0012/0040).
 		t := r.turn(ev.TurnID)
 		t.target = ev.Target
+	case voiceevent.EnsembleLead:
+		// An Ensemble Turn's elected Lead (#301, ADR-0025): the Lead speaks under the
+		// ensemble's original TurnID, so — like AddressRouted — record WHO answers so
+		// the coalescing TTSInvoked line is attributed to the Lead (a:<turn>, its name +
+		// NPC pill). The losing candidates publish no EnsembleLead and no TTSInvoked, so
+		// they leave no line.
+		t := r.turn(ev.TurnID)
+		t.target = ev.Target
 	case voiceevent.TTSInvoked:
 		// One sentence of the Agent's reply — coalesced into the turn's line.
 		t := r.turn(ev.TurnID)

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -63,3 +63,30 @@ func TestProjection_SayPersistenceTeeFires(t *testing.T) {
 		t.Errorf("persisted say line = {id %q who %q text %q}, want {a:s1 Bart Aye.}", got[0].LineID, got[0].Who, got[0].Text)
 	}
 }
+
+// TestProjection_EnsembleLeadAttributesLine pins #301: the Ensemble Turn's Lead
+// speaks under the ensemble's original TurnID, and its EnsembleLead attribution
+// makes the coalesced reply land as the Lead's line (a:<turn>, the Lead's name +
+// NPC pill) — exactly like an AddressRouted turn. A losing candidate publishes no
+// EnsembleLead and no TTSInvoked, so it leaves no line.
+func TestProjection_EnsembleLeadAttributesLine(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.EnsembleLead{
+		At: at(1), TurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "I speak first.", Index: 0, TurnID: "e1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want 1: %+v", len(v.Lines), v.Lines)
+	}
+	l := v.Lines[0]
+	if l.ID != "a:e1" || l.Who != "Bart" || l.Kind != KindNPC || l.Tag != "NPC" {
+		t.Errorf("ensemble lead line meta = {id %q who %q kind %q tag %q}, want {a:e1 Bart npc NPC}", l.ID, l.Who, l.Kind, l.Tag)
+	}
+	if l.Text != "I speak first." {
+		t.Errorf("ensemble lead line text = %q, want the Lead's reply", l.Text)
+	}
+}

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -330,6 +330,108 @@ func (r *Replier) turn(ctx context.Context, text string) []orchestrator.Reply {
 	return []orchestrator.Reply{{Sentence: reply, Voice: r.cfg.Persona.Voice}}
 }
 
+// Draft produces the Agent's would-be reply text for one utterance WITHOUT
+// mutating any state — the speculative fan-out half of an Ensemble Turn (ADR-0025,
+// #301). It assembles the SAME Hot Context [Replier.turn] would (system prompt +
+// bounded recent Transcript + the user message), but on a SNAPSHOT copy of the
+// history, so a candidate that LOSES the Lead race commits nothing: no user
+// message appended, no assistant message recorded (ADR-0012's zero-commit rule,
+// made structural). An empty completion returns "", nil (the Agent says nothing);
+// an engine error — including a ctx cancel when the loser's shared draft context is
+// cut after the winner is elected — returns "", err. The winning candidate's
+// [Replier.SpeakDraft] is what actually commits the turn.
+//
+// It honors ctx (bounded by [Config.TurnTimeout] like the LLM turn) and consults
+// Memory/Facts under it, so a barge tearing down the whole ensemble unwinds every
+// in-flight draft.
+func (r *Replier) Draft(ctx context.Context, text string) (string, error) {
+	ctx, cancel := r.withTurnTimeout(ctx)
+	defer cancel()
+
+	// Snapshot the history and append the user message on the COPY — Draft must not
+	// touch the loop's live history (purity).
+	r.mu.Lock()
+	history := append(make([]llm.Message, 0, len(r.history)+1), r.history...)
+	r.mu.Unlock()
+	history = append(history, llm.Message{Role: llm.RoleUser, Text: text})
+	history = trimHistory(history, r.cfg.HistoryTurns)
+
+	// Recall + facts run under ctx, never mutating loop state (they never did).
+	mem := r.recall(ctx, text)
+	facts := r.facts(ctx)
+
+	msgs := make([]llm.Message, 0, len(history)+1)
+	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt(mem, facts)})
+	msgs = append(msgs, history...)
+
+	reply, err := r.engine.Generate(ctx, msgs)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(reply), nil
+}
+
+// SpeakDraft speaks an already-generated draft (the winning Lead's, from a prior
+// [Replier.Draft]) as this Agent's turn (ADR-0025, #301). It appends the user
+// message (parity with [Replier.streamTurn], which always records the utterance it
+// answered), sentence-splits draft, and dispatches each sentence in order,
+// committing to history ONLY the text actually delivered (ADR-0012). dispatch is
+// the deliver-then-commit signal: a sentence joins the committed text only once
+// dispatch returns nil (fully synthesized under a live turn ctx); a dispatch
+// reporting the turn cancelled (a barge cutting the ensemble mid-draft) stops the
+// drain, and the sentences forwarded before the cut are committed while the rest
+// are dropped. It returns the delivered text; a ctx-cancel is the expected barge
+// path, not a failure, so it returns a nil error there.
+func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
+	r.mu.Lock()
+	r.history = append(r.history, llm.Message{Role: llm.RoleUser, Text: userText})
+	r.trimHistoryLocked()
+	r.mu.Unlock()
+
+	var split sentenceSplitter
+	var spoken strings.Builder
+	voice := r.cfg.Persona.Voice
+
+	// Deliver-then-commit (ADR-0012, mirrors streamTurn's emit): dispatch FIRST; a
+	// sentence joins the spoken builder only once dispatch returns nil.
+	emit := func(sentence string) error {
+		if e := dispatch(orchestrator.Reply{Sentence: sentence, Voice: voice}); e != nil {
+			return e
+		}
+		if spoken.Len() > 0 {
+			spoken.WriteByte(' ')
+		}
+		spoken.WriteString(sentence)
+		return nil
+	}
+
+	var dispErr error
+	for _, sentence := range split.Push(draft) {
+		if e := emit(sentence); e != nil {
+			dispErr = e
+			break
+		}
+	}
+	// Flush the trailing unterminated sentence — unless the turn was cut, in which
+	// case its tail was never spoken and must not be dispatched.
+	if dispErr == nil && ctx.Err() == nil {
+		if tail := split.Flush(); tail != "" {
+			if e := emit(tail); e != nil {
+				dispErr = e
+			}
+		}
+	}
+
+	r.commitSpoken(spoken.String())
+
+	// A cancel is the expected barge path (the whole ensemble was torn down), not a
+	// turn failure; surface only a genuine dispatch error under a live ctx.
+	if ctx.Err() != nil {
+		return spoken.String(), nil
+	}
+	return spoken.String(), dispErr
+}
+
 // ReplyStream returns the [orchestrator.StreamReplyFunc] that drives this loop
 // in streaming mode (B1): it dispatches each sentence of the reply to TTS the
 // moment it is ready, so first audio begins after the first sentence rather than
@@ -665,13 +767,20 @@ func memoryBlock(mem Memory) string {
 // HistoryTurns remain, keeping the most recent. A zero or negative
 // HistoryTurns means unbounded. Caller holds r.mu.
 func (r *Replier) trimHistoryLocked() {
-	if r.cfg.HistoryTurns <= 0 || len(r.history) <= r.cfg.HistoryTurns {
-		return
+	r.history = trimHistory(r.history, r.cfg.HistoryTurns)
+}
+
+// trimHistory keeps at most the last keep user/assistant messages of history,
+// re-slicing onto a fresh backing array when it trims (so the dropped turns can be
+// GC'd and the retained slice does not pin the whole conversation). A zero or
+// negative keep means unbounded, and a history already within the bound is returned
+// unchanged (same backing) — so the live [Replier.trimHistoryLocked] path is
+// byte-for-byte identical while [Replier.Draft] can trim a history COPY too.
+func trimHistory(history []llm.Message, keep int) []llm.Message {
+	if keep <= 0 || len(history) <= keep {
+		return history
 	}
-	// Re-slice onto a fresh backing array so the dropped turns can be GC'd and
-	// the retained slice does not pin the whole conversation.
-	keep := r.cfg.HistoryTurns
 	trimmed := make([]llm.Message, keep)
-	copy(trimmed, r.history[len(r.history)-keep:])
-	r.history = trimmed
+	copy(trimmed, history[len(history)-keep:])
+	return trimmed
 }

--- a/pkg/voice/agent/agent_ensemble_test.go
+++ b/pkg/voice/agent/agent_ensemble_test.go
@@ -1,0 +1,149 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+)
+
+// TestReplier_Draft_IsPure pins the Ensemble Turn's speculative-fan-out contract
+// (ADR-0025/0012, #301): Draft produces the Agent's would-be reply text WITHOUT
+// mutating anything — no user message appended, no assistant message committed —
+// so a LOSING candidate in the Lead race commits nothing. It reads the same Hot
+// Context the LLM turn would, but on a history SNAPSHOT.
+func TestReplier_Draft_IsPure(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye, traveler."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+	})
+
+	before := r.HistorySnapshot()
+
+	draft, err := r.Draft(t.Context(), "Hail, Bart.")
+	if err != nil {
+		t.Fatalf("Draft errored: %v", err)
+	}
+	if !strings.Contains(draft, "traveler") {
+		t.Fatalf("draft = %q, want the scripted reply", draft)
+	}
+	// The user message the LLM saw must be in the request, on a COPY of history.
+	last := prov.lastRequest(t)
+	if last.Messages[len(last.Messages)-1].Text != "Hail, Bart." {
+		t.Fatalf("last message = %q, want the drafted user utterance", last.Messages[len(last.Messages)-1].Text)
+	}
+	// Purity: history is byte-identical after Draft (no user msg, no assistant msg).
+	after := r.HistorySnapshot()
+	if len(after) != len(before) {
+		t.Fatalf("Draft mutated history: len before=%d after=%d (a losing draft must commit NOTHING)", len(before), len(after))
+	}
+}
+
+// TestReplier_Draft_CancelledCtxErrorsAndCommitsNothing pins that a Draft whose
+// ctx is already cancelled (the loser's shared draftCtx after the winner is
+// elected) returns an error, produces no text, and still mutates no history.
+func TestReplier_Draft_CancelledCtxErrorsAndCommitsNothing(t *testing.T) {
+	prov := &fakeProvider{reply: "Aye, traveler."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	draft, err := r.Draft(ctx, "Hail, Bart.")
+	if err == nil {
+		t.Fatal("Draft on a cancelled ctx must return an error")
+	}
+	if draft != "" {
+		t.Fatalf("draft = %q, want empty on a cancelled ctx", draft)
+	}
+	if len(r.HistorySnapshot()) != 0 {
+		t.Fatal("a cancelled Draft must commit nothing to history")
+	}
+}
+
+// draftReplier builds a Replier with no live LLM (SpeakDraft never generates — it
+// speaks a supplied draft), so a nil-ish provider is fine via the scripted fake.
+func draftReplier() *agent.Replier {
+	return agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "bart", Markdown: "You are Bart.", Voice: testVoice()},
+		Provider:    &fakeProvider{reply: "unused"},
+		Synthesizer: stubSynth{},
+	})
+}
+
+// TestReplier_SpeakDraft_CommitsUserMsgAndDelivered pins the winning Lead's commit
+// (ADR-0012, #301): SpeakDraft appends the user message (parity with the streaming
+// turn), sentence-splits the supplied draft, dispatches each in order, and commits
+// the DELIVERED text as the assistant turn — so the Lead's turn lands in history
+// exactly as an LLM turn would.
+func TestReplier_SpeakDraft_CommitsUserMsgAndDelivered(t *testing.T) {
+	r := draftReplier()
+
+	var got []string
+	dispatch := func(rep orchestrator.Reply) error {
+		got = append(got, rep.Sentence)
+		return nil
+	}
+
+	delivered, err := r.SpeakDraft(t.Context(), "Hail, Bart.", "First sentence. Second sentence.", dispatch)
+	if err != nil {
+		t.Fatalf("SpeakDraft errored: %v", err)
+	}
+	if want := "First sentence. Second sentence."; delivered != want {
+		t.Fatalf("delivered = %q, want %q", delivered, want)
+	}
+	if len(got) != 2 || got[0] != "First sentence." || got[1] != "Second sentence." {
+		t.Fatalf("dispatched sentences = %v, want the two split sentences in order", got)
+	}
+	hist := r.HistorySnapshot()
+	if len(hist) != 2 {
+		t.Fatalf("history len = %d, want 2 (user + assistant)", len(hist))
+	}
+	if hist[0].Text != "Hail, Bart." {
+		t.Fatalf("history[0] = %q, want the user utterance", hist[0].Text)
+	}
+	if hist[1].Text != "First sentence. Second sentence." {
+		t.Fatalf("history[1] = %q, want the delivered assistant text", hist[1].Text)
+	}
+}
+
+// TestReplier_SpeakDraft_CutMidDraftCommitsDeliveredOnly pins the barge path: a
+// dispatch that reports the turn cancelled mid-draft stops the drain, and only the
+// sentences forwarded BEFORE the cut are committed (ADR-0012 delivered-only).
+func TestReplier_SpeakDraft_CutMidDraftCommitsDeliveredOnly(t *testing.T) {
+	r := draftReplier()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var got []string
+	dispatch := func(rep orchestrator.Reply) error {
+		if ctx.Err() != nil {
+			return ctx.Err() // the turn was already cut — this sentence is not delivered
+		}
+		got = append(got, rep.Sentence)
+		cancel() // a barge cuts the turn right after the first sentence is forwarded
+		return nil
+	}
+
+	delivered, err := r.SpeakDraft(ctx, "Hail, Bart.", "First. Second. Third.", dispatch)
+	if err != nil {
+		t.Fatalf("SpeakDraft on a barge must not surface an error: %v", err)
+	}
+	if delivered != "First." {
+		t.Fatalf("delivered = %q, want only the first (forwarded) sentence", delivered)
+	}
+	if len(got) != 1 {
+		t.Fatalf("dispatched %d sentences, want 1 before the cut", len(got))
+	}
+	hist := r.HistorySnapshot()
+	if len(hist) != 2 || hist[1].Text != "First." {
+		t.Fatalf("history = %+v, want user + assistant committing only the delivered 'First.'", hist)
+	}
+}

--- a/pkg/voice/agent/cast.go
+++ b/pkg/voice/agent/cast.go
@@ -104,3 +104,28 @@ func (c *Cast) Reply() orchestrator.ReplyFunc {
 		return r.Reply()(ctx, e)
 	}
 }
+
+// Draft implements [orchestrator.EnsembleSpeaker]: it produces the addressed
+// Agent's would-be reply text WITHOUT mutating anything (the speculative fan-out
+// half of an Ensemble Turn, ADR-0025/#301), by delegating to that member's
+// [Replier.Draft]. An unknown (or removed) Agent yields "", nil — the same "no one
+// answers" signal the coordinator reads as an empty draft, never an error.
+func (c *Cast) Draft(ctx context.Context, e voiceevent.AddressRouted) (string, error) {
+	r := c.lookup(e.Target.AgentID)
+	if r == nil {
+		return "", nil // no Agent answers for this route
+	}
+	return r.Draft(ctx, e.Text)
+}
+
+// Speak implements [orchestrator.EnsembleSpeaker]: it speaks the winning Lead's
+// pre-generated draft as the addressed Agent's turn (committing the delivered text
+// to that member's history, ADR-0012), by delegating to [Replier.SpeakDraft]. An
+// unknown Agent dispatches nothing and returns "", nil.
+func (c *Cast) Speak(ctx context.Context, e voiceevent.AddressRouted, draft string, dispatch func(orchestrator.Reply) error) (string, error) {
+	r := c.lookup(e.Target.AgentID)
+	if r == nil {
+		return "", nil // no Agent answers for this route
+	}
+	return r.SpeakDraft(ctx, e.Text, draft, dispatch)
+}

--- a/pkg/voice/agent/cast_test.go
+++ b/pkg/voice/agent/cast_test.go
@@ -219,3 +219,61 @@ var (
 	_ orchestrator.StreamReplyFunc = agent.NewCast().ReplyStream()
 	_ orchestrator.ReplyFunc       = agent.NewCast().Reply()
 )
+
+// TestCast_Draft_RoutesByAgentID pins the EnsembleSpeaker.Draft half (#301): a
+// Draft for agent B produces B's would-be text (via B's Replier), and an unknown
+// Agent yields "", nil — the "no one answers" signal the coordinator treats as an
+// empty draft.
+func TestCast_Draft_RoutesByAgentID(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"I am A."}})
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"I am B."}})
+	cast := agent.NewCast(a, b)
+
+	draft, err := cast.Draft(context.Background(), routed("b", "who are you?"))
+	if err != nil {
+		t.Fatalf("Draft: %v", err)
+	}
+	if draft != "I am B." {
+		t.Fatalf("draft = %q, want B's text", draft)
+	}
+
+	// Unknown Agent: no member answers, "" nil (not an error).
+	got, err := cast.Draft(context.Background(), routed("zzz", "hello"))
+	if err != nil || got != "" {
+		t.Fatalf("Draft(unknown) = (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+// TestCast_Speak_RoutesByAgentID pins the EnsembleSpeaker.Speak half (#301): a
+// Speak for agent B dispatches B's draft in B's Voice and returns the delivered
+// text; an unknown Agent dispatches nothing and returns "", nil.
+func TestCast_Speak_RoutesByAgentID(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"unused"}})
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"unused"}})
+	cast := agent.NewCast(a, b)
+
+	var got []orchestrator.Reply
+	delivered, err := cast.Speak(context.Background(), routed("b", "who are you?"), "I am B.", func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Speak: %v", err)
+	}
+	if delivered != "I am B." {
+		t.Fatalf("delivered = %q, want the draft text", delivered)
+	}
+	if len(got) != 1 || got[0].Voice.VoiceID != "b" {
+		t.Fatalf("dispatched = %+v, want one sentence in b's voice", got)
+	}
+
+	// Unknown Agent: nothing dispatched, "" nil.
+	got = nil
+	delivered, err = cast.Speak(context.Background(), routed("zzz", "x"), "hi", func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	})
+	if err != nil || delivered != "" || len(got) != 0 {
+		t.Fatalf("Speak(unknown) = (%q, %v) dispatched %d, want (\"\", nil) and no dispatch", delivered, err, len(got))
+	}
+}

--- a/pkg/voice/orchestrator/address.go
+++ b/pkg/voice/orchestrator/address.go
@@ -104,6 +104,12 @@ func (d *AddressDetector) Bind(_ context.Context, bus *voiceevent.Bus) (cancel f
 		panic("orchestrator.AddressDetector.Bind: bus must not be nil")
 	}
 	return voiceevent.On(bus, func(final voiceevent.STTFinal) {
+		// Collect the GM-gate SURVIVORS first, then decide the atomicity of the set
+		// (ADR-0025, #301): one survivor publishes a plain [voiceevent.AddressRouted]
+		// (byte-identical to the pre-ensemble path, the MaxTargets=1 default); two or
+		// more publish ONE [voiceevent.EnsembleRouted] so the turn-taking layer runs
+		// the set as a single floor-holding Ensemble Turn; zero publishes nothing.
+		var survivors []voiceevent.AddressRouted
 		for _, routed := range d.matcher.TargetMatch(final.Text) {
 			// Butler GM-only address gate (ADR-0024): drop a Butler route whose
 			// SpeakerID is not an allowlisted GM (empty fails closed). Fail
@@ -116,7 +122,27 @@ func (d *AddressDetector) Bind(_ context.Context, bus *voiceevent.Bus) (cancel f
 			// Carry the turn correlation id (A3) from the utterance onto each
 			// routing decision it produced; the matcher does not know about it.
 			routed.TurnID = final.TurnID
-			bus.Publish(routed)
+			survivors = append(survivors, routed)
+		}
+		switch len(survivors) {
+		case 0:
+			return
+		case 1:
+			// Single-target: byte-identical to the pre-ensemble path.
+			bus.Publish(survivors[0])
+		default:
+			// Two or more: ONE atomic EnsembleRouted carrying the matcher's
+			// score-sorted target set (Targets[0] is the top-scored coalesce anchor).
+			targets := make([]voiceevent.AddressTarget, len(survivors))
+			for i, s := range survivors {
+				targets[i] = s.Target
+			}
+			bus.Publish(voiceevent.EnsembleRouted{
+				At:      survivors[0].At,
+				Text:    final.Text,
+				TurnID:  final.TurnID,
+				Targets: targets,
+			})
 		}
 	})
 }

--- a/pkg/voice/orchestrator/address_scoring_test.go
+++ b/pkg/voice/orchestrator/address_scoring_test.go
@@ -104,25 +104,58 @@ func TestScoringMatcher_Mishearing_RoutesToNPC(t *testing.T) {
 	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 1)
 }
 
-// TestScoringMatcher_Ensemble_PublishesEveryTarget proves the detector
-// publishes every decision the scoring matcher returns: with the single-target
-// cap lifted (an ensemble matcher), an utterance naming two NPCs yields two
-// address.routed events (an Ensemble Turn, ADR-0025), not one.
-func TestScoringMatcher_Ensemble_PublishesEveryTarget(t *testing.T) {
+// TestScoringMatcher_Ensemble_PublishesOneEnsembleRouted proves the detector makes
+// a multi-Agent decision set ATOMIC (ADR-0025, #301): with the single-target cap
+// lifted (an ensemble matcher), an utterance naming two NPCs yields exactly ONE
+// address.ensemble carrying both score-sorted targets — and ZERO plain
+// address.routed events. This REWRITES the earlier
+// TestScoringMatcher_Ensemble_PublishesEveryTarget (which asserted two
+// address.routed): the #301 contract supersedes it — an Ensemble Turn is one
+// floor-holding unit, so the detector emits one event, not N.
+func TestScoringMatcher_Ensemble_PublishesOneEnsembleRouted(t *testing.T) {
 	h := voicetest.New(t)
 	butlerAg, bartAg, goblinAg := scoringAgents()
 	d := newEnsembleDetector(butlerAg, bartAg, goblinAg)
 	t.Cleanup(d.Bind(t.Context(), h.Bus))
 
-	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart and the Goblin start arguing"})
+	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart and the Goblin start arguing", TurnID: "T-e"})
 
-	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 2)
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 1)
+	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 0)
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.AddressRouted) bool { return e.Target.AgentID == bartTarget.AgentID },
-		"address.routed → Bart",
+		func(e voiceevent.EnsembleRouted) bool {
+			if len(e.Targets) != 2 || e.TurnID != "T-e" {
+				return false
+			}
+			// Both named NPCs are present in the set.
+			ids := map[string]bool{}
+			for _, tgt := range e.Targets {
+				ids[tgt.AgentID] = true
+			}
+			return ids[bartTarget.AgentID] && ids[goblinTarget.AgentID]
+		},
+		"address.ensemble carrying both Bart and Goblin (score-sorted set)",
 	)
+}
+
+// TestScoringMatcher_SingleNameUnderEnsembleCap_PublishesPlainAddressRouted proves
+// the ensemble branch is dead code for a single-target utterance even when the cap
+// is lifted (#301 AC4): one named NPC yields exactly one plain address.routed and
+// no address.ensemble, so the single-route path is untouched.
+func TestScoringMatcher_SingleNameUnderEnsembleCap_PublishesPlainAddressRouted(t *testing.T) {
+	h := voicetest.New(t)
+	butlerAg, bartAg, goblinAg := scoringAgents()
+	d := newEnsembleDetector(butlerAg, bartAg, goblinAg)
+	t.Cleanup(d.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart, what's the special tonight?", TurnID: "T-s"})
+
+	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 1)
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 0)
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.AddressRouted) bool { return e.Target.AgentID == goblinTarget.AgentID },
-		"address.routed → Goblin",
+		func(e voiceevent.AddressRouted) bool {
+			return e.Target.AgentID == bartTarget.AgentID && e.TurnID == "T-s"
+		},
+		"address.routed → Bart (single-target, plain path)",
 	)
 }

--- a/pkg/voice/orchestrator/address_test.go
+++ b/pkg/voice/orchestrator/address_test.go
@@ -139,11 +139,14 @@ func TestAddressDetector_PublishesDecisionVerbatim(t *testing.T) {
 	)
 }
 
-// TestAddressDetector_PublishesEveryDecision pins the multi-target half of the
-// TargetMatcher contract: when one utterance addresses several Agents the
-// matcher returns several decisions and the detector publishes each of them,
-// not just the first.
-func TestAddressDetector_PublishesEveryDecision(t *testing.T) {
+// TestAddressDetector_MultiDecisionPublishesOneEnsembleRouted pins the
+// multi-target half of the TargetMatcher contract under the Ensemble Turn design
+// (ADR-0025, #301): when the matcher returns several decisions the detector makes
+// the set ATOMIC — ONE address.ensemble carrying every target in the matcher's
+// order — rather than N independent address.routed. This REWRITES the former
+// TestAddressDetector_PublishesEveryDecision (which asserted N address.routed): the
+// #301 contract supersedes it, since an Ensemble Turn is one floor-holding unit.
+func TestAddressDetector_MultiDecisionPublishesOneEnsembleRouted(t *testing.T) {
 	h := voicetest.New(t)
 	m := matchFunc(func(text string) []voiceevent.AddressRouted {
 		return []voiceevent.AddressRouted{
@@ -154,16 +157,16 @@ func TestAddressDetector_PublishesEveryDecision(t *testing.T) {
 	d := orchestrator.NewAddressDetector(m)
 	t.Cleanup(d.Bind(t.Context(), h.Bus))
 
-	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart and the Goblin start fighting."})
+	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart and the Goblin start fighting.", TurnID: "T-m"})
 
-	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 2)
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 1)
+	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 0)
 	voicetest.AssertEvent(t, h,
-		func(e voiceevent.AddressRouted) bool { return e.Target == bartTarget },
-		"address.routed → Bart",
-	)
-	voicetest.AssertEvent(t, h,
-		func(e voiceevent.AddressRouted) bool { return e.Target == goblinTarget },
-		"address.routed → Goblin",
+		func(e voiceevent.EnsembleRouted) bool {
+			return len(e.Targets) == 2 && e.Targets[0] == bartTarget && e.Targets[1] == goblinTarget &&
+				e.TurnID == "T-m" && e.Text == "Bart and the Goblin start fighting."
+		},
+		"address.ensemble carrying both targets in matcher order",
 	)
 }
 

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -55,6 +55,13 @@ type Conversation struct {
 	// turn gate. Deliberately independent of the mute view (GM puppeteering bypasses
 	// mute).
 	voiceOf VoiceLookup
+
+	// ensemble is the Ensemble Turn speaker ([WithEnsemble], #301): nil = feature
+	// off. When set, Register installs it on the replier, which runs a
+	// [voiceevent.EnsembleRouted] as a speculative fan-out + Lead race (ADR-0025).
+	// It REQUIRES barge-in (an ensemble is one floor-holding unit); Register panics
+	// if set without [WithBargeIn]/[WithBargeInCoalesce].
+	ensemble EnsembleSpeaker
 }
 
 // Option configures a [Conversation] at construction.
@@ -166,6 +173,20 @@ func WithDirectSpeech(voiceOf VoiceLookup) Option {
 	return func(c *Conversation) { c.voiceOf = voiceOf }
 }
 
+// WithEnsemble enables Ensemble Turns (ADR-0025, #301): when one utterance
+// addresses two or more Agents the detector publishes a [voiceevent.EnsembleRouted],
+// and the replier fans the candidates out into parallel speculative Drafts, races
+// them, and lets the first complete non-empty draft (the Lead) take the floor and
+// speak — the losers' drafts are discarded (Reactions are #302). It REQUIRES
+// barge-in ([WithBargeIn]/[WithBargeInCoalesce]) — the whole ensemble is ONE
+// floor-holding unit, so a single barge tears the unit down (ADR-0027); Register
+// panics if the speaker is set without it. A nil speaker is the feature-off default,
+// where an EnsembleRouted degrades to the top-scored single route. The production
+// speaker is agent.Cast (which also drives [WithReplyStream]).
+func WithEnsemble(s EnsembleSpeaker) Option {
+	return func(c *Conversation) { c.ensemble = s }
+}
+
 // WithErrorHandler sets the [ErrorFunc] used to report failures from stage calls
 // the reactors fire inside bus callbacks (currently the replier's TTS dispatch).
 // Without it such failures are dropped silently.
@@ -225,6 +246,14 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 		// estimated spend crosses the soft cap. Independent of barge-in and mute; nil
 		// is the feature-off default.
 		replier.gate = c.gate
+		// Ensemble Turn speaker (#301, ADR-0025): the replier runs a multi-Agent
+		// EnsembleRouted as a speculative fan-out + Lead race. It REQUIRES the barge-in
+		// floor — an ensemble is one floor-holding unit — so refuse the wiring without
+		// it (mirrors the fail-fast constructors).
+		if c.ensemble != nil && !c.bargeEnabled {
+			panic("orchestrator.Conversation.Register: WithEnsemble requires WithBargeIn or WithBargeInCoalesce")
+		}
+		replier.ensemble = c.ensemble
 		if c.bargeEnabled {
 			// Barge-in mode: the replier runs turns on the floor, and the BargeIn
 			// reactor yields it on a human interruption. Bind BargeIn before the

--- a/pkg/voice/orchestrator/conversation.go
+++ b/pkg/voice/orchestrator/conversation.go
@@ -228,6 +228,13 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 	if c.reply != nil && c.replyStream != nil {
 		panic("orchestrator.Conversation.Register: WithReply and WithReplyStream are mutually exclusive")
 	}
+	// Ensemble Turn speaker (#301, ADR-0025) REQUIRES the barge-in floor — an ensemble
+	// is one floor-holding unit. Validate UNCONDITIONALLY (before the reply-strategy
+	// branch), so WithEnsemble without barge-in is a loud wiring error even when no
+	// reply strategy is set, not a silent no-op.
+	if c.ensemble != nil && !c.bargeEnabled {
+		panic("orchestrator.Conversation.Register: WithEnsemble requires WithBargeIn or WithBargeInCoalesce")
+	}
 	if c.reply != nil || c.replyStream != nil {
 		if c.tts == nil {
 			panic("orchestrator.Conversation.Register: a reply strategy was set but no TTS stage was provided")
@@ -247,12 +254,8 @@ func (c *Conversation) Register(ctx context.Context) (cancel func()) {
 		// is the feature-off default.
 		replier.gate = c.gate
 		// Ensemble Turn speaker (#301, ADR-0025): the replier runs a multi-Agent
-		// EnsembleRouted as a speculative fan-out + Lead race. It REQUIRES the barge-in
-		// floor — an ensemble is one floor-holding unit — so refuse the wiring without
-		// it (mirrors the fail-fast constructors).
-		if c.ensemble != nil && !c.bargeEnabled {
-			panic("orchestrator.Conversation.Register: WithEnsemble requires WithBargeIn or WithBargeInCoalesce")
-		}
+		// EnsembleRouted as a speculative fan-out + Lead race. The barge-in requirement
+		// is validated above (unconditionally); here just install it.
 		replier.ensemble = c.ensemble
 		if c.bargeEnabled {
 			// Barge-in mode: the replier runs turns on the floor, and the BargeIn

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -75,7 +75,11 @@ func (r *Replier) handleEnsemble(ctx context.Context, bus *voiceevent.Bus, e voi
 	// Take the floor under the coalesce anchor Targets[0] (the top-scored). The
 	// anchor names one candidate until the race elects the Lead and retargets the
 	// floor ([Floor.SetHolderAgent]) — an accepted window (a VAD-split re-take
-	// naming another candidate supersedes until then, RISK in the #301 plan).
+	// naming another candidate supersedes until then, RISK in the #301 plan). In the
+	// SAME pre-election window a per-Agent mute cut ([Floor.YieldAgent]) of the anchor
+	// Targets[0] cancels turnCtx and tears the WHOLE ensemble down (the race loop's
+	// turnCtx.Done() branch returns) — correct: the ensemble is one floor-holding unit
+	// (ADR-0027), and muting the current holder cuts the unit just as a barge would.
 	turnCtx, release, coalesced := r.floor.Take(ctx, targets[0].AgentID)
 	if coalesced {
 		release() // no-op on the floor, keeps the take/release pairing honest
@@ -163,6 +167,14 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		if turnCtx.Err() == nil {
 			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndProviderError})
 		}
+		return
+	}
+	// Race the cancel: when a barge fires the same instant the winner's result lands,
+	// both the buffered result and turnCtx.Done() are ready and the select above may
+	// have picked the result. Re-check before electing so we never publish
+	// EnsembleLead after a TurnEnded{barge} — nor let SpeakDraft commit a user message
+	// for a turn nothing spoke in.
+	if turnCtx.Err() != nil {
 		return
 	}
 

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -1,0 +1,215 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// EnsembleSpeaker is the seam the [Replier] drives to run an Ensemble Turn
+// (ADR-0025, #301): when one utterance addresses two or more Agents the detector
+// publishes a single [voiceevent.EnsembleRouted], and the replier fans the
+// candidates out into parallel speculative Drafts, races them, and lets the first
+// complete non-empty draft — the Lead — take the floor and speak.
+//
+// Draft PURELY produces one candidate's would-be reply text: it writes no history,
+// synthesizes no TTS, commits no transcript, and publishes no event, so a LOSING
+// candidate commits nothing (ADR-0012's zero-commit rule made structural). "" means
+// the Agent says nothing; a routing to an Agent this speaker does not hold returns
+// "", nil. It must honor ctx — the losers' shared draft context is cancelled the
+// instant the winner is elected, and a barge tearing down the whole ensemble
+// cancels every in-flight draft.
+//
+// Speak renders the winning Lead's already-generated draft as that Agent's turn:
+// serial per-sentence dispatch, committing ONLY the delivered text (ADR-0012), and
+// returns the delivered text. dispatch synthesizes one sentence at a time (the
+// [PlaybackPump]'s single-in-flight contract) and reports a cancelled turn so Speak
+// stops the drain and commits only what was forwarded.
+//
+// The production implementation is [agent.Cast], which multiplexes both calls by
+// [voiceevent.AddressTarget.AgentID] across its member Repliers.
+type EnsembleSpeaker interface {
+	Draft(ctx context.Context, e voiceevent.AddressRouted) (string, error)
+	Speak(ctx context.Context, e voiceevent.AddressRouted, draft string, dispatch func(Reply) error) (delivered string, err error)
+}
+
+// handleEnsemble runs one [voiceevent.EnsembleRouted] decision set as ONE
+// floor-holding Ensemble Turn (ADR-0025/0027, #301). It mirrors the single-route
+// reactor's gates (mute pre-filter, spend cap, floor Take with its coalesce fold,
+// post-Take mute re-filter) but over a SET of candidate targets, then hands the
+// held floor to [Replier.runEnsemble] on its own goroutine so the bus callback does
+// not block.
+//
+// It runs inside the bus callback, so — like [Replier.handleRouted] — every path to
+// a spoken turn ends by spawning a goroutine, never by doing the turn's real-time
+// work here.
+func (r *Replier) handleEnsemble(ctx context.Context, bus *voiceevent.Bus, e voiceevent.EnsembleRouted) {
+	ctx = voiceevent.WithTurnID(ctx, e.TurnID)
+
+	// Mute pre-filter (#211): drop muted candidates BEFORE taking the floor. A fresh
+	// slice (cap 0) so the event's Targets are never mutated.
+	targets := filterMuted(e.Targets, r.mutes)
+
+	// Every candidate muted: no turn opens, no floor churn (mirrors handleRouted).
+	if len(targets) == 0 {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndMute})
+		return
+	}
+	// Degrade to the single-route path when only one candidate survives, when no
+	// ensemble speaker is wired, or when the barge-in floor is absent (an ensemble
+	// is one floor-holding unit — it needs the floor). The top-scored target
+	// (Targets[0] order preserved by the filter) answers via handleRouted.
+	if len(targets) == 1 || r.ensemble == nil || r.floor == nil {
+		r.handleRouted(ctx, bus, voiceevent.AddressRouted{
+			At: e.At, Text: e.Text, TurnID: e.TurnID, Target: targets[0],
+		})
+		return
+	}
+	// Spend soft cap (#130): refuse a NEW turn before taking the floor. A single
+	// pre-check is airtight (spend is monotonic).
+	if r.gate != nil && !r.gate.AllowTurn() {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSpendCap})
+		return
+	}
+	// Take the floor under the coalesce anchor Targets[0] (the top-scored). The
+	// anchor names one candidate until the race elects the Lead and retargets the
+	// floor ([Floor.SetHolderAgent]) — an accepted window (a VAD-split re-take
+	// naming another candidate supersedes until then, RISK in the #301 plan).
+	turnCtx, release, coalesced := r.floor.Take(ctx, targets[0].AgentID)
+	if coalesced {
+		release() // no-op on the floor, keeps the take/release pairing honest
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndSupersedeCoalesced, Text: e.Text})
+		return
+	}
+	// Race closure (#211): the mute view can flip between the pre-Take filter and
+	// this Take. Re-filter now that this turn holds the floor; if every candidate is
+	// now muted, release and end with the mute reason before any goroutine.
+	targets = filterMuted(targets, r.mutes)
+	if len(targets) == 0 {
+		release()
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndMute})
+		return
+	}
+	go r.runEnsemble(turnCtx, release, bus, e, targets)
+}
+
+// filterMuted returns the targets whose Agent is not muted by mutes, preserving
+// order, on a FRESH slice (so the caller's/event's backing array is never mutated).
+// A nil mute view returns the set unchanged (a copy).
+func filterMuted(targets []voiceevent.AddressTarget, mutes MuteView) []voiceevent.AddressTarget {
+	out := make([]voiceevent.AddressTarget, 0, len(targets))
+	for _, t := range targets {
+		if mutes != nil && mutes.Muted(t.AgentID) {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// runEnsemble is the held-floor half of an Ensemble Turn (#301): it fans the
+// candidates out into parallel speculative Drafts, races them for the first
+// complete non-empty draft (the Lead), and lets that Lead speak under the
+// ensemble's original TurnID while the losing drafts are cancelled and discarded.
+// It owns the floor for the whole unit — a barge cancelling turnCtx unwinds the
+// drafts, the Lead's synthesis, and the playback together (ADR-0027).
+func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voiceevent.Bus, e voiceevent.EnsembleRouted, targets []voiceevent.AddressTarget) {
+	defer release()
+
+	// The losers' drafts share this child context so the winner's election cancels
+	// them all at once, independently of turnCtx (which a barge cancels).
+	draftCtx, cancelDrafts := context.WithCancel(turnCtx)
+	defer cancelDrafts()
+
+	type draftResult struct {
+		target voiceevent.AddressTarget
+		text   string
+		err    error
+	}
+	// BUFFERED to len(targets): a losing Draft that finishes AFTER the winner is
+	// elected must never block on its send (nobody drains the channel then) — the
+	// goroutines would otherwise leak (#301 RISK).
+	results := make(chan draftResult, len(targets))
+	for _, t := range targets {
+		t := t
+		go func() {
+			text, err := r.ensemble.Draft(draftCtx, voiceevent.AddressRouted{
+				At: e.At, Text: e.Text, TurnID: e.TurnID, Target: t,
+			})
+			results <- draftResult{target: t, text: text, err: err}
+		}()
+	}
+
+	// Full-TEXT race (ADR-0025): the FIRST complete, non-empty draft wins. Failed or
+	// empty drafts are skipped; if every candidate is exhausted with nothing to say,
+	// the turn ends provider_error (only while turnCtx is still alive — a barge
+	// publishes its own TurnEnded).
+	var lead draftResult
+	won := false
+	for remaining := len(targets); remaining > 0 && !won; {
+		select {
+		case <-turnCtx.Done():
+			return // a barge/supersede tore the whole unit down mid-race
+		case res := <-results:
+			remaining--
+			if res.err == nil && res.text != "" {
+				lead = res
+				won = true
+			}
+		}
+	}
+	if !won {
+		if turnCtx.Err() == nil {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndProviderError})
+		}
+		return
+	}
+
+	// Elect the Lead: announce it (so the transcript relay attributes the turn's
+	// line to the winner), retarget the floor onto it (so a mute cut / coalesce keys
+	// on whoever actually speaks), and cancel the losing drafts.
+	bus.Publish(voiceevent.EnsembleLead{At: time.Now(), TurnID: e.TurnID, Target: lead.target})
+	r.floor.SetHolderAgent(e.TurnID, lead.target.AgentID)
+	cancelDrafts()
+
+	// Speak the Lead's draft under turnCtx. The dispatch closure mirrors
+	// dispatchStream's deliver-then-commit (ADR-0012): a synth failure is non-fatal
+	// but recorded (ttsFailed), and a ctx cancel — before OR after the vendor call —
+	// stops the drain so Speak commits only delivered sentences.
+	var ttsFailed bool
+	dispatch := func(rep Reply) error {
+		if err := turnCtx.Err(); err != nil {
+			return err
+		}
+		if err := r.tts.Dispatch(turnCtx, rep.Sentence, rep.Voice); err != nil {
+			if r.onError != nil {
+				r.onError(err)
+			}
+			if turnCtx.Err() != nil {
+				return turnCtx.Err()
+			}
+			ttsFailed = true
+			return nil
+		}
+		// Deliver-then-commit re-check (#363): Dispatch returns nil even when a barge
+		// cancelled the turn DURING the drain (tail audio cut). Report the cancel so
+		// Speak does not commit this undelivered sentence.
+		if err := turnCtx.Err(); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Speak commits the delivered text to the Lead's own history and stops the drain
+	// on a barge; the coordinator needs neither return here — the turn-end reason is
+	// carried by ttsFailed (below) or the barge's own TurnEnded.
+	_, _ = r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
+		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: lead.target,
+	}, lead.text, dispatch)
+
+	// A TTS synth failure that produced no audio under a live turn is announced as
+	// the turn-end reason (mirrors dispatchStream); a barge publishes its own.
+	if ttsFailed && turnCtx.Err() == nil {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndTTSError})
+	}
+}

--- a/pkg/voice/orchestrator/ensemble_test.go
+++ b/pkg/voice/orchestrator/ensemble_test.go
@@ -19,9 +19,10 @@ import (
 // replay-speed dependence (ADR-0021). Speak dispatches the draft (optionally split
 // across a pause gate so a barge can land mid-turn) and records which Agents spoke.
 type fakeEnsemble struct {
-	draft    map[string]string        // agentID -> draft text Draft returns
-	draftErr map[string]error         // agentID -> Draft error (optional)
-	gate     map[string]chan struct{} // agentID -> Draft release gate; nil/absent = immediate
+	draft     map[string]string        // agentID -> draft text Draft returns
+	draftErr  map[string]error         // agentID -> Draft error (optional)
+	gate      map[string]chan struct{} // agentID -> Draft release gate; nil/absent = immediate
+	ignoreCtx map[string]bool          // agentID -> Draft waits ONLY on the gate (returns success even if ctx already cancelled), modelling a Draft that completed the same instant the turn was cancelled
 
 	started   chan string // agentID pushed when a Draft begins (optional)
 	cancelled chan string // agentID pushed when a Draft's ctx was cancelled (optional)
@@ -40,13 +41,17 @@ func (s *fakeEnsemble) Draft(ctx context.Context, e voiceevent.AddressRouted) (s
 		s.started <- id
 	}
 	if g := s.gate[id]; g != nil {
-		select {
-		case <-g:
-		case <-ctx.Done():
-			if s.cancelled != nil {
-				s.cancelled <- id
+		if s.ignoreCtx[id] {
+			<-g // wait only on the gate: this Draft "already finished" when the turn was cut
+		} else {
+			select {
+			case <-g:
+			case <-ctx.Done():
+				if s.cancelled != nil {
+					s.cancelled <- id
+				}
+				return "", ctx.Err()
 			}
-			return "", ctx.Err()
 		}
 	}
 	if err := s.draftErr[id]; err != nil {
@@ -114,17 +119,18 @@ func ensembleReplier(h *voicetest.Harness, floor *orchestrator.Floor, spk orches
 	return replier
 }
 
-// TestReplier_Ensemble_FastestDraftLeadsAndSpeaks pins the Lead race (ADR-0025,
-// #301): with two candidates, the one whose Draft completes first (gate-pinned)
-// becomes the Lead — it is announced via EnsembleLead and is the only Agent that
-// speaks (exactly its TTSInvoked, one line). The slow candidate never speaks. No
-// sleeps: Mira's gate is never released, so Bart always wins.
+// TestReplier_Ensemble_FastestDraftLeadsAndSpeaks pins the Lead race skips
+// non-answers (ADR-0025, #301): Bart has a real draft, Goblin says nothing (""), so
+// Bart is elected Lead — announced via EnsembleLead and the only Agent that speaks
+// (exactly its TTSInvoked, one line). The speed-beats-score property (a slower
+// Targets[1] still winning over a hung Targets[0]) is pinned separately in
+// TestReplier_Ensemble_SlowerLowerScoredCandidateStillLeads.
 func TestReplier_Ensemble_FastestDraftLeadsAndSpeaks(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	spk := &fakeEnsemble{
-		draft:   map[string]string{bartTarget.AgentID: "Bart speaks."},
-		gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate() /* mira: none released */},
+		draft:   map[string]string{bartTarget.AgentID: "Bart speaks." /* goblin: no entry → empty draft, skipped */},
+		gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: closedGate()},
 		spokeCh: make(chan string, 2),
 	}
 	replier := ensembleReplier(h, floor, spk)
@@ -146,12 +152,121 @@ func TestReplier_Ensemble_FastestDraftLeadsAndSpeaks(t *testing.T) {
 		return e.TurnID == "T7" && e.Target.AgentID == bartTarget.AgentID
 	}, "ensemble.lead → Bart")
 	if got := spk.spokeIDs(); len(got) != 1 || got[0] != bartTarget.AgentID {
-		t.Fatalf("spoke = %v, want only Bart (the slow candidate must not speak)", got)
+		t.Fatalf("spoke = %v, want only Bart (the empty-draft candidate must not speak)", got)
 	}
 	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
 	voicetest.AssertEvent(t, h, func(e voiceevent.TTSInvoked) bool { return e.Sentence == "Bart speaks." && e.TurnID == "T7" }, "one tts.invoked for Bart's line")
 	// Clean turn: no TurnEnded of any reason.
 	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestReplier_Ensemble_SlowerLowerScoredCandidateStillLeads is the AC1 headline
+// (ADR-0025, #301): the FIRST complete non-empty draft wins the floor REGARDLESS of
+// score order. Targets[0] (the top-scored coalesce anchor, Bart) is gated FOREVER;
+// the lower-scored Targets[1] (Goblin) completes → Goblin is elected Lead and is the
+// one that speaks. A coordinator that skipped the race and just waited on Targets[0]
+// would deadlock here.
+func TestReplier_Ensemble_SlowerLowerScoredCandidateStillLeads(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft: map[string]string{bartTarget.AgentID: "Bart (too slow).", goblinTarget.AgentID: "Goblin wins."},
+		gate: map[string]chan struct{}{
+			bartTarget.AgentID:   make(chan struct{}), // Targets[0]: NEVER released (hung)
+			goblinTarget.AgentID: closedGate(),        // Targets[1]: completes immediately
+		},
+		cancelled: make(chan string, 2),
+		spokeCh:   make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T-race", Text: "Bart, Goblin — go!", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	select {
+	case who := <-spk.spokeCh:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("Speak ran for %q, want the faster lower-scored Goblin (Targets[1])", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the ensemble never elected the faster candidate (did the coordinator wait on Targets[0]?)")
+	}
+
+	voicetest.AssertEvent(t, h, func(e voiceevent.EnsembleLead) bool {
+		return e.TurnID == "T-race" && e.Target.AgentID == goblinTarget.AgentID
+	}, "ensemble.lead → Goblin (Targets[1], first complete draft)")
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	voicetest.AssertEvent(t, h, func(e voiceevent.TTSInvoked) bool { return e.Sentence == "Goblin wins." && e.TurnID == "T-race" }, "Goblin's line on the wire")
+	if got := spk.spokeIDs(); len(got) != 1 || got[0] != goblinTarget.AgentID {
+		t.Fatalf("spoke = %v, want only Goblin", got)
+	}
+	// The hung Targets[0] draft was cancelled by the election (leak-proof).
+	select {
+	case who := <-spk.cancelled:
+		if who != bartTarget.AgentID {
+			t.Fatalf("cancelled draft = %q, want the hung Bart", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the hung Targets[0] draft was never cancelled after the election")
+	}
+}
+
+// TestReplier_Ensemble_WinAfterCancelElectsNoLead pins the race-closure re-check
+// (#301): if a candidate's draft completes the SAME instant the turn is cancelled
+// (buffered result AND turnCtx.Done() both ready), no Lead may be elected — otherwise
+// EnsembleLead would publish after a TurnEnded and SpeakDraft would commit a user
+// message for a turn nothing spoke in. The winner's Draft ignores ctx (it "already
+// finished"); the turn is cancelled BEFORE its gate opens, so its success lands
+// post-cancel.
+func TestReplier_Ensemble_WinAfterCancelElectsNoLead(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	bartGate := make(chan struct{})
+	spk := &fakeEnsemble{
+		draft:     map[string]string{bartTarget.AgentID: "Bart speaks." /* goblin: empty, skipped */},
+		gate:      map[string]chan struct{}{bartTarget.AgentID: bartGate},
+		ignoreCtx: map[string]bool{bartTarget.AgentID: true},
+		started:   make(chan string, 2),
+		spokeCh:   make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tc", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// Wait until Bart's draft is in flight (blocked on its gate).
+	waitStarted(t, spk, bartTarget.AgentID)
+	// Cancel the turn (a barge/mute would do this via the floor), THEN let Bart's
+	// draft complete successfully — its winning result now arrives post-cancel.
+	floor.Yield()
+	close(bartGate)
+
+	// The re-check must swallow the post-cancel win: no Lead, nobody speaks.
+	select {
+	case <-time.After(300 * time.Millisecond):
+	case who := <-spk.spokeCh:
+		t.Fatalf("a cancelled ensemble must not elect a Lead; %q spoke", who)
+	}
+	voicetest.AssertNoEvent[voiceevent.EnsembleLead](t, h)
+	if len(spk.spokeIDs()) != 0 {
+		t.Fatalf("nobody may speak after a cancel; spoke = %v", spk.spokeIDs())
+	}
+}
+
+// waitStarted drains the fake's started channel until agentID's Draft has begun.
+func waitStarted(t *testing.T, s *fakeEnsemble, agentID string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case id := <-s.started:
+			if id == agentID {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("Draft for %q never started", agentID)
+		}
+	}
 }
 
 // TestReplier_Ensemble_LoserDraftDiscarded pins ADR-0012's zero-commit rule at the
@@ -391,4 +506,77 @@ func TestConversation_WithEnsemble_WithoutBargePanics(t *testing.T) {
 		}
 	}()
 	conv.Register(t.Context())
+}
+
+// countMute is a MuteView that reports NOT muted for the first flipAfter Muted
+// calls, then muted — so the pre-Take mute filter passes every candidate but the
+// post-Take re-filter (the race-closure) sees them all muted.
+type countMute struct {
+	mu        sync.Mutex
+	calls     int
+	flipAfter int
+}
+
+func (m *countMute) Muted(string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return m.calls > m.flipAfter
+}
+
+// TestReplier_Ensemble_SingleMutedOfTwo_DegradesToSurvivor pins the mute pre-filter
+// collapsing an ensemble to a single route (#211, #301): with one of two candidates
+// muted, only the survivor remains, so the turn degrades to the plain single-route
+// path for that survivor — no Lead race, no EnsembleLead.
+func TestReplier_Ensemble_SingleMutedOfTwo_DegradesToSurvivor(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+	var routedFor string
+	replier := orchestrator.NewStreamReplier(ttsStage, func(_ context.Context, e voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		routedFor = e.Target.AgentID
+		return dispatch(orchestrator.Reply{Sentence: "hi"})
+	}, nil)
+	replier.SetFloor(floor)
+	replier.SetEnsemble(&fakeEnsemble{}) // ensemble wired, but only one candidate survives the mute
+	replier.SetMutes(muteSet{bartTarget.AgentID: true})
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tsm", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool { return e.TurnID == "Tsm" }, "single-route dispatch for the surviving candidate")
+	if routedFor != goblinTarget.AgentID {
+		t.Fatalf("degrade routed to %q, want the un-muted survivor Goblin", routedFor)
+	}
+	voicetest.AssertEventCount[voiceevent.EnsembleLead](t, h, 0)
+}
+
+// TestReplier_Ensemble_PostTakeMuteReFilter_EndsMute pins the race-closure
+// (#211, #301): the mute view can flip to muted between the pre-Take filter and the
+// Take. When the post-Take re-filter finds every candidate muted, the floor is
+// released and the turn ends with the mute reason — before any draft runs.
+func TestReplier_Ensemble_PostTakeMuteReFilter_EndsMute(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:   map[string]string{bartTarget.AgentID: "x", goblinTarget.AgentID: "y"},
+		started: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	// flipAfter 2: the two pre-Take checks pass, the two post-Take checks report muted.
+	replier.SetMutes(&countMute{flipAfter: 2})
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tpm", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.AssertEvent(t, h, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "Tpm" && e.Reason == voiceevent.TurnEndMute
+	}, "turn.ended mute from the post-Take re-filter")
+	if floor.Active() {
+		t.Fatal("the floor must be released when the post-Take re-filter mutes every candidate")
+	}
+	voicetest.AssertEventCount[voiceevent.EnsembleLead](t, h, 0)
+	if len(spk.spokeIDs()) != 0 {
+		t.Fatal("no candidate may draft/speak after the post-Take mute re-filter")
+	}
 }

--- a/pkg/voice/orchestrator/ensemble_test.go
+++ b/pkg/voice/orchestrator/ensemble_test.go
@@ -1,0 +1,394 @@
+package orchestrator_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// fakeEnsemble is a gated [orchestrator.EnsembleSpeaker] for the coordinator tests:
+// each candidate's Draft blocks on a per-Agent release gate (nil gate = immediate),
+// so a test controls the RACE ORDER deterministically without sleeps or
+// replay-speed dependence (ADR-0021). Speak dispatches the draft (optionally split
+// across a pause gate so a barge can land mid-turn) and records which Agents spoke.
+type fakeEnsemble struct {
+	draft    map[string]string        // agentID -> draft text Draft returns
+	draftErr map[string]error         // agentID -> Draft error (optional)
+	gate     map[string]chan struct{} // agentID -> Draft release gate; nil/absent = immediate
+
+	started   chan string // agentID pushed when a Draft begins (optional)
+	cancelled chan string // agentID pushed when a Draft's ctx was cancelled (optional)
+
+	speakSentences map[string][]string // agentID -> sentences to dispatch (default: [draft])
+	speakPause     chan struct{}       // if set, Speak blocks after dispatching sentence[0]
+	spokeCh        chan string         // agentID pushed when Speak returns (optional)
+
+	mu    sync.Mutex
+	spoke []string
+}
+
+func (s *fakeEnsemble) Draft(ctx context.Context, e voiceevent.AddressRouted) (string, error) {
+	id := e.Target.AgentID
+	if s.started != nil {
+		s.started <- id
+	}
+	if g := s.gate[id]; g != nil {
+		select {
+		case <-g:
+		case <-ctx.Done():
+			if s.cancelled != nil {
+				s.cancelled <- id
+			}
+			return "", ctx.Err()
+		}
+	}
+	if err := s.draftErr[id]; err != nil {
+		return "", err
+	}
+	return s.draft[id], nil
+}
+
+func (s *fakeEnsemble) Speak(ctx context.Context, e voiceevent.AddressRouted, draft string, dispatch func(orchestrator.Reply) error) (string, error) {
+	id := e.Target.AgentID
+	s.mu.Lock()
+	s.spoke = append(s.spoke, id)
+	s.mu.Unlock()
+	if s.spokeCh != nil {
+		defer func() { s.spokeCh <- id }()
+	}
+
+	sentences := []string{draft}
+	if s.speakSentences != nil {
+		sentences = s.speakSentences[id]
+	}
+	var delivered strings.Builder
+	for i, snt := range sentences {
+		if err := dispatch(orchestrator.Reply{Sentence: snt, Voice: tts.Voice{VoiceID: id, Name: id}}); err != nil {
+			return delivered.String(), nil // barge: stop the drain, delivered-only
+		}
+		if delivered.Len() > 0 {
+			delivered.WriteByte(' ')
+		}
+		delivered.WriteString(snt)
+		if s.speakPause != nil && i == 0 {
+			select {
+			case <-s.speakPause:
+			case <-ctx.Done():
+				return delivered.String(), nil
+			}
+		}
+	}
+	return delivered.String(), nil
+}
+
+func (s *fakeEnsemble) spokeIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.spoke...)
+}
+
+// closedGate is an already-released Draft gate (the candidate drafts immediately).
+func closedGate() chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
+
+// ensembleReplier builds a floor-backed [orchestrator.Replier] wired with an
+// ensemble speaker — the coordinator under test. The stream reply strategy is a
+// never-called stub (only EnsembleRouted is published in these tests).
+func ensembleReplier(h *voicetest.Harness, floor *orchestrator.Floor, spk orchestrator.EnsembleSpeaker) *orchestrator.Replier {
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+	replier := orchestrator.NewStreamReplier(ttsStage, func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error {
+		return nil
+	}, nil)
+	replier.SetFloor(floor)
+	replier.SetEnsemble(spk)
+	return replier
+}
+
+// TestReplier_Ensemble_FastestDraftLeadsAndSpeaks pins the Lead race (ADR-0025,
+// #301): with two candidates, the one whose Draft completes first (gate-pinned)
+// becomes the Lead — it is announced via EnsembleLead and is the only Agent that
+// speaks (exactly its TTSInvoked, one line). The slow candidate never speaks. No
+// sleeps: Mira's gate is never released, so Bart always wins.
+func TestReplier_Ensemble_FastestDraftLeadsAndSpeaks(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:   map[string]string{bartTarget.AgentID: "Bart speaks."},
+		gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate() /* mira: none released */},
+		spokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T7", Text: "Bart, Mira — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The turn completes when the Lead's Speak returns.
+	select {
+	case who := <-spk.spokeCh:
+		if who != bartTarget.AgentID {
+			t.Fatalf("Speak ran for %q, want the elected Lead Bart", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the ensemble never elected a Lead / spoke")
+	}
+
+	voicetest.AssertEvent(t, h, func(e voiceevent.EnsembleLead) bool {
+		return e.TurnID == "T7" && e.Target.AgentID == bartTarget.AgentID
+	}, "ensemble.lead → Bart")
+	if got := spk.spokeIDs(); len(got) != 1 || got[0] != bartTarget.AgentID {
+		t.Fatalf("spoke = %v, want only Bart (the slow candidate must not speak)", got)
+	}
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	voicetest.AssertEvent(t, h, func(e voiceevent.TTSInvoked) bool { return e.Sentence == "Bart speaks." && e.TurnID == "T7" }, "one tts.invoked for Bart's line")
+	// Clean turn: no TurnEnded of any reason.
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestReplier_Ensemble_LoserDraftDiscarded pins ADR-0012's zero-commit rule at the
+// coordinator: once the Lead is elected, the losing candidate's shared draft ctx is
+// cancelled — its Draft returns via the cancel, it never speaks, and it produces no
+// TTSInvoked and no TurnEnded of its own.
+func TestReplier_Ensemble_LoserDraftDiscarded(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:     map[string]string{bartTarget.AgentID: "Bart speaks."},
+		gate:      map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+		cancelled: make(chan string, 2),
+		spokeCh:   make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T8", Text: "Bart, Mira — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// Winner speaks.
+	<-spk.spokeCh
+	// Loser's Draft was cancelled by the winner's election.
+	select {
+	case who := <-spk.cancelled:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("cancelled draft was %q, want the loser Goblin", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the losing draft was never cancelled after the Lead was elected")
+	}
+	if got := spk.spokeIDs(); len(got) != 1 || got[0] != bartTarget.AgentID {
+		t.Fatalf("spoke = %v, want only the Lead Bart", got)
+	}
+	// Exactly one TTSInvoked (Bart's), none from the loser.
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+}
+
+// TestReplier_Ensemble_BargeDuringLeadTearsDownWholeUnit pins ADR-0027: a human
+// barge while the Lead is audibly speaking cancels the ENTIRE ensemble turn — the
+// floor is yielded, TurnEnded{barge} is announced for the ensemble's TurnID, and
+// the Lead's Speak unwinds (delivered-only). The barge gate fires only once the Lead
+// is audible: FirstOpus marks it speaking, then a VADSpeechStart barges.
+func TestReplier_Ensemble_BargeDuringLeadTearsDownWholeUnit(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:          map[string]string{bartTarget.AgentID: "First. Second."},
+		gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+		cancelled:      make(chan string, 2),
+		speakSentences: map[string][]string{bartTarget.AgentID: {"First.", "Second."}},
+		speakPause:     make(chan struct{}), // never released: the Lead pauses after sentence 1 until the barge cancels ctx
+		spokeCh:        make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	// The barge reactor on the SAME floor: a speech_start while the Lead is audible
+	// yields the floor.
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T9", Text: "Bart, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// Wait until the Lead has dispatched its first sentence (it is now paused).
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "T9" && e.Sentence == "First."
+	}, "the Lead's first sentence is on the wire")
+
+	// The Lead is audible; a human barges.
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T9"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{})
+
+	// The whole unit is torn down: barge TurnEnded for the ensemble's TurnID.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "T9" && e.Reason == voiceevent.TurnEndBarge
+	}, "turn.ended barge for the whole ensemble")
+
+	// The Lead's Speak unwound and returned.
+	select {
+	case <-spk.spokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the Lead's Speak never returned after the barge")
+	}
+	// Only the first sentence reached the wire (the second was cut).
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	// The loser's draft was cancelled at election, never at barge.
+	select {
+	case who := <-spk.cancelled:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("cancelled draft = %q, want the loser Goblin", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the losing draft was never cancelled")
+	}
+	if floor.Active() {
+		t.Fatal("the floor must be free after the barge")
+	}
+}
+
+// TestReplier_Ensemble_AllDraftsEmptyEndsProviderError pins that when every
+// candidate draft fails or is empty, no Lead is elected: the turn ends
+// provider_error and the floor is released.
+func TestReplier_Ensemble_AllDraftsEmptyEndsProviderError(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:    map[string]string{bartTarget.AgentID: "" /* says nothing */},
+		draftErr: map[string]error{goblinTarget.AgentID: context.DeadlineExceeded},
+		gate:     map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: closedGate()},
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T10", Text: "Bart, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "T10" && e.Reason == voiceevent.TurnEndProviderError
+	}, "turn.ended provider_error when every draft is empty/failed")
+	if len(spk.spokeIDs()) != 0 {
+		t.Fatalf("nobody must speak when all drafts are empty; spoke = %v", spk.spokeIDs())
+	}
+	voicetest.AssertEventCount[voiceevent.EnsembleLead](t, h, 0)
+	// The floor was released (no holder).
+	if floor.Active() {
+		t.Fatal("the floor must be released after an all-empty ensemble")
+	}
+}
+
+// TestReplier_Ensemble_BothCandidatesMuted_NeverTakesFloor pins the mute pre-filter
+// (#211): when every candidate is muted the ensemble opens no turn — TurnEnded mute,
+// the floor is never taken, and no draft runs.
+func TestReplier_Ensemble_BothCandidatesMuted_NeverTakesFloor(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeEnsemble{
+		draft:   map[string]string{bartTarget.AgentID: "x", goblinTarget.AgentID: "y"},
+		started: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	replier.SetMutes(muteSet{bartTarget.AgentID: true, goblinTarget.AgentID: true})
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T11", Text: "Bart, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.AssertEvent(t, h, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "T11" && e.Reason == voiceevent.TurnEndMute
+	}, "turn.ended mute when every candidate is muted")
+	if floor.Active() {
+		t.Fatal("the floor must never be taken when every candidate is muted")
+	}
+	if len(spk.spokeIDs()) != 0 {
+		t.Fatal("no candidate may draft/speak when all are muted")
+	}
+}
+
+// TestReplier_Ensemble_NoEnsembleSpeakerDegradesToTopScored pins the degrade path:
+// an EnsembleRouted with no wired [orchestrator.EnsembleSpeaker] falls back to the
+// single-route reply path for the top-scored target (Targets[0]).
+func TestReplier_Ensemble_NoEnsembleSpeakerDegradesToTopScored(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+	var routedFor string
+	replier := orchestrator.NewStreamReplier(ttsStage, func(_ context.Context, e voiceevent.AddressRouted, dispatch func(orchestrator.Reply) error) error {
+		routedFor = e.Target.AgentID
+		return dispatch(orchestrator.Reply{Sentence: "hi"})
+	}, nil)
+	replier.SetFloor(floor)
+	// No SetEnsemble: r.ensemble stays nil → degrade.
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T-deg", Text: "Bart, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool { return e.TurnID == "T-deg" }, "single-route dispatch on degrade")
+	if routedFor != bartTarget.AgentID {
+		t.Fatalf("degrade routed to %q, want the top-scored Targets[0] Bart", routedFor)
+	}
+	voicetest.AssertEventCount[voiceevent.EnsembleLead](t, h, 0)
+}
+
+// TestConversation_WithEnsemble_RegistersLeadRace pins the PRODUCTION wiring (#301):
+// WithEnsemble installs the speaker on the replier built inside Register, sharing the
+// barge-in floor, so an EnsembleRouted runs the speculative Lead race end-to-end.
+func TestConversation_WithEnsemble_RegistersLeadRace(t *testing.T) {
+	h := voicetest.New(t)
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{})
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	spk := &fakeEnsemble{
+		draft:   map[string]string{bartTarget.AgentID: "Bart wins."},
+		gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate()},
+		spokeCh: make(chan string, 2),
+	}
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+		orchestrator.WithReplyStream(func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error { return nil }),
+		orchestrator.WithBargeInCoalesce(10*time.Millisecond, 0),
+		orchestrator.WithEnsemble(spk),
+	)
+	t.Cleanup(conv.Register(t.Context()))
+	if conv.Floor() == nil {
+		t.Fatal("Register must build the shared barge-in floor for the ensemble")
+	}
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tw", Text: "Bart, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	select {
+	case who := <-spk.spokeCh:
+		if who != bartTarget.AgentID {
+			t.Fatalf("Speak ran for %q, want the elected Lead Bart", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the registered ensemble never elected a Lead")
+	}
+	voicetest.AssertEvent(t, h, func(e voiceevent.EnsembleLead) bool {
+		return e.TurnID == "Tw" && e.Target.AgentID == bartTarget.AgentID
+	}, "ensemble.lead → Bart via the registered conversation")
+}
+
+// TestConversation_WithEnsemble_WithoutBargePanics pins that an ensemble speaker
+// wired without barge-in is a loud wiring error — an ensemble is one floor-holding
+// unit and needs the floor.
+func TestConversation_WithEnsemble_WithoutBargePanics(t *testing.T) {
+	h := voicetest.New(t)
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{})
+	sttStage := orchestrator.NewSTT(h.Bus, &recordingRecognizer{})
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{})
+
+	spk := &fakeEnsemble{}
+	conv := orchestrator.NewConversation(h.Bus, vadStage, sttStage, ttsStage,
+		orchestrator.WithReplyStream(func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error { return nil }),
+		orchestrator.WithEnsemble(spk), // no WithBargeIn
+	)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Register must panic when WithEnsemble is set without barge-in")
+		}
+	}()
+	conv.Register(t.Context())
+}

--- a/pkg/voice/orchestrator/export_test.go
+++ b/pkg/voice/orchestrator/export_test.go
@@ -40,6 +40,11 @@ func (d *DirectSpeech) SetFloor(floor *Floor) { d.floor = floor }
 // Conversation.Register from [WithTurnGate].
 func (d *DirectSpeech) SetGate(g TurnGate) { d.gate = g }
 
+// SetEnsemble installs the Ensemble Turn speaker on the replier for the ensemble
+// coordinator tests (external test package, #301). Production wiring sets
+// r.ensemble inside Conversation.Register from [WithEnsemble].
+func (r *Replier) SetEnsemble(s EnsembleSpeaker) { r.ensemble = s }
+
 // SetErrorHandler installs onError on the segmenter for the off-loop STT error
 // tests (external test package). Production wiring sets it inside
 // Conversation.Register from [WithErrorHandler].

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -197,6 +197,22 @@ func (f *Floor) YieldAgent(agentID string) (turnID string, yielded bool) {
 	return turnID, true
 }
 
+// SetHolderAgent retargets the floor's coalesce anchor and mute-cut key
+// ([Floor.holderAgent]) onto agentID, but only while turnID still holds the floor
+// (holderTurn == turnID AND a turn is held). It is the Ensemble Lead election
+// (#301, ADR-0025): the floor is Taken under the coalesce anchor Targets[0], and
+// once the speculative race elects a Lead the floor must name THAT agent so a
+// per-Agent mute cut ([Floor.YieldAgent], #211) and the coalesce window both key on
+// whoever is actually speaking. A stale turnID — a late election for a turn already
+// superseded/yielded — is a no-op, so it can never retarget a newer holder.
+func (f *Floor) SetHolderAgent(turnID, agentID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cancel != nil && f.holderTurn == turnID {
+		f.holderAgent = agentID
+	}
+}
+
 // Active reports whether a turn currently holds the floor (a turn is in flight,
 // from its [Floor.Take] until release/Yield — which spans the pre-audio LLM phase
 // as well as playback). It is a point-in-time read; callers must tolerate the

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -347,3 +347,40 @@ func TestFloor_YieldAgentOnFreeFloorReportsFalse(t *testing.T) {
 		t.Fatalf("YieldAgent on a free floor must report (\"\", false), got (%q, %v)", turnID, yielded)
 	}
 }
+
+// TestFloor_SetHolderAgentRetargetsMuteCut pins the Ensemble Lead election
+// (#301): once the Lead is chosen, the floor is retargeted from the coalesce
+// anchor (Targets[0]) onto the elected Lead, so a per-Agent mute cut
+// ([Floor.YieldAgent], #211) — and the coalesce window — name the agent actually
+// speaking. A stale turnID is a no-op (a late election for a superseded turn must
+// not retarget the current holder).
+func TestFloor_SetHolderAgentRetargetsMuteCut(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T-ens")
+	ctx, release, _ := f.Take(parent, "bart") // taken under the coalesce anchor
+	defer release()
+
+	// A mute cut for the elected Lead does nothing until the floor is retargeted.
+	if _, yielded := f.YieldAgent("mira"); yielded {
+		t.Fatal("YieldAgent(mira) must be a no-op before the floor is retargeted onto mira")
+	}
+
+	// Stale turnID: must not retarget the live holder.
+	f.SetHolderAgent("stale", "mira")
+	if _, yielded := f.YieldAgent("mira"); yielded {
+		t.Fatal("a stale-turnID SetHolderAgent must not retarget the current holder")
+	}
+
+	// Elect mira as Lead under the live turnID: now a mute cut for mira cuts it.
+	f.SetHolderAgent("T-ens", "mira")
+	turnID, yielded := f.YieldAgent("mira")
+	if !yielded {
+		t.Fatal("YieldAgent(mira) must cut the turn once the floor is retargeted onto mira")
+	}
+	if turnID != "T-ens" {
+		t.Fatalf("YieldAgent returned turnID %q, want T-ens", turnID)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("the retargeted mute cut must cancel the turn ctx")
+	}
+}

--- a/pkg/voice/orchestrator/reactor.go
+++ b/pkg/voice/orchestrator/reactor.go
@@ -899,6 +899,16 @@ type Replier struct {
 	// the mute race closure). Set only via the orchestrator wiring; not part of
 	// [NewReplier].
 	gate TurnGate
+
+	// ensemble, when non-nil, is the Ensemble Turn speaker ([WithEnsemble], #301,
+	// ADR-0025): on a [voiceevent.EnsembleRouted] the replier fans the candidates
+	// out into parallel [EnsembleSpeaker.Draft]s, races them, and lets the first
+	// complete non-empty draft (the Lead) take the floor and speak. Nil degrades an
+	// EnsembleRouted to the top-scored single route ([Replier.handleRouted]). Set
+	// only via the orchestrator wiring; not part of [NewReplier]. It requires the
+	// barge-in floor (WithEnsemble panics at Register without it) — the whole
+	// ensemble is ONE floor-holding unit.
+	ensemble EnsembleSpeaker
 }
 
 // NewReplier wires ttsStage and reply together. Both must be non-nil; passing
@@ -928,16 +938,35 @@ func NewStreamReplier(ttsStage *TTS, reply StreamReplyFunc, onError ErrorFunc) *
 	return &Replier{tts: ttsStage, replyStream: reply, onError: onError}
 }
 
-// Bind subscribes the replier to [voiceevent.AddressRouted] on bus and returns a
-// function that removes the subscription. It implements [Reactor]; bus must be
-// non-nil. Each [Reply] the [ReplyFunc] returns is dispatched in order under
-// ctx; a dispatch failure is reported through the ErrorFunc (callbacks cannot
-// return errors) and does not stop the remaining replies.
+// Bind subscribes the replier to [voiceevent.AddressRouted] AND
+// [voiceevent.EnsembleRouted] on bus and returns a function that removes both
+// subscriptions. It implements [Reactor]; bus must be non-nil. Each [Reply] the
+// [ReplyFunc] returns is dispatched in order under ctx; a dispatch failure is
+// reported through the ErrorFunc (callbacks cannot return errors) and does not stop
+// the remaining replies. An EnsembleRouted runs the speculative fan-out + Lead race
+// ([Replier.handleEnsemble], #301) when an [EnsembleSpeaker] is wired, else degrades
+// to the top-scored single route.
 func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func()) {
 	if bus == nil {
 		panic("orchestrator.Replier.Bind: bus must not be nil")
 	}
-	return voiceevent.On(bus, func(e voiceevent.AddressRouted) {
+	unsubRouted := voiceevent.On(bus, func(e voiceevent.AddressRouted) {
+		r.handleRouted(ctx, bus, e)
+	})
+	unsubEnsemble := voiceevent.On(bus, func(e voiceevent.EnsembleRouted) {
+		r.handleEnsemble(ctx, bus, e)
+	})
+	return func() {
+		unsubEnsemble()
+		unsubRouted()
+	}
+}
+
+// handleRouted runs one single-target routing decision: the pre-#301 reply-reactor
+// body, unchanged. It is a method (not an inline closure) so [Replier.handleEnsemble]
+// can degrade a one-survivor / no-ensemble-speaker EnsembleRouted onto it.
+func (r *Replier) handleRouted(ctx context.Context, bus *voiceevent.Bus, e voiceevent.AddressRouted) {
+	{
 		// Carry the turn correlation id (A3) into the dispatch context so the TTS
 		// stage and the wire tee stamp the same id on TTSInvoked / FirstAudio.
 		// Installed before the floor is taken so both the sync and barge-in
@@ -1027,7 +1056,7 @@ func (r *Replier) Bind(ctx context.Context, bus *voiceevent.Bus) (cancel func())
 				bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: reason})
 			}
 		}()
-	})
+	}
 }
 
 // dispatchAll renders one routing decision under ctx, returning the turn-end

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -170,6 +170,46 @@ type AddressRouted struct {
 // EventName implements [Event].
 func (AddressRouted) EventName() string { return "address.routed" }
 
+// EnsembleRouted marks the routing decision for one [STTFinal] utterance that
+// addressed TWO OR MORE Agents at once (ADR-0024 returns a set when
+// address.Config.MaxTargets > 1). It is the atomic Ensemble Turn signal (ADR-0025):
+// the address detector publishes exactly ONE EnsembleRouted for the whole set
+// instead of N independent [AddressRouted], so the turn-taking layer runs the set
+// as ONE floor-holding unit (speculative fan-out + Lead race) rather than N
+// contending turns. A single-target utterance still publishes a plain
+// [AddressRouted] — the byte-identical MaxTargets=1 default, where the ensemble
+// branch is dead code.
+//
+// Targets are the post-GM-gate survivors in the matcher's score-sorted order
+// (Targets[0] is the top-scored), and len(Targets) >= 2 by construction. Text and
+// TurnID mirror [AddressRouted]: the utterance text and the correlation id copied
+// from the originating [STTFinal] (A3).
+type EnsembleRouted struct {
+	At      time.Time
+	Text    string
+	TurnID  string
+	Targets []AddressTarget
+}
+
+// EventName implements [Event].
+func (EnsembleRouted) EventName() string { return "address.ensemble" }
+
+// EnsembleLead marks the Agent the speculative race elected as the Ensemble Turn's
+// Lead (ADR-0025, #301): the first candidate to finish a complete, non-empty draft
+// takes the floor and speaks under the ensemble's ORIGINAL TurnID. It is published
+// the moment the Lead is chosen, before its first sentence dispatches, so the
+// transcript relay attributes the turn's line to the winning Agent (exactly as
+// [AddressRouted] does for a single-target turn). The losing candidates' drafts are
+// discarded (ADR-0012 — a loser commits nothing); their Reactions are #302.
+type EnsembleLead struct {
+	At     time.Time
+	TurnID string
+	Target AddressTarget
+}
+
+// EventName implements [Event].
+func (EnsembleLead) EventName() string { return "ensemble.lead" }
+
 // SpeakRequested marks a GM-puppeteered direct-speech request: the `/say <text>
 // as:<agent>` slash command (ADR-0010, #295) asks an Agent to speak Text verbatim,
 // bypassing Address Detection and the LLM Replier entirely (ADR-0024 — /say is the


### PR DESCRIPTION
Closes #301

## What
Part 1 of ADR-0025's deferred design-of-record: when Address Detection returns 2+ Agents (matcher `MaxTargets > 1`), run their generations in parallel and let the fastest complete draft — the **Lead** — take the floor and speak. Losers' drafts are discarded (Reactions are #302). One Barge-in tears the whole unit down.

Implements the architect's `PLAN: #301` verbatim — interfaces `EnsembleRouted`/`EnsembleLead`/`EnsembleSpeaker`/`WithEnsemble`/`SetHolderAgent`/`Draft`/`SpeakDraft` pinned unchanged for #302 to build on.

## How (TDD, red→green per slice)
- **voiceevent** — `EnsembleRouted` (`address.ensemble`), `EnsembleLead` (`ensemble.lead`).
- **detector (address.go)** — collect GM-gate survivors; `len==1` → plain `AddressRouted` (byte-identical), `len>1` → ONE `EnsembleRouted` (score-sorted), `len==0` → nothing.
- **orchestrator/ensemble.go (new)** — `EnsembleSpeaker` seam + `handleEnsemble` (mute pre-filter, degrade, spend-cap, `Floor.Take` coalesce fold, post-Take mute re-filter) + `runEnsemble` (draftCtx child of turnCtx, N goroutines → **buffered** results chan, first complete non-empty draft wins, publish `EnsembleLead`, `SetHolderAgent`, cancel losers, `Speak` under turnCtx with dispatchStream-mirrored deliver-then-commit).
- **floor.go** — `SetHolderAgent(turnID, agentID)` retargets coalesce anchor + mute-cut onto the elected Lead (stale turnID = no-op).
- **agent** — `Replier.Draft` (PURE: history snapshot, no mutation — ADR-0012 losers commit nothing) + `Replier.SpeakDraft` (appends user msg, sentence-split, delivered-only commit); `Cast` implements `EnsembleSpeaker`.
- **conversation.go** — `WithEnsemble` (panics at Register without `WithBargeIn`/`WithBargeInCoalesce` — an ensemble is one floor-holding unit).
- **relay.go** — `EnsembleLead` attributes the Lead's coalescing line. **subscriber.go** — `EnsembleRouted` stage-mark mirrors `AddressRouted`.

Timing determinism via gate-engine test fakes (Draft blocks on a chan; the winner's gate is released, the loser's never) — **no sleeps, no replay-speed dependence** (ADR-0021).

## Acceptance criteria
- [x] `MaxTargets > 1`, one utterance → two NPCs → exactly one spoken response (the faster, cassette/gate-controlled)
- [x] Loser drafts fully discarded — no side effects, no transcript lines (ADR-0012)
- [x] Barge-in during the Lead cancels the entire ensemble turn (ADR-0027)
- [x] Default `MaxTargets 1` byte-identical; all existing cassettes/tests green (full `./...` green)

## Reviewer flags
- **Two existing tests rewritten** to the atomic-set contract (a multi-Agent decision publishes ONE `EnsembleRouted`, not N `AddressRouted`): `TestScoringMatcher_Ensemble_PublishesEveryTarget` → `_PublishesOneEnsembleRouted`, and `TestAddressDetector_PublishesEveryDecision` → `_MultiDecisionPublishesOneEnsembleRouted`. The #301 contract supersedes them.
- **No new LLM cassette required** — the Lead race is decided by test-injected gate engines supplying ORDER; cassettes supply TEXT. If review demands a React-prompt cassette it needs a user `-tags=record` run.
- **`-tags=record` caveat**: recording a live race would truncate loser cassettes. These tests use gated fakes, so the record path is unused here.
- **Production is not wired to enable ensembles** — `MaxTargets` stays a code-level `address.Config` field defaulting to 1 (ADR-0038); no operator toggle ships. The seam is exercised directly by tests; flipping the default is a future product call. `wirenpc`/`Roster` untouched.

## Verification
Full `go test ./...` green; `go test -race ./pkg/voice/orchestrator ./pkg/voice/agent` green; `golangci-lint run` clean on touched packages; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)