### PR TITLE
fix(#399): dice-gate enforcement — prompt hardening + invented-roll guard

### DIFF
--- a/pkg/tool/loop.go
+++ b/pkg/tool/loop.go
@@ -43,8 +43,12 @@ type Loop struct {
 	// round); false when it was stripped without executing (ungranted or
 	// unparseable). nil is a no-op. It is the observability seam kept OUT of this
 	// vendor/metric-agnostic package (ADR-0028): the wiring layer supplies a
-	// callback that increments a counter.
-	OnPseudoCall func(name string, recovered bool)
+	// callback that increments a counter. ctx is the turn's context.Context (the
+	// same one Run/RunStream execute under), so a wiring-layer callback can also
+	// reach any per-turn value it stashed there — e.g. #399's "dice actually
+	// called" recorder must learn about a RECOVERED pseudo-dice call, which never
+	// surfaced as a provider-native ToolCall.
+	OnPseudoCall func(ctx context.Context, name string, recovered bool)
 }
 
 // NewLoop builds a Loop over provider and the Agent's grants. Both must be
@@ -147,7 +151,7 @@ func (l *Loop) RunStream(ctx context.Context, messages []Message, onText func(de
 			}
 		}
 
-		l.recoverPseudoCalls(round, &asst)
+		l.recoverPseudoCalls(ctx, round, &asst)
 
 		if len(asst.ToolCalls) == 0 {
 			return asst.Text, nil
@@ -211,7 +215,7 @@ func (l *Loop) Run(ctx context.Context, messages []Message) (string, error) {
 		// Scrub + recover any pseudo-XML tool calls the model emitted as text
 		// (issue #410): clean the spoken text and promote parseable granted calls
 		// to real ToolCalls before the tool-round decision below.
-		l.recoverPseudoCalls(round, &asst)
+		l.recoverPseudoCalls(ctx, round, &asst)
 
 		if len(asst.ToolCalls) == 0 {
 			return asst.Text, nil
@@ -286,7 +290,7 @@ func errResult(callID, msg string) ToolResult {
 //
 // round seeds the synthetic ToolCall IDs ("pseudo-<round>-<i>") so a recovered
 // call correlates to its tool-role result exactly like a provider-issued call.
-func (l *Loop) recoverPseudoCalls(round int, asst *AssistantMessage) {
+func (l *Loop) recoverPseudoCalls(ctx context.Context, round int, asst *AssistantMessage) {
 	clean, matches := ExtractPseudoCalls(asst.Text)
 	if len(matches) == 0 {
 		return
@@ -304,13 +308,13 @@ func (l *Loop) recoverPseudoCalls(round int, asst *AssistantMessage) {
 					Name:  m.Name,
 					Input: m.Args,
 				})
-				l.firePseudoCall(m.Name, true)
+				l.firePseudoCall(ctx, m.Name, true)
 				continue
 			}
 		}
 		// Ungranted, unparseable, or ineligible: strip-only. The intent is lost
 		// but the leak is contained, and the occurrence is logged + metered.
-		l.firePseudoCall(m.Name, false)
+		l.firePseudoCall(ctx, m.Name, false)
 		slog.Warn("tool: stripped un-recoverable pseudo-XML tool call from assistant text",
 			"tool", m.Name, "recovered", false)
 	}
@@ -328,8 +332,8 @@ func inlineEligible(t Tool) bool {
 	return ok && pm.ProposalMediated()
 }
 
-func (l *Loop) firePseudoCall(name string, recovered bool) {
+func (l *Loop) firePseudoCall(ctx context.Context, name string, recovered bool) {
 	if l.OnPseudoCall != nil {
-		l.OnPseudoCall(name, recovered)
+		l.OnPseudoCall(ctx, name, recovered)
 	}
 }

--- a/pkg/tool/pseudocall_loop_test.go
+++ b/pkg/tool/pseudocall_loop_test.go
@@ -14,7 +14,7 @@ type pseudoRecorder struct {
 	recovered []bool
 }
 
-func (r *pseudoRecorder) hook(name string, recovered bool) {
+func (r *pseudoRecorder) hook(_ context.Context, name string, recovered bool) {
 	r.names = append(r.names, name)
 	r.recovered = append(r.recovered, recovered)
 }

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -103,6 +103,51 @@ func consumeForcedChoice(ctx context.Context) (llm.ToolChoice, bool) {
 	return f.choice, true
 }
 
+// calledToolsKey is the context key under which [withCalledTools] stores the
+// per-turn set of Tool names the adapter actually executed a call for. The
+// invented-roll guard (#399) reads it back to answer "was the dice Tool really
+// called this turn" — the signal the post-hoc regeneration hinges on.
+type calledToolsKey struct{}
+
+// calledTools is the per-turn recorder behind [calledToolsKey]: the adapter marks
+// every Tool the model emitted a call for; the guard queries it with [has]. Safe
+// for the loop's single goroutine plus the race detector.
+type calledTools struct {
+	mu    sync.Mutex
+	names map[string]bool
+}
+
+// newCalledTools builds an empty per-turn called-Tools recorder.
+func newCalledTools() *calledTools { return &calledTools{names: map[string]bool{}} }
+
+// withCalledTools returns ctx carrying c, so the adapter records executed tool-call
+// names into it as the turn runs.
+func withCalledTools(ctx context.Context, c *calledTools) context.Context {
+	return context.WithValue(ctx, calledToolsKey{}, c)
+}
+
+// has reports whether a call for name was recorded this turn.
+func (c *calledTools) has(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.names[name]
+}
+
+// recordCalledTools marks every tool-call name in calls on the per-turn recorder
+// ctx carries, if any (a ctx without one is a silent no-op — the pre-#399 path and
+// the forced regeneration round both run without a recorder).
+func recordCalledTools(ctx context.Context, calls []tool.ToolCall) {
+	c, _ := ctx.Value(calledToolsKey{}).(*calledTools)
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, tc := range calls {
+		c.names[tc.Name] = true
+	}
+}
+
 // providerAdapter makes a streaming [llm.Provider] usable as the non-streaming
 // [tool.Provider] the tool-use loop drives. model and maxTokens are baked in
 // here because [tool.Provider.Generate] carries no generation knobs — the
@@ -212,24 +257,32 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 		if a.isToolSyntax(res) {
 			// Attempt 2: immediate retry, same tools + choice (no backoff).
 			a.rec.MalformedToolGen(a.provName, observe.MalformedStreamError)
+			// The failed attempt is being discarded; meter any usage it already
+			// reported so a retried round's provider-REPORTED tokens are not dropped
+			// (reported-only, never an estimate — ADR-0045).
+			a.recordReportedUsage(res.haveUsage, res.usage)
 			if err := ctx.Err(); err != nil {
-				return tool.AssistantMessage{}, err // barge between attempts aborts
+				return a.abortBetweenAttempts(ctx, err) // barge between attempts aborts
 			}
 			res = a.attempt(ctx, messages, tools, choice, onText)
 
 			if a.isToolSyntax(res) {
 				// Attempt 3: regenerate tool-less. Tools stay declared; tool_choice none.
 				a.rec.MalformedToolGen(a.provName, observe.MalformedStreamError)
+				a.recordReportedUsage(res.haveUsage, res.usage)
 				slog.Warn("agenttool: repeated tool_use_failed; regenerating tool-less",
 					"provider", string(a.provName), "round", round)
 				if err := ctx.Err(); err != nil {
-					return tool.AssistantMessage{}, err
+					return a.abortBetweenAttempts(ctx, err)
 				}
 				res = a.attempt(ctx, messages, tools, llm.ToolChoice{Mode: llm.ToolChoiceNone}, onText)
 			}
 		}
 	}
 
+	// Record which Tools the resolved round actually asked to run, for the #399
+	// invented-roll guard; a no-op unless this turn installed a [calledTools] set.
+	recordCalledTools(ctx, res.msg.ToolCalls)
 	return a.recordOutcome(ctx, round, start, messages, res)
 }
 
@@ -243,6 +296,22 @@ func (a providerAdapter) isToolSyntax(res attemptResult) bool {
 	}
 	var tse *providererr.ToolSyntaxError
 	return errors.As(res.err, &tse)
+}
+
+// abortBetweenAttempts records the provider-call outcome for a ctx cancellation
+// that lands between tool-syntax attempts, then returns the ctx error. Without
+// this the between-attempts abort bypassed [recordOutcome] entirely, silently
+// dropping the provider_call the other cancel paths (kindStartErr, kindCtxErr)
+// record — so a barge here went uncounted. It classifies via the shared
+// [observe.CallOutcome] rule (a barge cancel is OutcomeCanceled, not a fault; a
+// deadline is a timeout fault), matching kindStartErr.
+func (a providerAdapter) abortBetweenAttempts(ctx context.Context, err error) (tool.AssistantMessage, error) {
+	outcome := observe.CallOutcome(ctx, err)
+	a.rec.ProviderCall(observe.StageLLM, a.provName, outcome)
+	if outcome.IsFault() {
+		a.rec.ProviderError(observe.StageLLM, a.provName)
+	}
+	return tool.AssistantMessage{}, err
 }
 
 // requestedChoice returns the tool choice for this round: the one-shot forced
@@ -451,15 +520,6 @@ type Engine struct {
 	provName observe.Provider
 }
 
-// loopFor selects the loop for this turn: the full grants when the utterance
-// plausibly needs dice, the dice-less grants otherwise.
-func (e *Engine) loopFor(messages []llm.Message) *tool.Loop {
-	if needsDice(e.language, messages) {
-		return e.full
-	}
-	return e.gated
-}
-
 // EngineOption configures a [NewEngine]: [WithMetrics] opts the per-round LLM
 // instrumentation in, and [WithLanguage] selects the dice gate's keyword set.
 // Without either, the Engine records nothing and gates dice in English (the
@@ -551,15 +611,10 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, agentID, model stri
 }
 
 // Generate implements [agent.Engine]. It converts the assembled Hot Context to
-// [tool.Message]s and runs the loop to its final text. It installs a fresh
-// per-turn round counter into ctx so the adapter's LLMRound spans index from 0
-// for this turn and never share state with a concurrent turn (barge-in).
+// [tool.Message]s and runs the loop to its final text (see [Engine.generate]).
 func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, error) {
 	start := time.Now()
-	// Stamp the caller identity once per turn (S2): a scope-narrowing Tool handler
-	// resolves the Agent from ctx, never the LLM args.
-	ctx = tool.WithCaller(ctx, e.agentID)
-	out, err := e.loopFor(messages).Run(withRoundCounter(ctx), toToolMessages(messages))
+	out, err := e.generate(ctx, messages, nil)
 	// #125: one full-turn span per Generate, spanning every round, recorded on the
 	// success AND error path so a turn that fails mid-loop is still measured.
 	e.rec.LLMTurn(e.provName, time.Since(start))
@@ -569,18 +624,100 @@ func (e *Engine) Generate(ctx context.Context, messages []llm.Message) (string, 
 // GenerateStream implements [agent.StreamingEngine] (B1): it runs the same
 // tool-use loop but streams the final answer's prose deltas to onText as they
 // arrive, so the voice loop can segment and dispatch sentences before the
-// completion finishes. It installs the same per-turn round counter as
-// [Engine.Generate], so the A3 LLMRound / provider-call metrics are recorded
-// identically on the streaming production path. Returns the full final text.
+// completion finishes. On a dice-armed turn the reply is BUFFERED and the whole
+// text is pushed once after the invented-roll guard clears (#399, ADR-0012: a
+// spoken invented number cannot be unsaid, so an armed turn must not stream live);
+// the caller's sentence splitter handles the whole-text push exactly as the
+// non-streaming RunStream fallback does. Returns the full final text.
 func (e *Engine) GenerateStream(ctx context.Context, messages []llm.Message, onText func(delta string) error) (string, error) {
 	start := time.Now()
-	// Stamp the caller identity once per turn (S2), identical to Generate.
-	ctx = tool.WithCaller(ctx, e.agentID)
-	out, err := e.loopFor(messages).RunStream(withRoundCounter(ctx), toToolMessages(messages), onText)
+	out, err := e.generate(ctx, messages, onText)
 	// #125: the streaming production path records the same one-per-turn LLMTurn span
 	// Generate does, on success and error alike.
 	e.rec.LLMTurn(e.provName, time.Since(start))
 	return out, err
+}
+
+// generate is the shared body of [Engine.Generate] and [Engine.GenerateStream]. It
+// computes the dice-arming decision ONCE (replacing the old double-call loop
+// selection), then:
+//
+//   - Unarmed turn: the dice-less loop runs, streaming straight through to onText
+//     when the caller wants it (byte-identical to the pre-#399 path).
+//   - Armed turn: the system prompt is hardened on a COPIED slice (#399 Option B),
+//     the turn runs BUFFERED through the full loop — even on the streaming path —
+//     while a [calledTools] recorder tracks whether the dice Tool was actually
+//     executed, and the post-hoc invented-roll guard (Option C) runs before any
+//     prose is handed to onText.
+//
+// onText nil selects the non-streaming Generate path. It always stamps the caller
+// identity (S2) and a fresh per-turn round counter so LLMRound spans index from 0.
+func (e *Engine) generate(ctx context.Context, messages []llm.Message, onText func(delta string) error) (string, error) {
+	// Stamp the caller identity once per turn (S2): a scope-narrowing Tool handler
+	// resolves the Agent from ctx, never the LLM args.
+	ctx = tool.WithCaller(ctx, e.agentID)
+
+	if !needsDice(e.language, messages) {
+		// Plain turn: dice-less loop, no hardening, stream straight through. This
+		// path is byte-identical to the pre-#399 behaviour.
+		msgs := toToolMessages(messages)
+		if onText != nil {
+			return e.gated.RunStream(withRoundCounter(ctx), msgs, onText)
+		}
+		return e.gated.Run(withRoundCounter(ctx), msgs)
+	}
+
+	// Armed turn: harden the system prompt (copied slice) and run BUFFERED so the
+	// guard can rewrite the whole reply before a single number is spoken.
+	msgs := toToolMessages(withDiceHardening(messages))
+	called := newCalledTools()
+	text, err := e.full.Run(withCalledTools(withRoundCounter(ctx), called), msgs)
+	if err != nil {
+		return "", err
+	}
+
+	// Post-hoc guard (Option C): dice was armed, the dice Tool was never actually
+	// called, and the reply narrates a numeric roll result → the model invented it.
+	// Regenerate ONCE with the dice Tool forced; the forced round's provider failures
+	// flow into the #398 policy (no new retry). The discarded draft is NEVER
+	// delivered — on a regeneration error the turn fails rather than speak the
+	// invented number (ADR-0030: a discarded draft must not surface).
+	if !called.has(diceToolName) && claimsRollResult(text) {
+		e.rec.MalformedToolGen(e.provName, observe.MalformedRollClaim)
+		slog.Warn("agenttool: dice armed but model narrated an unrolled result; regenerating with forced dice tool",
+			"provider", string(e.provName))
+		forced := withForcedToolChoice(withRoundCounter(ctx), llm.ToolChoice{Mode: llm.ToolChoiceTool, Tool: diceToolName})
+		regen, rerr := e.full.Run(forced, msgs)
+		if rerr != nil {
+			return "", rerr
+		}
+		text = regen // deliver the regenerated reply as-is — the guard fires at most once
+	}
+
+	// Deliver the (possibly regenerated) whole text once — same whole-text push the
+	// non-streaming RunStream fallback performs, so the caller's sentence splitter
+	// behaves identically.
+	if onText != nil && text != "" {
+		if err := onText(text); err != nil {
+			return "", err
+		}
+	}
+	return text, nil
+}
+
+// withDiceHardening returns messages with [diceHardeningInstruction] appended to
+// the system prompt, on a COPIED slice so the caller's Hot Context is untouched
+// (#399 Option B). If messages[0] is the system message its text is extended;
+// otherwise a system message carrying the instruction is prepended. Applied only
+// on dice-armed turns.
+func withDiceHardening(messages []llm.Message) []llm.Message {
+	if len(messages) > 0 && messages[0].Role == llm.RoleSystem {
+		out := make([]llm.Message, len(messages))
+		copy(out, messages)
+		out[0].Text = out[0].Text + "\n\n" + diceHardeningInstruction
+		return out
+	}
+	return append([]llm.Message{{Role: llm.RoleSystem, Text: diceHardeningInstruction}}, messages...)
 }
 
 // toToolMessages converts the agent loop's [llm.Message]s into [tool.Message]s.

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -148,6 +148,19 @@ func recordCalledTools(ctx context.Context, calls []tool.ToolCall) {
 	}
 }
 
+// markCalledTool marks a single Tool name on the per-turn recorder ctx carries, if
+// any (a no-op otherwise). It is the seam for a call the adapter never saw as a
+// provider-native ToolCall — a pkg/tool-recovered pseudo-XML call (#410/#399).
+func markCalledTool(ctx context.Context, name string) {
+	c, _ := ctx.Value(calledToolsKey{}).(*calledTools)
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.names[name] = true
+}
+
 // providerAdapter makes a streaming [llm.Provider] usable as the non-streaming
 // [tool.Provider] the tool-use loop drives. model and maxTokens are baked in
 // here because [tool.Provider.Generate] carries no generation knobs — the
@@ -600,8 +613,17 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, agentID, model stri
 		// counter family as #398 with the text_leak path so provider flake stays
 		// visible. The scrub itself lives in pkg/tool (vendor/metric-agnostic,
 		// ADR-0028); this callback is the observability wiring.
-		l.OnPseudoCall = func(string, bool) {
+		l.OnPseudoCall = func(ctx context.Context, name string, recovered bool) {
 			cfg.rec.MalformedToolGen(cfg.provName, observe.MalformedTextLeak)
+			// #399: a RECOVERED pseudo-XML dice call is promoted to a real executed
+			// ToolCall downstream in pkg/tool, so it never reached the adapter as a
+			// provider-native ToolCall — mark it in the turn's called-Tools set so the
+			// invented-roll guard does not mistake a correctly-rolled reply for an
+			// invented one (which would double-count with text_leak and force a
+			// needless second RNG draw + round-trip).
+			if recovered {
+				markCalledTool(ctx, name)
+			}
 		}
 		return l
 	}

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -1716,3 +1716,46 @@ func TestEngine_PseudoXMLTextLeak_MetersMalformedTextLeak(t *testing.T) {
 		t.Errorf("MalformedToolGen paths = %v, want exactly [text_leak]", paths)
 	}
 }
+
+// TestEngine_RecoveredPseudoDice_SuppressesInventedRollGuard is the #399 review
+// gate: on a dice-armed turn the model emits its dice call as pseudo-XML TEXT (no
+// provider error). pkg/tool recovers it into a REAL executed ToolCall (#410) that
+// the adapter never saw as a provider-native call — but the OnPseudoCall(recovered)
+// seam marks "dice" in the turn's called-Tools set, so the invented-roll guard does
+// NOT fire: exactly one loop run (no forced regeneration), NO roll_claim counted
+// (only the text_leak from the recovery), and the delivered text is the follow-up
+// round's answer built on the real roll.
+func TestEngine_RecoveredPseudoDice_SuppressesInventedRollGuard(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		// Round 0: the dice call arrives as pseudo-XML text — recovered + executed.
+		{text: `Let me roll. <function=dice {"count":1,"sides":20}</function>`, stop: "end_turn"},
+		// Round 1: answers with the real result in context.
+		{text: "The bones show a 14, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "The bones show a 14, traveler." {
+		t.Errorf("delivered = %q, want the follow-up round's answer (no regeneration)", got)
+	}
+	// text_leak counted once by the recovery; NO roll_claim — the guard saw dice called.
+	if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedTextLeak {
+		t.Errorf("MalformedToolGen paths = %v, want exactly [text_leak] (recovered pseudo-dice must not trip the roll-claim guard)", paths)
+	}
+	// Exactly one loop run: round 0 (recovered call) + round 1 (answer) = 2 requests,
+	// and no forced-regeneration round.
+	reqs := prov.requests()
+	if len(reqs) != 2 {
+		t.Fatalf("Complete calls = %d, want 2 (recovered round-trip, no regeneration)", len(reqs))
+	}
+	for i, r := range reqs {
+		if r.ToolChoice.Mode == llm.ToolChoiceTool {
+			t.Errorf("req[%d] used forced tool choice %+v; want no forced regeneration", i, r.ToolChoice)
+		}
+	}
+}

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -1231,16 +1231,27 @@ func (p *deltaThenToolSyntaxProvider) Complete(context.Context, llm.Request) (<-
 // tool-syntax failure that arrives AFTER a prose delta was already forwarded to
 // onText is never retried — a re-drive would re-speak. The error propagates on the
 // first call.
+//
+// #399 note: dice-armed turns now BUFFER (no live streaming), so this re-speak
+// protection is exercised on the still-live streaming path — a NON-dice tool
+// (here "capture") declared on a plain, dice-unarmed turn, which routes through the
+// gated loop's RunStream and forwards deltas live.
 func TestEngine_ToolSyntax_ForwardedDeltaNotRetried(t *testing.T) {
 	prov := &deltaThenToolSyntaxProvider{}
 	rec := &recordingStage{}
-	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 0, 0,
+	// Grant a non-dice read-only tool so the dice-unarmed (streaming) turn still
+	// declares a tool — the round is tool-armed without being dice-armed.
+	var seen string
+	reg := tool.NewRegistry()
+	reg.MustRegister(callerCaptureTool{got: &seen})
+	grants := tool.NewGrantSet(reg, tool.Grant{ToolName: "capture"})
+	eng := agenttool.NewEngine(prov, grants, "", "m", 0, 0,
 		agenttool.WithMetrics(rec, observe.ProviderGroq),
 		agenttool.WithRetry(instantAgentRetry()))
 
 	var streamed strings.Builder
 	_, err := eng.GenerateStream(context.Background(),
-		[]llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}},
+		[]llm.Message{{Role: llm.RoleUser, Text: "Tell me about the inn."}},
 		func(delta string) error { streamed.WriteString(delta); return nil })
 	if err == nil {
 		t.Fatal("GenerateStream returned nil after a mid-stream tool_use_failed")
@@ -1299,6 +1310,16 @@ func TestEngine_ToolSyntax_CtxCancelBetweenAttemptsAborts(t *testing.T) {
 	if prov.calls != 1 {
 		t.Errorf("Complete calls = %d, want 1 (the retry must not dial after a cancel)", prov.calls)
 	}
+	// #399 drive-by B: the between-attempts abort must record its provider_call
+	// (canceled), like the other cancel paths — not silently drop it. A barge cancel
+	// is not a fault, so no provider_error.
+	outcomes, provErrs := rec.providerCalls()
+	if len(outcomes) != 1 || outcomes[0] != observe.OutcomeCanceled {
+		t.Errorf("provider_call outcomes = %v, want [canceled] (abort must be counted)", outcomes)
+	}
+	if provErrs != 0 {
+		t.Errorf("provider_errors = %d on a barge cancel between attempts, want 0 (not a fault)", provErrs)
+	}
 }
 
 // callerCaptureTool is a read-only, scope-supporting Tool that records the
@@ -1337,5 +1358,332 @@ func TestEngine_StampsCallerIdentity(t *testing.T) {
 	}
 	if seen != "agent-bart" {
 		t.Errorf("handler saw CallerID %q, want the Engine's agentID agent-bart", seen)
+	}
+}
+
+// --- #399 dice-gate enforcement: prompt hardening + invented-roll guard ---
+
+// hardeningSubstr is a byte-stable slice of the dice-hardening instruction the
+// armed turn appends to the system prompt; asserting containment avoids coupling
+// the test to the (unexported) full constant while still pinning the instruction.
+const hardeningSubstr = "Never invent, guess, or roleplay a die result."
+
+// TestEngine_DiceHardening_ArmedTurnAppendsInstruction is AC "prompt hardening
+// present on dice-armed turns": an armed utterance's first (system) request carries
+// the hardening instruction; a plain unarmed turn's system prompt does not.
+func TestEngine_DiceHardening_ArmedTurnAppendsInstruction(t *testing.T) {
+	t.Run("armed turn hardens the system prompt", func(t *testing.T) {
+		prov := &scriptedProvider{steps: []step{
+			{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+			{text: "You rolled well.", stop: "end_turn"},
+		}}
+		eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0)
+		if _, err := eng.Generate(context.Background(), []llm.Message{
+			{Role: llm.RoleSystem, Text: "You are Bart."},
+			{Role: llm.RoleUser, Text: "Roll a d20 for me."},
+		}); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		sys := prov.requests()[0].Messages[0]
+		if sys.Role != llm.RoleSystem || !strings.Contains(sys.Text, hardeningSubstr) {
+			t.Errorf("armed system prompt = %q, want it to contain the hardening instruction", sys.Text)
+		}
+		if !strings.Contains(sys.Text, "You are Bart.") {
+			t.Errorf("armed system prompt dropped the original persona: %q", sys.Text)
+		}
+	})
+
+	t.Run("unarmed turn is not hardened", func(t *testing.T) {
+		prov := &scriptedProvider{steps: []step{{text: "A copper, traveler.", stop: "end_turn"}}}
+		eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0)
+		if _, err := eng.Generate(context.Background(), []llm.Message{
+			{Role: llm.RoleSystem, Text: "You are Bart."},
+			{Role: llm.RoleUser, Text: "How much for a pint?"},
+		}); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if sys := prov.requests()[0].Messages[0]; strings.Contains(sys.Text, hardeningSubstr) {
+			t.Errorf("unarmed system prompt was hardened: %q", sys.Text)
+		}
+	})
+}
+
+// TestEngine_InventedRoll_RegeneratesWithForcedDice is the headline AC: dice armed,
+// the model narrates a roll result WITHOUT calling the tool → the reply is discarded
+// and regenerated with the dice tool FORCED; the delivered reply reflects the
+// actually executed roll, and exactly one roll-claim malformed-gen is counted.
+func TestEngine_InventedRoll_RegeneratesWithForcedDice(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		// Run 1 (buffered): invents a result, no tool call.
+		{text: "Ah, eine 19! Du hast Gluck.", stop: "end_turn"},
+		// Forced regen round 0: now it calls the dice tool.
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		// Forced regen round 1: answers with the real result in context.
+		{text: "The bones show an 8, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{
+		{Role: llm.RoleSystem, Text: "You are Bart."},
+		{Role: llm.RoleUser, Text: "Wurfel einen D20 fur mich."},
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "The bones show an 8, traveler." {
+		t.Errorf("delivered = %q, want the regenerated reply reflecting the executed roll", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedRollClaim {
+		t.Errorf("MalformedToolGen paths = %v, want exactly [roll_claim]", paths)
+	}
+
+	reqs := prov.requests()
+	if len(reqs) != 3 {
+		t.Fatalf("Complete calls = %d, want 3 (buffered run + forced regen round-trip)", len(reqs))
+	}
+	// Buffered first run: auto choice.
+	if reqs[0].ToolChoice.Mode != llm.ToolChoiceAuto {
+		t.Errorf("first-run tool_choice = %q, want auto", reqs[0].ToolChoice.Mode)
+	}
+	// Forced regen round 0: pinned to the dice tool.
+	if reqs[1].ToolChoice.Mode != llm.ToolChoiceTool || reqs[1].ToolChoice.Tool != "dice" {
+		t.Errorf("forced-regen round-0 tool_choice = %+v, want tool:dice", reqs[1].ToolChoice)
+	}
+	// Forced regen round 1 (after the tool result): one-shot spent, back to auto.
+	if reqs[2].ToolChoice.Mode != llm.ToolChoiceAuto {
+		t.Errorf("forced-regen round-1 tool_choice = %q, want auto (forced choice is one-shot)", reqs[2].ToolChoice.Mode)
+	}
+}
+
+// TestEngine_NativeDiceCall_NoRegeneration is AC "dice armed, model calls the tool
+// properly → no regeneration": a proper tool round-trip fires the guard for nobody,
+// so there is exactly one loop run and no roll-claim counted.
+func TestEngine_NativeDiceCall_NoRegeneration(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "You rolled an 8, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "You rolled an 8, traveler." {
+		t.Errorf("delivered = %q, want the native round-trip answer", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 0 {
+		t.Errorf("MalformedToolGen paths = %v, want none (the tool was called)", paths)
+	}
+	reqs := prov.requests()
+	if len(reqs) != 2 {
+		t.Fatalf("Complete calls = %d, want 2 (single round-trip, no regeneration)", len(reqs))
+	}
+	for i, r := range reqs {
+		if r.ToolChoice.Mode == llm.ToolChoiceTool {
+			t.Errorf("req[%d] used forced tool choice %+v; want no forced regeneration", i, r.ToolChoice)
+		}
+	}
+}
+
+// TestEngine_NotArmed_GuardNeverFires is AC "dice not armed → reply text never
+// triggers the guard": a plain turn whose reply contains a bare number is delivered
+// untouched — the guard is gated on the dice-armed decision.
+func TestEngine_NotArmed_GuardNeverFires(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{{text: "That'll be 5 silver, traveler.", stop: "end_turn"}}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "How much for a room?"}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "That'll be 5 silver, traveler." {
+		t.Errorf("delivered = %q, want the reply untouched", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 0 {
+		t.Errorf("MalformedToolGen paths = %v, want none (guard is armed-only)", paths)
+	}
+	if n := len(prov.requests()); n != 1 {
+		t.Errorf("Complete calls = %d, want 1 (no regeneration on an unarmed turn)", n)
+	}
+}
+
+// TestEngine_InventedRoll_SingleEscalation is AC "guard fires at most once per
+// turn": if the FORCED regeneration still narrates a bare number, it is delivered
+// as-is — the guard does not loop. Exactly two loop runs (buffered + one regen).
+func TestEngine_InventedRoll_SingleEscalation(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "Ah, eine 19!", stop: "end_turn"},          // run 1: invented
+		{text: "Trust me, a solid 17.", stop: "end_turn"}, // forced regen: still a bare number, no tool call
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "Trust me, a solid 17." {
+		t.Errorf("delivered = %q, want the single regeneration delivered as-is", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 1 {
+		t.Errorf("MalformedToolGen count = %d, want 1 (guard fires at most once)", len(paths))
+	}
+	if n := len(prov.requests()); n != 2 {
+		t.Errorf("Complete calls = %d, want 2 (buffered run + exactly one regeneration)", n)
+	}
+}
+
+// guardRegenErrProvider narrates a bare roll result on its first (buffered) call,
+// then start-errors every forced regeneration call — so the #399 guard's one
+// escalation fails and the turn must propagate the error, never the invented draft.
+type guardRegenErrProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *guardRegenErrProvider) Complete(_ context.Context, _ llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.mu.Unlock()
+	if n == 1 {
+		ch := make(chan llm.StreamEvent)
+		go func() {
+			defer close(ch)
+			ch <- llm.StreamEvent{Type: llm.EventText, Text: "Ah, eine 19! "}
+			ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+		}()
+		return ch, nil
+	}
+	return nil, &providererr.HTTPError{Op: "test.Complete", StatusCode: 400, Status: "Bad Request", Body: "boom"}
+}
+
+// TestEngine_InventedRoll_RegenErrorPropagatesNeverDeliversDraft is AC-adjacent
+// (ADR-0030, #398/#399): when the forced regeneration fails at the provider, the
+// turn returns the error and NEVER delivers the discarded invented-roll draft.
+func TestEngine_InventedRoll_RegenErrorPropagatesNeverDeliversDraft(t *testing.T) {
+	prov := &guardRegenErrProvider{}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err == nil {
+		t.Fatal("Generate returned nil; want the forced-regeneration provider error")
+	}
+	if got != "" {
+		t.Errorf("delivered = %q on a failed regeneration; the discarded draft must never surface", got)
+	}
+}
+
+// TestEngine_GenerateStream_ArmedTurnBuffersThenDeliversOnce is AC/TDD-9: on the
+// streaming path a dice-armed turn BUFFERS — onText receives nothing until the guard
+// clears, then the whole final text exactly once (never live word-by-word deltas),
+// so an invented number can never be spoken mid-stream (ADR-0012).
+func TestEngine_GenerateStream_ArmedTurnBuffersThenDeliversOnce(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "You rolled a solid eight, traveler.", stop: "end_turn"},
+	}}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0)
+
+	var deltas []string
+	full, err := eng.GenerateStream(context.Background(),
+		[]llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}},
+		func(delta string) error { deltas = append(deltas, delta); return nil })
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if strings.TrimSpace(full) != "You rolled a solid eight, traveler." {
+		t.Errorf("full = %q, want the buffered final text", full)
+	}
+	if len(deltas) != 1 {
+		t.Fatalf("onText called %d times, want exactly 1 (whole-text push, buffered — not live deltas)", len(deltas))
+	}
+	if strings.TrimSpace(deltas[0]) != "You rolled a solid eight, traveler." {
+		t.Errorf("single delta = %q, want the whole final text", deltas[0])
+	}
+}
+
+// usageThenToolSyntaxProvider reports usage then fails tool-syntax on its first
+// `fails` calls (a mid-stream tool_use_failed AFTER an EventUsage), then streams the
+// answer with its own usage. It drives the #399 drive-by A: a discarded failed
+// attempt's provider-REPORTED usage must still be metered (ADR-0045).
+type usageThenToolSyntaxProvider struct {
+	mu         sync.Mutex
+	calls      int
+	fails      int
+	failUsage  llm.Usage
+	answer     string
+	finalUsage llm.Usage
+}
+
+func (p *usageThenToolSyntaxProvider) Complete(_ context.Context, _ llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.mu.Unlock()
+	ch := make(chan llm.StreamEvent, 3)
+	if n <= p.fails {
+		ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: p.failUsage}
+		ch <- llm.StreamEvent{Type: llm.EventError, Err: "tool_use_failed", ErrClass: llm.ErrClassToolSyntax}
+		close(ch)
+		return ch, nil
+	}
+	go func() {
+		defer close(ch)
+		ch <- llm.StreamEvent{Type: llm.EventText, Text: p.answer}
+		ch <- llm.StreamEvent{Type: llm.EventUsage, Usage: p.finalUsage}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	}()
+	return ch, nil
+}
+
+// TestEngine_ToolSyntax_RetriedAttemptReportedUsageMetered is #399 drive-by A: a
+// tool-syntax attempt that already reported usage before failing is discarded on
+// retry, but its provider-REPORTED tokens are still metered — never dropped, never
+// estimated (ADR-0045). Two LLMTokens spans: the failed attempt's + the final round's.
+func TestEngine_ToolSyntax_RetriedAttemptReportedUsageMetered(t *testing.T) {
+	prov := &usageThenToolSyntaxProvider{
+		fails:      1,
+		failUsage:  llm.Usage{InputTokens: 10, OutputTokens: 2},
+		answer:     "You rolled well.",
+		finalUsage: llm.Usage{InputTokens: 40, OutputTokens: 7},
+	}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	if _, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	toks := rec.tokenSpans()
+	if len(toks) != 2 {
+		t.Fatalf("LLMTokens spans = %d, want 2 (discarded attempt's reported usage + final round)", len(toks))
+	}
+	var sawFail, sawFinal bool
+	for _, tk := range toks {
+		if tk.in == 10 && tk.out == 2 {
+			sawFail = true
+		}
+		if tk.in == 40 && tk.out == 7 {
+			sawFinal = true
+		}
+	}
+	if !sawFail {
+		t.Error("the discarded tool-syntax attempt's reported usage (10/2) was dropped; want it metered")
+	}
+	if !sawFinal {
+		t.Error("the final recovered round's usage (40/7) was not metered")
 	}
 }

--- a/pkg/voice/agenttool/rollclaim.go
+++ b/pkg/voice/agenttool/rollclaim.go
@@ -1,0 +1,27 @@
+package agenttool
+
+import "regexp"
+
+// diceHardeningInstruction is appended to the system prompt on dice-armed turns
+// (#399, Option B): cheap prompt hardening that tells the model to call the dice
+// Tool and never narrate an invented result. Not airtight on its own — the
+// post-hoc [claimsRollResult] guard is the enforcement backstop.
+const diceHardeningInstruction = "When asked to roll dice, call the dice tool and report its actual result. Never invent, guess, or roleplay a die result."
+
+// standaloneRollNumber matches a bare 1..100 integer standing on its own word
+// boundaries — the numeric shape a narrated die result takes ("a 19", "eine 19",
+// "a perfect 100"). A number outside 1..100 (a price, a year) mostly falls
+// outside the range, but the detector is recall-biased on purpose (see
+// [claimsRollResult]).
+var standaloneRollNumber = regexp.MustCompile(`\b([1-9][0-9]?|100)\b`)
+
+// claimsRollResult reports whether text reads as a narrated die result (#399,
+// Option C): explicit die notation ("d20", "2w6", "d%") is stripped first — those
+// are the request, not a result — and what remains is checked for a standalone
+// 1..100 integer. Language-free and recall-biased: a false positive only costs one
+// regeneration on a turn where the dice Tool was already armed, whereas a false
+// negative would ship an invented number, so the detector leans toward firing.
+func claimsRollResult(text string) bool {
+	stripped := diceNotation.ReplaceAllString(text, " ")
+	return standaloneRollNumber.MatchString(stripped)
+}

--- a/pkg/voice/agenttool/rollclaim.go
+++ b/pkg/voice/agenttool/rollclaim.go
@@ -13,6 +13,13 @@ const diceHardeningInstruction = "When asked to roll dice, call the dice tool an
 // "a perfect 100"). A number outside 1..100 (a price, a year) mostly falls
 // outside the range, but the detector is recall-biased on purpose (see
 // [claimsRollResult]).
+//
+// Residual: the 1..100 cap misses a 3-digit invented result ("Ergebnis: 120") —
+// a false NEGATIVE. This is deliberate: extending to arbitrary integers would
+// false-POSITIVE on years, quantities, and gold amounts on the far more common
+// non-roll turns, and the cap covers every single die (d100 is the largest
+// standard die). Revisit if live traffic shows the model narrating multi-die SUMS
+// above 100 (e.g. "3d100") without calling the tool.
 var standaloneRollNumber = regexp.MustCompile(`\b([1-9][0-9]?|100)\b`)
 
 // claimsRollResult reports whether text reads as a narrated die result (#399,

--- a/pkg/voice/agenttool/rollclaim_internal_test.go
+++ b/pkg/voice/agenttool/rollclaim_internal_test.go
@@ -1,0 +1,31 @@
+package agenttool
+
+import "testing"
+
+// TestClaimsRollResult pins the recall-biased invented-roll detector (#399): after
+// stripping explicit die notation (so "W20"/"d20" tokens do not count as a claimed
+// result), a standalone 1..100 integer in the reply reads as a narrated roll result.
+// The detector is language-free and deliberately over-triggers — a false positive
+// only costs one regeneration on a turn where dice was already armed.
+func TestClaimsRollResult(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"bare result number", "Ah, eine 19! Du hast einen scharfen Blick.", true},
+		{"notation stripped leaves no number", "Ich würfle den W20 für dich.", false},
+		{"english notation stripped", "Let me roll a d20 for you.", false},
+		{"no numbers at all", "The bones are silent tonight, traveler.", false},
+		{"recall bias: non-roll number still fires", "Das macht 20 Goldstücke.", true},
+		{"three-digit non-roll number ignored", "Es kostet 250 Gold.", false},
+		{"hundred is a valid result", "A perfect 100 on the nose.", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claimsRollResult(tc.text); got != tc.want {
+				t.Errorf("claimsRollResult(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/voice-cassettes/llm-tool-dice.yaml
+++ b/tests/voice-cassettes/llm-tool-dice.yaml
@@ -14,13 +14,13 @@
 # against the live Groq API with `-tags=record` (GROQ_API_KEY supplies
 # credentials; the dice seed stays fixed in the test).
 exchanges:
-  - prompt_hash: 94d0e3189c69ee6b6fe388161f54ceab89eb6bbfa2871cbbfb806c02580244e1
+  - prompt_hash: f95da03d0b253bde411523d540677e72099284dba06ef137d64bfbbd9875fc98
     tool_calls:
       - id: toolu_roll1
         name: dice
         input: '{"count":1,"sides":20}'
     stop_reason: tool_use
-  - prompt_hash: 42ee6314e058ae5b1b559a3c22eee6ee8984ceedb1833c7976a85d7012362c92
+  - prompt_hash: 332b372ab31d70e03a8625f4ce9e18d0da515e7b0b04a9905ec4c7f5ebc1e882
     text: "The bones favor you tonight, traveler."
     stop_reason: end_turn
-notes: Hand-authored fixture for the tool-use-loop replay test; prompt_hashes pin model llama-3.3-70b-versatile (Groq); dice rng seeded PCG(42,99), first draw.
+notes: Hand-authored fixture for the tool-use-loop replay test; prompt_hashes pin model llama-3.3-70b-versatile (Groq); dice rng seeded PCG(42,99), first draw. Both hashes include the #399 dice-hardening instruction the armed turn appends to the system prompt (the utterance "Roll a d20 for my luck" arms the dice gate), so they reflect the hardened system message.


### PR DESCRIPTION
Closes #399

## What

Dice-armed turns now **enforce** tool use instead of merely offering it. Two layers over the #398 tool-choice seam, all inside `pkg/voice/agenttool`:

- **Prompt hardening (Option B):** on a dice-armed turn the system prompt gains `"When asked to roll dice, call the dice tool and report its actual result. Never invent, guess, or roleplay a die result."` on a COPIED Hot-Context slice (or a prepended system message when there is none).
- **Post-hoc invented-roll guard (Option C):** the arming decision is computed ONCE and the armed turn runs **BUFFERED** — `loop.Run` even on the `GenerateStream` path, because a spoken invented number cannot be unsaid (ADR-0012). If the dice tool was never actually called AND the reply narrates a bare 1..100 roll result (`rollclaim.go`, language-free + recall-biased: die-notation stripped first), the draft is discarded and the round regenerated **once** with `tool_choice=tool:dice`. The reply reflecting the actually-executed roll is delivered. A regeneration provider error propagates — the discarded draft is **never** delivered (ADR-0030). Guard fires at most once per turn; one `MalformedRollClaim` counted per escalation.

`Engine.Generate`/`GenerateStream` are refactored to a shared `generate()`. "Dice actually called" is a per-turn ctx recorder (`withCalledTools`) the adapter writes tool-call names into (pattern of `roundCounterKey`; zero `pkg/tool` change).

## Drive-by fixes (from PR #420 review, same package)

- A retried tool-syntax attempt's provider-REPORTED usage is now metered before the attempt is discarded, instead of dropped (reported-only, ADR-0045).
- The between-attempts ctx-cancel abort now records its `provider_call(canceled)` like the other cancel paths, rather than silently skipping `recordOutcome`.

## Tests (TDD)

- `TestClaimsRollResult` — detector: "Ah, eine 19!"→true; "Ich würfle den W20"→false (notation stripped); no numbers→false; "20 Goldstücke"→true (documented recall bias); 100 valid; 3-digit ignored.
- `TestEngine_DiceHardening_ArmedTurnAppendsInstruction` — armed system prompt hardened; unarmed not.
- `TestEngine_InventedRoll_RegeneratesWithForcedDice` — roll-claim text without a tool call → forced regen (`ToolChoice=tool:dice` on the forced round-0, auto after), executed roll delivered, `roll_claim=1`.
- `TestEngine_NativeDiceCall_NoRegeneration` — proper tool call → exactly one run, no regen.
- `TestEngine_NotArmed_GuardNeverFires` — unarmed numeric reply delivered untouched.
- `TestEngine_InventedRoll_SingleEscalation` — regen still claims → delivered as-is, exactly two runs.
- `TestEngine_InventedRoll_RegenErrorPropagatesNeverDeliversDraft` — regen provider error → error returned, draft not delivered.
- `TestEngine_GenerateStream_ArmedTurnBuffersThenDeliversOnce` — armed stream buffers → single whole-text push.
- `TestEngine_ToolSyntax_RetriedAttemptReportedUsageMetered` + extended `TestEngine_ToolSyntax_CtxCancelBetweenAttemptsAborts` — the two drive-bys.

Adapter one-shot forced choice is covered by the existing `TestForcedToolChoice_OneShotConsumedOnFirstCall` plus the forced-round request assertions above. `TestEngine_ToolSyntax_ForwardedDeltaNotRetried` was rerouted through a non-dice tool on the still-live streaming path (dice-armed turns no longer stream live).

## ADR-0021

The dice-armed turn's system prompt changed, so `tests/voice-cassettes/llm-tool-dice.yaml` prompt_hashes were re-derived deterministically (bench uses a `stubProvider`, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)