### PR TITLE
feat(#388): surface dropped_participant_refs in import summary

### DIFF
--- a/web/src/components/ImportCampaignButton.test.tsx
+++ b/web/src/components/ImportCampaignButton.test.tsx
@@ -37,6 +37,7 @@ const summaryFixture: ImportSummary = {
   sessions: 0,
   lines: 0,
   chunks: 0,
+  droppedParticipantRefs: 0,
 };
 
 // A stateful backend: SetActiveCampaign records the switch; ListCampaigns +
@@ -123,6 +124,44 @@ describe("ImportCampaignButton", () => {
     expect(within(success).getByRole("button", { name: /Switch/ })).toBeInTheDocument();
     // A toast fires too — unmount-proof feedback if the panel closes mid-flow.
     await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith(expect.stringMatching(/The Prancing Pony/)));
+  });
+
+  it("notes dropped participant refs in the success dialog when > 0 (plural)", async () => {
+    mockImport.mockResolvedValue({ ...summaryFixture, droppedParticipantRefs: 2 });
+    renderButton();
+
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+
+    const success = await screen.findByRole("alertdialog");
+    // Warning note — import still SUCCEEDED, so it's phrased as a caveat, not an error.
+    expect(
+      within(success).getByText(/2 participant references could not be mapped and were dropped/i),
+    ).toBeInTheDocument();
+  });
+
+  it("phrases the dropped-refs note in the singular for exactly one", async () => {
+    mockImport.mockResolvedValue({ ...summaryFixture, droppedParticipantRefs: 1 });
+    renderButton();
+
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+
+    const success = await screen.findByRole("alertdialog");
+    expect(
+      within(success).getByText(/1 participant reference could not be mapped and was dropped/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows NO dropped-refs note when none were dropped", async () => {
+    mockImport.mockResolvedValue({ ...summaryFixture, droppedParticipantRefs: 0 });
+    renderButton();
+
+    pickFile();
+    fireEvent.click(within(await screen.findByRole("alertdialog")).getByRole("button", { name: /^Import$/ }));
+
+    const success = await screen.findByRole("alertdialog");
+    expect(within(success).queryByText(/could not be mapped/i)).not.toBeInTheDocument();
   });
 
   it("toasts the failure so feedback survives a mid-upload panel dismissal", async () => {

--- a/web/src/components/ImportCampaignButton.test.tsx
+++ b/web/src/components/ImportCampaignButton.test.tsx
@@ -23,7 +23,7 @@ const mockImport = vi.mocked(importCampaignBundle);
 
 // Toasts are the unmount-proof feedback channel (they render outside the panel),
 // so assert them directly rather than only the inline alert/dialog.
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
 import { toast } from "sonner";
 const mockToast = vi.mocked(toast);
 
@@ -99,6 +99,7 @@ beforeEach(() => {
   mockImport.mockReset();
   mockToast.success.mockReset();
   mockToast.error.mockReset();
+  mockToast.warning.mockReset();
 });
 
 describe("ImportCampaignButton", () => {
@@ -135,9 +136,20 @@ describe("ImportCampaignButton", () => {
 
     const success = await screen.findByRole("alertdialog");
     // Warning note — import still SUCCEEDED, so it's phrased as a caveat, not an error.
-    expect(
-      within(success).getByText(/2 participant references could not be mapped and were dropped/i),
-    ).toBeInTheDocument();
+    const note = within(success).getByText(
+      /2 participant references could not be mapped and were dropped/i,
+    );
+    expect(note).toBeInTheDocument();
+    // Warning styling (not error): guards against a mutation to the danger class.
+    expect(note.closest(".gx-import-campaign__warning")).not.toBeNull();
+    // The caveat ALSO rides an unmount-proof warning toast (mirrors the success
+    // toast): an Escape between confirm-close and success-open can unmount the
+    // dialog, and the note must not vanish with it.
+    await waitFor(() =>
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        expect.stringMatching(/2 participant references could not be mapped and were dropped/i),
+      ),
+    );
   });
 
   it("phrases the dropped-refs note in the singular for exactly one", async () => {
@@ -162,6 +174,8 @@ describe("ImportCampaignButton", () => {
 
     const success = await screen.findByRole("alertdialog");
     expect(within(success).queryByText(/could not be mapped/i)).not.toBeInTheDocument();
+    // No drops → no warning toast either (only the plain success toast).
+    expect(mockToast.warning).not.toHaveBeenCalled();
   });
 
   it("toasts the failure so feedback survives a mid-upload panel dismissal", async () => {

--- a/web/src/components/ImportCampaignButton.tsx
+++ b/web/src/components/ImportCampaignButton.tsx
@@ -165,9 +165,21 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
         }}
         title={summary ? `Imported “${summary.name}”` : ""}
         description={
-          summary
-            ? `“${summary.name}” was imported as a new campaign — switch to it now?`
-            : undefined
+          summary ? (
+            <span className="gx-import-campaign__success">
+              “{summary.name}” was imported as a new campaign — switch to it now?
+              {summary.droppedParticipantRefs > 0 && (
+                // Import SUCCEEDED — some chunk participant refs mapped to no
+                // imported agent/character and were dropped (#381/#388). A caveat,
+                // not an error: warning styling, and the campaign is fully usable.
+                <span className="gx-import-campaign__warning" role="status">
+                  {summary.droppedParticipantRefs === 1
+                    ? "1 participant reference could not be mapped and was dropped."
+                    : `${summary.droppedParticipantRefs} participant references could not be mapped and were dropped.`}
+                </span>
+              )}
+            </span>
+          ) : undefined
         }
         confirmLabel="Switch"
         cancelLabel="Not now"

--- a/web/src/components/ImportCampaignButton.tsx
+++ b/web/src/components/ImportCampaignButton.tsx
@@ -11,6 +11,15 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 import "./importCampaignButton.css";
 
+// droppedRefsNote phrases the dropped-participant-refs caveat (singular/plural).
+// Shared by the success dialog note and the unmount-proof warning toast so they
+// never drift. Import still SUCCEEDED — this is a caveat, never an error.
+function droppedRefsNote(n: number): string {
+  return n === 1
+    ? "1 participant reference could not be mapped and was dropped."
+    : `${n} participant references could not be mapped and were dropped.`;
+}
+
 // ImportCampaignButton — the campaign-restore affordance in the switcher's
 // manage-view footer (#294, beside CreateCampaignForm). It uploads a Campaign
 // Bundle (the export's counterpart) over the plain-net/http importer, which mints
@@ -93,6 +102,14 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
       void invalidateList();
       setSummary(result);
       toast.success(`Imported “${result.name}”`);
+      // The dropped-refs caveat rides its OWN warning toast, not only the success
+      // dialog: an Escape/outside-click between the confirm dialog closing and the
+      // success dialog opening can unmount this component (see runImport note
+      // above), taking the dialog's note with it. The toast is the unmount-proof
+      // channel — warning styling (richColors), since the import still succeeded.
+      if (result.droppedParticipantRefs > 0) {
+        toast.warning(droppedRefsNote(result.droppedParticipantRefs));
+      }
     } catch (err) {
       const message = (err as Error).message;
       setError(message);
@@ -173,9 +190,7 @@ export function ImportCampaignButton({ onSwitched }: { onSwitched?: () => void }
                 // imported agent/character and were dropped (#381/#388). A caveat,
                 // not an error: warning styling, and the campaign is fully usable.
                 <span className="gx-import-campaign__warning" role="status">
-                  {summary.droppedParticipantRefs === 1
-                    ? "1 participant reference could not be mapped and was dropped."
-                    : `${summary.droppedParticipantRefs} participant references could not be mapped and were dropped.`}
+                  {droppedRefsNote(summary.droppedParticipantRefs)}
                 </span>
               )}
             </span>

--- a/web/src/components/importCampaignButton.css
+++ b/web/src/components/importCampaignButton.css
@@ -38,8 +38,8 @@
   margin-top: var(--spacing-sm);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm, 4px);
-  border: 1px solid var(--warning, #a86800);
-  background: color-mix(in srgb, var(--warning, #a86800) 12%, transparent);
-  color: var(--warning, #a86800);
+  border: 1px solid var(--status-warning);
+  background: var(--status-warning-bg);
+  color: var(--status-warning);
   font-size: 13px;
 }

--- a/web/src/components/importCampaignButton.css
+++ b/web/src/components/importCampaignButton.css
@@ -27,3 +27,19 @@
   color: var(--danger, #e5484d);
   font-size: 13px;
 }
+
+/* The success dialog stacks the switch prompt above an optional dropped-refs
+ * caveat. The note is a WARNING, not an error — the import still succeeded. */
+.gx-import-campaign__success {
+  display: block;
+}
+.gx-import-campaign__warning {
+  display: block;
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--warning, #a86800);
+  background: color-mix(in srgb, var(--warning, #a86800) 12%, transparent);
+  color: var(--warning, #a86800);
+  font-size: 13px;
+}

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -119,6 +119,7 @@ describe("importCampaignBundle", () => {
           sessions: 0,
           lines: 0,
           chunks: 0,
+          dropped_participant_refs: 0,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
@@ -146,7 +147,34 @@ describe("importCampaignBundle", () => {
       sessions: 0,
       lines: 0,
       chunks: 0,
+      droppedParticipantRefs: 0,
     });
+    vi.unstubAllGlobals();
+  });
+
+  it("maps dropped_participant_refs into droppedParticipantRefs on the summary", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          campaign_id: "camp-9",
+          name: "The Prancing Pony",
+          agents: 2,
+          nodes: 4,
+          edges: 2,
+          characters: 1,
+          sessions: 3,
+          lines: 10,
+          chunks: 5,
+          dropped_participant_refs: 2,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const summary = await importCampaignBundle(bundleFile());
+
+    expect(summary.droppedParticipantRefs).toBe(2);
     vi.unstubAllGlobals();
   });
 

--- a/web/src/lib/download.test.ts
+++ b/web/src/lib/download.test.ts
@@ -178,6 +178,33 @@ describe("importCampaignBundle", () => {
     vi.unstubAllGlobals();
   });
 
+  it("defaults droppedParticipantRefs to 0 when the field is absent (old server)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            campaign_id: "camp-9",
+            name: "The Prancing Pony",
+            agents: 0,
+            nodes: 0,
+            edges: 0,
+            characters: 0,
+            sessions: 0,
+            lines: 0,
+            chunks: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const summary = await importCampaignBundle(bundleFile());
+
+    expect(summary.droppedParticipantRefs).toBe(0);
+    vi.unstubAllGlobals();
+  });
+
   it("throws the server {error} message on a 400 bad-bundle response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -19,6 +19,10 @@ export type ImportSummary = {
   sessions: number;
   lines: number;
   chunks: number;
+  // Chunk participant refs that mapped to no imported agent/character and were
+  // dropped (#381/#388). Not fatal — the import still succeeds; the UI surfaces
+  // a warning note when > 0. The field is always present (zero absent-safe).
+  droppedParticipantRefs: number;
 };
 
 // The filename used when the server sends no Content-Disposition (it always does,
@@ -114,6 +118,7 @@ export async function importCampaignBundle(file: File): Promise<ImportSummary> {
     sessions: number;
     lines: number;
     chunks: number;
+    dropped_participant_refs: number;
   };
   return {
     campaignId: body.campaign_id,
@@ -125,5 +130,6 @@ export async function importCampaignBundle(file: File): Promise<ImportSummary> {
     sessions: body.sessions,
     lines: body.lines,
     chunks: body.chunks,
+    droppedParticipantRefs: body.dropped_participant_refs ?? 0,
   };
 }

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -118,7 +118,8 @@ export async function importCampaignBundle(file: File): Promise<ImportSummary> {
     sessions: number;
     lines: number;
     chunks: number;
-    dropped_participant_refs: number;
+    // Optional: a pre-#386 server omits it; default to 0 (zero absent-safe).
+    dropped_participant_refs?: number;
   };
   return {
     campaignId: body.campaign_id,


### PR DESCRIPTION
Closes #388

## What

The Campaign Bundle importer now returns `dropped_participant_refs` (#381/#386) — chunk participant refs that mapped to no imported agent/character and were dropped. The import still **succeeds**; this surfaces that caveat in the web UI.

- `web/src/lib/download.ts` — `ImportSummary` gains `droppedParticipantRefs`, parsed from the `dropped_participant_refs` JSON field (zero absent-safe).
- `ImportCampaignButton` success dialog — when `> 0`, appends a **warning-styled** note ("N participant references could not be mapped and were dropped"), singular/plural aware. Not an error: the import succeeded and the campaign is fully usable. Import still does not auto-activate (ADR-0053 d7).

## Tests (TDD, vertical slices)

`web/src/lib/download.test.ts`
- summary round-trip now asserts `droppedParticipantRefs: 0`
- `maps dropped_participant_refs into droppedParticipantRefs on the summary` (=2)

`web/src/components/ImportCampaignButton.test.tsx`
- `notes dropped participant refs in the success dialog when > 0 (plural)`
- `phrases the dropped-refs note in the singular for exactly one`
- `shows NO dropped-refs note when none were dropped`

Local: web typecheck clean, `vitest run` 241/241 pass, `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)