### PR TITLE
feat(#292): [E6] importer part 2 — sessions, transcripts, embedding regeneration

### DIFF
--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -13,8 +13,8 @@ import (
 // agent ref key to the minted (or, for the Butler, the trigger-created) Agent id;
 // part 1 fills it and part 2 (#292) consumes it IN-FUNCTION to remap a Chunk's
 // participated_agent_ids. The int counts feed the ServeImport JSON response.
-// DroppedParticipantRefs counts unmappable chunk participant refs (part 2 only);
-// it is always zero here.
+// DroppedParticipantRefs counts chunk participant refs that mapped to no imported
+// Agent and were dropped (not fatal).
 type ImportResult struct {
 	CampaignID uuid.UUID
 	Name       string
@@ -53,10 +53,13 @@ type ImportResult struct {
 // per bundle grant. With no Butler in the bundle the trigger defaults stand. The
 // Butler's address_only stays pinned true by the storage layer (ADR-0024).
 //
-// History (Voice Sessions + Transcript Lines/Chunks) is tolerated but UNTOUCHED
-// in part 1: a bundle carrying a History section imports its domain grains fine
-// and leaves Sessions/Lines/Chunks at zero. Part 2 (#292) fills them in the same
-// transaction.
+// History (Voice Sessions + Transcript Lines/Chunks) is imported in the SAME
+// transaction (#292): each Voice Session's status is coerced terminal, its Lines
+// keep their line_id/seq replay keys verbatim (ADR-0040), and its Chunks land
+// with embedding NULL so the destination's embedworker regenerates them
+// (ADR-0011) — a chunk's participated refs are remapped through AgentIDs and an
+// unmappable one is dropped and counted. A bundle with no History section imports
+// exactly as part 1 did (zero history counts).
 func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundle) (ImportResult, error) {
 	if err := CheckVersion(b.FormatVersion); err != nil {
 		return ImportResult{}, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
@@ -184,10 +187,113 @@ func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *B
 		res.Characters++
 	}
 
-	// History is part 2 (#292): its presence is tolerated, its rows are left for
-	// the next slice. Counts stay zero here.
+	if err := importHistory(ctx, tx, campaignID, b, res); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+// importHistory ingests the flag-gated transcript payload (#292, ADR-0053 §1/§3)
+// in the SAME transaction as the domain grains (ADR-0049): per Voice Session an
+// [storage.ImportVoiceSession] (status coerced terminal, ended_at defaulted to
+// started_at), then each Transcript Line UPSERTed with its line_id/seq VERBATIM
+// (ADR-0040 replay keys — never re-derived), then each Transcript Chunk INSERTed
+// with embedding NULL by construction so the destination's embedworker
+// regenerates it (ADR-0011 — this NEVER writes a vector or model). A chunk's
+// participated_agent_ids are remapped through res.AgentIDs; an unmappable ref is
+// DROPPED and counted in DroppedParticipantRefs (not fatal — a foreign agent
+// simply carries no local knowledge), while speaker snowflakes travel verbatim
+// (ADR-0053 §6). A nil History section is a no-op: counts stay zero (part-1 parity).
+func importHistory(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, b *Bundle, res *ImportResult) error {
+	if b.Campaign.History == nil {
+		return nil
+	}
+	for i := range b.Campaign.History.Sessions {
+		s := &b.Campaign.History.Sessions[i]
+		endedAt := s.EndedAt
+		if endedAt == nil {
+			// A terminal session always has an ended_at; a bundle missing one (a
+			// coerced non-terminal row) defaults it to started_at so no imported row
+			// looks live to GetLatestVoiceSession or the reconciler.
+			started := s.StartedAt
+			endedAt = &started
+		}
+		sessionID, err := tx.ImportVoiceSession(ctx, storage.VoiceSession{
+			CampaignID: campaignID,
+			StartedAt:  s.StartedAt,
+			EndedAt:    endedAt,
+			Status:     coerceTerminalStatus(s.Status),
+			LineCount:  s.LineCount,
+			EndReason:  s.EndReason,
+		})
+		if err != nil {
+			return fmt.Errorf("bundle: import: session %q: %w", s.ID, err)
+		}
+		res.Sessions++
+
+		for j := range s.Lines {
+			l := &s.Lines[j]
+			if err := tx.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+				VoiceSessionID:       sessionID,
+				CampaignID:           campaignID,
+				LineID:               l.LineID,
+				Seq:                  l.Seq,
+				Who:                  l.Who,
+				Tag:                  l.Tag,
+				Kind:                 l.Kind,
+				TS:                   l.TS,
+				Text:                 l.Text,
+				SpeakerDiscordUserID: l.SpeakerDiscordUserID,
+			}); err != nil {
+				return fmt.Errorf("bundle: import: session %q line %q: %w", s.ID, l.LineID, err)
+			}
+			res.Lines++
+		}
+
+		for j := range s.Chunks {
+			c := &s.Chunks[j]
+			participated := make([]uuid.UUID, 0, len(c.ParticipatedAgentIDs))
+			for _, ref := range c.ParticipatedAgentIDs {
+				agentID, ok := res.AgentIDs[ref]
+				if !ok {
+					// A participant that maps to no imported Agent (e.g. an Agent deleted
+					// before export, or a cross-campaign artifact) is dropped, not fatal —
+					// it just means no local NPC claims that chunk's knowledge.
+					res.DroppedParticipantRefs++
+					continue
+				}
+				participated = append(participated, agentID)
+			}
+			// embedding stays NULL and embedding_model '' by construction (ADR-0011):
+			// InsertTranscriptChunk never writes a vector, so the destination
+			// embedworker regenerates them. The backlog gauge is not refreshed here —
+			// the worker polls the DB on its own schedule.
+			if _, err := tx.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+				CampaignID:            campaignID,
+				VoiceSessionID:        sessionID,
+				Content:               c.Content,
+				SpeakerDiscordUserIDs: c.SpeakerDiscordUserIDs,
+				ParticipatedAgentIDs:  participated,
+				StartedAt:             c.StartedAt,
+			}); err != nil {
+				return fmt.Errorf("bundle: import: session %q chunk: %w", s.ID, err)
+			}
+			res.Chunks++
+		}
+	}
+	return nil
+}
+
+// coerceTerminalStatus maps an imported Voice Session status to a terminal one: a
+// 'failed' row keeps its status (a distinct terminal state, ADR-0053 §6 verbatim
+// spirit), anything else — including a stale 'running' from a crashed source —
+// becomes 'ended', so no imported row is ever revivable or owned by a live loop.
+func coerceTerminalStatus(status string) storage.VoiceSessionStatus {
+	if storage.VoiceSessionStatus(status) == storage.VoiceSessionFailed {
+		return storage.VoiceSessionFailed
+	}
+	return storage.VoiceSessionEnded
 }
 
 // mergeButler UPDATEs the trigger-created Butler from the bundle's Butler and

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -6,13 +6,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
 )
+
+// discardLogger swallows the embedworker's log output in the drain test.
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
 // freshTenant migrates a new DB and returns a Store + a fresh tenant to import
 // into — the "second database" the round-trip acceptance criterion demands.
@@ -393,19 +401,27 @@ func TestImportRejectsDuplicateAgentRef(t *testing.T) {
 	}
 }
 
-// TestImportToleratesHistorySection is TEST 9: a bundle carrying a History section
-// imports its part-1 domain grains fine and writes no session/line/chunk rows.
-func TestImportToleratesHistorySection(t *testing.T) {
+// TestImportSessionWithLines is #292 TEST 2: a bundle carrying one Session with
+// two Lines writes a terminal Voice Session, and its Lines render in seq order
+// with line_id/seq VERBATIM (the ADR-0040 replay keys, never "fixed") and the
+// speaker snowflake verbatim. Lines are supplied OUT of seq order to prove the
+// stored seq drives replay ordering, not bundle order.
+func TestImportSessionWithLines(t *testing.T) {
 	ctx := context.Background()
 	st, tid := freshTenant(t)
 
+	base := time.Date(2026, 6, 1, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
 	bnd := &bundle.Bundle{
 		FormatVersion: bundle.FormatVersion,
 		Campaign: bundle.Campaign{
-			Name: "Has History", System: "dnd5e", Language: "en",
+			Name: "One Session", System: "dnd5e", Language: "en",
 			History: &bundle.History{Sessions: []bundle.Session{{
-				ID: "s1", Status: "ended", LineCount: 1,
-				Lines: []bundle.Line{{LineID: "l1", Seq: 1, Who: "Frodo", Kind: "human", Text: "hi"}},
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 2,
+				Lines: []bundle.Line{
+					{LineID: "l2", Seq: 2, Who: "Bart", Kind: "agent", TS: base.Add(time.Second), Text: "second"},
+					{LineID: "l1", Seq: 1, Who: "Frodo", Kind: "human", TS: base, Text: "first", SpeakerDiscordUserID: "123456789"},
+				},
 			}}},
 		},
 	}
@@ -413,15 +429,409 @@ func TestImportToleratesHistorySection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
-	if res.Sessions != 0 || res.Lines != 0 || res.Chunks != 0 {
-		t.Errorf("part-1 counted history: sessions=%d lines=%d chunks=%d, want 0",
-			res.Sessions, res.Lines, res.Chunks)
+	if res.Sessions != 1 || res.Lines != 2 {
+		t.Fatalf("counts sessions=%d lines=%d, want 1/2", res.Sessions, res.Lines)
+	}
+
+	sessions, err := st.ListVoiceSessions(ctx, res.CampaignID, 100)
+	if err != nil {
+		t.Fatalf("ListVoiceSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("voice sessions = %d, want 1", len(sessions))
+	}
+	vs := sessions[0]
+	if vs.Status != storage.VoiceSessionEnded || vs.EndedAt == nil {
+		t.Errorf("imported session not terminal: %+v", vs)
+	}
+	if vs.LineCount != 2 {
+		t.Errorf("line_count = %d, want 2 (verbatim)", vs.LineCount)
+	}
+
+	lines, err := st.ListTranscriptLines(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	if len(lines) != 2 || lines[0].LineID != "l1" || lines[1].LineID != "l2" {
+		t.Fatalf("lines not in seq order (line_id/seq verbatim): %+v", lines)
+	}
+	if lines[0].Seq != 1 || lines[1].Seq != 2 {
+		t.Errorf("seq not verbatim: %+v", lines)
+	}
+	if lines[0].SpeakerDiscordUserID != "123456789" {
+		t.Errorf("speaker snowflake = %q, want verbatim 123456789", lines[0].SpeakerDiscordUserID)
+	}
+	if lines[1].SpeakerDiscordUserID != "" {
+		t.Errorf("agent line speaker = %q, want empty", lines[1].SpeakerDiscordUserID)
+	}
+}
+
+// TestImportCoercesNonTerminalSession is #292 TEST 3: a Session exported while
+// still 'running' (a source that crashed mid-session) imports as terminal
+// 'ended' with ended_at defaulted to started_at — no imported row ever looks live.
+func TestImportCoercesNonTerminalSession(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	base := time.Date(2026, 6, 3, 20, 0, 0, 0, time.UTC)
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Running Session", System: "dnd5e", Language: "en",
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, Status: "running", LineCount: 0,
+			}}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	sessions, err := st.ListVoiceSessions(ctx, res.CampaignID, 100)
+	if err != nil {
+		t.Fatalf("ListVoiceSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(sessions))
+	}
+	vs := sessions[0]
+	if vs.Status != storage.VoiceSessionEnded {
+		t.Errorf("status = %q, want ended (coerced from running)", vs.Status)
+	}
+	if vs.EndedAt == nil || !vs.EndedAt.Equal(base) {
+		t.Errorf("ended_at = %v, want started_at %v", vs.EndedAt, base)
+	}
+}
+
+// TestImportChunksRemapAndEmbedNull is #292 TEST 4: a Chunk's participated refs
+// are remapped to minted Agent ids; an unmappable ref is DROPPED and counted in
+// DroppedParticipantRefs (not fatal); and every imported Chunk lands with
+// embedding NULL + embedding_model ” so the embedworker regenerates it —
+// CountUnembeddedChunks == the imported chunk count.
+func TestImportChunksRemapAndEmbedNull(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	base := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Chunky", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{{ID: "a1", Role: "character", Name: "Bart"}},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 0,
+				Chunks: []bundle.Chunk{{
+					Content:               "the dragon spoke of gold",
+					SpeakerDiscordUserIDs: []string{"111", "222"},
+					ParticipatedAgentIDs:  []string{"a1", "ghost"},
+					StartedAt:             base,
+				}},
+			}}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Chunks != 1 {
+		t.Fatalf("Chunks = %d, want 1", res.Chunks)
+	}
+	if res.DroppedParticipantRefs != 1 {
+		t.Errorf("DroppedParticipantRefs = %d, want 1 (ghost dropped)", res.DroppedParticipantRefs)
+	}
+
+	bartID := res.AgentIDs["a1"]
+	if bartID == uuid.Nil {
+		t.Fatal("a1 not remapped")
+	}
+
+	// Every imported chunk is unembedded (embedding NULL by construction).
+	n, err := st.CountUnembeddedChunks(ctx)
+	if err != nil {
+		t.Fatalf("CountUnembeddedChunks: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("unembedded chunks = %d, want 1 (import never writes vectors)", n)
+	}
+
+	chunks, err := st.ListUnembeddedChunks(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListUnembeddedChunks: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("chunks = %d, want 1", len(chunks))
+	}
+	c := chunks[0]
+	if len(c.ParticipatedAgentIDs) != 1 || c.ParticipatedAgentIDs[0] != bartID {
+		t.Errorf("participated = %v, want [remapped Bart %s] (ghost dropped)", c.ParticipatedAgentIDs, bartID)
+	}
+	if c.EmbeddingModel != "" {
+		t.Errorf("embedding_model = %q, want '' (embedworker stamps it)", c.EmbeddingModel)
+	}
+	if len(c.SpeakerDiscordUserIDs) != 2 || c.SpeakerDiscordUserIDs[0] != "111" || c.SpeakerDiscordUserIDs[1] != "222" {
+		t.Errorf("speaker snowflakes = %v, want verbatim [111 222]", c.SpeakerDiscordUserIDs)
+	}
+}
+
+// TestImportedChunksEmbedAndRecall is #292 TEST 5 — the recall acceptance
+// criterion: imported Chunks land embedding NULL, the real embedworker (with a
+// deterministic fake provider) drains the backlog to zero, and afterwards
+// SearchChunksByAgent for the REMAPPED agent finds the imported content by
+// nearest-vector. The importer itself never writes a vector — recall emerges
+// only because the async worker regenerated the embeddings (ADR-0011).
+func TestImportedChunksEmbedAndRecall(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	base := time.Date(2026, 6, 5, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
+	const recallText = "the innkeeper mentioned a hidden cellar beneath the Prancing Pony"
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Recall", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{{ID: "a1", Role: "character", Name: "Bart"}},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 0,
+				Chunks: []bundle.Chunk{{
+					Content:              recallText,
+					ParticipatedAgentIDs: []string{"a1"},
+					StartedAt:            base,
+				}},
+			}}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	bartID := res.AgentIDs["a1"]
+
+	// Before the worker runs, recall finds nothing (embedding still NULL).
+	prov := embeddingstest.Deterministic{}
+	qvec, err := prov.Embed(ctx, []string{recallText})
+	if err != nil {
+		t.Fatalf("embed query: %v", err)
+	}
+	pre, err := st.SearchChunksByAgent(ctx, res.CampaignID, bartID, qvec[0], 5)
+	if err != nil {
+		t.Fatalf("SearchChunksByAgent (pre): %v", err)
+	}
+	if len(pre) != 0 {
+		t.Fatalf("recall before embedding = %d hits, want 0 (embedding NULL)", len(pre))
+	}
+
+	// Drain the backlog with the real worker + deterministic provider.
+	w := embedworker.New(st, prov, "test-model", nil, discardLogger(), embedworker.Config{Interval: 10 * time.Millisecond})
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() { w.Run(runCtx); close(done) }()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		n, err := st.CountUnembeddedChunks(ctx)
+		if err != nil {
+			t.Fatalf("CountUnembeddedChunks: %v", err)
+		}
+		if n == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("embed backlog never drained to 0")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	// Recall now finds the imported content for the remapped agent.
+	hits, err := st.SearchChunksByAgent(ctx, res.CampaignID, bartID, qvec[0], 5)
+	if err != nil {
+		t.Fatalf("SearchChunksByAgent (post): %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("recall after embedding found nothing; imported history not searchable")
+	}
+	if hits[0].Chunk.Content != recallText {
+		t.Errorf("nearest chunk = %q, want the imported content", hits[0].Chunk.Content)
+	}
+}
+
+// TestImportRoundTripWithHistory is #292 TEST 6: a seeded campaign with two Voice
+// Sessions (lines + a chunk) exported WITH history and imported into a fresh
+// database reproduces both sessions, their lines replay in seq order, and the
+// chunk's participated ref lands on the remapped destination agent.
+func TestImportRoundTripWithHistory(t *testing.T) {
+	ctx := context.Background()
+	src, srcCID, srcBartID := seededCampaign(t)
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	// Session 1: two lines (inserted out of order) + one chunk participated by Bart.
+	vs1, err := src.CreateVoiceSession(ctx, srcCID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession 1: %v", err)
+	}
+	if err := src.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs1.ID, CampaignID: srcCID, LineID: "l2", Seq: 2,
+		Who: "Bart", Kind: "agent", TS: base.Add(time.Second), Text: "second",
+	}); err != nil {
+		t.Fatalf("Upsert l2: %v", err)
+	}
+	if err := src.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs1.ID, CampaignID: srcCID, LineID: "l1", Seq: 1,
+		Who: "Frodo", Kind: "human", TS: base, Text: "first", SpeakerDiscordUserID: "123456789",
+	}); err != nil {
+		t.Fatalf("Upsert l1: %v", err)
+	}
+	if _, err := src.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: srcCID, VoiceSessionID: vs1.ID, Content: "first\nsecond",
+		SpeakerDiscordUserIDs: []string{"123456789"},
+		ParticipatedAgentIDs:  []uuid.UUID{srcBartID},
+		StartedAt:             base,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+	if _, err := src.EndVoiceSession(ctx, vs1.ID, 2); err != nil {
+		t.Fatalf("EndVoiceSession 1: %v", err)
+	}
+	// Session 2: one line.
+	vs2, err := src.CreateVoiceSession(ctx, srcCID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession 2: %v", err)
+	}
+	if err := src.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+		VoiceSessionID: vs2.ID, CampaignID: srcCID, LineID: "m1", Seq: 1,
+		Who: "Bart", Kind: "agent", TS: base.Add(time.Hour), Text: "later",
+	}); err != nil {
+		t.Fatalf("Upsert m1: %v", err)
+	}
+	if _, err := src.EndVoiceSession(ctx, vs2.ID, 1); err != nil {
+		t.Fatalf("EndVoiceSession 2: %v", err)
+	}
+
+	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	dst, tid := freshTenant(t)
+	res, err := bundle.Import(ctx, dst, tid, b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Sessions != 2 {
+		t.Errorf("Sessions = %d, want 2", res.Sessions)
+	}
+	if res.Lines != 3 {
+		t.Errorf("Lines = %d, want 3", res.Lines)
+	}
+	if res.Chunks != 1 {
+		t.Errorf("Chunks = %d, want 1", res.Chunks)
+	}
+
+	// Locate the destination Bart to assert chunk remap.
+	var dstBartID uuid.UUID
+	dstAgents, err := dst.ListAgents(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	for _, a := range dstAgents {
+		if a.Name == "Bart" {
+			dstBartID = a.ID
+		}
+	}
+
+	sessions, err := dst.ListVoiceSessions(ctx, res.CampaignID, 100)
+	if err != nil {
+		t.Fatalf("ListVoiceSessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("imported sessions = %d, want 2", len(sessions))
+	}
+	// Find the two-line session and assert replay order.
+	var twoLine uuid.UUID
+	for _, s := range sessions {
+		lines, err := dst.ListTranscriptLines(ctx, s.ID)
+		if err != nil {
+			t.Fatalf("ListTranscriptLines: %v", err)
+		}
+		if len(lines) == 2 {
+			twoLine = s.ID
+			if lines[0].LineID != "l1" || lines[1].LineID != "l2" {
+				t.Errorf("replay order = %v, want [l1 l2]", []string{lines[0].LineID, lines[1].LineID})
+			}
+		}
+	}
+	if twoLine == uuid.Nil {
+		t.Fatal("imported history lost the two-line session")
+	}
+
+	chunks, err := dst.ListTranscriptChunks(ctx, res.CampaignID, false)
+	if err != nil {
+		t.Fatalf("ListTranscriptChunks: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("imported chunks = %d, want 1", len(chunks))
+	}
+	if got := chunks[0].ParticipatedAgentIDs; len(got) != 1 || got[0] != dstBartID {
+		t.Errorf("chunk participated = %v, want remapped dst Bart %s", got, dstBartID)
+	}
+}
+
+// TestImportHistoryRollsBackWithPart1 is #292 TEST 8: a part-1 failure (an edge
+// referencing an unknown node) in a bundle that ALSO carries history rolls back
+// the whole import — the history rows never persist either (one transaction,
+// ADR-0049). No campaign and no orphaned voice session survive.
+func TestImportHistoryRollsBackWithPart1(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	base := time.Date(2026, 6, 6, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Doomed History", System: "dnd5e", Language: "en",
+			Nodes: []bundle.Node{{ID: "n1", Type: "location", Name: "Somewhere"}},
+			Edges: []bundle.Edge{{From: "n1", To: "ghost", Type: "resides_in"}},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 1,
+				Lines: []bundle.Line{{LineID: "l1", Seq: 1, Who: "Frodo", Kind: "human", TS: base, Text: "hi"}},
+			}}},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, bnd); err == nil {
+		t.Fatal("Import with bad edge succeeded; want error")
+	}
+	if _, err := st.FindCampaignByName(ctx, tid, "Doomed History"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("rolled-back import left a campaign: %v", err)
+	}
+}
+
+// TestImportHistorylessBundleUnchanged is #292 TEST 7 (regression): a bundle with
+// NO History section imports its part-1 domain grains and reports zero history
+// counts — identical to part 1.
+func TestImportHistorylessBundleUnchanged(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign:      bundle.Campaign{Name: "No History", System: "dnd5e", Language: "en"},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Sessions != 0 || res.Lines != 0 || res.Chunks != 0 || res.DroppedParticipantRefs != 0 {
+		t.Errorf("history-less bundle counted history: %+v", res)
 	}
 	sessions, err := st.ListVoiceSessions(ctx, res.CampaignID, 100)
 	if err != nil {
 		t.Fatalf("ListVoiceSessions: %v", err)
 	}
 	if len(sessions) != 0 {
-		t.Errorf("part-1 wrote %d voice sessions, want 0", len(sessions))
+		t.Errorf("history-less bundle wrote %d voice sessions, want 0", len(sessions))
 	}
 }

--- a/internal/storage/voice_session.go
+++ b/internal/storage/voice_session.go
@@ -41,6 +41,28 @@ func (s *Store) CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (V
 	return v, nil
 }
 
+// ImportVoiceSession inserts a historical Voice Session from a Campaign Bundle
+// (#292, ADR-0053): unlike [CreateVoiceSession], which mints a fresh 'running'
+// row with started_at=now(), this writes the bundle's started_at, ended_at,
+// status, line_count and end_reason VERBATIM and returns the freshly minted id.
+// The caller (bundle.Import) guarantees a terminal status (a non-terminal one is
+// coerced to 'ended' upstream) and a non-nil ended_at, so no live loop ever owns
+// an imported row. end_reason is written NULL when nil. It runs inside the import
+// transaction, so a later failure rolls the row back with the rest.
+func (s *Store) ImportVoiceSession(ctx context.Context, v VoiceSession) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO voice_sessions
+		   (campaign_id, started_at, ended_at, status, line_count, end_reason)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING id`,
+		v.CampaignID, v.StartedAt, v.EndedAt, v.Status, v.LineCount, v.EndReason).Scan(&id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: import voice session for campaign %s: %w", v.CampaignID, err)
+	}
+	return id, nil
+}
+
 // CloseVoiceSession closes a running Voice Session with an explicit terminal
 // status and end_reason: it sets ended_at=now(), status, the final line_count, and
 // end_reason (NULL when endReason is nil), returning the updated row. A missing id

--- a/internal/storage/voice_session_test.go
+++ b/internal/storage/voice_session_test.go
@@ -356,3 +356,82 @@ func TestEndVoiceSessionNotFound(t *testing.T) {
 		t.Errorf("GetVoiceSession(random) = %v, want ErrNotFound", err)
 	}
 }
+
+// TestImportVoiceSession is #292 TEST 1: the Campaign Bundle importer inserts a
+// historical Voice Session with EXPLICIT started_at/ended_at/status/line_count/
+// end_reason (unlike CreateVoiceSession, which defaults status='running' and
+// started_at=now()) and returns a freshly minted id. The caller (bundle.Import)
+// guarantees a terminal status; ImportVoiceSession writes the fields verbatim.
+func TestImportVoiceSession(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	started := time.Date(2026, 6, 1, 20, 0, 0, 0, time.UTC)
+	ended := started.Add(90 * time.Minute)
+	reason := "orphaned: reconciled at startup"
+	id, err := st.ImportVoiceSession(ctx, storage.VoiceSession{
+		CampaignID: campaignID,
+		StartedAt:  started,
+		EndedAt:    &ended,
+		Status:     storage.VoiceSessionEnded,
+		LineCount:  42,
+		EndReason:  &reason,
+	})
+	if err != nil {
+		t.Fatalf("ImportVoiceSession: %v", err)
+	}
+	if id == uuid.Nil {
+		t.Fatal("ImportVoiceSession returned nil id")
+	}
+
+	got, err := st.GetVoiceSession(ctx, id)
+	if err != nil {
+		t.Fatalf("GetVoiceSession: %v", err)
+	}
+	if !got.StartedAt.Equal(started) {
+		t.Errorf("started_at = %v, want %v", got.StartedAt, started)
+	}
+	if got.EndedAt == nil || !got.EndedAt.Equal(ended) {
+		t.Errorf("ended_at = %v, want %v", got.EndedAt, ended)
+	}
+	if got.Status != storage.VoiceSessionEnded {
+		t.Errorf("status = %q, want ended", got.Status)
+	}
+	if got.LineCount != 42 {
+		t.Errorf("line_count = %d, want 42", got.LineCount)
+	}
+	if got.EndReason == nil || *got.EndReason != reason {
+		t.Errorf("end_reason = %v, want %q", got.EndReason, reason)
+	}
+}
+
+// TestImportVoiceSessionNilEndReason proves a NULL end_reason (the clean-end
+// case) round-trips as nil, not "".
+func TestImportVoiceSessionNilEndReason(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	started := time.Date(2026, 6, 2, 20, 0, 0, 0, time.UTC)
+	ended := started.Add(time.Hour)
+	id, err := st.ImportVoiceSession(ctx, storage.VoiceSession{
+		CampaignID: campaignID,
+		StartedAt:  started,
+		EndedAt:    &ended,
+		Status:     storage.VoiceSessionEnded,
+		LineCount:  0,
+	})
+	if err != nil {
+		t.Fatalf("ImportVoiceSession: %v", err)
+	}
+	got, err := st.GetVoiceSession(ctx, id)
+	if err != nil {
+		t.Fatalf("GetVoiceSession: %v", err)
+	}
+	if got.EndReason != nil {
+		t.Errorf("end_reason = %q, want nil", *got.EndReason)
+	}
+}


### PR DESCRIPTION
Completes the Campaign Bundle importer with the flag-gated **History** payload, extending `bundle.Import`'s single transaction (ADR-0049) with the transcript grains. Builds on part 1 (#291, 34321cd).

## What lands
- **`storage.ImportVoiceSession`** — inserts a historical Voice Session with explicit `started_at/ended_at/status/line_count/end_reason` (unlike `CreateVoiceSession`, which mints a `running` row at `now()`), returns a fresh id. Caller guarantees terminal status.
- **History section in `importInTx`** (same tx):
  - per Session: `ImportVoiceSession` — status coerced non-terminal → `ended` (`failed` preserved), `ended_at` nil → `started_at`, `line_count` verbatim
  - per Line: `UpsertTranscriptLine` — `line_id`/`seq` **verbatim** (ADR-0040 replay keys, never re-derived); speaker snowflake verbatim
  - per Chunk: `InsertTranscriptChunk` — `embedding NULL` + `embedding_model ''` by construction → destination embedworker regenerates (ADR-0011, importer never writes a vector/model); `participated_agent_ids` remapped via part-1 `AgentIDs`, unmappable refs **dropped + counted** in `DroppedParticipantRefs`; snowflakes verbatim (ADR-0053 §6)
- Part-1 failure in a history bundle rolls back sessions/lines/chunks too (one tx); a history-less bundle imports identically to part 1.

## Acceptance criteria
- [x] Full round-trip incl. transcripts: replay renders lines in seq order
- [x] `participated_agent_ids` point at remapped agent UUIDs
- [x] Imported chunks embed automatically via embedworker (backlog drains, recall works) — proven by a real-worker + deterministic-provider drain test asserting `SearchChunksByAgent` finds imported content
- [x] Snowflake handling matches ADR policy (verbatim)
- [x] Bundles without transcript sections import unchanged from part 1

## Tests (TDD, integration/testcontainers)
2 storage tests (`ImportVoiceSession` + nil end_reason) and 7 importer tests: session+lines verbatim, status coercion, chunk remap/drop/embed-NULL, embedworker drain + recall, round-trip with 2 sessions, history-less regression, part-1-failure rollback. All green locally (`go test -tags=integration ./internal/bundle/ ./internal/storage/`), lint clean.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)