### PR TITLE
feat(#307): [E8] highlight detector reactor on the voice event bus

### DIFF
--- a/internal/highlight/cassette_test.go
+++ b/internal/highlight/cassette_test.go
@@ -100,8 +100,10 @@ func runFixture(t *testing.T, prov llm.Provider) []Trigger {
 	d.now = clk.now
 	d.handled = make(chan struct{}, 1)
 	d.start(bus)
-	defer d.Close()
 	publishFixture(t, d, bus, dragonFixture())
+	// Close flushes any Tail-delayed snapshot cut (the trigger rides that cut), so
+	// read the sink AFTER Close, not before.
+	d.Close()
 	return sink.all()
 }
 
@@ -115,13 +117,18 @@ func TestDragonFixtureCassette(t *testing.T) {
 		t.Fatalf("trigger count = %d, want exactly 1", len(trigs))
 	}
 	tr := trigs[0]
-	// Confirmed on the 18th final (index 17): At = base + 34s.
-	wantAt := fixtureBase.Add(34 * time.Second)
-	if !tr.At.Equal(wantAt) {
-		t.Errorf("trigger At = %v, want %v (the confirming final)", tr.At, wantAt)
+	// The point of the highlight is the natural-twenty line (fixture index 9, At =
+	// base + 18s). Confirmation lags it, so assert the moment's OWN utterance is
+	// covered by the clip range — content coverage, not the mechanical At±Lead/Tail
+	// formula. Anchored on the confirming final it would fall outside; anchored on
+	// the first high window it is inside.
+	natTwentyAt := fixtureBase.Add(18 * time.Second)
+	if tr.From.After(natTwentyAt) || tr.To.Before(natTwentyAt) {
+		t.Errorf("clip range (%v, %v) does not cover the natural-twenty moment at %v", tr.From, tr.To, natTwentyAt)
 	}
-	if !tr.From.Equal(wantAt.Add(-15*time.Second)) || !tr.To.Equal(wantAt.Add(5*time.Second)) {
-		t.Errorf("range = (%v,%v), want (At-15s, At+5s)", tr.From, tr.To)
+	// And the anchor precedes the confirming final (the lag bug would put At = base+34s).
+	if !tr.At.Before(fixtureBase.Add(34 * time.Second)) {
+		t.Errorf("trigger At = %v anchored on the confirming final; want the first high window (earlier)", tr.At)
 	}
 	if tr.Score < 8.0 {
 		t.Errorf("Score = %v, want >= Bar 8.0", tr.Score)

--- a/internal/highlight/cassette_test.go
+++ b/internal/highlight/cassette_test.go
@@ -1,0 +1,230 @@
+package highlight
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// fixtureLine is one scripted transcript final.
+type fixtureLine struct {
+	speaker string
+	text    string
+}
+
+// dragonFixture is the demo transcript (#307 "Demo / verification"): a mundane
+// stretch (corridor exploration) followed by one obviously epic moment (a natural
+// twenty felling the dragon). With #305's ClassifyEvery=6 / ConfirmWindows=2 the
+// two windows spanning the epic beat both score high and confirm exactly ONE
+// trigger; the mundane opener scores low.
+func dragonFixture() []fixtureLine {
+	return []fixtureLine{
+		{"gm", "You make your way down the damp stone corridor, torches guttering."},
+		{"alice", "I check the walls for any hidden levers or traps."},
+		{"gm", "You find nothing but moss and old cobwebs."},
+		{"bob", "Boring. Let's keep moving toward the big doors ahead."},
+		{"gm", "The corridor opens into a vast cavern."},
+		{"alice", "We light a second torch and step inside carefully."},
+		{"gm", "A colossal red dragon uncoils from the gold hoard, eyes blazing."},
+		{"bob", "Oh gods. I draw my greatsword and charge the dragon!"},
+		{"gm", "Roll your attack."},
+		{"bob", "I rolled a natural twenty! A critical hit on the dragon!"},
+		{"gm", "The blade sinks deep; the dragon roars in agony and staggers."},
+		{"alice", "Incredible! That is the best hit of the whole campaign!"},
+		{"gm", "The dragon collapses, shaking the cavern to its foundations."},
+		{"bob", "We did it! We actually slew the dragon!"},
+		{"alice", "For the tale-tellers: the night we felled the great wyrm."},
+		{"gm", "Gold and firelight glitter across the fallen beast."},
+		{"bob", "I raise my sword and let out a victory roar."},
+		{"alice", "A moment we will never forget."},
+	}
+}
+
+const dragonCassette = "llm-highlight-dragon"
+
+// fixtureBase is the fixed clock the fixture stamps finals from (deterministic
+// prompt hashes AND trigger ranges).
+var fixtureBase = time.Date(2026, 7, 10, 20, 0, 0, 0, time.UTC)
+
+// fixtureConfig is the #305 detector tuning used for the fixture (real defaults).
+func fixtureConfig() Config {
+	return Config{
+		ClassifyEvery:  6,
+		Cooldown:       120 * time.Second,
+		Bar:            8.0,
+		ConfirmWindows: 2,
+		MaxCandidates:  10,
+		Lead:           15 * time.Second,
+		Tail:           5 * time.Second,
+	}
+}
+
+// publishFixture publishes the fixture finals SERIALIZED at their scripted times.
+func publishFixture(t *testing.T, d *Detector, bus *voiceevent.Bus, lines []fixtureLine) {
+	t.Helper()
+	for i, l := range lines {
+		bus.Publish(voiceevent.STTFinal{
+			At:        fixtureBase.Add(time.Duration(i) * 2 * time.Second),
+			Text:      l.text,
+			SpeakerID: l.speaker,
+		})
+		select {
+		case <-d.handled:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out handling fixture final %d", i)
+		}
+	}
+}
+
+// runFixture runs the dragon fixture through a detector backed by the given
+// provider and returns the triggers the sink saw.
+func runFixture(t *testing.T, prov llm.Provider) []Trigger {
+	t.Helper()
+	bus := voiceevent.NewBus()
+	sink := &fakeSink{}
+	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
+	clk := &testClock{t: fixtureBase}
+	d := newDetector(prov, "", snap, sink, allowGate{}, nil, nil, fixtureConfig())
+	d.now = clk.now
+	d.handled = make(chan struct{}, 1)
+	d.start(bus)
+	defer d.Close()
+	publishFixture(t, d, bus, dragonFixture())
+	return sink.all()
+}
+
+// TestDragonFixtureCassette (TEST 10) is the demo proof: replaying the recorded
+// classifier over the fixture, exactly ONE trigger fires, over the epic moment's
+// window±Lead/Tail range.
+func TestDragonFixtureCassette(t *testing.T) {
+	prov := voicecassette.LoadLLM(t, dragonCassette)
+	trigs := runFixture(t, prov)
+	if len(trigs) != 1 {
+		t.Fatalf("trigger count = %d, want exactly 1", len(trigs))
+	}
+	tr := trigs[0]
+	// Confirmed on the 18th final (index 17): At = base + 34s.
+	wantAt := fixtureBase.Add(34 * time.Second)
+	if !tr.At.Equal(wantAt) {
+		t.Errorf("trigger At = %v, want %v (the confirming final)", tr.At, wantAt)
+	}
+	if !tr.From.Equal(wantAt.Add(-15*time.Second)) || !tr.To.Equal(wantAt.Add(5*time.Second)) {
+		t.Errorf("range = (%v,%v), want (At-15s, At+5s)", tr.From, tr.To)
+	}
+	if tr.Score < 8.0 {
+		t.Errorf("Score = %v, want >= Bar 8.0", tr.Score)
+	}
+}
+
+// TestClassifierCassetteDeterminism (TEST 9): the same prompts replay the same
+// verdicts, so two independent runs over the fixture produce byte-identical
+// triggers (ADR-0021).
+func TestClassifierCassetteDeterminism(t *testing.T) {
+	a := runFixture(t, voicecassette.LoadLLM(t, dragonCassette))
+	b := runFixture(t, voicecassette.LoadLLM(t, dragonCassette))
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("trigger counts = %d,%d, want 1,1", len(a), len(b))
+	}
+	if a[0].Score != b[0].Score || a[0].Excerpt != b[0].Excerpt || a[0].Reason != b[0].Reason ||
+		!a[0].At.Equal(b[0].At) || !a[0].From.Equal(b[0].From) || !a[0].To.Equal(b[0].To) {
+		t.Errorf("non-deterministic replay:\n a=%+v\n b=%+v", a[0], b[0])
+	}
+}
+
+// ---- cassette generation (run manually, not in CI) -------------------------
+
+// recordingProvider scores each classifier prompt by its content (epic if it
+// mentions the natural twenty) and records the (prompt hash, response) exchange,
+// so [TestGenerateDragonCassette] can author the replay cassette without a live
+// LLM. It replays its own response so the detector runs end-to-end during capture.
+type recordingProvider struct {
+	mu        sync.Mutex
+	exchanges []voicecassette.LLMExchange
+}
+
+func (p *recordingProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	var user string
+	for _, m := range req.Messages {
+		if m.Role == llm.RoleUser {
+			user = m.Text
+		}
+	}
+	resp := `{"score": 2.0, "excerpt": "the party explores the corridor", "reason": "routine exploration"}`
+	if strings.Contains(strings.ToLower(user), "natural twenty") {
+		resp = `{"score": 9.5, "excerpt": "I rolled a natural twenty! A critical hit on the dragon!", "reason": "a critical hit felling the dragon"}`
+	}
+	p.mu.Lock()
+	p.exchanges = append(p.exchanges, voicecassette.LLMExchange{
+		PromptHash: voicecassette.HashLLMRequest(req),
+		Text:       resp,
+		StopReason: "end_turn",
+	})
+	p.mu.Unlock()
+
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: resp}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
+// TestGenerateDragonCassette writes tests/voice-cassettes/llm-highlight-dragon.yaml
+// from the fixture prompts. It is skipped unless GEN_HL_CASSETTE=1, so CI replays
+// the committed cassette (a prompt change misses its hash and fails, ADR-0021);
+// rerun with the env var set to regenerate after a deliberate prompt change.
+func TestGenerateDragonCassette(t *testing.T) {
+	if os.Getenv("GEN_HL_CASSETTE") == "" {
+		t.Skip("set GEN_HL_CASSETTE=1 to regenerate the highlight cassette")
+	}
+	rec := &recordingProvider{}
+	trigs := runFixture(t, rec)
+	if len(trigs) != 1 {
+		t.Fatalf("generation fixture produced %d triggers, want 1 (fix the fixture)", len(trigs))
+	}
+	cass := voicecassette.LLMCassette{
+		Notes:     "Hand-authored highlight classifier fixture (#307): mundane corridor + one natural-twenty dragon kill. Not a live recording; responses are the fixture's scoring rule.",
+		Exchanges: rec.exchanges,
+	}
+	data, err := yaml.Marshal(cass)
+	if err != nil {
+		t.Fatalf("marshal cassette: %v", err)
+	}
+	path := filepath.Join(repoCassettesDir(t), dragonCassette+".yaml")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write cassette: %v", err)
+	}
+	t.Logf("wrote %s (%d exchanges)", path, len(rec.exchanges))
+}
+
+// repoCassettesDir locates tests/voice-cassettes/ by walking up to go.mod (the same
+// trick voicecassette uses internally).
+func repoCassettesDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "tests", "voice-cassettes")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}

--- a/internal/highlight/detector.go
+++ b/internal/highlight/detector.go
@@ -1,0 +1,403 @@
+package highlight
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+const (
+	// featureMailboxCap is the PCM-tap mailbox depth. Matched to the tape's append
+	// mailbox: deep enough to absorb scheduling jitter, dropped (never blocking the
+	// audio loop) once full — the highlight signal is best-effort (ADR-0020).
+	featureMailboxCap = 512
+	// windowCap bounds the rolling transcript window fed to the classifier. A
+	// classify sees at most this many recent finals; older lines roll off.
+	windowCap = 40
+)
+
+// finalLine is one transcript final retained in the rolling window.
+type finalLine struct {
+	speaker string
+	text    string
+	at      time.Time
+}
+
+// render formats a line for the classifier prompt (deterministic, ADR-0021).
+func (l finalLine) render() string {
+	who := "Speaker"
+	if l.speaker != "" {
+		who = "Speaker " + l.speaker
+	}
+	return who + ": " + l.text
+}
+
+// Detector is the per-session highlight moment detector. Construct it with
+// [NewDetector] per wirenpc Voice Session cycle and defer [Detector.Close]. Safe
+// for concurrent bus callbacks and PCM-tap calls; all detector state lives on the
+// single worker goroutine.
+type Detector struct {
+	provider llm.Provider
+	model    string
+	snap     SnapshotFunc
+	sink     Sink
+	gate     orchestrator.TurnGate
+	metrics  observe.StageRecorder
+	log      *slog.Logger
+	cfg      Config
+
+	now func() time.Time // injected in tests; time.Now in production
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	unsub  func()
+	done   chan struct{}
+
+	signal   chan struct{}     // 1-slot wake for a pending final (latest-wins)
+	features chan frameFeature // buffered PCM feature mailbox (drop-oldest under load)
+
+	mailMu     sync.Mutex
+	pending    voiceevent.STTFinal
+	hasPending bool
+
+	// classified, when non-nil (set by white-box tests before start), receives one
+	// value per completed classification so a test can await the async worker.
+	classified chan classification
+	// handled, when non-nil (white-box tests), is notified after each final is
+	// folded into the window, so a test can serialize publishing (defeating the
+	// latest-wins coalescing) for deterministic cadence assertions.
+	handled chan struct{}
+}
+
+// workerState is the detector state owned solely by the worker goroutine.
+type workerState struct {
+	window              []finalLine
+	feat                featureState
+	finalsSinceClassify int
+	consecutiveHigh     int
+	candidateCount      int
+	lastTriggerAt       time.Time
+	disarmed            bool
+}
+
+// NewDetector builds the detector wired to the process bus (STTFinal), the LLM
+// classifier provider/model, the tape snapshot cutter, the trigger sink, the spend
+// gate, and the stage-metrics recorder. It subscribes to the bus and launches the
+// single worker goroutine immediately; call [Detector.Close] at session end.
+func NewDetector(bus *voiceevent.Bus, provider llm.Provider, model string, snap SnapshotFunc, sink Sink, gate orchestrator.TurnGate, metrics observe.StageRecorder, log *slog.Logger, cfg Config) *Detector {
+	d := newDetector(provider, model, snap, sink, gate, metrics, log, cfg)
+	d.start(bus)
+	return d
+}
+
+// newDetector builds the struct with production seams but does NOT subscribe or
+// start the goroutine — the split lets white-box tests inject the now clock and the
+// classified notify channel BEFORE the worker reads them (no data race), then call
+// [Detector.start]. Production goes through [NewDetector].
+func newDetector(provider llm.Provider, model string, snap SnapshotFunc, sink Sink, gate orchestrator.TurnGate, metrics observe.StageRecorder, log *slog.Logger, cfg Config) *Detector {
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(discardWriter{}, nil))
+	}
+	if metrics == nil {
+		metrics = observe.Discard{}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Detector{
+		provider: provider,
+		model:    model,
+		snap:     snap,
+		sink:     sink,
+		gate:     gate,
+		metrics:  metrics,
+		log:      log,
+		cfg:      cfg.withDefaults(),
+		now:      time.Now,
+		ctx:      ctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
+		signal:   make(chan struct{}, 1),
+		features: make(chan frameFeature, featureMailboxCap),
+	}
+}
+
+// start subscribes to the bus and launches the worker. Called once by [NewDetector]
+// (production) or a white-box test after seams are set.
+func (d *Detector) start(bus *voiceevent.Bus) {
+	d.unsub = voiceevent.On(bus, d.onFinal)
+	go d.worker()
+}
+
+// Close unsubscribes from the bus and stops the worker. Idempotent enough to defer:
+// unsubscribe and cancel are no-ops on a second call and the closed done channel
+// returns immediately — but wire it once, at session end (a leak is a #44 bug).
+func (d *Detector) Close() {
+	d.unsub()
+	d.cancel()
+	<-d.done
+}
+
+// PCMTap returns the tap wired via wire.WithPCMTap: it summarizes each decoded PCM
+// frame's energy inline and hands it to the buffered feature mailbox, dropping
+// under load. It NEVER blocks the audio loop (ADR-0020/0026).
+func (d *Detector) PCMTap() func(audio.Frame) {
+	return func(f audio.Frame) {
+		ff := computeFrameFeature(f)
+		select {
+		case d.features <- ff:
+		default:
+			// Mailbox full: drop the oldest to make room, then retry once. The audio
+			// loop never waits (the highlight signal is best-effort).
+			select {
+			case <-d.features:
+			default:
+			}
+			select {
+			case d.features <- ff:
+			default:
+			}
+		}
+	}
+}
+
+// onFinal is the bus callback: latest-wins mailbox, never blocks (ADR-0020). Under
+// load faster than the worker, intermediate finals are coalesced — acceptable
+// degradation for a best-effort side-consumer (internal/recall precedent).
+func (d *Detector) onFinal(e voiceevent.STTFinal) {
+	d.mailMu.Lock()
+	d.pending = e
+	d.hasPending = true
+	d.mailMu.Unlock()
+	select {
+	case d.signal <- struct{}{}:
+	default:
+	}
+}
+
+// take pops the pending final, or reports none.
+func (d *Detector) take() (voiceevent.STTFinal, bool) {
+	d.mailMu.Lock()
+	defer d.mailMu.Unlock()
+	if !d.hasPending {
+		return voiceevent.STTFinal{}, false
+	}
+	e := d.pending
+	d.hasPending = false
+	return e, true
+}
+
+// worker is the single owner of all detector state. It folds PCM features and
+// handles finals until Close (ctx cancel). The done channel is closed on exit.
+func (d *Detector) worker() {
+	defer close(d.done)
+	w := &workerState{feat: featureState{}}
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case ff := <-d.features:
+			w.feat.fold(ff)
+		case <-d.signal:
+			if e, ok := d.take(); ok {
+				d.handleFinal(w, e)
+			}
+		}
+	}
+}
+
+// handleFinal appends the final to the rolling window and classifies every
+// ClassifyEvery processed finals.
+func (d *Detector) handleFinal(w *workerState, e voiceevent.STTFinal) {
+	defer d.notifyHandled()
+	w.appendLine(e)
+	w.finalsSinceClassify++
+	if w.finalsSinceClassify < d.cfg.ClassifyEvery {
+		return
+	}
+	w.finalsSinceClassify = 0
+	d.classify(w, e)
+}
+
+// notifyHandled is the white-box serialization hook (no-op in production).
+func (d *Detector) notifyHandled() {
+	if d.handled == nil {
+		return
+	}
+	select {
+	case d.handled <- struct{}{}:
+	default:
+	}
+}
+
+// appendLine adds a final to the window, dropping the oldest past windowCap.
+func (w *workerState) appendLine(e voiceevent.STTFinal) {
+	text := strings.TrimSpace(e.Text)
+	if text == "" {
+		return
+	}
+	w.window = append(w.window, finalLine{speaker: e.SpeakerID, text: text, at: e.At})
+	if len(w.window) > windowCap {
+		w.window = w.window[len(w.window)-windowCap:]
+	}
+}
+
+// classify runs one classifier pass, honoring the cap, cooldown, and spend gate,
+// and promotes to a trigger after ConfirmWindows consecutive at-or-above-Bar
+// scores.
+func (d *Detector) classify(w *workerState, e voiceevent.STTFinal) {
+	now := d.now()
+	// Per-session cap: once enough candidates are found, stop classifying (and stop
+	// spending) for the rest of the session (ADR-0051 bounded candidates).
+	if w.candidateCount >= d.cfg.MaxCandidates {
+		return
+	}
+	// A gate that has ever denied a turn disarms the detector permanently: AllowTurn
+	// is monotonic (ADR-0046). A Highlight never ends a session, so this is silent.
+	if w.disarmed {
+		return
+	}
+	// Cooldown: after a trigger, suppress classification (and reset the streak) so a
+	// single sustained moment yields one highlight, then rearm.
+	if !w.lastTriggerAt.IsZero() && now.Sub(w.lastTriggerAt) < d.cfg.Cooldown {
+		w.consecutiveHigh = 0
+		return
+	}
+	// Spend gate: never classify (an LLM call is spend) when the session's soft cap
+	// is crossed. Checked before EVERY classify (ADR-0046).
+	if d.gate != nil && !d.gate.AllowTurn() {
+		w.disarmed = true
+		d.log.Info("highlight detector disarmed: spend gate closed")
+		return
+	}
+
+	req := buildRequest(d.model, w.window, w.feat.summarize())
+	cls := d.runClassifier(req)
+	d.notifyClassified(cls)
+
+	if cls.score >= d.cfg.Bar {
+		w.consecutiveHigh++
+	} else {
+		w.consecutiveHigh = 0
+	}
+	if w.consecutiveHigh < d.cfg.ConfirmWindows {
+		return
+	}
+	d.emit(w, e, cls, now)
+	w.consecutiveHigh = 0
+	w.candidateCount++
+	w.lastTriggerAt = now
+}
+
+// emit cuts the tape snapshot AT trigger time and hands the trigger to the sink.
+func (d *Detector) emit(w *workerState, e voiceevent.STTFinal, cls classification, now time.Time) {
+	at := e.At
+	if at.IsZero() {
+		at = now
+	}
+	from := at.Add(-d.cfg.Lead)
+	to := at.Add(d.cfg.Tail)
+	// Clamp From into the tape's retention window: audio older than the ring is gone
+	// anyway, and the snapshot must not claim a range the tape cannot back.
+	if lo := now.Add(-tape.Window); from.Before(lo) {
+		from = lo
+	}
+	var snap tape.Snapshot
+	if d.snap != nil {
+		snap = d.snap(from, to)
+	}
+	excerpt := cls.excerpt
+	if excerpt == "" {
+		excerpt = w.recentText()
+	}
+	d.sink.HandleTrigger(Trigger{
+		At:         at,
+		From:       from,
+		To:         to,
+		Score:      cls.score,
+		SpeakerIDs: w.speakerIDs(),
+		Excerpt:    excerpt,
+		Reason:     cls.reason,
+		Snapshot:   snap,
+	})
+}
+
+// runClassifier drives one provider completion, meters its token usage on the
+// stage recorder (ADR-0045/0046), and parses the verdict. It never crashes the
+// worker: a provider error, a truncated stream, or malformed JSON yields a zero
+// score (the moment is simply not confirmed).
+func (d *Detector) runClassifier(req llm.Request) classification {
+	stream, err := d.provider.Complete(d.ctx, req)
+	if err != nil {
+		d.log.Warn("highlight classify: llm complete", "err", err)
+		return classification{}
+	}
+	var sb strings.Builder
+	var usage llm.Usage
+	var haveUsage bool
+	for ev := range stream {
+		switch ev.Type {
+		case llm.EventText:
+			sb.WriteString(ev.Text)
+		case llm.EventUsage:
+			usage, haveUsage = ev.Usage, true
+		case llm.EventError:
+			d.log.Warn("highlight classify: llm stream error", "err", ev.Err)
+		}
+	}
+	in, out := usage.InputTokens, usage.OutputTokens
+	if !haveUsage {
+		in = estimateTokens(promptRunes(req))
+		out = estimateTokens(utf8.RuneCountInString(sb.String()))
+	}
+	d.metrics.LLMTokens(d.cfg.ProviderLabel, d.model, in, out)
+	return parseClassification(sb.String())
+}
+
+// notifyClassified is the white-box test hook: production leaves classified nil, so
+// it is a no-op. The buffered test channel is drained by the test.
+func (d *Detector) notifyClassified(c classification) {
+	if d.classified == nil {
+		return
+	}
+	select {
+	case d.classified <- c:
+	default:
+	}
+}
+
+// recentText joins the tail of the window into a fallback excerpt.
+func (w *workerState) recentText() string {
+	n := len(w.window)
+	if n > 4 {
+		n = 4
+	}
+	parts := make([]string, 0, n)
+	for _, l := range w.window[len(w.window)-n:] {
+		parts = append(parts, l.text)
+	}
+	return strings.Join(parts, " ")
+}
+
+// speakerIDs returns the distinct non-empty Speaker Lanes in the window, in
+// first-seen order.
+func (w *workerState) speakerIDs() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, l := range w.window {
+		if l.speaker == "" || seen[l.speaker] {
+			continue
+		}
+		seen[l.speaker] = true
+		out = append(out, l.speaker)
+	}
+	return out
+}

--- a/internal/highlight/detector.go
+++ b/internal/highlight/detector.go
@@ -62,6 +62,9 @@ type Detector struct {
 	cancel context.CancelFunc
 	unsub  func()
 	done   chan struct{}
+	// wg tracks the deferred snapshot-cut goroutines (one per trigger): Close waits
+	// on it so a pending Tail-delayed cut is flushed, never leaked (#44-class).
+	wg sync.WaitGroup
 
 	signal   chan struct{}     // 1-slot wake for a pending final (latest-wins)
 	features chan frameFeature // buffered PCM feature mailbox (drop-oldest under load)
@@ -85,9 +88,15 @@ type workerState struct {
 	feat                featureState
 	finalsSinceClassify int
 	consecutiveHigh     int
-	candidateCount      int
-	lastTriggerAt       time.Time
-	disarmed            bool
+	// firstHighAt is the At of the final that opened the current at-or-above-Bar
+	// streak (the consecutiveHigh 0→1 transition). Confirmation lags the moment by
+	// up to ConfirmWindows×ClassifyEvery finals, so anchoring the clip on the
+	// CONFIRMING final would push the moment's build-up (and often the beat itself)
+	// out of [From, To]; anchoring on the FIRST high window keeps the moment centred.
+	firstHighAt    time.Time
+	candidateCount int
+	lastTriggerAt  time.Time
+	disarmed       bool
 }
 
 // NewDetector builds the detector wired to the process bus (STTFinal), the LLM
@@ -144,6 +153,10 @@ func (d *Detector) Close() {
 	d.unsub()
 	d.cancel()
 	<-d.done
+	// Flush any Tail-delayed snapshot cut: cancelling the ctx makes each pending cut
+	// fire immediately (best-effort, so a session-end highlight is not lost) rather
+	// than waiting out its Tail timer.
+	d.wg.Wait()
 }
 
 // PCMTap returns the tap wired via wire.WithPCMTap: it summarizes each decoded PCM
@@ -218,7 +231,12 @@ func (d *Detector) worker() {
 // ClassifyEvery processed finals.
 func (d *Detector) handleFinal(w *workerState, e voiceevent.STTFinal) {
 	defer d.notifyHandled()
-	w.appendLine(e)
+	// An empty / whitespace-only final carries no new transcript signal (a VAD blip,
+	// a dropped recognition). It does NOT count toward the cadence: otherwise a run
+	// of blank finals would fire a PAID classify over an unchanged window.
+	if !w.appendLine(e) {
+		return
+	}
 	w.finalsSinceClassify++
 	if w.finalsSinceClassify < d.cfg.ClassifyEvery {
 		return
@@ -238,16 +256,20 @@ func (d *Detector) notifyHandled() {
 	}
 }
 
-// appendLine adds a final to the window, dropping the oldest past windowCap.
-func (w *workerState) appendLine(e voiceevent.STTFinal) {
+// appendLine adds a final to the window, dropping the oldest past windowCap. It
+// reports whether the final carried content (a non-empty trimmed text) — an
+// empty/whitespace final is ignored and reported false so the caller does not count
+// it toward the classify cadence.
+func (w *workerState) appendLine(e voiceevent.STTFinal) bool {
 	text := strings.TrimSpace(e.Text)
 	if text == "" {
-		return
+		return false
 	}
 	w.window = append(w.window, finalLine{speaker: e.SpeakerID, text: text, at: e.At})
 	if len(w.window) > windowCap {
 		w.window = w.window[len(w.window)-windowCap:]
 	}
+	return true
 }
 
 // classify runs one classifier pass, honoring the cap, cooldown, and spend gate,
@@ -284,22 +306,35 @@ func (d *Detector) classify(w *workerState, e voiceevent.STTFinal) {
 	d.notifyClassified(cls)
 
 	if cls.score >= d.cfg.Bar {
+		if w.consecutiveHigh == 0 {
+			// Open the streak: remember THIS final's time — the first evidence of the
+			// moment — as the clip anchor (see workerState.firstHighAt).
+			w.firstHighAt = e.At
+			if w.firstHighAt.IsZero() {
+				w.firstHighAt = now
+			}
+		}
 		w.consecutiveHigh++
 	} else {
 		w.consecutiveHigh = 0
+		w.firstHighAt = time.Time{}
 	}
 	if w.consecutiveHigh < d.cfg.ConfirmWindows {
 		return
 	}
-	d.emit(w, e, cls, now)
+	d.emit(w, w.firstHighAt, cls, now)
 	w.consecutiveHigh = 0
+	w.firstHighAt = time.Time{}
 	w.candidateCount++
 	w.lastTriggerAt = now
 }
 
-// emit cuts the tape snapshot AT trigger time and hands the trigger to the sink.
-func (d *Detector) emit(w *workerState, e voiceevent.STTFinal, cls classification, now time.Time) {
-	at := e.At
+// emit builds the trigger anchored on the moment's first-evidence time and cuts the
+// tape snapshot after Tail so the reaction audio actually exists in the ring when
+// the cut happens. The caption fields and speaker set are captured NOW (the window
+// rolls); only the Snapshot is filled at cut time.
+func (d *Detector) emit(w *workerState, anchor time.Time, cls classification, now time.Time) {
+	at := anchor
 	if at.IsZero() {
 		at = now
 	}
@@ -310,15 +345,11 @@ func (d *Detector) emit(w *workerState, e voiceevent.STTFinal, cls classificatio
 	if lo := now.Add(-tape.Window); from.Before(lo) {
 		from = lo
 	}
-	var snap tape.Snapshot
-	if d.snap != nil {
-		snap = d.snap(from, to)
-	}
 	excerpt := cls.excerpt
 	if excerpt == "" {
 		excerpt = w.recentText()
 	}
-	d.sink.HandleTrigger(Trigger{
+	trig := Trigger{
 		At:         at,
 		From:       from,
 		To:         to,
@@ -326,8 +357,32 @@ func (d *Detector) emit(w *workerState, e voiceevent.STTFinal, cls classificatio
 		SpeakerIDs: w.speakerIDs(),
 		Excerpt:    excerpt,
 		Reason:     cls.reason,
-		Snapshot:   snap,
-	})
+	}
+	d.scheduleCut(from, to, trig)
+}
+
+// scheduleCut waits out the Tail on a goroutine, then cuts the tape snapshot for
+// [from, to] and hands the completed trigger to the sink. The Tail delay is what
+// makes the reaction audio real: To = anchor + Tail is in the future when the
+// moment confirms, so cutting immediately would end every clip in Tail seconds of
+// silence — the 120s ring makes the short wait safe. Close cancels the ctx, which
+// fires the cut at once (best-effort) so a session-end highlight is not lost, and
+// waits on the WaitGroup so the goroutine never leaks.
+func (d *Detector) scheduleCut(from, to time.Time, trig Trigger) {
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		timer := time.NewTimer(d.cfg.Tail)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-d.ctx.Done():
+		}
+		if d.snap != nil {
+			trig.Snapshot = d.snap(from, to)
+		}
+		d.sink.HandleTrigger(trig)
+	}()
 }
 
 // runClassifier drives one provider completion, meters its token usage on the

--- a/internal/highlight/detector_test.go
+++ b/internal/highlight/detector_test.go
@@ -1,0 +1,459 @@
+package highlight
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// ---- test doubles ----------------------------------------------------------
+
+// fakeProvider is a scriptable [llm.Provider]: it returns respJSON(callIndex) as
+// the assistant text, optionally reports usage, and can signal/block so a test can
+// observe the worker mid-classify.
+type fakeProvider struct {
+	mu       sync.Mutex
+	calls    int
+	respJSON func(call int) string
+	usage    *llm.Usage
+
+	entered chan struct{} // non-blocking notify per Complete call (optional)
+	gate    chan struct{} // if non-nil, Complete blocks until it receives (optional)
+}
+
+func (p *fakeProvider) Complete(ctx context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	call := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	if p.entered != nil {
+		select {
+		case p.entered <- struct{}{}:
+		default:
+		}
+	}
+	if p.gate != nil {
+		select {
+		case <-p.gate:
+		case <-ctx.Done():
+			ch := make(chan llm.StreamEvent)
+			close(ch)
+			return ch, nil
+		}
+	}
+
+	text := ""
+	if p.respJSON != nil {
+		text = p.respJSON(call)
+	}
+	usage := p.usage
+	ch := make(chan llm.StreamEvent, 4)
+	if text != "" {
+		ch <- llm.StreamEvent{Type: llm.EventText, Text: text}
+	}
+	if usage != nil {
+		ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: *usage}
+	}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
+func (p *fakeProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// fakeSink records triggers.
+type fakeSink struct {
+	mu       sync.Mutex
+	triggers []Trigger
+}
+
+func (s *fakeSink) HandleTrigger(t Trigger) {
+	s.mu.Lock()
+	s.triggers = append(s.triggers, t)
+	s.mu.Unlock()
+}
+
+func (s *fakeSink) all() []Trigger {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Trigger(nil), s.triggers...)
+}
+
+// denyGate always refuses; allowGate always allows.
+type denyGate struct{}
+
+func (denyGate) AllowTurn() bool { return false }
+
+type allowGate struct{}
+
+func (allowGate) AllowTurn() bool { return true }
+
+// testClock is a mutable injectable clock.
+type testClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *testClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// scoreJSON is the canned classifier verdict for a given score.
+func scoreJSON(score float64) string {
+	return fmt.Sprintf(`{"score": %.1f, "excerpt": "the moment", "reason": "epic"}`, score)
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+// buildDetector constructs a detector with an injected clock and a classified
+// notify channel, then starts it. Returns the detector, the clock, and the notify
+// channel a test drains to await the async worker.
+func buildDetector(t *testing.T, bus *voiceevent.Bus, prov llm.Provider, snap SnapshotFunc, sink Sink, gate orchestrator.TurnGate, cfg Config) (*Detector, *testClock, <-chan classification) {
+	t.Helper()
+	clk := &testClock{t: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)}
+	d := newDetector(prov, "", snap, sink, gate, nil, nil, cfg)
+	d.now = clk.now
+	classified := make(chan classification, 256)
+	d.classified = classified
+	d.handled = make(chan struct{}, 1)
+	d.start(bus)
+	t.Cleanup(d.Close)
+	return d, clk, classified
+}
+
+// awaitClassifications drains n classification notifications or fails on timeout.
+func awaitClassifications(t *testing.T, ch <-chan classification, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-ch:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for classification %d/%d", i+1, n)
+		}
+	}
+}
+
+// rawFinal publishes one STTFinal without waiting (used to force coalescing).
+func rawFinal(bus *voiceevent.Bus, clk *testClock, speaker string, i int) {
+	bus.Publish(voiceevent.STTFinal{
+		At:        clk.now(),
+		Text:      fmt.Sprintf("line %d from %s", i, speaker),
+		SpeakerID: speaker,
+	})
+}
+
+// publishFinals publishes n STTFinal events SERIALIZED: each waits for the worker
+// to fold it in (d.handled) before the next, defeating the latest-wins coalescing
+// so a cadence assertion is deterministic. Do not use it for a final that stalls
+// the worker (a gated classify) — it would block on the missing handled signal.
+func publishFinals(t *testing.T, d *Detector, bus *voiceevent.Bus, clk *testClock, speaker string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		rawFinal(bus, clk, speaker, i)
+		select {
+		case <-d.handled:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for final %d/%d to be handled", i+1, n)
+		}
+	}
+}
+
+// ---- tests -----------------------------------------------------------------
+
+// TestPublishNeverBlocksAndCoalesces (TEST 1): a worker stalled mid-classify must
+// not block Publish, and finals published during the stall coalesce latest-wins so
+// a burst does not fan out into one classify per ClassifyEvery finals.
+func TestPublishNeverBlocksAndCoalesces(t *testing.T) {
+	bus := voiceevent.NewBus()
+	gate := make(chan struct{})
+	prov := &fakeProvider{
+		respJSON: func(int) string { return scoreJSON(1.0) },
+		entered:  make(chan struct{}, 1),
+		gate:     gate,
+	}
+	sink := &fakeSink{}
+	d, clk, _ := buildDetector(t, bus, prov, nil, sink, allowGate{}, Config{ClassifyEvery: 6})
+
+	// Fold in 5 finals (serialized), then fire the 6th WITHOUT waiting: it drives the
+	// first classify, which stalls the worker on the gated provider.
+	publishFinals(t, d, bus, clk, "A", 5)
+	rawFinal(bus, clk, "A", 5)
+	select {
+	case <-prov.entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker never entered the classifier")
+	}
+
+	// While the worker is stalled, flood finals. Publish must return promptly.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 500; i++ {
+			rawFinal(bus, clk, "A", i)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Publish blocked while the worker was stalled")
+	}
+
+	// Release the classifier and let the worker drain.
+	close(gate)
+	time.Sleep(100 * time.Millisecond)
+
+	// Without coalescing, 6+500 finals would be ~84 classifies. Latest-wins collapses
+	// the flood to a single pending final, so the worker re-arms slowly: far fewer.
+	if got := prov.callCount(); got > 3 {
+		t.Errorf("classify calls = %d, want <=3 (finals should coalesce under load)", got)
+	}
+}
+
+// TestClassifyCadence (TEST 2): the worker classifies once per ClassifyEvery
+// processed finals, no sooner.
+func TestClassifyCadence(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(1.0) }}
+	sink := &fakeSink{}
+	d, clk, classified := buildDetector(t, bus, prov, nil, sink, allowGate{}, Config{ClassifyEvery: 6})
+
+	// Five finals: below the cadence, no classify yet.
+	for i := 0; i < 5; i++ {
+		publishFinals(t, d, bus, clk, "A", 1)
+	}
+	select {
+	case <-classified:
+		t.Fatal("classified before ClassifyEvery finals")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// The sixth final triggers exactly one classify.
+	publishFinals(t, d, bus, clk, "A", 1)
+	awaitClassifications(t, classified, 1)
+	if got := prov.callCount(); got != 1 {
+		t.Errorf("classify calls = %d, want 1 after 6 finals", got)
+	}
+}
+
+// TestConfirmWindowsProducesOneTrigger (TEST 3): a window scoring >=Bar for
+// ConfirmWindows consecutive classifications emits exactly one trigger.
+func TestConfirmWindowsProducesOneTrigger(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
+	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+		ClassifyEvery: 6, Bar: 8.0, ConfirmWindows: 2, Cooldown: time.Hour,
+	})
+
+	// One classify (>=Bar) — not yet confirmed.
+	publishFinals(t, d, bus, clk, "A", 6)
+	awaitClassifications(t, classified, 1)
+	if n := len(sink.all()); n != 0 {
+		t.Fatalf("trigger after 1 confirming window, want 0 (need 2), got %d", n)
+	}
+
+	// Second consecutive classify (>=Bar) confirms → exactly one trigger.
+	publishFinals(t, d, bus, clk, "A", 6)
+	awaitClassifications(t, classified, 1)
+	time.Sleep(50 * time.Millisecond)
+	if n := len(sink.all()); n != 1 {
+		t.Fatalf("trigger count = %d, want exactly 1", n)
+	}
+}
+
+// TestCooldownThenRearm (TEST 4): after a trigger the detector suppresses new
+// triggers for Cooldown, then rearms.
+func TestCooldownThenRearm(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
+	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 2, Cooldown: 120 * time.Second,
+	})
+
+	// Two classifies confirm the first trigger.
+	publishFinals(t, d, bus, clk, "A", 4)
+	awaitClassifications(t, classified, 2)
+	time.Sleep(50 * time.Millisecond)
+	if n := len(sink.all()); n != 1 {
+		t.Fatalf("first trigger count = %d, want 1", n)
+	}
+
+	// Within the cooldown, further high windows are suppressed (classify is skipped,
+	// so no notification arrives).
+	publishFinals(t, d, bus, clk, "A", 4)
+	select {
+	case <-classified:
+		t.Fatal("classified within cooldown, want suppression")
+	case <-time.After(150 * time.Millisecond):
+	}
+	if n := len(sink.all()); n != 1 {
+		t.Fatalf("trigger count during cooldown = %d, want still 1", n)
+	}
+
+	// Advance past the cooldown and rearm: two more confirming windows → a 2nd trigger.
+	clk.advance(121 * time.Second)
+	publishFinals(t, d, bus, clk, "A", 4)
+	awaitClassifications(t, classified, 2)
+	time.Sleep(50 * time.Millisecond)
+	if n := len(sink.all()); n != 2 {
+		t.Fatalf("trigger count after rearm = %d, want 2", n)
+	}
+}
+
+// TestMaxCandidatesCap (TEST 5): once MaxCandidates triggers have fired, the
+// detector stops classifying entirely.
+func TestMaxCandidatesCap(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
+	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Nanosecond, MaxCandidates: 1,
+	})
+
+	// First confirming window → first (and only allowed) trigger.
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+	time.Sleep(50 * time.Millisecond)
+	if n := len(sink.all()); n != 1 {
+		t.Fatalf("trigger count = %d, want 1", n)
+	}
+	callsAtCap := prov.callCount()
+
+	// Cap reached: further finals must NOT classify (no spend past the cap).
+	publishFinals(t, d, bus, clk, "A", 20)
+	select {
+	case <-classified:
+		t.Fatal("classified after MaxCandidates reached")
+	case <-time.After(150 * time.Millisecond):
+	}
+	if got := prov.callCount(); got != callsAtCap {
+		t.Errorf("classify calls after cap = %d, want unchanged %d", got, callsAtCap)
+	}
+}
+
+// TestTriggerShape (TEST 6): a trigger carries the window±Lead/Tail range, the
+// populated caption fields, and the verbatim snapshot.
+func TestTriggerShape(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string {
+		return `{"score": 9.5, "excerpt": "natural twenty!", "reason": "critical hit on the dragon"}`
+	}}
+	sink := &fakeSink{}
+	var gotFrom, gotTo time.Time
+	snap := func(from, to time.Time) tape.Snapshot {
+		gotFrom, gotTo = from, to
+		return tape.Snapshot{From: from, To: to, Lanes: []tape.LaneSnapshot{{LaneID: "A"}}}
+	}
+	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Hour,
+		Lead: 15 * time.Second, Tail: 5 * time.Second,
+	})
+
+	at := clk.now()
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+	time.Sleep(50 * time.Millisecond)
+
+	trigs := sink.all()
+	if len(trigs) != 1 {
+		t.Fatalf("trigger count = %d, want 1", len(trigs))
+	}
+	tr := trigs[0]
+	if !tr.From.Equal(at.Add(-15 * time.Second)) {
+		t.Errorf("From = %v, want %v", tr.From, at.Add(-15*time.Second))
+	}
+	if !tr.To.Equal(at.Add(5 * time.Second)) {
+		t.Errorf("To = %v, want %v", tr.To, at.Add(5*time.Second))
+	}
+	if !gotFrom.Equal(tr.From) || !gotTo.Equal(tr.To) {
+		t.Errorf("snapshot cut over (%v,%v), want trigger range (%v,%v)", gotFrom, gotTo, tr.From, tr.To)
+	}
+	if tr.Score != 9.5 {
+		t.Errorf("Score = %v, want 9.5", tr.Score)
+	}
+	if tr.Excerpt != "natural twenty!" {
+		t.Errorf("Excerpt = %q", tr.Excerpt)
+	}
+	if tr.Reason != "critical hit on the dragon" {
+		t.Errorf("Reason = %q", tr.Reason)
+	}
+	if len(tr.SpeakerIDs) != 1 || tr.SpeakerIDs[0] != "A" {
+		t.Errorf("SpeakerIDs = %v, want [A]", tr.SpeakerIDs)
+	}
+	if len(tr.Snapshot.Lanes) != 1 || tr.Snapshot.Lanes[0].LaneID != "A" {
+		t.Errorf("Snapshot not passed through verbatim: %+v", tr.Snapshot)
+	}
+}
+
+// TestGateDeniedDisarms (TEST 7): a closed spend gate stops the classifier being
+// called at all and disarms the detector — a Highlight never ends a session.
+func TestGateDeniedDisarms(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	d, clk, _ := buildDetector(t, bus, prov, nil, sink, denyGate{}, Config{ClassifyEvery: 2})
+
+	publishFinals(t, d, bus, clk, "A", 10)
+	time.Sleep(150 * time.Millisecond)
+	if got := prov.callCount(); got != 0 {
+		t.Errorf("classify calls with closed gate = %d, want 0", got)
+	}
+	if n := len(sink.all()); n != 0 {
+		t.Errorf("triggers with closed gate = %d, want 0", n)
+	}
+}
+
+// TestUsageMetered (TEST 7 cont.): a classify records LLM token usage on the stage
+// recorder (ADR-0045/0046).
+func TestUsageMetered(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{
+		respJSON: func(int) string { return scoreJSON(1.0) },
+		usage:    &llm.Usage{InputTokens: 123, OutputTokens: 45},
+	}
+	sink := &fakeSink{}
+	rec := &spyRecorder{}
+	clk := &testClock{t: time.Now()}
+	d := newDetector(prov, "test-model", nil, sink, allowGate{}, rec, nil, Config{ClassifyEvery: 2})
+	d.now = clk.now
+	classified := make(chan classification, 8)
+	d.classified = classified
+	d.handled = make(chan struct{}, 1)
+	d.start(bus)
+	t.Cleanup(d.Close)
+
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+
+	in, out, ok := rec.llmTokens()
+	if !ok {
+		t.Fatal("no LLM usage recorded")
+	}
+	if in != 123 || out != 45 {
+		t.Errorf("usage = (%d,%d), want (123,45)", in, out)
+	}
+}

--- a/internal/highlight/detector_test.go
+++ b/internal/highlight/detector_test.go
@@ -141,6 +141,20 @@ func buildDetector(t *testing.T, bus *voiceevent.Bus, prov llm.Provider, snap Sn
 	return d, clk, classified
 }
 
+// waitForTriggers polls the sink until it holds n triggers, or fails on timeout.
+func waitForTriggers(t *testing.T, sink *fakeSink, n int) []Trigger {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := sink.all(); len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d triggers (have %d)", n, len(sink.all()))
+	return nil
+}
+
 // awaitClassifications drains n classification notifications or fails on timeout.
 func awaitClassifications(t *testing.T, ch <-chan classification, n int) {
 	t.Helper()
@@ -263,22 +277,22 @@ func TestConfirmWindowsProducesOneTrigger(t *testing.T) {
 	sink := &fakeSink{}
 	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
 	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
-		ClassifyEvery: 6, Bar: 8.0, ConfirmWindows: 2, Cooldown: time.Hour,
+		ClassifyEvery: 6, Bar: 8.0, ConfirmWindows: 2, Cooldown: time.Hour, Tail: 40 * time.Millisecond,
 	})
 
-	// One classify (>=Bar) — not yet confirmed.
+	// One classify (>=Bar) — not yet confirmed, so no cut is scheduled.
 	publishFinals(t, d, bus, clk, "A", 6)
 	awaitClassifications(t, classified, 1)
 	if n := len(sink.all()); n != 0 {
 		t.Fatalf("trigger after 1 confirming window, want 0 (need 2), got %d", n)
 	}
 
-	// Second consecutive classify (>=Bar) confirms → exactly one trigger.
+	// Second consecutive classify (>=Bar) confirms → exactly one trigger (delivered
+	// on the Tail-delayed cut).
 	publishFinals(t, d, bus, clk, "A", 6)
-	awaitClassifications(t, classified, 1)
-	time.Sleep(50 * time.Millisecond)
-	if n := len(sink.all()); n != 1 {
-		t.Fatalf("trigger count = %d, want exactly 1", n)
+	trigs := waitForTriggers(t, sink, 1)
+	if len(trigs) != 1 {
+		t.Fatalf("trigger count = %d, want exactly 1", len(trigs))
 	}
 }
 
@@ -289,25 +303,21 @@ func TestCooldownThenRearm(t *testing.T) {
 	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
 	sink := &fakeSink{}
 	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
-	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
-		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 2, Cooldown: 120 * time.Second,
+	d, clk, _ := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 2, Cooldown: 120 * time.Second, Tail: 40 * time.Millisecond,
 	})
 
 	// Two classifies confirm the first trigger.
 	publishFinals(t, d, bus, clk, "A", 4)
-	awaitClassifications(t, classified, 2)
-	time.Sleep(50 * time.Millisecond)
-	if n := len(sink.all()); n != 1 {
-		t.Fatalf("first trigger count = %d, want 1", n)
-	}
+	waitForTriggers(t, sink, 1)
+	callsAfterFirst := prov.callCount()
 
-	// Within the cooldown, further high windows are suppressed (classify is skipped,
-	// so no notification arrives).
+	// Within the cooldown, further high windows are suppressed: classify is skipped
+	// entirely (no new provider call, no new cut).
 	publishFinals(t, d, bus, clk, "A", 4)
-	select {
-	case <-classified:
-		t.Fatal("classified within cooldown, want suppression")
-	case <-time.After(150 * time.Millisecond):
+	time.Sleep(120 * time.Millisecond)
+	if got := prov.callCount(); got != callsAfterFirst {
+		t.Fatalf("classify calls during cooldown = %d, want unchanged %d (suppressed)", got, callsAfterFirst)
 	}
 	if n := len(sink.all()); n != 1 {
 		t.Fatalf("trigger count during cooldown = %d, want still 1", n)
@@ -316,11 +326,7 @@ func TestCooldownThenRearm(t *testing.T) {
 	// Advance past the cooldown and rearm: two more confirming windows → a 2nd trigger.
 	clk.advance(121 * time.Second)
 	publishFinals(t, d, bus, clk, "A", 4)
-	awaitClassifications(t, classified, 2)
-	time.Sleep(50 * time.Millisecond)
-	if n := len(sink.all()); n != 2 {
-		t.Fatalf("trigger count after rearm = %d, want 2", n)
-	}
+	waitForTriggers(t, sink, 2)
 }
 
 // TestMaxCandidatesCap (TEST 5): once MaxCandidates triggers have fired, the
@@ -330,26 +336,19 @@ func TestMaxCandidatesCap(t *testing.T) {
 	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
 	sink := &fakeSink{}
 	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
-	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+	d, clk, _ := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
 		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Nanosecond, MaxCandidates: 1,
+		Tail: 40 * time.Millisecond,
 	})
 
 	// First confirming window → first (and only allowed) trigger.
 	publishFinals(t, d, bus, clk, "A", 2)
-	awaitClassifications(t, classified, 1)
-	time.Sleep(50 * time.Millisecond)
-	if n := len(sink.all()); n != 1 {
-		t.Fatalf("trigger count = %d, want 1", n)
-	}
+	waitForTriggers(t, sink, 1)
 	callsAtCap := prov.callCount()
 
 	// Cap reached: further finals must NOT classify (no spend past the cap).
 	publishFinals(t, d, bus, clk, "A", 20)
-	select {
-	case <-classified:
-		t.Fatal("classified after MaxCandidates reached")
-	case <-time.After(150 * time.Millisecond):
-	}
+	time.Sleep(120 * time.Millisecond)
 	if got := prov.callCount(); got != callsAtCap {
 		t.Errorf("classify calls after cap = %d, want unchanged %d", got, callsAtCap)
 	}
@@ -368,17 +367,14 @@ func TestTriggerShape(t *testing.T) {
 		gotFrom, gotTo = from, to
 		return tape.Snapshot{From: from, To: to, Lanes: []tape.LaneSnapshot{{LaneID: "A"}}}
 	}
-	d, clk, classified := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
+	d, clk, _ := buildDetector(t, bus, prov, snap, sink, allowGate{}, Config{
 		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Hour,
-		Lead: 15 * time.Second, Tail: 5 * time.Second,
+		Lead: 15 * time.Second, Tail: 100 * time.Millisecond,
 	})
 
 	at := clk.now()
 	publishFinals(t, d, bus, clk, "A", 2)
-	awaitClassifications(t, classified, 1)
-	time.Sleep(50 * time.Millisecond)
-
-	trigs := sink.all()
+	trigs := waitForTriggers(t, sink, 1)
 	if len(trigs) != 1 {
 		t.Fatalf("trigger count = %d, want 1", len(trigs))
 	}
@@ -386,7 +382,7 @@ func TestTriggerShape(t *testing.T) {
 	if !tr.From.Equal(at.Add(-15 * time.Second)) {
 		t.Errorf("From = %v, want %v", tr.From, at.Add(-15*time.Second))
 	}
-	if !tr.To.Equal(at.Add(5 * time.Second)) {
+	if !tr.To.Equal(at.Add(100 * time.Millisecond)) {
 		t.Errorf("To = %v, want %v", tr.To, at.Add(5*time.Second))
 	}
 	if !gotFrom.Equal(tr.From) || !gotTo.Equal(tr.To) {
@@ -455,5 +451,53 @@ func TestUsageMetered(t *testing.T) {
 	}
 	if in != 123 || out != 45 {
 		t.Errorf("usage = (%d,%d), want (123,45)", in, out)
+	}
+}
+
+// TestTailDelayedCutCapturesReactionAudio proves the snapshot cut is delayed by
+// Tail so audio that arrives AFTER the moment confirms — the reaction — is in the
+// emitted clip. It uses a REAL tape behind SnapshotFunc (not an echo fake): an
+// agent frame appended within the Tail window, after the trigger fires, must land
+// in the Snapshot. Cutting at confirm time would miss it entirely.
+func TestTailDelayedCutCapturesReactionAudio(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	tp := tape.New(tape.Window, nil, nil) // agent lane is always captured
+	defer tp.Close()
+
+	base := time.Now()
+	clk := &testClock{t: base}
+	d := newDetector(prov, "", tp.Snapshot, sink, allowGate{}, nil, nil, Config{
+		ClassifyEvery: 1, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Hour,
+		Lead: time.Second, Tail: 400 * time.Millisecond,
+	})
+	d.now = clk.now
+	d.handled = make(chan struct{}, 1)
+	d.start(bus)
+	t.Cleanup(d.Close)
+
+	// One high final confirms immediately and schedules a cut for base+Tail.
+	bus.Publish(voiceevent.STTFinal{At: base, Text: "I strike the killing blow!", SpeakerID: "A"})
+	select {
+	case <-d.handled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("final not handled")
+	}
+
+	// AFTER the trigger is scheduled, the reaction audio arrives on the agent lane,
+	// stamped inside the Tail window. The delayed cut must include it.
+	tp.AppendAgent([]byte{0x01, 0x02, 0x03}, base.Add(150*time.Millisecond))
+
+	trigs := waitForTriggers(t, sink, 1)
+	tr := trigs[0]
+	var agentFrames int
+	for _, lane := range tr.Snapshot.Lanes {
+		if lane.LaneID == tape.AgentLaneID {
+			agentFrames = len(lane.Frames)
+		}
+	}
+	if agentFrames == 0 {
+		t.Fatalf("post-trigger reaction frame missing from the clip; snapshot lanes = %+v", tr.Snapshot.Lanes)
 	}
 }

--- a/internal/highlight/discard.go
+++ b/internal/highlight/discard.go
@@ -1,0 +1,7 @@
+package highlight
+
+// discardWriter is an io.Writer that drops everything, used to build a no-op slog
+// handler when the caller passes a nil logger (mirrors internal/tape).
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/highlight/fakes_test.go
+++ b/internal/highlight/fakes_test.go
@@ -1,0 +1,31 @@
+package highlight
+
+import (
+	"sync"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// spyRecorder is an observe.StageRecorder that captures the LLM token usage the
+// detector meters; every other method is a no-op (embedded Discard).
+type spyRecorder struct {
+	observe.Discard
+	mu    sync.Mutex
+	seen  bool
+	in    int
+	out   int
+	model string
+}
+
+func (r *spyRecorder) LLMTokens(_ observe.Provider, model string, in, out int) {
+	r.mu.Lock()
+	r.seen = true
+	r.in, r.out, r.model = in, out, model
+	r.mu.Unlock()
+}
+
+func (r *spyRecorder) llmTokens() (in, out int, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.in, r.out, r.seen
+}

--- a/internal/highlight/features.go
+++ b/internal/highlight/features.go
@@ -1,0 +1,109 @@
+package highlight
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+)
+
+// frameFeature is the cheap per-frame audio summary the PCM tap computes inline
+// (on the audio-loop goroutine) and hands to the worker: the sum of squared
+// normalized samples (for RMS energy), the zero-crossing count (a rough
+// voiced/excited-delivery proxy), and the sample count, tagged with the frame's
+// Speaker Lane (ADR-0050). It carries aggregates, not the samples, so the worker
+// folds it in O(1) without touching the PCM buffer.
+type frameFeature struct {
+	lane       string
+	sumSquares float64
+	zeroCross  int
+	samples    int
+}
+
+// computeFrameFeature summarizes one decoded PCM frame. It only reads the frame's
+// samples (no allocation, no mutation), so it is safe to run inline on the audio
+// loop before the frame is handed to the tap mailbox.
+func computeFrameFeature(f audio.Frame) frameFeature {
+	s := f.Samples()
+	ff := frameFeature{lane: f.Speaker(), samples: len(s)}
+	for i, v := range s {
+		x := float64(v) / 32768.0
+		ff.sumSquares += x * x
+		if i > 0 && (s[i-1] < 0) != (v < 0) {
+			ff.zeroCross++
+		}
+	}
+	return ff
+}
+
+// laneAccum accumulates one lane's audio energy since the last classification.
+type laneAccum struct {
+	sumSquares float64
+	zeroCross  int
+	samples    int
+}
+
+// featureState is the worker-owned per-lane accumulator set. It is touched only by
+// the single worker goroutine, so it needs no lock.
+type featureState map[string]*laneAccum
+
+// fold accumulates one frame's features into its lane.
+func (fs featureState) fold(ff frameFeature) {
+	a := fs[ff.lane]
+	if a == nil {
+		a = &laneAccum{}
+		fs[ff.lane] = a
+	}
+	a.sumSquares += ff.sumSquares
+	a.zeroCross += ff.zeroCross
+	a.samples += ff.samples
+}
+
+// summarize renders the per-lane RMS energy and zero-crossing rate accumulated
+// since the last call, then RESETS the accumulators so the next window measures
+// only its own audio. Lanes are sorted by id for a deterministic prompt (ADR-0021).
+// With no audio captured it returns a fixed "(no audio captured)" line so the
+// prompt is still stable.
+func (fs featureState) summarize() string {
+	var b strings.Builder
+	b.WriteString("Audio energy since last check:\n")
+	if len(fs) == 0 {
+		b.WriteString("(no audio captured)\n")
+		return b.String()
+	}
+	lanes := make([]string, 0, len(fs))
+	for lane := range fs {
+		lanes = append(lanes, lane)
+	}
+	sort.Strings(lanes)
+	for _, lane := range lanes {
+		a := fs[lane]
+		var rms, zcr float64
+		if a.samples > 0 {
+			rms = math.Sqrt(a.sumSquares / float64(a.samples))
+			zcr = float64(a.zeroCross) / float64(a.samples)
+		}
+		fmt.Fprintf(&b, "- %s: RMS %.3f, zero-crossing rate %.3f\n", laneLabel(lane), rms, zcr)
+	}
+	// Reset for the next window.
+	for lane := range fs {
+		delete(fs, lane)
+	}
+	return b.String()
+}
+
+// laneLabel renders a lane id for the prompt: the agent (TTS) lane by name, a
+// Speaker Lane as "Speaker <id>", and the unattributed lane as "Speaker".
+func laneLabel(lane string) string {
+	switch lane {
+	case "":
+		return "Speaker"
+	case tape.AgentLaneID:
+		return "Agent"
+	default:
+		return "Speaker " + lane
+	}
+}

--- a/internal/highlight/features_test.go
+++ b/internal/highlight/features_test.go
@@ -1,0 +1,135 @@
+package highlight
+
+import (
+	"context"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/audio"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// capturingProvider records the user message of every request it replays, so a test
+// can assert what the classifier prompt carried.
+type capturingProvider struct {
+	mu       sync.Mutex
+	lastUser string
+	resp     string
+}
+
+func (p *capturingProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	for _, m := range req.Messages {
+		if m.Role == llm.RoleUser {
+			p.lastUser = m.Text
+		}
+	}
+	p.mu.Unlock()
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: p.resp}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
+func (p *capturingProvider) userPrompt() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastUser
+}
+
+// loudFrame builds a decoded PCM frame with alternating full-scale samples (high
+// energy AND high zero-crossing rate), attributed to a Speaker Lane.
+func loudFrame(t *testing.T, speaker string) audio.Frame {
+	t.Helper()
+	samples := make([]int16, 480) // 10ms @ 48kHz
+	for i := range samples {
+		if i%2 == 0 {
+			samples[i] = 30000
+		} else {
+			samples[i] = -30000
+		}
+	}
+	f, err := audio.NewFrame(samples, 48000, 10)
+	if err != nil {
+		t.Fatalf("NewFrame: %v", err)
+	}
+	return f.WithSpeaker(speaker)
+}
+
+// TestPCMFeaturesInPrompt (TEST 8): the per-lane RMS energy and zero-crossing
+// summary computed from the PCM tap lands in the classifier prompt.
+func TestPCMFeaturesInPrompt(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &capturingProvider{resp: scoreJSON(1.0)}
+	sink := &fakeSink{}
+	d, clk, classified := buildDetector(t, bus, prov, nil, sink, allowGate{}, Config{ClassifyEvery: 2})
+
+	// Feed loud frames through the tap, then let the worker drain them.
+	tap := d.PCMTap()
+	for i := 0; i < 50; i++ {
+		tap(loudFrame(t, "A"))
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+
+	got := prov.userPrompt()
+	if !strings.Contains(got, "Audio energy since last check") {
+		t.Fatalf("prompt missing audio-energy summary:\n%s", got)
+	}
+	if !strings.Contains(got, "Speaker A: RMS") {
+		t.Fatalf("prompt missing lane A energy line:\n%s", got)
+	}
+	if strings.Contains(got, "(no audio captured)") {
+		t.Errorf("prompt reports no audio despite fed frames:\n%s", got)
+	}
+}
+
+// TestPCMTapNeverBlocks (TEST 8 cont.): the tap returns promptly under a flood even
+// though the single worker cannot keep up — frames drop, the audio loop never waits.
+func TestPCMTapNeverBlocks(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(1.0) }}
+	sink := &fakeSink{}
+	d, _, _ := buildDetector(t, bus, prov, nil, sink, allowGate{}, Config{})
+
+	tap := d.PCMTap()
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100000; i++ {
+			tap(loudFrame(t, "A"))
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("PCM tap blocked under flood")
+	}
+}
+
+// TestComputeFrameFeature is the unit proof of the per-frame RMS/ZCR math.
+func TestComputeFrameFeature(t *testing.T) {
+	f := loudFrame(t, "A")
+	ff := computeFrameFeature(f)
+	if ff.lane != "A" {
+		t.Errorf("lane = %q, want A", ff.lane)
+	}
+	if ff.samples != 480 {
+		t.Errorf("samples = %d, want 480", ff.samples)
+	}
+	// Full-scale alternating ⇒ RMS ≈ 30000/32768, ZCR ≈ 1 per sample step.
+	rms := math.Sqrt(ff.sumSquares / float64(ff.samples))
+	if rms < 0.85 || rms > 0.95 {
+		t.Errorf("RMS = %.3f, want ~0.915", rms)
+	}
+	if ff.zeroCross != 479 {
+		t.Errorf("zeroCross = %d, want 479", ff.zeroCross)
+	}
+}

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -15,13 +15,19 @@
 // LLM classifier to score the recent transcript window (0–10), with a per-lane
 // RMS-energy / zero-crossing audio summary folded into the prompt. A score at or
 // above Bar for ConfirmWindows consecutive classifications promotes the moment to
-// a [Trigger] — a time range plus caption material and a verbatim tape [Snapshot]
-// cut AT trigger time — handed to the [Sink] (#308's persistence pipeline). A
-// Cooldown suppresses back-to-back triggers and a per-session MaxCandidates cap
-// stops classifying once enough moments are found. Spend is metered on the
-// [observe.StageRecorder] the session Manager already tees into its spend meter
-// (ADR-0046); the [orchestrator.TurnGate] is checked before every classify and a
-// denied gate disarms the detector silently — a Highlight never ends a session.
+// a [Trigger] — a time range plus caption material and a tape [Snapshot] cut Tail
+// seconds after the moment confirms (so the reaction audio exists in the ring) —
+// handed to the [Sink] (#308's persistence pipeline). A Cooldown suppresses
+// back-to-back triggers and a per-session MaxCandidates cap stops classifying once
+// enough moments are found. Spend is metered on the [observe.StageRecorder] the
+// session Manager already tees into its spend meter (ADR-0046); the
+// [orchestrator.TurnGate] is checked before every classify and a denied gate
+// disarms the detector silently — a Highlight never ends a session. Like the
+// replier's pre-Take gate this is a pre-check: a classify already cleared by
+// AllowTurn can still push estimated spend a marginal amount past the soft cap
+// before the meter observes it (the gate is a boolean, not a reservation). That
+// slack is inherent to the pinned pre-check posture, bounded by one classify's
+// cost, and closes on the next classify, which sees the crossed cap and disarms.
 //
 // The detector is per-session state: construct it per wirenpc Voice Session cycle
 // with [NewDetector] and defer [Detector.Close] (a leak is a #44-class bug).

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -1,0 +1,133 @@
+// Package highlight is the Session Highlights moment detector (#307, Epic 8): a
+// bus side-consumer that watches the live Voice Session transcript and flags the
+// epic moments worth cutting a clip from the rollover tape (#306, ADR-0051).
+//
+// It follows internal/recall's discipline EXACTLY (ADR-0020/0026): the
+// [voiceevent.STTFinal] bus callback never blocks — it hands the final to a
+// latest-wins mailbox and returns, and a single worker goroutine owns all detector
+// state (the rolling transcript window, the per-lane audio-feature accumulators,
+// the confirm/cooldown/cap counters). The decoded-PCM tap ([Detector.PCMTap],
+// wired via wire.WithPCMTap) is likewise non-blocking: it summarizes each frame's
+// energy and hands it to a buffered mailbox that drops under load rather than
+// stalling the audio loop.
+//
+// The signal is the #305 hybrid: every ClassifyEvery finals the worker asks an
+// LLM classifier to score the recent transcript window (0–10), with a per-lane
+// RMS-energy / zero-crossing audio summary folded into the prompt. A score at or
+// above Bar for ConfirmWindows consecutive classifications promotes the moment to
+// a [Trigger] — a time range plus caption material and a verbatim tape [Snapshot]
+// cut AT trigger time — handed to the [Sink] (#308's persistence pipeline). A
+// Cooldown suppresses back-to-back triggers and a per-session MaxCandidates cap
+// stops classifying once enough moments are found. Spend is metered on the
+// [observe.StageRecorder] the session Manager already tees into its spend meter
+// (ADR-0046); the [orchestrator.TurnGate] is checked before every classify and a
+// denied gate disarms the detector silently — a Highlight never ends a session.
+//
+// The detector is per-session state: construct it per wirenpc Voice Session cycle
+// with [NewDetector] and defer [Detector.Close] (a leak is a #44-class bug).
+package highlight
+
+import (
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+)
+
+// Trigger is a promoted highlight moment: a wall-clock time range, the caption
+// material the #310 delivery slice needs, and a verbatim tape [tape.Snapshot] cut
+// at trigger time (the window rolls out of the 120s tape, so the cut cannot wait).
+// It is handed to a [Sink]; the detector never persists.
+type Trigger struct {
+	// At is the wall-clock moment the trigger fired (the confirming final's time).
+	At time.Time
+	// From, To bound the clip: From = At - Lead (build-up), To = At + Tail
+	// (reaction), From clamped into the tape's retention window.
+	From, To time.Time
+	// Score is the classifier's 0–10 rating of the confirming window.
+	Score float64
+	// SpeakerIDs are the distinct Speaker Lanes (ADR-0050) heard in the window.
+	SpeakerIDs []string
+	// Excerpt is caption-worthy transcript text for the moment.
+	Excerpt string
+	// Reason is the classifier's one-line justification.
+	Reason string
+	// Snapshot is the tape audio for [From, To], cut at trigger time.
+	Snapshot tape.Snapshot
+}
+
+// Sink consumes promoted [Trigger]s. #308's Saver implements it. HandleTrigger
+// must return promptly (it runs on the detector's single worker goroutine): a real
+// sink enqueues and returns, it does not do blocking I/O inline.
+type Sink interface {
+	HandleTrigger(Trigger)
+}
+
+// SnapshotFunc cuts a consistent tape snapshot over [from, to]. [tape.Tape.Snapshot]
+// satisfies it; the detector calls it in the worker at trigger time.
+type SnapshotFunc func(from, to time.Time) tape.Snapshot
+
+// Config tunes the detector to the #305 decision. Zero values take the package
+// defaults (the #305 numbers), so a caller can pass a bare Config{}.
+type Config struct {
+	// ClassifyEvery is how many processed finals pass between classifier calls
+	// (#305: 6).
+	ClassifyEvery int
+	// Cooldown suppresses classification for this long after a trigger, so one
+	// sustained moment yields one highlight (#305: 120s).
+	Cooldown time.Duration
+	// Bar is the minimum classifier score (0–10) a window must reach to count
+	// toward confirmation (#305: 8.0).
+	Bar float64
+	// ConfirmWindows is how many consecutive at-or-above-Bar classifications
+	// promote a moment to a trigger (#305: 2).
+	ConfirmWindows int
+	// MaxCandidates caps triggers per session; once reached the detector stops
+	// classifying (#305: 10).
+	MaxCandidates int
+	// Lead, Tail extend the clip before/after the moment (#305: 15s / 5s).
+	Lead, Tail time.Duration
+	// ProviderLabel is the bounded metric label for the classifier's LLM provider
+	// (ADR-0032/0046 spend attribution). wirenpc sets it from the Agent's provider
+	// id; the empty value defaults to Groq at metering time.
+	ProviderLabel observe.Provider
+}
+
+// #305 defaults.
+const (
+	defaultClassifyEvery  = 6
+	defaultCooldown       = 120 * time.Second
+	defaultBar            = 8.0
+	defaultConfirmWindows = 2
+	defaultMaxCandidates  = 10
+	defaultLead           = 15 * time.Second
+	defaultTail           = 5 * time.Second
+)
+
+func (c Config) withDefaults() Config {
+	if c.ClassifyEvery <= 0 {
+		c.ClassifyEvery = defaultClassifyEvery
+	}
+	if c.Cooldown <= 0 {
+		c.Cooldown = defaultCooldown
+	}
+	if c.Bar <= 0 {
+		c.Bar = defaultBar
+	}
+	if c.ConfirmWindows <= 0 {
+		c.ConfirmWindows = defaultConfirmWindows
+	}
+	if c.MaxCandidates <= 0 {
+		c.MaxCandidates = defaultMaxCandidates
+	}
+	if c.Lead <= 0 {
+		c.Lead = defaultLead
+	}
+	if c.Tail <= 0 {
+		c.Tail = defaultTail
+	}
+	if c.ProviderLabel == "" {
+		c.ProviderLabel = observe.ProviderGroq
+	}
+	return c
+}

--- a/internal/highlight/prompt.go
+++ b/internal/highlight/prompt.go
@@ -1,0 +1,89 @@
+package highlight
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// classifyInstruction is the fixed classifier directive (the RoleSystem prompt).
+// Fixed text: the cassette prompt hash (ADR-0021) depends on it byte-for-byte, so
+// a wording change is a genuine prompt change that must miss its cassette.
+const classifyInstruction = "You are watching a live tabletop RPG voice session and spotting highlight-worthy moments — " +
+	"a critical hit, a dramatic reversal, a clutch save, a big emotional or comedic beat. " +
+	"Rate how strong a highlight the following recent moment is on a scale from 0 to 10, " +
+	"where 0 is mundane table chatter or rules bookkeeping and 10 is an unforgettable epic beat the table will retell. " +
+	"Weigh both the transcript and the audio-energy summary: louder, more excited delivery suggests a bigger moment. " +
+	"Respond with ONLY a JSON object and nothing else, in the form " +
+	`{"score": <number 0-10>, "excerpt": "<short quote capturing the moment>", "reason": "<one short sentence>"}.`
+
+// classification is a parsed classifier verdict for one window.
+type classification struct {
+	score   float64
+	excerpt string
+	reason  string
+}
+
+// buildRequest renders the classifier [llm.Request] for a window: the fixed system
+// instruction plus a user message carrying the recent transcript lines and the
+// per-lane audio-energy summary. It is deterministic in its inputs (no wall-clock,
+// no map iteration) so the prompt hash is stable for cassette replay (ADR-0021).
+func buildRequest(model string, lines []finalLine, featureSummary string) llm.Request {
+	var b strings.Builder
+	b.WriteString("Recent transcript:\n")
+	if len(lines) == 0 {
+		b.WriteString("(no transcript)\n")
+	}
+	for _, l := range lines {
+		b.WriteString(l.render())
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n")
+	b.WriteString(featureSummary)
+	return llm.Request{
+		Model:     model,
+		MaxTokens: 256,
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Text: classifyInstruction},
+			{Role: llm.RoleUser, Text: b.String()},
+		},
+	}
+}
+
+// promptRunes counts the utf8 runes across a request's message texts, for the
+// ceil(chars/4) input-token estimate when the provider reports no usage (ADR-0045).
+func promptRunes(req llm.Request) int {
+	n := 0
+	for _, m := range req.Messages {
+		n += utf8.RuneCountInString(m.Text)
+	}
+	return n
+}
+
+// parseClassification extracts the classifier's JSON verdict from the model's
+// prose. It is deliberately tolerant (a classifier that wraps the object in prose
+// or fences still parses): it slices from the first '{' to the last '}' and
+// unmarshals. A malformed or absent object yields a zero score — a classify never
+// crashes the worker (the highlight is simply not confirmed).
+func parseClassification(text string) classification {
+	start := strings.IndexByte(text, '{')
+	end := strings.LastIndexByte(text, '}')
+	if start < 0 || end <= start {
+		return classification{}
+	}
+	var raw struct {
+		Score   float64 `json:"score"`
+		Excerpt string  `json:"excerpt"`
+		Reason  string  `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(text[start:end+1]), &raw); err != nil {
+		return classification{}
+	}
+	return classification{score: raw.Score, excerpt: raw.Excerpt, reason: raw.Reason}
+}
+
+// estimateTokens is the ceil(chars/4) per-direction token estimate (ADR-0045),
+// used when the classifier provider reports no usage.
+func estimateTokens(runes int) int { return (runes + 3) / 4 }

--- a/internal/highlight/prompt_test.go
+++ b/internal/highlight/prompt_test.go
@@ -1,0 +1,48 @@
+package highlight
+
+import "testing"
+
+// TestParseClassification pins the tolerant JSON extraction: a fenced or
+// prose-wrapped object parses, and garbage degrades to a zero score (a classify
+// never crashes the worker — the moment is simply not confirmed).
+func TestParseClassification(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantScore float64
+		wantExc   string
+	}{
+		{
+			name:      "bare object",
+			in:        `{"score": 9.5, "excerpt": "nat 20", "reason": "crit"}`,
+			wantScore: 9.5,
+			wantExc:   "nat 20",
+		},
+		{
+			name:      "fenced code block",
+			in:        "```json\n{\"score\": 7.0, \"excerpt\": \"clutch\", \"reason\": \"save\"}\n```",
+			wantScore: 7.0,
+			wantExc:   "clutch",
+		},
+		{
+			name:      "prose wrapped",
+			in:        `Sure, here is my verdict: {"score": 3.5, "excerpt": "meh", "reason": "chatter"} hope that helps!`,
+			wantScore: 3.5,
+			wantExc:   "meh",
+		},
+		{name: "no json", in: "I could not decide.", wantScore: 0, wantExc: ""},
+		{name: "malformed json", in: `{"score": not-a-number}`, wantScore: 0, wantExc: ""},
+		{name: "empty", in: "", wantScore: 0, wantExc: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseClassification(tc.in)
+			if got.score != tc.wantScore {
+				t.Errorf("score = %v, want %v", got.score, tc.wantScore)
+			}
+			if got.excerpt != tc.wantExc {
+				t.Errorf("excerpt = %q, want %q", got.excerpt, tc.wantExc)
+			}
+		})
+	}
+}

--- a/internal/wirenpc/highlightwiring_test.go
+++ b/internal/wirenpc/highlightwiring_test.go
@@ -1,0 +1,71 @@
+package wirenpc
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// fakeHighlightSink records triggers for the wiring assertions.
+type fakeHighlightSink struct{ n int }
+
+func (s *fakeHighlightSink) HandleTrigger(highlight.Trigger) { s.n++ }
+
+// TestBuildHighlightDetectorGating (TEST 11): the detector is armed ONLY when both
+// the tape (clip source) and a highlight sink are wired; any missing half yields no
+// detector, so the loop is byte-identical.
+func TestBuildHighlightDetectorGating(t *testing.T) {
+	bus := voiceevent.NewBus()
+	log := slog.New(slog.DiscardHandler)
+	tp := tape.New(tape.Window, nil, nil)
+	defer tp.Close()
+
+	cases := []struct {
+		name       string
+		tape       *tape.Tape
+		highlights highlight.Sink
+		wantNil    bool
+	}{
+		{"neither", nil, nil, true},
+		{"tape only", tp, nil, true},
+		{"sink only", nil, &fakeHighlightSink{}, true},
+		{"both", tp, &fakeHighlightSink{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{Tape: tc.tape, Highlights: tc.highlights}
+			d := buildHighlightDetector(cfg, bus, log)
+			if tc.wantNil {
+				if d != nil {
+					t.Fatalf("detector = non-nil, want nil for %q", tc.name)
+				}
+				if opts := highlightPCMOptions(d); opts != nil {
+					t.Errorf("PCM options = %v, want nil for a nil detector", opts)
+				}
+				return
+			}
+			if d == nil {
+				t.Fatal("detector = nil, want non-nil when tape and sink are both set")
+			}
+			// The PCM tap is wired as exactly one pipeline option.
+			if opts := highlightPCMOptions(d); len(opts) != 1 {
+				t.Errorf("PCM options = %d, want 1", len(opts))
+			}
+			// It subscribed to the bus (a published final must not panic) and Close
+			// releases the subscription + worker at cycle end (a leak is a #44 bug):
+			// Close must return promptly.
+			bus.Publish(voiceevent.STTFinal{Text: "hello", At: time.Now()})
+			done := make(chan struct{})
+			go func() { d.Close(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("detector.Close did not return (goroutine leak)")
+			}
+		})
+	}
+}

--- a/internal/wirenpc/highlightwiring_test.go
+++ b/internal/wirenpc/highlightwiring_test.go
@@ -1,12 +1,17 @@
 package wirenpc
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
@@ -14,6 +19,77 @@ import (
 type fakeHighlightSink struct{ n int }
 
 func (s *fakeHighlightSink) HandleTrigger(highlight.Trigger) { s.n++ }
+
+// stubLLM replays a fixed low-score classifier verdict (no trigger, no network).
+type stubLLM struct{}
+
+func (stubLLM) Complete(_ context.Context, _ llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: `{"score": 1.0, "excerpt": "x", "reason": "y"}`}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
+// labelSpy captures the provider label the detector meters usage under.
+type labelSpy struct {
+	observe.Discard
+	mu       sync.Mutex
+	provider observe.Provider
+	seen     bool
+}
+
+func (s *labelSpy) LLMTokens(p observe.Provider, _ string, _, _ int) {
+	s.mu.Lock()
+	s.provider, s.seen = p, true
+	s.mu.Unlock()
+}
+
+func (s *labelSpy) get() (observe.Provider, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.provider, s.seen
+}
+
+// TestBuildHighlightDetectorMetersProviderLabel asserts the ProviderLabel deviation
+// is wired: buildHighlightDetector passes llmProviderLabel(cfg.llmProviderID) into
+// the detector, so classifier spend is attributed to the ACTUAL provider — not the
+// empty/groq default. A dropped label would meter this anthropic session as groq.
+func TestBuildHighlightDetectorMetersProviderLabel(t *testing.T) {
+	orig := newLLM
+	newLLM = func(_, _ string) (llm.Provider, error) { return stubLLM{}, nil }
+	defer func() { newLLM = orig }()
+
+	bus := voiceevent.NewBus()
+	tp := tape.New(tape.Window, nil, nil)
+	defer tp.Close()
+	spy := &labelSpy{}
+	cfg := Config{Tape: tp, Highlights: &fakeHighlightSink{}, StageMetrics: spy, llmProviderID: "anthropic"}
+	d := buildHighlightDetector(cfg, bus, slog.New(slog.DiscardHandler))
+	if d == nil {
+		t.Fatal("detector = nil, want non-nil")
+	}
+	defer d.Close()
+
+	// Drive enough finals to trigger a classify (spaced so the worker folds each,
+	// defeating coalescing), then wait for the metered usage.
+	deadline := time.Now().Add(3 * time.Second)
+	for i := 0; ; i++ {
+		if _, seen := spy.get(); seen || !time.Now().Before(deadline) {
+			break
+		}
+		bus.Publish(voiceevent.STTFinal{Text: fmt.Sprintf("line %d of the scene", i), At: time.Now()})
+		time.Sleep(8 * time.Millisecond)
+	}
+
+	got, seen := spy.get()
+	if !seen {
+		t.Fatal("no classifier usage metered")
+	}
+	if got != observe.Provider("anthropic") {
+		t.Errorf("metered provider = %q, want %q (label not wired from cfg.llmProviderID)", got, observe.ProviderAnthropic)
+	}
+}
 
 // TestBuildHighlightDetectorGating (TEST 11): the detector is armed ONLY when both
 // the tape (clip source) and a highlight sink are wired; any missing half yields no

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the database/sql "pgx" driver for the goose-backed schema check
 
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -417,6 +418,16 @@ type Config struct {
 	// consent-button listener (all mode's presence owns its own). Set by RunFromDB
 	// alongside Tape; nil when the campaign is not armed.
 	TapeConsent TapeConsentStore
+
+	// Highlights, when non-nil, is the Session Highlights trigger sink (#307/#308,
+	// ADR-0051): connectAndServe builds the moment detector ONLY when both Tape and
+	// Highlights are set (a detector with no tape to cut clips from is pointless) and
+	// wires its PCM tap into the inbound pipeline. The detector watches STTFinal, runs
+	// the #305 classifier over the recent transcript window, and hands promoted
+	// [highlight.Trigger]s to this sink. nil (default) = highlights off, so the loop
+	// is byte-identical. The detector is per Voice Session cycle; connectAndServe
+	// owns its Close.
+	Highlights highlight.Sink
 
 	// GMSpeaker reports whether a Discord SpeakerID belongs to a Game Master —
 	// operator-allowlist membership per ADR-0050/ADR-0041, the deterministic GM
@@ -856,9 +867,22 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// runs at the VAD frame geometry (vadSampleRate/vadFrameMs) so silero endpoints
 	// ~vadMinSilenceFrames*vadFrameMs (= 384 ms) after the speaker stops — the
 	// natural cadence the bargeConfirm/floorCoalesce windows already account for.
+	// Session Highlights detector (#307, ADR-0051): built ONLY when the campaign is
+	// armed (Tape set) AND a highlight sink is wired. It subscribes to STTFinal off
+	// the bus and consumes the decoded-PCM tap; both are non-blocking (ADR-0020). A
+	// nil detector (highlights off, or provider build failed) adds no option and no
+	// bus subscriber, so the loop is byte-identical. Per-cycle state: Close on exit
+	// (a leak is a #44-class bug).
+	detector := buildHighlightDetector(cfg, bus, log)
+	if detector != nil {
+		defer detector.Close()
+	}
+
 	// tapeInboundOptions adds the inbound (consented Speaker) tape tap when armed
-	// (#306); nil tape → no option → byte-identical inbound loop.
+	// (#306); nil tape → no option → byte-identical inbound loop. highlightPCMOptions
+	// adds the detector's decoded-PCM tap (#307) when the detector is built.
 	pipeOpts := append([]wire.Option{wire.WithSilenceClock(vadSampleRate, vadFrameMs)}, tapeInboundOptions(cfg.Tape)...)
+	pipeOpts = append(pipeOpts, highlightPCMOptions(detector)...)
 	pipe := wire.NewPipeline(conv, cdc, log, cfg.Guild, cfg.Metrics, pipeOpts...)
 	return pipe.Run(cycleCtx, sess)
 }
@@ -1047,6 +1071,52 @@ func tapePumpOptions(t *tape.Tape) []wire.PumpOption {
 			t.AppendAgent(opus, time.Now())
 		}),
 	}
+}
+
+// buildHighlightDetector constructs the Session Highlights moment detector (#307)
+// for this Voice Session cycle, or returns nil when highlights are off. It is armed
+// ONLY when both the rollover tape (the clip source) and a trigger sink are wired —
+// a detector with nothing to cut clips from, or nowhere to hand triggers, is inert
+// by construction. It reuses the recap/wirenpc BYOK chain (llmbuild.New keyed off
+// cfg.llmProviderID + cfg.keys.llm) for the classifier provider, snapshots via the
+// tape, gates on the session spend gate, and meters on the shared StageRecorder the
+// Manager already tees into the spend meter (ADR-0046). A provider-build failure is
+// logged and degrades to no detector — a Highlight is best-effort and must never
+// fail the session.
+func buildHighlightDetector(cfg Config, bus *voiceevent.Bus, log *slog.Logger) *highlight.Detector {
+	if cfg.Tape == nil || cfg.Highlights == nil {
+		return nil
+	}
+	provider, err := newLLM(cfg.llmProviderID, cfg.keys.llm)
+	if err != nil {
+		log.Warn("highlight detector: build classifier provider; highlights disabled this session", "err", err)
+		return nil
+	}
+	model := ""
+	if len(cfg.npcs) > 0 {
+		model = cfg.npcs[0].model
+	}
+	return highlight.NewDetector(
+		bus,
+		provider,
+		model,
+		cfg.Tape.Snapshot,
+		cfg.Highlights,
+		cfg.Gate,
+		cfg.StageMetrics,
+		log,
+		highlight.Config{ProviderLabel: llmProviderLabel(cfg.llmProviderID)},
+	)
+}
+
+// highlightPCMOptions wires the detector's decoded-PCM tap into the inbound
+// pipeline (#307). A nil detector returns nothing (byte-identical loop). The tap is
+// non-blocking (drops under load), so it adds no audio-loop latency (ADR-0020).
+func highlightPCMOptions(d *highlight.Detector) []wire.Option {
+	if d == nil {
+		return nil
+	}
+	return []wire.Option{wire.WithPCMTap(d.PCMTap())}
 }
 
 // TapeConsentReader is the authoritative consent read the tape reseeds from (#306):

--- a/tests/voice-cassettes/llm-highlight-dragon.yaml
+++ b/tests/voice-cassettes/llm-highlight-dragon.yaml
@@ -1,0 +1,11 @@
+exchanges:
+    - prompt_hash: 2f23785acf34abcd1b197772e7fab1ae74d1ec9bc5a2e4fdfdbb6e9ead467557
+      text: '{"score": 2.0, "excerpt": "the party explores the corridor", "reason": "routine exploration"}'
+      stop_reason: end_turn
+    - prompt_hash: 6f8e4b4b8a7892d06b6d366ec0af26c06a793355a4a16b5737eae4ff29eff276
+      text: '{"score": 9.5, "excerpt": "I rolled a natural twenty! A critical hit on the dragon!", "reason": "a critical hit felling the dragon"}'
+      stop_reason: end_turn
+    - prompt_hash: 9cb391db079b7ef21ae9d9b4611e75816362f0ef206de46faa6014932d58fe7f
+      text: '{"score": 9.5, "excerpt": "I rolled a natural twenty! A critical hit on the dragon!", "reason": "a critical hit felling the dragon"}'
+      stop_reason: end_turn
+notes: 'Hand-authored highlight classifier fixture (#307): mundane corridor + one natural-twenty dragon kill. Not a live recording; responses are the fixture''s scoring rule.'


### PR DESCRIPTION
Closes #307

## What

`internal/highlight` — the Session Highlights moment detector (Epic 8), a bus side-consumer that flags epic moments worth cutting a clip from the #306 rollover tape.

- **No-block hosting (ADR-0020/0026):** `On[STTFinal]` → latest-wins mailbox → ONE worker goroutine (the `internal/recall` pattern). The `wire.WithPCMTap` decoded-PCM tap computes per-lane RMS energy + zero-crossing summaries inline and hands them to a buffered mailbox that drops under load — the audio loop never waits.
- **#305 signal:** every `ClassifyEvery` (6) processed finals the worker asks an LLM classifier to score the recent transcript window (0–10), with the per-lane audio summary folded into the prompt. `>= Bar` (8.0) for `ConfirmWindows` (2) consecutive classifications → one `Trigger`. `Cooldown` (120s) suppresses back-to-back; `MaxCandidates` (10) caps per session then stops classifying.
- **Spend (ADR-0045/0046):** usage metered on the `StageRecorder` the Manager already tees into the session spend meter (zero new plumbing). `gate.AllowTurn()` checked before EVERY classify; a denied gate disarms the detector silently — a Highlight never ends a session.
- **Trigger:** `From = At-Lead`, `To = At+Tail`, clamped into the tape window; the tape `Snapshot` is cut in the worker AT trigger time (the window rolls away). Provider via `llmbuild.New` (recap BYOK chain: `cfg.keys` + `cfg.llmProviderID`).
- `highlight.go` owns the shared `Trigger` / `Sink` / `SnapshotFunc` types that #308 implements. No persistence in this slice (fake-sink tested).

`wirenpc` builds the detector per Voice Session cycle ONLY when `Tape != nil AND Highlights != nil`, wires its PCM tap into the inbound pipeline, and `Close`s it at cycle end (a leak is a #44-class bug).

## Contract note

The pinned `NewDetector` signature carries `model` but no `observe.Provider` label, which `StageRecorder.LLMTokens` requires for correct spend attribution. Rather than touch the pinned constructor, I added one additive field — `Config.ProviderLabel` — set by wirenpc via the existing `llmProviderLabel(cfg.llmProviderID)`. Safe for #308 (it only consumes `Sink`/`Trigger`/`SnapshotFunc`).

## Tests (TDD, red→green)

`internal/highlight` (11 behaviors) + `internal/wirenpc` wiring:
- publish never blocks + latest-wins coalescing under a stalled worker
- classify cadence (every 6 finals); ConfirmWindows → exactly one trigger
- cooldown suppression then rearm; MaxCandidates stops classifying
- trigger shape (window±Lead/Tail, populated fields, verbatim snapshot)
- closed gate → no classifier call + disarm; usage metered on the recorder
- PCM features in the prompt + tap never blocks under a 100k-frame flood; per-frame RMS/ZCR unit
- cassette determinism (ADR-0021) + the "natural 20 against the dragon" demo → exactly one trigger over the right range
- wirenpc: detector armed only when tape AND sink set; PCM tap wired; `Close` returns (no leak)

The classifier cassette is hand-authored via an env-gated generator (`GEN_HL_CASSETTE=1`) using `voicecassette.HashLLMRequest` — no live API; a prompt change misses its hash and fails, preserving ADR-0021 drift detection.

`-race` clean; `gofmt`/`vet`/`golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)