### PR TITLE
fix(#391): end all-start-error Ensemble Reaction with TurnEnded{tts_error}

### DIFF
--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -302,6 +302,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		decision    chan string
 		s1Ch        chan string
 		done        chan struct{}
+		ttsErrCh    chan bool
 		cancelReact func()
 	)
 	if lookaheadOn {
@@ -314,12 +315,17 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		// RELEASE (F1) — after EnsembleReaction attributes who spoke — not at pre-render.
 		s1Ch = make(chan string, 1)
 		done = make(chan struct{})
+		// ttsErrCh carries the Reaction's all-start-error verdict (#391) from the
+		// prerender goroutine to releaseReaction: true iff every reaction sentence failed
+		// to start (nothing delivered), so the coordinator ends the sub-turn tts_error
+		// after the goroutine returns. Buffered so the goroutine's send never blocks.
+		ttsErrCh = make(chan bool, 1)
 		defer func() {
 			cancelReact()
 			<-done
 			r.lookahead.DiscardLookahead(rID)
 		}()
-		go r.prerenderReaction(reactCtx, rt, e, reactor, rID, lead.target.Name, lead.text, reactCh, decision, s1Ch, done)
+		go r.prerenderReaction(reactCtx, rt, e, reactor, rID, lead.target.Name, lead.text, reactCh, decision, s1Ch, done, ttsErrCh)
 	}
 
 	// Speak the Lead's draft under turnCtx. The dispatch closure mirrors
@@ -385,7 +391,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	// the pump lane; announce and release it for a near-zero onset gap. The uniform
 	// defer above discards anything left held on any early return here.
 	if lookaheadOn {
-		r.releaseReaction(turnCtx, bus, e, reactor, rID, decision, s1Ch, done)
+		r.releaseReaction(turnCtx, bus, e, reactor, rID, decision, s1Ch, done, ttsErrCh)
 		return
 	}
 	r.speakReaction(turnCtx, rt, bus, e, reactor, lead.target.Name, lead.text, reactCh)
@@ -400,7 +406,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 // holds that sentence until [Replier.releaseReaction] releases it. reactCtx is a
 // child of turnCtx cancelled by the coordinator's uniform teardown (barge/gate-fail/
 // decline/happy), so a torn-down unit unwinds this goroutine. It closes done on exit.
-func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText string, reactCh <-chan reactionResult, decision chan<- string, s1Ch chan<- string, done chan<- struct{}) {
+func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText string, reactCh <-chan reactionResult, decision chan<- string, s1Ch chan<- string, done chan<- struct{}, ttsErrCh chan<- bool) {
 	defer close(done)
 
 	var reaction string
@@ -418,6 +424,7 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 
 	rctx := voiceevent.WithTurnID(reactCtx, rID)
 	first := true
+	var ttsFailed bool
 	dispatch := func(rep Reply) error {
 		if err := reactCtx.Err(); err != nil {
 			return err
@@ -440,6 +447,7 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 			if reactCtx.Err() != nil {
 				return reactCtx.Err()
 			}
+			ttsFailed = true
 			if lookahead {
 				// ANY start-error on the held first sentence aborts the Reaction as a unit
 				// (see [errReactionLookaheadAborted]): converting ErrNotDelivered into a
@@ -456,9 +464,17 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 		}
 		return nil
 	}
-	_, _ = rt.SpeakReaction(rctx, voiceevent.AddressRouted{
+	delivered, _ := rt.SpeakReaction(rctx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
 	}, leadName, leadText, reaction, dispatch)
+
+	// Hand releaseReaction the all-start-error verdict (#391): true iff a sentence
+	// failed to start AND nothing was delivered — the held first sentence aborted the
+	// unit (delivered "") — so the coordinator ends the sub-turn tts_error. A partial
+	// delivery (delivered != "") keeps current semantics (ADR-0012) and reports false.
+	// A ctx-cancel (barge) sets no ttsFailed, so it also reports false; releaseReaction
+	// takes its barge branch instead.
+	ttsErrCh <- ttsFailed && delivered == ""
 }
 
 // releaseReaction is the coordinator tail of the look-ahead Reaction (#375): after
@@ -470,7 +486,7 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 // publishes a barge [voiceevent.TurnEnded] under the reaction's own id (legacy parity;
 // the Lead's already-delivered line stays committed). A decline or a barge before the
 // release publishes nothing; the uniform defer discards any held audio.
-func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID string, decision <-chan string, s1Ch <-chan string, done <-chan struct{}) {
+func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID string, decision <-chan string, s1Ch <-chan string, done <-chan struct{}, ttsErrCh <-chan bool) {
 	var reaction string
 	select {
 	case <-turnCtx.Done():
@@ -507,6 +523,14 @@ func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, 
 	// The two-TurnEnded-on-barge semantics are intentional (see that method's note).
 	if turnCtx.Err() != nil {
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndBarge})
+		return
+	}
+	// All reaction sentences failed to START (nothing delivered) — the held first
+	// sentence aborted the unit under a live turn (#391). End the sub-turn tts_error,
+	// mirroring the Lead, so the reaction id (already announced via EnsembleReaction,
+	// but with no FirstAudio) is never reaped by the metrics TTL sweep as abandoned.
+	if <-ttsErrCh {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndTTSError})
 	}
 }
 
@@ -546,7 +570,10 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 	rctx := voiceevent.WithTurnID(turnCtx, rID)
 	bus.Publish(voiceevent.EnsembleReaction{At: time.Now(), TurnID: rID, LeadTurnID: e.TurnID, Target: reactor})
 
-	var dispatched bool
+	var (
+		dispatched bool
+		ttsFailed  bool
+	)
 	dispatch := func(rep Reply) error {
 		if err := turnCtx.Err(); err != nil {
 			return err
@@ -561,6 +588,7 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 			}
 			// Start-error under a LIVE ctx (#362): NOT delivered, do not commit — but
 			// the Reaction turn is still alive, so keep draining later sentences.
+			ttsFailed = true
 			return ErrNotDelivered
 		}
 		if err := turnCtx.Err(); err != nil {
@@ -568,9 +596,20 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 		}
 		return nil
 	}
-	_, _ = rt.SpeakReaction(rctx, voiceevent.AddressRouted{
+	delivered, _ := rt.SpeakReaction(rctx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
 	}, leadName, leadText, reaction, dispatch)
+
+	// All reaction sentences failed to START (nothing delivered) under a live turn:
+	// end the sub-turn tts_error (#391), mirroring the Lead (dispatchStream), so the
+	// reaction id — already announced via EnsembleReaction, but with no FirstAudio —
+	// is never reaped by the metrics TTL sweep as an abandoned/no_first_audio turn. A
+	// partial delivery (delivered != "") keeps current semantics (ADR-0012): its
+	// FirstAudio is the success signal, so no terminal event fires. Mutually exclusive
+	// with the barge branch below (that one needs a cancelled ctx).
+	if ttsFailed && delivered == "" && turnCtx.Err() == nil {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndTTSError})
+	}
 
 	// A barge cutting the Reaction mid-playback ends this sub-turn under its OWN id
 	// (the Lead's delivered line is untouched). Only when the Reaction actually began

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -600,14 +600,19 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
 	}, leadName, leadText, reaction, dispatch)
 
+	// Sample the barge state ONCE for both terminal branches below: a barge landing
+	// between them must not fire BOTH a tts_error (from a nil re-sample) and a barge
+	// (from a later non-nil re-sample) for the same rID. One snapshot makes the two
+	// genuinely exclusive.
+	bargeErr := turnCtx.Err()
+
 	// All reaction sentences failed to START (nothing delivered) under a live turn:
 	// end the sub-turn tts_error (#391), mirroring the Lead (dispatchStream), so the
 	// reaction id — already announced via EnsembleReaction, but with no FirstAudio —
 	// is never reaped by the metrics TTL sweep as an abandoned/no_first_audio turn. A
 	// partial delivery (delivered != "") keeps current semantics (ADR-0012): its
-	// FirstAudio is the success signal, so no terminal event fires. Mutually exclusive
-	// with the barge branch below (that one needs a cancelled ctx).
-	if ttsFailed && delivered == "" && turnCtx.Err() == nil {
+	// FirstAudio is the success signal, so no terminal event fires.
+	if ttsFailed && delivered == "" && bargeErr == nil {
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndTTSError})
 	}
 
@@ -624,7 +629,7 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 	// clobber neither. The Lead's line — cleanly completed before the barge — keeps its
 	// delivered text; the relay treats a TurnEnded after a line is delivered as a normal
 	// interruption, not a re-count.
-	if dispatched && turnCtx.Err() != nil {
+	if dispatched && bargeErr != nil {
 		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndBarge})
 	}
 }

--- a/pkg/voice/orchestrator/ensemble_crosstalk_test.go
+++ b/pkg/voice/orchestrator/ensemble_crosstalk_test.go
@@ -611,6 +611,72 @@ func TestReplier_Ensemble_ReactionAllStartErrorEndsTurn(t *testing.T) {
 	voicetest.AssertEventCount[voiceevent.TurnEnded](t, h, 1)
 }
 
+// TestReplier_Ensemble_ReactionPartialDeliveryNoTTSError pins #391 AC2 (legacy path):
+// a Reaction where SOME sentences fail to start but ≥1 is delivered keeps current
+// semantics (ADR-0012) — the delivered prefix commits, its FirstAudio is the success
+// signal, and NO TurnEnded{tts_error} fires. The reaction's first sentence "Aye."
+// start-errors (skip-and-continue) but "Indeed." delivers, so delivered != "".
+func TestReplier_Ensemble_ReactionPartialDeliveryNoTTSError(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}),
+			spokeCh:        make(chan string, 2),
+		},
+		react:          map[string]string{goblinTarget.AgentID: "Aye. Indeed."},
+		reactSentences: map[string][]string{goblinTarget.AgentID: {"Aye.", "Indeed."}},
+		reactSpokeCh:   make(chan string, 2),
+	}
+	// The Lead's sentence + the reaction's SECOND sentence synthesize fine; only the
+	// reaction's FIRST sentence start-errors → partial delivery ("Indeed." commits).
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"Aye.": true}})
+	replier := orchestrator.NewStreamReplier(ttsStage, func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error {
+		return nil
+	}, nil)
+	replier.SetFloor(floor)
+	replier.SetEnsemble(spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tpd", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tpd" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tpd"})
+	close(spk.speakPause)
+
+	// The reaction plays and commits its delivered prefix "Indeed." (the "Aye." skipped).
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		if e.LeadTurnID == "Tpd" && e.Target.AgentID == goblinTarget.AgentID {
+			rID = e.TurnID
+			return true
+		}
+		return false
+	}, "ensemble.reaction announced for the reactor")
+	select {
+	case <-spk.reactSpokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the Reaction's SpeakReaction never returned")
+	}
+	waitFloorFree(t, floor)
+
+	if got := spk.reactDeliveredFor(goblinTarget.AgentID); got != "Indeed." {
+		t.Fatalf("partial reaction committed %q, want the delivered prefix %q", got, "Indeed.")
+	}
+	// Partial delivery is NOT a tts_error, and no barge fired: zero TurnEnded for rID.
+	for _, e := range h.Events() {
+		if te, ok := e.(voiceevent.TurnEnded); ok && te.TurnID == rID {
+			t.Fatalf("partial-delivery reaction published TurnEnded{%s}, want none (AC2)", te.Reason)
+		}
+	}
+}
+
 // TestReplier_Ensemble_TTSFailedLeadSkipsReaction pins ADR-0027 for the Reaction gate
 // (#302): a Lead whose ONLY sentence fails synthesis produced NO audio and NO
 // FirstOpus, so the floor never armed. Even though its (undelivered) text is committed

--- a/pkg/voice/orchestrator/ensemble_crosstalk_test.go
+++ b/pkg/voice/orchestrator/ensemble_crosstalk_test.go
@@ -550,6 +550,67 @@ func TestReplier_Ensemble_ZeroDeliveredLeadSkipsReaction(t *testing.T) {
 	}
 }
 
+// TestReplier_Ensemble_ReactionAllStartErrorEndsTurn pins #391 (legacy #302 path):
+// when EVERY sentence of the Cross-talk Reaction fails to START synthesis — nothing
+// delivered — under a live turn, the reaction sub-turn is announced (EnsembleReaction)
+// and THEN ended with TurnEnded{rID, tts_error}, mirroring the Lead. Without the
+// terminal event the reaction id emits EnsembleReaction but no FirstAudio and no
+// TurnEnded, so the metrics TTL sweep miscounts it as an abandoned/no_first_audio turn.
+func TestReplier_Ensemble_ReactionAllStartErrorEndsTurn(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}), // pause so the floor arms before the reaction gate
+			spokeCh:        make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "I react anyway."},
+		reactSpokeCh: make(chan string, 2),
+	}
+	// The Lead's sentence synthesizes fine; the reaction's ONLY sentence start-errors.
+	ttsStage := orchestrator.NewTTS(h.Bus, selectiveSynth{failOn: map[string]bool{"I react anyway.": true}})
+	replier := orchestrator.NewStreamReplier(ttsStage, func(context.Context, voiceevent.AddressRouted, func(orchestrator.Reply) error) error {
+		return nil
+	}, nil)
+	replier.SetFloor(floor)
+	replier.SetEnsemble(spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tp", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	// The Lead is audible: arm the floor, then release it so the Reaction is reached.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tp" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tp"})
+	close(spk.speakPause)
+
+	// The reaction is announced, then ended tts_error (all its sentences failed to start).
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		if e.LeadTurnID == "Tp" && e.Target.AgentID == goblinTarget.AgentID {
+			rID = e.TurnID
+			return true
+		}
+		return false
+	}, "ensemble.reaction announced for the reactor")
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == rID && e.Reason == voiceevent.TurnEndTTSError
+	}, "turn.ended tts_error for the reaction sub-turn (no TTL reap)")
+
+	waitFloorFree(t, floor)
+	// Nothing delivered, and the ONLY turn-end is the reaction's tts_error (no barge, and
+	// the Lead's own turn cleanly delivered so it emits none).
+	if got := spk.reactDeliveredFor(goblinTarget.AgentID); got != "" {
+		t.Fatalf("an all-start-error reaction committed %q, want nothing", got)
+	}
+	voicetest.AssertEventCount[voiceevent.TurnEnded](t, h, 1)
+}
+
 // TestReplier_Ensemble_TTSFailedLeadSkipsReaction pins ADR-0027 for the Reaction gate
 // (#302): a Lead whose ONLY sentence fails synthesis produced NO audio and NO
 // FirstOpus, so the floor never armed. Even though its (undelivered) text is committed

--- a/pkg/voice/orchestrator/ensemble_lookahead_test.go
+++ b/pkg/voice/orchestrator/ensemble_lookahead_test.go
@@ -540,6 +540,62 @@ func TestReplier_Lookahead_FirstDispatchStartErrorAborts(t *testing.T) {
 	}
 }
 
+// TestReplier_Lookahead_FirstStartErrorEndsTurn pins #391 for the look-ahead path:
+// when the held first (and only) reaction sentence fails to START synthesis, the
+// released reaction sub-turn — already announced via EnsembleReaction — is ended with
+// TurnEnded{rID, tts_error} so it is never TTL-reaped as abandoned. Nothing commits.
+func TestReplier_Lookahead_FirstStartErrorEndsTurn(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	pump := newFakeLookahead()
+	// The reaction's ONLY (held) sentence start-errors → nothing delivered.
+	synth := &laneSynth{pump: pump, holdGate: make(chan struct{}), failOn: map[string]bool{"React one.": true}}
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}),
+			spokeCh:        make(chan string, 2),
+		},
+		react:        map[string]string{goblinTarget.AgentID: "React one."},
+		reactSpokeCh: make(chan string, 2),
+	}
+	replier := lookaheadReplier(h, floor, spk, pump, synth)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tp", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tp" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tp"})
+	close(spk.speakPause)
+
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		rID = e.TurnID
+		return e.LeadTurnID == "Tp"
+	}, "ensemble.reaction announced")
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == rID && e.Reason == voiceevent.TurnEndTTSError
+	}, "turn.ended tts_error for the released reaction (no TTL reap)")
+
+	select {
+	case <-spk.reactSpokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SpeakReaction never returned after the first-sentence start-error")
+	}
+	waitFloorFree(t, floor)
+	pump.waitDiscard(t)
+	// No barge fired: the reaction's tts_error is the only turn-end.
+	voicetest.AssertEventCount[voiceevent.TurnEnded](t, h, 1)
+	if got := spk.reactDeliveredFor(goblinTarget.AgentID); got != "" {
+		t.Fatalf("an aborted reaction committed %q, want nothing", got)
+	}
+}
+
 // TestReplier_Lookahead_BargeDuringReactionEndsSubTurn pins #375 legacy parity: a
 // barge WHILE the released Reaction plays ends the reaction sub-turn with a barge
 // TurnEnded under its OWN id.

--- a/pkg/voice/orchestrator/ensemble_lookahead_test.go
+++ b/pkg/voice/orchestrator/ensemble_lookahead_test.go
@@ -596,6 +596,64 @@ func TestReplier_Lookahead_FirstStartErrorEndsTurn(t *testing.T) {
 	}
 }
 
+// TestReplier_Lookahead_PartialDeliveryNoTTSError pins #391 AC2 for the look-ahead
+// path: when the held FIRST sentence delivers but a LATER sentence start-errors
+// (skip-and-continue, #362), the reaction commits its delivered prefix and NO
+// TurnEnded{tts_error} fires — the delivered prefix's FirstAudio is the success signal.
+func TestReplier_Lookahead_PartialDeliveryNoTTSError(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	pump := newFakeLookahead()
+	// The held first sentence "React one." delivers; the SECOND "React two." start-errors.
+	synth := &laneSynth{pump: pump, holdGate: make(chan struct{}), failOn: map[string]bool{"React two.": true}}
+	spk := &fakeCrossTalk{
+		fakeEnsemble: &fakeEnsemble{
+			draft:          map[string]string{bartTarget.AgentID: "Bart leads."},
+			gate:           map[string]chan struct{}{bartTarget.AgentID: closedGate(), goblinTarget.AgentID: make(chan struct{})},
+			speakSentences: map[string][]string{bartTarget.AgentID: {"Bart leads."}},
+			speakPause:     make(chan struct{}),
+			spokeCh:        make(chan string, 2),
+		},
+		react:          map[string]string{goblinTarget.AgentID: "React one. React two."},
+		reactSentences: map[string][]string{goblinTarget.AgentID: {"React one.", "React two."}},
+		reactSpokeCh:   make(chan string, 2),
+	}
+	replier := lookaheadReplier(h, floor, spk, pump, synth)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tpd", Text: "Bart, Goblin?", Targets: []voiceevent.AddressTarget{bartTarget, goblinTarget}})
+
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tpd" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tpd"})
+	close(spk.speakPause)
+
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		rID = e.TurnID
+		return e.LeadTurnID == "Tpd"
+	}, "ensemble.reaction announced")
+	select {
+	case <-spk.reactSpokeCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SpeakReaction never returned")
+	}
+	waitFloorFree(t, floor)
+	pump.waitDiscard(t)
+
+	if got := spk.reactDeliveredFor(goblinTarget.AgentID); got != "React one." {
+		t.Fatalf("partial reaction committed %q, want the delivered prefix %q", got, "React one.")
+	}
+	// Partial delivery is NOT a tts_error, and no barge fired: zero TurnEnded for rID.
+	for _, e := range h.Events() {
+		if te, ok := e.(voiceevent.TurnEnded); ok && te.TurnID == rID {
+			t.Fatalf("partial-delivery reaction published TurnEnded{%s}, want none (AC2)", te.Reason)
+		}
+	}
+}
+
 // TestReplier_Lookahead_BargeDuringReactionEndsSubTurn pins #375 legacy parity: a
 // barge WHILE the released Reaction plays ends the reaction sub-turn with a barge
 // TurnEnded under its OWN id.


### PR DESCRIPTION
Closes #391

## Problem

An Ensemble **Cross-talk Reaction** whose every sentence fails to START synthesis published `EnsembleReaction{rID}` but never a terminal `TurnEnded`. The reaction sub-turn therefore had `EnsembleReaction` + (in look-ahead) a `TTSInvoked`, but **no `FirstAudio` and no `TurnEnded`** — so the metrics TTL sweep miscounted it as an abandoned/`no_first_audio` turn. The Lead already handled this via `dispatchStream` (tts_error); the Reaction did not.

Scout suspected only the legacy `speakReaction` path leaked. **Verified false** — the look-ahead path (`prerenderReaction`/`releaseReaction`, #375) leaks too: the decision channel carries React *text*, which is non-empty; the TTS start-error happens later, at dispatch, after `EnsembleReaction` is published at release. Both paths are fixed.

## Fix

Track `tts_error` like the Lead and end the reaction sub-turn with `TurnEnded{rID, tts_error}` when **nothing was delivered** (all sentences failed to start), on both paths:

- **`speakReaction`** (legacy #302): capture `SpeakReaction`'s delivered text + a `ttsFailed` flag; publish `tts_error` when `ttsFailed && delivered == "" && ctx live`.
- **`prerenderReaction`/`releaseReaction`** (look-ahead #375): the goroutine hands the all-start-error verdict to the coordinator over a new buffered `ttsErrCh`; the held first sentence's abort (`delivered ""`) ends the released sub-turn `tts_error`.

**Partial delivery keeps current semantics** (ADR-0012): its `FirstAudio` is the success signal, so no terminal event fires. The `tts_error` branch is mutually exclusive with the existing barge branch (that one needs a cancelled ctx).

## Tests (TDD, red→green)

- `TestReplier_Ensemble_ReactionAllStartErrorEndsTurn` — legacy path: reaction's only sentence start-errors → `EnsembleReaction` then `TurnEnded{rID, tts_error}`, nothing committed, exactly one `TurnEnded` (no barge, no TTL reap).
- `TestReplier_Lookahead_FirstStartErrorEndsTurn` — look-ahead path: held first sentence start-errors → released reaction ends `tts_error`, nothing committed, no barge.

Full `pkg/voice/orchestrator` suite green under `-race`; `golangci-lint` 0 issues; `go vet -tags integration ./...` clean (after `buf generate`).

> Note: sibling #389 also edits `ensemble.go` — kept this diff tight to the tts_error/`TurnEnded` concern; a rebase may be needed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)