### PR TITLE
feat(#294): [E6] web Export/Import on the Campaign switcher

### DIFF
--- a/web/src/components/CampaignRowActions.test.tsx
+++ b/web/src/components/CampaignRowActions.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
@@ -14,6 +14,21 @@ import {
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { CampaignRowActions } from "./CampaignRowActions";
+
+// Export runs through the plain-fetch bundle helpers; mock them so the row's
+// Export flow is observable without a real network/download pipeline.
+vi.mock("@/lib/download", () => ({
+  fetchCampaignExport: vi.fn(),
+  downloadBlob: vi.fn(),
+}));
+import { fetchCampaignExport, downloadBlob } from "@/lib/download";
+const mockFetchExport = vi.mocked(fetchCampaignExport);
+const mockDownloadBlob = vi.mocked(downloadBlob);
+
+beforeEach(() => {
+  mockFetchExport.mockReset();
+  mockDownloadBlob.mockReset();
+});
 
 // A minimal Connect backend recording each lifecycle call so the tests assert the
 // right RPC fired. ListCampaigns is served so the post-mutation invalidation has a
@@ -120,7 +135,8 @@ describe("CampaignRowActions", () => {
     renderActions({ id: "a", name: "Alpha Quest", archived: false });
     const trigger = screen.getByRole("button", { name: /Campaign actions/i });
     fireEvent.click(trigger);
-    expect(screen.getByRole("menuitem", { name: /^Archive$/ })).toHaveFocus();
+    // Export now leads the menu, so it's the first enabled item focus lands on.
+    expect(screen.getByRole("menuitem", { name: /Export/ })).toHaveFocus();
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
@@ -152,5 +168,36 @@ describe("CampaignRowActions", () => {
     expect(confirm).toBeEnabled();
     fireEvent.click(confirm);
     await waitFor(() => expect(calls.deleteCampaign).toBe(1));
+  });
+
+  it("offers Export on an active row and downloads the fetched bundle", async () => {
+    mockFetchExport.mockResolvedValue({
+      blob: new Blob(["gz"]),
+      filename: "Alpha Quest.glyphoxa.json.gz",
+    });
+    renderActions({ id: "a", name: "Alpha Quest", archived: false });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Export/ }));
+
+    await waitFor(() => expect(mockFetchExport).toHaveBeenCalledWith("a"));
+    await waitFor(() =>
+      expect(mockDownloadBlob).toHaveBeenCalledWith(expect.any(Blob), "Alpha Quest.glyphoxa.json.gz"),
+    );
+  });
+
+  it("offers Export on an archived row too (bundles are a backup)", () => {
+    renderActions({ id: "z", name: "Zombie Vault", archived: true });
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: /Export/ })).toBeInTheDocument();
+  });
+
+  it("surfaces an export failure and does not download", async () => {
+    mockFetchExport.mockRejectedValue(new Error("export exploded"));
+    renderActions({ id: "a", name: "Alpha Quest", archived: false });
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Export/ }));
+
+    await waitFor(() => expect(mockFetchExport).toHaveBeenCalled());
+    expect(mockDownloadBlob).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/CampaignRowActions.tsx
+++ b/web/src/components/CampaignRowActions.tsx
@@ -3,10 +3,11 @@ import { createPortal } from "react-dom";
 import { useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Archive, ArchiveRestore, MoreHorizontal, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Download, MoreHorizontal, Trash2 } from "lucide-react";
 
 import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 import { invalidateActiveCampaignScopedQueries } from "@/lib/campaignCache";
+import { fetchCampaignExport, downloadBlob } from "@/lib/download";
 import { usePopoverDismiss } from "@/components/ui/usePopoverDismiss";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
@@ -34,14 +35,16 @@ type CampaignRow = { id: string; name: string; archived: boolean };
 type MenuPos = { top: number; right: number; flipUp: boolean };
 
 // A conservative menu-height estimate for the flip decision, taken before the
-// menu has laid out. The tallest variant (archived: Unarchive + Delete…) is ~2
-// rows plus padding; overestimating only flips slightly earlier, which is safe.
-const MENU_HEIGHT_ESTIMATE = 96;
+// menu has laid out. Every variant now leads with Export, so the tallest
+// (archived: Export + Unarchive + Delete…) is ~3 rows plus padding;
+// overestimating only flips slightly earlier, which is safe.
+const MENU_HEIGHT_ESTIMATE = 128;
 
 export function CampaignRowActions({ campaign }: { campaign: CampaignRow }) {
   const queryClient = useQueryClient();
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [pos, setPos] = useState<MenuPos | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -113,6 +116,24 @@ export function CampaignRowActions({ campaign }: { campaign: CampaignRow }) {
     void invalidateActiveCampaignScopedQueries(queryClient);
   };
 
+  // Export streams the campaign's bundle over the plain-net/http endpoint (not a
+  // Connect RPC — bundles are gzip, ADR-0015/0053) and saves it via a transient
+  // download anchor. Available on EVERY row, archived included: a bundle is a
+  // backup, and an archived campaign is exactly what an operator wants to snapshot
+  // before a hard delete. A failure toasts and never triggers a download.
+  const runExport = async () => {
+    setExporting(true);
+    try {
+      const { blob, filename } = await fetchCampaignExport(campaign.id);
+      downloadBlob(blob, filename);
+      setMenuOpen(false);
+    } catch (err) {
+      toast.error(`Couldn't export campaign: ${(err as Error).message}`);
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const archive = useMutation(CampaignService.method.archiveCampaign, {
     onSuccess: () => {
       setMenuOpen(false);
@@ -175,6 +196,15 @@ export function CampaignRowActions({ campaign }: { campaign: CampaignRow }) {
                 : undefined
             }
           >
+            <button
+              type="button"
+              role="menuitem"
+              className="gx-select__item"
+              disabled={exporting}
+              onClick={() => void runExport()}
+            >
+              <Download size={14} /> {exporting ? "Exporting…" : "Export"}
+            </button>
             {campaign.archived ? (
               <>
                 <button

--- a/web/src/components/CampaignSwitcher.test.tsx
+++ b/web/src/components/CampaignSwitcher.test.tsx
@@ -622,6 +622,15 @@ describe("CampaignSwitcher", () => {
     expect(screen.queryByRole("button", { name: /campaign settings/i })).not.toBeInTheDocument();
   });
 
+  it("offers an Import campaign action in the manage-view footer (#294)", async () => {
+    renderSwitcher(mockBackend({ campaigns: [{ id: "a", name: "Alpha Quest" }], activeId: "a" }));
+    await screen.findByText("Alpha Quest");
+    openPanel();
+    await screen.findByRole("group", { name: /campaigns/i });
+    // The bundle-import affordance sits in the list footer beside New campaign.
+    expect(await screen.findByRole("button", { name: /import campaign/i })).toBeInTheDocument();
+  });
+
   it("disables the settings action when no active campaign resolves (#268)", async () => {
     // Campaigns exist but resolution FAILS (non-NotFound): the list still opens,
     // and the settings button renders — but disabled, since there is no resolved

--- a/web/src/components/CampaignSwitcher.tsx
+++ b/web/src/components/CampaignSwitcher.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/Badge";
 import { CampaignRowActions } from "./CampaignRowActions";
 import { CreateCampaignForm, useCreateCampaign } from "./CreateCampaignForm";
 import { CampaignSettingsForm } from "./CampaignSettingsForm";
+import { ImportCampaignButton } from "./ImportCampaignButton";
 
 import "./campaignSwitcher.css";
 
@@ -261,6 +262,12 @@ export function CampaignSwitcher() {
               <button type="button" className="gx-campaign-switcher__new" onClick={enterCreate}>
                 <Plus size={15} /> New campaign
               </button>
+
+              {/* Restore a campaign from an exported bundle (#294). It mints a new
+                  campaign and, on an explicit "Switch", runs the same
+                  SetActiveCampaign path a normal switch does — so it closes the
+                  panel on success. */}
+              <ImportCampaignButton onSwitched={close} />
 
               {/* Edit the resolved Active Campaign's name / System / Language
                   (#268). Disabled until a campaign resolves — there is nothing to

--- a/web/src/components/ImportCampaignButton.test.tsx
+++ b/web/src/components/ImportCampaignButton.test.tsx
@@ -21,6 +21,12 @@ vi.mock("@/lib/download", () => ({ importCampaignBundle: vi.fn() }));
 import { importCampaignBundle, type ImportSummary } from "@/lib/download";
 const mockImport = vi.mocked(importCampaignBundle);
 
+// Toasts are the unmount-proof feedback channel (they render outside the panel),
+// so assert them directly rather than only the inline alert/dialog.
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+import { toast } from "sonner";
+const mockToast = vi.mocked(toast);
+
 const summaryFixture: ImportSummary = {
   campaignId: "imported-1",
   name: "The Prancing Pony",
@@ -90,6 +96,8 @@ function pickFile(name = "bundle.glyphoxa.json.gz") {
 
 beforeEach(() => {
   mockImport.mockReset();
+  mockToast.success.mockReset();
+  mockToast.error.mockReset();
 });
 
 describe("ImportCampaignButton", () => {
@@ -113,6 +121,18 @@ describe("ImportCampaignButton", () => {
     const success = await screen.findByRole("alertdialog");
     expect(within(success).getByRole("heading", { name: /Imported.*The Prancing Pony/ })).toBeInTheDocument();
     expect(within(success).getByRole("button", { name: /Switch/ })).toBeInTheDocument();
+    // A toast fires too — unmount-proof feedback if the panel closes mid-flow.
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith(expect.stringMatching(/The Prancing Pony/)));
+  });
+
+  it("toasts the failure so feedback survives a mid-upload panel dismissal", async () => {
+    mockImport.mockRejectedValue(new Error("import failed"));
+    renderButton();
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+    // The confirm dialog is already closed by Radix; without a toast a failure
+    // after a panel dismissal would report nowhere.
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith(expect.stringMatching(/import failed/)));
   });
 
   it("surfaces the server error message when the import fails", async () => {

--- a/web/src/components/ImportCampaignButton.test.tsx
+++ b/web/src/components/ImportCampaignButton.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { useQuery } from "@connectrpc/connect-query";
+
+import {
+  CampaignService,
+  ListCampaignsResponseSchema,
+  SetActiveCampaignResponseSchema,
+  CampaignSchema,
+  GetCampaignRosterResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { ImportCampaignButton } from "./ImportCampaignButton";
+
+// The bundle upload rides the plain-fetch helper; mock it so the import flow is
+// observable without a network/multipart round-trip.
+vi.mock("@/lib/download", () => ({ importCampaignBundle: vi.fn() }));
+import { importCampaignBundle, type ImportSummary } from "@/lib/download";
+const mockImport = vi.mocked(importCampaignBundle);
+
+const summaryFixture: ImportSummary = {
+  campaignId: "imported-1",
+  name: "The Prancing Pony",
+  agents: 2,
+  nodes: 4,
+  edges: 2,
+  characters: 1,
+  sessions: 0,
+  lines: 0,
+  chunks: 0,
+};
+
+// A stateful backend: SetActiveCampaign records the switch; ListCampaigns +
+// getCampaignRoster let probes prove the post-import invalidation and the switch
+// sweep from the screen's side.
+function mockBackend(calls: Record<string, number> = {}) {
+  const bump = (m: string) => {
+    calls[m] = (calls[m] ?? 0) + 1;
+  };
+  return createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listCampaigns: () => {
+        bump("listCampaigns");
+        return create(ListCampaignsResponseSchema, { campaigns: [] });
+      },
+      setActiveCampaign: (req) => {
+        bump("setActiveCampaign");
+        return create(SetActiveCampaignResponseSchema, {
+          campaign: create(CampaignSchema, { id: req.campaignId, name: "The Prancing Pony" }),
+        });
+      },
+      getCampaignRoster: () => {
+        bump("getCampaignRoster");
+        return create(GetCampaignRosterResponseSchema, { roster: [] });
+      },
+    });
+  });
+}
+
+function ListProbe() {
+  const { data } = useQuery(CampaignService.method.listCampaigns, {});
+  return <div data-testid="list-probe">{data ? "loaded" : "…"}</div>;
+}
+
+function RosterProbe() {
+  const { data } = useQuery(CampaignService.method.getCampaignRoster, {});
+  return <div data-testid="roster-probe">{data ? "loaded" : "…"}</div>;
+}
+
+function renderButton(calls?: Record<string, number>, onSwitched?: () => void) {
+  return render(
+    <Providers transport={mockBackend(calls)} queryClient={makeQueryClient()}>
+      <ImportCampaignButton onSwitched={onSwitched} />
+      <ListProbe />
+      <RosterProbe />
+    </Providers>,
+  );
+}
+
+// pickFile fires a change on the hidden file input with a bundle File.
+function pickFile(name = "bundle.glyphoxa.json.gz") {
+  const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+  const file = new File(["{}"], name, { type: "application/gzip" });
+  Object.defineProperty(input, "files", { value: [file], configurable: true });
+  fireEvent.change(input);
+}
+
+beforeEach(() => {
+  mockImport.mockReset();
+});
+
+describe("ImportCampaignButton", () => {
+  it("confirms, uploads, then offers to switch to the imported campaign", async () => {
+    mockImport.mockResolvedValue(summaryFixture);
+    renderButton();
+
+    // Pick a file → a confirm dialog gates the upload (no fire-on-pick).
+    pickFile();
+    const confirm = await screen.findByRole("alertdialog");
+    expect(within(confirm).getByText(/bundle\.glyphoxa\.json\.gz/)).toBeInTheDocument();
+    expect(mockImport).not.toHaveBeenCalled();
+
+    // Confirm → the upload fires with the picked file.
+    fireEvent.click(within(confirm).getByRole("button", { name: /^Import$/ }));
+    await waitFor(() => expect(mockImport).toHaveBeenCalledOnce());
+    expect(mockImport.mock.calls[0][0]).toBeInstanceOf(File);
+
+    // Success dialog names the campaign and offers an explicit Switch (ADR-0053 d7:
+    // import never auto-activates).
+    const success = await screen.findByRole("alertdialog");
+    expect(within(success).getByRole("heading", { name: /Imported.*The Prancing Pony/ })).toBeInTheDocument();
+    expect(within(success).getByRole("button", { name: /Switch/ })).toBeInTheDocument();
+  });
+
+  it("surfaces the server error message when the import fails", async () => {
+    mockImport.mockRejectedValue(new Error("bundle too large (limit 32 MiB)"));
+    renderButton();
+
+    pickFile();
+    const confirm = await screen.findByRole("alertdialog");
+    fireEvent.click(within(confirm).getByRole("button", { name: /^Import$/ }));
+
+    expect(await screen.findByText(/bundle too large/)).toBeInTheDocument();
+  });
+
+  it("refreshes the campaign list on import even when the switch is declined", async () => {
+    mockImport.mockResolvedValue(summaryFixture);
+    const calls: Record<string, number> = {};
+    renderButton(calls);
+    // Let the ListProbe seed the campaign-list cache first.
+    await waitFor(() => expect(calls.listCampaigns).toBeGreaterThanOrEqual(1));
+    const listedBefore = calls.listCampaigns;
+
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+
+    // Success prompt is up; decline the switch (Not now).
+    const success = await screen.findByRole("alertdialog");
+    fireEvent.click(within(success).getByRole("button", { name: /Not now/ }));
+
+    // listCampaigns is sweep-INVARIANT, so the import must invalidate it explicitly
+    // or the freshly imported campaign is invisible in the picker until a reload.
+    await waitFor(() => expect(calls.listCampaigns).toBeGreaterThan(listedBefore));
+    // Declining did NOT switch.
+    expect(calls.setActiveCampaign ?? 0).toBe(0);
+  });
+
+  it("switches to the imported campaign and sweeps campaign-scoped caches", async () => {
+    mockImport.mockResolvedValue(summaryFixture);
+    const calls: Record<string, number> = {};
+    const onSwitched = vi.fn();
+    renderButton(calls, onSwitched);
+    // Seed the roster probe (a campaign-scoped read the sweep must refetch).
+    await waitFor(() => expect(calls.getCampaignRoster).toBeGreaterThanOrEqual(1));
+    const rosterBefore = calls.getCampaignRoster;
+
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+    const success = await screen.findByRole("alertdialog");
+    fireEvent.click(within(success).getByRole("button", { name: /Switch/ }));
+
+    // The switch fired with the imported campaign's id…
+    await waitFor(() => expect(calls.setActiveCampaign).toBe(1));
+    // …its success ran the campaign-scoped sweep, refetching the roster probe…
+    await waitFor(() => expect(calls.getCampaignRoster).toBeGreaterThan(rosterBefore));
+    // …and told the parent so it can close the switcher panel.
+    await waitFor(() => expect(onSwitched).toHaveBeenCalled());
+  });
+});

--- a/web/src/components/ImportCampaignButton.tsx
+++ b/web/src/components/ImportCampaignButton.tsx
@@ -1,0 +1,167 @@
+import { useRef, useState } from "react";
+import { useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Upload } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import { invalidateActiveCampaignScopedQueries } from "@/lib/campaignCache";
+import { importCampaignBundle, type ImportSummary } from "@/lib/download";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+import "./importCampaignButton.css";
+
+// ImportCampaignButton — the campaign-restore affordance in the switcher's
+// manage-view footer (#294, beside CreateCampaignForm). It uploads a Campaign
+// Bundle (the export's counterpart) over the plain-net/http importer, which mints
+// a NEW campaign and does NOT auto-activate it (ADR-0053 d7). So the flow is:
+// pick a file → confirm (nothing is overwritten, but an upload is deliberate) →
+// pending upload → a success prompt that reports the imported name and offers an
+// EXPLICIT switch. Declining leaves the imported campaign in the list, unselected.
+//
+// listCampaigns is campaign-INVARIANT — the Active-Campaign sweep deliberately
+// skips it (campaignCache.ts), so a fresh import would be invisible in the picker
+// until a reload unless we invalidate it explicitly. We do that the moment the
+// import succeeds, BEFORE any switch decision, so the new campaign shows up either
+// way. A "Switch" runs the normal SetActiveCampaign path, whose success then runs
+// the campaign-scoped sweep so every screen follows the new selection.
+//
+// fetch exposes no upload progress, so the pending state is a disabled/"Importing…"
+// affordance rather than a percentage bar.
+export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }) {
+  const queryClient = useQueryClient();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // pendingFile drives the confirm dialog; summary drives the success/switch
+  // dialog. They never coexist — a successful import clears the file and sets the
+  // summary. error is the last upload failure, shown inline in the confirm dialog.
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const invalidateList = () =>
+    queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listCampaigns,
+        cardinality: "finite",
+      }),
+    });
+
+  const setActive = useMutation(CampaignService.method.setActiveCampaign, {
+    onSuccess: () => {
+      void invalidateActiveCampaignScopedQueries(queryClient);
+      setSummary(null);
+      onSwitched?.();
+    },
+    onError: (err) => toast.error(`Imported it, but couldn't switch to it: ${err.message}`),
+  });
+
+  // Opening the native file picker; the input is reset on each open so re-picking
+  // the SAME file still fires a change (browsers suppress an unchanged value).
+  const openPicker = () => {
+    setError(null);
+    inputRef.current?.click();
+  };
+
+  const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    e.target.value = "";
+    if (file) {
+      setError(null);
+      setPendingFile(file);
+    }
+  };
+
+  // Radix AlertDialog.Action closes the dialog on click, so the confirm dialog is
+  // gone by the time the upload resolves. Capture the file, then upload against
+  // that value — a failure surfaces in the standalone alert below the trigger
+  // (not the now-closed dialog), and a success opens the switch prompt.
+  const runImport = async (file: File) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await importCampaignBundle(file);
+      // The new campaign must appear in the picker whether or not the operator
+      // switches to it — listCampaigns is sweep-invariant, so invalidate it now.
+      void invalidateList();
+      setSummary(result);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".gz,.json,application/gzip,application/json"
+        className="gx-import-campaign__input"
+        onChange={onFileChosen}
+      />
+      <button
+        type="button"
+        className="gx-campaign-switcher__new gx-import-campaign__trigger"
+        onClick={openPicker}
+        disabled={busy}
+      >
+        <Upload size={15} /> {busy ? "Importing…" : "Import campaign"}
+      </button>
+
+      {/* fetch exposes no upload progress, so a failure shows here as a persistent
+          alert rather than a progress bar; it clears on the next pick/open. */}
+      {error && (
+        <p className="gx-import-campaign__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Confirm gate — an upload is deliberate; a stray file pick shouldn't mint a
+          campaign. */}
+      <ConfirmDialog
+        open={pendingFile !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingFile(null);
+        }}
+        title="Import campaign?"
+        description={
+          <span className="gx-import-campaign__file">
+            Create a new campaign from <strong>{pendingFile?.name}</strong>. Nothing existing is
+            overwritten.
+          </span>
+        }
+        confirmLabel="Import"
+        cancelLabel="Cancel"
+        confirmDisabled={busy}
+        destructive={false}
+        onConfirm={() => {
+          const file = pendingFile;
+          if (file) void runImport(file);
+        }}
+      />
+
+      {/* Success — report the imported campaign and offer an EXPLICIT switch
+          (ADR-0053 d7). Declining keeps it in the list, unselected. */}
+      <ConfirmDialog
+        open={summary !== null}
+        onOpenChange={(o) => {
+          if (!o) setSummary(null);
+        }}
+        title={summary ? `Imported “${summary.name}”` : ""}
+        description={
+          summary
+            ? `“${summary.name}” was imported as a new campaign — switch to it now?`
+            : undefined
+        }
+        confirmLabel="Switch"
+        cancelLabel="Not now"
+        confirmDisabled={setActive.isPending}
+        destructive={false}
+        onConfirm={() => summary && setActive.mutate({ campaignId: summary.campaignId })}
+      />
+    </>
+  );
+}

--- a/web/src/components/ImportCampaignButton.tsx
+++ b/web/src/components/ImportCampaignButton.tsx
@@ -77,6 +77,12 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
   // gone by the time the upload resolves. Capture the file, then upload against
   // that value — a failure surfaces in the standalone alert below the trigger
   // (not the now-closed dialog), and a success opens the switch prompt.
+  //
+  // Both outcomes ALSO toast (ADR-0017): between the confirm dialog closing and
+  // the success dialog opening no modal is mounted, so an Escape / outside-click
+  // can dismiss the whole switcher panel and unmount this component mid-upload —
+  // the inline alert/dialog would then report nowhere. The toast is anchored
+  // outside the panel, so feedback survives that unmount either way.
   const runImport = async (file: File) => {
     setBusy(true);
     setError(null);
@@ -86,8 +92,11 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
       // switches to it — listCampaigns is sweep-invariant, so invalidate it now.
       void invalidateList();
       setSummary(result);
+      toast.success(`Imported “${result.name}”`);
     } catch (err) {
-      setError((err as Error).message);
+      const message = (err as Error).message;
+      setError(message);
+      toast.error(`Couldn't import campaign: ${message}`);
     } finally {
       setBusy(false);
     }
@@ -95,11 +104,15 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
 
   return (
     <>
+      {/* Driven programmatically from the visible trigger, so it's an off-screen,
+          non-focusable, screen-reader-hidden element — not a stray tab stop. */}
       <input
         ref={inputRef}
         type="file"
         accept=".gz,.json,application/gzip,application/json"
         className="gx-import-campaign__input"
+        tabIndex={-1}
+        aria-hidden="true"
         onChange={onFileChosen}
       />
       <button

--- a/web/src/components/importCampaignButton.css
+++ b/web/src/components/importCampaignButton.css
@@ -1,0 +1,29 @@
+/* Campaign Bundle import affordance (#294) — a footer button beside "New
+ * campaign" that opens the native file picker, then a confirm → success/switch
+ * dialog flow. Shares the switcher footer's .gx-campaign-switcher__new row look. */
+
+/* The file <input> is driven programmatically from the trigger; keep it out of
+ * layout and off-screen without display:none (which some browsers refuse to
+ * .click()). */
+.gx-import-campaign__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* The confirm dialog's body stacks the explanatory line above any upload error. */
+.gx-import-campaign__file {
+  display: block;
+}
+.gx-import-campaign__error {
+  display: block;
+  margin-top: var(--spacing-sm);
+  color: var(--danger, #e5484d);
+  font-size: 13px;
+}

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { downloadBlob, fetchCampaignExport, importCampaignBundle } from "./download";
+
+// jsdom has no real download pipeline: URL.createObjectURL is unimplemented and
+// anchor.click() is a no-op. We stub the object-URL lifecycle (mirrors audio.ts)
+// and observe the transient <a download> node the helper builds.
+const createObjectURL = vi.fn(() => "blob:export");
+const revokeObjectURL = vi.fn();
+
+beforeEach(() => {
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  (URL as unknown as Record<string, unknown>).createObjectURL = createObjectURL;
+  (URL as unknown as Record<string, unknown>).revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  delete (URL as unknown as Record<string, unknown>).createObjectURL;
+  delete (URL as unknown as Record<string, unknown>).revokeObjectURL;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("downloadBlob", () => {
+  it("creates and clicks a hidden <a download=filename>, then revokes the object URL", () => {
+    // Observe the anchor at click time: the helper removes it synchronously after.
+    let clicked: { download: string; href: string } | null = null;
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreate(tag) as HTMLElement;
+      if (tag === "a") {
+        el.addEventListener("click", () => {
+          const a = el as HTMLAnchorElement;
+          clicked = { download: a.download, href: a.href };
+        });
+      }
+      return el;
+    });
+
+    downloadBlob(new Blob(["x"]), "camp.glyphoxa.json.gz");
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(clicked).not.toBeNull();
+    expect(clicked!.download).toBe("camp.glyphoxa.json.gz");
+    expect(clicked!.href).toContain("blob:export");
+    // The transient anchor is gone and its object URL released — no DOM/blob leak.
+    expect(document.querySelector("a")).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
+  });
+});
+
+describe("fetchCampaignExport", () => {
+  it("returns the blob and the filename from Content-Disposition on 200", async () => {
+    const blob = new Blob(["bundle-bytes"], { type: "application/gzip" });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(blob, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/gzip",
+          "Content-Disposition": 'attachment; filename="The Prancing Pony.glyphoxa.json.gz"',
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await fetchCampaignExport("camp-1");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/campaigns/camp-1/export");
+    expect(out.filename).toBe("The Prancing Pony.glyphoxa.json.gz");
+    expect(out.blob).toBeInstanceOf(Blob);
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to a default filename when Content-Disposition is absent", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(new Blob(["x"]), { status: 200 })));
+    const out = await fetchCampaignExport("camp-1");
+    expect(out.filename).toBe("campaign.glyphoxa.json.gz");
+    vi.unstubAllGlobals();
+  });
+
+  it("throws the server's error text on a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("campaign not found", { status: 404 })),
+    );
+    await expect(fetchCampaignExport("missing")).rejects.toThrow(/campaign not found/);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("importCampaignBundle", () => {
+  const bundleFile = () =>
+    new File(["{}"], "bundle.glyphoxa.json.gz", { type: "application/gzip" });
+
+  afterEach(() => {
+    document.cookie = "glyphoxa_csrf=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  });
+
+  it("POSTs the file as multipart field 'bundle' with the CSRF header and returns the summary", async () => {
+    document.cookie = "glyphoxa_csrf=tok-123";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          campaign_id: "camp-9",
+          name: "The Prancing Pony",
+          agents: 2,
+          nodes: 4,
+          edges: 2,
+          characters: 1,
+          sessions: 0,
+          lines: 0,
+          chunks: 0,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const summary = await importCampaignBundle(bundleFile());
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/campaigns/import");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get("bundle")).toBeInstanceOf(File);
+    expect((init.headers as Record<string, string>)["X-CSRF-Token"]).toBe("tok-123");
+    // Same-origin credentialed by default — never opt out, or the operator gate rejects.
+    expect(init.credentials).toBeUndefined();
+
+    expect(summary).toEqual({
+      campaignId: "camp-9",
+      name: "The Prancing Pony",
+      agents: 2,
+      nodes: 4,
+      edges: 2,
+      characters: 1,
+      sessions: 0,
+      lines: 0,
+      chunks: 0,
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("throws the server {error} message on a 400 bad-bundle response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "unsupported bundle format v2 (this build reads v1)" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    await expect(importCampaignBundle(bundleFile())).rejects.toThrow(/unsupported bundle format v2/);
+    vi.unstubAllGlobals();
+  });
+
+  it("throws the server {error} message on a 413 oversized response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "bundle too large (limit 32 MiB)" }), {
+          status: 413,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    await expect(importCampaignBundle(bundleFile())).rejects.toThrow(/too large/);
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -38,15 +38,23 @@ describe("downloadBlob", () => {
       return el;
     });
 
+    vi.useFakeTimers();
     downloadBlob(new Blob(["x"]), "camp.glyphoxa.json.gz");
 
     expect(createObjectURL).toHaveBeenCalledOnce();
     expect(clicked).not.toBeNull();
     expect(clicked!.download).toBe("camp.glyphoxa.json.gz");
     expect(clicked!.href).toContain("blob:export");
-    // The transient anchor is gone and its object URL released — no DOM/blob leak.
+    // The transient anchor is gone immediately.
     expect(document.querySelector("a")).toBeNull();
+
+    // The object URL is revoked on a DEFERRED timer (Safari aborts large-blob
+    // downloads on an immediate revoke), so it's still live right after the click…
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    // …and released once the timer fires — no leak.
+    vi.advanceTimersByTime(10_000);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
+    vi.useRealTimers();
   });
 });
 
@@ -156,17 +164,21 @@ describe("importCampaignBundle", () => {
     vi.unstubAllGlobals();
   });
 
-  it("throws the server {error} message on a 413 oversized response", async () => {
+  it("throws the server's PLAIN-TEXT message on a 413 oversized response", async () => {
+    // ServeImport's MaxBytesReader 413 is http.Error plain text, NOT JSON — the
+    // client must surface it verbatim, not a generic "Import failed (413)".
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ error: "bundle too large (limit 32 MiB)" }), {
+        new Response("bundle exceeds maximum upload size\n", {
           status: 413,
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
         }),
       ),
     );
-    await expect(importCampaignBundle(bundleFile())).rejects.toThrow(/too large/);
+    await expect(importCampaignBundle(bundleFile())).rejects.toThrow(
+      /bundle exceeds maximum upload size/,
+    );
     vi.unstubAllGlobals();
   });
 });

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -1,0 +1,118 @@
+import { readCookie } from "./transport";
+
+// Campaign Bundle export/import over the plain-net/http endpoints that sit beside
+// the Connect handler (ADR-0015/0053): GET /api/v1/campaigns/{id}/export streams a
+// gzip bundle; POST /api/v1/campaigns/import takes a multipart upload. Both are
+// same-origin, so the session cookie rides along by default — we must NOT set
+// credentials:'omit', or the operator gate (ADR-0041) rejects the request. The
+// import is a state change, so it carries the CSRF double-submit header (ADR-0016).
+
+// ImportSummary is the JSON counts the importer returns (ADR-0053 d7: import does
+// NOT auto-activate, so the summary drives an explicit "switch to it?" prompt).
+export type ImportSummary = {
+  campaignId: string;
+  name: string;
+  agents: number;
+  nodes: number;
+  edges: number;
+  characters: number;
+  sessions: number;
+  lines: number;
+  chunks: number;
+};
+
+// The filename used when the server sends no Content-Disposition (it always does,
+// but a proxy could strip it — a sensible name beats a bare "download").
+const FALLBACK_FILENAME = "campaign.glyphoxa.json.gz";
+
+// downloadBlob saves a blob to disk by clicking a transient <a download>. The
+// anchor is appended (some browsers ignore a click on a detached node), clicked,
+// then removed and its object URL revoked so nothing leaks. Defensively no-op
+// outside a real browser (jsdom, where URL.createObjectURL is unimplemented) so
+// callers can fire-and-forget — mirrors audio.ts's jsdom guard.
+export function downloadBlob(blob: Blob, filename: string): void {
+  if (typeof document === "undefined" || typeof URL?.createObjectURL !== "function") return;
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.style.display = "none";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+// filenameFromDisposition pulls the filename out of a Content-Disposition header,
+// falling back to a stable default when it's absent or unparseable.
+function filenameFromDisposition(header: string | null): string {
+  if (!header) return FALLBACK_FILENAME;
+  const match = header.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i);
+  return match ? decodeURIComponent(match[1]) : FALLBACK_FILENAME;
+}
+
+// fetchCampaignExport downloads a campaign's bundle. Returns the blob plus the
+// server-chosen filename (from Content-Disposition). A non-OK response throws the
+// server's plain-text error so the caller can surface it in a toast.
+export async function fetchCampaignExport(
+  campaignId: string,
+): Promise<{ blob: Blob; filename: string }> {
+  const res = await fetch(`/api/v1/campaigns/${campaignId}/export`);
+  if (!res.ok) {
+    const text = (await res.text()).trim();
+    throw new Error(text || `Export failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  return { blob, filename: filenameFromDisposition(res.headers.get("Content-Disposition")) };
+}
+
+// importCampaignBundle uploads a bundle file to the importer. The file rides a
+// multipart field named "bundle"; the CSRF token mirrors the glyphoxa_csrf cookie
+// into X-CSRF-Token (ADR-0016 double-submit). On success it returns the counts;
+// on any error (400 bad bundle, 413 too large, 500) it throws the server's
+// {"error": …} message so the caller shows exactly why it failed.
+export async function importCampaignBundle(file: File): Promise<ImportSummary> {
+  const form = new FormData();
+  form.append("bundle", file);
+  const token = readCookie("glyphoxa_csrf");
+  const res = await fetch("/api/v1/campaigns/import", {
+    method: "POST",
+    body: form,
+    headers: token ? { "X-CSRF-Token": token } : {},
+  });
+  if (!res.ok) {
+    let message = `Import failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // Non-JSON body (e.g. a proxy's 413 page) — keep the status-based message.
+    }
+    throw new Error(message);
+  }
+  const body = (await res.json()) as {
+    campaign_id: string;
+    name: string;
+    agents: number;
+    nodes: number;
+    edges: number;
+    characters: number;
+    sessions: number;
+    lines: number;
+    chunks: number;
+  };
+  return {
+    campaignId: body.campaign_id,
+    name: body.name,
+    agents: body.agents,
+    nodes: body.nodes,
+    edges: body.edges,
+    characters: body.characters,
+    sessions: body.sessions,
+    lines: body.lines,
+    chunks: body.chunks,
+  };
+}

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -27,9 +27,15 @@ const FALLBACK_FILENAME = "campaign.glyphoxa.json.gz";
 
 // downloadBlob saves a blob to disk by clicking a transient <a download>. The
 // anchor is appended (some browsers ignore a click on a detached node), clicked,
-// then removed and its object URL revoked so nothing leaks. Defensively no-op
-// outside a real browser (jsdom, where URL.createObjectURL is unimplemented) so
-// callers can fire-and-forget — mirrors audio.ts's jsdom guard.
+// then removed. Defensively no-op outside a real browser (jsdom, where
+// URL.createObjectURL is unimplemented) so callers can fire-and-forget — mirrors
+// audio.ts's jsdom guard.
+//
+// The object URL is revoked on a DEFERRED timer, not synchronously: Safari
+// historically aborts an in-flight download when its blob URL is revoked in the
+// same tick as the click, and bundles run up to the 32 MiB cap (ADR-0048). A
+// ~10s delay lets the browser start reading the blob before it's released; the
+// leak window is bounded and one-shot.
 export function downloadBlob(blob: Blob, filename: string): void {
   if (typeof document === "undefined" || typeof URL?.createObjectURL !== "function") return;
   const url = URL.createObjectURL(blob);
@@ -42,7 +48,7 @@ export function downloadBlob(blob: Blob, filename: string): void {
     a.click();
     a.remove();
   } finally {
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
   }
 }
 
@@ -84,12 +90,17 @@ export async function importCampaignBundle(file: File): Promise<ImportSummary> {
     headers: token ? { "X-CSRF-Token": token } : {},
   });
   if (!res.ok) {
-    let message = `Import failed (${res.status})`;
+    // The importer's JSON errors carry {"error": …} (400 bad bundle, 500), but the
+    // MaxBytesReader 413 is plain text ("bundle exceeds maximum upload size"). Read
+    // the body ONCE as text and prefer its JSON error field when it parses, else
+    // fall back to the raw text — so BOTH shapes surface cleanly (AC: oversized).
+    const text = (await res.text()).trim();
+    let message = text || `Import failed (${res.status})`;
     try {
-      const body = (await res.json()) as { error?: string };
+      const body = JSON.parse(text) as { error?: string };
       if (body?.error) message = body.error;
     } catch {
-      // Non-JSON body (e.g. a proxy's 413 page) — keep the status-based message.
+      // Non-JSON body (the plain-text 413) — keep the raw text.
     }
     throw new Error(message);
   }

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -9,8 +9,10 @@ import type { Interceptor } from "@connectrpc/connect";
 // adds the double-submit header.
 
 // readCookie returns a cookie value by name, or null. Used to mirror the
-// non-HttpOnly glyphoxa_csrf cookie into the request header.
-function readCookie(name: string): string | null {
+// non-HttpOnly glyphoxa_csrf cookie into the request header — both by the Connect
+// CSRF interceptor below and by the plain-fetch bundle upload (download.ts, #294),
+// which speaks the same double-submit protocol (ADR-0016).
+export function readCookie(name: string): string | null {
   const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
   return match ? decodeURIComponent(match[1]) : null;
 }


### PR DESCRIPTION
## What
The SPA's first file-transfer plumbing (web-only — builds on the merged #290 exporter + #291 importer, no backend changes).

- **`web/src/lib/download.ts`** (new): `downloadBlob` (jsdom-guarded transient `<a download>` + object-URL revoke, `audio.ts` precedent), `fetchCampaignExport` (blob + filename from `Content-Disposition`, fallback `campaign.glyphoxa.json.gz`, non-OK throws server text), `importCampaignBundle` (POST FormData field `bundle` to `/api/v1/campaigns/import`, `X-CSRF-Token` from `glyphoxa_csrf` cookie — ADR-0016 double-submit; same-origin credentialed by default, never `credentials:'omit'`; 400/413 throw the server `{error}`).
- **`transport.ts`**: `readCookie` now exported (shared by the CSRF interceptor and the upload).
- **`CampaignRowActions`**: new **Export** menuitem (Download icon) on **every** row incl. archived (a bundle is a backup); `MENU_HEIGHT_ESTIMATE` bumped for the extra row; failure toasts, no download.
- **`ImportCampaignButton`** (new): file pick → ConfirmDialog → pending → success dialog "Imported <name> — switch to it?". Explicit **Switch** runs the existing `SetActiveCampaign` path + the campaign-scoped sweep (ADR-0053 d7 — import never auto-activates). Always invalidates the sweep-**invariant** `listCampaigns` key on import success, so a fresh import is visible in the picker even when the switch is declined. Server `{error}` (incl. oversized 413) surfaces inline. Mounted in the switcher's manage-view footer.

## Tests (TDD, 15 added, co-located)
- `download.test.ts` (7): downloadBlob anchor/revoke; fetchCampaignExport 200+filename / fallback / non-OK throws; importCampaignBundle multipart+CSRF+summary / 400 / 413.
- `CampaignRowActions.test.tsx` (+3): Export on active downloads fetched bundle; Export present on archived; failure → no download.
- `ImportCampaignButton.test.tsx` (4): confirm→upload→switch prompt; error surfaces server message; listCampaigns invalidated even when switch declined; Switch → setActive + sweep.
- `CampaignSwitcher.test.tsx` (+1): Import action in the footer.

All 236 web tests pass; `tsc --noEmit` + `vite build` green.

## Manual verification for the orchestrator
fetch exposes no upload-progress API, so the pending state is a disabled/"Importing…" affordance rather than a percentage bar (noted in code). Worth a live browser check: Export "The Prancing Pony", re-import, and confirm the "switch to it?" prompt + roster (the #294 demo flow — export A → import B → switch → see Bart).

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)