### PR TITLE
fix(#389): route ensemble Butler drafts through the text modality gate

### DIFF
--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -401,6 +401,35 @@ func (r *Replier) Draft(ctx context.Context, text string) (string, error) {
 // are dropped. It returns the delivered text; a ctx-cancel is the expected barge
 // path, not a failure, so it returns a nil error there.
 func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
+	// A Lead draft's modality decision keys on the very utterance it commits.
+	return r.speakDraftModality(ctx, userText, userText, draft, dispatch)
+}
+
+// ReactsAsText reports whether this Agent would deliver its Cross-talk Reaction
+// (reaction) to utterance as channel TEXT rather than speech — the SAME
+// [AnswerAsText] decision [Replier.SpeakReaction] applies (voiceless Butler, an
+// explicit request, or a #297-d2 long answer). It is the coordinator's pre-render
+// seam (#389, ADR-0025/0027): the Ensemble coordinator classifies the reactor BEFORE
+// entering the look-ahead pre-render, so a text reactor is routed through the
+// post-gate tail — its irreversible TextSink post never happens mid-Lead-playback (an
+// audio Reaction is held in the pump lane and discardable; a text post is not). It
+// keys on the RAW utterance, matching the modality decision SpeakReaction makes. A
+// nil TextSink (every non-Butler) is never text.
+func (r *Replier) ReactsAsText(utterance, reaction string) bool {
+	if r.cfg.TextSink == nil {
+		return false
+	}
+	voiceless := r.cfg.Persona.Voice.VoiceID == ""
+	return AnswerAsText(utterance, reaction, voiceless)
+}
+
+// speakDraftModality is the shared body of [Replier.SpeakDraft] and
+// [Replier.SpeakReaction]. commitText is what a delivered turn appends as the user
+// message (the composite Cross-talk line for a Reaction, the raw utterance for a
+// Lead); modalityUtterance is what [AnswerAsText] keys on — always the RAW utterance,
+// so a Reaction's quoted Lead line never contaminates the keyword match (#389 finding
+// 3). draft is the answer text.
+func (r *Replier) speakDraftModality(ctx context.Context, commitText, modalityUtterance, draft string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
 	// Text-modality gate (#389, ADR-0009 2026-07-10 amendment): a Butler with a
 	// TextSink routes its winning draft by the SAME [AnswerAsText] decision the routed
 	// streaming path uses ([Replier.textModalityTurn]). A text-modality draft — a
@@ -416,11 +445,11 @@ func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispat
 	// (never the sentinel), mirroring [Replier.textModalityTurn].
 	if r.cfg.TextSink != nil && strings.TrimSpace(draft) != "" {
 		voiceless := r.cfg.Persona.Voice.VoiceID == ""
-		if AnswerAsText(userText, draft, voiceless) {
+		if AnswerAsText(modalityUtterance, draft, voiceless) {
 			if err := r.cfg.TextSink(ctx, draft); err != nil {
 				return "", err
 			}
-			r.appendUser(userText)
+			r.appendUser(commitText)
 			r.commitSpoken(draft)
 			return draft, orchestrator.ErrTextDelivered
 		}
@@ -443,7 +472,7 @@ func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispat
 			return
 		}
 		userAppended = true
-		r.appendUser(userText)
+		r.appendUser(commitText)
 	}
 
 	// Deliver-then-commit (ADR-0012, mirrors streamTurn's emit): dispatch FIRST; a
@@ -571,14 +600,16 @@ func isSilenceSentinel(reply string) bool {
 }
 
 // SpeakReaction speaks an already-generated Cross-talk Reaction (from a prior
-// [Replier.React]) as this Agent's own sub-turn (ADR-0025, #302). It reuses
-// [Replier.SpeakDraft] with the SAME composite user text React reasoned over
-// ([crossTalkUserText]) so the committed user message and the prompt never drift,
-// and delivers the reaction under deliver-then-commit (ADR-0012). It returns the
-// delivered text; a ctx-cancel (a barge cutting the reaction mid-playback) commits
-// only the sentences spoken before the cut.
+// [Replier.React]) as this Agent's own sub-turn (ADR-0025, #302). It commits the SAME
+// composite user text React reasoned over ([crossTalkUserText]) so the committed user
+// message and the prompt never drift, and delivers the reaction under
+// deliver-then-commit (ADR-0012). The text-modality decision (#389), however, keys on
+// the RAW utterance — NOT the composite — so the Lead's quoted line can never flip a
+// voiced reactor to text via a keyword match ("Post it on the tavern board.", finding
+// 3). It returns the delivered text; a ctx-cancel (a barge cutting the reaction
+// mid-playback) commits only the sentences spoken before the cut.
 func (r *Replier) SpeakReaction(ctx context.Context, userText, leadName, leadText, reaction string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
-	return r.SpeakDraft(ctx, crossTalkUserText(userText, leadName, leadText), reaction, dispatch)
+	return r.speakDraftModality(ctx, crossTalkUserText(userText, leadName, leadText), userText, reaction, dispatch)
 }
 
 // ReplyStream returns the [orchestrator.StreamReplyFunc] that drives this loop

--- a/pkg/voice/agent/agent.go
+++ b/pkg/voice/agent/agent.go
@@ -401,6 +401,31 @@ func (r *Replier) Draft(ctx context.Context, text string) (string, error) {
 // are dropped. It returns the delivered text; a ctx-cancel is the expected barge
 // path, not a failure, so it returns a nil error there.
 func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispatch func(orchestrator.Reply) error) (delivered string, err error) {
+	// Text-modality gate (#389, ADR-0009 2026-07-10 amendment): a Butler with a
+	// TextSink routes its winning draft by the SAME [AnswerAsText] decision the routed
+	// streaming path uses ([Replier.textModalityTurn]). A text-modality draft — a
+	// voiceless Butler (empty VoiceID), an explicit "as text" request, or a long result
+	// (#297 d2) — is posted WHOLE to the channel chat with ZERO TTS dispatch, committed
+	// user+assistant (ADR-0012 text-delivered commits), and reported with the
+	// [orchestrator.ErrTextDelivered] sentinel so the ensemble coordinator publishes
+	// TurnEnded(text_delivered), keeping metrics/relay consistent with the routed path.
+	// Because this precedes every dispatch, a voiceless Butler can NEVER reach TTS with
+	// an empty VoiceID on the ensemble Draft/Speak path OR the Cross-talk Reaction path
+	// ([Replier.SpeakReaction] delegates here) — the structural-unreachability guarantee.
+	// A failed post delivered nothing, so it commits nothing and surfaces the post error
+	// (never the sentinel), mirroring [Replier.textModalityTurn].
+	if r.cfg.TextSink != nil && strings.TrimSpace(draft) != "" {
+		voiceless := r.cfg.Persona.Voice.VoiceID == ""
+		if AnswerAsText(userText, draft, voiceless) {
+			if err := r.cfg.TextSink(ctx, draft); err != nil {
+				return "", err
+			}
+			r.appendUser(userText)
+			r.commitSpoken(draft)
+			return draft, orchestrator.ErrTextDelivered
+		}
+	}
+
 	var split sentenceSplitter
 	var spoken strings.Builder
 	voice := r.cfg.Persona.Voice
@@ -418,10 +443,7 @@ func (r *Replier) SpeakDraft(ctx context.Context, userText, draft string, dispat
 			return
 		}
 		userAppended = true
-		r.mu.Lock()
-		r.history = append(r.history, llm.Message{Role: llm.RoleUser, Text: userText})
-		r.trimHistoryLocked()
-		r.mu.Unlock()
+		r.appendUser(userText)
 	}
 
 	// Deliver-then-commit (ADR-0012, mirrors streamTurn's emit): dispatch FIRST; a
@@ -803,6 +825,17 @@ func (r *Replier) HistorySnapshot() []llm.Message {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]llm.Message(nil), r.history...)
+}
+
+// appendUser appends the utterance as a user message under the history lock and
+// trims to [Config.HistoryTurns]. It is the single user-append site shared by the
+// streaming/batch turns' eager append, [Replier.SpeakDraft]'s deliver-then-commit
+// lazy append, and its text-modality branch (#389).
+func (r *Replier) appendUser(text string) {
+	r.mu.Lock()
+	r.history = append(r.history, llm.Message{Role: llm.RoleUser, Text: text})
+	r.trimHistoryLocked()
+	r.mu.Unlock()
 }
 
 // commitSpoken records the text actually delivered to the pump as the assistant

--- a/pkg/voice/agent/agent_ensemble_textmodality_test.go
+++ b/pkg/voice/agent/agent_ensemble_textmodality_test.go
@@ -160,3 +160,31 @@ func TestReplier_SpeakReaction_VoicelessButler_DeliversTextNoDispatch(t *testing
 		t.Errorf("posted=%q delivered=%q, want the reaction delivered as text", posted, delivered)
 	}
 }
+
+// TestReplier_SpeakReaction_ModalityKeysOnRawUtterance pins #389 finding 3: a VOICED
+// Butler reactor's modality is decided on the RAW utterance, NOT the Cross-talk
+// composite. Here the raw utterance carries no text-forcing phrase, but the Lead's
+// quoted line does ("Post it …"). Keying on the composite would flip the reactor to
+// text; keying on the raw utterance keeps it SPOKEN (a short answer with a Voice).
+func TestReplier_SpeakReaction_ModalityKeysOnRawUtterance(t *testing.T) {
+	sinkCalled := false
+	r := textSinkReplier(t, batchEngine{}, false, func(context.Context, string) error {
+		sinkCalled = true
+		return nil
+	})
+
+	var got []string
+	_, err := r.SpeakReaction(t.Context(), "Bart, Glyphoxa — thoughts?", "Bart", "Post it on the tavern board.", "Aye, a fine idea.", func(rep orchestrator.Reply) error {
+		got = append(got, rep.Sentence)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SpeakReaction errored: %v", err)
+	}
+	if sinkCalled {
+		t.Error("modality keyed on the composite Lead line → wrongly text; want spoken (raw utterance has no phrase)")
+	}
+	if len(got) == 0 {
+		t.Fatal("the voiced reactor was not spoken; want sentence-split TTS dispatch")
+	}
+}

--- a/pkg/voice/agent/agent_ensemble_textmodality_test.go
+++ b/pkg/voice/agent/agent_ensemble_textmodality_test.go
@@ -1,0 +1,162 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+)
+
+// TestReplier_SpeakDraft_VoicelessButler_DeliversTextNoDispatch is the #389
+// headline: a voiceless Butler co-addressed in an Ensemble Turn (won the Lead race,
+// its draft handed to SpeakDraft) must deliver its draft as channel TEXT and NEVER
+// dispatch TTS — a Butler with an empty VoiceID has no Voice to speak with, so an
+// empty-VoiceID dispatch must be STRUCTURALLY unreachable. SpeakDraft posts the
+// whole draft via the TextSink, dispatches nothing, commits user+assistant
+// (ADR-0012), and returns the [orchestrator.ErrTextDelivered] terminal sentinel.
+func TestReplier_SpeakDraft_VoicelessButler_DeliversTextNoDispatch(t *testing.T) {
+	var posted string
+	var dispatched int
+	r := textSinkReplier(t, batchEngine{}, true, func(_ context.Context, text string) error {
+		posted = text
+		return nil
+	})
+
+	delivered, err := r.SpeakDraft(t.Context(), "Glyphoxa, roll two d6", "Nine.", func(orchestrator.Reply) error {
+		dispatched++
+		return nil
+	})
+	if !errors.Is(err, orchestrator.ErrTextDelivered) {
+		t.Fatalf("SpeakDraft err = %v, want ErrTextDelivered", err)
+	}
+	if dispatched != 0 {
+		t.Errorf("voiceless Butler dispatched %d to TTS, want 0 (empty-VoiceID dispatch must be unreachable)", dispatched)
+	}
+	if posted != "Nine." {
+		t.Errorf("posted = %q, want %q", posted, "Nine.")
+	}
+	if delivered != "Nine." {
+		t.Errorf("delivered = %q, want %q", delivered, "Nine.")
+	}
+	hist := r.HistorySnapshot()
+	if len(hist) != 2 || hist[0].Text != "Glyphoxa, roll two d6" || hist[1].Text != "Nine." {
+		t.Fatalf("history = %+v, want user+assistant committed on the text branch", hist)
+	}
+}
+
+// TestReplier_SpeakDraft_LongAnswer_DeliversText pins the #297 d2 long-answer rule
+// on the ensemble path: a VOICED Butler whose winning draft exceeds the size
+// threshold posts as text (no TTS dispatch), exactly as the routed streaming path
+// does — the ensemble Draft/Speak path consults the SAME modality decision.
+func TestReplier_SpeakDraft_LongAnswer_DeliversText(t *testing.T) {
+	long := strings.TrimSpace(strings.Repeat("word ", 200)) // > 400 runes
+	var posted string
+	var dispatched int
+	r := textSinkReplier(t, batchEngine{}, false, func(_ context.Context, text string) error {
+		posted = text
+		return nil
+	})
+
+	delivered, err := r.SpeakDraft(t.Context(), "Glyphoxa, recap last session", long, func(orchestrator.Reply) error {
+		dispatched++
+		return nil
+	})
+	if !errors.Is(err, orchestrator.ErrTextDelivered) {
+		t.Fatalf("SpeakDraft err = %v, want ErrTextDelivered (long answer → text)", err)
+	}
+	if dispatched != 0 {
+		t.Errorf("long answer dispatched %d to TTS, want 0", dispatched)
+	}
+	if posted != long || delivered != long {
+		t.Errorf("posted/delivered mismatch, want the whole long answer")
+	}
+}
+
+// TestReplier_SpeakDraft_ShortVoicedAnswer_Spoken pins that a TextSink does not
+// hijack a SHORT VOICED answer: a Butler with a real Voice speaks a short draft
+// (sentence-split dispatch), never touching the sink and never returning the
+// text-delivered sentinel — modality is decided the same way as the routed path.
+func TestReplier_SpeakDraft_ShortVoicedAnswer_Spoken(t *testing.T) {
+	sinkCalled := false
+	r := textSinkReplier(t, batchEngine{}, false, func(context.Context, string) error {
+		sinkCalled = true
+		return nil
+	})
+
+	var got []string
+	delivered, err := r.SpeakDraft(t.Context(), "Glyphoxa, roll two d6", "Two sixes. Total nine.", func(rep orchestrator.Reply) error {
+		got = append(got, rep.Sentence)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SpeakDraft errored: %v", err)
+	}
+	if sinkCalled {
+		t.Error("TextSink called for a short voiced answer, want spoken via TTS")
+	}
+	want := []string{"Two sixes.", "Total nine."}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("dispatched %q, want %q (sentence-split spoken)", got, want)
+	}
+	if delivered != "Two sixes. Total nine." {
+		t.Errorf("delivered = %q, want the whole spoken draft", delivered)
+	}
+}
+
+// TestReplier_SpeakDraft_TextSink_PostError_NotCommitted pins ADR-0012
+// deliver-then-commit on the ensemble text branch: a failed TextSink post means the
+// answer was never delivered, so nothing is committed and the sentinel is NOT
+// returned (the coordinator must not record a text_delivered success).
+func TestReplier_SpeakDraft_TextSink_PostError_NotCommitted(t *testing.T) {
+	postErr := errors.New("channel post failed")
+	r := textSinkReplier(t, batchEngine{}, true, func(context.Context, string) error {
+		return postErr
+	})
+
+	delivered, err := r.SpeakDraft(t.Context(), "Glyphoxa, roll two d6", "Nine.", func(orchestrator.Reply) error {
+		t.Fatal("a text-modality answer must not dispatch TTS")
+		return nil
+	})
+	if !errors.Is(err, postErr) {
+		t.Fatalf("SpeakDraft err = %v, want the post error", err)
+	}
+	if errors.Is(err, orchestrator.ErrTextDelivered) {
+		t.Fatal("a failed post must not report ErrTextDelivered")
+	}
+	if delivered != "" {
+		t.Errorf("delivered = %q, want empty on a failed post", delivered)
+	}
+	if len(r.HistorySnapshot()) != 0 {
+		t.Errorf("a failed post committed to history: %+v", r.HistorySnapshot())
+	}
+}
+
+// TestReplier_SpeakReaction_VoicelessButler_DeliversTextNoDispatch pins the
+// structural-unreachability AC on the CROSS-TALK REACTION path (#302/#389): because
+// SpeakReaction delegates to SpeakDraft, a voiceless Butler elected as reactor also
+// delivers its Reaction as text and dispatches ZERO TTS — a voiceless Butler never
+// TTS-dispatches on ANY ensemble path.
+func TestReplier_SpeakReaction_VoicelessButler_DeliversTextNoDispatch(t *testing.T) {
+	var posted string
+	var dispatched int
+	r := textSinkReplier(t, batchEngine{}, true, func(_ context.Context, text string) error {
+		posted = text
+		return nil
+	})
+
+	delivered, err := r.SpeakReaction(t.Context(), "Bart, Glyphoxa — thoughts?", "Bart", "We ride at dawn.", "A fine plan.", func(orchestrator.Reply) error {
+		dispatched++
+		return nil
+	})
+	if !errors.Is(err, orchestrator.ErrTextDelivered) {
+		t.Fatalf("SpeakReaction err = %v, want ErrTextDelivered", err)
+	}
+	if dispatched != 0 {
+		t.Errorf("voiceless Butler reactor dispatched %d to TTS, want 0", dispatched)
+	}
+	if posted != "A fine plan." || delivered != "A fine plan." {
+		t.Errorf("posted=%q delivered=%q, want the reaction delivered as text", posted, delivered)
+	}
+}

--- a/pkg/voice/agent/cast.go
+++ b/pkg/voice/agent/cast.go
@@ -143,6 +143,18 @@ func (c *Cast) React(ctx context.Context, e voiceevent.AddressRouted, leadName, 
 	return r.React(ctx, e.Text, leadName, leadText)
 }
 
+// ReactsAsText implements [orchestrator.ReactionModality]: it reports whether the
+// addressed Agent would deliver its Cross-talk Reaction as channel TEXT (the same
+// [AnswerAsText] decision SpeakReaction applies), the coordinator's pre-render seam
+// (#389). An unknown (or removed) Agent — and every non-Butler — is never text.
+func (c *Cast) ReactsAsText(agentID, utterance, reaction string) bool {
+	r := c.lookup(agentID)
+	if r == nil {
+		return false
+	}
+	return r.ReactsAsText(utterance, reaction)
+}
+
 // SpeakReaction implements [orchestrator.CrossTalker]: it speaks the addressed
 // Agent's pre-generated Reaction as its own sub-turn (committing the delivered text
 // to that member's history, ADR-0012), by delegating to [Replier.SpeakReaction]. An

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -70,6 +70,22 @@ type CrossTalker interface {
 	SpeakReaction(ctx context.Context, e voiceevent.AddressRouted, leadName, leadText, reaction string, dispatch func(Reply) error) (delivered string, err error)
 }
 
+// ReactionModality is the optional pre-render classification seam of a [CrossTalker]
+// (#389, ADR-0025/0027): given the reactor's generated Reaction, it reports whether
+// that reactor will deliver it as channel TEXT (a voiceless Butler, an explicit
+// request, or a #297-d2 long answer) rather than speech — the SAME decision the
+// reactor's SpeakReaction makes internally. The coordinator discovers it by a type
+// assertion on the wired speaker; a text Reaction is routed AROUND the look-ahead
+// pre-render (its FIRST sentence would otherwise be synthesized — and, for text, its
+// TextSink post committed — DURING the Lead's playback, before the audible-Lead gate,
+// posting a Reaction to a line nobody may yet have heard, ADR-0025/0027/ADR-0012).
+// Audio is held in the pump lane and discardable; a text post is irreversible, so a
+// text reactor must wait for the post-gate tail. A speaker that does not implement
+// this classifies every reactor as audio — the #375 pre-render path, unchanged.
+type ReactionModality interface {
+	ReactsAsText(agentID, utterance, reaction string) bool
+}
+
 // handleEnsemble runs one [voiceevent.EnsembleRouted] decision set as ONE
 // floor-holding Ensemble Turn (ADR-0025/0027, #301). It mirrors the single-route
 // reactor's gates (mute pre-filter, spend cap, floor Take with its coalesce fold,
@@ -299,7 +315,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	lookaheadOn := r.lookahead != nil && hasReactor
 	var (
 		rID         string
-		decision    chan string
+		decision    chan reactionDecision
 		s1Ch        chan string
 		done        chan struct{}
 		cancelReact func()
@@ -308,7 +324,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		rID = voiceevent.NewTurnID()
 		var reactCtx context.Context
 		reactCtx, cancelReact = context.WithCancel(turnCtx)
-		decision = make(chan string, 1)
+		decision = make(chan reactionDecision, 1)
 		// s1Ch carries the Reaction's FIRST (held) sentence text from the prerender
 		// goroutine to releaseReaction, so the coordinator announces its TTSInvoked at
 		// RELEASE (F1) — after EnsembleReaction attributes who spoke — not at pre-render.
@@ -394,10 +410,11 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 		return
 	}
 	// Look-ahead path (#375): the Reaction's first-sentence audio is already held in
-	// the pump lane; announce and release it for a near-zero onset gap. The uniform
-	// defer above discards anything left held on any early return here.
+	// the pump lane; announce and release it for a near-zero onset gap. A text reactor
+	// (#389) held nothing — releaseReaction posts it now, post-gate. The uniform defer
+	// above discards anything left held on any early return here.
 	if lookaheadOn {
-		r.releaseReaction(turnCtx, bus, e, reactor, rID, decision, s1Ch, done)
+		r.releaseReaction(turnCtx, rt, bus, e, reactor, rID, lead.target.Name, lead.text, decision, s1Ch, done)
 		return
 	}
 	r.speakReaction(turnCtx, rt, bus, e, reactor, lead.target.Name, lead.text, reactCh)
@@ -412,7 +429,7 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 // holds that sentence until [Replier.releaseReaction] releases it. reactCtx is a
 // child of turnCtx cancelled by the coordinator's uniform teardown (barge/gate-fail/
 // decline/happy), so a torn-down unit unwinds this goroutine. It closes done on exit.
-func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText string, reactCh <-chan reactionResult, decision chan<- string, s1Ch chan<- string, done chan<- struct{}) {
+func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText string, reactCh <-chan reactionResult, decision chan<- reactionDecision, s1Ch chan<- string, done chan<- struct{}) {
 	defer close(done)
 
 	var reaction string
@@ -422,10 +439,26 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 	case res := <-reactCh:
 		reaction = res.text // a React error surfaces as "" — treated as a decline
 	}
-	// Report the decision so the coordinator (post-Speak) knows whether to release.
-	decision <- reaction
-	if reaction == "" || reactCtx.Err() != nil {
-		return // declined, or the unit was cut the instant it finished
+	// Classify the reactor's modality BEFORE pre-rendering (#389): a text reactor (a
+	// voiceless Butler, an explicit request, or a #297-d2 long answer) must NOT enter
+	// the pre-render seam — its SpeakReaction would post to the channel chat and commit
+	// to history DURING the Lead's playback, before the audible-Lead gate, reacting to
+	// a line nobody may yet have heard (ADR-0025/0027/ADR-0012). Only audio Reactions
+	// hold a first sentence in the pump lane; a text Reaction is posted post-gate by
+	// [Replier.releaseReaction]. A speaker without [ReactionModality] classifies every
+	// reactor as audio (the #375 path, unchanged). The classifier keys on the RAW
+	// utterance, matching SpeakReaction's own decision.
+	isText := false
+	if reaction != "" {
+		if mod, ok := rt.(ReactionModality); ok {
+			isText = mod.ReactsAsText(reactor.AgentID, e.Text, reaction)
+		}
+	}
+	// Report the decision so the coordinator (post-Speak) knows whether to release held
+	// audio, post the text Reaction, or do nothing (decline).
+	decision <- reactionDecision{text: reaction, isText: isText}
+	if reaction == "" || isText || reactCtx.Err() != nil {
+		return // declined, a text reactor (post-gate tail owns the post), or cut
 	}
 
 	rctx := voiceevent.WithTurnID(reactCtx, rID)
@@ -482,29 +515,35 @@ func (r *Replier) prerenderReaction(reactCtx context.Context, rt CrossTalker, e 
 // publishes a barge [voiceevent.TurnEnded] under the reaction's own id (legacy parity;
 // the Lead's already-delivered line stays committed). A decline or a barge before the
 // release publishes nothing; the uniform defer discards any held audio.
-func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID string, decision <-chan string, s1Ch <-chan string, done <-chan struct{}) {
-	var reaction string
+func (r *Replier) releaseReaction(turnCtx context.Context, rt CrossTalker, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText string, decision <-chan reactionDecision, s1Ch <-chan string, done <-chan struct{}) {
+	var d reactionDecision
 	select {
 	case <-turnCtx.Done():
 		return // a barge tore the unit down while the Reaction generated
-	case reaction = <-decision:
+	case d = <-decision:
 	}
-	if reaction == "" || turnCtx.Err() != nil {
+	if d.text == "" || turnCtx.Err() != nil {
 		return // the reactor declined, or a barge landed the instant it finished
 	}
 
-	// Wait for the prerender goroutine to reach the held first dispatch (it hands us the
-	// sentence text on s1Ch, then blocks on the pump lane). Safe: reactCtx ⊂ turnCtx, so
-	// a barge cancels both and the turnCtx.Done arm returns without announcing.
-	//
-	// The <-done arm covers a voiceless / long / text-requested reactor (#389): its
-	// SpeakReaction routes to SpeakDraft's TEXT branch and NEVER calls the dispatch
-	// closure, so no first sentence is ever held (s1Ch stays empty) and the prerender
-	// goroutine closes done. Without this arm releaseReaction would block on s1Ch
-	// forever. done closes only after the goroutine has returned, so once it fires the
-	// s1Ch state is final: a non-blocking re-check distinguishes a held-then-aborted
-	// first sentence (s1Ch has it — proceed) from a text-delivered reactor (empty —
-	// return without announcing, so no audio-less sub-turn line is ever created).
+	// Text reactor (#389): nothing was pre-rendered — the whole Reaction is delivered
+	// post-gate now, so its irreversible TextSink post lands AFTER the Lead ended and is
+	// audibly on the wire (this tail runs only past the audible-Lead gate). This is the
+	// SAME post-gate handling as the no-look-ahead [Replier.speakReaction], so look-ahead
+	// on and off produce identical observable events for a text reactor.
+	if d.isText {
+		r.postTextReaction(turnCtx, rt, bus, e, reactor, rID, leadName, leadText, d.text)
+		return
+	}
+
+	// Audio reactor: wait for the prerender goroutine to reach the held first dispatch
+	// (it hands us the sentence text on s1Ch, then blocks on the pump lane). Safe:
+	// reactCtx ⊂ turnCtx, so a barge cancels both and the turnCtx.Done arm returns
+	// without announcing. The <-done arm is a safety net for a prerender that returned
+	// WITHOUT ever holding a first sentence (its reactCtx was cut before the first
+	// dispatch): done closes only after the goroutine returns, so once it fires the
+	// s1Ch state is final — a non-blocking re-check distinguishes a held-then-aborted
+	// first sentence (s1Ch has it — proceed) from nothing held (return, no line).
 	var s1 string
 	select {
 	case <-turnCtx.Done():
@@ -543,6 +582,42 @@ func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, 
 type reactionResult struct {
 	text string
 	err  error
+}
+
+// reactionDecision is the prerender goroutine's report to the look-ahead coordinator
+// tail (#375/#389): the reactor's generated Reaction text ("" = decline) and whether
+// that reactor delivers it as TEXT (classified via [ReactionModality] BEFORE any
+// pre-render). isText routes the post-gate tail: a text reactor held no audio and is
+// posted by [Replier.postTextReaction]; an audio reactor's first sentence waits in the
+// pump lane for [Replier.releaseReaction].
+type reactionDecision struct {
+	text   string
+	isText bool
+}
+
+// postTextReaction delivers a text-modality Cross-talk Reaction POST-GATE (#389): the
+// Lead has ended and is audibly on the wire (the caller runs only past the
+// audible-Lead gate), so the reactor's irreversible TextSink post now lands after the
+// audience heard the line it reacts to (ADR-0025/0027). It announces the sub-turn
+// (attribution) BEFORE the post, then delegates to [CrossTalker.SpeakReaction] whose
+// text branch posts to channel chat with ZERO dispatch, and maps the
+// [ErrTextDelivered] sentinel to TurnEnded(text_delivered) so the metrics TTL sweep
+// records a success — identical events to the no-look-ahead [Replier.speakReaction]
+// text path. The dispatch closure is a guard: a text reactor never dispatches, so a
+// call would mean the classifier and SpeakReaction disagree; it reports ErrNotDelivered
+// rather than synthesize (defensive — should not happen). A barge landing during the
+// post publishes no terminal (turnCtx cut); the Lead's line stays committed.
+func (r *Replier) postTextReaction(turnCtx context.Context, rt CrossTalker, bus *voiceevent.Bus, e voiceevent.EnsembleRouted, reactor voiceevent.AddressTarget, rID, leadName, leadText, reaction string) {
+	bus.Publish(voiceevent.EnsembleReaction{At: time.Now(), TurnID: rID, LeadTurnID: e.TurnID, Target: reactor})
+	_, err := rt.SpeakReaction(voiceevent.WithTurnID(turnCtx, rID), voiceevent.AddressRouted{
+		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
+	}, leadName, leadText, reaction, func(Reply) error { return ErrNotDelivered })
+	if turnCtx.Err() != nil {
+		return
+	}
+	if errors.Is(err, ErrTextDelivered) {
+		bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndTextDelivered})
+	}
 }
 
 // speakReaction is the Cross-talk Reaction sub-turn (#302, ADR-0025): it waits for

--- a/pkg/voice/orchestrator/ensemble.go
+++ b/pkg/voice/orchestrator/ensemble.go
@@ -357,9 +357,21 @@ func (r *Replier) runEnsemble(turnCtx context.Context, release func(), bus *voic
 	}
 	// Speak commits the delivered text to the Lead's own history and stops the drain
 	// on a barge.
-	_, _ = r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
+	_, speakErr := r.ensemble.Speak(turnCtx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: lead.target,
 	}, lead.text, dispatch)
+
+	// A voiceless / long / text-requested Lead (#389) delivered its draft as channel
+	// TEXT with ZERO TTS dispatch: mirror the routed path's ErrTextDelivered mapping
+	// and publish the text_delivered terminal so the metrics TTL sweep records a
+	// SUCCESS rather than reaping a no-first-audio turn. The Lead is not audibly on the
+	// wire, so no Cross-talk Reaction opens (the floor never armed) — end the unit here.
+	if errors.Is(speakErr, ErrTextDelivered) {
+		if turnCtx.Err() == nil {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: e.TurnID, Reason: voiceevent.TurnEndTextDelivered})
+		}
+		return
+	}
 
 	// A TTS synth failure that produced no audio under a live turn is announced as
 	// the turn-end reason (mirrors dispatchStream); a barge publishes its own.
@@ -484,11 +496,26 @@ func (r *Replier) releaseReaction(turnCtx context.Context, bus *voiceevent.Bus, 
 	// Wait for the prerender goroutine to reach the held first dispatch (it hands us the
 	// sentence text on s1Ch, then blocks on the pump lane). Safe: reactCtx ⊂ turnCtx, so
 	// a barge cancels both and the turnCtx.Done arm returns without announcing.
+	//
+	// The <-done arm covers a voiceless / long / text-requested reactor (#389): its
+	// SpeakReaction routes to SpeakDraft's TEXT branch and NEVER calls the dispatch
+	// closure, so no first sentence is ever held (s1Ch stays empty) and the prerender
+	// goroutine closes done. Without this arm releaseReaction would block on s1Ch
+	// forever. done closes only after the goroutine has returned, so once it fires the
+	// s1Ch state is final: a non-blocking re-check distinguishes a held-then-aborted
+	// first sentence (s1Ch has it — proceed) from a text-delivered reactor (empty —
+	// return without announcing, so no audio-less sub-turn line is ever created).
 	var s1 string
 	select {
 	case <-turnCtx.Done():
 		return
 	case s1 = <-s1Ch:
+	case <-done:
+		select {
+		case s1 = <-s1Ch:
+		default:
+			return
+		}
 	}
 
 	// Announce the sub-turn BEFORE releasing its audio (F1): EnsembleReaction attributes
@@ -568,9 +595,21 @@ func (r *Replier) speakReaction(turnCtx context.Context, rt CrossTalker, bus *vo
 		}
 		return nil
 	}
-	_, _ = rt.SpeakReaction(rctx, voiceevent.AddressRouted{
+	_, reactErr := rt.SpeakReaction(rctx, voiceevent.AddressRouted{
 		At: e.At, Text: e.Text, TurnID: e.TurnID, Target: reactor,
 	}, leadName, leadText, reaction, dispatch)
+
+	// A voiceless / long / text-requested reactor (#389) delivered its Reaction as
+	// channel TEXT with ZERO TTS dispatch (SpeakReaction → SpeakDraft's text branch).
+	// EnsembleReaction already created this sub-turn's line, so publish its
+	// text_delivered terminal — otherwise the metrics TTL sweep reaps the audio-less
+	// sub-turn as abandoned. Mirrors the routed path's ErrTextDelivered mapping.
+	if errors.Is(reactErr, ErrTextDelivered) {
+		if turnCtx.Err() == nil {
+			bus.Publish(voiceevent.TurnEnded{At: time.Now(), TurnID: rID, Reason: voiceevent.TurnEndTextDelivered})
+		}
+		return
+	}
 
 	// A barge cutting the Reaction mid-playback ends this sub-turn under its OWN id
 	// (the Lead's delivered line is untouched). Only when the Reaction actually began

--- a/pkg/voice/orchestrator/ensemble_textmodality_test.go
+++ b/pkg/voice/orchestrator/ensemble_textmodality_test.go
@@ -2,9 +2,13 @@ package orchestrator_test
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -186,55 +190,107 @@ func TestReplier_Ensemble_TextDeliveredReactor_PublishesTerminal(t *testing.T) {
 	}
 }
 
-// TestReplier_Lookahead_TextDeliveredReactor_NoHang pins the #389 look-ahead guard:
-// a voiceless Butler reactor text-delivers (SpeakReaction never calls the dispatch
-// closure), so the prerender goroutine holds NO first sentence — s1Ch stays empty and
-// done closes. releaseReaction's <-done arm must return instead of blocking forever on
-// s1Ch. The turn completes (floor freed), the uniform defer's DiscardLookahead fires,
-// and no EnsembleReaction / reaction TTSInvoked is published (the Reaction went to
-// channel text, not the wire).
-func TestReplier_Lookahead_TextDeliveredReactor_NoHang(t *testing.T) {
+// reactorEngine is a scripted [agent.Engine] for the REAL-Cast look-ahead text-reactor
+// test: a Cross-talk turn (its user message carries the composite `<lead> says: "…"`)
+// generates the Reaction; any other call (the speculative Draft) returns "" so this
+// Agent never wins the Lead race and is left as the sole remaining reactor.
+type reactorEngine struct{ reaction string }
+
+func (e reactorEngine) Generate(_ context.Context, msgs []llm.Message) (string, error) {
+	for _, m := range msgs {
+		if strings.Contains(m.Text, `says: "`) {
+			return e.reaction, nil
+		}
+	}
+	return "", nil
+}
+
+// TestReplier_Lookahead_TextReactor_PostsAfterLeadThroughRealCast is the #389
+// finding-1/-2 regression, driven through the REAL agent.Cast (production wires the
+// look-ahead pump, so prerenderReaction/releaseReaction IS the production Cross-talk
+// path). A voiced Character Lead speaks; a VOICELESS Butler reactor with a real
+// TextSink is co-addressed. The coordinator must classify the reactor as text BEFORE
+// pre-render (ReactionModality), keep it OUT of the pump lane, and post its Reaction
+// only via the post-gate tail — so the irreversible TextSink post lands AFTER the Lead
+// is audibly on the wire (floor.Speaking), with EnsembleReaction + TurnEnded(text_delivered)
+// and NO second TTSInvoked. Look-ahead on now produces the SAME events as off.
+func TestReplier_Lookahead_TextReactor_PostsAfterLeadThroughRealCast(t *testing.T) {
 	h := voicetest.New(t)
 	floor := orchestrator.NewFloor()
 	pump := newFakeLookahead()
-	synth := &laneSynth{pump: pump, holdGate: make(chan struct{})}
-	defer close(synth.holdGate)
+	synth := &laneSynth{pump: pump, holdSet: map[string]bool{"Bart leads.": true}, holdGate: make(chan struct{})}
 
-	spk := &textReactorSpeaker{
-		leadID:     bartTarget.AgentID,
-		leadDraft:  "Bart leads.",
-		reaction:   "As you wish, my lord.",
-		speakPause: make(chan struct{}),
-		reactSpoke: make(chan string, 2),
-	}
-	replier := lookaheadReplier(h, floor, spk, pump, synth)
+	// The real Lead: a voiced Character whose Draft/Speak run through agent.Replier.
+	leadRep := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: bartTarget.AgentID, Markdown: "You are Bart.", Voice: tts.Voice{ProviderID: "test", VoiceID: "bart", Name: "Bart"}},
+		Engine:      fixedEngine{reply: "Bart leads."},
+		Synthesizer: synth,
+	})
+	// The real reactor: a VOICELESS Butler (empty VoiceID) with a TextSink. Its
+	// SpeakReaction routes through the real speakDraftModality TEXT branch.
+	var (
+		postMu       sync.Mutex
+		posted       string
+		postSawAudio bool
+	)
+	butlerRep := agent.NewReplier(agent.Config{
+		Persona:     agent.Persona{AgentID: butlerTarget.AgentID, Markdown: "You are Glyphoxa.", Voice: tts.Voice{ProviderID: "test", VoiceID: "", Name: "Glyphoxa"}},
+		Engine:      reactorEngine{reaction: "As you wish, my lord."},
+		Synthesizer: synth,
+		TextSink: func(_ context.Context, text string) error {
+			postMu.Lock()
+			posted = text
+			postSawAudio = floor.Speaking() // the Lead must be audible when the text posts
+			postMu.Unlock()
+			return nil
+		},
+	})
+	cast := agent.NewCast(leadRep, butlerRep)
+
+	replier := lookaheadReplier(h, floor, cast, pump, synth)
 	t.Cleanup(replier.Bind(t.Context(), h.Bus))
 	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
 
-	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tl", Text: "Bart, Glyphoxa?", Targets: []voiceevent.AddressTarget{bartTarget, butlerTarget}})
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tl", Text: "Bart, Glyphoxa — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, butlerTarget}})
 
-	// Arm the floor once the Lead is audible, then release the paused Lead.
+	// The Lead's sentence is on the wire but HELD by the lane synth (Speak blocked). Arm
+	// the floor, then release the Lead so its Speak returns and the post-gate tail runs.
 	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
 		return e.TurnID == "Tl" && e.Sentence == "Bart leads."
 	}, "the Lead's sentence is on the wire")
-	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tl"})
-	close(spk.speakPause)
-
-	// The reactor's SpeakReaction returned (text-delivered) — the coordinator must not
-	// wedge on s1Ch.
-	select {
-	case <-spk.reactSpoke:
-	case <-time.After(2 * time.Second):
-		t.Fatal("the text reactor's SpeakReaction never returned (look-ahead release wedged on s1Ch?)")
+	// The reactor's text post must NOT have happened yet — it is forbidden mid-Lead.
+	postMu.Lock()
+	early := posted
+	postMu.Unlock()
+	if early != "" {
+		t.Fatalf("the text Reaction posted DURING the Lead's playback (%q) — must wait for the post-gate tail", early)
 	}
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tl"})
+	close(synth.holdGate)
 
-	// The uniform defer ran and the whole unit completed.
-	pump.waitDiscard(t)
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		if e.LeadTurnID == "Tl" && e.Target.AgentID == butlerTarget.AgentID {
+			rID = e.TurnID
+			return true
+		}
+		return false
+	}, "ensemble.reaction announced for the Butler reactor (post-gate)")
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == rID && e.Reason == voiceevent.TurnEndTextDelivered
+	}, "turn.ended(text_delivered) for the text reactor")
 	waitFloorFree(t, floor)
 
-	// No audio-less reaction line was created, and the reactor dispatched no audio.
-	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	postMu.Lock()
+	gotPost, sawAudio := posted, postSawAudio
+	postMu.Unlock()
+	if gotPost != "As you wish, my lord." {
+		t.Errorf("TextSink post = %q, want the reaction delivered as text", gotPost)
+	}
+	if !sawAudio {
+		t.Error("the text Reaction posted before the Lead was audibly on the wire (must be post-gate)")
+	}
 	if got := ttsInvokedInOrder(t, h); len(got) != 1 || got[0].TurnID != "Tl" {
-		t.Fatalf("TTSInvoked = %v, want exactly the Lead's (a text reactor holds/dispatches nothing)", got)
+		t.Fatalf("TTSInvoked = %v, want exactly the Lead's (a text reactor dispatches nothing)", got)
 	}
 }

--- a/pkg/voice/orchestrator/ensemble_textmodality_test.go
+++ b/pkg/voice/orchestrator/ensemble_textmodality_test.go
@@ -1,0 +1,240 @@
+package orchestrator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// textLeadSpeaker is a minimal [orchestrator.EnsembleSpeaker] whose elected Lead
+// (leadID) delivers its draft as TEXT: Speak returns [orchestrator.ErrTextDelivered]
+// WITHOUT calling dispatch, exactly as the real [agent.Replier.SpeakDraft] does for a
+// voiceless / long / text-requested Butler draft (#389). It implements NO CrossTalker,
+// so the coordinator runs the Lead-only path. spokeCh reports when Speak returns.
+type textLeadSpeaker struct {
+	draft   map[string]string
+	leadID  string
+	spokeCh chan string
+}
+
+func (s *textLeadSpeaker) Draft(_ context.Context, e voiceevent.AddressRouted) (string, error) {
+	return s.draft[e.Target.AgentID], nil
+}
+
+func (s *textLeadSpeaker) Speak(_ context.Context, e voiceevent.AddressRouted, draft string, dispatch func(orchestrator.Reply) error) (string, error) {
+	if s.spokeCh != nil {
+		defer func() { s.spokeCh <- e.Target.AgentID }()
+	}
+	if e.Target.AgentID == s.leadID {
+		// Text delivery: post handled inside the real Replier; the coordinator sees the
+		// terminal sentinel and must publish TurnEnded(text_delivered) with ZERO dispatch.
+		return draft, orchestrator.ErrTextDelivered
+	}
+	_ = dispatch(orchestrator.Reply{Sentence: draft})
+	return draft, nil
+}
+
+// TestReplier_Ensemble_TextDeliveredLead_PublishesTerminal pins the coordinator side
+// of #389: when the elected Lead delivers as text (Speak returns ErrTextDelivered),
+// the ensemble publishes TurnEnded(text_delivered) — mirroring the routed path's
+// ErrTextDelivered→TurnEndTextDelivered mapping — dispatches NO TTS (no TTSInvoked),
+// and opens no Cross-talk Reaction (a text Lead is never audibly on the wire).
+func TestReplier_Ensemble_TextDeliveredLead_PublishesTerminal(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &textLeadSpeaker{
+		draft:   map[string]string{butlerTarget.AgentID: "A long recap posted as text."},
+		leadID:  butlerTarget.AgentID,
+		spokeCh: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+
+	// Bart has no draft (empty → skipped); the Butler is the sole non-empty draft → Lead.
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Ttext", Text: "Bart, Glyphoxa — recap?", Targets: []voiceevent.AddressTarget{bartTarget, butlerTarget}})
+
+	select {
+	case who := <-spk.spokeCh:
+		if who != butlerTarget.AgentID {
+			t.Fatalf("Speak ran for %q, want the Butler Lead", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the ensemble never elected / spoke a Lead")
+	}
+
+	voicetest.AssertEvent(t, h, func(e voiceevent.EnsembleLead) bool {
+		return e.TurnID == "Ttext" && e.Target.AgentID == butlerTarget.AgentID
+	}, "ensemble.lead → Butler")
+	// The terminal: a text-delivered Lead is a SUCCESS with no first audio.
+	voicetest.AssertEvent(t, h, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == "Ttext" && e.Reason == voiceevent.TurnEndTextDelivered
+	}, "turn.ended(text_delivered) for the text Lead")
+	// A text turn dispatches no TTS.
+	voicetest.AssertNoEvent[voiceevent.TTSInvoked](t, h)
+	// No Cross-talk Reaction opens off a text Lead.
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+}
+
+// textReactorSpeaker: a spoken Character Lead (leadID) plus a voiceless-Butler
+// reactor (reactorID) whose SpeakReaction routes to text — it returns
+// ErrTextDelivered WITHOUT dispatching, exactly as the real Replier does for a
+// voiceless Butler elected as Cross-talk reactor (#389/#302). The reactor's
+// speculative draft is empty so it is the sole remaining candidate (the coordinator
+// makes it the reactor without waiting on a draft).
+type textReactorSpeaker struct {
+	leadID     string
+	leadDraft  string
+	reaction   string
+	speakPause chan struct{} // Lead pauses after its sentence so the test can arm the floor
+	reactSpoke chan string   // reactorID pushed when SpeakReaction returns
+}
+
+func (s *textReactorSpeaker) Draft(_ context.Context, e voiceevent.AddressRouted) (string, error) {
+	if e.Target.AgentID == s.leadID {
+		return s.leadDraft, nil
+	}
+	return "", nil // reactor: empty speculative draft (regenerates a Reaction)
+}
+
+func (s *textReactorSpeaker) Speak(ctx context.Context, e voiceevent.AddressRouted, draft string, dispatch func(orchestrator.Reply) error) (string, error) {
+	if err := dispatch(orchestrator.Reply{Sentence: draft, Voice: tts.Voice{VoiceID: e.Target.AgentID, Name: e.Target.AgentID}}); err != nil {
+		return "", nil
+	}
+	if s.speakPause != nil {
+		select {
+		case <-s.speakPause:
+		case <-ctx.Done():
+		}
+	}
+	return draft, nil
+}
+
+func (s *textReactorSpeaker) React(_ context.Context, _ voiceevent.AddressRouted, _, _ string) (string, error) {
+	return s.reaction, nil
+}
+
+func (s *textReactorSpeaker) SpeakReaction(_ context.Context, e voiceevent.AddressRouted, _, _, reaction string, dispatch func(orchestrator.Reply) error) (string, error) {
+	if s.reactSpoke != nil {
+		defer func() { s.reactSpoke <- e.Target.AgentID }()
+	}
+	// Voiceless Butler reactor: deliver as text, ZERO dispatch, return the sentinel.
+	return reaction, orchestrator.ErrTextDelivered
+}
+
+// TestReplier_Ensemble_TextDeliveredReactor_PublishesTerminal pins the Cross-talk
+// Reaction side of #389: a voiceless Butler elected as reactor delivers its Reaction
+// as TEXT (SpeakReaction → ErrTextDelivered, no dispatch). Its sub-turn line was
+// already announced via EnsembleReaction, so the coordinator publishes
+// TurnEnded(rID, text_delivered) — the reactor never dispatches a second TTSInvoked,
+// and the sub-turn does not hang or leak.
+func TestReplier_Ensemble_TextDeliveredReactor_PublishesTerminal(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	spk := &textReactorSpeaker{
+		leadID:     bartTarget.AgentID,
+		leadDraft:  "Bart leads.",
+		reaction:   "As you wish, my lord.",
+		speakPause: make(chan struct{}),
+		reactSpoke: make(chan string, 2),
+	}
+	replier := ensembleReplier(h, floor, spk)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	// BargeIn wires FirstOpus → Floor.MarkSpeaking so the Lead's FirstOpus arms the floor.
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tr", Text: "Bart, Glyphoxa — thoughts?", Targets: []voiceevent.AddressTarget{bartTarget, butlerTarget}})
+
+	// The Lead's sentence reaches the wire; arm the floor so the Reaction may play.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tr" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tr"})
+
+	// Release the Lead so its Speak returns and the reactor's text Reaction runs.
+	close(spk.speakPause)
+
+	var rID string
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleReaction) bool {
+		if e.LeadTurnID == "Tr" && e.Target.AgentID == butlerTarget.AgentID {
+			rID = e.TurnID
+			return true
+		}
+		return false
+	}, "ensemble.reaction announced for the Butler reactor")
+
+	select {
+	case who := <-spk.reactSpoke:
+		if who != butlerTarget.AgentID {
+			t.Fatalf("SpeakReaction ran for %q, want the Butler reactor", who)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reactor's SpeakReaction never returned (a text reactor must not hang)")
+	}
+
+	// The reactor's sub-turn ends text_delivered, never a second TTSInvoked.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
+		return e.TurnID == rID && e.Reason == voiceevent.TurnEndTextDelivered
+	}, "turn.ended(text_delivered) for the text reactor")
+	waitFloorFree(t, floor)
+	if got := ttsInvokedInOrder(t, h); len(got) != 1 || got[0].TurnID != "Tr" {
+		t.Fatalf("TTSInvoked = %v, want exactly the Lead's (the text reactor dispatches none)", got)
+	}
+}
+
+// TestReplier_Lookahead_TextDeliveredReactor_NoHang pins the #389 look-ahead guard:
+// a voiceless Butler reactor text-delivers (SpeakReaction never calls the dispatch
+// closure), so the prerender goroutine holds NO first sentence — s1Ch stays empty and
+// done closes. releaseReaction's <-done arm must return instead of blocking forever on
+// s1Ch. The turn completes (floor freed), the uniform defer's DiscardLookahead fires,
+// and no EnsembleReaction / reaction TTSInvoked is published (the Reaction went to
+// channel text, not the wire).
+func TestReplier_Lookahead_TextDeliveredReactor_NoHang(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	pump := newFakeLookahead()
+	synth := &laneSynth{pump: pump, holdGate: make(chan struct{})}
+	defer close(synth.holdGate)
+
+	spk := &textReactorSpeaker{
+		leadID:     bartTarget.AgentID,
+		leadDraft:  "Bart leads.",
+		reaction:   "As you wish, my lord.",
+		speakPause: make(chan struct{}),
+		reactSpoke: make(chan string, 2),
+	}
+	replier := lookaheadReplier(h, floor, spk, pump, synth)
+	t.Cleanup(replier.Bind(t.Context(), h.Bus))
+	t.Cleanup(orchestrator.NewBargeIn(floor, 0).Bind(t.Context(), h.Bus))
+
+	h.Bus.Publish(voiceevent.EnsembleRouted{TurnID: "Tl", Text: "Bart, Glyphoxa?", Targets: []voiceevent.AddressTarget{bartTarget, butlerTarget}})
+
+	// Arm the floor once the Lead is audible, then release the paused Lead.
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TTSInvoked) bool {
+		return e.TurnID == "Tl" && e.Sentence == "Bart leads."
+	}, "the Lead's sentence is on the wire")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "Tl"})
+	close(spk.speakPause)
+
+	// The reactor's SpeakReaction returned (text-delivered) — the coordinator must not
+	// wedge on s1Ch.
+	select {
+	case <-spk.reactSpoke:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the text reactor's SpeakReaction never returned (look-ahead release wedged on s1Ch?)")
+	}
+
+	// The uniform defer ran and the whole unit completed.
+	pump.waitDiscard(t)
+	waitFloorFree(t, floor)
+
+	// No audio-less reaction line was created, and the reactor dispatched no audio.
+	voicetest.AssertNoEvent[voiceevent.EnsembleReaction](t, h)
+	if got := ttsInvokedInOrder(t, h); len(got) != 1 || got[0].TurnID != "Tl" {
+		t.Fatalf("TTSInvoked = %v, want exactly the Lead's (a text reactor holds/dispatches nothing)", got)
+	}
+}


### PR DESCRIPTION
## Problem

The Ensemble Turn draft/speak path (`orchestrator.runEnsemble` → `Cast.Speak` → `Replier.SpeakDraft`) **always** dispatched the winning Lead's draft to TTS via the emit closure. It never consulted the routed streaming path's modality decision (`AnswerAsText`/`TextSink`). So a **voiceless Butler** co-addressed in an Ensemble Turn dispatched TTS with an **empty VoiceID** instead of delivering its answer as channel text.

## Fix

- **`Replier.SpeakDraft` (agent):** with a `TextSink` installed, route the draft by the SAME `AnswerAsText` decision `textModalityTurn` uses (voiceless / explicit "as text" / #297-d2 long answer). A text-modality draft posts whole via the `TextSink` with **zero TTS dispatch**, commits user+assistant (ADR-0012 text-delivered commits), and returns the `ErrTextDelivered` sentinel. Because this precedes every dispatch, a voiceless Butler can **never** reach `r.tts.Dispatch` with an empty VoiceID on the Draft/Speak path **or** the Cross-talk Reaction path (`SpeakReaction` delegates to `SpeakDraft`) — the structural-unreachability guarantee. A failed post commits nothing and surfaces the post error, never the sentinel.
- **`runEnsemble` (coordinator):** map `ErrTextDelivered` from the Lead's `Speak` and the reactor's `SpeakReaction` to `TurnEnded(text_delivered)`, mirroring the routed path's `ErrTextDelivered → TurnEndTextDelivered` mapping, so the metrics TTL sweep records a success rather than reaping an audio-less turn.
- **`releaseReaction` (look-ahead #375):** add a `<-done` arm to the s1-wait so a text reactor (which holds no first sentence, `s1Ch` stays empty) never wedges. A non-blocking `s1Ch` re-check keeps the held-then-aborted (#375) path deterministic.

## AC coverage

- [x] Ensemble draft/speak path consults the same modality decision as the routed path (`AnswerAsText`/`TextSink`)
- [x] Voiceless Butler co-addressed in an Ensemble Turn delivers text, never dispatches TTS with empty VoiceID
- [x] Long-answer rule (#297 d2) honored on the ensemble path
- [x] Tests: ensemble w/ voiceless Butler → text delivery + no TTS dispatch; empty-VoiceID dispatch structurally unreachable

## Tests added (8)

`pkg/voice/agent/agent_ensemble_textmodality_test.go`
- `TestReplier_SpeakDraft_VoicelessButler_DeliversTextNoDispatch`
- `TestReplier_SpeakDraft_LongAnswer_DeliversText`
- `TestReplier_SpeakDraft_ShortVoicedAnswer_Spoken`
- `TestReplier_SpeakDraft_TextSink_PostError_NotCommitted`
- `TestReplier_SpeakReaction_VoicelessButler_DeliversTextNoDispatch`

`pkg/voice/orchestrator/ensemble_textmodality_test.go`
- `TestReplier_Ensemble_TextDeliveredLead_PublishesTerminal`
- `TestReplier_Ensemble_TextDeliveredReactor_PublishesTerminal`
- `TestReplier_Lookahead_TextDeliveredReactor_NoHang`

Local: `go test -race ./pkg/voice/orchestrator/ ./pkg/voice/agent/` green, `go vet -tags integration ./...` clean, `golangci-lint` 0 issues.

> Note: overlaps `pkg/voice/orchestrator/ensemble.go` + ensemble tests with #391 (Reaction tts_error `TurnEnded`); diff kept tight to modality, expect a possible rebase.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)