### PR TITLE
feat(#411): remember_knowledge write-time dedup + self-awareness

### DIFF
--- a/internal/knowledge/dedup_test.go
+++ b/internal/knowledge/dedup_test.go
@@ -26,8 +26,9 @@ func TestExistingKnowledge_OwnNodeGathersPendingAndEstablished(t *testing.T) {
 	aid := uuid.New()
 	ownNodeID := uuid.New()
 	store := &fakeStore{
-		linkedNode: storage.KGNode{ID: ownNodeID, Name: "Gesa", Body: "Gesa liebt Kuchen\nGesa wohnt im Wald"},
-		linkedOK:   true,
+		allNodes: []storage.KGNode{
+			{ID: ownNodeID, Name: "Gesa", Body: "Gesa liebt Kuchen\nGesa wohnt im Wald"},
+		},
 		pending: []storage.KnowledgeProposal{
 			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: ownNodeID.String(), Subject: "Gesa", Fact: "ist die Schwester von Arturus"}),
 			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: uuid.New().String(), Subject: "Arturus", Fact: "ist ein Ritter"}), // different target
@@ -76,6 +77,53 @@ func TestExistingKnowledge_CampaignBySubjectName(t *testing.T) {
 	}
 	if len(known.Pending) != 1 || known.Pending[0] != "is old" {
 		t.Errorf("pending = %q, want the same-subject proposal", known.Pending)
+	}
+}
+
+// Cross-path unification (#411): an own_node pending row (keyed by node id) must
+// suppress a Butler campaign re-proposal of the same fact (keyed by subject name),
+// because the subject name resolves to the same Node. Without unification the two
+// keys diverge and the duplicate slips through invisibly.
+func TestExistingKnowledge_UnifiesOwnNodeAndCampaignKeys(t *testing.T) {
+	cid := uuid.New()
+	gesaID := uuid.New()
+	store := &fakeStore{
+		allNodes: []storage.KGNode{{ID: gesaID, Name: "Gesa"}},
+		pending: []storage.KnowledgeProposal{
+			// An own_node proposal the NPC already made (keyed by node id).
+			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: gesaID.String(), Subject: "Gesa", Fact: "ist die Schwester von Arturus"}),
+		},
+	}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	// The Butler now re-proposes the same fact campaign-scoped (no node id, subject
+	// by name) — it must see the NPC's pending row via the unified key.
+	w := tool.ProposedWrite{Kind: "fact", Subject: "Gesa", Fact: "ist die Schwester von Arturus"}
+	known, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), w)
+	if err != nil {
+		t.Fatalf("ExistingKnowledge: %v", err)
+	}
+	if len(known.Pending) != 1 || known.Pending[0] != "ist die Schwester von Arturus" {
+		t.Errorf("campaign proposal did not see the own_node pending row: %q", known.Pending)
+	}
+}
+
+// Established facts on a gm_private Node are NEVER surfaced — echoing a body line
+// would leak a GM secret into a prompt (ADR-0008).
+func TestExistingKnowledge_SkipsGMPrivateEstablished(t *testing.T) {
+	cid := uuid.New()
+	secretID := uuid.New()
+	store := &fakeStore{
+		allNodes: []storage.KGNode{{ID: secretID, Name: "The Traitor", Body: "is secretly the spy", GMPrivate: true}},
+	}
+	adapter := knowledge.New(store, liveSession(cid))
+	w := tool.ProposedWrite{Kind: "fact", Subject: "The Traitor", Fact: "is secretly the spy"}
+	known, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), w)
+	if err != nil {
+		t.Fatalf("ExistingKnowledge: %v", err)
+	}
+	if len(known.Established) != 0 {
+		t.Errorf("gm_private body leaked into established facts: %q", known.Established)
 	}
 }
 

--- a/internal/knowledge/dedup_test.go
+++ b/internal/knowledge/dedup_test.go
@@ -1,0 +1,88 @@
+package knowledge_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/knowledge"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
+)
+
+func pendingRow(cid uuid.UUID, w tool.ProposedWrite) storage.KnowledgeProposal {
+	b, _ := json.Marshal(w)
+	return storage.KnowledgeProposal{CampaignID: cid, ProposedWrite: b, Status: "pending"}
+}
+
+// ExistingKnowledge gathers, for an own_node proposal's target, the target Node's
+// established body facts (split into lines) and the salient text of the pending
+// proposals addressing the SAME target — and excludes pending proposals about a
+// different target.
+func TestExistingKnowledge_OwnNodeGathersPendingAndEstablished(t *testing.T) {
+	cid := uuid.New()
+	aid := uuid.New()
+	ownNodeID := uuid.New()
+	store := &fakeStore{
+		linkedNode: storage.KGNode{ID: ownNodeID, Name: "Gesa", Body: "Gesa liebt Kuchen\nGesa wohnt im Wald"},
+		linkedOK:   true,
+		pending: []storage.KnowledgeProposal{
+			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: ownNodeID.String(), Subject: "Gesa", Fact: "ist die Schwester von Arturus"}),
+			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: uuid.New().String(), Subject: "Arturus", Fact: "ist ein Ritter"}), // different target
+		},
+	}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	w := tool.ProposedWrite{Kind: "fact", NodeID: ownNodeID.String(), Subject: "Gesa", Fact: "something new"}
+	known, err := adapter.ExistingKnowledge(context.Background(), aid.String(), w)
+	if err != nil {
+		t.Fatalf("ExistingKnowledge: %v", err)
+	}
+	if store.gotPendCID != cid {
+		t.Errorf("pending scoped to %v, want active campaign %v", store.gotPendCID, cid)
+	}
+	if len(known.Established) != 2 {
+		t.Errorf("established = %q, want the 2 body lines", known.Established)
+	}
+	if len(known.Pending) != 1 || known.Pending[0] != "ist die Schwester von Arturus" {
+		t.Errorf("pending = %q, want only the same-target proposal's salient", known.Pending)
+	}
+}
+
+// For a campaign proposal (no anchor node), the established facts come from the
+// subject Node found by normalized name, and pending is filtered by subject.
+func TestExistingKnowledge_CampaignBySubjectName(t *testing.T) {
+	cid := uuid.New()
+	store := &fakeStore{
+		allNodes: []storage.KGNode{
+			{ID: uuid.New(), Name: "The Duke", Body: "rules the city"},
+			{ID: uuid.New(), Name: "Someone Else", Body: "irrelevant"},
+		},
+		pending: []storage.KnowledgeProposal{
+			pendingRow(cid, tool.ProposedWrite{Kind: "fact", Subject: "the duke", Fact: "is old"}),
+		},
+	}
+	adapter := knowledge.New(store, liveSession(cid))
+
+	w := tool.ProposedWrite{Kind: "fact", Subject: "The Duke", Fact: "new fact"}
+	known, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), w)
+	if err != nil {
+		t.Fatalf("ExistingKnowledge: %v", err)
+	}
+	if len(known.Established) != 1 || known.Established[0] != "rules the city" {
+		t.Errorf("established = %q, want the Duke's body", known.Established)
+	}
+	if len(known.Pending) != 1 || known.Pending[0] != "is old" {
+		t.Errorf("pending = %q, want the same-subject proposal", known.Pending)
+	}
+}
+
+// No active session is a clean error the handler can fail open on.
+func TestExistingKnowledge_NoSessionErrors(t *testing.T) {
+	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	if _, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), tool.ProposedWrite{Kind: "fact", Subject: "X", Fact: "y"}); err == nil {
+		t.Error("want error with no active session")
+	}
+}

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -255,32 +255,58 @@ func (a *Adapter) CreateProposal(ctx context.Context, agentID string, w tool.Pro
 // back to the model. It gathers two candidate sets, both scoped to the target
 // entity (never global): the target Node's established body facts (its body split
 // into non-empty lines) and the salient text of every PENDING proposal addressing
-// the same target ([tool.ProposalTargetKey]). The Campaign is the active session's
-// (no session ⇒ ErrNoActiveSession); the comparison itself is the handler's.
-func (a *Adapter) ExistingKnowledge(ctx context.Context, agentID string, w tool.ProposedWrite) (tool.KnownForTarget, error) {
+// the same target.
+//
+// The target key is UNIFIED across the two write paths: an own_node proposal keys
+// on its anchor node id, and a campaign proposal keys on its subject NAME — but the
+// same real entity would then carry two keys, so a Butler and its linked NPC would
+// double-propose the same fact invisibly to each other. Here the subject name is
+// resolved to the node id via the campaign's Node list, so both paths collapse onto
+// "id:<node>" whenever the subject names a real Node; only an unresolvable name
+// keeps a "subj:" key. Established body facts skip gm_private Nodes — a GM secret
+// must never surface into a prompt via the echo (ADR-0008). No session ⇒
+// ErrNoActiveSession; the comparison itself is the handler's.
+func (a *Adapter) ExistingKnowledge(ctx context.Context, _ string, w tool.ProposedWrite) (tool.KnownForTarget, error) {
 	campaignID, err := a.activeCampaign()
 	if err != nil {
 		return tool.KnownForTarget{}, err
 	}
 
+	nodes, err := a.store.ListNodes(ctx, campaignID)
+	if err != nil {
+		return tool.KnownForTarget{}, fmt.Errorf("knowledge: existing knowledge: list nodes: %w", err)
+	}
+	nameToID := make(map[string]string, len(nodes))
+	idToNode := make(map[string]storage.KGNode, len(nodes))
+	for _, n := range nodes {
+		idToNode[n.ID.String()] = n
+		if k := textnorm.Normalize(n.Name); k != "" {
+			nameToID[k] = n.ID.String()
+		}
+	}
+
+	wantKey := canonicalTargetKey(w, nameToID)
+	if wantKey == "" {
+		return tool.KnownForTarget{}, nil // no identifiable target ⇒ nothing to compare
+	}
+
 	var known tool.KnownForTarget
-	if body, ok, err := a.targetBody(ctx, agentID, w); err != nil {
-		return tool.KnownForTarget{}, err
-	} else if ok {
-		known.Established = bodyLines(body)
+	if id, ok := strings.CutPrefix(wantKey, "id:"); ok {
+		if n, ok := idToNode[id]; ok && !n.GMPrivate {
+			known.Established = bodyLines(n.Body)
+		}
 	}
 
 	pending, err := a.store.ListPendingKnowledgeProposals(ctx, campaignID)
 	if err != nil {
 		return tool.KnownForTarget{}, fmt.Errorf("knowledge: existing knowledge: %w", err)
 	}
-	wantKey := tool.ProposalTargetKey(w)
 	for _, p := range pending {
 		var pw tool.ProposedWrite
 		if err := json.Unmarshal(p.ProposedWrite, &pw); err != nil {
 			continue // a malformed legacy row is not a comparable duplicate
 		}
-		if tool.ProposalTargetKey(pw) == wantKey {
+		if canonicalTargetKey(pw, nameToID) == wantKey {
 			if s := tool.ProposalSalient(pw); s != "" {
 				known.Pending = append(known.Pending, s)
 			}
@@ -289,47 +315,26 @@ func (a *Adapter) ExistingKnowledge(ctx context.Context, agentID string, w tool.
 	return known, nil
 }
 
-// targetBody resolves the body prose of the Node a proposal is about, for the
-// established-fact dedup. An own_node proposal (w.NodeID set) targets the caller's
-// own linked Node; a campaign proposal targets the Node whose name matches the
-// subject (fact/edge) or the new entry's own name (node). ok=false means no such
-// Node exists yet (nothing established to match).
-func (a *Adapter) targetBody(ctx context.Context, agentID string, w tool.ProposedWrite) (string, bool, error) {
+// canonicalTargetKey is [tool.ProposalTargetKey] with subject-name → node-id
+// resolution layered on: a subject that names a real Node collapses onto the
+// node-id key so own_node and campaign proposals about the same entity unify. An
+// unresolvable name keeps the pure "subj:" key; an empty target yields "".
+func canonicalTargetKey(w tool.ProposedWrite, nameToID map[string]string) string {
 	if w.NodeID != "" {
-		if aid, err := uuid.Parse(agentID); err == nil && aid != uuid.Nil {
-			node, ok, err := a.store.AgentLinkedNode(ctx, aid)
-			if err != nil {
-				return "", false, fmt.Errorf("knowledge: existing knowledge: own node: %w", err)
-			}
-			if ok && node.ID.String() == w.NodeID {
-				return node.Body, true, nil
-			}
-		}
-		return "", false, nil
+		return "id:" + w.NodeID
 	}
-
 	name := w.Subject
 	if name == "" && w.Kind == "node" {
 		name = w.Name
 	}
-	if strings.TrimSpace(name) == "" {
-		return "", false, nil
+	n := textnorm.Normalize(name)
+	if n == "" {
+		return ""
 	}
-	campaignID, err := a.activeCampaign()
-	if err != nil {
-		return "", false, err
+	if id, ok := nameToID[n]; ok {
+		return "id:" + id
 	}
-	nodes, err := a.store.ListNodes(ctx, campaignID)
-	if err != nil {
-		return "", false, fmt.Errorf("knowledge: existing knowledge: list nodes: %w", err)
-	}
-	want := textnorm.Normalize(name)
-	for _, n := range nodes {
-		if textnorm.Normalize(n.Name) == want {
-			return n.Body, true, nil
-		}
-	}
-	return "", false, nil
+	return "subj:" + n
 }
 
 // bodyLines splits a Node's body prose into its individual established facts —

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -19,11 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/textnorm"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
@@ -55,6 +57,12 @@ type Store interface {
 	// ADR-0052) — the sole effect of remember_knowledge. proposedWrite is the raw
 	// jsonb payload; nothing touches kg_node/kg_edge until the GM approves.
 	CreateKnowledgeProposal(ctx context.Context, campaignID, agentID uuid.UUID, proposedWrite []byte) error
+	// ListPendingKnowledgeProposals backs the #411 write-time dedup: the pending
+	// queue a re-proposal is checked against.
+	ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error)
+	// ListNodes resolves a campaign-scoped proposal's subject Node by name so its
+	// established body facts can be dedup candidates (#411).
+	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
 }
 
 // Sessions reports the active Voice Session (for its Campaign). *session.Manager
@@ -239,6 +247,102 @@ func (a *Adapter) CreateProposal(ctx context.Context, agentID string, w tool.Pro
 		return fmt.Errorf("knowledge: create proposal: %w", err)
 	}
 	return nil
+}
+
+// ExistingKnowledge implements [tool.KGWriter] (#411, ADR-0052 mechanism a): it
+// reports what the KG already holds for a proposal's target so the handler can
+// suppress an exact/normalized re-proposal and echo the target's pending proposals
+// back to the model. It gathers two candidate sets, both scoped to the target
+// entity (never global): the target Node's established body facts (its body split
+// into non-empty lines) and the salient text of every PENDING proposal addressing
+// the same target ([tool.ProposalTargetKey]). The Campaign is the active session's
+// (no session ⇒ ErrNoActiveSession); the comparison itself is the handler's.
+func (a *Adapter) ExistingKnowledge(ctx context.Context, agentID string, w tool.ProposedWrite) (tool.KnownForTarget, error) {
+	campaignID, err := a.activeCampaign()
+	if err != nil {
+		return tool.KnownForTarget{}, err
+	}
+
+	var known tool.KnownForTarget
+	if body, ok, err := a.targetBody(ctx, agentID, w); err != nil {
+		return tool.KnownForTarget{}, err
+	} else if ok {
+		known.Established = bodyLines(body)
+	}
+
+	pending, err := a.store.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		return tool.KnownForTarget{}, fmt.Errorf("knowledge: existing knowledge: %w", err)
+	}
+	wantKey := tool.ProposalTargetKey(w)
+	for _, p := range pending {
+		var pw tool.ProposedWrite
+		if err := json.Unmarshal(p.ProposedWrite, &pw); err != nil {
+			continue // a malformed legacy row is not a comparable duplicate
+		}
+		if tool.ProposalTargetKey(pw) == wantKey {
+			if s := tool.ProposalSalient(pw); s != "" {
+				known.Pending = append(known.Pending, s)
+			}
+		}
+	}
+	return known, nil
+}
+
+// targetBody resolves the body prose of the Node a proposal is about, for the
+// established-fact dedup. An own_node proposal (w.NodeID set) targets the caller's
+// own linked Node; a campaign proposal targets the Node whose name matches the
+// subject (fact/edge) or the new entry's own name (node). ok=false means no such
+// Node exists yet (nothing established to match).
+func (a *Adapter) targetBody(ctx context.Context, agentID string, w tool.ProposedWrite) (string, bool, error) {
+	if w.NodeID != "" {
+		if aid, err := uuid.Parse(agentID); err == nil && aid != uuid.Nil {
+			node, ok, err := a.store.AgentLinkedNode(ctx, aid)
+			if err != nil {
+				return "", false, fmt.Errorf("knowledge: existing knowledge: own node: %w", err)
+			}
+			if ok && node.ID.String() == w.NodeID {
+				return node.Body, true, nil
+			}
+		}
+		return "", false, nil
+	}
+
+	name := w.Subject
+	if name == "" && w.Kind == "node" {
+		name = w.Name
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", false, nil
+	}
+	campaignID, err := a.activeCampaign()
+	if err != nil {
+		return "", false, err
+	}
+	nodes, err := a.store.ListNodes(ctx, campaignID)
+	if err != nil {
+		return "", false, fmt.Errorf("knowledge: existing knowledge: list nodes: %w", err)
+	}
+	want := textnorm.Normalize(name)
+	for _, n := range nodes {
+		if textnorm.Normalize(n.Name) == want {
+			return n.Body, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// bodyLines splits a Node's body prose into its individual established facts —
+// one per non-empty, trimmed line — the granularity the GM-approved writes append
+// at, so a re-proposal of a single line is caught.
+func bodyLines(body string) []string {
+	var out []string
+	for _, ln := range strings.Split(body, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // Compile-time assertions that the adapter satisfies the tool seams.

--- a/internal/knowledge/knowledge_proposal_integration_test.go
+++ b/internal/knowledge/knowledge_proposal_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -146,5 +147,45 @@ func TestRememberKnowledge_OwnNodeProposal_RealDB(t *testing.T) {
 	}
 	if remaining != 0 {
 		t.Errorf("agent DELETE did not cascade proposals: %d remain", remaining)
+	}
+}
+
+// TestRememberKnowledge_DoubleRememberOneRow_RealDB closes the fake-mirror
+// seam-drift gap for the #411 write-time dedup: it drives the full
+// handler→adapter→real Postgres path twice with the same fact and asserts exactly
+// ONE proposal row survives — the second call's ExistingKnowledge reads the first
+// (now-persisted) proposal back from the real store and suppresses the repeat.
+func TestRememberKnowledge_DoubleRememberOneRow_RealDB(t *testing.T) {
+	dsn := startPostgres(t)
+	store, _, campaignID, agentID, _ := seedProposalWorld(t, dsn)
+	ctx := context.Background()
+
+	adapter := knowledge.New(store, staticSession{
+		sess: storage.VoiceSession{CampaignID: campaignID}, live: true,
+	})
+	rk := tool.NewRememberKnowledge(adapter)
+	callCtx := tool.WithCaller(ctx, agentID.String())
+	args := json.RawMessage(`{"kind":"fact","fact":"I brew the finest ale in the realm"}`)
+	cfg := json.RawMessage(`{"scope":"own_node"}`)
+
+	if _, err := rk.Execute(callCtx, args, cfg); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	// A reworded/re-cased repeat of the SAME fact — the normalized guard catches it.
+	repeat := json.RawMessage(`{"kind":"fact","fact":"I brew THE finest ale in the realm!"}`)
+	out, err := rk.Execute(callCtx, repeat, cfg)
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "already") {
+		t.Errorf("second call did not report already-noted: %q", out)
+	}
+
+	pending, err := store.ListPendingKnowledgeProposals(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListPendingKnowledgeProposals: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("double-remember persisted %d rows, want exactly 1", len(pending))
 	}
 }

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -37,6 +37,23 @@ type fakeStore struct {
 	proposalJSON  []byte
 	proposalErrAt error // ctx.Err() observed INSIDE the store call
 	createErr     error
+
+	// Dedup read seam (#411).
+	pending      []storage.KnowledgeProposal // ListPendingKnowledgeProposals result
+	allNodes     []storage.KGNode            // ListNodes result
+	gotPendCID   uuid.UUID
+	gotNodesCID  uuid.UUID
+	pendingErr   error
+	listNodesErr error
+}
+
+func (f *fakeStore) ListPendingKnowledgeProposals(_ context.Context, cid uuid.UUID) ([]storage.KnowledgeProposal, error) {
+	f.gotPendCID = cid
+	return f.pending, f.pendingErr
+}
+func (f *fakeStore) ListNodes(_ context.Context, cid uuid.UUID) ([]storage.KGNode, error) {
+	f.gotNodesCID = cid
+	return f.allNodes, f.listNodesErr
 }
 
 func (f *fakeStore) AgentLinkedNode(_ context.Context, aid uuid.UUID) (storage.KGNode, bool, error) {

--- a/internal/recall/normalize.go
+++ b/internal/recall/normalize.go
@@ -1,37 +1,12 @@
 package recall
 
-import (
-	"strings"
-	"unicode"
-)
+import "github.com/MrWong99/Glyphoxa/internal/textnorm"
 
 // normalize folds an utterance to its speculation-cache comparison form: lower
 // case, punctuation stripped, whitespace collapsed to single spaces and trimmed.
 // It is the self-heal key of ADR-0042 — the [STTFinal] text is normalized and
 // matched against the normalized partial a speculation prefetched on, so casing,
 // trailing punctuation, and interim-whitespace jitter between the partial and the
-// final do not defeat the cache. Deliberately a tiny local function: the recall
-// path must not import the voicetest helpers.
-func normalize(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	pendingSpace := false
-	for _, r := range s {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsNumber(r):
-			if pendingSpace && b.Len() > 0 {
-				b.WriteByte(' ')
-			}
-			pendingSpace = false
-			b.WriteRune(unicode.ToLower(r))
-		case unicode.IsSpace(r):
-			pendingSpace = true
-		default:
-			// Punctuation is dropped without joining the surrounding words: it acts
-			// as a soft boundary so "well,now" and "well now" both normalize to
-			// "well now", but the space is only emitted if a word actually follows.
-			pendingSpace = true
-		}
-	}
-	return b.String()
-}
+// final do not defeat the cache. It delegates to the single shared normaliser in
+// internal/textnorm so the recall cache and the #411 proposal dedup never drift.
+func normalize(s string) string { return textnorm.Normalize(s) }

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -44,9 +44,12 @@ func scanKnowledgeProposal(row pgx.Row) (KnowledgeProposal, error) {
 }
 
 // CreateKnowledgeProposal inserts a pending proposal and returns the persisted
-// row. proposedWrite is the raw jsonb payload (the caller marshals it). There is
-// NO dedup — near-duplicate proposals are surfaced side-by-side for the GM to
-// merge or reject (ADR-0052: similarity is a hint, not a semantic judgment).
+// row. proposedWrite is the raw jsonb payload (the caller marshals it). This layer
+// does NO dedup by design: exact/normalized write-time dedup lives one layer up in
+// the Tool handler (pkg/tool remember_knowledge, #411), which suppresses a repeat
+// BEFORE calling here; genuine near-duplicates that differ in wording still land
+// side-by-side for the GM to merge or reject (ADR-0052: similarity is a hint, not a
+// semantic judgment — no auto-merge).
 func (s *Store) CreateKnowledgeProposal(ctx context.Context, campaignID, agentID uuid.UUID, proposedWrite []byte) error {
 	_, err := s.db.Exec(ctx,
 		`INSERT INTO knowledge_proposal (campaign_id, authoring_agent_id, proposed_write)

--- a/internal/textnorm/textnorm.go
+++ b/internal/textnorm/textnorm.go
@@ -1,0 +1,40 @@
+// Package textnorm holds the single text-normalisation used across Glyphoxa to
+// compare free text for equivalence: lower case, punctuation stripped, whitespace
+// collapsed to single spaces and trimmed. It is a stdlib-only leaf so any package
+// can depend on it without risking an import cycle (the ADR-0042 speculation cache
+// in internal/recall and the #411 write-time proposal dedup in pkg/tool share it).
+package textnorm
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Normalize folds a string to its comparison form: lower case, punctuation
+// stripped, whitespace collapsed to single spaces and trimmed. Punctuation acts
+// as a soft word boundary — "well,now" and "well now" both normalize to
+// "well now" — but a space is only emitted when a word actually follows, so
+// trailing punctuation and edge whitespace never leak into the result.
+func Normalize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	pendingSpace := false
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			if pendingSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			pendingSpace = false
+			b.WriteRune(unicode.ToLower(r))
+		case unicode.IsSpace(r):
+			pendingSpace = true
+		default:
+			// Punctuation is dropped without joining the surrounding words: it acts
+			// as a soft boundary so "well,now" and "well now" both normalize to
+			// "well now", but the space is only emitted if a word actually follows.
+			pendingSpace = true
+		}
+	}
+	return b.String()
+}

--- a/internal/textnorm/textnorm_test.go
+++ b/internal/textnorm/textnorm_test.go
@@ -1,0 +1,30 @@
+package textnorm_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/textnorm"
+)
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercase", "Hello World", "hello world"},
+		{"trailing punctuation dropped", "Gesa ist die Schwester.", "gesa ist die schwester"},
+		{"collapse whitespace", "well   now\tthen", "well now then"},
+		{"trim edges", "  hi  ", "hi"},
+		{"punctuation is a soft boundary", "well,now", "well now"},
+		{"casefold plus punctuation equal", "Gesa ist die Schwester!", "gesa ist die schwester"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := textnorm.Normalize(tc.in); got != tc.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/tool/deps.go
+++ b/pkg/tool/deps.go
@@ -77,9 +77,32 @@ type KGNodeRef struct {
 //   - CreateProposal records the proposal row (status pending). It is the ONLY
 //     side effect; per ADR-0052 barge semantics the adapter writes it under a
 //     cancel-immune context so a barged turn's proposal is never rolled back.
+//   - ExistingKnowledge reports what the KG already holds for a proposal's target
+//     (#411): the salient text of the target's pending proposals plus its
+//     established facts, so the handler can suppress an exact/normalized
+//     re-proposal and echo the target's pending proposals back to the model. It is
+//     a READ; a nil/empty result simply means nothing is known yet.
 type KGWriter interface {
 	OwnNode(ctx context.Context, agentID string) (KGNodeRef, bool, error)
 	CreateProposal(ctx context.Context, agentID string, w ProposedWrite) error
+	ExistingKnowledge(ctx context.Context, agentID string, w ProposedWrite) (KnownForTarget, error)
+}
+
+// KnownForTarget is what the Knowledge Graph already holds for one proposal's
+// target (#411), gathered by the [KGWriter] adapter and judged by the handler:
+//
+//   - Pending is the salient text of every pending Knowledge Proposal addressing
+//     the SAME target (per [ProposalTargetKey]). It is both a dedup candidate set
+//     and the echo list fed back to the model so it can see what it has already
+//     proposed this session and stop repeating itself (ADR-0052 mechanism c).
+//   - Established is the target Node's already-canon facts (its body, split into
+//     lines). A re-proposal that matches one creates no row.
+//
+// Both are RAW text (unnormalized): the handler normalizes at compare time via the
+// shared [textnorm.Normalize], and echoes the raw pending wording verbatim.
+type KnownForTarget struct {
+	Pending     []string
+	Established []string
 }
 
 // TranscriptHit is one persisted transcript Line the knowledge adapter surfaces

--- a/pkg/tool/remember_dedup.go
+++ b/pkg/tool/remember_dedup.go
@@ -1,0 +1,71 @@
+package tool
+
+import (
+	"strings"
+
+	"github.com/MrWong99/Glyphoxa/internal/textnorm"
+)
+
+// Write-time dedup for remember_knowledge (#411, ADR-0052 mechanism a): before a
+// proposal row is created, the handler compares its salient text — normalized
+// (casefold, punctuation stripped, whitespace collapsed) via the shared
+// [textnorm.Normalize] — against what the KG already holds for the same target:
+// the target's pending proposals and its established facts. An exact/normalized
+// hit creates NO row and the tool reports the fact is already noted, so the model
+// stops re-remembering the same thing every turn. Similarity beyond exact/
+// normalized (embeddings) is out of scope (ADR-0052 no-auto-merge posture).
+
+// ProposalSalient projects a [ProposedWrite] onto the free text the dedup guard
+// compares. A fact is its statement; an edge is its relation and target; a new
+// entry is its name and body. The result is compared normalized, so exact casing
+// and punctuation here do not matter.
+func ProposalSalient(w ProposedWrite) string {
+	switch w.Kind {
+	case proposalKindFact:
+		return w.Fact
+	case proposalKindEdge:
+		return strings.TrimSpace(w.Relation + " " + w.Target)
+	case proposalKindNode:
+		return strings.TrimSpace(w.Name + " " + w.Body)
+	default:
+		return strings.TrimSpace(w.Fact + " " + w.Name + " " + w.Body)
+	}
+}
+
+// ProposalTargetKey identifies the entity a proposal is ABOUT, so the guard only
+// compares proposals addressing the same target — a coincidental text clash
+// between two different subjects is never suppressed. An own_node proposal is
+// keyed by its anchor node id (subject is cosmetic there); a campaign fact/edge by
+// its normalized subject; a new entry by its own normalized name. An empty key
+// means "no identifiable target" and the caller skips dedup.
+func ProposalTargetKey(w ProposedWrite) string {
+	if w.NodeID != "" {
+		return "id:" + w.NodeID
+	}
+	if s := textnorm.Normalize(w.Subject); s != "" {
+		return "subj:" + s
+	}
+	if w.Kind == proposalKindNode {
+		if n := textnorm.Normalize(w.Name); n != "" {
+			return "name:" + n
+		}
+	}
+	return ""
+}
+
+// firstKnownMatch returns the raw existing text whose normalized form equals the
+// normalized salient text, or ok=false when the salient is new (or empty). It
+// returns the RAW candidate so the tool result can echo the exact known wording
+// back to the model.
+func firstKnownMatch(salient string, known []string) (string, bool) {
+	want := textnorm.Normalize(salient)
+	if want == "" {
+		return "", false
+	}
+	for _, k := range known {
+		if textnorm.Normalize(k) == want {
+			return k, true
+		}
+	}
+	return "", false
+}

--- a/pkg/tool/remember_dedup_handler_test.go
+++ b/pkg/tool/remember_dedup_handler_test.go
@@ -106,14 +106,41 @@ func TestRememberKnowledge_ResultEchoesPending(t *testing.T) {
 	}
 }
 
-// AC4 (hardening): the tool description tells the model not to re-propose known or
-// already-proposed facts.
+// AC4 (hardening): the description honestly scopes the guard (exact/normalized,
+// NOT reworded), tells the model not to re-propose within the session, and
+// explicitly warns against reworded repeats — it must NOT claim reworded repeats
+// are ignored (they are not; that would invite reworded spam).
 func TestRememberKnowledge_DescriptionHardened(t *testing.T) {
 	d := strings.ToLower((&RememberKnowledge{}).Description())
-	for _, want := range []string{"already", "not"} {
+	for _, want := range []string{"not already known", "session", "normalized", "different words"} {
 		if !strings.Contains(d, want) {
 			t.Errorf("description missing %q guidance: %q", want, d)
 		}
+	}
+	if strings.Contains(d, "reworded repeats are ignored") || strings.Contains(d, "reworded repeats are dropped") {
+		t.Errorf("description falsely claims reworded repeats are ignored: %q", d)
+	}
+}
+
+// The echo caps each pending fact's length so a long fact cannot blow the
+// hot-context budget (a count cap alone still admits ~20k characters).
+func TestRememberKnowledge_EchoTruncatesLongPending(t *testing.T) {
+	longFact := strings.Repeat("a", 5000)
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		known: KnownForTarget{Pending: []string{longFact}},
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	out, err := rk.Execute(ctx, json.RawMessage(`{"kind":"fact","fact":"Gesa hasst Spinnen"}`), cfgOwnNode)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, longFact) {
+		t.Error("echo included the full untruncated 5000-char fact")
+	}
+	if !strings.Contains(out, "…") {
+		t.Errorf("truncated echo missing ellipsis: %q", out)
 	}
 }
 

--- a/pkg/tool/remember_dedup_handler_test.go
+++ b/pkg/tool/remember_dedup_handler_test.go
@@ -1,0 +1,135 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// AC1: an exact/normalized re-proposal of an existing PENDING proposal for the
+// same target creates no row and the tool reports it is already noted, echoing the
+// known wording so the model learns it.
+func TestRememberKnowledge_DedupAgainstPending(t *testing.T) {
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		known: KnownForTarget{Pending: []string{"Gesa ist die Schwester von Arturus."}},
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	out, err := rk.Execute(ctx, json.RawMessage(
+		`{"kind":"fact","fact":"gesa ist die schwester von arturus"}`), cfgOwnNode)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(w.created) != 0 {
+		t.Fatalf("a duplicate created a row: %+v", w.created)
+	}
+	if !strings.Contains(strings.ToLower(out), "already") {
+		t.Errorf("result does not say already-noted: %q", out)
+	}
+	if !strings.Contains(out, "Gesa ist die Schwester von Arturus.") {
+		t.Errorf("result does not echo the matched wording: %q", out)
+	}
+}
+
+// AC1: a re-proposal of an ESTABLISHED node fact (already-canon body line) is
+// likewise suppressed.
+func TestRememberKnowledge_DedupAgainstEstablished(t *testing.T) {
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		known: KnownForTarget{Established: []string{"Gesa liebt es ihren Bruder zu ärgern"}},
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	_, err := rk.Execute(ctx, json.RawMessage(
+		`{"kind":"fact","fact":"Gesa liebt es, ihren Bruder zu ärgern!"}`), cfgOwnNode)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(w.created) != 0 {
+		t.Fatalf("a known established fact created a row: %+v", w.created)
+	}
+}
+
+// AC3: a genuinely new fact still creates a proposal.
+func TestRememberKnowledge_NewFactStillCreates(t *testing.T) {
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		known: KnownForTarget{Pending: []string{"Gesa ist die Schwester von Arturus."}},
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	_, err := rk.Execute(ctx, json.RawMessage(
+		`{"kind":"fact","fact":"Gesa hasst Spinnen"}`), cfgOwnNode)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("a new fact was not created: %d rows", len(w.created))
+	}
+}
+
+// AC2: a scripted double-remember of the same fact in one session yields exactly
+// one proposal row — the second call sees the first as pending and suppresses it.
+func TestRememberKnowledge_DoubleRememberYieldsOneRow(t *testing.T) {
+	w := &fakeKGWriter{ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	args := json.RawMessage(`{"kind":"fact","fact":"Gesa mag Kuchen"}`)
+	if _, err := rk.Execute(ctx, args, cfgOwnNode); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	if _, err := rk.Execute(ctx, args, cfgOwnNode); err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("double-remember created %d rows, want exactly 1", len(w.created))
+	}
+}
+
+// AC4 (echo): the tool result feeds the agent its own pending proposals for the
+// target so it can see what it has proposed this session.
+func TestRememberKnowledge_ResultEchoesPending(t *testing.T) {
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		known: KnownForTarget{Pending: []string{"Gesa ist die Schwester von Arturus."}},
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	out, err := rk.Execute(ctx, json.RawMessage(`{"kind":"fact","fact":"Gesa hasst Spinnen"}`), cfgOwnNode)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Gesa ist die Schwester von Arturus.") {
+		t.Errorf("success result did not echo the agent's pending proposals: %q", out)
+	}
+}
+
+// AC4 (hardening): the tool description tells the model not to re-propose known or
+// already-proposed facts.
+func TestRememberKnowledge_DescriptionHardened(t *testing.T) {
+	d := strings.ToLower((&RememberKnowledge{}).Description())
+	for _, want := range []string{"already", "not"} {
+		if !strings.Contains(d, want) {
+			t.Errorf("description missing %q guidance: %q", want, d)
+		}
+	}
+}
+
+// A dedup read hiccup must never drop the NPC's memory: the guard fails OPEN and
+// the proposal is still created.
+func TestRememberKnowledge_DedupReadErrorFailsOpen(t *testing.T) {
+	w := &fakeKGWriter{
+		ownRef: KGNodeRef{ID: "node-1", Name: "Gesa"}, ownOK: true,
+		knownErr: context.DeadlineExceeded,
+	}
+	rk := NewRememberKnowledge(w)
+	ctx := WithCaller(context.Background(), "agent-9")
+	if _, err := rk.Execute(ctx, json.RawMessage(`{"kind":"fact","fact":"Gesa mag Kuchen"}`), cfgOwnNode); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(w.created) != 1 {
+		t.Fatalf("dedup read error dropped the proposal: %d rows", len(w.created))
+	}
+}

--- a/pkg/tool/remember_dedup_test.go
+++ b/pkg/tool/remember_dedup_test.go
@@ -1,0 +1,66 @@
+package tool
+
+import "testing"
+
+// ProposalSalient projects a proposed write onto the free text a dedup compares.
+func TestProposalSalient(t *testing.T) {
+	cases := []struct {
+		name string
+		w    ProposedWrite
+		want string
+	}{
+		{"fact is its fact text", ProposedWrite{Kind: "fact", Subject: "Gesa", Fact: "ist die Schwester"}, "ist die Schwester"},
+		{"edge is relation and target", ProposedWrite{Kind: "edge", Subject: "Gesa", Relation: "parent_of", Target: "Arturus"}, "parent_of Arturus"},
+		{"node is name and body", ProposedWrite{Kind: "node", Name: "Ironhold", Body: "a smiths' guild"}, "Ironhold a smiths' guild"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProposalSalient(tc.w); got != tc.want {
+				t.Errorf("ProposalSalient = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ProposalTargetKey identifies the entity a proposal is about, so dedup only
+// compares proposals addressing the SAME target (not a coincidental text clash
+// across two different subjects).
+func TestProposalTargetKey(t *testing.T) {
+	// An own_node proposal is keyed by its anchor node id, regardless of subject.
+	if k := ProposalTargetKey(ProposedWrite{Kind: "fact", NodeID: "n1", Subject: "Gesa", Fact: "x"}); k != "id:n1" {
+		t.Errorf("own-node key = %q, want id:n1", k)
+	}
+	// A campaign proposal with no anchor is keyed by its normalized subject, so
+	// casing/punctuation variants of the same subject collapse together.
+	a := ProposalTargetKey(ProposedWrite{Kind: "fact", Subject: "The Duke", Fact: "x"})
+	b := ProposalTargetKey(ProposedWrite{Kind: "fact", Subject: "the duke!", Fact: "y"})
+	if a == "" || a != b {
+		t.Errorf("subject keys differ: %q vs %q", a, b)
+	}
+	// A new-entry proposal is keyed by the new entry's own name.
+	if k := ProposalTargetKey(ProposedWrite{Kind: "node", Name: "Ironhold"}); k == "" {
+		t.Error("node key empty")
+	}
+	// Two different subjects must NOT share a key.
+	if ProposalTargetKey(ProposedWrite{Subject: "Gesa"}) == ProposalTargetKey(ProposedWrite{Subject: "Arturus"}) {
+		t.Error("distinct subjects share a target key")
+	}
+}
+
+// firstKnownMatch returns the raw existing text that is normalized-equal to the
+// salient text — the exact/normalized write-time guard (#411, mechanism a).
+func TestFirstKnownMatch(t *testing.T) {
+	known := []string{"Gesa ist die Schwester von Arturus.", "Gesa mag Kuchen"}
+	// A casing/punctuation variant of a known fact matches and echoes the known text.
+	if m, ok := firstKnownMatch("gesa ist die schwester von arturus", known); !ok || m != known[0] {
+		t.Errorf("normalized variant did not match: got %q ok=%v", m, ok)
+	}
+	// A genuinely new fact matches nothing.
+	if m, ok := firstKnownMatch("Gesa hasst Spinnen", known); ok {
+		t.Errorf("new fact matched %q", m)
+	}
+	// An empty salient never matches (guards a proposal with no comparable text).
+	if _, ok := firstKnownMatch("", known); ok {
+		t.Error("empty salient matched")
+	}
+}

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -143,10 +143,16 @@ func NewRememberKnowledge(dst KGWriter) *RememberKnowledge {
 // Name implements [Tool].
 func (*RememberKnowledge) Name() string { return "remember_knowledge" }
 
-// Description implements [Tool].
+// Description implements [Tool]. It is hardened against the #411 proposal flood:
+// the model is told to remember only genuinely NEW facts and never to re-remember
+// something it already proposed this session (the tool echoes the target's pending
+// proposals back on every call, and silently suppresses exact/normalized repeats).
 func (*RememberKnowledge) Description() string {
 	return "Remember a new fact, relationship or entry about the world. " +
-		"It is saved as a suggestion for the GM to review — not instantly canon."
+		"It is saved as a suggestion for the GM to review — not instantly canon. " +
+		"Only remember facts that are NOT already known to you: never re-propose a " +
+		"fact you already remembered earlier in this session, and do not restate a " +
+		"fact the world already records. Exact and reworded repeats are ignored."
 }
 
 // InputSchema implements [Tool].
@@ -210,10 +216,59 @@ func (rk *RememberKnowledge) Execute(ctx context.Context, args json.RawMessage, 
 		return "", err
 	}
 
+	// Write-time dedup (#411, ADR-0052 mechanism a): suppress an exact/normalized
+	// re-proposal of something already pending for this target or already canon on
+	// its Node, and feed the agent its own pending proposals so it stops repeating
+	// itself. The read is best-effort — a KG hiccup must never drop the NPC's
+	// memory — so it FAILS OPEN to creating the row.
+	var known KnownForTarget
+	if k, err := rk.dst.ExistingKnowledge(ctx, CallerID(ctx), w); err == nil {
+		known = k
+		if matched, dup := firstKnownMatch(ProposalSalient(w), append(known.Established, known.Pending...)); dup {
+			return alreadyNotedResult(matched, known.Pending), nil
+		}
+	}
+
 	if err := rk.dst.CreateProposal(ctx, CallerID(ctx), w); err != nil {
 		return "", fmt.Errorf("remember_knowledge: %w", err)
 	}
-	return "Noted — saved for the GM's review.", nil
+	return notedResult(known.Pending), nil
+}
+
+// maxEchoedPending caps how many of the target's pending proposals are echoed
+// back to the model, so a busy target cannot blow the tool result up.
+const maxEchoedPending = 10
+
+// alreadyNotedResult is the tool result when a proposal duplicates a known fact:
+// no row was created, and it names the exact known wording (plus the target's
+// other pending proposals) so the model stops re-remembering it.
+func alreadyNotedResult(matched string, pending []string) string {
+	return withPendingEcho(fmt.Sprintf(
+		"Already noted — %q is already known, so no new suggestion was saved.", matched), pending)
+}
+
+// notedResult is the tool result for a freshly created proposal; it echoes the
+// target's pending proposals so the model can see what it has already suggested
+// this session (ADR-0052 mechanism c).
+func notedResult(pending []string) string {
+	return withPendingEcho("Noted — saved for the GM's review.", pending)
+}
+
+// withPendingEcho appends the target's pending proposal texts (capped) to a tool
+// result, so the agent sees its own session proposals and does not repeat them.
+func withPendingEcho(lead string, pending []string) string {
+	if len(pending) == 0 {
+		return lead
+	}
+	if len(pending) > maxEchoedPending {
+		pending = pending[:maxEchoedPending]
+	}
+	quoted := make([]string, len(pending))
+	for i, p := range pending {
+		quoted[i] = fmt.Sprintf("%q", p)
+	}
+	return lead + " You have already proposed these facts about this subject (do not repeat them): " +
+		strings.Join(quoted, "; ") + "."
 }
 
 // validateArgs enforces the per-kind required fields and the text-length caps,

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"unicode/utf8"
 )
@@ -152,7 +153,9 @@ func (*RememberKnowledge) Description() string {
 		"It is saved as a suggestion for the GM to review — not instantly canon. " +
 		"Only remember facts that are NOT already known to you: never re-propose a " +
 		"fact you already remembered earlier in this session, and do not restate a " +
-		"fact the world already records. Exact and reworded repeats are ignored."
+		"fact the world already records. Exact and normalized (case/punctuation) " +
+		"repeats are dropped automatically, but a fact you reword in DIFFERENT words " +
+		"is not caught — so do not re-propose the same fact phrased differently."
 }
 
 // InputSchema implements [Tool].
@@ -227,6 +230,11 @@ func (rk *RememberKnowledge) Execute(ctx context.Context, args json.RawMessage, 
 		if matched, dup := firstKnownMatch(ProposalSalient(w), append(known.Established, known.Pending...)); dup {
 			return alreadyNotedResult(matched, known.Pending), nil
 		}
+	} else {
+		// Fail OPEN: a KG read hiccup must never drop the NPC's memory. Warn so a
+		// SYSTEMATIC dedup failure (which silently reopens the proposal flood) is
+		// visible to the operator instead of degrading unnoticed.
+		slog.WarnContext(ctx, "remember_knowledge: dedup read failed; proposing without dedup", "error", err)
 	}
 
 	if err := rk.dst.CreateProposal(ctx, CallerID(ctx), w); err != nil {
@@ -236,8 +244,13 @@ func (rk *RememberKnowledge) Execute(ctx context.Context, args json.RawMessage, 
 }
 
 // maxEchoedPending caps how many of the target's pending proposals are echoed
-// back to the model, so a busy target cannot blow the tool result up.
-const maxEchoedPending = 10
+// back to the model, and maxEchoedRunes caps each one's length, so a busy target
+// with long facts cannot blow the hot-context budget up via the echo (a count cap
+// alone still admits ~20k characters).
+const (
+	maxEchoedPending = 10
+	maxEchoedRunes   = 200
+)
 
 // alreadyNotedResult is the tool result when a proposal duplicates a known fact:
 // no row was created, and it names the exact known wording (plus the target's
@@ -265,7 +278,7 @@ func withPendingEcho(lead string, pending []string) string {
 	}
 	quoted := make([]string, len(pending))
 	for i, p := range pending {
-		quoted[i] = fmt.Sprintf("%q", p)
+		quoted[i] = fmt.Sprintf("%q", truncateRunes(p, maxEchoedRunes))
 	}
 	return lead + " You have already proposed these facts about this subject (do not repeat them): " +
 		strings.Join(quoted, "; ") + "."

--- a/pkg/tool/remember_knowledge_test.go
+++ b/pkg/tool/remember_knowledge_test.go
@@ -21,6 +21,32 @@ type fakeKGWriter struct {
 	createCtx     context.Context
 	createErr     error
 	onCreate      func()
+
+	// known seeds what the KG already holds (established facts + cross-agent
+	// pending). ExistingKnowledge ALSO reflects this fake's own prior created
+	// proposals for the same target, so a scripted double-remember in one session
+	// sees the first row and suppresses the second — no real DB needed.
+	known      KnownForTarget
+	knownErr   error
+	knownCalls int
+}
+
+func (f *fakeKGWriter) ExistingKnowledge(_ context.Context, _ string, w ProposedWrite) (KnownForTarget, error) {
+	f.knownCalls++
+	if f.knownErr != nil {
+		return KnownForTarget{}, f.knownErr
+	}
+	out := KnownForTarget{
+		Pending:     append([]string(nil), f.known.Pending...),
+		Established: append([]string(nil), f.known.Established...),
+	}
+	key := ProposalTargetKey(w)
+	for _, p := range f.created {
+		if ProposalTargetKey(p) == key {
+			out.Pending = append(out.Pending, ProposalSalient(p))
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeKGWriter) OwnNode(_ context.Context, agentID string) (KGNodeRef, bool, error) {


### PR DESCRIPTION
Closes #411

## What

`remember_knowledge` floods the GM proposal queue with exact and reworded repeats of facts it already proposed or that are already canon (live play: one fact re-proposed 8+ times in ~30 min). Implements ADR-0052 mechanisms **(a)** cheap write-time guard and **(c)** tool-description hardening + self-awareness. Per triage: (b) embedding-similarity and (d) GM bulk actions deferred.

## How

- **`internal/textnorm`** — extracts the single normaliser (was unexported in `internal/recall`) into a stdlib-only leaf, so `pkg/tool` can reuse it without the import cycle `recall → storage → pkg/tool`. `recall` now delegates; behaviour unchanged (its tests still pass).
- **`pkg/tool`** — `ProposalSalient` / `ProposalTargetKey` / `firstKnownMatch` do the exact/normalized comparison, **scoped to the proposal's target** so a coincidental text clash across two different subjects is never suppressed. `Execute` consults the new `KGWriter.ExistingKnowledge` before creating a row: a hit against the target's pending proposals **or** established Node facts creates **no row** and returns an already-noted result naming the matched wording. Every result echoes the target's pending proposals so the model sees what it already suggested this session. Dedup **fails open** — a KG read hiccup never drops the NPC's memory. Description hardened.
- **`internal/knowledge`** — `ExistingKnowledge` gathers the target Node's body facts (own node by id; campaign subject by normalized name) plus the same-target pending proposals' salient text, scoped to the active session's Campaign (never global).

## Tests (TDD, red→green)

Per-AC evidence:

- **AC1 (re-proposal of pending/established → no row, already-noted)**: `TestRememberKnowledge_DedupAgainstPending`, `TestRememberKnowledge_DedupAgainstEstablished` (pkg/tool); `TestExistingKnowledge_OwnNodeGathersPendingAndEstablished`, `TestExistingKnowledge_CampaignBySubjectName` (internal/knowledge).
- **AC2 (double-remember in one session → exactly one row)**: `TestRememberKnowledge_DoubleRememberYieldsOneRow`.
- **AC3 (genuinely new facts still create)**: `TestRememberKnowledge_NewFactStillCreates`.
- **AC4 (description hardened; agent sees its pending/session proposals)**: `TestRememberKnowledge_DescriptionHardened`, `TestRememberKnowledge_ResultEchoesPending`.
- Supporting: `TestProposalSalient`, `TestProposalTargetKey`, `TestFirstKnownMatch`, `TestRememberKnowledge_DedupReadErrorFailsOpen` (fail-open), `TestNormalize` (textnorm).

Local: `go test -race ./...` green, `golangci-lint run` 0 issues, `buf generate` + `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)