### PR TITLE
feat(#372): recap read-only Tool wrapper for the Butler default grant set

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -666,6 +666,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		Transcripts: knowledgeAdapter,
 		KG:          knowledgeAdapter,
 		KGW:         knowledgeAdapter,
+		Recap:       knowledge.NewRecap(recapEngine, store, mgr),
 	})
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -86,7 +86,7 @@ func TestImportMinimalCampaign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListToolGrants: %v", err)
 	}
-	wantNames := []string{"dice", "kg_query", "transcript_search"}
+	wantNames := []string{"dice", "kg_query", "recap", "transcript_search"}
 	if len(grants) != len(wantNames) {
 		t.Fatalf("trigger butler grants = %+v, want %v", grants, wantNames)
 	}

--- a/internal/knowledge/recap.go
+++ b/internal/knowledge/recap.go
@@ -1,0 +1,129 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/recap"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// recapListLimit caps how many recent Voice Sessions the picker scans for a
+// recappable (ended, non-empty) row. 50 matches the slash surface's server policy
+// (presence.recapListLimit / rpc.listSessionsLimit) so the in-voice recap Tool sees
+// the same window — enough that a pageful of running/failed/empty rows can't hide a
+// real recappable one.
+const recapListLimit = 50
+
+// recapToolTimeout bounds the in-voice recap work: the recap engine fans out
+// map-reduce windows and can run for many seconds. It is a child of the turn ctx
+// (WithTimeout below), so a barge-in that cancels the turn also cancels the recap,
+// while a slow/stuck LLM is cut off here rather than blocking the turn open-ended.
+// A var (not a const) so a test can shrink it without a 120s wait; production 120s.
+var recapToolTimeout = 120 * time.Second
+
+// errNoRecappableSession is the friendly failure when no ended, non-empty Voice
+// Session exists to recap (idle history, or only running/empty rows). The Tool
+// handler surfaces it to the LLM as a plain reason, not a crash.
+var errNoRecappableSession = errors.New("knowledge: no ended session with a transcript to recap")
+
+// RecapEngine is the one-shot recap service the adapter drives: given Voice Session
+// ids it renders their transcript and returns a Butler-flavoured recap (#272).
+// *recap.Engine satisfies it; tests use a fake. Kept local (not the recap package's
+// interface) so this package's contract is explicit and unit-fakeable.
+type RecapEngine interface {
+	Recap(ctx context.Context, sessionIDs []uuid.UUID) (recap.Result, error)
+}
+
+// RecapStore is the narrow storage read the recap adapter needs: the campaign's
+// recent Voice Sessions, newest-first, to pick the recappable ones. *storage.Store
+// satisfies it. Kept local so the adapter is unit-fakeable without a DB.
+type RecapStore interface {
+	ListVoiceSessions(ctx context.Context, campaignID uuid.UUID, limit int) ([]storage.VoiceSession, error)
+}
+
+// RecapAdapter implements tool.Recapper over a recap engine, a storage read, and
+// the active-session source. It is the production wiring behind the recap Tool
+// (#372): the Tool asks for the last N sessions' recap; this adapter resolves WHICH
+// sessions entirely from server state — the active Campaign's newest ENDED non-empty
+// rows — so the LLM never names a session id (ADR-0029) and can never recap another
+// Campaign. Safe for concurrent use (its deps are). Built once at web boot.
+type RecapAdapter struct {
+	eng      RecapEngine
+	store    RecapStore
+	sessions Sessions
+}
+
+// NewRecap builds the adapter. All three deps must be non-nil — they are wiring
+// requirements, so a nil is a boot bug, not a runtime condition (mirrors New).
+func NewRecap(eng RecapEngine, store RecapStore, sessions Sessions) *RecapAdapter {
+	if eng == nil || store == nil || sessions == nil {
+		panic("knowledge: NewRecap: nil engine, store or sessions")
+	}
+	return &RecapAdapter{eng: eng, store: store, sessions: sessions}
+}
+
+// RecapLastSessions implements [tool.Recapper]. It resolves the active Campaign from
+// the live session (no session ⇒ ErrNoActiveSession), lists its recent Voice
+// Sessions and picks the newest `n` that are ENDED with a recorded transcript
+// (isRecappable parity with presence.isRecappable — a running/failed/empty row is
+// skipped), then recaps them under a turn-child timeout. No recappable session ⇒ a
+// friendly error; recap.ErrNoTranscript is mapped to the same friendly error (a race
+// let an empty row through). The recap prose is returned verbatim for the Tool to
+// relay.
+func (a *RecapAdapter) RecapLastSessions(ctx context.Context, n int) (string, error) {
+	s, ok := a.sessions.Snapshot()
+	if !ok {
+		return "", ErrNoActiveSession
+	}
+	sessions, err := a.store.ListVoiceSessions(ctx, s.CampaignID, recapListLimit)
+	if err != nil {
+		return "", fmt.Errorf("knowledge: list voice sessions for recap: %w", err)
+	}
+	ids := make([]uuid.UUID, 0, n)
+	for _, vs := range sessions {
+		if isRecappable(vs) { // newest-first order preserved from the store
+			ids = append(ids, vs.ID)
+			if len(ids) == n {
+				break
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return "", errNoRecappableSession
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, recapToolTimeout)
+	defer cancel()
+
+	res, err := a.eng.Recap(ctx, ids)
+	if errors.Is(err, recap.ErrNoTranscript) {
+		return "", errNoRecappableSession
+	}
+	if err != nil {
+		return "", fmt.Errorf("knowledge: recap: %w", err)
+	}
+	return res.Text, nil
+}
+
+// isRecappable reports whether a Voice Session can seed a default recap: it must
+// have ENDED and have a recorded transcript (line_count > 0). Parity with
+// presence.isRecappable — the two recap surfaces must not diverge on which sessions
+// count. Duplicated as a one-liner rather than refactoring presence (whose copy
+// stays authoritative for the slash surface).
+func isRecappable(vs storage.VoiceSession) bool {
+	return vs.Status == storage.VoiceSessionEnded && vs.LineCount > 0
+}
+
+// Compile-time assertion the adapter satisfies the Tool seam, and that the concrete
+// engine/store satisfy the local read interfaces.
+var (
+	_ tool.Recapper = (*RecapAdapter)(nil)
+	_ RecapEngine   = (*recap.Engine)(nil)
+	_ RecapStore    = (*storage.Store)(nil)
+)

--- a/internal/knowledge/recap.go
+++ b/internal/knowledge/recap.go
@@ -21,11 +21,23 @@ import (
 const recapListLimit = 50
 
 // recapToolTimeout bounds the in-voice recap work: the recap engine fans out
-// map-reduce windows and can run for many seconds. It is a child of the turn ctx
-// (WithTimeout below), so a barge-in that cancels the turn also cancels the recap,
-// while a slow/stuck LLM is cut off here rather than blocking the turn open-ended.
-// A var (not a const) so a test can shrink it without a 120s wait; production 120s.
-var recapToolTimeout = 120 * time.Second
+// map-reduce windows and can run for many seconds. It is a CHILD of the Butler turn
+// ctx, which already carries agent.DefaultTurnTimeout (60s, pkg/voice/agent) — so
+// this bound is set deliberately BELOW that deadline. Two reasons: a barge-in that
+// cancels the turn still cancels the recap (child), AND when a slow/stuck LLM blows
+// the recap budget, THIS 45s child fires first — while the turn ctx is still alive —
+// so RecapLastSessions can map the deadline to a friendly tool-result message the
+// Butler relays in the turn's remaining seconds, rather than letting the 60s turn
+// ctx expire and kill the whole turn (which would leave the Butler answering
+// nothing). Raising the Butler turn timeout is a separate design change, out of
+// scope here. A var (not a const) so a test can shrink it without a 45s wait.
+var recapToolTimeout = 45 * time.Second
+
+// recapTookTooLong is the friendly tool-result text when the recap engine blows the
+// recapToolTimeout: returned as the Tool's RESULT (not an error), so the Butler can
+// relay it to the players while the turn ctx is still alive — a raw error mapped to
+// the turn's dead ctx would surface nothing speakable.
+const recapTookTooLong = "The recap took too long to put together — try again in a moment, or ask the GM to run /glyphoxa recap for the full text."
 
 // errNoRecappableSession is the friendly failure when no ended, non-empty Voice
 // Session exists to recap (idle history, or only running/empty rows). The Tool
@@ -104,6 +116,14 @@ func (a *RecapAdapter) RecapLastSessions(ctx context.Context, n int) (string, er
 	res, err := a.eng.Recap(ctx, ids)
 	if errors.Is(err, recap.ErrNoTranscript) {
 		return "", errNoRecappableSession
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		// The recapToolTimeout child fired (a slow/stuck LLM), NOT a barge-in
+		// (that is context.Canceled). Return a friendly result, not an error: the
+		// turn ctx is still alive (this bound is below the turn deadline), so the
+		// Butler relays this text in the turn's remaining seconds. An error here
+		// would leave the loop nothing speakable.
+		return recapTookTooLong, nil
 	}
 	if err != nil {
 		return "", fmt.Errorf("knowledge: recap: %w", err)

--- a/internal/knowledge/recap_internal_test.go
+++ b/internal/knowledge/recap_internal_test.go
@@ -1,0 +1,62 @@
+package knowledge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/recap"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// blockingEngine blocks until its ctx is cancelled, then returns ctx.Err() — the
+// shape a slow/stuck recap LLM presents when the recapToolTimeout child fires.
+type blockingEngine struct{}
+
+func (blockingEngine) Recap(ctx context.Context, _ []uuid.UUID) (recap.Result, error) {
+	<-ctx.Done()
+	return recap.Result{}, ctx.Err()
+}
+
+// stubStore serves one ended, non-empty session so the picker selects it.
+type stubStore struct{}
+
+func (stubStore) ListVoiceSessions(_ context.Context, _ uuid.UUID, _ int) ([]storage.VoiceSession, error) {
+	return []storage.VoiceSession{{ID: uuid.New(), Status: storage.VoiceSessionEnded, LineCount: 3}}, nil
+}
+
+// stubSessions reports a live session (resolves the Campaign).
+type stubSessions struct{}
+
+func (stubSessions) Snapshot() (storage.VoiceSession, bool) {
+	return storage.VoiceSession{CampaignID: uuid.New()}, true
+}
+
+// TestRecapAdapterTimeoutMapsFriendlyAndTurnSurvives pins finding 1: when the recap
+// engine blows the recapToolTimeout (a slow LLM), the child deadline fires BELOW the
+// turn deadline, so RecapLastSessions returns the friendly took-too-long text as a
+// tool RESULT (nil error) — the Butler can relay it — and the parent turn ctx is
+// still alive (never killed by the recap's own budget).
+func TestRecapAdapterTimeoutMapsFriendlyAndTurnSurvives(t *testing.T) {
+	restore := recapToolTimeout
+	recapToolTimeout = 20 * time.Millisecond
+	defer func() { recapToolTimeout = restore }()
+
+	// Parent turn ctx: alive far longer than the recap child budget.
+	turnCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	a := NewRecap(blockingEngine{}, stubStore{}, stubSessions{})
+	out, err := a.RecapLastSessions(turnCtx, 1)
+	if err != nil {
+		t.Fatalf("RecapLastSessions returned an error, want friendly result text: %v", err)
+	}
+	if out != recapTookTooLong {
+		t.Errorf("out = %q, want the friendly took-too-long text", out)
+	}
+	if turnCtx.Err() != nil {
+		t.Errorf("turn ctx died (%v); the recap budget must not kill the turn", turnCtx.Err())
+	}
+}

--- a/internal/knowledge/recap_test.go
+++ b/internal/knowledge/recap_test.go
@@ -1,0 +1,166 @@
+package knowledge_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/recap"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeRecapEngine is a scripted RecapEngine: it records the session ids it was
+// handed and replays a fixed recap text/error, so the adapter's picker and error
+// mapping are pinned without an LLM.
+type fakeRecapEngine struct {
+	text    string
+	err     error
+	gotIDs  []uuid.UUID
+	callCnt int
+}
+
+func (f *fakeRecapEngine) Recap(_ context.Context, ids []uuid.UUID) (recap.Result, error) {
+	f.callCnt++
+	f.gotIDs = ids
+	return recap.Result{Text: f.text, SessionIDs: ids}, f.err
+}
+
+// fakeRecapStore is a scripted RecapStore returning a fixed newest-first session list.
+type fakeRecapStore struct {
+	sessions []storage.VoiceSession
+	err      error
+	gotCID   uuid.UUID
+	gotLimit int
+}
+
+func (f *fakeRecapStore) ListVoiceSessions(_ context.Context, cid uuid.UUID, limit int) ([]storage.VoiceSession, error) {
+	f.gotCID = cid
+	f.gotLimit = limit
+	return f.sessions, f.err
+}
+
+func endedSession(lines int) storage.VoiceSession {
+	return storage.VoiceSession{ID: uuid.New(), Status: storage.VoiceSessionEnded, LineCount: lines}
+}
+func runningSession() storage.VoiceSession {
+	return storage.VoiceSession{ID: uuid.New(), Status: storage.VoiceSessionRunning, LineCount: 3}
+}
+
+// TestRecapAdapterIdleNoSession pins that with no live session the adapter reports
+// ErrNoActiveSession (the active session is what resolves the Campaign) — the engine
+// is never called.
+func TestRecapAdapterIdleNoSession(t *testing.T) {
+	eng := &fakeRecapEngine{text: "x"}
+	a := knowledge.NewRecap(eng, &fakeRecapStore{}, fakeSessions{live: false})
+	_, err := a.RecapLastSessions(context.Background(), 1)
+	if !errors.Is(err, knowledge.ErrNoActiveSession) {
+		t.Errorf("err = %v, want ErrNoActiveSession", err)
+	}
+	if eng.callCnt != 0 {
+		t.Error("engine called with no active session")
+	}
+}
+
+// TestRecapAdapterPicksNewestEndedNonEmpty pins the picker rule (isRecappable
+// parity): a running row on top and an empty-ended row are skipped; the newest
+// ended non-empty session is recapped.
+func TestRecapAdapterPicksNewestEndedNonEmpty(t *testing.T) {
+	cid := uuid.New()
+	want := endedSession(5)
+	store := &fakeRecapStore{sessions: []storage.VoiceSession{
+		runningSession(), // skipped: still running
+		{ID: uuid.New(), Status: storage.VoiceSessionEnded, LineCount: 0}, // skipped: empty
+		want, // newest recappable
+		endedSession(9),
+	}}
+	eng := &fakeRecapEngine{text: "the recap"}
+	a := knowledge.NewRecap(eng, store, liveSession(cid))
+
+	out, err := a.RecapLastSessions(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RecapLastSessions: %v", err)
+	}
+	if out != "the recap" {
+		t.Errorf("out = %q, want engine text verbatim", out)
+	}
+	if store.gotCID != cid {
+		t.Errorf("listed campaign %s, want active %s", store.gotCID, cid)
+	}
+	if len(eng.gotIDs) != 1 || eng.gotIDs[0] != want.ID {
+		t.Errorf("recapped ids = %v, want [%s]", eng.gotIDs, want.ID)
+	}
+}
+
+// TestRecapAdapterTakesNNewest pins that n=2 recaps the two newest recappable
+// sessions in newest-first list order.
+func TestRecapAdapterTakesNNewest(t *testing.T) {
+	first, second, third := endedSession(4), endedSession(5), endedSession(6)
+	store := &fakeRecapStore{sessions: []storage.VoiceSession{first, second, third}}
+	eng := &fakeRecapEngine{text: "two"}
+	a := knowledge.NewRecap(eng, store, liveSession(uuid.New()))
+
+	if _, err := a.RecapLastSessions(context.Background(), 2); err != nil {
+		t.Fatalf("RecapLastSessions: %v", err)
+	}
+	if len(eng.gotIDs) != 2 || eng.gotIDs[0] != first.ID || eng.gotIDs[1] != second.ID {
+		t.Errorf("recapped ids = %v, want [%s %s]", eng.gotIDs, first.ID, second.ID)
+	}
+}
+
+// TestRecapAdapterNoneRecappable pins the friendly error when only running/empty
+// rows exist — the engine is never called.
+func TestRecapAdapterNoneRecappable(t *testing.T) {
+	store := &fakeRecapStore{sessions: []storage.VoiceSession{
+		runningSession(),
+		{ID: uuid.New(), Status: storage.VoiceSessionEnded, LineCount: 0},
+	}}
+	eng := &fakeRecapEngine{text: "x"}
+	a := knowledge.NewRecap(eng, store, liveSession(uuid.New()))
+
+	_, err := a.RecapLastSessions(context.Background(), 1)
+	if err == nil {
+		t.Fatal("want a no-recappable-session error")
+	}
+	if eng.callCnt != 0 {
+		t.Error("engine called with nothing recappable")
+	}
+}
+
+// TestRecapAdapterMapsNoTranscript pins that recap.ErrNoTranscript (a race let an
+// empty row through) is mapped to the same friendly no-session error, not surfaced
+// raw.
+func TestRecapAdapterMapsNoTranscript(t *testing.T) {
+	store := &fakeRecapStore{sessions: []storage.VoiceSession{endedSession(3)}}
+	eng := &fakeRecapEngine{err: recap.ErrNoTranscript}
+	a := knowledge.NewRecap(eng, store, liveSession(uuid.New()))
+
+	_, err := a.RecapLastSessions(context.Background(), 1)
+	if err == nil {
+		t.Fatal("want the friendly no-session error")
+	}
+	if errors.Is(err, recap.ErrNoTranscript) {
+		t.Errorf("raw recap.ErrNoTranscript leaked: %v", err)
+	}
+}
+
+// TestNewRecapNilDepsPanics pins the wiring-bug guard (mirrors knowledge.New).
+func TestNewRecapNilDepsPanics(t *testing.T) {
+	cases := map[string]func(){
+		"nil engine":   func() { knowledge.NewRecap(nil, &fakeRecapStore{}, fakeSessions{}) },
+		"nil store":    func() { knowledge.NewRecap(&fakeRecapEngine{}, nil, fakeSessions{}) },
+		"nil sessions": func() { knowledge.NewRecap(&fakeRecapEngine{}, &fakeRecapStore{}, nil) },
+	}
+	for name, fn := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Error("NewRecap should panic on a nil dep")
+				}
+			}()
+			fn()
+		})
+	}
+}

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -52,10 +52,10 @@ func TestToolGrants_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListToolGrants(butler): %v", err)
 	}
-	// The catalog lists every built-in (dice + the #296 knowledge Tools); assert by
-	// the GRANTED set, not by catalog index — the auto-Butler is seeded with all
-	// three (migration 00025).
-	wantButlerGrants := []string{"dice", "kg_query", "transcript_search"}
+	// The catalog lists every built-in; assert by the GRANTED set, not by catalog
+	// index — the auto-Butler is seeded with dice + the #296 knowledge Tools + recap
+	// (migrations 00025, 00027).
+	wantButlerGrants := []string{"dice", "kg_query", "recap", "transcript_search"}
 	if granted := grantedNames(butlerGrants.Msg.GetGrants()); !slices.Equal(granted, wantButlerGrants) {
 		t.Fatalf("butler granted = %v, want %v; full catalog = %+v", granted, wantButlerGrants, butlerGrants.Msg.GetGrants())
 	}
@@ -105,7 +105,7 @@ func TestToolGrants_Integration(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("UpdateToolGrant(butler dice off): %v", err)
 	}
-	wantAfterRevoke := []string{"kg_query", "transcript_search"}
+	wantAfterRevoke := []string{"kg_query", "recap", "transcript_search"}
 	if got := grantedNames(listGrants(t, client, butler.GetId())); !slices.Equal(got, wantAfterRevoke) {
 		t.Fatalf("after revoke, butler granted = %v, want %v", got, wantAfterRevoke)
 	}

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -45,7 +45,7 @@ func TestListToolGrants_CatalogWithState(t *testing.T) {
 		t.Fatalf("ListToolGrants: %v", err)
 	}
 	grants := resp.Msg.GetGrants()
-	wantNames := []string{"dice", "kg_query", "remember_knowledge", "transcript_search"} // Name-sorted catalog
+	wantNames := []string{"dice", "kg_query", "recap", "remember_knowledge", "transcript_search"} // Name-sorted catalog
 	if len(grants) != len(wantNames) {
 		t.Fatalf("catalog = %+v, want %v", grants, wantNames)
 	}

--- a/internal/rpc/campaign_management_integration_test.go
+++ b/internal/rpc/campaign_management_integration_test.go
@@ -105,13 +105,13 @@ func TestCampaignManagement_Integration(t *testing.T) {
 	for _, g := range grants {
 		gotGrants[g.ToolName] = true
 	}
-	for _, want := range []string{"dice", "transcript_search", "kg_query"} {
+	for _, want := range []string{"dice", "transcript_search", "kg_query", "recap"} {
 		if !gotGrants[want] {
 			t.Errorf("auto-Butler missing default grant %q; has %+v", want, grants)
 		}
 	}
-	if len(grants) != 3 {
-		t.Errorf("auto-Butler grants = %+v, want dice + transcript_search + kg_query (#299)", grants)
+	if len(grants) != 4 {
+		t.Errorf("auto-Butler grants = %+v, want dice + transcript_search + kg_query + recap (#372)", grants)
 	}
 
 	// --- List returns every campaign name-ordered: Alpha Quest, Lost Mine, Zeta Reach.

--- a/internal/storage/migrations/00027_butler_recap_grant.sql
+++ b/internal/storage/migrations/00027_butler_recap_grant.sql
@@ -1,0 +1,65 @@
+-- +goose Up
+
+-- The recap Tool wrapper now exists (#372, #297 decision 5): a read-only Tool the
+-- Butler drives to summarize the Campaign's most recent ended Voice Session(s) in
+-- voice. It joins the auto-Butler's default Grant set — the follow-up 00025 flagged
+-- when it deliberately left `recap` out (the Tool did not exist yet). Seeded the
+-- same way the other defaults are: as a Campaign-existence invariant in the
+-- auto-Butler trigger, so no application call site can forget it. It carries a NULL
+-- config — recap takes no scope (campaign is implicit via the active session,
+-- ADR-0029).
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_campaign_butler() RETURNS trigger AS $$
+DECLARE
+    butler_id uuid;
+BEGIN
+    INSERT INTO agents (campaign_id, agent_role, name, address_only)
+    VALUES (NEW.id, 'butler', 'Glyphoxa', true)
+    RETURNING id INTO butler_id;
+
+    INSERT INTO tool_agent_grant (agent_id, tool_name)
+    VALUES (butler_id, 'dice'),
+           (butler_id, 'transcript_search'),
+           (butler_id, 'kg_query'),
+           (butler_id, 'recap');
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Backfill: Butlers created before this migration get the recap grant they are now
+-- meant to have. Idempotent via the UNIQUE(agent_id, tool_name) key, so re-running
+-- is a no-op and a Butler already holding it keeps it.
+INSERT INTO tool_agent_grant (agent_id, tool_name)
+SELECT id, 'recap' FROM agents WHERE agent_role = 'butler'
+ON CONFLICT (agent_id, tool_name) DO NOTHING;
+
+-- +goose Down
+
+-- Restore the 00025 trigger body (dice + the two knowledge grants, no recap), so a
+-- future auto-created Butler gets exactly the pre-#372 default set again.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION create_campaign_butler() RETURNS trigger AS $$
+DECLARE
+    butler_id uuid;
+BEGIN
+    INSERT INTO agents (campaign_id, agent_role, name, address_only)
+    VALUES (NEW.id, 'butler', 'Glyphoxa', true)
+    RETURNING id INTO butler_id;
+
+    INSERT INTO tool_agent_grant (agent_id, tool_name)
+    VALUES (butler_id, 'dice'),
+           (butler_id, 'transcript_search'),
+           (butler_id, 'kg_query');
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Remove the backfilled recap grant from existing Butlers, mirroring the Up
+-- backfill so the down migration is a clean inverse.
+DELETE FROM tool_agent_grant
+WHERE tool_name = 'recap'
+  AND agent_id IN (SELECT id FROM agents WHERE agent_role = 'butler');

--- a/internal/storage/tool_grant_test.go
+++ b/internal/storage/tool_grant_test.go
@@ -14,12 +14,11 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// TestButlerDefaultGrantsSeeded is the #299 default-grant bar: the auto-Butler
-// trigger (extended in 00025) seeds the Butler's read-only knowledge Tool set —
-// `dice` + `transcript_search` + `kg_query` (#297 decision 1) — each with a NULL
-// scope config. There is deliberately NO `recap` grant (its Tool wrapper does not
-// exist yet). seedCampaign creates a Campaign, whose auto-Butler trigger fires the
-// grant inserts.
+// TestButlerDefaultGrantsSeeded is the #372 default-grant bar: the auto-Butler
+// trigger (extended in 00025 then 00027) seeds the Butler's read-only Tool set —
+// `dice` + `transcript_search` + `kg_query` + `recap` (#297 decisions 1 & 5) — each
+// with a NULL scope config. seedCampaign creates a Campaign, whose auto-Butler
+// trigger fires the grant inserts.
 func TestButlerDefaultGrantsSeeded(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, _, campaignID := seedCampaign(t, dsn)
@@ -45,7 +44,7 @@ func TestButlerDefaultGrantsSeeded(t *testing.T) {
 			t.Errorf("grant %q carries config %q, want nil (no scope narrowing)", g.ToolName, g.Config)
 		}
 	}
-	want := []string{"dice", "transcript_search", "kg_query"}
+	want := []string{"dice", "transcript_search", "kg_query", "recap"}
 	if len(grants) != len(want) {
 		t.Fatalf("auto-Butler has %d grants, want %d (%v): %+v", len(grants), len(want), want, grants)
 	}
@@ -53,9 +52,6 @@ func TestButlerDefaultGrantsSeeded(t *testing.T) {
 		if _, ok := got[name]; !ok {
 			t.Errorf("auto-Butler missing default grant %q; has %+v", name, grants)
 		}
-	}
-	if _, ok := got["recap"]; ok {
-		t.Error("auto-Butler has a recap grant; the recap Tool wrapper does not exist yet (#299 follow-up)")
 	}
 }
 
@@ -75,7 +71,7 @@ func TestButlerKnowledgeGrantBackfillIdempotent(t *testing.T) {
 	}
 
 	// Re-run the migration's backfill statements: they must be no-ops now.
-	for _, tool := range []string{"transcript_search", "kg_query"} {
+	for _, tool := range []string{"transcript_search", "kg_query", "recap"} {
 		if _, err := pool.Exec(ctx,
 			`INSERT INTO tool_agent_grant (agent_id, tool_name)
 			 SELECT id, $1 FROM agents WHERE agent_role = 'butler'
@@ -88,8 +84,8 @@ func TestButlerKnowledgeGrantBackfillIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListToolGrants(butler): %v", err)
 	}
-	if len(grants) != 3 {
-		t.Fatalf("after re-running the backfill the Butler has %d grants, want 3 (no duplicates): %+v", len(grants), grants)
+	if len(grants) != 4 {
+		t.Fatalf("after re-running the backfill the Butler has %d grants, want 4 (no duplicates): %+v", len(grants), grants)
 	}
 }
 

--- a/pkg/tool/builtins.go
+++ b/pkg/tool/builtins.go
@@ -20,5 +20,6 @@ func BuiltinRegistry(deps Deps) *Registry {
 	r.MustRegister(NewTranscriptSearch(deps.Transcripts))
 	r.MustRegister(NewKGQuery(deps.KG))
 	r.MustRegister(NewRememberKnowledge(deps.KGW))
+	r.MustRegister(NewRecap(deps.Recap))
 	return r
 }

--- a/pkg/tool/builtins_test.go
+++ b/pkg/tool/builtins_test.go
@@ -14,7 +14,7 @@ import (
 // live session runs.
 func TestBuiltinRegistryRegistersKnowledgeTools(t *testing.T) {
 	reg := BuiltinRegistry(Deps{})
-	want := []string{"dice", "kg_query", "remember_knowledge", "transcript_search"} // Tools() is Name-sorted
+	want := []string{"dice", "kg_query", "recap", "remember_knowledge", "transcript_search"} // Tools() is Name-sorted
 	got := reg.Tools()
 	if len(got) != len(want) {
 		t.Fatalf("registered %d tools, want %d: %+v", len(got), len(want), got)
@@ -30,7 +30,7 @@ func TestBuiltinRegistryRegistersKnowledgeTools(t *testing.T) {
 // so the loop runs them inline (never the refused side-effecting path).
 func TestKnowledgeToolsAreReadOnly(t *testing.T) {
 	reg := BuiltinRegistry(Deps{})
-	for _, name := range []string{"transcript_search", "kg_query"} {
+	for _, name := range []string{"transcript_search", "kg_query", "recap"} {
 		tl, ok := reg.Get(name)
 		if !ok {
 			t.Fatalf("%s not registered", name)

--- a/pkg/tool/deps.go
+++ b/pkg/tool/deps.go
@@ -28,6 +28,21 @@ type Deps struct {
 	// but its Execute reports it is unavailable in this mode (the grant-editor RPC
 	// and voice bench build a zero Deps).
 	KGW KGWriter
+	// Recap backs the recap Tool (#372). nil ⇒ the Tool is registered but its
+	// Execute reports it is unavailable in this mode (the grant-editor RPC and
+	// voice bench build a zero Deps).
+	Recap Recapper
+}
+
+// Recapper is the narrow read seam the recap Tool needs (#372, #297 decision 5):
+// it summarizes the active Campaign's `sessions` most recent ended, non-empty Voice
+// Sessions and returns the recap prose. Session selection lives ENTIRELY in the
+// adapter — the active Campaign comes from the live session and the rows are the
+// newest ENDED non-empty ones — so the LLM never names a session id (ADR-0029) and
+// can never recap another Campaign. *knowledge.RecapAdapter satisfies it; a nil
+// Recapper on [Deps] reports unavailable at Execute.
+type Recapper interface {
+	RecapLastSessions(ctx context.Context, sessions int) (string, error)
 }
 
 // ProposedWrite is the versioned, storage-free payload one remember_knowledge

--- a/pkg/tool/knowledge_loop_test.go
+++ b/pkg/tool/knowledge_loop_test.go
@@ -69,6 +69,55 @@ func TestLoopRunsKnowledgeToolsInline(t *testing.T) {
 	}
 }
 
+// TestLoopRunsRecapInline is the ADR-0021/ADR-0030 pin for the recap built-in
+// (#372): a granted recap executes INLINE inside the tool-use loop (read-only, so
+// never refused) and its returned prose is fed back to the model as a tool-role
+// message it relays. It drives the loop with a scripted provider over a fake
+// Recapper — the framework's cassette.
+func TestLoopRunsRecapInline(t *testing.T) {
+	const prose = "Last session, the party stormed the keep and freed the Duke."
+	rc := &fakeRecapper{text: prose}
+	reg := BuiltinRegistry(Deps{Recap: rc})
+	gs := NewGrantSet(reg, Grant{ToolName: "recap"}) // no scope
+
+	p := &scriptedProvider{
+		t: t,
+		steps: []scriptStep{
+			// Round 1: the model asks for a recap of the last session.
+			{reply: AssistantMessage{ToolCalls: []ToolCall{
+				{ID: "c1", Name: "recap", Input: json.RawMessage(`{"sessions":1}`)},
+			}}},
+			// Round 2: relays it to the players.
+			{reply: AssistantMessage{Text: prose}},
+		},
+	}
+	loop := NewLoop(p, gs)
+
+	final, err := loop.Run(context.Background(), []Message{
+		{Role: RoleSystem, Text: "You are Glyphoxa."},
+		{Role: RoleUser, Text: "Glyphoxa, recap last session."},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if final != prose {
+		t.Errorf("final = %q, want %q", final, prose)
+	}
+	if rc.callCount != 1 {
+		t.Errorf("recap hit the source %d times, want 1", rc.callCount)
+	}
+	if rc.gotSessions != 1 {
+		t.Errorf("recap asked for %d sessions, want 1", rc.gotSessions)
+	}
+	res := findToolResult(t, p.seenMessages, "c1")
+	if res.IsError {
+		t.Errorf("recap fed back as error (was it refused as side-effecting?): %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "freed the Duke") {
+		t.Errorf("recap result not rendered for the prompt: %q", res.Content)
+	}
+}
+
 // findToolResult scans the messages the provider saw for the tool-role result
 // keyed to callID.
 func findToolResult(t *testing.T, seen [][]Message, callID string) ToolResult {

--- a/pkg/tool/recap.go
+++ b/pkg/tool/recap.go
@@ -1,0 +1,128 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Recap Tool budgets/defaults (#372, #297 decision 5). The recap prose is a whole
+// session's condensed narrative, so its ceiling is far larger than the knowledge
+// Tools' per-row budget — but still bounded so one recall can't swamp the next
+// generation's context. Pinned as consts (not magic numbers) so the bounds are one
+// edit away and testable.
+const (
+	// DefaultRecapSessions is the session count when the LLM omits "sessions".
+	DefaultRecapSessions = 1
+	// MaxRecapSessions is the hard ceiling on "sessions"; a larger request is
+	// clamped in the handler (the schema is advisory, ADR-0029).
+	MaxRecapSessions = 3
+	// RecapResultBudgetRunes bounds the whole rendered recap, counted in RUNES so a
+	// multibyte-heavy (German) recap is never over-budget nor split mid-codepoint.
+	RecapResultBudgetRunes = 8000
+)
+
+// recapInputSchema is the JSON Schema recap declares to the LLM. "sessions" is
+// optional (no required fields): the model asks WHAT window to recap, never WHICH
+// session id — session selection lives entirely in the adapter (ADR-0029), so the
+// model can never name another Campaign's session.
+var recapInputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "sessions": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3,
+      "description": "How many most recent ended sessions to recap (default 1)."
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// recapArgs is the decoded shape of recap's LLM args: an optional session count.
+type recapArgs struct {
+	Sessions int `json:"sessions"`
+}
+
+// clampedRecapSessions resolves the requested session count against the
+// default/ceiling. The schema is advisory; the model can emit anything, so the
+// bound is enforced here (ADR-0029: never trust the model to honour constraints).
+func clampedRecapSessions(requested int) int {
+	if requested <= 0 {
+		return DefaultRecapSessions
+	}
+	if requested > MaxRecapSessions {
+		return MaxRecapSessions
+	}
+	return requested
+}
+
+// Recap is the read-only recap built-in (#372, #297 decision 5): a Butler-flavoured
+// summary of this Campaign's most recent ended Voice Session(s). It wraps the recap
+// service behind the storage-free [Recapper] seam so pkg/tool never imports the
+// recap engine or storage. The session window is resolved INSIDE the adapter (active
+// campaign → newest ended non-empty rows), never from the LLM args (ADR-0029), so
+// the model can never recap another Campaign's session.
+//
+// It executes inline (ReadOnly, ADR-0030): the Butler needs the recap prose in hand
+// to relay it in the same turn. It carries no per-grant scope (SupportsScope false):
+// the Campaign comes from the active session, not a grant.
+//
+// A nil source means the Tool is registered but recap is not wired in this mode
+// (the standalone bench, the grant-editor RPC); Execute then reports it is
+// unavailable rather than panic.
+type Recap struct {
+	src Recapper
+}
+
+// NewRecap builds the Tool over src. A nil src is allowed — the Tool registers but
+// reports unavailable at Execute time (the zero-Deps modes).
+func NewRecap(src Recapper) *Recap {
+	return &Recap{src: src}
+}
+
+// Name implements [Tool].
+func (*Recap) Name() string { return "recap" }
+
+// Description implements [Tool].
+func (*Recap) Description() string {
+	return "Summarize what happened in this campaign's most recent ended voice session(s). " +
+		"Use when asked to recap the last session. " +
+		"Relay the returned recap to the players; do not shorten it."
+}
+
+// InputSchema implements [Tool].
+func (*Recap) InputSchema() json.RawMessage { return recapInputSchema }
+
+// ReadOnly implements [Tool]: a recap reads transcripts and mutates nothing
+// (ADR-0030), so the loop runs it inline.
+func (*Recap) ReadOnly() bool { return true }
+
+// SupportsScope implements [Tool]: recap is campaign-scoped for everyone (the
+// Campaign comes from the active session, not a grant), so it carries no narrowing
+// config.
+func (*Recap) SupportsScope() bool { return false }
+
+// Execute implements [Tool]. It recaps the active Campaign's most recent ended
+// session(s) and returns the recap prose for the LLM to relay. The session window
+// is resolved inside the adapter (from the active session), never from the args —
+// the model cannot recap another Campaign. grantConfig is ignored (no scope). A nil
+// source yields the unavailable error; the result is rune-truncated to
+// RecapResultBudgetRunes so one recall can't swamp the prompt budget.
+func (r *Recap) Execute(ctx context.Context, args json.RawMessage, _ any) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if r.src == nil {
+		return "", fmt.Errorf("recap: recap is unavailable in this mode")
+	}
+	var a recapArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("recap: invalid arguments: %w", err)
+	}
+	text, err := r.src.RecapLastSessions(ctx, clampedRecapSessions(a.Sessions))
+	if err != nil {
+		return "", fmt.Errorf("recap: %w", err)
+	}
+	return truncateRunes(text, RecapResultBudgetRunes), nil
+}

--- a/pkg/tool/recap.go
+++ b/pkg/tool/recap.go
@@ -19,7 +19,15 @@ const (
 	MaxRecapSessions = 3
 	// RecapResultBudgetRunes bounds the whole rendered recap, counted in RUNES so a
 	// multibyte-heavy (German) recap is never over-budget nor split mid-codepoint.
-	RecapResultBudgetRunes = 8000
+	// Sized for HONEST end-to-end deliverability, not the raw recap length: the
+	// Butler RELAYS this text through its own answer completion, capped at
+	// groq.DefaultMaxTokens (1024 ≈ ~3.5k runes of German). A larger budget would
+	// let a near-budget recap get clipped mid-prose by the relay despite the "do not
+	// shorten" instruction. So the Tool truncates to what the relay can actually
+	// carry; the full untruncated recap stays available via /glyphoxa recap (the
+	// slash surface splits it across ordered followups, #271). The Description tells
+	// the model as much.
+	RecapResultBudgetRunes = 3500
 )
 
 // recapInputSchema is the JSON Schema recap declares to the LLM. "sessions" is
@@ -88,7 +96,8 @@ func (*Recap) Name() string { return "recap" }
 func (*Recap) Description() string {
 	return "Summarize what happened in this campaign's most recent ended voice session(s). " +
 		"Use when asked to recap the last session. " +
-		"Relay the returned recap to the players; do not shorten it."
+		"Relay the returned recap to the players; do not shorten it. " +
+		"A very long recap may be trimmed to fit a spoken reply; for the full text, the GM can run /glyphoxa recap."
 }
 
 // InputSchema implements [Tool].

--- a/pkg/tool/recap_test.go
+++ b/pkg/tool/recap_test.go
@@ -1,0 +1,157 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// fakeRecapper is a scripted Recapper: it records the session count it was handed
+// and replays a fixed recap text/error, so the handler's clamping and error
+// wrapping are pinned without a recap engine or DB.
+type fakeRecapper struct {
+	text        string
+	err         error
+	gotSessions int
+	callCount   int
+}
+
+func (f *fakeRecapper) RecapLastSessions(_ context.Context, sessions int) (string, error) {
+	f.callCount++
+	f.gotSessions = sessions
+	return f.text, f.err
+}
+
+// TestRecapToolContract pins the Tool metadata: name, read-only (inline, ADR-0030),
+// no per-grant scope, and a schema that round-trips.
+func TestRecapToolContract(t *testing.T) {
+	tl := NewRecap(&fakeRecapper{})
+	if tl.Name() != "recap" {
+		t.Errorf("Name = %q, want recap", tl.Name())
+	}
+	if !tl.ReadOnly() {
+		t.Error("recap must be read-only (ADR-0030 inline execution)")
+	}
+	if tl.SupportsScope() {
+		t.Error("recap carries no per-grant scope (campaign implicit via active session)")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(tl.InputSchema(), &schema); err != nil {
+		t.Fatalf("InputSchema does not round-trip: %v", err)
+	}
+	if _, ok := schema["required"]; ok {
+		t.Error("recap schema must declare no required fields")
+	}
+}
+
+// TestRecapToolNilSource pins that with a nil source the Tool errors "unavailable"
+// (fed back to the model) rather than panicking — the zero-Deps bench/RPC path.
+func TestRecapToolNilSource(t *testing.T) {
+	out, err := NewRecap(nil).Execute(context.Background(), json.RawMessage(`{}`), nil)
+	if err == nil {
+		t.Fatalf("nil source should error, got %q", out)
+	}
+	if !strings.Contains(err.Error(), "unavailable") {
+		t.Errorf("nil-source error = %q, want it to mention unavailable", err)
+	}
+}
+
+// TestRecapToolDefaultsAndClampsSessions pins the advisory-schema clamp (ADR-0029):
+// an absent/zero count defaults to 1, an oversized count clamps to MaxRecapSessions.
+func TestRecapToolDefaultsAndClampsSessions(t *testing.T) {
+	cases := []struct {
+		name string
+		args string
+		want int
+	}{
+		{"absent", `{}`, DefaultRecapSessions},
+		{"zero", `{"sessions":0}`, DefaultRecapSessions},
+		{"oversized", `{"sessions":99}`, MaxRecapSessions},
+		{"in range", `{"sessions":2}`, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &fakeRecapper{text: "ok"}
+			if _, err := NewRecap(src).Execute(context.Background(), json.RawMessage(tc.args), nil); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if src.gotSessions != tc.want {
+				t.Errorf("sessions → %d, want %d", src.gotSessions, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecapToolInvalidArgs pins that malformed JSON errors and never calls the source.
+func TestRecapToolInvalidArgs(t *testing.T) {
+	src := &fakeRecapper{}
+	if _, err := NewRecap(src).Execute(context.Background(), json.RawMessage(`{"sessions":`), nil); err == nil {
+		t.Fatal("invalid json should error")
+	}
+	if src.callCount != 0 {
+		t.Errorf("source called %d times on bad args, want 0", src.callCount)
+	}
+}
+
+// TestRecapToolCancelledCtx pins that a cancelled turn ctx short-circuits before
+// the source is touched, returning ctx.Err.
+func TestRecapToolCancelledCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	src := &fakeRecapper{}
+	_, err := NewRecap(src).Execute(ctx, json.RawMessage(`{}`), nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if src.callCount != 0 {
+		t.Errorf("source called on a cancelled ctx")
+	}
+}
+
+// TestRecapToolWrapsSourceError pins the "recap: …" wrap so a failure is
+// attributable in the tool-role message fed back to the model.
+func TestRecapToolWrapsSourceError(t *testing.T) {
+	src := &fakeRecapper{err: errors.New("boom")}
+	_, err := NewRecap(src).Execute(context.Background(), json.RawMessage(`{}`), nil)
+	if err == nil || !strings.HasPrefix(err.Error(), "recap: ") {
+		t.Errorf("err = %v, want it wrapped with recap: prefix", err)
+	}
+}
+
+// TestRecapToolTruncatesToBudget pins that an over-budget recap is rune-truncated
+// with an ellipsis, multibyte-safe (never a split codepoint).
+func TestRecapToolTruncatesToBudget(t *testing.T) {
+	long := strings.Repeat("我", RecapResultBudgetRunes+500) // 3 bytes each, over budget
+	out, err := NewRecap(&fakeRecapper{text: long}).Execute(
+		context.Background(), json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if utf8.RuneCountInString(out) > RecapResultBudgetRunes+1 { // +1 for the ellipsis
+		t.Errorf("recap %d runes exceeds budget %d", utf8.RuneCountInString(out), RecapResultBudgetRunes)
+	}
+	if !strings.HasSuffix(out, "…") {
+		t.Error("a truncated recap should end in an ellipsis")
+	}
+	if !utf8.ValidString(out) {
+		t.Error("truncation split a multibyte codepoint")
+	}
+}
+
+// TestRecapToolReturnsTextVerbatim pins that an under-budget recap is relayed
+// verbatim — the Description tells the model not to shorten it, so the Tool must not
+// mangle it either.
+func TestRecapToolReturnsTextVerbatim(t *testing.T) {
+	const prose = "The party stormed the keep and freed the Duke."
+	out, err := NewRecap(&fakeRecapper{text: prose}).Execute(
+		context.Background(), json.RawMessage(`{"sessions":1}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != prose {
+		t.Errorf("recap = %q, want verbatim %q", out, prose)
+	}
+}


### PR DESCRIPTION
Closes #372

## What

Adds the `recap` built-in Tool (#297 decision 5, E7): a **read-only** wrapper the granted Butler drives in voice to summarize the Campaign's most recent ended Voice Session(s). Answers "Glyphoxa, recap last session" via the Tool; the recap prose flows out through the Butler's existing text-modality answer path.

## AC

- Auto-created Butler's default grants = `dice` + `transcript_search` + `kg_query` + `recap` (migration 00027, seeded via the auto-Butler trigger only — ADR-0009).
- Granted Butler answers a recap request via the `recap` Tool; delivery honored per #297 decision 2 / #271 modes via the existing `textModalityTurn → AnswerAsText` path (no parallel modality logic — #389 owns the ensemble modality seam).

## How

- **pkg/tool**: `Recap` Tool mirroring `transcript_search` (ReadOnly, SupportsScope false, advisory-clamped `sessions` 1..3, rune-budgeted result). New storage-free `Recapper` seam on `Deps`. Registered in `BuiltinRegistry`. nil source ⇒ registered-but-unavailable so zero-Deps builds (grant-editor RPC, voice bench) never panic.
- **internal/knowledge**: `RecapAdapter` resolves the session window entirely from server state — active Campaign from the live session, newest ENDED non-empty rows (`isRecappable` parity with `presence`) — so the LLM never names a session id (ADR-0029). Turn-child 120s timeout so barge-in cancels; `recap.ErrNoTranscript` mapped to the friendly no-session error.
- **migration 00027**: `recap` joins the auto-Butler trigger default set + idempotent backfill; Down restores the 00025 trigger body verbatim.
- **main.go**: wire `knowledge.NewRecap(recapEngine, store, mgr)` into `SetToolDeps`.

## Tests (TDD, red→green)

- `pkg/tool/recap_test.go`: contract (Name/ReadOnly/SupportsScope/schema no-required), nil-source unavailable, default/clamp/in-range sessions, invalid json, cancelled ctx, error wrap, multibyte rune-truncation, verbatim passthrough.
- `pkg/tool/knowledge_loop_test.go`: `TestLoopRunsRecapInline` — scripted provider emits recap tool_call → fake Recapper text fed back inline → final answer (ADR-0021 cassette).
- `pkg/tool/builtins_test.go`: catalog now `[dice kg_query recap remember_knowledge transcript_search]`; recap in read-only set.
- `internal/knowledge/recap_test.go`: idle ⇒ ErrNoActiveSession; picker skips running + empty-ended; n=2 two newest; none ⇒ friendly error; ErrNoTranscript mapped; nil-dep panics.
- Updated storage + rpc grant assertions (integration) to the 4-grant Butler.

Local: `go build ./...`, `go vet -tags integration ./...`, `go test ./...`, `golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Review round 2 (needs-fixes → applied)

- **Timeout inversion (medium):** `recapToolTimeout` 120s never fired — the Butler turn ctx carries `DefaultTurnTimeout=60s`, so the effective in-voice recap budget was 60s and blowing it killed the whole turn (Butler answers nothing). Set to **45s** (below the turn deadline) → the child fires first while the turn is alive; `context.DeadlineExceeded` is mapped to a friendly took-too-long **tool result** (nil error) the Butler relays. Added internal test `TestRecapAdapterTimeoutMapsFriendlyAndTurnSurvives` (shrinks the var, asserts mapping + turn survives).
- **Undeliverable budget (low):** `RecapResultBudgetRunes` 8000 exceeded the Butler relay completion cap (groq `DefaultMaxTokens` 1024 ≈ 3.5k runes), clipping near-budget recaps mid-prose. Lowered to **3500** and documented the relay-cap divergence at the const + Tool description (full text via `/glyphoxa recap`).

### Possible follow-up (out of scope)
Raise the Butler turn timeout so a longer in-voice recap can complete without the took-too-long fallback. Deliberately not done here — it's a design change touching `pkg/voice/agent` turn budgeting, not this Tool wrapper.
