### PR TITLE
feat(#293): [E6] glyphoxa seed --bundle + canonical demo bundle in CI smoke

### DIFF
--- a/cmd/glyphoxa/seed.go
+++ b/cmd/glyphoxa/seed.go
@@ -3,26 +3,59 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
 
-// RunSeed is the `glyphoxa seed` subcommand: it seeds the demo Tenant/Campaign
-// and the live Character NPC into Postgres (task #5), idempotently. The schema
-// must already be applied (`glyphoxa migrate up`).
+// seedBundleTenantName is the Tenant the `-bundle` seed mints when the DB holds
+// none yet (ADR-0053): a self-host operator's first `seed -bundle` lands the
+// campaign under a fresh "Glyphoxa" Tenant; a subsequent seed reuses whatever
+// Tenant already exists ([storage.Store.FirstTenant]) rather than duplicating it.
+const seedBundleTenantName = "Glyphoxa"
+
+// RunSeed is the `glyphoxa seed` subcommand. With no arguments it seeds the demo
+// Tenant/Campaign and the live Character NPC (task #5), idempotently — the legacy
+// path, byte-for-byte unchanged. With `-bundle <file>` it instead imports a
+// campaign bundle (ADR-0053, #293): a canonical demo bundle ships one playable
+// campaign (roster + KG + a player character) that an operator logs into and then
+// configures BYOK keys against. The schema must already be applied
+// (`glyphoxa migrate up`).
 //
 // Connection string: $GLYPHOXA_DATABASE_URL (or $DATABASE_URL).
-// Credential-encryption secret: $GLYPHOXA_SECRET (ADR-0004 single app secret) —
-// used only to seal the placeholder credentials the seed writes (real provider
-// keys live in the OS keyring, not the DB).
-func RunSeed(ctx context.Context, log *slog.Logger, _ []string) error {
+// Credential-encryption secret: $GLYPHOXA_SECRET (ADR-0004 single app secret) is
+// required only by the legacy path — it seals the placeholder credentials that
+// path writes. The bundle path carries NO secrets (they are excluded from a
+// bundle, ADR-0053 §2), so it never touches the cipher.
+func RunSeed(ctx context.Context, log *slog.Logger, args []string) error {
+	fs := flag.NewFlagSet("seed", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	bundlePath := fs.String("bundle", "", "import a campaign bundle (.glyphoxa.json[.gz]) instead of the built-in demo NPC")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *bundlePath != "" {
+		return runSeedBundle(ctx, log, *bundlePath)
+	}
+	return runSeedLegacy(ctx, log)
+}
+
+// runSeedLegacy is the original demo-NPC seed (task #5): it requires the app
+// cipher and delegates to [wirenpc.SeedNPC], which is idempotent on the demo
+// Tenant name.
+func runSeedLegacy(ctx context.Context, log *slog.Logger) error {
 	dsn := databaseURL()
 	if dsn == "" {
 		return fmt.Errorf("seed: set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL)")
@@ -43,6 +76,75 @@ func RunSeed(ctx context.Context, log *slog.Logger, _ []string) error {
 		return err
 	}
 	return nil
+}
+
+// runSeedBundle imports a campaign bundle from path (ADR-0053, #293). It decodes
+// the file BEFORE opening the DB so a mistyped path fails fast without a
+// connection. The importer is always-mint (ADR-0053 §4): idempotence lives HERE,
+// in a campaign-name precheck — if the resolved Tenant already holds a campaign
+// of the bundle's name the seed logs and skips (exit 0), so re-running `seed
+// -bundle` on a provisioned DB is a no-op rather than a duplicate campaign.
+func runSeedBundle(ctx context.Context, log *slog.Logger, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("seed: open bundle %s: %w", path, err)
+	}
+	defer f.Close()
+	b, err := bundle.Decode(f)
+	if err != nil {
+		return fmt.Errorf("seed: decode bundle %s: %w", path, err)
+	}
+
+	dsn := databaseURL()
+	if dsn == "" {
+		return fmt.Errorf("seed: set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL)")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("seed: open db: %w", err)
+	}
+	defer pool.Close()
+	st := storage.New(pool)
+
+	tenantID, err := resolveSeedTenant(ctx, st)
+	if err != nil {
+		return err
+	}
+
+	// Idempotence gate (ADR-0053 §4): the importer never dedups, so a name
+	// precheck is the only skip. Existing campaign of this name -> log + exit 0.
+	if _, err := st.FindCampaignByName(ctx, tenantID, b.Campaign.Name); err == nil {
+		log.Info("seed: campaign already present, skipping", "campaign", b.Campaign.Name)
+		return nil
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return fmt.Errorf("seed: check campaign %q: %w", b.Campaign.Name, err)
+	}
+
+	res, err := bundle.Import(ctx, st, tenantID, b)
+	if err != nil {
+		return fmt.Errorf("seed: import bundle: %w", err)
+	}
+	log.Info("seed: imported campaign bundle",
+		"campaign", res.Name, "agents", res.Agents, "nodes", res.Nodes,
+		"edges", res.Edges, "characters", res.Characters)
+	return nil
+}
+
+// resolveSeedTenant returns the Tenant the bundle imports under: the earliest
+// existing Tenant if the DB has one, else a freshly-minted "Glyphoxa" Tenant.
+func resolveSeedTenant(ctx context.Context, st *storage.Store) (uuid.UUID, error) {
+	tenant, err := st.FirstTenant(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		id, err := st.CreateTenant(ctx, seedBundleTenantName)
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("seed: create tenant: %w", err)
+		}
+		return id, nil
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("seed: resolve tenant: %w", err)
+	}
+	return tenant.ID, nil
 }
 
 // databaseURL resolves the Postgres connection string from the environment.

--- a/cmd/glyphoxa/seed.go
+++ b/cmd/glyphoxa/seed.go
@@ -46,7 +46,19 @@ func RunSeed(ctx context.Context, log *slog.Logger, args []string) error {
 		return err
 	}
 
-	if *bundlePath != "" {
+	// Distinguish flag-absent (legacy demo-NPC seed) from flag-present-but-empty
+	// (`-bundle ""`, a mistake): the empty-string default alone can't tell them
+	// apart, so consult fs.Visit for whether -bundle was actually given.
+	bundleSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "bundle" {
+			bundleSet = true
+		}
+	})
+	if bundleSet {
+		if *bundlePath == "" {
+			return fmt.Errorf("seed: -bundle requires a bundle file path (got empty)")
+		}
 		return runSeedBundle(ctx, log, *bundlePath)
 	}
 	return runSeedLegacy(ctx, log)

--- a/cmd/glyphoxa/seed_bundle_fixture_test.go
+++ b/cmd/glyphoxa/seed_bundle_fixture_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// demoBundlePath is the canonical demo bundle shipped for `seed -bundle` and the
+// container smoke test, relative to this package.
+const demoBundlePath = "../../scripts/testdata/demo.glyphoxa.json"
+
+// TestDemoBundleFixtureValid is the fixture-validity guard (TEST 6): it decodes
+// the committed demo bundle and resolves every intra-bundle reference the way the
+// importer will, WITHOUT a database. It fails loudly if the fixture goes stale —
+// most importantly on a FormatVersion bump (bundle.Decode refuses a newer
+// version), but also on a dangling node→agent link, an edge to a missing node, or
+// a voice blob the canonical mapper can't parse. Keeping this Docker-free means CI
+// catches a broken demo bundle on the fast `test` gate, not only in the smoke job.
+func TestDemoBundleFixtureValid(t *testing.T) {
+	f, err := os.Open(demoBundlePath)
+	if err != nil {
+		t.Fatalf("open demo bundle: %v", err)
+	}
+	defer f.Close()
+
+	b, err := bundle.Decode(f)
+	if err != nil {
+		t.Fatalf("decode demo bundle: %v", err)
+	}
+
+	if b.Campaign.Name != "The Prancing Pony" {
+		t.Errorf("campaign name = %q, want %q", b.Campaign.Name, "The Prancing Pony")
+	}
+	if b.Campaign.System != "dnd5e" || b.Campaign.Language != "en" {
+		t.Errorf("campaign system/language = %q/%q, want dnd5e/en", b.Campaign.System, b.Campaign.Language)
+	}
+	if b.Campaign.History != nil {
+		t.Errorf("demo bundle carries a History section; it must be history-less")
+	}
+
+	// Agents: exactly one Butler, at least one Character, and every voice parses
+	// through the SINGLE canonical reader (catches a drifted voice shape, #224).
+	agentRefs := make(map[string]bool, len(b.Campaign.Agents))
+	butlers, characters := 0, 0
+	for i := range b.Campaign.Agents {
+		a := &b.Campaign.Agents[i]
+		if agentRefs[a.ID] {
+			t.Fatalf("duplicate agent ref %q", a.ID)
+		}
+		agentRefs[a.ID] = true
+		switch a.Role {
+		case string(storage.AgentRoleButler):
+			butlers++
+		case string(storage.AgentRoleCharacter):
+			characters++
+		default:
+			t.Errorf("agent %q has unknown role %q", a.ID, a.Role)
+		}
+		if _, err := storage.VoiceFromJSON(a.Voice); err != nil {
+			t.Errorf("agent %q voice does not parse through VoiceFromJSON: %v", a.ID, err)
+		}
+	}
+	if butlers != 1 {
+		t.Errorf("butler count = %d, want exactly 1", butlers)
+	}
+	if characters < 1 {
+		t.Errorf("character NPC count = %d, want at least 1", characters)
+	}
+
+	// Nodes: unique refs; each node→agent link resolves to a real agent.
+	nodeRefs := make(map[string]bool, len(b.Campaign.Nodes))
+	linkedNPCNode := false
+	for i := range b.Campaign.Nodes {
+		n := &b.Campaign.Nodes[i]
+		if nodeRefs[n.ID] {
+			t.Fatalf("duplicate node ref %q", n.ID)
+		}
+		nodeRefs[n.ID] = true
+		if n.AgentID != "" {
+			if !agentRefs[n.AgentID] {
+				t.Errorf("node %q links unknown agent %q", n.ID, n.AgentID)
+			}
+			linkedNPCNode = true
+		}
+	}
+	if !linkedNPCNode {
+		t.Errorf("no node links to an agent; demo should include an NPC-node agent link")
+	}
+	if len(b.Campaign.Nodes) < 3 {
+		t.Errorf("node count = %d, want 3-4", len(b.Campaign.Nodes))
+	}
+
+	// Edges: at least two, and each endpoint resolves + validates the ADR-0008
+	// object-side rule the importer's CreateEdge enforces.
+	if len(b.Campaign.Edges) < 2 {
+		t.Errorf("edge count = %d, want at least 2", len(b.Campaign.Edges))
+	}
+	nodeType := make(map[string]storage.KGNodeType, len(b.Campaign.Nodes))
+	for i := range b.Campaign.Nodes {
+		nodeType[b.Campaign.Nodes[i].ID] = storage.KGNodeType(b.Campaign.Nodes[i].Type)
+	}
+	for i := range b.Campaign.Edges {
+		e := &b.Campaign.Edges[i]
+		if !nodeRefs[e.From] {
+			t.Errorf("edge references unknown from-node %q", e.From)
+		}
+		if !nodeRefs[e.To] {
+			t.Errorf("edge references unknown to-node %q", e.To)
+		}
+		if err := storage.ValidateEdge(storage.KGEdgeType(e.Type), nodeType[e.From], nodeType[e.To]); err != nil {
+			t.Errorf("edge %s->%s (%s) invalid: %v", e.From, e.To, e.Type, err)
+		}
+	}
+
+	if len(b.Campaign.Characters) < 1 {
+		t.Errorf("player character count = %d, want at least 1", len(b.Campaign.Characters))
+	}
+}

--- a/cmd/glyphoxa/seed_integration_test.go
+++ b/cmd/glyphoxa/seed_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// migrateSeedDB stands up a freshly migrated DB, points $GLYPHOXA_DATABASE_URL at
+// it, and returns a Store for assertions.
+func migrateSeedDB(t *testing.T) *storage.Store {
+	t.Helper()
+	ctx := context.Background()
+	dsn := startPostgres(t)
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	_ = db.Close()
+
+	t.Setenv("GLYPHOXA_DATABASE_URL", dsn)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return storage.New(pool)
+}
+
+// TestRunSeedBundle_FreshDB is TEST 3: `seed -bundle demo.glyphoxa.json` against a
+// fresh DB mints the "Glyphoxa" Tenant and imports the demo campaign — two agents
+// (Butler + Bart), the KG, and the player character — with NO $GLYPHOXA_SECRET set
+// (the bundle path carries no secrets).
+func TestRunSeedBundle_FreshDB(t *testing.T) {
+	ctx := context.Background()
+	st := migrateSeedDB(t)
+	os.Unsetenv("GLYPHOXA_SECRET")
+
+	if err := RunSeed(ctx, slog.Default(), []string{"-bundle", demoBundlePath}); err != nil {
+		t.Fatalf("seed -bundle: %v", err)
+	}
+
+	tenant, err := st.FirstTenant(ctx)
+	if err != nil {
+		t.Fatalf("FirstTenant: %v", err)
+	}
+	if tenant.Name != "Glyphoxa" {
+		t.Errorf("tenant name = %q, want Glyphoxa", tenant.Name)
+	}
+
+	campaign, err := st.FindCampaignByName(ctx, tenant.ID, "The Prancing Pony")
+	if err != nil {
+		t.Fatalf("FindCampaignByName: %v", err)
+	}
+
+	agents, err := st.ListAgents(ctx, campaign.ID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Errorf("agent count = %d, want 2 (Butler + Bart)", len(agents))
+	}
+	var hasBart bool
+	for _, a := range agents {
+		if a.Name == "Bart" {
+			hasBart = true
+		}
+	}
+	if !hasBart {
+		t.Errorf("imported roster missing Bart")
+	}
+
+	nodes, err := st.ListNodes(ctx, campaign.ID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) < 3 {
+		t.Errorf("node count = %d, want >= 3", len(nodes))
+	}
+	edges, err := st.ListEdges(ctx, campaign.ID)
+	if err != nil {
+		t.Fatalf("ListEdges: %v", err)
+	}
+	if len(edges) < 2 {
+		t.Errorf("edge count = %d, want >= 2", len(edges))
+	}
+	chars, err := st.ListCharacters(ctx, campaign.ID)
+	if err != nil {
+		t.Fatalf("ListCharacters: %v", err)
+	}
+	if len(chars) < 1 {
+		t.Errorf("player character count = %d, want >= 1", len(chars))
+	}
+}
+
+// TestRunSeedBundle_Idempotent is TEST 4: a second `seed -bundle` is a no-op — the
+// campaign-name precheck skips (exit 0) and no duplicate campaign appears.
+func TestRunSeedBundle_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	st := migrateSeedDB(t)
+	os.Unsetenv("GLYPHOXA_SECRET")
+
+	for i := 0; i < 2; i++ {
+		if err := RunSeed(ctx, slog.Default(), []string{"-bundle", demoBundlePath}); err != nil {
+			t.Fatalf("seed -bundle run %d: %v", i, err)
+		}
+	}
+
+	campaigns, err := st.ListCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if len(campaigns) != 1 {
+		t.Errorf("campaign count after two seeds = %d, want 1", len(campaigns))
+	}
+}
+
+// TestRunSeedBundle_CoexistsWithLegacySeed is TEST 5: the legacy demo-NPC seed
+// runs first (its Tenant + "The Prancing Pony" campaign), then `seed -bundle`
+// reuses that Tenant, finds the campaign name, and skips — no second campaign.
+func TestRunSeedBundle_CoexistsWithLegacySeed(t *testing.T) {
+	ctx := context.Background()
+	st := migrateSeedDB(t)
+
+	// Legacy path needs a valid app secret to seal its placeholder credentials.
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	t.Setenv("GLYPHOXA_SECRET", base64.StdEncoding.EncodeToString(key))
+
+	if err := RunSeed(ctx, slog.Default(), nil); err != nil {
+		t.Fatalf("legacy seed: %v", err)
+	}
+	if err := RunSeed(ctx, slog.Default(), []string{"-bundle", demoBundlePath}); err != nil {
+		t.Fatalf("seed -bundle after legacy: %v", err)
+	}
+
+	campaigns, err := st.ListCampaigns(ctx)
+	if err != nil {
+		t.Fatalf("ListCampaigns: %v", err)
+	}
+	if len(campaigns) != 1 {
+		t.Errorf("campaign count = %d, want 1 (bundle skipped the existing name)", len(campaigns))
+	}
+}

--- a/cmd/glyphoxa/seed_integration_test.go
+++ b/cmd/glyphoxa/seed_integration_test.go
@@ -43,6 +43,25 @@ func migrateSeedDB(t *testing.T) *storage.Store {
 	return storage.New(pool)
 }
 
+// unsetSecret removes $GLYPHOXA_SECRET for the duration of one test and restores
+// the prior value on cleanup — the bundle seed path must work with no secret set,
+// but the unset must not leak into other package tests (t.Setenv can only SET, not
+// unset, so we save/restore by hand).
+func unsetSecret(t *testing.T) {
+	t.Helper()
+	prev, had := os.LookupEnv("GLYPHOXA_SECRET")
+	if err := os.Unsetenv("GLYPHOXA_SECRET"); err != nil {
+		t.Fatalf("unset GLYPHOXA_SECRET: %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("GLYPHOXA_SECRET", prev)
+		} else {
+			_ = os.Unsetenv("GLYPHOXA_SECRET")
+		}
+	})
+}
+
 // TestRunSeedBundle_FreshDB is TEST 3: `seed -bundle demo.glyphoxa.json` against a
 // fresh DB mints the "Glyphoxa" Tenant and imports the demo campaign — two agents
 // (Butler + Bart), the KG, and the player character — with NO $GLYPHOXA_SECRET set
@@ -50,7 +69,7 @@ func migrateSeedDB(t *testing.T) *storage.Store {
 func TestRunSeedBundle_FreshDB(t *testing.T) {
 	ctx := context.Background()
 	st := migrateSeedDB(t)
-	os.Unsetenv("GLYPHOXA_SECRET")
+	unsetSecret(t)
 
 	if err := RunSeed(ctx, slog.Default(), []string{"-bundle", demoBundlePath}); err != nil {
 		t.Fatalf("seed -bundle: %v", err)
@@ -114,7 +133,7 @@ func TestRunSeedBundle_FreshDB(t *testing.T) {
 func TestRunSeedBundle_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	st := migrateSeedDB(t)
-	os.Unsetenv("GLYPHOXA_SECRET")
+	unsetSecret(t)
 
 	for i := 0; i < 2; i++ {
 		if err := RunSeed(ctx, slog.Default(), []string{"-bundle", demoBundlePath}); err != nil {

--- a/cmd/glyphoxa/seed_test.go
+++ b/cmd/glyphoxa/seed_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestRunSeed_BundleMissingFile is TEST 2 (arg parse): `seed -bundle <path>` with
+// a nonexistent file fails fast with an actionable error naming the path, before
+// any DB connection — a mistyped bundle path should not need Postgres to report.
+func TestRunSeed_BundleMissingFile(t *testing.T) {
+	err := RunSeed(context.Background(), slog.Default(),
+		[]string{"-bundle", "/no/such/demo.glyphoxa.json"})
+	if err == nil || !strings.Contains(err.Error(), "/no/such/demo.glyphoxa.json") {
+		t.Fatalf("missing bundle file: err=%v, want mention of the path", err)
+	}
+}
+
+// TestRunSeed_UnknownFlag rejects an unknown flag rather than silently falling
+// through to the legacy demo-NPC path.
+func TestRunSeed_UnknownFlag(t *testing.T) {
+	err := RunSeed(context.Background(), slog.Default(), []string{"-nope"})
+	if err == nil {
+		t.Fatal("unknown flag: want error, got nil")
+	}
+}

--- a/cmd/glyphoxa/seed_test.go
+++ b/cmd/glyphoxa/seed_test.go
@@ -18,6 +18,16 @@ func TestRunSeed_BundleMissingFile(t *testing.T) {
 	}
 }
 
+// TestRunSeed_BundleEmptyPath errors on an explicit empty `-bundle ""` rather
+// than silently falling through to the legacy demo-NPC seed — a flag given with
+// no value is a mistake, not a request for the legacy path.
+func TestRunSeed_BundleEmptyPath(t *testing.T) {
+	err := RunSeed(context.Background(), slog.Default(), []string{"-bundle", ""})
+	if err == nil || !strings.Contains(err.Error(), "-bundle") {
+		t.Fatalf("empty -bundle: err=%v, want a -bundle complaint (not legacy fallthrough)", err)
+	}
+}
+
 // TestRunSeed_UnknownFlag rejects an unknown flag rather than silently falling
 // through to the legacy demo-NPC path.
 func TestRunSeed_UnknownFlag(t *testing.T) {

--- a/internal/storage/tenant_test.go
+++ b/internal/storage/tenant_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestFirstTenantEmpty asserts FirstTenant returns ErrNotFound on a freshly
+// migrated (tenant-less) database — the seed's "no tenant yet" branch.
+func TestFirstTenantEmpty(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	_, err := st.FirstTenant(ctx)
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("FirstTenant on empty DB = %v, want ErrNotFound", err)
+	}
+}
+
+// TestFirstTenantReturnsEarliest asserts FirstTenant returns the earliest-created
+// Tenant — the one the -bundle seed reuses so a bundle import lands beside any
+// pre-existing tenant instead of minting a duplicate "Glyphoxa".
+func TestFirstTenantReturnsEarliest(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	firstID, err := st.CreateTenant(ctx, "Alpha")
+	if err != nil {
+		t.Fatalf("create first tenant: %v", err)
+	}
+	if _, err := st.CreateTenant(ctx, "Beta"); err != nil {
+		t.Fatalf("create second tenant: %v", err)
+	}
+
+	got, err := st.FirstTenant(ctx)
+	if err != nil {
+		t.Fatalf("FirstTenant: %v", err)
+	}
+	if got.ID != firstID {
+		t.Fatalf("FirstTenant = %q (%s), want earliest %q", got.Name, got.ID, firstID)
+	}
+}

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -357,6 +357,26 @@ func (s *Store) FindTenantByName(ctx context.Context, name string) (Tenant, erro
 	return t, nil
 }
 
+// FirstTenant returns the earliest-created Tenant, or ErrNotFound when the DB
+// holds none. The `glyphoxa seed -bundle` path uses it to land a bundle beside
+// an already-provisioned Tenant instead of minting a duplicate one (ADR-0053):
+// the ordering is deterministic (created_at then id) so a multi-tenant DB always
+// resolves the same Tenant.
+func (s *Store) FirstTenant(ctx context.Context) (Tenant, error) {
+	var t Tenant
+	err := s.db.QueryRow(ctx,
+		`SELECT id, name, created_at, updated_at
+		   FROM tenant ORDER BY created_at, id LIMIT 1`).
+		Scan(&t.ID, &t.Name, &t.CreatedAt, &t.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Tenant{}, ErrNotFound
+	}
+	if err != nil {
+		return Tenant{}, fmt.Errorf("storage: first tenant: %w", err)
+	}
+	return t, nil
+}
+
 // FindCampaignByName returns the Tenant's Campaign with the given name, or
 // ErrNotFound. It returns the full row rather than just the ID so a caller
 // wiring a Voice Session gets the Campaign Language (the matcher's phonetic

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -173,6 +173,100 @@ fi
 assert_spa
 
 # ---------------------------------------------------------------------------
+# 6. `glyphoxa seed -bundle` against a real Postgres (#293): the canonical demo
+#    bundle (scripts/testdata/demo.glyphoxa.json) imports cleanly and
+#    idempotently, so the self-host "seed a playable campaign" story actually
+#    works end-to-end through the shipped image. Unlike the DB-less checks above
+#    this needs a database, so it stands up a throwaway pgvector Postgres on a
+#    SCOPED docker network (NOT --network none — the seed container must reach
+#    the DB by name) and runs the image against it. Assertions go through
+#    `docker exec … psql` so the host needs no psql client. All state is torn
+#    down by a trap on exit.
+# ---------------------------------------------------------------------------
+printf '[6] seed -bundle imports the demo bundle idempotently against Postgres\n'
+
+SMOKE_NET="glyphoxa-smoke-net-$$"
+PG_NAME="glyphoxa-smoke-pg-$$"
+PG_IMAGE="pgvector/pgvector:pg17"
+DB_URL="postgres://glyphoxa:glyphoxa@${PG_NAME}:5432/glyphoxa?sslmode=disable"
+TESTDATA_DIR="$(cd "$(dirname "$0")/testdata" && pwd)"
+
+seed_cleanup() {
+	docker rm -f "$PG_NAME" >/dev/null 2>&1 || true
+	docker network rm "$SMOKE_NET" >/dev/null 2>&1 || true
+}
+trap seed_cleanup EXIT
+
+# psql_count runs a scalar COUNT query inside the DB container and trims whitespace.
+psql_count() {
+	docker exec "$PG_NAME" psql -U glyphoxa -d glyphoxa -tAc "$1" 2>/dev/null | tr -d '[:space:]'
+}
+# run_glyphoxa runs the image on the scoped network with the DSN env and the demo
+# bundle bind-mounted read-only at /demo.glyphoxa.json.
+run_glyphoxa() {
+	docker run --rm --network "$SMOKE_NET" \
+		-e GLYPHOXA_DATABASE_URL="$DB_URL" \
+		-v "$TESTDATA_DIR/demo.glyphoxa.json:/demo.glyphoxa.json:ro" \
+		"$IMAGE" "$@"
+}
+
+if ! docker network create "$SMOKE_NET" >/dev/null 2>&1; then
+	bad "could not create scoped docker network $SMOKE_NET"
+elif ! docker run -d --name "$PG_NAME" --network "$SMOKE_NET" \
+	-e POSTGRES_USER=glyphoxa -e POSTGRES_PASSWORD=glyphoxa -e POSTGRES_DB=glyphoxa \
+	"$PG_IMAGE" >/dev/null 2>&1; then
+	bad "could not start throwaway Postgres ($PG_IMAGE)"
+else
+	ready=0
+	for _ in $(seq 1 30); do
+		if docker exec "$PG_NAME" pg_isready -U glyphoxa -d glyphoxa >/dev/null 2>&1; then
+			ready=1
+			break
+		fi
+		sleep 1
+	done
+	if [ "$ready" -ne 1 ]; then
+		bad 'throwaway Postgres never became ready'
+	else
+		if run_glyphoxa migrate up >/dev/null 2>&1; then
+			ok 'migrate up succeeded'
+		else
+			bad 'migrate up failed'
+		fi
+		if run_glyphoxa seed -bundle /demo.glyphoxa.json >/dev/null 2>&1; then
+			ok 'seed -bundle succeeded'
+		else
+			bad 'seed -bundle failed'
+		fi
+		camp="$(psql_count 'SELECT count(*) FROM campaign;')"
+		agents="$(psql_count 'SELECT count(*) FROM agents;')"
+		if [ "$camp" = "1" ]; then
+			ok 'exactly one campaign after seed'
+		else
+			bad "campaign count = ${camp:-<none>}, want 1"
+		fi
+		if [ "$agents" = "2" ]; then
+			ok 'exactly two agents (Butler + Bart)'
+		else
+			bad "agent count = ${agents:-<none>}, want 2"
+		fi
+		# Idempotence (ADR-0053 §4): re-running the seed hits the name precheck and
+		# skips, so the campaign count must stay at 1 (no always-mint duplicate).
+		if run_glyphoxa seed -bundle /demo.glyphoxa.json >/dev/null 2>&1; then
+			ok 're-run seed -bundle exited 0'
+		else
+			bad 're-run seed -bundle failed'
+		fi
+		camp2="$(psql_count 'SELECT count(*) FROM campaign;')"
+		if [ "$camp2" = "1" ]; then
+			ok 'still one campaign after re-run (idempotent)'
+		else
+			bad "campaign count after re-run = ${camp2:-<none>}, want 1"
+		fi
+	fi
+fi
+
+# ---------------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------------
 summary

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -209,6 +209,22 @@ run_glyphoxa() {
 		-v "$TESTDATA_DIR/demo.glyphoxa.json:/demo.glyphoxa.json:ro" \
 		"$IMAGE" "$@"
 }
+# run_step runs the image capturing its COMBINED output; on failure it echoes that
+# output (indented) so a CI failure here is diagnosable instead of a bare non-zero
+# exit swallowed by >/dev/null. Returns the command's own status for the caller's
+# if/else so set -e never aborts the section mid-way.
+run_step() {
+	local label="$1"
+	shift
+	local out rc
+	if out="$(run_glyphoxa "$@" 2>&1)"; then
+		return 0
+	fi
+	rc=$?
+	note "$label output (exit $rc):"
+	printf '%s\n' "$out" | sed 's/^/      /'
+	return "$rc"
+}
 
 if ! docker network create "$SMOKE_NET" >/dev/null 2>&1; then
 	bad "could not create scoped docker network $SMOKE_NET"
@@ -228,12 +244,12 @@ else
 	if [ "$ready" -ne 1 ]; then
 		bad 'throwaway Postgres never became ready'
 	else
-		if run_glyphoxa migrate up >/dev/null 2>&1; then
+		if run_step 'migrate up' migrate up; then
 			ok 'migrate up succeeded'
 		else
 			bad 'migrate up failed'
 		fi
-		if run_glyphoxa seed -bundle /demo.glyphoxa.json >/dev/null 2>&1; then
+		if run_step 'seed -bundle' seed -bundle /demo.glyphoxa.json; then
 			ok 'seed -bundle succeeded'
 		else
 			bad 'seed -bundle failed'
@@ -252,7 +268,7 @@ else
 		fi
 		# Idempotence (ADR-0053 §4): re-running the seed hits the name precheck and
 		# skips, so the campaign count must stay at 1 (no always-mint duplicate).
-		if run_glyphoxa seed -bundle /demo.glyphoxa.json >/dev/null 2>&1; then
+		if run_step 're-run seed -bundle' seed -bundle /demo.glyphoxa.json; then
 			ok 're-run seed -bundle exited 0'
 		else
 			bad 're-run seed -bundle failed'

--- a/scripts/testdata/demo.glyphoxa.json
+++ b/scripts/testdata/demo.glyphoxa.json
@@ -1,0 +1,85 @@
+{
+  "format_version": 1,
+  "exported_at": "2026-07-10T00:00:00Z",
+  "campaign": {
+    "name": "The Prancing Pony",
+    "system": "dnd5e",
+    "language": "en",
+    "agents": [
+      {
+        "id": "butler",
+        "role": "butler",
+        "name": "Glyphoxa",
+        "title": "Master of Ceremonies",
+        "persona": "You are Glyphoxa, the campaign's ever-present butler. You keep the table running: you answer rules questions, roll dice when asked, and never break the fiction of the Prancing Pony's common room. Stay concise and gracious.",
+        "aliases": ["butler", "glyphoxa"],
+        "grants": [
+          { "tool_name": "dice" }
+        ]
+      },
+      {
+        "id": "bart",
+        "role": "character",
+        "name": "Bart",
+        "persona": "You are Bart, the gruff but warm-hearted innkeeper of the Prancing Pony.\nYou speak in short, vivid sentences with a tavern-keeper's cadence. You know the\nlocal rumors, the regulars, and the price of a room. Stay in character; never\nmention being an AI.",
+        "voice": {
+          "ProviderID": "elevenlabs",
+          "VoiceID": "JBFqnCBsd6RMkjVDRZzb",
+          "Name": "Bart",
+          "Language": "en",
+          "Settings": {
+            "model_id": "eleven_v3",
+            "output_format": "pcm_48000",
+            "voice_settings": {
+              "stability": 0.5,
+              "similarity_boost": 0.75,
+              "use_speaker_boost": true
+            }
+          }
+        },
+        "aliases": ["innkeeper", "barkeep"],
+        "grants": [
+          { "tool_name": "dice" }
+        ]
+      }
+    ],
+    "nodes": [
+      {
+        "id": "n_bart",
+        "type": "npc",
+        "name": "Bart",
+        "body": "The innkeeper of the Prancing Pony. Gruff, warm-hearted, knows every rumor in Bree.",
+        "agent_id": "bart"
+      },
+      {
+        "id": "n_pony",
+        "type": "location",
+        "name": "The Prancing Pony",
+        "body": "A crossroads inn: low beams, a roaring hearth, and travelers from every road."
+      },
+      {
+        "id": "n_bree",
+        "type": "location",
+        "name": "Bree",
+        "body": "A walled market town where the great roads meet."
+      },
+      {
+        "id": "n_watch",
+        "type": "faction",
+        "name": "The Bree Watch",
+        "body": "The town's volunteer guard, keeping the gates and the peace."
+      }
+    ],
+    "edges": [
+      { "from": "n_pony", "to": "n_bree", "type": "resides_in" },
+      { "from": "n_bart", "to": "n_watch", "type": "member_of" }
+    ],
+    "characters": [
+      {
+        "name": "Aria Longstride",
+        "aliases": ["Aria"],
+        "discord_user_id": "100000000000000001"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #293

## What

`glyphoxa seed -bundle <file>` imports a campaign bundle (ADR-0053) so a self-host operator can seed a **playable** demo campaign in one command. The bare `glyphoxa seed` legacy demo-NPC path is byte-identical.

- **`seed -bundle`**: decode file (before any DB connect, so a mistyped path fails fast) -> resolve Tenant via `storage.FirstTenant` (else mint `"Glyphoxa"`) -> **idempotence gate = campaign-name precheck** (exists -> log + skip, exit 0) -> `bundle.Import`. The importer stays always-mint (ADR-0053 d4); idempotence lives only in the seed's precheck.
- **Secrets**: legacy path still requires `$GLYPHOXA_SECRET`; the bundle path carries no secrets (ADR-0053 §2) and skips the cipher entirely.
- **`storage.FirstTenant`**: earliest Tenant by `(created_at, id)`, `ErrNotFound` on empty DB. A storage function, not a migration — no migration in this slice.
- **`scripts/testdata/demo.glyphoxa.json`**: plain JSON, history-less. Campaign "The Prancing Pony" (dnd5e/en), Butler persona tweak, one Bart-style Character NPC on the canonical ElevenLabs voice (`storage.VoiceFromJSON` shape), a 4-node / 2-edge KG including an NPC-node agent link, and one player character.

## Tests (TDD, red->green)

- `internal/storage`: `FirstTenant` earliest + empty-DB `ErrNotFound` (integration).
- `cmd/glyphoxa` unit: arg parse (missing `-bundle` file names the path; unknown flag rejected); **fixture-validity guard** (Docker-free Decode + ref resolution + voice parse — catches a stale fixture on a `FormatVersion` bump on the fast `test` gate).
- `cmd/glyphoxa` integration: fresh-DB import (tenant "Glyphoxa", campaign + 2 agents + KG + PC); idempotent re-run (1 campaign); coexistence with the legacy seed (bundle skips the existing name).
- `scripts/container-smoke.sh` new section **[6]**: scoped docker network (not `--network none`) + throwaway pgvector Postgres, `migrate up` then `seed -bundle` (bind-mounted demo), `psql` asserts campaign=1 / agents=2, re-run stays 1, trap cleanup. `container-smoke-test.sh` only self-tests the SPA gate (no section stubs), so no mirror needed.

## Notes

- The demo bundle has **no `provider_config`** (secrets are excluded from bundles). "Playable" here means login + roster + KG + PC; BYOK provider keys are configured after import via the console.
- `deploy/charts/glyphoxa/templates/seed-job.yaml` is **UNCHANGED** this slice (ADR-0034) — its command grammar is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)