### PR TITLE
feat(#308): [E8] Session Highlights persistence — blob-backed clips, RPCs, 7-day purge

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,12 +18,15 @@ import (
 	"time"
 
 	"github.com/disgoorg/snowflake/v2"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/bundle"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/jobs"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
 	"github.com/MrWong99/Glyphoxa/internal/knowledge"
@@ -353,6 +357,10 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	}
 	defer pool.Close()
 	store := storage.New(pool)
+	// The blob seam (ADR-0048): the v1 Postgres bytea backend, shared by the Voice
+	// process (Session Highlight clip writes) and the Web process (clip serve). Both
+	// meet only through Postgres, never shared memory (#308).
+	blobStore := blob.NewPostgres(pool)
 
 	// Boot-time session sweep (ADR-0041 amendment, issue #184): the allowlist
 	// gates only NEW logins at the OAuth callback, so sessions issued before the
@@ -557,6 +565,17 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	chunker := transcript.NewChunker(eventBus, mgr, store, metrics, log, transcript.ChunkerConfig{})
 	chunker.SetResolver(speakerResolver) // #281: resolved name as each human line's chunk prefix
 	mgr.SetChunkFlusher(chunker)
+
+	// Session Highlights persistence (#308, Epic 8, ADR-0051): the Saver is #307's
+	// detector Sink — it encodes each Trigger's tape snapshot to a clip (behind the
+	// blob seam), writes a 'candidate' highlight row, and on session end schedules
+	// the 7-day candidate purge job. It rides the SAME base voice config the manager
+	// copies per session (cfg.Highlights = the Saver), and the manager Begins/
+	// Finalizes it per session (beside transcript.Finalize). In web-only mode the
+	// manager starts no sessions, so it stays dormant; the RPC read side + clip serve
+	// (below) reach the same rows through Postgres regardless.
+	highlightSaver := highlight.NewSaver(store, blobStore, jobEnqueuer{store}, log)
+	mgr.SetHighlights(highlightSaver)
 	// Seed the backlog gauge from the DB at boot so it reads the true count before
 	// the first chunk is written (idempotent Set-from-COUNT, ADR-0032). A read
 	// failure logs and leaves the gauge at 0 rather than failing the boot.
@@ -575,7 +594,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// bespoke and recap/import stay synchronous RPCs. With an empty registry the
 	// runner idles without touching the DB.
 	jobRunner := jobs.New(store, metrics, log, jobs.Config{})
-	// Job-kind handlers register here; none exist yet.
+	// Session Highlights candidate purge (#308, ADR-0051/0049): the 7-day sweep of a
+	// session's still-candidate highlights. Idempotent + at-least-once — it drops
+	// each clip through the blob seam FIRST, then the rows. Registered in web AND all
+	// mode (the sweep needs only the DB + blob backend, not the voice loop).
+	jobRunner.Register(highlight.JobKindPurgeCandidates, highlight.PurgeHandler(store, blobStore, log))
 	go jobRunner.Run(ctx)
 
 	// Resolve the process embeddings provider ONCE and share it across the two
@@ -668,7 +691,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			return pres.VoiceChannelMembers(ctx, channelID)
 		}
 	}
-	mounts := managementMounts(store, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, presenceRefresh, memberLister)
+	mounts := managementMounts(store, blobStore, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, presenceRefresh, memberLister)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -725,11 +748,41 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 // still stands and the API simply has no way in. cipher seals BYOK provider
 // keys (ADR-0004); it may be nil (saving keys then fails CodeFailedPrecondition).
 // mgr drives the in-process voice loop for SessionService (#72, ADR-0039).
+// jobEnqueuer adapts *storage.Store to the highlight.JobEnqueuer seam (#308): it
+// JSON-marshals the payload and enqueues a job with an explicit future run_after
+// (the 7-day candidate purge horizon), which plain EnqueueJob cannot express.
+type jobEnqueuer struct{ store *storage.Store }
+
+func (e jobEnqueuer) Enqueue(ctx context.Context, kind string, payload any, runAfter time.Time) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", kind, err)
+	}
+	_, err = e.store.EnqueueJobAt(ctx, kind, b, 0, runAfter)
+	return err
+}
+
+// highlightClipSweeper adapts *storage.Store + blob.Store to the RPC campaign
+// hard-delete's clip sweep (#308, ADR-0048): list a campaign's highlight clip
+// keys, then drop each blob through the seam.
+type highlightClipSweeper struct {
+	store *storage.Store
+	blobs blob.Store
+}
+
+func (s highlightClipSweeper) CampaignClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error) {
+	return s.store.ListCampaignHighlightClipKeys(ctx, campaignID)
+}
+
+func (s highlightClipSweeper) DeleteClip(ctx context.Context, key string) error {
+	return s.blobs.Delete(ctx, key)
+}
+
 // relay serves the live transcript over SSE + a JSON snapshot (#73, ADR-0014):
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
 // Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error)) []web.Mount {
+func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error)) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses
@@ -769,6 +822,10 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 	// the live relay re-resolves future lines with the new mapping (#281, ADR-0039
 	// in-proc direct-method invalidation).
 	campaignSrv.SetSpeakerInvalidator(speakerResolver)
+	// A campaign hard delete sweeps its Session Highlight clips out of blob storage
+	// (#308, ADR-0048): the highlight rows cascade with the campaign, but their clip
+	// blobs have no FK and must be dropped through the seam.
+	campaignSrv.SetHighlightClipSweeper(highlightClipSweeper{store: store, blobs: blobStore})
 	campaignPath, campaignHandler := campaignSrv.Handler(stack.HandlerOptions()...)
 	authPath, authHandler := authServer.Handler(stack.HandlerOptions()...)
 	// VoiceService (#70) serves the live provider data the Configuration +
@@ -802,7 +859,18 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 	// and meters usage, so SessionService.GenerateRecap is CSRF-guarded like a
 	// mutation. It is constructed ONCE in runWeb and passed in, so the GenerateRecap
 	// RPC (#274) and the /glyphoxa recap slash command (#273) share one instance.
-	sessionPath, sessionHandler := rpc.NewSessionServer(mgr, store, recapEngine, log).Handler(stack.HandlerOptions()...)
+	sessionSrv := rpc.NewSessionServer(mgr, store, recapEngine, log)
+	// Session Highlights read/mutate (#308): List/Get/Promote/Delete over the same
+	// store + blob seam the Voice process writes through. Wired here so the many
+	// NewSessionServer call sites keep their signature.
+	sessionSrv.SetHighlights(store, blobStore)
+	sessionPath, sessionHandler := sessionSrv.Handler(stack.HandlerOptions()...)
+
+	// Session Highlight clip serve (#308/#309): GET /api/v1/highlights/{id}/clip, a
+	// plain net/http byte stream (ADR-0015) beside the SSE relay, operator-gated by
+	// auth.RequireSession. Tenant-scoped row load + blob.Get + http.ServeContent
+	// (Range → scrub).
+	clipServer := highlight.NewClipServer(store, blobStore, log)
 
 	// The campaign-bundle transport (#290, ADR-0053) is a PLAIN net/http mount
 	// beside the SSE relay, not a Connect service (ADR-0015): a streamed gzip
@@ -824,6 +892,8 @@ func managementMounts(store *storage.Store, cipher *crypto.Cipher, metrics obser
 		// validates the glyphoxa_session cookie the EventSource/fetch send.
 		{Path: "GET /api/v1/sessions/{id}/events", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeEvents))},
 		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
+		// Session Highlight clip (#308): operator-gated audio byte stream with Range.
+		{Path: "GET /api/v1/highlights/{id}/clip", Handler: auth.RequireSession(store, http.HandlerFunc(clipServer.ServeClip))},
 		// Campaign bundle export (#290): streamed gzip download, operator-gated.
 		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, http.HandlerFunc(bundleHandler.ServeExport))},
 		// Campaign bundle import (#291): multipart upload, operator-gated, plus the

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -599,7 +599,19 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// each clip through the blob seam FIRST, then the rows. Registered in web AND all
 	// mode (the sweep needs only the DB + blob backend, not the voice loop).
 	jobRunner.Register(highlight.JobKindPurgeCandidates, highlight.PurgeHandler(store, blobStore, log))
+	// Session Highlight campaign-clip sweep (#308, ADR-0048/0049): drops a hard-deleted
+	// Campaign's clip blobs, enqueued in the delete's own transaction (idempotent).
+	jobRunner.Register(highlight.JobKindSweepCampaignClips, highlight.CampaignSweepHandler(blobStore, log))
 	go jobRunner.Run(ctx)
+
+	// Boot-time retention backstop (#308, ADR-0051, the ReconcileOrphans/#184 spirit):
+	// a crash between a session ending and the Saver scheduling its 7-day candidate
+	// purge would strand those candidates. At boot, enqueue a purge for every ended
+	// session that has candidates but no live purge job. Loud-but-non-fatal: a failure
+	// logs and boot continues (the next boot retries).
+	if err := highlight.SweepMissingCandidatePurges(ctx, store, jobEnqueuer{store}, log); err != nil {
+		log.Warn("highlight purge backstop sweep failed at boot", "err", err)
+	}
 
 	// Resolve the process embeddings provider ONCE and share it across the two
 	// consumers (#122): the async backfill worker (#116) drains the NULL-embedding
@@ -870,7 +882,10 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// plain net/http byte stream (ADR-0015) beside the SSE relay, operator-gated by
 	// auth.RequireSession. Tenant-scoped row load + blob.Get + http.ServeContent
 	// (Range → scrub).
-	clipServer := highlight.NewClipServer(store, blobStore, log)
+	// The clip route scopes to the Active Campaign server-side (#308), sharing the
+	// SessionServer's read-side resolution so a foreign-campaign clip id is 404 just
+	// like the Highlight RPCs.
+	clipServer := highlight.NewClipServer(store, blobStore, sessionSrv.ResolveActiveCampaign, log)
 
 	// The campaign-bundle transport (#290, ADR-0053) is a PLAIN net/http mount
 	// beside the SSE relay, not a Connect service (ADR-0015): a streamed gzip

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -21,6 +21,13 @@ type ClipStore interface {
 	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
 }
 
+// CampaignResolver resolves the request's Active Campaign server-side (#308): the
+// live Voice Session's campaign first, else the operator's profile-first durable
+// selection. ok is false when neither resolves (a never-run state). The web tier
+// wires *rpc.SessionServer.ResolveActiveCampaign; nil disables campaign scoping
+// (tenant-only, e.g. a voice-standalone build with no web resolver).
+type CampaignResolver func(ctx context.Context) (uuid.UUID, bool, error)
+
 // ClipServer serves a Highlight's audio clip over plain HTTP (#308/#309): GET
 // /api/v1/highlights/{id}/clip, mounted behind auth.RequireSession beside the SSE
 // relay (ADR-0015 — a byte stream, not a Connect unary). It loads the row
@@ -28,17 +35,19 @@ type ClipStore interface {
 // it with http.ServeContent so the browser <audio> scrubber's Range requests
 // resolve to partial content.
 type ClipServer struct {
-	store ClipStore
-	blobs blob.Store
-	log   *slog.Logger
+	store   ClipStore
+	blobs   blob.Store
+	resolve CampaignResolver
+	log     *slog.Logger
 }
 
-// NewClipServer wraps the highlight store + blob seam in a ClipServer.
-func NewClipServer(store ClipStore, blobs blob.Store, log *slog.Logger) *ClipServer {
+// NewClipServer wraps the highlight store + blob seam + Active-Campaign resolver in
+// a ClipServer. A nil resolver disables campaign scoping (tenant-only).
+func NewClipServer(store ClipStore, blobs blob.Store, resolve CampaignResolver, log *slog.Logger) *ClipServer {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &ClipServer{store: store, blobs: blobs, log: log}
+	return &ClipServer{store: store, blobs: blobs, resolve: resolve, log: log}
 }
 
 // ServeClip streams one Highlight's clip. The auth.RequireSession wrapper has
@@ -68,6 +77,22 @@ func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
 		c.log.Error("highlight clip: load row", "err", err, "highlight", id)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
+	}
+
+	// Active-Campaign scoping (#308): a clip whose highlight belongs to another
+	// campaign than the resolved Active Campaign is 404 — existence never leaked, the
+	// same posture the Highlight RPCs adopt. A nil resolver leaves scoping tenant-only.
+	if c.resolve != nil {
+		campaignID, ok, rerr := c.resolve(req.Context())
+		if rerr != nil {
+			c.log.Error("highlight clip: resolve active campaign", "err", rerr, "highlight", id)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !ok || h.CampaignID != campaignID {
+			http.NotFound(w, req)
+			return
+		}
 	}
 
 	rc, _, err := c.blobs.Get(req.Context(), h.ClipKey)

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -1,0 +1,96 @@
+package highlight
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// ClipStore is the read surface the clip serve needs; *storage.Store satisfies
+// it. GetHighlight is tenant-scoped (a foreign-tenant id reads as absent).
+type ClipStore interface {
+	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
+}
+
+// ClipServer serves a Highlight's audio clip over plain HTTP (#308/#309): GET
+// /api/v1/highlights/{id}/clip, mounted behind auth.RequireSession beside the SSE
+// relay (ADR-0015 — a byte stream, not a Connect unary). It loads the row
+// tenant-scoped, fetches the clip through the blob seam (ADR-0048), and streams
+// it with http.ServeContent so the browser <audio> scrubber's Range requests
+// resolve to partial content.
+type ClipServer struct {
+	store ClipStore
+	blobs blob.Store
+	log   *slog.Logger
+}
+
+// NewClipServer wraps the highlight store + blob seam in a ClipServer.
+func NewClipServer(store ClipStore, blobs blob.Store, log *slog.Logger) *ClipServer {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ClipServer{store: store, blobs: blobs, log: log}
+}
+
+// ServeClip streams one Highlight's clip. The auth.RequireSession wrapper has
+// already authenticated the operator and injected the tenant; this handler
+// re-reads the tenant to scope the row load, so a foreign-tenant id (or an
+// unparsable one) is 404 — existence is never leaked. A missing blob is also 404
+// (the row and clip should agree, but a purge race must not 500). http.ServeContent
+// handles Range (scrub) and conditional requests off the row's created_at.
+func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
+	tenantID, ok := auth.TenantID(req.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(req.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+
+	h, err := c.store.GetHighlight(req.Context(), tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight clip: load row", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	rc, _, err := c.blobs.Get(req.Context(), h.ClipKey)
+	if errors.Is(err, blob.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight clip: fetch blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		c.log.Error("highlight clip: read blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", h.ClipContentType)
+	// ServeContent honors Range + If-Modified-Since; the name only informs a
+	// fallback content-type sniff, which our explicit header pre-empts.
+	http.ServeContent(w, req, "clip.wav", h.CreatedAt, bytes.NewReader(data))
+}

--- a/internal/highlight/http_test.go
+++ b/internal/highlight/http_test.go
@@ -16,9 +16,10 @@ import (
 
 // fakeClipStore returns a single highlight for its owning tenant.
 type fakeClipStore struct {
-	tenantID uuid.UUID
-	id       uuid.UUID
-	clipKey  string
+	tenantID   uuid.UUID
+	id         uuid.UUID
+	campaignID uuid.UUID
+	clipKey    string
 }
 
 func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
@@ -28,6 +29,7 @@ func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) 
 	return storage.Highlight{
 		ID:              f.id,
 		TenantID:        f.tenantID,
+		CampaignID:      f.campaignID,
 		Status:          storage.HighlightCandidate,
 		ClipKey:         f.clipKey,
 		ClipContentType: "audio/wav",
@@ -49,8 +51,16 @@ func clipRequest(t *testing.T, tenantID uuid.UUID, id string, rangeHdr string) *
 }
 
 func newClipFixture(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID) {
+	srv, tenantID, id, _ := newClipFixtureCampaign(t)
+	return srv, tenantID, id
+}
+
+// newClipFixtureCampaign is newClipFixture plus the highlight's campaign id and a
+// resolver that resolves the Active Campaign to it, so the campaign-scoping check
+// passes on the happy path (#308).
+func newClipFixtureCampaign(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID, uuid.UUID) {
 	t.Helper()
-	tenantID, id := uuid.New(), uuid.New()
+	tenantID, id, campaignID := uuid.New(), uuid.New(), uuid.New()
 	key, err := blob.Key(tenantID, "highlight", id, "clip.wav")
 	if err != nil {
 		t.Fatalf("build key: %v", err)
@@ -58,8 +68,9 @@ func newClipFixture(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID) {
 	blobs := newFakeBlobs()
 	// A 200-byte "WAV" so Range math is meaningful.
 	blobs.data[key] = make([]byte, 200)
-	store := &fakeClipStore{tenantID: tenantID, id: id, clipKey: key}
-	return NewClipServer(store, blobs, testLog()), tenantID, id
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: campaignID, clipKey: key}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return campaignID, true, nil }
+	return NewClipServer(store, blobs, resolve, testLog()), tenantID, id, campaignID
 }
 
 func TestClip_ServesWithContentType(t *testing.T) {
@@ -115,5 +126,44 @@ func TestClip_UnparsableID404(t *testing.T) {
 	srv.ServeClip(rr, clipRequest(t, tenantID, "not-a-uuid", ""))
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}
+
+// TestClip_CrossCampaign404: a clip whose highlight belongs to ANOTHER campaign than
+// the resolved Active Campaign is 404 — the same campaign-scoping posture the RPCs
+// adopt (#308), existence never leaked.
+func TestClip_CrossCampaign404(t *testing.T) {
+	tenantID, id, otherCampaign := uuid.New(), uuid.New(), uuid.New()
+	key, err := blob.Key(tenantID, "highlight", id, "clip.wav")
+	if err != nil {
+		t.Fatalf("build key: %v", err)
+	}
+	blobs := newFakeBlobs()
+	blobs.data[key] = make([]byte, 200)
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: otherCampaign, clipKey: key}
+	// The Active Campaign resolves to a DIFFERENT campaign than the highlight's.
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return uuid.New(), true, nil }
+	srv := NewClipServer(store, blobs, resolve, testLog())
+
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-campaign clip: want 404, got %d", rr.Code)
+	}
+}
+
+// TestClip_MissingBlob404: the row exists but its clip blob is gone (a purge race) —
+// the handler must 404, not 500 (#308, finding #6).
+func TestClip_MissingBlob404(t *testing.T) {
+	srv, tenantID, id, _ := newClipFixtureCampaign(t)
+	// Drop the blob out from under the row (the purge deleted the clip first).
+	key, _ := blob.Key(tenantID, "highlight", id, "clip.wav")
+	if err := srv.blobs.Delete(context.Background(), key); err != nil {
+		t.Fatalf("delete blob: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("missing blob: want 404, got %d", rr.Code)
 	}
 }

--- a/internal/highlight/http_test.go
+++ b/internal/highlight/http_test.go
@@ -1,0 +1,119 @@
+package highlight
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeClipStore returns a single highlight for its owning tenant.
+type fakeClipStore struct {
+	tenantID uuid.UUID
+	id       uuid.UUID
+	clipKey  string
+}
+
+func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	if tenantID != f.tenantID || id != f.id {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	return storage.Highlight{
+		ID:              f.id,
+		TenantID:        f.tenantID,
+		Status:          storage.HighlightCandidate,
+		ClipKey:         f.clipKey,
+		ClipContentType: "audio/wav",
+		CreatedAt:       time.Now(),
+	}, nil
+}
+
+func clipRequest(t *testing.T, tenantID uuid.UUID, id string, rangeHdr string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/"+id+"/clip", nil)
+	req.SetPathValue("id", id)
+	if tenantID != uuid.Nil {
+		req = req.WithContext(auth.WithTenant(req.Context(), tenantID))
+	}
+	if rangeHdr != "" {
+		req.Header.Set("Range", rangeHdr)
+	}
+	return req
+}
+
+func newClipFixture(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	tenantID, id := uuid.New(), uuid.New()
+	key, err := blob.Key(tenantID, "highlight", id, "clip.wav")
+	if err != nil {
+		t.Fatalf("build key: %v", err)
+	}
+	blobs := newFakeBlobs()
+	// A 200-byte "WAV" so Range math is meaningful.
+	blobs.data[key] = make([]byte, 200)
+	store := &fakeClipStore{tenantID: tenantID, id: id, clipKey: key}
+	return NewClipServer(store, blobs, testLog()), tenantID, id
+}
+
+func TestClip_ServesWithContentType(t *testing.T) {
+	srv, tenantID, id := newClipFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, tenantID, id.String(), ""))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "audio/wav" {
+		t.Fatalf("want audio/wav, got %q", ct)
+	}
+	if rr.Body.Len() != 200 {
+		t.Fatalf("want 200 bytes, got %d", rr.Body.Len())
+	}
+}
+
+func TestClip_RangeReturnsPartial(t *testing.T) {
+	srv, tenantID, id := newClipFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, tenantID, id.String(), "bytes=0-99"))
+
+	if rr.Code != http.StatusPartialContent {
+		t.Fatalf("want 206 Partial Content, got %d", rr.Code)
+	}
+	if rr.Body.Len() != 100 {
+		t.Fatalf("want 100 bytes, got %d", rr.Body.Len())
+	}
+}
+
+func TestClip_NoTenant401(t *testing.T) {
+	srv, _, id := newClipFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, uuid.Nil, id.String(), ""))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rr.Code)
+	}
+}
+
+func TestClip_ForeignTenant404(t *testing.T) {
+	srv, _, id := newClipFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, uuid.New(), id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}
+
+func TestClip_UnparsableID404(t *testing.T) {
+	srv, tenantID, _ := newClipFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeClip(rr, clipRequest(t, tenantID, "not-a-uuid", ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}

--- a/internal/highlight/purge.go
+++ b/internal/highlight/purge.go
@@ -1,0 +1,74 @@
+package highlight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+)
+
+// JobKindPurgeCandidates is the background-job kind that drops a Voice Session's
+// still-candidate highlights once their 7-day horizon passes (ADR-0051/0049).
+const JobKindPurgeCandidates = "highlight.purge_candidates"
+
+// purgeDelay is the candidate retention window (ADR-0051): a candidate highlight
+// not promoted within 7 days is purged.
+const purgeDelay = 7 * 24 * time.Hour
+
+// purgePayload is the purge job's payload: which session's candidates to sweep.
+// It carries no tenant — the session id scopes the sweep (the row cascade and
+// blob keys derive from it), and the handler runs process-wide (ADR-0049).
+type purgePayload struct {
+	VoiceSessionID uuid.UUID `json:"voice_session_id"`
+}
+
+// PurgeStore is the storage surface the purge handler needs; *storage.Store
+// satisfies it and tests fake it.
+type PurgeStore interface {
+	ListSessionCandidateClipKeys(ctx context.Context, voiceSessionID uuid.UUID) ([]string, error)
+	DeleteSessionCandidates(ctx context.Context, voiceSessionID uuid.UUID) (int, error)
+}
+
+// PurgeHandler builds the background-job handler for JobKindPurgeCandidates. It
+// is at-least-once and idempotent (ADR-0049): it drops each remaining candidate's
+// blob FIRST (through the seam, ADR-0048) and only then deletes the rows, so a
+// crash between the two leaves a re-runnable job (the surviving rows still list
+// their keys). Promoted highlights are untouched — the storage sweep filters to
+// status='candidate'. A re-run after a clean purge lists nothing and deletes
+// nothing. The returned func matches the jobs runner's HandlerFunc.
+func PurgeHandler(store PurgeStore, blobs blob.Store, log *slog.Logger) func(context.Context, json.RawMessage) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	return func(ctx context.Context, payload json.RawMessage) error {
+		var p purgePayload
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return fmt.Errorf("highlight purge: decode payload: %w", err)
+		}
+
+		keys, err := store.ListSessionCandidateClipKeys(ctx, p.VoiceSessionID)
+		if err != nil {
+			return fmt.Errorf("highlight purge: list candidate clip keys: %w", err)
+		}
+		// Blob first (ADR-0048): drop each clip through the seam before removing the
+		// rows, so a mid-sweep crash never orphans a blob whose row is already gone.
+		for _, k := range keys {
+			if err := blobs.Delete(ctx, k); err != nil {
+				return fmt.Errorf("highlight purge: delete clip %q: %w", k, err)
+			}
+		}
+		n, err := store.DeleteSessionCandidates(ctx, p.VoiceSessionID)
+		if err != nil {
+			return fmt.Errorf("highlight purge: delete candidate rows: %w", err)
+		}
+		if n > 0 {
+			log.Info("purged candidate highlights", "voice_session", p.VoiceSessionID, "count", n)
+		}
+		return nil
+	}
+}

--- a/internal/highlight/purge.go
+++ b/internal/highlight/purge.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
 // JobKindPurgeCandidates is the background-job kind that drops a Voice Session's
@@ -84,10 +85,10 @@ type PurgeStore interface {
 }
 
 // PurgeScheduleStore is the storage surface the boot-time purge backstop needs:
-// the ended Voice Sessions that still hold candidate highlights but have no purge
-// job scheduled. *storage.Store satisfies it.
+// the ended Voice Sessions (id + ended_at) that still hold candidate highlights but
+// have no purge job scheduled. *storage.Store satisfies it.
 type PurgeScheduleStore interface {
-	ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]uuid.UUID, error)
+	ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]storage.SessionPurgeCandidate, error)
 }
 
 // SweepMissingCandidatePurges is the boot-time retention backstop (ADR-0051, the
@@ -95,7 +96,11 @@ type PurgeScheduleStore interface {
 // crash between a session ending and Finalize scheduling its purge would strand
 // that session's candidate highlights forever (their 7-day horizon never enqueued).
 // At boot — before serving — this finds every ended session with candidates and NO
-// pending/running/done purge job and enqueues one, 7 days out. It complements, not
+// pending/running/done purge job and enqueues one. The horizon anchors at session
+// END (ended_at + 7d), NOT boot time, so ADR-0051's 7-day safety purge is honored
+// regardless of when the crash-restart lands: a session that ended 8 days ago is
+// past-due and purges immediately (a now-floor keeps run_after from going negative),
+// while one that ended yesterday keeps its remaining ~6 days. It complements, not
 // replaces, Finalize's per-session scheduling. A per-session enqueue failure logs
 // and the sweep continues (the next boot retries), so one bad row never stalls the
 // rest; a store-list failure is returned (a boot-time diagnostic).
@@ -103,19 +108,26 @@ func SweepMissingCandidatePurges(ctx context.Context, store PurgeScheduleStore, 
 	if log == nil {
 		log = slog.Default()
 	}
-	ids, err := store.ListSessionsNeedingCandidatePurge(ctx, JobKindPurgeCandidates)
+	candidates, err := store.ListSessionsNeedingCandidatePurge(ctx, JobKindPurgeCandidates)
 	if err != nil {
 		return fmt.Errorf("highlight purge sweep: list sessions needing purge: %w", err)
 	}
-	for _, id := range ids {
-		payload := purgePayload{VoiceSessionID: id}
-		if err := enqueue.Enqueue(ctx, JobKindPurgeCandidates, payload, time.Now().Add(purgeDelay)); err != nil {
-			log.Error("highlight purge sweep: enqueue backstop purge", "err", err, "voice_session", id)
+	now := time.Now()
+	for _, c := range candidates {
+		// Anchor at session end: ended_at + 7d, floored at now so a long-past session
+		// purges immediately rather than 7 days after this boot (ADR-0051).
+		runAfter := c.EndedAt.Add(purgeDelay)
+		if runAfter.Before(now) {
+			runAfter = now
+		}
+		payload := purgePayload{VoiceSessionID: c.VoiceSessionID}
+		if err := enqueue.Enqueue(ctx, JobKindPurgeCandidates, payload, runAfter); err != nil {
+			log.Error("highlight purge sweep: enqueue backstop purge", "err", err, "voice_session", c.VoiceSessionID)
 			continue
 		}
 	}
-	if len(ids) > 0 {
-		log.Warn("scheduled backstop candidate purge for orphaned ended sessions", "count", len(ids))
+	if len(candidates) > 0 {
+		log.Warn("scheduled backstop candidate purge for orphaned ended sessions", "count", len(candidates))
 	}
 	return nil
 }

--- a/internal/highlight/purge.go
+++ b/internal/highlight/purge.go
@@ -16,6 +16,55 @@ import (
 // still-candidate highlights once their 7-day horizon passes (ADR-0051/0049).
 const JobKindPurgeCandidates = "highlight.purge_candidates"
 
+// JobKindSweepCampaignClips is the background-job kind that drops a hard-deleted
+// Campaign's Highlight clip blobs (#308, ADR-0048). The highlight ROWS cascade
+// with the campaign row; their clip blobs have no FK, so they are swept through
+// the seam. The job is enqueued in the SAME transaction as the campaign delete, so
+// it exists iff the delete committed — no orphan sweep of a surviving campaign, no
+// lost sweep of a crashed process (ADR-0049 at-least-once + idempotent).
+const JobKindSweepCampaignClips = "highlight.sweep_campaign_clips"
+
+// campaignSweepPayload carries the clip keys a campaign hard-delete must drop. The
+// keys are captured BEFORE the row cascade removes the highlight rows (after which
+// they can no longer be listed).
+type campaignSweepPayload struct {
+	ClipKeys []string `json:"clip_keys"`
+}
+
+// MarshalCampaignSweep builds the JobKindSweepCampaignClips payload from the clip
+// keys captured before a campaign delete. The RPC layer marshals it and hands it,
+// with the kind, to the delete-in-one-tx store method.
+func MarshalCampaignSweep(clipKeys []string) ([]byte, error) {
+	return json.Marshal(campaignSweepPayload{ClipKeys: clipKeys})
+}
+
+// CampaignSweepHandler builds the JobKindSweepCampaignClips handler: it drops each
+// carried clip key through the blob seam (ADR-0048). Idempotent + at-least-once
+// (ADR-0049): blob.Delete on an absent key is a no-op (internal/blob/postgres.go),
+// so a re-run after a partial sweep, or after a prior success, completes cleanly. A
+// backend error on any key returns so the job retries the whole set (re-deleting an
+// already-gone key is harmless).
+func CampaignSweepHandler(blobs blob.Store, log *slog.Logger) func(context.Context, json.RawMessage) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	return func(ctx context.Context, payload json.RawMessage) error {
+		var p campaignSweepPayload
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return fmt.Errorf("highlight campaign sweep: decode payload: %w", err)
+		}
+		for _, k := range p.ClipKeys {
+			if err := blobs.Delete(ctx, k); err != nil {
+				return fmt.Errorf("highlight campaign sweep: delete clip %q: %w", k, err)
+			}
+		}
+		if len(p.ClipKeys) > 0 {
+			log.Info("swept hard-deleted campaign highlight clips", "count", len(p.ClipKeys))
+		}
+		return nil
+	}
+}
+
 // purgeDelay is the candidate retention window (ADR-0051): a candidate highlight
 // not promoted within 7 days is purged.
 const purgeDelay = 7 * 24 * time.Hour
@@ -32,6 +81,43 @@ type purgePayload struct {
 type PurgeStore interface {
 	ListSessionCandidateClipKeys(ctx context.Context, voiceSessionID uuid.UUID) ([]string, error)
 	DeleteSessionCandidates(ctx context.Context, voiceSessionID uuid.UUID) (int, error)
+}
+
+// PurgeScheduleStore is the storage surface the boot-time purge backstop needs:
+// the ended Voice Sessions that still hold candidate highlights but have no purge
+// job scheduled. *storage.Store satisfies it.
+type PurgeScheduleStore interface {
+	ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]uuid.UUID, error)
+}
+
+// SweepMissingCandidatePurges is the boot-time retention backstop (ADR-0051, the
+// #184 "rows are the source of truth, reconcile on boot" spirit / ADR-0043): a
+// crash between a session ending and Finalize scheduling its purge would strand
+// that session's candidate highlights forever (their 7-day horizon never enqueued).
+// At boot — before serving — this finds every ended session with candidates and NO
+// pending/running/done purge job and enqueues one, 7 days out. It complements, not
+// replaces, Finalize's per-session scheduling. A per-session enqueue failure logs
+// and the sweep continues (the next boot retries), so one bad row never stalls the
+// rest; a store-list failure is returned (a boot-time diagnostic).
+func SweepMissingCandidatePurges(ctx context.Context, store PurgeScheduleStore, enqueue JobEnqueuer, log *slog.Logger) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	ids, err := store.ListSessionsNeedingCandidatePurge(ctx, JobKindPurgeCandidates)
+	if err != nil {
+		return fmt.Errorf("highlight purge sweep: list sessions needing purge: %w", err)
+	}
+	for _, id := range ids {
+		payload := purgePayload{VoiceSessionID: id}
+		if err := enqueue.Enqueue(ctx, JobKindPurgeCandidates, payload, time.Now().Add(purgeDelay)); err != nil {
+			log.Error("highlight purge sweep: enqueue backstop purge", "err", err, "voice_session", id)
+			continue
+		}
+	}
+	if len(ids) > 0 {
+		log.Warn("scheduled backstop candidate purge for orphaned ended sessions", "count", len(ids))
+	}
+	return nil
 }
 
 // PurgeHandler builds the background-job handler for JobKindPurgeCandidates. It

--- a/internal/highlight/purge_test.go
+++ b/internal/highlight/purge_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
 // fakePurgeStore records candidate keys and delete calls; order of blob-vs-row is
@@ -123,39 +125,49 @@ func TestPurge_ListErrorPropagates(t *testing.T) {
 // fakeScheduleStore returns the sessions the boot sweep should schedule a purge
 // for, recording the purge kind the sweep asked with.
 type fakeScheduleStore struct {
-	ids     []uuid.UUID
-	gotKind string
-	listErr error
+	candidates []storage.SessionPurgeCandidate
+	gotKind    string
+	listErr    error
 }
 
-func (f *fakeScheduleStore) ListSessionsNeedingCandidatePurge(_ context.Context, purgeKind string) ([]uuid.UUID, error) {
+func (f *fakeScheduleStore) ListSessionsNeedingCandidatePurge(_ context.Context, purgeKind string) ([]storage.SessionPurgeCandidate, error) {
 	f.gotKind = purgeKind
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	return f.ids, nil
+	return f.candidates, nil
+}
+
+// enqueued records one backstop purge enqueue (session + scheduled horizon).
+type enqueued struct {
+	session  uuid.UUID
+	kind     string
+	runAfter time.Time
 }
 
 // recordingEnqueuer records every purge enqueue the boot sweep makes.
 type recordingEnqueuer struct {
-	mu       sync.Mutex
-	sessions []uuid.UUID
-	kinds    []string
+	mu  sync.Mutex
+	all []enqueued
 }
 
-func (r *recordingEnqueuer) Enqueue(_ context.Context, kind string, payload any, _ time.Time) error {
+func (r *recordingEnqueuer) Enqueue(_ context.Context, kind string, payload any, runAfter time.Time) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.kinds = append(r.kinds, kind)
+	e := enqueued{kind: kind, runAfter: runAfter}
 	if p, ok := payload.(purgePayload); ok {
-		r.sessions = append(r.sessions, p.VoiceSessionID)
+		e.session = p.VoiceSessionID
 	}
+	r.all = append(r.all, e)
 	return nil
 }
 
 func TestSweepMissingCandidatePurges_EnqueuesForOrphans(t *testing.T) {
 	s1, s2 := uuid.New(), uuid.New()
-	store := &fakeScheduleStore{ids: []uuid.UUID{s1, s2}}
+	store := &fakeScheduleStore{candidates: []storage.SessionPurgeCandidate{
+		{VoiceSessionID: s1, EndedAt: time.Now()},
+		{VoiceSessionID: s2, EndedAt: time.Now()},
+	}}
 	enq := &recordingEnqueuer{}
 
 	if err := SweepMissingCandidatePurges(context.Background(), store, enq, testLog()); err != nil {
@@ -164,13 +176,49 @@ func TestSweepMissingCandidatePurges_EnqueuesForOrphans(t *testing.T) {
 	if store.gotKind != JobKindPurgeCandidates {
 		t.Fatalf("sweep asked with wrong kind: %q", store.gotKind)
 	}
-	if len(enq.sessions) != 2 || enq.sessions[0] != s1 || enq.sessions[1] != s2 {
-		t.Fatalf("backstop purges not enqueued per orphan: %v", enq.sessions)
+	if len(enq.all) != 2 || enq.all[0].session != s1 || enq.all[1].session != s2 {
+		t.Fatalf("backstop purges not enqueued per orphan: %v", enq.all)
 	}
-	for _, k := range enq.kinds {
-		if k != JobKindPurgeCandidates {
-			t.Fatalf("enqueued wrong job kind: %q", k)
+	for _, e := range enq.all {
+		if e.kind != JobKindPurgeCandidates {
+			t.Fatalf("enqueued wrong job kind: %q", e.kind)
 		}
+	}
+}
+
+// TestSweepMissingCandidatePurges_AnchorsHorizonAtSessionEnd pins ADR-0051's 7-day
+// safety window to session END, not boot time: a session that ended 8 days ago is
+// past-due (run_after ≈ now), and one that ended a day ago keeps its remaining
+// window (run_after ≈ ended_at + 7d).
+func TestSweepMissingCandidatePurges_AnchorsHorizonAtSessionEnd(t *testing.T) {
+	pastDue := uuid.New()
+	recent := uuid.New()
+	pastEnded := time.Now().Add(-8 * 24 * time.Hour) // ended > 7d ago → past-due
+	recentEnded := time.Now().Add(-24 * time.Hour)   // ended 1d ago → ~6d left
+	store := &fakeScheduleStore{candidates: []storage.SessionPurgeCandidate{
+		{VoiceSessionID: pastDue, EndedAt: pastEnded},
+		{VoiceSessionID: recent, EndedAt: recentEnded},
+	}}
+	enq := &recordingEnqueuer{}
+
+	before := time.Now()
+	if err := SweepMissingCandidatePurges(context.Background(), store, enq, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	after := time.Now()
+
+	byID := map[uuid.UUID]time.Time{}
+	for _, e := range enq.all {
+		byID[e.session] = e.runAfter
+	}
+	// Past-due: floored at now (runs immediately), NOT ended_at+7d (which would be ~1d ago).
+	if ra := byID[pastDue]; ra.Before(before) || ra.After(after) {
+		t.Fatalf("past-due horizon = %v, want ~now [%v,%v]", ra, before, after)
+	}
+	// Recent: anchored at ended_at + 7d, well in the future — NOT now+7d.
+	wantRecent := recentEnded.Add(purgeDelay)
+	if ra := byID[recent]; ra.Sub(wantRecent).Abs() > time.Second {
+		t.Fatalf("recent horizon = %v, want ended_at+7d ≈ %v", ra, wantRecent)
 	}
 }
 
@@ -180,8 +228,8 @@ func TestSweepMissingCandidatePurges_NoOrphansNoEnqueue(t *testing.T) {
 	if err := SweepMissingCandidatePurges(context.Background(), store, enq, testLog()); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
-	if len(enq.sessions) != 0 {
-		t.Fatalf("no orphans should enqueue nothing, got %v", enq.sessions)
+	if len(enq.all) != 0 {
+		t.Fatalf("no orphans should enqueue nothing, got %v", enq.all)
 	}
 }
 

--- a/internal/highlight/purge_test.go
+++ b/internal/highlight/purge_test.go
@@ -1,0 +1,131 @@
+package highlight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// fakePurgeStore records candidate keys and delete calls; order of blob-vs-row is
+// asserted via a shared event log.
+type fakePurgeStore struct {
+	mu        sync.Mutex
+	keys      []string
+	deleted   bool
+	deleteN   int
+	events    *[]string
+	listErr   error
+	deleteErr error
+}
+
+func (f *fakePurgeStore) ListSessionCandidateClipKeys(_ context.Context, _ uuid.UUID) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleted {
+		return nil, nil // already purged: idempotent re-run sees nothing
+	}
+	return append([]string(nil), f.keys...), nil
+}
+
+func (f *fakePurgeStore) DeleteSessionCandidates(_ context.Context, _ uuid.UUID) (int, error) {
+	if f.deleteErr != nil {
+		return 0, f.deleteErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*f.events = append(*f.events, "row-delete")
+	if f.deleted {
+		return 0, nil
+	}
+	f.deleted = true
+	n := len(f.keys)
+	f.deleteN = n
+	return n, nil
+}
+
+func testLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func payloadFor(id uuid.UUID) json.RawMessage {
+	b, _ := json.Marshal(purgePayload{VoiceSessionID: id})
+	return b
+}
+
+func TestPurge_BlobFirstThenRows(t *testing.T) {
+	var events []string
+	store := &fakePurgeStore{keys: []string{"k1", "k2"}, events: &events}
+	blobs := newFakeBlobs()
+	blobs.data["k1"] = []byte("a")
+	blobs.data["k2"] = []byte("b")
+	// Record blob deletes into the same event log by wrapping.
+	del := recordingBlobs{fakeBlobs: blobs, events: &events}
+
+	h := PurgeHandler(store, &del, testLog())
+	if err := h(context.Background(), payloadFor(uuid.New())); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+
+	// Every blob delete happens BEFORE the single row delete.
+	if len(events) != 3 || events[2] != "row-delete" {
+		t.Fatalf("blob-first ordering violated: %v", events)
+	}
+	if !store.deleted || store.deleteN != 2 {
+		t.Fatalf("rows not deleted: %+v", store)
+	}
+	if blobs.keys() != 0 {
+		t.Fatalf("clips not dropped: %d left", blobs.keys())
+	}
+}
+
+func TestPurge_Idempotent(t *testing.T) {
+	var events []string
+	store := &fakePurgeStore{keys: []string{"k1"}, events: &events}
+	blobs := newFakeBlobs()
+	blobs.data["k1"] = []byte("a")
+	del := recordingBlobs{fakeBlobs: blobs, events: &events}
+	h := PurgeHandler(store, &del, testLog())
+
+	id := uuid.New()
+	if err := h(context.Background(), payloadFor(id)); err != nil {
+		t.Fatalf("first purge: %v", err)
+	}
+	// Second run: nothing left to do, still succeeds.
+	if err := h(context.Background(), payloadFor(id)); err != nil {
+		t.Fatalf("second purge (idempotent): %v", err)
+	}
+}
+
+func TestPurge_BadPayload(t *testing.T) {
+	store := &fakePurgeStore{events: &[]string{}}
+	h := PurgeHandler(store, newFakeBlobs(), testLog())
+	if err := h(context.Background(), json.RawMessage("not json")); err == nil {
+		t.Fatal("want error on bad payload")
+	}
+}
+
+func TestPurge_ListErrorPropagates(t *testing.T) {
+	store := &fakePurgeStore{listErr: errors.New("db down"), events: &[]string{}}
+	h := PurgeHandler(store, newFakeBlobs(), testLog())
+	if err := h(context.Background(), payloadFor(uuid.New())); err == nil {
+		t.Fatal("want error when list fails")
+	}
+}
+
+// recordingBlobs wraps fakeBlobs to log each Delete into the shared event slice.
+type recordingBlobs struct {
+	*fakeBlobs
+	events *[]string
+}
+
+func (r *recordingBlobs) Delete(ctx context.Context, key string) error {
+	*r.events = append(*r.events, "blob-delete")
+	return r.fakeBlobs.Delete(ctx, key)
+}

--- a/internal/highlight/purge_test.go
+++ b/internal/highlight/purge_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -116,6 +117,131 @@ func TestPurge_ListErrorPropagates(t *testing.T) {
 	h := PurgeHandler(store, newFakeBlobs(), testLog())
 	if err := h(context.Background(), payloadFor(uuid.New())); err == nil {
 		t.Fatal("want error when list fails")
+	}
+}
+
+// fakeScheduleStore returns the sessions the boot sweep should schedule a purge
+// for, recording the purge kind the sweep asked with.
+type fakeScheduleStore struct {
+	ids     []uuid.UUID
+	gotKind string
+	listErr error
+}
+
+func (f *fakeScheduleStore) ListSessionsNeedingCandidatePurge(_ context.Context, purgeKind string) ([]uuid.UUID, error) {
+	f.gotKind = purgeKind
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.ids, nil
+}
+
+// recordingEnqueuer records every purge enqueue the boot sweep makes.
+type recordingEnqueuer struct {
+	mu       sync.Mutex
+	sessions []uuid.UUID
+	kinds    []string
+}
+
+func (r *recordingEnqueuer) Enqueue(_ context.Context, kind string, payload any, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.kinds = append(r.kinds, kind)
+	if p, ok := payload.(purgePayload); ok {
+		r.sessions = append(r.sessions, p.VoiceSessionID)
+	}
+	return nil
+}
+
+func TestSweepMissingCandidatePurges_EnqueuesForOrphans(t *testing.T) {
+	s1, s2 := uuid.New(), uuid.New()
+	store := &fakeScheduleStore{ids: []uuid.UUID{s1, s2}}
+	enq := &recordingEnqueuer{}
+
+	if err := SweepMissingCandidatePurges(context.Background(), store, enq, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if store.gotKind != JobKindPurgeCandidates {
+		t.Fatalf("sweep asked with wrong kind: %q", store.gotKind)
+	}
+	if len(enq.sessions) != 2 || enq.sessions[0] != s1 || enq.sessions[1] != s2 {
+		t.Fatalf("backstop purges not enqueued per orphan: %v", enq.sessions)
+	}
+	for _, k := range enq.kinds {
+		if k != JobKindPurgeCandidates {
+			t.Fatalf("enqueued wrong job kind: %q", k)
+		}
+	}
+}
+
+func TestSweepMissingCandidatePurges_NoOrphansNoEnqueue(t *testing.T) {
+	store := &fakeScheduleStore{}
+	enq := &recordingEnqueuer{}
+	if err := SweepMissingCandidatePurges(context.Background(), store, enq, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(enq.sessions) != 0 {
+		t.Fatalf("no orphans should enqueue nothing, got %v", enq.sessions)
+	}
+}
+
+func TestSweepMissingCandidatePurges_ListErrorReturned(t *testing.T) {
+	store := &fakeScheduleStore{listErr: errors.New("db down")}
+	if err := SweepMissingCandidatePurges(context.Background(), store, &recordingEnqueuer{}, testLog()); err == nil {
+		t.Fatal("want error when the session list fails")
+	}
+}
+
+func TestPurge_RowDeleteErrorPropagates(t *testing.T) {
+	store := &fakePurgeStore{keys: []string{"k1"}, events: &[]string{}, deleteErr: errors.New("row delete boom")}
+	blobs := newFakeBlobs()
+	blobs.data["k1"] = []byte("a")
+	h := PurgeHandler(store, blobs, testLog())
+	if err := h(context.Background(), payloadFor(uuid.New())); err == nil {
+		t.Fatal("want error when the row delete fails")
+	}
+}
+
+func TestPurge_BlobDeleteErrorPropagates(t *testing.T) {
+	store := &fakePurgeStore{keys: []string{"k1"}, events: &[]string{}}
+	blobs := newFakeBlobs()
+	blobs.data["k1"] = []byte("a")
+	blobs.deleteErr = errors.New("blob backend down")
+	h := PurgeHandler(store, blobs, testLog())
+	if err := h(context.Background(), payloadFor(uuid.New())); err == nil {
+		t.Fatal("want error when the blob delete fails")
+	}
+	// Blob-first: the row delete must NOT have run after the blob delete failed.
+	if store.deleted {
+		t.Fatal("rows deleted despite a failed blob delete (blob-first violated)")
+	}
+}
+
+func TestCampaignSweep_DeletesCarriedKeys(t *testing.T) {
+	blobs := newFakeBlobs()
+	blobs.data["k1"] = []byte("a")
+	blobs.data["k2"] = []byte("b")
+	payload, err := MarshalCampaignSweep([]string{"k1", "k2"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	h := CampaignSweepHandler(blobs, testLog())
+	if err := h(context.Background(), payload); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if blobs.keys() != 0 {
+		t.Fatalf("carried clips not swept: %d left", blobs.keys())
+	}
+}
+
+func TestCampaignSweep_IdempotentOnMissingKeys(t *testing.T) {
+	blobs := newFakeBlobs() // no data: every key is already absent
+	payload, _ := MarshalCampaignSweep([]string{"gone-1", "gone-2"})
+	h := CampaignSweepHandler(blobs, testLog())
+	// Absent keys delete cleanly (blob.Delete absent-key = nil), so a re-run of a
+	// partially-or-fully completed sweep succeeds.
+	if err := h(context.Background(), payload); err != nil {
+		t.Fatalf("sweep over missing keys should be a no-op, got %v", err)
 	}
 }
 

--- a/internal/highlight/saver.go
+++ b/internal/highlight/saver.go
@@ -3,6 +3,7 @@ package highlight
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -129,13 +130,20 @@ func (s *Saver) HandleTrigger(t Trigger) {
 	}
 }
 
+// enqueueTimeout bounds the purge-schedule Enqueue when the caller's ctx has
+// already expired during the drain — the purge horizon must still be recorded, so
+// it runs on a fresh short budget rather than an already-dead context.
+const enqueueTimeout = 5 * time.Second
+
 // Finalize drains the bound session's worker (a flush barrier: it closes the
 // mailbox and waits for the worker to finish every queued trigger), then
 // schedules the 7-day candidate purge job and unbinds. The Manager calls it at
 // EVERY loop exit beside transcript.Finalize (Stop, self-exit, Shutdown), so a
 // session's candidates always get a purge horizon. Idle (no bound session) is a
-// no-op. A ctx timeout during the drain returns the error (the Manager logs it)
-// and the purge is NOT scheduled — the boot sweep is the backstop.
+// no-op. A ctx timeout during the drain is returned (the Manager logs it) but the
+// purge is STILL scheduled off the captured session id — a drain timeout must not
+// lose the purge horizon (that would strand candidates until the boot sweep, which
+// is a backstop, not the primary path).
 func (s *Saver) Finalize(ctx context.Context) error {
 	s.mu.Lock()
 	ss := s.sess
@@ -148,19 +156,29 @@ func (s *Saver) Finalize(ctx context.Context) error {
 	// Flush barrier: no more sends can happen (sess is nil, HandleTrigger drops),
 	// so closing the mailbox lets the worker drain every buffered trigger and exit.
 	close(ss.queue)
+	var drainErr error
 	select {
 	case <-ss.done:
 	case <-ctx.Done():
-		return ctx.Err()
+		drainErr = ctx.Err()
 	}
 
-	// Schedule the candidate purge 7 days out (ADR-0051). At-least-once + idempotent
-	// (ADR-0049): the handler blob-deletes then row-deletes remaining candidates.
-	payload := purgePayload{VoiceSessionID: ss.voiceSessionID}
-	if err := s.enqueue.Enqueue(ctx, JobKindPurgeCandidates, payload, time.Now().Add(purgeDelay)); err != nil {
-		return err
+	// Schedule the candidate purge 7 days out (ADR-0051) REGARDLESS of the drain
+	// outcome — ss captured the session id before the unbind, so a drain timeout can
+	// still record the horizon. At-least-once + idempotent (ADR-0049): the handler
+	// blob-deletes then row-deletes remaining candidates. If the drain timed out, the
+	// caller's ctx is dead, so enqueue on a fresh short budget.
+	enqCtx := ctx
+	if drainErr != nil {
+		var cancel context.CancelFunc
+		enqCtx, cancel = context.WithTimeout(context.Background(), enqueueTimeout)
+		defer cancel()
 	}
-	return nil
+	payload := purgePayload{VoiceSessionID: ss.voiceSessionID}
+	if err := s.enqueue.Enqueue(enqCtx, JobKindPurgeCandidates, payload, time.Now().Add(purgeDelay)); err != nil {
+		return errors.Join(drainErr, err)
+	}
+	return drainErr
 }
 
 // worker is the per-session goroutine: it serially saves each queued trigger and
@@ -214,6 +232,13 @@ func (s *Saver) save(ss *saverSession, t Trigger) {
 	}
 	if err := s.store.CreateHighlight(ctx, h); err != nil {
 		s.log.Error("highlight saver: create highlight row", "err", err, "voice_session", ss.voiceSessionID)
+		// Compensate the orphaned clip (ADR-0048): the blob is stored but no row will
+		// ever reference it, so drop it through the seam. A compensation failure only
+		// logs — the row create already failed, and a lingering blob is the lesser evil
+		// than crashing the worker (the campaign-delete sweep is the last-resort cleanup).
+		if derr := s.blobs.Delete(ctx, key); derr != nil {
+			s.log.Error("highlight saver: compensate orphan clip", "err", derr, "voice_session", ss.voiceSessionID, "key", key)
+		}
 		return
 	}
 	s.log.Info("highlight saved", "voice_session", ss.voiceSessionID, "highlight", highlightID, "score", t.Score)

--- a/internal/highlight/saver.go
+++ b/internal/highlight/saver.go
@@ -1,0 +1,220 @@
+package highlight
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/mixdown"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// The Saver is #308's [Sink]: it turns each detector [Trigger] into a stored
+// audio clip (behind the blob seam, ADR-0048) plus a 'candidate' highlight row,
+// then — on session end — schedules the 7-day candidate purge (ADR-0051/0049).
+//
+// It follows the same no-block discipline the detector demands of a Sink
+// (ADR-0020/0026): HandleTrigger runs on the detector's single worker goroutine,
+// so it only hands the trigger to a bounded mailbox and returns; a full mailbox
+// drops + logs rather than stalling detection. A separate per-session worker
+// goroutine does the blocking I/O (WAVClip → blob.Put → CreateHighlight). A save
+// failure logs and is dropped — one missed highlight never crashes the session.
+//
+// The Saver is a process singleton bound to one Voice Session at a time (there is
+// only ever one live session, ADR-0039). Begin binds a session and starts its
+// worker; Finalize drains the worker, schedules the purge, and unbinds. It rides
+// the VOICE process; the RPC read side and clip serve ride the WEB process — they
+// meet only through Postgres (the blob backend), never shared memory.
+
+// saveQueue bounds a session's pending-trigger mailbox. A detector emits at most
+// MaxCandidates (#305: 10) triggers a session, so 16 is generous headroom; a
+// (pathological) overflow drops the newest and logs.
+const saveQueue = 16
+
+// saveTimeout bounds one trigger's WAVClip → blob.Put → CreateHighlight so a
+// stalled DB/blob backend can't wedge the single per-session worker.
+const saveTimeout = 30 * time.Second
+
+// Store is the persistence surface the Saver's worker needs; *storage.Store
+// satisfies it and tests fake it.
+type Store interface {
+	CreateHighlight(ctx context.Context, h storage.Highlight) error
+}
+
+// JobEnqueuer schedules the candidate purge job (ADR-0049). It is the small
+// adapter over storage.EnqueueJob's kind/payload/run_after surface; main.go wires
+// it. payload is JSON-marshalled by the adapter.
+type JobEnqueuer interface {
+	Enqueue(ctx context.Context, kind string, payload any, runAfter time.Time) error
+}
+
+// Saver implements [Sink]. Construct with [NewSaver], then drive it from the
+// session Manager: Begin at session Start, HandleTrigger via cfg.Highlights,
+// Finalize at loop exit.
+type Saver struct {
+	store   Store
+	blobs   blob.Store
+	enqueue JobEnqueuer
+	log     *slog.Logger
+
+	mu   sync.Mutex
+	sess *saverSession // nil when unbound (idle)
+}
+
+// saverSession is the Saver's per-Voice-Session binding: the owning ids and the
+// worker's mailbox + done signal. Recreated by each Begin, torn down by Finalize.
+type saverSession struct {
+	voiceSessionID uuid.UUID
+	campaignID     uuid.UUID
+	tenantID       uuid.UUID
+	queue          chan Trigger
+	done           chan struct{} // closed when the worker goroutine exits
+}
+
+// NewSaver builds a Saver over the storage + blob + job-enqueue seams.
+func NewSaver(store Store, blobs blob.Store, enqueue JobEnqueuer, log *slog.Logger) *Saver {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Saver{store: store, blobs: blobs, enqueue: enqueue, log: log}
+}
+
+// Begin binds the Saver to a new Voice Session and starts its worker goroutine.
+// The Manager calls it at Start, before any trigger can fire. A Begin while a
+// prior session is still bound (a missing Finalize) replaces the binding after
+// tearing the old worker down — defensive; the normal path is Finalize then Begin.
+func (s *Saver) Begin(voiceSessionID, campaignID, tenantID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sess != nil {
+		close(s.sess.queue)
+		old := s.sess
+		s.sess = nil
+		go func() { <-old.done }() // reap without blocking Begin
+	}
+	ss := &saverSession{
+		voiceSessionID: voiceSessionID,
+		campaignID:     campaignID,
+		tenantID:       tenantID,
+		queue:          make(chan Trigger, saveQueue),
+		done:           make(chan struct{}),
+	}
+	s.sess = ss
+	go s.worker(ss)
+}
+
+// HandleTrigger is the [Sink] impl: a non-blocking hand-off to the bound
+// session's worker. It runs on the detector's worker goroutine, so it never does
+// I/O inline and never blocks — a full mailbox drops the trigger and logs, and a
+// trigger arriving with no session bound (a detector outliving Finalize) is
+// likewise dropped. Guarded by mu so a concurrent Finalize can never close the
+// queue mid-send.
+func (s *Saver) HandleTrigger(t Trigger) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ss := s.sess
+	if ss == nil {
+		s.log.Warn("highlight saver: trigger with no bound session, dropping", "score", t.Score)
+		return
+	}
+	select {
+	case ss.queue <- t:
+	default:
+		s.log.Warn("highlight saver: save queue full, dropping trigger", "score", t.Score)
+	}
+}
+
+// Finalize drains the bound session's worker (a flush barrier: it closes the
+// mailbox and waits for the worker to finish every queued trigger), then
+// schedules the 7-day candidate purge job and unbinds. The Manager calls it at
+// EVERY loop exit beside transcript.Finalize (Stop, self-exit, Shutdown), so a
+// session's candidates always get a purge horizon. Idle (no bound session) is a
+// no-op. A ctx timeout during the drain returns the error (the Manager logs it)
+// and the purge is NOT scheduled — the boot sweep is the backstop.
+func (s *Saver) Finalize(ctx context.Context) error {
+	s.mu.Lock()
+	ss := s.sess
+	s.sess = nil
+	s.mu.Unlock()
+	if ss == nil {
+		return nil
+	}
+
+	// Flush barrier: no more sends can happen (sess is nil, HandleTrigger drops),
+	// so closing the mailbox lets the worker drain every buffered trigger and exit.
+	close(ss.queue)
+	select {
+	case <-ss.done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Schedule the candidate purge 7 days out (ADR-0051). At-least-once + idempotent
+	// (ADR-0049): the handler blob-deletes then row-deletes remaining candidates.
+	payload := purgePayload{VoiceSessionID: ss.voiceSessionID}
+	if err := s.enqueue.Enqueue(ctx, JobKindPurgeCandidates, payload, time.Now().Add(purgeDelay)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// worker is the per-session goroutine: it serially saves each queued trigger and
+// exits when the mailbox is closed (Finalize's barrier). A save failure logs and
+// is dropped so one bad trigger never stops the drain.
+func (s *Saver) worker(ss *saverSession) {
+	defer close(ss.done)
+	for t := range ss.queue {
+		s.save(ss, t)
+	}
+}
+
+// save encodes one trigger's tape snapshot to a WAV clip, stores it behind the
+// blob seam, and writes the 'candidate' highlight row. The blob key is
+// deterministic (blob.Key) so the row and its clip agree and the delete hook can
+// reconstruct it. Any step failing logs and returns — best-effort durability.
+func (s *Saver) save(ss *saverSession, t Trigger) {
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
+
+	highlightID := uuid.New()
+	key, err := blob.Key(ss.tenantID, "highlight", highlightID, "clip.wav")
+	if err != nil {
+		s.log.Error("highlight saver: build clip key", "err", err)
+		return
+	}
+	wav, err := mixdown.WAVClip(t.Snapshot, mixdown.Options{})
+	if err != nil {
+		s.log.Error("highlight saver: encode clip", "err", err, "voice_session", ss.voiceSessionID)
+		return
+	}
+	if err := s.blobs.Put(ctx, key, "audio/wav", bytes.NewReader(wav), int64(len(wav))); err != nil {
+		s.log.Error("highlight saver: store clip", "err", err, "voice_session", ss.voiceSessionID)
+		return
+	}
+	h := storage.Highlight{
+		ID:              highlightID,
+		TenantID:        ss.tenantID,
+		VoiceSessionID:  ss.voiceSessionID,
+		CampaignID:      ss.campaignID,
+		Status:          storage.HighlightCandidate,
+		StartsAt:        t.From,
+		EndsAt:          t.To,
+		Score:           t.Score,
+		Excerpt:         t.Excerpt,
+		Reason:          t.Reason,
+		SpeakerIDs:      t.SpeakerIDs,
+		ClipKey:         key,
+		ClipContentType: "audio/wav",
+		ClipSizeBytes:   int64(len(wav)),
+	}
+	if err := s.store.CreateHighlight(ctx, h); err != nil {
+		s.log.Error("highlight saver: create highlight row", "err", err, "voice_session", ss.voiceSessionID)
+		return
+	}
+	s.log.Info("highlight saved", "voice_session", ss.voiceSessionID, "highlight", highlightID, "score", t.Score)
+}

--- a/internal/highlight/saver_test.go
+++ b/internal/highlight/saver_test.go
@@ -44,10 +44,11 @@ func (f *fakeHighlightStore) count() int {
 // fakeBlobs is an in-memory blob.Store. put can be gated on a channel to hold the
 // worker; putErr forces a Put failure.
 type fakeBlobs struct {
-	mu     sync.Mutex
-	data   map[string][]byte
-	gate   chan struct{} // if non-nil, Put blocks until a receive
-	putErr error
+	mu        sync.Mutex
+	data      map[string][]byte
+	gate      chan struct{} // if non-nil, Put blocks until a receive
+	putErr    error
+	deleteErr error // if set, Delete returns it (blob-backend failure)
 }
 
 func newFakeBlobs() *fakeBlobs { return &fakeBlobs{data: map[string][]byte{}} }
@@ -79,6 +80,9 @@ func (f *fakeBlobs) Get(_ context.Context, key string) (io.ReadCloser, blob.Meta
 func (f *fakeBlobs) Delete(_ context.Context, key string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	delete(f.data, key)
 	return nil
 }
@@ -188,6 +192,33 @@ func TestSaver_Finalize_SchedulesPurge(t *testing.T) {
 	}
 }
 
+func TestSaver_Finalize_DrainTimeoutStillEnqueues(t *testing.T) {
+	saver, _, blobs, enq := newTestSaver(t)
+	blobs.gate = make(chan struct{}) // hold the worker inside Put so the drain can't finish
+	defer close(blobs.gate)          // release on test exit so the worker goroutine can reap
+
+	vsID := uuid.New()
+	saver.Begin(vsID, uuid.New(), uuid.New())
+	saver.HandleTrigger(newTrigger()) // the worker will block on the gated Put
+
+	// A ctx that is already effectively expired: the drain times out.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	err := saver.Finalize(ctx)
+	if err == nil {
+		t.Fatalf("want a drain-timeout error, got nil")
+	}
+	// Drain timing out must NOT lose the purge horizon: the purge is still scheduled
+	// off the captured session id (the boot sweep is a backstop, not the only path).
+	if enq.calls != 1 || enq.kind != JobKindPurgeCandidates {
+		t.Fatalf("drain timeout skipped purge scheduling: calls=%d kind=%q", enq.calls, enq.kind)
+	}
+	p, ok := enq.payload.(purgePayload)
+	if !ok || p.VoiceSessionID != vsID {
+		t.Fatalf("purge payload wrong after drain timeout: %#v", enq.payload)
+	}
+}
+
 func TestSaver_Finalize_IdleNoop(t *testing.T) {
 	saver, _, _, enq := newTestSaver(t)
 	if err := saver.Finalize(context.Background()); err != nil {
@@ -233,16 +264,22 @@ func TestSaver_HandleTrigger_NonBlockingDropsWhenFull(t *testing.T) {
 }
 
 func TestSaver_WorkerFailureSurvives(t *testing.T) {
-	saver, store, _, _ := newTestSaver(t)
+	saver, store, blobs, _ := newTestSaver(t)
 	store.failNext = true // first CreateHighlight fails
 
 	saver.Begin(uuid.New(), uuid.New(), uuid.New())
-	saver.HandleTrigger(newTrigger()) // fails at CreateHighlight
+	saver.HandleTrigger(newTrigger()) // Put ok, then CreateHighlight fails
 	saver.HandleTrigger(newTrigger()) // must still be processed
 	if err := saver.Finalize(context.Background()); err != nil {
 		t.Fatalf("finalize: %v", err)
 	}
 	if store.count() != 1 {
 		t.Fatalf("worker did not survive a failed save: got %d rows", store.count())
+	}
+	// The failed save's clip must be compensated away (ADR-0048): a blob.Put that
+	// succeeds followed by a CreateHighlight that fails leaves NO orphan blob, so only
+	// the one successfully-rowed clip remains.
+	if blobs.keys() != 1 {
+		t.Fatalf("orphan clip not cleaned after row-create failure: %d clips left", blobs.keys())
 	}
 }

--- a/internal/highlight/saver_test.go
+++ b/internal/highlight/saver_test.go
@@ -1,0 +1,248 @@
+package highlight
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+)
+
+// fakeHighlightStore records created highlights and can be told to fail.
+type fakeHighlightStore struct {
+	mu       sync.Mutex
+	created  []storage.Highlight
+	failNext bool
+}
+
+func (f *fakeHighlightStore) CreateHighlight(_ context.Context, h storage.Highlight) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNext {
+		f.failNext = false
+		return errors.New("boom")
+	}
+	f.created = append(f.created, h)
+	return nil
+}
+
+func (f *fakeHighlightStore) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.created)
+}
+
+// fakeBlobs is an in-memory blob.Store. put can be gated on a channel to hold the
+// worker; putErr forces a Put failure.
+type fakeBlobs struct {
+	mu     sync.Mutex
+	data   map[string][]byte
+	gate   chan struct{} // if non-nil, Put blocks until a receive
+	putErr error
+}
+
+func newFakeBlobs() *fakeBlobs { return &fakeBlobs{data: map[string][]byte{}} }
+
+func (f *fakeBlobs) Put(_ context.Context, key, _ string, r io.Reader, _ int64) error {
+	if f.gate != nil {
+		<-f.gate
+	}
+	if f.putErr != nil {
+		return f.putErr
+	}
+	b, _ := io.ReadAll(r)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key] = b
+	return nil
+}
+
+func (f *fakeBlobs) Get(_ context.Context, key string) (io.ReadCloser, blob.Meta, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b, ok := f.data[key]
+	if !ok {
+		return nil, blob.Meta{}, blob.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(b)), blob.Meta{ContentType: "audio/wav", Size: int64(len(b))}, nil
+}
+
+func (f *fakeBlobs) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, key)
+	return nil
+}
+
+func (f *fakeBlobs) keys() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.data)
+}
+
+// fakeEnqueuer records the last enqueued job.
+type fakeEnqueuer struct {
+	mu       sync.Mutex
+	kind     string
+	payload  any
+	runAfter time.Time
+	calls    int
+}
+
+func (f *fakeEnqueuer) Enqueue(_ context.Context, kind string, payload any, runAfter time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.kind = kind
+	f.payload = payload
+	f.runAfter = runAfter
+	f.calls++
+	return nil
+}
+
+func newTrigger() Trigger {
+	t0 := time.Now()
+	return Trigger{
+		At:         t0,
+		From:       t0.Add(-15 * time.Second),
+		To:         t0.Add(5 * time.Second),
+		Score:      9.5,
+		SpeakerIDs: []string{"111", "222"},
+		Excerpt:    "natural 20 against the dragon",
+		Reason:     "critical hit",
+		Snapshot:   tape.Snapshot{From: t0.Add(-15 * time.Second), To: t0.Add(5 * time.Second)},
+	}
+}
+
+func newTestSaver(t *testing.T) (*Saver, *fakeHighlightStore, *fakeBlobs, *fakeEnqueuer) {
+	t.Helper()
+	store := &fakeHighlightStore{}
+	blobs := newFakeBlobs()
+	enq := &fakeEnqueuer{}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewSaver(store, blobs, enq, log), store, blobs, enq
+}
+
+func TestSaver_HandleTrigger_ClipAndRow(t *testing.T) {
+	saver, store, blobs, _ := newTestSaver(t)
+	vsID, campID, tenID := uuid.New(), uuid.New(), uuid.New()
+
+	saver.Begin(vsID, campID, tenID)
+	saver.HandleTrigger(newTrigger())
+	if err := saver.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	if store.count() != 1 {
+		t.Fatalf("want 1 highlight row, got %d", store.count())
+	}
+	h := store.created[0]
+	if h.Status != storage.HighlightCandidate {
+		t.Fatalf("want candidate status, got %q", h.Status)
+	}
+	if h.VoiceSessionID != vsID || h.CampaignID != campID || h.TenantID != tenID {
+		t.Fatalf("owning ids not threaded: %+v", h)
+	}
+	if h.Excerpt != "natural 20 against the dragon" || h.Score != 9.5 {
+		t.Fatalf("caption fields not threaded: %+v", h)
+	}
+	if h.ClipSizeBytes == 0 {
+		t.Fatalf("clip size not recorded")
+	}
+	if blobs.keys() != 1 {
+		t.Fatalf("want 1 stored clip, got %d", blobs.keys())
+	}
+	if _, ok := blobs.data[h.ClipKey]; !ok {
+		t.Fatalf("row clip_key %q has no stored blob", h.ClipKey)
+	}
+}
+
+func TestSaver_Finalize_SchedulesPurge(t *testing.T) {
+	saver, _, _, enq := newTestSaver(t)
+	vsID := uuid.New()
+
+	saver.Begin(vsID, uuid.New(), uuid.New())
+	before := time.Now().Add(purgeDelay)
+	if err := saver.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	after := time.Now().Add(purgeDelay)
+
+	if enq.calls != 1 || enq.kind != JobKindPurgeCandidates {
+		t.Fatalf("want one purge enqueue, got calls=%d kind=%q", enq.calls, enq.kind)
+	}
+	if enq.runAfter.Before(before) || enq.runAfter.After(after.Add(time.Second)) {
+		t.Fatalf("purge run_after %v not ~7d out", enq.runAfter)
+	}
+	p, ok := enq.payload.(purgePayload)
+	if !ok || p.VoiceSessionID != vsID {
+		t.Fatalf("purge payload wrong: %#v", enq.payload)
+	}
+}
+
+func TestSaver_Finalize_IdleNoop(t *testing.T) {
+	saver, _, _, enq := newTestSaver(t)
+	if err := saver.Finalize(context.Background()); err != nil {
+		t.Fatalf("idle finalize: %v", err)
+	}
+	if enq.calls != 0 {
+		t.Fatalf("idle finalize scheduled a purge")
+	}
+}
+
+func TestSaver_HandleTrigger_NonBlockingDropsWhenFull(t *testing.T) {
+	saver, store, blobs, _ := newTestSaver(t)
+	blobs.gate = make(chan struct{}) // hold the worker inside the first Put
+
+	saver.Begin(uuid.New(), uuid.New(), uuid.New())
+
+	// Push far more than the mailbox holds; none of these must block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < saveQueue+64; i++ {
+			saver.HandleTrigger(newTrigger())
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleTrigger blocked when the queue was full")
+	}
+
+	// Release the worker and let it drain the buffered triggers.
+	close(blobs.gate)
+	if err := saver.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	// At most one in-flight + saveQueue buffered ever get saved; the rest dropped.
+	if store.count() > saveQueue+1 {
+		t.Fatalf("saved %d, expected the overflow to be dropped (<= %d)", store.count(), saveQueue+1)
+	}
+	if store.count() == 0 {
+		t.Fatalf("nothing saved at all")
+	}
+}
+
+func TestSaver_WorkerFailureSurvives(t *testing.T) {
+	saver, store, _, _ := newTestSaver(t)
+	store.failNext = true // first CreateHighlight fails
+
+	saver.Begin(uuid.New(), uuid.New(), uuid.New())
+	saver.HandleTrigger(newTrigger()) // fails at CreateHighlight
+	saver.HandleTrigger(newTrigger()) // must still be processed
+	if err := saver.Finalize(context.Background()); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if store.count() != 1 {
+		t.Fatalf("worker did not survive a failed save: got %d rows", store.count())
+	}
+}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -53,6 +53,11 @@ type campaignStore interface {
 	ArchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
 	UnarchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
 	DeleteCampaign(ctx context.Context, id uuid.UUID) error
+	// DeleteCampaignWithJob hard-deletes AND enqueues a follow-up job atomically
+	// (#308): the campaign hard delete uses it to schedule the Highlight-clip blob
+	// sweep in the delete's own transaction, so the sweep exists iff the delete
+	// committed (no orphan sweep of a surviving campaign, no lost sweep on a crash).
+	DeleteCampaignWithJob(ctx context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error
 	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
 	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
 	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -104,6 +104,29 @@ type CampaignServer struct {
 	// re-resolves future lines with the new mapping. Nil disables (feature off / no
 	// live resolver); set once at boot before serving.
 	speakerInv SpeakerInvalidator
+	// clips sweeps a campaign's Session Highlight clips out of blob storage on hard
+	// delete (#308, ADR-0048): highlight rows cascade with the campaign, but the
+	// clip blobs have NO FK and must be dropped through the seam. Nil disables the
+	// sweep (web-only / no blob backend); set once at boot before serving.
+	clips HighlightClipSweeper
+}
+
+// HighlightClipSweeper drops a campaign's Session Highlight clips through the blob
+// seam on hard delete (#308, ADR-0048). main.go wires it over
+// storage.ListCampaignHighlightClipKeys + blob.Delete. The keys are listed BEFORE
+// the campaign row delete (which cascades the highlight rows away) and the blobs
+// are dropped AFTER the delete succeeds, so a refused delete never orphans a live
+// campaign's clips.
+type HighlightClipSweeper interface {
+	CampaignClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error)
+	DeleteClip(ctx context.Context, key string) error
+}
+
+// SetHighlightClipSweeper wires the highlight-clip blob sweep the campaign hard
+// delete runs (#308). Called once at boot before serving; nil leaves the sweep
+// off (the highlight rows still cascade, only their blobs would linger).
+func (s *CampaignServer) SetHighlightClipSweeper(sw HighlightClipSweeper) {
+	s.clips = sw
 }
 
 // SpeakerInvalidator drops a campaign's cached speaker→name resolutions. The live

--- a/internal/rpc/campaign_archive.go
+++ b/internal/rpc/campaign_archive.go
@@ -110,6 +110,20 @@ func (s *CampaignServer) DeleteCampaign(
 		return nil, err
 	}
 
+	// Capture the campaign's Highlight clip keys BEFORE the delete — the row cascade
+	// removes the highlight rows, after which they can't be listed (#308, ADR-0048).
+	// The blobs themselves are dropped only AFTER the delete succeeds, so a refused
+	// delete (not archived / not found) never orphans a live campaign's clips.
+	var clipKeys []string
+	if s.clips != nil {
+		keys, err := s.clips.CampaignClipKeys(ctx, id)
+		if err != nil {
+			slog.Default().Error("DeleteCampaign: list highlight clip keys failed", "campaign_id", id, "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		clipKeys = keys
+	}
+
 	if err := s.store.DeleteCampaign(ctx, id); err != nil {
 		switch {
 		case errors.Is(err, storage.ErrNotFound):
@@ -119,6 +133,15 @@ func (s *CampaignServer) DeleteCampaign(
 		default:
 			slog.Default().Error("DeleteCampaign: store delete failed", "campaign_id", id, "err", err)
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	// The rows are gone (cascade); drop their clips through the seam. Best-effort:
+	// a blob-delete failure here leaves an orphan blob but the campaign is already
+	// deleted, so it logs rather than failing the RPC (idempotent Delete anyway).
+	for _, k := range clipKeys {
+		if err := s.clips.DeleteClip(ctx, k); err != nil {
+			slog.Default().Warn("DeleteCampaign: highlight clip left orphaned", "campaign_id", id, "key", k, "err", err)
 		}
 	}
 	return connect.NewResponse(&managementv1.DeleteCampaignResponse{}), nil

--- a/internal/rpc/campaign_archive.go
+++ b/internal/rpc/campaign_archive.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -112,8 +113,6 @@ func (s *CampaignServer) DeleteCampaign(
 
 	// Capture the campaign's Highlight clip keys BEFORE the delete — the row cascade
 	// removes the highlight rows, after which they can't be listed (#308, ADR-0048).
-	// The blobs themselves are dropped only AFTER the delete succeeds, so a refused
-	// delete (not archived / not found) never orphans a live campaign's clips.
 	var clipKeys []string
 	if s.clips != nil {
 		keys, err := s.clips.CampaignClipKeys(ctx, id)
@@ -124,24 +123,41 @@ func (s *CampaignServer) DeleteCampaign(
 		clipKeys = keys
 	}
 
-	if err := s.store.DeleteCampaign(ctx, id); err != nil {
+	// The blob sweep is a DURABLE job enqueued in the delete's OWN transaction
+	// (#308, ADR-0049): it exists iff the delete committed, so a refused delete never
+	// schedules a sweep of a surviving campaign's clips, and a crash right after the
+	// delete never loses the sweep. With no clips there is nothing to sweep, so the
+	// plain delete runs. The inline best-effort sweep below is a fast-path; the job is
+	// the backstop that guarantees eventual cleanup.
+	var deleteErr error
+	if len(clipKeys) > 0 {
+		payload, merr := highlight.MarshalCampaignSweep(clipKeys)
+		if merr != nil {
+			slog.Default().Error("DeleteCampaign: marshal clip sweep payload failed", "campaign_id", id, "err", merr)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		deleteErr = s.store.DeleteCampaignWithJob(ctx, id, highlight.JobKindSweepCampaignClips, payload)
+	} else {
+		deleteErr = s.store.DeleteCampaign(ctx, id)
+	}
+	if deleteErr != nil {
 		switch {
-		case errors.Is(err, storage.ErrNotFound):
+		case errors.Is(deleteErr, storage.ErrNotFound):
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("campaign not found"))
-		case errors.Is(err, storage.ErrNotArchived):
+		case errors.Is(deleteErr, storage.ErrNotArchived):
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("campaign must be archived before deletion"))
 		default:
-			slog.Default().Error("DeleteCampaign: store delete failed", "campaign_id", id, "err", err)
+			slog.Default().Error("DeleteCampaign: store delete failed", "campaign_id", id, "err", deleteErr)
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
 	}
 
-	// The rows are gone (cascade); drop their clips through the seam. Best-effort:
-	// a blob-delete failure here leaves an orphan blob but the campaign is already
-	// deleted, so it logs rather than failing the RPC (idempotent Delete anyway).
+	// Fast-path: the rows are gone (cascade); drop their clips through the seam now so
+	// storage reclaims immediately. Best-effort — a failure here logs and leaves the
+	// blob for the durable sweep job (idempotent Delete), never failing the RPC.
 	for _, k := range clipKeys {
 		if err := s.clips.DeleteClip(ctx, k); err != nil {
-			slog.Default().Warn("DeleteCampaign: highlight clip left orphaned", "campaign_id", id, "key", k, "err", err)
+			slog.Default().Warn("DeleteCampaign: highlight clip sweep deferred to job", "campaign_id", id, "key", k, "err", err)
 		}
 	}
 	return connect.NewResponse(&managementv1.DeleteCampaignResponse{}), nil

--- a/internal/rpc/campaign_archive_test.go
+++ b/internal/rpc/campaign_archive_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -184,6 +186,57 @@ func TestDeleteCampaign_SweepsHighlightClips(t *testing.T) {
 	}
 	if len(sweeper.deleted) != 2 || sweeper.deleted[0] != "k1" || sweeper.deleted[1] != "k2" {
 		t.Fatalf("clips not swept: %v", sweeper.deleted)
+	}
+}
+
+// TestDeleteCampaign_EnqueuesDurableClipSweep: a hard delete enqueues the durable
+// blob-sweep job carrying the listed clip keys, in the delete's own transaction
+// (#308, ADR-0049) — the backstop that survives a crash after the row cascade.
+func TestDeleteCampaign_EnqueuesDurableClipSweep(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	sweeper := &fakeClipSweeper{keys: []string{"k1", "k2"}}
+	srv := rpc.NewCampaignServer(store)
+	srv.SetHighlightClipSweeper(sweeper)
+
+	if _, err := srv.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteCampaign: %v", err)
+	}
+	if store.deleteJobKind != highlight.JobKindSweepCampaignClips {
+		t.Fatalf("durable sweep job not enqueued: kind=%q", store.deleteJobKind)
+	}
+	// The payload must carry exactly the listed clip keys.
+	var p struct {
+		ClipKeys []string `json:"clip_keys"`
+	}
+	if err := json.Unmarshal(store.deleteJobPayload, &p); err != nil {
+		t.Fatalf("sweep payload not JSON: %v", err)
+	}
+	if len(p.ClipKeys) != 2 || p.ClipKeys[0] != "k1" || p.ClipKeys[1] != "k2" {
+		t.Fatalf("sweep payload keys = %v, want [k1 k2]", p.ClipKeys)
+	}
+}
+
+// TestDeleteCampaign_NoClipsNoJob: a campaign with no highlight clips takes the
+// plain delete path (no sweep job to enqueue).
+func TestDeleteCampaign_NoClipsNoJob(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	sweeper := &fakeClipSweeper{} // no keys
+	srv := rpc.NewCampaignServer(store)
+	srv.SetHighlightClipSweeper(sweeper)
+
+	if _, err := srv.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()})); err != nil {
+		t.Fatalf("DeleteCampaign: %v", err)
+	}
+	if store.deleteJobKind != "" {
+		t.Fatalf("no-clip delete should enqueue no job, got kind=%q", store.deleteJobKind)
+	}
+	if len(store.deleteCalls) != 1 {
+		t.Fatalf("campaign not deleted: %+v", store.deleteCalls)
 	}
 }
 

--- a/internal/rpc/campaign_archive_test.go
+++ b/internal/rpc/campaign_archive_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -142,6 +143,67 @@ func TestDeleteCampaign_HappyPath(t *testing.T) {
 	}
 	if len(store.deleteCalls) != 1 || store.deleteCalls[0] != id {
 		t.Errorf("delete calls = %+v, want [%s]", store.deleteCalls, id)
+	}
+}
+
+// fakeClipSweeper records the highlight-clip sweep a campaign hard delete runs.
+type fakeClipSweeper struct {
+	keys    []string
+	deleted []string
+	listErr error
+}
+
+func (f *fakeClipSweeper) CampaignClipKeys(context.Context, uuid.UUID) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.keys, nil
+}
+
+func (f *fakeClipSweeper) DeleteClip(_ context.Context, key string) error {
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
+// TestDeleteCampaign_SweepsHighlightClips: a successful hard delete drops every
+// highlight clip through the blob seam (#308, ADR-0048).
+func TestDeleteCampaign_SweepsHighlightClips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	id := uuid.New()
+	sweeper := &fakeClipSweeper{keys: []string{"k1", "k2"}}
+	srv := rpc.NewCampaignServer(store)
+	srv.SetHighlightClipSweeper(sweeper)
+
+	if _, err := srv.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: id.String()})); err != nil {
+		t.Fatalf("DeleteCampaign: %v", err)
+	}
+	if len(store.deleteCalls) != 1 {
+		t.Fatalf("campaign not deleted: %+v", store.deleteCalls)
+	}
+	if len(sweeper.deleted) != 2 || sweeper.deleted[0] != "k1" || sweeper.deleted[1] != "k2" {
+		t.Fatalf("clips not swept: %v", sweeper.deleted)
+	}
+}
+
+// TestDeleteCampaign_RefusedKeepsClips: a refused delete (not archived) must NOT
+// drop any clips (the campaign is still live).
+func TestDeleteCampaign_RefusedKeepsClips(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.deleteCampaignErr = storage.ErrNotArchived
+	sweeper := &fakeClipSweeper{keys: []string{"k1"}}
+	srv := rpc.NewCampaignServer(store)
+	srv.SetHighlightClipSweeper(sweeper)
+
+	_, err := srv.DeleteCampaign(context.Background(),
+		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("want FailedPrecondition, got %v", err)
+	}
+	if len(sweeper.deleted) != 0 {
+		t.Fatalf("refused delete swept clips: %v", sweeper.deleted)
 	}
 }
 

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -71,6 +71,8 @@ type fakeCampaignStore struct {
 	unarchiveErr      error
 	deleteCalls       []uuid.UUID
 	deleteCampaignErr error
+	deleteJobKind     string // the follow-up job kind DeleteCampaignWithJob enqueued (#308)
+	deleteJobPayload  []byte // the follow-up job payload (the clip keys to sweep)
 	// listNodesCampaign/searchNodesCampaign record the campaign id ListNodes /
 	// SearchNodes resolved so the scope precedence can be asserted (#222).
 	listNodesCampaign   uuid.UUID
@@ -275,6 +277,18 @@ func (f *fakeCampaignStore) UnarchiveCampaign(_ context.Context, id uuid.UUID) (
 func (f *fakeCampaignStore) DeleteCampaign(_ context.Context, id uuid.UUID) error {
 	f.deleteCalls = append(f.deleteCalls, id)
 	return f.deleteCampaignErr
+}
+
+func (f *fakeCampaignStore) DeleteCampaignWithJob(_ context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error {
+	f.deleteCalls = append(f.deleteCalls, id)
+	if f.deleteCampaignErr != nil {
+		// Delete refused inside the tx: nothing committed, so no job is recorded — the
+		// real store enqueues in the SAME tx that rolls back.
+		return f.deleteCampaignErr
+	}
+	f.deleteJobKind = jobKind
+	f.deleteJobPayload = jobPayload
+	return nil
 }
 
 func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -77,6 +77,9 @@ func (fakeReader) UnarchiveCampaign(context.Context, uuid.UUID) (storage.Campaig
 func (fakeReader) DeleteCampaign(context.Context, uuid.UUID) error {
 	return nil
 }
+func (fakeReader) DeleteCampaignWithJob(context.Context, uuid.UUID, string, []byte) error {
+	return nil
+}
 
 // The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
 // tests; stub it so fakeReader still satisfies the widened interface. The CRUD

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -15,10 +15,38 @@ import (
 // Session Highlights RPCs (#308, Epic 8) on SessionService: List/Get read the
 // tenant's highlights, Promote keeps a candidate past the 7-day purge, Delete
 // drops a highlight and its clip (blob-then-row, ADR-0048). Every method is
-// tenant-scoped server-side (ADR-0039) — the client never supplies a tenant, and
-// a foreign/unknown id is CodeNotFound (existence never leaked, the SetAgentMute
-// posture). PromoteHighlight deliberately does NOT enqueue enrichment; that is
-// #311's hook.
+// tenant-scoped AND Active-Campaign-scoped server-side (ADR-0039, #342/#353/#356):
+// the client never supplies a tenant, the Campaign is resolved server-side (live
+// Voice Session first, else the profile-first durable selection), and a highlight
+// (or session) belonging to ANOTHER campaign is CodeNotFound — existence never
+// leaked, exactly the GenerateRecap "names nothing" posture. PromoteHighlight
+// deliberately does NOT enqueue enrichment; that is #311's hook.
+
+// errNoSuchHighlight is the single static NotFound every Highlight RPC returns for
+// a foreign-tenant, cross-campaign, unknown, or unparsable id — so a probe can
+// never learn whether an id it does not own exists (mirrors SetAgentMute /
+// GenerateRecap).
+func errNoSuchHighlight() *connect.Error {
+	return connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
+}
+
+// activeCampaignForHighlight resolves the Active Campaign every Highlight RPC scopes
+// to (the SAME searchCampaign policy the other reads use: live Voice Session first,
+// else the profile-first durable selection). A resolve failure is CodeInternal; NO
+// active campaign is treated as "the id names nothing" — the static NotFound — so
+// the scoping check has a campaign to compare against without leaking a distinct
+// error.
+func (s *SessionServer) activeCampaignForHighlight(ctx context.Context) (uuid.UUID, error) {
+	campaignID, ok, err := s.searchCampaign(ctx)
+	if err != nil {
+		s.log.Error("Highlights: resolve active campaign failed", "err", err)
+		return uuid.Nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if !ok {
+		return uuid.Nil, errNoSuchHighlight()
+	}
+	return campaignID, nil
+}
 
 // HighlightStore is the storage surface the Highlight RPCs need; *storage.Store
 // satisfies it. Every method is tenant-scoped.
@@ -54,10 +82,12 @@ func (s *SessionServer) highlightsEnabled() error {
 	return nil
 }
 
-// ListHighlights returns the tenant's Highlights for one Voice Session, newest
-// moment first (#308). The voice_session_id is client-supplied but the read is
-// tenant-scoped, so it can only ever surface the operator's own highlights. An
-// unparsable id is CodeInvalidArgument; a session with none yields an empty list.
+// ListHighlights returns the tenant's Highlights for one Voice Session in the
+// Active Campaign, newest moment first (#308). The Campaign is resolved server-side
+// and the Voice Session MUST belong to it: an unparsable id, an unknown session, or
+// a session in another campaign is CodeNotFound (it names nothing in the Active
+// Campaign — the GenerateRecap posture), never CodeInvalidArgument. A session it
+// owns with no highlights yields an empty list.
 func (s *SessionServer) ListHighlights(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListHighlightsRequest],
@@ -69,9 +99,27 @@ func (s *SessionServer) ListHighlights(
 	if err != nil {
 		return nil, err
 	}
-	sessionID, err := uuid.Parse(req.Msg.GetVoiceSessionId())
+	sessionID, perr := uuid.Parse(req.Msg.GetVoiceSessionId())
+	if perr != nil {
+		return nil, errNoSuchHighlight() // a non-UUID id names no session
+	}
+
+	campaignID, err := s.activeCampaignForHighlight(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid voice session id"))
+		return nil, err
+	}
+	// The session must belong to the Active Campaign, else it is cross-campaign and
+	// NotFound (existence never leaked) — the same ownership check GenerateRecap runs.
+	vs, gerr := s.store.GetVoiceSession(ctx, sessionID)
+	if errors.Is(gerr, storage.ErrNotFound) {
+		return nil, errNoSuchHighlight()
+	}
+	if gerr != nil {
+		s.log.Error("ListHighlights: load voice session failed", "err", gerr)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if vs.CampaignID != campaignID {
+		return nil, errNoSuchHighlight()
 	}
 
 	rows, err := s.highlights.ListHighlights(ctx, tenantID, sessionID)
@@ -86,9 +134,9 @@ func (s *SessionServer) ListHighlights(
 	return connect.NewResponse(&managementv1.ListHighlightsResponse{Highlights: out}), nil
 }
 
-// GetHighlight returns one Highlight by id, tenant-scoped (#308). A foreign or
-// unknown id is CodeNotFound (existence never leaked); an unparsable id is the
-// same NotFound (it names nothing).
+// GetHighlight returns one Highlight by id, tenant- AND Active-Campaign-scoped
+// (#308). A foreign-tenant, cross-campaign, unknown, or unparsable id is all the
+// same CodeNotFound (existence never leaked).
 func (s *SessionServer) GetHighlight(
 	ctx context.Context,
 	req *connect.Request[managementv1.GetHighlightRequest],
@@ -100,27 +148,34 @@ func (s *SessionServer) GetHighlight(
 	if err != nil {
 		return nil, err
 	}
-	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
-	id, err := uuid.Parse(req.Msg.GetId())
+	id, perr := uuid.Parse(req.Msg.GetId())
+	if perr != nil {
+		return nil, errNoSuchHighlight()
+	}
+	campaignID, err := s.activeCampaignForHighlight(ctx)
 	if err != nil {
-		return nil, notFound
+		return nil, err
 	}
 
 	h, err := s.highlights.GetHighlight(ctx, tenantID, id)
 	if errors.Is(err, storage.ErrNotFound) {
-		return nil, notFound
+		return nil, errNoSuchHighlight()
 	}
 	if err != nil {
 		s.log.Error("GetHighlight: store get failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
+	if h.CampaignID != campaignID {
+		return nil, errNoSuchHighlight() // cross-campaign: never leak that it exists
+	}
 	return connect.NewResponse(&managementv1.GetHighlightResponse{Highlight: toProtoHighlight(h)}), nil
 }
 
-// PromoteHighlight flips a candidate Highlight to 'promoted' within the tenant
-// (#308/#309), returning the updated row. Idempotent on the server. A
-// foreign/unknown/unparsable id is CodeNotFound. It does NOT enqueue enrichment
-// (#311's hook).
+// PromoteHighlight flips a candidate Highlight to 'promoted' within the tenant and
+// Active Campaign (#308/#309), returning the updated row. Idempotent on the server.
+// A foreign-tenant, cross-campaign, unknown, or unparsable id is CodeNotFound. The
+// campaign ownership is checked BEFORE the mutation, so another campaign's row is
+// never promoted. It does NOT enqueue enrichment (#311's hook).
 func (s *SessionServer) PromoteHighlight(
 	ctx context.Context,
 	req *connect.Request[managementv1.PromoteHighlightRequest],
@@ -132,15 +187,31 @@ func (s *SessionServer) PromoteHighlight(
 	if err != nil {
 		return nil, err
 	}
-	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
-	id, err := uuid.Parse(req.Msg.GetId())
+	id, perr := uuid.Parse(req.Msg.GetId())
+	if perr != nil {
+		return nil, errNoSuchHighlight()
+	}
+	campaignID, err := s.activeCampaignForHighlight(ctx)
 	if err != nil {
-		return nil, notFound
+		return nil, err
+	}
+	// Load first to check campaign ownership BEFORE mutating — a cross-campaign row
+	// must never be promoted.
+	existing, gerr := s.highlights.GetHighlight(ctx, tenantID, id)
+	if errors.Is(gerr, storage.ErrNotFound) {
+		return nil, errNoSuchHighlight()
+	}
+	if gerr != nil {
+		s.log.Error("PromoteHighlight: load row failed", "err", gerr)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if existing.CampaignID != campaignID {
+		return nil, errNoSuchHighlight()
 	}
 
 	h, err := s.highlights.PromoteHighlight(ctx, tenantID, id)
 	if errors.Is(err, storage.ErrNotFound) {
-		return nil, notFound
+		return nil, errNoSuchHighlight()
 	}
 	if err != nil {
 		s.log.Error("PromoteHighlight: store promote failed", "err", err)
@@ -149,10 +220,12 @@ func (s *SessionServer) PromoteHighlight(
 	return connect.NewResponse(&managementv1.PromoteHighlightResponse{Highlight: toProtoHighlight(h)}), nil
 }
 
-// DeleteHighlight removes one Highlight and its clip within the tenant (#308).
-// Order is blob-then-row (ADR-0048): the row is loaded to read its clip_key, the
-// clip is dropped through the seam (idempotent — an absent clip still deletes the
-// row), then the row is removed. A foreign/unknown/unparsable id is CodeNotFound.
+// DeleteHighlight removes one Highlight and its clip within the tenant and Active
+// Campaign (#308). Order is blob-then-row (ADR-0048): the row is loaded to read its
+// clip_key AND check campaign ownership BEFORE removing anything, the clip is
+// dropped through the seam (idempotent — an absent clip still deletes the row), then
+// the row is removed. A foreign-tenant, cross-campaign, unknown, or unparsable id is
+// CodeNotFound with no side effects.
 func (s *SessionServer) DeleteHighlight(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteHighlightRequest],
@@ -164,21 +237,27 @@ func (s *SessionServer) DeleteHighlight(
 	if err != nil {
 		return nil, err
 	}
-	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
-	id, err := uuid.Parse(req.Msg.GetId())
+	id, perr := uuid.Parse(req.Msg.GetId())
+	if perr != nil {
+		return nil, errNoSuchHighlight()
+	}
+	campaignID, err := s.activeCampaignForHighlight(ctx)
 	if err != nil {
-		return nil, notFound
+		return nil, err
 	}
 
 	// Load the row first so we have the clip key BEFORE removing anything, and so a
-	// foreign/unknown id is NotFound without side effects.
+	// foreign-tenant / cross-campaign / unknown id is NotFound without side effects.
 	h, err := s.highlights.GetHighlight(ctx, tenantID, id)
 	if errors.Is(err, storage.ErrNotFound) {
-		return nil, notFound
+		return nil, errNoSuchHighlight()
 	}
 	if err != nil {
 		s.log.Error("DeleteHighlight: load row failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if h.CampaignID != campaignID {
+		return nil, errNoSuchHighlight() // cross-campaign: never delete, never leak existence
 	}
 
 	// Blob first (idempotent Delete): a missing clip must not block the row delete.
@@ -190,7 +269,7 @@ func (s *SessionServer) DeleteHighlight(
 	}
 	if _, err := s.highlights.DeleteHighlight(ctx, tenantID, id); err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, notFound
+			return nil, errNoSuchHighlight()
 		}
 		s.log.Error("DeleteHighlight: delete row failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -1,0 +1,224 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Session Highlights RPCs (#308, Epic 8) on SessionService: List/Get read the
+// tenant's highlights, Promote keeps a candidate past the 7-day purge, Delete
+// drops a highlight and its clip (blob-then-row, ADR-0048). Every method is
+// tenant-scoped server-side (ADR-0039) — the client never supplies a tenant, and
+// a foreign/unknown id is CodeNotFound (existence never leaked, the SetAgentMute
+// posture). PromoteHighlight deliberately does NOT enqueue enrichment; that is
+// #311's hook.
+
+// HighlightStore is the storage surface the Highlight RPCs need; *storage.Store
+// satisfies it. Every method is tenant-scoped.
+type HighlightStore interface {
+	ListHighlights(ctx context.Context, tenantID, voiceSessionID uuid.UUID) ([]storage.Highlight, error)
+	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
+	PromoteHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
+	DeleteHighlight(ctx context.Context, tenantID, id uuid.UUID) (string, error)
+}
+
+// highlightBlobs is the blob-seam surface DeleteHighlight needs (ADR-0048): drop
+// the clip before the row. *blob.Postgres satisfies it. Kept narrow so the RPC
+// package carries no import of the concrete backend.
+type highlightBlobs interface {
+	Delete(ctx context.Context, key string) error
+}
+
+// SetHighlights wires the Session Highlights read/mutate seam onto the
+// SessionServer (#308). Called once at boot after the store + blob backend are
+// built; the many NewSessionServer call sites keep their signature. Unwired, the
+// Highlight RPCs report CodeUnimplemented.
+func (s *SessionServer) SetHighlights(store HighlightStore, blobs highlightBlobs) {
+	s.highlights = store
+	s.blobs = blobs
+}
+
+// notWired is the CodeUnimplemented error a Highlight RPC returns when the server
+// was built without the highlight seam (web-standalone tests, keyless boots).
+func (s *SessionServer) highlightsEnabled() error {
+	if s.highlights == nil {
+		return connect.NewError(connect.CodeUnimplemented, errors.New("highlights are not enabled on this server"))
+	}
+	return nil
+}
+
+// ListHighlights returns the tenant's Highlights for one Voice Session, newest
+// moment first (#308). The voice_session_id is client-supplied but the read is
+// tenant-scoped, so it can only ever surface the operator's own highlights. An
+// unparsable id is CodeInvalidArgument; a session with none yields an empty list.
+func (s *SessionServer) ListHighlights(
+	ctx context.Context,
+	req *connect.Request[managementv1.ListHighlightsRequest],
+) (*connect.Response[managementv1.ListHighlightsResponse], error) {
+	if err := s.highlightsEnabled(); err != nil {
+		return nil, err
+	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sessionID, err := uuid.Parse(req.Msg.GetVoiceSessionId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid voice session id"))
+	}
+
+	rows, err := s.highlights.ListHighlights(ctx, tenantID, sessionID)
+	if err != nil {
+		s.log.Error("ListHighlights: store list failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	out := make([]*managementv1.Highlight, 0, len(rows))
+	for _, h := range rows {
+		out = append(out, toProtoHighlight(h))
+	}
+	return connect.NewResponse(&managementv1.ListHighlightsResponse{Highlights: out}), nil
+}
+
+// GetHighlight returns one Highlight by id, tenant-scoped (#308). A foreign or
+// unknown id is CodeNotFound (existence never leaked); an unparsable id is the
+// same NotFound (it names nothing).
+func (s *SessionServer) GetHighlight(
+	ctx context.Context,
+	req *connect.Request[managementv1.GetHighlightRequest],
+) (*connect.Response[managementv1.GetHighlightResponse], error) {
+	if err := s.highlightsEnabled(); err != nil {
+		return nil, err
+	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, notFound
+	}
+
+	h, err := s.highlights.GetHighlight(ctx, tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, notFound
+	}
+	if err != nil {
+		s.log.Error("GetHighlight: store get failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.GetHighlightResponse{Highlight: toProtoHighlight(h)}), nil
+}
+
+// PromoteHighlight flips a candidate Highlight to 'promoted' within the tenant
+// (#308/#309), returning the updated row. Idempotent on the server. A
+// foreign/unknown/unparsable id is CodeNotFound. It does NOT enqueue enrichment
+// (#311's hook).
+func (s *SessionServer) PromoteHighlight(
+	ctx context.Context,
+	req *connect.Request[managementv1.PromoteHighlightRequest],
+) (*connect.Response[managementv1.PromoteHighlightResponse], error) {
+	if err := s.highlightsEnabled(); err != nil {
+		return nil, err
+	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, notFound
+	}
+
+	h, err := s.highlights.PromoteHighlight(ctx, tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, notFound
+	}
+	if err != nil {
+		s.log.Error("PromoteHighlight: store promote failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.PromoteHighlightResponse{Highlight: toProtoHighlight(h)}), nil
+}
+
+// DeleteHighlight removes one Highlight and its clip within the tenant (#308).
+// Order is blob-then-row (ADR-0048): the row is loaded to read its clip_key, the
+// clip is dropped through the seam (idempotent — an absent clip still deletes the
+// row), then the row is removed. A foreign/unknown/unparsable id is CodeNotFound.
+func (s *SessionServer) DeleteHighlight(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteHighlightRequest],
+) (*connect.Response[managementv1.DeleteHighlightResponse], error) {
+	if err := s.highlightsEnabled(); err != nil {
+		return nil, err
+	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	notFound := connect.NewError(connect.CodeNotFound, errors.New("no such highlight"))
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, notFound
+	}
+
+	// Load the row first so we have the clip key BEFORE removing anything, and so a
+	// foreign/unknown id is NotFound without side effects.
+	h, err := s.highlights.GetHighlight(ctx, tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, notFound
+	}
+	if err != nil {
+		s.log.Error("DeleteHighlight: load row failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Blob first (idempotent Delete): a missing clip must not block the row delete.
+	if s.blobs != nil {
+		if err := s.blobs.Delete(ctx, h.ClipKey); err != nil {
+			s.log.Error("DeleteHighlight: delete clip failed", "err", err, "highlight", id)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+	if _, err := s.highlights.DeleteHighlight(ctx, tenantID, id); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, notFound
+		}
+		s.log.Error("DeleteHighlight: delete row failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.DeleteHighlightResponse{}), nil
+}
+
+// toProtoHighlight maps a storage.Highlight onto its wire view (#308). clip_key
+// is deliberately omitted (an internal blob-seam detail); promoted_at is set only
+// once the row is promoted.
+func toProtoHighlight(h storage.Highlight) *managementv1.Highlight {
+	pb := &managementv1.Highlight{
+		Id:              h.ID.String(),
+		VoiceSessionId:  h.VoiceSessionID.String(),
+		CampaignId:      h.CampaignID.String(),
+		Status:          h.Status,
+		StartsAt:        timestamppb.New(h.StartsAt),
+		EndsAt:          timestamppb.New(h.EndsAt),
+		Score:           h.Score,
+		Excerpt:         h.Excerpt,
+		Reason:          h.Reason,
+		SpeakerIds:      h.SpeakerIDs,
+		ClipContentType: h.ClipContentType,
+		ClipSizeBytes:   h.ClipSizeBytes,
+		CreatedAt:       timestamppb.New(h.CreatedAt),
+	}
+	if h.PromotedAt != nil {
+		pb.PromotedAt = timestamppb.New(*h.PromotedAt)
+	}
+	return pb
+}

--- a/internal/rpc/highlight_test.go
+++ b/internal/rpc/highlight_test.go
@@ -98,16 +98,21 @@ func (f *fakeRPCBlobs) Delete(_ context.Context, key string) error {
 }
 
 // newHighlightClient mounts a SessionServer with the highlight seam wired and an
-// authenticated operator on tenantID.
-func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs) managementv1connect.SessionServiceClient {
+// authenticated operator on tenantID. sstore drives the Active-Campaign resolution
+// (#308 campaign scoping) and the voice-session ownership lookups; a nil sstore
+// falls back to a plain activeStore() (the legacy tenant-only tests).
+func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs, sstore *fakeSessionStore) managementv1connect.SessionServiceClient {
 	t.Helper()
+	if sstore == nil {
+		sstore = activeStore()
+	}
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			ctx = auth.WithTenant(ctx, tenantID)
 			return next(ctx, req)
 		}
 	})
-	srv := rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil)
+	srv := rpc.NewSessionServer(&fakeSessionManager{}, sstore, nil, nil)
 	srv.SetHighlights(hstore, blobs)
 	mux := http.NewServeMux()
 	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
@@ -116,13 +121,28 @@ func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightSt
 	return managementv1connect.NewSessionServiceClient(http.DefaultClient, httpSrv.URL, connect.WithProtoJSON())
 }
 
-func seedRPCHighlight(store *fakeHighlightStore, tenantID, sessionID uuid.UUID, status string) storage.Highlight {
+// campaignStore returns a fakeSessionStore whose resolved Active Campaign is
+// campaignID and that owns the given voice sessions (each mapped to campaignID), so
+// the highlight RPCs' cross-campaign checks have a session to look up.
+func campaignSessionStore(campaignID uuid.UUID, sessionIDs ...uuid.UUID) *fakeSessionStore {
+	s := &fakeSessionStore{
+		campaign:      storage.Campaign{ID: campaignID, TenantID: uuid.New(), Name: "Active"},
+		latestErr:     storage.ErrNotFound,
+		voiceSessions: map[uuid.UUID]storage.VoiceSession{},
+	}
+	for _, id := range sessionIDs {
+		s.voiceSessions[id] = storage.VoiceSession{ID: id, CampaignID: campaignID}
+	}
+	return s
+}
+
+func seedRPCHighlight(store *fakeHighlightStore, tenantID, sessionID, campaignID uuid.UUID, status string) storage.Highlight {
 	id := uuid.New()
 	h := storage.Highlight{
 		ID:              id,
 		TenantID:        tenantID,
 		VoiceSessionID:  sessionID,
-		CampaignID:      uuid.New(),
+		CampaignID:      campaignID,
 		Status:          status,
 		StartsAt:        time.Now().Add(-15 * time.Second),
 		EndsAt:          time.Now().Add(5 * time.Second),
@@ -139,12 +159,13 @@ func seedRPCHighlight(store *fakeHighlightStore, tenantID, sessionID uuid.UUID, 
 func TestRPCHighlight_ListAndGet_TenantScoped(t *testing.T) {
 	tenantID := uuid.New()
 	sessionID := uuid.New()
+	campaignID := uuid.New()
 	store := newFakeHighlightStore(tenantID)
-	h := seedRPCHighlight(store, tenantID, sessionID, storage.HighlightCandidate)
+	h := seedRPCHighlight(store, tenantID, sessionID, campaignID, storage.HighlightCandidate)
 	// A different tenant's row that must never surface.
-	seedRPCHighlight(store, uuid.New(), sessionID, storage.HighlightCandidate)
+	seedRPCHighlight(store, uuid.New(), sessionID, campaignID, storage.HighlightCandidate)
 
-	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID, sessionID))
 
 	list, err := client.ListHighlights(context.Background(),
 		connect.NewRequest(&managementv1.ListHighlightsRequest{VoiceSessionId: sessionID.String()}))
@@ -167,11 +188,12 @@ func TestRPCHighlight_ListAndGet_TenantScoped(t *testing.T) {
 
 func TestRPCHighlight_Get_ForeignTenantNotFound(t *testing.T) {
 	tenantID := uuid.New()
+	campaignID := uuid.New()
 	store := newFakeHighlightStore(tenantID)
 	// A highlight owned by a DIFFERENT tenant.
-	other := seedRPCHighlight(store, uuid.New(), uuid.New(), storage.HighlightCandidate)
+	other := seedRPCHighlight(store, uuid.New(), uuid.New(), campaignID, storage.HighlightCandidate)
 
-	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID))
 	_, err := client.GetHighlight(context.Background(),
 		connect.NewRequest(&managementv1.GetHighlightRequest{Id: other.ID.String()}))
 	if connect.CodeOf(err) != connect.CodeNotFound {
@@ -181,10 +203,11 @@ func TestRPCHighlight_Get_ForeignTenantNotFound(t *testing.T) {
 
 func TestRPCHighlight_Promote(t *testing.T) {
 	tenantID := uuid.New()
+	campaignID := uuid.New()
 	store := newFakeHighlightStore(tenantID)
-	h := seedRPCHighlight(store, tenantID, uuid.New(), storage.HighlightCandidate)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
 
-	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID))
 	res, err := client.PromoteHighlight(context.Background(),
 		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: h.ID.String()}))
 	if err != nil {
@@ -200,11 +223,12 @@ func TestRPCHighlight_Promote(t *testing.T) {
 
 func TestRPCHighlight_Delete_BlobThenRow(t *testing.T) {
 	tenantID := uuid.New()
+	campaignID := uuid.New()
 	store := newFakeHighlightStore(tenantID)
-	h := seedRPCHighlight(store, tenantID, uuid.New(), storage.HighlightCandidate)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
 	blobs := &fakeRPCBlobs{}
 
-	client := newHighlightClient(t, tenantID, store, blobs)
+	client := newHighlightClient(t, tenantID, store, blobs, campaignSessionStore(campaignID))
 	if _, err := client.DeleteHighlight(context.Background(),
 		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()})); err != nil {
 		t.Fatalf("delete: %v", err)
@@ -220,5 +244,67 @@ func TestRPCHighlight_Delete_BlobThenRow(t *testing.T) {
 		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()}))
 	if connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("double delete: want NotFound, got %v", err)
+	}
+}
+
+// TestRPCHighlight_CrossCampaign_NotFound is the campaign-scoping posture (#308,
+// #342/#353/#356): a highlight (or its session) belonging to ANOTHER campaign than
+// the resolved Active Campaign is CodeNotFound on every RPC — existence never
+// leaked, exactly like GenerateRecap.
+func TestRPCHighlight_CrossCampaign_NotFound(t *testing.T) {
+	tenantID := uuid.New()
+	activeCampaign := uuid.New()
+	otherCampaign := uuid.New()
+	otherSession := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	// A row owned by the SAME tenant but a DIFFERENT campaign + session.
+	foreign := seedRPCHighlight(store, tenantID, otherSession, otherCampaign, storage.HighlightCandidate)
+
+	// The active campaign resolves to activeCampaign; otherSession is registered as
+	// belonging to otherCampaign so List can see it is cross-campaign.
+	sstore := campaignSessionStore(activeCampaign)
+	sstore.voiceSessions[otherSession] = storage.VoiceSession{ID: otherSession, CampaignID: otherCampaign}
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, sstore)
+	ctx := context.Background()
+
+	if _, err := client.ListHighlights(ctx,
+		connect.NewRequest(&managementv1.ListHighlightsRequest{VoiceSessionId: otherSession.String()})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("List cross-campaign: want NotFound, got %v", err)
+	}
+	if _, err := client.GetHighlight(ctx,
+		connect.NewRequest(&managementv1.GetHighlightRequest{Id: foreign.ID.String()})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("Get cross-campaign: want NotFound, got %v", err)
+	}
+	if _, err := client.PromoteHighlight(ctx,
+		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: foreign.ID.String()})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("Promote cross-campaign: want NotFound, got %v", err)
+	}
+	// A cross-campaign row must never be promoted.
+	if got, _ := store.GetHighlight(ctx, tenantID, foreign.ID); got.Status != storage.HighlightCandidate {
+		t.Fatalf("cross-campaign Promote mutated the row: %q", got.Status)
+	}
+	if _, err := client.DeleteHighlight(ctx,
+		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: foreign.ID.String()})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("Delete cross-campaign: want NotFound, got %v", err)
+	}
+	// A cross-campaign row must never be deleted.
+	if _, err := store.GetHighlight(ctx, tenantID, foreign.ID); err != nil {
+		t.Fatalf("cross-campaign Delete removed the row: %v", err)
+	}
+}
+
+// TestRPCHighlight_List_UnparsableSessionNotFound: an unparsable voice_session_id
+// names no session in the Active Campaign, so it is CodeNotFound (align with
+// GenerateRecap's "names nothing" posture), not InvalidArgument.
+func TestRPCHighlight_List_UnparsableSessionNotFound(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID))
+
+	_, err := client.ListHighlights(context.Background(),
+		connect.NewRequest(&managementv1.ListHighlightsRequest{VoiceSessionId: "not-a-uuid"}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("unparsable session id: want NotFound, got %v", err)
 	}
 }

--- a/internal/rpc/highlight_test.go
+++ b/internal/rpc/highlight_test.go
@@ -1,0 +1,224 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeHighlightStore is a tenant-scoped in-memory highlight store for the RPC tests.
+type fakeHighlightStore struct {
+	mu       sync.Mutex
+	tenantID uuid.UUID
+	rows     map[uuid.UUID]storage.Highlight
+}
+
+func newFakeHighlightStore(tenantID uuid.UUID) *fakeHighlightStore {
+	return &fakeHighlightStore{tenantID: tenantID, rows: map[uuid.UUID]storage.Highlight{}}
+}
+
+func (f *fakeHighlightStore) put(h storage.Highlight) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows[h.ID] = h
+}
+
+func (f *fakeHighlightStore) ListHighlights(_ context.Context, tenantID, sessionID uuid.UUID) ([]storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []storage.Highlight
+	for _, h := range f.rows {
+		if h.TenantID == tenantID && h.VoiceSessionID == sessionID {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeHighlightStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	return h, nil
+}
+
+func (f *fakeHighlightStore) PromoteHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	if h.PromotedAt == nil {
+		now := time.Now()
+		h.PromotedAt = &now
+	}
+	h.Status = storage.HighlightPromoted
+	f.rows[id] = h
+	return h, nil
+}
+
+func (f *fakeHighlightStore) DeleteHighlight(_ context.Context, tenantID, id uuid.UUID) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID {
+		return "", storage.ErrNotFound
+	}
+	delete(f.rows, id)
+	return h.ClipKey, nil
+}
+
+// fakeRPCBlobs records the keys deleted through the seam.
+type fakeRPCBlobs struct {
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (f *fakeRPCBlobs) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
+// newHighlightClient mounts a SessionServer with the highlight seam wired and an
+// authenticated operator on tenantID.
+func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs) managementv1connect.SessionServiceClient {
+	t.Helper()
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx = auth.WithTenant(ctx, tenantID)
+			return next(ctx, req)
+		}
+	})
+	srv := rpc.NewSessionServer(&fakeSessionManager{}, activeStore(), nil, nil)
+	srv.SetHighlights(hstore, blobs)
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
+	httpSrv := httptest.NewServer(mux)
+	t.Cleanup(httpSrv.Close)
+	return managementv1connect.NewSessionServiceClient(http.DefaultClient, httpSrv.URL, connect.WithProtoJSON())
+}
+
+func seedRPCHighlight(store *fakeHighlightStore, tenantID, sessionID uuid.UUID, status string) storage.Highlight {
+	id := uuid.New()
+	h := storage.Highlight{
+		ID:              id,
+		TenantID:        tenantID,
+		VoiceSessionID:  sessionID,
+		CampaignID:      uuid.New(),
+		Status:          status,
+		StartsAt:        time.Now().Add(-15 * time.Second),
+		EndsAt:          time.Now().Add(5 * time.Second),
+		Score:           9,
+		Excerpt:         "nat 20",
+		ClipKey:         "t/" + tenantID.String() + "/highlight/" + id.String() + "/clip.wav",
+		ClipContentType: "audio/wav",
+		ClipSizeBytes:   1234,
+	}
+	store.put(h)
+	return h
+}
+
+func TestRPCHighlight_ListAndGet_TenantScoped(t *testing.T) {
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, sessionID, storage.HighlightCandidate)
+	// A different tenant's row that must never surface.
+	seedRPCHighlight(store, uuid.New(), sessionID, storage.HighlightCandidate)
+
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+
+	list, err := client.ListHighlights(context.Background(),
+		connect.NewRequest(&managementv1.ListHighlightsRequest{VoiceSessionId: sessionID.String()}))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Msg.GetHighlights()) != 1 || list.Msg.GetHighlights()[0].GetId() != h.ID.String() {
+		t.Fatalf("list not tenant-scoped: %+v", list.Msg.GetHighlights())
+	}
+
+	got, err := client.GetHighlight(context.Background(),
+		connect.NewRequest(&managementv1.GetHighlightRequest{Id: h.ID.String()}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Msg.GetHighlight().GetClipContentType() != "audio/wav" {
+		t.Fatalf("get returned wrong row: %+v", got.Msg.GetHighlight())
+	}
+}
+
+func TestRPCHighlight_Get_ForeignTenantNotFound(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	// A highlight owned by a DIFFERENT tenant.
+	other := seedRPCHighlight(store, uuid.New(), uuid.New(), storage.HighlightCandidate)
+
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+	_, err := client.GetHighlight(context.Background(),
+		connect.NewRequest(&managementv1.GetHighlightRequest{Id: other.ID.String()}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("want CodeNotFound, got %v", err)
+	}
+}
+
+func TestRPCHighlight_Promote(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), storage.HighlightCandidate)
+
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{})
+	res, err := client.PromoteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: h.ID.String()}))
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if res.Msg.GetHighlight().GetStatus() != storage.HighlightPromoted {
+		t.Fatalf("want promoted, got %q", res.Msg.GetHighlight().GetStatus())
+	}
+	if res.Msg.GetHighlight().GetPromotedAt() == nil {
+		t.Fatalf("promoted_at not set")
+	}
+}
+
+func TestRPCHighlight_Delete_BlobThenRow(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), storage.HighlightCandidate)
+	blobs := &fakeRPCBlobs{}
+
+	client := newHighlightClient(t, tenantID, store, blobs)
+	if _, err := client.DeleteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()})); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(blobs.deleted) != 1 || blobs.deleted[0] != h.ClipKey {
+		t.Fatalf("clip not deleted through seam: %v", blobs.deleted)
+	}
+	if _, err := store.GetHighlight(context.Background(), tenantID, h.ID); err == nil {
+		t.Fatalf("row not deleted")
+	}
+	// Deleting again is NotFound.
+	_, err := client.DeleteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()}))
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("double delete: want NotFound, got %v", err)
+	}
+}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -92,6 +92,13 @@ type SessionServer struct {
 	store    SessionStore
 	recapper RecapEngine
 	log      *slog.Logger
+
+	// highlights + blobs back the Session Highlights RPCs (#308); wired via
+	// SetHighlights after construction so the many existing call sites keep their
+	// signature. Nil (unwired, e.g. keyless tests) makes the Highlight RPCs report
+	// CodeUnimplemented rather than panic.
+	highlights HighlightStore
+	blobs      highlightBlobs
 }
 
 var _ managementv1connect.SessionServiceHandler = (*SessionServer)(nil)

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -482,6 +482,16 @@ func (s *SessionServer) GenerateRecap(
 	}), nil
 }
 
+// ResolveActiveCampaign exposes the SessionServer's read-side Active-Campaign
+// resolution (searchCampaign: live Voice Session first, else the profile-first
+// durable selection) for out-of-band HTTP surfaces that share the posture — the
+// Highlight clip byte stream (#308), a plain net/http mount that is not a Connect
+// method and so cannot reach searchCampaign directly. ok is false when neither
+// resolves (never-run state).
+func (s *SessionServer) ResolveActiveCampaign(ctx context.Context) (uuid.UUID, bool, error) {
+	return s.searchCampaign(ctx)
+}
+
 // searchCampaign resolves the campaign the web transcript search scopes to: the
 // live Voice Session's campaign first (the same in-process truth GetSession uses,
 // so search scopes to exactly the transcript on screen), otherwise the

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -103,6 +104,20 @@ type TranscriptFinalizer interface {
 	Finalize(ctx context.Context, id uuid.UUID) (int, error)
 }
 
+// Highlighter is the Session Highlights persistence pipeline (#308, Epic 8): the
+// Manager Begins it at Start (binding the session's owning ids), the live detector
+// feeds it Triggers through cfg.Highlights, and the Manager Finalizes it at loop
+// exit (scheduling the 7-day candidate purge) — beside transcript.Finalize, at
+// EVERY exit path. *highlight.Saver satisfies it. It embeds highlight.Sink so the
+// SAME value wires onto the base voice config's cfg.Highlights. Defined here (not
+// imported as a concrete type) to keep the seam narrow; nil (highlights off, or a
+// web-only Manager that drives no voice) makes Begin/Finalize no-ops.
+type Highlighter interface {
+	highlight.Sink
+	Begin(voiceSessionID, campaignID, tenantID uuid.UUID)
+	Finalize(ctx context.Context) error
+}
+
 // ChunkFinalizer closes a session's open Transcript Chunk on Stop / loop exit
 // (#104, ADR-0011): a lone trailing utterance is flushed ONLY here, at session
 // end. *transcript.Chunker satisfies it; defined here (not imported) so the
@@ -164,6 +179,7 @@ type Manager struct {
 	cipher     *crypto.Cipher      // decrypts the saved deployment Bot token (#87); nil without $GLYPHOXA_SECRET
 	transcript TranscriptFinalizer // finalizes persisted lines on Stop (#74); nil keeps line_count at 0
 	chunker    ChunkFinalizer      // closes the open Transcript Chunk on Stop (#104); nil = no chunking
+	highlights Highlighter         // persists Session Highlights + schedules purge on Stop (#308); nil = highlights off
 	log        *slog.Logger
 	enabled    bool          // false in web-only mode: Start is rejected (ADR-0039)
 	endTimeout time.Duration // per-step end budget (Finalize, end-write); endTimeout in prod, shrunk in tests
@@ -255,6 +271,17 @@ func (m *Manager) SetFacts(f agent.FactsRecaller) {
 // behave, the model just gets an "unavailable" tool result).
 func (m *Manager) SetToolDeps(d tool.Deps) {
 	m.base.ToolDeps = d
+}
+
+// SetHighlights wires the Session Highlights persistence pipeline (#308): the
+// Manager Begins/Finalizes it per session, and the SAME value flows onto the base
+// voice config as cfg.Highlights (the detector's Sink) every session copies. Like
+// SetTranscript it is set once at boot — the Saver needs the store + blob backend,
+// built alongside the Manager — before any session can start, so no lock is
+// needed. nil leaves highlights off (the detector, if any, gets a nil Sink).
+func (m *Manager) SetHighlights(h Highlighter) {
+	m.highlights = h
+	m.base.Highlights = h
 }
 
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no
@@ -373,6 +400,14 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		as.meter = meter
 	}
 
+	// Bind the Highlights pipeline to this session before the loop (and its
+	// detector) can fire a Trigger (#308): Begin records the owning ids the Saver
+	// stamps onto every candidate row + its blob key. Finalize (runLoop) unbinds and
+	// schedules the purge. A nil Highlighter (highlights off / web-only) is skipped.
+	if m.highlights != nil {
+		m.highlights.Begin(vs.ID, campaignID, tenantID)
+	}
+
 	m.active = as
 	go m.runLoop(runCtx, as, cfg)
 	return vs, nil
@@ -473,6 +508,20 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 		} else {
 			lineCount = n
 		}
+	}
+
+	// Finalize the Session Highlights pipeline beside the transcript (#308): drain
+	// the Saver's worker (persisting any queued clips) and schedule the 7-day
+	// candidate purge, then unbind. Its OWN budget (like Finalize/chunk flush) — a
+	// slow drain / enqueue logs and never blocks the row from ending. Runs at EVERY
+	// loop exit (Stop, self-exit, Shutdown), so a session's candidates always get a
+	// purge horizon (ADR-0051). nil (highlights off) is skipped.
+	if m.highlights != nil {
+		hlCtx, hlCancel := context.WithTimeout(base, m.endTimeout)
+		if err := m.highlights.Finalize(hlCtx); err != nil {
+			m.log.Warn("finalize highlights before end", "err", err, "voice_session", as.session.ID)
+		}
+		hlCancel()
 	}
 
 	// Close the session's open Transcript Chunk (#104, ADR-0011): a lone trailing

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
@@ -509,6 +510,72 @@ func TestStopFinalizesTranscriptCount(t *testing.T) {
 	}
 	if id, called := fin.seen(); called != 1 || id != vs.ID {
 		t.Errorf("finalize seen id=%s called=%d, want id=%s called=1", id, called, vs.ID)
+	}
+}
+
+// spyHighlighter records Begin/Finalize so a test can assert the Manager binds
+// and unbinds the Session Highlights pipeline at Start/loop-exit (#308).
+type spyHighlighter struct {
+	mu         sync.Mutex
+	beginArgs  [3]uuid.UUID
+	beginCalls int
+	finalizes  int
+}
+
+func (s *spyHighlighter) HandleTrigger(highlight.Trigger) {}
+
+func (s *spyHighlighter) Begin(voiceSessionID, campaignID, tenantID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.beginArgs = [3]uuid.UUID{voiceSessionID, campaignID, tenantID}
+	s.beginCalls++
+}
+
+func (s *spyHighlighter) Finalize(context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.finalizes++
+	return nil
+}
+
+func (s *spyHighlighter) seen() (begins, finals int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.beginCalls, s.finalizes
+}
+
+// TestManagerBeginsAndFinalizesHighlights is #308's Manager slice: Start binds the
+// Highlights pipeline to the session's owning ids, and loop exit finalizes it
+// (nothing dangles) — the SAME lifecycle transcript.Finalize gets.
+func TestManagerBeginsAndFinalizesHighlights(t *testing.T) {
+	store := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, store, runner.run, true)
+	spy := &spyHighlighter{}
+	mgr.SetHighlights(spy)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	vs, err := mgr.Start(context.Background(), tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop runner never started")
+	}
+	if begins, _ := spy.seen(); begins != 1 {
+		t.Fatalf("Begin called %d times, want 1", begins)
+	}
+	if spy.beginArgs != [3]uuid.UUID{vs.ID, campaignID, tenantID} {
+		t.Fatalf("Begin args = %v, want session/campaign/tenant %v/%v/%v", spy.beginArgs, vs.ID, campaignID, tenantID)
+	}
+
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if begins, finals := spy.seen(); begins != 1 || finals != 1 {
+		t.Fatalf("after Stop: begins=%d finals=%d, want 1/1", begins, finals)
 	}
 }
 

--- a/internal/storage/campaign_archive.go
+++ b/internal/storage/campaign_archive.go
@@ -132,3 +132,22 @@ func (s *Store) DeleteCampaign(ctx context.Context, id uuid.UUID) error {
 	}
 	return nil
 }
+
+// DeleteCampaignWithJob hard-deletes an archived campaign AND enqueues a follow-up
+// job in the SAME transaction (#308, ADR-0048/0049): the job row exists if and only
+// if the delete committed. This closes the blob-orphan window a delete-then-enqueue
+// would open — a refused/failed delete never leaves a sweep that would drop a
+// surviving campaign's clips, and a crash right after the delete never loses the
+// sweep. The delete's error mapping (ErrNotFound / ErrNotArchived) is unchanged.
+// jobPayload must be non-empty; callers with nothing to sweep use [DeleteCampaign].
+func (s *Store) DeleteCampaignWithJob(ctx context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error {
+	return s.InTx(ctx, func(tx *Store) error {
+		if err := tx.DeleteCampaign(ctx, id); err != nil {
+			return err
+		}
+		if _, err := tx.EnqueueJob(ctx, jobKind, jobPayload, 0); err != nil {
+			return fmt.Errorf("storage: enqueue campaign-delete job: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/storage/campaign_archive_test.go
+++ b/internal/storage/campaign_archive_test.go
@@ -230,6 +230,12 @@ func TestDeleteCampaignCascade(t *testing.T) {
 		t.Fatalf("insert transcript chunk: %v", err)
 	}
 
+	// A Session Highlight under the same session (#308): its voice_session_id FK is
+	// ON DELETE RESTRICT, but campaign_id CASCADEs, so the campaign hard-delete removes
+	// the highlight row BEFORE the cascaded voice_sessions delete — proving RESTRICT is
+	// inert on the campaign-delete path (it only blocks a direct session delete).
+	seedHighlight(t, st, tenantID, sessionID, campaignID, storage.HighlightCandidate)
+
 	// Delete before archiving is refused; the row survives.
 	if err := st.DeleteCampaign(ctx, campaignID); !errors.Is(err, storage.ErrNotArchived) {
 		t.Fatalf("DeleteCampaign(non-archived) = %v, want ErrNotArchived", err)
@@ -260,6 +266,7 @@ func TestDeleteCampaignCascade(t *testing.T) {
 		{"voice_sessions", `SELECT count(*) FROM voice_sessions WHERE campaign_id = $1`, campaignID},
 		{"transcript_line", `SELECT count(*) FROM transcript_line WHERE campaign_id = $1`, campaignID},
 		{"transcript_chunk", `SELECT count(*) FROM transcript_chunk WHERE campaign_id = $1`, campaignID},
+		{"highlight", `SELECT count(*) FROM highlight WHERE campaign_id = $1`, campaignID},
 	} {
 		var n int
 		if err := pool.QueryRow(ctx, tc.query, tc.arg).Scan(&n); err != nil {
@@ -274,5 +281,56 @@ func TestDeleteCampaignCascade(t *testing.T) {
 	// An unknown id is ErrNotFound.
 	if err := st.DeleteCampaign(ctx, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("DeleteCampaign(random) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDeleteCampaignWithJob_Atomic proves the delete + follow-up job enqueue are one
+// transaction (#308): a committed delete leaves exactly one pending job carrying the
+// payload, and a REFUSED delete (not archived) enqueues NO job — no orphan sweep of a
+// surviving campaign.
+func TestDeleteCampaignWithJob_Atomic(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	const kind = "highlight.sweep_campaign_clips"
+	payload := []byte(`{"clip_keys":["k1","k2"]}`)
+
+	countJobs := func() int {
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM job WHERE kind = $1`, kind).Scan(&n); err != nil {
+			t.Fatalf("count jobs: %v", err)
+		}
+		return n
+	}
+
+	// Not archived → refused, and NO job enqueued (the tx rolled back).
+	if err := st.DeleteCampaignWithJob(ctx, campaignID, kind, payload); !errors.Is(err, storage.ErrNotArchived) {
+		t.Fatalf("DeleteCampaignWithJob(non-archived) = %v, want ErrNotArchived", err)
+	}
+	if n := countJobs(); n != 0 {
+		t.Fatalf("refused delete enqueued %d jobs, want 0", n)
+	}
+
+	// Archive, then delete-with-job for real → campaign gone AND one job enqueued.
+	if _, err := st.ArchiveCampaign(ctx, campaignID); err != nil {
+		t.Fatalf("ArchiveCampaign: %v", err)
+	}
+	if err := st.DeleteCampaignWithJob(ctx, campaignID, kind, payload); err != nil {
+		t.Fatalf("DeleteCampaignWithJob(archived): %v", err)
+	}
+	if _, err := st.GetCampaign(ctx, campaignID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("campaign should be gone: %v", err)
+	}
+	if n := countJobs(); n != 1 {
+		t.Fatalf("committed delete enqueued %d jobs, want 1", n)
+	}
+	var gotPayload []byte
+	if err := pool.QueryRow(ctx, `SELECT payload FROM job WHERE kind = $1`, kind).Scan(&gotPayload); err != nil {
+		t.Fatalf("read job payload: %v", err)
+	}
+	if string(gotPayload) != `{"clip_keys": ["k1", "k2"]}` && string(gotPayload) != string(payload) {
+		t.Fatalf("job payload = %s, want the carried clip keys", gotPayload)
 	}
 }

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -208,18 +208,28 @@ func (s *Store) DeleteSessionCandidates(ctx context.Context, voiceSessionID uuid
 	return int(tag.RowsAffected()), nil
 }
 
-// ListSessionsNeedingCandidatePurge returns the ids of ENDED Voice Sessions that
-// still hold at least one 'candidate' highlight but have NO purge job of the given
-// kind in a live state (pending/running/done) — the sessions whose 7-day purge was
-// never scheduled because a crash landed between the session ending and the Saver's
-// Finalize enqueue (#308, ADR-0051). It is the input to the boot-time backstop
-// sweep. A job is matched on its payload's voice_session_id (the purge payload's
-// only field); 'dead' jobs are treated as absent so a permanently-failed purge is
-// re-scheduled. Session-scoped, carries no tenant (the sweep is process-wide,
-// ADR-0049).
-func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]uuid.UUID, error) {
+// SessionPurgeCandidate is an ended Voice Session the boot backstop must schedule a
+// candidate purge for: its id plus the ended_at the 7-day horizon anchors to
+// (ADR-0051), so a session that ended long ago is purged immediately rather than
+// 7 days after boot.
+type SessionPurgeCandidate struct {
+	VoiceSessionID uuid.UUID
+	EndedAt        time.Time
+}
+
+// ListSessionsNeedingCandidatePurge returns the ENDED Voice Sessions (id + ended_at)
+// that still hold at least one 'candidate' highlight but have NO purge job of the
+// given kind in a live state (pending/running/done) — the sessions whose 7-day purge
+// was never scheduled because a crash landed between the session ending and the
+// Saver's Finalize enqueue (#308, ADR-0051). It is the input to the boot-time
+// backstop sweep. ended_at is returned so the sweep anchors the horizon at session
+// END (ended_at+7d), not boot time. A job is matched on its payload's
+// voice_session_id (the purge payload's only field); 'dead' jobs are treated as
+// absent so a permanently-failed purge is re-scheduled. Session-scoped, carries no
+// tenant (the sweep is process-wide, ADR-0049).
+func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]SessionPurgeCandidate, error) {
 	rows, err := s.db.Query(ctx,
-		`SELECT DISTINCT h.voice_session_id
+		`SELECT DISTINCT h.voice_session_id, vs.ended_at
 		   FROM highlight h
 		   JOIN voice_sessions vs ON vs.id = h.voice_session_id
 		  WHERE h.status = 'candidate'
@@ -235,13 +245,13 @@ func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind
 	}
 	defer rows.Close()
 
-	var out []uuid.UUID
+	var out []SessionPurgeCandidate
 	for rows.Next() {
-		var id uuid.UUID
-		if err := rows.Scan(&id); err != nil {
+		var c SessionPurgeCandidate
+		if err := rows.Scan(&c.VoiceSessionID, &c.EndedAt); err != nil {
 			return nil, fmt.Errorf("storage: scan session needing purge: %w", err)
 		}
-		out = append(out, id)
+		out = append(out, c)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("storage: list sessions needing candidate purge: %w", err)

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -1,0 +1,240 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Session Highlights persistence (#308, Epic 8, ADR-0051): one highlight row per
+// detected epic moment. A row is born 'candidate' with a 7-day purge horizon;
+// only an explicit GM promotion flips it to 'promoted' (kept indefinitely). The
+// audio clip lives behind the blob seam (ADR-0048): clip_key reconstructs the
+// blob.Key and deletion goes through blob.Delete, never a DB cascade to the blob.
+//
+// Read/promote/delete are tenant-scoped (single-operator today, ADR-0039, but the
+// WHERE tenant_id guard is the seam the multi-tenant future keys off). The two
+// sweep helpers — DeleteSessionCandidates (the 7-day purge job) and
+// ListCampaignHighlightClipKeys (the campaign hard-delete blob sweep) — scope by
+// session/campaign instead: their callers carry no tenant, only the owning id.
+
+// Highlight status values (CHECK-constrained in the schema).
+const (
+	// HighlightCandidate: freshly detected, subject to the 7-day purge.
+	HighlightCandidate = "candidate"
+	// HighlightPromoted: an explicit GM keep; never purged.
+	HighlightPromoted = "promoted"
+)
+
+// Highlight is one persisted Session Highlight row (#308).
+type Highlight struct {
+	ID              uuid.UUID
+	TenantID        uuid.UUID
+	VoiceSessionID  uuid.UUID
+	CampaignID      uuid.UUID
+	Status          string
+	StartsAt        time.Time
+	EndsAt          time.Time
+	Score           float64
+	Excerpt         string
+	Reason          string
+	SpeakerIDs      []string
+	ClipKey         string
+	ClipContentType string
+	ClipSizeBytes   int64
+	CreatedAt       time.Time
+	PromotedAt      *time.Time
+}
+
+const highlightColumns = `
+	id, tenant_id, voice_session_id, campaign_id, status,
+	starts_at, ends_at, score, excerpt, reason, speaker_ids,
+	clip_key, clip_content_type, clip_size_bytes, created_at, promoted_at`
+
+func scanHighlight(row pgx.Row) (Highlight, error) {
+	var (
+		h  Highlight
+		pr *time.Time
+	)
+	err := row.Scan(
+		&h.ID, &h.TenantID, &h.VoiceSessionID, &h.CampaignID, &h.Status,
+		&h.StartsAt, &h.EndsAt, &h.Score, &h.Excerpt, &h.Reason, &h.SpeakerIDs,
+		&h.ClipKey, &h.ClipContentType, &h.ClipSizeBytes, &h.CreatedAt, &pr,
+	)
+	h.PromotedAt = pr
+	return h, err
+}
+
+// CreateHighlight inserts one detected highlight as a 'candidate' (the Saver's
+// worker calls it after the clip is stored, #308). id/status/clip metadata are
+// caller-supplied so the row and its blob.Key agree; empty SpeakerIDs are stored
+// as the empty array (never NULL). A blank Status defaults to 'candidate'.
+func (s *Store) CreateHighlight(ctx context.Context, h Highlight) error {
+	if h.ID == uuid.Nil {
+		h.ID = uuid.New()
+	}
+	if h.Status == "" {
+		h.Status = HighlightCandidate
+	}
+	if h.ClipContentType == "" {
+		h.ClipContentType = "audio/wav"
+	}
+	speakers := h.SpeakerIDs
+	if speakers == nil {
+		speakers = []string{}
+	}
+	_, err := s.db.Exec(ctx,
+		`INSERT INTO highlight
+		   (id, tenant_id, voice_session_id, campaign_id, status,
+		    starts_at, ends_at, score, excerpt, reason, speaker_ids,
+		    clip_key, clip_content_type, clip_size_bytes)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+		h.ID, h.TenantID, h.VoiceSessionID, h.CampaignID, h.Status,
+		h.StartsAt, h.EndsAt, h.Score, h.Excerpt, h.Reason, speakers,
+		h.ClipKey, h.ClipContentType, h.ClipSizeBytes)
+	if err != nil {
+		return fmt.Errorf("storage: create highlight: %w", err)
+	}
+	return nil
+}
+
+// GetHighlight loads one highlight by id within the tenant, or ErrNotFound. The
+// tenant guard means a foreign-tenant id reads as absent (never leaked).
+func (s *Store) GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (Highlight, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+highlightColumns+` FROM highlight WHERE id = $1 AND tenant_id = $2`, id, tenantID)
+	h, err := scanHighlight(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Highlight{}, ErrNotFound
+	}
+	if err != nil {
+		return Highlight{}, fmt.Errorf("storage: get highlight %s: %w", id, err)
+	}
+	return h, nil
+}
+
+// ListHighlights returns a Voice Session's highlights within the tenant, newest
+// moment first (starts_at DESC, id DESC for a stable tie-break). It backs the GM
+// session-end review UI (#309). An empty result is not an error.
+func (s *Store) ListHighlights(ctx context.Context, tenantID, voiceSessionID uuid.UUID) ([]Highlight, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+highlightColumns+`
+		   FROM highlight
+		  WHERE tenant_id = $1 AND voice_session_id = $2
+		  ORDER BY starts_at DESC, id DESC`, tenantID, voiceSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list highlights: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Highlight
+	for rows.Next() {
+		h, err := scanHighlight(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan highlight: %w", err)
+		}
+		out = append(out, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list highlights: %w", err)
+	}
+	return out, nil
+}
+
+// PromoteHighlight flips a candidate to 'promoted' and stamps promoted_at within
+// the tenant, returning the updated row (#309 GM keep). It is idempotent: a
+// re-promote keeps the ORIGINAL promoted_at (COALESCE) so the audit trail of WHEN
+// the GM first kept it survives. A missing id (or foreign tenant) yields
+// ErrNotFound. It deliberately does NOT enqueue enrichment — that is #311's hook.
+func (s *Store) PromoteHighlight(ctx context.Context, tenantID, id uuid.UUID) (Highlight, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE highlight
+		    SET status = 'promoted', promoted_at = COALESCE(promoted_at, now())
+		  WHERE id = $1 AND tenant_id = $2
+		 RETURNING `+highlightColumns, id, tenantID)
+	h, err := scanHighlight(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Highlight{}, ErrNotFound
+	}
+	if err != nil {
+		return Highlight{}, fmt.Errorf("storage: promote highlight %s: %w", id, err)
+	}
+	return h, nil
+}
+
+// DeleteHighlight removes one highlight within the tenant and returns its
+// clip_key so the caller can drop the blob through the seam (ADR-0048). A missing
+// id (or foreign tenant) yields ErrNotFound. The blob delete is the caller's
+// responsibility and runs BEFORE this in the RPC (blob-then-row), but the key is
+// returned so a delete driven off a prior read still has it.
+func (s *Store) DeleteHighlight(ctx context.Context, tenantID, id uuid.UUID) (string, error) {
+	var clipKey string
+	err := s.db.QueryRow(ctx,
+		`DELETE FROM highlight WHERE id = $1 AND tenant_id = $2 RETURNING clip_key`, id, tenantID).
+		Scan(&clipKey)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("storage: delete highlight %s: %w", id, err)
+	}
+	return clipKey, nil
+}
+
+// ListSessionCandidateClipKeys returns the clip_key of every remaining CANDIDATE
+// highlight for a Voice Session — the blob keys the 7-day purge job drops through
+// the seam BEFORE it deletes the rows (blob-first, ADR-0048). Promoted rows are
+// excluded (they are kept). Session-scoped (the purge payload carries no tenant).
+func (s *Store) ListSessionCandidateClipKeys(ctx context.Context, voiceSessionID uuid.UUID) ([]string, error) {
+	return s.scanClipKeys(ctx,
+		`SELECT clip_key FROM highlight WHERE voice_session_id = $1 AND status = 'candidate'`,
+		voiceSessionID)
+}
+
+// DeleteSessionCandidates removes every remaining CANDIDATE highlight row for a
+// Voice Session (the 7-day purge, #308/ADR-0051), returning how many rows were
+// deleted. Promoted rows are untouched. Idempotent: a second run deletes nothing.
+// The caller drops the blobs first via ListSessionCandidateClipKeys.
+func (s *Store) DeleteSessionCandidates(ctx context.Context, voiceSessionID uuid.UUID) (int, error) {
+	tag, err := s.db.Exec(ctx,
+		`DELETE FROM highlight WHERE voice_session_id = $1 AND status = 'candidate'`, voiceSessionID)
+	if err != nil {
+		return 0, fmt.Errorf("storage: delete session candidates: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// ListCampaignHighlightClipKeys returns the clip_key of EVERY highlight
+// (candidate and promoted) in a Campaign — the blob keys a campaign hard-delete
+// sweeps through the seam BEFORE the row cascade removes them (ADR-0048). No
+// status filter: a campaign delete takes its highlights with it, kept or not.
+func (s *Store) ListCampaignHighlightClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error) {
+	return s.scanClipKeys(ctx,
+		`SELECT clip_key FROM highlight WHERE campaign_id = $1`, campaignID)
+}
+
+// scanClipKeys runs a single-column clip_key query and collects the results.
+func (s *Store) scanClipKeys(ctx context.Context, sql string, arg uuid.UUID) ([]string, error) {
+	rows, err := s.db.Query(ctx, sql, arg)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list highlight clip keys: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, fmt.Errorf("storage: scan highlight clip key: %w", err)
+		}
+		out = append(out, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list highlight clip keys: %w", err)
+	}
+	return out, nil
+}

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -208,6 +208,47 @@ func (s *Store) DeleteSessionCandidates(ctx context.Context, voiceSessionID uuid
 	return int(tag.RowsAffected()), nil
 }
 
+// ListSessionsNeedingCandidatePurge returns the ids of ENDED Voice Sessions that
+// still hold at least one 'candidate' highlight but have NO purge job of the given
+// kind in a live state (pending/running/done) — the sessions whose 7-day purge was
+// never scheduled because a crash landed between the session ending and the Saver's
+// Finalize enqueue (#308, ADR-0051). It is the input to the boot-time backstop
+// sweep. A job is matched on its payload's voice_session_id (the purge payload's
+// only field); 'dead' jobs are treated as absent so a permanently-failed purge is
+// re-scheduled. Session-scoped, carries no tenant (the sweep is process-wide,
+// ADR-0049).
+func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind string) ([]uuid.UUID, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT DISTINCT h.voice_session_id
+		   FROM highlight h
+		   JOIN voice_sessions vs ON vs.id = h.voice_session_id
+		  WHERE h.status = 'candidate'
+		    AND vs.ended_at IS NOT NULL
+		    AND NOT EXISTS (
+		          SELECT 1 FROM job j
+		           WHERE j.kind = $1
+		             AND j.status IN ('pending','running','done')
+		             AND j.payload->>'voice_session_id' = h.voice_session_id::text
+		        )`, purgeKind)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list sessions needing candidate purge: %w", err)
+	}
+	defer rows.Close()
+
+	var out []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("storage: scan session needing purge: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list sessions needing candidate purge: %w", err)
+	}
+	return out, nil
+}
+
 // ListCampaignHighlightClipKeys returns the clip_key of EVERY highlight
 // (candidate and promoted) in a Campaign — the blob keys a campaign hard-delete
 // sweeps through the seam BEFORE the row cascade removes them (ADR-0048). No

--- a/internal/storage/highlight_test.go
+++ b/internal/storage/highlight_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// seedHighlight creates a candidate highlight row for the given session and
+// returns its id + clip key.
+func seedHighlight(t *testing.T, st *storage.Store, tenantID, sessionID, campaignID uuid.UUID, status string) (uuid.UUID, string) {
+	t.Helper()
+	id := uuid.New()
+	key := "t/" + tenantID.String() + "/highlight/" + id.String() + "/clip.wav"
+	h := storage.Highlight{
+		ID:              id,
+		TenantID:        tenantID,
+		VoiceSessionID:  sessionID,
+		CampaignID:      campaignID,
+		Status:          status,
+		StartsAt:        time.Now().Add(-15 * time.Second),
+		EndsAt:          time.Now().Add(5 * time.Second),
+		Score:           9.0,
+		Excerpt:         "natural 20 against the dragon",
+		Reason:          "critical hit",
+		SpeakerIDs:      []string{"111", "222"},
+		ClipKey:         key,
+		ClipContentType: "audio/wav",
+		ClipSizeBytes:   4444,
+	}
+	if err := st.CreateHighlight(context.Background(), h); err != nil {
+		t.Fatalf("create highlight: %v", err)
+	}
+	return id, key
+}
+
+func TestHighlight_CreateGetList_TenantScoped(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("create voice session: %v", err)
+	}
+
+	id, key := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+
+	got, err := st.GetHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("get highlight: %v", err)
+	}
+	if got.Status != storage.HighlightCandidate || got.ClipKey != key {
+		t.Fatalf("round-trip mismatch: status=%q key=%q", got.Status, got.ClipKey)
+	}
+	if len(got.SpeakerIDs) != 2 || got.Excerpt != "natural 20 against the dragon" {
+		t.Fatalf("field mismatch: %+v", got)
+	}
+	if got.PromotedAt != nil {
+		t.Fatalf("candidate should have nil promoted_at, got %v", got.PromotedAt)
+	}
+
+	// Foreign tenant reads as absent.
+	if _, err := st.GetHighlight(ctx, uuid.New(), id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("foreign tenant get: want ErrNotFound, got %v", err)
+	}
+
+	list, err := st.ListHighlights(ctx, tenantID, vs.ID)
+	if err != nil {
+		t.Fatalf("list highlights: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != id {
+		t.Fatalf("list mismatch: %+v", list)
+	}
+	// Foreign tenant lists empty.
+	if l, err := st.ListHighlights(ctx, uuid.New(), vs.ID); err != nil || len(l) != 0 {
+		t.Fatalf("foreign tenant list: want empty, got %v err=%v", l, err)
+	}
+}
+
+func TestHighlight_Promote_Idempotent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+
+	promoted, err := st.PromoteHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if promoted.Status != storage.HighlightPromoted || promoted.PromotedAt == nil {
+		t.Fatalf("promote did not flip status/stamp: %+v", promoted)
+	}
+	firstStamp := *promoted.PromotedAt
+
+	// Double-promote keeps the original stamp (idempotent).
+	again, err := st.PromoteHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("re-promote: %v", err)
+	}
+	if !again.PromotedAt.Equal(firstStamp) {
+		t.Fatalf("re-promote changed the stamp: %v != %v", again.PromotedAt, firstStamp)
+	}
+
+	// Missing id is ErrNotFound.
+	if _, err := st.PromoteHighlight(ctx, tenantID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("promote missing: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestHighlight_Delete_ReturnsClipKey(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, key := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+
+	gotKey, err := st.DeleteHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if gotKey != key {
+		t.Fatalf("delete returned key %q, want %q", gotKey, key)
+	}
+	if _, err := st.GetHighlight(ctx, tenantID, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("get after delete: want ErrNotFound, got %v", err)
+	}
+	// Double-delete is ErrNotFound.
+	if _, err := st.DeleteHighlight(ctx, tenantID, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("double delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestHighlight_SessionCandidateSweep(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	candID, candKey := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	promID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+
+	keys, err := st.ListSessionCandidateClipKeys(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("list candidate keys: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != candKey {
+		t.Fatalf("candidate keys mismatch: %v", keys)
+	}
+
+	n, err := st.DeleteSessionCandidates(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("delete candidates: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted %d candidates, want 1", n)
+	}
+	// Candidate gone, promoted untouched.
+	if _, err := st.GetHighlight(ctx, tenantID, candID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("candidate should be purged, got %v", err)
+	}
+	if _, err := st.GetHighlight(ctx, tenantID, promID); err != nil {
+		t.Fatalf("promoted should survive: %v", err)
+	}
+	// Idempotent.
+	if n, err := st.DeleteSessionCandidates(ctx, vs.ID); err != nil || n != 0 {
+		t.Fatalf("second sweep: want 0/nil, got %d/%v", n, err)
+	}
+}
+
+func TestHighlight_CampaignClipKeySweep(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	_, k1 := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	_, k2 := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+
+	keys, err := st.ListCampaignHighlightClipKeys(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list campaign keys: %v", err)
+	}
+	// Both candidate AND promoted (a campaign delete takes them all).
+	set := map[string]bool{}
+	for _, k := range keys {
+		set[k] = true
+	}
+	if !set[k1] || !set[k2] || len(keys) != 2 {
+		t.Fatalf("campaign clip keys mismatch: %v", keys)
+	}
+}

--- a/internal/storage/highlight_test.go
+++ b/internal/storage/highlight_test.go
@@ -182,6 +182,56 @@ func TestHighlight_SessionCandidateSweep(t *testing.T) {
 	}
 }
 
+// TestHighlight_ListSessionsNeedingCandidatePurge is the boot-backstop query
+// (#308, ADR-0051): an ENDED session with candidates and NO live purge job is
+// listed; a session that already has a pending purge job is NOT; a still-RUNNING
+// session is NOT; a session whose only highlights are promoted is NOT.
+func TestHighlight_ListSessionsNeedingCandidatePurge(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	const purgeKind = "highlight.purge_candidates"
+
+	// Orphan: ended, has a candidate, no purge job → must be listed.
+	orphan, _ := st.CreateVoiceSession(ctx, campaignID)
+	seedHighlight(t, st, tenantID, orphan.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.EndVoiceSession(ctx, orphan.ID, 0); err != nil {
+		t.Fatalf("end orphan: %v", err)
+	}
+
+	// Already scheduled: ended, has a candidate, but a pending purge job exists → NOT listed.
+	scheduled, _ := st.CreateVoiceSession(ctx, campaignID)
+	seedHighlight(t, st, tenantID, scheduled.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.EndVoiceSession(ctx, scheduled.ID, 0); err != nil {
+		t.Fatalf("end scheduled: %v", err)
+	}
+	payload := []byte(`{"voice_session_id":"` + scheduled.ID.String() + `"}`)
+	if _, err := st.EnqueueJob(ctx, purgeKind, payload, 0); err != nil {
+		t.Fatalf("enqueue existing purge: %v", err)
+	}
+
+	// Running: has a candidate but not ended → NOT listed (Finalize will schedule it).
+	running, _ := st.CreateVoiceSession(ctx, campaignID)
+	seedHighlight(t, st, tenantID, running.ID, campaignID, storage.HighlightCandidate)
+
+	// Promoted-only: ended but its only highlight is promoted (kept) → NOT listed.
+	promotedOnly, _ := st.CreateVoiceSession(ctx, campaignID)
+	seedHighlight(t, st, tenantID, promotedOnly.ID, campaignID, storage.HighlightPromoted)
+	if _, err := st.EndVoiceSession(ctx, promotedOnly.ID, 0); err != nil {
+		t.Fatalf("end promotedOnly: %v", err)
+	}
+
+	ids, err := st.ListSessionsNeedingCandidatePurge(ctx, purgeKind)
+	if err != nil {
+		t.Fatalf("list sessions needing purge: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != orphan.ID {
+		t.Fatalf("want only the orphan session %s, got %v", orphan.ID, ids)
+	}
+}
+
 func TestHighlight_CampaignClipKeySweep(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)

--- a/internal/storage/highlight_test.go
+++ b/internal/storage/highlight_test.go
@@ -223,12 +223,16 @@ func TestHighlight_ListSessionsNeedingCandidatePurge(t *testing.T) {
 		t.Fatalf("end promotedOnly: %v", err)
 	}
 
-	ids, err := st.ListSessionsNeedingCandidatePurge(ctx, purgeKind)
+	got, err := st.ListSessionsNeedingCandidatePurge(ctx, purgeKind)
 	if err != nil {
 		t.Fatalf("list sessions needing purge: %v", err)
 	}
-	if len(ids) != 1 || ids[0] != orphan.ID {
-		t.Fatalf("want only the orphan session %s, got %v", orphan.ID, ids)
+	if len(got) != 1 || got[0].VoiceSessionID != orphan.ID {
+		t.Fatalf("want only the orphan session %s, got %+v", orphan.ID, got)
+	}
+	// ended_at is returned so the boot sweep anchors the 7-day horizon at session end.
+	if got[0].EndedAt.IsZero() {
+		t.Fatalf("orphan candidate carries no ended_at: %+v", got[0])
 	}
 }
 

--- a/internal/storage/job.go
+++ b/internal/storage/job.go
@@ -86,6 +86,32 @@ func (s *Store) EnqueueJob(ctx context.Context, kind string, payload []byte, max
 	return id, nil
 }
 
+// EnqueueJobAt is EnqueueJob with an explicit run_after: the job stays pending
+// (not runnable) until runAfter arrives. It backs deferred work like the Session
+// Highlights 7-day candidate purge (#308, ADR-0051/0049). A zero runAfter falls
+// back to now() (immediately runnable), matching EnqueueJob.
+func (s *Store) EnqueueJobAt(ctx context.Context, kind string, payload []byte, maxAttempts int, runAfter time.Time) (uuid.UUID, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultJobMaxAttempts
+	}
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	if runAfter.IsZero() {
+		runAfter = time.Now()
+	}
+	var id uuid.UUID
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO job (kind, payload, max_attempts, run_after)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id`,
+		kind, payload, maxAttempts, runAfter).Scan(&id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: enqueue job %q at %s: %w", kind, runAfter, err)
+	}
+	return id, nil
+}
+
 // ClaimJob atomically claims the single oldest runnable job in any of kinds and
 // returns it in its post-claim state (status='running', attempts incremented,
 // leased_until = now()+lease). Runnable means a pending job whose run_after has

--- a/internal/storage/migrations/00024_highlight.sql
+++ b/internal/storage/migrations/00024_highlight.sql
@@ -4,13 +4,24 @@
 -- ADR-0051) and only an explicit GM promotion flips it to 'promoted' (kept). The
 -- audio clip lives behind the blob seam (ADR-0048) — clip_key reconstructs the
 -- blob.Key, and there is deliberately NO FK to the blob: deletion goes through
--- the seam (blob.Delete), never a DB cascade. The campaign_id / voice_session_id
--- FKs DO cascade so a campaign/session hard-delete removes the rows (the blob
--- keys are swept via ListCampaignHighlightClipKeys BEFORE the row cascade).
+-- the seam (blob.Delete), never a DB cascade.
+--
+-- campaign_id CASCADEs: a campaign hard-delete (#265) takes its highlight rows
+-- with it, and the clip blobs are swept via ListCampaignHighlightClipKeys BEFORE
+-- the delete commits (the campaign-delete tx also enqueues the blob sweep job).
+--
+-- voice_session_id is ON DELETE RESTRICT, NOT CASCADE, deliberately: there is NO
+-- session-delete path today (sessions are only ever ended, never individually
+-- removed), so RESTRICT is inert on every real flow — including campaign delete,
+-- where the campaign_id CASCADE removes the highlight rows before the cascaded
+-- voice_sessions delete is checked. Its job is to be a tripwire: if a future
+-- session-delete path is ever added, RESTRICT makes it fail loudly rather than
+-- silently cascading highlight rows away and orphaning their clip blobs (there is
+-- no blob sweep on a session delete).
 CREATE TABLE highlight (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     tenant_id uuid NOT NULL REFERENCES tenant(id),
-    voice_session_id uuid NOT NULL REFERENCES voice_sessions(id) ON DELETE CASCADE,
+    voice_session_id uuid NOT NULL REFERENCES voice_sessions(id) ON DELETE RESTRICT,
     campaign_id uuid NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
     status text NOT NULL DEFAULT 'candidate' CHECK (status IN ('candidate','promoted')),
     starts_at timestamptz NOT NULL,

--- a/internal/storage/migrations/00024_highlight.sql
+++ b/internal/storage/migrations/00024_highlight.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- Session Highlights persistence (#308, Epic 8, ADR-0051): a two-tier highlight
+-- row per detected epic moment. status starts 'candidate' (7-day purge horizon,
+-- ADR-0051) and only an explicit GM promotion flips it to 'promoted' (kept). The
+-- audio clip lives behind the blob seam (ADR-0048) — clip_key reconstructs the
+-- blob.Key, and there is deliberately NO FK to the blob: deletion goes through
+-- the seam (blob.Delete), never a DB cascade. The campaign_id / voice_session_id
+-- FKs DO cascade so a campaign/session hard-delete removes the rows (the blob
+-- keys are swept via ListCampaignHighlightClipKeys BEFORE the row cascade).
+CREATE TABLE highlight (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenant(id),
+    voice_session_id uuid NOT NULL REFERENCES voice_sessions(id) ON DELETE CASCADE,
+    campaign_id uuid NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,
+    status text NOT NULL DEFAULT 'candidate' CHECK (status IN ('candidate','promoted')),
+    starts_at timestamptz NOT NULL,
+    ends_at timestamptz NOT NULL,
+    score double precision NOT NULL,
+    excerpt text NOT NULL DEFAULT '',
+    reason text NOT NULL DEFAULT '',
+    speaker_ids text[] NOT NULL DEFAULT '{}',
+    clip_key text NOT NULL,
+    clip_content_type text NOT NULL DEFAULT 'audio/wav',
+    clip_size_bytes bigint NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    promoted_at timestamptz
+);
+CREATE INDEX highlight_session_idx ON highlight (voice_session_id);
+CREATE INDEX highlight_campaign_idx ON highlight (campaign_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS highlight;

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -1042,7 +1042,110 @@ service SessionService {
   // NOT NO_SIDE_EFFECTS: each call spends provider money + records usage, so
   // CSRF + auth guard it like a mutation.
   rpc GenerateRecap(GenerateRecapRequest) returns (GenerateRecapResponse);
+  // ListHighlights returns the Session Highlights for one Voice Session (#308,
+  // Epic 8) — the candidate + promoted moments the GM reviews after a session,
+  // newest moment first. Tenant-scoped server-side (ADR-0039), so it never
+  // returns another tenant's highlights. A read (NO_SIDE_EFFECTS).
+  rpc ListHighlights(ListHighlightsRequest) returns (ListHighlightsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // GetHighlight returns one Session Highlight by id (#308). Tenant-scoped: a
+  // foreign-tenant id is CodeNotFound (existence never leaked). A read
+  // (NO_SIDE_EFFECTS).
+  rpc GetHighlight(GetHighlightRequest) returns (GetHighlightResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // PromoteHighlight flips a candidate Highlight to 'promoted' so it survives the
+  // 7-day candidate purge (#308/ADR-0051), returning the updated row. Idempotent
+  // on the server (a re-promote keeps the original promoted_at), but it is a
+  // state change, so CSRF + auth guard it. A missing/foreign id is CodeNotFound.
+  rpc PromoteHighlight(PromoteHighlightRequest) returns (PromoteHighlightResponse);
+  // DeleteHighlight removes one Highlight and its audio clip (blob-then-row,
+  // ADR-0048), returning nothing (#308). A missing/foreign id is CodeNotFound.
+  // State-changing: CSRF + auth guard it.
+  rpc DeleteHighlight(DeleteHighlightRequest) returns (DeleteHighlightResponse);
 }
+
+// Highlight is the wire view of a Session Highlight row (#308, Epic 8): a
+// detected epic moment with its time range, caption material, speaker lanes, and
+// the clip's content-type/size (the clip bytes stream from
+// GET /api/v1/highlights/{id}/clip, not this message). clip_key is deliberately
+// NOT exposed — it is an internal blob-seam detail (ADR-0048).
+message Highlight {
+  // id is the highlight's UUID.
+  string id = 1;
+  // voice_session_id is the Voice Session the moment was detected in.
+  string voice_session_id = 2;
+  // campaign_id is the Campaign the session ran for.
+  string campaign_id = 3;
+  // status is "candidate" (subject to the 7-day purge) or "promoted" (kept).
+  string status = 4;
+  // starts_at bounds the clip's start (moment - lead).
+  google.protobuf.Timestamp starts_at = 5;
+  // ends_at bounds the clip's end (moment + tail).
+  google.protobuf.Timestamp ends_at = 6;
+  // score is the classifier's 0-10 rating of the moment.
+  double score = 7;
+  // excerpt is caption-worthy transcript text for the moment.
+  string excerpt = 8;
+  // reason is the classifier's one-line justification.
+  string reason = 9;
+  // speaker_ids are the distinct Speaker Lanes (Discord user ids) heard.
+  repeated string speaker_ids = 10;
+  // clip_content_type is the stored clip's MIME type ("audio/wav").
+  string clip_content_type = 11;
+  // clip_size_bytes is the stored clip's size in bytes.
+  int64 clip_size_bytes = 12;
+  // created_at is when the highlight was detected + stored.
+  google.protobuf.Timestamp created_at = 13;
+  // promoted_at is when the GM promoted it; unset while a candidate.
+  google.protobuf.Timestamp promoted_at = 14;
+}
+
+// ListHighlightsRequest names the Voice Session whose Highlights to list.
+message ListHighlightsRequest {
+  // voice_session_id is the session to list Highlights for.
+  string voice_session_id = 1;
+}
+
+// ListHighlightsResponse carries the session's Highlights, newest moment first.
+message ListHighlightsResponse {
+  // highlights are the session's Highlights (candidate and promoted).
+  repeated Highlight highlights = 1;
+}
+
+// GetHighlightRequest names one Highlight by id.
+message GetHighlightRequest {
+  // id is the Highlight to load.
+  string id = 1;
+}
+
+// GetHighlightResponse carries the requested Highlight.
+message GetHighlightResponse {
+  // highlight is the requested row.
+  Highlight highlight = 1;
+}
+
+// PromoteHighlightRequest names the Highlight to promote.
+message PromoteHighlightRequest {
+  // id is the Highlight to promote (candidate -> promoted).
+  string id = 1;
+}
+
+// PromoteHighlightResponse carries the promoted Highlight.
+message PromoteHighlightResponse {
+  // highlight is the updated (promoted) row.
+  Highlight highlight = 1;
+}
+
+// DeleteHighlightRequest names the Highlight to delete.
+message DeleteHighlightRequest {
+  // id is the Highlight to delete (row + clip).
+  string id = 1;
+}
+
+// DeleteHighlightResponse is empty; the delete cascades the clip through the seam.
+message DeleteHighlightResponse {}
 
 // GenerateRecapRequest carries the Voice Session ids to recap; each must belong
 // to the server-resolved Active Campaign (ADR-0039) — a cross-campaign or


### PR DESCRIPTION
Closes #308

Implements #308 (arch-e8 contract §D + PLAN: #308). Persists the #307 detector's `Trigger`s into durable Session Highlights.

## What lands
- **migration `00024_highlight.sql`** — `highlight` table; `status` candidate/promoted CHECK; `clip_key` text with **no FK to the blob** (deletion via the seam, ADR-0048); `campaign_id`/`voice_session_id` FKs `ON DELETE CASCADE` so a campaign/session hard-delete removes the rows (blob keys swept first). Migration number **00024 was free on `main`** (highest was `00023_tape_consent`); the contract's number stands.
- **`internal/storage/highlight.go`** — tenant-scoped `CreateHighlight` / `GetHighlight` / `ListHighlights` / `PromoteHighlight` (idempotent, COALESCE stamp) / `DeleteHighlight` (returns clip_key); session/campaign sweeps `ListSessionCandidateClipKeys` / `DeleteSessionCandidates` / `ListCampaignHighlightClipKeys`; plus `EnqueueJobAt` (future `run_after`, which plain `EnqueueJob` couldn't express).
- **`internal/highlight`** — `Saver` (the detector `Sink`): non-blocking cap-16 mailbox → per-session worker (`mixdown.WAVClip` → `blob.Put` → `CreateHighlight`); `Begin`/`HandleTrigger`/`Finalize` (flush barrier then enqueue `highlight.purge_candidates` +7d, then unbind). Purge handler (blob-delete FIRST, then rows; idempotent; promoted untouched). Clip HTTP serve (`http.ServeContent`, Range/scrub).
- **proto** — `SessionService` `ListHighlights`/`GetHighlight` (`NO_SIDE_EFFECTS`) + `PromoteHighlight`/`DeleteHighlight`; `Highlight` message fields 1–14. RPC handlers tenant-scoped server-side; foreign/unknown id → `CodeNotFound`; Delete = blob-then-row; **Promote does NOT enqueue enrichment** (#311's hook).
- **Manager** — `SetHighlights`/`Begin`(Start)/`Finalize`(runLoop, beside `transcript.Finalize`, at every exit path).
- **Campaign hard delete** sweeps highlight clip blobs via `ListCampaignHighlightClipKeys` (keys captured before the row cascade, blobs dropped only after the delete succeeds).
- **`cmd/glyphoxa/main.go`** — Postgres blob backend; Saver in the voice path; purge handler + clip route (`GET /api/v1/highlights/{id}/clip`, `auth.RequireSession`) in the web path. Web/voice split works through shared Postgres, no shared memory.

## Tests (TDD, red→green per slice)
- storage integration: round-trip tenant-scoped, promote idempotent, delete returns clip_key, session candidate sweep (promoted survives), campaign clip-key sweep.
- Saver unit: clip+row written; purge scheduled +7d; idle no-op; non-blocking drop when full; worker survives a failed save.
- purge unit: blob-first ordering, idempotent, bad payload / list-error propagate.
- clip serve unit: 200 audio/wav, 206 Range, 401 no tenant, 404 foreign tenant / unparsable id.
- RPC unit: list/get tenant-scoped, foreign→NotFound, promote, delete blob-then-row + double-delete NotFound.
- Manager unit: Begin binds owning ids at Start, Finalize at loop exit.
- campaign delete unit: sweeps clips on success, keeps them on refused delete.

Local: `go build/vet ./...` (incl. `-tags integration`), affected unit + `-race` suites, `golangci-lint` (0 issues), `buf lint` + `buf generate` all clean. Not polling remote CI.

## Notes / open question
- Contract §D schema omitted `ON DELETE CASCADE` on `campaign_id`/`voice_session_id`, but the "campaign delete sweeps clip keys" requirement needs the rows to cascade (otherwise `DeleteCampaign` RESTRICT-fails). Added the cascades; blob keys are swept via the seam before the cascade. Flagging in case the architect intended row-level pre-delete instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)