### PR TITLE
feat(#311): [E8] AI image generation provider Component (Gemini)

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -27,9 +27,11 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/bundle"
 	"github.com/MrWong99/Glyphoxa/internal/embedworker"
 	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/imagegen"
 	"github.com/MrWong99/Glyphoxa/internal/jobs"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
 	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/recall"
@@ -602,6 +604,37 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// Session Highlight campaign-clip sweep (#308, ADR-0048/0049): drops a hard-deleted
 	// Campaign's clip blobs, enqueued in the delete's own transaction (idempotent).
 	jobRunner.Register(highlight.JobKindSweepCampaignClips, highlight.CampaignSweepHandler(blobStore, log))
+	// Session Highlight AI image enrichment (#311, ADR-0004 amendment/0049): a
+	// promoted Highlight gets a Gemini-generated scene that lands through the blob
+	// seam. The factory resolves the tenant's image BYOK key under the hybrid policy
+	// (ADR-0039): a saved key needs the cipher (else a loud error, never a silent
+	// env fallback), no row falls back to GEMINI_API_KEY, and neither present is
+	// ErrImageNotConfigured (the handler leaves the Highlight intact without media).
+	imageFactory := func(fctx context.Context, tenantID uuid.UUID) (imagegen.Generator, string, error) {
+		var cfgPtr *storage.ProviderConfig
+		cfg, cerr := store.GetProviderConfigByComponent(fctx, tenantID, storage.ComponentImage)
+		if cerr == nil {
+			cfgPtr = &cfg
+		} else if !errors.Is(cerr, storage.ErrNotFound) {
+			return nil, "", cerr
+		}
+		key, kerr := llmbuild.ResolveKey(cipher, cfgPtr, storage.ComponentImage)
+		if kerr != nil {
+			return nil, "", kerr // saved key without cipher = loud error (ADR-0039)
+		}
+		if key == "" {
+			key = os.Getenv(imagegen.APIKeyEnv)
+		}
+		if key == "" {
+			return nil, "", highlight.ErrImageNotConfigured
+		}
+		model := imagegen.DefaultModel
+		if cfgPtr != nil && cfgPtr.Model != "" {
+			model = cfgPtr.Model
+		}
+		return imagegen.NewGemini(key, imagegen.WithModel(model)), model, nil
+	}
+	jobRunner.Register(highlight.JobKindEnrichImage, highlight.EnrichImageHandler(store, blobStore, imageFactory, metrics, log))
 	go jobRunner.Run(ctx)
 
 	// Boot-time retention backstop (#308, ADR-0051, the ReconcileOrphans/#184 spirit):
@@ -876,7 +909,7 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// Session Highlights read/mutate (#308): List/Get/Promote/Delete over the same
 	// store + blob seam the Voice process writes through. Wired here so the many
 	// NewSessionServer call sites keep their signature.
-	sessionSrv.SetHighlights(store, blobStore)
+	sessionSrv.SetHighlights(store, blobStore, jobEnqueuer{store})
 	sessionPath, sessionHandler := sessionSrv.Handler(stack.HandlerOptions()...)
 
 	// Session Highlight clip serve (#308/#309): GET /api/v1/highlights/{id}/clip, a
@@ -910,6 +943,9 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
 		// Session Highlight clip (#308): operator-gated audio byte stream with Range.
 		{Path: "GET /api/v1/highlights/{id}/clip", Handler: auth.RequireSession(store, http.HandlerFunc(clipServer.ServeClip))},
+		// Session Highlight AI image (#311): operator-gated image byte stream, same
+		// tenant + Active-Campaign 404 posture as the clip; no image yet → 404.
+		{Path: "GET /api/v1/highlights/{id}/image", Handler: auth.RequireSession(store, http.HandlerFunc(clipServer.ServeImage))},
 		// Campaign bundle export (#290): streamed gzip download, operator-gated.
 		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, http.HandlerFunc(bundleHandler.ServeExport))},
 		// Campaign bundle import (#291): multipart upload, operator-gated, plus the

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -1,0 +1,189 @@
+package highlight
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/imagegen"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// JobKindEnrichImage is the background-job kind that generates an AI image for a
+// promoted Highlight and lands it on the row through the blob seam (#311, Epic 8,
+// ADR-0004 amendment / ADR-0049). PromoteHighlight enqueues it; the handler is
+// idempotent + at-least-once.
+const JobKindEnrichImage = "highlight.enrich_image"
+
+// imageBlobName is the blob.Key name segment for a Highlight's generated image
+// (mirrors the clip's "clip.wav"). The key is t/<tenant>/highlight/<id>/image.
+const imageBlobName = "image"
+
+// excerptPromptLimit bounds the transcript excerpt folded into the image prompt
+// (runes, not bytes) so a long moment cannot blow up the request.
+const excerptPromptLimit = 1000
+
+// ErrImageNotConfigured is the sentinel a [GeneratorFactory] returns when the
+// tenant has no image provider key (no BYOK row AND no GEMINI_API_KEY). The
+// handler treats it as a clean no-op: the Highlight stays intact without media
+// (AC), no retry, no spend.
+var ErrImageNotConfigured = errors.New("highlight: image generation is not configured")
+
+// GeneratorFactory builds the tenant's image [imagegen.Generator] and returns the
+// model id to meter against. It resolves the BYOK key under the hybrid policy
+// (ADR-0039) and returns [ErrImageNotConfigured] when no key is available. main.go
+// wires it from the store + cipher; tests fake it.
+type GeneratorFactory func(ctx context.Context, tenantID uuid.UUID) (gen imagegen.Generator, model string, err error)
+
+// enrichPayload is the enrichment job's payload: which Highlight to enrich and
+// the tenant that owns it (the handler carries no ambient tenant, ADR-0049).
+type enrichPayload struct {
+	HighlightID uuid.UUID `json:"highlight_id"`
+	TenantID    uuid.UUID `json:"tenant_id"`
+}
+
+// MarshalEnrichImage builds the JobKindEnrichImage payload PromoteHighlight
+// enqueues. The RPC layer marshals it through its enqueuer seam.
+func MarshalEnrichImage(highlightID, tenantID uuid.UUID) ([]byte, error) {
+	return json.Marshal(enrichPayload{HighlightID: highlightID, TenantID: tenantID})
+}
+
+// EnrichStore is the storage surface the enrichment handler needs; *storage.Store
+// satisfies it and tests fake it. GetHighlight is tenant-scoped; SetHighlightImage
+// lands the result (ErrNotFound if the row was deleted meanwhile).
+type EnrichStore interface {
+	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
+	SetHighlightImage(ctx context.Context, id uuid.UUID, imageKey, contentType string, sizeBytes int64) error
+}
+
+// EnrichImageHandler builds the JobKindEnrichImage handler (ADR-0049). It is
+// idempotent + at-least-once:
+//
+//   - the Highlight is gone (deleted before the job ran) → nil (done).
+//   - the Highlight already has an image → nil (no double spend on a re-run).
+//   - image generation is not configured for the tenant → log + nil (the
+//     Highlight stays intact without media, AC — never a retry loop on a missing
+//     key).
+//   - otherwise generate → meter usage (caps-free spend meter teed onto the
+//     production recorder; Gemini bills the image as output tokens, so it prices
+//     through LLMTokens — no image-specific meter, #311) → store the image behind
+//     the blob seam at the deterministic key → record it on the row. A row that
+//     vanished between the read and the write compensates the orphaned blob and
+//     returns nil (done). A provider or blob error returns so the runner retries /
+//     dead-letters — the row is never mutated, so the Highlight is intact (AC).
+func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFactory, rec observe.StageRecorder, log *slog.Logger) func(context.Context, json.RawMessage) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	if rec == nil {
+		rec = observe.Discard{}
+	}
+	return func(ctx context.Context, payload json.RawMessage) error {
+		var p enrichPayload
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return fmt.Errorf("highlight enrich: decode payload: %w", err)
+		}
+
+		h, err := store.GetHighlight(ctx, p.TenantID, p.HighlightID)
+		if errors.Is(err, storage.ErrNotFound) {
+			// The Highlight was deleted before enrichment ran: nothing to do.
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("highlight enrich: load highlight %s: %w", p.HighlightID, err)
+		}
+		if h.ImageKey != "" {
+			// Already enriched (a re-run of an at-least-once job): stop before any
+			// spend so the same Highlight is never billed twice.
+			return nil
+		}
+
+		gen, model, err := factory(ctx, p.TenantID)
+		if errors.Is(err, ErrImageNotConfigured) {
+			log.Info("highlight enrich: image generation not configured, leaving highlight without media",
+				"highlight", p.HighlightID, "tenant", p.TenantID)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("highlight enrich: build generator: %w", err)
+		}
+
+		res, err := gen.Generate(ctx, buildImagePrompt(h.Excerpt, h.Reason))
+		if err != nil {
+			// Provider error: return it so the runner retries / dead-letters. The row
+			// is untouched — the Highlight keeps its clip and stays imageless (AC).
+			return fmt.Errorf("highlight enrich: generate image: %w", err)
+		}
+
+		// Meter the spend (ADR-0045/0046): a caps-free meter teed onto the production
+		// recorder prices the image's tokens AND moves the glyphoxa_voice_llm_tokens
+		// series. The enrichment job is off-session and never cap-gated (the recap
+		// posture). Gemini bills the image as output tokens → LLMTokens.
+		meter := spend.NewMeter(spend.Caps{}, log, nil, nil)
+		observe.TeeUsage(rec, meter).LLMTokens(observe.ProviderGemini, model, res.PromptTokens, res.OutputTokens)
+		log.Info("highlight enrich: image generated",
+			"highlight", p.HighlightID,
+			"model", model,
+			"input_tokens", res.PromptTokens,
+			"output_tokens", res.OutputTokens,
+			"estimated_usd", meter.Status().EstimatedUSD,
+		)
+
+		key, err := blob.Key(p.TenantID, "highlight", p.HighlightID, imageBlobName)
+		if err != nil {
+			return fmt.Errorf("highlight enrich: build image key: %w", err)
+		}
+		if err := blobs.Put(ctx, key, res.ContentType, bytes.NewReader(res.Data), int64(len(res.Data))); err != nil {
+			return fmt.Errorf("highlight enrich: store image: %w", err)
+		}
+		if err := store.SetHighlightImage(ctx, p.HighlightID, key, res.ContentType, int64(len(res.Data))); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				// The Highlight was deleted between the read and this write: the image
+				// blob we just stored is now an orphan. Compensate through the seam
+				// (ADR-0048) and treat the job as done — there is no row to enrich.
+				if derr := blobs.Delete(ctx, key); derr != nil {
+					log.Error("highlight enrich: compensate orphan image", "err", derr, "key", key)
+				}
+				return nil
+			}
+			return fmt.Errorf("highlight enrich: record image on highlight: %w", err)
+		}
+		return nil
+	}
+}
+
+// buildImagePrompt renders the fixed image prompt from a Highlight's caption
+// material (#311). Speaker IDs are deliberately NOT used. The excerpt is truncated
+// to excerptPromptLimit runes.
+func buildImagePrompt(excerpt, reason string) string {
+	return fmt.Sprintf(
+		"Illustrate this tabletop RPG moment as a single dramatic fantasy scene, no text or lettering in the image. Moment: %s. Why it is memorable: %s.",
+		truncateRunes(excerpt, excerptPromptLimit), reason)
+}
+
+// truncateRunes returns s truncated to at most n runes.
+func truncateRunes(s string, n int) string {
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	var b strings.Builder
+	i := 0
+	for _, r := range s {
+		if i >= n {
+			break
+		}
+		b.WriteRune(r)
+		i++
+	}
+	return b.String()
+}

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -105,6 +105,13 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		if h.ImageKey != "" {
 			// Already enriched (a re-run of an at-least-once job): stop before any
 			// spend so the same Highlight is never billed twice.
+			//
+			// KNOWN residual race (follow-up issue planned): this guard is
+			// read-then-act, not a lock. Two replicas promoting the same Highlight at
+			// once can both read ImageKey=="" and both Generate — bounded to one extra
+			// image's spend, and the second SetHighlightImage simply overwrites the
+			// first's deterministic key (harmless result, no orphan). The single-Voice
+			// -Session deployment (ADR-0039) makes this near-impossible in practice.
 			return nil
 		}
 
@@ -119,6 +126,14 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		}
 
 		res, err := gen.Generate(ctx, buildImagePrompt(h.Excerpt, h.Reason))
+		if errors.Is(err, imagegen.ErrImageTooLarge) {
+			// PERMANENT: an oversize image can never be stored, and a retry only
+			// re-bills the same generation. Log + return nil — the Highlight stays
+			// intact without media (AC), no dead-letter churn.
+			log.Warn("highlight enrich: generated image exceeds blob cap, leaving highlight without media",
+				"highlight", p.HighlightID)
+			return nil
+		}
 		if err != nil {
 			// Provider error: return it so the runner retries / dead-letters. The row
 			// is untouched — the Highlight keeps its clip and stays imageless (AC).
@@ -144,6 +159,12 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 			return fmt.Errorf("highlight enrich: build image key: %w", err)
 		}
 		if err := blobs.Put(ctx, key, res.ContentType, bytes.NewReader(res.Data), int64(len(res.Data))); err != nil {
+			if errors.Is(err, blob.ErrTooLarge) {
+				// Same PERMANENT posture as an oversize generation: never retryable.
+				log.Warn("highlight enrich: image exceeds blob cap at Put, leaving highlight without media",
+					"highlight", p.HighlightID)
+				return nil
+			}
 			return fmt.Errorf("highlight enrich: store image: %w", err)
 		}
 		if err := store.SetHighlightImage(ctx, p.HighlightID, key, res.ContentType, int64(len(res.Data))); err != nil {

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -1,0 +1,247 @@
+package highlight
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/imagegen"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// --- fakes ---
+
+// fakeEnrichStore is an in-memory EnrichStore keyed by highlight id.
+type fakeEnrichStore struct {
+	mu         sync.Mutex
+	rows       map[uuid.UUID]storage.Highlight
+	setCalls   int
+	setErr     error // returned by SetHighlightImage when non-nil
+	lastImgKey string
+	lastImgCT  string
+	lastImgSz  int64
+}
+
+func newFakeEnrichStore() *fakeEnrichStore {
+	return &fakeEnrichStore{rows: map[uuid.UUID]storage.Highlight{}}
+}
+
+func (f *fakeEnrichStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	return h, nil
+}
+
+func (f *fakeEnrichStore) SetHighlightImage(_ context.Context, id uuid.UUID, key, ct string, sz int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls++
+	if f.setErr != nil {
+		return f.setErr
+	}
+	h, ok := f.rows[id]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	h.ImageKey, h.ImageContentType, h.ImageSizeBytes = key, ct, sz
+	f.rows[id] = h
+	f.lastImgKey, f.lastImgCT, f.lastImgSz = key, ct, sz
+	return nil
+}
+
+// fakeBlobs (in-memory blob.Store) is declared in saver_test.go and shared here.
+
+// fakeGen is a Generator that returns a canned Result and counts calls.
+type fakeGen struct {
+	mu      sync.Mutex
+	calls   int
+	res     imagegen.Result
+	err     error
+	gotArgs string
+}
+
+func (g *fakeGen) Generate(_ context.Context, prompt string) (imagegen.Result, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls++
+	g.gotArgs = prompt
+	return g.res, g.err
+}
+
+// provRecorder captures the LLMTokens provider + counts (the package spyRecorder
+// drops the provider).
+type provRecorder struct {
+	observe.Discard
+	mu       sync.Mutex
+	provider observe.Provider
+	model    string
+	in, out  int
+	seen     bool
+}
+
+func (r *provRecorder) LLMTokens(p observe.Provider, model string, in, out int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.provider, r.model, r.in, r.out, r.seen = p, model, in, out, true
+}
+
+// seedRow inserts a promoted, imageless highlight and returns it.
+func seedRow(store *fakeEnrichStore, tenantID uuid.UUID) storage.Highlight {
+	h := storage.Highlight{
+		ID:              uuid.New(),
+		TenantID:        tenantID,
+		CampaignID:      uuid.New(),
+		Status:          storage.HighlightPromoted,
+		Excerpt:         "natural 20 against the ancient red dragon",
+		Reason:          "a clutch critical hit that saved the party",
+		ClipKey:         "t/" + tenantID.String() + "/highlight/x/clip.wav",
+		ClipContentType: "audio/wav",
+	}
+	store.rows[h.ID] = h
+	return h
+}
+
+func factoryReturning(gen imagegen.Generator, model string, err error) GeneratorFactory {
+	return func(context.Context, uuid.UUID) (imagegen.Generator, string, error) {
+		return gen, model, err
+	}
+}
+
+// --- tests ---
+
+func TestEnrichImageHandler_HappyPath(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+	gen := &fakeGen{res: imagegen.Result{Data: []byte("PNGDATA"), ContentType: "image/png", PromptTokens: 40, OutputTokens: 1290}}
+	rec := &provRecorder{}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "gemini-2.5-flash-image", nil), rec, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	wantKey := "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	if !blobs.has(wantKey) {
+		t.Fatalf("image blob not stored at %q; have %v", wantKey, blobs.data)
+	}
+	if store.lastImgKey != wantKey || store.lastImgCT != "image/png" || store.lastImgSz != int64(len("PNGDATA")) {
+		t.Fatalf("row image not set: %q/%q/%d", store.lastImgKey, store.lastImgCT, store.lastImgSz)
+	}
+	// Prompt uses excerpt + reason, never speaker ids.
+	if !strings.Contains(gen.gotArgs, "natural 20") || !strings.Contains(gen.gotArgs, "clutch critical hit") {
+		t.Errorf("prompt missing caption material: %q", gen.gotArgs)
+	}
+	// Metered as Gemini LLM tokens.
+	if !rec.seen || rec.provider != observe.ProviderGemini || rec.in != 40 || rec.out != 1290 {
+		t.Errorf("metering wrong: seen=%v provider=%q in=%d out=%d", rec.seen, rec.provider, rec.in, rec.out)
+	}
+}
+
+func TestEnrichImageHandler_Idempotent_AlreadyEnriched(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	h.ImageKey = "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	store.rows[h.ID] = h
+	blobs := newFakeBlobs()
+	gen := &fakeGen{res: imagegen.Result{Data: []byte("X"), ContentType: "image/png"}}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if gen.calls != 0 {
+		t.Fatalf("generator called %d times on an already-enriched highlight; want 0", gen.calls)
+	}
+}
+
+func TestEnrichImageHandler_RowGone_Nil(t *testing.T) {
+	store := newFakeEnrichStore()
+	gen := &fakeGen{}
+	handler := EnrichImageHandler(store, newFakeBlobs(), factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(uuid.New(), uuid.New())
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("deleted highlight should be a clean nil, got %v", err)
+	}
+	if gen.calls != 0 {
+		t.Fatalf("generator called for a missing row")
+	}
+}
+
+func TestEnrichImageHandler_NotConfigured_Nil(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(nil, "", ErrImageNotConfigured), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("unconfigured provider should be a clean nil, got %v", err)
+	}
+	// Highlight intact, no image.
+	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+	if got.ImageKey != "" {
+		t.Fatalf("row should stay imageless when not configured, got %q", got.ImageKey)
+	}
+}
+
+func TestEnrichImageHandler_GeneratorError_ReturnsErr_RowUntouched(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+	gen := &fakeGen{err: errors.New("provider 503")}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+	if err := handler(context.Background(), payload); err == nil {
+		t.Fatal("generator error must return an error so the runner retries")
+	}
+	// Nothing stored, row untouched (AC).
+	if len(blobs.data) != 0 {
+		t.Fatalf("no blob should be stored on generator failure")
+	}
+	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+	if got.ImageKey != "" {
+		t.Fatalf("row must be untouched on generator failure")
+	}
+}
+
+func TestEnrichImageHandler_Compensation_RowDeletedDuringWrite(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	// SetHighlightImage reports the row vanished after generation.
+	store.setErr = storage.ErrNotFound
+	blobs := newFakeBlobs()
+	gen := &fakeGen{res: imagegen.Result{Data: []byte("PNG"), ContentType: "image/png", OutputTokens: 1290}}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+	if err := handler(context.Background(), payload); err != nil {
+		t.Fatalf("a row deleted mid-write should be a clean nil, got %v", err)
+	}
+	wantKey := "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	// The just-stored orphan blob was compensated (deleted).
+	if blobs.has(wantKey) {
+		t.Fatalf("orphan image blob was not compensated")
+	}
+	if len(blobs.deleted) != 1 || blobs.deleted[0] != wantKey {
+		t.Fatalf("expected exactly the orphan key deleted, got %v", blobs.deleted)
+	}
+}

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -119,3 +119,78 @@ func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
 	// fallback content-type sniff, which our explicit header pre-empts.
 	http.ServeContent(w, req, "clip.wav", h.CreatedAt, bytes.NewReader(data))
 }
+
+// ServeImage streams one Highlight's AI-generated image (#311), mirroring
+// ServeClip: GET /api/v1/highlights/{id}/image behind auth.RequireSession. It
+// applies the same tenant + Active-Campaign 404 posture (existence never leaked)
+// and serves through http.ServeContent (Range/conditional). A Highlight with no
+// image yet (image_key == "") is 404 — the enrichment has not run, is not
+// configured, or failed, and there is nothing to serve. A missing blob is also
+// 404 (a purge race must not 500).
+func (c *ClipServer) ServeImage(w http.ResponseWriter, req *http.Request) {
+	tenantID, ok := auth.TenantID(req.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(req.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+
+	h, err := c.store.GetHighlight(req.Context(), tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight image: load row", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Active-Campaign scoping (#308 posture): an image whose highlight belongs to a
+	// campaign other than the resolved Active Campaign is 404. A nil resolver leaves
+	// scoping tenant-only.
+	if c.resolve != nil {
+		campaignID, ok, rerr := c.resolve(req.Context())
+		if rerr != nil {
+			c.log.Error("highlight image: resolve active campaign", "err", rerr, "highlight", id)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !ok || h.CampaignID != campaignID {
+			http.NotFound(w, req)
+			return
+		}
+	}
+
+	// No image yet: nothing to serve. 404 keeps the posture uniform with a foreign id.
+	if h.ImageKey == "" {
+		http.NotFound(w, req)
+		return
+	}
+
+	rc, _, err := c.blobs.Get(req.Context(), h.ImageKey)
+	if errors.Is(err, blob.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight image: fetch blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		c.log.Error("highlight image: read blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", h.ImageContentType)
+	http.ServeContent(w, req, "image", h.CreatedAt, bytes.NewReader(data))
+}

--- a/internal/highlight/http_test.go
+++ b/internal/highlight/http_test.go
@@ -20,6 +20,8 @@ type fakeClipStore struct {
 	id         uuid.UUID
 	campaignID uuid.UUID
 	clipKey    string
+	imageKey   string // empty = no image yet (#311)
+	imageCT    string
 }
 
 func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
@@ -27,13 +29,15 @@ func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) 
 		return storage.Highlight{}, storage.ErrNotFound
 	}
 	return storage.Highlight{
-		ID:              f.id,
-		TenantID:        f.tenantID,
-		CampaignID:      f.campaignID,
-		Status:          storage.HighlightCandidate,
-		ClipKey:         f.clipKey,
-		ClipContentType: "audio/wav",
-		CreatedAt:       time.Now(),
+		ID:               f.id,
+		TenantID:         f.tenantID,
+		CampaignID:       f.campaignID,
+		Status:           storage.HighlightCandidate,
+		ClipKey:          f.clipKey,
+		ClipContentType:  "audio/wav",
+		ImageKey:         f.imageKey,
+		ImageContentType: f.imageCT,
+		CreatedAt:        time.Now(),
 	}, nil
 }
 
@@ -149,6 +153,107 @@ func TestClip_CrossCampaign404(t *testing.T) {
 	srv.ServeClip(rr, clipRequest(t, tenantID, id.String(), ""))
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("cross-campaign clip: want 404, got %d", rr.Code)
+	}
+}
+
+// --- image serve (#311) ---
+
+// imageRequest builds a GET /highlights/{id}/image request with the tenant injected.
+func imageRequest(t *testing.T, tenantID uuid.UUID, id, rangeHdr string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/"+id+"/image", nil)
+	req.SetPathValue("id", id)
+	if tenantID != uuid.Nil {
+		req = req.WithContext(auth.WithTenant(req.Context(), tenantID))
+	}
+	if rangeHdr != "" {
+		req.Header.Set("Range", rangeHdr)
+	}
+	return req
+}
+
+// newImageFixture builds a ClipServer over a highlight that HAS an image, plus a
+// resolver that resolves the Active Campaign to its campaign.
+func newImageFixture(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	tenantID, id, campaignID := uuid.New(), uuid.New(), uuid.New()
+	clipKey, _ := blob.Key(tenantID, "highlight", id, "clip.wav")
+	imgKey, err := blob.Key(tenantID, "highlight", id, "image")
+	if err != nil {
+		t.Fatalf("build image key: %v", err)
+	}
+	blobs := newFakeBlobs()
+	blobs.data[imgKey] = make([]byte, 300)
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: campaignID, clipKey: clipKey, imageKey: imgKey, imageCT: "image/png"}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return campaignID, true, nil }
+	return NewClipServer(store, blobs, resolve, testLog()), tenantID, id
+}
+
+func TestImage_ServesWithContentType(t *testing.T) {
+	srv, tenantID, id := newImageFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeImage(rr, imageRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("want image/png, got %q", ct)
+	}
+	if rr.Body.Len() != 300 {
+		t.Fatalf("want 300 bytes, got %d", rr.Body.Len())
+	}
+}
+
+func TestImage_RangeReturnsPartial(t *testing.T) {
+	srv, tenantID, id := newImageFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeImage(rr, imageRequest(t, tenantID, id.String(), "bytes=0-149"))
+	if rr.Code != http.StatusPartialContent {
+		t.Fatalf("want 206, got %d", rr.Code)
+	}
+	if rr.Body.Len() != 150 {
+		t.Fatalf("want 150 bytes, got %d", rr.Body.Len())
+	}
+}
+
+func TestImage_EmptyImageKey404(t *testing.T) {
+	// A highlight with no image yet: image_key == "".
+	tenantID, id, campaignID := uuid.New(), uuid.New(), uuid.New()
+	clipKey, _ := blob.Key(tenantID, "highlight", id, "clip.wav")
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: campaignID, clipKey: clipKey}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return campaignID, true, nil }
+	srv := NewClipServer(store, newFakeBlobs(), resolve, testLog())
+
+	rr := httptest.NewRecorder()
+	srv.ServeImage(rr, imageRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("no image yet: want 404, got %d", rr.Code)
+	}
+}
+
+func TestImage_ForeignTenant404(t *testing.T) {
+	srv, _, id := newImageFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeImage(rr, imageRequest(t, uuid.New(), id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}
+
+func TestImage_CrossCampaign404(t *testing.T) {
+	tenantID, id, otherCampaign := uuid.New(), uuid.New(), uuid.New()
+	imgKey, _ := blob.Key(tenantID, "highlight", id, "image")
+	blobs := newFakeBlobs()
+	blobs.data[imgKey] = make([]byte, 100)
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: otherCampaign, imageKey: imgKey, imageCT: "image/png"}
+	// Active Campaign resolves to a different campaign than the highlight's.
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return uuid.New(), true, nil }
+	srv := NewClipServer(store, blobs, resolve, testLog())
+
+	rr := httptest.NewRecorder()
+	srv.ServeImage(rr, imageRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-campaign image: want 404, got %d", rr.Code)
 	}
 }
 

--- a/internal/highlight/saver_test.go
+++ b/internal/highlight/saver_test.go
@@ -48,7 +48,8 @@ type fakeBlobs struct {
 	data      map[string][]byte
 	gate      chan struct{} // if non-nil, Put blocks until a receive
 	putErr    error
-	deleteErr error // if set, Delete returns it (blob-backend failure)
+	deleteErr error    // if set, Delete returns it (blob-backend failure)
+	deleted   []string // keys passed to Delete (compensation assertions)
 }
 
 func newFakeBlobs() *fakeBlobs { return &fakeBlobs{data: map[string][]byte{}} }
@@ -84,6 +85,7 @@ func (f *fakeBlobs) Delete(_ context.Context, key string) error {
 		return f.deleteErr
 	}
 	delete(f.data, key)
+	f.deleted = append(f.deleted, key)
 	return nil
 }
 
@@ -91,6 +93,13 @@ func (f *fakeBlobs) keys() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.data)
+}
+
+func (f *fakeBlobs) has(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.data[key]
+	return ok
 }
 
 // fakeEnqueuer records the last enqueued job.

--- a/internal/imagegen/imagegen.go
+++ b/internal/imagegen/imagegen.go
@@ -17,12 +17,21 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 )
+
+// ErrImageTooLarge is returned when a generated image exceeds the blob seam's
+// per-blob cap (blob.MaxSize). It is a PERMANENT failure — retrying re-bills the
+// same oversize generation — so the enrichment handler treats it as a clean no-op
+// (log + leave the Highlight intact) rather than a retryable error.
+var ErrImageTooLarge = errors.New("imagegen: generated image exceeds the blob size cap")
 
 const (
 	// ProviderID is the stable string identifying this adapter; it matches the
@@ -45,6 +54,12 @@ const (
 	// apiKeyHeader is Gemini's native-endpoint auth header (NOT a Bearer token —
 	// the compat endpoint uses Authorization, this one uses x-goog-api-key).
 	apiKeyHeader = "x-goog-api-key"
+
+	// maxResponseBytes bounds the response read: the blob cap (blob.MaxSize)
+	// doubled covers a full-cap image base64-encoded (~4/3 inflation) plus JSON
+	// envelope, so an at-cap image still parses while an unbounded body cannot
+	// exhaust memory. The post-decode blob.MaxSize check owns the actual reject.
+	maxResponseBytes = 2 * blob.MaxSize
 )
 
 // Result is one generated image plus the token counts the provider metered for
@@ -157,8 +172,11 @@ func (g *Gemini) Generate(ctx context.Context, prompt string) (Result, error) {
 	}
 
 	body, err := json.Marshal(generateContentRequest{
-		Contents:         []reqContent{{Parts: []reqPart{{Text: prompt}}}},
-		GenerationConfig: generationConfig{ResponseModalities: []string{"IMAGE"}},
+		Contents: []reqContent{{Parts: []reqPart{{Text: prompt}}}},
+		// ["TEXT","IMAGE"], NOT image-only: the canonical Gemini image-generation
+		// examples request both modalities, and image-only has 400'd on prior models.
+		// The parser skips any leading text part and takes the first inlineData image.
+		GenerationConfig: generationConfig{ResponseModalities: []string{"TEXT", "IMAGE"}},
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("imagegen: marshal request: %w", err)
@@ -178,7 +196,11 @@ func (g *Gemini) Generate(ctx context.Context, prompt string) (Result, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	// Bound the response read to the blob cap plus base64/JSON headroom (base64
+	// inflates ~4/3): a body that decodes past blob.MaxSize can never be stored, so
+	// reading beyond this only wastes memory. maxResponseBytes over-reads slightly
+	// so an at-cap image still parses and the post-decode check owns the reject.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return Result{}, fmt.Errorf("imagegen: read response: %w", err)
 	}
@@ -199,6 +221,9 @@ func (g *Gemini) Generate(ctx context.Context, prompt string) (Result, error) {
 			data, err := base64.StdEncoding.DecodeString(p.InlineData.Data)
 			if err != nil {
 				return Result{}, fmt.Errorf("imagegen: decode inline image: %w", err)
+			}
+			if int64(len(data)) > blob.MaxSize {
+				return Result{}, ErrImageTooLarge
 			}
 			return Result{
 				Data:         data,

--- a/internal/imagegen/imagegen.go
+++ b/internal/imagegen/imagegen.go
@@ -1,0 +1,221 @@
+// Package imagegen is the AI image-generation seam (#311, Epic 8, ADR-0004
+// amendment): a small [Generator] interface plus a Gemini adapter that turns a
+// text prompt into a single generated image. The highlight enrichment job
+// (internal/highlight, ADR-0049) drives it post-promotion and lands the result
+// on the Highlight through the blob seam (ADR-0048).
+//
+// The Gemini adapter is a plain net/http client against the native
+// generateContent REST surface, deliberately NOT the Google SDK — the same
+// posture internal/discordinvite / internal/discordtag take (an SDK's rate
+// limiter leaks a cleanup goroutine per call, and the request/response shape here
+// is one POST). The base URL, model, and http.Client are seams so unit tests
+// drive a httptest fake and the default `go test` makes no vendor call.
+package imagegen
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	// ProviderID is the stable string identifying this adapter; it matches the
+	// Provider Config's provider name and observe.ProviderGemini.
+	ProviderID = "gemini"
+
+	// DefaultModel is the Gemini image-generation model used when no model is
+	// configured. It is the "flash image" preview model (billed per output image,
+	// ~1290 output tokens each — see internal/spend/prices.go).
+	DefaultModel = "gemini-2.5-flash-image"
+
+	// DefaultBaseURL is the native Generative Language API root. The request path
+	// {base}/v1beta/models/{model}:generateContent is appended per call.
+	DefaultBaseURL = "https://generativelanguage.googleapis.com"
+
+	// APIKeyEnv is the environment variable the enrichment factory falls back to
+	// when no BYOK key is stored (the hybrid key policy, ADR-0039).
+	APIKeyEnv = "GEMINI_API_KEY"
+
+	// apiKeyHeader is Gemini's native-endpoint auth header (NOT a Bearer token —
+	// the compat endpoint uses Authorization, this one uses x-goog-api-key).
+	apiKeyHeader = "x-goog-api-key"
+)
+
+// Result is one generated image plus the token counts the provider metered for
+// the request (ADR-0045): PromptTokens is the input, OutputTokens the image's
+// billed output tokens (Gemini bills a generated image as output tokens, so it
+// prices through the LLM usage sink — no image-specific meter, #311).
+type Result struct {
+	Data         []byte
+	ContentType  string
+	PromptTokens int
+	OutputTokens int
+}
+
+// Generator turns a text prompt into a single generated image. *Gemini is the
+// v1 implementation; the enrichment job depends on this interface so tests fake
+// it and later providers can slot in behind ADR-0004.
+type Generator interface {
+	Generate(ctx context.Context, prompt string) (Result, error)
+}
+
+// Option customises a [Gemini] adapter.
+type Option func(*Gemini)
+
+// WithBaseURL overrides the API base URL (httptest server / self-hosted gateway).
+func WithBaseURL(u string) Option { return func(g *Gemini) { g.baseURL = u } }
+
+// WithModel sets the image model requested (defaults to [DefaultModel]).
+func WithModel(m string) Option { return func(g *Gemini) { g.model = m } }
+
+// WithHTTPClient supplies a custom http.Client (timeouts, transport). Defaults to
+// a client with a generous timeout — image generation is slower than a text turn.
+func WithHTTPClient(h *http.Client) Option { return func(g *Gemini) { g.httpClient = h } }
+
+// Gemini is the plain-net/http Gemini image adapter. Construct with [NewGemini];
+// the zero value is not usable. Safe for concurrent use.
+type Gemini struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	httpClient *http.Client
+}
+
+var _ Generator = (*Gemini)(nil)
+
+// NewGemini builds a Gemini image [Generator]. An empty apiKey falls back to
+// GEMINI_API_KEY (the hybrid env path, ADR-0039); if that is also empty, Generate
+// returns a missing-key error rather than panicking, so a keyless boot links.
+func NewGemini(apiKey string, opts ...Option) *Gemini {
+	if apiKey == "" {
+		apiKey = os.Getenv(APIKeyEnv)
+	}
+	g := &Gemini{
+		apiKey:     apiKey,
+		baseURL:    DefaultBaseURL,
+		model:      DefaultModel,
+		httpClient: &http.Client{Timeout: 90 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g
+}
+
+// generateContentRequest is the native generateContent body. It asks for the
+// IMAGE response modality so the model returns inline image bytes.
+type generateContentRequest struct {
+	Contents         []reqContent     `json:"contents"`
+	GenerationConfig generationConfig `json:"generationConfig"`
+}
+
+type reqContent struct {
+	Parts []reqPart `json:"parts"`
+}
+
+type reqPart struct {
+	Text string `json:"text"`
+}
+
+type generationConfig struct {
+	ResponseModalities []string `json:"responseModalities"`
+}
+
+// generateContentResponse is the subset of the native response we parse: the
+// first candidate's inline image data + the usage token counts.
+type generateContentResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				InlineData *struct {
+					MimeType string `json:"mimeType"`
+					Data     string `json:"data"`
+				} `json:"inlineData"`
+			} `json:"parts"`
+		} `json:"content"`
+	} `json:"candidates"`
+	UsageMetadata struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+	} `json:"usageMetadata"`
+}
+
+// Generate POSTs the prompt to Gemini's generateContent and returns the first
+// inline image with its MIME type and the request's token counts. An empty key,
+// a non-2xx status, or a response carrying no inline image data is an error (the
+// enrichment job returns it so the runner retries / dead-letters, leaving the
+// Highlight intact).
+func (g *Gemini) Generate(ctx context.Context, prompt string) (Result, error) {
+	if g.apiKey == "" {
+		return Result{}, fmt.Errorf("imagegen: missing API key (set %s)", APIKeyEnv)
+	}
+
+	body, err := json.Marshal(generateContentRequest{
+		Contents:         []reqContent{{Parts: []reqPart{{Text: prompt}}}},
+		GenerationConfig: generationConfig{ResponseModalities: []string{"IMAGE"}},
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("imagegen: marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", g.baseURL, g.model)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("imagegen: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(apiKeyHeader, g.apiKey)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("imagegen: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return Result{}, fmt.Errorf("imagegen: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Result{}, fmt.Errorf("imagegen: HTTP %d: %s", resp.StatusCode, truncate(respBody, 256))
+	}
+
+	var parsed generateContentResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return Result{}, fmt.Errorf("imagegen: decode response: %w", err)
+	}
+
+	for _, c := range parsed.Candidates {
+		for _, p := range c.Content.Parts {
+			if p.InlineData == nil || p.InlineData.Data == "" {
+				continue
+			}
+			data, err := base64.StdEncoding.DecodeString(p.InlineData.Data)
+			if err != nil {
+				return Result{}, fmt.Errorf("imagegen: decode inline image: %w", err)
+			}
+			return Result{
+				Data:         data,
+				ContentType:  p.InlineData.MimeType,
+				PromptTokens: parsed.UsageMetadata.PromptTokenCount,
+				OutputTokens: parsed.UsageMetadata.CandidatesTokenCount,
+			}, nil
+		}
+	}
+	return Result{}, fmt.Errorf("imagegen: response carried no inline image data")
+}
+
+// truncate bounds an error's echoed response body so a huge error page cannot
+// bloat a log line.
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/internal/imagegen/imagegen_test.go
+++ b/internal/imagegen/imagegen_test.go
@@ -1,0 +1,151 @@
+package imagegen_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/imagegen"
+)
+
+// wantPNG is the decoded image bytes the golden fixture base64-encodes.
+var wantPNG = []byte("\x89PNG\r\n\x1a\n-fake-image-bytes")
+
+// goldenResponse is a captured-shape generateContent success: one candidate with
+// an inline PNG, plus usageMetadata token counts.
+func goldenResponse(t *testing.T) string {
+	t.Helper()
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						// A leading text part the model sometimes emits — the adapter
+						// must skip it and find the inlineData part.
+						map[string]any{"text": "Here is your scene."},
+						map[string]any{
+							"inlineData": map[string]any{
+								"mimeType": "image/png",
+								"data":     base64.StdEncoding.EncodeToString(wantPNG),
+							},
+						},
+					},
+				},
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     37,
+			"candidatesTokenCount": 1290,
+		},
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal golden: %v", err)
+	}
+	return string(b)
+}
+
+func TestGemini_Generate_RequestShapeAndParse(t *testing.T) {
+	var gotPath, gotKey, gotCT string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-goog-api-key")
+		gotCT = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, goldenResponse(t))
+	}))
+	defer srv.Close()
+
+	gen := imagegen.NewGemini("secret-key",
+		imagegen.WithBaseURL(srv.URL),
+		imagegen.WithModel("gemini-2.5-flash-image"))
+
+	res, err := gen.Generate(context.Background(), "a dragon burns the tavern")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// Request shape (the shared contract #309/#310 consume).
+	if gotPath != "/v1beta/models/gemini-2.5-flash-image:generateContent" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotKey != "secret-key" {
+		t.Errorf("api key header = %q", gotKey)
+	}
+	if !strings.HasPrefix(gotCT, "application/json") {
+		t.Errorf("content-type = %q", gotCT)
+	}
+	// generationConfig.responseModalities == ["IMAGE"]
+	gc, _ := gotBody["generationConfig"].(map[string]any)
+	mods, _ := gc["responseModalities"].([]any)
+	if len(mods) != 1 || mods[0] != "IMAGE" {
+		t.Errorf("responseModalities = %v", mods)
+	}
+	// contents[0].parts[0].text == prompt
+	contents, _ := gotBody["contents"].([]any)
+	if len(contents) != 1 {
+		t.Fatalf("contents = %v", contents)
+	}
+	c0, _ := contents[0].(map[string]any)
+	parts, _ := c0["parts"].([]any)
+	p0, _ := parts[0].(map[string]any)
+	if p0["text"] != "a dragon burns the tavern" {
+		t.Errorf("prompt text = %v", p0["text"])
+	}
+
+	// Parse: decoded bytes, MIME, and usage counts.
+	if string(res.Data) != string(wantPNG) {
+		t.Errorf("image bytes mismatch: %q", res.Data)
+	}
+	if res.ContentType != "image/png" {
+		t.Errorf("content type = %q", res.ContentType)
+	}
+	if res.PromptTokens != 37 || res.OutputTokens != 1290 {
+		t.Errorf("tokens = %d/%d, want 37/1290", res.PromptTokens, res.OutputTokens)
+	}
+}
+
+func TestGemini_Generate_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"quota"}}`)
+	}))
+	defer srv.Close()
+
+	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
+	if _, err := gen.Generate(context.Background(), "x"); err == nil {
+		t.Fatal("want error on 429, got nil")
+	} else if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error should carry the status: %v", err)
+	}
+}
+
+func TestGemini_Generate_NoInlineData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A text-only candidate (safety refusal / model returned prose, no image).
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"text":"I can't do that"}]}}]}`)
+	}))
+	defer srv.Close()
+
+	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
+	if _, err := gen.Generate(context.Background(), "x"); err == nil {
+		t.Fatal("want error when no inline image data, got nil")
+	}
+}
+
+func TestGemini_Generate_EmptyKey(t *testing.T) {
+	t.Setenv(imagegen.APIKeyEnv, "")
+	gen := imagegen.NewGemini("") // no arg, no env → missing key
+	if _, err := gen.Generate(context.Background(), "x"); err == nil {
+		t.Fatal("want missing-key error, got nil")
+	}
+}

--- a/internal/imagegen/imagegen_test.go
+++ b/internal/imagegen/imagegen_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/imagegen"
 )
 
@@ -83,11 +85,12 @@ func TestGemini_Generate_RequestShapeAndParse(t *testing.T) {
 	if !strings.HasPrefix(gotCT, "application/json") {
 		t.Errorf("content-type = %q", gotCT)
 	}
-	// generationConfig.responseModalities == ["IMAGE"]
+	// generationConfig.responseModalities == ["TEXT","IMAGE"] (canonical shape;
+	// image-only 400'd on prior models). The parser skips the text part.
 	gc, _ := gotBody["generationConfig"].(map[string]any)
 	mods, _ := gc["responseModalities"].([]any)
-	if len(mods) != 1 || mods[0] != "IMAGE" {
-		t.Errorf("responseModalities = %v", mods)
+	if len(mods) != 2 || mods[0] != "TEXT" || mods[1] != "IMAGE" {
+		t.Errorf("responseModalities = %v, want [TEXT IMAGE]", mods)
 	}
 	// contents[0].parts[0].text == prompt
 	contents, _ := gotBody["contents"].([]any)
@@ -139,6 +142,28 @@ func TestGemini_Generate_NoInlineData(t *testing.T) {
 	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
 	if _, err := gen.Generate(context.Background(), "x"); err == nil {
 		t.Fatal("want error when no inline image data, got nil")
+	}
+}
+
+func TestGemini_Generate_OversizeIsPermanent(t *testing.T) {
+	// An image decoding past the blob cap must return ErrImageTooLarge (permanent),
+	// so the handler skips it instead of re-billing on every retry.
+	big := make([]byte, blob.MaxSize+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := json.Marshal(map[string]any{
+			"candidates": []any{map[string]any{"content": map[string]any{"parts": []any{
+				map[string]any{"inlineData": map[string]any{"mimeType": "image/png", "data": base64.StdEncoding.EncodeToString(big)}},
+			}}}},
+		})
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
+	_, err := gen.Generate(context.Background(), "x")
+	if !errors.Is(err, imagegen.ErrImageTooLarge) {
+		t.Fatalf("want ErrImageTooLarge, got %v", err)
 	}
 }
 

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -23,7 +23,7 @@ import (
 // Voice Session first, else the profile-first durable selection), and a highlight
 // (or session) belonging to ANOTHER campaign is CodeNotFound — existence never
 // leaked, exactly the GenerateRecap "names nothing" posture. PromoteHighlight
-// deliberately does NOT enqueue enrichment; that is #311's hook.
+// enqueues AI image enrichment (#311) on a successful keep.
 
 // errNoSuchHighlight is the single static NotFound every Highlight RPC returns for
 // a foreign-tenant, cross-campaign, unknown, or unparsable id — so a probe can
@@ -190,7 +190,8 @@ func (s *SessionServer) GetHighlight(
 // Active Campaign (#308/#309), returning the updated row. Idempotent on the server.
 // A foreign-tenant, cross-campaign, unknown, or unparsable id is CodeNotFound. The
 // campaign ownership is checked BEFORE the mutation, so another campaign's row is
-// never promoted. It does NOT enqueue enrichment (#311's hook).
+// never promoted. On a successful keep it enqueues AI image enrichment (#311)
+// unless the Highlight is already enriched.
 func (s *SessionServer) PromoteHighlight(
 	ctx context.Context,
 	req *connect.Request[managementv1.PromoteHighlightRequest],
@@ -236,9 +237,10 @@ func (s *SessionServer) PromoteHighlight(
 	// Enqueue AI image enrichment (#311, ADR-0049): a promoted Highlight with no
 	// image yet gets a background generation job. Skipped when already enriched
 	// (an idempotent re-promote never re-spends) or when the enqueuer is unwired.
-	// An enqueue failure is logged only — the promotion succeeded and the boot
-	// backstop / a re-promote can re-trigger enrichment; failing the RPC here would
-	// wrongly report the keep as failed.
+	// An enqueue failure is logged only — the promotion succeeded, and a GM
+	// re-promote re-triggers enrichment (there is NO boot sweep for enrichment;
+	// SweepMissingCandidatePurges covers only the purge job — follow-up issue
+	// planned). Failing the RPC here would wrongly report the keep as failed.
 	if s.enqueue != nil && h.ImageKey == "" {
 		payload, merr := highlight.MarshalEnrichImage(h.ID, tenantID)
 		if merr != nil {
@@ -288,6 +290,17 @@ func (s *SessionServer) DeleteHighlight(
 	}
 	if h.CampaignID != campaignID {
 		return nil, errNoSuchHighlight() // cross-campaign: never delete, never leak existence
+	}
+
+	// KNOWN residual race (follow-up issue planned): an enrichment job can commit
+	// SetHighlightImage between the load above and the blob deletes below, so the
+	// image_key read there is stale-empty and the just-stored image blob is orphaned
+	// (there is no global orphan sweep). Cheap shrink: re-read the row immediately
+	// before the blob deletes to pick up a freshly-committed image_key, closing the
+	// window to the microseconds between this read and the delete. A re-read failure
+	// is non-fatal — fall back to the earlier snapshot and still delete the clip+row.
+	if fresh, rerr := s.highlights.GetHighlight(ctx, tenantID, id); rerr == nil {
+		h.ImageKey = fresh.ImageKey
 	}
 
 	// Blob first (idempotent Delete): a missing clip must not block the row delete.

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -2,13 +2,16 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -58,19 +61,31 @@ type HighlightStore interface {
 }
 
 // highlightBlobs is the blob-seam surface DeleteHighlight needs (ADR-0048): drop
-// the clip before the row. *blob.Postgres satisfies it. Kept narrow so the RPC
-// package carries no import of the concrete backend.
+// the clip (and image, #311) before the row. *blob.Postgres satisfies it. Kept
+// narrow so the RPC package carries no import of the concrete backend.
 type highlightBlobs interface {
 	Delete(ctx context.Context, key string) error
+}
+
+// HighlightEnqueuer schedules the image-enrichment job PromoteHighlight fires
+// (#311, ADR-0049). It is the same kind/payload/run_after adapter the Saver's
+// purge scheduler uses; main.go wires *storage.Store behind it. A nil enqueuer
+// (unwired, keyless tests) makes promotion skip enrichment — the promote itself
+// still succeeds.
+type HighlightEnqueuer interface {
+	Enqueue(ctx context.Context, kind string, payload any, runAfter time.Time) error
 }
 
 // SetHighlights wires the Session Highlights read/mutate seam onto the
 // SessionServer (#308). Called once at boot after the store + blob backend are
 // built; the many NewSessionServer call sites keep their signature. Unwired, the
-// Highlight RPCs report CodeUnimplemented.
-func (s *SessionServer) SetHighlights(store HighlightStore, blobs highlightBlobs) {
+// Highlight RPCs report CodeUnimplemented. enqueue (#311) is the image-enrichment
+// job scheduler PromoteHighlight fires; nil disables enrichment (promote still
+// works).
+func (s *SessionServer) SetHighlights(store HighlightStore, blobs highlightBlobs, enqueue HighlightEnqueuer) {
 	s.highlights = store
 	s.blobs = blobs
+	s.enqueue = enqueue
 }
 
 // notWired is the CodeUnimplemented error a Highlight RPC returns when the server
@@ -217,6 +232,21 @@ func (s *SessionServer) PromoteHighlight(
 		s.log.Error("PromoteHighlight: store promote failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
+
+	// Enqueue AI image enrichment (#311, ADR-0049): a promoted Highlight with no
+	// image yet gets a background generation job. Skipped when already enriched
+	// (an idempotent re-promote never re-spends) or when the enqueuer is unwired.
+	// An enqueue failure is logged only — the promotion succeeded and the boot
+	// backstop / a re-promote can re-trigger enrichment; failing the RPC here would
+	// wrongly report the keep as failed.
+	if s.enqueue != nil && h.ImageKey == "" {
+		payload, merr := highlight.MarshalEnrichImage(h.ID, tenantID)
+		if merr != nil {
+			s.log.Error("PromoteHighlight: marshal enrich payload failed", "err", merr, "highlight", h.ID)
+		} else if eerr := s.enqueue.Enqueue(ctx, highlight.JobKindEnrichImage, json.RawMessage(payload), time.Now()); eerr != nil {
+			s.log.Error("PromoteHighlight: enqueue image enrichment failed", "err", eerr, "highlight", h.ID)
+		}
+	}
 	return connect.NewResponse(&managementv1.PromoteHighlightResponse{Highlight: toProtoHighlight(h)}), nil
 }
 
@@ -261,10 +291,19 @@ func (s *SessionServer) DeleteHighlight(
 	}
 
 	// Blob first (idempotent Delete): a missing clip must not block the row delete.
+	// A Highlight owns up to two blobs — the audio clip and (once enriched, #311)
+	// the generated image — so drop both before the row (ADR-0048). The image key
+	// is only present on an enriched row; an empty one is skipped.
 	if s.blobs != nil {
 		if err := s.blobs.Delete(ctx, h.ClipKey); err != nil {
 			s.log.Error("DeleteHighlight: delete clip failed", "err", err, "highlight", id)
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+		if h.ImageKey != "" {
+			if err := s.blobs.Delete(ctx, h.ImageKey); err != nil {
+				s.log.Error("DeleteHighlight: delete image failed", "err", err, "highlight", id)
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+			}
 		}
 	}
 	if _, err := s.highlights.DeleteHighlight(ctx, tenantID, id); err != nil {
@@ -294,7 +333,12 @@ func toProtoHighlight(h storage.Highlight) *managementv1.Highlight {
 		SpeakerIds:      h.SpeakerIDs,
 		ClipContentType: h.ClipContentType,
 		ClipSizeBytes:   h.ClipSizeBytes,
-		CreatedAt:       timestamppb.New(h.CreatedAt),
+		// Image fields (#311): content type + size are exposed so the UI knows an
+		// image exists and its type; image_key is deliberately omitted (an internal
+		// blob-seam detail, the clip_key posture). Empty when no image yet.
+		ImageContentType: h.ImageContentType,
+		ImageSizeBytes:   h.ImageSizeBytes,
+		CreatedAt:        timestamppb.New(h.CreatedAt),
 	}
 	if h.PromotedAt != nil {
 		pb.PromotedAt = timestamppb.New(*h.PromotedAt)

--- a/internal/rpc/highlight_test.go
+++ b/internal/rpc/highlight_test.go
@@ -2,6 +2,8 @@ package rpc_test
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -14,6 +16,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -97,11 +100,41 @@ func (f *fakeRPCBlobs) Delete(_ context.Context, key string) error {
 	return nil
 }
 
+func (f *fakeRPCBlobs) deletedKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.deleted...)
+}
+
+// fakeHighlightEnqueuer records image-enrichment jobs PromoteHighlight schedules.
+type fakeHighlightEnqueuer struct {
+	mu       sync.Mutex
+	calls    int
+	kind     string
+	payload  any
+	runAfter time.Time
+	err      error // returned by Enqueue when set (enqueue-failure test)
+}
+
+func (f *fakeHighlightEnqueuer) Enqueue(_ context.Context, kind string, payload any, runAfter time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.kind, f.payload, f.runAfter = kind, payload, runAfter
+	return f.err
+}
+
 // newHighlightClient mounts a SessionServer with the highlight seam wired and an
 // authenticated operator on tenantID. sstore drives the Active-Campaign resolution
 // (#308 campaign scoping) and the voice-session ownership lookups; a nil sstore
 // falls back to a plain activeStore() (the legacy tenant-only tests).
 func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs, sstore *fakeSessionStore) managementv1connect.SessionServiceClient {
+	return newHighlightClientEnq(t, tenantID, hstore, blobs, sstore, nil)
+}
+
+// newHighlightClientEnq is newHighlightClient plus an explicit enrichment enqueuer
+// (#311). A nil enqueuer disables enrichment (promote still succeeds).
+func newHighlightClientEnq(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs, sstore *fakeSessionStore, enqueue rpc.HighlightEnqueuer) managementv1connect.SessionServiceClient {
 	t.Helper()
 	if sstore == nil {
 		sstore = activeStore()
@@ -113,7 +146,7 @@ func newHighlightClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightSt
 		}
 	})
 	srv := rpc.NewSessionServer(&fakeSessionManager{}, sstore, nil, nil)
-	srv.SetHighlights(hstore, blobs)
+	srv.SetHighlights(hstore, blobs, enqueue)
 	mux := http.NewServeMux()
 	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
 	httpSrv := httptest.NewServer(mux)
@@ -244,6 +277,143 @@ func TestRPCHighlight_Delete_BlobThenRow(t *testing.T) {
 		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()}))
 	if connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("double delete: want NotFound, got %v", err)
+	}
+}
+
+func TestRPCHighlight_Promote_EnqueuesImageEnrichment(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
+	enq := &fakeHighlightEnqueuer{}
+
+	client := newHighlightClientEnq(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), enq)
+	if _, err := client.PromoteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: h.ID.String()})); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if enq.calls != 1 || enq.kind != highlight.JobKindEnrichImage {
+		t.Fatalf("enqueue calls=%d kind=%q, want 1 %q", enq.calls, enq.kind, highlight.JobKindEnrichImage)
+	}
+	// Payload decodes to the promoted highlight + tenant.
+	raw, ok := enq.payload.(json.RawMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want json.RawMessage", enq.payload)
+	}
+	var got struct {
+		HighlightID uuid.UUID `json:"highlight_id"`
+		TenantID    uuid.UUID `json:"tenant_id"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got.HighlightID != h.ID || got.TenantID != tenantID {
+		t.Fatalf("payload = %+v, want highlight %s tenant %s", got, h.ID, tenantID)
+	}
+}
+
+func TestRPCHighlight_Promote_SkipsEnqueueWhenAlreadyEnriched(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
+	// Already enriched: a re-promote must NOT re-enqueue (no double spend).
+	h.ImageKey = "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	h.ImageContentType = "image/png"
+	store.put(h)
+	enq := &fakeHighlightEnqueuer{}
+
+	client := newHighlightClientEnq(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), enq)
+	if _, err := client.PromoteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: h.ID.String()})); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if enq.calls != 0 {
+		t.Fatalf("enqueue called %d times for an already-enriched highlight; want 0", enq.calls)
+	}
+}
+
+func TestRPCHighlight_Promote_EnqueueFailureStillPromotes(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
+	enq := &fakeHighlightEnqueuer{err: errors.New("job table down")}
+
+	client := newHighlightClientEnq(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), enq)
+	res, err := client.PromoteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.PromoteHighlightRequest{Id: h.ID.String()}))
+	if err != nil {
+		t.Fatalf("promote must succeed despite enqueue failure, got %v", err)
+	}
+	if res.Msg.GetHighlight().GetStatus() != storage.HighlightPromoted {
+		t.Fatalf("want promoted, got %q", res.Msg.GetHighlight().GetStatus())
+	}
+}
+
+func TestRPCHighlight_Delete_RemovesBothBlobs(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+	h.ImageKey = "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	h.ImageContentType = "image/png"
+	h.ImageSizeBytes = 42
+	store.put(h)
+	blobs := &fakeRPCBlobs{}
+
+	client := newHighlightClient(t, tenantID, store, blobs, campaignSessionStore(campaignID))
+	if _, err := client.DeleteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()})); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	del := blobs.deletedKeys()
+	if len(del) != 2 || del[0] != h.ClipKey || del[1] != h.ImageKey {
+		t.Fatalf("want clip then image deleted, got %v", del)
+	}
+}
+
+func TestRPCHighlight_Delete_EmptyImageKey_ClipOnly(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
+	blobs := &fakeRPCBlobs{}
+
+	client := newHighlightClient(t, tenantID, store, blobs, campaignSessionStore(campaignID))
+	if _, err := client.DeleteHighlight(context.Background(),
+		connect.NewRequest(&managementv1.DeleteHighlightRequest{Id: h.ID.String()})); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	del := blobs.deletedKeys()
+	if len(del) != 1 || del[0] != h.ClipKey {
+		t.Fatalf("unenriched highlight should delete clip only, got %v", del)
+	}
+}
+
+func TestRPCHighlight_Get_ImageFields(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+	h.ImageKey = "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/image"
+	h.ImageContentType = "image/png"
+	h.ImageSizeBytes = 4242
+	store.put(h)
+
+	client := newHighlightClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID))
+	res, err := client.GetHighlight(context.Background(),
+		connect.NewRequest(&managementv1.GetHighlightRequest{Id: h.ID.String()}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	got := res.Msg.GetHighlight()
+	// Image content-type + size exposed; clip fields still present (regression).
+	if got.GetImageContentType() != "image/png" || got.GetImageSizeBytes() != 4242 {
+		t.Fatalf("image fields = %q/%d", got.GetImageContentType(), got.GetImageSizeBytes())
+	}
+	if got.GetClipContentType() != "audio/wav" || got.GetClipSizeBytes() != 1234 {
+		t.Fatalf("clip fields regressed = %q/%d", got.GetClipContentType(), got.GetClipSizeBytes())
 	}
 }
 

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -65,6 +65,10 @@ type byokSlot struct {
 var byokSlots = []byokSlot{
 	{provider: "groq", components: []storage.Component{storage.ComponentLLM}},
 	{provider: "elevenlabs", components: []storage.Component{storage.ComponentTTS, storage.ComponentSTT}},
+	// Gemini backs the image Component (#311, ADR-0004 amendment): a distinct
+	// BYOK slot + health check, even though Gemini already appears in the LLM
+	// matrix — the image key is managed on its own Configuration row.
+	{provider: "gemini", components: []storage.Component{storage.ComponentImage}},
 }
 
 func slotFor(provider string) (byokSlot, bool) {

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -202,10 +202,10 @@ func TestProviderList_EmptyShowsKeyNeeded(t *testing.T) {
 		t.Fatalf("List: %v", err)
 	}
 	creds := resp.Msg.GetCredentials()
-	if len(creds) != 3 {
-		t.Fatalf("credentials = %d, want 3 (discord, groq, elevenlabs)", len(creds))
+	if len(creds) != 4 {
+		t.Fatalf("credentials = %d, want 4 (discord, groq, elevenlabs, gemini)", len(creds))
 	}
-	for _, want := range []string{"discord", "groq", "elevenlabs"} {
+	for _, want := range []string{"discord", "groq", "elevenlabs", "gemini"} {
 		c := credByProvider(creds, want)
 		if c == nil {
 			t.Fatalf("missing credential slot %q", want)
@@ -262,6 +262,33 @@ func TestProviderSave_SealStoreLast4_WriteOnly(t *testing.T) {
 	}
 	if string(opened) != secret {
 		t.Errorf("round-trip = %q, want %q", opened, secret)
+	}
+}
+
+func TestProviderSave_GeminiUpsertsImage(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	cipher := testCipher(t)
+	client, _ := newProviderClient(t, store, cipher)
+
+	const secret = "test-gemini-secret-3333"
+	resp, err := client.SaveProviderConfig(context.Background(), connect.NewRequest(&managementv1.SaveProviderConfigRequest{
+		Provider: "gemini", Secret: secret,
+	}))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	cred := resp.Msg.GetCredential()
+	if cred.GetComponent() != "image" || cred.GetProvider() != "gemini" {
+		t.Errorf("component/provider = %q/%q, want image/gemini", cred.GetComponent(), cred.GetProvider())
+	}
+	// The image Component row was upserted with the sealed key.
+	row, ok := store.configs["image|gemini"]
+	if !ok {
+		t.Fatalf("missing upserted image|gemini row")
+	}
+	if row.CredentialsLast4 != crypto.Last4(secret) {
+		t.Errorf("image last4 = %q, want %q", row.CredentialsLast4, crypto.Last4(secret))
 	}
 }
 

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -99,6 +99,9 @@ type SessionServer struct {
 	// CodeUnimplemented rather than panic.
 	highlights HighlightStore
 	blobs      highlightBlobs
+	// enqueue schedules the image-enrichment job on promotion (#311, ADR-0049);
+	// nil disables enrichment (the promote itself still succeeds).
+	enqueue HighlightEnqueuer
 }
 
 var _ managementv1connect.SessionServiceHandler = (*SessionServer)(nil)

--- a/internal/rpc/voice.go
+++ b/internal/rpc/voice.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/discordtag"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/gemini"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm/groq"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
@@ -82,6 +83,9 @@ type VoiceServer struct {
 	// pingLLM is the Groq liveness test-call (a real key -> nil). Defaults to a
 	// GET against the Groq models endpoint.
 	pingLLM func(ctx context.Context, apiKey string) error
+	// pingImage is the Gemini image-provider liveness test-call (#311). Defaults
+	// to a GET against Gemini's OpenAI-compat models endpoint; unit tests fake it.
+	pingImage func(ctx context.Context, apiKey string) error
 	// listModels fetches a provider's live model catalog for the model select
 	// (#227). Defaults to the Groq OpenAI-compatible GET /models via the shared
 	// adapter; unit tests fake it so the default `go test` makes no vendor call.
@@ -147,6 +151,7 @@ func NewVoiceServer(store voiceStore, cipher *crypto.Cipher, log *slog.Logger) *
 		newLister:    func(apiKey string) tts.VoiceLister { return elevenlabs.New(apiKey) },
 		newSynth:     func(apiKey string) tts.Synthesizer { return elevenlabs.New(apiKey) },
 		pingLLM:      livePingGroq,
+		pingImage:    livePingGemini,
 		listModels:   func(ctx context.Context, apiKey string) ([]string, error) { return groq.New(apiKey).ListModels(ctx) },
 		botTag:       func(ctx context.Context, token string) (string, error) { return discordtag.Resolve(ctx, token, log) },
 		now:          time.Now,
@@ -460,6 +465,7 @@ func (s *VoiceServer) probeProviders(ctx context.Context, tenantID uuid.UUID, la
 	}{
 		{"groq", s.healthLLM},
 		{"elevenlabs", s.healthTTS},
+		{"gemini", s.healthImage},
 		{"discord", func(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
 			return s.healthDiscord(ctx, tenantID, lastBotTag)
 		}},
@@ -516,6 +522,21 @@ func (s *VoiceServer) healthLLM(ctx context.Context, tenantID uuid.UUID) *manage
 		return degraded("groq", err)
 	}
 	return healthy("groq")
+}
+
+// healthImage pings the Gemini image provider with the decrypted image key (#311),
+// mirroring healthLLM. No configured key (nor GEMINI_API_KEY fallback) → degraded.
+func (s *VoiceServer) healthImage(ctx context.Context, tenantID uuid.UUID) *managementv1.ProviderHealth {
+	key, err := s.resolveComponentKey(ctx, tenantID, storage.ComponentImage)
+	if err != nil {
+		return degraded("gemini", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	if err := s.pingImage(cctx, key); err != nil {
+		return degraded("gemini", err)
+	}
+	return healthy("gemini")
 }
 
 // healthTTS reuses ListVoices as the ElevenLabs liveness probe (GET /v1/voices).
@@ -711,6 +732,37 @@ func livePingGroq(ctx context.Context, apiKey string) error {
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("groq ping: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// geminiPingClient bounds the Gemini image-provider health probe (#311).
+var geminiPingClient = &http.Client{Timeout: healthCheckTimeout}
+
+// livePingGemini is the default Gemini image-provider liveness test-call (#311):
+// a GET against the OpenAI-compatibility /models endpoint with the bearer key
+// (mirrors livePingGroq — the same key family already serves Gemini LLM/embeddings
+// through this surface). A 2xx means the key authenticates. An empty key falls
+// back to GEMINI_API_KEY (the hybrid env path, ADR-0039).
+func livePingGemini(ctx context.Context, apiKey string) error {
+	if apiKey == "" {
+		apiKey = os.Getenv(gemini.APIKeyEnv)
+	}
+	if apiKey == "" {
+		return fmt.Errorf("gemini: missing API key (set %s)", gemini.APIKeyEnv)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gemini.DefaultBaseURL+"/models", nil)
+	if err != nil {
+		return fmt.Errorf("gemini ping: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := geminiPingClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("gemini ping: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("gemini ping: HTTP %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -310,6 +310,7 @@ func TestGetProviderHealth_AllHealthyResolvesBotTag(t *testing.T) {
 	srv := NewVoiceServer(store, cipher, nil)
 	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{} }
 	srv.pingLLM = func(context.Context, string) error { return nil }
+	srv.pingImage = func(context.Context, string) error { return nil }
 	srv.botTag = func(context.Context, string) (string, error) { return "Glyphoxa#4823", nil }
 
 	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
@@ -346,6 +347,7 @@ func TestGetProviderHealth_DegradedOnFailures(t *testing.T) {
 	srv := NewVoiceServer(store, cipher, nil)
 	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{err: errors.New("401 unauthorized")} }
 	srv.pingLLM = func(context.Context, string) error { return errors.New("groq down") }
+	srv.pingImage = func(context.Context, string) error { return errors.New("gemini down") }
 	srv.botTag = func(context.Context, string) (string, error) { return "", errors.New("bad token") }
 
 	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -359,6 +359,66 @@ func TestGetProviderHealth_DegradedOnFailures(t *testing.T) {
 	}
 }
 
+// TestGetProviderHealth_GeminiImagePing pins the #311 image-provider health check:
+// a Gemini key that pings 2xx reports healthy off the fake pingImage seam, and a
+// failing ping reports degraded — the same posture as the Groq LLM check.
+func TestGetProviderHealth_GeminiImagePing(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := healthyStore(t, cipher)
+	store.configs[storage.ComponentImage] = savedConfig(t, cipher, storage.ComponentImage, "gemini", "gemini-key")
+
+	srv := NewVoiceServer(store, cipher, nil)
+	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{} }
+	srv.pingLLM = func(context.Context, string) error { return nil }
+	srv.botTag = func(context.Context, string) (string, error) { return "Glyphoxa#4823", nil }
+
+	var gotKey string
+	srv.pingImage = func(_ context.Context, key string) error { gotKey = key; return nil }
+
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	var gemini *managementv1.ProviderHealth
+	for _, p := range resp.Msg.GetProviders() {
+		if p.GetProvider() == "gemini" {
+			gemini = p
+		}
+	}
+	if gemini == nil || gemini.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_HEALTHY {
+		t.Fatalf("gemini not healthy off a passing ping: %+v", gemini)
+	}
+	if gotKey != "gemini-key" {
+		t.Errorf("pingImage got key %q, want the decrypted tenant image key", gotKey)
+	}
+}
+
+// TestGetProviderHealth_GeminiImagePingFails: a failing image ping degrades the
+// gemini slot (mirrors the Groq degraded posture).
+func TestGetProviderHealth_GeminiImagePingFails(t *testing.T) {
+	t.Parallel()
+	cipher := voiceTestCipher(t)
+	store := healthyStore(t, cipher)
+	store.configs[storage.ComponentImage] = savedConfig(t, cipher, storage.ComponentImage, "gemini", "gemini-key")
+
+	srv := NewVoiceServer(store, cipher, nil)
+	srv.newLister = func(string) tts.VoiceLister { return &fakeLister{} }
+	srv.pingLLM = func(context.Context, string) error { return nil }
+	srv.botTag = func(context.Context, string) (string, error) { return "Glyphoxa#4823", nil }
+	srv.pingImage = func(context.Context, string) error { return errors.New("gemini 403") }
+
+	resp, err := srv.GetProviderHealth(tenantCtx(), connect.NewRequest(&managementv1.GetProviderHealthRequest{}))
+	if err != nil {
+		t.Fatalf("GetProviderHealth: %v", err)
+	}
+	for _, p := range resp.Msg.GetProviders() {
+		if p.GetProvider() == "gemini" && p.GetStatus() != managementv1.HealthStatus_HEALTH_STATUS_DEGRADED {
+			t.Fatalf("gemini should be degraded on a failing ping: %+v", p)
+		}
+	}
+}
+
 func mustSeal(t *testing.T, c *crypto.Cipher, s string) []byte {
 	t.Helper()
 	ct, err := c.Seal([]byte(s))
@@ -407,6 +467,10 @@ func TestGetProviderHealth_ChecksRunConcurrently(t *testing.T) {
 		sleepCtx(ctx, checkDelay)
 		return nil
 	}
+	srv.pingImage = func(ctx context.Context, _ string) error {
+		sleepCtx(ctx, checkDelay)
+		return nil
+	}
 	srv.botTag = func(ctx context.Context, _ string) (string, error) {
 		sleepCtx(ctx, checkDelay)
 		return "Glyphoxa#4823", nil
@@ -418,8 +482,8 @@ func TestGetProviderHealth_ChecksRunConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetProviderHealth: %v", err)
 	}
-	if got := len(resp.Msg.GetProviders()); got != 3 {
-		t.Fatalf("providers = %d, want 3", got)
+	if got := len(resp.Msg.GetProviders()); got != 4 {
+		t.Fatalf("providers = %d, want 4", got)
 	}
 	if elapsed < checkDelay {
 		t.Errorf("elapsed %v < one check's delay %v — checks were skipped, not run", elapsed, checkDelay)
@@ -447,7 +511,7 @@ func sleepCtx(ctx context.Context, d time.Duration) {
 // countingHealthSeams wires all three provider seams to atomic counters so a
 // test can pin how often the vendors were actually touched.
 type countingHealthSeams struct {
-	lister, llm, discord atomic.Int64
+	lister, llm, image, discord atomic.Int64
 }
 
 func (c *countingHealthSeams) wire(srv *VoiceServer) {
@@ -459,14 +523,18 @@ func (c *countingHealthSeams) wire(srv *VoiceServer) {
 		c.llm.Add(1)
 		return nil
 	}
+	srv.pingImage = func(context.Context, string) error {
+		c.image.Add(1)
+		return nil
+	}
 	srv.botTag = func(context.Context, string) (string, error) {
 		c.discord.Add(1)
 		return "Glyphoxa#4823", nil
 	}
 }
 
-func (c *countingHealthSeams) counts() [3]int64 {
-	return [3]int64{c.lister.Load(), c.llm.Load(), c.discord.Load()}
+func (c *countingHealthSeams) counts() [4]int64 {
+	return [4]int64{c.lister.Load(), c.llm.Load(), c.image.Load(), c.discord.Load()}
 }
 
 // TestGetProviderHealth_CachedWithinTTL pins #150's server-side TTL cache: two
@@ -494,12 +562,12 @@ func TestGetProviderHealth_CachedWithinTTL(t *testing.T) {
 	}
 
 	first := req()
-	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+	if got := seams.counts(); got != [4]int64{1, 1, 1, 1} {
 		t.Fatalf("counts after first call = %v, want each vendor touched once", got)
 	}
 
 	second := req()
-	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+	if got := seams.counts(); got != [4]int64{1, 1, 1, 1} {
 		t.Errorf("counts after second call within TTL = %v, want still 1 each (served from cache)", got)
 	}
 	if len(second.GetProviders()) != len(first.GetProviders()) {
@@ -509,7 +577,7 @@ func TestGetProviderHealth_CachedWithinTTL(t *testing.T) {
 	// Advance past the TTL: the next call probes the vendors again.
 	now = now.Add(healthCacheTTL + time.Second)
 	req()
-	if got := seams.counts(); got != [3]int64{2, 2, 2} {
+	if got := seams.counts(); got != [4]int64{2, 2, 2, 2} {
 		t.Errorf("counts after TTL expiry = %v, want each vendor probed again (2)", got)
 	}
 }
@@ -716,7 +784,7 @@ func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
 	}
 
 	health("initial")
-	if got := seams.counts(); got != [3]int64{1, 1, 1} {
+	if got := seams.counts(); got != [4]int64{1, 1, 1, 1} {
 		t.Fatalf("counts after initial call = %v, want 1 each", got)
 	}
 
@@ -727,7 +795,7 @@ func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
 		t.Fatalf("SaveProviderConfig: %v", err)
 	}
 	health("after key save")
-	if got := seams.counts(); got != [3]int64{2, 2, 2} {
+	if got := seams.counts(); got != [4]int64{2, 2, 2, 2} {
 		t.Errorf("counts after key save = %v, want 2 each (cache busted)", got)
 	}
 
@@ -738,7 +806,7 @@ func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
 		t.Fatalf("SaveDiscordSettings: %v", err)
 	}
 	health("after discord save")
-	if got := seams.counts(); got != [3]int64{3, 3, 3} {
+	if got := seams.counts(); got != [4]int64{3, 3, 3, 3} {
 		t.Errorf("counts after discord save = %v, want 3 each (cache busted)", got)
 	}
 }
@@ -868,8 +936,8 @@ func TestGetProviderHealth_WaitersShareLeaderProbe(t *testing.T) {
 	if elapsed >= 2*srv.probeTimeout {
 		t.Errorf("%d concurrent callers took %v — waiters ran their own probes instead of sharing the leader's (probeTimeout %v)", n, elapsed, srv.probeTimeout)
 	}
-	// One probe = 3 store reads (LLM config, TTS config, deployment config).
-	if got := bs.reads.Load(); got != 3 {
-		t.Errorf("store reads = %d, want 3 (exactly one probe launched)", got)
+	// One probe = 4 store reads (LLM config, TTS config, image config, deployment config).
+	if got := bs.reads.Load(); got != 4 {
+		t.Errorf("store reads = %d, want 4 (exactly one probe launched)", got)
 	}
 }

--- a/internal/spend/meter_test.go
+++ b/internal/spend/meter_test.go
@@ -31,6 +31,17 @@ func TestMeterKnownLLMPrice(t *testing.T) {
 	approx(t, m.Status().EstimatedUSD, want.inputPerMTok+want.outputPerMTok)
 }
 
+// TestMeterGeminiImagePrice: a generated image (#311) is metered as Gemini LLM
+// output tokens and priced from the known image-model entry (no default warning).
+func TestMeterGeminiImagePrice(t *testing.T) {
+	m := NewMeter(Caps{}, nil, nil, nil)
+	// One image ≈ 1290 output tokens plus a small prompt.
+	m.LLMTokens(observe.ProviderGemini, "gemini-2.5-flash-image", 40, 1290)
+	want := llmPrices[llmKey{observe.ProviderGemini, "gemini-2.5-flash-image"}]
+	expected := 40.0/1e6*want.inputPerMTok + 1290.0/1e6*want.outputPerMTok
+	approx(t, m.Status().EstimatedUSD, expected)
+}
+
 // TestMeterUnknownModelWarnsOnce uses a model with no price entry: it falls back
 // to the conservative default AND logs exactly one warning even across repeats.
 func TestMeterUnknownModelWarnsOnce(t *testing.T) {

--- a/internal/spend/prices.go
+++ b/internal/spend/prices.go
@@ -37,6 +37,11 @@ var llmPrices = map[llmKey]llmRate{
 	// Groq Llama 3.3 70B Versatile — Groq public API pricing, captured 2026-07-07:
 	// $0.59 / 1M input tokens, $0.79 / 1M output tokens. ESTIMATE (tier-dependent).
 	{observe.ProviderGroq, "llama-3.3-70b-versatile"}: {inputPerMTok: 0.59, outputPerMTok: 0.79},
+	// Gemini 2.5 Flash Image — image generation billed as tokens (#311, ADR-0004
+	// amendment). ESTIMATE captured 2026-07-11; 1 image ≈ 1290 output tokens ≈
+	// $0.039. Priced through the LLM sink because Gemini meters a generated image
+	// as output tokens (no image-specific usage kind, ADR-0045).
+	{observe.ProviderGemini, "gemini-2.5-flash-image"}: {inputPerMTok: 0.30, outputPerMTok: 30.00},
 }
 
 // ttsPricePer1kChars are the known per-1000-character TTS rates (USD). ElevenLabs

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -46,14 +46,24 @@ type Highlight struct {
 	ClipKey         string
 	ClipContentType string
 	ClipSizeBytes   int64
-	CreatedAt       time.Time
-	PromotedAt      *time.Time
+	// ImageKey / ImageContentType / ImageSizeBytes carry the AI-generated scene
+	// (#311, Epic 8, ADR-0004 amendment): the enrichment job stores an image
+	// behind the blob seam (ADR-0048) and lands it here. ImageKey == "" means no
+	// image yet (unenriched, unconfigured, or a failed generation — the row stays
+	// intact without media). ImageKey is NEVER exposed on the wire (clip_key
+	// posture): the image is served through GET /highlights/{id}/image.
+	ImageKey         string
+	ImageContentType string
+	ImageSizeBytes   int64
+	CreatedAt        time.Time
+	PromotedAt       *time.Time
 }
 
 const highlightColumns = `
 	id, tenant_id, voice_session_id, campaign_id, status,
 	starts_at, ends_at, score, excerpt, reason, speaker_ids,
-	clip_key, clip_content_type, clip_size_bytes, created_at, promoted_at`
+	clip_key, clip_content_type, clip_size_bytes,
+	image_key, image_content_type, image_size_bytes, created_at, promoted_at`
 
 func scanHighlight(row pgx.Row) (Highlight, error) {
 	var (
@@ -63,7 +73,8 @@ func scanHighlight(row pgx.Row) (Highlight, error) {
 	err := row.Scan(
 		&h.ID, &h.TenantID, &h.VoiceSessionID, &h.CampaignID, &h.Status,
 		&h.StartsAt, &h.EndsAt, &h.Score, &h.Excerpt, &h.Reason, &h.SpeakerIDs,
-		&h.ClipKey, &h.ClipContentType, &h.ClipSizeBytes, &h.CreatedAt, &pr,
+		&h.ClipKey, &h.ClipContentType, &h.ClipSizeBytes,
+		&h.ImageKey, &h.ImageContentType, &h.ImageSizeBytes, &h.CreatedAt, &pr,
 	)
 	h.PromotedAt = pr
 	return h, err
@@ -185,6 +196,29 @@ func (s *Store) DeleteHighlight(ctx context.Context, tenantID, id uuid.UUID) (st
 	return clipKey, nil
 }
 
+// SetHighlightImage lands an AI-generated image on a Highlight (#311): the
+// enrichment job (ADR-0049) stores the image behind the blob seam (ADR-0048) and
+// then records its key, MIME type, and size here. It is tenant-free (the handler
+// carries no tenant — the id scopes the row, and image_key derives from the
+// tenant baked into the blob key) and returns ErrNotFound if the row is gone (a
+// Highlight deleted between the job's GetHighlight and this write — the handler
+// compensates by deleting the just-stored blob). Idempotent at the row level: a
+// re-run overwrites the same deterministic key with the same fields.
+func (s *Store) SetHighlightImage(ctx context.Context, id uuid.UUID, imageKey, contentType string, sizeBytes int64) error {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE highlight
+		    SET image_key = $2, image_content_type = $3, image_size_bytes = $4
+		  WHERE id = $1`,
+		id, imageKey, contentType, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("storage: set highlight image %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // ListSessionCandidateClipKeys returns the clip_key of every remaining CANDIDATE
 // highlight for a Voice Session — the blob keys the 7-day purge job drops through
 // the seam BEFORE it deletes the rows (blob-first, ADR-0048). Promoted rows are
@@ -259,13 +293,17 @@ func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind
 	return out, nil
 }
 
-// ListCampaignHighlightClipKeys returns the clip_key of EVERY highlight
-// (candidate and promoted) in a Campaign — the blob keys a campaign hard-delete
-// sweeps through the seam BEFORE the row cascade removes them (ADR-0048). No
-// status filter: a campaign delete takes its highlights with it, kept or not.
+// ListCampaignHighlightClipKeys returns EVERY blob key a campaign hard-delete
+// must sweep through the seam BEFORE the row cascade removes the highlights
+// (ADR-0048): each highlight's clip_key AND its image_key when non-empty (#311 —
+// a promoted, enriched Highlight owns two blobs). No status filter: a campaign
+// delete takes its highlights with it, kept or not. clip_key is always present;
+// image_key is UNION ALL'd only where set, so unenriched rows contribute one key.
 func (s *Store) ListCampaignHighlightClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error) {
 	return s.scanClipKeys(ctx,
-		`SELECT clip_key FROM highlight WHERE campaign_id = $1`, campaignID)
+		`SELECT clip_key FROM highlight WHERE campaign_id = $1
+		 UNION ALL
+		 SELECT image_key FROM highlight WHERE campaign_id = $1 AND image_key <> ''`, campaignID)
 }
 
 // scanClipKeys runs a single-column clip_key query and collects the results.

--- a/internal/storage/highlight_test.go
+++ b/internal/storage/highlight_test.go
@@ -144,6 +144,78 @@ func TestHighlight_Delete_ReturnsClipKey(t *testing.T) {
 	}
 }
 
+func TestHighlight_SetImage(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+
+	// Freshly created row has no image.
+	before, err := st.GetHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("get before: %v", err)
+	}
+	if before.ImageKey != "" || before.ImageContentType != "" || before.ImageSizeBytes != 0 {
+		t.Fatalf("want empty image on fresh row, got %q/%q/%d", before.ImageKey, before.ImageContentType, before.ImageSizeBytes)
+	}
+
+	imgKey := "t/" + tenantID.String() + "/highlight/" + id.String() + "/image"
+	if err := st.SetHighlightImage(ctx, id, imgKey, "image/png", 9001); err != nil {
+		t.Fatalf("set image: %v", err)
+	}
+	after, err := st.GetHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("get after: %v", err)
+	}
+	if after.ImageKey != imgKey || after.ImageContentType != "image/png" || after.ImageSizeBytes != 9001 {
+		t.Fatalf("image not persisted: %q/%q/%d", after.ImageKey, after.ImageContentType, after.ImageSizeBytes)
+	}
+}
+
+func TestHighlight_SetImage_NotFound(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if err := st.SetHighlightImage(ctx, uuid.New(), "t/x/highlight/y/image", "image/png", 1); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("set image on missing row: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestHighlight_CampaignClipKeySweep_IncludesImages(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id1, clip1 := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+	_, clip2 := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+
+	// Only the first highlight is enriched with an image.
+	imgKey := "t/" + tenantID.String() + "/highlight/" + id1.String() + "/image"
+	if err := st.SetHighlightImage(ctx, id1, imgKey, "image/png", 42); err != nil {
+		t.Fatalf("set image: %v", err)
+	}
+
+	keys, err := st.ListCampaignHighlightClipKeys(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list campaign keys: %v", err)
+	}
+	set := map[string]bool{}
+	for _, k := range keys {
+		set[k] = true
+	}
+	// Both clips PLUS the one image key; the unenriched row contributes no image.
+	if !set[clip1] || !set[clip2] || !set[imgKey] || len(keys) != 3 {
+		t.Fatalf("campaign sweep keys mismatch: %v", keys)
+	}
+}
+
 func TestHighlight_SessionCandidateSweep(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)

--- a/internal/storage/migrations/00028_highlight_image.sql
+++ b/internal/storage/migrations/00028_highlight_image.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- AI image enrichment for Session Highlights (#311, Epic 8, ADR-0004 amendment):
+-- the `image` provider Component (Gemini) generates a dramatic scene for a
+-- promoted Highlight, and the result lands on the row through the blob seam
+-- (ADR-0048) exactly like the audio clip. image_key reconstructs the blob.Key;
+-- there is deliberately NO FK to the blob (deletion goes through blob.Delete,
+-- never a DB cascade). An empty image_key means "no image yet" — a promoted
+-- Highlight whose enrichment has not run, is not configured, or failed (the row
+-- stays intact without media, AC).
+--
+-- The provider_component enum gains 'image' so a Provider Config can bind the new
+-- Component. ADD VALUE is NOT referenced in this migration (the columns are plain
+-- text/bigint), so it is safe inside goose's transaction; a re-run is a no-op via
+-- IF NOT EXISTS.
+--
+-- NOTE (merge order): 00027 belongs to #372 (recap tool, in flight); this
+-- migration is numbered 00028 and merges AFTER it.
+ALTER TYPE provider_component ADD VALUE IF NOT EXISTS 'image';
+
+ALTER TABLE highlight ADD COLUMN image_key text NOT NULL DEFAULT '';
+ALTER TABLE highlight ADD COLUMN image_content_type text NOT NULL DEFAULT '';
+ALTER TABLE highlight ADD COLUMN image_size_bytes bigint NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE highlight DROP COLUMN IF EXISTS image_size_bytes;
+ALTER TABLE highlight DROP COLUMN IF EXISTS image_content_type;
+ALTER TABLE highlight DROP COLUMN IF EXISTS image_key;
+-- The 'image' enum value cannot be dropped: Postgres has no ALTER TYPE ... DROP
+-- VALUE. Leaving it is harmless (nothing references it after the columns go), so
+-- the Down deliberately does not attempt it.

--- a/internal/storage/migrations/00028_highlight_image.sql
+++ b/internal/storage/migrations/00028_highlight_image.sql
@@ -13,8 +13,8 @@
 -- text/bigint), so it is safe inside goose's transaction; a re-run is a no-op via
 -- IF NOT EXISTS.
 --
--- NOTE (merge order): 00027 belongs to #372 (recap tool, in flight); this
--- migration is numbered 00028 and merges AFTER it.
+-- NOTE (merge order): 00027 is already on main (#397, commit a501335), so 00028
+-- is the next free number and merges normally.
 ALTER TYPE provider_component ADD VALUE IF NOT EXISTS 'image';
 
 ALTER TABLE highlight ADD COLUMN image_key text NOT NULL DEFAULT '';

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -25,6 +25,9 @@ const (
 	ComponentTTS        Component = "tts"
 	ComponentEmbeddings Component = "embeddings"
 	ComponentS2S        Component = "s2s"
+	// ComponentImage is AI image generation (#311, Epic 8, ADR-0004 amendment):
+	// the enum value the 00028 migration adds. Gemini is its v1 provider.
+	ComponentImage Component = "image"
 )
 
 // Tenant is the top-level isolation boundary.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -1100,6 +1100,13 @@ message Highlight {
   google.protobuf.Timestamp created_at = 13;
   // promoted_at is when the GM promoted it; unset while a candidate.
   google.protobuf.Timestamp promoted_at = 14;
+  // image_content_type is the AI-generated scene's MIME type (#311, Epic 8);
+  // empty means no image yet (unenriched, unconfigured, or a failed generation).
+  // The image bytes are served through GET /highlights/{id}/image; the blob key
+  // is NEVER exposed (clip_key posture).
+  string image_content_type = 15;
+  // image_size_bytes is the stored image's size in bytes (0 when no image yet).
+  int64 image_size_bytes = 16;
 }
 
 // ListHighlightsRequest names the Voice Session whose Highlights to list.

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -64,7 +64,7 @@ const GROQ_MODELS = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"];
 // saved slots and the async health the GetProviderHealth RPC reports (#70).
 function mockBackend(
   opts: {
-    saved?: Partial<Record<"groq" | "elevenlabs" | "discord", string>>;
+    saved?: Partial<Record<"groq" | "elevenlabs" | "discord" | "gemini", string>>;
     health?: ProviderHealth[];
     // discordSaves captures every SaveDiscordSettings request so tests can pin
     // the wire shape (#142: a token-only save must omit the ID fields).
@@ -105,6 +105,7 @@ function mockBackend(
     groqModel: "",
     groq: opts.saved?.groq,
     elevenlabs: opts.saved?.elevenlabs,
+    gemini: opts.saved?.gemini,
     discord: opts.saved?.discord,
     guildId: "",
     voiceChannelId: "",
@@ -131,6 +132,7 @@ function mockBackend(
             cred("discord", "discord", state.discord),
             cred("llm", "groq", state.groq, state.groqModel),
             cred("tts", "elevenlabs", state.elevenlabs),
+            cred("image", "gemini", state.gemini),
           ],
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
@@ -155,8 +157,11 @@ function mockBackend(
           state.groqModel = req.model;
         }
         if (req.provider === "elevenlabs") state.elevenlabs = last4;
+        if (req.provider === "gemini") state.gemini = last4;
+        const comp =
+          req.provider === "groq" ? "llm" : req.provider === "gemini" ? "image" : "tts";
         return create(SaveProviderConfigResponseSchema, {
-          credential: cred(req.provider === "groq" ? "llm" : "tts", req.provider, last4, req.model),
+          credential: cred(comp, req.provider, last4, req.model),
         });
       },
       saveDiscordSettings: (req) => {
@@ -232,9 +237,31 @@ describe("Configuration", () => {
 
   it("shows a Key-needed badge for each unsaved credential", async () => {
     renderScreen();
-    // Three secret slots start unsaved → three Key-needed badges.
-    expect(await screen.findAllByText(/key needed/i)).toHaveLength(3);
+    // Four secret slots start unsaved → four Key-needed badges (discord, groq,
+    // elevenlabs, gemini).
+    expect(await screen.findAllByText(/key needed/i)).toHaveLength(4);
     expect(screen.queryByText(/healthy/i)).not.toBeInTheDocument();
+  });
+
+  it("saves the Gemini image key write-only: the row masks and shows Replace", async () => {
+    const saves: Array<{ provider: string; secret: string; model: string }> = [];
+    renderScreen(mockBackend({ providerSaves: saves }));
+
+    // The Gemini image slot renders its own card.
+    const geminiInput = await screen.findByLabelText("Gemini key");
+    const geminiRow = geminiInput.closest(".gx-provider-row") as HTMLElement;
+    expect(within(geminiRow).getByText("Gemini")).toBeInTheDocument();
+    expect(within(geminiRow).getByText("Image")).toBeInTheDocument();
+
+    fireEvent.change(geminiInput, { target: { value: "gm-secret-abcd" } });
+    fireEvent.click(within(geminiRow).getByRole("button", { name: "Save" }));
+
+    // After the invalidated list refetches, the row masks with a Replace affordance.
+    expect(await within(geminiRow).findByText("••••••••")).toBeInTheDocument();
+    expect(within(geminiRow).getByRole("button", { name: /replace/i })).toBeInTheDocument();
+    // The save went out as the gemini provider; plaintext never lands in the DOM.
+    expect(saves.some((s) => s.provider === "gemini" && s.secret === "gm-secret-abcd")).toBe(true);
+    expect(screen.queryByText(/gm-secret-abcd/)).not.toBeInTheDocument();
   });
 
   it("saves a provider key write-only: the row masks and the badge turns Healthy", async () => {

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { MessagesSquare, BrainCircuit, AudioLines, RefreshCw } from "lucide-react";
+import { MessagesSquare, BrainCircuit, AudioLines, ImagePlus, RefreshCw } from "lucide-react";
 
 import {
   CampaignService,
@@ -38,6 +38,7 @@ import "./configuration.css";
 const BYOK_SLOTS = [
   { provider: "groq", label: "Groq", kind: "LLM", icon: <BrainCircuit size={19} />, placeholder: "Paste your Groq API key" },
   { provider: "elevenlabs", label: "ElevenLabs", kind: "Speech", icon: <AudioLines size={19} />, placeholder: "Paste your ElevenLabs API key" },
+  { provider: "gemini", label: "Gemini", kind: "Image", icon: <ImagePlus size={19} />, placeholder: "Paste your Gemini API key" },
 ] as const;
 
 function credentialFor(creds: ProviderCredential[], provider: string): ProviderCredential | undefined {


### PR DESCRIPTION
Closes #311

## What

Adds the `image` provider Component (ADR-0004 amendment — Gemini, image-only v1) end to end: a Gemini image adapter, promotion-triggered background enrichment, blob-seam delivery, and spend metering.

## Slices (TDD)

- **proto** — `Highlight` gains `image_content_type = 15` / `image_size_bytes = 16`. `image_key` is never exposed (clip_key posture).
- **migration `00028_highlight_image.sql`** — `ALTER TYPE provider_component ADD VALUE IF NOT EXISTS 'image'`; `highlight += image_key / image_content_type / image_size_bytes`. Down drops the 3 columns; the enum value can't be dropped (commented).
- **`internal/imagegen`** (new) — plain `net/http` Gemini `Generator` (native `generateContent`, `x-goog-api-key`, `responseModalities:["IMAGE"]`), no SDK; httptest-faked (request shape, b64 decode, usage counts, error paths).
- **`internal/highlight`** — `JobKindEnrichImage` + idempotent `EnrichImageHandler` (skip-if-enriched → no double spend, not-configured no-op leaves the Highlight intact, generator error retries with row untouched, orphan-blob compensation on a row that vanished mid-write); fixed image prompt (excerpt≤1000 runes + reason, no speaker ids); `ServeImage` HTTP handler (tenant + Active-Campaign 404, `image_key==""` → 404, Range).
- **`internal/rpc`** — `PromoteHighlight` enqueues enrichment (skips when already enriched, enqueue failure logs but promote succeeds); `DeleteHighlight` drops clip then image blob; `toProtoHighlight` image fields; `gemini` byok slot + `pingImage` health probe.
- **`internal/spend`** — `gemini-2.5-flash-image` price ESTIMATE (`$0.30` in / `$30.00` out per 1M; ~1290 output tokens ≈ $0.039), metered through `LLMTokens` (Gemini bills the image as output tokens — no observe interface change).
- **`internal/storage`** — `SetHighlightImage` (ErrNotFound when row gone); campaign clip-key sweep `UNION ALL`s non-empty image keys.
- **web** — Configuration Gemini **Image** card (write-only save).
- **`main.go`** — image factory (hybrid key: saved-key-needs-cipher loud error, else `GEMINI_API_KEY`, else `ErrImageNotConfigured`), handler registration beside the purge job (web + all modes), `SetHighlights` enqueuer, `GET /api/v1/highlights/{id}/image` route.

## Merge order

Migration **00027** is already on main (#397, commit a501335); **00028** is the next free number and merges normally.

## Local gates (all green)

`go build ./...`, `go vet -tags integration ./...`, `golangci-lint run ./...` (0 issues), `go test ./...`, `go test -tags integration ./internal/{storage,rpc,highlight}/`, `buf lint` + `buf breaking` (additive), web `tsc --noEmit` + full `vitest` (238 tests).

Known: main-branch buf BSR push quota failure — PR gates unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
