### PR TITLE
fix(#398): tool_use_failed retry + tool-less fallback

### DIFF
--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -77,6 +77,12 @@ type PrometheusRecorder struct {
 	ttsCharacters   *prometheus.CounterVec // provider
 	sttAudioSeconds *prometheus.CounterVec // provider
 
+	// malformed tool generations (#398/#399/#410): provider flake frequency by the
+	// detection path that caught it. Process-level (namespace glyphoxa_llm_*, no voice
+	// subsystem) since it is an LLM-provider health signal, not a voice-pipeline stage;
+	// both labels are bounded enums (ADR-0032).
+	malformedToolGen *prometheus.CounterVec // provider, path
+
 	// turn lifecycle (StageRecorder): the survivorship counterpart to
 	// response_latency — every turn records one terminal outcome.
 	turnTotal *prometheus.CounterVec // outcome, reason
@@ -234,6 +240,16 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		Help:      "Transcript chunks awaiting embedding (embedding IS NULL).",
 	})
 
+	// Malformed-tool-generation counter (#398): namespace glyphoxa_llm_* (an
+	// LLM-provider health signal, not a voice-pipeline stage), provider + path both
+	// bounded enums (ADR-0032).
+	r.malformedToolGen = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "llm",
+		Name:      "malformed_toolgen_total",
+		Help:      "Malformed tool generations by provider and the detection path that caught it (#398: a tool_use_failed retried; #399/#410 add roll_claim/text_leak).",
+	}, []string{"provider", "path"})
+
 	r.memoryRecall = counterVec("memory_recall_total",
 		"NPC memory recalls by outcome (#122, ADR-0042): a speculation hit, an inline miss, or a degraded skip.",
 		"outcome")
@@ -273,7 +289,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
 		r.memoryRecall, r.kgFacts,
 		r.jobsBacklog, r.jobsTotal, r.jobDuration,
-		r.llmTokens, r.ttsCharacters, r.sttAudioSeconds,
+		r.llmTokens, r.ttsCharacters, r.sttAudioSeconds, r.malformedToolGen,
 		// Standard runtime collectors so /metrics also reports process/Go health.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		collectors.NewGoCollector(),
@@ -363,6 +379,13 @@ func (r *PrometheusRecorder) TTSCharacters(p Provider, chars int) {
 // exported in the base unit seconds (Prometheus convention).
 func (r *PrometheusRecorder) STTAudioSeconds(p Provider, d time.Duration) {
 	r.sttAudioSeconds.WithLabelValues(string(p)).Add(d.Seconds())
+}
+
+// MalformedToolGen counts one malformed tool generation by provider and the
+// detection path that caught it (#398/#399/#410). Both labels are bounded enums
+// (ADR-0032); the series lives at glyphoxa_llm_malformed_toolgen_total.
+func (r *PrometheusRecorder) MalformedToolGen(p Provider, path MalformedPath) {
+	r.malformedToolGen.WithLabelValues(string(p), string(path)).Inc()
 }
 
 // MemoryRecall counts one NPC memory recall by its bounded outcome (#122,

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -64,6 +64,8 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	rec.KGFacts(FactsEmpty)
 	rec.KGFacts(FactsDegraded)
 
+	rec.MalformedToolGen(ProviderGroq, MalformedStreamError)
+
 	out := scrape(t, rec)
 
 	// Every family is present and namespaced glyphoxa_voice_* (embedding_backlog
@@ -96,6 +98,7 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 		`glyphoxa_kg_facts_total{outcome="ok"} 1`,
 		`glyphoxa_kg_facts_total{outcome="empty"} 1`,
 		`glyphoxa_kg_facts_total{outcome="degraded"} 1`,
+		`glyphoxa_llm_malformed_toolgen_total{path="stream_error",provider="groq"} 1`,
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(out, want) {

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -175,6 +175,26 @@ const (
 	ReasonSpendCap TurnReason = "spend_cap"
 )
 
+// MalformedPath is the bounded label naming WHICH detection site caught a
+// malformed tool generation on the [StageRecorder.MalformedToolGen] counter
+// (#398/#399/#410). All three values are reserved now so the series' label space
+// is fixed from the first slice (ADR-0032 bounded labels); #398 emits only
+// [MalformedStreamError], with #399/#410 lighting up the other two.
+type MalformedPath string
+
+const (
+	// MalformedStreamError: the provider surfaced a tool_use_failed — as an
+	// in-stream error frame or a 400 start error — and the agenttool bridge caught it
+	// (#398). The malformed generation never reached the transcript.
+	MalformedStreamError MalformedPath = "stream_error"
+	// MalformedTextLeak: pseudo-XML arrived as ordinary assistant prose with NO
+	// provider error, caught by the text-path scrubber (#410, pkg/tool).
+	MalformedTextLeak MalformedPath = "text_leak"
+	// MalformedRollClaim: the model narrated a dice result it never actually rolled
+	// via the tool, caught by the roll-claim guard (#399).
+	MalformedRollClaim MalformedPath = "roll_claim"
+)
+
 // StageRecorder records the orchestrator's per-stage / per-turn latency
 // histograms and the provider-call counters. It is the contract the bus-driven
 // sibling subscriber (latency spans) and the provider adapters (provider calls,
@@ -268,6 +288,15 @@ type StageRecorder interface {
 	// audio. (glyphoxa_voice_tts_characters_total{provider}) — WIRED by the TTS
 	// stage after a successful Synthesize start.
 	TTSCharacters(provider Provider, chars int)
+	// MalformedToolGen counts one malformed tool generation by provider and the
+	// detection path that caught it (#398/#399/#410): a provider tool_use_failed the
+	// agenttool bridge retried ([MalformedStreamError]), a pseudo-XML text leak, or a
+	// fabricated roll claim. It keeps provider-flake frequency observable even when
+	// the retry / fallback fully recovers the turn (an operator sees a healthy turn
+	// but the meter still ticks). (glyphoxa_llm_malformed_toolgen_total{provider,path})
+	// — WIRED by agenttool.providerAdapter per malformed generation.
+	MalformedToolGen(provider Provider, path MalformedPath)
+
 	// STTAudioSeconds counts the audio duration submitted to an STT recognizer
 	// (#127, ADR-0045/0042): the batch path bills the submitted clip length, the
 	// streaming path the voiced+pre-roll duration accumulated per utterance and
@@ -296,6 +325,7 @@ func (Discard) ProviderCall(Stage, Provider, Outcome)       {}
 func (Discard) ProviderError(Stage, Provider)               {}
 func (Discard) TurnOutcome(TurnOutcome, TurnReason)         {}
 func (Discard) LLMTokens(Provider, string, int, int)        {}
+func (Discard) MalformedToolGen(Provider, MalformedPath)    {}
 func (Discard) TTSCharacters(Provider, int)                 {}
 func (Discard) STTAudioSeconds(Provider, time.Duration)     {}
 

--- a/internal/observe/subscriber_test.go
+++ b/internal/observe/subscriber_test.go
@@ -61,6 +61,7 @@ func (r *recordingStage) ProviderError(Stage, Provider)               {}
 func (r *recordingStage) LLMTokens(Provider, string, int, int)        {}
 func (r *recordingStage) TTSCharacters(Provider, int)                 {}
 func (r *recordingStage) STTAudioSeconds(Provider, time.Duration)     {}
+func (r *recordingStage) MalformedToolGen(Provider, MalformedPath)    {}
 func (r *recordingStage) TurnOutcome(outcome TurnOutcome, reason TurnReason) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -23,12 +23,15 @@ package agenttool
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"sync"
 	"time"
 	"unicode/utf8"
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/retry"
 )
 
@@ -56,6 +59,48 @@ func nextRound(ctx context.Context) int {
 	i := *p
 	*p++
 	return i
+}
+
+// forcedChoiceKey is the context key under which [withForcedToolChoice] stores a
+// one-shot tool-choice override the adapter applies to the FIRST completion of a
+// turn. It is consumed exactly once (later rounds revert to auto), so a caller can
+// force e.g. tool_choice "required" on the opening round without pinning every
+// subsequent round.
+type forcedChoiceKey struct{}
+
+// forcedChoice is the one-shot holder behind [forcedChoiceKey]: the once gate makes
+// [consumeForcedChoice] hand the override to the first caller only.
+type forcedChoice struct {
+	choice llm.ToolChoice
+	mu     sync.Mutex
+	done   bool
+}
+
+// withForcedToolChoice returns ctx carrying a one-shot tool-choice override the
+// adapter applies to the FIRST [llm.Provider.Complete] of the turn (#399 consumes
+// this to force a tool call on the opening round; #398 ships the seam). Later rounds
+// revert to the default auto. Shipped now with adapter consumption wired but unused
+// by [Engine.Generate] / [Engine.GenerateStream] themselves.
+func withForcedToolChoice(ctx context.Context, choice llm.ToolChoice) context.Context {
+	return context.WithValue(ctx, forcedChoiceKey{}, &forcedChoice{choice: choice})
+}
+
+// consumeForcedChoice returns the one-shot forced tool choice and true the first
+// time it is called on a ctx carrying one, then (zero, false) forever after — so
+// only the turn's first completion is forced. A ctx without an override yields
+// (zero, false) immediately.
+func consumeForcedChoice(ctx context.Context) (llm.ToolChoice, bool) {
+	f, _ := ctx.Value(forcedChoiceKey{}).(*forcedChoice)
+	if f == nil {
+		return llm.ToolChoice{}, false
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.done {
+		return llm.ToolChoice{}, false
+	}
+	f.done = true
+	return f.choice, true
 }
 
 // providerAdapter makes a streaming [llm.Provider] usable as the non-streaming
@@ -109,52 +154,136 @@ func (a providerAdapter) GenerateStream(ctx context.Context, messages []tool.Mes
 	return a.complete(ctx, messages, tools, onText)
 }
 
-// complete issues one streaming completion, drains it, and records the A3
-// per-round span + provider-call counter. When onText is non-nil, each
-// [llm.EventText] delta is forwarded as it arrives (the streaming path); an error
-// onText returns aborts the drain and propagates. The accumulated text and tool
-// calls are returned as the [tool.AssistantMessage] the loop expects either way.
+// attemptKind classifies how one [providerAdapter.attempt] ended, so [complete]
+// records the round's final-outcome metrics (LLMRound / ProviderCall, ADR-0044) and
+// meters usage (ADR-0045) in one place rather than duplicating the rules per branch.
+type attemptKind int
+
+const (
+	kindSuccess   attemptKind = iota // clean EventDone
+	kindBarge                        // onText returned an error mid-drain (downstream cancel)
+	kindStartErr                     // Complete could not start (retry.Do exhausted / non-retryable)
+	kindStreamErr                    // terminal EventError (may carry a tool-syntax class)
+	kindTruncated                    // stream ended without EventDone, ctx still live
+	kindCtxErr                       // stream ended without EventDone because ctx was cancelled
+)
+
+// attemptResult is one [providerAdapter.attempt]'s outcome, drained but not yet
+// metered — [complete] inspects kind to record the final-outcome span/counter and
+// the reported-or-estimate usage exactly once for the whole round.
+type attemptResult struct {
+	msg            tool.AssistantMessage
+	forwardedDelta bool // a prose delta was forwarded to onText before the outcome
+	haveUsage      bool
+	usage          llm.Usage
+	err            error // nil only on kindSuccess
+	kind           attemptKind
+}
+
+// complete issues one logical round (one requested choice, with an in-turn retry
+// and a tool-less fallback for the tool-syntax failure class) and records the A3
+// per-round span + provider-call counter + usage on the FINAL outcome only
+// (ADR-0044/0045). When onText is non-nil each [llm.EventText] delta is forwarded as
+// it arrives (the streaming path); an error onText returns aborts the drain and
+// propagates.
+//
+// Tool-syntax policy (#398, tool-armed rounds only): a round that fails with the
+// provider's tool_use_failed class and has NOT yet forwarded any prose is retried
+// once with the same tools+choice (no backoff); a second failure of the same class
+// regenerates tool-less (tools stay DECLARED, tool_choice none — the conversation
+// may hold prior tool_call/tool messages). A round that already forwarded a delta is
+// never retried (ADR-0044 mid-stream rule), and a ctx cancellation between attempts
+// aborts. Every malformed generation increments MalformedToolGen so provider flake
+// stays visible even when the turn fully recovers.
 func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, tools []tool.Decl, onText func(delta string) error) (tool.AssistantMessage, error) {
 	round := nextRound(ctx)
 	start := time.Now()
 
-	// Retry a transient START failure (429/5xx/net) with backoff before draining
-	// any deltas (#124, ADR-0044); a non-retryable error fails fast and a barge
-	// cutting ctx aborts at once, bounded by the per-turn deadline. Only the start
-	// is retried — a mid-stream failure below is never re-driven (re-speak risk).
-	// Metrics below fire on the final outcome only (#125), so a recovered retry
-	// records one round span, not one per attempt.
+	// The requested tool choice: a one-shot forced override on the turn's first
+	// completion (#399 seam), else the default auto. Consumed here so later rounds
+	// revert to auto.
+	choice := a.requestedChoice(ctx)
+
+	res := a.attempt(ctx, messages, tools, choice, onText)
+
+	// Tool-syntax retry + tool-less fallback — tool-armed rounds only (a no-tool round
+	// can never emit a tool_use_failed, and never retries per ADR-0044).
+	if len(tools) > 0 {
+		if a.isToolSyntax(res) {
+			// Attempt 2: immediate retry, same tools + choice (no backoff).
+			a.rec.MalformedToolGen(a.provName, observe.MalformedStreamError)
+			if err := ctx.Err(); err != nil {
+				return tool.AssistantMessage{}, err // barge between attempts aborts
+			}
+			res = a.attempt(ctx, messages, tools, choice, onText)
+
+			if a.isToolSyntax(res) {
+				// Attempt 3: regenerate tool-less. Tools stay declared; tool_choice none.
+				a.rec.MalformedToolGen(a.provName, observe.MalformedStreamError)
+				slog.Warn("agenttool: repeated tool_use_failed; regenerating tool-less",
+					"provider", string(a.provName), "round", round)
+				if err := ctx.Err(); err != nil {
+					return tool.AssistantMessage{}, err
+				}
+				res = a.attempt(ctx, messages, tools, llm.ToolChoice{Mode: llm.ToolChoiceNone}, onText)
+			}
+		}
+	}
+
+	return a.recordOutcome(ctx, round, start, messages, res)
+}
+
+// isToolSyntax reports whether res failed with the provider's tool-syntax class AND
+// had not yet forwarded a prose delta — the two conditions the #398 retry / fallback
+// requires (a mid-stream failure after audio already went out is never re-driven,
+// ADR-0044).
+func (a providerAdapter) isToolSyntax(res attemptResult) bool {
+	if res.forwardedDelta {
+		return false
+	}
+	var tse *providererr.ToolSyntaxError
+	return errors.As(res.err, &tse)
+}
+
+// requestedChoice returns the tool choice for this round: the one-shot forced
+// override on the turn's first completion (#399 seam), consumed here, else the
+// zero-value auto.
+func (a providerAdapter) requestedChoice(ctx context.Context) llm.ToolChoice {
+	if tc, ok := consumeForcedChoice(ctx); ok {
+		return tc
+	}
+	return llm.ToolChoice{}
+}
+
+// attempt issues ONE streaming completion for the round and drains it, classifying
+// the outcome without recording any final-outcome metric (its caller [complete]
+// owns those, once per round). It still bounds a transient START failure (429/5xx/
+// net) with the injected retry backoff (#124, ADR-0044): only the start is retried,
+// never a mid-stream delta failure (re-speak risk). A terminal EventError carrying
+// [llm.ErrClassToolSyntax] is surfaced as a typed [*providererr.ToolSyntaxError] so
+// [complete] can drive the tool-syntax policy.
+func (a providerAdapter) attempt(ctx context.Context, messages []tool.Message, tools []tool.Decl, choice llm.ToolChoice, onText func(delta string) error) attemptResult {
 	stream, err := retry.Do(ctx, a.retry, func(ctx context.Context) (<-chan llm.StreamEvent, error) {
 		return a.provider.Complete(ctx, llm.Request{
-			Model:     a.model,
-			MaxTokens: a.maxTokens,
-			Messages:  toLLMMessages(messages),
-			Tools:     toLLMToolDefs(tools),
+			Model:      a.model,
+			MaxTokens:  a.maxTokens,
+			Messages:   toLLMMessages(messages),
+			Tools:      toLLMToolDefs(tools),
+			ToolChoice: choice,
 		})
 	})
 	if err != nil {
-		// A start failure has no round span (no completion happened); attribute it to
-		// the LLM stage via the shared [observe.CallOutcome] rule so LLM agrees with
-		// STT/TTS: a barge-in cancel is OutcomeCanceled (NOT a vendor fault), a fired
-		// deadline is OutcomeTimeout, anything else is OutcomeError. ProviderError is
-		// bumped only on a fault, so a barge before first token does not inflate the
-		// error ratio (#239 review).
-		outcome := observe.CallOutcome(ctx, err)
-		a.rec.ProviderCall(observe.StageLLM, a.provName, outcome)
-		if outcome.IsFault() {
-			a.rec.ProviderError(observe.StageLLM, a.provName)
-		}
-		return tool.AssistantMessage{}, err
+		return attemptResult{err: err, kind: kindStartErr}
 	}
 
 	var out tool.AssistantMessage
 	var text []byte
 	var done bool
 	var streamErr error
+	var forwarded bool
 	// usage/haveUsage stash the provider-reported token accounting from the additive
-	// EventUsage (#127, ADR-0045). It rides a distinct event, not EventDone, and may
-	// arrive before or after done — draining to close (as we do) captures it either
-	// way.
+	// EventUsage (#127, ADR-0045); draining to close captures it whether it arrives
+	// before or after EventDone.
 	var usage llm.Usage
 	var haveUsage bool
 	for ev := range stream {
@@ -163,15 +292,10 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 			text = append(text, ev.Text...)
 			if onText != nil {
 				if err := onText(ev.Text); err != nil {
-					// Downstream cancel (barge-in): record the round we did and stop. A
-					// barge records the provider-reported usage IF it already arrived, never
-					// an estimate — a partial turn is not metered by guesswork (ADR-0045).
 					out.Text = string(text)
-					a.rec.LLMRound(a.provName, round, len(out.ToolCalls) > 0, time.Since(start))
-					a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
-					a.recordReportedUsage(haveUsage, usage)
-					return out, err
+					return attemptResult{msg: out, forwardedDelta: forwarded, haveUsage: haveUsage, usage: usage, err: err, kind: kindBarge}
 				}
+				forwarded = true
 			}
 		case llm.EventToolCall:
 			out.ToolCalls = append(out.ToolCalls, tool.ToolCall{
@@ -184,31 +308,70 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 		case llm.EventDone:
 			done = true
 		case llm.EventError:
-			streamErr = errors.New(ev.Err)
+			// A tool_use_failed is surfaced as a typed ToolSyntaxError so complete can
+			// retry/fallback; any other class stays a plain error (propagates).
+			if ev.ErrClass == llm.ErrClassToolSyntax {
+				streamErr = &providererr.ToolSyntaxError{Op: "agenttool.complete", Msg: ev.Err}
+			} else {
+				streamErr = errors.New(ev.Err)
+			}
 		}
 	}
 	if streamErr != nil {
-		// A mid-stream error records reported usage if it arrived, else nothing.
-		a.recordReportedUsage(haveUsage, usage)
-		return tool.AssistantMessage{}, streamErr
+		return attemptResult{forwardedDelta: forwarded, haveUsage: haveUsage, usage: usage, err: streamErr, kind: kindStreamErr}
 	}
 	if !done {
-		a.recordReportedUsage(haveUsage, usage)
 		if err := ctx.Err(); err != nil {
-			return tool.AssistantMessage{}, err
+			return attemptResult{forwardedDelta: forwarded, haveUsage: haveUsage, usage: usage, err: err, kind: kindCtxErr}
 		}
-		return tool.AssistantMessage{}, errors.New("agenttool: completion stream ended without done event (truncated response)")
+		return attemptResult{forwardedDelta: forwarded, haveUsage: haveUsage, usage: usage,
+			err:  errors.New("agenttool: completion stream ended without done event (truncated response)"),
+			kind: kindTruncated}
 	}
 	out.Text = string(text)
+	return attemptResult{msg: out, forwardedDelta: forwarded, haveUsage: haveUsage, usage: usage, kind: kindSuccess}
+}
 
-	hadToolCall := len(out.ToolCalls) > 0
-	a.rec.LLMRound(a.provName, round, hadToolCall, time.Since(start))
-	a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
-	// A completed round meters its tokens: the provider-reported counts, or a
-	// documented ceil(chars/4) estimate per direction when none was reported — never
-	// zero (AC, ADR-0045). An atomic counter add; it never blocks or fails the turn.
-	a.recordUsage(haveUsage, usage, messages, out.Text)
-	return out, nil
+// recordOutcome records the round's FINAL-outcome metrics (ADR-0044) and meters its
+// usage (ADR-0045) from the resolved attempt, then returns the message/error the
+// loop consumes. The per-kind rules preserve the pre-#398 behaviour exactly: a
+// success or barge records one LLMRound + provider_call(ok); a start failure records
+// provider_call with the shared [observe.CallOutcome] classification (a barge cancel
+// is not a fault); a mid-stream / truncation failure records no provider_call
+// (ADR-0044 does not meter mid-stream faults) but meters any reported usage.
+func (a providerAdapter) recordOutcome(ctx context.Context, round int, start time.Time, messages []tool.Message, res attemptResult) (tool.AssistantMessage, error) {
+	switch res.kind {
+	case kindSuccess:
+		a.rec.LLMRound(a.provName, round, len(res.msg.ToolCalls) > 0, time.Since(start))
+		a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
+		a.recordUsage(res.haveUsage, res.usage, messages, res.msg.Text)
+		return res.msg, nil
+
+	case kindBarge:
+		// The round produced output before a downstream cancel: record it, and meter
+		// only the provider-reported usage if it already arrived (never an estimate).
+		a.rec.LLMRound(a.provName, round, len(res.msg.ToolCalls) > 0, time.Since(start))
+		a.rec.ProviderCall(observe.StageLLM, a.provName, observe.OutcomeOK)
+		a.recordReportedUsage(res.haveUsage, res.usage)
+		return res.msg, res.err
+
+	case kindStartErr:
+		// No completion happened; attribute to the LLM stage via the shared outcome
+		// rule so a barge cancel is OutcomeCanceled (not a fault) while a vendor start
+		// failure is OutcomeError (a fault), matching STT/TTS (#239 review).
+		outcome := observe.CallOutcome(ctx, res.err)
+		a.rec.ProviderCall(observe.StageLLM, a.provName, outcome)
+		if outcome.IsFault() {
+			a.rec.ProviderError(observe.StageLLM, a.provName)
+		}
+		return tool.AssistantMessage{}, res.err
+
+	default: // kindStreamErr, kindTruncated, kindCtxErr
+		// A mid-stream / truncation / cancel failure meters reported usage if it
+		// arrived, else nothing (ADR-0045), and records no provider_call (ADR-0044).
+		a.recordReportedUsage(res.haveUsage, res.usage)
+		return tool.AssistantMessage{}, res.err
+	}
 }
 
 // recordReportedUsage records provider-reported token usage if it arrived, else

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -181,10 +181,23 @@ type recordingStage struct {
 	rounds       []llmRound
 	callsOK      int
 	callsErr     int
-	turns        []observe.Provider // one LLMTurn span per Engine.Generate/GenerateStream
-	outcomes     []observe.Outcome  // every ProviderCall outcome, in order
-	providerErrs int                // ProviderError invocations
-	tokens       []llmTokensRec     // one LLMTokens per drained Complete (reported or estimate)
+	turns        []observe.Provider      // one LLMTurn span per Engine.Generate/GenerateStream
+	outcomes     []observe.Outcome       // every ProviderCall outcome, in order
+	providerErrs int                     // ProviderError invocations
+	tokens       []llmTokensRec          // one LLMTokens per drained Complete (reported or estimate)
+	malformed    []observe.MalformedPath // one per MalformedToolGen (#398)
+}
+
+func (r *recordingStage) MalformedToolGen(_ observe.Provider, path observe.MalformedPath) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.malformed = append(r.malformed, path)
+}
+
+func (r *recordingStage) malformedPaths() []observe.MalformedPath {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]observe.MalformedPath(nil), r.malformed...)
 }
 
 func (r *recordingStage) LLMRound(p observe.Provider, idx int, hadToolCall bool, _ time.Duration) {
@@ -1018,6 +1031,273 @@ func TestEngine_EventError_PropagatesAsError(t *testing.T) {
 	_, err := eng.Generate(t.Context(), []llm.Message{{Role: llm.RoleUser, Text: "hi"}})
 	if err == nil || !strings.Contains(err.Error(), "connection reset") {
 		t.Fatalf("Generate on EventError = %v, want the provider's error", err)
+	}
+}
+
+// toolSyntaxProvider fails its leading `fails` Complete calls with the provider's
+// tool-syntax failure class (#398) — either a *providererr.ToolSyntaxError start
+// error (viaStream=false) or a mid-stream EventError carrying ErrClass tool_syntax
+// (viaStream=true) — then streams `answer`. It records every Request (so a test can
+// prove the fallback round declared the same tools with tool_choice none) and the
+// tool-choice each call carried. Keyless.
+type toolSyntaxProvider struct {
+	mu        sync.Mutex
+	fails     int
+	viaStream bool
+	answer    string
+	reqs      []llm.Request
+	calls     int
+}
+
+func (p *toolSyntaxProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.reqs = append(p.reqs, req)
+	p.mu.Unlock()
+
+	if n <= p.fails {
+		if !p.viaStream {
+			return nil, &providererr.ToolSyntaxError{Op: "test.Complete", Msg: `test: HTTP 400: {"code":"tool_use_failed"}`}
+		}
+		ch := make(chan llm.StreamEvent, 1)
+		ch <- llm.StreamEvent{Type: llm.EventError, Err: "test: read stream: tool_use_failed", ErrClass: llm.ErrClassToolSyntax}
+		close(ch)
+		return ch, nil
+	}
+	ch := make(chan llm.StreamEvent)
+	go func() {
+		defer close(ch)
+		for _, w := range strings.Fields(p.answer) {
+			ch <- llm.StreamEvent{Type: llm.EventText, Text: w + " "}
+		}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	}()
+	return ch, nil
+}
+
+func (p *toolSyntaxProvider) requests() []llm.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]llm.Request(nil), p.reqs...)
+}
+
+// TestEngine_ToolSyntax_RetriesOnceThenDelivers is AC 1 (#398): a tool-armed round
+// that fails once with tool_use_failed is retried once with the SAME tools; the
+// retry succeeds and its answer is delivered normally. The malformed generation is
+// counted once, and the final metrics are the recovered-round shape (one LLMRound,
+// one provider_call ok, no provider_error) — final-outcome-only per ADR-0044.
+func TestEngine_ToolSyntax_RetriesOnceThenDelivers(t *testing.T) {
+	for _, viaStream := range []bool{false, true} {
+		name := "start_error"
+		if viaStream {
+			name = "in_stream_error"
+		}
+		t.Run(name, func(t *testing.T) {
+			prov := &toolSyntaxProvider{fails: 1, viaStream: viaStream, answer: "You rolled well, traveler."}
+			rec := &recordingStage{}
+			eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+				agenttool.WithMetrics(rec, observe.ProviderGroq),
+				agenttool.WithRetry(instantAgentRetry()))
+
+			got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+			if err != nil {
+				t.Fatalf("Generate after one tool_use_failed: %v", err)
+			}
+			if strings.TrimSpace(got) != "You rolled well, traveler." {
+				t.Errorf("final text = %q, want the retry answer", got)
+			}
+			if prov.calls != 2 {
+				t.Errorf("Complete calls = %d, want 2 (one tool_use_failed retried once)", prov.calls)
+			}
+			if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedStreamError {
+				t.Errorf("MalformedToolGen paths = %v, want exactly [stream_error]", paths)
+			}
+			// The retry re-declared the same tools with the requested (auto) choice.
+			reqs := prov.requests()
+			if len(reqs) != 2 || len(reqs[1].Tools) == 0 {
+				t.Fatalf("retry request tools = %+v, want the same tools re-declared", reqs[1].Tools)
+			}
+			if reqs[1].ToolChoice.Mode != llm.ToolChoiceAuto {
+				t.Errorf("retry tool_choice = %q, want auto (same as the first attempt)", reqs[1].ToolChoice.Mode)
+			}
+
+			rounds, callsOK, callsErr := rec.snapshot()
+			if len(rounds) != 1 {
+				t.Errorf("LLMRound spans = %d, want 1 (final outcome only)", len(rounds))
+			}
+			if callsOK != 1 || callsErr != 0 {
+				t.Errorf("provider calls ok=%d err=%d, want 1/0 (recovered)", callsOK, callsErr)
+			}
+			if _, provErrs := rec.providerCalls(); provErrs != 0 {
+				t.Errorf("provider_errors = %d, want 0 (the retry recovered)", provErrs)
+			}
+		})
+	}
+}
+
+// TestEngine_ToolSyntax_FallsBackToolLessAfterTwoFailures is AC 2 (#398): a
+// tool-armed round that fails tool_use_failed TWICE regenerates without tool use —
+// the third request keeps the tools DECLARED but sets tool_choice none — and that
+// answer is delivered (nil error, NOT abandoned). Two malformed generations are
+// counted; the recovered final round records provider_call ok with no error.
+func TestEngine_ToolSyntax_FallsBackToolLessAfterTwoFailures(t *testing.T) {
+	prov := &toolSyntaxProvider{fails: 2, answer: "I cannot consult the bones right now, but you steady yourself."}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err != nil {
+		t.Fatalf("Generate after two tool_use_failed: %v (turn must NOT be abandoned)", err)
+	}
+	if strings.TrimSpace(got) != "I cannot consult the bones right now, but you steady yourself." {
+		t.Errorf("final text = %q, want the tool-less fallback answer", got)
+	}
+	if prov.calls != 3 {
+		t.Errorf("Complete calls = %d, want 3 (attempt, retry, tool-less fallback)", prov.calls)
+	}
+
+	// The fallback request (third) must keep the tools declared AND set tool_choice
+	// none — the conversation may hold prior tool_call/tool messages, so tools are
+	// not stripped.
+	reqs := prov.requests()
+	if len(reqs) != 3 {
+		t.Fatalf("recorded %d requests, want 3", len(reqs))
+	}
+	if len(reqs[2].Tools) == 0 {
+		t.Errorf("fallback request stripped the tools; want them still declared")
+	}
+	if reqs[2].ToolChoice.Mode != llm.ToolChoiceNone {
+		t.Errorf("fallback tool_choice = %q, want none", reqs[2].ToolChoice.Mode)
+	}
+	// The first two attempts used the requested (auto) choice.
+	if reqs[0].ToolChoice.Mode != llm.ToolChoiceAuto || reqs[1].ToolChoice.Mode != llm.ToolChoiceAuto {
+		t.Errorf("attempts 1/2 tool_choice = %q/%q, want auto/auto", reqs[0].ToolChoice.Mode, reqs[1].ToolChoice.Mode)
+	}
+
+	if paths := rec.malformedPaths(); len(paths) != 2 {
+		t.Errorf("MalformedToolGen count = %d, want 2 (both failures counted)", len(paths))
+	}
+	rounds, callsOK, callsErr := rec.snapshot()
+	if len(rounds) != 1 || callsOK != 1 || callsErr != 0 {
+		t.Errorf("final metrics rounds=%d ok=%d err=%d, want 1/1/0 (recovered, final-outcome-only)", len(rounds), callsOK, callsErr)
+	}
+	if _, provErrs := rec.providerCalls(); provErrs != 0 {
+		t.Errorf("provider_errors = %d, want 0 (fallback recovered the turn)", provErrs)
+	}
+}
+
+// TestEngine_NonToolSyntaxError_NotRetried is AC 3 (#398): a mid-stream provider
+// error of a DIFFERENT class (not tool_use_failed) on a tool-armed round is NOT
+// retried by the tool-syntax path — it propagates on the first call, and no
+// malformed-generation is counted.
+func TestEngine_NonToolSyntaxError_NotRetried(t *testing.T) {
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(errorEventProvider{}, diceGrants(t), "", "m", 0, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	_, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err == nil || !strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("Generate on a non-tool-syntax error = %v, want the provider error propagated", err)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 0 {
+		t.Errorf("MalformedToolGen count = %d on a non-tool-syntax error, want 0", len(paths))
+	}
+}
+
+// deltaThenToolSyntaxProvider forwards one prose delta, then aborts the stream with
+// a tool_use_failed EventError — the ADR-0044 mid-stream case: audio may already be
+// out, so the round must NOT be retried even though the failure class is tool-syntax.
+type deltaThenToolSyntaxProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *deltaThenToolSyntaxProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: "You feel "}
+	ch <- llm.StreamEvent{Type: llm.EventError, Err: "tool_use_failed", ErrClass: llm.ErrClassToolSyntax}
+	close(ch)
+	return ch, nil
+}
+
+// TestEngine_ToolSyntax_ForwardedDeltaNotRetried is AC-adjacent (#398, ADR-0044): a
+// tool-syntax failure that arrives AFTER a prose delta was already forwarded to
+// onText is never retried — a re-drive would re-speak. The error propagates on the
+// first call.
+func TestEngine_ToolSyntax_ForwardedDeltaNotRetried(t *testing.T) {
+	prov := &deltaThenToolSyntaxProvider{}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 0, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	var streamed strings.Builder
+	_, err := eng.GenerateStream(context.Background(),
+		[]llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}},
+		func(delta string) error { streamed.WriteString(delta); return nil })
+	if err == nil {
+		t.Fatal("GenerateStream returned nil after a mid-stream tool_use_failed")
+	}
+	if prov.calls != 1 {
+		t.Errorf("Complete calls = %d, want 1 (a forwarded delta forbids the retry)", prov.calls)
+	}
+	if strings.TrimSpace(streamed.String()) != "You feel" {
+		t.Errorf("streamed = %q, want the one forwarded delta", streamed.String())
+	}
+}
+
+// cancelOnFirstProvider fails the first tool-armed call with a tool-syntax start
+// error but cancels the turn ctx first — so complete's between-attempt ctx check
+// aborts before the retry ever dials.
+type cancelOnFirstProvider struct {
+	mu     sync.Mutex
+	calls  int
+	cancel context.CancelFunc
+}
+
+func (p *cancelOnFirstProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.mu.Unlock()
+	if n == 1 {
+		p.cancel() // barge lands between attempt 1's failure and the retry
+		return nil, &providererr.ToolSyntaxError{Op: "test.Complete", Msg: "tool_use_failed"}
+	}
+	ch := make(chan llm.StreamEvent)
+	go func() {
+		defer close(ch)
+		ch <- llm.StreamEvent{Type: llm.EventText, Text: "should not reach here "}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	}()
+	return ch, nil
+}
+
+// TestEngine_ToolSyntax_CtxCancelBetweenAttemptsAborts is AC-adjacent (#398): a ctx
+// cancellation landing between the first tool-syntax failure and its retry aborts
+// with the ctx error and never issues the retry.
+func TestEngine_ToolSyntax_CtxCancelBetweenAttemptsAborts(t *testing.T) {
+	prov := &cancelOnFirstProvider{}
+	ctx, cancel := context.WithCancel(context.Background())
+	prov.cancel = cancel
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 0, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	_, err := eng.Generate(ctx, []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Generate = %v, want context.Canceled (abort between attempts)", err)
+	}
+	if prov.calls != 1 {
+		t.Errorf("Complete calls = %d, want 1 (the retry must not dial after a cancel)", prov.calls)
 	}
 }
 

--- a/pkg/voice/agenttool/forcedchoice_internal_test.go
+++ b/pkg/voice/agenttool/forcedchoice_internal_test.go
@@ -1,0 +1,29 @@
+package agenttool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+)
+
+// TestForcedToolChoice_OneShotConsumedOnFirstCall pins the #399 seam #398 ships: a
+// ctx carrying [withForcedToolChoice] hands the override to the FIRST completion's
+// [providerAdapter.requestedChoice] and then reverts to auto, so only the turn's
+// opening round is forced. A ctx without an override always yields auto.
+func TestForcedToolChoice_OneShotConsumedOnFirstCall(t *testing.T) {
+	a := providerAdapter{}
+
+	// No override → auto, every call.
+	if got := a.requestedChoice(context.Background()); got.Mode != llm.ToolChoiceAuto {
+		t.Errorf("requestedChoice with no override = %+v, want auto", got)
+	}
+
+	ctx := withForcedToolChoice(context.Background(), llm.ToolChoice{Mode: llm.ToolChoiceRequired})
+	if got := a.requestedChoice(ctx); got.Mode != llm.ToolChoiceRequired {
+		t.Errorf("first requestedChoice = %+v, want the forced required override", got)
+	}
+	if got := a.requestedChoice(ctx); got.Mode != llm.ToolChoiceAuto {
+		t.Errorf("second requestedChoice = %+v, want auto (override is one-shot)", got)
+	}
+}

--- a/pkg/voice/llm/anthropic/anthropic_test.go
+++ b/pkg/voice/llm/anthropic/anthropic_test.go
@@ -362,6 +362,77 @@ func TestComplete_RequestShape_PinsBodyAndHeaders(t *testing.T) {
 	}
 }
 
+// TestComplete_ToolChoice_MapsModesToWire pins the #398/#399 per-round knob on the
+// Anthropic wire: the zero value stays {type:auto} (byte-identical to pre-#398), the
+// tool-less fallback maps to {type:none}, Required maps to Anthropic's {type:any},
+// and the pinned-Tool mode maps to {type:tool,name:X}. tool_choice is only present
+// when tools are declared.
+func TestComplete_ToolChoice_MapsModesToWire(t *testing.T) {
+	capttc := func(t *testing.T, tc llm.ToolChoice) (typ, name string, present bool) {
+		t.Helper()
+		var capture atomic.Value
+		srv := sseServer(t, &capture, sse(`{"type":"message_delta","delta":{"stop_reason":"end_turn"}}`))
+		defer srv.Close()
+		c := anthropic.New("k", anthropic.WithBaseURL(srv.URL), anthropic.WithModel("claude-test"))
+		ch, err := c.Complete(context.Background(), llm.Request{
+			MaxTokens:  128,
+			Messages:   []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}},
+			Tools:      []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+			ToolChoice: tc,
+		})
+		if err != nil {
+			t.Fatalf("Complete: %v", err)
+		}
+		collect(t, ch)
+		raw, _ := capture.Load().([]byte)
+		var body struct {
+			ToolChoice *struct {
+				Type string `json:"type"`
+				Name string `json:"name"`
+			} `json:"tool_choice"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("request body not JSON: %v\nbody: %s", err, raw)
+		}
+		if body.ToolChoice == nil {
+			return "", "", false
+		}
+		return body.ToolChoice.Type, body.ToolChoice.Name, true
+	}
+
+	if typ, _, ok := capttc(t, llm.ToolChoice{}); !ok || typ != "auto" {
+		t.Errorf("zero ToolChoice → tool_choice type = %q (present=%v), want auto", typ, ok)
+	}
+	if typ, _, ok := capttc(t, llm.ToolChoice{Mode: llm.ToolChoiceNone}); !ok || typ != "none" {
+		t.Errorf("None → tool_choice type = %q (present=%v), want none", typ, ok)
+	}
+	if typ, _, ok := capttc(t, llm.ToolChoice{Mode: llm.ToolChoiceRequired}); !ok || typ != "any" {
+		t.Errorf("Required → tool_choice type = %q (present=%v), want any (Anthropic's required)", typ, ok)
+	}
+	if typ, name, ok := capttc(t, llm.ToolChoice{Mode: llm.ToolChoiceTool, Tool: "dice"}); !ok || typ != "tool" || name != "dice" {
+		t.Errorf("Tool → tool_choice = {%q,%q} (present=%v), want {tool,dice}", typ, name, ok)
+	}
+
+	// No tools declared: tool_choice absent even with a mode set.
+	var capture atomic.Value
+	srv := sseServer(t, &capture, sse(`{"type":"message_delta","delta":{"stop_reason":"end_turn"}}`))
+	defer srv.Close()
+	c := anthropic.New("k", anthropic.WithBaseURL(srv.URL), anthropic.WithModel("claude-test"))
+	ch, err := c.Complete(context.Background(), llm.Request{
+		MaxTokens:  128,
+		Messages:   []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+		ToolChoice: llm.ToolChoice{Mode: llm.ToolChoiceRequired},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	collect(t, ch)
+	raw, _ := capture.Load().([]byte)
+	if strings.Contains(string(raw), "tool_choice") {
+		t.Errorf("tool_choice present with no tools declared; got %s", raw)
+	}
+}
+
 // TestComplete_ToolResultRoundTrip_MapsToUserToolResultBlocks pins the ADR-0028
 // return path: a [llm.RoleTool] message (the results the tool-use loop appends
 // after executing an assistant turn's calls) must serialize as one user-role

--- a/pkg/voice/llm/anthropic/complete.go
+++ b/pkg/voice/llm/anthropic/complete.go
@@ -76,10 +76,12 @@ type wireTool struct {
 	InputSchema json.RawMessage `json:"input_schema"`
 }
 
-// wireToolChoice mirrors the Anthropic tool_choice object. The adapter sets
-// {type: "auto"} whenever tools are present, letting the model decide.
+// wireToolChoice mirrors the Anthropic tool_choice object. Type is the choice
+// discriminator ("auto"|"none"|"any"|"tool"); Name is set only for the pinned-tool
+// choice ({type:"tool",name:X}), so it carries omitempty (#398/#399).
 type wireToolChoice struct {
 	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
 }
 
 // Complete implements [llm.Provider]. It posts a streaming Messages request and
@@ -120,7 +122,7 @@ func (c *Client) Complete(ctx context.Context, req llm.Request) (<-chan llm.Stre
 		Stream:    true,
 	}
 	if len(body.Tools) > 0 {
-		body.ToolChoice = &wireToolChoice{Type: "auto"}
+		body.ToolChoice = wireToolChoiceFor(req.ToolChoice)
 	}
 
 	payload, err := json.Marshal(body)
@@ -212,6 +214,23 @@ func toolResultBlocks(m llm.Message) []contentBlock {
 		}
 	}
 	return blocks
+}
+
+// wireToolChoiceFor maps the [llm.ToolChoice] knob onto the Anthropic tool_choice
+// object (#398/#399). Auto (the zero value) → {type:auto}, byte-identical to the
+// pre-#398 wire; None → {type:none}; Required → {type:any} (Anthropic's spelling of
+// "must call some tool"); Tool → {type:tool,name:X} pinning the model to one tool.
+func wireToolChoiceFor(tc llm.ToolChoice) *wireToolChoice {
+	switch tc.Mode {
+	case llm.ToolChoiceNone:
+		return &wireToolChoice{Type: "none"}
+	case llm.ToolChoiceRequired:
+		return &wireToolChoice{Type: "any"}
+	case llm.ToolChoiceTool:
+		return &wireToolChoice{Type: "tool", Name: tc.Tool}
+	default: // ToolChoiceAuto / zero
+		return &wireToolChoice{Type: "auto"}
+	}
 }
 
 // toWireTools maps the [llm.ToolDef]s onto the Anthropic tools array. Returns

--- a/pkg/voice/llm/llm.go
+++ b/pkg/voice/llm/llm.go
@@ -122,6 +122,41 @@ type ToolDef struct {
 	InputSchema json.RawMessage
 }
 
+// ToolChoiceMode is the per-round tool-choice knob a [Request] carries: it tells
+// the Provider whether the model may call a Tool this round, must call one, or is
+// pinned to a named Tool. It is a bounded enum, mapped onto each vendor's wire in
+// the adapter (ADR-0028). The zero value is [ToolChoiceAuto] — the model decides —
+// so an unset [Request.ToolChoice] preserves today's behaviour byte-for-byte.
+type ToolChoiceMode string
+
+const (
+	// ToolChoiceAuto lets the model decide whether to call a Tool. It is the zero
+	// value, so a [Request] that never sets ToolChoice is Auto — the pre-#398 wire.
+	ToolChoiceAuto ToolChoiceMode = ""
+
+	// ToolChoiceNone forbids tool calls this round: the Tools stay DECLARED (the
+	// conversation may hold prior tool_call / tool-role messages that must remain
+	// well-formed) but the model must answer in prose. The tool-less fallback round
+	// (#398) uses this after a repeated tool-syntax failure.
+	ToolChoiceNone ToolChoiceMode = "none"
+
+	// ToolChoiceRequired forces the model to call some Tool this round (#399).
+	ToolChoiceRequired ToolChoiceMode = "required"
+
+	// ToolChoiceTool pins the model to the single Tool named in [ToolChoice.Tool]
+	// (#399).
+	ToolChoiceTool ToolChoiceMode = "tool"
+)
+
+// ToolChoice is the per-round tool-choice selection on a [Request]. Tool is
+// meaningful only when Mode is [ToolChoiceTool]; it names the one Tool the model
+// is pinned to. A [Request] whose Tools list is empty ignores ToolChoice — there
+// is nothing to choose — so the field is inert on a no-tool round.
+type ToolChoice struct {
+	Mode ToolChoiceMode
+	Tool string // set iff Mode == ToolChoiceTool
+}
+
 // Request is one completion call: the assembled conversation plus the Tools the
 // Agent may call and generation limits. The system prompt travels as a
 // [RoleSystem] [Message] in Messages; providers route it to their native system
@@ -143,6 +178,11 @@ type Request struct {
 	// MaxTokens caps the completion length. Zero lets the Provider choose a
 	// sane default.
 	MaxTokens int
+
+	// ToolChoice is the per-round tool-choice knob (#398/#399). Ignored when Tools
+	// is empty. The zero value is [ToolChoiceAuto], so a Request that never sets it
+	// serializes exactly as before this field existed (cassette hashes unchanged).
+	ToolChoice ToolChoice
 }
 
 // StreamEventType discriminates a [StreamEvent].
@@ -191,6 +231,27 @@ type Usage struct {
 	OutputTokens int
 }
 
+// ErrClass classifies an [EventError] (and, downstream, a start error) so a
+// consumer can act on the KIND of failure without string-matching the message.
+// It is an ADDITIVE, bounded enum: the zero value [ErrClassNone] is the default
+// unclassified failure, so an event that never sets it — every pre-#398 error and
+// every cassette — reads as before. Only the OpenAI-compat adapter sets a
+// non-zero class today ([ErrClassToolSyntax]); the agenttool bridge maps it to a
+// typed [github.com/MrWong99/Glyphoxa/pkg/voice/providererr.ToolSyntaxError] to
+// drive the retry / tool-less-fallback policy (#398).
+type ErrClass string
+
+const (
+	// ErrClassNone is the unclassified failure (transport, malformed frame, size
+	// bound) — the zero value, so any error that does not opt in stays here.
+	ErrClassNone ErrClass = ""
+
+	// ErrClassToolSyntax marks a provider "tool_use_failed": the model emitted
+	// malformed pseudo-XML instead of a native tool call. It is the one class the
+	// #398 retry path acts on.
+	ErrClassToolSyntax ErrClass = "tool_syntax"
+)
+
 // StreamEvent is one item in a [Provider] completion stream. The active fields
 // depend on Type: Text on [EventText], ToolCall on [EventToolCall], StopReason
 // on [EventDone], Usage on [EventUsage].
@@ -209,6 +270,12 @@ type StreamEvent struct {
 	// Err is the failure description on an [EventError]. A string, not an
 	// error, so cassette recordings serialize it faithfully (ADR-0021).
 	Err string
+
+	// ErrClass optionally classifies an [EventError] (#398). ADDITIVE: the zero
+	// value [ErrClassNone] is the default, so events that do not set it — and every
+	// old cassette — are unchanged. [ErrClassToolSyntax] marks a tool_use_failed the
+	// agenttool bridge retries.
+	ErrClass ErrClass
 
 	// Usage is the token accounting on an [EventUsage].
 	Usage Usage

--- a/pkg/voice/llm/openaicompat/complete.go
+++ b/pkg/voice/llm/openaicompat/complete.go
@@ -74,9 +74,11 @@ func (c *Client) Complete(ctx context.Context, req llm.Request) (<-chan llm.Stre
 	}
 	if tools := toTools(req.Tools); len(tools) > 0 {
 		params.Tools = tools
-		// auto: the model decides whether to call a tool. The SDK defaults to auto
-		// when tools are present, but we set it explicitly so the wire is stable.
-		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String("auto")}
+		// The per-round tool-choice knob (#398/#399). The zero value maps to "auto"
+		// exactly as before — the SDK defaults to auto when tools are present, but we
+		// set it explicitly so the wire is stable. tool_choice is only sent when tools
+		// are declared (the llm.Request contract: ToolChoice is inert with no tools).
+		params.ToolChoice = toToolChoice(req.ToolChoice)
 	}
 	if c.reasoningEffort != "" {
 		params.ReasoningEffort = openai.ReasoningEffort(c.reasoningEffort)
@@ -118,6 +120,13 @@ func (c *Client) Complete(ctx context.Context, req llm.Request) (<-chan llm.Stre
 // (transport, empty request) keeps the plain prose wrap — it is not retryable and
 // needs no status.
 func (c *Client) startError(err error) error {
+	// A tool_use_failed 400 is a per-round policy signal, not a transient HTTP
+	// fault: surface it as a distinct [*providererr.ToolSyntaxError] so the agenttool
+	// bridge retries the round tool-less rather than the generic retry helper failing
+	// fast on a 4xx (#398). Byte-preserve the SDK message for diagnosability.
+	if isToolSyntaxErr(err) {
+		return &providererr.ToolSyntaxError{Op: c.name + ".Complete", Msg: err.Error()}
+	}
 	var apiErr *openai.Error
 	if errors.As(err, &apiErr) && apiErr.StatusCode != 0 {
 		return &providererr.HTTPError{
@@ -203,6 +212,28 @@ func toolResultMessages(m llm.Message) []openai.ChatCompletionMessageParamUnion 
 		out = append(out, openai.ToolMessage(tr.Content, tr.CallID))
 	}
 	return out
+}
+
+// toToolChoice maps the [llm.ToolChoice] knob onto the OpenAI tool_choice union
+// (#398/#399): Auto (the zero value) and None/Required serialize as the bare
+// strings "auto"/"none"/"required"; Tool serializes as the named-function object
+// pinning the model to one tool. The Auto default keeps the pre-#398 wire
+// byte-identical for every turn that never sets a choice.
+func toToolChoice(tc llm.ToolChoice) openai.ChatCompletionToolChoiceOptionUnionParam {
+	switch tc.Mode {
+	case llm.ToolChoiceNone:
+		return openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String("none")}
+	case llm.ToolChoiceRequired:
+		return openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String("required")}
+	case llm.ToolChoiceTool:
+		return openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfFunctionToolChoice: &openai.ChatCompletionNamedToolChoiceParam{
+				Function: openai.ChatCompletionNamedToolChoiceFunctionParam{Name: tc.Tool},
+			},
+		}
+	default: // ToolChoiceAuto / zero
+		return openai.ChatCompletionToolChoiceOptionUnionParam{OfAuto: openai.String("auto")}
+	}
 }
 
 // toTools maps the [llm.ToolDef]s onto the OpenAI function-tools array. Returns
@@ -370,6 +401,68 @@ func (c *Client) streamEvents(ctx context.Context, stream *ssestream.Stream[open
 		if ctx.Err() != nil {
 			return // cancellation closes cleanly; not a stream failure
 		}
-		fail(fmt.Sprintf("%s: read stream: %s", c.name, err.Error()))
+		// A provider tool_use_failed surfaces here as an in-stream error frame
+		// (the SDK sets stream.Err() from a data: {"error":{…}} chunk). Classify it
+		// so the agenttool bridge retries the round rather than abandon the turn
+		// (#398); any other stream failure stays the default unclassified error.
+		msg := fmt.Sprintf("%s: read stream: %s", c.name, err.Error())
+		if isToolSyntaxErr(err) {
+			send(llm.StreamEvent{Type: llm.EventError, Err: msg, ErrClass: llm.ErrClassToolSyntax})
+			return
+		}
+		fail(msg)
 	}
+}
+
+// toolUseFailedCode is the provider error code Groq (and other OpenAI-compat
+// gateways) return when the model emitted malformed pseudo-XML instead of a native
+// tool call. Detecting it is what lets the agenttool bridge retry the round and, on
+// a repeat, regenerate tool-less rather than abandon the voice turn (#398).
+const toolUseFailedCode = "tool_use_failed"
+
+// isToolSyntaxErr reports whether err carries the provider's tool_use_failed code,
+// on either detection path: the SDK's typed [*openai.Error] (a 400 start error,
+// whose Code / RawJSON body carries it) or the in-stream [ssestream.StreamError]
+// (whose message embeds the error-object JSON). It reads the typed Code first, then
+// falls back to extracting the first embedded JSON object and reading its "code" —
+// so neither path relies on brittle whole-string substring matching.
+func isToolSyntaxErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *openai.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.Code == toolUseFailedCode {
+			return true
+		}
+		if codeInJSON(apiErr.RawJSON()) == toolUseFailedCode {
+			return true
+		}
+	}
+	return codeInJSON(err.Error()) == toolUseFailedCode
+}
+
+// codeInJSON extracts the first '{'-delimited JSON object embedded in s and returns
+// its error code — either a top-level "code" or a nested "error":{"code"} — or ""
+// if nothing parses. A [json.Decoder] is used so trailing text after the object
+// (the StreamError's prefix leaves none, but a defensive parse costs nothing) does
+// not defeat the decode.
+func codeInJSON(s string) string {
+	i := strings.IndexByte(s, '{')
+	if i < 0 {
+		return ""
+	}
+	var probe struct {
+		Code  string `json:"code"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(strings.NewReader(s[i:])).Decode(&probe); err != nil {
+		return ""
+	}
+	if probe.Code != "" {
+		return probe.Code
+	}
+	return probe.Error.Code
 }

--- a/pkg/voice/llm/openaicompat/openaicompat_test.go
+++ b/pkg/voice/llm/openaicompat/openaicompat_test.go
@@ -420,6 +420,68 @@ func TestComplete_RequestShape_PinsBodyAndHeaders(t *testing.T) {
 	}
 }
 
+// TestComplete_ToolChoice_SerializesModes pins the #398/#399 per-round knob on the
+// OpenAI-compat wire: the zero value stays "auto" (byte-identical to pre-#398, so
+// every existing turn is unchanged), "none"/"required" serialize as bare strings,
+// and the pinned-Tool mode serializes as the named-function object. tool_choice is
+// only present when tools are declared.
+func TestComplete_ToolChoice_SerializesModes(t *testing.T) {
+	reqWith := func(tc llm.ToolChoice) llm.Request {
+		return llm.Request{
+			Messages:   []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+			Tools:      []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+			ToolChoice: tc,
+		}
+	}
+	// scalar decodes tool_choice when it is a bare string ("auto"/"none"/"required").
+	scalar := func(t *testing.T, raw []byte) string {
+		t.Helper()
+		var body struct {
+			ToolChoice string `json:"tool_choice"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("tool_choice not a scalar string: %v\nbody: %s", err, raw)
+		}
+		return body.ToolChoice
+	}
+
+	if got := scalar(t, captureBody(t, reqWith(llm.ToolChoice{}))); got != "auto" {
+		t.Errorf("zero ToolChoice → tool_choice = %q, want auto (unchanged wire)", got)
+	}
+	if got := scalar(t, captureBody(t, reqWith(llm.ToolChoice{Mode: llm.ToolChoiceNone}))); got != "none" {
+		t.Errorf("None → tool_choice = %q, want none", got)
+	}
+	if got := scalar(t, captureBody(t, reqWith(llm.ToolChoice{Mode: llm.ToolChoiceRequired}))); got != "required" {
+		t.Errorf("Required → tool_choice = %q, want required", got)
+	}
+
+	// Tool mode: the named-function object union.
+	var namedBody struct {
+		ToolChoice struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		} `json:"tool_choice"`
+	}
+	raw := captureBody(t, reqWith(llm.ToolChoice{Mode: llm.ToolChoiceTool, Tool: "dice"}))
+	if err := json.Unmarshal(raw, &namedBody); err != nil {
+		t.Fatalf("named tool_choice not an object: %v\nbody: %s", err, raw)
+	}
+	if namedBody.ToolChoice.Type != "function" || namedBody.ToolChoice.Function.Name != "dice" {
+		t.Errorf("Tool mode → tool_choice = %+v, want {function, dice}", namedBody.ToolChoice)
+	}
+
+	// No tools declared: tool_choice must be absent even if a mode is set.
+	noTools := captureBody(t, llm.Request{
+		Messages:   []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+		ToolChoice: llm.ToolChoice{Mode: llm.ToolChoiceRequired},
+	})
+	if strings.Contains(string(noTools), "tool_choice") {
+		t.Errorf("tool_choice present with no tools declared; got %s", noTools)
+	}
+}
+
 // TestComplete_ModelSelection pins the configurable-model contract: with no
 // per-call override the body carries the constructor default; a non-empty
 // [llm.Request.Model] wins over it.
@@ -616,6 +678,65 @@ func TestComplete_429_TypedHTTPError(t *testing.T) {
 			t.Errorf("error %q missing required substring %q", err, must)
 		}
 	}
+}
+
+// TestComplete_StartToolUseFailed_TypedToolSyntaxError pins #398 detection site
+// two: a 400 whose body carries "code":"tool_use_failed" surfaces as a
+// [*providererr.ToolSyntaxError] (NOT the generic [*providererr.HTTPError]), so the
+// agenttool bridge routes it into the retry / tool-less-fallback path instead of
+// treating it as a hard 4xx. A generic 400 with no tool_use_failed code stays a
+// plain HTTPError — the regression guard that the new path does not swallow every
+// bad request.
+func TestComplete_StartToolUseFailed_TypedToolSyntaxError(t *testing.T) {
+	t.Run("400 tool_use_failed → ToolSyntaxError", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"Failed to call a function.","type":"invalid_request_error","code":"tool_use_failed","failed_generation":"<function=dice></function>"}}`))
+		}))
+		defer srv.Close()
+		c := newClient(srv.URL)
+		_, err := c.Complete(context.Background(), llm.Request{
+			Messages: []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}},
+			Tools:    []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		})
+		var tse *providererr.ToolSyntaxError
+		if !errors.As(err, &tse) {
+			t.Fatalf("error %v is not a *providererr.ToolSyntaxError", err)
+		}
+		var he *providererr.HTTPError
+		if errors.As(err, &he) {
+			t.Errorf("a tool_use_failed 400 must NOT also be an HTTPError; got %v", he)
+		}
+		if retry.Retryable(err) {
+			t.Error("a tool_use_failed error must not be retryable by the generic retry helper")
+		}
+		if !strings.Contains(tse.Error(), "tool_use_failed") {
+			t.Errorf("ToolSyntaxError message %q does not preserve the provider body", tse.Error())
+		}
+	})
+
+	t.Run("generic 400 stays HTTPError", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"missing model","type":"invalid_request_error","code":"invalid_request"}}`))
+		}))
+		defer srv.Close()
+		c := newClient(srv.URL)
+		_, err := c.Complete(context.Background(), llm.Request{
+			Messages: []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+		})
+		var he *providererr.HTTPError
+		if !errors.As(err, &he) {
+			t.Fatalf("generic 400 error %v is not a *providererr.HTTPError", err)
+		}
+		if he.StatusCode != 400 {
+			t.Errorf("StatusCode = %d, want 400", he.StatusCode)
+		}
+		var tse *providererr.ToolSyntaxError
+		if errors.As(err, &tse) {
+			t.Errorf("a generic 400 must NOT be a ToolSyntaxError; got %v", tse)
+		}
+	})
 }
 
 // TestComplete_MalformedFrame_EmitsEventError pins the truncation contract: a
@@ -846,4 +967,61 @@ func TestComplete_ContextCanceled_NoTerminalEvent(t *testing.T) {
 			t.Error("got EventDone on ctx cancel, want clean close")
 		}
 	}
+}
+
+// TestComplete_InStreamToolUseFailed_ClassifiesToolSyntax pins #398 detection site
+// one: Groq surfaces a malformed pseudo-XML tool call as an in-stream error frame
+// carrying "code":"tool_use_failed". The adapter must terminate with an
+// [llm.EventError] whose ErrClass is [llm.ErrClassToolSyntax] (never an
+// [llm.EventDone]), so the agenttool bridge can retry the round rather than
+// abandon the turn. A generic in-stream error frame stays [llm.ErrClassNone].
+func TestComplete_InStreamToolUseFailed_ClassifiesToolSyntax(t *testing.T) {
+	toolFail := sse(`{"error":{"message":"Failed to call a function. Please adjust your prompt.","type":"invalid_request_error","code":"tool_use_failed","failed_generation":"<function=dice{\"sides\":20}</function>"}}`)
+
+	t.Run("tool_use_failed → ErrClassToolSyntax", func(t *testing.T) {
+		srv := sseServer(t, nil, toolFail)
+		defer srv.Close()
+		c := newClient(srv.URL)
+		ch, err := c.Complete(context.Background(), llm.Request{
+			Messages: []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}},
+			Tools:    []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		})
+		if err != nil {
+			t.Fatalf("Complete: %v", err)
+		}
+		events := collect(t, ch)
+		last := events[len(events)-1]
+		if last.Type != llm.EventError {
+			t.Fatalf("last event = %+v, want EventError", last)
+		}
+		if last.ErrClass != llm.ErrClassToolSyntax {
+			t.Errorf("ErrClass = %q, want %q", last.ErrClass, llm.ErrClassToolSyntax)
+		}
+		for _, ev := range events {
+			if ev.Type == llm.EventDone {
+				t.Error("stream emitted EventDone despite the tool_use_failed error")
+			}
+		}
+	})
+
+	t.Run("generic in-stream error stays ErrClassNone", func(t *testing.T) {
+		srv := sseServer(t, nil, sse(`{"error":{"message":"upstream boom","type":"server_error","code":"internal"}}`))
+		defer srv.Close()
+		c := newClient(srv.URL)
+		ch, err := c.Complete(context.Background(), llm.Request{
+			Messages: []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+			Tools:    []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		})
+		if err != nil {
+			t.Fatalf("Complete: %v", err)
+		}
+		events := collect(t, ch)
+		last := events[len(events)-1]
+		if last.Type != llm.EventError {
+			t.Fatalf("last event = %+v, want EventError", last)
+		}
+		if last.ErrClass != llm.ErrClassNone {
+			t.Errorf("ErrClass = %q, want none for a non-tool-syntax stream error", last.ErrClass)
+		}
+	})
 }

--- a/pkg/voice/providererr/providererr.go
+++ b/pkg/voice/providererr/providererr.go
@@ -29,3 +29,22 @@ type HTTPError struct {
 func (e *HTTPError) Error() string {
 	return fmt.Sprintf("%s: HTTP %d %s: %s", e.Op, e.StatusCode, e.Status, e.Body)
 }
+
+// ToolSyntaxError is a provider "tool_use_failed": the model emitted malformed
+// pseudo-XML instead of a native tool call, so the vendor (Groq surfaces this) 400s
+// the start call or aborts the stream (#398). It is a DISTINCT type, deliberately
+// NOT a [HTTPError] and NOT matched by the generic [github.com/MrWong99/Glyphoxa/pkg/voice/retry].Do
+// predicates: a tool-syntax failure is not a transient 429/5xx to back off on but a
+// per-round policy signal the agenttool bridge acts on (retry once with the same
+// tools, then regenerate tool-less). Op names the adapter operation for
+// diagnosability; Msg is preserved byte-for-byte from the surfaced provider text so
+// logs and any downstream string compare are unchanged.
+type ToolSyntaxError struct {
+	Op  string
+	Msg string
+}
+
+// Error returns Msg verbatim — the surfaced provider message, byte-preserved so a
+// log or a substring check on the underlying error text sees exactly what the
+// vendor returned.
+func (e *ToolSyntaxError) Error() string { return e.Msg }

--- a/pkg/voice/voicebench/recorder_tap.go
+++ b/pkg/voice/voicebench/recorder_tap.go
@@ -136,5 +136,9 @@ func (t *recorderTap) LLMTokens(observe.Provider, string, int, int)    {}
 func (t *recorderTap) TTSCharacters(observe.Provider, int)             {}
 func (t *recorderTap) STTAudioSeconds(observe.Provider, time.Duration) {}
 
+// MalformedToolGen (#398) is a provider-flake counter, not a latency stage, so the
+// bench tap ignores it.
+func (t *recorderTap) MalformedToolGen(observe.Provider, observe.MalformedPath) {}
+
 // compile-time assertion: the tap satisfies the recorder the orchestrator drives.
 var _ observe.StageRecorder = (*recorderTap)(nil)

--- a/pkg/voice/voicecassette/llm.go
+++ b/pkg/voice/voicecassette/llm.go
@@ -174,6 +174,23 @@ func (p *LLMProvider) Complete(ctx context.Context, req llm.Request) (<-chan llm
 	return ch, nil
 }
 
+// encodeToolChoice renders a [llm.ToolChoice] as the cassette-hash token (#398):
+// the zero value (Auto) encodes to "" so it drops out under omitempty and old
+// cassettes never drift; None/Required encode to their bare mode; the pinned-tool
+// choice encodes as "tool:<name>" so a different pinned tool hashes distinctly.
+func encodeToolChoice(tc llm.ToolChoice) string {
+	switch tc.Mode {
+	case llm.ToolChoiceNone:
+		return "none"
+	case llm.ToolChoiceRequired:
+		return "required"
+	case llm.ToolChoiceTool:
+		return "tool:" + tc.Tool
+	default: // ToolChoiceAuto / zero
+		return ""
+	}
+}
+
 // HashLLMRequest returns the hex sha256 cassette key for req: the rendered
 // prompt the model would see. It marshals model + system + messages + tools to
 // canonical JSON and hashes the bytes. Exported so the record path and test
@@ -200,8 +217,15 @@ func HashLLMRequest(req llm.Request) string {
 		MaxTokens int           `json:"max_tokens"`
 		Messages  []hMsg        `json:"messages"`
 		Tools     []llm.ToolDef `json:"tools,omitempty"`
+		// ToolChoice is the encoded per-round tool-choice knob (#398). It is
+		// omitempty and the zero-value [llm.ToolChoice] encodes to "" (see
+		// [encodeToolChoice]), so a request that never sets a choice hashes
+		// byte-identical to a pre-field cassette (ADR-0021). A non-zero choice — a
+		// tool-less fallback or a forced round — is a genuine prompt change and hashes
+		// distinctly.
+		ToolChoice string `json:"tool_choice,omitempty"`
 	}
-	h := hReq{Model: req.Model, MaxTokens: req.MaxTokens, Tools: req.Tools}
+	h := hReq{Model: req.Model, MaxTokens: req.MaxTokens, Tools: req.Tools, ToolChoice: encodeToolChoice(req.ToolChoice)}
 	for _, m := range req.Messages {
 		h.Messages = append(h.Messages, hMsg{
 			Role:        string(m.Role),

--- a/pkg/voice/voicecassette/llm_test.go
+++ b/pkg/voice/voicecassette/llm_test.go
@@ -2,6 +2,7 @@ package voicecassette_test
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand/v2"
 	"strings"
 	"testing"
@@ -11,6 +12,49 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
 )
+
+// TestHashLLMRequest_ToolChoice_ZeroValueStable is the ADR-0021 cassette-stability
+// guard for the additive [llm.Request.ToolChoice] field (#398): a request whose
+// ToolChoice is the zero value MUST hash byte-identical to the pre-field golden, so
+// every committed cassette replays unchanged. A non-zero ToolChoice is a genuine
+// prompt change and MUST hash differently (a tool-less fallback round is a distinct
+// exchange).
+func TestHashLLMRequest_ToolChoice_ZeroValueStable(t *testing.T) {
+	// Golden hash of this exact request captured before ToolChoice was added to
+	// llm.Request — the byte-identity anchor for old cassettes.
+	const golden = "b8262e44fc234f55f0004320c982f2af83ca5502c21abc0f7c2fe6d05cb63c07"
+
+	base := llm.Request{
+		Model:     "m",
+		MaxTokens: 256,
+		Messages:  []llm.Message{{Role: llm.RoleUser, Text: "hi"}},
+		Tools:     []llm.ToolDef{{Name: "dice", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	}
+	if got := voicecassette.HashLLMRequest(base); got != golden {
+		t.Errorf("zero-ToolChoice hash = %s, want the pre-field golden %s (old cassettes must not drift)", got, golden)
+	}
+
+	// An explicit Auto is the same as the zero value — also must not drift.
+	auto := base
+	auto.ToolChoice = llm.ToolChoice{Mode: llm.ToolChoiceAuto}
+	if got := voicecassette.HashLLMRequest(auto); got != golden {
+		t.Errorf("explicit-Auto hash = %s, want the golden %s", got, golden)
+	}
+
+	// A non-zero choice must change the hash — a fallback / forced round is a
+	// distinct exchange.
+	for _, tc := range []llm.ToolChoice{
+		{Mode: llm.ToolChoiceNone},
+		{Mode: llm.ToolChoiceRequired},
+		{Mode: llm.ToolChoiceTool, Tool: "dice"},
+	} {
+		changed := base
+		changed.ToolChoice = tc
+		if got := voicecassette.HashLLMRequest(changed); got == golden {
+			t.Errorf("ToolChoice %+v hashed identical to the zero value; want a distinct hash", tc)
+		}
+	}
+}
 
 // drain accumulates a completion stream's text and collects tool calls + stop.
 func drain(t *testing.T, ch <-chan llm.StreamEvent) (text string, calls []llm.ToolCall, stop string) {


### PR DESCRIPTION
Closes #398

## What

A tool-armed generation round that fails with the provider's tool-syntax class (Groq surfaces malformed pseudo-XML as `tool_use_failed`) no longer abandons the voice turn. The `agenttool` bridge retries the round **once** with the same tools, then regenerates **tool-less** (tools stay declared, `tool_choice: none`) so the NPC still answers in character instead of going silent. Every malformed generation increments a counter so provider flake stays visible even when the turn fully recovers.

## Shared contract (this PR owns; #399/#410 consume)

- `pkg/voice/llm`: `ToolChoice{Mode,Tool}` on `Request` (ignored when `Tools` empty; zero value = auto, so cassette hashes stay byte-identical). Additive `StreamEvent.ErrClass` (`ErrClassToolSyntax`).
- `pkg/voice/providererr.ToolSyntaxError`: `Error()` returns `Msg` byte-preserved; **not** matched by generic `retry.Do` predicates.
- `internal/observe`: `StageRecorder.MalformedToolGen(provider, path)` → `glyphoxa_llm_malformed_toolgen_total{provider,path}`. All three `MalformedPath` consts reserved now (`stream_error` live; `text_leak`/`roll_claim` for #410/#399). Wired on Discard no-op + Prometheus + assert recorder.
- Adapter wire mapping: openaicompat `auto/none/required/tool`; anthropic `auto/none/any/tool+name`.
- `voicecassette` hash encodes `tool_choice` (`omitempty`); zero value keeps old hashes byte-identical (tested).
- `withForcedToolChoice` one-shot ctx helper (adapter consumes on first completion; #399 wires the caller).

## Policy (agenttool `complete` → `attempt()` split)

Tool-armed rounds only. Attempt with requested choice → on `*ToolSyntaxError` with no forwarded delta, immediate retry (no backoff) → same class again, slog + regenerate `tool_choice none` keeping tools declared. A forwarded prose delta forbids retry (ADR-0044 mid-stream rule); a ctx cancel between attempts aborts. Metrics record final outcome only (ADR-0044); each attempt's reported usage still recorded (ADR-0045). Detection lives **only** in openaicompat; `agenttool` converts `ErrClass → *ToolSyntaxError`. Generic 400 stays `*HTTPError` (regression test).

## Per-AC test names

- **AC1 (retry once → deliver):** `TestEngine_ToolSyntax_RetriesOnceThenDelivers` (start-error + in-stream subtests)
- **AC2 (fail twice → tool-less fallback, not abandoned):** `TestEngine_ToolSyntax_FallsBackToolLessAfterTwoFailures`
- **AC3 (non-tool-syntax not retried):** `TestEngine_NonToolSyntaxError_NotRetried`
- **AC4 (counter per malformed gen):** asserted in the above via `MalformedToolGen` + `internal/observe.TestPrometheusScrapeExposesSeries`
- **AC5 (terminal event all branches):** covered by AC1/AC2 delivering + `TestEngine_ToolSyntax_ForwardedDeltaNotRetried` / `TestEngine_ToolSyntax_CtxCancelBetweenAttemptsAborts` propagating
- **Contract tests:** `TestComplete_InStreamToolUseFailed_ClassifiesToolSyntax`, `TestComplete_StartToolUseFailed_TypedToolSyntaxError`, `TestComplete_ToolChoice_SerializesModes` (openaicompat), `TestComplete_ToolChoice_MapsModesToWire` (anthropic), `TestHashLLMRequest_ToolChoice_ZeroValueStable` (voicecassette), `TestForcedToolChoice_OneShotConsumedOnFirstCall`

Local: `go test ./...` green, `go vet` clean, `golangci-lint` 0 issues on changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)