### PR TITLE
fix(#381): surface DroppedParticipantRefs

### DIFF
--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -80,9 +80,9 @@ func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
 // importResponse is the ServeImport 200 body: the minted campaign identity plus
 // the per-section counts the UI surfaces ("Imported <name>"). A history-less
 // bundle reports zero sessions/lines/chunks. DroppedParticipantRefs is ALWAYS
-// present (ADR-0053 §4 stable shape) — a chunk participant ref that mapped to no
-// imported Agent was dropped (not fatal), and a nonzero count also lands as a
-// slog.Warn in the importer (#381).
+// present so the response shape is stable for clients — a chunk participant ref
+// that mapped to no imported Agent was dropped (not fatal), and a nonzero count
+// also lands as a slog.Warn in the importer (#381).
 type importResponse struct {
 	CampaignID             string `json:"campaign_id"`
 	Name                   string `json:"name"`

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -78,18 +78,22 @@ func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
 }
 
 // importResponse is the ServeImport 200 body: the minted campaign identity plus
-// the per-section counts the UI surfaces ("Imported <name>"). Part 1 always
-// reports zero sessions/lines/chunks (History is part 2, #292).
+// the per-section counts the UI surfaces ("Imported <name>"). A history-less
+// bundle reports zero sessions/lines/chunks. DroppedParticipantRefs is ALWAYS
+// present (ADR-0053 §4 stable shape) — a chunk participant ref that mapped to no
+// imported Agent was dropped (not fatal), and a nonzero count also lands as a
+// slog.Warn in the importer (#381).
 type importResponse struct {
-	CampaignID string `json:"campaign_id"`
-	Name       string `json:"name"`
-	Agents     int    `json:"agents"`
-	Nodes      int    `json:"nodes"`
-	Edges      int    `json:"edges"`
-	Characters int    `json:"characters"`
-	Sessions   int    `json:"sessions"`
-	Lines      int    `json:"lines"`
-	Chunks     int    `json:"chunks"`
+	CampaignID             string `json:"campaign_id"`
+	Name                   string `json:"name"`
+	Agents                 int    `json:"agents"`
+	Nodes                  int    `json:"nodes"`
+	Edges                  int    `json:"edges"`
+	Characters             int    `json:"characters"`
+	Sessions               int    `json:"sessions"`
+	Lines                  int    `json:"lines"`
+	Chunks                 int    `json:"chunks"`
+	DroppedParticipantRefs int    `json:"dropped_participant_refs"`
 }
 
 // ServeImport ingests an uploaded campaign bundle: POST /api/v1/campaigns/import,
@@ -158,15 +162,16 @@ func (h *Handler) ServeImport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(importResponse{
-		CampaignID: res.CampaignID.String(),
-		Name:       res.Name,
-		Agents:     res.Agents,
-		Nodes:      res.Nodes,
-		Edges:      res.Edges,
-		Characters: res.Characters,
-		Sessions:   res.Sessions,
-		Lines:      res.Lines,
-		Chunks:     res.Chunks,
+		CampaignID:             res.CampaignID.String(),
+		Name:                   res.Name,
+		Agents:                 res.Agents,
+		Nodes:                  res.Nodes,
+		Edges:                  res.Edges,
+		Characters:             res.Characters,
+		Sessions:               res.Sessions,
+		Lines:                  res.Lines,
+		Chunks:                 res.Chunks,
+		DroppedParticipantRefs: res.DroppedParticipantRefs,
 	})
 }
 

--- a/internal/bundle/handler_import_test.go
+++ b/internal/bundle/handler_import_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -201,6 +202,55 @@ func TestServeImport(t *testing.T) {
 		// session user, not a client header).
 		if _, err := st.FindCampaignByName(ctx, tenantID, "Uploaded Campaign"); err != nil {
 			t.Fatalf("imported campaign not found under operator tenant: %v", err)
+		}
+	})
+
+	t.Run("response carries dropped_participant_refs (stable shape, zero absent)", func(t *testing.T) {
+		body, ct := multipartBundle(t, good)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authedImport(t, body, ct))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d body=%q, want 200", rec.Code, rec.Body.String())
+		}
+		// The field is ALWAYS present (ADR-0053 §4 stable response shape): a bundle
+		// with no unmappable participant refs still marshals it as 0, never omitted.
+		if !strings.Contains(rec.Body.String(), `"dropped_participant_refs"`) {
+			t.Errorf("200 body missing dropped_participant_refs field: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("dropped_participant_refs counts unmappable refs from history", func(t *testing.T) {
+		base := time.Date(2026, 6, 7, 20, 0, 0, 0, time.UTC)
+		ended := base.Add(time.Hour)
+		dropper := encodeBundle(t, &bundle.Bundle{
+			FormatVersion: bundle.FormatVersion,
+			Campaign: bundle.Campaign{
+				Name: "Dropped Refs", System: "dnd5e", Language: "en",
+				Agents: []bundle.Agent{{ID: "a1", Role: "character", Name: "Bart"}},
+				History: &bundle.History{Sessions: []bundle.Session{{
+					ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 0,
+					Chunks: []bundle.Chunk{{
+						Content:              "the dragon spoke of gold",
+						ParticipatedAgentIDs: []string{"a1", "ghost"},
+						StartedAt:            base,
+					}},
+				}}},
+			},
+		})
+		body, ct := multipartBundle(t, dropper)
+		rec := httptest.NewRecorder()
+		route.ServeHTTP(rec, authedImport(t, body, ct))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d body=%q, want 200", rec.Code, rec.Body.String())
+		}
+		var payload struct {
+			DroppedParticipantRefs int `json:"dropped_participant_refs"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode 200 body: %v", err)
+		}
+		if payload.DroppedParticipantRefs != 1 {
+			t.Errorf("dropped_participant_refs = %d, want 1 (ghost dropped)", payload.DroppedParticipantRefs)
 		}
 	})
 }

--- a/internal/bundle/handler_import_test.go
+++ b/internal/bundle/handler_import_test.go
@@ -212,8 +212,8 @@ func TestServeImport(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("code=%d body=%q, want 200", rec.Code, rec.Body.String())
 		}
-		// The field is ALWAYS present (ADR-0053 §4 stable response shape): a bundle
-		// with no unmappable participant refs still marshals it as 0, never omitted.
+		// The field is ALWAYS present so the response shape is stable for clients: a
+		// bundle with no unmappable participant refs still marshals it as 0, never omitted.
 		if !strings.Contains(rec.Body.String(), `"dropped_participant_refs"`) {
 			t.Errorf("200 body missing dropped_participant_refs field: %s", rec.Body.String())
 		}

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -14,7 +14,8 @@ import (
 // agent ref key to the minted (or, for the Butler, the trigger-created) Agent id;
 // part 1 fills it and part 2 (#292) consumes it IN-FUNCTION to remap a Chunk's
 // participated_agent_ids. Every int count — including DroppedParticipantRefs —
-// feeds the ServeImport JSON response (ADR-0053 §4 stable shape).
+// feeds the ServeImport JSON response, always present so the response shape is
+// stable for clients.
 // DroppedParticipantRefs counts chunk participant refs that mapped to no imported
 // Agent and were dropped (not fatal); a nonzero value also emits a single
 // slog.Warn from importHistory (#381), so a lossy import is never silent.
@@ -79,6 +80,15 @@ func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundl
 	})
 	if err != nil {
 		return ImportResult{}, err
+	}
+	// Surface a lossy import (a foreign/deleted participant carried no local NPC):
+	// gated on count>0, one WARN on the request-scoped logger with campaign_id +
+	// count (ADR-0032), so the count is visible in logs, not just the response JSON.
+	// Emitted AFTER commit succeeds, so a rolled-back import never logs a
+	// campaign_id that did not persist.
+	if res.DroppedParticipantRefs > 0 {
+		observe.CtxLogger(ctx).Warn("bundle: import dropped participant refs",
+			"campaign_id", res.CampaignID, "count", res.DroppedParticipantRefs)
 	}
 	return res, nil
 }
@@ -291,13 +301,6 @@ func importHistory(ctx context.Context, tx *storage.Store, campaignID uuid.UUID,
 			}
 			res.Chunks++
 		}
-	}
-	// Surface a lossy import (a foreign/deleted participant carried no local NPC):
-	// gated on count>0, one WARN on the request-scoped logger with campaign_id +
-	// count (ADR-0032), so the count is visible in logs, not just the response JSON.
-	if res.DroppedParticipantRefs > 0 {
-		observe.CtxLogger(ctx).Warn("bundle: import dropped participant refs",
-			"campaign_id", campaignID, "count", res.DroppedParticipantRefs)
 	}
 	return nil
 }

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
 // ImportResult reports what an [Import] persisted. AgentIDs maps each bundle
 // agent ref key to the minted (or, for the Butler, the trigger-created) Agent id;
 // part 1 fills it and part 2 (#292) consumes it IN-FUNCTION to remap a Chunk's
-// participated_agent_ids. The int counts feed the ServeImport JSON response.
+// participated_agent_ids. Every int count — including DroppedParticipantRefs —
+// feeds the ServeImport JSON response (ADR-0053 §4 stable shape).
 // DroppedParticipantRefs counts chunk participant refs that mapped to no imported
-// Agent and were dropped (not fatal).
+// Agent and were dropped (not fatal); a nonzero value also emits a single
+// slog.Warn from importHistory (#381), so a lossy import is never silent.
 type ImportResult struct {
 	CampaignID uuid.UUID
 	Name       string
@@ -234,6 +237,13 @@ func importHistory(ctx context.Context, tx *storage.Store, campaignID uuid.UUID,
 
 		for j := range s.Lines {
 			l := &s.Lines[j]
+			// Edge (documented, no behavior change): two bundle Lines sharing a line_id
+			// COALESCE at the DB upsert (ADR-0040 replay key = (voice_session_id,
+			// line_id)) — the last write wins on text/who while an earlier seq can
+			// linger, and res.Lines still counts BOTH inputs, so the reported Lines can
+			// exceed the persisted row count. A well-formed exported bundle never
+			// carries dup line_ids; this only bites a hand-edited/foreign bundle, and
+			// the import stays correct-by-replay. Left as-is per #381 review.
 			if err := tx.UpsertTranscriptLine(ctx, storage.TranscriptLine{
 				VoiceSessionID:       sessionID,
 				CampaignID:           campaignID,
@@ -281,6 +291,13 @@ func importHistory(ctx context.Context, tx *storage.Store, campaignID uuid.UUID,
 			}
 			res.Chunks++
 		}
+	}
+	// Surface a lossy import (a foreign/deleted participant carried no local NPC):
+	// gated on count>0, one WARN on the request-scoped logger with campaign_id +
+	// count (ADR-0032), so the count is visible in logs, not just the response JSON.
+	if res.DroppedParticipantRefs > 0 {
+		observe.CtxLogger(ctx).Warn("bundle: import dropped participant refs",
+			"campaign_id", campaignID, "count", res.DroppedParticipantRefs)
 	}
 	return nil
 }

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -3,11 +3,13 @@
 package bundle_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/bundle"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings/embeddingstest"
 )
@@ -806,6 +809,88 @@ func TestImportHistoryRollsBackWithPart1(t *testing.T) {
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Doomed History"); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("rolled-back import left a campaign: %v", err)
+	}
+}
+
+// TestImportWarnsOnDroppedParticipantRefs (#381): when a chunk carries a
+// participant ref that maps to no imported Agent, the importer emits a single
+// slog.Warn on the context logger (ADR-0032 request-scoped) carrying campaign_id
+// and the dropped count — so a lossy import is visible in the logs, not silent.
+func TestImportWarnsOnDroppedParticipantRefs(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	ctx = observe.WithLogger(ctx, log)
+
+	base := time.Date(2026, 6, 8, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Warns", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{{ID: "a1", Role: "character", Name: "Bart"}},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 0,
+				Chunks: []bundle.Chunk{{
+					Content:              "the dragon spoke of gold",
+					ParticipatedAgentIDs: []string{"a1", "ghost", "phantom"},
+					StartedAt:            base,
+				}},
+			}}},
+		},
+	}
+	res, err := bundle.Import(ctx, st, tid, bnd)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.DroppedParticipantRefs != 2 {
+		t.Fatalf("DroppedParticipantRefs = %d, want 2", res.DroppedParticipantRefs)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("no WARN emitted for dropped refs: %q", logged)
+	}
+	if !strings.Contains(logged, res.CampaignID.String()) {
+		t.Errorf("warn missing campaign_id %s: %q", res.CampaignID, logged)
+	}
+	if !strings.Contains(logged, "count=2") {
+		t.Errorf("warn missing count=2: %q", logged)
+	}
+}
+
+// TestImportSilentWhenNoDroppedRefs (#381): a clean import (every participant ref
+// maps) emits NO dropped-refs warning — the log line is gated on count > 0.
+func TestImportSilentWhenNoDroppedRefs(t *testing.T) {
+	ctx := context.Background()
+	st, tid := freshTenant(t)
+
+	var buf bytes.Buffer
+	ctx = observe.WithLogger(ctx, slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	base := time.Date(2026, 6, 9, 20, 0, 0, 0, time.UTC)
+	ended := base.Add(time.Hour)
+	bnd := &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		Campaign: bundle.Campaign{
+			Name: "Clean", System: "dnd5e", Language: "en",
+			Agents: []bundle.Agent{{ID: "a1", Role: "character", Name: "Bart"}},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: base, EndedAt: &ended, Status: "ended", LineCount: 0,
+				Chunks: []bundle.Chunk{{
+					Content:              "the dragon spoke of gold",
+					ParticipatedAgentIDs: []string{"a1"},
+					StartedAt:            base,
+				}},
+			}}},
+		},
+	}
+	if _, err := bundle.Import(ctx, st, tid, bnd); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("clean import emitted a warning: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## What

The importer counted chunk participant refs that mapped to no imported Agent (`internal/bundle/import.go`) but never surfaced the total — a lossy import was silent in both the logs and the response JSON.

## Changes

- **Response:** `dropped_participant_refs` (int) is now ALWAYS present in the `ServeImport` 200 body (always present so the response shape is stable for clients — 0 when nothing dropped, never omitted).
- **Log:** a single `slog.Warn` from `Import` (after the tx commits) when the count > 0, carrying `campaign_id` + `count` on the request-scoped context logger (ADR-0032). Emitting post-commit avoids logging a `campaign_id` that a rolled-back import never persisted.
- **Docs:** fixed the stale `ImportResult` doc comment (every int count, including `DroppedParticipantRefs`, feeds the response); documented the dup-`line_id` upsert coalescing edge (first seq + last text, over-counted `Lines`) near the upsert — no behavior change (per review).

## Tests (TDD, +4)

- `TestServeImport/response carries dropped_participant_refs` — field always present.
- `TestServeImport/dropped_participant_refs counts unmappable refs from history` — value lands in the response JSON.
- `TestImportWarnsOnDroppedParticipantRefs` — WARN with campaign_id + count on the context logger.
- `TestImportSilentWhenNoDroppedRefs` — clean import emits no warning (gated on count > 0).

All `internal/bundle` integration tests green locally; `go vet` + `golangci-lint` clean.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)