### PR TITLE
fix(#406): highlight enrichment reconciliation — boot sweep + race-proof claim + orphan cleanup

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -670,6 +670,17 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		log.Warn("highlight purge backstop sweep failed at boot", "err", err)
 	}
 
+	// Boot-time enrichment reconciliation (#406, ADR-0043/0048/0049): the same
+	// rows-are-the-source-of-truth backstop for image enrichment. It re-enqueues
+	// enrichment for every promoted Highlight left imageless with no live enrich job
+	// (recovering a crash between promote-commit and the enqueue), and drops image
+	// blobs whose Highlight row is gone (the delete-vs-enrich orphan the RPC's
+	// re-read window only shrinks). Loud-but-non-fatal: a failure logs and boot
+	// continues, exactly like the purge backstop above.
+	if err := highlight.SweepEnrichmentReconciliation(ctx, store, blobStore, jobEnqueuer{store}, log); err != nil {
+		log.Warn("highlight enrichment reconciliation sweep failed at boot", "err", err)
+	}
+
 	// Resolve the process embeddings provider ONCE and share it across the two
 	// consumers (#122): the async backfill worker (#116) drains the NULL-embedding
 	// backlog, and the NPC memory recaller (#122) embeds utterances for Hot Context

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
@@ -58,12 +59,30 @@ func MarshalEnrichImage(highlightID, tenantID uuid.UUID) ([]byte, error) {
 	return json.Marshal(enrichPayload{HighlightID: highlightID, TenantID: tenantID})
 }
 
+// enrichClaimTTL is how long a claim on a Highlight's image enrichment stays
+// valid before it is reclaimable (#406). It MUST exceed the runner's per-handler
+// lease deadline (ADR-0049 default 5m) so a live winner is never reclaimed
+// mid-generation, while a crashed winner's claim eventually frees and a later
+// retry (or boot re-enqueue) re-drives the enrichment.
+const enrichClaimTTL = 10 * time.Minute
+
 // EnrichStore is the storage surface the enrichment handler needs; *storage.Store
 // satisfies it and tests fake it. GetHighlight is tenant-scoped; SetHighlightImage
 // lands the result (ErrNotFound if the row was deleted meanwhile).
+// TryClaimHighlightEnrich / ReleaseHighlightEnrichClaim implement the race-proof
+// claim (#406): a conditional state transition so two concurrent enrich jobs for
+// the same Highlight run the provider Generate AT MOST once.
 type EnrichStore interface {
 	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
 	SetHighlightImage(ctx context.Context, id uuid.UUID, imageKey, contentType string, sizeBytes int64) error
+	// TryClaimHighlightEnrich atomically claims the enrichment of an imageless
+	// Highlight: it reports true iff THIS caller won the claim (the row is still
+	// imageless and no fresh claim within ttl is held). A false (no error) means a
+	// concurrent worker holds the claim or the row was enriched meanwhile.
+	TryClaimHighlightEnrich(ctx context.Context, id uuid.UUID, ttl time.Duration) (bool, error)
+	// ReleaseHighlightEnrichClaim clears a claim so a retry (or a later
+	// re-promotion) can re-claim without waiting out the ttl. Idempotent.
+	ReleaseHighlightEnrichClaim(ctx context.Context, id uuid.UUID) error
 }
 
 // EnrichImageHandler builds the JobKindEnrichImage handler (ADR-0049). It is
@@ -105,23 +124,42 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		if h.ImageKey != "" {
 			// Already enriched (a re-run of an at-least-once job): stop before any
 			// spend so the same Highlight is never billed twice.
-			//
-			// KNOWN residual race (follow-up issue planned): this guard is
-			// read-then-act, not a lock. Two replicas promoting the same Highlight at
-			// once can both read ImageKey=="" and both Generate — bounded to one extra
-			// image's spend, and the second SetHighlightImage simply overwrites the
-			// first's deterministic key (harmless result, no orphan). The single-Voice
-			// -Session deployment (ADR-0039) makes this near-impossible in practice.
 			return nil
+		}
+
+		// Race-proof claim (#406): a conditional state transition so two concurrent
+		// enrich jobs for the SAME Highlight run Generate AT MOST once. A false-no-error
+		// means a live winner holds the claim (or the row was enriched between our read
+		// and here): return a retryable error so this duplicate job re-checks after
+		// backoff — the next attempt sees the winner's image_key and completes, or (if
+		// the winner crashed) reclaims the stale claim after enrichClaimTTL. The marker
+		// lives on a column that never reaches the wire (toProtoHighlight omits it), so
+		// no sentinel leaks into an RPC response.
+		claimed, err := store.TryClaimHighlightEnrich(ctx, p.HighlightID, enrichClaimTTL)
+		if err != nil {
+			return fmt.Errorf("highlight enrich: claim highlight %s: %w", p.HighlightID, err)
+		}
+		if !claimed {
+			return fmt.Errorf("highlight enrich: %s claimed by a concurrent worker", p.HighlightID)
+		}
+		// From here we OWN the claim. Release it on every exit that does NOT land an
+		// image so a fast retry (or a later re-promotion) can re-claim without waiting
+		// out the ttl; a release failure is non-fatal (the ttl backs it up).
+		release := func() {
+			if rerr := store.ReleaseHighlightEnrichClaim(ctx, p.HighlightID); rerr != nil {
+				log.Error("highlight enrich: release claim", "err", rerr, "highlight", p.HighlightID)
+			}
 		}
 
 		gen, model, err := factory(ctx, p.TenantID)
 		if errors.Is(err, ErrImageNotConfigured) {
+			release()
 			log.Info("highlight enrich: image generation not configured, leaving highlight without media",
 				"highlight", p.HighlightID, "tenant", p.TenantID)
 			return nil
 		}
 		if err != nil {
+			release()
 			return fmt.Errorf("highlight enrich: build generator: %w", err)
 		}
 
@@ -130,6 +168,7 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 			// PERMANENT: an oversize image can never be stored, and a retry only
 			// re-bills the same generation. Log + return nil — the Highlight stays
 			// intact without media (AC), no dead-letter churn.
+			release()
 			log.Warn("highlight enrich: generated image exceeds blob cap, leaving highlight without media",
 				"highlight", p.HighlightID)
 			return nil
@@ -137,6 +176,7 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		if err != nil {
 			// Provider error: return it so the runner retries / dead-letters. The row
 			// is untouched — the Highlight keeps its clip and stays imageless (AC).
+			release()
 			return fmt.Errorf("highlight enrich: generate image: %w", err)
 		}
 
@@ -156,15 +196,18 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 
 		key, err := blob.Key(p.TenantID, "highlight", p.HighlightID, imageBlobName)
 		if err != nil {
+			release()
 			return fmt.Errorf("highlight enrich: build image key: %w", err)
 		}
 		if err := blobs.Put(ctx, key, res.ContentType, bytes.NewReader(res.Data), int64(len(res.Data))); err != nil {
 			if errors.Is(err, blob.ErrTooLarge) {
 				// Same PERMANENT posture as an oversize generation: never retryable.
+				release()
 				log.Warn("highlight enrich: image exceeds blob cap at Put, leaving highlight without media",
 					"highlight", p.HighlightID)
 				return nil
 			}
+			release()
 			return fmt.Errorf("highlight enrich: store image: %w", err)
 		}
 		if err := store.SetHighlightImage(ctx, p.HighlightID, key, res.ContentType, int64(len(res.Data))); err != nil {
@@ -177,10 +220,83 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 				}
 				return nil
 			}
+			release()
 			return fmt.Errorf("highlight enrich: record image on highlight: %w", err)
 		}
 		return nil
 	}
+}
+
+// ReconcileStore is the storage surface the boot enrichment reconciliation sweep
+// needs (#406); *storage.Store satisfies it and tests fake it.
+type ReconcileStore interface {
+	ListPromotedHighlightsNeedingEnrichment(ctx context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error)
+	ListOrphanHighlightImageKeys(ctx context.Context) ([]string, error)
+}
+
+// SweepEnrichmentReconciliation is the boot-time enrichment backstop (#406, the
+// pattern-sibling of SweepMissingCandidatePurges / ADR-0043 "rows are the source
+// of truth, reconcile on boot"). Before serving, it does ONE sweep with two halves:
+//
+//   - (a) enqueue image enrichment for every PROMOTED Highlight left imageless with
+//     no live enrich job — recovering a crash between promote-commit and the enqueue
+//     (AC1). It complements, not replaces, PromoteHighlight's per-promotion enqueue.
+//   - (b) drop every ORPHAN image blob — an image under the Highlight image
+//     owner-kind prefix whose Highlight row is gone (a delete-vs-enrich interleaving
+//     that committed the image after the delete read the row imageless), closing the
+//     window DeleteHighlight's re-read only shrinks (AC3). It touches ONLY that
+//     prefix (ADR-0048), never another owner's blobs, and never a live enrichment's
+//     in-flight blob (the row still exists).
+//
+// Both halves run even if one's list fails: a store-list error is collected and
+// returned so boot logs it, but the sweep never aborts (AC4) — the caller (main.go)
+// treats a returned error as loud-but-non-fatal, exactly like the purge backstop. A
+// per-item enqueue/delete error logs and the sweep continues (the next boot retries).
+func SweepEnrichmentReconciliation(ctx context.Context, store ReconcileStore, blobs blob.Store, enqueue JobEnqueuer, log *slog.Logger) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	var errs []error
+
+	// (a) Re-enqueue enrichment for imageless promoted Highlights.
+	targets, err := store.ListPromotedHighlightsNeedingEnrichment(ctx, JobKindEnrichImage)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list promoted highlights needing enrichment: %w", err))
+	} else {
+		for _, t := range targets {
+			payload := enrichPayload{HighlightID: t.HighlightID, TenantID: t.TenantID}
+			if err := enqueue.Enqueue(ctx, JobKindEnrichImage, payload, time.Now()); err != nil {
+				log.Error("highlight enrich sweep: enqueue backstop enrichment", "err", err, "highlight", t.HighlightID)
+				continue
+			}
+		}
+		if len(targets) > 0 {
+			log.Warn("scheduled backstop image enrichment for imageless promoted highlights", "count", len(targets))
+		}
+	}
+
+	// (b) Collect orphaned image blobs.
+	keys, err := store.ListOrphanHighlightImageKeys(ctx)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list orphan image keys: %w", err))
+	} else {
+		swept := 0
+		for _, k := range keys {
+			if err := blobs.Delete(ctx, k); err != nil {
+				log.Error("highlight enrich sweep: delete orphan image", "err", err, "key", k)
+				continue
+			}
+			swept++
+		}
+		if swept > 0 {
+			log.Warn("swept orphaned highlight image blobs", "count", swept)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("highlight enrich sweep: %w", errors.Join(errs...))
+	}
+	return nil
 }
 
 // buildImagePrompt renders the fixed image prompt from a Highlight's caption

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -25,6 +26,11 @@ type fakeEnrichStore struct {
 	lastImgKey string
 	lastImgCT  string
 	lastImgSz  int64
+
+	claimed      map[uuid.UUID]time.Time // live claims (id -> claimed_at)
+	claimErr     error                   // returned by TryClaimHighlightEnrich when non-nil
+	claimCalls   int
+	releaseCalls int
 }
 
 func newFakeEnrichStore() *fakeEnrichStore {
@@ -55,6 +61,34 @@ func (f *fakeEnrichStore) SetHighlightImage(_ context.Context, id uuid.UUID, key
 	h.ImageKey, h.ImageContentType, h.ImageSizeBytes = key, ct, sz
 	f.rows[id] = h
 	f.lastImgKey, f.lastImgCT, f.lastImgSz = key, ct, sz
+	return nil
+}
+
+func (f *fakeEnrichStore) TryClaimHighlightEnrich(_ context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.claimErr != nil {
+		return false, f.claimErr
+	}
+	if h, ok := f.rows[id]; ok && h.ImageKey != "" {
+		return false, nil // already enriched: nothing to claim
+	}
+	if prev, ok := f.claimed[id]; ok && time.Since(prev) < ttl {
+		return false, nil // a fresh claim is held by a concurrent worker
+	}
+	if f.claimed == nil {
+		f.claimed = map[uuid.UUID]time.Time{}
+	}
+	f.claimed[id] = time.Now()
+	f.claimCalls++
+	return true, nil
+}
+
+func (f *fakeEnrichStore) ReleaseHighlightEnrichClaim(_ context.Context, id uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseCalls++
+	delete(f.claimed, id)
 	return nil
 }
 
@@ -147,6 +181,184 @@ func TestEnrichImageHandler_HappyPath(t *testing.T) {
 	// Metered as Gemini LLM tokens.
 	if !rec.seen || rec.provider != observe.ProviderGemini || rec.in != 40 || rec.out != 1290 {
 		t.Errorf("metering wrong: seen=%v provider=%q in=%d out=%d", rec.seen, rec.provider, rec.in, rec.out)
+	}
+}
+
+// TestEnrichImageHandler_Claim_GeneratesAtMostOnce pins AC2 (#406): two enrich
+// jobs racing for the SAME Highlight run the provider Generate at most once — the
+// conditional claim lets exactly one win; the loser never spends.
+func TestEnrichImageHandler_Claim_GeneratesAtMostOnce(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+	gen := &fakeGen{res: imagegen.Result{Data: []byte("PNGDATA"), ContentType: "image/png", OutputTokens: 1290}}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = handler(context.Background(), payload)
+		}(i)
+	}
+	wg.Wait()
+
+	if gen.calls != 1 {
+		t.Fatalf("Generate ran %d times; the claim must pin it to exactly 1", gen.calls)
+	}
+	// Exactly one image blob was stored (the winner's), and the row is enriched.
+	if blobs.keys() != 1 {
+		t.Fatalf("want exactly one image blob stored, got %d", blobs.keys())
+	}
+	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+	if got.ImageKey == "" {
+		t.Fatal("winner did not land the image on the row")
+	}
+}
+
+// --- boot reconciliation sweep (#406) ---
+
+// fakeReconcileStore feeds the boot enrichment reconciliation sweep: the promoted
+// imageless targets to re-enqueue, and the orphan image blob keys to collect.
+type fakeReconcileStore struct {
+	targets   []storage.HighlightEnrichTarget
+	gotKind   string
+	orphans   []string
+	targetErr error
+	orphanErr error
+}
+
+func (f *fakeReconcileStore) ListPromotedHighlightsNeedingEnrichment(_ context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error) {
+	f.gotKind = enrichKind
+	if f.targetErr != nil {
+		return nil, f.targetErr
+	}
+	return f.targets, nil
+}
+
+func (f *fakeReconcileStore) ListOrphanHighlightImageKeys(_ context.Context) ([]string, error) {
+	if f.orphanErr != nil {
+		return nil, f.orphanErr
+	}
+	return f.orphans, nil
+}
+
+// enrichEnqueued records one backstop enrichment enqueue.
+type enrichEnqueued struct {
+	kind    string
+	payload enrichPayload
+}
+
+type enrichRecordingEnqueuer struct {
+	mu  sync.Mutex
+	all []enrichEnqueued
+}
+
+func (r *enrichRecordingEnqueuer) Enqueue(_ context.Context, kind string, payload any, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := enrichEnqueued{kind: kind}
+	if p, ok := payload.(enrichPayload); ok {
+		e.payload = p
+	}
+	r.all = append(r.all, e)
+	return nil
+}
+
+// TestSweepEnrichmentReconciliation_EnqueuesForImagelessPromoted pins AC1 (#406):
+// the boot sweep enqueues image enrichment for every promoted Highlight left
+// imageless (the crash-between-promote-and-enqueue backstop).
+func TestSweepEnrichmentReconciliation_EnqueuesForImagelessPromoted(t *testing.T) {
+	t1, t2 := uuid.New(), uuid.New()
+	h1, h2 := uuid.New(), uuid.New()
+	store := &fakeReconcileStore{targets: []storage.HighlightEnrichTarget{
+		{HighlightID: h1, TenantID: t1},
+		{HighlightID: h2, TenantID: t2},
+	}}
+	enq := &enrichRecordingEnqueuer{}
+
+	if err := SweepEnrichmentReconciliation(context.Background(), store, newFakeBlobs(), enq, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if store.gotKind != JobKindEnrichImage {
+		t.Fatalf("sweep asked with wrong kind: %q", store.gotKind)
+	}
+	if len(enq.all) != 2 {
+		t.Fatalf("want 2 backstop enrichments enqueued, got %d", len(enq.all))
+	}
+	for _, e := range enq.all {
+		if e.kind != JobKindEnrichImage {
+			t.Fatalf("enqueued wrong kind: %q", e.kind)
+		}
+	}
+	if enq.all[0].payload.HighlightID != h1 || enq.all[0].payload.TenantID != t1 {
+		t.Fatalf("first enqueue payload wrong: %+v", enq.all[0].payload)
+	}
+	if enq.all[1].payload.HighlightID != h2 || enq.all[1].payload.TenantID != t2 {
+		t.Fatalf("second enqueue payload wrong: %+v", enq.all[1].payload)
+	}
+}
+
+// TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs pins AC3 (#406): the
+// boot sweep drops image blobs whose Highlight row is gone (the delete-vs-enrich
+// interleaving orphan) through the seam.
+func TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs(t *testing.T) {
+	blobs := newFakeBlobs()
+	k1 := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
+	k2 := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
+	blobs.data[k1] = []byte("a")
+	blobs.data[k2] = []byte("b")
+	store := &fakeReconcileStore{orphans: []string{k1, k2}}
+
+	if err := SweepEnrichmentReconciliation(context.Background(), store, blobs, &enrichRecordingEnqueuer{}, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if blobs.keys() != 0 {
+		t.Fatalf("orphan image blobs not swept: %d left", blobs.keys())
+	}
+}
+
+// TestSweepEnrichmentReconciliation_NoWorkNoSideEffects: an empty catalog enqueues
+// and deletes nothing.
+func TestSweepEnrichmentReconciliation_NoWorkNoSideEffects(t *testing.T) {
+	blobs := newFakeBlobs()
+	blobs.data["t/x/highlight/y/image"] = []byte("keep") // not reported as orphan
+	enq := &enrichRecordingEnqueuer{}
+	store := &fakeReconcileStore{}
+	if err := SweepEnrichmentReconciliation(context.Background(), store, blobs, enq, testLog()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(enq.all) != 0 {
+		t.Fatalf("no targets should enqueue nothing, got %v", enq.all)
+	}
+	if blobs.keys() != 1 {
+		t.Fatalf("no orphans should delete nothing, got %d left", blobs.keys())
+	}
+}
+
+// TestSweepEnrichmentReconciliation_ListErrorNonFatal pins AC4 (#406): a store
+// list failure is reported (so boot logs it) but never aborts — the OTHER half of
+// the sweep still runs. Here the target list fails yet the orphan sweep proceeds.
+func TestSweepEnrichmentReconciliation_ListErrorNonFatal(t *testing.T) {
+	blobs := newFakeBlobs()
+	orphan := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
+	blobs.data[orphan] = []byte("a")
+	store := &fakeReconcileStore{
+		targetErr: errors.New("db down"),
+		orphans:   []string{orphan},
+	}
+	err := SweepEnrichmentReconciliation(context.Background(), store, blobs, &enrichRecordingEnqueuer{}, testLog())
+	if err == nil {
+		t.Fatal("want an error surfaced when a list fails (boot logs it non-fatally)")
+	}
+	// The orphan sweep still ran despite the target-list failure.
+	if blobs.keys() != 0 {
+		t.Fatalf("orphan sweep should still run when the target list fails; %d blobs left", blobs.keys())
 	}
 }
 

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -241,10 +241,11 @@ func (s *SessionServer) PromoteHighlight(
 	// Enqueue AI image enrichment (#311, ADR-0049): a promoted Highlight with no
 	// image yet gets a background generation job. Skipped when already enriched
 	// (an idempotent re-promote never re-spends) or when the enqueuer is unwired.
-	// An enqueue failure is logged only — the promotion succeeded, and a GM
-	// re-promote re-triggers enrichment (there is NO boot sweep for enrichment;
-	// SweepMissingCandidatePurges covers only the purge job — follow-up issue
-	// planned). Failing the RPC here would wrongly report the keep as failed.
+	// An enqueue failure is logged only — the promotion succeeded, and the boot
+	// reconciliation sweep (#406, highlight.SweepEnrichmentReconciliation) is the
+	// backstop: it re-enqueues enrichment for any promoted Highlight left imageless
+	// with no live enrich job, so a lost enqueue here is recovered at next boot.
+	// Failing the RPC here would wrongly report the keep as failed.
 	if s.enqueue != nil && h.ImageKey == "" {
 		payload, merr := highlight.MarshalEnrichImage(h.ID, tenantID)
 		if merr != nil {
@@ -296,13 +297,15 @@ func (s *SessionServer) DeleteHighlight(
 		return nil, errNoSuchHighlight() // cross-campaign: never delete, never leak existence
 	}
 
-	// KNOWN residual race (follow-up issue planned): an enrichment job can commit
+	// Residual race, now backstopped (#406): an enrichment job can commit
 	// SetHighlightImage between the load above and the blob deletes below, so the
-	// image_key read there is stale-empty and the just-stored image blob is orphaned
-	// (there is no global orphan sweep). Cheap shrink: re-read the row immediately
-	// before the blob deletes to pick up a freshly-committed image_key, closing the
-	// window to the microseconds between this read and the delete. A re-read failure
-	// is non-fatal — fall back to the earlier snapshot and still delete the clip+row.
+	// image_key read there is stale-empty and the just-stored image blob would be
+	// orphaned. Cheap shrink: re-read the row immediately before the blob deletes to
+	// pick up a freshly-committed image_key, narrowing the window to the microseconds
+	// between this read and the delete. A re-read failure is non-fatal — fall back to
+	// the earlier snapshot and still delete the clip+row. Whatever image blob still
+	// slips through this shrunk window is collected by the boot orphan sweep
+	// (highlight.SweepEnrichmentReconciliation), so it is never permanently orphaned.
 	if fresh, rerr := s.highlights.GetHighlight(ctx, tenantID, id); rerr == nil {
 		h.ImageKey = fresh.ImageKey
 	}

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -306,6 +306,129 @@ func (s *Store) ListCampaignHighlightClipKeys(ctx context.Context, campaignID uu
 		 SELECT image_key FROM highlight WHERE campaign_id = $1 AND image_key <> ''`, campaignID)
 }
 
+// HighlightEnrichTarget is a promoted, still-imageless Highlight the boot
+// reconciliation sweep must (re)enqueue image enrichment for (#406): the id plus
+// the tenant that owns it, exactly the enrich job payload's two fields (the sweep
+// carries no ambient tenant — it is process-wide, ADR-0049).
+type HighlightEnrichTarget struct {
+	HighlightID uuid.UUID
+	TenantID    uuid.UUID
+}
+
+// ListPromotedHighlightsNeedingEnrichment returns every PROMOTED Highlight with an
+// empty image_key and NO enrich job of the given kind in a live state
+// (pending/running/done) — the promoted Highlights whose image enrichment was
+// never enqueued (a crash between promote-commit and the enqueue) or whose only
+// enqueue was lost (#406). It is the (a) half of the boot reconciliation sweep,
+// mirroring ListSessionsNeedingCandidatePurge. A 'done' job counts as satisfied so
+// an unconfigured/failed-permanent enrichment (the handler returns nil and leaves
+// the row imageless by design) is NOT re-swept every boot; 'dead' is treated as
+// absent so a genuinely dead-lettered enrichment is re-scheduled. A job is matched
+// on its payload's highlight_id. Process-wide, carries no tenant.
+func (s *Store) ListPromotedHighlightsNeedingEnrichment(ctx context.Context, enrichKind string) ([]HighlightEnrichTarget, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT h.id, h.tenant_id
+		   FROM highlight h
+		  WHERE h.status = 'promoted'
+		    AND h.image_key = ''
+		    AND NOT EXISTS (
+		          SELECT 1 FROM job j
+		           WHERE j.kind = $1
+		             AND j.status IN ('pending','running','done')
+		             AND j.payload->>'highlight_id' = h.id::text
+		        )`, enrichKind)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list promoted highlights needing enrichment: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HighlightEnrichTarget
+	for rows.Next() {
+		var t HighlightEnrichTarget
+		if err := rows.Scan(&t.HighlightID, &t.TenantID); err != nil {
+			return nil, fmt.Errorf("storage: scan enrich target: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list promoted highlights needing enrichment: %w", err)
+	}
+	return out, nil
+}
+
+// TryClaimHighlightEnrich atomically claims the image enrichment of a Highlight
+// (#406): a conditional UPDATE that stamps image_enrich_claimed_at iff the row is
+// still imageless AND no claim newer than ttl is held. It reports whether THIS
+// caller won (RowsAffected == 1). A false-no-error means a live worker holds the
+// claim or the row was enriched meanwhile. The lease (ttl) makes a crashed
+// claimant's claim reclaimable, so a Highlight is never stranded imageless. The
+// column is never scanned onto the wire, so the marker cannot leak into an RPC
+// response. Tenant-free (the id scopes the row, like SetHighlightImage).
+func (s *Store) TryClaimHighlightEnrich(ctx context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
+	cutoff := time.Now().Add(-ttl)
+	tag, err := s.db.Exec(ctx,
+		`UPDATE highlight
+		    SET image_enrich_claimed_at = now()
+		  WHERE id = $1
+		    AND image_key = ''
+		    AND (image_enrich_claimed_at IS NULL OR image_enrich_claimed_at < $2)`,
+		id, cutoff)
+	if err != nil {
+		return false, fmt.Errorf("storage: claim highlight enrich %s: %w", id, err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// ReleaseHighlightEnrichClaim clears a Highlight's enrichment claim (#406) so a
+// retry (or a later re-promotion) can re-claim without waiting out the ttl. It is
+// idempotent — clearing an already-null claim is a no-op — and tenant-free.
+func (s *Store) ReleaseHighlightEnrichClaim(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.db.Exec(ctx,
+		`UPDATE highlight SET image_enrich_claimed_at = NULL WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("storage: release highlight enrich claim %s: %w", id, err)
+	}
+	return nil
+}
+
+// ListOrphanHighlightImageKeys returns every blob key under the Highlight IMAGE
+// owner-kind prefix (t/<tenant>/highlight/<id>/image, ADR-0048) whose embedded
+// Highlight id no longer matches any highlight row — the images a delete-vs-enrich
+// interleaving orphaned (the delete read the row with an empty image_key, then the
+// enrich committed a blob whose row was already gone), #406. It is the (b) half of
+// the boot reconciliation sweep. It ONLY matches the image name segment, so a
+// Highlight's audio clip (name 'clip.wav') under the SAME owner-kind is never
+// touched, and it only touches the 'highlight' owner-kind — never another owner's
+// blobs. An in-flight enrichment (row still present, image_key not yet set) is
+// NOT collected because the row's id still matches. Process-wide, carries no tenant.
+func (s *Store) ListOrphanHighlightImageKeys(ctx context.Context) ([]string, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT b.key
+		   FROM blob b
+		  WHERE split_part(b.key, '/', 3) = 'highlight'
+		    AND split_part(b.key, '/', 5) = 'image'
+		    AND NOT EXISTS (
+		          SELECT 1 FROM highlight h
+		           WHERE h.id::text = split_part(b.key, '/', 4)
+		        )`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list orphan highlight image keys: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, fmt.Errorf("storage: scan orphan image key: %w", err)
+		}
+		out = append(out, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list orphan highlight image keys: %w", err)
+	}
+	return out, nil
+}
+
 // scanClipKeys runs a single-column clip_key query and collects the results.
 func (s *Store) scanClipKeys(ctx context.Context, sql string, arg uuid.UUID) ([]string, error) {
 	rows, err := s.db.Query(ctx, sql, arg)

--- a/internal/storage/highlight_enrich_reconcile_test.go
+++ b/internal/storage/highlight_enrich_reconcile_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// enrichJobPayload marshals the enrich job payload the reconciliation query
+// matches on (highlight_id).
+func enrichJobPayload(t *testing.T, highlightID, tenantID uuid.UUID) []byte {
+	t.Helper()
+	b, err := highlight.MarshalEnrichImage(highlightID, tenantID)
+	if err != nil {
+		t.Fatalf("marshal enrich payload: %v", err)
+	}
+	return b
+}
+
+// TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob
+// pins the (a)-half query of the boot reconciliation sweep (#406): only PROMOTED,
+// image_key='' Highlights with no pending/running/done enrich job are returned.
+func TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("create voice session: %v", err)
+	}
+
+	// (want) promoted, imageless, no job → a target.
+	wantID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.PromoteHighlight(ctx, tenantID, wantID); err != nil {
+		t.Fatalf("promote want: %v", err)
+	}
+
+	// promoted, imageless, but a pending enrich job exists → excluded.
+	hasJobID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.PromoteHighlight(ctx, tenantID, hasJobID); err != nil {
+		t.Fatalf("promote hasJob: %v", err)
+	}
+	if _, err := st.EnqueueJob(ctx, highlight.JobKindEnrichImage, enrichJobPayload(t, hasJobID, tenantID), 0); err != nil {
+		t.Fatalf("enqueue enrich job: %v", err)
+	}
+
+	// promoted but already enriched → excluded.
+	enrichedID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.PromoteHighlight(ctx, tenantID, enrichedID); err != nil {
+		t.Fatalf("promote enriched: %v", err)
+	}
+	imgKey := "t/" + tenantID.String() + "/highlight/" + enrichedID.String() + "/image"
+	if err := st.SetHighlightImage(ctx, enrichedID, imgKey, "image/png", 10); err != nil {
+		t.Fatalf("set image: %v", err)
+	}
+
+	// candidate (never promoted) → excluded.
+	seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+
+	got, err := st.ListPromotedHighlightsNeedingEnrichment(ctx, highlight.JobKindEnrichImage)
+	if err != nil {
+		t.Fatalf("list needing enrichment: %v", err)
+	}
+	if len(got) != 1 || got[0].HighlightID != wantID || got[0].TenantID != tenantID {
+		t.Fatalf("want exactly the imageless-promoted-no-job target %s, got %+v", wantID, got)
+	}
+}
+
+// TestTryClaimHighlightEnrich_ConditionalTransition pins the race-proof claim
+// (#406): the first claim wins, a second fresh claim loses, a release re-opens it,
+// and an already-imaged row is unclaimable.
+func TestTryClaimHighlightEnrich_ConditionalTransition(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("create voice session: %v", err)
+	}
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+
+	// First claim wins.
+	won, err := st.TryClaimHighlightEnrich(ctx, id, time.Hour)
+	if err != nil || !won {
+		t.Fatalf("first claim: won=%v err=%v; want won", won, err)
+	}
+	// Second, within the lease, loses (a concurrent worker holds it).
+	won, err = st.TryClaimHighlightEnrich(ctx, id, time.Hour)
+	if err != nil || won {
+		t.Fatalf("second claim: won=%v err=%v; want lost", won, err)
+	}
+	// Release re-opens the claim.
+	if err := st.ReleaseHighlightEnrichClaim(ctx, id); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	won, err = st.TryClaimHighlightEnrich(ctx, id, time.Hour)
+	if err != nil || !won {
+		t.Fatalf("post-release claim: won=%v err=%v; want won", won, err)
+	}
+	// A stale claim (ttl already elapsed) is reclaimable.
+	won, err = st.TryClaimHighlightEnrich(ctx, id, time.Nanosecond)
+	if err != nil || !won {
+		t.Fatalf("stale-claim reclaim: won=%v err=%v; want won", won, err)
+	}
+
+	// Once enriched (image_key set), the row is unclaimable — no double spend.
+	imgKey := "t/" + tenantID.String() + "/highlight/" + id.String() + "/image"
+	if err := st.SetHighlightImage(ctx, id, imgKey, "image/png", 10); err != nil {
+		t.Fatalf("set image: %v", err)
+	}
+	won, err = st.TryClaimHighlightEnrich(ctx, id, time.Hour)
+	if err != nil || won {
+		t.Fatalf("claim on enriched row: won=%v err=%v; want lost", won, err)
+	}
+}
+
+// TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow pins the (b)-half query
+// (#406): only image blobs whose Highlight row is gone are returned — a live row's
+// image, the audio clip (same owner-kind, different name), and other owners' blobs
+// are all left alone.
+func TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	blobs := blob.NewPostgres(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("create voice session: %v", err)
+	}
+
+	put := func(key string) {
+		if err := blobs.Put(ctx, key, "image/png", strings.NewReader("x"), 1); err != nil {
+			t.Fatalf("put blob %s: %v", key, err)
+		}
+	}
+
+	// A live, enriched Highlight: row present + its image blob → NOT orphan.
+	liveID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+	liveImg, _ := blob.Key(tenantID, "highlight", liveID, "image")
+	put(liveImg)
+	if err := st.SetHighlightImage(ctx, liveID, liveImg, "image/png", 1); err != nil {
+		t.Fatalf("set live image: %v", err)
+	}
+	// The same Highlight's audio clip (same owner-kind, name clip.wav) → NOT matched.
+	liveClip, _ := blob.Key(tenantID, "highlight", liveID, "clip.wav")
+	put(liveClip)
+
+	// An image blob whose Highlight row is GONE (delete-vs-enrich interleaving) → orphan.
+	goneID := uuid.New()
+	orphanImg, _ := blob.Key(tenantID, "highlight", goneID, "image")
+	put(orphanImg)
+
+	// A blob under a DIFFERENT owner-kind → never touched.
+	otherOwner, _ := blob.Key(tenantID, "campaign", uuid.New(), "image")
+	put(otherOwner)
+
+	got, err := st.ListOrphanHighlightImageKeys(ctx)
+	if err != nil {
+		t.Fatalf("list orphan image keys: %v", err)
+	}
+	if len(got) != 1 || got[0] != orphanImg {
+		t.Fatalf("want exactly the row-less image %s, got %+v", orphanImg, got)
+	}
+}

--- a/internal/storage/migrations/00032_highlight_enrich_claim.sql
+++ b/internal/storage/migrations/00032_highlight_enrich_claim.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Race-proof Highlight image-enrichment claim (#406): a nullable timestamp the
+-- enrich job sets to claim a Highlight before it spends on generation, so two
+-- concurrent enrich jobs for the same Highlight run the provider Generate AT MOST
+-- once (a conditional UPDATE claims iff still imageless and no fresh claim within
+-- the lease). It is DELIBERATELY absent from `highlightColumns` and never scanned
+-- onto the wire (toProtoHighlight omits it) — the marker never leaks into an RPC
+-- response. NULL means unclaimed; a stale claim (older than the enrich lease) is
+-- reclaimable, so a crashed worker never strands a Highlight imageless.
+ALTER TABLE highlight ADD COLUMN image_enrich_claimed_at timestamptz;
+
+-- +goose Down
+ALTER TABLE highlight DROP COLUMN IF EXISTS image_enrich_claimed_at;


### PR DESCRIPTION
Closes #406.

Folds the three highlight image-enrichment residuals into one reconciliation concern.

## What changed
- **Race-proof claim (AC2):** `EnrichImageHandler` claims a Highlight via a conditional, lease-based `UPDATE` (`image_enrich_claimed_at`) before spending. Two concurrent enrich jobs for the same Highlight run provider `Generate` **at most once** — the loser returns a retryable error; a crashed winner's claim frees after `enrichClaimTTL` (10m, > runner lease). The marker never reaches the wire (`highlightColumns` / `toProtoHighlight` omit it, so no sentinel leaks into an RPC response). On every non-success exit the claim is released so a fast retry / later re-promotion re-claims without waiting out the ttl.
- **Boot reconciliation sweep (AC1 + AC3):** `SweepEnrichmentReconciliation`, the pattern-sibling of `SweepMissingCandidatePurges`, does one sweep with two halves:
  - (a) re-enqueues enrichment for every **promoted, imageless** Highlight with no live enrich job — recovers a crash between promote-commit and the enqueue.
  - (b) drops **orphan image blobs** — image-name blobs under the `highlight` owner-kind whose row is gone (the delete-vs-enrich interleaving). Only that owner-kind + `image` name segment; never a clip, never another owner, never a live enrichment's in-flight blob (row still present).
- **Non-fatal at boot (AC4):** both halves run even if one list fails; the sweep returns a joined error which `main.go` logs `Warn` and continues — exactly like the purge backstop.

## Storage
Migration `00032` adds nullable `image_enrich_claimed_at`. New methods: `ListPromotedHighlightsNeedingEnrichment`, `TryClaimHighlightEnrich`, `ReleaseHighlightEnrichClaim`, `ListOrphanHighlightImageKeys`.

## Tests (per AC)
- AC1 — `TestSweepEnrichmentReconciliation_EnqueuesForImagelessPromoted`; storage `TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob`
- AC2 — `TestEnrichImageHandler_Claim_GeneratesAtMostOnce` (concurrent, pins Generate==1); storage `TestTryClaimHighlightEnrich_ConditionalTransition`
- AC3 — `TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs`; storage `TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow`
- AC4 — `TestSweepEnrichmentReconciliation_ListErrorNonFatal`

Full `go test -race ./...` green; storage integration (testcontainers Postgres) green; `golangci-lint` clean; `go vet` (default + record tag) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)