### PR TITLE
feat(#365): ButlerVoicer wiring — SpeakAsButler = SayAs(butler id)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -508,9 +508,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			presence.SearchCommand(store, mgr),
 			// /glyphoxa recap (#273): recaps the Active Campaign's latest ended Voice
 			// Session via the SAME shared slash resolver, delivered per the invoker's
-			// choice (voiced/public/ephemeral, #271). butler is nil — the Butler is not
-			// voiced today (ADR-0009/0024), so a voiced request degrades to public text.
-			presence.RecapCommand(store, mgr, recapEngine, nil),
+			// choice (voiced/public/ephemeral, #271). The Manager is the ButlerVoicer
+			// (#365): the now-voiced Butler (ADR-0009 #299) speaks a `voiced` recap via
+			// SpeakAsButler → SayAs, so it lands as a KindButler transcript line; with no
+			// live session a voiced request still degrades to public text.
+			presence.RecapCommand(store, mgr, recapEngine, mgr),
 			// /glyphoxa mute <npc> + muteall (#211): the Manager is their SessionMuter
 			// and the mute view the live loop reads (NewManager wired cfg.Mutes = mgr).
 			presence.MuteCommand(mgr, store),

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -511,7 +511,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			// choice (voiced/public/ephemeral, #271). The Manager is the ButlerVoicer
 			// (#365): the now-voiced Butler (ADR-0009 #299) speaks a `voiced` recap via
 			// SpeakAsButler → SayAs, so it lands as a KindButler transcript line; with no
-			// live session a voiced request still degrades to public text.
+			// live session OR a voiceless Butler a voiced request degrades to public text.
 			presence.RecapCommand(store, mgr, recapEngine, mgr),
 			// /glyphoxa mute <npc> + muteall (#211): the Manager is their SessionMuter
 			// and the mute view the live loop reads (NewManager wired cfg.Mutes = mgr).

--- a/internal/presence/recap.go
+++ b/internal/presence/recap.go
@@ -68,9 +68,10 @@ type RecapStore interface {
 // ButlerVoicer is the decision-6a socket for a truly VOICED recap: speaking the
 // recap prose into the live voice channel as the Butler. *session.Manager satisfies
 // it structurally (#365): the now-voiced Butler (ADR-0009 #299) speaks via
-// SpeakAsButler → SayAs, landing the recap as a KindButler transcript line. It is
-// still nil-tolerant — with no wired voicer OR no live session a `voiced` request
-// degrades to public text with a hint (decision 6a).
+// SpeakAsButler → SayAs, landing the recap as a KindButler transcript line. The
+// `voiced` request still degrades to public text with a hint (decision 6a) whenever
+// it can't truly be voiced: no wired voicer, no live session, or a VOICELESS Butler
+// (SpeakAsButler returns an error, which deliverRecap turns into the same degrade).
 type ButlerVoicer interface {
 	SpeakAsButler(ctx context.Context, text string) error
 }
@@ -255,13 +256,18 @@ func isRecappable(vs storage.VoiceSession) bool {
 // kept under Discord's 2000-char cap (never truncated, #271).
 func deliverRecap(ctx context.Context, ic *Interaction, butler ButlerVoicer, voiceMode bool, delivery string, publicReply bool, text string) error {
 	if voiceMode {
-		if err := butler.SpeakAsButler(ctx, text); err != nil {
-			return fmt.Errorf("presence: voice recap via butler: %w", err)
+		if err := butler.SpeakAsButler(ctx, text); err == nil {
+			// The confirmation is GM-only, matching the ephemeral placeholder. As the first
+			// post-Defer reply it lands as the placeholder edit (registry-wide rule, #335) at
+			// the Defer's ephemeral visibility — exactly right.
+			return ic.Followup("Recap voiced in the voice channel.", true)
 		}
-		// The confirmation is GM-only, matching the ephemeral placeholder. As the first
-		// post-Defer reply it lands as the placeholder edit (registry-wide rule, #335) at
-		// the Defer's ephemeral visibility — exactly right.
-		return ic.Followup("Recap voiced in the voice channel.", true)
+		// The Butler could not actually voice it — the default Butler is voiceless
+		// (ErrButlerVoiceless), or the live session ended during the up-to-120s recap
+		// (ErrNoActiveSession). Do NOT discard the finished recap or claim a phantom
+		// voicing (ADR-0012 deliver-then-commit): fall through to the SAME public-text
+		// degrade path an unwired voicer takes (decision 6a), so the room still gets it.
+		publicReply = true
 	}
 
 	body := text

--- a/internal/presence/recap.go
+++ b/internal/presence/recap.go
@@ -66,10 +66,11 @@ type RecapStore interface {
 }
 
 // ButlerVoicer is the decision-6a socket for a truly VOICED recap: speaking the
-// recap prose into the live voice channel as the Butler. NOBODY implements it in
-// this epic — the Butler is address-only and has never been voiced (ADR-0009/0024),
-// so the wiring passes nil and a `voiced` request degrades to public text with a
-// hint. Epic 7 fills this in.
+// recap prose into the live voice channel as the Butler. *session.Manager satisfies
+// it structurally (#365): the now-voiced Butler (ADR-0009 #299) speaks via
+// SpeakAsButler → SayAs, landing the recap as a KindButler transcript line. It is
+// still nil-tolerant — with no wired voicer OR no live session a `voiced` request
+// degrades to public text with a hint (decision 6a).
 type ButlerVoicer interface {
 	SpeakAsButler(ctx context.Context, text string) error
 }

--- a/internal/presence/recap_test.go
+++ b/internal/presence/recap_test.go
@@ -403,6 +403,32 @@ func TestRecapVoicedDegradesToPublic(t *testing.T) {
 	}
 }
 
+// TestRecapVoicedButlerErrorDegradesToPublic pins #365 review finding 2: when a
+// wired ButlerVoicer is picked (live session) but SpeakAsButler FAILS — a voiceless
+// Butler (ErrButlerVoiceless), or the session ending during the up-to-120s recap
+// (ErrNoActiveSession) — the finished recap is NOT discarded and the GM is NOT told
+// it was voiced. It degrades to the SAME public-text-with-hint path as an unwired
+// voicer, so the room gets the recap and no phantom "voiced" claim is made.
+func TestRecapVoicedButlerErrorDegradesToPublic(t *testing.T) {
+	c := campaign("Lost Mine")
+	store := recapStore(c, endedSession(c.ID, time.Now(), 12))
+	store.byID = map[uuid.UUID]storage.VoiceSession{}
+	store.fakeSessionStore.byID = map[uuid.UUID]storage.Campaign{c.ID: c}
+	eng := &fakeRecapEngine{result: recap.Result{Text: "The keep fell at dawn."}}
+	voicer := &fakeButlerVoicer{err: errors.New("butler has no voice")}
+	live := &fakeVoice{active: true, snap: storage.VoiceSession{CampaignID: c.ID}}
+
+	resp := dispatchRecap(t, store, live, eng, voicer, map[string]string{"delivery": deliveryVoiced})
+
+	body := assertPublicDelivery(t, resp)
+	if !strings.HasPrefix(body, voicedDegradeHint) {
+		t.Errorf("degraded public body = %q, want the degrade hint prefix", body)
+	}
+	if !strings.Contains(body, "keep fell") {
+		t.Errorf("degraded public body = %q, want it still carrying the recap prose", body)
+	}
+}
+
 // TestRecapOversizedPublicSplits (finding 5c / oversized-public): an over-length
 // PUBLIC recap consumes the placeholder once (ephemeral), then posts MULTIPLE public
 // Followups each ≤2000 runes, in order, never truncated.

--- a/internal/presence/say_test.go
+++ b/internal/presence/say_test.go
@@ -108,6 +108,33 @@ func TestSayCommand_UnknownAgentRefused(t *testing.T) {
 	}
 }
 
+// TestSayCommand_ButlerRefusedOnHandle pins #365 review finding 4: the manager
+// SayAs now ACCEPTS the Butler (SpeakAsButler needs it), so the Discord /say
+// puppet-exclusion must hold at the presence Handle path — not only in Autocomplete.
+// The Address-Only Butler is filtered out of the resolvable roster (voiced()), so a
+// GM naming the Butler by name OR by UUID gets an ephemeral "no such Agent" refusal
+// and SayAs is NEVER called (no accidental Butler puppeting, ADR-0009/0024).
+func TestSayCommand_ButlerRefusedOnHandle(t *testing.T) {
+	campaign := uuid.New()
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+
+	for _, as := range []string{"Glyphoxa", butler.ID.String()} {
+		sayer := &fakeSayer{active: true, campaignID: campaign}
+		lister := &fakeLister{agents: []storage.Agent{butler, bart}}
+		resp := &fakeResponder{}
+		if err := SayCommand(sayer, lister).Handle(context.Background(), sayIC(resp, "hi", as)); err != nil {
+			t.Fatalf("Handle(as=%q): %v", as, err)
+		}
+		if len(sayer.calls) != 0 {
+			t.Fatalf("SayAs called for the Butler (as=%q), want 0 calls (puppet-excluded)", as)
+		}
+		if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
+			t.Fatalf("butler refusal (as=%q) = %+v, want one ephemeral error", as, resp.replies)
+		}
+	}
+}
+
 // TestSayCommand_HappyCallsSayAs pins the success path: a resolved voiced NPC is
 // spoken via SayAs(id, text) and the GM gets an ephemeral ack naming the Agent.
 func TestSayCommand_HappyCallsSayAs(t *testing.T) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -784,22 +784,23 @@ func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) 
 }
 
 // SayAs publishes a GM-puppeteered direct-speech request (#295, ADR-0010): the
-// voiced Character NPC with agentID speaks text verbatim in the live Voice Session.
-// It refuses when idle (ErrNoActiveSession) and rejects an agentID that is not a
-// voiced CHARACTER NPC of the active session's Campaign — a foreign agent, an
-// unknown id, or the Butler (voiced now per ADR-0009 #299, but Address-Only and
-// excluded from the /say Character roster by voicedAgents, ADR-0010) — with
-// ErrAgentNotInCampaign.
+// voiced Agent with agentID speaks text verbatim in the live Voice Session. It
+// refuses when idle (ErrNoActiveSession) and rejects an agentID that is not an
+// Agent of the active session's Campaign — a foreign agent or an unknown id — with
+// ErrAgentNotInCampaign. The now-voiced Butler (ADR-0009 #299 amendment) IS a valid
+// target reached via [Manager.SpeakAsButler]; the Discord /say roster still excludes
+// it (say.go's voiced filter), so a GM cannot puppet it by hand.
 //
 // Validation and the publish are SESSION-ATOMIC (mirrors SetAgentMute): the active
 // session is captured, its Campaign is listed with m.mu released (the store read may
 // block), then the event is published only if the SAME session is still active — so
 // a session swap between the roster read and the publish can never voice a foreign
 // agent into the new session. It publishes [voiceevent.SpeakRequested] carrying the
-// agent's Target (id + character role + display name), a fresh TurnID, and the text
-// — NOT [voiceevent.AddressRouted], which would trigger the LLM Replier (ADR-0024).
-// The GM mute is deliberately NOT consulted here (puppeteering is a GM override, so
-// a muted NPC still speaks a /say — the DirectSpeech reactor bypasses the mute gate).
+// agent's Target (id + the Agent's OWN role + display name — a butler-role Target
+// projects a KindButler line, ADR-0040), a fresh TurnID, and the text — NOT
+// [voiceevent.AddressRouted], which would trigger the LLM Replier (ADR-0024). The GM
+// mute is deliberately NOT consulted here (puppeteering is a GM override, so a muted
+// NPC still speaks a /say — the DirectSpeech reactor bypasses the mute gate).
 func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
 	m.mu.Lock()
 	as := m.active
@@ -816,7 +817,7 @@ func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
 	}
 	var target storage.Agent
 	found := false
-	for _, a := range voicedAgents(agents) {
+	for _, a := range agents {
 		if a.ID.String() == agentID {
 			target = a
 			found = true
@@ -843,13 +844,54 @@ func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
 			TurnID: voiceevent.NewTurnID(),
 			Target: voiceevent.AddressTarget{
 				AgentID:   agentID,
-				AgentRole: voiceevent.AgentRoleCharacter,
+				AgentRole: sayRole(target.Role),
 				Name:      target.Name,
 			},
 			Text: text,
 		})
 	}
 	return nil
+}
+
+// sayRole maps an Agent's storage Role to the [voiceevent.AddressTarget] role
+// string the transcript relay keys its Line Kind off (ADR-0040): the Butler yields
+// the butler role (→ KindButler pill), every other Agent the character role. The two
+// vocabularies share their underlying strings, but mapping explicitly keeps SayAs
+// decoupled from that coincidence.
+func sayRole(r storage.AgentRole) string {
+	if r == storage.AgentRoleButler {
+		return voiceevent.AgentRoleButler
+	}
+	return voiceevent.AgentRoleCharacter
+}
+
+// SpeakAsButler voices text verbatim as the Active Campaign's Butler in the live
+// Voice Session (#365) — the recap decision-6a voiced on-ramp (satisfies
+// presence.ButlerVoicer structurally). It resolves the session's Butler from the
+// roster and delegates to [Manager.SayAs], so the published SpeakRequested carries
+// the Butler's butler-role Target and the transcript projects a KindButler line
+// through the NORMAL relay projection (no hand-crafted row). It refuses when idle
+// (ErrNoActiveSession); a campaign with no Butler yields ErrAgentNotInCampaign.
+func (m *Manager) SpeakAsButler(ctx context.Context, text string) error {
+	m.mu.Lock()
+	as := m.active
+	if as == nil {
+		m.mu.Unlock()
+		return ErrNoActiveSession
+	}
+	campaignID := as.campaignID
+	m.mu.Unlock()
+
+	agents, err := m.store.ListAgents(ctx, campaignID)
+	if err != nil {
+		return fmt.Errorf("session: list agents for butler say: %w", err)
+	}
+	for _, a := range agents {
+		if a.Role == storage.AgentRoleButler {
+			return m.SayAs(ctx, a.ID.String(), text)
+		}
+	}
+	return ErrAgentNotInCampaign
 }
 
 // agentInList reports whether agentID (a UUID string) names an Agent in agents.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -68,6 +68,13 @@ var (
 	// mute writes to, so a session swap can't sneak a foreign agent into the new
 	// session's mute set. Mapped to CodeNotFound.
 	ErrAgentNotInCampaign = errors.New("session: no such Agent in the Active Campaign")
+
+	// ErrButlerVoiceless is returned by SpeakAsButler when the Active Campaign's
+	// Butler has no synthesizable Voice (empty VoiceID — the default auto-Butler is
+	// voiceless). Voicing it would publish a KindButler transcript line that never
+	// produces audio (elevenlabs.Synthesize rejects an empty VoiceID), so the caller
+	// degrades to text instead of claiming a phantom voicing (ADR-0012, #365).
+	ErrButlerVoiceless = errors.New("session: the Butler has no voice to speak with")
 )
 
 // Store is the narrow storage surface the Manager needs: the saved Discord
@@ -871,7 +878,10 @@ func sayRole(r storage.AgentRole) string {
 // roster and delegates to [Manager.SayAs], so the published SpeakRequested carries
 // the Butler's butler-role Target and the transcript projects a KindButler line
 // through the NORMAL relay projection (no hand-crafted row). It refuses when idle
-// (ErrNoActiveSession); a campaign with no Butler yields ErrAgentNotInCampaign.
+// (ErrNoActiveSession), a campaign with no Butler yields ErrAgentNotInCampaign, and
+// a VOICELESS Butler (empty VoiceID — the default auto-Butler) yields
+// ErrButlerVoiceless BEFORE any publish, so the recap surface can degrade to text
+// rather than persist a phantom line for unsynthesizable speech (AC1, ADR-0012).
 func (m *Manager) SpeakAsButler(ctx context.Context, text string) error {
 	m.mu.Lock()
 	as := m.active
@@ -887,9 +897,20 @@ func (m *Manager) SpeakAsButler(ctx context.Context, text string) error {
 		return fmt.Errorf("session: list agents for butler say: %w", err)
 	}
 	for _, a := range agents {
-		if a.Role == storage.AgentRoleButler {
-			return m.SayAs(ctx, a.ID.String(), text)
+		if a.Role != storage.AgentRoleButler {
+			continue
 		}
+		// The default auto-Butler is voiceless (empty VoiceID). Refuse BEFORE SayAs
+		// publishes anything, so no phantom KindButler line is persisted for speech the
+		// room can never hear (AC1: "when a live session has a VOICED Butler").
+		voice, err := storage.VoiceFromJSON(a.Voice)
+		if err != nil {
+			return fmt.Errorf("session: decode butler voice: %w", err)
+		}
+		if voice.VoiceID == "" {
+			return ErrButlerVoiceless
+		}
+		return m.SayAs(ctx, a.ID.String(), text)
 	}
 	return ErrAgentNotInCampaign
 }

--- a/internal/session/manager_say_test.go
+++ b/internal/session/manager_say_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -10,6 +11,12 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
+
+// voiceJSON builds a canonical Agent voice column carrying voiceID — the shape
+// storage.VoiceFromJSON reads back — so a test Butler counts as VOICED.
+func voiceJSON(voiceID string) json.RawMessage {
+	return json.RawMessage(`{"VoiceID":"` + voiceID + `"}`)
+}
 
 // TestSayAs_IdleReturnsNoActiveSession pins the active-session requirement (#295,
 // ADR-0010): a /say with no live Voice Session is refused before any roster lookup
@@ -89,7 +96,7 @@ func TestSayAs_ButlerPublishesButlerRole(t *testing.T) {
 // (→ KindButler line) and the verbatim text — the recap decision-6a voiced path.
 func TestSpeakAsButler_PublishesButlerLine(t *testing.T) {
 	store := newFakeStore()
-	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa", Voice: voiceJSON("v1")}
 	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
 	store.agents = []storage.Agent{bart, butler}
 	mgr, bus := muteManager(t, store)
@@ -134,6 +141,29 @@ func TestSpeakAsButler_IdleReturnsNoActiveSession(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("idle SpeakAsButler published %d SpeakRequested, want none", len(got))
+	}
+}
+
+// TestSpeakAsButler_VoicelessRefused pins the voiced-Butler precondition (#365, AC1):
+// the default auto-Butler is VOICELESS (empty VoiceID). Voicing it would publish a
+// KindButler transcript line the room never hears (elevenlabs.Synthesize hard-errors
+// on an empty VoiceID → tts_error, zero audio) — a phantom line + false "voiced"
+// claim (ADR-0012). So SpeakAsButler refuses a voiceless Butler with ErrButlerVoiceless
+// BEFORE publishing anything; the recap surface degrades that to public text.
+func TestSpeakAsButler_VoicelessRefused(t *testing.T) {
+	store := newFakeStore()
+	// No Voice column → VoiceFromJSON zero → empty VoiceID → voiceless.
+	store.agents = []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}}
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SpeakAsButler(context.Background(), "hello"); err != session.ErrButlerVoiceless {
+		t.Fatalf("SpeakAsButler with a voiceless Butler = %v, want ErrButlerVoiceless", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("voiceless SpeakAsButler published %d SpeakRequested, want none (no phantom line)", len(got))
 	}
 }
 

--- a/internal/session/manager_say_test.go
+++ b/internal/session/manager_say_test.go
@@ -46,18 +46,113 @@ func TestSayAs_ForeignAgentRejected(t *testing.T) {
 	}
 }
 
-// TestSayAs_ButlerRejected pins the Address-Only Butler exclusion (ADR-0009/0024):
-// the Butler is never voiced, so /say cannot puppet it (the Butler on-ramp is the
-// #299-blocked follow-up); it is refused ErrAgentNotInCampaign.
-func TestSayAs_ButlerRejected(t *testing.T) {
+// TestSayAs_ButlerPublishesButlerRole pins the Butler voicer on-ramp (#365,
+// ADR-0009 Butler-in-Cast amendment): the now-voiced Butler CAN be voiced verbatim,
+// and its SpeakRequested carries the BUTLER role (so the relay projects a KindButler
+// line) plus the Butler's display name — the role is derived from the Agent, not
+// hardcoded to Character. The Discord /say roster still excludes the Butler (say.go's
+// voiced filter); this is the programmatic SpeakAsButler path.
+func TestSayAs_ButlerPublishesButlerRole(t *testing.T) {
 	store := newFakeStore()
-	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Butler"}
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}
 	store.agents = []storage.Agent{butler}
-	mgr, _ := muteManager(t, store)
+	mgr, bus := muteManager(t, store)
 	startMuteSession(t, mgr)
 
-	if err := mgr.SayAs(context.Background(), butler.ID.String(), "hello"); err != session.ErrAgentNotInCampaign {
-		t.Fatalf("SayAs with the Butler = %v, want ErrAgentNotInCampaign", err)
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SayAs(context.Background(), butler.ID.String(), "At your service."); err != nil {
+		t.Fatalf("SayAs with the Butler: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("SayAs published %d SpeakRequested, want 1", len(got))
+	}
+	e := got[0]
+	if e.Target.AgentID != butler.ID.String() {
+		t.Errorf("Target.AgentID = %q, want %q", e.Target.AgentID, butler.ID.String())
+	}
+	if e.Target.AgentRole != voiceevent.AgentRoleButler {
+		t.Errorf("Target.AgentRole = %q, want %q (KindButler line)", e.Target.AgentRole, voiceevent.AgentRoleButler)
+	}
+	if e.Target.Name != "Glyphoxa" {
+		t.Errorf("Target.Name = %q, want Glyphoxa", e.Target.Name)
+	}
+	if e.Text != "At your service." {
+		t.Errorf("Text = %q, want the verbatim /say text", e.Text)
+	}
+}
+
+// TestSpeakAsButler_PublishesButlerLine pins the Butler voicer on-ramp (#365): with
+// a live session whose Campaign has a voiced Butler, SpeakAsButler resolves the Butler
+// and publishes exactly one SpeakRequested carrying the Butler's butler-role Target
+// (→ KindButler line) and the verbatim text — the recap decision-6a voiced path.
+func TestSpeakAsButler_PublishesButlerLine(t *testing.T) {
+	store := newFakeStore()
+	butler := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}
+	bart := storage.Agent{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}
+	store.agents = []storage.Agent{bart, butler}
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SpeakAsButler(context.Background(), "Here is your recap."); err != nil {
+		t.Fatalf("SpeakAsButler: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("SpeakAsButler published %d SpeakRequested, want 1", len(got))
+	}
+	e := got[0]
+	if e.Target.AgentID != butler.ID.String() {
+		t.Errorf("Target.AgentID = %q, want the Butler's %q", e.Target.AgentID, butler.ID.String())
+	}
+	if e.Target.AgentRole != voiceevent.AgentRoleButler {
+		t.Errorf("Target.AgentRole = %q, want %q (KindButler line)", e.Target.AgentRole, voiceevent.AgentRoleButler)
+	}
+	if e.Target.Name != "Glyphoxa" {
+		t.Errorf("Target.Name = %q, want Glyphoxa", e.Target.Name)
+	}
+	if e.Text != "Here is your recap." {
+		t.Errorf("Text = %q, want the verbatim recap text", e.Text)
+	}
+}
+
+// TestSpeakAsButler_IdleReturnsNoActiveSession pins the active-session guard (#365):
+// SpeakAsButler with no live Voice Session is refused before any roster lookup and
+// publishes nothing.
+func TestSpeakAsButler_IdleReturnsNoActiveSession(t *testing.T) {
+	store := newFakeStore()
+	store.agents = []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa"}}
+	mgr, bus := muteManager(t, store)
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SpeakAsButler(context.Background(), "hello"); err != session.ErrNoActiveSession {
+		t.Fatalf("SpeakAsButler while idle = %v, want ErrNoActiveSession", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("idle SpeakAsButler published %d SpeakRequested, want none", len(got))
+	}
+}
+
+// TestSpeakAsButler_NoButlerRejected pins the missing-Butler guard (#365): a live
+// Campaign with no Butler in its roster yields ErrAgentNotInCampaign and publishes
+// nothing.
+func TestSpeakAsButler_NoButlerRejected(t *testing.T) {
+	store := newFakeStore()
+	store.agents = []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Bart"}}
+	mgr, bus := muteManager(t, store)
+	startMuteSession(t, mgr)
+	var got []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { got = append(got, e) }))
+
+	if err := mgr.SpeakAsButler(context.Background(), "hello"); err != session.ErrAgentNotInCampaign {
+		t.Fatalf("SpeakAsButler with no Butler = %v, want ErrAgentNotInCampaign", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("butler-less SpeakAsButler published %d SpeakRequested, want none", len(got))
 	}
 }
 

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -64,6 +64,43 @@ func TestProjection_SayPersistenceTeeFires(t *testing.T) {
 	}
 }
 
+// TestProjection_ButlerSayLine pins #365 AC2: a Butler /say (SpeakAsButler → SayAs)
+// lands through the SAME SpeakRequested → TTSInvoked projection a Character /say uses —
+// no hand-crafted row — but the butler-role Target makes the line render with the
+// KindButler kind + "Butler" pill, and it persists via the normal relay tee.
+func TestProjection_ButlerSayLine(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(bus, fs, store, nil)
+
+	bus.Publish(voiceevent.SpeakRequested{
+		At: at(1), TurnID: "s1", Text: "At your service.",
+		Target: voiceevent.AddressTarget{AgentID: "butler-id", AgentRole: "butler", Name: "Glyphoxa"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "At your service.", Index: 0, TurnID: "s1"})
+
+	v := r.View(fs.id.String())
+	if len(v.Lines) != 1 {
+		t.Fatalf("got %d lines, want 1: %+v", len(v.Lines), v.Lines)
+	}
+	l := v.Lines[0]
+	if l.ID != "a:s1" || l.Who != "Glyphoxa" || l.Kind != KindButler || l.Tag != "Butler" {
+		t.Errorf("butler say line meta = {id %q who %q kind %q tag %q}, want {a:s1 Glyphoxa butler Butler}", l.ID, l.Who, l.Kind, l.Tag)
+	}
+	if l.Text != "At your service." {
+		t.Errorf("butler say line text = %q, want the verbatim /say text", l.Text)
+	}
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got, _ := store.ListTranscriptLines(context.Background(), fs.id)
+	if len(got) != 1 || got[0].LineID != "a:s1" || got[0].Who != "Glyphoxa" || got[0].Text != "At your service." {
+		t.Errorf("persisted butler say line = %+v, want one {a:s1 Glyphoxa At your service.}", got)
+	}
+}
+
 // TestProjection_EnsembleLeadAttributesLine pins #301: the Ensemble Turn's Lead
 // speaks under the ensemble's original TurnID, and its EnsembleLead attribution
 // makes the coalesced reply land as the Lead's line (a:<turn>, the Lead's name +


### PR DESCRIPTION
Closes #365

## What

Wires the recap decision-6a **voiced** on-ramp so the now-voiced Butler (ADR-0009 #299 amendment) can speak verbatim in the live Voice Session.

- `Manager.SayAs` now searches the **full** roster (not just `voicedAgents`) and derives the `SpeakRequested` Target role from the Agent (`sayRole`), so a **butler-role** Target projects a `KindButler` line through the normal relay projection (ADR-0040) — no hand-crafted transcript row.
- New `Manager.SpeakAsButler(ctx, text)` resolves the live session's Butler and delegates to `SayAs`; it satisfies `presence.ButlerVoicer` structurally. Refuses when idle (`ErrNoActiveSession`); a Butler-less campaign yields `ErrAgentNotInCampaign`.
- `cmd/glyphoxa/main.go` passes `mgr` (was `nil`) into `RecapCommand`, so a `voiced` recap is truly spoken as the Butler.

## Guardrails preserved

- Discord `/say` roster still excludes the Butler (`say.go`'s `voiced` filter) — no hand-puppeting.
- Mute surfaces stay Character-only (`voicedAgents` untouched on the mute paths, ADR-0009).

## Tests (TDD, no hand-crafted rows)

- `TestSayAs_ButlerPublishesButlerRole` — Butler is sayable, publishes butler-role Target.
- `TestSpeakAsButler_PublishesButlerLine` — resolves Butler → one SpeakRequested, butler role + name + verbatim text.
- `TestSpeakAsButler_IdleReturnsNoActiveSession` — idle guard, publishes nothing.
- `TestSpeakAsButler_NoButlerRejected` — Butler-less campaign → `ErrAgentNotInCampaign`, publishes nothing.
- Existing `TestProjection_ButlerKind` already proves butler-role → `KindButler`/"Butler" pill through the relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)