### PR TITLE
fix(#421): enrichment claim/sweep hardening — seam List, cancel-immune release, single-clock lease

### DIFF
--- a/internal/blob/blob.go
+++ b/internal/blob/blob.go
@@ -60,10 +60,23 @@ type Store interface {
 	// Delete removes the blob at key. Deleting an absent key returns nil
 	// (idempotent).
 	Delete(ctx context.Context, key string) error
+	// List returns the keys of every stored blob whose key begins with prefix, in
+	// ascending key order. It reads keys ONLY (never the bytes). It exists so the
+	// process-wide reconciliation sweeps (e.g. the Highlight orphan-image sweep,
+	// #406/#421) can enumerate blobs THROUGH the seam instead of querying a
+	// backend's table directly — an S3 swap re-implements List and the sweep is
+	// unchanged. An empty prefix lists everything; pass AllKeysPrefix to walk the
+	// whole store.
+	List(ctx context.Context, prefix string) ([]string, error)
 }
 
 // keyPrefix is the mandatory first segment of every key.
 const keyPrefix = "t"
+
+// AllKeysPrefix matches every valid key — all keys are tenant-rooted under
+// keyPrefix. A process-wide sweep that carries no tenant (ADR-0049) passes it to
+// List to enumerate the whole store, then filters by owner-kind/name in Go.
+const AllKeysPrefix = keyPrefix + "/"
 
 // Key builds the canonical tenant-scoped key
 // t/<tenant_id>/<owner-kind>/<owner-id>/<name>. It is deterministic — the same
@@ -86,39 +99,61 @@ func Key(tenantID uuid.UUID, ownerKind string, ownerID uuid.UUID, name string) (
 	return key, nil
 }
 
+// KeyParts is the decoded structure of a canonical key
+// (t/<tenant_id>/<owner-kind>/<owner-id>/<name>). ParseKey produces it so callers
+// that must reason about a key's owner-kind/name (e.g. the reconciliation sweeps)
+// do that in the blob package rather than re-deriving segment indices at the call
+// site — the package owns key structure (ADR-0048).
+type KeyParts struct {
+	TenantID  uuid.UUID
+	OwnerKind string
+	OwnerID   uuid.UUID
+	Name      string
+}
+
 // ValidateKey parses a key and returns the tenant id it encodes, or
-// ErrInvalidKey. A valid key is exactly five segments —
-// "t"/<uuid>/<kind>/<owner-id>/<name> — with a parseable tenant uuid and
-// non-empty kind and name. The backend calls this and derives the tenant_id
-// column from the result, so an invalid key never reaches SQL.
+// ErrInvalidKey. It is the narrow form of ParseKey the backend uses to derive the
+// tenant_id column, so an invalid key never reaches SQL.
 func ValidateKey(key string) (tenantID uuid.UUID, err error) {
+	parts, err := ParseKey(key)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return parts.TenantID, nil
+}
+
+// ParseKey decodes a key into its parts, or ErrInvalidKey. A valid key is exactly
+// five segments — "t"/<uuid>/<kind>/<owner-id>/<name> — with parseable, canonical
+// tenant and owner uuids and non-empty kind and name.
+func ParseKey(key string) (KeyParts, error) {
 	segs := strings.Split(key, "/")
 	if len(segs) != 5 {
-		return uuid.Nil, ErrInvalidKey
+		return KeyParts{}, ErrInvalidKey
 	}
 	if segs[0] != keyPrefix {
-		return uuid.Nil, ErrInvalidKey
+		return KeyParts{}, ErrInvalidKey
 	}
 	tenant, perr := uuid.Parse(segs[1])
 	if perr != nil {
-		return uuid.Nil, ErrInvalidKey
+		return KeyParts{}, ErrInvalidKey
 	}
 	// uuid.Parse tolerates braces/urn/no-dash forms; require the canonical dashed
 	// string so one logical blob has exactly one key. A non-canonical hand-built
 	// key would otherwise become an orphan the E8 delete hook can never
 	// reconstruct via Key().
 	if segs[1] != tenant.String() {
-		return uuid.Nil, ErrInvalidKey
+		return KeyParts{}, ErrInvalidKey
 	}
 	// segs[2] = owner-kind, segs[3] = owner-id, segs[4] = name. Kind and name
 	// must be non-empty; a slash inside either is impossible (it would raise the
 	// segment count above five). The owner-id gets the same canonical-uuid
 	// discipline as the tenant.
 	if segs[2] == "" || segs[4] == "" {
-		return uuid.Nil, ErrInvalidKey
+		return KeyParts{}, ErrInvalidKey
 	}
-	if owner, oerr := uuid.Parse(segs[3]); oerr != nil || segs[3] != owner.String() {
-		return uuid.Nil, ErrInvalidKey
+	owner, oerr := uuid.Parse(segs[3])
+	if oerr != nil || segs[3] != owner.String() {
+		return KeyParts{}, ErrInvalidKey
 	}
-	return tenant, nil
+	return KeyParts{TenantID: tenant, OwnerKind: segs[2], OwnerID: owner, Name: segs[4]}, nil
 }

--- a/internal/blob/postgres.go
+++ b/internal/blob/postgres.go
@@ -103,6 +103,34 @@ func (p *Postgres) Get(ctx context.Context, key string) (io.ReadCloser, Meta, er
 	return io.NopCloser(bytes.NewReader(raw)), meta, nil
 }
 
+// List returns the keys of every blob whose key begins with prefix, ascending.
+// It scans the key column ONLY (never bytea), so a whole-store walk stays cheap.
+// starts_with keeps the prefix a literal (no LIKE metacharacter surprises). The
+// prefix is not key-validated: it is a partial key by design (a bare owner-kind
+// cannot be prefix-isolated because the tenant segment comes first), and callers
+// filter the results by owner-kind/name via blob.ParseKey.
+func (p *Postgres) List(ctx context.Context, prefix string) ([]string, error) {
+	rows, err := p.pool.Query(ctx,
+		`SELECT key FROM blob WHERE starts_with(key, $1) ORDER BY key`, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("blob: list %q: %w", prefix, err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, fmt.Errorf("blob: scan key: %w", err)
+		}
+		out = append(out, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("blob: list %q: %w", prefix, err)
+	}
+	return out, nil
+}
+
 // Delete removes the blob at key. Deleting an absent key returns nil
 // (idempotent) — the deterministic Key() plus this Delete are the lifecycle
 // mechanism owning rows use (ADR-0048; wiring is E8's). An invalid key is

--- a/internal/blob/postgres_test.go
+++ b/internal/blob/postgres_test.go
@@ -313,3 +313,62 @@ func TestSizeCapBoundary(t *testing.T) {
 		t.Fatalf("Put over cap err = %v, want ErrTooLarge", err)
 	}
 }
+
+// TestListPrefixScan proves List returns exactly the keys under a prefix, in
+// ascending order, reading keys only. It is the seam capability the process-wide
+// reconciliation sweeps enumerate blobs through (#421), replacing a direct query
+// against the blob table.
+func TestListPrefixScan(t *testing.T) {
+	store, pool := newStore(t)
+	ctx := context.Background()
+	tenant := seedTenant(t, pool, "acme")
+	other := seedTenant(t, pool, "beta")
+
+	owner := uuid.New()
+	kImg := mustKey(t, tenant, owner, "image")
+	kClip := mustKey(t, tenant, owner, "clip.wav")
+	kOther := mustKey(t, other, uuid.New(), "image")
+	for _, k := range []string{kImg, kClip, kOther} {
+		if err := store.Put(ctx, k, "image/png", bytes.NewReader([]byte("x")), 1); err != nil {
+			t.Fatalf("put %s: %v", k, err)
+		}
+	}
+
+	// AllKeysPrefix walks the whole store, ascending.
+	all, err := store.List(ctx, blob.AllKeysPrefix)
+	if err != nil {
+		t.Fatalf("List all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("List all = %v, want 3 keys", all)
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1] > all[i] {
+			t.Fatalf("List not ascending: %v", all)
+		}
+	}
+
+	// A tenant-scoped prefix isolates one tenant's blobs.
+	tenantPrefix := "t/" + tenant.String() + "/"
+	scoped, err := store.List(ctx, tenantPrefix)
+	if err != nil {
+		t.Fatalf("List tenant: %v", err)
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("tenant-scoped List = %v, want the 2 acme keys", scoped)
+	}
+	for _, k := range scoped {
+		if k == kOther {
+			t.Fatalf("tenant prefix leaked another tenant's key: %v", scoped)
+		}
+	}
+
+	// A prefix that matches nothing is an empty (non-error) result.
+	none, err := store.List(ctx, "t/"+uuid.New().String()+"/")
+	if err != nil {
+		t.Fatalf("List empty: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("no-match List = %v, want empty", none)
+	}
+}

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -26,6 +26,11 @@ import (
 // idempotent + at-least-once.
 const JobKindEnrichImage = "highlight.enrich_image"
 
+// highlightOwnerKind is the blob.Key owner-kind segment a Highlight's blobs live
+// under (t/<tenant>/highlight/<id>/<name>): both its audio clip and its generated
+// image. The orphan-image sweep scopes to this owner-kind.
+const highlightOwnerKind = "highlight"
+
 // imageBlobName is the blob.Key name segment for a Highlight's generated image
 // (mirrors the clip's "clip.wav"). The key is t/<tenant>/highlight/<id>/image.
 const imageBlobName = "image"
@@ -200,7 +205,7 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 			"estimated_usd", meter.Status().EstimatedUSD,
 		)
 
-		key, err := blob.Key(p.TenantID, "highlight", p.HighlightID, imageBlobName)
+		key, err := blob.Key(p.TenantID, highlightOwnerKind, p.HighlightID, imageBlobName)
 		if err != nil {
 			release()
 			return fmt.Errorf("highlight enrich: build image key: %w", err)
@@ -234,10 +239,13 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 }
 
 // ReconcileStore is the storage surface the boot enrichment reconciliation sweep
-// needs (#406); *storage.Store satisfies it and tests fake it.
+// needs (#406); *storage.Store satisfies it and tests fake it. HighlightsExist is
+// the membership half of the orphan-image anti-join (#421): the sweep enumerates
+// image blobs through the blob seam and asks the store which of their embedded
+// Highlight ids still have a row — the absent ones are the orphans.
 type ReconcileStore interface {
 	ListPromotedHighlightsNeedingEnrichment(ctx context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error)
-	ListOrphanHighlightImageKeys(ctx context.Context) ([]string, error)
+	HighlightsExist(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]bool, error)
 }
 
 // SweepEnrichmentReconciliation is the boot-time enrichment backstop (#406, the
@@ -248,11 +256,14 @@ type ReconcileStore interface {
 //     no live enrich job — recovering a crash between promote-commit and the enqueue
 //     (AC1). It complements, not replaces, PromoteHighlight's per-promotion enqueue.
 //   - (b) drop every ORPHAN image blob — an image under the Highlight image
-//     owner-kind prefix whose Highlight row is gone (a delete-vs-enrich interleaving
+//     owner-kind whose Highlight row is gone (a delete-vs-enrich interleaving
 //     that committed the image after the delete read the row imageless), closing the
-//     window DeleteHighlight's re-read only shrinks (AC3). It touches ONLY that
-//     prefix (ADR-0048), never another owner's blobs, and never a live enrichment's
-//     in-flight blob (the row still exists).
+//     window DeleteHighlight's re-read only shrinks (AC3). The blobs are enumerated
+//     THROUGH the blob seam (blob.Store.List, #421) — never a direct query against a
+//     backend table — so the sweep survives an S3 swap; the anti-join against live
+//     rows (store.HighlightsExist) happens in Go. It touches ONLY the 'highlight'
+//     owner-kind + 'image' name (ADR-0048), never a clip, another owner's blob, or a
+//     live enrichment's in-flight blob (the row still exists).
 //
 // Both halves run even if one's list fails: a store-list error is collected and
 // returned so boot logs it, but the sweep never aborts (AC4) — the caller (main.go)
@@ -281,21 +292,42 @@ func SweepEnrichmentReconciliation(ctx context.Context, store ReconcileStore, bl
 		}
 	}
 
-	// (b) Collect orphaned image blobs.
-	keys, err := store.ListOrphanHighlightImageKeys(ctx)
+	// (b) Sweep orphaned image blobs. Enumerate every blob through the seam, keep
+	// only the Highlight image blobs (owner-kind 'highlight', name 'image'), then
+	// anti-join their embedded Highlight ids against the live rows in Go: a blob
+	// whose id has no row is an orphan.
+	allKeys, err := blobs.List(ctx, blob.AllKeysPrefix)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("list orphan image keys: %w", err))
+		errs = append(errs, fmt.Errorf("list blob keys: %w", err))
 	} else {
-		swept := 0
-		for _, k := range keys {
-			if err := blobs.Delete(ctx, k); err != nil {
-				log.Error("highlight enrich sweep: delete orphan image", "err", err, "key", k)
+		var imageKeys []string
+		var ids []uuid.UUID
+		for _, k := range allKeys {
+			parts, perr := blob.ParseKey(k)
+			if perr != nil || parts.OwnerKind != highlightOwnerKind || parts.Name != imageBlobName {
 				continue
 			}
-			swept++
+			imageKeys = append(imageKeys, k)
+			ids = append(ids, parts.OwnerID)
 		}
-		if swept > 0 {
-			log.Warn("swept orphaned highlight image blobs", "count", swept)
+		present, perr := store.HighlightsExist(ctx, ids)
+		if perr != nil {
+			errs = append(errs, fmt.Errorf("check highlight rows for orphan images: %w", perr))
+		} else {
+			swept := 0
+			for i, k := range imageKeys {
+				if present[ids[i]] {
+					continue // the row still exists: a live or in-flight enrichment, not an orphan
+				}
+				if err := blobs.Delete(ctx, k); err != nil {
+					log.Error("highlight enrich sweep: delete orphan image", "err", err, "key", k)
+					continue
+				}
+				swept++
+			}
+			if swept > 0 {
+				log.Warn("swept orphaned highlight image blobs", "count", swept)
+			}
 		}
 	}
 

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -151,13 +151,18 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		// image so a fast retry (or a later re-promotion) can re-claim without waiting
 		// out the ttl; a release failure is non-fatal (the ttl backs it up).
 		//
-		// The release runs on a cancel-immune ctx (#421): an error-path exit is
+		// The release runs on a fresh bounded ctx (#421): an error-path exit is
 		// frequently reached BECAUSE the handler ctx was cancelled (lease timeout or
 		// shutdown), and a release on that dead ctx would always fail — stranding the
 		// claim for the full ttl and burning every retry against it. context.WithoutCancel
-		// keeps the deadline/values but drops the cancellation so the release still commits.
+		// drops the parent's cancellation AND its deadline (Go: no Done, no Deadline), so
+		// we re-impose our OWN 10s timeout — otherwise this becomes the handler's only
+		// unbounded DB call and a hung conn would wedge the SERIAL job-runner drain across
+		// every background job kind until restart (the voice-STT-wedge class).
 		release := func() {
-			if rerr := store.ReleaseHighlightEnrichClaim(context.WithoutCancel(ctx), p.HighlightID); rerr != nil {
+			rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			defer cancel()
+			if rerr := store.ReleaseHighlightEnrichClaim(rctx, p.HighlightID); rerr != nil {
 				log.Error("highlight enrich: release claim", "err", rerr, "highlight", p.HighlightID)
 			}
 		}

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -145,8 +145,14 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 		// From here we OWN the claim. Release it on every exit that does NOT land an
 		// image so a fast retry (or a later re-promotion) can re-claim without waiting
 		// out the ttl; a release failure is non-fatal (the ttl backs it up).
+		//
+		// The release runs on a cancel-immune ctx (#421): an error-path exit is
+		// frequently reached BECAUSE the handler ctx was cancelled (lease timeout or
+		// shutdown), and a release on that dead ctx would always fail — stranding the
+		// claim for the full ttl and burning every retry against it. context.WithoutCancel
+		// keeps the deadline/values but drops the cancellation so the release still commits.
 		release := func() {
-			if rerr := store.ReleaseHighlightEnrichClaim(ctx, p.HighlightID); rerr != nil {
+			if rerr := store.ReleaseHighlightEnrichClaim(context.WithoutCancel(ctx), p.HighlightID); rerr != nil {
 				log.Error("highlight enrich: release claim", "err", rerr, "highlight", p.HighlightID)
 			}
 		}

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -275,13 +275,15 @@ func TestEnrichImageHandler_ReleasesClaimUnderCancelledCtx(t *testing.T) {
 // --- boot reconciliation sweep (#406) ---
 
 // fakeReconcileStore feeds the boot enrichment reconciliation sweep: the promoted
-// imageless targets to re-enqueue, and the orphan image blob keys to collect.
+// imageless targets to re-enqueue, and the set of Highlight ids that still have a
+// row (the orphan-image anti-join's membership half).
 type fakeReconcileStore struct {
 	targets   []storage.HighlightEnrichTarget
 	gotKind   string
-	orphans   []string
+	live      map[uuid.UUID]bool // ids with a surviving row
 	targetErr error
-	orphanErr error
+	existErr  error
+	gotExist  []uuid.UUID // ids the sweep asked HighlightsExist about
 }
 
 func (f *fakeReconcileStore) ListPromotedHighlightsNeedingEnrichment(_ context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error) {
@@ -292,11 +294,18 @@ func (f *fakeReconcileStore) ListPromotedHighlightsNeedingEnrichment(_ context.C
 	return f.targets, nil
 }
 
-func (f *fakeReconcileStore) ListOrphanHighlightImageKeys(_ context.Context) ([]string, error) {
-	if f.orphanErr != nil {
-		return nil, f.orphanErr
+func (f *fakeReconcileStore) HighlightsExist(_ context.Context, ids []uuid.UUID) (map[uuid.UUID]bool, error) {
+	f.gotExist = ids
+	if f.existErr != nil {
+		return nil, f.existErr
 	}
-	return f.orphans, nil
+	present := map[uuid.UUID]bool{}
+	for _, id := range ids {
+		if f.live[id] {
+			present[id] = true
+		}
+	}
+	return present, nil
 }
 
 // enrichEnqueued records one backstop enrichment enqueue.
@@ -355,61 +364,110 @@ func TestSweepEnrichmentReconciliation_EnqueuesForImagelessPromoted(t *testing.T
 	}
 }
 
-// TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs pins AC3 (#406): the
-// boot sweep drops image blobs whose Highlight row is gone (the delete-vs-enrich
-// interleaving orphan) through the seam.
+// imageKey builds a Highlight image blob key for the given tenant/highlight.
+func imageKey(tenantID, highlightID uuid.UUID) string {
+	return "t/" + tenantID.String() + "/highlight/" + highlightID.String() + "/image"
+}
+
+// TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs pins AC3 (#406/#421):
+// the boot sweep enumerates blobs THROUGH the seam (blob.Store.List), anti-joins
+// their embedded Highlight ids against live rows in Go, and drops ONLY the images
+// whose row is gone — the delete-vs-enrich interleaving orphans. A live row's
+// image, its audio clip (same owner-kind, different name), and another owner's
+// blob are all left untouched.
 func TestSweepEnrichmentReconciliation_CollectsOrphanImageBlobs(t *testing.T) {
+	tenantID := uuid.New()
+	liveID, goneID := uuid.New(), uuid.New()
+
 	blobs := newFakeBlobs()
-	k1 := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
-	k2 := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
-	blobs.data[k1] = []byte("a")
-	blobs.data[k2] = []byte("b")
-	store := &fakeReconcileStore{orphans: []string{k1, k2}}
+	liveImg := imageKey(tenantID, liveID)
+	liveClip := "t/" + tenantID.String() + "/highlight/" + liveID.String() + "/clip.wav"
+	orphanImg := imageKey(tenantID, goneID)
+	otherOwner := "t/" + tenantID.String() + "/campaign/" + uuid.New().String() + "/image"
+	blobs.data[liveImg] = []byte("live")
+	blobs.data[liveClip] = []byte("clip")
+	blobs.data[orphanImg] = []byte("orphan")
+	blobs.data[otherOwner] = []byte("other")
+
+	// Only liveID still has a row.
+	store := &fakeReconcileStore{live: map[uuid.UUID]bool{liveID: true}}
 
 	if err := SweepEnrichmentReconciliation(context.Background(), store, blobs, &enrichRecordingEnqueuer{}, testLog()); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
-	if blobs.keys() != 0 {
-		t.Fatalf("orphan image blobs not swept: %d left", blobs.keys())
+	if blobs.has(orphanImg) {
+		t.Fatal("orphan image blob (row gone) was not swept")
+	}
+	if !blobs.has(liveImg) || !blobs.has(liveClip) || !blobs.has(otherOwner) {
+		t.Fatalf("sweep touched a non-orphan blob: live=%v clip=%v other=%v",
+			blobs.has(liveImg), blobs.has(liveClip), blobs.has(otherOwner))
+	}
+	// The anti-join only asked about the highlight IMAGE keys, never the clip or
+	// the other owner's blob.
+	if len(store.gotExist) != 2 {
+		t.Fatalf("want membership checked for the 2 highlight image ids, got %v", store.gotExist)
 	}
 }
 
 // TestSweepEnrichmentReconciliation_NoWorkNoSideEffects: an empty catalog enqueues
-// and deletes nothing.
+// and deletes nothing — a live row's image is kept.
 func TestSweepEnrichmentReconciliation_NoWorkNoSideEffects(t *testing.T) {
+	tenantID, liveID := uuid.New(), uuid.New()
 	blobs := newFakeBlobs()
-	blobs.data["t/x/highlight/y/image"] = []byte("keep") // not reported as orphan
+	liveImg := imageKey(tenantID, liveID)
+	blobs.data[liveImg] = []byte("keep") // a live row's image, never an orphan
 	enq := &enrichRecordingEnqueuer{}
-	store := &fakeReconcileStore{}
+	store := &fakeReconcileStore{live: map[uuid.UUID]bool{liveID: true}}
 	if err := SweepEnrichmentReconciliation(context.Background(), store, blobs, enq, testLog()); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
 	if len(enq.all) != 0 {
 		t.Fatalf("no targets should enqueue nothing, got %v", enq.all)
 	}
-	if blobs.keys() != 1 {
-		t.Fatalf("no orphans should delete nothing, got %d left", blobs.keys())
+	if !blobs.has(liveImg) {
+		t.Fatal("a live row's image must not be swept")
 	}
 }
 
-// TestSweepEnrichmentReconciliation_ListErrorNonFatal pins AC4 (#406): a store
-// list failure is reported (so boot logs it) but never aborts — the OTHER half of
-// the sweep still runs. Here the target list fails yet the orphan sweep proceeds.
+// TestSweepEnrichmentReconciliation_ListErrorNonFatal pins AC4 (#406): a list
+// failure is reported (so boot logs it) but never aborts — the OTHER half of the
+// sweep still runs. Here the (a) target list fails yet the (b) orphan sweep
+// proceeds and drops the orphan.
 func TestSweepEnrichmentReconciliation_ListErrorNonFatal(t *testing.T) {
+	tenantID, goneID := uuid.New(), uuid.New()
 	blobs := newFakeBlobs()
-	orphan := "t/" + uuid.New().String() + "/highlight/" + uuid.New().String() + "/image"
+	orphan := imageKey(tenantID, goneID)
 	blobs.data[orphan] = []byte("a")
 	store := &fakeReconcileStore{
 		targetErr: errors.New("db down"),
-		orphans:   []string{orphan},
+		live:      map[uuid.UUID]bool{}, // goneID has no row → orphan
 	}
 	err := SweepEnrichmentReconciliation(context.Background(), store, blobs, &enrichRecordingEnqueuer{}, testLog())
 	if err == nil {
 		t.Fatal("want an error surfaced when a list fails (boot logs it non-fatally)")
 	}
 	// The orphan sweep still ran despite the target-list failure.
-	if blobs.keys() != 0 {
-		t.Fatalf("orphan sweep should still run when the target list fails; %d blobs left", blobs.keys())
+	if blobs.has(orphan) {
+		t.Fatal("orphan sweep should still run when the target list fails")
+	}
+}
+
+// TestSweepEnrichmentReconciliation_BlobListErrorNonFatal: the (b) blob-seam List
+// failing is reported but does not abort the (a) enqueue half.
+func TestSweepEnrichmentReconciliation_BlobListErrorNonFatal(t *testing.T) {
+	t1, h1 := uuid.New(), uuid.New()
+	blobs := newFakeBlobs()
+	blobs.listErr = errors.New("seam list down")
+	enq := &enrichRecordingEnqueuer{}
+	store := &fakeReconcileStore{targets: []storage.HighlightEnrichTarget{{HighlightID: h1, TenantID: t1}}}
+
+	err := SweepEnrichmentReconciliation(context.Background(), store, blobs, enq, testLog())
+	if err == nil {
+		t.Fatal("want an error surfaced when the blob-seam List fails")
+	}
+	// The (a) enqueue half still ran despite the (b) list failure.
+	if len(enq.all) != 1 {
+		t.Fatalf("target enqueue should still run when the blob list fails, got %d", len(enq.all))
 	}
 }
 

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -67,6 +67,7 @@ func (f *fakeEnrichStore) SetHighlightImage(_ context.Context, id uuid.UUID, key
 func (f *fakeEnrichStore) TryClaimHighlightEnrich(_ context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.claimCalls++ // count EVERY attempt (win or lose), not just winners
 	if f.claimErr != nil {
 		return false, f.claimErr
 	}
@@ -80,14 +81,20 @@ func (f *fakeEnrichStore) TryClaimHighlightEnrich(_ context.Context, id uuid.UUI
 		f.claimed = map[uuid.UUID]time.Time{}
 	}
 	f.claimed[id] = time.Now()
-	f.claimCalls++
 	return true, nil
 }
 
-func (f *fakeEnrichStore) ReleaseHighlightEnrichClaim(_ context.Context, id uuid.UUID) error {
+// ReleaseHighlightEnrichClaim mimics a real DB call: a cancelled ctx fails the
+// statement and the claim is NOT cleared. The handler must therefore release with
+// a cancel-immune ctx (context.WithoutCancel) so an error-path release under a
+// dead handler ctx still frees the claim.
+func (f *fakeEnrichStore) ReleaseHighlightEnrichClaim(ctx context.Context, id uuid.UUID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.releaseCalls++
+	if err := ctx.Err(); err != nil {
+		return err // a cancelled/expired ctx aborts the release; the claim lingers
+	}
 	delete(f.claimed, id)
 	return nil
 }
@@ -218,6 +225,50 @@ func TestEnrichImageHandler_Claim_GeneratesAtMostOnce(t *testing.T) {
 	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
 	if got.ImageKey == "" {
 		t.Fatal("winner did not land the image on the row")
+	}
+	// Both jobs attempted the claim; the winner landed the image, so NO release
+	// happened (release is only for non-image exits), and the loser bailed before
+	// owning the claim.
+	if store.claimCalls != 2 {
+		t.Fatalf("want 2 claim attempts (one per job), got %d", store.claimCalls)
+	}
+	if store.releaseCalls != 0 {
+		t.Fatalf("a winning enrichment must not release its claim, got %d releases", store.releaseCalls)
+	}
+}
+
+// TestEnrichImageHandler_ReleasesClaimUnderCancelledCtx pins the finding-2 fix
+// (#421): on an error-path exit the handler releases its claim so a fast retry can
+// re-claim without waiting out the TTL — and that release must succeed even when
+// the handler ctx is already cancelled (lease-timeout or shutdown). The release
+// therefore runs on a cancel-immune ctx.
+func TestEnrichImageHandler_ReleasesClaimUnderCancelledCtx(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+	// A provider error is a release-then-return exit path.
+	gen := &fakeGen{err: errors.New("provider 503")}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the handler runs with an already-dead ctx
+
+	if err := handler(ctx, payload); err == nil {
+		t.Fatal("provider error must surface so the runner retries")
+	}
+	// The claim was released despite the cancelled ctx: a real retry can re-claim
+	// immediately instead of burning attempts against a lingering claim.
+	if store.releaseCalls != 1 {
+		t.Fatalf("want exactly one release attempt, got %d", store.releaseCalls)
+	}
+	store.mu.Lock()
+	_, stillClaimed := store.claimed[h.ID]
+	store.mu.Unlock()
+	if stillClaimed {
+		t.Fatal("claim lingered: release ran with the dead handler ctx instead of a cancel-immune one")
 	}
 }
 

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -31,6 +31,33 @@ type fakeEnrichStore struct {
 	claimErr     error                   // returned by TryClaimHighlightEnrich when non-nil
 	claimCalls   int
 	releaseCalls int
+
+	// readBarrier, when set, holds every GetHighlight caller until N of them have
+	// arrived, then releases them together — so racing enrich jobs all read the
+	// un-enriched row BEFORE any of them writes (no timing assumption).
+	readBarrier *readBarrier
+}
+
+// readBarrier releases the first n callers together once all n have arrived.
+type readBarrier struct {
+	mu      sync.Mutex
+	n       int
+	arrived int
+	release chan struct{}
+}
+
+func newReadBarrier(n int) *readBarrier {
+	return &readBarrier{n: n, release: make(chan struct{})}
+}
+
+func (b *readBarrier) wait() {
+	b.mu.Lock()
+	b.arrived++
+	if b.arrived == b.n {
+		close(b.release)
+	}
+	b.mu.Unlock()
+	<-b.release
 }
 
 func newFakeEnrichStore() *fakeEnrichStore {
@@ -39,8 +66,14 @@ func newFakeEnrichStore() *fakeEnrichStore {
 
 func (f *fakeEnrichStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	h, ok := f.rows[id]
+	f.mu.Unlock()
+	// Barrier AFTER the snapshot (and NOT under f.mu, which would deadlock the
+	// arrivals): every reader captures the row's state before any of them returns,
+	// so a concurrent winner's later write can't make a loser read an enriched row.
+	if f.readBarrier != nil {
+		f.readBarrier.wait()
+	}
 	if !ok || h.TenantID != tenantID {
 		return storage.Highlight{}, storage.ErrNotFound
 	}
@@ -197,6 +230,11 @@ func TestEnrichImageHandler_HappyPath(t *testing.T) {
 func TestEnrichImageHandler_Claim_GeneratesAtMostOnce(t *testing.T) {
 	tenantID := uuid.New()
 	store := newFakeEnrichStore()
+	// Both jobs must clear the initial GetHighlight read BEFORE either writes, so
+	// neither can exit early via the idempotent ImageKey!="" guard — otherwise the
+	// loser races the winner's write and never attempts the claim. The barrier makes
+	// it deterministic (no sleeps).
+	store.readBarrier = newReadBarrier(2)
 	h := seedRow(store, tenantID)
 	blobs := newFakeBlobs()
 	gen := &fakeGen{res: imagegen.Result{Data: []byte("PNGDATA"), ContentType: "image/png", OutputTokens: 1290}}

--- a/internal/highlight/saver_test.go
+++ b/internal/highlight/saver_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -49,6 +51,7 @@ type fakeBlobs struct {
 	gate      chan struct{} // if non-nil, Put blocks until a receive
 	putErr    error
 	deleteErr error    // if set, Delete returns it (blob-backend failure)
+	listErr   error    // if set, List returns it (seam-list failure)
 	deleted   []string // keys passed to Delete (compensation assertions)
 }
 
@@ -87,6 +90,22 @@ func (f *fakeBlobs) Delete(_ context.Context, key string) error {
 	delete(f.data, key)
 	f.deleted = append(f.deleted, key)
 	return nil
+}
+
+func (f *fakeBlobs) List(_ context.Context, prefix string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var out []string
+	for k := range f.data {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 func (f *fakeBlobs) keys() int {

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -395,43 +395,38 @@ func (s *Store) ReleaseHighlightEnrichClaim(ctx context.Context, id uuid.UUID) e
 	return nil
 }
 
-// ListOrphanHighlightImageKeys returns every blob key under the Highlight IMAGE
-// owner-kind prefix (t/<tenant>/highlight/<id>/image, ADR-0048) whose embedded
-// Highlight id no longer matches any highlight row — the images a delete-vs-enrich
-// interleaving orphaned (the delete read the row with an empty image_key, then the
-// enrich committed a blob whose row was already gone), #406. It is the (b) half of
-// the boot reconciliation sweep. It ONLY matches the image name segment, so a
-// Highlight's audio clip (name 'clip.wav') under the SAME owner-kind is never
-// touched, and it only touches the 'highlight' owner-kind — never another owner's
-// blobs. An in-flight enrichment (row still present, image_key not yet set) is
-// NOT collected because the row's id still matches. Process-wide, carries no tenant.
-func (s *Store) ListOrphanHighlightImageKeys(ctx context.Context) ([]string, error) {
+// HighlightsExist reports which of the given Highlight ids still have a row,
+// returning a set (present ids map to true; absent ids are simply not in the map).
+// It is the membership half of the boot orphan-image sweep's anti-join (#421): the
+// sweep enumerates image blobs THROUGH the blob seam (blob.Store.List), extracts
+// each blob's Highlight id, then asks this which of them still exist — the blobs
+// whose id is absent are the delete-vs-enrich orphans. Keeping the anti-join in Go
+// (not a SELECT against the blob table) is what keeps the orphan sweep working
+// across a blob-backend swap (ADR-0048). An empty input runs no query. Process-wide,
+// carries no tenant (the ids are globally unique PKs).
+func (s *Store) HighlightsExist(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]bool, error) {
+	present := make(map[uuid.UUID]bool, len(ids))
+	if len(ids) == 0 {
+		return present, nil
+	}
 	rows, err := s.db.Query(ctx,
-		`SELECT b.key
-		   FROM blob b
-		  WHERE split_part(b.key, '/', 3) = 'highlight'
-		    AND split_part(b.key, '/', 5) = 'image'
-		    AND NOT EXISTS (
-		          SELECT 1 FROM highlight h
-		           WHERE h.id::text = split_part(b.key, '/', 4)
-		        )`)
+		`SELECT id FROM highlight WHERE id = ANY($1)`, ids)
 	if err != nil {
-		return nil, fmt.Errorf("storage: list orphan highlight image keys: %w", err)
+		return nil, fmt.Errorf("storage: highlights exist: %w", err)
 	}
 	defer rows.Close()
 
-	var out []string
 	for rows.Next() {
-		var k string
-		if err := rows.Scan(&k); err != nil {
-			return nil, fmt.Errorf("storage: scan orphan image key: %w", err)
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("storage: scan highlight id: %w", err)
 		}
-		out = append(out, k)
+		present[id] = true
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("storage: list orphan highlight image keys: %w", err)
+		return nil, fmt.Errorf("storage: highlights exist: %w", err)
 	}
-	return out, nil
+	return present, nil
 }
 
 // scanClipKeys runs a single-column clip_key query and collects the results.

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -365,14 +365,19 @@ func (s *Store) ListPromotedHighlightsNeedingEnrichment(ctx context.Context, enr
 // column is never scanned onto the wire, so the marker cannot leak into an RPC
 // response. Tenant-free (the id scopes the row, like SetHighlightImage).
 func (s *Store) TryClaimHighlightEnrich(ctx context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
-	cutoff := time.Now().Add(-ttl)
+	// Single-clock lease (#421): the stamp AND the expiry cutoff are both DB now(),
+	// so an app-clock skewed AHEAD of the DB can no longer shorten the effective TTL
+	// and reclaim a still-LIVE winner mid-generation (a double Generate). The app
+	// contributes only the TTL magnitude, never a wall-clock reading. make_interval's
+	// secs is double precision, so a sub-second TTL survives.
 	tag, err := s.db.Exec(ctx,
 		`UPDATE highlight
 		    SET image_enrich_claimed_at = now()
 		  WHERE id = $1
 		    AND image_key = ''
-		    AND (image_enrich_claimed_at IS NULL OR image_enrich_claimed_at < $2)`,
-		id, cutoff)
+		    AND (image_enrich_claimed_at IS NULL
+		         OR image_enrich_claimed_at < now() - make_interval(secs => $2))`,
+		id, ttl.Seconds())
 	if err != nil {
 		return false, fmt.Errorf("storage: claim highlight enrich %s: %w", id, err)
 	}

--- a/internal/storage/highlight_enrich_reconcile_test.go
+++ b/internal/storage/highlight_enrich_reconcile_test.go
@@ -26,7 +26,7 @@ func enrichJobPayload(t *testing.T, highlightID, tenantID uuid.UUID) []byte {
 
 // TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob
 // pins the (a)-half query of the boot reconciliation sweep (#406): only PROMOTED,
-// image_key=” Highlights with no pending/running/done enrich job are returned.
+// image_key='' Highlights with no pending/running/done enrich job are returned.
 func TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)

--- a/internal/storage/highlight_enrich_reconcile_test.go
+++ b/internal/storage/highlight_enrich_reconcile_test.go
@@ -4,13 +4,11 @@ package storage_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 
-	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -28,7 +26,7 @@ func enrichJobPayload(t *testing.T, highlightID, tenantID uuid.UUID) []byte {
 
 // TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob
 // pins the (a)-half query of the boot reconciliation sweep (#406): only PROMOTED,
-// image_key='' Highlights with no pending/running/done enrich job are returned.
+// image_key=” Highlights with no pending/running/done enrich job are returned.
 func TestListPromotedHighlightsNeedingEnrichment_SelectsOnlyImagelessPromotedWithNoLiveJob(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)
@@ -127,53 +125,44 @@ func TestTryClaimHighlightEnrich_ConditionalTransition(t *testing.T) {
 	}
 }
 
-// TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow pins the (b)-half query
-// (#406): only image blobs whose Highlight row is gone are returned — a live row's
-// image, the audio clip (same owner-kind, different name), and other owners' blobs
-// are all left alone.
-func TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow(t *testing.T) {
+// TestHighlightsExist_ReportsSurvivingRows pins the membership half of the boot
+// orphan-image sweep's anti-join (#421): given a mix of ids, only those with a
+// surviving highlight row come back present; a deleted/never-existed id is absent.
+// The anti-join itself (candidate blobs − present rows) runs in the sweep, in Go.
+func TestHighlightsExist_ReportsSurvivingRows(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)
 	ctx := context.Background()
 	st := storage.New(pool)
-	blobs := blob.NewPostgres(pool)
 
 	vs, err := st.CreateVoiceSession(ctx, campaignID)
 	if err != nil {
 		t.Fatalf("create voice session: %v", err)
 	}
 
-	put := func(key string) {
-		if err := blobs.Put(ctx, key, "image/png", strings.NewReader("x"), 1); err != nil {
-			t.Fatalf("put blob %s: %v", key, err)
-		}
-	}
-
-	// A live, enriched Highlight: row present + its image blob → NOT orphan.
 	liveID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
-	liveImg, _ := blob.Key(tenantID, "highlight", liveID, "image")
-	put(liveImg)
-	if err := st.SetHighlightImage(ctx, liveID, liveImg, "image/png", 1); err != nil {
-		t.Fatalf("set live image: %v", err)
-	}
-	// The same Highlight's audio clip (same owner-kind, name clip.wav) → NOT matched.
-	liveClip, _ := blob.Key(tenantID, "highlight", liveID, "clip.wav")
-	put(liveClip)
+	goneID := uuid.New() // no row was ever created
 
-	// An image blob whose Highlight row is GONE (delete-vs-enrich interleaving) → orphan.
-	goneID := uuid.New()
-	orphanImg, _ := blob.Key(tenantID, "highlight", goneID, "image")
-	put(orphanImg)
-
-	// A blob under a DIFFERENT owner-kind → never touched.
-	otherOwner, _ := blob.Key(tenantID, "campaign", uuid.New(), "image")
-	put(otherOwner)
-
-	got, err := st.ListOrphanHighlightImageKeys(ctx)
+	present, err := st.HighlightsExist(ctx, []uuid.UUID{liveID, goneID})
 	if err != nil {
-		t.Fatalf("list orphan image keys: %v", err)
+		t.Fatalf("highlights exist: %v", err)
 	}
-	if len(got) != 1 || got[0] != orphanImg {
-		t.Fatalf("want exactly the row-less image %s, got %+v", orphanImg, got)
+	if !present[liveID] {
+		t.Fatalf("live highlight %s reported absent", liveID)
+	}
+	if present[goneID] {
+		t.Fatalf("row-less id %s reported present", goneID)
+	}
+	if len(present) != 1 {
+		t.Fatalf("want exactly the surviving id in the set, got %v", present)
+	}
+
+	// Empty input runs no query and returns an empty set.
+	empty, err := st.HighlightsExist(ctx, nil)
+	if err != nil {
+		t.Fatalf("highlights exist (empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty input should yield an empty set, got %v", empty)
 	}
 }


### PR DESCRIPTION
Follow-up from the PR #418 review (#406). Four hardening items from that review — none broke an AC (all degrade to TTL-wait + boot-sweep recovery), tightened here as one small slice. No change to claim semantics, sweep scope, or job retry policy.

## Findings

**1 — blob-seam bypass in the orphan sweep** (`internal/blob`, `internal/highlight/enrich.go`, `internal/storage/highlight.go`)
`storage.ListOrphanHighlightImageKeys` queried the Postgres `blob` TABLE directly — the only blob-seam bypass in the repo (ADR-0048 chose the seam so an S3 swap stays contained); after a backend swap the sweep would silently find nothing and no test would fail. Now the seam gains `List(ctx, prefix)` (key-only enumeration; Postgres `starts_with` + `ORDER BY key`) and `ParseKey`/`KeyParts` (owner-kind/name/owner-id decoded in the blob package instead of via segment indices; `ValidateKey` delegates to it). `SweepEnrichmentReconciliation` (b) enumerates blobs through the seam, filters to the `highlight`/`image` owner-kind+name in Go, and anti-joins the embedded ids against live rows via the new bounded `storage.HighlightsExist` (`id = ANY`). The join lives in Go, so the sweep survives a backend swap.

**2 — release under a dead ctx** (`internal/highlight/enrich.go`)
`release()` closed over the handler ctx; on lease-timeout/shutdown every error-path release ran with a cancelled ctx and always failed, so the claim lingered the full 10m TTL and retries burned attempts against it. Release now runs on `context.WithoutCancel(ctx)`.

**3 — mixed-clock lease** (`internal/storage/highlight.go`)
`TryClaimHighlightEnrich` computed the cutoff from app `time.Now()` and compared it against a DB-stamped `now()` — an app clock skewed ahead of the DB shortened the effective TTL and could reclaim a LIVE winner (double Generate). The predicate is now entirely DB-clocked: `image_enrich_claimed_at < now() - make_interval(secs => $2)`; the app contributes only the TTL magnitude.

**4 — dead test plumbing** (`internal/highlight/enrich_test.go`)
`fakeEnrichStore.claimCalls/releaseCalls` were never asserted and `claimCalls` only counted winners. `claimCalls` now counts every attempt and both counters are asserted.

## Acceptance criteria
- [x] Orphan listing goes through the blob seam — `blob.Store.List`; fails on backend swap (sweep unit test drives `fakeBlobs.List`; blob `List` + `HighlightsExist` integration tests)
- [x] Release proven to succeed under a cancelled handler ctx — `TestEnrichImageHandler_ReleasesClaimUnderCancelledCtx`
- [x] Lease expiry compare is single-clock (SQL-side) — no app clock in the predicate; `TestTryClaimHighlightEnrich_ConditionalTransition` (incl. sub-second TTL) stays green
- [x] Dead test plumbing asserted — race test (2 claims / 0 releases) + cancelled-ctx test (1 release that clears the claim)

## Tests
Added/changed: `TestEnrichImageHandler_ReleasesClaimUnderCancelledCtx`, `TestSweepEnrichmentReconciliation_BlobListErrorNonFatal`, rewrote the three orphan-sweep unit tests to the seam+anti-join path, `TestListPrefixScan` (blob integration), `TestHighlightsExist_ReportsSurvivingRows` (storage integration); assertions added to the race test. Removed `TestListOrphanHighlightImageKeys_OnlyImageBlobsWithNoRow` (function deleted).

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
