### PR TITLE
feat(#300): [E7] remember_knowledge — GM review surface (PR-b)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/web"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
 
@@ -621,9 +622,15 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// for BOTH: the backlog gauge exposes the permanent stall and NPC memory recall
 	// stays disabled (AC6 — Agent turns behave exactly as before), rather than
 	// crashing the process.
+	// embedProvider is hoisted out of the resolve branch so the Knowledge Proposal
+	// review surface's similarity hint (#300) can share the SAME resolved provider:
+	// nil (an unsupported provider or a config-read error) leaves the hint on its
+	// fulltext fallback, exactly as the backfill worker stalls loudly.
+	var embedProvider embeddings.Provider
 	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
 		log.Error("embeddings provider unavailable; embedding backfill and NPC memory recall disabled", "err", err)
 	} else {
+		embedProvider = provider
 		// Backfill worker (#116, ADR-0011): claims chunks written with embedding NULL,
 		// embeds their text, and UPDATEs each row — draining the gauge toward zero and
 		// making the chunks returnable by embedding-filtered retrieval. It needs only
@@ -704,7 +711,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			return pres.VoiceChannelMembers(ctx, channelID)
 		}
 	}
-	mounts := managementMounts(store, blobStore, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, presenceRefresh, memberLister)
+	mounts := managementMounts(store, blobStore, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, presenceRefresh, memberLister, embedProvider)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -795,7 +802,7 @@ func (s highlightClipSweeper) DeleteClip(ctx context.Context, key string) error 
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
 // Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error)) []web.Mount {
+func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error), embedProvider embeddings.Provider) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses
@@ -823,6 +830,12 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// campaign so the GM mutes the NPCs actually in the channel, not a durable
 	// selection changed mid-session (#222).
 	campaignSrv.SetSessions(mgr)
+	// The Knowledge Proposal review surface's similarity hint (#300, ADR-0052) shares
+	// the resolved embeddings provider: nil (keyless / unsupported) leaves the hint on
+	// its fulltext fallback rather than disabling review.
+	if embedProvider != nil {
+		campaignSrv.SetEmbedder(embedProvider)
+	}
 	// The Players panel's member picker (#279) lists the Discord Users currently in
 	// the operator's configured voice channel, resolved from the deployment config
 	// and read off the standing presence's voice-state cache (no privileged intent).

--- a/internal/embedworker/worker.go
+++ b/internal/embedworker/worker.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,13 +46,22 @@ type Store interface {
 	SetChunkEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error
 	// CountUnembeddedChunks reports the remaining NULL-embedding backlog (gauge).
 	CountUnembeddedChunks(ctx context.Context) (int, error)
+	// ListUnembeddedNodes returns up to limit Knowledge Graph Nodes still awaiting
+	// an embedding, oldest first — the node half of the backfill queue (#300).
+	ListUnembeddedNodes(ctx context.Context, limit int) ([]storage.KGNode, error)
+	// SetNodeEmbedding fills one Node's vector and stamps the model.
+	SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error
+	// CountUnembeddedNodes reports the remaining NULL-embedding Node backlog (gauge).
+	CountUnembeddedNodes(ctx context.Context) (int, error)
 }
 
 // BacklogGauge receives the current NULL-embedding backlog after each pass that
 // wrote at least one embedding (Set-from-COUNT, never Inc/Dec — ADR-0032).
-// *observe.PrometheusRecorder satisfies it; a nil gauge disables the update.
+// *observe.PrometheusRecorder satisfies it; a nil gauge disables the update. The
+// chunk and Node backlogs are separate gauges (#300).
 type BacklogGauge interface {
 	SetEmbeddingBacklog(n int)
+	SetKGEmbeddingBacklog(n int)
 }
 
 // ProviderConfigStore is the single read [ResolveProvider] needs; *storage.Store
@@ -133,13 +143,22 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 }
 
-// pass claims one batch, embeds it, and writes each vector. An error stops the
-// pass early: a pre-write error (list, provider, wrong count/dimension) writes
+// pass drains one batch from EACH backlog — Transcript Chunks and Knowledge Graph
+// Nodes (#300) — the two independent so an error draining one never starves the
+// other. Both phases carry the same batch/timeout/dim-validation/retry-forever
+// discipline; each re-claims its own leftover work next pass.
+func (w *Worker) pass(ctx context.Context) {
+	w.passChunks(ctx)
+	w.passNodes(ctx)
+}
+
+// passChunks claims one batch, embeds it, and writes each vector. An error stops
+// the phase early: a pre-write error (list, provider, wrong count/dimension) writes
 // nothing, while a mid-batch write error keeps the rows already written and
 // leaves the rest NULL. The still-NULL chunks are re-claimed next pass (the
 // retry). The gauge is re-read only after the whole batch of writes succeeds; a
-// short or aborted pass leaves it as the last pass set it.
-func (w *Worker) pass(ctx context.Context) {
+// short or aborted phase leaves it as the last pass set it.
+func (w *Worker) passChunks(ctx context.Context) {
 	chunks, err := w.store.ListUnembeddedChunks(ctx, w.cfg.BatchSize)
 	if err != nil {
 		w.log.Warn("embed backfill: list unembedded chunks failed; retrying next pass", "err", err)
@@ -154,28 +173,9 @@ func (w *Worker) pass(ctx context.Context) {
 		texts[i] = c.Content
 	}
 
-	callCtx, cancel := context.WithTimeout(ctx, w.cfg.CallTimeout)
-	defer cancel()
-	vecs, err := w.provider.Embed(callCtx, texts)
-	if err != nil {
-		w.log.Warn("embed backfill: provider embed failed; chunks stay NULL, retrying next pass",
-			"batch", len(chunks), "err", err)
+	vecs, ok := w.embedBatch(ctx, "chunks", texts)
+	if !ok {
 		return
-	}
-	if len(vecs) != len(chunks) {
-		w.log.Warn("embed backfill: provider returned wrong vector count; abandoning pass",
-			"want", len(chunks), "got", len(vecs))
-		return
-	}
-	// Validate every dimension BEFORE writing any row: a wrong dimension signals a
-	// mis-configured model, so the whole batch is suspect — write none and retry
-	// rather than corrupt the vector store with a partial, wrong-shape write.
-	for i, v := range vecs {
-		if len(v) != embeddings.Dim {
-			w.log.Warn("embed backfill: provider returned a wrong-dimension vector; abandoning pass",
-				"index", i, "want", embeddings.Dim, "got", len(v))
-			return
-		}
 	}
 
 	// Write each row; a failure stops the loop but keeps the rows already written
@@ -191,12 +191,86 @@ func (w *Worker) pass(ctx context.Context) {
 
 	n, err := w.store.CountUnembeddedChunks(ctx)
 	if err != nil {
-		w.log.Warn("embed backfill: recount backlog failed; gauge left stale", "err", err)
+		w.log.Warn("embed backfill: recount chunk backlog failed; gauge left stale", "err", err)
 		return
 	}
 	if w.gauge != nil {
 		w.gauge.SetEmbeddingBacklog(n)
 	}
+}
+
+// passNodes is the Knowledge Graph Node half of the backfill (#300), mirroring
+// passChunks exactly. The embed text is the Node's name + body joined by a blank
+// line and trimmed, so a body-less Node still embeds on its name alone. A wiki edit
+// resets the row's embedding (storage.UpdateNode), so it is re-claimed here.
+func (w *Worker) passNodes(ctx context.Context) {
+	nodes, err := w.store.ListUnembeddedNodes(ctx, w.cfg.BatchSize)
+	if err != nil {
+		w.log.Warn("embed backfill: list unembedded nodes failed; retrying next pass", "err", err)
+		return
+	}
+	if len(nodes) == 0 {
+		return
+	}
+
+	texts := make([]string, len(nodes))
+	for i, n := range nodes {
+		texts[i] = strings.TrimSpace(n.Name + "\n\n" + n.Body)
+	}
+
+	vecs, ok := w.embedBatch(ctx, "nodes", texts)
+	if !ok {
+		return
+	}
+
+	for i, n := range nodes {
+		if err := w.store.SetNodeEmbedding(ctx, n.ID, vecs[i], w.model); err != nil {
+			w.log.Warn("embed backfill: set node embedding failed; this and later nodes retry next pass",
+				"node_id", n.ID, "err", err)
+			return
+		}
+	}
+
+	count, err := w.store.CountUnembeddedNodes(ctx)
+	if err != nil {
+		w.log.Warn("embed backfill: recount node backlog failed; gauge left stale", "err", err)
+		return
+	}
+	if w.gauge != nil {
+		w.gauge.SetKGEmbeddingBacklog(count)
+	}
+}
+
+// embedBatch runs the shared provider call + validation both phases use: a timeout
+// derived from the run context, a total (one vector per input) and dimension check
+// BEFORE any write. ok=false means the batch is unusable and the phase must abandon
+// this pass (nothing written), leaving the rows NULL for the next pass. kind is the
+// phase label for logs.
+func (w *Worker) embedBatch(ctx context.Context, kind string, texts []string) ([][]float32, bool) {
+	callCtx, cancel := context.WithTimeout(ctx, w.cfg.CallTimeout)
+	defer cancel()
+	vecs, err := w.provider.Embed(callCtx, texts)
+	if err != nil {
+		w.log.Warn("embed backfill: provider embed failed; rows stay NULL, retrying next pass",
+			"kind", kind, "batch", len(texts), "err", err)
+		return nil, false
+	}
+	if len(vecs) != len(texts) {
+		w.log.Warn("embed backfill: provider returned wrong vector count; abandoning pass",
+			"kind", kind, "want", len(texts), "got", len(vecs))
+		return nil, false
+	}
+	// Validate every dimension BEFORE writing any row: a wrong dimension signals a
+	// mis-configured model, so the whole batch is suspect — write none and retry
+	// rather than corrupt the vector store with a partial, wrong-shape write.
+	for i, v := range vecs {
+		if len(v) != embeddings.Dim {
+			w.log.Warn("embed backfill: provider returned a wrong-dimension vector; abandoning pass",
+				"kind", kind, "index", i, "want", embeddings.Dim, "got", len(v))
+			return nil, false
+		}
+	}
+	return vecs, true
 }
 
 // ResolveProvider resolves the process's embeddings Provider and its model from

--- a/internal/embedworker/worker.go
+++ b/internal/embedworker/worker.go
@@ -49,8 +49,10 @@ type Store interface {
 	// ListUnembeddedNodes returns up to limit Knowledge Graph Nodes still awaiting
 	// an embedding, oldest first — the node half of the backfill queue (#300).
 	ListUnembeddedNodes(ctx context.Context, limit int) ([]storage.KGNode, error)
-	// SetNodeEmbedding fills one Node's vector and stamps the model.
-	SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error
+	// SetNodeEmbedding fills one Node's vector and stamps the model, guarded on the
+	// updatedAt the row was LISTED with so a concurrent edit (which bumps updated_at
+	// and NULLs the embedding) is not clobbered by a stale vector (#300).
+	SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string, updatedAt time.Time) error
 	// CountUnembeddedNodes reports the remaining NULL-embedding Node backlog (gauge).
 	CountUnembeddedNodes(ctx context.Context) (int, error)
 }
@@ -224,7 +226,10 @@ func (w *Worker) passNodes(ctx context.Context) {
 	}
 
 	for i, n := range nodes {
-		if err := w.store.SetNodeEmbedding(ctx, n.ID, vecs[i], w.model); err != nil {
+		// Guard the write on the listed updated_at: a Node edited/approved since we
+		// listed it (embedding NULLed, updated_at bumped) matches 0 rows and stays in
+		// the backlog for the next pass to re-embed with fresh text (#300).
+		if err := w.store.SetNodeEmbedding(ctx, n.ID, vecs[i], w.model, n.UpdatedAt); err != nil {
 			w.log.Warn("embed backfill: set node embedding failed; this and later nodes retry next pass",
 				"node_id", n.ID, "err", err)
 			return

--- a/internal/embedworker/worker_test.go
+++ b/internal/embedworker/worker_test.go
@@ -43,6 +43,9 @@ type fakeStore struct {
 	nodeListErr   error
 	nodeSetFailID uuid.UUID
 	nodeCountErr  error
+	// nodeUpdatedAt holds the LIVE updated_at per node id, so a test can bump it
+	// mid-pass to simulate a concurrent edit and exercise the stale-write guard.
+	nodeUpdatedAt map[uuid.UUID]time.Time
 }
 
 type embedRecord struct {
@@ -108,11 +111,18 @@ func (f *fakeStore) ListUnembeddedNodes(_ context.Context, limit int) ([]storage
 	return out, nil
 }
 
-func (f *fakeStore) SetNodeEmbedding(_ context.Context, id uuid.UUID, vec []float32, model string) error {
+func (f *fakeStore) SetNodeEmbedding(_ context.Context, id uuid.UUID, vec []float32, model string, updatedAt time.Time) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.nodeSetFailID != uuid.Nil && id == f.nodeSetFailID {
 		return errors.New("set node embedding: injected write failure")
+	}
+	// Model the storage guard: a row whose live updated_at no longer matches the
+	// one the worker listed matches 0 rows — nothing is written, the row stays in
+	// the backlog. nodeUpdatedAt holds the LIVE updated_at per id (default: the
+	// listed one, so a normal write succeeds).
+	if cur, ok := f.nodeUpdatedAt[id]; ok && !cur.Equal(updatedAt) {
+		return nil // 0 rows: stale write ignored
 	}
 	for i, n := range f.pendingNodes {
 		if n.ID == id {
@@ -125,6 +135,18 @@ func (f *fakeStore) SetNodeEmbedding(_ context.Context, id uuid.UUID, vec []floa
 	}
 	f.embeddedNodes[id] = embedRecord{vec: append([]float32(nil), vec...), model: model}
 	return nil
+}
+
+// bumpNodeUpdatedAt simulates a concurrent edit landing on a node mid-pass: the
+// live updated_at moves away from what the worker listed, so its pending SetNode-
+// Embedding write will match 0 rows.
+func (f *fakeStore) bumpNodeUpdatedAt(id uuid.UUID, to time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.nodeUpdatedAt == nil {
+		f.nodeUpdatedAt = map[uuid.UUID]time.Time{}
+	}
+	f.nodeUpdatedAt[id] = to
 }
 
 func (f *fakeStore) CountUnembeddedNodes(_ context.Context) (int, error) {
@@ -210,7 +232,49 @@ func chunk(content string) storage.TranscriptChunk {
 }
 
 func node(name, body string) storage.KGNode {
-	return storage.KGNode{ID: uuid.New(), CampaignID: uuid.New(), Name: name, Body: body}
+	return storage.KGNode{
+		ID: uuid.New(), CampaignID: uuid.New(), Name: name, Body: body,
+		UpdatedAt: time.Unix(1_700_000_000, 0),
+	}
+}
+
+// editingProvider runs a callback on the FIRST Embed call — after the worker has
+// listed the batch, before it writes — so a test can land a concurrent edit
+// mid-pass. It then delegates to inner for the actual vectors.
+type editingProvider struct {
+	once  sync.Once
+	edit  func()
+	inner embeddings.Provider
+}
+
+func (p *editingProvider) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	p.once.Do(p.edit)
+	return p.inner.Embed(ctx, texts)
+}
+
+// TestPassNodeStaleEditIgnored: a Node edited BETWEEN list and write (its live
+// updated_at moves) is not clobbered by the now-stale vector — the write matches 0
+// rows and the row stays in the backlog for the next pass. Guards the mutable-node
+// stale-embedding race.
+func TestPassNodeStaleEditIgnored(t *testing.T) {
+	n := node("Bart", "v1")
+	store := &fakeStore{pendingNodes: []storage.KGNode{n}}
+	prov := &editingProvider{
+		inner: embeddingstest.Deterministic{},
+		// Simulate a GM edit landing mid-pass: the live updated_at moves off what
+		// the worker listed.
+		edit: func() { store.bumpNodeUpdatedAt(n.ID, time.Unix(1_700_000_099, 0)) },
+	}
+	w := New(store, prov, "m", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+
+	if _, ok := store.nodeEmbedRecord(n.ID); ok {
+		t.Error("stale vector was installed on an edited node; the guard must skip it")
+	}
+	if store.pendingNodeCount() != 1 {
+		t.Errorf("pendingNodes = %d, want 1 (edited node stays for next pass)", store.pendingNodeCount())
+	}
 }
 
 // TestPassEmbedsNodeBacklog: the node phase mirrors the chunk phase — it drains

--- a/internal/embedworker/worker_test.go
+++ b/internal/embedworker/worker_test.go
@@ -35,6 +35,14 @@ type fakeStore struct {
 	listErr   error
 	setFailID uuid.UUID
 	countErr  error
+
+	// Node backlog (#300): mirrors the chunk fields so a test can drive the node
+	// phase independently.
+	pendingNodes  []storage.KGNode
+	embeddedNodes map[uuid.UUID]embedRecord
+	nodeListErr   error
+	nodeSetFailID uuid.UUID
+	nodeCountErr  error
 }
 
 type embedRecord struct {
@@ -85,10 +93,72 @@ func (f *fakeStore) CountUnembeddedChunks(_ context.Context) (int, error) {
 	return len(f.pending), nil
 }
 
+func (f *fakeStore) ListUnembeddedNodes(_ context.Context, limit int) ([]storage.KGNode, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.nodeListErr != nil {
+		return nil, f.nodeListErr
+	}
+	n := limit
+	if n > len(f.pendingNodes) {
+		n = len(f.pendingNodes)
+	}
+	out := make([]storage.KGNode, n)
+	copy(out, f.pendingNodes[:n])
+	return out, nil
+}
+
+func (f *fakeStore) SetNodeEmbedding(_ context.Context, id uuid.UUID, vec []float32, model string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.nodeSetFailID != uuid.Nil && id == f.nodeSetFailID {
+		return errors.New("set node embedding: injected write failure")
+	}
+	for i, n := range f.pendingNodes {
+		if n.ID == id {
+			f.pendingNodes = append(f.pendingNodes[:i], f.pendingNodes[i+1:]...)
+			break
+		}
+	}
+	if f.embeddedNodes == nil {
+		f.embeddedNodes = map[uuid.UUID]embedRecord{}
+	}
+	f.embeddedNodes[id] = embedRecord{vec: append([]float32(nil), vec...), model: model}
+	return nil
+}
+
+func (f *fakeStore) CountUnembeddedNodes(_ context.Context) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.nodeCountErr != nil {
+		return 0, f.nodeCountErr
+	}
+	return len(f.pendingNodes), nil
+}
+
 func (f *fakeStore) embeddedCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.embedded)
+}
+
+func (f *fakeStore) embeddedNodeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.embeddedNodes)
+}
+
+func (f *fakeStore) pendingNodeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pendingNodes)
+}
+
+func (f *fakeStore) nodeEmbedRecord(id uuid.UUID) (embedRecord, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.embeddedNodes[id]
+	return r, ok
 }
 
 func (f *fakeStore) pendingCount() int {
@@ -106,14 +176,27 @@ func (f *fakeStore) isEmbedded(id uuid.UUID) bool {
 
 // fakeGauge records every Set so a test can assert the backlog curve.
 type fakeGauge struct {
-	mu   sync.Mutex
-	sets []int
+	mu       sync.Mutex
+	sets     []int
+	nodeSets []int
 }
 
 func (g *fakeGauge) SetEmbeddingBacklog(n int) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.sets = append(g.sets, n)
+}
+
+func (g *fakeGauge) SetKGEmbeddingBacklog(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.nodeSets = append(g.nodeSets, n)
+}
+
+func (g *fakeGauge) nodeSnapshot() []int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]int(nil), g.nodeSets...)
 }
 
 func (g *fakeGauge) snapshot() []int {
@@ -124,6 +207,64 @@ func (g *fakeGauge) snapshot() []int {
 
 func chunk(content string) storage.TranscriptChunk {
 	return storage.TranscriptChunk{ID: uuid.New(), CampaignID: uuid.New(), Content: content}
+}
+
+func node(name, body string) storage.KGNode {
+	return storage.KGNode{ID: uuid.New(), CampaignID: uuid.New(), Name: name, Body: body}
+}
+
+// TestPassEmbedsNodeBacklog: the node phase mirrors the chunk phase — it drains
+// the Node backlog, embeds name+body (trimmed, blank-line joined), stamps the
+// model, and Sets the KG backlog gauge to the true remaining count.
+func TestPassEmbedsNodeBacklog(t *testing.T) {
+	n0, n1 := node("Bart", "An innkeeper."), node("Neverwinter", "")
+	store := &fakeStore{pendingNodes: []storage.KGNode{n0, n1}}
+	gauge := &fakeGauge{}
+	w := New(store, embeddingstest.Deterministic{}, "nomic-embed-text", gauge, discardLog(), Config{})
+
+	w.pass(context.Background())
+
+	if store.pendingNodeCount() != 0 || store.embeddedNodeCount() != 2 {
+		t.Fatalf("pendingNodes=%d embeddedNodes=%d, want 0/2", store.pendingNodeCount(), store.embeddedNodeCount())
+	}
+	rec, ok := store.nodeEmbedRecord(n0.ID)
+	if !ok {
+		t.Fatal("n0 not embedded")
+	}
+	if len(rec.vec) != embeddings.Dim {
+		t.Errorf("node vector = %d dims, want %d", len(rec.vec), embeddings.Dim)
+	}
+	if rec.model != "nomic-embed-text" {
+		t.Errorf("node model = %q, want nomic-embed-text", rec.model)
+	}
+	// A body-less node still embeds (name alone), never a panic or skip.
+	if _, ok := store.nodeEmbedRecord(n1.ID); !ok {
+		t.Error("body-less node n1 not embedded")
+	}
+	sets := gauge.nodeSnapshot()
+	if len(sets) == 0 || sets[len(sets)-1] != 0 {
+		t.Errorf("KG backlog gauge = %v, want final 0", sets)
+	}
+}
+
+// TestPassNodePhaseIndependentOfChunkError: a failing chunk phase must not starve
+// the node phase — the two backlogs drain independently.
+func TestPassNodePhaseIndependentOfChunkError(t *testing.T) {
+	store := &fakeStore{
+		pending:      []storage.TranscriptChunk{chunk("c")},
+		listErr:      errors.New("chunk db down"),
+		pendingNodes: []storage.KGNode{node("N", "b")},
+	}
+	w := New(store, embeddingstest.Deterministic{}, "m", nil, discardLog(), Config{})
+
+	w.pass(context.Background())
+
+	if store.embeddedCount() != 0 {
+		t.Errorf("chunks embedded = %d, want 0 (chunk phase failed)", store.embeddedCount())
+	}
+	if store.embeddedNodeCount() != 1 {
+		t.Errorf("nodes embedded = %d, want 1 (node phase must still run)", store.embeddedNodeCount())
+	}
 }
 
 // Test 1: three NULL chunks are all embedded with 768-dim vectors and the model

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -87,6 +87,11 @@ type PrometheusRecorder struct {
 	// it stays idempotent across writers and restarts.
 	embeddingBacklog prometheus.Gauge
 
+	// KG embedding backlog (#300, ADR-0032): Knowledge Graph Nodes awaiting an
+	// embedding for the review-surface similarity hint. The embedworker Node phase
+	// Sets it from CountUnembeddedNodes, Set-from-COUNT like embeddingBacklog.
+	kgEmbeddingBacklog prometheus.Gauge
+
 	// memory recall (#122, ADR-0042/0032): NPC Hot Context recalls by outcome —
 	// a speculation hit, an inline miss, or a degraded/unconfigured skip. The
 	// outcome label is a bounded three-value enum (ADR-0032).
@@ -234,6 +239,12 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		Help:      "Transcript chunks awaiting embedding (embedding IS NULL).",
 	})
 
+	r.kgEmbeddingBacklog = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace, // process-level like embedding_backlog (ADR-0032)
+		Name:      "kg_embedding_backlog",
+		Help:      "Knowledge Graph Nodes awaiting embedding (embedding IS NULL).",
+	})
+
 	r.memoryRecall = counterVec("memory_recall_total",
 		"NPC memory recalls by outcome (#122, ADR-0042): a speculation hit, an inline miss, or a degraded skip.",
 		"outcome")
@@ -271,7 +282,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		r.responseLatency, r.vadHangover, r.addressDetect, r.codecDecode,
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
-		r.memoryRecall, r.kgFacts,
+		r.kgEmbeddingBacklog, r.memoryRecall, r.kgFacts,
 		r.jobsBacklog, r.jobsTotal, r.jobDuration,
 		r.llmTokens, r.ttsCharacters, r.sttAudioSeconds,
 		// Standard runtime collectors so /metrics also reports process/Go health.
@@ -388,6 +399,13 @@ func (r *PrometheusRecorder) KGFacts(o FactsOutcome) {
 // the DB rather than resuming a drifted in-memory delta.
 func (r *PrometheusRecorder) SetEmbeddingBacklog(n int) {
 	r.embeddingBacklog.Set(float64(n))
+}
+
+// SetKGEmbeddingBacklog publishes the current count of Knowledge Graph Nodes
+// awaiting an embedding (#300, ADR-0032). Set-from-COUNT like SetEmbeddingBacklog,
+// so it stays idempotent across the embedworker Node phase and process restarts.
+func (r *PrometheusRecorder) SetKGEmbeddingBacklog(n int) {
+	r.kgEmbeddingBacklog.Set(float64(n))
 }
 
 // --- background job runner (jobs.Metrics, #286/ADR-0049) ---

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -73,6 +73,15 @@ type campaignStore interface {
 	NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
 	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
 	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+	// Knowledge Proposal review (#300, ADR-0052): the GM review surface's list of
+	// pending proposals, the single-proposal read the similarity hint keys off, the
+	// atomic approve/reject writes, and the embedding-vector nearest-neighbour search
+	// the similarity hint runs.
+	ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error)
+	GetPendingKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) (storage.KnowledgeProposal, error)
+	ApproveKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
+	RejectKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
+	SimilarNodes(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.KGNode, error)
 	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
 	UpsertToolGrant(ctx context.Context, g storage.NewToolGrant) error
 	DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error
@@ -114,6 +123,25 @@ type CampaignServer struct {
 	// clip blobs have NO FK and must be dropped through the seam. Nil disables the
 	// sweep (web-only / no blob backend); set once at boot before serving.
 	clips HighlightClipSweeper
+	// embedder embeds a proposal's subject text for the ListSimilarKnowledge vector
+	// hint (#300, ADR-0011/0052). Nil (no embeddings provider wired, or a keyless
+	// deployment) makes the hint degrade silently to fulltext SearchNodes. Set once
+	// at boot before serving, so no lock is needed.
+	embedder Embedder
+}
+
+// Embedder embeds short texts to query vectors for the Knowledge Proposal
+// similarity hint (#300, ADR-0052). The resolved embeddings provider satisfies it;
+// nil disables the vector path (the hint falls back to fulltext search).
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+// SetEmbedder wires the embeddings provider the ListSimilarKnowledge vector hint
+// uses (#300). Called once at boot before serving; nil leaves the hint on the
+// fulltext fallback only.
+func (s *CampaignServer) SetEmbedder(e Embedder) {
+	s.embedder = e
 }
 
 // HighlightClipSweeper drops a campaign's Session Highlight clips through the blob

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -144,6 +144,27 @@ type fakeCampaignStore struct {
 	grantUpsertErr error
 	grantDeleteErr error
 
+	// Knowledge Proposal review state (#300): pendingProposals backs the list read;
+	// getProposal/getProposalErr back GetPendingKnowledgeProposal; approve/reject
+	// record calls and force error paths; similarResults/similarErr back SimilarNodes
+	// and similarQueryVec records the vector it was queried with.
+	pendingProposals      []storage.KnowledgeProposal
+	listProposalsErr      error
+	listProposalsCampaign uuid.UUID
+	getProposal           storage.KnowledgeProposal
+	getProposalErr        error
+	getProposalCampaign   uuid.UUID
+	approveErr            error
+	approveCalls          []uuid.UUID
+	approveCampaign       uuid.UUID
+	rejectErr             error
+	rejectCalls           []uuid.UUID
+	rejectCampaign        uuid.UUID
+	similarResults        []storage.KGNode
+	similarErr            error
+	similarCalls          int
+	similarQueryVec       []float32
+
 	// Player Character state (#276): characters backs ListCharacters/Update/Delete;
 	// charsCreated records CreateCharacter inputs; charsListCampaign records the
 	// campaign id ListCharacters resolved (scope assertion); the *Err hooks force
@@ -505,6 +526,21 @@ func crudClient(t *testing.T, store *fakeCampaignStore) managementv1connect.Camp
 	t.Cleanup(srv.Close)
 	return managementv1connect.NewCampaignServiceClient(
 		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
+	)
+}
+
+// crudClientWithEmbedder is crudClient with a wired Embedder so the
+// ListSimilarKnowledge vector path (#300) is exercised.
+func crudClientWithEmbedder(t *testing.T, store *fakeCampaignStore, emb rpc.Embedder) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	srv := rpc.NewCampaignServer(store)
+	srv.SetEmbedder(emb)
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler())
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, s.URL, connect.WithProtoJSON(),
 	)
 }
 

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -129,6 +129,21 @@ func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.UUID, uuid.NullU
 func (fakeReader) SearchNodes(context.Context, uuid.UUID, string, int) ([]storage.KGNode, error) {
 	return nil, nil
 }
+func (fakeReader) ListPendingKnowledgeProposals(context.Context, uuid.UUID) ([]storage.KnowledgeProposal, error) {
+	return nil, nil
+}
+func (fakeReader) GetPendingKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) (storage.KnowledgeProposal, error) {
+	return storage.KnowledgeProposal{}, nil
+}
+func (fakeReader) ApproveKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (fakeReader) RejectKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (fakeReader) SimilarNodes(context.Context, uuid.UUID, []float32, int) ([]storage.KGNode, error) {
+	return nil, nil
+}
 func (fakeReader) ListToolGrants(context.Context, uuid.UUID) ([]storage.ToolGrant, error) {
 	return nil, nil
 }

--- a/internal/rpc/knowledge_proposal.go
+++ b/internal/rpc/knowledge_proposal.go
@@ -1,0 +1,270 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// Knowledge Proposal review handlers (#300, ADR-0052) on CampaignServer: the GM
+// review surface for the pending queue an Agent's remember_knowledge call files
+// into. List renders each proposal (parsing the jsonb write into a oneof), approve
+// lands the write atomically, reject drops it, and the similarity hint surfaces
+// existing Nodes near a proposal's subject so the GM merges rather than duplicates
+// (similarity is a HINT — no auto-merge, ADR-0052). They resolve the single
+// operator's active campaign server-side (ADR-0039), like the KG Node handlers.
+
+// similarEmbedTimeout bounds the ListSimilarKnowledge embedding call — the hint is
+// nice-to-have, so a slow provider must not hang the review surface; on timeout it
+// degrades to fulltext search.
+const similarEmbedTimeout = 15 * time.Second
+
+// similarNodesLimit caps the similarity hint at 5 nearest entries (ADR-0052).
+const similarNodesLimit = 5
+
+// ListKnowledgeProposals returns the active campaign's pending proposals
+// oldest-first, each with its authoring Agent's name and its parsed write. An
+// unparseable jsonb row is still listed (write oneof left UNSET) so the GM can
+// reject it. No campaign is CodeNotFound; a storage failure is CodeInternal.
+func (s *CampaignServer) ListKnowledgeProposals(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListKnowledgeProposalsRequest],
+) (*connect.Response[managementv1.ListKnowledgeProposalsResponse], error) {
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ListKnowledgeProposals: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	proposals, err := s.store.ListPendingKnowledgeProposals(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("ListKnowledgeProposals: store list failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := make([]*managementv1.KnowledgeProposal, 0, len(proposals))
+	for _, p := range proposals {
+		out = append(out, toProtoKnowledgeProposal(p))
+	}
+	return connect.NewResponse(&managementv1.ListKnowledgeProposalsResponse{Proposals: out}), nil
+}
+
+// ApproveKnowledgeProposal lands a pending proposal's write on the KG and marks it
+// approved. An unparsable id is CodeInvalidArgument; a missing/already-reviewed id
+// is CodeNotFound; a refused write is CodeFailedPrecondition carrying the storage
+// reason verbatim so the GM sees exactly what to fix.
+func (s *CampaignServer) ApproveKnowledgeProposal(
+	ctx context.Context,
+	req *connect.Request[managementv1.ApproveKnowledgeProposalRequest],
+) (*connect.Response[managementv1.ApproveKnowledgeProposalResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
+	}
+
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ApproveKnowledgeProposal: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	switch err := s.store.ApproveKnowledgeProposal(ctx, c.ID, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.ApproveKnowledgeProposalResponse{}), nil
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("proposal already reviewed or gone"))
+	default:
+		var blocked *storage.ProposalBlockedError
+		if errors.As(err, &blocked) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(blocked.Reason))
+		}
+		slog.Default().Error("ApproveKnowledgeProposal: store approve failed", "proposal_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// RejectKnowledgeProposal drops a pending proposal without touching the KG. An
+// unparsable id is CodeInvalidArgument; a missing/already-reviewed id is
+// CodeNotFound.
+func (s *CampaignServer) RejectKnowledgeProposal(
+	ctx context.Context,
+	req *connect.Request[managementv1.RejectKnowledgeProposalRequest],
+) (*connect.Response[managementv1.RejectKnowledgeProposalResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
+	}
+
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("RejectKnowledgeProposal: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	switch err := s.store.RejectKnowledgeProposal(ctx, c.ID, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.RejectKnowledgeProposalResponse{}), nil
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("proposal already reviewed or gone"))
+	default:
+		slog.Default().Error("RejectKnowledgeProposal: store reject failed", "proposal_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// ListSimilarKnowledge returns up to 5 existing Nodes most similar to a pending
+// proposal's subject — the ADR-0011 review hint. An unparsable id is
+// CodeInvalidArgument; a missing/already-reviewed proposal is CodeNotFound. When
+// an embeddings provider is wired it embeds the subject text and runs the vector
+// nearest-neighbour search; with no provider OR any failure (embed error/timeout)
+// it degrades SILENTLY to fulltext SearchNodes — the hint is best-effort and must
+// never fail the review.
+func (s *CampaignServer) ListSimilarKnowledge(
+	ctx context.Context,
+	req *connect.Request[managementv1.ListSimilarKnowledgeRequest],
+) (*connect.Response[managementv1.ListSimilarKnowledgeResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetProposalId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
+	}
+
+	c, err := s.activeCampaign(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("ListSimilarKnowledge: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	p, err := s.store.GetPendingKnowledgeProposal(ctx, c.ID, id)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("proposal already reviewed or gone"))
+		}
+		slog.Default().Error("ListSimilarKnowledge: get proposal failed", "proposal_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	queryText := similarityQueryText(p.ProposedWrite)
+
+	nodes, err := s.similarNodes(ctx, c.ID, queryText)
+	if err != nil {
+		slog.Default().Error("ListSimilarKnowledge: similarity search failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := make([]*managementv1.Node, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, toProtoNode(n))
+	}
+	return connect.NewResponse(&managementv1.ListSimilarKnowledgeResponse{Nodes: out}), nil
+}
+
+// similarNodes runs the vector nearest-neighbour search when an embedder is wired
+// and the embed succeeds; otherwise it degrades silently to fulltext SearchNodes.
+// A whitespace-only query short-circuits to no hits (SearchNodes would reject it).
+func (s *CampaignServer) similarNodes(ctx context.Context, campaignID uuid.UUID, queryText string) ([]storage.KGNode, error) {
+	if strings.TrimSpace(queryText) == "" {
+		return nil, nil
+	}
+	if s.embedder != nil {
+		embedCtx, cancel := context.WithTimeout(ctx, similarEmbedTimeout)
+		defer cancel()
+		vecs, err := s.embedder.Embed(embedCtx, []string{queryText})
+		if err != nil || len(vecs) != 1 {
+			slog.Default().Warn("ListSimilarKnowledge: embed failed; degrading to fulltext hint",
+				"err", err, "vecs", len(vecs))
+		} else {
+			return s.store.SimilarNodes(ctx, campaignID, vecs[0], similarNodesLimit)
+		}
+	}
+	// Fulltext fallback: no embedder, or the embed failed.
+	return s.store.SearchNodes(ctx, campaignID, queryText, similarNodesLimit)
+}
+
+// similarityQueryText derives the search text for a proposal's subject per kind
+// (#300): a fact is "subject: fact"; an edge is "subject relation target"; a node
+// is "name\n\nbody". An unparseable write yields "" (no hint).
+func similarityQueryText(raw json.RawMessage) string {
+	var w tool.ProposedWrite
+	if err := json.Unmarshal(raw, &w); err != nil {
+		return ""
+	}
+	switch w.Kind {
+	case "fact":
+		return w.Subject + ": " + w.Fact
+	case "edge":
+		return w.Subject + " " + w.Relation + " " + w.Target
+	case "node":
+		return w.Name + "\n\n" + w.Body
+	default:
+		return ""
+	}
+}
+
+// toProtoKnowledgeProposal maps a storage proposal onto its wire representation,
+// parsing the proposed_write jsonb into the write oneof. A parse failure (or an
+// unknown kind) leaves the oneof UNSET and logs a warning — the row is STILL listed
+// so the GM can reject an unreadable proposal.
+func toProtoKnowledgeProposal(p storage.KnowledgeProposal) *managementv1.KnowledgeProposal {
+	out := &managementv1.KnowledgeProposal{
+		Id:                 p.ID.String(),
+		AuthoringAgentId:   p.AuthoringAgentID.String(),
+		AuthoringAgentName: p.AuthoringAgentName,
+		CreatedAt:          timestamppb.New(p.CreatedAt),
+	}
+
+	var w tool.ProposedWrite
+	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil || w.V != 1 {
+		slog.Default().Warn("KnowledgeProposal: unparseable proposed_write; listing with unset write",
+			"proposal_id", p.ID, "err", err)
+		return out // write oneof left unset → UI renders "unreadable — reject"
+	}
+
+	switch w.Kind {
+	case "fact":
+		out.Write = &managementv1.KnowledgeProposal_Fact{Fact: &managementv1.ProposedFact{
+			NodeId:  w.NodeID,
+			Subject: w.Subject,
+			Fact:    w.Fact,
+		}}
+	case "edge":
+		out.Write = &managementv1.KnowledgeProposal_Edge{Edge: &managementv1.ProposedEdge{
+			NodeId:   w.NodeID,
+			Subject:  w.Subject,
+			Relation: toProtoEdgeType(storage.KGEdgeType(w.Relation)),
+			Target:   w.Target,
+		}}
+	case "node":
+		out.Write = &managementv1.KnowledgeProposal_Node{Node: &managementv1.ProposedNode{
+			NodeType: toProtoNodeType(storage.KGNodeType(w.NodeType)),
+			Name:     w.Name,
+			Body:     w.Body,
+		}}
+	default:
+		slog.Default().Warn("KnowledgeProposal: unknown kind; listing with unset write",
+			"proposal_id", p.ID, "kind", w.Kind)
+	}
+	return out
+}

--- a/internal/rpc/knowledge_proposal.go
+++ b/internal/rpc/knowledge_proposal.go
@@ -15,7 +15,13 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 )
+
+// proposalWriteVersion mirrors the storage/tool ProposedWrite schema version
+// (ADR-0052 "v":1). A row whose version differs is unreadable and listed with an
+// unset write oneof.
+const proposalWriteVersion = 1
 
 // Knowledge Proposal review handlers (#300, ADR-0052) on CampaignServer: the GM
 // review surface for the pending queue an Agent's remember_knowledge call files
@@ -192,10 +198,16 @@ func (s *CampaignServer) similarNodes(ctx context.Context, campaignID uuid.UUID,
 		embedCtx, cancel := context.WithTimeout(ctx, similarEmbedTimeout)
 		defer cancel()
 		vecs, err := s.embedder.Embed(embedCtx, []string{queryText})
-		if err != nil || len(vecs) != 1 {
+		switch {
+		case err != nil || len(vecs) != 1:
 			slog.Default().Warn("ListSimilarKnowledge: embed failed; degrading to fulltext hint",
 				"err", err, "vecs", len(vecs))
-		} else {
+		case len(vecs[0]) != embeddings.Dim:
+			// A wrong-dimension vector would make the ::vector cast in SimilarNodes fail
+			// (CodeInternal). The hint is best-effort — degrade to fulltext instead.
+			slog.Default().Warn("ListSimilarKnowledge: embed returned wrong dimension; degrading to fulltext hint",
+				"want", embeddings.Dim, "got", len(vecs[0]))
+		default:
 			return s.store.SimilarNodes(ctx, campaignID, vecs[0], similarNodesLimit)
 		}
 	}
@@ -236,7 +248,7 @@ func toProtoKnowledgeProposal(p storage.KnowledgeProposal) *managementv1.Knowled
 	}
 
 	var w tool.ProposedWrite
-	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil || w.V != 1 {
+	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil || w.V != proposalWriteVersion {
 		slog.Default().Warn("KnowledgeProposal: unparseable proposed_write; listing with unset write",
 			"proposal_id", p.ID, "err", err)
 		return out // write oneof left unset → UI renders "unreadable — reject"

--- a/internal/rpc/knowledge_proposal_test.go
+++ b/internal/rpc/knowledge_proposal_test.go
@@ -14,6 +14,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 )
 
 // --- fakeCampaignStore proposal-review methods (#300) ---
@@ -242,7 +243,7 @@ func TestListSimilarKnowledge_EmbedderPath(t *testing.T) {
 		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"}),
 	}
 	store.similarResults = []storage.KGNode{{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}}
-	emb := &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}}
+	emb := &fakeEmbedder{vec: make([]float32, embeddings.Dim)} // correct dimension → vector path
 	client := crudClientWithEmbedder(t, store, emb)
 
 	resp, err := client.ListSimilarKnowledge(context.Background(),
@@ -258,6 +259,31 @@ func TestListSimilarKnowledge_EmbedderPath(t *testing.T) {
 	}
 	if len(emb.texts) != 1 || emb.texts[0] != "Bart: Fears dark" {
 		t.Errorf("embedded texts = %v, want [\"Bart: Fears dark\"]", emb.texts)
+	}
+}
+
+// TestListSimilarKnowledge_WrongDimFallsBackToFTS: an embedder returning a
+// wrong-dimension vector degrades to fulltext rather than failing with CodeInternal
+// on the ::vector cast.
+func TestListSimilarKnowledge_WrongDimFallsBackToFTS(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.getProposal = storage.KnowledgeProposal{
+		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"}),
+	}
+	emb := &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}} // 3 dims, not embeddings.Dim
+	client := crudClientWithEmbedder(t, store, emb)
+
+	if _, err := client.ListSimilarKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()})); err != nil {
+		t.Fatalf("ListSimilarKnowledge: %v", err)
+	}
+	if store.similarCalls != 0 {
+		t.Errorf("vector path ran with a wrong-dim vector: %d", store.similarCalls)
+	}
+	if store.searchCalls != 1 {
+		t.Errorf("fts fallback not taken: searchCalls=%d, want 1", store.searchCalls)
 	}
 }
 

--- a/internal/rpc/knowledge_proposal_test.go
+++ b/internal/rpc/knowledge_proposal_test.go
@@ -1,0 +1,329 @@
+package rpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// --- fakeCampaignStore proposal-review methods (#300) ---
+
+func (f *fakeCampaignStore) ListPendingKnowledgeProposals(_ context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error) {
+	f.listProposalsCampaign = campaignID
+	return f.pendingProposals, f.listProposalsErr
+}
+
+func (f *fakeCampaignStore) GetPendingKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) (storage.KnowledgeProposal, error) {
+	f.getProposalCampaign = campaignID
+	if f.getProposalErr != nil {
+		return storage.KnowledgeProposal{}, f.getProposalErr
+	}
+	return f.getProposal, nil
+}
+
+func (f *fakeCampaignStore) ApproveKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
+	f.approveCampaign = campaignID
+	f.approveCalls = append(f.approveCalls, id)
+	return f.approveErr
+}
+
+func (f *fakeCampaignStore) RejectKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
+	f.rejectCampaign = campaignID
+	f.rejectCalls = append(f.rejectCalls, id)
+	return f.rejectErr
+}
+
+func (f *fakeCampaignStore) SimilarNodes(_ context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.KGNode, error) {
+	f.similarCalls++
+	f.similarQueryVec = query
+	if f.similarErr != nil {
+		return nil, f.similarErr
+	}
+	return f.similarResults, nil
+}
+
+// fakeEmbedder records its input texts and returns a fixed vector (or an error).
+type fakeEmbedder struct {
+	texts []string
+	vec   []float32
+	err   error
+}
+
+func (e *fakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	e.texts = append(e.texts, texts...)
+	if e.err != nil {
+		return nil, e.err
+	}
+	return [][]float32{e.vec}, nil
+}
+
+// proposalRaw marshals a ProposedWrite into a proposal row's jsonb.
+func proposalRaw(t *testing.T, w tool.ProposedWrite) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestListKnowledgeProposals_MapsThreeKinds asserts the jsonb→oneof mapping for
+// fact/edge/node and that an unparseable row is still listed with an unset write.
+func TestListKnowledgeProposals_MapsThreeKinds(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
+	store.pendingProposals = []storage.KnowledgeProposal{
+		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Bart", CreatedAt: time.Now(),
+			ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"})},
+		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Glyphoxa", CreatedAt: time.Now(),
+			ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "edge", Subject: "Bart", Relation: "resides_in", Target: "Inn"})},
+		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Glyphoxa", CreatedAt: time.Now(),
+			ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "node", NodeType: "faction", Name: "Zhent", Body: "shadow"})},
+		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Glyphoxa", CreatedAt: time.Now(),
+			ProposedWrite: json.RawMessage(`{"garbage":true}`)},
+	}
+	client := crudClient(t, store)
+
+	resp, err := client.ListKnowledgeProposals(context.Background(),
+		connect.NewRequest(&managementv1.ListKnowledgeProposalsRequest{}))
+	if err != nil {
+		t.Fatalf("ListKnowledgeProposals: %v", err)
+	}
+	ps := resp.Msg.GetProposals()
+	if len(ps) != 4 {
+		t.Fatalf("got %d proposals, want 4 (incl. the unparseable one)", len(ps))
+	}
+	if ps[0].GetFact() == nil || ps[0].GetFact().GetFact() != "Fears dark" || ps[0].GetAuthoringAgentName() != "Bart" {
+		t.Errorf("fact mapping wrong: %+v", ps[0])
+	}
+	if e := ps[1].GetEdge(); e == nil || e.GetRelation() != managementv1.EdgeType_EDGE_TYPE_RESIDES_IN || e.GetTarget() != "Inn" {
+		t.Errorf("edge mapping wrong: %+v", ps[1])
+	}
+	if n := ps[2].GetNode(); n == nil || n.GetNodeType() != managementv1.NodeType_NODE_TYPE_FACTION || n.GetName() != "Zhent" {
+		t.Errorf("node mapping wrong: %+v", ps[2])
+	}
+	// Unparseable: write oneof unset, but still present.
+	if ps[3].GetFact() != nil || ps[3].GetEdge() != nil || ps[3].GetNode() != nil {
+		t.Errorf("unparseable row should have unset write oneof: %+v", ps[3])
+	}
+	if store.listProposalsCampaign != store.campaign.ID {
+		t.Errorf("list scoped to %s, want active %s", store.listProposalsCampaign, store.campaign.ID)
+	}
+}
+
+func TestListKnowledgeProposals_NoCampaignIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campErr = storage.ErrNotFound
+	client := crudClient(t, store)
+	_, err := client.ListKnowledgeProposals(context.Background(),
+		connect.NewRequest(&managementv1.ListKnowledgeProposalsRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}
+
+// TestApproveKnowledgeProposal_ErrorMapping covers the whole error surface.
+func TestApproveKnowledgeProposal_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		client := crudClient(t, store)
+		_, err := client.ApproveKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: "not-a-uuid"}))
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", got)
+		}
+	})
+
+	t.Run("happy path scopes to active campaign", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		client := crudClient(t, store)
+		id := uuid.New()
+		if _, err := client.ApproveKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: id.String()})); err != nil {
+			t.Fatalf("approve: %v", err)
+		}
+		if store.approveCampaign != store.campaign.ID || len(store.approveCalls) != 1 || store.approveCalls[0] != id {
+			t.Errorf("approve not scoped/forwarded: campaign=%s calls=%v", store.approveCampaign, store.approveCalls)
+		}
+	})
+
+	t.Run("not found is NotFound", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.approveErr = storage.ErrNotFound
+		client := crudClient(t, store)
+		_, err := client.ApproveKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: uuid.New().String()}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("blocked is FailedPrecondition with verbatim reason", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.approveErr = &storage.ProposalBlockedError{Reason: `no wiki entry named "Waterdeep" — create it first, then approve; or reject`}
+		client := crudClient(t, store)
+		_, err := client.ApproveKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: uuid.New().String()}))
+		if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+			t.Fatalf("code = %v, want FailedPrecondition", got)
+		}
+		if !strings.Contains(err.Error(), `no wiki entry named "Waterdeep" — create it first, then approve; or reject`) {
+			t.Errorf("error = %q, want the verbatim storage reason", err.Error())
+		}
+	})
+}
+
+func TestRejectKnowledgeProposal_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		client := crudClient(t, store)
+		_, err := client.RejectKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: "x"}))
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", got)
+		}
+	})
+
+	t.Run("not found is NotFound", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.rejectErr = storage.ErrNotFound
+		client := crudClient(t, store)
+		_, err := client.RejectKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: uuid.New().String()}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("happy path forwards id", func(t *testing.T) {
+		store := newFakeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		client := crudClient(t, store)
+		id := uuid.New()
+		if _, err := client.RejectKnowledgeProposal(context.Background(),
+			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: id.String()})); err != nil {
+			t.Fatalf("reject: %v", err)
+		}
+		if len(store.rejectCalls) != 1 || store.rejectCalls[0] != id {
+			t.Errorf("reject not forwarded: %v", store.rejectCalls)
+		}
+	})
+}
+
+// TestListSimilarKnowledge_EmbedderPath: with an embedder wired, the subject text
+// is embedded and SimilarNodes is queried with the resulting vector.
+func TestListSimilarKnowledge_EmbedderPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.getProposal = storage.KnowledgeProposal{
+		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"}),
+	}
+	store.similarResults = []storage.KGNode{{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}}
+	emb := &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}}
+	client := crudClientWithEmbedder(t, store, emb)
+
+	resp, err := client.ListSimilarKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
+	if err != nil {
+		t.Fatalf("ListSimilarKnowledge: %v", err)
+	}
+	if len(resp.Msg.GetNodes()) != 1 || resp.Msg.GetNodes()[0].GetName() != "Bart" {
+		t.Errorf("nodes = %+v, want [Bart]", resp.Msg.GetNodes())
+	}
+	if store.similarCalls != 1 {
+		t.Errorf("SimilarNodes called %d times, want 1 (vector path)", store.similarCalls)
+	}
+	if len(emb.texts) != 1 || emb.texts[0] != "Bart: Fears dark" {
+		t.Errorf("embedded texts = %v, want [\"Bart: Fears dark\"]", emb.texts)
+	}
+}
+
+// TestListSimilarKnowledge_NilEmbedderFallsBackToFTS: with no embedder, the hint
+// runs SearchNodes with the subject text.
+func TestListSimilarKnowledge_NilEmbedderFallsBackToFTS(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.getProposal = storage.KnowledgeProposal{
+		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "node", Name: "Zhent", Body: "shadow"}),
+	}
+	store.searchResults = []storage.KGNode{{ID: uuid.New(), Type: storage.KGNodeFaction, Name: "Zhentarim"}}
+	client := crudClient(t, store) // no embedder
+
+	resp, err := client.ListSimilarKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
+	if err != nil {
+		t.Fatalf("ListSimilarKnowledge: %v", err)
+	}
+	if store.similarCalls != 0 {
+		t.Errorf("vector SimilarNodes called %d times, want 0 (no embedder)", store.similarCalls)
+	}
+	if store.searchCalls != 1 || store.searchQuery != "Zhent\n\nshadow" {
+		t.Errorf("fts search: calls=%d query=%q, want 1 / %q", store.searchCalls, store.searchQuery, "Zhent\n\nshadow")
+	}
+	if len(resp.Msg.GetNodes()) != 1 {
+		t.Errorf("nodes = %+v, want 1", resp.Msg.GetNodes())
+	}
+}
+
+// TestListSimilarKnowledge_EmbedErrorFallsBackToFTS: an embed error degrades
+// silently to fulltext search rather than failing the review.
+func TestListSimilarKnowledge_EmbedErrorFallsBackToFTS(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.getProposal = storage.KnowledgeProposal{
+		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "edge", Subject: "Bart", Relation: "knows", Target: "Gundren"}),
+	}
+	emb := &fakeEmbedder{err: errors.New("provider down")}
+	client := crudClientWithEmbedder(t, store, emb)
+
+	if _, err := client.ListSimilarKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()})); err != nil {
+		t.Fatalf("ListSimilarKnowledge: %v", err)
+	}
+	if store.similarCalls != 0 {
+		t.Errorf("vector path ran despite embed error: %d", store.similarCalls)
+	}
+	if store.searchCalls != 1 || store.searchQuery != "Bart knows Gundren" {
+		t.Errorf("fts fallback: calls=%d query=%q", store.searchCalls, store.searchQuery)
+	}
+}
+
+// TestListSimilarKnowledge_MissingProposalIsNotFound: an already-reviewed/gone
+// proposal is CodeNotFound.
+func TestListSimilarKnowledge_MissingProposalIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	store.getProposalErr = storage.ErrNotFound
+	client := crudClient(t, store)
+	_, err := client.ListSimilarKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+}

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -140,56 +140,72 @@ func pgErrCode(err error) (string, bool) {
 // a duplicate (from, to, type) yields ErrConflict. Validation on the immutable
 // node_type is sound without a trigger because a Node's type never changes.
 func (s *Store) CreateEdge(ctx context.Context, e NewKGEdge) (KGEdge, error) {
-	if e.FromNodeID == e.ToNodeID {
-		return KGEdge{}, ErrInvalidEdge
-	}
-
 	var created KGEdge
 	err := s.InTx(ctx, func(tx *Store) error {
-		rows, err := tx.db.Query(ctx,
-			`SELECT id, node_type FROM kg_node WHERE id IN ($1, $2) AND campaign_id = $3`,
-			e.FromNodeID, e.ToNodeID, e.CampaignID)
+		c, err := createEdgeTx(ctx, tx, e)
 		if err != nil {
-			return fmt.Errorf("storage: create edge: load endpoints: %w", err)
-		}
-		types := map[uuid.UUID]KGNodeType{}
-		for rows.Next() {
-			var id uuid.UUID
-			var t KGNodeType
-			if err := rows.Scan(&id, &t); err != nil {
-				rows.Close()
-				return fmt.Errorf("storage: create edge: scan endpoint: %w", err)
-			}
-			types[id] = t
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf("storage: create edge: load endpoints: %w", err)
-		}
-
-		fromType, okFrom := types[e.FromNodeID]
-		toType, okTo := types[e.ToNodeID]
-		if !okFrom || !okTo {
-			return ErrNotFound
-		}
-		if err := ValidateEdge(e.Type, fromType, toType); err != nil {
 			return err
-		}
-
-		row := tx.db.QueryRow(ctx,
-			`INSERT INTO kg_edge (campaign_id, from_node_id, to_node_id, edge_type)
-			 VALUES ($1, $2, $3, $4::kg_edge_type)
-			 RETURNING `+kgEdgeColumns,
-			e.CampaignID, e.FromNodeID, e.ToNodeID, e.Type)
-		c, err := scanKGEdge(row)
-		if err != nil {
-			return mapEdgeWriteErr("insert edge", err)
 		}
 		created = c
 		return nil
 	})
 	if err != nil {
 		return KGEdge{}, err
+	}
+	return created, nil
+}
+
+// createEdgeTx is the shared Edge-creation body run INSIDE an existing
+// transaction (#300): it self-edge-rejects, loads both endpoints' types
+// campaign-scoped, enforces the validity matrix, and INSERTs — the exact steps
+// CreateEdge used to inline. It is reused by ApproveKnowledgeProposal so an
+// approved edge proposal lands under the SAME tx that claims the proposal row,
+// with behaviour identical to a GM-authored CreateEdge (self-edge → ErrInvalidEdge,
+// missing/cross-campaign endpoint → ErrNotFound, matrix violation → ErrInvalidEdge,
+// duplicate → ErrConflict). tx MUST already be a transaction-bound Store.
+func createEdgeTx(ctx context.Context, tx *Store, e NewKGEdge) (KGEdge, error) {
+	if e.FromNodeID == e.ToNodeID {
+		return KGEdge{}, ErrInvalidEdge
+	}
+
+	rows, err := tx.db.Query(ctx,
+		`SELECT id, node_type FROM kg_node WHERE id IN ($1, $2) AND campaign_id = $3`,
+		e.FromNodeID, e.ToNodeID, e.CampaignID)
+	if err != nil {
+		return KGEdge{}, fmt.Errorf("storage: create edge: load endpoints: %w", err)
+	}
+	types := map[uuid.UUID]KGNodeType{}
+	for rows.Next() {
+		var id uuid.UUID
+		var t KGNodeType
+		if err := rows.Scan(&id, &t); err != nil {
+			rows.Close()
+			return KGEdge{}, fmt.Errorf("storage: create edge: scan endpoint: %w", err)
+		}
+		types[id] = t
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return KGEdge{}, fmt.Errorf("storage: create edge: load endpoints: %w", err)
+	}
+
+	fromType, okFrom := types[e.FromNodeID]
+	toType, okTo := types[e.ToNodeID]
+	if !okFrom || !okTo {
+		return KGEdge{}, ErrNotFound
+	}
+	if err := ValidateEdge(e.Type, fromType, toType); err != nil {
+		return KGEdge{}, err
+	}
+
+	row := tx.db.QueryRow(ctx,
+		`INSERT INTO kg_edge (campaign_id, from_node_id, to_node_id, edge_type)
+		 VALUES ($1, $2, $3, $4::kg_edge_type)
+		 RETURNING `+kgEdgeColumns,
+		e.CampaignID, e.FromNodeID, e.ToNodeID, e.Type)
+	created, err := scanKGEdge(row)
+	if err != nil {
+		return KGEdge{}, mapEdgeWriteErr("insert edge", err)
 	}
 	return created, nil
 }

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -104,11 +104,16 @@ type KGNodeUpdate struct {
 // so a Node in another Campaign matches no row and yields ErrNotFound — a
 // cross-campaign mutation is refused server-side. A missing id yields ErrNotFound.
 func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) {
+	// A wiki edit invalidates any existing embedding: reset it to NULL and clear
+	// the model stamp so the row re-enters the embedworker backfill queue (#300,
+	// ADR-0011) and future similarity hints reflect the new text.
 	row := s.db.QueryRow(ctx,
 		`UPDATE kg_node SET
 		    name = $2,
 		    body = $3,
 		    gm_private = $4,
+		    embedding = NULL,
+		    embedding_model = '',
 		    updated_at = now()
 		  WHERE id = $1 AND campaign_id = $5
 		 RETURNING `+kgNodeColumns,
@@ -226,4 +231,102 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 		return nil, fmt.Errorf("storage: agent node facts for agent %s: %w", agentID, err)
 	}
 	return out, nil
+}
+
+// SimilarNodes returns the k Knowledge Graph Nodes in campaignID nearest the
+// query vector by cosine distance (<=>), nearest first — the ADR-0011 similarity
+// hint the GM review surface shows beside a Knowledge Proposal (#300, ADR-0052).
+// NULL-embedding rows are excluded (the partial HNSW index). Unlike the
+// prompt-facing searches this INCLUDES gm_private Nodes: it is GM-facing review
+// only, so the exclusion that guards NPC prompts does not apply here. NEVER reuse
+// this for NPC prompt assembly — it would leak GM secrets. k <= 0 is a caller bug
+// and errors. The query vector reuses encodeVector + a server-side ::vector cast,
+// so storage carries no pgvector-go dependency.
+func (s *Store) SimilarNodes(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]KGNode, error) {
+	if k <= 0 {
+		return nil, fmt.Errorf("storage: similar nodes: k must be > 0, got %d", k)
+	}
+	rows, err := s.db.Query(ctx,
+		`SELECT `+kgNodeColumns+`
+		   FROM kg_node
+		  WHERE campaign_id = $1 AND embedding IS NOT NULL
+		  ORDER BY embedding <=> $2::vector
+		  LIMIT $3`, campaignID, encodeVector(query), k)
+	if err != nil {
+		return nil, fmt.Errorf("storage: similar kg nodes for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []KGNode
+	for rows.Next() {
+		n, err := scanKGNode(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan similar kg node: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: similar kg nodes for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}
+
+// ListUnembeddedNodes returns up to limit Knowledge Graph Nodes still awaiting an
+// embedding (embedding IS NULL), oldest first — the node half of the embedworker
+// backfill queue (#300, ADR-0011), mirroring ListUnembeddedChunks. An empty
+// result means the backlog is drained. The name+body is embedded by the worker;
+// both columns are selected via kgNodeColumns.
+func (s *Store) ListUnembeddedNodes(ctx context.Context, limit int) ([]KGNode, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+kgNodeColumns+`
+		   FROM kg_node
+		  WHERE embedding IS NULL
+		  ORDER BY created_at, id
+		  LIMIT $1`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list unembedded kg nodes: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KGNode
+	for rows.Next() {
+		n, err := scanKGNode(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan unembedded kg node: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list unembedded kg nodes: %w", err)
+	}
+	return out, nil
+}
+
+// SetNodeEmbedding fills one Node's embedding vector and stamps the model that
+// produced it (#300, ADR-0011), mirroring SetChunkEmbedding. The vector is passed
+// as pgvector's text form and cast server-side (::vector) so storage carries no
+// pgvector-go dependency; the column is vector(768), so a wrong-length vector is
+// rejected by Postgres. Once set, the row leaves the NULL-embedding backlog and
+// becomes returnable by SimilarNodes.
+func (s *Store) SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error {
+	if _, err := s.db.Exec(ctx,
+		`UPDATE kg_node
+		    SET embedding = $2::vector, embedding_model = $3
+		  WHERE id = $1`, id, encodeVector(vec), model); err != nil {
+		return fmt.Errorf("storage: set kg node embedding %s: %w", id, err)
+	}
+	return nil
+}
+
+// CountUnembeddedNodes returns the number of Knowledge Graph Nodes still awaiting
+// an embedding (embedding IS NULL) — the node embedding-backlog gauge value (#300,
+// ADR-0032), mirroring CountUnembeddedChunks. Process-wide (no campaign filter) to
+// keep the metric's cardinality bounded.
+func (s *Store) CountUnembeddedNodes(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRow(ctx,
+		`SELECT count(*) FROM kg_node WHERE embedding IS NULL`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("storage: count unembedded kg nodes: %w", err)
+	}
+	return n, nil
 }

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -104,16 +104,22 @@ type KGNodeUpdate struct {
 // so a Node in another Campaign matches no row and yields ErrNotFound — a
 // cross-campaign mutation is refused server-side. A missing id yields ErrNotFound.
 func (s *Store) UpdateNode(ctx context.Context, u KGNodeUpdate) (KGNode, error) {
-	// A wiki edit invalidates any existing embedding: reset it to NULL and clear
-	// the model stamp so the row re-enters the embedworker backfill queue (#300,
-	// ADR-0011) and future similarity hints reflect the new text.
+	// A wiki edit that changes the embedded TEXT (name or body) invalidates any
+	// existing embedding: reset it to NULL + clear the model stamp so the row
+	// re-enters the embedworker backfill queue (#300, ADR-0011) and future
+	// similarity hints reflect the new text. A gm_private-only toggle leaves the
+	// embedding intact (the vector is unchanged), avoiding a needless re-embed. The
+	// CASE keys off IS DISTINCT FROM so the decision is made in the same statement
+	// with no extra read.
 	row := s.db.QueryRow(ctx,
 		`UPDATE kg_node SET
+		    embedding = CASE WHEN name IS DISTINCT FROM $2 OR body IS DISTINCT FROM $3
+		                     THEN NULL ELSE embedding END,
+		    embedding_model = CASE WHEN name IS DISTINCT FROM $2 OR body IS DISTINCT FROM $3
+		                           THEN '' ELSE embedding_model END,
 		    name = $2,
 		    body = $3,
 		    gm_private = $4,
-		    embedding = NULL,
-		    embedding_model = '',
 		    updated_at = now()
 		  WHERE id = $1 AND campaign_id = $5
 		 RETURNING `+kgNodeColumns,
@@ -308,11 +314,18 @@ func (s *Store) ListUnembeddedNodes(ctx context.Context, limit int) ([]KGNode, e
 // pgvector-go dependency; the column is vector(768), so a wrong-length vector is
 // rejected by Postgres. Once set, the row leaves the NULL-embedding backlog and
 // becomes returnable by SimilarNodes.
-func (s *Store) SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string) error {
+//
+// Unlike a Transcript Chunk, a Node is MUTABLE: a GM edit or a fact-approval can
+// reset the embedding to NULL and bump updated_at WHILE the worker's (up to 60s)
+// Embed call is in flight. Writing the now-stale vector back would install a v1
+// vector on a v2 row and it would never re-embed (embedding IS NOT NULL). So the
+// write is guarded on the updated_at the worker LISTED: a row edited since is not
+// matched (0 rows) and stays NULL for the next pass to re-embed with fresh text.
+func (s *Store) SetNodeEmbedding(ctx context.Context, id uuid.UUID, vec []float32, model string, updatedAt time.Time) error {
 	if _, err := s.db.Exec(ctx,
 		`UPDATE kg_node
 		    SET embedding = $2::vector, embedding_model = $3
-		  WHERE id = $1`, id, encodeVector(vec), model); err != nil {
+		  WHERE id = $1 AND updated_at = $4`, id, encodeVector(vec), model, updatedAt); err != nil {
 		return fmt.Errorf("storage: set kg node embedding %s: %w", id, err)
 	}
 	return nil

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -193,14 +193,22 @@ func (tx *Store) applyProposedFact(ctx context.Context, campaignID uuid.UUID, w 
 	if err != nil {
 		return err
 	}
-	if _, err := tx.db.Exec(ctx,
+	tag, err := tx.db.Exec(ctx,
 		`UPDATE kg_node
 		    SET body = CASE WHEN body = '' THEN $2 ELSE body || E'\n\n' || $2 END,
 		        embedding = NULL,
 		        embedding_model = '',
 		        updated_at = now()
-		  WHERE id = $1 AND campaign_id = $3`, anchor, w.Fact, campaignID); err != nil {
+		  WHERE id = $1 AND campaign_id = $3`, anchor, w.Fact, campaignID)
+	if err != nil {
 		return fmt.Errorf("storage: approve fact: append body: %w", err)
+	}
+	// The anchor was resolved earlier in this same tx, but a concurrent DELETE could
+	// land between resolve and UPDATE. 0 rows means the entry is gone: block (tx
+	// rolls back, row stays pending) rather than silently swallow the fact —
+	// consistent with the edge path's dangling-endpoint refusal.
+	if tag.RowsAffected() == 0 {
+		return &ProposalBlockedError{Reason: "the entry this proposal is about no longer exists — reject it"}
 	}
 	return nil
 }

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
 // Knowledge Proposal persistence (ADR-0052, #300): the pending queue an Agent's
@@ -20,28 +23,47 @@ import (
 // approval time.
 
 // KnowledgeProposal is one persisted proposal row. ProposedWrite is the raw
-// jsonb tagged union; ReviewedAt is nil until the GM acts.
+// jsonb tagged union; ReviewedAt is nil until the GM acts. AuthoringAgentName is
+// the filing Agent's display name, joined from the agents table by the list/get
+// reads (empty on a bare row that skipped the join).
 type KnowledgeProposal struct {
-	ID               uuid.UUID
-	CampaignID       uuid.UUID
-	AuthoringAgentID uuid.UUID
-	ProposedWrite    json.RawMessage
-	Status           string
-	CreatedAt        time.Time
-	ReviewedAt       *time.Time
+	ID                 uuid.UUID
+	CampaignID         uuid.UUID
+	AuthoringAgentID   uuid.UUID
+	AuthoringAgentName string
+	ProposedWrite      json.RawMessage
+	Status             string
+	CreatedAt          time.Time
+	ReviewedAt         *time.Time
 }
 
-const knowledgeProposalColumns = `
-	id, campaign_id, authoring_agent_id, proposed_write, status, created_at, reviewed_at`
+// knowledgeProposalJoinColumns selects the proposal columns plus the joined
+// authoring Agent name — the review surface shows "who proposed this". The JOIN is
+// inner: an authoring_agent_id always references a live agents row (ON DELETE
+// CASCADE reaps the proposal with its Agent), so a pending proposal always has a
+// name.
+const knowledgeProposalJoinColumns = `
+	p.id, p.campaign_id, p.authoring_agent_id, a.name,
+	p.proposed_write, p.status, p.created_at, p.reviewed_at`
 
-func scanKnowledgeProposal(row pgx.Row) (KnowledgeProposal, error) {
+func scanKnowledgeProposalJoined(row pgx.Row) (KnowledgeProposal, error) {
 	var p KnowledgeProposal
 	err := row.Scan(
-		&p.ID, &p.CampaignID, &p.AuthoringAgentID, &p.ProposedWrite,
-		&p.Status, &p.CreatedAt, &p.ReviewedAt,
+		&p.ID, &p.CampaignID, &p.AuthoringAgentID, &p.AuthoringAgentName,
+		&p.ProposedWrite, &p.Status, &p.CreatedAt, &p.ReviewedAt,
 	)
 	return p, err
 }
+
+// ProposalBlockedError is returned by ApproveKnowledgeProposal when the proposed
+// write cannot land as-is (an unresolvable/ambiguous subject, a dangling anchor,
+// an edge matrix violation or duplicate, or an unreadable payload). Reason is a
+// human-actionable message the GM sees; the proposal row stays pending so the GM
+// can fix the wiki and re-approve, or reject. The RPC layer maps it to
+// CodeFailedPrecondition with Reason verbatim.
+type ProposalBlockedError struct{ Reason string }
+
+func (e *ProposalBlockedError) Error() string { return e.Reason }
 
 // CreateKnowledgeProposal inserts a pending proposal and returns the persisted
 // row. proposedWrite is the raw jsonb payload (the caller marshals it). There is
@@ -63,10 +85,11 @@ func (s *Store) CreateKnowledgeProposal(ctx context.Context, campaignID, agentID
 // queue yields an empty slice, not an error.
 func (s *Store) ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]KnowledgeProposal, error) {
 	rows, err := s.db.Query(ctx,
-		`SELECT `+knowledgeProposalColumns+`
-		   FROM knowledge_proposal
-		  WHERE campaign_id = $1 AND status = 'pending'
-		  ORDER BY created_at, id`, campaignID)
+		`SELECT `+knowledgeProposalJoinColumns+`
+		   FROM knowledge_proposal p
+		   JOIN agents a ON a.id = p.authoring_agent_id
+		  WHERE p.campaign_id = $1 AND p.status = 'pending'
+		  ORDER BY p.created_at, p.id`, campaignID)
 	if err != nil {
 		return nil, fmt.Errorf("storage: list pending knowledge proposals: %w", err)
 	}
@@ -74,7 +97,7 @@ func (s *Store) ListPendingKnowledgeProposals(ctx context.Context, campaignID uu
 
 	var out []KnowledgeProposal
 	for rows.Next() {
-		p, err := scanKnowledgeProposal(rows)
+		p, err := scanKnowledgeProposalJoined(rows)
 		if err != nil {
 			return nil, fmt.Errorf("storage: scan knowledge proposal: %w", err)
 		}
@@ -84,6 +107,231 @@ func (s *Store) ListPendingKnowledgeProposals(ctx context.Context, campaignID uu
 		return nil, fmt.Errorf("storage: list pending knowledge proposals: %w", err)
 	}
 	return out, nil
+}
+
+// GetPendingKnowledgeProposal loads a single PENDING proposal by id, scoped to its
+// Campaign and joined to its authoring Agent's name (#300, ADR-0052). An
+// already-reviewed or missing id — or one in another Campaign — yields ErrNotFound;
+// the review surface uses it to build the similarity-hint query for a live
+// proposal only.
+func (s *Store) GetPendingKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) (KnowledgeProposal, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+knowledgeProposalJoinColumns+`
+		   FROM knowledge_proposal p
+		   JOIN agents a ON a.id = p.authoring_agent_id
+		  WHERE p.id = $1 AND p.campaign_id = $2 AND p.status = 'pending'`, id, campaignID)
+	p, err := scanKnowledgeProposalJoined(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return KnowledgeProposal{}, ErrNotFound
+	}
+	if err != nil {
+		return KnowledgeProposal{}, fmt.Errorf("storage: get pending knowledge proposal %s: %w", id, err)
+	}
+	return p, nil
+}
+
+// ApproveKnowledgeProposal lands a pending proposal's write on the Knowledge Graph
+// and marks it approved — ATOMICALLY (#300, ADR-0052): the claim UPDATE and the KG
+// write share one transaction, so a refused write rolls the claim back and the row
+// stays pending (never a half-approved proposal, never a lost race). The claim is
+// conditional on status='pending' and takes the row lock, so a concurrent
+// double-approve sees 0 rows and yields ErrNotFound. An unreadable payload (wrong
+// version / unknown kind) or an unlandable write (unresolvable/ambiguous subject,
+// dangling anchor, edge matrix violation, duplicate, self-edge) yields a
+// *ProposalBlockedError with a human reason and leaves the row pending.
+//
+// Per ADR-0052 there is NO auto-merge: a fact/edge subject that names no wiki
+// entry is refused with an actionable message, never silently created or fuzzily
+// matched.
+func (s *Store) ApproveKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error {
+	return s.InTx(ctx, func(tx *Store) error {
+		var raw json.RawMessage
+		err := tx.db.QueryRow(ctx,
+			`UPDATE knowledge_proposal
+			    SET status = 'approved', reviewed_at = now()
+			  WHERE id = $1 AND campaign_id = $2 AND status = 'pending'
+			 RETURNING proposed_write`, id, campaignID).Scan(&raw)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("storage: approve knowledge proposal %s: claim: %w", id, err)
+		}
+
+		var w tool.ProposedWrite
+		if err := json.Unmarshal(raw, &w); err != nil {
+			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
+		}
+		if w.V != proposalWriteVersion {
+			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
+		}
+		switch w.Kind {
+		case "fact":
+			return tx.applyProposedFact(ctx, campaignID, w)
+		case "edge":
+			return tx.applyProposedEdge(ctx, campaignID, w)
+		case "node":
+			return tx.applyProposedNode(ctx, campaignID, w)
+		default:
+			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
+		}
+	})
+}
+
+// proposalWriteVersion mirrors tool's stamped schema version (ADR-0052 "v":1). An
+// approved row whose version differs is unreadable and must be rejected.
+const proposalWriteVersion = 1
+
+// applyProposedFact appends the proposal's fact sentence to the target Node's body
+// (blank body → the fact alone; non-blank → separated by a blank line) and resets
+// the Node's embedding so the edit re-enters the backfill queue. The anchor is the
+// proposal's NodeID when set (an own_node NPC proposal), else the Subject resolved
+// by name. A NodeID that no longer resolves is blocked (the entry was deleted
+// after the proposal was filed). Runs inside the approval tx.
+func (tx *Store) applyProposedFact(ctx context.Context, campaignID uuid.UUID, w tool.ProposedWrite) error {
+	anchor, err := tx.resolveProposalAnchor(ctx, campaignID, w.NodeID, w.Subject)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.db.Exec(ctx,
+		`UPDATE kg_node
+		    SET body = CASE WHEN body = '' THEN $2 ELSE body || E'\n\n' || $2 END,
+		        embedding = NULL,
+		        embedding_model = '',
+		        updated_at = now()
+		  WHERE id = $1 AND campaign_id = $3`, anchor, w.Fact, campaignID); err != nil {
+		return fmt.Errorf("storage: approve fact: append body: %w", err)
+	}
+	return nil
+}
+
+// applyProposedEdge creates the proposed Edge inside the approval tx, reusing the
+// exact GM-authored CreateEdge path (createEdgeTx: endpoint load + validity matrix
+// + insert). The FROM Node is the NodeID when set, else the Subject resolved by
+// name; the TO Node is the Target resolved by name (Target is a NAME until
+// approval, ADR-0052). CreateEdge's storage errors are translated to human
+// ProposalBlockedError reasons the GM can act on.
+func (tx *Store) applyProposedEdge(ctx context.Context, campaignID uuid.UUID, w tool.ProposedWrite) error {
+	from, err := tx.resolveProposalAnchor(ctx, campaignID, w.NodeID, w.Subject)
+	if err != nil {
+		return err
+	}
+	to, err := tx.resolveNodeByName(ctx, campaignID, w.Target)
+	if err != nil {
+		return err
+	}
+	_, err = createEdgeTx(ctx, tx, NewKGEdge{
+		CampaignID: campaignID,
+		FromNodeID: from,
+		ToNodeID:   to,
+		Type:       KGEdgeType(w.Relation),
+	})
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrConflict):
+		return &ProposalBlockedError{Reason: "this relationship already exists — reject the proposal"}
+	case errors.Is(err, ErrInvalidEdge):
+		// Self-edge or a validity-matrix violation: an actionable structural refusal.
+		return &ProposalBlockedError{Reason: fmt.Sprintf(
+			"a %q relationship isn't allowed between these entries — reject the proposal", w.Relation)}
+	case errors.Is(err, ErrNotFound):
+		// createEdgeTx already saw both resolved ids; a not-found here means the row
+		// vanished mid-tx. Treat as a blocked, re-triable refusal.
+		return &ProposalBlockedError{Reason: "one of the entries this relationship connects no longer exists — reject it"}
+	default:
+		return fmt.Errorf("storage: approve edge: %w", err)
+	}
+}
+
+// applyProposedNode inserts the proposed brand-new Node (Butler-scope, gm_private
+// false, embedding NULL so the backfill worker embeds it) inside the approval tx.
+func (tx *Store) applyProposedNode(ctx context.Context, campaignID uuid.UUID, w tool.ProposedWrite) error {
+	if _, err := tx.db.Exec(ctx,
+		`INSERT INTO kg_node (campaign_id, node_type, name, body, gm_private)
+		 VALUES ($1, $2::kg_node_type, $3, $4, false)`,
+		campaignID, w.NodeType, w.Name, w.Body); err != nil {
+		return fmt.Errorf("storage: approve node: insert: %w", err)
+	}
+	return nil
+}
+
+// resolveProposalAnchor resolves the Node a fact/edge proposal attaches to: the
+// nodeID when the proposal carries one (an own_node NPC proposal anchored on its
+// linked Node), else the subject resolved by name. A nodeID that no longer resolves
+// in this Campaign is blocked (the entry was deleted after filing).
+func (tx *Store) resolveProposalAnchor(ctx context.Context, campaignID uuid.UUID, nodeID, subject string) (uuid.UUID, error) {
+	if strings.TrimSpace(nodeID) != "" {
+		id, err := uuid.Parse(nodeID)
+		if err != nil {
+			return uuid.Nil, &ProposalBlockedError{Reason: "the entry this proposal is about no longer exists — reject it"}
+		}
+		var exists bool
+		if err := tx.db.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM kg_node WHERE id = $1 AND campaign_id = $2)`,
+			id, campaignID).Scan(&exists); err != nil {
+			return uuid.Nil, fmt.Errorf("storage: resolve proposal anchor: %w", err)
+		}
+		if !exists {
+			return uuid.Nil, &ProposalBlockedError{Reason: "the entry this proposal is about no longer exists — reject it"}
+		}
+		return id, nil
+	}
+	return tx.resolveNodeByName(ctx, campaignID, subject)
+}
+
+// resolveNodeByName resolves a Node by case-insensitive, trimmed name within a
+// Campaign — the ADR-0052 no-auto-merge resolution: exactly one match lands, zero
+// or many are refused with an actionable reason so the GM fixes the wiki first. It
+// never creates or fuzzily matches.
+func (tx *Store) resolveNodeByName(ctx context.Context, campaignID uuid.UUID, name string) (uuid.UUID, error) {
+	display := strings.TrimSpace(name)
+	rows, err := tx.db.Query(ctx,
+		`SELECT id FROM kg_node WHERE campaign_id = $1 AND lower(name) = lower(btrim($2))`,
+		campaignID, name)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("storage: resolve node by name: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return uuid.Nil, fmt.Errorf("storage: resolve node by name: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return uuid.Nil, fmt.Errorf("storage: resolve node by name: %w", err)
+	}
+	switch len(ids) {
+	case 1:
+		return ids[0], nil
+	case 0:
+		return uuid.Nil, &ProposalBlockedError{Reason: fmt.Sprintf(
+			"no wiki entry named %q — create it first, then approve; or reject", display)}
+	default:
+		return uuid.Nil, &ProposalBlockedError{Reason: fmt.Sprintf(
+			"multiple entries named %q — rename one first", display)}
+	}
+}
+
+// RejectKnowledgeProposal drops a pending proposal (status rejected, reviewed_at
+// stamped) WITHOUT touching the KG (#300, ADR-0052). The row is kept for audit. A
+// missing/already-reviewed id — or one in another Campaign — yields ErrNotFound.
+func (s *Store) RejectKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE knowledge_proposal
+		    SET status = 'rejected', reviewed_at = now()
+		  WHERE id = $1 AND campaign_id = $2 AND status = 'pending'`, id, campaignID)
+	if err != nil {
+		return fmt.Errorf("storage: reject knowledge proposal %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // AgentLinkedNode returns the Node an Agent is linked to (the NPC-Node↔Agent

--- a/internal/storage/knowledge_proposal_review_test.go
+++ b/internal/storage/knowledge_proposal_review_test.go
@@ -139,7 +139,7 @@ func TestApproveFactViaNodeID(t *testing.T) {
 		t.Fatalf("CreateNode: %v", err)
 	}
 	// Give it an embedding so we can prove approval resets it.
-	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(0), "m"); err != nil {
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(0), "m", node.UpdatedAt); err != nil {
 		t.Fatalf("SetNodeEmbedding: %v", err)
 	}
 
@@ -408,18 +408,98 @@ func TestNodeEmbeddingRoundTrip(t *testing.T) {
 	if n, _ := st.CountUnembeddedNodes(ctx); n != 1 {
 		t.Errorf("initial unembedded count = %d, want 1", n)
 	}
-	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(3), "m"); err != nil {
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(3), "m", node.UpdatedAt); err != nil {
 		t.Fatalf("SetNodeEmbedding: %v", err)
 	}
 	if n, _ := st.CountUnembeddedNodes(ctx); n != 0 {
 		t.Errorf("after embed count = %d, want 0", n)
 	}
-	// UpdateNode resets the embedding.
-	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: node.ID, CampaignID: campaignID, Name: "N", Body: "b2"}); err != nil {
+	// A gm_private-only toggle (name+body unchanged) must NOT reset the embedding.
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: node.ID, CampaignID: campaignID, Name: "N", Body: "b", GMPrivate: true}); err != nil {
+		t.Fatalf("UpdateNode (gm toggle): %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 0 {
+		t.Errorf("after gm_private toggle count = %d, want 0 (embedding NOT reset — text unchanged)", n)
+	}
+
+	// A text edit (body changed) DOES reset the embedding.
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: node.ID, CampaignID: campaignID, Name: "N", Body: "b2", GMPrivate: true}); err != nil {
 		t.Fatalf("UpdateNode: %v", err)
 	}
 	if n, _ := st.CountUnembeddedNodes(ctx); n != 1 {
 		t.Errorf("after edit count = %d, want 1 (embedding reset)", n)
+	}
+}
+
+// TestSetNodeEmbeddingStaleGuard: a SetNodeEmbedding whose updated_at no longer
+// matches the row (a concurrent edit bumped it) writes 0 rows and leaves the row
+// unembedded — the embedworker's next pass re-embeds the fresh text. This closes
+// the mutable-node stale-embedding race (a chunk is immutable; a Node is not).
+func TestSetNodeEmbeddingStaleGuard(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	node, err := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "N", Body: "v1"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	staleUpdatedAt := node.UpdatedAt
+
+	// A concurrent edit lands (new text, bumped updated_at, embedding NULLed).
+	edited, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: node.ID, CampaignID: campaignID, Name: "N", Body: "v2"})
+	if err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+
+	// The worker (which listed v1) writes with the STALE updated_at → 0 rows, row
+	// stays unembedded.
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(0), "m", staleUpdatedAt); err != nil {
+		t.Fatalf("SetNodeEmbedding (stale): %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 1 {
+		t.Errorf("after stale write count = %d, want 1 (stale vector must NOT install)", n)
+	}
+
+	// A write with the CURRENT updated_at succeeds.
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(0), "m", edited.UpdatedAt); err != nil {
+		t.Fatalf("SetNodeEmbedding (current): %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 0 {
+		t.Errorf("after fresh write count = %d, want 0", n)
+	}
+}
+
+// TestApproveFactSubjectDeletedBeforeApprove: a fact proposal whose subject entry
+// is deleted before approval is blocked (the fact never silently vanishes) and the
+// row stays pending — the user-visible half of the applyProposedFact RowsAffected
+// backstop.
+func TestApproveFactSubjectDeletedBeforeApprove(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	node, err := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "Rumor", Body: "x"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "fact", Subject: "Rumor", Fact: "It grows.",
+	})
+	if err := st.DeleteNode(ctx, campaignID, node.ID); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+
+	err = st.ApproveKnowledgeProposal(ctx, campaignID, id)
+	var blocked *storage.ProposalBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("approve after delete: got %v, want ProposalBlockedError", err)
+	}
+	if !pendingIDs(t, st, campaignID)[id] {
+		t.Error("blocked proposal must stay pending (fact never silently lost)")
 	}
 }
 
@@ -436,10 +516,10 @@ func TestSimilarNodes(t *testing.T) {
 	a, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "A"})
 	b, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "B"})
 	st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "C"})
-	if err := st.SetNodeEmbedding(ctx, a.ID, unitVec(0), "m"); err != nil {
+	if err := st.SetNodeEmbedding(ctx, a.ID, unitVec(0), "m", a.UpdatedAt); err != nil {
 		t.Fatalf("embed A: %v", err)
 	}
-	if err := st.SetNodeEmbedding(ctx, b.ID, unitVec(1), "m"); err != nil {
+	if err := st.SetNodeEmbedding(ctx, b.ID, unitVec(1), "m", b.UpdatedAt); err != nil {
 		t.Fatalf("embed B: %v", err)
 	}
 
@@ -450,7 +530,7 @@ func TestSimilarNodes(t *testing.T) {
 		t.Fatalf("insert other campaign: %v", err)
 	}
 	on, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: other, Type: storage.KGNodeNote, Name: "Other-A"})
-	st.SetNodeEmbedding(ctx, on.ID, unitVec(0), "m")
+	st.SetNodeEmbedding(ctx, on.ID, unitVec(0), "m", on.UpdatedAt)
 
 	got, err := st.SimilarNodes(ctx, campaignID, unitVec(0), 5)
 	if err != nil {

--- a/internal/storage/knowledge_proposal_review_test.go
+++ b/internal/storage/knowledge_proposal_review_test.go
@@ -1,0 +1,479 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+// seedButlerAgent returns the auto-created Butler's id for a seeded campaign — a
+// live agents row the proposal's authoring_agent_id FK can reference.
+func seedButlerAgent(t *testing.T, st *storage.Store, campaignID uuid.UUID) uuid.UUID {
+	t.Helper()
+	b, err := st.GetButler(context.Background(), campaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	return b.ID
+}
+
+// fileProposal writes one pending proposal and returns its id (via the list read).
+func fileProposal(t *testing.T, st *storage.Store, campaignID, agentID uuid.UUID, w tool.ProposedWrite) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	payload, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal proposed write: %v", err)
+	}
+	before, err := st.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list before: %v", err)
+	}
+	if err := st.CreateKnowledgeProposal(ctx, campaignID, agentID, payload); err != nil {
+		t.Fatalf("CreateKnowledgeProposal: %v", err)
+	}
+	after, err := st.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list after: %v", err)
+	}
+	// Find the id present in after but not before.
+	seen := map[uuid.UUID]bool{}
+	for _, p := range before {
+		seen[p.ID] = true
+	}
+	for _, p := range after {
+		if !seen[p.ID] {
+			return p.ID
+		}
+	}
+	t.Fatal("filed proposal not found in pending list")
+	return uuid.Nil
+}
+
+func nodeBody(t *testing.T, st *storage.Store, campaignID, id uuid.UUID) string {
+	t.Helper()
+	nodes, err := st.ListNodes(context.Background(), campaignID)
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	for _, n := range nodes {
+		if n.ID == id {
+			return n.Body
+		}
+	}
+	t.Fatalf("node %s not found", id)
+	return ""
+}
+
+// pendingIDs is the set of pending-proposal ids for the campaign.
+func pendingIDs(t *testing.T, st *storage.Store, campaignID uuid.UUID) map[uuid.UUID]bool {
+	t.Helper()
+	ps, err := st.ListPendingKnowledgeProposals(context.Background(), campaignID)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	out := map[uuid.UUID]bool{}
+	for _, p := range ps {
+		out[p.ID] = true
+	}
+	return out
+}
+
+// TestRejectKnowledgeProposal: reject flips status (row dropped from pending) and
+// touches no KG; a second reject / a missing id is ErrNotFound.
+func TestRejectKnowledgeProposal(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "node", NodeType: "note", Name: "Rumor", Body: "x",
+	})
+
+	if err := st.RejectKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("RejectKnowledgeProposal: %v", err)
+	}
+	if pendingIDs(t, st, campaignID)[id] {
+		t.Error("rejected proposal still pending")
+	}
+	// No node was created by a reject.
+	nodes, _ := st.ListNodes(ctx, campaignID)
+	if len(nodes) != 0 {
+		t.Errorf("reject created %d nodes, want 0", len(nodes))
+	}
+	// A second reject is ErrNotFound (already reviewed).
+	if err := st.RejectKnowledgeProposal(ctx, campaignID, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("double reject: got %v, want ErrNotFound", err)
+	}
+	// A random id is ErrNotFound.
+	if err := st.RejectKnowledgeProposal(ctx, campaignID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("reject missing: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestApproveFactViaNodeID: an own_node fact anchored on node_id appends to the
+// Node's body (joined by a blank line onto existing prose) and resets the
+// embedding so the row re-enters the backfill queue.
+func TestApproveFactViaNodeID(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	node, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Bart", Body: "An innkeeper.",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	// Give it an embedding so we can prove approval resets it.
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(0), "m"); err != nil {
+		t.Fatalf("SetNodeEmbedding: %v", err)
+	}
+
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "fact", NodeID: node.ID.String(), Subject: "Bart", Fact: "He fears the dark.",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("ApproveKnowledgeProposal: %v", err)
+	}
+
+	want := "An innkeeper.\n\nHe fears the dark."
+	if got := nodeBody(t, st, campaignID, node.ID); got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+	if pendingIDs(t, st, campaignID)[id] {
+		t.Error("approved proposal still pending")
+	}
+	// Embedding reset → node back in the unembedded queue.
+	un, err := st.ListUnembeddedNodes(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListUnembeddedNodes: %v", err)
+	}
+	found := false
+	for _, n := range un {
+		if n.ID == node.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("approved fact did not reset the node's embedding (not in unembedded queue)")
+	}
+}
+
+// TestApproveFactViaSubject covers name resolution: a case-insensitive/trimmed
+// match lands onto a blank body (no separator); an unknown subject is blocked and
+// the row stays pending (tx rollback); an ambiguous subject is blocked.
+func TestApproveFactViaSubject(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	loc, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Neverwinter",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+
+	// Case-insensitive + trimmed subject resolves; blank body → fact alone.
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "fact", Subject: "  neverWINTER ", Fact: "A cold city.",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("Approve (subject): %v", err)
+	}
+	if got := nodeBody(t, st, campaignID, loc.ID); got != "A cold city." {
+		t.Errorf("body = %q, want %q", got, "A cold city.")
+	}
+
+	// Unknown subject → blocked, row stays pending, KG untouched.
+	unknownID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "fact", Subject: "Waterdeep", Fact: "A big city.",
+	})
+	err = st.ApproveKnowledgeProposal(ctx, campaignID, unknownID)
+	var blocked *storage.ProposalBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("approve unknown subject: got %v, want ProposalBlockedError", err)
+	}
+	if !strings.Contains(blocked.Reason, "no wiki entry named") {
+		t.Errorf("reason = %q, want no-entry message", blocked.Reason)
+	}
+	if !pendingIDs(t, st, campaignID)[unknownID] {
+		t.Error("blocked proposal was consumed; must stay pending (tx rollback)")
+	}
+
+	// Ambiguous subject: two entries share a name → blocked.
+	if _, err := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeItem, Name: "Ring"}); err != nil {
+		t.Fatalf("CreateNode ring1: %v", err)
+	}
+	if _, err := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "ring"}); err != nil {
+		t.Fatalf("CreateNode ring2: %v", err)
+	}
+	ambID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "fact", Subject: "Ring", Fact: "It is gold.",
+	})
+	err = st.ApproveKnowledgeProposal(ctx, campaignID, ambID)
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "multiple entries named") {
+		t.Errorf("approve ambiguous: got %v, want multiple-entries blocked", err)
+	}
+	if !pendingIDs(t, st, campaignID)[ambID] {
+		t.Error("ambiguous proposal must stay pending")
+	}
+}
+
+// TestApproveEdge covers the happy edge plus each structural refusal: matrix
+// violation, duplicate, missing target, dangling node_id.
+func TestApproveEdge(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	npc, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNPC, Name: "Bart"})
+	loc, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Inn"})
+	fac, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeFaction, Name: "Guild"})
+	_ = fac
+
+	// Happy: Bart resides_in Inn (resides_in → Location, valid).
+	okID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "edge", NodeID: npc.ID.String(), Subject: "Bart", Relation: "resides_in", Target: "Inn",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, okID); err != nil {
+		t.Fatalf("approve valid edge: %v", err)
+	}
+	out, _, err := st.NodeEdges(ctx, campaignID, npc.ID)
+	if err != nil || len(out) != 1 || out[0].ToNodeID != loc.ID {
+		t.Fatalf("edge not created: out=%v err=%v", out, err)
+	}
+
+	var blocked *storage.ProposalBlockedError
+
+	// Duplicate: same (from,to,type) again → blocked.
+	dupID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "edge", NodeID: npc.ID.String(), Subject: "Bart", Relation: "resides_in", Target: "Inn",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, dupID); !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "already exists") {
+		t.Errorf("approve duplicate: got %v, want already-exists blocked", err)
+	}
+	if !pendingIDs(t, st, campaignID)[dupID] {
+		t.Error("duplicate proposal must stay pending")
+	}
+
+	// Matrix violation: resides_in → Faction is invalid.
+	badID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "edge", NodeID: npc.ID.String(), Subject: "Bart", Relation: "resides_in", Target: "Guild",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, badID); !errors.As(err, &blocked) {
+		t.Errorf("approve matrix violation: got %v, want blocked", err)
+	}
+
+	// Missing target: no entry named "Nowhere".
+	missID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "edge", NodeID: npc.ID.String(), Subject: "Bart", Relation: "knows", Target: "Nowhere",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, missID); !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "no wiki entry named") {
+		t.Errorf("approve missing target: got %v, want no-entry blocked", err)
+	}
+
+	// Dangling node_id: a syntactically-valid uuid that no longer exists.
+	danglingID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "edge", NodeID: uuid.New().String(), Subject: "Ghost", Relation: "knows", Target: "Inn",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, danglingID); !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "no longer exists") {
+		t.Errorf("approve dangling node_id: got %v, want dangling blocked", err)
+	}
+}
+
+// TestApproveNode: a new-entry proposal inserts a gm_public Node; a v≠1 payload is
+// blocked and stays pending.
+func TestApproveNode(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "node", NodeType: "faction", Name: "Zhentarim", Body: "A shadowy network.",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("approve node: %v", err)
+	}
+	nodes, _ := st.ListNodes(ctx, campaignID)
+	var created *storage.KGNode
+	for i := range nodes {
+		if nodes[i].Name == "Zhentarim" {
+			created = &nodes[i]
+		}
+	}
+	if created == nil {
+		t.Fatal("approved node not created")
+	}
+	if created.Type != storage.KGNodeFaction || created.Body != "A shadowy network." || created.GMPrivate {
+		t.Errorf("created node wrong: %+v", created)
+	}
+
+	// v≠1 → unreadable, blocked, stays pending.
+	badID := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 2, Kind: "node", NodeType: "note", Name: "Future", Body: "y",
+	})
+	err := st.ApproveKnowledgeProposal(ctx, campaignID, badID)
+	var blocked *storage.ProposalBlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "unreadable") {
+		t.Errorf("approve v!=1: got %v, want unreadable blocked", err)
+	}
+	if !pendingIDs(t, st, campaignID)[badID] {
+		t.Error("unreadable proposal must stay pending")
+	}
+}
+
+// TestApproveDoubleIsNotFound: the second approve of the same id sees no pending
+// row (already approved) and returns ErrNotFound.
+func TestApproveDoubleIsNotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: 1, Kind: "node", NodeType: "note", Name: "Once", Body: "x",
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("double approve: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestListPendingCarriesAgentName: the list read joins the authoring Agent's name.
+func TestListPendingCarriesAgentName(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	fileProposal(t, st, campaignID, butler, tool.ProposedWrite{V: 1, Kind: "node", NodeType: "note", Name: "n", Body: "b"})
+	ps, err := st.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ps) != 1 {
+		t.Fatalf("len = %d, want 1", len(ps))
+	}
+	if ps[0].AuthoringAgentName != "Glyphoxa" {
+		t.Errorf("authoring name = %q, want Glyphoxa (the Butler)", ps[0].AuthoringAgentName)
+	}
+	// GetPendingKnowledgeProposal carries the name too; a random id is ErrNotFound.
+	got, err := st.GetPendingKnowledgeProposal(ctx, campaignID, ps[0].ID)
+	if err != nil || got.AuthoringAgentName != "Glyphoxa" {
+		t.Errorf("GetPending: got %+v err %v", got, err)
+	}
+	if _, err := st.GetPendingKnowledgeProposal(ctx, campaignID, uuid.New()); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("GetPending missing: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestNodeEmbeddingRoundTrip: a new Node lists unembedded; setting its embedding
+// removes it from the queue and drops the count; UpdateNode resets it back into
+// the queue.
+func TestNodeEmbeddingRoundTrip(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	node, err := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "N", Body: "b"})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 1 {
+		t.Errorf("initial unembedded count = %d, want 1", n)
+	}
+	if err := st.SetNodeEmbedding(ctx, node.ID, unitVec(3), "m"); err != nil {
+		t.Fatalf("SetNodeEmbedding: %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 0 {
+		t.Errorf("after embed count = %d, want 0", n)
+	}
+	// UpdateNode resets the embedding.
+	if _, err := st.UpdateNode(ctx, storage.KGNodeUpdate{ID: node.ID, CampaignID: campaignID, Name: "N", Body: "b2"}); err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	if n, _ := st.CountUnembeddedNodes(ctx); n != 1 {
+		t.Errorf("after edit count = %d, want 1 (embedding reset)", n)
+	}
+}
+
+// TestSimilarNodes: scoping (campaign + non-null embedding), order (nearest first),
+// limit.
+func TestSimilarNodes(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Node A embedded along axis 0 (nearest to a query along axis 0); B along axis
+	// 1 (farther); C left unembedded (must be excluded).
+	a, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "A"})
+	b, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "B"})
+	st.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignID, Type: storage.KGNodeNote, Name: "C"})
+	if err := st.SetNodeEmbedding(ctx, a.ID, unitVec(0), "m"); err != nil {
+		t.Fatalf("embed A: %v", err)
+	}
+	if err := st.SetNodeEmbedding(ctx, b.ID, unitVec(1), "m"); err != nil {
+		t.Fatalf("embed B: %v", err)
+	}
+
+	// A node in another campaign must never appear (scoping).
+	var other uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name) VALUES ($1, 'Other') RETURNING id`, tenantID).Scan(&other); err != nil {
+		t.Fatalf("insert other campaign: %v", err)
+	}
+	on, _ := st.CreateNode(ctx, storage.NewKGNode{CampaignID: other, Type: storage.KGNodeNote, Name: "Other-A"})
+	st.SetNodeEmbedding(ctx, on.ID, unitVec(0), "m")
+
+	got, err := st.SimilarNodes(ctx, campaignID, unitVec(0), 5)
+	if err != nil {
+		t.Fatalf("SimilarNodes: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (C unembedded + other-campaign excluded)", len(got))
+	}
+	if got[0].ID != a.ID || got[1].ID != b.ID {
+		t.Errorf("order = [%s %s], want [A=%s B=%s] (nearest first)", got[0].Name, got[1].Name, a.ID, b.ID)
+	}
+	// Limit honoured.
+	lim, err := st.SimilarNodes(ctx, campaignID, unitVec(0), 1)
+	if err != nil || len(lim) != 1 || lim[0].ID != a.ID {
+		t.Errorf("limit 1: got %v err %v, want [A]", lim, err)
+	}
+}
+
+// unitVec returns a 768-dim unit vector with 1.0 at index axis, 0 elsewhere — a
+// deterministic embedding whose cosine distance to another axis is maximal and to
+// itself is zero.
+func unitVec(axis int) []float32 {
+	v := make([]float32, 768)
+	v[axis] = 1
+	return v
+}

--- a/internal/storage/migrations/00030_kg_node_embedding.sql
+++ b/internal/storage/migrations/00030_kg_node_embedding.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+
+-- Knowledge Graph Node embeddings (#300 PR-b, ADR-0011/0052): the GM review
+-- surface surfaces embedding-similar existing Nodes beside each Knowledge
+-- Proposal so the GM merges/rewrites/rejects rather than duplicating canon. This
+-- mirrors the transcript_chunk async-embed pipeline (ADR-0011): the column is
+-- added NULL, the embedworker backfills it, and the ANN search filters
+-- embedding IS NOT NULL. An ALTER on the existing table (ADR-0031: never rewrite
+-- 00010). embedding_model records which model produced the vector, so a
+-- model-switch re-embed pass can key off provenance.
+--
+-- The partial HNSW index (vector_cosine_ops, embedding IS NOT NULL) serves the
+-- nearest-neighbour search; still-NULL rows are simply invisible to it until the
+-- backfill worker fills them. Existing rows are left NULL for the worker to embed.
+ALTER TABLE kg_node ADD COLUMN embedding vector(768);
+ALTER TABLE kg_node ADD COLUMN embedding_model text NOT NULL DEFAULT '';
+
+CREATE INDEX kg_node_embedding_hnsw_idx
+    ON kg_node USING hnsw (embedding vector_cosine_ops)
+    WHERE embedding IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS kg_node_embedding_hnsw_idx;
+ALTER TABLE kg_node DROP COLUMN IF EXISTS embedding;
+ALTER TABLE kg_node DROP COLUMN IF EXISTS embedding_model;

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -134,6 +134,42 @@ service CampaignService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // ListKnowledgeProposals returns the active campaign's PENDING Knowledge
+  // Proposals oldest-first — the GM review queue an Agent's remember_knowledge
+  // call files into (#300, ADR-0052). Each carries its authoring Agent's joined
+  // name and the parsed proposed write (fact/edge/node); an unparseable jsonb row
+  // is still listed with an UNSET write oneof so the GM can reject it. It is a
+  // read (NO_SIDE_EFFECTS), so the CSRF check is exempt.
+  rpc ListKnowledgeProposals(ListKnowledgeProposalsRequest) returns (ListKnowledgeProposalsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // ApproveKnowledgeProposal lands a pending proposal's write on the Knowledge
+  // Graph and marks it approved, atomically (#300, ADR-0052): the claim UPDATE and
+  // the KG write share one transaction. A refused write (unresolvable subject,
+  // matrix violation, duplicate, dangling anchor, unreadable payload) is
+  // CodeFailedPrecondition with an actionable reason and leaves the row pending; a
+  // missing/already-reviewed id is CodeNotFound; an unparsable id is
+  // CodeInvalidArgument. State-changing: the auth + CSRF interceptors guard it.
+  rpc ApproveKnowledgeProposal(ApproveKnowledgeProposalRequest) returns (ApproveKnowledgeProposalResponse);
+
+  // RejectKnowledgeProposal drops a pending proposal (status rejected, row kept)
+  // without touching the KG (#300, ADR-0052). A missing/already-reviewed id is
+  // CodeNotFound; an unparsable id is CodeInvalidArgument. State-changing: the auth
+  // + CSRF interceptors guard it.
+  rpc RejectKnowledgeProposal(RejectKnowledgeProposalRequest) returns (RejectKnowledgeProposalResponse);
+
+  // ListSimilarKnowledge returns up to 5 existing Nodes most similar to a pending
+  // proposal's subject — the ADR-0011 embedding-vector hint the review surface
+  // shows beside each proposal so the GM can merge/rewrite/reject rather than
+  // duplicate canon (ADR-0052: similarity is a hint, never an auto-merge). It
+  // degrades silently to fulltext search when no embeddings provider is wired. A
+  // missing/already-reviewed proposal id is CodeNotFound. It is a read
+  // (NO_SIDE_EFFECTS), so the CSRF check is exempt.
+  rpc ListSimilarKnowledge(ListSimilarKnowledgeRequest) returns (ListSimilarKnowledgeResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
   // ListToolGrants returns, for one Agent, EVERY built-in Tool (the ADR-0028
   // Registry is the available-Tools source) paired with the Agent's current grant
   // state — granted or not, its per-grant scope config, and whether the Tool
@@ -474,6 +510,113 @@ message SearchNodesRequest {
 message SearchNodesResponse {
   // nodes are the matching Knowledge Graph Nodes, ranked by relevance; gm_private
   // Nodes are included (GM-facing search).
+  repeated Node nodes = 1;
+}
+
+// ProposedFact is a remember_knowledge proposal to append a fact sentence to an
+// existing Node's body (#300, ADR-0052). node_id anchors an own_node-scoped NPC
+// proposal to its linked Node; when empty, subject names the target Node by name
+// (resolved at approval, no auto-merge).
+message ProposedFact {
+  // node_id is the anchor Node's UUID for an own_node-scoped proposal; empty when
+  // the target is named by subject.
+  string node_id = 1;
+  // subject is the target Node's name (the fallback resolution key when node_id is
+  // empty; also the display label).
+  string subject = 2;
+  // fact is the sentence to append to the Node's body.
+  string fact = 3;
+}
+
+// ProposedEdge is a remember_knowledge proposal to create a typed directional
+// Edge (#300, ADR-0052). node_id/subject name the FROM Node; target NAMES the TO
+// Node (a name, not an id — it is resolved at approval, ADR-0052 no auto-merge).
+message ProposedEdge {
+  // node_id is the from-Node's UUID for an own_node-scoped proposal; empty when
+  // the from-Node is named by subject.
+  string node_id = 1;
+  // subject is the from-Node's name (resolution key / display label).
+  string subject = 2;
+  // relation is the Edge type.
+  EdgeType relation = 3;
+  // target is the to-Node's NAME (resolved to a Node at approval time).
+  string target = 4;
+}
+
+// ProposedNode is a remember_knowledge proposal to create a new Node (#300,
+// ADR-0052; Butler-scope only). The Node is created gm_private=false.
+message ProposedNode {
+  // node_type is the new Node's type.
+  NodeType node_type = 1;
+  // name is the new Node's display name.
+  string name = 2;
+  // body is the new Node's prose.
+  string body = 3;
+}
+
+// KnowledgeProposal is one pending Knowledge Proposal for GM review (#300,
+// ADR-0052). The write oneof carries the parsed proposed write; it is UNSET when
+// the stored jsonb could not be parsed (a versioned-shape mismatch), which the UI
+// renders as "unreadable — reject".
+message KnowledgeProposal {
+  // id is the proposal's UUID.
+  string id = 1;
+  // authoring_agent_id is the Agent that filed the proposal.
+  string authoring_agent_id = 2;
+  // authoring_agent_name is that Agent's display name, joined server-side.
+  string authoring_agent_name = 3;
+  // created_at is when the proposal was filed.
+  google.protobuf.Timestamp created_at = 4;
+  // write is the parsed proposed write; UNSET when the row is unparseable.
+  oneof write {
+    ProposedFact fact = 5;
+    ProposedEdge edge = 6;
+    ProposedNode node = 7;
+  }
+}
+
+// ListKnowledgeProposalsRequest is the (empty) request; the active campaign is
+// resolved server-side (single operator, ADR-0039). There is no pagination — the
+// server returns the whole pending queue oldest-first.
+message ListKnowledgeProposalsRequest {}
+
+// ListKnowledgeProposalsResponse carries the pending queue oldest-first.
+message ListKnowledgeProposalsResponse {
+  // proposals are the campaign's pending Knowledge Proposals, oldest-first.
+  repeated KnowledgeProposal proposals = 1;
+}
+
+// ApproveKnowledgeProposalRequest names the proposal to approve. There is no
+// reason field — approve either lands the write or refuses with a reason.
+message ApproveKnowledgeProposalRequest {
+  // id is the proposal to approve.
+  string id = 1;
+}
+
+// ApproveKnowledgeProposalResponse is the (empty) response for a landed write.
+message ApproveKnowledgeProposalResponse {}
+
+// RejectKnowledgeProposalRequest names the proposal to reject.
+message RejectKnowledgeProposalRequest {
+  // id is the proposal to reject.
+  string id = 1;
+}
+
+// RejectKnowledgeProposalResponse is the (empty) response for a dropped proposal.
+message RejectKnowledgeProposalResponse {}
+
+// ListSimilarKnowledgeRequest names the pending proposal whose subject to search
+// for similar existing Nodes.
+message ListSimilarKnowledgeRequest {
+  // proposal_id is the pending proposal to find similar entries for.
+  string proposal_id = 1;
+}
+
+// ListSimilarKnowledgeResponse carries up to 5 existing Nodes nearest the
+// proposal's subject, nearest first (the ADR-0011 similarity hint).
+message ListSimilarKnowledgeResponse {
+  // nodes are the most-similar existing Nodes, nearest first (≤5). gm_private
+  // Nodes ARE included — this is a GM-facing review hint, never an NPC prompt.
   repeated Node nodes = 1;
 }
 

--- a/web/src/lib/connectError.ts
+++ b/web/src/lib/connectError.ts
@@ -12,6 +12,17 @@ export function isUnauthenticated(error: unknown): boolean {
   return ConnectError.from(error).code === Code.Unauthenticated;
 }
 
+// failedPreconditionMessage returns the server's message when the error is a
+// CodeFailedPrecondition, else null. The Knowledge Proposal review surface (#300)
+// uses it to show a rejected-approval's actionable reason ("no wiki entry named
+// …") inline on the card, distinct from an unexpected failure. ConnectError.from
+// strips the "[failed_precondition] " prefix into .rawMessage, the verbatim
+// server reason.
+export function failedPreconditionMessage(error: unknown): string | null {
+  const ce = ConnectError.from(error);
+  return ce.code === Code.FailedPrecondition ? ce.rawMessage : null;
+}
+
 // isNotFound reports the server's CodeNotFound. The campaign surfaces use it as
 // the "no campaign exists yet" signal (#267): GetActiveCampaign fails with
 // CodeNotFound exactly when the Tenant has zero campaigns (resolution otherwise

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -21,6 +21,7 @@ import {
   CharacterSchema,
   ListCharactersResponseSchema,
   ListDiscordVoiceMembersResponseSchema,
+  ListKnowledgeProposalsResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -151,6 +152,9 @@ function mockTransport() {
           ],
         }),
       listDiscordVoiceMembers: () => create(ListDiscordVoiceMembersResponseSchema, {}),
+      // Proposals view (#300): an empty queue is enough for the tab-switch test to
+      // prove the panel mounts on its own RPC.
+      listKnowledgeProposals: () => create(ListKnowledgeProposalsResponseSchema, { proposals: [] }),
     });
   });
   return { transport, npcs, previewCalls, grants };
@@ -347,6 +351,17 @@ describe("Campaign", () => {
     // Back to Cast — the roster is unchanged.
     fireEvent.click(screen.getByRole("tab", { name: "Cast" }));
     expect(await screen.findByText("Bart")).toBeInTheDocument();
+  });
+
+  it("exposes a fourth Proposals tab that mounts the review panel (#300)", async () => {
+    renderScreen();
+    expect(await screen.findByText("Bart")).toBeInTheDocument();
+
+    // Switch to Proposals — the panel mounts on its own ListKnowledgeProposals RPC.
+    fireEvent.click(screen.getByRole("tab", { name: "Proposals" }));
+    expect(await screen.findByText(/No pending suggestions/i)).toBeInTheDocument();
+    // The roster (Cast) is no longer mounted.
+    expect(screen.queryByText("Bart")).not.toBeInTheDocument();
   });
 
   it("surfaces an error cue when the voice preview fails", async () => {

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/Button";
 import { playAudioBlob } from "@/lib/audio";
 import { KnowledgePanel } from "./KnowledgePanel";
 import { PlayersPanel } from "./PlayersPanel";
+import { ProposalsPanel } from "./ProposalsPanel";
 
 import "./campaign.css";
 
@@ -60,7 +61,7 @@ export function Campaign() {
   // Cast (roster editor), Knowledge (KG entries), or Players (Character ↔ Discord
   // User bindings, #279) — the design's seg-control beside the title. Cast is the
   // default so the roster is what loads first (#71).
-  const [view, setView] = useState<"cast" | "knowledge" | "players">("cast");
+  const [view, setView] = useState<"cast" | "knowledge" | "players" | "proposals">("cast");
 
   const invalidateRoster = () =>
     queryClient.invalidateQueries({
@@ -119,6 +120,15 @@ export function Campaign() {
             >
               Players
             </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "proposals"}
+              data-active={view === "proposals" ? "true" : undefined}
+              onClick={() => setView("proposals")}
+            >
+              Proposals
+            </button>
           </div>
         </div>
         <div className="gx-campaign-screen__sub">
@@ -128,7 +138,9 @@ export function Campaign() {
               ? "What the world knows. Public entries prime your NPCs; GM-private ones stay yours."
               : view === "players"
                 ? "Bind each Discord User to their Character so the transcript names their voice."
-                : "One Butler is required; add as many NPCs as your table needs."}
+                : view === "proposals"
+                  ? "What your NPCs want to remember. Approve to make it canon, or reject."
+                  : "One Butler is required; add as many NPCs as your table needs."}
           </span>
         </div>
       </header>
@@ -137,6 +149,8 @@ export function Campaign() {
         <KnowledgePanel />
       ) : view === "players" ? (
         <PlayersPanel />
+      ) : view === "proposals" ? (
+        <ProposalsPanel />
       ) : status === "pending" ? (
         <div className="gx-skeleton" data-testid="roster-loading" />
       ) : status === "error" ? (

--- a/web/src/screens/campaign/ProposalsPanel.test.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import {
+  CampaignService,
+  NodeType,
+  EdgeType,
+  NodeSchema,
+  KnowledgeProposalSchema,
+  ProposedFactSchema,
+  ProposedEdgeSchema,
+  ProposedNodeSchema,
+  ListKnowledgeProposalsResponseSchema,
+  ApproveKnowledgeProposalResponseSchema,
+  RejectKnowledgeProposalResponseSchema,
+  ListSimilarKnowledgeResponseSchema,
+  type ApproveKnowledgeProposalRequest,
+  type RejectKnowledgeProposalRequest,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { ProposalsPanel } from "./ProposalsPanel";
+
+const factProposal = create(KnowledgeProposalSchema, {
+  id: "p-fact",
+  authoringAgentId: "a1",
+  authoringAgentName: "Innkeeper NPC",
+  createdAt: timestampFromDate(new Date("2026-07-11T10:00:00Z")),
+  write: { case: "fact", value: create(ProposedFactSchema, { subject: "Bart", fact: "He fears the dark." }) },
+});
+const edgeProposal = create(KnowledgeProposalSchema, {
+  id: "p-edge",
+  authoringAgentName: "Glyphoxa",
+  createdAt: timestampFromDate(new Date("2026-07-11T10:01:00Z")),
+  write: {
+    case: "edge",
+    value: create(ProposedEdgeSchema, { subject: "Gundren", relation: EdgeType.RESIDES_IN, target: "The Inn" }),
+  },
+});
+const nodeProposal = create(KnowledgeProposalSchema, {
+  id: "p-node",
+  authoringAgentName: "Glyphoxa",
+  createdAt: timestampFromDate(new Date("2026-07-11T10:02:00Z")),
+  write: {
+    case: "node",
+    value: create(ProposedNodeSchema, { nodeType: NodeType.FACTION, name: "Zhentarim", body: "A shadow network." }),
+  },
+});
+// An unparseable row: the server left the write oneof unset.
+const unreadableProposal = create(KnowledgeProposalSchema, {
+  id: "p-bad",
+  authoringAgentName: "Glyphoxa",
+  createdAt: timestampFromDate(new Date("2026-07-11T10:03:00Z")),
+});
+
+function mockTransport(
+  proposals: ReturnType<typeof create<typeof KnowledgeProposalSchema>>[],
+  opts: {
+    approveError?: ConnectError;
+    similar?: ReturnType<typeof create<typeof NodeSchema>>[];
+  } = {},
+) {
+  let list = [...proposals];
+  const approveCalls: ApproveKnowledgeProposalRequest[] = [];
+  const rejectCalls: RejectKnowledgeProposalRequest[] = [];
+
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listKnowledgeProposals: () => create(ListKnowledgeProposalsResponseSchema, { proposals: list }),
+      listSimilarKnowledge: () =>
+        create(ListSimilarKnowledgeResponseSchema, { nodes: opts.similar ?? [] }),
+      approveKnowledgeProposal: (req) => {
+        approveCalls.push(req);
+        if (opts.approveError) throw opts.approveError;
+        list = list.filter((p) => p.id !== req.id);
+        return create(ApproveKnowledgeProposalResponseSchema, {});
+      },
+      rejectKnowledgeProposal: (req) => {
+        rejectCalls.push(req);
+        list = list.filter((p) => p.id !== req.id);
+        return create(RejectKnowledgeProposalResponseSchema, {});
+      },
+    });
+  });
+  return { transport, approveCalls, rejectCalls };
+}
+
+function renderPanel(
+  proposals: ReturnType<typeof create<typeof KnowledgeProposalSchema>>[],
+  opts?: { approveError?: ConnectError; similar?: ReturnType<typeof create<typeof NodeSchema>>[] },
+) {
+  const ctx = mockTransport(proposals, opts);
+  render(
+    <Providers transport={ctx.transport} queryClient={makeQueryClient()}>
+      <ProposalsPanel />
+    </Providers>,
+  );
+  return ctx;
+}
+
+describe("ProposalsPanel", () => {
+  it("renders the empty state when there are no pending proposals", async () => {
+    renderPanel([]);
+    expect(await screen.findByText(/No pending suggestions/i)).toBeInTheDocument();
+  });
+
+  it("renders fact, edge and node proposals in human form", async () => {
+    renderPanel([factProposal, edgeProposal, nodeProposal]);
+
+    // Fact: Subject — fact, with the authoring agent.
+    expect(await screen.findByText("Innkeeper NPC")).toBeInTheDocument();
+    expect(screen.getByText("Bart")).toBeInTheDocument();
+    expect(screen.getByText(/He fears the dark\./)).toBeInTheDocument();
+    // Edge: Subject —relation→ Target.
+    expect(screen.getByText(/resides_in/)).toBeInTheDocument();
+    expect(screen.getByText("The Inn")).toBeInTheDocument();
+    // Node: New Faction: Name + body.
+    expect(screen.getByText(/New Faction:/)).toBeInTheDocument();
+    expect(screen.getByText("Zhentarim")).toBeInTheDocument();
+    expect(screen.getByText(/A shadow network\./)).toBeInTheDocument();
+  });
+
+  it("renders an unreadable proposal so the GM can still reject it", async () => {
+    renderPanel([unreadableProposal]);
+    expect(await screen.findByText(/Unreadable proposal/i)).toBeInTheDocument();
+    // The Reject action is still present.
+    expect(screen.getByRole("button", { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it("approves a proposal, removing it from the queue", async () => {
+    const { approveCalls } = renderPanel([factProposal]);
+    await screen.findByText("Bart");
+
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+
+    await waitFor(() => expect(screen.queryByText("Bart")).not.toBeInTheDocument());
+    expect(approveCalls).toHaveLength(1);
+    expect(approveCalls[0].id).toBe("p-fact");
+  });
+
+  it("shows the server's reason inline when an approval is refused", async () => {
+    renderPanel([factProposal], {
+      approveError: new ConnectError(
+        'no wiki entry named "Bart" — create it first, then approve; or reject',
+        Code.FailedPrecondition,
+      ),
+    });
+    await screen.findByText("Bart");
+
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/no wiki entry named "Bart"/);
+    // The proposal is NOT removed on a refused approval.
+    expect(screen.getByText(/He fears the dark\./)).toBeInTheDocument();
+  });
+
+  it("rejects a proposal only after confirming in the dialog", async () => {
+    const { rejectCalls } = renderPanel([factProposal]);
+    await screen.findByText("Bart");
+
+    fireEvent.click(screen.getByRole("button", { name: /reject/i }));
+    // A confirm dialog gates the reject (no RPC yet).
+    const dialog = await screen.findByRole("alertdialog");
+    expect(rejectCalls).toHaveLength(0);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /reject suggestion/i }));
+    await waitFor(() => expect(screen.queryByText("Bart")).not.toBeInTheDocument());
+    expect(rejectCalls).toHaveLength(1);
+    expect(rejectCalls[0].id).toBe("p-fact");
+  });
+
+  it("renders the similarity hint's existing entries", async () => {
+    renderPanel([factProposal], {
+      similar: [create(NodeSchema, { id: "n1", nodeType: NodeType.NPC, name: "Bartholomew" })],
+    });
+    await screen.findByText("Bart");
+    expect(await screen.findByText("Bartholomew")).toBeInTheDocument();
+    expect(screen.getByText(/Similar existing entries/i)).toBeInTheDocument();
+  });
+
+  it("shows 'No similar entries.' when the hint is empty", async () => {
+    renderPanel([factProposal], { similar: [] });
+    await screen.findByText("Bart");
+    expect(await screen.findByText(/No similar entries\./i)).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/ProposalsPanel.test.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.test.tsx
@@ -66,12 +66,15 @@ function mockTransport(
   let list = [...proposals];
   const approveCalls: ApproveKnowledgeProposalRequest[] = [];
   const rejectCalls: RejectKnowledgeProposalRequest[] = [];
+  const counters = { similarCalls: 0 };
 
   const transport = createRouterTransport(({ service }) => {
     service(CampaignService, {
       listKnowledgeProposals: () => create(ListKnowledgeProposalsResponseSchema, { proposals: list }),
-      listSimilarKnowledge: () =>
-        create(ListSimilarKnowledgeResponseSchema, { nodes: opts.similar ?? [] }),
+      listSimilarKnowledge: () => {
+        counters.similarCalls++;
+        return create(ListSimilarKnowledgeResponseSchema, { nodes: opts.similar ?? [] });
+      },
       approveKnowledgeProposal: (req) => {
         approveCalls.push(req);
         if (opts.approveError) throw opts.approveError;
@@ -85,7 +88,7 @@ function mockTransport(
       },
     });
   });
-  return { transport, approveCalls, rejectCalls };
+  return { transport, approveCalls, rejectCalls, counters };
 }
 
 function renderPanel(
@@ -173,18 +176,25 @@ describe("ProposalsPanel", () => {
     expect(rejectCalls[0].id).toBe("p-fact");
   });
 
-  it("renders the similarity hint's existing entries", async () => {
-    renderPanel([factProposal], {
+  it("only fetches the similarity hint after the GM opts in (lazy, no fan-out)", async () => {
+    const { counters } = renderPanel([factProposal], {
       similar: [create(NodeSchema, { id: "n1", nodeType: NodeType.NPC, name: "Bartholomew" })],
     });
     await screen.findByText("Bart");
+    // Not fired on mount — the RPC embeds a provider call, so it must be opt-in.
+    expect(counters.similarCalls).toBe(0);
+    expect(screen.queryByText("Bartholomew")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show similar/i }));
     expect(await screen.findByText("Bartholomew")).toBeInTheDocument();
     expect(screen.getByText(/Similar existing entries/i)).toBeInTheDocument();
+    expect(counters.similarCalls).toBe(1);
   });
 
   it("shows 'No similar entries.' when the hint is empty", async () => {
     renderPanel([factProposal], { similar: [] });
     await screen.findByText("Bart");
+    fireEvent.click(screen.getByRole("button", { name: /show similar/i }));
     expect(await screen.findByText(/No similar entries\./i)).toBeInTheDocument();
   });
 });

--- a/web/src/screens/campaign/ProposalsPanel.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.tsx
@@ -64,8 +64,9 @@ export function ProposalsPanel() {
   const proposals = data?.proposals ?? [];
 
   // A review action must refresh the queue AND the wiki list (an approved write
-  // lands a new/edited Node the Knowledge panel shows). Both keys are built
-  // without an input so they prefix-match every cached query.
+  // lands a new/edited Node the Knowledge panel shows) AND any cached node-edges
+  // (an approved edge adds a relationship the relations view / delete-count reads).
+  // Each key is built without an input so it prefix-matches every cached query.
   const invalidateAfterReview = () => {
     void queryClient.invalidateQueries({
       queryKey: createConnectQueryKey({
@@ -76,6 +77,12 @@ export function ProposalsPanel() {
     void queryClient.invalidateQueries({
       queryKey: createConnectQueryKey({
         schema: CampaignService.method.listNodes,
+        cardinality: "finite",
+      }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listNodeEdges,
         cardinality: "finite",
       }),
     });
@@ -248,10 +255,23 @@ function ProposalWrite({ proposal }: { proposal: KnowledgeProposal }) {
 // subject (the ADR-0011 vector hint) so the GM can merge or reject rather than
 // duplicate. A skeleton shows while loading; "No similar entries." when none.
 function SimilarHint({ proposalId }: { proposalId: string }) {
-  const { data, status } = useQuery(CampaignService.method.listSimilarKnowledge, {
-    proposalId,
-  });
+  // Truly lazy: the similarity RPC embeds the subject (a provider call), so it
+  // fires ONLY after the GM opts in — never on mount for every card (that would
+  // fan N concurrent Embed calls across the whole queue).
+  const [show, setShow] = useState(false);
+  const { data, status } = useQuery(
+    CampaignService.method.listSimilarKnowledge,
+    { proposalId },
+    { enabled: show },
+  );
 
+  if (!show) {
+    return (
+      <button type="button" className="gx-proposal-card__similar-btn" onClick={() => setShow(true)}>
+        <Sparkles size={12} /> Show similar entries
+      </button>
+    );
+  }
   if (status === "pending") {
     return <div className="gx-skeleton gx-proposal-card__similar-skel" data-testid="similar-loading" />;
   }

--- a/web/src/screens/campaign/ProposalsPanel.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.tsx
@@ -1,0 +1,284 @@
+import { useState } from "react";
+import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { timestampDate } from "@bufbuild/protobuf/wkt";
+import { Check, Sparkles, X } from "lucide-react";
+
+import { CampaignService, EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { KnowledgeProposal } from "@gen/glyphoxa/management/v1/management_pb";
+import { Card } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { failedPreconditionMessage } from "@/lib/connectError";
+
+// The Proposals panel (#300, ADR-0052) backs the Campaign screen's "Proposals"
+// view: the GM review queue an Agent's remember_knowledge call files into. Each
+// card renders the parsed write (fact/edge/node — or "unreadable" when the stored
+// payload could not be parsed), a lazy similarity hint of existing entries, and
+// Approve / Reject actions. Approve lands the write server-side atomically; a
+// refused approval (no such entry, matrix violation, duplicate) surfaces the
+// server's actionable reason inline. Reject drops the suggestion. Similarity is a
+// HINT the GM acts on — never an auto-merge (ADR-0052).
+
+// Per-relation label, mirroring the kg_edge vocabulary (ADR-0008).
+const EDGE_LABEL: Record<number, string> = {
+  [EdgeType.RESIDES_IN]: "resides_in",
+  [EdgeType.MEMBER_OF]: "member_of",
+  [EdgeType.OWNS]: "owns",
+  [EdgeType.KNOWS]: "knows",
+  [EdgeType.ENEMY_OF]: "enemy_of",
+  [EdgeType.ALLY_OF]: "ally_of",
+  [EdgeType.PARENT_OF]: "parent_of",
+  [EdgeType.PARTICIPATED_IN]: "participated_in",
+  [EdgeType.MENTIONED_IN]: "mentioned_in",
+};
+
+// Per-type GM label (mirrors KnowledgePanel's TYPE_META labels). The Note label
+// doubles as the defensive fallback for an unknown/unspecified type.
+const NODE_TYPE_LABEL: Record<number, string> = {
+  [NodeType.CHARACTER]: "Character",
+  [NodeType.NPC]: "NPC",
+  [NodeType.LOCATION]: "Location",
+  [NodeType.FACTION]: "Faction",
+  [NodeType.ITEM]: "Item",
+  [NodeType.PLOT_THREAD]: "Plot thread",
+  [NodeType.NOTE]: "Note",
+};
+
+function nodeTypeLabel(t: NodeType): string {
+  return NODE_TYPE_LABEL[t] ?? "Note";
+}
+
+function fmtWhen(p: KnowledgeProposal): string {
+  if (!p.createdAt) return "";
+  return timestampDate(p.createdAt).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function ProposalsPanel() {
+  const queryClient = useQueryClient();
+  const { data, status, error } = useQuery(CampaignService.method.listKnowledgeProposals, {});
+  const proposals = data?.proposals ?? [];
+
+  // A review action must refresh the queue AND the wiki list (an approved write
+  // lands a new/edited Node the Knowledge panel shows). Both keys are built
+  // without an input so they prefix-match every cached query.
+  const invalidateAfterReview = () => {
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listKnowledgeProposals,
+        cardinality: "finite",
+      }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listNodes,
+        cardinality: "finite",
+      }),
+    });
+  };
+
+  if (status === "pending") {
+    return <div className="gx-skeleton" data-testid="proposals-loading" />;
+  }
+  if (status === "error") {
+    return (
+      <p className="gx-campaign__error" role="alert">
+        Could not load suggestions: {error.message}
+      </p>
+    );
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <p className="gx-kg-empty">
+        No pending suggestions. Agents with the remember grant will file them here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="gx-proposals-list">
+      {proposals.map((p) => (
+        <ProposalCard key={p.id} proposal={p} onReviewed={invalidateAfterReview} />
+      ))}
+    </div>
+  );
+}
+
+// ProposalCard renders one pending proposal: who + when, the kind badge, the
+// human-rendered write, a lazy similarity hint, and Approve/Reject. A refused
+// approval (FailedPrecondition) shows the server's reason inline so the GM knows
+// exactly what to fix; any other failure shows a generic inline error.
+function ProposalCard({
+  proposal,
+  onReviewed,
+}: {
+  proposal: KnowledgeProposal;
+  onReviewed: () => void;
+}) {
+  const [confirmReject, setConfirmReject] = useState(false);
+
+  const approve = useMutation(CampaignService.method.approveKnowledgeProposal, {
+    onSuccess: () => onReviewed(),
+  });
+  const reject = useMutation(CampaignService.method.rejectKnowledgeProposal, {
+    onSuccess: () => onReviewed(),
+  });
+
+  // A refused approval carries an actionable server reason; anything else is a
+  // generic failure. Reject failures fall into the same inline line so a dead
+  // button is never silent.
+  const blockedReason = approve.isError ? failedPreconditionMessage(approve.error) : null;
+  const inlineError = blockedReason
+    ? blockedReason
+    : approve.isError
+      ? `Couldn't approve: ${approve.error.message}`
+      : reject.isError
+        ? `Couldn't reject: ${reject.error.message}`
+        : null;
+
+  const pending = approve.isPending || reject.isPending;
+
+  return (
+    <Card className="gx-proposal-card">
+      <div className="gx-proposal-card__head">
+        <span className="gx-proposal-card__author">{proposal.authoringAgentName}</span>
+        <span className="gx-proposal-card__when">{fmtWhen(proposal)}</span>
+        <KindBadge proposal={proposal} />
+      </div>
+
+      <div className="gx-proposal-card__write">
+        <ProposalWrite proposal={proposal} />
+      </div>
+
+      <SimilarHint proposalId={proposal.id} />
+
+      <div className="gx-proposal-card__actions">
+        <Button
+          variant="primary"
+          size="sm"
+          iconStart={<Check size={14} />}
+          onClick={() => approve.mutate({ id: proposal.id })}
+          disabled={pending}
+        >
+          Approve
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          iconStart={<X size={14} />}
+          onClick={() => setConfirmReject(true)}
+          disabled={pending}
+        >
+          Reject
+        </Button>
+        {inlineError && (
+          <span className="gx-editor__status gx-editor__status--error" role="alert">
+            {inlineError}
+          </span>
+        )}
+      </div>
+
+      {confirmReject && (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setConfirmReject(false);
+          }}
+          title="Reject this suggestion?"
+          description="The suggestion is dropped and never becomes canon. This can't be undone."
+          confirmLabel="Reject suggestion"
+          onConfirm={() => {
+            reject.mutate({ id: proposal.id });
+            setConfirmReject(false);
+          }}
+        />
+      )}
+    </Card>
+  );
+}
+
+// KindBadge labels the proposal's kind, or "Unreadable" when the write is unset.
+function KindBadge({ proposal }: { proposal: KnowledgeProposal }) {
+  const kind = proposal.write.case;
+  if (kind === "fact") return <Badge size="sm">Fact</Badge>;
+  if (kind === "edge") return <Badge size="sm">Relationship</Badge>;
+  if (kind === "node") return <Badge size="sm">New entry</Badge>;
+  return (
+    <Badge variant="neutral" size="sm">
+      Unreadable
+    </Badge>
+  );
+}
+
+// ProposalWrite renders the human form of the proposed write per kind.
+function ProposalWrite({ proposal }: { proposal: KnowledgeProposal }) {
+  const w = proposal.write;
+  switch (w.case) {
+    case "fact":
+      return (
+        <span>
+          <strong>{w.value.subject}</strong> — {w.value.fact}
+        </span>
+      );
+    case "edge":
+      return (
+        <span>
+          <strong>{w.value.subject}</strong> —{EDGE_LABEL[w.value.relation] ?? ""}→{" "}
+          <strong>{w.value.target}</strong>
+        </span>
+      );
+    case "node":
+      return (
+        <span>
+          New {nodeTypeLabel(w.value.nodeType)}: <strong>{w.value.name}</strong>
+          {w.value.body && <span className="gx-proposal-card__body"> — {w.value.body}</span>}
+        </span>
+      );
+    default:
+      return <span className="gx-proposal-card__unreadable">Unreadable proposal</span>;
+  }
+}
+
+// SimilarHint lazily fetches the existing entries most similar to a proposal's
+// subject (the ADR-0011 vector hint) so the GM can merge or reject rather than
+// duplicate. A skeleton shows while loading; "No similar entries." when none.
+function SimilarHint({ proposalId }: { proposalId: string }) {
+  const { data, status } = useQuery(CampaignService.method.listSimilarKnowledge, {
+    proposalId,
+  });
+
+  if (status === "pending") {
+    return <div className="gx-skeleton gx-proposal-card__similar-skel" data-testid="similar-loading" />;
+  }
+  if (status === "error") {
+    return null; // the hint is best-effort; a failure is silent (no scary error on a suggestion)
+  }
+
+  const nodes = data.nodes;
+  return (
+    <div className="gx-proposal-card__similar">
+      <span className="gx-proposal-card__similar-title">
+        <Sparkles size={12} /> Similar existing entries
+      </span>
+      {nodes.length === 0 ? (
+        <span className="gx-proposal-card__similar-empty">No similar entries.</span>
+      ) : (
+        <ul className="gx-proposal-card__similar-list">
+          {nodes.map((n) => (
+            <li key={n.id}>
+              <span className="gx-proposal-card__similar-name">{n.name}</span>
+              <Badge size="sm" variant="neutral">
+                {nodeTypeLabel(n.nodeType)}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -740,3 +740,101 @@
   gap: var(--spacing-sm);
   flex-wrap: wrap;
 }
+
+/* Knowledge Proposal review (#300). A single-column stack of review cards. */
+.gx-proposals-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  max-width: 720px;
+}
+
+.gx-proposal-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+}
+
+.gx-proposal-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.gx-proposal-card__author {
+  font-weight: 600;
+}
+
+.gx-proposal-card__when {
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+  margin-right: auto;
+}
+
+.gx-proposal-card__write {
+  font-size: var(--body-md);
+  line-height: 1.5;
+}
+
+.gx-proposal-card__body {
+  color: var(--text-subtle);
+}
+
+.gx-proposal-card__unreadable {
+  color: var(--text-subtle);
+  font-style: italic;
+}
+
+.gx-proposal-card__similar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: var(--surface-sunken, rgba(127, 127, 127, 0.08));
+}
+
+.gx-proposal-card__similar-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+}
+
+.gx-proposal-card__similar-empty {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+}
+
+.gx-proposal-card__similar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gx-proposal-card__similar-list li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.gx-proposal-card__similar-name {
+  font-size: var(--body-sm);
+}
+
+.gx-proposal-card__similar-skel {
+  height: 2rem;
+}
+
+.gx-proposal-card__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -838,3 +838,21 @@
   gap: var(--spacing-sm);
   flex-wrap: wrap;
 }
+
+.gx-proposal-card__similar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+  padding: 4px 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.25));
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-subtle);
+  font-size: var(--body-sm);
+  cursor: pointer;
+}
+
+.gx-proposal-card__similar-btn:hover {
+  color: var(--text);
+}


### PR DESCRIPTION
## What

The GM review surface for **Knowledge Proposals** (ADR-0052, PR-b). PR-a (#390) shipped the pending queue an Agent's `remember_knowledge` call files into; this ships the GM's side: **list → review → approve/reject**, with an embedding-similarity hint so the GM merges rather than duplicates canon.

Closes #300

## How

- **proto** — `CampaignService` gains `ListKnowledgeProposals` (NO_SIDE_EFFECTS), `ApproveKnowledgeProposal`, `RejectKnowledgeProposal`, `ListSimilarKnowledge` (NO_SIDE_EFFECTS) + `KnowledgeProposal`/`ProposedFact`/`ProposedEdge`/`ProposedNode` messages. The `write` oneof is UNSET for an unparseable row → the UI renders "unreadable — reject".
- **migration `00030_kg_node_embedding.sql`** — `kg_node.embedding vector(768)` + `embedding_model` + partial HNSW index; existing rows stay NULL for the embedworker to backfill.
- **storage** — atomic `ApproveKnowledgeProposal`: the claim `UPDATE` and the KG write share **one transaction**, so a refused write rolls the claim back and the row stays pending. No auto-merge — a fact/edge subject that names no wiki entry is refused with an actionable `ProposalBlockedError` reason. `createEdgeTx` extracted from `CreateEdge` (behaviour identical) and reused for approved edges. `SimilarNodes` + node embed round-trip; `UpdateNode` resets the embedding.
- **embedworker** — a Node phase mirrors the chunk phase (same batch/timeout/dim-validation/retry-forever), independent so one backlog can't starve the other; new `glyphoxa_kg_embedding_backlog` gauge.
- **rpc** — `knowledge_proposal.go` handlers on `CampaignServer`; `Embedder` seam (`SetEmbedder`, wired to the resolved embeddings provider in `main.go`) with **silent** fulltext fallback when no provider is wired or the embed fails.
- **web** — a fourth **Proposals** tab + `ProposalsPanel`: per-card write render (fact/edge/node/unreadable), lazy similarity hint, Approve (direct) / Reject (ConfirmDialog), inline `FailedPrecondition` reason.

## Constraints honoured

ADR-0052 no auto-merge (refuse with actionable error; similarity is a hint) · ADR-0030 untouched (`loop.go`) · ADR-0011 async embed pattern mirrored · `kgNodeColumns`/`scanKGNode` never select `embedding` · claim UPDATE + KG write share one tx · unparseable rows still list.

## Tests

TDD, 19 behaviours across storage/embedworker/rpc/web. All local gates green: storage & rpc integration (incl. migrate up/down reversibility), web build + 246 vitest, `go vet -tags integration ./...`, golangci-lint 0 issues, `buf lint` + `buf breaking` vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**MERGE ORDER: after #404 (00028). 00029 intentionally unused — next slice takes 00031.** goose sees no gap-missing files (00027 = #372, 00028 = #404, 00030 = this PR).
