### PR TITLE
feat(#291): [E6] campaign bundle importer part 1 — domain grains, ID remap, Butler merge

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -780,8 +780,8 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 	// The campaign-bundle transport (#290, ADR-0053) is a PLAIN net/http mount
 	// beside the SSE relay, not a Connect service (ADR-0015): a streamed gzip
 	// download does not fit Connect's message model. Operator-only via
-	// auth.RequireSession, the same gate the relay reads (ADR-0041). #291 adds the
-	// POST import mount here next.
+	// auth.RequireSession, the same gate the relay reads (ADR-0041). The GET export
+	// (#290) and the POST import (#291) share this handler.
 	bundleHandler := &bundle.Handler{Store: store, Log: log}
 
 	return []web.Mount{
@@ -799,6 +799,11 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
 		// Campaign bundle export (#290): streamed gzip download, operator-gated.
 		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, http.HandlerFunc(bundleHandler.ServeExport))},
+		// Campaign bundle import (#291): multipart upload, operator-gated, plus the
+		// plain-HTTP CSRF double-submit (ADR-0016) the SPA satisfies with the
+		// script-readable glyphoxa_csrf cookie — a state-changing POST outside the
+		// Connect chain needs it (RequireSession alone gates only the session).
+		{Path: "POST /api/v1/campaigns/import", Handler: auth.RequireSession(store, auth.RequireCSRF(http.HandlerFunc(bundleHandler.ServeImport)))},
 		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
 		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,17 +1,24 @@
 package auth
 
-import "net/http"
+import (
+	"crypto/subtle"
+	"net/http"
+)
 
 // RequireSession is the net/http guard for the plain (non-Connect) read
-// endpoints — the SSE transcript relay and its snapshot (ADR-0014 Hop-B). Those
-// handlers live OUTSIDE the Connect interceptor chain ([NewAuthInterceptor]), so
-// they would be unauthenticated without this. It mirrors the interceptor's gate:
-// the glyphoxa_session cookie must resolve to an operator via [Authenticator],
-// else the request is rejected 401.
+// endpoints — the SSE transcript relay and its snapshot (ADR-0014 Hop-B) — and
+// the plain import POST (#291). Those handlers live OUTSIDE the Connect
+// interceptor chain ([NewAuthInterceptor]), so they would be unauthenticated
+// without this. It mirrors the interceptor's gate: the glyphoxa_session cookie
+// must resolve to an operator via [Authenticator], else the request is rejected
+// 401. On success it injects the resolved operator into the request context
+// ([CurrentUser]) — a pure addition mirroring the interceptor's WithUser, so a
+// downstream handler (ServeImport) resolves the tenant off the session; the relay
+// handlers that ignore it are unaffected.
 //
 // EventSource and same-origin fetch send the cookie automatically, so no custom
-// header is needed; both are GET reads, so there is no CSRF check (ADR-0016
-// exempts NO_SIDE_EFFECTS reads).
+// header is needed; GET reads need no CSRF check (ADR-0016 exempts NO_SIDE_EFFECTS
+// reads). A state-changing POST additionally wraps in [RequireCSRF].
 func RequireSession(a Authenticator, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := cookieValue(r.Header, SessionCookieName)
@@ -19,8 +26,29 @@ func RequireSession(a Authenticator, next http.Handler) http.Handler {
 			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
 		}
-		if _, err := a.AuthenticateSession(r.Context(), token); err != nil {
+		u, err := a.AuthenticateSession(r.Context(), token)
+		if err != nil {
 			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(WithUser(r.Context(), u)))
+	})
+}
+
+// RequireCSRF is the plain-HTTP double-submit CSRF guard (ADR-0016): the mirror
+// of [NewCSRFInterceptor] for a state-changing net/http POST that bypasses the
+// Connect chain (the import upload). The glyphoxa_csrf cookie must
+// constant-time-match the X-CSRF-Token header, else 403. RequireSession alone is
+// insufficient — a same-origin cookie rides along on a cross-site POST, so the
+// header the SPA sets from the script-readable cookie is what proves intent.
+// Compose it INSIDE RequireSession (auth first, then anti-forgery).
+func RequireCSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := cookieValue(r.Header, CSRFCookieName)
+		header := r.Header.Get("X-CSRF-Token")
+		if cookie == "" || header == "" ||
+			subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
+			http.Error(w, "CSRF token mismatch", http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -58,6 +58,88 @@ func TestRequireSession_InvalidCookie401(t *testing.T) {
 	}
 }
 
+// TestRequireSession_InjectsUser proves the guard now puts the resolved operator
+// into the request context (a pure addition — the relay handlers that ignore it
+// are unaffected), so a downstream plain handler (ServeImport) can read the
+// tenant off the session without re-authenticating.
+func TestRequireSession_InjectsUser(t *testing.T) {
+	want := storage.User{ID: uuid.New(), Name: "op", Role: "operator"}
+	authN := fakeAuthN{users: map[string]storage.User{validToken: want}}
+
+	var got storage.User
+	var ok bool
+	h := auth.RequireSession(authN, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got, ok = auth.CurrentUser(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/campaigns/import", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: validToken})
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !ok {
+		t.Fatal("no user injected into ctx")
+	}
+	if got.ID != want.ID {
+		t.Fatalf("user ID = %s, want %s", got.ID, want.ID)
+	}
+}
+
+// TestRequireCSRF drives the plain-HTTP double-submit mirror of the Connect CSRF
+// interceptor (ADR-0016): the glyphoxa_csrf cookie must constant-time-match the
+// X-CSRF-Token header, else 403; RequireSession alone does not gate a plain POST.
+func TestRequireCSRF(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("served"))
+	})
+	guard := auth.RequireCSRF(ok)
+
+	newReq := func() *http.Request {
+		return httptest.NewRequest(http.MethodPost, "/api/v1/campaigns/import", nil)
+	}
+
+	t.Run("match passes", func(t *testing.T) {
+		req := newReq()
+		req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: "tok123"})
+		req.Header.Set("X-CSRF-Token", "tok123")
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK || rec.Body.String() != "served" {
+			t.Fatalf("match: code=%d body=%q", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("mismatch is 403", func(t *testing.T) {
+		req := newReq()
+		req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: "tok123"})
+		req.Header.Set("X-CSRF-Token", "other")
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("mismatch: code=%d, want 403", rec.Code)
+		}
+	})
+
+	t.Run("missing header is 403", func(t *testing.T) {
+		req := newReq()
+		req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: "tok123"})
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("missing header: code=%d, want 403", rec.Code)
+		}
+	})
+
+	t.Run("missing cookie is 403", func(t *testing.T) {
+		req := newReq()
+		req.Header.Set("X-CSRF-Token", "tok123")
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("missing cookie: code=%d, want 403", rec.Code)
+		}
+	})
+}
+
 // guard against an accidentally-blocking next call: ensure the downstream
 // handler is never invoked without auth.
 func TestRequireSession_DoesNotCallNextUnauthed(t *testing.T) {

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -72,6 +75,120 @@ func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
 		// logged — the client sees a truncated download and retries.
 		h.logError("encode bundle", err)
 	}
+}
+
+// importResponse is the ServeImport 200 body: the minted campaign identity plus
+// the per-section counts the UI surfaces ("Imported <name>"). Part 1 always
+// reports zero sessions/lines/chunks (History is part 2, #292).
+type importResponse struct {
+	CampaignID string `json:"campaign_id"`
+	Name       string `json:"name"`
+	Agents     int    `json:"agents"`
+	Nodes      int    `json:"nodes"`
+	Edges      int    `json:"edges"`
+	Characters int    `json:"characters"`
+	Sessions   int    `json:"sessions"`
+	Lines      int    `json:"lines"`
+	Chunks     int    `json:"chunks"`
+}
+
+// ServeImport ingests an uploaded campaign bundle: POST /api/v1/campaigns/import,
+// multipart form field "bundle". The mount wraps it in auth.RequireSession (401
+// gate + operator injected) THEN auth.RequireCSRF (403 double-submit, ADR-0016) —
+// this handler assumes both have passed and reads the operator from the context.
+//
+// The request body is capped by http.MaxBytesReader at [blob.MaxSize] (ADR-0048's
+// 32 MiB constant used purely as a request cap — blob.Store is NOT involved, the
+// bundle never lands in object storage) BEFORE anything reads it, so an oversized
+// upload is a clean 413 rather than an OOM. A malformed bundle or a newer/older
+// unsupported format_version is 400 with a message naming both versions
+// (ADR-0053 §7); the import runs SYNCHRONOUSLY (ADR-0049, no job row) and does NOT
+// auto-activate the imported campaign (ADR-0053 §7 — the UI offers the switch).
+func (h *Handler) ServeImport(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, blob.MaxSize)
+
+	file, _, err := r.FormFile("bundle")
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "bundle exceeds maximum upload size", http.StatusRequestEntityTooLarge)
+			return
+		}
+		writeImportError(w, http.StatusBadRequest, "missing or invalid bundle upload")
+		return
+	}
+	defer file.Close()
+
+	b, err := Decode(file)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "bundle exceeds maximum upload size", http.StatusRequestEntityTooLarge)
+			return
+		}
+		// Decode already wraps ErrNewerFormat/ErrUnsupportedFormat with a message
+		// naming both versions; a plain parse failure is an opaque bad request.
+		writeImportError(w, http.StatusBadRequest, importErrorMessage(err))
+		return
+	}
+
+	u, ok := auth.CurrentUser(r.Context())
+	if !ok {
+		// RequireSession injects the operator, so a miss is a wiring bug, not a
+		// client error.
+		h.logError("no operator in import context", errors.New("missing user"))
+		http.Error(w, "import failed", http.StatusInternalServerError)
+		return
+	}
+	tenantID, err := h.Store.TenantForUser(r.Context(), u.ID)
+	if err != nil {
+		h.logError("resolve tenant for import", err)
+		http.Error(w, "import failed", http.StatusInternalServerError)
+		return
+	}
+
+	res, err := Import(r.Context(), h.Store, tenantID, b)
+	if err != nil {
+		if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) {
+			writeImportError(w, http.StatusBadRequest, importErrorMessage(err))
+			return
+		}
+		h.logError("import bundle", err)
+		http.Error(w, "import failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(importResponse{
+		CampaignID: res.CampaignID.String(),
+		Name:       res.Name,
+		Agents:     res.Agents,
+		Nodes:      res.Nodes,
+		Edges:      res.Edges,
+		Characters: res.Characters,
+		Sessions:   res.Sessions,
+		Lines:      res.Lines,
+		Chunks:     res.Chunks,
+	})
+}
+
+// importErrorMessage surfaces the version-refusal message (which names both
+// versions) verbatim to the client, but keeps any other decode failure opaque so
+// an internal error string never leaks through the 400 body.
+func importErrorMessage(err error) string {
+	if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) {
+		return err.Error()
+	}
+	return "invalid campaign bundle"
+}
+
+// writeImportError writes a JSON {"error": ...} body with the given status — the
+// shape the web upload path reads for its failure toast.
+func writeImportError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 func (h *Handler) logError(msg string, err error) {

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -121,13 +121,10 @@ func (h *Handler) ServeImport(w http.ResponseWriter, r *http.Request) {
 
 	b, err := Decode(file)
 	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			http.Error(w, "bundle exceeds maximum upload size", http.StatusRequestEntityTooLarge)
-			return
-		}
-		// Decode already wraps ErrNewerFormat/ErrUnsupportedFormat with a message
-		// naming both versions; a plain parse failure is an opaque bad request.
+		// The size cap surfaces at FormFile above (it reads the multipart body), so
+		// Decode never sees a MaxBytesError. Decode already wraps
+		// ErrNewerFormat/ErrUnsupportedFormat with a message naming both versions;
+		// a plain parse failure is an opaque bad request.
 		writeImportError(w, http.StatusBadRequest, importErrorMessage(err))
 		return
 	}

--- a/internal/bundle/handler_import_test.go
+++ b/internal/bundle/handler_import_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package bundle_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fixedAuthN authenticates one token to one specific operator, so the import
+// mount's tenant resolution (TenantForUser) has a real user to key off.
+type fixedAuthN struct {
+	token string
+	user  storage.User
+}
+
+func (f fixedAuthN) AuthenticateSession(_ context.Context, token string) (storage.User, error) {
+	if token == f.token {
+		return f.user, nil
+	}
+	return storage.User{}, storage.ErrNotFound
+}
+
+// importRoute mounts ServeImport exactly as cmd/glyphoxa/main.go does — behind
+// auth.RequireSession THEN auth.RequireCSRF on POST /api/v1/campaigns/import.
+func importRoute(st *storage.Store, authN auth.Authenticator) http.Handler {
+	h := &bundle.Handler{Store: st}
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/campaigns/import",
+		auth.RequireSession(authN, auth.RequireCSRF(http.HandlerFunc(h.ServeImport))))
+	return mux
+}
+
+// operatorStore migrates a fresh DB, creates an operator user + bound tenant, and
+// returns the store, the user, and the tenant id.
+func operatorStore(t *testing.T) (*storage.Store, storage.User, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	st := storage.New(migratedPool(t))
+	user, err := st.UpsertUser(ctx, storage.UpsertUserParams{DiscordUserID: "op-1", Name: "Operator"})
+	if err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	tenant, err := st.ResolveOperatorTenant(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ResolveOperatorTenant: %v", err)
+	}
+	return st, user, tenant.ID
+}
+
+// multipartBundle builds a POST body carrying raw as the "bundle" file field and
+// returns the body plus the multipart Content-Type.
+func multipartBundle(t *testing.T, raw []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("bundle", "campaign.glyphoxa.json.gz")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(raw); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}
+
+// encodeBundle gzip-encodes a bundle to bytes for upload.
+func encodeBundle(t *testing.T, b *bundle.Bundle) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := bundle.Encode(&buf, b); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+const (
+	importToken = "valid-session-token"
+	importCSRF  = "csrf-token-123"
+)
+
+// authedImport builds a POST /api/v1/campaigns/import request with the session
+// cookie, the CSRF cookie, and the matching X-CSRF-Token header.
+func authedImport(t *testing.T, body io.Reader, contentType string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/campaigns/import", body)
+	req.Header.Set("Content-Type", contentType)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: importToken})
+	req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: importCSRF})
+	req.Header.Set("X-CSRF-Token", importCSRF)
+	return req
+}
+
+func TestServeImport(t *testing.T) {
+	ctx := context.Background()
+	st, user, tenantID := operatorStore(t)
+	route := importRoute(st, fixedAuthN{token: importToken, user: user})
+
+	good := encodeBundle(t, &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign:      bundle.Campaign{Name: "Uploaded Campaign", System: "dnd5e", Language: "en"},
+	})
+
+	t.Run("no cookie is 401", func(t *testing.T) {
+		body, ct := multipartBundle(t, good)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/campaigns/import", body)
+		req.Header.Set("Content-Type", ct)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("code=%d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("CSRF mismatch is 403", func(t *testing.T) {
+		body, ct := multipartBundle(t, good)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/campaigns/import", body)
+		req.Header.Set("Content-Type", ct)
+		req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: importToken})
+		req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: importCSRF})
+		req.Header.Set("X-CSRF-Token", "wrong")
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("code=%d, want 403", rec.Code)
+		}
+	})
+
+	t.Run("oversized upload is 413", func(t *testing.T) {
+		huge := make([]byte, (32<<20)+4096) // > blob.MaxSize
+		body, ct := multipartBundle(t, huge)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authedImport(t, body, ct))
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("code=%d, want 413", rec.Code)
+		}
+	})
+
+	t.Run("newer version is 400 naming both versions", func(t *testing.T) {
+		newer := encodeBundle(t, &bundle.Bundle{
+			FormatVersion: bundle.FormatVersion + 1,
+			Campaign:      bundle.Campaign{Name: "Future", System: "dnd5e", Language: "en"},
+		})
+		body, ct := multipartBundle(t, newer)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authedImport(t, body, ct))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("code=%d, want 400", rec.Code)
+		}
+		var payload struct {
+			Error string `json:"error"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode error body: %v", err)
+		}
+		want := strconv.Itoa(bundle.FormatVersion + 1)
+		if !strings.Contains(payload.Error, want) || !strings.Contains(payload.Error, strconv.Itoa(bundle.FormatVersion)) {
+			t.Errorf("error %q does not name both versions", payload.Error)
+		}
+	})
+
+	t.Run("valid upload is 200 with counts and resolves tenant", func(t *testing.T) {
+		body, ct := multipartBundle(t, good)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authedImport(t, body, ct))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d body=%q, want 200", rec.Code, rec.Body.String())
+		}
+		var payload struct {
+			CampaignID string `json:"campaign_id"`
+			Name       string `json:"name"`
+			Sessions   int    `json:"sessions"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode 200 body: %v", err)
+		}
+		if payload.Name != "Uploaded Campaign" || payload.CampaignID == "" {
+			t.Fatalf("payload = %+v", payload)
+		}
+		if payload.Sessions != 0 {
+			t.Errorf("part-1 reported sessions=%d, want 0", payload.Sessions)
+		}
+		// The campaign landed under the operator's tenant (tenant resolved from the
+		// session user, not a client header).
+		if _, err := st.FindCampaignByName(ctx, tenantID, "Uploaded Campaign"); err != nil {
+			t.Fatalf("imported campaign not found under operator tenant: %v", err)
+		}
+	})
+}

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -93,9 +93,20 @@ func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *B
 	}
 	res.CampaignID = campaignID
 
+	butlerSeen := false
 	for i := range b.Campaign.Agents {
 		a := &b.Campaign.Agents[i]
+		if _, dup := res.AgentIDs[a.ID]; dup {
+			return fmt.Errorf("bundle: import: duplicate agent ref %q", a.ID)
+		}
 		if a.Role == string(storage.AgentRoleButler) {
+			if butlerSeen {
+				// A Campaign has exactly one Butler (ADR-0009, types.go): a second in
+				// the bundle would last-wins-overwrite the first and lie in the counts,
+				// so it is a hard error that rolls the import back.
+				return fmt.Errorf("bundle: import: more than one butler in bundle")
+			}
+			butlerSeen = true
 			if err := mergeButler(ctx, tx, campaignID, a, res); err != nil {
 				return err
 			}
@@ -109,6 +120,11 @@ func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *B
 	nodeIDs := make(map[string]uuid.UUID, len(b.Campaign.Nodes))
 	for i := range b.Campaign.Nodes {
 		n := &b.Campaign.Nodes[i]
+		if _, dup := nodeIDs[n.ID]; dup {
+			// Two nodes sharing a ref key would clobber the remap, binding edges/links
+			// to the wrong node — same all-or-nothing discipline as an unknown ref.
+			return fmt.Errorf("bundle: import: duplicate node ref %q", n.ID)
+		}
 		created, err := tx.CreateNode(ctx, storage.NewKGNode{
 			CampaignID: campaignID,
 			Type:       storage.KGNodeType(n.Type),

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -1,0 +1,271 @@
+package bundle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// ImportResult reports what an [Import] persisted. AgentIDs maps each bundle
+// agent ref key to the minted (or, for the Butler, the trigger-created) Agent id;
+// part 1 fills it and part 2 (#292) consumes it IN-FUNCTION to remap a Chunk's
+// participated_agent_ids. The int counts feed the ServeImport JSON response.
+// DroppedParticipantRefs counts unmappable chunk participant refs (part 2 only);
+// it is always zero here.
+type ImportResult struct {
+	CampaignID uuid.UUID
+	Name       string
+	// AgentIDs remaps bundle agent ref -> minted id (Butler ref -> the merged row).
+	AgentIDs               map[string]uuid.UUID
+	Agents                 int
+	Nodes                  int
+	Edges                  int
+	Characters             int
+	Sessions               int
+	Lines                  int
+	Chunks                 int
+	DroppedParticipantRefs int
+}
+
+// Import ingests a [Bundle] into a fresh Campaign under tenantID, in ONE
+// transaction (ADR-0049 synchronous; ADR-0053 §4/§5/§7). It mints fresh UUIDs for
+// every entity and remaps intra-bundle references, so the same bundle imported
+// twice yields two independent Campaigns (ADR-0053 §4: idempotent re-import is a
+// non-goal). Any unknown cross-reference (a node's agent link, an edge endpoint)
+// is a hard error that rolls the whole import back — a bundle is all-or-nothing.
+//
+// The compatibility gate runs FIRST (ADR-0053 §7): a newer or unsupported
+// format_version is refused with a message naming both versions, before any DB
+// work. Provider bindings are never imported — the exporter stripped them
+// (ADR-0053 §2), and every Agent lands with NULL provider FKs (the tenant-level
+// fallback in wirenpc tolerates that, resolving providers per tenant). Voice is
+// validated through the canonical [storage.VoiceFromJSON] before insert so a
+// malformed voice fails loudly, never becomes a silent NPC (#224).
+//
+// Butler merge (ADR-0009): CreateCampaign fires the auto-Butler trigger, which
+// inserts the campaign's Butler plus its default dice grant; a partial unique
+// index forbids a second Butler. So when the bundle carries a Butler this UPDATEs
+// the trigger-created row (name/title/persona/voice/aliases) and REPLACES its
+// grants exactly — deleting every trigger grant (including dice) then creating one
+// per bundle grant. With no Butler in the bundle the trigger defaults stand. The
+// Butler's address_only stays pinned true by the storage layer (ADR-0024).
+//
+// History (Voice Sessions + Transcript Lines/Chunks) is tolerated but UNTOUCHED
+// in part 1: a bundle carrying a History section imports its domain grains fine
+// and leaves Sessions/Lines/Chunks at zero. Part 2 (#292) fills them in the same
+// transaction.
+func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundle) (ImportResult, error) {
+	if err := CheckVersion(b.FormatVersion); err != nil {
+		return ImportResult{}, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
+			b.FormatVersion, FormatVersion, err)
+	}
+
+	res := ImportResult{
+		Name:     b.Campaign.Name,
+		AgentIDs: make(map[string]uuid.UUID),
+	}
+
+	err := st.InTx(ctx, func(tx *storage.Store) error {
+		return importInTx(ctx, tx, tenantID, b, &res)
+	})
+	if err != nil {
+		return ImportResult{}, err
+	}
+	return res, nil
+}
+
+// importInTx runs the whole ingest against a tx-bound Store (see [Import]). It is
+// split out so the transaction body reads top-to-bottom: campaign → Butler merge
+// → character Agents → Nodes → node↔Agent links → Edges → Characters. Every step
+// records or consumes the ref→id remaps in res.AgentIDs and a local node map.
+func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *Bundle, res *ImportResult) error {
+	campaignID, err := tx.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID,
+		Name:     b.Campaign.Name,
+		System:   b.Campaign.System,
+		Language: b.Campaign.Language,
+	})
+	if err != nil {
+		return fmt.Errorf("bundle: import: create campaign: %w", err)
+	}
+	res.CampaignID = campaignID
+
+	for i := range b.Campaign.Agents {
+		a := &b.Campaign.Agents[i]
+		if a.Role == string(storage.AgentRoleButler) {
+			if err := mergeButler(ctx, tx, campaignID, a, res); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := createCharacterAgent(ctx, tx, campaignID, a, res); err != nil {
+			return err
+		}
+	}
+
+	nodeIDs := make(map[string]uuid.UUID, len(b.Campaign.Nodes))
+	for i := range b.Campaign.Nodes {
+		n := &b.Campaign.Nodes[i]
+		created, err := tx.CreateNode(ctx, storage.NewKGNode{
+			CampaignID: campaignID,
+			Type:       storage.KGNodeType(n.Type),
+			Name:       n.Name,
+			Body:       n.Body,
+			GMPrivate:  n.GMPrivate,
+		})
+		if err != nil {
+			return fmt.Errorf("bundle: import: create node %q: %w", n.Name, err)
+		}
+		nodeIDs[n.ID] = created.ID
+		res.Nodes++
+
+		if n.AgentID != "" {
+			agentID, ok := res.AgentIDs[n.AgentID]
+			if !ok {
+				return fmt.Errorf("bundle: import: node %q references unknown agent %q", n.Name, n.AgentID)
+			}
+			if _, err := tx.SetNodeAgent(ctx, campaignID, created.ID,
+				uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
+				return fmt.Errorf("bundle: import: link node %q to agent: %w", n.Name, err)
+			}
+		}
+	}
+
+	for i := range b.Campaign.Edges {
+		e := &b.Campaign.Edges[i]
+		from, ok := nodeIDs[e.From]
+		if !ok {
+			return fmt.Errorf("bundle: import: edge references unknown from-node %q", e.From)
+		}
+		to, ok := nodeIDs[e.To]
+		if !ok {
+			return fmt.Errorf("bundle: import: edge references unknown to-node %q", e.To)
+		}
+		if _, err := tx.CreateEdge(ctx, storage.NewKGEdge{
+			CampaignID: campaignID,
+			FromNodeID: from,
+			ToNodeID:   to,
+			Type:       storage.KGEdgeType(e.Type),
+		}); err != nil {
+			return fmt.Errorf("bundle: import: create edge %s->%s: %w", e.From, e.To, err)
+		}
+		res.Edges++
+	}
+
+	for i := range b.Campaign.Characters {
+		c := &b.Campaign.Characters[i]
+		if _, err := tx.CreateCharacter(ctx, storage.NewCharacter{
+			CampaignID:    campaignID,
+			Name:          c.Name,
+			Aliases:       c.Aliases,
+			DiscordUserID: c.DiscordUserID,
+		}); err != nil {
+			return fmt.Errorf("bundle: import: create character %q: %w", c.Name, err)
+		}
+		res.Characters++
+	}
+
+	// History is part 2 (#292): its presence is tolerated, its rows are left for
+	// the next slice. Counts stay zero here.
+
+	return nil
+}
+
+// mergeButler UPDATEs the trigger-created Butler from the bundle's Butler and
+// replaces its Tool Grants exactly (ADR-0009 §5): the trigger already inserted the
+// Butler + its default dice grant, so a second insert is impossible. Provider FKs
+// are nulled (secrets never travel in a bundle, ADR-0053 §2); address_only is left
+// to the storage layer, which force-keeps a Butler's true (ADR-0024). The Butler
+// ref is recorded in AgentIDs so a node could link to it if the bundle so wires.
+func mergeButler(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
+	butler, err := tx.GetButler(ctx, campaignID)
+	if err != nil {
+		return fmt.Errorf("bundle: import: get trigger-created butler: %w", err)
+	}
+	if _, err := storage.VoiceFromJSON(a.Voice); err != nil {
+		return fmt.Errorf("bundle: import: butler voice: %w", err)
+	}
+	if _, err := tx.UpdateAgent(ctx, storage.AgentUpdate{
+		ID:                    butler.ID,
+		CampaignID:            campaignID,
+		Name:                  a.Name,
+		Title:                 a.Title,
+		Persona:               a.Persona,
+		Voice:                 a.Voice,
+		VoiceProviderConfigID: uuid.NullUUID{},
+		LLMProviderConfigID:   uuid.NullUUID{},
+		AddressOnly:           a.AddressOnly,
+		Aliases:               a.Aliases,
+	}); err != nil {
+		return fmt.Errorf("bundle: import: merge butler: %w", err)
+	}
+
+	// Replace grants exactly: delete every existing grant (incl. the trigger's
+	// dice) then create one per bundle grant. This is how a Butler that was
+	// re-scoped in the source (dice removed, another tool added) round-trips
+	// without the trigger default lingering or duplicating.
+	existing, err := tx.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		return fmt.Errorf("bundle: import: list butler grants: %w", err)
+	}
+	for _, g := range existing {
+		if err := tx.DeleteToolGrant(ctx, butler.ID, g.ToolName); err != nil {
+			return fmt.Errorf("bundle: import: delete butler grant %q: %w", g.ToolName, err)
+		}
+	}
+	if err := createGrants(ctx, tx, butler.ID, a.Grants); err != nil {
+		return err
+	}
+
+	res.AgentIDs[a.ID] = butler.ID
+	res.Agents++
+	return nil
+}
+
+// createCharacterAgent inserts one Character NPC Agent with NULL provider FKs and
+// its Tool Grants, recording the ref→id remap. Speaker-colour slot assignment is
+// server-side and depends on bundle order (deterministic).
+func createCharacterAgent(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
+	if _, err := storage.VoiceFromJSON(a.Voice); err != nil {
+		return fmt.Errorf("bundle: import: agent %q voice: %w", a.Name, err)
+	}
+	agentID, err := tx.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:            campaignID,
+		Role:                  storage.AgentRoleCharacter,
+		Name:                  a.Name,
+		Title:                 a.Title,
+		Persona:               a.Persona,
+		Voice:                 a.Voice,
+		VoiceProviderConfigID: uuid.NullUUID{},
+		LLMProviderConfigID:   uuid.NullUUID{},
+		AddressOnly:           a.AddressOnly,
+		Aliases:               a.Aliases,
+	})
+	if err != nil {
+		return fmt.Errorf("bundle: import: create agent %q: %w", a.Name, err)
+	}
+	if err := createGrants(ctx, tx, agentID, a.Grants); err != nil {
+		return err
+	}
+	res.AgentIDs[a.ID] = agentID
+	res.Agents++
+	return nil
+}
+
+// createGrants creates one Tool Grant per bundle grant for an Agent, carrying the
+// scope Config verbatim (nil when the grant narrows nothing, e.g. dice).
+func createGrants(ctx context.Context, tx *storage.Store, agentID uuid.UUID, grants []Grant) error {
+	for _, g := range grants {
+		if _, err := tx.CreateToolGrant(ctx, storage.NewToolGrant{
+			AgentID:  agentID,
+			ToolName: g.ToolName,
+			Config:   g.Config,
+		}); err != nil {
+			return fmt.Errorf("bundle: import: create grant %q: %w", g.ToolName, err)
+		}
+	}
+	return nil
+}

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -1,0 +1,332 @@
+//go:build integration
+
+package bundle_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// freshTenant migrates a new DB and returns a Store + a fresh tenant to import
+// into — the "second database" the round-trip acceptance criterion demands.
+func freshTenant(t *testing.T) (*storage.Store, uuid.UUID) {
+	t.Helper()
+	pool := migratedPool(t)
+	st := storage.New(pool)
+	tid, err := st.CreateTenant(context.Background(), "Import Target")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	return st, tid
+}
+
+// TestImportRefusesNewerVersion is TEST 3: a bundle written by a newer build is
+// refused (ErrNewerFormat) before any DB work — no campaign lands.
+func TestImportRefusesNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion + 1,
+		Campaign:      bundle.Campaign{Name: "From The Future", System: "dnd5e", Language: "en"},
+	}
+	_, err := bundle.Import(ctx, st, tid, b)
+	if !errors.Is(err, bundle.ErrNewerFormat) {
+		t.Fatalf("Import err = %v, want ErrNewerFormat", err)
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "From The Future"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("refused import still wrote a campaign: %v", err)
+	}
+}
+
+// TestImportMinimalCampaign is TEST 4: a hand-written campaign-only bundle creates
+// the campaign row and the trigger-created Butler with its default dice grant.
+func TestImportMinimalCampaign(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign:      bundle.Campaign{Name: "Bare Campaign", System: "dnd5e", Language: "en"},
+	}
+	res, err := bundle.Import(ctx, st, tid, b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.CampaignID == uuid.Nil {
+		t.Fatal("result CampaignID unset")
+	}
+	if res.Name != "Bare Campaign" {
+		t.Errorf("result Name = %q", res.Name)
+	}
+
+	butler, err := st.GetButler(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	grants, err := st.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	if len(grants) != 1 || grants[0].ToolName != "dice" {
+		t.Fatalf("trigger butler grants = %+v, want single dice", grants)
+	}
+}
+
+// TestImportButlerMerge is TEST 5: a bundle Butler with persona/voice/grants
+// produces exactly ONE Butler row, its editable fields UPDATEd, its grants equal
+// to the bundle's exactly (the trigger dice replaced, not duplicated),
+// address_only pinned true, and provider FKs NULL.
+func TestImportButlerMerge(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	voice := json.RawMessage(`{"ProviderID":"elevenlabs","VoiceID":"butler-voice","Name":"Jeeves"}`)
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Butler Merge", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{{
+				ID: "butler-ref", Role: "butler", Name: "Alfred", Title: "The Butler",
+				Persona: "Impeccably dry.", Voice: voice, AddressOnly: true,
+				Aliases: []string{"Al"},
+				Grants:  []bundle.Grant{{ToolName: "rules_lookup"}},
+			}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Agents != 1 {
+		t.Errorf("result Agents = %d, want 1", res.Agents)
+	}
+
+	agents, err := st.ListAgents(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	butlers := 0
+	for _, a := range agents {
+		if a.Role == storage.AgentRoleButler {
+			butlers++
+		}
+	}
+	if butlers != 1 {
+		t.Fatalf("butler count = %d, want exactly 1", butlers)
+	}
+
+	butler, err := st.GetButler(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	if butler.Name != "Alfred" || butler.Title != "The Butler" || butler.Persona != "Impeccably dry." {
+		t.Errorf("butler fields not merged: %+v", butler)
+	}
+	if !butler.AddressOnly {
+		t.Error("butler address_only not pinned true")
+	}
+	if butler.VoiceProviderConfigID.Valid || butler.LLMProviderConfigID.Valid {
+		t.Error("butler provider FKs not NULL")
+	}
+	if id, ok := res.AgentIDs["butler-ref"]; !ok || id != butler.ID {
+		t.Errorf("AgentIDs[butler-ref] = %v, want %v", id, butler.ID)
+	}
+
+	grants, err := st.ListToolGrants(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	if len(grants) != 1 || grants[0].ToolName != "rules_lookup" {
+		t.Fatalf("butler grants = %+v, want single rules_lookup (dice replaced)", grants)
+	}
+}
+
+// TestImportRoundTrip is TEST 6: export a seeded campaign (Butler + Bart + grants
+// + KG + PC) and import it into a SECOND database under a fresh tenant. The domain
+// grains are reproduced, the node↔agent link is remapped, every minted UUID
+// differs from the source, and the Character's discord_user_id is verbatim.
+func TestImportRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	src, srcCID, srcBartID := seededCampaign(t)
+
+	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	dst, tid := freshTenant(t)
+	res, err := bundle.Import(ctx, dst, tid, b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	if res.CampaignID == srcCID {
+		t.Error("imported campaign id equals source (not minted fresh)")
+	}
+	if res.Agents != len(b.Campaign.Agents) {
+		t.Errorf("result Agents = %d, want %d", res.Agents, len(b.Campaign.Agents))
+	}
+
+	agents, err := dst.ListAgents(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	var dstBart storage.Agent
+	var haveButler bool
+	for _, a := range agents {
+		if a.ID == srcBartID {
+			t.Error("imported Bart reused source UUID")
+		}
+		switch a.Role {
+		case storage.AgentRoleButler:
+			haveButler = true
+			if a.VoiceProviderConfigID.Valid || a.LLMProviderConfigID.Valid {
+				t.Error("imported butler carries provider FKs")
+			}
+		case storage.AgentRoleCharacter:
+			if a.Name == "Bart" {
+				dstBart = a
+			}
+		}
+	}
+	if !haveButler {
+		t.Fatal("imported campaign has no butler")
+	}
+	if dstBart.ID == uuid.Nil {
+		t.Fatal("imported campaign missing Bart")
+	}
+	if dstBart.VoiceProviderConfigID.Valid || dstBart.LLMProviderConfigID.Valid {
+		t.Error("imported Bart carries provider FKs; want NULL")
+	}
+
+	bartGrants, err := dst.ListToolGrants(ctx, dstBart.ID)
+	if err != nil {
+		t.Fatalf("ListToolGrants(Bart): %v", err)
+	}
+	if len(bartGrants) != 1 || bartGrants[0].ToolName != "dice" {
+		t.Errorf("Bart grants = %+v, want single dice", bartGrants)
+	}
+
+	nodes, err := dst.ListNodes(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("node count = %d, want 2", len(nodes))
+	}
+	var linked bool
+	for _, n := range nodes {
+		if n.Type == storage.KGNodeNPC {
+			if !n.AgentID.Valid || n.AgentID.UUID != dstBart.ID {
+				t.Errorf("npc node agent link = %v, want remapped Bart %v", n.AgentID, dstBart.ID)
+			}
+			linked = true
+		}
+	}
+	if !linked {
+		t.Error("no npc node with remapped agent link")
+	}
+
+	edges, err := dst.ListEdges(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListEdges: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Errorf("edge count = %d, want 1", len(edges))
+	}
+
+	chars, err := dst.ListCharacters(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListCharacters: %v", err)
+	}
+	if len(chars) != 1 || chars[0].DiscordUserID != "123456789" {
+		t.Fatalf("characters = %+v, want Frodo with verbatim discord id", chars)
+	}
+}
+
+// TestImportTwiceMakesTwoCampaigns is TEST 7: the same bundle imported twice
+// yields two independent campaigns (ADR-0053 §4 always-mint).
+func TestImportTwiceMakesTwoCampaigns(t *testing.T) {
+	ctx := context.Background()
+	src, srcCID, _ := seededCampaign(t)
+	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	dst, tid := freshTenant(t)
+	first, err := bundle.Import(ctx, dst, tid, b)
+	if err != nil {
+		t.Fatalf("Import #1: %v", err)
+	}
+	second, err := bundle.Import(ctx, dst, tid, b)
+	if err != nil {
+		t.Fatalf("Import #2: %v", err)
+	}
+	if first.CampaignID == second.CampaignID {
+		t.Fatal("two imports produced one campaign; want two independent")
+	}
+}
+
+// TestImportMidBundleFailureRollsBack is TEST 8: an edge referencing an unknown
+// node aborts the import and leaves ZERO rows (single transaction).
+func TestImportMidBundleFailureRollsBack(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Doomed Import", System: "dnd5e", Language: "en",
+			Nodes: []bundle.Node{{ID: "n1", Type: "location", Name: "Somewhere"}},
+			Edges: []bundle.Edge{{From: "n1", To: "ghost", Type: "resides_in"}},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+		t.Fatal("Import with unknown edge ref succeeded; want error")
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "Doomed Import"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("failed import left a campaign behind: %v", err)
+	}
+}
+
+// TestImportToleratesHistorySection is TEST 9: a bundle carrying a History section
+// imports its part-1 domain grains fine and writes no session/line/chunk rows.
+func TestImportToleratesHistorySection(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Has History", System: "dnd5e", Language: "en",
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", Status: "ended", LineCount: 1,
+				Lines: []bundle.Line{{LineID: "l1", Seq: 1, Who: "Frodo", Kind: "human", Text: "hi"}},
+			}}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Sessions != 0 || res.Lines != 0 || res.Chunks != 0 {
+		t.Errorf("part-1 counted history: sessions=%d lines=%d chunks=%d, want 0",
+			res.Sessions, res.Lines, res.Chunks)
+	}
+	sessions, err := st.ListVoiceSessions(ctx, res.CampaignID, 100)
+	if err != nil {
+		t.Fatalf("ListVoiceSessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("part-1 wrote %d voice sessions, want 0", len(sessions))
+	}
+}

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -222,17 +222,26 @@ func TestImportRoundTrip(t *testing.T) {
 	if len(nodes) != 2 {
 		t.Fatalf("node count = %d, want 2", len(nodes))
 	}
-	var linked bool
+	var npcNode, locNode storage.KGNode
 	for _, n := range nodes {
-		if n.Type == storage.KGNodeNPC {
+		switch n.Type {
+		case storage.KGNodeNPC:
+			npcNode = n
 			if !n.AgentID.Valid || n.AgentID.UUID != dstBart.ID {
 				t.Errorf("npc node agent link = %v, want remapped Bart %v", n.AgentID, dstBart.ID)
 			}
-			linked = true
+			if n.Name != "Barliman" || !n.GMPrivate {
+				t.Errorf("npc node name/gm_private not round-tripped: %+v", n)
+			}
+		case storage.KGNodeLocation:
+			locNode = n
+			if n.Name != "The Prancing Pony" || n.Body != "A cozy inn." {
+				t.Errorf("location node name/body not round-tripped: %+v", n)
+			}
 		}
 	}
-	if !linked {
-		t.Error("no npc node with remapped agent link")
+	if npcNode.ID == uuid.Nil || locNode.ID == uuid.Nil {
+		t.Fatal("round-trip lost the npc or location node")
 	}
 
 	edges, err := dst.ListEdges(ctx, res.CampaignID)
@@ -240,15 +249,25 @@ func TestImportRoundTrip(t *testing.T) {
 		t.Fatalf("ListEdges: %v", err)
 	}
 	if len(edges) != 1 {
-		t.Errorf("edge count = %d, want 1", len(edges))
+		t.Fatalf("edge count = %d, want 1", len(edges))
+	}
+	// Edge content: the resides_in edge points npc -> location, direction preserved,
+	// endpoints remapped to the fresh node ids.
+	e := edges[0]
+	if e.Type != storage.KGEdgeResidesIn || e.FromNodeID != npcNode.ID || e.ToNodeID != locNode.ID {
+		t.Errorf("edge = %+v, want resides_in npc(%s)->loc(%s)", e, npcNode.ID, locNode.ID)
 	}
 
 	chars, err := dst.ListCharacters(ctx, res.CampaignID)
 	if err != nil {
 		t.Fatalf("ListCharacters: %v", err)
 	}
-	if len(chars) != 1 || chars[0].DiscordUserID != "123456789" {
-		t.Fatalf("characters = %+v, want Frodo with verbatim discord id", chars)
+	if len(chars) != 1 {
+		t.Fatalf("character count = %d, want 1", len(chars))
+	}
+	if chars[0].Name != "Frodo" || chars[0].DiscordUserID != "123456789" ||
+		len(chars[0].Aliases) != 1 || chars[0].Aliases[0] != "Mr. Underhill" {
+		t.Fatalf("character not round-tripped: %+v", chars[0])
 	}
 }
 
@@ -295,6 +314,82 @@ func TestImportMidBundleFailureRollsBack(t *testing.T) {
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Doomed Import"); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("failed import left a campaign behind: %v", err)
+	}
+}
+
+// TestImportRejectsSecondButler proves a bundle carrying TWO Butlers is refused
+// (rollback), never last-wins: a Campaign has exactly one Butler (types.go), so a
+// second would silently overwrite the first's fields/grants and inflate the
+// reported Agents count above what the DB holds.
+func TestImportRejectsSecondButler(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Two Butlers", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{
+				{ID: "b1", Role: "butler", Name: "Alfred"},
+				{ID: "b2", Role: "butler", Name: "Jeeves"},
+			},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+		t.Fatal("Import with two butlers succeeded; want error")
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "Two Butlers"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("rejected two-butler import left a campaign: %v", err)
+	}
+}
+
+// TestImportRejectsDuplicateNodeRef proves two nodes sharing a ref key abort the
+// import (rollback): a silent clobber of the remap map would bind edges/links to
+// the wrong node.
+func TestImportRejectsDuplicateNodeRef(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Dup Node", System: "dnd5e", Language: "en",
+			Nodes: []bundle.Node{
+				{ID: "n1", Type: "location", Name: "First"},
+				{ID: "n1", Type: "location", Name: "Second"},
+			},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+		t.Fatal("Import with duplicate node ref succeeded; want error")
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "Dup Node"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("rejected dup-node import left a campaign: %v", err)
+	}
+}
+
+// TestImportRejectsDuplicateAgentRef proves two Character Agents sharing a ref key
+// abort the import (rollback): a clobbered agent remap would link a node to the
+// wrong Agent.
+func TestImportRejectsDuplicateAgentRef(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	b := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Dup Agent", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{
+				{ID: "a1", Role: "character", Name: "Bart"},
+				{ID: "a1", Role: "character", Name: "Barty"},
+			},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+		t.Fatal("Import with duplicate agent ref succeeded; want error")
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "Dup Agent"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("rejected dup-agent import left a campaign: %v", err)
 	}
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -44,10 +44,22 @@ func New(pool *pgxpool.Pool) *Store {
 
 // InTx runs fn against a Store bound to a single transaction, committing if fn
 // returns nil and rolling back otherwise. Used by multi-row operations that must
-// be atomic (e.g. the live-NPC seed). Not available on a tx-bound Store.
+// be atomic (e.g. the live-NPC seed).
+//
+// On a Store ALREADY bound to a transaction (created by an enclosing InTx), it
+// FLATTENS: fn runs against the same tx-bound Store, with no nested Begin and no
+// savepoint (#291). This lets a method that uses InTx internally (e.g.
+// CreateEdge) compose inside a larger import transaction. The caveat is that the
+// inner call's atomicity then becomes the OUTER transaction's: an error raised
+// after such an inner "commit" still rolls the whole outer tx back — there is no
+// independent inner rollback boundary. That is exactly what the bundle importer
+// wants (one all-or-nothing import), but a caller relying on partial-commit
+// semantics from a nested InTx would be surprised.
 func (s *Store) InTx(ctx context.Context, fn func(*Store) error) error {
 	if s.pool == nil {
-		return errors.New("storage: InTx requires a pool-backed Store")
+		// Already tx-bound: run in the ambient transaction (flatten). No commit or
+		// rollback here — the outermost InTx owns the transaction boundary.
+		return fn(s)
 	}
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -314,3 +314,44 @@ func TestGetActiveCampaignEmpty(t *testing.T) {
 		t.Fatalf("GetActiveCampaign on empty DB: got %v, want ErrNotFound", err)
 	}
 }
+
+// TestInTx_FlattensOnTxBoundStore proves the #291 amendment: calling InTx on a
+// Store already bound to a transaction runs the fn in that AMBIENT transaction
+// (no error, no nested Begin), so a method that uses InTx internally (CreateEdge)
+// composes inside a larger import transaction. Inner atomicity is the outer tx's:
+// an error after an inner-InTx write rolls the whole outer tx back.
+func TestInTx_FlattensOnTxBoundStore(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	sentinel := errors.New("boom")
+
+	// The outer InTx runs a nested InTx (flatten) that writes a campaign, then
+	// fails. The whole thing must roll back — the campaign must not persist.
+	err := st.InTx(ctx, func(tx *storage.Store) error {
+		var innerID uuid.UUID
+		if err := tx.InTx(ctx, func(tx2 *storage.Store) error {
+			id, err := tx2.CreateCampaign(ctx, storage.NewCampaign{
+				TenantID: tenantID, Name: "Flatten Probe", System: "dnd5e", Language: "en",
+			})
+			innerID = id
+			return err
+		}); err != nil {
+			return err
+		}
+		if innerID == uuid.Nil {
+			t.Fatal("inner InTx did not run / returned nil id")
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("outer InTx err = %v, want sentinel", err)
+	}
+
+	// The flattened inner write must have been discarded by the outer rollback.
+	if _, err := st.FindCampaignByName(ctx, tenantID, "Flatten Probe"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("flattened write survived rollback: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #291.

## What
Bundle **importer part 1** (E6): ingest a campaign bundle's domain grains — campaign, Agents (Butler merged), Tool Grants, KG Nodes/Edges incl. the NPC-Node↔Agent link, and Characters — in **one transaction**, minting fresh UUIDs and remapping every intra-bundle reference (ADR-0053 §4). Transcript History is part 2 (#292): tolerated but untouched here (counts 0).

## How
- `bundle.Import(ctx, st, tenantID, b) (ImportResult, error)` — CheckVersion first (refuse newer/unsupported, message names both versions, ADR-0053 §7), then `st.InTx`: CreateCampaign (fires ADR-0009 auto-Butler trigger) → Butler merge → character Agents → Nodes → node↔Agent links → Edges → Characters. Unknown ref anywhere = error = rollback.
- **Butler merge** (ADR-0009 §5): `UpdateAgent` the trigger row (name/title/persona/voice/aliases; provider FKs `uuid.NullUUID{}`; `address_only` stays pinned true by storage), grants replaced exactly (delete each existing incl. trigger dice, create per bundle grant). No bundle Butler → trigger defaults stand.
- Character Agents insert with NULL provider FKs (tenant fallback tolerates); voice validated via `storage.VoiceFromJSON` before insert (#224).
- **Delivery**: `POST /api/v1/campaigns/import` (plain net/http beside the SSE relay, ADR-0015). `http.MaxBytesReader(blob.MaxSize)` request cap FIRST (ADR-0048, `blob.Store` uninvolved), multipart field `bundle`, tenant from the session user, `200` JSON counts / `400` / `413` / `500`. Synchronous (ADR-0049), NO auto-activate (ADR-0053 §7).

## Seam changes
- `storage.InTx` **flattens** on a tx-bound Store (runs `fn` in the ambient tx, no savepoint) so `CreateEdge` (uses InTx internally) composes inside the import tx. Documented caveat: inner atomicity = outer tx's.
- `auth.RequireSession` now injects the operator into ctx (pure addition; relay handlers unaffected).
- New `auth.RequireCSRF` — plain-HTTP double-submit mirror of the Connect CSRF interceptor (constant-time compare, ADR-0016) for the state-changing POST.

## Tests (TDD, red→green)
14 behaviors added, all green locally (`-tags=integration`, testcontainers Postgres):
- auth: RequireSession user-injection; RequireCSRF match/mismatch/missing-header/missing-cookie.
- storage: InTx flatten runs in ambient tx, outer rollback discards inner writes.
- import: version refusal (DB untouched); minimal campaign (trigger Butler + dice grant); Butler merge (one row, fields updated, grants exact, address_only true, FKs NULL); full export→import round-trip on a 2nd DB (grains reproduced, node link remapped, all UUIDs fresh, discord id verbatim); same bundle twice → two campaigns; mid-bundle failure → zero rows; History section tolerated (counts 0).
- handler: 401 / 403 CSRF / 413 oversized / 400 newer-version (names both versions) / 200 counts + tenant resolved from session user.

Local: `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), fast tests + full integration for `internal/bundle` + `internal/storage` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)