### PR TITLE
fix(#428): highlight-classify observability — per-pass logs + bounded outcome metric

### DIFF
--- a/internal/highlight/detector.go
+++ b/internal/highlight/detector.go
@@ -495,6 +495,14 @@ func (d *Detector) logClassify(w *workerState, cls classification, outcome obser
 			"outcome", string(outcome),
 			"window", len(w.window),
 			"excerpt", boundExcerpt(raw, classifyExcerptRunes))
+	case observe.HighlightLLMError:
+		// The complete/stream WARN in runClassifier already carries the error detail;
+		// this adds the uniform per-pass line so every outcome is greppable by the
+		// shared message + outcome/window attrs (#428 Finding 3).
+		d.log.Warn("highlight classify",
+			"parsed", false,
+			"window", len(w.window),
+			"outcome", string(outcome))
 	case observe.HighlightOK:
 		d.log.Info("highlight classify",
 			"score", cls.score,

--- a/internal/highlight/detector.go
+++ b/internal/highlight/detector.go
@@ -26,6 +26,20 @@ const (
 	windowCap = 40
 )
 
+// classifyMetrics counts Session-Highlights classifier passes by bounded outcome
+// (#428). It is the detector's non-StageRecorder metric seam: the production
+// *observe.PrometheusRecorder satisfies it, so the injected StageRecorder is
+// type-asserted onto it — no constructor widening (ADR-0032 bounded-label counter).
+type classifyMetrics interface {
+	HighlightClassify(observe.HighlightOutcome)
+}
+
+// noopClassifyMetrics is the default when the injected recorder does not implement
+// the outcome sink (a test Discard, a keyless build): outcomes are simply not counted.
+type noopClassifyMetrics struct{}
+
+func (noopClassifyMetrics) HighlightClassify(observe.HighlightOutcome) {}
+
 // finalLine is one transcript final retained in the rolling window.
 type finalLine struct {
 	speaker string
@@ -53,8 +67,13 @@ type Detector struct {
 	sink     Sink
 	gate     orchestrator.TurnGate
 	metrics  observe.StageRecorder
-	log      *slog.Logger
-	cfg      Config
+	// classifyMetric counts one classify-outcome per pass (#428). It is recovered
+	// from the injected StageRecorder when that recorder also satisfies it (the
+	// production *observe.PrometheusRecorder does) — a non-StageRecorder bounded-label
+	// counter reached without widening the constructor (ADR-0032). Never nil.
+	classifyMetric classifyMetrics
+	log            *slog.Logger
+	cfg            Config
 
 	now func() time.Time // injected in tests; time.Now in production
 
@@ -120,22 +139,29 @@ func newDetector(provider llm.Provider, model string, snap SnapshotFunc, sink Si
 	if metrics == nil {
 		metrics = observe.Discard{}
 	}
+	// Recover the classify-outcome sink from the shared recorder without a new seam:
+	// the production recorder implements it; anything else counts nothing (#428).
+	var classifyMetric classifyMetrics = noopClassifyMetrics{}
+	if cm, ok := metrics.(classifyMetrics); ok {
+		classifyMetric = cm
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Detector{
-		provider: provider,
-		model:    model,
-		snap:     snap,
-		sink:     sink,
-		gate:     gate,
-		metrics:  metrics,
-		log:      log,
-		cfg:      cfg.withDefaults(),
-		now:      time.Now,
-		ctx:      ctx,
-		cancel:   cancel,
-		done:     make(chan struct{}),
-		signal:   make(chan struct{}, 1),
-		features: make(chan frameFeature, featureMailboxCap),
+		provider:       provider,
+		model:          model,
+		snap:           snap,
+		sink:           sink,
+		gate:           gate,
+		metrics:        metrics,
+		classifyMetric: classifyMetric,
+		log:            log,
+		cfg:            cfg.withDefaults(),
+		now:            time.Now,
+		ctx:            ctx,
+		cancel:         cancel,
+		done:           make(chan struct{}),
+		signal:         make(chan struct{}, 1),
+		features:       make(chan frameFeature, featureMailboxCap),
 	}
 }
 
@@ -302,7 +328,11 @@ func (d *Detector) classify(w *workerState, e voiceevent.STTFinal) {
 	}
 
 	req := buildRequest(d.model, w.window, w.feat.summarize())
-	cls := d.runClassifier(req)
+	cls, outcome, raw := d.runClassifier(req)
+	// One outcome count per classify pass (#428, bounded label — ADR-0032), plus the
+	// single per-pass observability line, before the confirm/streak bookkeeping.
+	d.classifyMetric.HighlightClassify(outcome)
+	d.logClassify(w, cls, outcome, raw)
 	d.notifyClassified(cls)
 
 	if cls.score >= d.cfg.Bar {
@@ -358,6 +388,10 @@ func (d *Detector) emit(w *workerState, anchor time.Time, cls classification, no
 		Excerpt:    excerpt,
 		Reason:     cls.reason,
 	}
+	// A confirmed trigger is the headline highlight signal: log it at INFO with the
+	// score and the clip range so a live run shows promotions, not just below-bar
+	// passes (#428). AC4.
+	d.log.Info("highlight trigger confirmed", "score", trig.Score, "from", trig.From, "to", trig.To)
 	d.scheduleCut(from, to, trig)
 }
 
@@ -385,19 +419,28 @@ func (d *Detector) scheduleCut(from, to time.Time, trig Trigger) {
 	}()
 }
 
+// classifyExcerptRunes bounds the raw model text logged on a parse-fail WARN: the
+// full generation is never logged (it can be long and carry chain-of-thought), only
+// a leading excerpt of at most this many runes (not bytes) for triage (#428).
+const classifyExcerptRunes = 200
+
 // runClassifier drives one provider completion, meters its token usage on the
 // stage recorder (ADR-0045/0046), and parses the verdict. It never crashes the
 // worker: a provider error, a truncated stream, or malformed JSON yields a zero
-// score (the moment is simply not confirmed).
-func (d *Detector) runClassifier(req llm.Request) classification {
+// score (the moment is simply not confirmed). It returns the parsed verdict, the
+// bounded classify outcome (#428) with precedence llm_error > parse_failed > ok, and
+// the raw model text (for the parse-fail excerpt). The existing complete/stream
+// WARNs are retained; the per-pass INFO/WARN and the outcome count are the caller's.
+func (d *Detector) runClassifier(req llm.Request) (classification, observe.HighlightOutcome, string) {
 	stream, err := d.provider.Complete(d.ctx, req)
 	if err != nil {
 		d.log.Warn("highlight classify: llm complete", "err", err)
-		return classification{}
+		return classification{}, observe.HighlightLLMError, ""
 	}
 	var sb strings.Builder
 	var usage llm.Usage
 	var haveUsage bool
+	var streamErr bool
 	for ev := range stream {
 		switch ev.Type {
 		case llm.EventText:
@@ -406,6 +449,7 @@ func (d *Detector) runClassifier(req llm.Request) classification {
 			usage, haveUsage = ev.Usage, true
 		case llm.EventError:
 			d.log.Warn("highlight classify: llm stream error", "err", ev.Err)
+			streamErr = true
 		}
 	}
 	in, out := usage.InputTokens, usage.OutputTokens
@@ -414,7 +458,50 @@ func (d *Detector) runClassifier(req llm.Request) classification {
 		out = estimateTokens(utf8.RuneCountInString(sb.String()))
 	}
 	d.metrics.LLMTokens(d.cfg.ProviderLabel, d.model, in, out)
-	return parseClassification(sb.String())
+	raw := sb.String()
+	cls, parsed := parseClassification(raw)
+	// Precedence: a stream error outranks a parse outcome — the model never
+	// delivered a trustworthy verdict, so the pass is an llm_error even if the
+	// truncated text happened to slice into parseable JSON.
+	if streamErr {
+		return cls, observe.HighlightLLMError, raw
+	}
+	if !parsed {
+		return cls, observe.HighlightParseFailed, raw
+	}
+	return cls, observe.HighlightOK, raw
+}
+
+// boundExcerpt returns text truncated to at most n runes (not bytes), for the
+// parse-fail WARN excerpt (#428).
+func boundExcerpt(text string, n int) string {
+	if utf8.RuneCountInString(text) <= n {
+		return text
+	}
+	runes := []rune(text)
+	return string(runes[:n])
+}
+
+// logClassify emits the one per-pass observability line for a classify (#428): an
+// INFO carrying the score, the parsed flag and the transcript-window line count on a
+// parsed verdict (so a below-bar pass is visible in the default live config), or a
+// WARN with a rune-bounded raw excerpt when the completed stream held no parseable
+// verdict. An llm_error pass already logged its complete/stream WARN in
+// runClassifier, so it adds no second line here (the outcome counter carries it).
+func (d *Detector) logClassify(w *workerState, cls classification, outcome observe.HighlightOutcome, raw string) {
+	switch outcome {
+	case observe.HighlightParseFailed:
+		d.log.Warn("highlight classify: unparseable verdict",
+			"outcome", string(outcome),
+			"window", len(w.window),
+			"excerpt", boundExcerpt(raw, classifyExcerptRunes))
+	case observe.HighlightOK:
+		d.log.Info("highlight classify",
+			"score", cls.score,
+			"parsed", true,
+			"window", len(w.window),
+			"outcome", string(outcome))
+	}
 }
 
 // notifyClassified is the white-box test hook: production leaves classified nil, so

--- a/internal/highlight/observe_test.go
+++ b/internal/highlight/observe_test.go
@@ -1,0 +1,294 @@
+package highlight
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/llm"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// ---- observability test doubles --------------------------------------------
+
+// logCapture is a slog.Handler that retains every record so a test can assert the
+// level, message and attrs the detector logged.
+type logCapture struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (c *logCapture) Enabled(context.Context, slog.Level) bool { return true }
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	c.records = append(c.records, r.Clone())
+	c.mu.Unlock()
+	return nil
+}
+func (c *logCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *logCapture) WithGroup(string) slog.Handler      { return c }
+
+// find returns the first record with the given message, or ok=false.
+func (c *logCapture) find(msg string) (slog.Record, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, r := range c.records {
+		if r.Message == msg {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+// attrValue reads one attr's value off a record.
+func attrValue(r slog.Record, key string) (slog.Value, bool) {
+	var v slog.Value
+	found := false
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			v, found = a.Value, true
+			return false
+		}
+		return true
+	})
+	return v, found
+}
+
+// captureMetrics is a StageRecorder that also implements the highlight-classify
+// outcome sink, retaining every outcome the detector counts.
+type captureMetrics struct {
+	observe.Discard
+	mu       sync.Mutex
+	outcomes []observe.HighlightOutcome
+}
+
+func (m *captureMetrics) HighlightClassify(o observe.HighlightOutcome) {
+	m.mu.Lock()
+	m.outcomes = append(m.outcomes, o)
+	m.mu.Unlock()
+}
+
+func (m *captureMetrics) all() []observe.HighlightOutcome {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]observe.HighlightOutcome(nil), m.outcomes...)
+}
+
+// errCompleteProvider fails the Complete call outright (an llm_error before any
+// stream frame).
+type errCompleteProvider struct{}
+
+func (errCompleteProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	return nil, errors.New("complete boom")
+}
+
+// streamErrProvider completes but surfaces an in-stream error frame.
+type streamErrProvider struct{}
+
+func (streamErrProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 2)
+	ch <- llm.StreamEvent{Type: llm.EventError, Err: "mid-stream boom"}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
+// startObserved builds and starts a detector with an injected clock, classified
+// notify channel, capturing metrics and log — the observability-test analogue of
+// buildDetector.
+func startObserved(t *testing.T, bus *voiceevent.Bus, prov llm.Provider, snap SnapshotFunc, sink Sink, gate orchestrator.TurnGate, metrics observe.StageRecorder, log *slog.Logger, cfg Config) (*Detector, *testClock, <-chan classification) {
+	t.Helper()
+	clk := &testClock{t: time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)}
+	d := newDetector(prov, "test-model", snap, sink, gate, metrics, log, cfg)
+	d.now = clk.now
+	classified := make(chan classification, 256)
+	d.classified = classified
+	d.handled = make(chan struct{}, 1)
+	d.start(bus)
+	t.Cleanup(d.Close)
+	return d, clk, classified
+}
+
+// ---- tests -----------------------------------------------------------------
+
+// TestClassifyBelowBarLogsInfo (AC1): a classify that parses and scores below Bar
+// emits one INFO line carrying the score, a parsed=true flag, and the window line
+// count, and counts outcome ok.
+func TestClassifyBelowBarLogsInfo(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(2.0) }}
+	sink := &fakeSink{}
+	cap := &logCapture{}
+	metrics := &captureMetrics{}
+	d, clk, classified := startObserved(t, bus, prov, nil, sink, allowGate{}, metrics, slog.New(cap), Config{ClassifyEvery: 6, Bar: 8.0})
+
+	for i := 0; i < 6; i++ {
+		publishFinals(t, d, bus, clk, "A", 1)
+	}
+	awaitClassifications(t, classified, 1)
+
+	rec, ok := cap.find("highlight classify")
+	if !ok {
+		t.Fatal("no INFO classify log line emitted")
+	}
+	if rec.Level != slog.LevelInfo {
+		t.Errorf("classify log level = %v, want INFO", rec.Level)
+	}
+	if v, ok := attrValue(rec, "score"); !ok || v.Float64() != 2.0 {
+		t.Errorf("score attr = %v (ok=%v), want 2.0", v, ok)
+	}
+	if v, ok := attrValue(rec, "parsed"); !ok || v.Bool() != true {
+		t.Errorf("parsed attr = %v (ok=%v), want true", v, ok)
+	}
+	if v, ok := attrValue(rec, "window"); !ok || v.Int64() != 6 {
+		t.Errorf("window attr = %v (ok=%v), want 6", v, ok)
+	}
+	if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightOK {
+		t.Errorf("outcomes = %v, want [ok]", got)
+	}
+}
+
+// TestClassifyParseFailWarns (AC2): a completed stream whose text carries no
+// parseable verdict logs a WARN with a rune-bounded excerpt and counts parse_failed.
+func TestClassifyParseFailWarns(t *testing.T) {
+	long := strings.Repeat("é", 500) // 500 runes, 1000 bytes — no JSON object at all
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return long }}
+	sink := &fakeSink{}
+	cap := &logCapture{}
+	metrics := &captureMetrics{}
+	d, clk, classified := startObserved(t, bus, prov, nil, sink, allowGate{}, metrics, slog.New(cap), Config{ClassifyEvery: 2, Bar: 8.0})
+
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+
+	rec, ok := cap.find("highlight classify: unparseable verdict")
+	if !ok {
+		t.Fatal("no WARN parse-fail log line emitted")
+	}
+	if rec.Level != slog.LevelWarn {
+		t.Errorf("parse-fail log level = %v, want WARN", rec.Level)
+	}
+	v, ok := attrValue(rec, "excerpt")
+	if !ok {
+		t.Fatal("no excerpt attr on parse-fail WARN")
+	}
+	exc := v.String()
+	if n := utf8.RuneCountInString(exc); n > 200 {
+		t.Errorf("excerpt rune count = %d, want <=200 (bounded)", n)
+	}
+	if !strings.HasPrefix(long, exc) {
+		t.Errorf("excerpt is not a prefix of the raw model text")
+	}
+	if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightParseFailed {
+		t.Errorf("outcomes = %v, want [parse_failed]", got)
+	}
+}
+
+// TestClassifyLLMErrorCounts (AC3): a provider Complete error and an in-stream
+// error frame both count llm_error, and the existing WARNs are retained.
+func TestClassifyLLMErrorCounts(t *testing.T) {
+	t.Run("complete error", func(t *testing.T) {
+		bus := voiceevent.NewBus()
+		sink := &fakeSink{}
+		cap := &logCapture{}
+		metrics := &captureMetrics{}
+		d, clk, classified := startObserved(t, bus, errCompleteProvider{}, nil, sink, allowGate{}, metrics, slog.New(cap), Config{ClassifyEvery: 2})
+
+		publishFinals(t, d, bus, clk, "A", 2)
+		awaitClassifications(t, classified, 1)
+
+		if _, ok := cap.find("highlight classify: llm complete"); !ok {
+			t.Error("existing complete-error WARN not retained")
+		}
+		if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightLLMError {
+			t.Errorf("outcomes = %v, want [llm_error]", got)
+		}
+	})
+
+	t.Run("stream error frame", func(t *testing.T) {
+		bus := voiceevent.NewBus()
+		sink := &fakeSink{}
+		cap := &logCapture{}
+		metrics := &captureMetrics{}
+		d, clk, classified := startObserved(t, bus, streamErrProvider{}, nil, sink, allowGate{}, metrics, slog.New(cap), Config{ClassifyEvery: 2})
+
+		publishFinals(t, d, bus, clk, "A", 2)
+		awaitClassifications(t, classified, 1)
+
+		if _, ok := cap.find("highlight classify: llm stream error"); !ok {
+			t.Error("existing stream-error WARN not retained")
+		}
+		if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightLLMError {
+			t.Errorf("outcomes = %v, want [llm_error]", got)
+		}
+	})
+}
+
+// TestTriggerLogsInfo (AC4): a confirmed trigger logs at INFO with the score and
+// the clip From/To range.
+func TestTriggerLogsInfo(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(9.0) }}
+	sink := &fakeSink{}
+	snap := func(from, to time.Time) tape.Snapshot { return tape.Snapshot{From: from, To: to} }
+	cap := &logCapture{}
+	metrics := &captureMetrics{}
+	d, clk, _ := startObserved(t, bus, prov, snap, sink, allowGate{}, metrics, slog.New(cap), Config{
+		ClassifyEvery: 2, Bar: 8.0, ConfirmWindows: 1, Cooldown: time.Hour,
+		Lead: 15 * time.Second, Tail: 40 * time.Millisecond,
+	})
+
+	at := clk.now()
+	publishFinals(t, d, bus, clk, "A", 2)
+	waitForTriggers(t, sink, 1)
+
+	rec, ok := cap.find("highlight trigger confirmed")
+	if !ok {
+		t.Fatal("no INFO trigger log line emitted")
+	}
+	if rec.Level != slog.LevelInfo {
+		t.Errorf("trigger log level = %v, want INFO", rec.Level)
+	}
+	if v, ok := attrValue(rec, "score"); !ok || v.Float64() != 9.0 {
+		t.Errorf("score attr = %v (ok=%v), want 9.0", v, ok)
+	}
+	if v, ok := attrValue(rec, "from"); !ok || v.Time().Before(at.Add(-16*time.Second)) || v.Time().After(at.Add(-14*time.Second)) {
+		t.Errorf("from attr = %v (ok=%v), want ~at-15s", v, ok)
+	}
+	if _, ok := attrValue(rec, "to"); !ok {
+		t.Error("no to attr on trigger INFO")
+	}
+}
+
+// TestOutcomeCounterIncrementsPerPass (AC5): every classify pass increments the
+// outcome counter exactly once — three low-score passes yield three ok increments.
+func TestOutcomeCounterIncrementsPerPass(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(1.0) }}
+	sink := &fakeSink{}
+	metrics := &captureMetrics{}
+	d, clk, classified := startObserved(t, bus, prov, nil, sink, allowGate{}, metrics, slog.New(&logCapture{}), Config{ClassifyEvery: 2, Bar: 8.0})
+
+	for i := 0; i < 3; i++ {
+		publishFinals(t, d, bus, clk, "A", 2)
+		awaitClassifications(t, classified, 1)
+	}
+
+	if got := metrics.all(); len(got) != 3 {
+		t.Fatalf("outcome count = %d, want 3 (one per pass)", len(got))
+	}
+	for i, o := range metrics.all() {
+		if o != observe.HighlightOK {
+			t.Errorf("outcome[%d] = %q, want ok", i, o)
+		}
+	}
+}

--- a/internal/highlight/observe_test.go
+++ b/internal/highlight/observe_test.go
@@ -101,6 +101,20 @@ func (streamErrProvider) Complete(context.Context, llm.Request) (<-chan llm.Stre
 	return ch, nil
 }
 
+// streamErrThenValidProvider surfaces an in-stream error frame AND a fully parseable
+// verdict, so the outcome hinges purely on precedence: llm_error must outrank a
+// clean parse (a regression that checked parse→ok first would wrongly report ok).
+type streamErrThenValidProvider struct{}
+
+func (streamErrThenValidProvider) Complete(context.Context, llm.Request) (<-chan llm.StreamEvent, error) {
+	ch := make(chan llm.StreamEvent, 3)
+	ch <- llm.StreamEvent{Type: llm.EventText, Text: `{"score": 3.0, "excerpt": "x", "reason": "y"}`}
+	ch <- llm.StreamEvent{Type: llm.EventError, Err: "mid-stream boom"}
+	ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "end_turn"}
+	close(ch)
+	return ch, nil
+}
+
 // startObserved builds and starts a detector with an injected clock, classified
 // notify channel, capturing metrics and log — the observability-test analogue of
 // buildDetector.
@@ -153,6 +167,28 @@ func TestClassifyBelowBarLogsInfo(t *testing.T) {
 	}
 	if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightOK {
 		t.Errorf("outcomes = %v, want [ok]", got)
+	}
+}
+
+// TestClassifyOutcomeCountedThroughUsageTee (AC5, capped-session path): a capped
+// tenant's Manager wraps the recorder in observe.TeeUsage(base, meter) before it
+// reaches the detector. The tee embeds StageRecorder only, so the outcome-sink
+// capability must forward through it — otherwise glyphoxa_voice_highlight_classify_total
+// never increments for exactly the capped sessions where classify+spend-gate
+// interplay matters. Here the teed recorder must still deliver the outcome to base.
+func TestClassifyOutcomeCountedThroughUsageTee(t *testing.T) {
+	bus := voiceevent.NewBus()
+	prov := &fakeProvider{respJSON: func(int) string { return scoreJSON(2.0) }}
+	sink := &fakeSink{}
+	base := &captureMetrics{}
+	teed := observe.TeeUsage(base, observe.Discard{}) // meter stand-in: any UsageSink
+	d, clk, classified := startObserved(t, bus, prov, nil, sink, allowGate{}, teed, slog.New(&logCapture{}), Config{ClassifyEvery: 2, Bar: 8.0})
+
+	publishFinals(t, d, bus, clk, "A", 2)
+	awaitClassifications(t, classified, 1)
+
+	if got := base.all(); len(got) != 1 || got[0] != observe.HighlightOK {
+		t.Errorf("outcomes through tee = %v, want [ok] (capability lost behind the usage tee)", got)
 	}
 }
 
@@ -209,6 +245,18 @@ func TestClassifyLLMErrorCounts(t *testing.T) {
 		if _, ok := cap.find("highlight classify: llm complete"); !ok {
 			t.Error("existing complete-error WARN not retained")
 		}
+		// Uniform per-pass line: every outcome is greppable by the shared "highlight
+		// classify" message carrying outcome + window (Finding 3).
+		rec, ok := cap.find("highlight classify")
+		if !ok {
+			t.Fatal("no uniform per-pass line on the llm_error path")
+		}
+		if v, ok := attrValue(rec, "outcome"); !ok || v.String() != string(observe.HighlightLLMError) {
+			t.Errorf("outcome attr = %v (ok=%v), want llm_error", v, ok)
+		}
+		if v, ok := attrValue(rec, "window"); !ok || v.Int64() != 2 {
+			t.Errorf("window attr = %v (ok=%v), want 2", v, ok)
+		}
 		if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightLLMError {
 			t.Errorf("outcomes = %v, want [llm_error]", got)
 		}
@@ -229,6 +277,22 @@ func TestClassifyLLMErrorCounts(t *testing.T) {
 		}
 		if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightLLMError {
 			t.Errorf("outcomes = %v, want [llm_error]", got)
+		}
+	})
+
+	// Precedence proof: a stream error alongside a fully parseable verdict is
+	// llm_error, not ok — the model never delivered a trustworthy verdict.
+	t.Run("stream error outranks a clean parse", func(t *testing.T) {
+		bus := voiceevent.NewBus()
+		sink := &fakeSink{}
+		metrics := &captureMetrics{}
+		d, clk, classified := startObserved(t, bus, streamErrThenValidProvider{}, nil, sink, allowGate{}, metrics, slog.New(&logCapture{}), Config{ClassifyEvery: 2})
+
+		publishFinals(t, d, bus, clk, "A", 2)
+		awaitClassifications(t, classified, 1)
+
+		if got := metrics.all(); len(got) != 1 || got[0] != observe.HighlightLLMError {
+			t.Errorf("outcomes = %v, want [llm_error] (precedence llm_error > ok broken)", got)
 		}
 	})
 }

--- a/internal/highlight/prompt.go
+++ b/internal/highlight/prompt.go
@@ -65,13 +65,16 @@ func promptRunes(req llm.Request) int {
 // parseClassification extracts the classifier's JSON verdict from the model's
 // prose. It is deliberately tolerant (a classifier that wraps the object in prose
 // or fences still parses): it slices from the first '{' to the last '}' and
-// unmarshals. A malformed or absent object yields a zero score — a classify never
-// crashes the worker (the highlight is simply not confirmed).
-func parseClassification(text string) classification {
+// unmarshals. It reports parse success as the second return: a malformed or absent
+// object yields a zero score AND ok=false, so the caller can distinguish a genuine
+// low-score verdict from an unparseable stream (#428) — either way a classify never
+// crashes the worker (the highlight is simply not confirmed). The slicing behaviour
+// is identical to the pre-#428 tolerant parse; only the ok signal is new.
+func parseClassification(text string) (classification, bool) {
 	start := strings.IndexByte(text, '{')
 	end := strings.LastIndexByte(text, '}')
 	if start < 0 || end <= start {
-		return classification{}
+		return classification{}, false
 	}
 	var raw struct {
 		Score   float64 `json:"score"`
@@ -79,9 +82,9 @@ func parseClassification(text string) classification {
 		Reason  string  `json:"reason"`
 	}
 	if err := json.Unmarshal([]byte(text[start:end+1]), &raw); err != nil {
-		return classification{}
+		return classification{}, false
 	}
-	return classification{score: raw.Score, excerpt: raw.Excerpt, reason: raw.Reason}
+	return classification{score: raw.Score, excerpt: raw.Excerpt, reason: raw.Reason}, true
 }
 
 // estimateTokens is the ceil(chars/4) per-direction token estimate (ADR-0045),

--- a/internal/highlight/prompt_test.go
+++ b/internal/highlight/prompt_test.go
@@ -11,37 +11,44 @@ func TestParseClassification(t *testing.T) {
 		in        string
 		wantScore float64
 		wantExc   string
+		wantOK    bool
 	}{
 		{
 			name:      "bare object",
 			in:        `{"score": 9.5, "excerpt": "nat 20", "reason": "crit"}`,
 			wantScore: 9.5,
 			wantExc:   "nat 20",
+			wantOK:    true,
 		},
 		{
 			name:      "fenced code block",
 			in:        "```json\n{\"score\": 7.0, \"excerpt\": \"clutch\", \"reason\": \"save\"}\n```",
 			wantScore: 7.0,
 			wantExc:   "clutch",
+			wantOK:    true,
 		},
 		{
 			name:      "prose wrapped",
 			in:        `Sure, here is my verdict: {"score": 3.5, "excerpt": "meh", "reason": "chatter"} hope that helps!`,
 			wantScore: 3.5,
 			wantExc:   "meh",
+			wantOK:    true,
 		},
-		{name: "no json", in: "I could not decide.", wantScore: 0, wantExc: ""},
-		{name: "malformed json", in: `{"score": not-a-number}`, wantScore: 0, wantExc: ""},
-		{name: "empty", in: "", wantScore: 0, wantExc: ""},
+		{name: "no json", in: "I could not decide.", wantScore: 0, wantExc: "", wantOK: false},
+		{name: "malformed json", in: `{"score": not-a-number}`, wantScore: 0, wantExc: "", wantOK: false},
+		{name: "empty", in: "", wantScore: 0, wantExc: "", wantOK: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseClassification(tc.in)
+			got, ok := parseClassification(tc.in)
 			if got.score != tc.wantScore {
 				t.Errorf("score = %v, want %v", got.score, tc.wantScore)
 			}
 			if got.excerpt != tc.wantExc {
 				t.Errorf("excerpt = %q, want %q", got.excerpt, tc.wantExc)
+			}
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
 			}
 		})
 	}

--- a/internal/observe/prometheus.go
+++ b/internal/observe/prometheus.go
@@ -98,6 +98,13 @@ type PrometheusRecorder struct {
 	// Sets it from CountUnembeddedNodes, Set-from-COUNT like embeddingBacklog.
 	kgEmbeddingBacklog prometheus.Gauge
 
+	// highlight classify (#428, ADR-0032): Session-Highlights classifier passes by
+	// bounded outcome (ok / parse_failed / llm_error). Non-StageRecorder like
+	// memoryRecall/kgFacts — the detector records against a local interface this
+	// adapter satisfies. Makes a live classifier pass observable next to the shared
+	// llm_tokens meter it is otherwise indistinguishable from.
+	highlightClassify *prometheus.CounterVec // outcome
+
 	// memory recall (#122, ADR-0042/0032): NPC Hot Context recalls by outcome —
 	// a speculation hit, an inline miss, or a degraded/unconfigured skip. The
 	// outcome label is a bounded three-value enum (ADR-0032).
@@ -138,6 +145,25 @@ const (
 	// FactsDegraded: the read degraded to no-facts — the budget elapsed or the DB
 	// read failed. A barge cancel is NOT degraded (it counts nothing).
 	FactsDegraded FactsOutcome = "degraded"
+)
+
+// HighlightOutcome is the bounded outcome label on the Session-Highlights
+// classify-outcome counter (glyphoxa_voice_highlight_classify_total, #428). Exactly
+// three values reach a series (ADR-0032): the classifier stream parsed a verdict,
+// the completed stream carried no parseable verdict, or the provider Complete/stream
+// errored. One increment per classify pass; the precedence when more than one could
+// apply is llm_error > parse_failed > ok (the detector owns that resolution).
+type HighlightOutcome string
+
+const (
+	// HighlightOK: the classifier completed and its verdict parsed to a score.
+	HighlightOK HighlightOutcome = "ok"
+	// HighlightParseFailed: the stream completed with no parseable JSON verdict, so
+	// the score degraded to zero (the moment is simply not confirmed).
+	HighlightParseFailed HighlightOutcome = "parse_failed"
+	// HighlightLLMError: the provider Complete call failed, or the stream surfaced an
+	// error frame. Distinct from a parse failure — the model never delivered a verdict.
+	HighlightLLMError HighlightOutcome = "llm_error"
 )
 
 // RecallOutcome is the bounded outcome label on the NPC memory-recall counter
@@ -261,6 +287,10 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		Help:      "Malformed tool generations by provider and the detection path that caught it (#398: a tool_use_failed retried; #399/#410 add roll_claim/text_leak).",
 	}, []string{"provider", "path"})
 
+	r.highlightClassify = counterVec("highlight_classify_total",
+		"Session-Highlights classifier passes by bounded outcome (#428, ADR-0032): a parsed verdict (ok), a completed stream with no parseable verdict (parse_failed), or a provider Complete/stream error (llm_error).",
+		"outcome")
+
 	r.memoryRecall = counterVec("memory_recall_total",
 		"NPC memory recalls by outcome (#122, ADR-0042): a speculation hit, an inline miss, or a degraded skip.",
 		"outcome")
@@ -298,7 +328,7 @@ func NewPrometheusRecorder() *PrometheusRecorder {
 		r.responseLatency, r.vadHangover, r.addressDetect, r.codecDecode,
 		r.codecEncode, r.sttRequest, r.ttsTTFB, r.ttsTotal, r.llmRound, r.llmTurn,
 		r.providerCalls, r.providerErrors, r.turnTotal, r.embeddingBacklog,
-		r.kgEmbeddingBacklog, r.memoryRecall, r.kgFacts,
+		r.kgEmbeddingBacklog, r.memoryRecall, r.kgFacts, r.highlightClassify,
 		r.jobsBacklog, r.jobsTotal, r.jobDuration,
 		r.llmTokens, r.ttsCharacters, r.sttAudioSeconds, r.malformedToolGen,
 		// Standard runtime collectors so /metrics also reports process/Go health.
@@ -405,6 +435,14 @@ func (r *PrometheusRecorder) MalformedToolGen(p Provider, path MalformedPath) {
 // StageRecorder contract: recall is not an orchestrator stage.
 func (r *PrometheusRecorder) MemoryRecall(o RecallOutcome) {
 	r.memoryRecall.WithLabelValues(string(o)).Inc()
+}
+
+// HighlightClassify counts one Session-Highlights classifier pass by its bounded
+// outcome (#428, ADR-0032). It is the standalone classify-metrics sink the
+// internal/highlight detector records against (its local interface), separate from
+// the StageRecorder contract: a classify is not an orchestrator stage.
+func (r *PrometheusRecorder) HighlightClassify(o HighlightOutcome) {
+	r.highlightClassify.WithLabelValues(string(o)).Inc()
 }
 
 // KGFacts counts one NPC Hot Context KG-fact read by its bounded outcome (#126,

--- a/internal/observe/prometheus_test.go
+++ b/internal/observe/prometheus_test.go
@@ -107,6 +107,31 @@ func TestPrometheusScrapeExposesSeries(t *testing.T) {
 	}
 }
 
+// TestHighlightClassifyMetric pins the Session-Highlights classify-outcome series
+// (#428, ADR-0032): one increment per outcome exposes the exact
+// glyphoxa_voice_highlight_classify_total name with the bounded outcome label, and
+// the label space is exactly the three fixed values.
+func TestHighlightClassifyMetric(t *testing.T) {
+	rec := NewPrometheusRecorder()
+
+	rec.HighlightClassify(HighlightOK)
+	rec.HighlightClassify(HighlightParseFailed)
+	rec.HighlightClassify(HighlightLLMError)
+
+	out := scrape(t, rec)
+
+	wantSubstrings := []string{
+		`glyphoxa_voice_highlight_classify_total{outcome="ok"} 1`,
+		`glyphoxa_voice_highlight_classify_total{outcome="parse_failed"} 1`,
+		`glyphoxa_voice_highlight_classify_total{outcome="llm_error"} 1`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(out, want) {
+			t.Errorf("scrape missing %q", want)
+		}
+	}
+}
+
 // TestJobRunnerMetrics pins the background-job-runner series (#286, ADR-0049):
 // the three families expose their exact glyphoxa_jobs_* / glyphoxa_job_* names
 // and kind/outcome labels, and SetJobBacklog is a Set (idempotent) not an Inc —

--- a/internal/observe/usage.go
+++ b/internal/observe/usage.go
@@ -50,3 +50,15 @@ func (t teeRecorder) STTAudioSeconds(provider Provider, d time.Duration) {
 	t.StageRecorder.STTAudioSeconds(provider, d)
 	t.sink.STTAudioSeconds(provider, d)
 }
+
+// HighlightClassify forwards the Session-Highlights outcome count to the wrapped
+// base when it implements the sink (#428). The tee embeds StageRecorder only, so
+// without this override a capability the detector recovers by type-assertion —
+// HighlightClassify is NOT on StageRecorder — is silently lost behind the spend tee,
+// and the counter never increments for capped sessions. Re-asserting on base keeps
+// the recovery working through any tee depth (base may itself be a tee).
+func (t teeRecorder) HighlightClassify(o HighlightOutcome) {
+	if hc, ok := t.StageRecorder.(interface{ HighlightClassify(HighlightOutcome) }); ok {
+		hc.HighlightClassify(o)
+	}
+}


### PR DESCRIPTION
Closes #428

## What

Makes every Session-Highlights classifier pass observable in the default live config, so a live session can distinguish **never classified** from **ran and scored below bar** from **ran and failed to parse**. Per the authoritative triage Agent Brief, this is an **observability** change — detector cadence/threshold/trigger behavior is unchanged.

## Changes

- **`internal/observe`**: new `glyphoxa_voice_highlight_classify_total{outcome}` CounterVec, registered next to the voice-stage metrics. Bounded label = exactly the fixed enum `ok | parse_failed | llm_error` (ADR-0032). Exposed via a `HighlightClassify(HighlightOutcome)` method mirroring the existing non-StageRecorder `MemoryRecall`/`KGFacts` pattern — StageRecorder is **not** extended.
- **`internal/highlight/prompt.go`**: `parseClassification` now returns a parse-ok bool instead of silently degrading a malformed verdict to a bare zero score; tolerant slicing behavior is byte-identical.
- **`internal/highlight/detector.go`**:
  - `runClassifier` returns the verdict, the pass outcome (precedence `llm_error > parse_failed > ok`, one per pass — a Complete error *and* a stream `EventError` both → `llm_error`) and the raw model text. Existing complete/stream WARNs retained.
  - One per-pass log line: **INFO** (`score`, `parsed`, `window` line count) on a parsed verdict; **WARN** with a **200-rune-bounded** excerpt on an unparseable stream.
  - A confirmed trigger logs **INFO** with `score` + `from`/`to`.
  - Outcome counted once per pass via a sink recovered from the already-injected `StageRecorder` (production `*PrometheusRecorder` satisfies it) — no constructor widening.

## Tests (TDD)

- `observe`: `TestHighlightClassifyMetric` — series name + three bounded outcomes.
- `highlight`: below-bar INFO fields, parse-fail WARN + bounded excerpt + `parse_failed`, Complete-error and stream-error both `llm_error` (existing WARNs retained), trigger INFO with score+From/To, counter increments once per pass. `TestParseClassification` extended for the parse-ok bool.
- All existing detector + `wirenpc` gating/label tests pass unmodified. No live LLM calls — stub providers + captured slog handler only; keyless/cassette posture holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)