### PR TITLE
feat(#302): [E7] Ensemble Turns pt2 — Cross-talk Reaction

### DIFF
--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -359,6 +359,15 @@ func (r *Relay) project(e voiceevent.Event) {
 		// they leave no line.
 		t := r.turn(ev.TurnID)
 		t.target = ev.Target
+	case voiceevent.EnsembleReaction:
+		// An Ensemble Turn's Cross-talk Reaction (#302, ADR-0025): the reactor speaks
+		// under its OWN fresh sub-turn id (ev.TurnID), so — like EnsembleLead — record
+		// WHO reacts, keyed on that id, so the reaction's coalescing TTSInvoked line
+		// lands as a SEPARATE line (a:<rID>, the reactor's name + NPC pill) beneath the
+		// Lead's rather than coalescing into it. A declined Reaction publishes no
+		// EnsembleReaction and no TTSInvoked, so it leaves no line.
+		t := r.turn(ev.TurnID)
+		t.target = ev.Target
 	case voiceevent.TTSInvoked:
 		// One sentence of the Agent's reply — coalesced into the turn's line.
 		t := r.turn(ev.TurnID)

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -90,3 +90,55 @@ func TestProjection_EnsembleLeadAttributesLine(t *testing.T) {
 		t.Errorf("ensemble lead line text = %q, want the Lead's reply", l.Text)
 	}
 }
+
+// TestProjection_EnsembleReactionSeparateLine pins #302: the Cross-talk Reaction is a
+// distinct sub-turn under its OWN fresh TurnID, so its EnsembleReaction attribution
+// lands the reaction as a SEPARATE line (a:<rID>, the reactor's own name + NPC pill)
+// beneath the Lead's — never coalesced into the Lead's line.
+func TestProjection_EnsembleReactionSeparateLine(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.EnsembleLead{
+		At: at(1), TurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "I speak first.", Index: 0, TurnID: "e1"})
+	bus.Publish(voiceevent.EnsembleReaction{
+		At: at(3), TurnID: "r1", LeadTurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "goblin", AgentRole: "character", Name: "Goblin"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "I disagree.", Index: 0, TurnID: "r1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 2 {
+		t.Fatalf("got %d lines, want 2 (Lead + reaction): %+v", len(v.Lines), v.Lines)
+	}
+	lead, reaction := v.Lines[0], v.Lines[1]
+	if lead.ID != "a:e1" || lead.Who != "Bart" || lead.Text != "I speak first." {
+		t.Errorf("lead line = {id %q who %q text %q}, want {a:e1 Bart I speak first.}", lead.ID, lead.Who, lead.Text)
+	}
+	if reaction.ID != "a:r1" || reaction.Who != "Goblin" || reaction.Kind != KindNPC || reaction.Tag != "NPC" {
+		t.Errorf("reaction line meta = {id %q who %q kind %q tag %q}, want {a:r1 Goblin npc NPC}", reaction.ID, reaction.Who, reaction.Kind, reaction.Tag)
+	}
+	if reaction.Text != "I disagree." {
+		t.Errorf("reaction line text = %q, want the reactor's reply", reaction.Text)
+	}
+}
+
+// TestProjection_EnsembleReactionDeclineNoLine pins the decline path (#302, ADR-0012):
+// a Reaction that never played publishes no EnsembleReaction and no TTSInvoked, so it
+// leaves no line — only the Lead's.
+func TestProjection_EnsembleReactionDeclineNoLine(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.EnsembleLead{
+		At: at(1), TurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "I speak first.", Index: 0, TurnID: "e1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want only the Lead's (a decline leaves no line): %+v", len(v.Lines), v.Lines)
+	}
+}

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -142,3 +142,34 @@ func TestProjection_EnsembleReactionDeclineNoLine(t *testing.T) {
 		t.Fatalf("got %d lines, want only the Lead's (a decline leaves no line): %+v", len(v.Lines), v.Lines)
 	}
 }
+
+// TestProjection_EnsembleReactionBargeMarksLineEnded pins #302 (plan test 11, third
+// clause): a barge during the reaction's playback ends its sub-turn (TurnEnded{rID,
+// barge}); the relay marks that turn ended so a LATE reaction sentence — which a barge
+// can deliver after the end — does not clobber the finalized reaction line.
+func TestProjection_EnsembleReactionBargeMarksLineEnded(t *testing.T) {
+	bus, r, _, id := liveRelay(t)
+
+	bus.Publish(voiceevent.EnsembleLead{
+		At: at(1), TurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "I speak first.", Index: 0, TurnID: "e1"})
+	bus.Publish(voiceevent.EnsembleReaction{
+		At: at(3), TurnID: "r1", LeadTurnID: "e1",
+		Target: voiceevent.AddressTarget{AgentID: "goblin", AgentRole: "character", Name: "Goblin"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "I disagree.", Index: 0, TurnID: "r1"})
+	// A barge cuts the reaction: its sub-turn ends.
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "r1", Reason: voiceevent.TurnEndBarge})
+	// A late reaction sentence a barge delivered after the end must be dropped.
+	bus.Publish(voiceevent.TTSInvoked{At: at(6), Sentence: " and clobber!", Index: 1, TurnID: "r1"})
+
+	v := r.View(id)
+	if len(v.Lines) != 2 {
+		t.Fatalf("got %d lines, want 2 (Lead + reaction): %+v", len(v.Lines), v.Lines)
+	}
+	if got := v.Lines[1].Text; got != "I disagree." {
+		t.Errorf("reaction line text = %q, want %q (the post-end sentence must not clobber the finalized line)", got, "I disagree.")
+	}
+}

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -490,10 +490,21 @@ func (r *Replier) React(ctx context.Context, userText, leadName, leadText string
 		return "", err
 	}
 	reply = strings.TrimSpace(reply)
-	if reply == "" || reply == crossTalkSilence {
+	if isSilenceSentinel(reply) {
 		return "", nil // the Reactor declined (ADR-0025 zero-delivered)
 	}
 	return reply, nil
+}
+
+// isSilenceSentinel reports whether reply is a Cross-talk decline: empty, or nothing
+// but the [crossTalkSilence] token (#302 hardening). Live models emit case/punctuation
+// variants — "[silence]", "[SILENCE].", `"[silence]."` — so the match is
+// case-insensitive over the reply stripped of surrounding whitespace, quotes, and
+// trailing punctuation. A reply that merely MENTIONS the token amid other words is a
+// real reply, not a decline (a contains-ONLY check, not a substring check).
+func isSilenceSentinel(reply string) bool {
+	trimmed := strings.Trim(strings.TrimSpace(reply), " \t\n\"'.,!?")
+	return trimmed == "" || strings.EqualFold(trimmed, crossTalkSilence)
 }
 
 // SpeakReaction speaks an already-generated Cross-talk Reaction (from a prior

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -432,6 +432,81 @@ func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispat
 	return spoken.String(), dispErr
 }
 
+// crossTalkSilence is the sentinel a Cross-talk Reaction emits to DECLINE speaking
+// (ADR-0025, #302): the Reaction prompt permits an explicit "stay silent" output to
+// avoid hollow "yeah, what he said" filler. A reply equal to it (or empty) means the
+// Agent reacts with nothing — no event, no dispatch, no commit (ADR-0012).
+const crossTalkSilence = "[SILENCE]"
+
+// crossTalkInstruction is the system-prompt addendum for a Cross-talk Reaction turn
+// (ADR-0025): it frames the just-heard Lead line as cross-talk this Agent may react
+// to, and permits the [crossTalkSilence] decline. It is appended to the Agent's own
+// system prompt ONLY on the React path, so a normal turn's prompt is unchanged.
+const crossTalkInstruction = "Another character has just spoken in the conversation, quoted below. " +
+	"React briefly in your own voice — a short agreement, a pointed disagreement, or an aside — " +
+	"but only if you have something worth adding. If you would just echo them or have nothing to add, " +
+	"reply with exactly " + crossTalkSilence + " and nothing else."
+
+// crossTalkUserText composes the user message for a Cross-talk Reaction (ADR-0025,
+// #302): the original utterance, then the Lead's delivered line attributed to it. It
+// is the SINGLE composition site — [Replier.React] feeds it to the LLM as the turn's
+// user message AND [Replier.SpeakReaction] commits the SAME text to history, so the
+// reacting Agent's recorded turn and the prompt it reasoned over never drift.
+func crossTalkUserText(userText, leadName, leadText string) string {
+	return userText + "\n\n" + leadName + ` says: "` + leadText + `"`
+}
+
+// React produces this Agent's would-be Cross-talk Reaction to the Lead's delivered
+// line WITHOUT mutating any state — the speculative half of the Reaction phase of an
+// Ensemble Turn (ADR-0025, #302). Like [Replier.Draft] it reads Hot Context on a
+// history SNAPSHOT (so a reaction that is never spoken commits nothing, ADR-0012),
+// but its user message is the composite [crossTalkUserText] and its system prompt
+// carries the [crossTalkInstruction] permitting the decline sentinel. An empty
+// completion OR the [crossTalkSilence] sentinel returns "", nil — the Agent declines
+// to react. It honors ctx (bounded by [Config.TurnTimeout]) so a barge tearing the
+// whole ensemble down unwinds an in-flight reaction generation.
+func (r *Replier) React(ctx context.Context, userText, leadName, leadText string) (string, error) {
+	ctx, cancel := r.withTurnTimeout(ctx)
+	defer cancel()
+
+	// Snapshot + append the composite user message on the COPY (purity, as Draft).
+	r.mu.Lock()
+	history := append(make([]llm.Message, 0, len(r.history)+1), r.history...)
+	r.mu.Unlock()
+	history = append(history, llm.Message{Role: llm.RoleUser, Text: crossTalkUserText(userText, leadName, leadText)})
+	history = trimHistory(history, r.cfg.HistoryTurns)
+
+	// Recall keys on the raw utterance (the memory the Agent brings to the moment),
+	// not the composite — the cross-talk line is context, not a new topic.
+	mem := r.recall(ctx, userText)
+	facts := r.facts(ctx)
+
+	msgs := make([]llm.Message, 0, len(history)+1)
+	msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Text: r.systemPrompt(mem, facts) + "\n\n" + crossTalkInstruction})
+	msgs = append(msgs, history...)
+
+	reply, err := r.engine.Generate(ctx, msgs)
+	if err != nil {
+		return "", err
+	}
+	reply = strings.TrimSpace(reply)
+	if reply == "" || reply == crossTalkSilence {
+		return "", nil // the Reactor declined (ADR-0025 zero-delivered)
+	}
+	return reply, nil
+}
+
+// SpeakReaction speaks an already-generated Cross-talk Reaction (from a prior
+// [Replier.React]) as this Agent's own sub-turn (ADR-0025, #302). It reuses
+// [Replier.SpeakDraft] with the SAME composite user text React reasoned over
+// ([crossTalkUserText]) so the committed user message and the prompt never drift,
+// and delivers the reaction under deliver-then-commit (ADR-0012). It returns the
+// delivered text; a ctx-cancel (a barge cutting the reaction mid-playback) commits
+// only the sentences spoken before the cut.
+func (r *Replier) SpeakReaction(ctx context.Context, userText, leadName, leadText, reaction string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
+	return r.SpeakDraft(ctx, crossTalkUserText(userText, leadName, leadText), reaction, dispatch)
+}
+
 // ReplyStream returns the [orchestrator.StreamReplyFunc] that drives this loop
 // in streaming mode (B1): it dispatches each sentence of the reply to TTS the
 // moment it is ready, so first audio begins after the first sentence rather than

--- a/pkg/voice/agent/agent_crosstalk_test.go
+++ b/pkg/voice/agent/agent_crosstalk_test.go
@@ -53,6 +53,10 @@ func TestReplier_React_DeclineSentinel(t *testing.T) {
 		{"sentinel", "[SILENCE]"},
 		{"sentinel-padded", "  [SILENCE]\n"},
 		{"empty", ""},
+		{"lowercase", "[silence]"},
+		{"trailing-period", "[SILENCE]."},
+		{"quoted-punct", `"[silence]."`},
+		{"mixed-case-bang", "  [Silence]!  "},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			prov := &fakeProvider{reply: tc.reply}
@@ -73,5 +77,25 @@ func TestReplier_React_DeclineSentinel(t *testing.T) {
 				t.Fatal("a declined Reaction must commit nothing to history")
 			}
 		})
+	}
+}
+
+// TestReplier_React_SentinelSubstringIsNotDecline pins that the decline is a
+// contains-ONLY-sentinel check (#302 hardening): a real reply that merely mentions the
+// token is spoken, not swallowed.
+func TestReplier_React_SentinelSubstringIsNotDecline(t *testing.T) {
+	prov := &fakeProvider{reply: "[SILENCE] would be rude, so I will answer."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "mira", Markdown: "You are Mira.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+	})
+
+	reaction, err := r.React(t.Context(), "Bart, Mira?", "Bart", "The bridge is out.")
+	if err != nil {
+		t.Fatalf("React errored: %v", err)
+	}
+	if reaction != "[SILENCE] would be rude, so I will answer." {
+		t.Fatalf("reaction = %q, want the full reply (a reply that only mentions the sentinel is not a decline)", reaction)
 	}
 }

--- a/pkg/voice/agent/agent_crosstalk_test.go
+++ b/pkg/voice/agent/agent_crosstalk_test.go
@@ -1,0 +1,77 @@
+package agent_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+)
+
+// TestReplier_React_CompositePrompt pins the Cross-talk Reaction prompt (ADR-0025,
+// #302): React feeds the Lead's delivered text to this Agent as Cross-talk. The
+// user message the LLM sees is the SINGLE composition site crossTalkUserText — the
+// original utterance plus `<lead> says: "<lead text>"` — and React is PURE (a
+// speculative reaction commits nothing until it is actually spoken).
+func TestReplier_React_CompositePrompt(t *testing.T) {
+	prov := &fakeProvider{reply: "I disagree, actually."}
+	r := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: "mira", Markdown: "You are Mira.", Voice: testVoice()},
+		Provider:    prov,
+		Synthesizer: stubSynth{},
+	})
+
+	reaction, err := r.React(t.Context(), "Bart, Mira — thoughts?", "Bart", "The bridge is out.")
+	if err != nil {
+		t.Fatalf("React errored: %v", err)
+	}
+	if !strings.Contains(reaction, "disagree") {
+		t.Fatalf("reaction = %q, want the scripted reply", reaction)
+	}
+
+	last := prov.lastRequest(t)
+	userMsg := last.Messages[len(last.Messages)-1].Text
+	if !strings.Contains(userMsg, "Bart, Mira — thoughts?") {
+		t.Fatalf("composite user msg = %q, want the original utterance", userMsg)
+	}
+	if !strings.Contains(userMsg, `Bart says: "The bridge is out."`) {
+		t.Fatalf("composite user msg = %q, want the Lead's cross-talk line", userMsg)
+	}
+	// Purity: a speculative Reaction mutates no history (ADR-0012).
+	if len(r.HistorySnapshot()) != 0 {
+		t.Fatal("React must commit nothing to history (purity)")
+	}
+}
+
+// TestReplier_React_DeclineSentinel pins the decline path (ADR-0025, #302): a
+// Reaction whose model output is the "[SILENCE]" sentinel — or empty — is a DECLINE,
+// so React returns "", nil (no reaction). History stays untouched.
+func TestReplier_React_DeclineSentinel(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reply string
+	}{
+		{"sentinel", "[SILENCE]"},
+		{"sentinel-padded", "  [SILENCE]\n"},
+		{"empty", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &fakeProvider{reply: tc.reply}
+			r := agent.NewReplier(agent.Config{
+				Persona:     agent.Persona{AgentID: "mira", Markdown: "You are Mira.", Voice: testVoice()},
+				Provider:    prov,
+				Synthesizer: stubSynth{},
+			})
+
+			reaction, err := r.React(t.Context(), "Bart, Mira?", "Bart", "The bridge is out.")
+			if err != nil {
+				t.Fatalf("React errored: %v", err)
+			}
+			if reaction != "" {
+				t.Fatalf("reaction = %q, want empty on decline", reaction)
+			}
+			if len(r.HistorySnapshot()) != 0 {
+				t.Fatal("a declined Reaction must commit nothing to history")
+			}
+		})
+	}
+}

--- a/pkg/voice/agent/cast.go
+++ b/pkg/voice/agent/cast.go
@@ -129,3 +129,28 @@ func (c *Cast) Speak(ctx context.Context, e voiceevent.AddressRouted, draft stri
 	}
 	return r.SpeakDraft(ctx, e.Text, draft, dispatch)
 }
+
+// React implements [orchestrator.CrossTalker]: it produces the addressed Agent's
+// would-be Cross-talk Reaction to the Lead's delivered line WITHOUT mutating
+// anything (the speculative half of the Reaction phase, ADR-0025/#302), by
+// delegating to that member's [Replier.React]. An unknown (or removed) Agent yields
+// "", nil — the "no one reacts" signal the coordinator reads as a decline.
+func (c *Cast) React(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText string) (string, error) {
+	r := c.lookup(e.Target.AgentID)
+	if r == nil {
+		return "", nil // no Agent reacts for this route
+	}
+	return r.React(ctx, e.Text, leadName, leadText)
+}
+
+// SpeakReaction implements [orchestrator.CrossTalker]: it speaks the addressed
+// Agent's pre-generated Reaction as its own sub-turn (committing the delivered text
+// to that member's history, ADR-0012), by delegating to [Replier.SpeakReaction]. An
+// unknown Agent dispatches nothing and returns "", nil.
+func (c *Cast) SpeakReaction(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText, reaction string, dispatch func(orchestrator.Reply) error) (string, error) {
+	r := c.lookup(e.Target.AgentID)
+	if r == nil {
+		return "", nil // no Agent reacts for this route
+	}
+	return r.SpeakReaction(ctx, e.Text, leadName, leadText, reaction, dispatch)
+}

--- a/pkg/voice/agent/cast_test.go
+++ b/pkg/voice/agent/cast_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -218,7 +219,78 @@ func TestCast_ConcurrentAddRemoveDispatch(t *testing.T) {
 var (
 	_ orchestrator.StreamReplyFunc = agent.NewCast().ReplyStream()
 	_ orchestrator.ReplyFunc       = agent.NewCast().Reply()
+	_ orchestrator.CrossTalker     = agent.NewCast()
 )
+
+// TestCast_React_RoutesByAgentID pins the CrossTalker.React half (#302): a React
+// for agent B produces B's would-be Cross-talk Reaction (via B's Replier), and an
+// unknown Agent yields "", nil — the "no one reacts" signal the coordinator treats
+// as a decline.
+func TestCast_React_RoutesByAgentID(t *testing.T) {
+	a := castReplier("a", &fakeStreamEngine{deltas: []string{"unused"}})
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"I disagree."}})
+	cast := agent.NewCast(a, b)
+
+	reaction, err := cast.React(context.Background(), routed("b", "what do you two think?"), "A", "The bridge is out.")
+	if err != nil {
+		t.Fatalf("React: %v", err)
+	}
+	if reaction != "I disagree." {
+		t.Fatalf("reaction = %q, want B's cross-talk reply", reaction)
+	}
+
+	// Unknown Agent: no member reacts, "" nil (not an error).
+	got, err := cast.React(context.Background(), routed("zzz", "x"), "A", "y")
+	if err != nil || got != "" {
+		t.Fatalf("React(unknown) = (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+// TestCast_SpeakReaction_CommitsCompositeAndDelivered pins the CrossTalker.SpeakReaction
+// half (#302, ADR-0012): SpeakReaction dispatches the reaction in B's Voice and
+// commits to B's history the SAME composite user message React reasoned over (the
+// utterance + the Lead's cross-talk line) plus the delivered assistant text. An
+// unknown Agent dispatches nothing and commits nothing.
+func TestCast_SpeakReaction_CommitsCompositeAndDelivered(t *testing.T) {
+	b := castReplier("b", &fakeStreamEngine{deltas: []string{"unused"}})
+	cast := agent.NewCast(b)
+
+	var got []orchestrator.Reply
+	delivered, err := cast.SpeakReaction(context.Background(), routed("b", "what do you two think?"), "A", "The bridge is out.", "I disagree. Strongly.", func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SpeakReaction: %v", err)
+	}
+	if delivered != "I disagree. Strongly." {
+		t.Fatalf("delivered = %q, want the reaction text", delivered)
+	}
+	if len(got) != 2 || got[0].Voice.VoiceID != "b" {
+		t.Fatalf("dispatched = %+v, want two sentences in b's voice", got)
+	}
+
+	hist := b.HistorySnapshot()
+	if len(hist) != 2 {
+		t.Fatalf("history len = %d, want 2 (composite user + delivered assistant)", len(hist))
+	}
+	if !strings.Contains(hist[0].Text, "what do you two think?") || !strings.Contains(hist[0].Text, `A says: "The bridge is out."`) {
+		t.Fatalf("committed user msg = %q, want the composite cross-talk text", hist[0].Text)
+	}
+	if hist[1].Text != "I disagree. Strongly." {
+		t.Fatalf("committed assistant = %q, want the delivered reaction", hist[1].Text)
+	}
+
+	// Unknown Agent: nothing dispatched, "" nil.
+	got = nil
+	delivered, err = cast.SpeakReaction(context.Background(), routed("zzz", "x"), "A", "y", "hi", func(rep orchestrator.Reply) error {
+		got = append(got, rep)
+		return nil
+	})
+	if err != nil || delivered != "" || len(got) != 0 {
+		t.Fatalf("SpeakReaction(unknown) = (%q, %v) dispatched %d, want (\"\", nil) and no dispatch", delivered, err, len(got))
+	}
+}
 
 // TestCast_Draft_RoutesByAgentID pins the EnsembleSpeaker.Draft half (#301): a
 // Draft for agent B produces B's would-be text (via B's Replier), and an unknown

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -175,12 +175,17 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	// publishes its own TurnEnded).
 	var lead draftResult
 	won := false
-	for remaining := len(targets); remaining > 0 && !won; {
+	// pending counts the draft results not yet consumed. It carries past the race so
+	// the reactor pick below knows how many results can STILL arrive on the channel —
+	// keying the pick on the targets slice instead would wait on results the race loop
+	// already drained (errored/empty candidates it skipped), wedging the turn forever.
+	pending := len(targets)
+	for pending > 0 && !won {
 		select {
 		case <-turnCtx.Done():
 			return // a barge/supersede tore the whole unit down mid-race
 		case res := <-results:
-			remaining--
+			pending--
 			if res.err == nil && res.text != "" {
 				lead = res
 				won = true
@@ -222,20 +227,31 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	)
 	if canReact && len(remaining) > 0 {
 		if len(remaining) == 1 {
+			// Exactly one other Agent: it is the reactor. Its speculative draft is
+			// discarded (it regenerates a Reaction), so we never wait for that draft —
+			// a hung/gated loser must not stall the pick.
 			reactor = remaining[0]
 			hasReactor = true
 		} else {
-			// 3+ addressed: the FASTEST remaining draft to arrive names the reactor
+			// 3+ addressed: the FASTEST remaining draft to ARRIVE names the reactor
 			// (ADR-0025 — its speculative draft is discarded, it regenerates a
-			// Reaction). Bounded by each Draft's own TurnTimeout; a barge during the
-			// wait tears the whole unit down (turnCtx.Done()).
-			select {
-			case <-turnCtx.Done():
-				cancelDrafts()
-				return
-			case res := <-results:
-				reactor = res.target
-				hasReactor = true
+			// Reaction). Only pending (not-yet-consumed) results can still arrive; the
+			// race loop already drained the empty/errored candidates it skipped, so we
+			// bound the wait by pending to avoid blocking on a result that will never
+			// come. Empty/errored arrivals are skipped here too — a candidate with
+			// nothing to draft is not made the reactor. A barge tears the unit down.
+			for pending > 0 && !hasReactor {
+				select {
+				case <-turnCtx.Done():
+					cancelDrafts()
+					return
+				case res := <-results:
+					pending--
+					if res.err == nil && res.text != "" {
+						reactor = res.target
+						hasReactor = true
+					}
+				}
 			}
 		}
 	}
@@ -286,10 +302,8 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		return nil
 	}
 	// Speak commits the delivered text to the Lead's own history and stops the drain
-	// on a barge. Its delivered return gates the Reaction: a Reaction plays ONLY if
-	// the Lead delivered at least one sentence (ADR-0025) — otherwise the ensemble
-	// spoke nothing worth reacting to.
-	delivered, _ := r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
+	// on a barge.
+	_, _ = r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: lead.target,
 	}, lead.text, dispatch)
 
@@ -299,10 +313,17 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndTTSError})
 	}
 
-	// The Reaction plays only when there is a reactor, the Lead actually delivered a
-	// sentence, and the unit is still live (a barge anywhere above tears it down and a
-	// queued Reaction after a barge is FORBIDDEN, ADR-0027).
-	if !hasReactor || delivered == "" || turnCtx.Err() != nil {
+	// The Reaction plays only when there is a reactor, the unit is still live (a barge
+	// anywhere above tears it down and a queued Reaction after a barge is FORBIDDEN,
+	// ADR-0027), and the Lead is AUDIBLY on the wire ([Floor.Speaking] — its FirstOpus
+	// fired). Gating on audible delivery, not committed text, is load-bearing: an
+	// all-synthesis-failed Lead still commits its (undelivered) text but produced no
+	// audio and no FirstOpus, so the floor never armed — a Reaction played then would
+	// be UNBARGEABLE (its own FirstOpus{rID} can't arm a floor whose holder turn is the
+	// Lead's) and would speak AFTER the Lead's TurnEnded{tts_error}. Floor.Speaking
+	// true ⟺ FirstOpus(lead) fired ⟺ the barge is armed through the gap and the
+	// Reaction (ADR-0027).
+	if !hasReactor || turnCtx.Err() != nil || !r.floor.Speaking() {
 		return
 	}
 	r.speakReaction(turnCtx, rt, bus, e, reactor, lead.target.Name, lead.text, reactCh)
@@ -368,9 +389,19 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
 	}, leadName, leadText, reaction, dispatch)
 
-	// A barge cutting the Reaction mid-playback ends this sub-turn under its own id
+	// A barge cutting the Reaction mid-playback ends this sub-turn under its OWN id
 	// (the Lead's delivered line is untouched). Only when the Reaction actually began
 	// dispatching — a barge before the first sentence played nothing to interrupt.
+	//
+	// INTENTIONAL two TurnEnded on a reaction barge: the [BargeIn] that yielded the
+	// floor also publishes TurnEnded{lead-turn, barge} (the floor's holder turn is the
+	// Lead's throughout the one-unit floor, ADR-0027), and we add TurnEnded{rID, barge}
+	// for the reaction sub-turn. Both are correct floor-unit semantics: the barge tore
+	// down the whole unit, and each of the unit's transcript lines (the Lead's under the
+	// original TurnID, the reaction's under rID) is marked ended so a late sentence can
+	// clobber neither. The Lead's line — cleanly completed before the barge — keeps its
+	// delivered text; the relay treats a TurnEnded after a line is delivered as a normal
+	// interruption, not a re-count.
 	if dispatched && turnCtx.Err() != nil {
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndBarge})
 	}

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -34,6 +34,30 @@ type EnsembleSpeaker interface {
 	Speak(ctx context.Context, e voiceevent.AddressRouted, draft string, dispatch func(Reply) error) (delivered string, err error)
 }
 
+// CrossTalker is the Cross-talk Reaction extension of [EnsembleSpeaker] (ADR-0025,
+// #302): after an Ensemble Turn's Lead speaks, the coordinator feeds the Lead's
+// delivered text to at most one other addressed Agent as Cross-talk, and that Agent
+// generates a Reaction — a short affirmation, a longer disagreement, or a decline.
+// The coordinator discovers this capability by a type assertion on the wired
+// [EnsembleSpeaker] (r.ensemble.(CrossTalker)); a speaker that does not implement it
+// runs the Lead-only Ensemble Turn of #301 unchanged.
+//
+// React PURELY produces the reacting Agent's would-be Reaction text: like
+// [EnsembleSpeaker.Draft] it writes no history, synthesizes no TTS, and commits
+// nothing, so a reaction that is never spoken (a decline, or a barge before it
+// plays) commits nothing (ADR-0012). "" means the Agent declines to react. It honors
+// ctx — a barge tearing the ensemble down cancels the in-flight reaction generation.
+// leadName/leadText are the Lead's display name and its delivered line.
+//
+// SpeakReaction renders an already-generated Reaction as the reacting Agent's own
+// sub-turn: serial per-sentence dispatch committing ONLY the delivered text
+// (ADR-0012), returning the delivered text. It commits the SAME composite user
+// message React reasoned over so the recorded turn and the prompt never drift.
+type CrossTalker interface {
+	React(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText string) (string, error)
+	SpeakReaction(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText, reaction string, dispatch func(Reply) error) (delivered string, err error)
+}
+
 // handleEnsemble runs one [voiceevent.EnsembleRouted] decision set as ONE
 // floor-holding Ensemble Turn (ADR-0025/0027, #301). It mirrors the single-route
 // reactor's gates (mute pre-filter, spend cap, floor Take with its coalesce fold,
@@ -179,11 +203,60 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	}
 
 	// Elect the Lead: announce it (so the transcript relay attributes the turn's
-	// line to the winner), retarget the floor onto it (so a mute cut / coalesce keys
-	// on whoever actually speaks), and cancel the losing drafts.
+	// line to the winner) and retarget the floor onto it (so a mute cut / coalesce
+	// keys on whoever actually speaks).
 	bus.Publish(voiceevent.EnsembleLead{At: time.Now(), TurnID: e.TurnID, Target: lead.target})
 	r.floor.SetHolderAgent(e.TurnID, lead.target.AgentID)
+
+	// Cross-talk Reaction phase (#302, ADR-0025): if the wired speaker can cross-talk
+	// and at least one addressed Agent remains besides the Lead, elect exactly ONE
+	// reactor and generate its Reaction DURING the Lead's playback. Without a
+	// [CrossTalker] — or with no other candidate — this is the Lead-only Ensemble Turn
+	// of #301, unchanged.
+	rt, canReact := r.ensemble.(CrossTalker)
+	remaining := targetsExcept(targets, lead.target.AgentID)
+
+	var (
+		reactor    voiceevent.AddressTarget
+		hasReactor bool
+	)
+	if canReact && len(remaining) > 0 {
+		if len(remaining) == 1 {
+			reactor = remaining[0]
+			hasReactor = true
+		} else {
+			// 3+ addressed: the FASTEST remaining draft to arrive names the reactor
+			// (ADR-0025 — its speculative draft is discarded, it regenerates a
+			// Reaction). Bounded by each Draft's own TurnTimeout; a barge during the
+			// wait tears the whole unit down (turnCtx.Done()).
+			select {
+			case <-turnCtx.Done():
+				cancelDrafts()
+				return
+			case res := <-results:
+				reactor = res.target
+				hasReactor = true
+			}
+		}
+	}
+	// The speculative drafts are done being raced (winner elected, reactor picked):
+	// cancel them all. React runs under turnCtx (NOT draftCtx), so this never cancels
+	// the reaction generation launched below.
 	cancelDrafts()
+
+	// Launch the reactor's React NOW so it generates and pre-renders TEXT while the
+	// Lead's audio plays (ADR-0025), landing on a BUFFERED channel so the goroutine
+	// never blocks if the unit is torn down before we read it.
+	var reactCh chan reactionResult
+	if hasReactor {
+		reactCh = make(chan reactionResult, 1)
+		go func() {
+			text, err := rt.React(turnCtx, voiceevent.AddressRouted{
+				At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
+			}, lead.target.Name, lead.text)
+			reactCh <- reactionResult{text: text, err: err}
+		}()
+	}
 
 	// Speak the Lead's draft under turnCtx. The dispatch closure mirrors
 	// dispatchStream's deliver-then-commit (ADR-0012): a synth failure is non-fatal
@@ -213,9 +286,10 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		return nil
 	}
 	// Speak commits the delivered text to the Lead's own history and stops the drain
-	// on a barge; the coordinator needs neither return here — the turn-end reason is
-	// carried by ttsFailed (below) or the barge's own TurnEnded.
-	_, _ = r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
+	// on a barge. Its delivered return gates the Reaction: a Reaction plays ONLY if
+	// the Lead delivered at least one sentence (ADR-0025) — otherwise the ensemble
+	// spoke nothing worth reacting to.
+	delivered, _ := r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: lead.target,
 	}, lead.text, dispatch)
 
@@ -224,4 +298,94 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	if ttsFailed && turnCtx.Err() == nil {
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndTTSError})
 	}
+
+	// The Reaction plays only when there is a reactor, the Lead actually delivered a
+	// sentence, and the unit is still live (a barge anywhere above tears it down and a
+	// queued Reaction after a barge is FORBIDDEN, ADR-0027).
+	if !hasReactor || delivered == "" || turnCtx.Err() != nil {
+		return
+	}
+	r.speakReaction(turnCtx, rt, bus, e, reactor, lead.target.Name, lead.text, reactCh)
+}
+
+// reactionResult is the outcome of a reactor's [CrossTalker.React] (#302): the
+// would-be Reaction text ("" = decline / error) carried from the generation
+// goroutine to [Replier.speakReaction].
+type reactionResult struct {
+	text string
+	err  error
+}
+
+// speakReaction is the Cross-talk Reaction sub-turn (#302, ADR-0025): it waits for
+// the reactor's generated Reaction (already in flight during the Lead's playback),
+// and — when non-empty and the unit is still live — mints a FRESH sub-turn id,
+// announces [voiceevent.EnsembleReaction], and speaks the Reaction under that id.
+// A decline (empty reaction) or a barge that fired before the Reaction dispatched
+// leaves no event and no line. A barge DURING the Reaction's playback tears it down
+// and ends the sub-turn with a barge [voiceevent.TurnEnded] carrying the reaction's
+// own id — the Lead's already-delivered line stays committed. leadName/leadText are
+// the Lead's display name and delivered draft, fed to the reactor as Cross-talk.
+func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, leadName, leadText string, wait <-chan reactionResult) {
+	var reaction string
+	select {
+	case <-turnCtx.Done():
+		return // a barge tore the unit down while the Reaction generated
+	case res := <-wait:
+		reaction = res.text // a React error surfaces as "" — treated as a decline
+	}
+	if reaction == "" || turnCtx.Err() != nil {
+		return // the reactor declined, or a barge landed the instant it finished
+	}
+
+	// A distinct sub-turn: a FRESH id so the reaction's TTSInvoked / FirstOpus /
+	// TurnEnded correlate independently and land on their own transcript line, linked
+	// back to the Lead via LeadTurnID. Published immediately before the first dispatch.
+	rID := voiceevent.NewTurnID()
+	rctx := voiceevent.WithTurnID(turnCtx, rID)
+	bus.Publish(voiceevent.EnsembleReaction{At: time.Now(), TurnID: rID, LeadTurnID: e.TurnID, Target: reactor})
+
+	var dispatched bool
+	dispatch := func(rep Reply) error {
+		if err := turnCtx.Err(); err != nil {
+			return err
+		}
+		dispatched = true
+		if err := r.tts.Dispatch(rctx, rep.Sentence, rep.Voice); err != nil {
+			if r.onError != nil {
+				r.onError(err)
+			}
+			if turnCtx.Err() != nil {
+				return turnCtx.Err()
+			}
+			return nil // a synth failure is non-fatal; keep draining the Reaction
+		}
+		if err := turnCtx.Err(); err != nil {
+			return err
+		}
+		return nil
+	}
+	_, _ = rt.SpeakReaction(rctx, voiceevent.AddressRouted{
+		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
+	}, leadName, leadText, reaction, dispatch)
+
+	// A barge cutting the Reaction mid-playback ends this sub-turn under its own id
+	// (the Lead's delivered line is untouched). Only when the Reaction actually began
+	// dispatching — a barge before the first sentence played nothing to interrupt.
+	if dispatched && turnCtx.Err() != nil {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndBarge})
+	}
+}
+
+// targetsExcept returns the targets whose AgentID is not agentID, preserving order
+// on a fresh slice — the addressed candidates that remain after the Lead is elected,
+// from which the Cross-talk reactor is chosen (#302).
+func targetsExcept(targets []voiceevent.AddressTarget, agentID string) []voiceevent.AddressTarget {
+	out := make([]voiceevent.AddressTarget, 0, len(targets))
+	for _, t := range targets {
+		if t.AgentID == agentID {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }

--- a/pkg/voice/orchestrator/ensemble_crosstalk_test.go
+++ b/pkg/voice/orchestrator/ensemble_crosstalk_test.go
@@ -116,6 +116,9 @@ func TestReplier_Ensemble_ReactionFollowsLead(t *testing.T) {
 	}
 	replier := ensembleReplier(h, floor, spk)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	// BargeIn drives FirstOpus → Floor.MarkSpeaking (production always wires barge with
+	// an ensemble), so the Lead's FirstOpus below actually arms the floor.
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
 
 	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Te", Text: "Bart, Goblin — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
 
@@ -124,6 +127,9 @@ func TestReplier_Ensemble_ReactionFollowsLead(t *testing.T) {
 	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
 		return e.TurnID == "Te" && e.Sentence == "Bart leads."
 	}, "the Lead's sentence is on the wire")
+	// Arm the floor with the Lead's FirstOpus (as the wire would) — a Reaction plays
+	// only once the Lead is audible, keeping the whole unit barge-able.
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Te"})
 	select {
 	case who := <-spk.reactStarted:
 		if who != goblinTarget.AgentID {
@@ -265,6 +271,7 @@ func TestReplier_Ensemble_BargeDuringReactionEndsSubTurn(t *testing.T) {
 			draft:          map[string]string{bartTarget.AgentID: "Bart done."},
 			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
 			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart done."}},
+			speakPause:     make(chan struct{}), // pause so the floor is armed before the reaction gate
 			spokeCh:        make(chan string, 2),
 		},
 		react:          map[string]string{goblinTarget.AgentID: "React one. React two."},
@@ -279,11 +286,13 @@ func TestReplier_Ensemble_BargeDuringReactionEndsSubTurn(t *testing.T) {
 	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tr", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
 
 	// The Lead delivered its sentence; arm the floor with its FirstOpus (as the wire
-	// would), so the unit stays barge-able through the gap and the Reaction.
+	// would), so the unit stays barge-able through the gap and the Reaction. Release the
+	// paused Lead only after the floor is armed.
 	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
 		return e.TurnID == "Tr" && e.Sentence == "Bart done."
 	}, "the Lead's sentence is on the wire")
 	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tr"})
+	close(spk.speakPause)
 
 	// The Reaction begins under its fresh sub-turn id and pauses after sentence 1.
 	var rID string
@@ -302,6 +311,13 @@ func TestReplier_Ensemble_BargeDuringReactionEndsSubTurn(t *testing.T) {
 	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
 		return e.TurnID == rID && e.Reason == voiceevent.TurnEndBarge
 	}, "turn.ended barge for the reaction sub-turn")
+	// INTENTIONAL: the barge ALSO ends the Lead's turn under the ensemble's original
+	// TurnID (the floor's holder turn throughout the one-unit floor, ADR-0027). Both
+	// TurnEnded are correct floor-unit semantics; the Lead's already-delivered line
+	// stays committed (the relay treats a post-delivery TurnEnded as an interruption).
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "Tr" && e.Reason == voiceevent.TurnEndBarge
+	}, "turn.ended barge for the Lead's turn (the floor unit)")
 
 	select {
 	case <-spk.reactSpokeCh:
@@ -341,6 +357,7 @@ func TestReplier_Ensemble_ThreeTargets_FastestRemainingReacts(t *testing.T) {
 	}
 	replier := ensembleReplier(h, floor, spk)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
 
 	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T3", Text: "Bart, Goblin, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget, miraTarget}})
 
@@ -348,6 +365,8 @@ func TestReplier_Ensemble_ThreeTargets_FastestRemainingReacts(t *testing.T) {
 		return e.TurnID == "T3" && e.Target.AgentID == bartTarget.AgentID
 	}, "Bart elected Lead")
 
+	// Arm the floor with the Lead's FirstOpus so the Reaction may play (barge-able).
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T3"})
 	// Release Goblin so it is the fastest remaining draft to arrive — the reactor.
 	close(goblinGate)
 
@@ -393,17 +412,27 @@ func TestReplier_Ensemble_ReactionDepthCappedAtOne(t *testing.T) {
 	floor := orchestrator.NewFloor()
 	spk := &fakeCrossTalk{
 		fakeEnsemble: &fakeEnsemble{
-			draft:   map[string]string{bartTarget.AgentID: "Bart leads."},
-			gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
-			spokeCh: make(chan string, 2),
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}), // pause so the test can arm the floor before the reaction gate
+			spokeCh:        make(chan string, 2),
 		},
 		react:        map[string]string{goblinTarget.AgentID: "I have a reaction."},
 		reactSpokeCh: make(chan string, 2),
 	}
 	replier := ensembleReplier(h, floor, spk)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
 
 	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tc", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead is audible: arm the floor, then release it so the Reaction plays.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tc" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tc"})
+	close(spk.speakPause)
 
 	// Wait for the reaction to actually play out.
 	select {
@@ -453,4 +482,104 @@ func TestReplier_Ensemble_ZeroDeliveredLeadSkipsReaction(t *testing.T) {
 		t.Fatalf("%q spoke a reaction after a zero-delivered Lead; none may play", who)
 	case <-time.After(100 * time.Millisecond):
 	}
+}
+
+// TestReplier_Ensemble_TTSFailedLeadSkipsReaction pins ADR-0027 for the Reaction gate
+// (#302): a Lead whose ONLY sentence fails synthesis produced NO audio and NO
+// FirstOpus, so the floor never armed. Even though its (undelivered) text is committed
+// to history, the Reaction must NOT play — a Reaction after the Lead's
+// TurnEnded{tts_error}, atop an un-armed floor, would be UNBARGEABLE (ADR-0027). The
+// gate keys on Floor.Speaking (audible delivery), not committed text.
+func TestReplier_Ensemble_TTSFailedLeadSkipsReaction(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:   map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			spokeCh: make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I react anyway."},
+		reactSpokeCh: make(chan string, 2),
+	}
+	// The Lead's ONLY sentence fails synth (no FirstOpus ever); a bound BargeIn drives
+	// the FirstOpus→MarkSpeaking wiring so this is a faithful "no audio" scenario.
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"Bart leads.": true}})
+	replier := orchestrator.NewStreamReplier(ttsStage, func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error {
+		return nil
+	}, nil)
+	replier.SetFloor(floor)
+	replier.SetEnsemble(spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tf", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "Tf" && e.Reason == voiceevent.TurnEndTTSError
+	}, "the ensemble ended tts_error (the Lead produced no audio)")
+
+	// No Reaction plays atop the un-armed floor, and nothing reacted.
+	select {
+	case who := <-spk.reactSpokeCh:
+		t.Fatalf("%q spoke a reaction after a no-audio Lead; the floor never armed (unbargeable)", who)
+	case <-time.After(200 * time.Millisecond):
+	}
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	if floor.Speaking() {
+		t.Fatal("floor must not be Speaking after a no-audio Lead")
+	}
+}
+
+// TestReplier_Ensemble_ThreeTargets_FastEmptyDraftsNoWedge pins that the reactor pick
+// never blocks on a result that will never arrive (#302, reviewer finding 1): with 3
+// targets where two finish FAST with empty drafts (consumed by the Lead race before
+// the slow winner lands), the reactor pick must not wait on the drained results
+// channel. The Lead still speaks; the pick keys on OUTSTANDING results, not the
+// remaining-targets slice.
+func TestReplier_Ensemble_ThreeTargets_FastEmptyDraftsNoWedge(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	bartGate := make(chan struct{})
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft: map[string]string{
+				bartTarget.AgentID:   "Bart leads.",
+				goblinTarget.AgentID: "", // fast decline
+				miraTarget.AgentID:   "", // fast decline
+			},
+			gate: map[string]chan struct{}{
+				bartTarget.AgentID:   bartGate,     // slow: finishes AFTER the empties are consumed
+				goblinTarget.AgentID: closedGate(), // instant
+				miraTarget.AgentID:   closedGate(), // instant
+			},
+			started: make(chan string, 4),
+			spokeCh: make(chan string, 2),
+		},
+		react:        map[string]string{},
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tw", Text: "Bart, Goblin, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget, miraTarget}})
+
+	// All three drafts started; the two empties are already buffered/consumed.
+	for i := 0; i < 3; i++ {
+		<-spk.started
+	}
+	// Let the race loop consume both empty results, then let Bart finish.
+	time.Sleep(50 * time.Millisecond)
+	close(bartGate)
+
+	select {
+	case who := <-spk.spokeCh:
+		if who != bartTarget.AgentID {
+			t.Fatalf("spoke = %q, want Bart", who)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WEDGED: the Lead never spoke — reactor pick waited on a drained results channel")
+	}
+	// Both remaining candidates declined their drafts, so no one reacts.
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
 }

--- a/pkg/voice/orchestrator/ensemble_crosstalk_test.go
+++ b/pkg/voice/orchestrator/ensemble_crosstalk_test.go
@@ -83,6 +83,21 @@ func (s *fakeCrossTalk) SpeakReaction(ctx context.Context, e voiceevent.AddressR
 	return delivered.String(), nil
 }
 
+// waitFloorFree blocks until floor is released (runEnsemble has fully returned) or
+// fails after 2s. It synchronizes a negative assertion on the whole ensemble turn: a
+// free floor means the coordinator ran its last statement, so the observed-event log
+// is complete.
+func waitFloorFree(t *testing.T, floor *orchestrator.Floor) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for floor.Active() {
+		if time.Now().After(deadline) {
+			t.Fatal("the floor was never released — runEnsemble did not return")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 // ttsInvokedInOrder returns the observed [voiceevent.TTSInvoked] events in order.
 func ttsInvokedInOrder(t *testing.T, h *voicetest.Harness) []voiceevent.TTSInvoked {
 	t.Helper()
@@ -177,21 +192,39 @@ func TestReplier_Ensemble_ReactorDeclines(t *testing.T) {
 	floor := orchestrator.NewFloor()
 	spk := &fakeCrossTalk{
 		fakeEnsemble: &fakeEnsemble{
-			draft:   map[string]string{bartTarget.AgentID: "Bart leads."},
-			gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
-			spokeCh: make(chan string, 2),
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}), // pause so the floor is armed before the reaction gate — the decline branch must actually run
+			spokeCh:        make(chan string, 2),
 		},
 		react:        map[string]string{ /* goblin: no entry → "" → decline */ },
 		reactSpokeCh: make(chan string, 2),
 	}
 	replier := ensembleReplier(h, floor, spk)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	// Arm the floor exactly as the reaction-playing tests do — otherwise the audible
+	// gate would skip the reaction BEFORE the decline branch runs, passing vacuously.
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
 
 	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Td", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead is audible: arm the floor, then release it so the reactor's decline is
+	// actually reached (React returns "" → no event, no line).
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Td" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Td"})
+	close(spk.speakPause)
 
 	<-spk.spokeCh // the Lead's Speak returned
 
 	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleLead) bool { return e.TurnID == "Td" }, "the Lead was elected")
+	// Wait for runEnsemble to FULLY return — the floor is released only after the
+	// reactor's decline path ran to completion (speakReaction: read React's "" → return).
+	// Without this, the assertions below snapshot BEFORE the coordinator reaches the
+	// decline branch, passing vacuously even if a mutation published EnsembleReaction.
+	waitFloorFree(t, floor)
 	// A declined Reaction publishes nothing and speaks nothing.
 	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
 	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)

--- a/pkg/voice/orchestrator/ensemble_crosstalk_test.go
+++ b/pkg/voice/orchestrator/ensemble_crosstalk_test.go
@@ -1,0 +1,456 @@
+package orchestrator_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// miraTarget is a third addressed candidate for the 3+-target reactor-pick tests.
+var miraTarget = voiceevent.AddressTarget{AgentID: "npc-mira", AgentRole: voiceevent.AgentRoleCharacter, Name: "Mira"}
+
+// fakeCrossTalk is the gated [orchestrator.CrossTalker] for the #302 coordinator
+// tests: it embeds the #301 [fakeEnsemble] (Draft/Speak) and adds React/SpeakReaction
+// with the same per-Agent gate/pause machinery so a test drives the Cross-talk
+// Reaction phase deterministically without sleeps (ADR-0021).
+type fakeCrossTalk struct {
+	*fakeEnsemble
+
+	react          map[string]string        // agentID -> reaction text React returns
+	reactErr       map[string]error         // agentID -> React error (optional)
+	reactGate      map[string]chan struct{} // agentID -> React release gate; nil/absent = immediate
+	reactStarted   chan string              // agentID pushed when React begins (optional)
+	reactCancelled chan string              // agentID pushed when React's ctx was cancelled (optional)
+
+	reactSentences map[string][]string // agentID -> sentences SpeakReaction dispatches (default: [reaction])
+	reactPause     chan struct{}       // if set, SpeakReaction blocks after dispatching sentence[0]
+	reactSpokeCh   chan string         // agentID pushed when SpeakReaction returns (optional)
+}
+
+func (s *fakeCrossTalk) React(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText string) (string, error) {
+	id := e.Target.AgentID
+	if s.reactStarted != nil {
+		s.reactStarted <- id
+	}
+	if g := s.reactGate[id]; g != nil {
+		select {
+		case <-g:
+		case <-ctx.Done():
+			if s.reactCancelled != nil {
+				s.reactCancelled <- id
+			}
+			return "", ctx.Err()
+		}
+	}
+	if err := s.reactErr[id]; err != nil {
+		return "", err
+	}
+	return s.react[id], nil
+}
+
+func (s *fakeCrossTalk) SpeakReaction(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText, reaction string, dispatch func(orchestrator.Reply) error) (string, error) {
+	id := e.Target.AgentID
+	if s.reactSpokeCh != nil {
+		defer func() { s.reactSpokeCh <- id }()
+	}
+	sentences := []string{reaction}
+	if s.reactSentences != nil {
+		sentences = s.reactSentences[id]
+	}
+	var delivered strings.Builder
+	for i, snt := range sentences {
+		if err := dispatch(orchestrator.Reply{Sentence: snt, Voice: tts.Voice{VoiceID: id, Name: id}}); err != nil {
+			return delivered.String(), nil // barge: stop the drain, delivered-only
+		}
+		if delivered.Len() > 0 {
+			delivered.WriteByte(' ')
+		}
+		delivered.WriteString(snt)
+		if s.reactPause != nil && i == 0 {
+			select {
+			case <-s.reactPause:
+			case <-ctx.Done():
+				return delivered.String(), nil
+			}
+		}
+	}
+	return delivered.String(), nil
+}
+
+// ttsInvokedInOrder returns the observed [voiceevent.TTSInvoked] events in order.
+func ttsInvokedInOrder(t *testing.T, h *voicetest.Harness) []voiceevent.TTSInvoked {
+	t.Helper()
+	var out []voiceevent.TTSInvoked
+	for _, e := range h.Events() {
+		if ti, ok := e.(voiceevent.TTSInvoked); ok {
+			out = append(out, ti)
+		}
+	}
+	return out
+}
+
+// TestReplier_Ensemble_ReactionFollowsLead is the #302 AC1 headline (ADR-0025): after
+// the Lead speaks, exactly one other addressed Agent's Cross-talk Reaction follows —
+// under a FRESH TurnID linked to the Lead's, its sentences AFTER the Lead's last, and
+// its React generation STARTED during the Lead's playback (before Speak returned).
+func TestReplier_Ensemble_ReactionFollowsLead(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}), // the Lead pauses after its sentence until the test releases it
+			spokeCh:        make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I disagree, loudly."},
+		reactStarted: make(chan string, 2),
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Te", Text: "Bart, Goblin — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead dispatched its sentence and is now paused; the reactor's React ran
+	// DURING that playback (before the Lead's Speak returned).
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Te" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	select {
+	case who := <-spk.reactStarted:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("React started for %q, want the remaining candidate Goblin", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reactor's React never started during the Lead's playback")
+	}
+
+	// Release the Lead so its Speak returns; the queued Reaction then plays.
+	close(spk.speakPause)
+
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		if e.LeadTurnID == "Te" && e.Target.AgentID == goblinTarget.AgentID {
+			rID = e.TurnID
+			return true
+		}
+		return false
+	}, "ensemble.reaction for Goblin linked to the Lead's turn")
+
+	if rID == "" || rID == "Te" {
+		t.Fatalf("reaction TurnID = %q, want a FRESH id distinct from the Lead's Te", rID)
+	}
+
+	// The reaction's sentence lands under the fresh sub-turn id, AFTER the Lead's last.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == rID && e.Sentence == "I disagree, loudly."
+	}, "the reaction sentence on the wire under the reaction sub-turn")
+
+	got := ttsInvokedInOrder(t, h)
+	if len(got) != 2 {
+		t.Fatalf("TTSInvoked = %d, want 2 (Lead then reaction)", len(got))
+	}
+	if got[0].TurnID != "Te" || got[1].TurnID != rID {
+		t.Fatalf("TTSInvoked order = [%s, %s], want [Te, %s] (reactor AFTER the Lead's last)", got[0].TurnID, got[1].TurnID, rID)
+	}
+}
+
+// TestReplier_Ensemble_ReactorDeclines pins the decline path (ADR-0025, #302): when
+// the reactor's React returns "" (the "[SILENCE]" sentinel upstream), the Lead speaks
+// alone — no EnsembleReaction, no second TTSInvoked, no reaction TurnEnded.
+func TestReplier_Ensemble_ReactorDeclines(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:   map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			spokeCh: make(chan string, 2),
+		},
+		react:        map[string]string{ /* goblin: no entry → "" → decline */ },
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Td", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	<-spk.spokeCh // the Lead's Speak returned
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleLead) bool { return e.TurnID == "Td" }, "the Lead was elected")
+	// A declined Reaction publishes nothing and speaks nothing.
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestReplier_Ensemble_BargeDuringLeadDiscardsReaction pins ADR-0027 for the Reaction
+// queue: a human barge while the Lead speaks — with the reactor's React still
+// generating — tears the WHOLE unit down. The reaction never plays: React's ctx is
+// cancelled, no EnsembleReaction is published, and the only turn-end is the barge for
+// the ensemble's original TurnID. A queued Reaction after a barge is FORBIDDEN.
+func TestReplier_Ensemble_BargeDuringLeadDiscardsReaction(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "First. Second."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"First.", "Second."}},
+			speakPause:     make(chan struct{}), // the Lead pauses after sentence 1 until the barge cancels ctx
+			spokeCh:        make(chan string, 2),
+		},
+		react:          map[string]string{goblinTarget.AgentID: "I would react."},
+		reactGate:      map[string]chan struct{}{goblinTarget.AgentID: make(chan struct{})}, // React never releases — it is cut by the barge
+		reactStarted:   make(chan string, 2),
+		reactCancelled: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tb", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead is audibly speaking and the reactor's React has started.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tb" && e.Sentence == "First."
+	}, "the Lead's first sentence is on the wire")
+	<-spk.reactStarted
+
+	// A human barges while the Lead is audible.
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tb"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{})
+
+	// The whole unit tears down: barge for the ensemble's original TurnID.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "Tb" && e.Reason == voiceevent.TurnEndBarge
+	}, "turn.ended barge for the ensemble")
+
+	// The reactor's React was cancelled and it never reached the wire.
+	select {
+	case who := <-spk.reactCancelled:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("React cancelled for %q, want the reactor Goblin", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reactor's React was never cancelled by the barge")
+	}
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	// Only the Lead's first sentence reached the wire (its second and any reaction cut).
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 1)
+	if floor.Active() {
+		t.Fatal("the floor must be free after the barge")
+	}
+}
+
+// TestReplier_Ensemble_BargeDuringReactionEndsSubTurn pins the independently-barge-able
+// Reaction (ADR-0025/0027, #302): a human barge WHILE the Reaction plays tears the
+// unit down. The Reaction's dispatch unwinds (delivered-only), the reaction sub-turn
+// ends with a barge TurnEnded carrying its OWN id, and the Lead's already-delivered
+// line stays committed. The floor stays armed across the whole unit from the Lead's
+// FirstOpus, so the barge lands during the Reaction's playback.
+func TestReplier_Ensemble_BargeDuringReactionEndsSubTurn(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart done."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart done."}},
+			spokeCh:        make(chan string, 2),
+		},
+		react:          map[string]string{goblinTarget.AgentID: "React one. React two."},
+		reactSentences: map[string][]string{goblinTarget.AgentID: {"React one.", "React two."}},
+		reactPause:     make(chan struct{}), // the Reaction pauses after sentence 1 until the barge cancels ctx
+		reactSpokeCh:   make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tr", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead delivered its sentence; arm the floor with its FirstOpus (as the wire
+	// would), so the unit stays barge-able through the gap and the Reaction.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tr" && e.Sentence == "Bart done."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tr"})
+
+	// The Reaction begins under its fresh sub-turn id and pauses after sentence 1.
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		rID = e.TurnID
+		return e.LeadTurnID == "Tr"
+	}, "ensemble.reaction published")
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == rID && e.Sentence == "React one."
+	}, "the Reaction's first sentence is on the wire")
+
+	// A human barges DURING the Reaction's playback.
+	h.Bus.Publish(voiceevent.VADSpeechStart{})
+
+	// The reaction sub-turn ends with a barge under its OWN id.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == rID && e.Reason == voiceevent.TurnEndBarge
+	}, "turn.ended barge for the reaction sub-turn")
+
+	select {
+	case <-spk.reactSpokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the Reaction's SpeakReaction never returned after the barge")
+	}
+	// Only the Reaction's first sentence reached the wire (Lead + reaction sentence 1).
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 2)
+	if floor.Active() {
+		t.Fatal("the floor must be free after the barge")
+	}
+}
+
+// TestReplier_Ensemble_ThreeTargets_FastestRemainingReacts pins the ADR-0025 breadth
+// bound (#302): with 3+ Agents addressed, only ONE — the fastest of the candidates
+// remaining after the Lead — reacts; the rest stay silent that turn. The Lead (Bart)
+// wins the race with the others gated; the first remaining draft to arrive (Goblin)
+// is the reactor, and the third (Mira) is silent and its speculative draft cancelled.
+func TestReplier_Ensemble_ThreeTargets_FastestRemainingReacts(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	goblinGate := make(chan struct{})
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft: map[string]string{bartTarget.AgentID: "Bart leads.", goblinTarget.AgentID: "Goblin draft (discarded).", miraTarget.AgentID: "Mira draft (discarded)."},
+			gate: map[string]chan struct{}{
+				bartTarget.AgentID:   closedGate(),        // wins the Lead race alone (others gated)
+				goblinTarget.AgentID: goblinGate,          // released post-election → fastest remaining → reactor
+				miraTarget.AgentID:   make(chan struct{}), // never released → cancelled, silent
+			},
+			cancelled: make(chan string, 4),
+			spokeCh:   make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I have a hot take."},
+		reactStarted: make(chan string, 4),
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "T3", Text: "Bart, Goblin, Mira?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget, miraTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleLead) bool {
+		return e.TurnID == "T3" && e.Target.AgentID == bartTarget.AgentID
+	}, "Bart elected Lead")
+
+	// Release Goblin so it is the fastest remaining draft to arrive — the reactor.
+	close(goblinGate)
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		return e.LeadTurnID == "T3" && e.Target.AgentID == goblinTarget.AgentID
+	}, "Goblin (fastest remaining) reacts")
+
+	// Only Goblin reacted — Mira never did.
+	select {
+	case who := <-spk.reactStarted:
+		if who != goblinTarget.AgentID {
+			t.Fatalf("React started for %q, want only the reactor Goblin", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reactor's React never started")
+	}
+
+	// Mira stayed silent: its speculative draft was cancelled and it never reacted.
+	sawMiraCancelled := false
+	for !sawMiraCancelled {
+		select {
+		case who := <-spk.cancelled:
+			if who == miraTarget.AgentID {
+				sawMiraCancelled = true
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("the silent third candidate Mira's draft was never cancelled")
+		}
+	}
+	select {
+	case who := <-spk.reactStarted:
+		t.Fatalf("a third candidate reacted (%q); only the fastest remaining may react", who)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestReplier_Ensemble_ReactionDepthCappedAtOne pins the ADR-0025 depth cap (#302): a
+// Reaction never re-triggers the Ensemble machinery. After a full Lead + Reaction, the
+// reaction sub-turn publishes NO new routing (no AddressRouted / EnsembleRouted), no
+// second EnsembleReaction, and no second EnsembleLead — it runs exactly once.
+func TestReplier_Ensemble_ReactionDepthCappedAtOne(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:   map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:    map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			spokeCh: make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I have a reaction."},
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tc", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// Wait for the reaction to actually play out.
+	select {
+	case <-spk.reactSpokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reaction never played")
+	}
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool { return e.LeadTurnID == "Tc" }, "the reaction played once")
+
+	// Depth 1: no re-routing, exactly one of each ensemble signal, no reaction-to-reaction.
+	voicetest.AssertNoEvent[voiceevent.AddressRouted](t, h)
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 1)
+	voicetest.AssertEventCount[voiceevent.EnsembleLead](t, h, 1)
+	voicetest.AssertEventCount[voiceevent.EnsembleReaction](t, h, 1)
+}
+
+// TestReplier_Ensemble_ZeroDeliveredLeadSkipsReaction pins the "Lead delivered ≥1
+// sentence" precondition (ADR-0025, #302): if the elected Lead speaks nothing (its
+// dispatch delivered zero sentences — a barge or synth gap), there is nothing to
+// cross-talk, so no Reaction is published or spoken even though a reactor stood ready.
+func TestReplier_Ensemble_ZeroDeliveredLeadSkipsReaction(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {}}, // the Lead delivers NOTHING
+			spokeCh:        make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I would have reacted."},
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tz", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	<-spk.spokeCh // the Lead's (empty) Speak returned
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleLead) bool { return e.TurnID == "Tz" }, "the Lead was elected")
+
+	// The Lead delivered nothing, so no Reaction plays.
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	voicetest.AssertEventCount[voiceevent.TTSInvoked](t, h, 0)
+	select {
+	case who := <-spk.reactSpokeCh:
+		t.Fatalf("%q spoke a reaction after a zero-delivered Lead; none may play", who)
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -210,6 +210,32 @@ type EnsembleLead struct {
 // EventName implements [Event].
 func (EnsembleLead) EventName() string { return "ensemble.lead" }
 
+// EnsembleReaction marks the Cross-talk Reaction phase of an Ensemble Turn (ADR-0025,
+// #302): after the Lead delivered at least one sentence, the coordinator fed the
+// Lead's text to one other addressed Agent as Cross-talk, and that Agent produced a
+// non-empty Reaction it is about to speak. It is published ONLY when the reaction is
+// non-empty (a decline publishes nothing), immediately before the reaction's first
+// sentence dispatches, so the transcript relay attributes the reaction's line to the
+// reacting Agent.
+//
+// Unlike the Lead — which speaks under the ensemble's ORIGINAL TurnID — the Reaction
+// is a distinct sub-turn: TurnID is a FRESH [NewTurnID] (so its [TTSInvoked] /
+// [FirstOpus] / TurnEnded correlate as an independent turn and land on their own
+// transcript line), and LeadTurnID links back to the Lead's turn it reacted to. The
+// Reaction is independently barge-able: a human barge during its playback ends it
+// with a TurnEnded carrying THIS TurnID, while the Lead's already-delivered line
+// stays committed. Depth is capped at 1 — a Reaction never triggers a further
+// Reaction (ADR-0025).
+type EnsembleReaction struct {
+	At         time.Time
+	TurnID     string // FRESH NewTurnID for the reaction sub-turn
+	LeadTurnID string // the Lead's (ensemble original) TurnID this reacts to
+	Target     AddressTarget
+}
+
+// EventName implements [Event].
+func (EnsembleReaction) EventName() string { return "ensemble.reaction" }
+
 // SpeakRequested marks a GM-puppeteered direct-speech request: the `/say <text>
 // as:<agent>` slash command (ADR-0010, #295) asks an Agent to speak Text verbatim,
 // bypassing Address Detection and the LLM Replier entirely (ADR-0024 — /say is the


### PR DESCRIPTION
Closes #302. Builds on #301 (b090b4e), consumed unchanged.

The second half of ADR-0025: after the Ensemble Turn's Lead takes the floor and speaks, feed its delivered text to at most one other addressed Agent as **Cross-talk**; that Agent generates a **Reaction** — a short affirmation, a longer disagreement, or a decline — that plays after the Lead, reaction depth capped at 1.

## What landed (TDD, red→green per slice)
- **voiceevent** `EnsembleReaction{TurnID (fresh NewTurnID), LeadTurnID, Target}` — published ONLY for a non-empty reaction, immediately before its first dispatch; a decline publishes nothing.
- **agent** `Replier.React` (pure — history snapshot, no commit; `[SILENCE]` sentinel or empty ⇒ decline) and `Replier.SpeakReaction`, both over a single `crossTalkUserText` composition site used for BOTH the React prompt AND the SpeakReaction history commit, so the recorded turn and the reasoned-over prompt never drift. `agent.Cast` implements `orchestrator.CrossTalker`.
- **orchestrator** the coordinator discovers cross-talk by a **type assertion** on the wired `EnsembleSpeaker` (`r.ensemble.(CrossTalker)`) — no new option. Phase structure enforces the hard constraints:
  - the Reaction NEVER dispatches before the Lead's last `Dispatch` returned (no overlapping dispatches into the single-in-flight pump);
  - the Reaction plays only if the Lead delivered ≥1 sentence (guarantees `FirstOpus(T)` fired → floor armed through the gap + reaction playback);
  - a barge anywhere (draft / lead / gap / reaction) tears down the ONE floor unit; a queued reaction after a barge is forbidden; a barge during reaction playback ends the sub-turn with `TurnEnded{rID, barge}` while the Lead's delivered line stays committed;
  - 3+ targets: the **fastest remaining** draft to arrive names the reactor (its speculative draft discarded), the rest stay silent; the reactor-pick `select` includes `turnCtx.Done()` (barge-bounded), and generation is bounded by each Draft's TurnTimeout;
  - depth cap 1 is structural — the reaction path publishes no `AddressRouted`/`EnsembleRouted` and runs once.
- **relay** `EnsembleReaction` lands the reaction as its own line (`a:<rID>`) beneath the Lead's; a decline leaves no line.

Determinism: coordinator tests use gated fakes (React/SpeakReaction release gates supply order, cassettes would supply text) — zero sleeps, one bounded negative-assertion window (per #301 precedent). No new LLM cassette required; if review wants a live React-prompt cassette that needs a `-tags=record` run with live keys.

## Audio pre-render deferral (explicit)
`pkg/voice/wire/pump.go` (~L27-31) deliberately defers eager pre-buffering — the lockstep tee has no buffer seam, so sentence N+1's synthesis back-pressures until N finishes. **#302 pre-renders TEXT only**: React generation runs concurrently during the Lead's playback, but the Reaction's audio dispatch only begins after the Lead's last Dispatch returned. Net: the Reaction onset gap is **one TTS TTFB** (~200-300ms), not gapless. Filed **#375** (ready-for-agent) for a pump pre-render queue seam, citing that comment.

## Tests added (13 functions, gate-deterministic)
- `agent`: React composite prompt; React decline (sentinel/padded/empty); Cast.React routing; Cast.SpeakReaction commits composite user msg + delivered.
- `orchestrator`: reaction-follows-lead (fresh rID + LeadTurnID, sentences after Lead's last, React started during playback); reactor declines; barge during Lead discards reaction; barge during reaction ends the sub-turn; 3-target fastest-remaining reacts (third silent + cancelled); depth capped at 1; zero-delivered Lead skips reaction.
- `transcript`: reaction lands a separate attributed line; decline leaves no line.

Byte-identity preserved: `#301` fakeEnsemble does not implement `CrossTalker`, so the Lead-only path is unchanged; `MaxTargets=1` default keeps the whole ensemble branch dead code.

Follow-up: #375 (pump pre-render queue seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)