### PR TITLE
feat(#300): [E7] remember_knowledge Tool — KG write proposals (PR-a)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -630,6 +630,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	mgr.SetToolDeps(tool.Deps{
 		Transcripts: knowledgeAdapter,
 		KG:          knowledgeAdapter,
+		KGW:         knowledgeAdapter,
 	})
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -16,8 +16,10 @@ package knowledge
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -45,6 +47,14 @@ type Store interface {
 	// AgentNodeFacts is the Agent's own edge-aware neighbourhood, already
 	// gm_private-filtered (#133).
 	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
+	// AgentLinkedNode is the Agent's own linked Node (the NPC-Node↔Agent link),
+	// the anchor an own_node-scoped remember_knowledge proposal attaches to (#300,
+	// ADR-0052). ok=false means the Agent has no linked entry.
+	AgentLinkedNode(ctx context.Context, agentID uuid.UUID) (storage.KGNode, bool, error)
+	// CreateKnowledgeProposal records a pending Knowledge Proposal (#300,
+	// ADR-0052) — the sole effect of remember_knowledge. proposedWrite is the raw
+	// jsonb payload; nothing touches kg_node/kg_edge until the GM approves.
+	CreateKnowledgeProposal(ctx context.Context, campaignID, agentID uuid.UUID, proposedWrite []byte) error
 }
 
 // Sessions reports the active Voice Session (for its Campaign). *session.Manager
@@ -179,8 +189,61 @@ func typeLabel(t storage.KGNodeType) string {
 	}
 }
 
+// proposalWriteTimeout bounds the cancel-immune proposal INSERT: ADR-0052 barge
+// semantics require the write to SURVIVE the turn's cancellation (a barged reply
+// still yields its proposal), so it runs under context.WithoutCancel; the timeout
+// then prevents a goroutine leak if the DB is wedged.
+const proposalWriteTimeout = 5 * time.Second
+
+// OwnNode implements [tool.KGWriter]. It resolves the caller's own linked Node
+// (ADR-0008) for own_node-scoped proposals. The agentID is the turn ctx caller,
+// never the LLM args; an empty or unparseable id has no linked Node (ok=false),
+// so the handler refuses rather than proposing against a wrong Node.
+func (a *Adapter) OwnNode(ctx context.Context, agentID string) (tool.KGNodeRef, bool, error) {
+	aid, err := uuid.Parse(agentID)
+	if err != nil || aid == uuid.Nil {
+		return tool.KGNodeRef{}, false, nil
+	}
+	node, ok, err := a.store.AgentLinkedNode(ctx, aid)
+	if err != nil {
+		return tool.KGNodeRef{}, false, fmt.Errorf("knowledge: own node: %w", err)
+	}
+	if !ok {
+		return tool.KGNodeRef{}, false, nil
+	}
+	return tool.KGNodeRef{ID: node.ID.String(), Name: node.Name}, true, nil
+}
+
+// CreateProposal implements [tool.KGWriter]. It resolves the Campaign from the
+// active session (no session ⇒ ErrNoActiveSession), marshals the storage-free
+// [tool.ProposedWrite] to jsonb HERE, and INSERTs the pending proposal. The
+// insert runs under context.WithoutCancel(ctx) with a bounded timeout so a
+// barge-in (turn ctx cancel) does not roll back a proposal the NPC already made
+// (ADR-0052), while a wedged DB still cannot leak the goroutine.
+func (a *Adapter) CreateProposal(ctx context.Context, agentID string, w tool.ProposedWrite) error {
+	campaignID, err := a.activeCampaign()
+	if err != nil {
+		return err
+	}
+	aid, err := uuid.Parse(agentID)
+	if err != nil || aid == uuid.Nil {
+		return fmt.Errorf("knowledge: create proposal: invalid authoring agent id %q", agentID)
+	}
+	payload, err := json.Marshal(w)
+	if err != nil {
+		return fmt.Errorf("knowledge: create proposal: marshal proposed write: %w", err)
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), proposalWriteTimeout)
+	defer cancel()
+	if err := a.store.CreateKnowledgeProposal(writeCtx, campaignID, aid, payload); err != nil {
+		return fmt.Errorf("knowledge: create proposal: %w", err)
+	}
+	return nil
+}
+
 // Compile-time assertions that the adapter satisfies the tool seams.
 var (
 	_ tool.TranscriptSearcher = (*Adapter)(nil)
 	_ tool.KGReader           = (*Adapter)(nil)
+	_ tool.KGWriter           = (*Adapter)(nil)
 )

--- a/internal/knowledge/knowledge_proposal_integration_test.go
+++ b/internal/knowledge/knowledge_proposal_integration_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+// Drives the #300 remember_knowledge write path against a real Postgres
+// (testcontainers, ADR-0033): migration 00026 applies, the Tool handler resolves
+// the caller's own linked Node and records a pending Knowledge Proposal with the
+// exact jsonb shape, and deleting the authoring Agent cascades the proposal away.
+// Nothing here touches kg_node/kg_edge — a proposal is a suggestion only (ADR-0052).
+
+package knowledge_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// seedProposalWorld builds a Campaign with one Character NPC Agent linked to its
+// own NPC Node, returning the store, pool, campaign, agent, and linked-node ids.
+func seedProposalWorld(t *testing.T, dsn string) (*storage.Store, *pgxpool.Pool, uuid.UUID, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := storage.MigrateUp(ctx, db); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	var tenantID, campaignID, agentID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenant (name) VALUES ('Acme') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Lost Mine', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaignID); err != nil {
+		t.Fatalf("insert campaign: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO agents (campaign_id, agent_role, name) VALUES ($1, 'character', 'Bartholomew')
+		 RETURNING id`, campaignID).Scan(&agentID); err != nil {
+		t.Fatalf("insert agent: %v", err)
+	}
+
+	store := storage.New(pool)
+	node, err := store.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Bartholomew",
+	})
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	if _, err := store.SetNodeAgent(ctx, campaignID, node.ID,
+		uuid.NullUUID{UUID: agentID, Valid: true}); err != nil {
+		t.Fatalf("link node to agent: %v", err)
+	}
+	return store, pool, campaignID, agentID, node.ID
+}
+
+func TestRememberKnowledge_OwnNodeProposal_RealDB(t *testing.T) {
+	dsn := startPostgres(t)
+	store, pool, campaignID, agentID, nodeID := seedProposalWorld(t, dsn)
+	ctx := context.Background()
+
+	adapter := knowledge.New(store, staticSession{
+		sess: storage.VoiceSession{CampaignID: campaignID}, live: true,
+	})
+	rk := tool.NewRememberKnowledge(adapter)
+
+	// The full handler path: own_node grant, caller stamped on the ctx.
+	callCtx := tool.WithCaller(ctx, agentID.String())
+	out, err := rk.Execute(callCtx,
+		json.RawMessage(`{"kind":"fact","subject":"ignored by handler","fact":"I brew the finest ale in the realm"}`),
+		json.RawMessage(`{"scope":"own_node"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out == "" {
+		t.Error("empty success text")
+	}
+
+	pending, err := store.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListPendingKnowledgeProposals: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending proposals = %d, want 1", len(pending))
+	}
+	p := pending[0]
+	if p.CampaignID != campaignID || p.AuthoringAgentID != agentID {
+		t.Errorf("proposal scope = campaign %v / agent %v, want %v / %v",
+			p.CampaignID, p.AuthoringAgentID, campaignID, agentID)
+	}
+	if p.Status != "pending" || p.ReviewedAt != nil {
+		t.Errorf("proposal status = %q reviewedAt=%v, want pending/nil", p.Status, p.ReviewedAt)
+	}
+	var w tool.ProposedWrite
+	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil {
+		t.Fatalf("proposed_write jsonb: %v (%s)", err, p.ProposedWrite)
+	}
+	want := tool.ProposedWrite{
+		V: 1, Kind: "fact", NodeID: nodeID.String(),
+		Subject: "Bartholomew", // handler OVERWROTE the LLM subject with the own Node's name
+		Fact:    "I brew the finest ale in the realm",
+	}
+	if w != want {
+		t.Errorf("proposed_write = %+v, want %+v", w, want)
+	}
+
+	// The KG canon is untouched: the fact only lives as a proposal.
+	facts, err := adapter.OwnNodeFacts(ctx, agentID.String())
+	if err != nil {
+		t.Fatalf("OwnNodeFacts: %v", err)
+	}
+	for _, f := range facts {
+		if f.Body == want.Fact {
+			t.Errorf("proposal leaked into KG canon: %+v", f)
+		}
+	}
+
+	// Deleting the authoring Agent cascades the proposal (ON DELETE CASCADE).
+	if _, err := pool.Exec(ctx, `DELETE FROM agents WHERE id = $1`, agentID); err != nil {
+		t.Fatalf("delete agent: %v", err)
+	}
+	var remaining int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_proposal WHERE campaign_id = $1`, campaignID).Scan(&remaining); err != nil {
+		t.Fatalf("count after delete: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("agent DELETE did not cascade proposals: %d remain", remaining)
+	}
+}

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -2,13 +2,16 @@ package knowledge_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/knowledge"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
 // fakeStore is a scripted knowledge.Store: it records the campaign/agent it was
@@ -24,6 +27,31 @@ type fakeStore struct {
 	gotLineCID   uuid.UUID
 	gotAgentID   uuid.UUID
 	agentQueried bool
+
+	// Knowledge Proposal write seam (#300).
+	linkedNode    storage.KGNode
+	linkedOK      bool
+	gotLinkedAID  uuid.UUID
+	proposalCID   uuid.UUID
+	proposalAID   uuid.UUID
+	proposalJSON  []byte
+	proposalErrAt error // ctx.Err() observed INSIDE the store call
+	createErr     error
+}
+
+func (f *fakeStore) AgentLinkedNode(_ context.Context, aid uuid.UUID) (storage.KGNode, bool, error) {
+	f.gotLinkedAID = aid
+	return f.linkedNode, f.linkedOK, nil
+}
+func (f *fakeStore) CreateKnowledgeProposal(ctx context.Context, cid, aid uuid.UUID, pw []byte) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.proposalCID = cid
+	f.proposalAID = aid
+	f.proposalJSON = pw
+	f.proposalErrAt = ctx.Err()
+	return nil
 }
 
 func (f *fakeStore) SearchPublicNodes(_ context.Context, cid uuid.UUID, _ string, _ int) ([]storage.KGNode, error) {
@@ -142,5 +170,87 @@ func TestOwnNodeFactsResolvesAgent(t *testing.T) {
 	}
 	if store.agentQueried {
 		t.Error("empty caller must not hit the store")
+	}
+}
+
+// TestOwnNodeResolvesLinkedNode pins that OwnNode keys AgentLinkedNode by the
+// caller's agent id and projects it into a storage-free ref; an empty/invalid id
+// or an unlinked Agent reports ok=false without a wider fallback.
+func TestOwnNodeResolvesLinkedNode(t *testing.T) {
+	aid := uuid.New()
+	nid := uuid.New()
+	store := &fakeStore{linkedNode: storage.KGNode{ID: nid, Name: "Bartholomew"}, linkedOK: true}
+	adapter := knowledge.New(store, liveSession(uuid.New()))
+
+	ref, ok, err := adapter.OwnNode(context.Background(), aid.String())
+	if err != nil || !ok {
+		t.Fatalf("OwnNode: ok=%v err=%v", ok, err)
+	}
+	if store.gotLinkedAID != aid {
+		t.Errorf("AgentLinkedNode keyed by %v, want %v", store.gotLinkedAID, aid)
+	}
+	if ref.ID != nid.String() || ref.Name != "Bartholomew" {
+		t.Errorf("ref = %+v, want id %s name Bartholomew", ref, nid)
+	}
+
+	if _, ok, err := adapter.OwnNode(context.Background(), ""); ok || err != nil {
+		t.Errorf("empty caller: ok=%v err=%v, want false/nil", ok, err)
+	}
+
+	store.linkedOK = false
+	if _, ok, _ := adapter.OwnNode(context.Background(), aid.String()); ok {
+		t.Error("unlinked agent should report ok=false")
+	}
+}
+
+// TestCreateProposalShapeAndScope pins the adapter's write path (test 9): the
+// Campaign comes from the active session (never the caller), the proposed write
+// is marshalled to the exact jsonb shape, and the insert runs under a
+// cancel-immune context so a barge cannot roll it back (ADR-0052).
+func TestCreateProposalShapeAndScope(t *testing.T) {
+	cid := uuid.New()
+	aid := uuid.New()
+	store := &fakeStore{}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	// The turn ctx is ALREADY cancelled (barge) when the write starts; the store's
+	// write ctx must NOT observe it (context.WithoutCancel).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w := tool.ProposedWrite{V: 1, Kind: "fact", NodeID: "node-1", Subject: "Bartholomew", Fact: "brews ale"}
+	if err := adapter.CreateProposal(ctx, aid.String(), w); err != nil {
+		t.Fatalf("CreateProposal: %v", err)
+	}
+	if store.proposalCID != cid {
+		t.Errorf("proposal scoped to %v, want active session's campaign %v", store.proposalCID, cid)
+	}
+	if store.proposalAID != aid {
+		t.Errorf("proposal authored by %v, want %v", store.proposalAID, aid)
+	}
+	var got tool.ProposedWrite
+	if err := json.Unmarshal(store.proposalJSON, &got); err != nil {
+		t.Fatalf("stored jsonb not valid ProposedWrite: %v (%s)", err, store.proposalJSON)
+	}
+	if got != w {
+		t.Errorf("stored write = %+v, want %+v", got, w)
+	}
+	// Absent-kind fields must be omitted, not stored as empty strings.
+	if s := string(store.proposalJSON); strings.Contains(s, `"relation"`) || strings.Contains(s, `"target"`) || strings.Contains(s, `"body"`) {
+		t.Errorf("empty fields not omitted from jsonb: %s", s)
+	}
+
+	if store.proposalErrAt != nil {
+		t.Errorf("write ctx observed the barge cancel: %v (WithoutCancel not applied)", store.proposalErrAt)
+	}
+}
+
+// TestCreateProposalNoSessionErrors pins the no-active-session error path for the
+// write seam.
+func TestCreateProposalNoSessionErrors(t *testing.T) {
+	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	err := adapter.CreateProposal(context.Background(), uuid.New().String(),
+		tool.ProposedWrite{V: 1, Kind: "fact", Fact: "x"})
+	if !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("CreateProposal with no session = %v, want ErrNoActiveSession", err)
 	}
 }

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -45,7 +45,7 @@ func TestListToolGrants_CatalogWithState(t *testing.T) {
 		t.Fatalf("ListToolGrants: %v", err)
 	}
 	grants := resp.Msg.GetGrants()
-	wantNames := []string{"dice", "kg_query", "transcript_search"} // Name-sorted catalog
+	wantNames := []string{"dice", "kg_query", "remember_knowledge", "transcript_search"} // Name-sorted catalog
 	if len(grants) != len(wantNames) {
 		t.Fatalf("catalog = %+v, want %v", grants, wantNames)
 	}
@@ -64,6 +64,9 @@ func TestListToolGrants_CatalogWithState(t *testing.T) {
 	}
 	if !scopeByName["kg_query"] {
 		t.Error("kg_query must advertise scope support (ADR-0029 own_node vs campaign)")
+	}
+	if !scopeByName["remember_knowledge"] {
+		t.Error("remember_knowledge must advertise scope support (ADR-0052 own_node vs campaign)")
 	}
 	if scopeByName["dice"] {
 		t.Error("dice must not advertise scope support")

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Knowledge Proposal persistence (ADR-0052, #300): the pending queue an Agent's
+// remember_knowledge call writes to. Nothing here touches kg_node/kg_edge — a
+// proposal is a SUGGESTION the GM reviews (PR-b). The layer is deliberately thin:
+// a create for the Tool handler, a list for the review surface, and the
+// agent→own-Node lookup the own_node scope anchors on. proposed_write is stored
+// verbatim as jsonb (the pkg/tool.ProposedWrite union), interpreted only at
+// approval time.
+
+// KnowledgeProposal is one persisted proposal row. ProposedWrite is the raw
+// jsonb tagged union; ReviewedAt is nil until the GM acts.
+type KnowledgeProposal struct {
+	ID               uuid.UUID
+	CampaignID       uuid.UUID
+	AuthoringAgentID uuid.UUID
+	ProposedWrite    json.RawMessage
+	Status           string
+	CreatedAt        time.Time
+	ReviewedAt       *time.Time
+}
+
+const knowledgeProposalColumns = `
+	id, campaign_id, authoring_agent_id, proposed_write, status, created_at, reviewed_at`
+
+func scanKnowledgeProposal(row pgx.Row) (KnowledgeProposal, error) {
+	var p KnowledgeProposal
+	err := row.Scan(
+		&p.ID, &p.CampaignID, &p.AuthoringAgentID, &p.ProposedWrite,
+		&p.Status, &p.CreatedAt, &p.ReviewedAt,
+	)
+	return p, err
+}
+
+// CreateKnowledgeProposal inserts a pending proposal and returns the persisted
+// row. proposedWrite is the raw jsonb payload (the caller marshals it). There is
+// NO dedup — near-duplicate proposals are surfaced side-by-side for the GM to
+// merge or reject (ADR-0052: similarity is a hint, not a semantic judgment).
+func (s *Store) CreateKnowledgeProposal(ctx context.Context, campaignID, agentID uuid.UUID, proposedWrite []byte) error {
+	_, err := s.db.Exec(ctx,
+		`INSERT INTO knowledge_proposal (campaign_id, authoring_agent_id, proposed_write)
+		 VALUES ($1, $2, $3)`,
+		campaignID, agentID, proposedWrite)
+	if err != nil {
+		return fmt.Errorf("storage: create knowledge proposal: %w", err)
+	}
+	return nil
+}
+
+// ListPendingKnowledgeProposals returns a Campaign's pending proposals
+// oldest-first (the review order), hitting the partial pending index. An empty
+// queue yields an empty slice, not an error.
+func (s *Store) ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]KnowledgeProposal, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+knowledgeProposalColumns+`
+		   FROM knowledge_proposal
+		  WHERE campaign_id = $1 AND status = 'pending'
+		  ORDER BY created_at, id`, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list pending knowledge proposals: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KnowledgeProposal
+	for rows.Next() {
+		p, err := scanKnowledgeProposal(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan knowledge proposal: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list pending knowledge proposals: %w", err)
+	}
+	return out, nil
+}
+
+// AgentLinkedNode returns the Node an Agent is linked to (the NPC-Node↔Agent
+// link, ADR-0008; kg_node.agent_id), the anchor an own_node-scoped
+// remember_knowledge proposal attaches to. ok=false (no error) means the Agent
+// has no linked entry — the Tool handler refuses rather than proposing against a
+// wrong Node. The link is unique per Agent, so at most one row exists.
+func (s *Store) AgentLinkedNode(ctx context.Context, agentID uuid.UUID) (KGNode, bool, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+kgNodeColumns+` FROM kg_node WHERE agent_id = $1 LIMIT 1`, agentID)
+	n, err := scanKGNode(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return KGNode{}, false, nil
+	}
+	if err != nil {
+		return KGNode{}, false, fmt.Errorf("storage: agent linked node for agent %s: %w", agentID, err)
+	}
+	return n, true, nil
+}

--- a/internal/storage/migrations/00026_knowledge_proposal.sql
+++ b/internal/storage/migrations/00026_knowledge_proposal.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+
+-- Knowledge Proposals (ADR-0052, #300): an Agent's remember_knowledge call
+-- records a PENDING proposal here — nothing touches kg_node/kg_edge until the GM
+-- approves it in the review surface (PR-b). This is the KG's v1 trust model: an
+-- Agent can only ever SUGGEST canon, never write it. The proposed_write jsonb is
+-- the versioned tagged union pkg/tool.ProposedWrite marshals ("v":1; kind
+-- fact/edge/node); it is stored verbatim and interpreted only at approval time.
+--
+-- No Butler grant is seeded here: the write authority is opt-in per Agent via the
+-- grant editor's scope (ADR-0029), never a table-level default. ON DELETE CASCADE
+-- ties a proposal to both its Campaign and its authoring Agent so deleting either
+-- reaps the queue with no cleanup code.
+--
+-- NOTE (merge order): this migration is numbered 00026 and assumes 00024/00025
+-- (in-flight PRs) land first; renumber on rebase if they do not.
+
+CREATE TYPE knowledge_proposal_status AS ENUM ('pending', 'approved', 'rejected');
+
+CREATE TABLE knowledge_proposal (
+    id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id        uuid NOT NULL REFERENCES campaign (id) ON DELETE CASCADE,
+    authoring_agent_id uuid NOT NULL REFERENCES agents (id) ON DELETE CASCADE,
+    proposed_write     jsonb NOT NULL,
+    status             knowledge_proposal_status NOT NULL DEFAULT 'pending',
+    created_at         timestamptz NOT NULL DEFAULT now(),
+    reviewed_at        timestamptz
+);
+
+-- The review surface (PR-b) lists a Campaign's pending queue oldest-first; a
+-- partial index keeps that read cheap and skips already-reviewed rows.
+CREATE INDEX knowledge_proposal_pending_idx
+    ON knowledge_proposal (campaign_id, created_at)
+    WHERE status = 'pending';
+
+-- +goose Down
+
+DROP TABLE knowledge_proposal;
+DROP TYPE knowledge_proposal_status;

--- a/pkg/tool/builtins.go
+++ b/pkg/tool/builtins.go
@@ -19,5 +19,6 @@ func BuiltinRegistry(deps Deps) *Registry {
 	r.MustRegister(NewDice())
 	r.MustRegister(NewTranscriptSearch(deps.Transcripts))
 	r.MustRegister(NewKGQuery(deps.KG))
+	r.MustRegister(NewRememberKnowledge(deps.KGW))
 	return r
 }

--- a/pkg/tool/builtins_test.go
+++ b/pkg/tool/builtins_test.go
@@ -14,7 +14,7 @@ import (
 // live session runs.
 func TestBuiltinRegistryRegistersKnowledgeTools(t *testing.T) {
 	reg := BuiltinRegistry(Deps{})
-	want := []string{"dice", "kg_query", "transcript_search"} // Tools() is Name-sorted
+	want := []string{"dice", "kg_query", "remember_knowledge", "transcript_search"} // Tools() is Name-sorted
 	got := reg.Tools()
 	if len(got) != len(want) {
 		t.Fatalf("registered %d tools, want %d: %+v", len(got), len(want), got)

--- a/pkg/tool/deps.go
+++ b/pkg/tool/deps.go
@@ -24,6 +24,62 @@ type Deps struct {
 	// KG backs kg_query. nil ⇒ the Tool is registered but its Execute reports it
 	// is unavailable.
 	KG KGReader
+	// KGW backs remember_knowledge (#300, ADR-0052). nil ⇒ the Tool is registered
+	// but its Execute reports it is unavailable in this mode (the grant-editor RPC
+	// and voice bench build a zero Deps).
+	KGW KGWriter
+}
+
+// ProposedWrite is the versioned, storage-free payload one remember_knowledge
+// call proposes to the Knowledge Graph (#300, ADR-0052). It is a tagged union
+// over Kind ("fact", "edge", "node"); the adapter marshals it to the
+// knowledge_proposal.proposed_write jsonb verbatim, so the field set and json
+// tags ARE the on-disk contract. V is the schema version (always 1) so a future
+// shape change is detectable. Fields not part of a Kind stay zero and omitempty
+// keeps them out of the jsonb.
+//
+// Per ADR-0052 a proposal is the ONLY effect of the Tool — nothing touches
+// kg_node/kg_edge until the GM approves in PR-b's review surface. A speculative
+// draft (ADR-0053 ensemble fan-out) that is later discarded may still leave a
+// proposal row; that is ADR-0052-consistent (the NPC heard the fact) and the GM
+// review is the safety net.
+type ProposedWrite struct {
+	V        int    `json:"v"`
+	Kind     string `json:"kind"`
+	NodeID   string `json:"node_id,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	Fact     string `json:"fact,omitempty"`
+	Relation string `json:"relation,omitempty"`
+	Target   string `json:"target,omitempty"`
+	NodeType string `json:"node_type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Body     string `json:"body,omitempty"`
+}
+
+// KGNodeRef is a storage-free handle to an Agent's own linked Node (ADR-0008
+// NPC-Node↔Agent link): its id (the anchor a Character NPC's own_node proposals
+// attach to) and its display Name (the subject the handler stamps over whatever
+// the LLM supplied). Kept storage-free so pkg/tool never sees a storage type.
+type KGNodeRef struct {
+	ID   string
+	Name string
+}
+
+// KGWriter is the narrow write seam remember_knowledge needs (#300, ADR-0052).
+// It is deliberately not part of [KGReader]: writing is a distinct authority.
+// *knowledge.Adapter satisfies it; a nil KGW on [Deps] reports unavailable at
+// Execute.
+//
+//   - OwnNode resolves the caller's own linked Node for own_node-scoped
+//     proposals. The agentID is the turn ctx caller ([CallerID]), never the LLM
+//     args. ok=false means the Agent has no linked wiki entry — the handler
+//     refuses rather than proposing against a wrong or absent Node.
+//   - CreateProposal records the proposal row (status pending). It is the ONLY
+//     side effect; per ADR-0052 barge semantics the adapter writes it under a
+//     cancel-immune context so a barged turn's proposal is never rolled back.
+type KGWriter interface {
+	OwnNode(ctx context.Context, agentID string) (KGNodeRef, bool, error)
+	CreateProposal(ctx context.Context, agentID string, w ProposedWrite) error
 }
 
 // TranscriptHit is one persisted transcript Line the knowledge adapter surfaces

--- a/pkg/tool/loop.go
+++ b/pkg/tool/loop.go
@@ -25,8 +25,9 @@ var ErrMaxRoundsExceeded = errors.New("tool: max tool-call rounds exceeded")
 //
 // Least-privilege (ADR-0029) and side-effect timing (ADR-0030) are both
 // enforced here: only Tools the Agent is granted are declared and executable,
-// and only read-only Tools run inline — a non-read-only Tool is refused
-// because v1.0 does not build the deferred-to-turn-commit path.
+// and only read-only — or [ProposalMediated] (ADR-0052) — Tools run inline. A
+// non-read-only Tool that is not proposal-mediated is refused because v1.0 does
+// not build the deferred-to-turn-commit path.
 type Loop struct {
 	provider Provider
 	grants   *GrantSet
@@ -220,9 +221,13 @@ func (l *Loop) execute(ctx context.Context, call ToolCall) ToolResult {
 	if !t.ReadOnly() {
 		// ADR-0030: side-effecting Tools must defer to turn-commit; that path
 		// is not built in v1.0, so refuse rather than mutate state inline from
-		// a draft that may be discarded.
-		return errResult(call.ID, fmt.Sprintf(
-			"tool %q is not read-only; side-effecting tools are not supported in this version", call.Name))
+		// a draft that may be discarded. ADR-0052 carves out ONE exception: a
+		// proposal-mediated Tool (remember_knowledge) whose only effect is a
+		// GM-reviewed proposal row is safe to run inline, so it falls through.
+		if pm, ok := t.(ProposalMediated); !ok || !pm.ProposalMediated() {
+			return errResult(call.ID, fmt.Sprintf(
+				"tool %q is not read-only; side-effecting tools are not supported in this version", call.Name))
+		}
 	}
 
 	out, err := t.Execute(ctx, call.Input, config)

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -1,0 +1,319 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// MaxProposalTextRunes caps the free-text fields a remember_knowledge proposal
+// carries (fact / body / name), in runes: a pathological wall of text has no
+// business in the GM's review queue, and the cap bounds one proposed_write's
+// jsonb. Enforced in the handler, per-field, before the writer is ever called.
+const MaxProposalTextRunes = 2000
+
+// Proposal kinds (ADR-0052). fact/edge may be proposed own_node or campaign;
+// node (a brand-new wiki entry) is Butler-only (campaign scope).
+const (
+	proposalKindFact = "fact"
+	proposalKindEdge = "edge"
+	proposalKindNode = "node"
+)
+
+// proposalWriteVersion is the schema version stamped onto every ProposedWrite
+// (ADR-0052 "v":1), so a later shape change is detectable on the stored jsonb.
+const proposalWriteVersion = 1
+
+// relationValues is the closed set of Edge relations an Agent may propose,
+// mirroring the kg_edge relation vocabulary (ADR-0008). Exact lowercase
+// snake_case — the review surface and the eventual approved write depend on it.
+var relationValues = map[string]bool{
+	"resides_in":      true,
+	"member_of":       true,
+	"owns":            true,
+	"knows":           true,
+	"enemy_of":        true,
+	"ally_of":         true,
+	"parent_of":       true,
+	"participated_in": true,
+	"mentioned_in":    true,
+}
+
+// nodeTypeValues is the closed set of Node types a Butler may propose for a new
+// entry, mirroring storage.KGNodeType (ADR-0008). Exact lowercase snake_case.
+var nodeTypeValues = map[string]bool{
+	"character":   true,
+	"npc":         true,
+	"location":    true,
+	"faction":     true,
+	"item":        true,
+	"plot_thread": true,
+	"note":        true,
+}
+
+// rememberKnowledgeInputSchema is the JSON Schema declared to the LLM. Scope is
+// NEVER an argument (ADR-0029: it lives in the grant, enforced in the handler);
+// the model only ever names WHAT it wants to remember, never on whose authority.
+var rememberKnowledgeInputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["fact", "edge", "node"],
+      "description": "fact: a statement about an entity. edge: a relationship between two entities. node: a brand-new entry for the world."
+    },
+    "subject": {
+      "type": "string",
+      "description": "The name of the entity the fact or edge is about (for a campaign-wide proposal). Ignored when you may only write about yourself."
+    },
+    "fact": {
+      "type": "string",
+      "description": "The fact to remember about the subject (kind=fact)."
+    },
+    "relation": {
+      "type": "string",
+      "enum": ["resides_in", "member_of", "owns", "knows", "enemy_of", "ally_of", "parent_of", "participated_in", "mentioned_in"],
+      "description": "The relationship type (kind=edge)."
+    },
+    "target": {
+      "type": "string",
+      "description": "The name of the entity on the other end of the relationship (kind=edge)."
+    },
+    "node_type": {
+      "type": "string",
+      "enum": ["character", "npc", "location", "faction", "item", "plot_thread", "note"],
+      "description": "The type of the new entry (kind=node)."
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the new entry (kind=node)."
+    },
+    "body": {
+      "type": "string",
+      "description": "The prose describing the new entry (kind=node)."
+    }
+  },
+  "required": ["kind"]
+}`)
+
+// rememberArgs is the decoded LLM argument set. Scope is absent by design.
+type rememberArgs struct {
+	Kind     string `json:"kind"`
+	Subject  string `json:"subject"`
+	Fact     string `json:"fact"`
+	Relation string `json:"relation"`
+	Target   string `json:"target"`
+	NodeType string `json:"node_type"`
+	Name     string `json:"name"`
+	Body     string `json:"body"`
+}
+
+// RememberKnowledge is the first side-effecting built-in (#300, ADR-0052): an
+// Agent's proposal that a new fact, relationship, or entry be added to the
+// Knowledge Graph. Its ONLY effect is a pending Knowledge Proposal row for the
+// GM to review — nothing touches campaign canon until the GM approves. It is
+// therefore [ProposalMediated] and runs inline in the loop despite ReadOnly
+// being false.
+//
+// The write authority is narrowed per Agent Role via the ADR-0029 grant scope,
+// enforced HERE, never by the LLM:
+//
+//   - own_node (a Character NPC's default, and the fail-closed default): may
+//     propose facts on its OWN linked Node and Edges FROM it. The subject and
+//     anchor are the caller's own Node (resolved from the turn ctx, not the
+//     args), so a crafted subject cannot make an innkeeper propose facts about
+//     the distant war. Creating a new entry (kind=node) is refused.
+//   - campaign (the Butler's grant): may propose facts, edges, and brand-new
+//     entries anywhere in the Campaign; the subject is taken from the args.
+type RememberKnowledge struct {
+	dst KGWriter
+}
+
+// NewRememberKnowledge builds the Tool over dst. A nil dst registers the Tool
+// (the grant editor's catalog is identical in every mode) but its Execute reports
+// it is unavailable rather than panicking.
+func NewRememberKnowledge(dst KGWriter) *RememberKnowledge {
+	return &RememberKnowledge{dst: dst}
+}
+
+// Name implements [Tool].
+func (*RememberKnowledge) Name() string { return "remember_knowledge" }
+
+// Description implements [Tool].
+func (*RememberKnowledge) Description() string {
+	return "Remember a new fact, relationship or entry about the world. " +
+		"It is saved as a suggestion for the GM to review — not instantly canon."
+}
+
+// InputSchema implements [Tool].
+func (*RememberKnowledge) InputSchema() json.RawMessage { return rememberKnowledgeInputSchema }
+
+// ReadOnly implements [Tool]: remember_knowledge writes a proposal, so it is not
+// read-only (ADR-0030). It runs inline anyway via [ProposalMediated] (ADR-0052).
+func (*RememberKnowledge) ReadOnly() bool { return false }
+
+// ProposalMediated implements [ProposalMediated]: the only effect is a GM-reviewed
+// proposal, so the loop runs it inline despite ReadOnly=false (ADR-0052).
+func (*RememberKnowledge) ProposalMediated() bool { return true }
+
+// SupportsScope implements [Tool]: the write authority is narrowed per Agent via
+// the grant scope (own_node vs campaign), so the grant editor renders its scope
+// UI (ADR-0029).
+func (*RememberKnowledge) SupportsScope() bool { return true }
+
+// Execute implements [Tool]. It resolves the effective scope from grantConfig
+// (never the args, fail-closed to own_node), validates the per-kind arguments,
+// builds the [ProposedWrite], and records it as a pending proposal. A nil writer
+// reports unavailable; a misconfigured grant fails loudly; a bad argument or a
+// scope violation returns an error result the LLM can read, and — for own_node
+// refusals and unlinked callers — the writer is NEVER called.
+func (rk *RememberKnowledge) Execute(ctx context.Context, args json.RawMessage, grantConfig any) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if rk.dst == nil {
+		return "", fmt.Errorf("remember_knowledge: knowledge writes are unavailable in this mode")
+	}
+
+	scope, err := parseScope(grantConfig)
+	if err != nil {
+		return "", fmt.Errorf("remember_knowledge: %w", err)
+	}
+	if scope == "" {
+		scope = scopeOwnNode // write direction fails CLOSED to the narrowest scope (S3)
+	}
+
+	var a rememberArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("remember_knowledge: invalid arguments: %w", err)
+	}
+	a.Kind = strings.TrimSpace(a.Kind)
+
+	if err := validateArgs(a); err != nil {
+		return "", err
+	}
+
+	var w ProposedWrite
+	switch scope {
+	case scopeOwnNode:
+		w, err = rk.ownNodeWrite(ctx, a)
+	case scopeCampaign:
+		w, err = campaignWrite(a)
+	default:
+		return "", fmt.Errorf("remember_knowledge: unsupported scope %q", scope)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	if err := rk.dst.CreateProposal(ctx, CallerID(ctx), w); err != nil {
+		return "", fmt.Errorf("remember_knowledge: %w", err)
+	}
+	return "Noted — saved for the GM's review.", nil
+}
+
+// validateArgs enforces the per-kind required fields and the text-length caps,
+// BEFORE any scope resolution reaches the writer. It is intentionally scope-blind
+// (subject requirements are checked per scope): an unknown kind or an overlong
+// body must be rejected the same way for a Butler and an NPC.
+func validateArgs(a rememberArgs) error {
+	switch a.Kind {
+	case proposalKindFact:
+		if strings.TrimSpace(a.Fact) == "" {
+			return fmt.Errorf("remember_knowledge: a fact requires the 'fact' text")
+		}
+		if err := capText("fact", a.Fact); err != nil {
+			return err
+		}
+	case proposalKindEdge:
+		if !relationValues[a.Relation] {
+			return fmt.Errorf("remember_knowledge: %q is not a known relation", a.Relation)
+		}
+		if strings.TrimSpace(a.Target) == "" {
+			return fmt.Errorf("remember_knowledge: an edge requires a 'target'")
+		}
+	case proposalKindNode:
+		if strings.TrimSpace(a.Name) == "" {
+			return fmt.Errorf("remember_knowledge: a new entry requires a 'name'")
+		}
+		if !nodeTypeValues[a.NodeType] {
+			return fmt.Errorf("remember_knowledge: %q is not a known node_type", a.NodeType)
+		}
+		if err := capText("name", a.Name); err != nil {
+			return err
+		}
+		if err := capText("body", a.Body); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("remember_knowledge: unknown kind %q", a.Kind)
+	}
+	return nil
+}
+
+// capText rejects a field longer than MaxProposalTextRunes (rune-counted).
+func capText(field, s string) error {
+	if utf8.RuneCountInString(s) > MaxProposalTextRunes {
+		return fmt.Errorf("remember_knowledge: %s is too long (max %d characters)", field, MaxProposalTextRunes)
+	}
+	return nil
+}
+
+// ownNodeWrite builds a proposal anchored on the CALLER's own linked Node. A new
+// entry (kind=node) is refused (an NPC may not create entries); the subject and
+// anchor node_id are the caller's own Node, overwriting whatever the LLM
+// supplied, and an Agent with no linked entry is refused with the writer never
+// called.
+func (rk *RememberKnowledge) ownNodeWrite(ctx context.Context, a rememberArgs) (ProposedWrite, error) {
+	if a.Kind == proposalKindNode {
+		return ProposedWrite{}, fmt.Errorf("remember_knowledge: you may not create new entries; you can only remember facts about yourself")
+	}
+	ref, ok, err := rk.dst.OwnNode(ctx, CallerID(ctx))
+	if err != nil {
+		return ProposedWrite{}, fmt.Errorf("remember_knowledge: %w", err)
+	}
+	if !ok {
+		return ProposedWrite{}, fmt.Errorf("remember_knowledge: you have no linked wiki entry to remember facts about")
+	}
+	w := ProposedWrite{V: proposalWriteVersion, Kind: a.Kind, NodeID: ref.ID, Subject: ref.Name}
+	switch a.Kind {
+	case proposalKindFact:
+		w.Fact = a.Fact
+	case proposalKindEdge:
+		w.Relation = a.Relation
+		w.Target = a.Target
+	}
+	return w, nil
+}
+
+// campaignWrite builds a campaign-scoped proposal (the Butler's grant): all three
+// kinds are allowed, the subject is preserved from the args, and there is no
+// anchor node_id (the review surface resolves the subject by name).
+func campaignWrite(a rememberArgs) (ProposedWrite, error) {
+	w := ProposedWrite{V: proposalWriteVersion, Kind: a.Kind}
+	switch a.Kind {
+	case proposalKindFact:
+		if strings.TrimSpace(a.Subject) == "" {
+			return ProposedWrite{}, fmt.Errorf("remember_knowledge: a fact requires a 'subject'")
+		}
+		w.Subject = a.Subject
+		w.Fact = a.Fact
+	case proposalKindEdge:
+		if strings.TrimSpace(a.Subject) == "" {
+			return ProposedWrite{}, fmt.Errorf("remember_knowledge: an edge requires a 'subject'")
+		}
+		w.Subject = a.Subject
+		w.Relation = a.Relation
+		w.Target = a.Target
+	case proposalKindNode:
+		w.NodeType = a.NodeType
+		w.Name = a.Name
+		w.Body = a.Body
+	}
+	return w, nil
+}
+
+// Compile-time assertion that RememberKnowledge is proposal-mediated.
+var _ ProposalMediated = (*RememberKnowledge)(nil)

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -8,10 +8,12 @@ import (
 	"unicode/utf8"
 )
 
-// MaxProposalTextRunes caps the free-text fields a remember_knowledge proposal
-// carries (fact / body / name), in runes: a pathological wall of text has no
-// business in the GM's review queue, and the cap bounds one proposed_write's
-// jsonb. Enforced in the handler, per-field, before the writer is ever called.
+// MaxProposalTextRunes caps the free-text (prose) fields a remember_knowledge
+// proposal carries — fact and body — in runes: a pathological wall of text has no
+// business in the GM's review queue. The shorter entity-name fields (subject,
+// target, name) are capped at MaxKGNameRunes instead. Together these two caps
+// bound EVERY field, so one proposed_write's jsonb is bounded. Enforced in the
+// handler, per-field, before the writer is ever called.
 const MaxProposalTextRunes = 2000
 
 // Proposal kinds (ADR-0052). fact/edge may be proposed own_node or campaign;
@@ -227,12 +229,21 @@ func validateArgs(a rememberArgs) error {
 		if err := capText("fact", a.Fact); err != nil {
 			return err
 		}
+		if err := capName("subject", a.Subject); err != nil {
+			return err
+		}
 	case proposalKindEdge:
 		if !relationValues[a.Relation] {
 			return fmt.Errorf("remember_knowledge: %q is not a known relation", a.Relation)
 		}
 		if strings.TrimSpace(a.Target) == "" {
 			return fmt.Errorf("remember_knowledge: an edge requires a 'target'")
+		}
+		if err := capName("subject", a.Subject); err != nil {
+			return err
+		}
+		if err := capName("target", a.Target); err != nil {
+			return err
 		}
 	case proposalKindNode:
 		if strings.TrimSpace(a.Name) == "" {
@@ -253,10 +264,21 @@ func validateArgs(a rememberArgs) error {
 	return nil
 }
 
-// capText rejects a field longer than MaxProposalTextRunes (rune-counted).
+// capText rejects a prose field longer than MaxProposalTextRunes (rune-counted).
 func capText(field, s string) error {
 	if utf8.RuneCountInString(s) > MaxProposalTextRunes {
 		return fmt.Errorf("remember_knowledge: %s is too long (max %d characters)", field, MaxProposalTextRunes)
+	}
+	return nil
+}
+
+// capName rejects an entity-name field (subject/target) longer than
+// MaxKGNameRunes (rune-counted). It is scope-blind so the cap holds for an
+// own_node edge target as well as a campaign subject/target — no field escapes
+// unbounded into the proposed_write jsonb.
+func capName(field, s string) error {
+	if utf8.RuneCountInString(s) > MaxKGNameRunes {
+		return fmt.Errorf("remember_knowledge: %s is too long (max %d characters)", field, MaxKGNameRunes)
 	}
 	return nil
 }

--- a/pkg/tool/remember_knowledge_test.go
+++ b/pkg/tool/remember_knowledge_test.go
@@ -1,0 +1,336 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// fakeKGWriter records what remember_knowledge asked the KG write seam to do so
+// tests can assert the handler's scope enforcement without a real DB.
+type fakeKGWriter struct {
+	ownRef     KGNodeRef
+	ownOK      bool
+	ownErr     error
+	ownCalled  bool
+	ownAgentID string
+
+	created       []ProposedWrite
+	createAgentID string
+	createCtx     context.Context
+	createErr     error
+	onCreate      func()
+}
+
+func (f *fakeKGWriter) OwnNode(_ context.Context, agentID string) (KGNodeRef, bool, error) {
+	f.ownCalled = true
+	f.ownAgentID = agentID
+	return f.ownRef, f.ownOK, f.ownErr
+}
+
+func (f *fakeKGWriter) CreateProposal(ctx context.Context, agentID string, w ProposedWrite) error {
+	if f.onCreate != nil {
+		f.onCreate()
+	}
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.createAgentID = agentID
+	f.createCtx = ctx
+	f.created = append(f.created, w)
+	return nil
+}
+
+var (
+	cfgOwnNode  = json.RawMessage(`{"scope":"own_node"}`)
+	cfgCampaign = json.RawMessage(`{"scope":"campaign"}`)
+)
+
+// Test 1: per-kind argument validation refuses bad calls and NEVER reaches the
+// write seam — no OwnNode lookup, no proposal row.
+func TestRememberKnowledge_ArgValidation(t *testing.T) {
+	long := strings.Repeat("x", MaxProposalTextRunes+1)
+	cases := []struct {
+		name string
+		args string
+	}{
+		{"unknown kind", `{"kind":"blah"}`},
+		{"empty kind", `{"kind":""}`},
+		{"fact missing text", `{"kind":"fact","subject":"The Duke"}`},
+		{"fact too long", `{"kind":"fact","subject":"X","fact":"` + long + `"}`},
+		{"edge bad relation", `{"kind":"edge","subject":"X","relation":"loves","target":"Y"}`},
+		{"edge missing target", `{"kind":"edge","subject":"X","relation":"knows"}`},
+		{"node missing name", `{"kind":"node","node_type":"npc"}`},
+		{"node bad type", `{"kind":"node","name":"X","node_type":"dragon"}`},
+		{"node name too long", `{"kind":"node","node_type":"npc","name":"` + long + `"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &fakeKGWriter{ownRef: KGNodeRef{ID: "n1", Name: "Bart"}, ownOK: true}
+			rk := NewRememberKnowledge(w)
+			ctx := WithCaller(context.Background(), "agent-1")
+			_, err := rk.Execute(ctx, json.RawMessage(tc.args), cfgCampaign)
+			if err == nil {
+				t.Fatalf("want validation error, got nil")
+			}
+			if len(w.created) != 0 {
+				t.Errorf("writer.CreateProposal was called on a bad arg: %+v", w.created)
+			}
+			if w.ownCalled {
+				t.Errorf("writer.OwnNode was called on a bad arg")
+			}
+		})
+	}
+}
+
+// Test 2: an own_node fact/edge anchors on the CALLER's own Node — the subject is
+// overwritten with the own Node's name and the anchor node_id is the own Node's
+// id, resolved from the ctx caller (never the LLM's subject arg).
+func TestRememberKnowledge_OwnNodeAnchoring(t *testing.T) {
+	t.Run("fact overwrites subject", func(t *testing.T) {
+		w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bartholomew"}, ownOK: true}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "agent-9")
+		out, err := rk.Execute(ctx, json.RawMessage(
+			`{"kind":"fact","subject":"Someone Else","fact":"I brew the best ale"}`), cfgOwnNode)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(out, "GM") {
+			t.Errorf("success text = %q", out)
+		}
+		if w.ownAgentID != "agent-9" {
+			t.Errorf("OwnNode resolved agent %q, want agent-9", w.ownAgentID)
+		}
+		if w.createAgentID != "agent-9" {
+			t.Errorf("CreateProposal agent %q, want agent-9", w.createAgentID)
+		}
+		got := w.created[0]
+		want := ProposedWrite{V: 1, Kind: "fact", NodeID: "node-1", Subject: "Bartholomew", Fact: "I brew the best ale"}
+		if got != want {
+			t.Errorf("proposed write = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("edge is FROM own node", func(t *testing.T) {
+		w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bartholomew"}, ownOK: true}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "agent-9")
+		_, err := rk.Execute(ctx, json.RawMessage(
+			`{"kind":"edge","subject":"ignored","relation":"knows","target":"The Duke"}`), cfgOwnNode)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		got := w.created[0]
+		want := ProposedWrite{V: 1, Kind: "edge", NodeID: "node-1", Subject: "Bartholomew", Relation: "knows", Target: "The Duke"}
+		if got != want {
+			t.Errorf("proposed write = %+v, want %+v", got, want)
+		}
+	})
+}
+
+// Test 3: an own_node-scoped Agent may NOT create a new entry (kind=node); the
+// write seam is never touched.
+func TestRememberKnowledge_OwnNodeRefusesNewEntry(t *testing.T) {
+	w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bart"}, ownOK: true}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	_, err := rk.Execute(ctx, json.RawMessage(
+		`{"kind":"node","name":"New Town","node_type":"location"}`), cfgOwnNode)
+	if err == nil {
+		t.Fatal("want refusal for kind=node under own_node, got nil")
+	}
+	if w.ownCalled {
+		t.Error("OwnNode was called on a refused new-entry proposal")
+	}
+	if len(w.created) != 0 {
+		t.Errorf("a proposal was created: %+v", w.created)
+	}
+}
+
+// Test 4: an Agent with no linked wiki entry — or an unstamped ctx — cannot
+// propose own_node facts; the handler refuses with zero proposals.
+func TestRememberKnowledge_OwnNodeUnlinked(t *testing.T) {
+	t.Run("unstamped ctx", func(t *testing.T) {
+		w := &fakeKGWriter{ownOK: false} // no caller id ⇒ no own node
+		rk := NewRememberKnowledge(w)
+		_, err := rk.Execute(context.Background(), json.RawMessage(
+			`{"kind":"fact","fact":"I brew ale"}`), cfgOwnNode)
+		if err == nil {
+			t.Fatal("want error for unlinked/unstamped caller, got nil")
+		}
+		if len(w.created) != 0 {
+			t.Errorf("a proposal was created: %+v", w.created)
+		}
+	})
+
+	t.Run("linked node absent", func(t *testing.T) {
+		w := &fakeKGWriter{ownOK: false}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "agent-9")
+		_, err := rk.Execute(ctx, json.RawMessage(
+			`{"kind":"fact","fact":"I brew ale"}`), cfgOwnNode)
+		if err == nil {
+			t.Fatal("want error for agent with no linked node, got nil")
+		}
+		if len(w.created) != 0 {
+			t.Errorf("a proposal was created: %+v", w.created)
+		}
+	})
+}
+
+// Test 5: a campaign-scoped Agent (the Butler) proposes all three kinds with the
+// subject preserved from the args and no own-node anchor.
+func TestRememberKnowledge_CampaignScope(t *testing.T) {
+	t.Run("fact preserves subject", func(t *testing.T) {
+		w := &fakeKGWriter{}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "butler-1")
+		_, err := rk.Execute(ctx, json.RawMessage(
+			`{"kind":"fact","subject":"The Duke","fact":"rules the city"}`), cfgCampaign)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if w.ownCalled {
+			t.Error("OwnNode was called under campaign scope")
+		}
+		got := w.created[0]
+		want := ProposedWrite{V: 1, Kind: "fact", Subject: "The Duke", Fact: "rules the city"}
+		if got != want {
+			t.Errorf("proposed write = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("new entry", func(t *testing.T) {
+		w := &fakeKGWriter{}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "butler-1")
+		_, err := rk.Execute(ctx, json.RawMessage(
+			`{"kind":"node","node_type":"faction","name":"Ironhold","body":"a smiths' guild"}`), cfgCampaign)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		got := w.created[0]
+		want := ProposedWrite{V: 1, Kind: "node", NodeType: "faction", Name: "Ironhold", Body: "a smiths' guild"}
+		if got != want {
+			t.Errorf("proposed write = %+v, want %+v", got, want)
+		}
+	})
+}
+
+// Test 6: scope resolution — nil config fails CLOSED to own_node, a bogus scope
+// fails LOUD, and a nil writer reports unavailable.
+func TestRememberKnowledge_ScopeResolution(t *testing.T) {
+	t.Run("nil config defaults own_node", func(t *testing.T) {
+		w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bart"}, ownOK: true}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "agent-9")
+		_, err := rk.Execute(ctx, json.RawMessage(`{"kind":"fact","fact":"I brew ale"}`), nil)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !w.ownCalled {
+			t.Error("nil config did not fail closed to own_node (OwnNode never called)")
+		}
+		if w.created[0].NodeID != "node-1" {
+			t.Errorf("proposal not anchored on own node: %+v", w.created[0])
+		}
+	})
+
+	t.Run("bogus scope is loud", func(t *testing.T) {
+		w := &fakeKGWriter{}
+		rk := NewRememberKnowledge(w)
+		ctx := WithCaller(context.Background(), "agent-9")
+		_, err := rk.Execute(ctx, json.RawMessage(`{"kind":"fact","fact":"x"}`),
+			json.RawMessage(`{"scope":"world"}`))
+		if err == nil {
+			t.Fatal("want loud error for unknown scope, got nil")
+		}
+		if len(w.created) != 0 {
+			t.Errorf("a proposal was created under a bogus scope: %+v", w.created)
+		}
+	})
+
+	t.Run("nil writer unavailable", func(t *testing.T) {
+		rk := NewRememberKnowledge(nil)
+		_, err := rk.Execute(context.Background(), json.RawMessage(`{"kind":"fact","fact":"x"}`), cfgCampaign)
+		if err == nil {
+			t.Fatal("want unavailable error for nil writer, got nil")
+		}
+	})
+}
+
+// Test 7: remember_knowledge executes INLINE in the loop (it is proposal-mediated
+// despite ReadOnly=false), while a plain non-read-only, non-proposal Tool is still
+// hard-refused — the ADR-0030 refusal survives ADR-0052's carve-out.
+func TestLoopRunsRememberKnowledgeInline(t *testing.T) {
+	w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bart"}, ownOK: true}
+	reg := BuiltinRegistry(Deps{KGW: w})
+	reg.MustRegister(stubTool{name: "mutate", readOnly: false}) // NOT proposal-mediated
+	gs := NewGrantSet(reg,
+		Grant{ToolName: "remember_knowledge", Config: cfgOwnNode},
+		Grant{ToolName: "mutate"},
+	)
+
+	p := &scriptedProvider{
+		t: t,
+		steps: []scriptStep{
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c1", Name: "remember_knowledge", Input: json.RawMessage(`{"kind":"fact","fact":"I brew ale"}`)},
+			}}},
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c2", Name: "mutate", Input: json.RawMessage(`{}`)},
+			}}},
+			{reply: AssistantMessage{Text: "done"}},
+		},
+	}
+	loop := NewLoop(p, gs)
+	ctx := WithCaller(context.Background(), "agent-9")
+	if _, err := loop.Run(ctx, []Message{{Role: RoleUser, Text: "remember this"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	remember := findToolResult(t, p.seenMessages, "c1")
+	if remember.IsError {
+		t.Errorf("remember_knowledge was refused inline: %q", remember.Content)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("want 1 proposal created, got %d", len(w.created))
+	}
+	mutate := findToolResult(t, p.seenMessages, "c2")
+	if !mutate.IsError || !strings.Contains(mutate.Content, "not read-only") {
+		t.Errorf("plain non-read-only tool was NOT hard-refused: %+v", mutate)
+	}
+}
+
+// Test 8: barge pin — a cancel landing exactly at write time still leaves the
+// proposal; the loop errors on the next round but the row is never rolled back
+// (ADR-0052: a barged reply still yields its proposal).
+func TestLoopRememberKnowledgeSurvivesBarge(t *testing.T) {
+	ctx, cancel := context.WithCancel(WithCaller(context.Background(), "agent-9"))
+	w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Bart"}, ownOK: true}
+	w.onCreate = cancel // the barge lands as the proposal is written
+
+	reg := BuiltinRegistry(Deps{KGW: w})
+	gs := NewGrantSet(reg, Grant{ToolName: "remember_knowledge", Config: cfgOwnNode})
+	p := &scriptedProvider{
+		t: t,
+		steps: []scriptStep{
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c1", Name: "remember_knowledge", Input: json.RawMessage(`{"kind":"fact","fact":"I brew ale"}`)},
+			}}},
+			// A second step would speak final text, but the cancelled ctx aborts
+			// the loop at the top of round 1 before it is reached.
+			{reply: AssistantMessage{Text: "unreachable"}},
+		},
+	}
+	loop := NewLoop(p, gs)
+	_, err := loop.Run(ctx, []Message{{Role: RoleUser, Text: "remember this"}})
+	if err == nil {
+		t.Fatal("want the barged loop to error, got nil")
+	}
+	if len(w.created) != 1 {
+		t.Errorf("barge rolled back the proposal: %d created, want 1", len(w.created))
+	}
+}

--- a/pkg/tool/remember_knowledge_test.go
+++ b/pkg/tool/remember_knowledge_test.go
@@ -51,6 +51,7 @@ var (
 // write seam — no OwnNode lookup, no proposal row.
 func TestRememberKnowledge_ArgValidation(t *testing.T) {
 	long := strings.Repeat("x", MaxProposalTextRunes+1)
+	longName := strings.Repeat("x", MaxKGNameRunes+1) // entity names cap at MaxKGNameRunes
 	cases := []struct {
 		name string
 		args string
@@ -59,8 +60,11 @@ func TestRememberKnowledge_ArgValidation(t *testing.T) {
 		{"empty kind", `{"kind":""}`},
 		{"fact missing text", `{"kind":"fact","subject":"The Duke"}`},
 		{"fact too long", `{"kind":"fact","subject":"X","fact":"` + long + `"}`},
+		{"fact subject too long", `{"kind":"fact","subject":"` + longName + `","fact":"x"}`},
 		{"edge bad relation", `{"kind":"edge","subject":"X","relation":"loves","target":"Y"}`},
 		{"edge missing target", `{"kind":"edge","subject":"X","relation":"knows"}`},
+		{"edge subject too long", `{"kind":"edge","subject":"` + longName + `","relation":"knows","target":"Y"}`},
+		{"edge target too long", `{"kind":"edge","subject":"X","relation":"knows","target":"` + longName + `"}`},
 		{"node missing name", `{"kind":"node","node_type":"npc"}`},
 		{"node bad type", `{"kind":"node","name":"X","node_type":"dragon"}`},
 		{"node name too long", `{"kind":"node","node_type":"npc","name":"` + long + `"}`},

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -9,11 +9,14 @@
 // Agent loop assembles its prompt, then hands messages + granted tools to
 // [Loop.Run] and gets back the LLM's final text.
 //
-// v1.0 ships exactly one Tool — [Dice] — and only the read-only inline
-// execution path of ADR-0030. The side-effecting / deferred-to-turn-commit
-// path is deliberately not built (no side-effecting Tool exists yet); a Tool
-// that reports it is not read-only is rejected by the loop rather than
-// silently inlined. See package-level ADR references.
+// The read-only inline execution path of ADR-0030 is the default; the
+// side-effecting / deferred-to-turn-commit path is deliberately not built (an
+// atomic-with-the-utterance effect has no v1 Tool). A Tool that reports it is
+// not read-only is rejected by the loop rather than silently inlined — UNLESS it
+// is proposal-mediated (ADR-0052): a [ProposalMediated] Tool's only effect is a
+// GM-reviewed Knowledge Proposal row, not a canon mutation, so it runs inline
+// and a barged draft may still leave a (harmless, GM-gated) proposal. See
+// package-level ADR references.
 package tool
 
 import (
@@ -65,4 +68,20 @@ type Tool interface {
 	// context: honoring its cancellation lets barge-in tear down an in-flight
 	// call (ADR-0030).
 	Execute(ctx context.Context, args json.RawMessage, grantConfig any) (string, error)
+}
+
+// ProposalMediated is the optional capability a non-read-only [Tool] declares to
+// opt out of the loop's hard-refusal of side-effecting Tools (ADR-0052). Its
+// ONLY effect is a GM-reviewed Knowledge Proposal — nothing touches campaign
+// canon until the GM approves — so, unlike a turn-commit effect, it is safe to
+// run inline from a possibly-discarded draft: a barged reply still yields the
+// proposal (the NPC heard the fact), and the GM review is the safety net for
+// anything malformed. A Tool that is not read-only AND not proposal-mediated is
+// still refused inline (the ADR-0030 machinery is unbuilt). remember_knowledge is
+// the sole v1 implementor.
+type ProposalMediated interface {
+	Tool
+	// ProposalMediated reports that this Tool's effect is a GM-reviewed proposal,
+	// not a canon mutation, so the loop may run it inline despite ReadOnly=false.
+	ProposalMediated() bool
 }


### PR DESCRIPTION
## What

The first side-effecting Tool: `remember_knowledge`. An Agent's call records a **pending Knowledge Proposal** row for the GM to review — nothing touches `kg_node`/`kg_edge` until approval (ADR-0052). The proposal row is the **only** effect.

Closes #300 (PR-a). PR-b (GM review RPCs/UI) is out of scope.

## How

- **pkg/tool**: `ProposedWrite` versioned union (`"v":1`; kinds fact/edge/node) + `KGWriter`/`KGNodeRef` seams (`deps.go`); `ProposalMediated` capability (`tool.go`); loop carve-out — a proposal-mediated Tool runs inline despite `ReadOnly()==false`, while the ADR-0030 hard-refusal survives for any other side-effecting Tool (`loop.go`); `RememberKnowledge` handler (`remember_knowledge.go`): per-kind arg validation, scope from grant config + `CallerID` only (fail-closed to `own_node`), own_node overwrites subject/anchor with the caller's own Node and refuses `kind=node`, campaign preserves subject and allows all three kinds, 2000-rune text caps.
- **internal/storage**: `00026_knowledge_proposal.sql` (enum + table + partial pending index, no Butler grant seeding), `CreateKnowledgeProposal`/`ListPendingKnowledgeProposals`/`AgentLinkedNode`.
- **internal/knowledge**: adapter implements `tool.KGWriter`; the INSERT runs under `context.WithoutCancel(ctx)` + 5s timeout so a barged reply still yields its proposal (ADR-0052 barge semantics) without leaking a goroutine.
- Wiring: `main.go` sets `KGW`; `BuiltinRegistry` registers the Tool; nil `KGW` stays panic-free (zero-Deps registries report "unavailable").

## Behavior note (issue AC override)

The issue body's stale "a barged turn writes nothing" AC is **overridden by ADR-0052**: a barged reply still yields its proposal (the NPC heard the fact; GM review is the safety net). Pinned by `TestLoopRememberKnowledgeSurvivesBarge` + the adapter's WithoutCancel test.

## Risks / notes

- Speculative-draft duplicate proposals are ADR-0052-consistent (documented on `ProposedWrite`).
- Accepted low finding: a mid-turn Active-Campaign flip can attribute a proposal to the new campaign (transient; GM review catches it).
- Migration is numbered **00026** and assumes 00024/00025 (in-flight PRs #382/#373) land first; renumber on rebase if not. Goose tolerates numeric gaps.

## Tests (TDD, each RED first)

12 new tests: arg-validation table, own_node anchoring (subject overwrite, edge FROM own node), own_node refuses new entry, unlinked/unstamped caller, campaign pass-through, scope resolution (fail-closed / loud / nil-writer), loop inline-exec + non-proposal refusal regression pin, barge survival pin, adapter shape/scope/WithoutCancel + no-session, and a `//go:build integration` end-to-end vs real Postgres (migration applies, pending row fields, agent DELETE cascade). Local unit + `-tags integration` green for pkg/tool, internal/knowledge, internal/storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)