### PR TITLE
chore(#354): compose.yml pulls published ghcr image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,23 @@ is [docs/configuration.md](docs/configuration.md); the game-running walkthrough 
 
 ### Fastest: Docker Compose
 
-`compose.yml` stands up a pgvector Postgres + the Glyphoxa image in `-mode all`,
-which auto-migrates at startup — so this reaches the login screen against a
-migrated DB with no separate migrate step ([ADR-0034](docs/adr/0034-deployment-artifacts.md)):
+`compose.yml` stands up a pgvector Postgres + the published Glyphoxa image
+(`ghcr.io/mrwong99/glyphoxa`) in `-mode all`, which auto-migrates at startup —
+so this reaches the login screen against a migrated DB with no separate
+migrate step ([ADR-0034](docs/adr/0034-deployment-artifacts.md)). A machine
+with only Docker needs nothing else:
 
 ```sh
 cp .env.example .env              # fill GLYPHOXA_SECRET + DISCORD_OAUTH_* + GLYPHOXA_OPERATOR_IDS (docs/configuration.md §5–§6)
-make proto                        # gen/ is context-fed into the image build
-(cd web && npm ci && npm run build)   # SPA bundle → internal/spa/dist (else a blank page)
-docker compose up --build
+docker compose up
 ```
 
 Then open `http://127.0.0.1:8080` and sign in with Discord. For a bare-metal
 box, `deploy/glyphoxa.service` runs the same `-mode all` under systemd
-(docs/configuration.md §10).
+(docs/configuration.md §10). To run against a source checkout instead of the
+published image, `docker compose up --build` falls back to the local `build:`
+(needs `make proto` + `(cd web && npm ci && npm run build)` first — see
+docs/configuration.md §9).
 
 ### Build from source
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,18 +1,24 @@
-# Glyphoxa — self-host on-ramp (ADR-0034, issue #282).
+# Glyphoxa — self-host on-ramp (ADR-0034, issue #282, issue #354).
 #
-# The zero-to-running path: `docker compose up --build` stands up a pgvector
-# Postgres and the single Glyphoxa image in the default `-mode all` (web + the
-# in-process voice loop). `all` mode auto-applies the embedded migrations at
-# startup under the advisory lock (ADR-0031), so there is NO separate migrate
-# step — the app reaches the login screen against a migrated DB on its own.
-#
-# BEFORE the first build (gen/ is gitignored and the SPA bundle is context-fed,
-# ADR-0034), on the host:
+# The zero-to-running path: `docker compose up` pulls the published
+# ghcr.io/mrwong99/glyphoxa image and stands up a pgvector Postgres alongside
+# it, in the default `-mode all` (web + the in-process voice loop). `all` mode
+# auto-applies the embedded migrations at startup under the advisory lock
+# (ADR-0031), so there is NO separate migrate step — the app reaches the login
+# screen against a migrated DB on its own. A machine with only Docker needs
+# nothing else:
 #   cp .env.example .env && $EDITOR .env   # fill GLYPHOXA_SECRET, DISCORD_OAUTH_*, GLYPHOXA_OPERATOR_IDS
+#   docker compose up
+# Then open http://127.0.0.1:8080 and sign in with Discord.
+#
+# `build:` stays below as the documented fallback for source checkouts (e.g.
+# testing an unreleased change): `docker compose up --build` builds locally
+# instead of pulling, but first needs buf + node/npm on the host to produce
+# gen/ and the SPA bundle (gen/ is gitignored and the SPA bundle is
+# context-fed, ADR-0034):
 #   make proto                             # buf generate → gen/ (needed in the build context)
 #   (cd web && npm ci && npm run build)    # Vite bundle → internal/spa/dist (else a blank placeholder page)
 #   docker compose up --build
-# Then open http://127.0.0.1:8080 and sign in with Discord.
 #
 # Secrets come from `.env` (shell-format `export NAME='value'`, gitignored) via
 # env_file — Compose strips the `export` prefix and quotes. The DB connection is
@@ -38,7 +44,11 @@ services:
     restart: unless-stopped
 
   glyphoxa:
+    image: ghcr.io/mrwong99/glyphoxa:v0.2.0
     build:
+      # Fallback for `docker compose up --build` from a source checkout — see
+      # the file header. Not used by a plain `docker compose up`, which pulls
+      # `image:` above instead.
       context: .
     # The image's default CMD is `-mode all` (Dockerfile) — the self-host default
     # (ADR-0005/0034). Override the whole command to run another Mode, e.g.

--- a/compose.yml
+++ b/compose.yml
@@ -44,11 +44,14 @@ services:
     restart: unless-stopped
 
   glyphoxa:
+    # Bump on each release — release-image.yml publishes v<version> to ghcr.
     image: ghcr.io/mrwong99/glyphoxa:v0.2.0
     build:
       # Fallback for `docker compose up --build` from a source checkout — see
-      # the file header. Not used by a plain `docker compose up`, which pulls
-      # `image:` above instead.
+      # the file header. NOTE: `--build` tags the local build with the `image:`
+      # name above, so every later plain `docker compose up` keeps running that
+      # dev-built image (no pull_policy set). Run `docker compose pull glyphoxa`
+      # to restore the published image.
       context: .
     # The image's default CMD is `-mode all` (Dockerfile) — the self-host default
     # (ADR-0005/0034). Override the whole command to run another Mode, e.g.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,9 @@ separate migrate step**.
 
 The `glyphoxa` service pulls the published `ghcr.io/mrwong99/glyphoxa` image
 (built by `release-image.yml` on each release, ADR-0034), so a machine with
-only Docker needs nothing else — no buf, no Node/npm, no local build:
+only Docker needs nothing else — no buf, no Node/npm, no local build. The image
+is pinned to an explicit version tag (`:v0.2.0`) in `compose.yml`; to upgrade,
+bump that tag to the release you want and re-run `docker compose pull glyphoxa`:
 
 ```sh
 cp .env.example .env

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,20 +187,29 @@ image in the default `-mode all`. Because `all` mode auto-migrates at startup,
 `docker compose up` reaches the login screen against a migrated DB with **no
 separate migrate step**.
 
-The image is **context-fed** (ADR-0034): the gitignored `gen/` proto stubs and
-the Vite SPA bundle are produced on the host and shipped into the build context,
-not generated inside `docker build`. So on a fresh checkout, before the first
-build:
+The `glyphoxa` service pulls the published `ghcr.io/mrwong99/glyphoxa` image
+(built by `release-image.yml` on each release, ADR-0034), so a machine with
+only Docker needs nothing else — no buf, no Node/npm, no local build:
 
 ```sh
 cp .env.example .env
 $EDITOR .env        # GLYPHOXA_SECRET, DISCORD_OAUTH_*, GLYPHOXA_OPERATOR_IDS (§5–§6)
+docker compose up
+```
+
+Then open `http://127.0.0.1:8080` and **Sign in with Discord**.
+
+To run against a source checkout instead of the published image (e.g. testing
+an unreleased change), use the `build:` fallback still in `compose.yml`. That
+path is **context-fed** (ADR-0034): the gitignored `gen/` proto stubs and the
+Vite SPA bundle are produced on the host and shipped into the build context,
+not generated inside `docker build`:
+
+```sh
 make proto                        # buf generate → gen/  (must exist in the build context)
 (cd web && npm ci && npm run build)   # Vite bundle → internal/spa/dist (else a blank page)
 docker compose up --build
 ```
-
-Then open `http://127.0.0.1:8080` and **Sign in with Discord**.
 
 - **Secrets** load from `.env` via the service's `env_file`. Compose strips the
   shell `export ` prefix and quotes, so the same `.env` the source build sources
@@ -215,7 +224,7 @@ Then open `http://127.0.0.1:8080` and **Sign in with Discord**.
 - The app port publishes on `127.0.0.1:8080` (loopback), matching the default
   OAuth redirect. To reach it from a LAN, change the host side of the `ports:`
   mapping and update `DISCORD_OAUTH_REDIRECT_URL` to match.
-- **Smoke steps:** `docker compose up --build` → wait for the app log line that
+- **Smoke steps:** `docker compose up` → wait for the app log line that
   the web tier is listening → `curl -fsS http://127.0.0.1:8080/` returns the SPA
   → the browser reaches the login screen. `docker compose down -v` tears it down
   and drops the volume.


### PR DESCRIPTION
## Summary
- `compose.yml` `glyphoxa` service now adds `image: ghcr.io/mrwong99/glyphoxa:v0.2.0` (pinned version tag) — a machine with only Docker can `docker compose up` and reach the login screen with no buf/node/npm host toolchain.
- `build: context: .` stays as the documented fallback for `docker compose up --build` from a source checkout.
- `docs/configuration.md` §9 and the README quickstart updated to lead with the plain `docker compose up` pull path, with the source-build path called out as the `--build` fallback.

## Validation
- `docker compose config` parses clean (both `image:` and `build:` present on the service).
- `docker compose pull glyphoxa` resolves and pulls `ghcr.io/mrwong99/glyphoxa:v0.2.0` successfully.
- Did not start the full stack.

Closes #354