### PR TITLE
Small deepenings from the 2026-07-14 architecture review: spend.PriceOnly, providererr tests, Active-Campaign cross-refs

### DIFF
--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -196,18 +196,19 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 			return fmt.Errorf("highlight enrich: generate image: %w", err)
 		}
 
-		// Meter the spend (ADR-0045/0046): a caps-free meter teed onto the production
-		// recorder prices the image's tokens AND moves the glyphoxa_voice_llm_tokens
-		// series. The enrichment job is off-session and never cap-gated (the recap
-		// posture). Gemini bills the image as output tokens → LLMTokens.
-		meter := spend.NewMeter(spend.Caps{}, log, nil, nil)
-		observe.TeeUsage(rec, meter).LLMTokens(observe.ProviderGemini, model, res.PromptTokens, res.OutputTokens)
+		// Meter the spend (ADR-0045/0046): spend.PriceOnly tees a caps-free meter
+		// onto the production recorder, pricing the image's tokens AND moving the
+		// glyphoxa_voice_llm_tokens series. The enrichment job is off-session and
+		// never cap-gated (the recap posture). Gemini bills the image as output
+		// tokens → LLMTokens.
+		priced, estimatedUSD := spend.PriceOnly(rec, log)
+		priced.LLMTokens(observe.ProviderGemini, model, res.PromptTokens, res.OutputTokens)
 		log.Info("highlight enrich: image generated",
 			"highlight", p.HighlightID,
 			"model", model,
 			"input_tokens", res.PromptTokens,
 			"output_tokens", res.OutputTokens,
-			"estimated_usd", meter.Status().EstimatedUSD,
+			"estimated_usd", estimatedUSD(),
 		)
 
 		key, err := blob.Key(p.TenantID, highlightOwnerKind, p.HighlightID, imageBlobName)

--- a/internal/recap/recap.go
+++ b/internal/recap/recap.go
@@ -198,17 +198,17 @@ func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (res Result,
 		priceModel = groq.DefaultModel
 	}
 
-	// Metering (gate #271 posture): a caps-free meter teed alongside the production
-	// recorder — usage is recorded and priced, but the meter has NO caps and the
-	// engine never reads one or calls AllowTurn (ADR-0046 is live-session-only).
-	meter := spend.NewMeter(spend.Caps{}, e.log, nil, nil)
+	// Metering (gate #271 posture): spend.PriceOnly tees a caps-free meter
+	// alongside the production recorder — usage is recorded and priced, but the
+	// engine never reads a cap or calls AllowTurn (ADR-0046 is live-session-only).
+	rec, estimatedUSD := spend.PriceOnly(e.metrics, e.log)
 	caller := &llmCaller{
 		ctx:        ctx,
 		provider:   provider,
 		model:      model,
 		priceModel: priceModel,
 		label:      providerLabel(providerID),
-		rec:        observe.TeeUsage(e.metrics, meter),
+		rec:        rec,
 	}
 
 	chronIDs := make([]uuid.UUID, len(sessions))
@@ -220,12 +220,11 @@ func (e *Engine) Recap(ctx context.Context, sessionIDs []uuid.UUID) (res Result,
 	// once the meter/caller exist; the earlier provider-resolution errors spent
 	// nothing and have no meter to report.
 	defer func() {
-		status := meter.Status()
 		e.log.Info("recap: llm usage",
 			"voice_session_ids", chronIDs,
 			"input_tokens", caller.totalIn,
 			"output_tokens", caller.totalOut,
-			"estimated_usd", status.EstimatedUSD,
+			"estimated_usd", estimatedUSD(),
 			"ok", err == nil,
 		)
 	}()

--- a/internal/rpc/active_campaign.go
+++ b/internal/rpc/active_campaign.go
@@ -38,6 +38,15 @@ type activeCampaignResolver interface {
 // no session source (e.g. keyless unit tests), which skips step 1. The Manager
 // enforces a single active session (ErrSessionActive), so there is at most one
 // live campaign — no multi-session tie-break is needed.
+//
+// Two sibling surfaces implement DELIBERATE variants of this walk, not drift:
+// the slash surface (internal/presence.resolveActiveCampaign) drops step 3 and
+// fails instead (ADR-0009 strictness — the GM has /glyphoxa use right there),
+// and the standalone voice boot (cmd/glyphoxa.resolveStandaloneCampaign) drops
+// step 1 because no session source exists at boot. They also differ on a live
+// session whose campaign row vanished: this surface propagates the store error,
+// presence falls through to the durable selection rather than fail the command.
+// Change the policy only after deciding it for all three.
 func resolveActiveCampaign(ctx context.Context, live func() (uuid.UUID, bool), store activeCampaignResolver) (storage.Campaign, error) {
 	if live != nil {
 		if id, active := live(); active {

--- a/internal/spend/priceonly.go
+++ b/internal/spend/priceonly.go
@@ -1,0 +1,22 @@
+package spend
+
+import (
+	"log/slog"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// PriceOnly returns a [observe.StageRecorder] that forwards every call to base
+// and additionally prices the usage trio on a caps-free [Meter] — the shared
+// off-session metering posture (#271/#272 gate posture): usage is recorded and
+// priced for attribution, but nothing is cap-gated and AllowTurn is never
+// consulted (ADR-0046 caps are live-session-only). estimatedUSD reads the
+// running estimate for the caller's attribution log line.
+//
+// Off-session LLM/image call sites (the Recap engine, the Highlight enrichment
+// job) ask for pricing in one call instead of hand-assembling the
+// caps-free-meter + TeeUsage + Status ritual.
+func PriceOnly(base observe.StageRecorder, log *slog.Logger) (rec observe.StageRecorder, estimatedUSD func() float64) {
+	m := NewMeter(Caps{}, log, nil, nil)
+	return observe.TeeUsage(base, m), func() float64 { return m.Status().EstimatedUSD }
+}

--- a/internal/spend/priceonly_test.go
+++ b/internal/spend/priceonly_test.go
@@ -1,0 +1,51 @@
+package spend
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// priceOnlyBase proves the recorder PriceOnly returns still forwards usage to
+// the production base recorder.
+type priceOnlyBase struct {
+	observe.Discard
+	llm int
+}
+
+func (b *priceOnlyBase) LLMTokens(observe.Provider, string, int, int) { b.llm++ }
+
+func TestPriceOnly_TeesToBaseAndPrices(t *testing.T) {
+	base := &priceOnlyBase{}
+	rec, estimatedUSD := PriceOnly(base, slog.New(slog.DiscardHandler))
+
+	if got := estimatedUSD(); got != 0 {
+		t.Fatalf("estimate before any usage = %v, want 0", got)
+	}
+
+	rec.LLMTokens(observe.ProviderGroq, "openai/gpt-oss-120b", 1_000_000, 1_000_000)
+	if base.llm != 1 {
+		t.Fatalf("base recorder saw %d LLMTokens calls, want 1 (tee must not swallow usage)", base.llm)
+	}
+	first := estimatedUSD()
+	if first <= 0 {
+		t.Fatalf("estimate after usage = %v, want > 0 (priced or fail-closed default, never free)", first)
+	}
+
+	rec.LLMTokens(observe.ProviderGroq, "openai/gpt-oss-120b", 1_000_000, 1_000_000)
+	if second := estimatedUSD(); second <= first {
+		t.Fatalf("estimate after second usage = %v, want > %v (running total)", second, first)
+	}
+}
+
+// TestPriceOnly_UnknownModelStillPrices pins the fail-closed posture through the
+// helper: an unpriced (provider, model) must produce a positive estimate via the
+// deliberately HIGH defaults (ADR-0046), never a silent zero.
+func TestPriceOnly_UnknownModelStillPrices(t *testing.T) {
+	rec, estimatedUSD := PriceOnly(&priceOnlyBase{}, slog.New(slog.DiscardHandler))
+	rec.LLMTokens(observe.Provider("nonesuch"), "model-not-in-price-map", 1_000_000, 1_000_000)
+	if got := estimatedUSD(); got <= 0 {
+		t.Fatalf("estimate for unknown model = %v, want > 0 (fail-closed defaults)", got)
+	}
+}

--- a/pkg/voice/orchestrator/ensemble_textmodality_test.go
+++ b/pkg/voice/orchestrator/ensemble_textmodality_test.go
@@ -71,11 +71,14 @@ func TestReplier_Ensemble_TextDeliveredLead_PublishesTerminal(t *testing.T) {
 		t.Fatal("the ensemble never elected / spoke a Lead")
 	}
 
-	voicetest.AssertEvent(t, h, func(e voiceevent.EnsembleLead) bool {
+	// WaitEvent, not AssertEvent: the coalesced spokeCh receive joins Speak, but
+	// the coordinator goroutine publishes ensemble.lead and the terminal AFTER it
+	// — AssertEvent snapshots once and races that publisher (flaked in CI).
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.EnsembleLead) bool {
 		return e.TurnID == "Ttext" && e.Target.AgentID == butlerTarget.AgentID
 	}, "ensemble.lead → Butler")
 	// The terminal: a text-delivered Lead is a SUCCESS with no first audio.
-	voicetest.AssertEvent(t, h, func(e voiceevent.TurnEnded) bool {
+	voicetest.WaitEvent(t, h, 2*time.Second, func(e voiceevent.TurnEnded) bool {
 		return e.TurnID == "Ttext" && e.Reason == voiceevent.TurnEndTextDelivered
 	}, "turn.ended(text_delivered) for the text Lead")
 	// A text turn dispatches no TTS.

--- a/pkg/voice/providererr/providererr_test.go
+++ b/pkg/voice/providererr/providererr_test.go
@@ -1,0 +1,70 @@
+package providererr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestHTTPError_ErrorFormat pins the rendered message byte-for-byte: the doc
+// comment promises it is identical to the adapters' pre-typed readErrorResponse
+// output, and logs/string-compares downstream rely on that.
+func TestHTTPError_ErrorFormat(t *testing.T) {
+	err := &HTTPError{
+		Op:         "elevenlabs.Transcribe",
+		StatusCode: 429,
+		Status:     "429 Too Many Requests",
+		Body:       "rate limited",
+	}
+	want := "elevenlabs.Transcribe: HTTP 429 429 Too Many Requests: rate limited"
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestHTTPError_AsThroughWrap pins the property the retry helper depends on
+// (ADR-0044): errors.As must find the typed error through fmt.Errorf %w
+// wrapping, with the status code intact — that is what makes classification
+// structural instead of a substring match.
+func TestHTTPError_AsThroughWrap(t *testing.T) {
+	inner := &HTTPError{Op: "anthropic.Complete", StatusCode: 503, Status: "503 Service Unavailable", Body: "overloaded"}
+	wrapped := fmt.Errorf("agenttool: llm round: %w", fmt.Errorf("start: %w", inner))
+
+	var httpErr *HTTPError
+	if !errors.As(wrapped, &httpErr) {
+		t.Fatalf("errors.As failed to find *HTTPError through two wraps")
+	}
+	if httpErr.StatusCode != 503 {
+		t.Fatalf("StatusCode through wrap = %d, want 503", httpErr.StatusCode)
+	}
+	if httpErr != inner {
+		t.Fatalf("errors.As returned a different value than the wrapped one")
+	}
+}
+
+// TestToolSyntaxError_MsgVerbatim pins the byte-preserved provider text: logs and
+// downstream substring checks must see exactly what the vendor returned.
+func TestToolSyntaxError_MsgVerbatim(t *testing.T) {
+	msg := `400: {"error":{"code":"tool_use_failed","failed_generation":"<function=dice>"}}`
+	err := &ToolSyntaxError{Op: "groq.Complete", Msg: msg}
+	if got := err.Error(); got != msg {
+		t.Fatalf("Error() = %q, want the verbatim provider message %q", got, msg)
+	}
+
+	var tse *ToolSyntaxError
+	if !errors.As(fmt.Errorf("round 2: %w", err), &tse) {
+		t.Fatalf("errors.As failed to find *ToolSyntaxError through a wrap")
+	}
+}
+
+// TestToolSyntaxError_IsNotHTTPError pins the deliberate distinctness the doc
+// comment promises: a tool-syntax failure must NOT classify as a transient
+// HTTPError (it is a per-round policy signal for the agenttool bridge, never a
+// back-off-and-retry case), even when wrapped.
+func TestToolSyntaxError_IsNotHTTPError(t *testing.T) {
+	wrapped := fmt.Errorf("start: %w", &ToolSyntaxError{Op: "groq.Complete", Msg: "tool_use_failed"})
+	var httpErr *HTTPError
+	if errors.As(wrapped, &httpErr) {
+		t.Fatalf("*ToolSyntaxError matched *HTTPError; the types must stay distinct for retry classification")
+	}
+}


### PR DESCRIPTION
Three small, independent quick wins from the 2026-07-14 architecture review (the items small enough to fix inline; the larger smaller-deepenings went to #452/#453/#454).

## 1. `spend.PriceOnly` (commit 1)

The Recap engine and the Highlight enrichment job each hand-assembled the same off-session metering ritual: caps-free `Meter` + `observe.TeeUsage` + `Status().EstimatedUSD` read-back. One helper now owns it; both call sites shrink to a single call. Behavior unchanged — same tee, same fail-closed pricing, never cap-gated (ADR-0046 stays live-session-only). New tests pin the tee-to-base, running-total, and fail-closed-for-unknown-model properties through the helper.

## 2. `providererr` tests (commit 2)

The one load-bearing voice package with zero tests — retry's ADR-0044 classification is a type assertion on these errors. Pinned: byte-identical `Error()` renderings (doc-comment promise), `errors.As` through `%w` wrapping with the status code intact, and the deliberate `HTTPError`/`ToolSyntaxError` distinctness (a tool-syntax failure must never classify as a transient back-off case, #398).

## 3. Active-Campaign resolver: consolidation **rejected**, cross-refs added instead (commit 3)

The review proposed one flag-configured resolver replacing the three hand-written walks. Having read all three: they diverge on more axes than flags express — different store methods (`GetActiveCampaignForUser` vs `GetOperatorActiveCampaign`), different live sources (closure vs `Snapshot()`), different NotFound-on-live behavior (web propagates, slash falls through), and different error mapping (ADR-0009 strict fail vs actionable boot message). A shared abstraction would be bigger and murkier than the ~25 well-documented lines per variant it replaces. Instead, the web-tier variant (the only one that didn't name its siblings) now documents the deliberate divergence, so a future reader or architecture review doesn't mistake it for drift. Happy to record this as a short ADR if wanted.

## Test evidence

- `go build ./...` clean, `gofmt` clean, `golangci-lint run` on touched packages: 0 issues
- `go test`: `internal/spend`, `pkg/voice/providererr`, `internal/recap`, `internal/highlight`, `internal/rpc` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)