### PR TITLE
fix(#408): inject tenant on plain-HTTP highlight clip/image mounts

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -958,10 +958,14 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 		{Path: "GET /api/v1/sessions/{id}/events", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeEvents))},
 		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, http.HandlerFunc(relay.ServeSnapshot))},
 		// Session Highlight clip (#308): operator-gated audio byte stream with Range.
-		{Path: "GET /api/v1/highlights/{id}/clip", Handler: auth.RequireSession(store, http.HandlerFunc(clipServer.ServeClip))},
+		// ServeClip/ServeImage require the tenant, so the mount is session AND tenant
+		// (#408): RequireTenant (inside RequireSession) resolves it server-side off the
+		// operator — the plain-HTTP mirror of the Connect tenant interceptor. Without it
+		// TenantID always missed and every request 401'd.
+		{Path: "GET /api/v1/highlights/{id}/clip", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(clipServer.ServeClip)))},
 		// Session Highlight AI image (#311): operator-gated image byte stream, same
 		// tenant + Active-Campaign 404 posture as the clip; no image yet → 404.
-		{Path: "GET /api/v1/highlights/{id}/image", Handler: auth.RequireSession(store, http.HandlerFunc(clipServer.ServeImage))},
+		{Path: "GET /api/v1/highlights/{id}/image", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(clipServer.ServeImage)))},
 		// Campaign bundle export (#290): streamed gzip download, operator-gated.
 		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, http.HandlerFunc(bundleHandler.ServeExport))},
 		// Campaign bundle import (#291): multipart upload, operator-gated, plus the

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"crypto/subtle"
+	"log/slog"
 	"net/http"
 )
 
@@ -66,6 +67,10 @@ func RequireTenant(tr TenantResolver, next http.Handler) http.Handler {
 		}
 		tenantID, err := tr.TenantForUser(r.Context(), u.ID)
 		if err != nil {
+			// Mirror NewTenantInterceptor's log (interceptors.go) so a 401 here is
+			// never a blind wall — the exact debugging pain that made #408 need a live
+			// repro. The byte handlers require a tenant, so we reject rather than proceed.
+			slog.Default().Warn("require tenant: no tenant for operator", "user_id", u.ID, "err", err)
 			http.Error(w, "authentication required", http.StatusUnauthorized)
 			return
 		}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -35,6 +35,44 @@ func RequireSession(a Authenticator, next http.Handler) http.Handler {
 	})
 }
 
+// RequireTenant is the net/http mirror of [NewTenantInterceptor] for the plain
+// (non-Connect) byte endpoints whose handlers require a tenant — the Session
+// Highlight clip (#308) and image (#311) mounts. It MUST be composed INSIDE
+// [RequireSession] (session first, then tenant): it reads the operator that guard
+// injected ([CurrentUser]) and resolves the bound tenant SERVER-SIDE via
+// [TenantResolver] (ADR-0039 thin pass-through) — never from a client header —
+// then injects it ([WithTenant]) so the handler's [TenantID] read hits.
+//
+// This closes #408: those mounts previously wrapped only RequireSession (user,
+// no tenant), so the handlers' TenantID lookup always missed and every clip/image
+// request 401'd in production, while the Connect RPCs (which carry the tenant
+// interceptor) returned 200 with the same cookie.
+//
+// Failure posture differs from the Connect interceptor deliberately. The
+// interceptor proceeds tenantless and lets each handler fail on its own terms
+// (some Connect procedures are tenant-agnostic). These byte handlers ALWAYS need
+// a tenant, so a missing operator or an unresolved tenant rejects 401 here —
+// fail-fast with the same code the handler would return anyway. The other plain
+// mounts that do NOT read TenantID — the SSE relay + snapshot (relay.ServeEvents/
+// ServeSnapshot) and the bundle export/import (bundle.ServeExport/ServeImport,
+// which resolves the tenant off the session itself) — do NOT compose this wrapper
+// and stay unchanged.
+func RequireTenant(tr TenantResolver, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, ok := CurrentUser(r.Context())
+		if !ok {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		tenantID, err := tr.TenantForUser(r.Context(), u.ID)
+		if err != nil {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(WithTenant(r.Context(), tenantID)))
+	})
+}
+
 // RequireCSRF is the plain-HTTP double-submit CSRF guard (ADR-0016): the mirror
 // of [NewCSRFInterceptor] for a state-changing net/http POST that bypasses the
 // Connect chain (the import upload). The glyphoxa_csrf cookie must

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -83,6 +83,89 @@ func TestRequireSession_InjectsUser(t *testing.T) {
 	}
 }
 
+// TestRequireTenant_ChainInjectsTenant proves the real RequireSession+RequireTenant
+// chain — the plain-HTTP mirror of the Connect auth→tenant interceptor stack —
+// resolves the operator's tenant SERVER-SIDE (never a client header) and injects
+// it into the request ctx, so a downstream byte handler (ServeClip/ServeImage)
+// reads a present TenantID. This is the class of test that would have caught #408:
+// the mounts wrapped only RequireSession (user, no tenant), so TenantID always
+// missed → every clip/image 401'd.
+func TestRequireTenant_ChainInjectsTenant(t *testing.T) {
+	op := storage.User{ID: uuid.New(), Name: "op", Role: "operator"}
+	wantTenant := uuid.New()
+	authN := fakeAuthN{users: map[string]storage.User{validToken: op}}
+	tr := fakeTenant{id: wantTenant}
+
+	var gotTenant uuid.UUID
+	var ok bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant, ok = auth.TenantID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	chain := auth.RequireSession(authN, auth.RequireTenant(tr, inner))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/x/clip", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: validToken})
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chain: code=%d, want 200", rec.Code)
+	}
+	if !ok {
+		t.Fatal("no tenant injected into ctx by the RequireSession+RequireTenant chain")
+	}
+	if gotTenant != wantTenant {
+		t.Fatalf("tenant = %s, want %s", gotTenant, wantTenant)
+	}
+}
+
+// TestRequireTenant_ResolveFailure401 documents the byte-endpoint posture: when the
+// operator has no resolvable tenant, RequireTenant rejects 401 (the handlers
+// require a tenant, so proceeding tenantless only 401s deeper — this fails fast
+// with the same code). Unlike the Connect NewTenantInterceptor, which proceeds
+// tenantless and lets each handler fail on its own terms.
+func TestRequireTenant_ResolveFailure401(t *testing.T) {
+	op := storage.User{ID: uuid.New(), Name: "op", Role: "operator"}
+	authN := fakeAuthN{users: map[string]storage.User{validToken: op}}
+	tr := fakeTenant{err: storage.ErrNotFound}
+
+	called := false
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
+	chain := auth.RequireSession(authN, auth.RequireTenant(tr, inner))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/x/clip", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: validToken})
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("resolve failure: code=%d, want 401", rec.Code)
+	}
+	if called {
+		t.Fatal("inner handler ran despite an unresolved tenant")
+	}
+}
+
+// TestRequireTenant_MissingUser401 is the defensive path: RequireTenant used
+// without an upstream RequireSession has no operator in ctx and must reject 401
+// rather than resolve a nil-user tenant.
+func TestRequireTenant_MissingUser401(t *testing.T) {
+	tr := fakeTenant{id: uuid.New()}
+	called := false
+	h := auth.RequireTenant(tr, http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing user: code=%d, want 401", rec.Code)
+	}
+	if called {
+		t.Fatal("inner handler ran without an operator in ctx")
+	}
+}
+
 // TestRequireCSRF drives the plain-HTTP double-submit mirror of the Connect CSRF
 // interceptor (ADR-0016): the glyphoxa_csrf cookie must constant-time-match the
 // X-CSRF-Token header, else 403; RequireSession alone does not gate a plain POST.

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -29,8 +29,9 @@ type ClipStore interface {
 type CampaignResolver func(ctx context.Context) (uuid.UUID, bool, error)
 
 // ClipServer serves a Highlight's audio clip over plain HTTP (#308/#309): GET
-// /api/v1/highlights/{id}/clip, mounted behind auth.RequireSession beside the SSE
-// relay (ADR-0015 — a byte stream, not a Connect unary). It loads the row
+// /api/v1/highlights/{id}/clip, mounted behind auth.RequireSession +
+// auth.RequireTenant (#408 — session AND tenant) beside the SSE relay (ADR-0015 —
+// a byte stream, not a Connect unary). It loads the row
 // tenant-scoped, fetches the clip through the blob seam (ADR-0048), and streams
 // it with http.ServeContent so the browser <audio> scrubber's Range requests
 // resolve to partial content.
@@ -50,10 +51,13 @@ func NewClipServer(store ClipStore, blobs blob.Store, resolve CampaignResolver, 
 	return &ClipServer{store: store, blobs: blobs, resolve: resolve, log: log}
 }
 
-// ServeClip streams one Highlight's clip. The auth.RequireSession wrapper has
-// already authenticated the operator and injected the tenant; this handler
-// re-reads the tenant to scope the row load, so a foreign-tenant id (or an
-// unparsable one) is 404 — existence is never leaked. A missing blob is also 404
+// ServeClip streams one Highlight's clip. CONTRACT (#408): the mount must be
+// "session AND tenant", not just session — auth.RequireSession authenticates the
+// operator, and auth.RequireTenant (composed inside it) resolves and injects the
+// tenant server-side. RequireSession ALONE injects only the user, so TenantID
+// misses and this handler 401s every request (the production bug #408 fixed). This
+// handler re-reads that injected tenant to scope the row load, so a foreign-tenant
+// id (or an unparsable one) is 404 — existence is never leaked. A missing blob is also 404
 // (the row and clip should agree, but a purge race must not 500). http.ServeContent
 // handles Range (scrub) and conditional requests off the row's created_at.
 func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
@@ -121,7 +125,8 @@ func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
 }
 
 // ServeImage streams one Highlight's AI-generated image (#311), mirroring
-// ServeClip: GET /api/v1/highlights/{id}/image behind auth.RequireSession. It
+// ServeClip: GET /api/v1/highlights/{id}/image behind auth.RequireSession +
+// auth.RequireTenant (session AND tenant, per #408 — see ServeClip). It
 // applies the same tenant + Active-Campaign 404 posture (existence never leaked)
 // and serves through http.ServeContent (Range/conditional). A Highlight with no
 // image yet (image_key == "") is 404 — the enrichment has not run, is not

--- a/internal/highlight/http_test.go
+++ b/internal/highlight/http_test.go
@@ -257,6 +257,80 @@ func TestImage_CrossCampaign404(t *testing.T) {
 	}
 }
 
+// --- real middleware chain (#408) ---
+//
+// These drive ServeClip through the ACTUAL auth.RequireSession + auth.RequireTenant
+// stack (the production mount composition) with only a session cookie — no
+// pre-injected tenant. This is the class of test the unit tests above (which
+// pre-inject auth.WithTenant) could not catch: #408 was that the mounts wrapped
+// only RequireSession, so TenantID always missed and every clip 401'd.
+
+// chainAuthN is a one-token Authenticator for the middleware chain tests.
+type chainAuthN struct {
+	token string
+	user  storage.User
+}
+
+func (a chainAuthN) AuthenticateSession(_ context.Context, token string) (storage.User, error) {
+	if token == a.token {
+		return a.user, nil
+	}
+	return storage.User{}, storage.ErrNotFound
+}
+
+// chainTenant resolves every operator to a fixed tenant (the thin ADR-0039
+// pass-through), server-side — the point being the client never supplies it.
+type chainTenant struct{ tenantID uuid.UUID }
+
+func (t chainTenant) TenantForUser(context.Context, uuid.UUID) (uuid.UUID, error) {
+	return t.tenantID, nil
+}
+
+// TestClip_RealChainServesWithCookieOnly proves that a request carrying ONLY a
+// valid session cookie (the tenant is NOT pre-injected) is served 200 with bytes
+// through the real RequireSession→RequireTenant→ServeClip chain. Regression guard
+// for #408.
+func TestClip_RealChainServesWithCookieOnly(t *testing.T) {
+	srv, tenantID, id := newClipFixture(t)
+	const token = "sess-abc"
+	authN := chainAuthN{token: token, user: storage.User{ID: uuid.New(), Role: "operator"}}
+	chain := auth.RequireSession(authN, auth.RequireTenant(chainTenant{tenantID: tenantID}, http.HandlerFunc(srv.ServeClip)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/"+id.String()+"/clip", nil)
+	req.SetPathValue("id", id.String())
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("real chain, cookie only: want 200, got %d", rr.Code)
+	}
+	if rr.Body.Len() != 200 {
+		t.Fatalf("want 200 bytes, got %d", rr.Body.Len())
+	}
+}
+
+// TestClip_RealChainForeignTenant404 proves the chain still enforces tenant
+// scoping: when the operator's resolved tenant differs from the highlight's owner,
+// the row reads as absent → 404, existence never leaked.
+func TestClip_RealChainForeignTenant404(t *testing.T) {
+	srv, _, id := newClipFixture(t)
+	const token = "sess-abc"
+	authN := chainAuthN{token: token, user: storage.User{ID: uuid.New(), Role: "operator"}}
+	// A tenant that does NOT own the fixture highlight.
+	chain := auth.RequireSession(authN, auth.RequireTenant(chainTenant{tenantID: uuid.New()}, http.HandlerFunc(srv.ServeClip)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/"+id.String()+"/clip", nil)
+	req.SetPathValue("id", id.String())
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("real chain, foreign tenant: want 404, got %d", rr.Code)
+	}
+}
+
 // TestClip_MissingBlob404: the row exists but its clip blob is gone (a purge race) —
 // the handler must 404, not 500 (#308, finding #6).
 func TestClip_MissingBlob404(t *testing.T) {


### PR DESCRIPTION
## Problem

`internal/highlight/http.go` `ServeClip`/`ServeImage` require `auth.TenantID(ctx)`, but the plain-HTTP mounts (`cmd/glyphoxa/main.go`) wrapped only `auth.RequireSession` — which injects the operator (`WithUser`) and nothing else. Tenant was only ever injected by the Connect `NewTenantInterceptor`, so **every real clip/image request 401'd** in production ("unauthenticated") while the RPCs returned 200 with the same cookie. Live-repro'd 2026-07-11: valid cookie → RPC 200, clip 401. Blocks the #309 replay AC (playback dead).

CI never caught it because the highlight http tests pre-inject the tenant into the ctx (unit-level) and no test drove the byte endpoints through the real middleware stack.

## Fix

Add `auth.RequireTenant(tr TenantResolver, next http.Handler)` — the net/http mirror of `NewTenantInterceptor`. Composed **inside** `RequireSession`, it reads the injected operator and resolves the bound tenant **server-side** via `TenantForUser` (never a client header, ADR-0039), then injects it via `WithTenant`.

- Applied to the clip + image mounts.
- Byte-endpoint failure posture: a missing operator or unresolved tenant → **401** (fail-fast with the code the handler would return anyway), deliberately unlike the Connect interceptor which proceeds tenantless. Documented in the wrapper docstring.
- Audited the other plain mounts: the SSE relay/snapshot and bundle export/import do **not** read `TenantID` (import resolves the tenant off the session itself) → left unchanged, noted in the docstring.

## Tests (TDD)

- `TestRequireTenant_ChainInjectsTenant` — real `RequireSession`+`RequireTenant` chain over a fake handler asserts `TenantID` present.
- `TestRequireTenant_ResolveFailure401` / `TestRequireTenant_MissingUser401` — posture guards.
- `TestClip_RealChainServesWithCookieOnly` — `ServeClip` driven through the REAL chain with **only** a session cookie → 200 + bytes (the class of test that would have caught this; existing unit tests pre-inject the tenant, kept intact).
- `TestClip_RealChainForeignTenant404` — chain still enforces tenant scoping → 404.
- Docstring regression note in `http.go`: the mount contract is "session AND tenant".

Local: `go build ./...`, `go vet -tags integration ./...`, `go test ./internal/auth/ ./internal/highlight/`, `golangci-lint run` all green.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)