### PR TITLE
fix(#374): CI audio job runs opus-tagged tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,15 @@ jobs:
           go build -tags "opus nolibopusfile" ./...
           go vet -tags "opus nolibopusfile" ./...
 
+      # The opus-tagged unit tests (real libopus codec round-trip, PlaybackSource
+      # concurrency) are deterministic and keyless (ADR-0021) but CGO-gated behind
+      # `//go:build opus`, so the default no-CGO PR gate never compiles them. Run
+      # them HERE — separate from build+vet for concern clarity (#374). `-race`
+      # because codec/PlaybackSource pulls cross-goroutine. Targeted at the two
+      # packages that own opus-gated tests (mixdown decode, wire codec).
+      - name: Test (opus tags)
+        run: go test -race -tags "opus nolibopusfile" ./internal/mixdown/... ./pkg/voice/wire/...
+
       # The cassette-tier latency benchmark (Epic C): real silero VAD + codec,
       # cassettes for the network providers — keyless (no secrets, ADR-0021) but
       # CGO, so it runs HERE, not in the default no-CGO gate (ADR-0033 addendum).


### PR DESCRIPTION
## Problem

The audio/CGO job (`ci.yml` audio) only **built + vetted** the opus tag combo and ran the cassette benchmark. It never RAN the opus-tagged unit tests — `TestWAVClip_RealOpusRoundTrip` (internal/mixdown) and the 9 codec tests (pkg/voice/wire/codec) have **never executed in CI** since they live behind `//go:build opus`, which the default no-CGO PR gate excludes.

## Change

New dedicated `Test (opus tags)` step in the audio job:

```
go test -race -tags "opus nolibopusfile" ./internal/mixdown/... ./pkg/voice/wire/...
```

- Separate step (not folded into build+vet) for concern clarity.
- `-race` because codec/PlaybackSource pulls cross-goroutine.
- Targeted at the two packages owning opus-gated tests.
- Deterministic + keyless (ADR-0021); CGO-gated so it belongs in the audio job (ADR-0033).

## Local verification (libopus present)

```
ok  internal/mixdown        1.440s
ok  pkg/voice/wire          1.367s
ok  pkg/voice/wire/codec    1.066s
ok  pkg/voice/wire/codec/dsp 1.011s
```

`TestWAVClip_RealOpusRoundTrip` PASS; 9 codec `=== RUN` funcs execute and pass. **No test fixes needed** — the tests were healthy, just never wired into CI.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)