### PR TITLE
fix(#431,#432,#434): barge-in listens like a human — real soft-overlap, no stale cancels, no unprompted turns

### DIFF
--- a/docs/adr/0027-barge-in-confirm-window-cancels-turn.md
+++ b/docs/adr/0027-barge-in-confirm-window-cancels-turn.md
@@ -41,6 +41,16 @@ A barge-in tears down the **entire** Ensemble Turn (ADR-0025), not just the Lead
 - **Interrupted-Agent priority bias.** Address Detection (ADR-0024) gives a recently-interrupted Agent a small priority multiplier in the last-speaker-continuation stage, capturing the social fact that we cut someone off but still expect them to finish.
 - **Cosmetic fade-out** on hard cut (above).
 
+## Amendment: voiced-duration disarm + Gate-1 re-check at expiry (2026-07-15, #431/#432)
+
+Two defects from the 2026-07-14 review tightened the trigger's mechanics; the decision itself is unchanged.
+
+**Soft-overlap keys on the provisional end of voicing, not the segment boundary (#431).** The original wiring disarmed the confirm window only on `vad.speech_end` — which Silero emits a full min-silence hangover (production: 12 × 32ms = 384ms) *after* voicing stops. With the hangover longer than the window (250ms), the disarm could never precede timer expiry, so *every* voiced burst barged and Soft-overlap was unreachable — the fire-fast-at-onset design this ADR explicitly rejected, with a fixed 250ms delay bolted on. The VAD stage now also publishes the provisional in-utterance transitions `vad.voicing_stopped` (first sub-threshold frame — the speaker actually fell silent; the barge window disarms on it) and `vad.voicing_resumed` (voicing picked back up before the hangover elapsed, which fires no fresh `speech_start`; the window re-arms on it). "Continuous voiced speech" is thus measured on when voicing *stops*, not on when the hangover-delayed segment closes; the hangover keeps its one job — utterance merging for STT — and segmentation is untouched. `speech_end` still disarms as a fallback for VAD sources without provisional transitions. A timing test in `wirenpc` replays the production constants so a regression back into "disarm can never win" fails CI.
+
+**Gate 1 is re-validated when the window expires (#432).** Arming captures the *speaking turn's identity*, and the expiring timer yields the floor only if that same turn still holds it and is still audible (`Floor.SpeakingTurn` / `Floor.YieldTurn`). Previously the expiry called a bare `Floor.Yield`, cancelling whatever held the floor at that moment — including a new, pre-audio turn that took the floor mid-window, exactly the `no_audio` self-cancel class Gate 1 exists to prevent. The strict identity reading is deliberate: a *different* speaking turn that started mid-window is one the human had not heard when they began talking, so their speech is not an interruption of it; the human's next voicing onset arms a fresh window against it.
+
+The per-Agent confirm-window tunable promised above remains unimplemented (no config surface yet); deployments run the wirenpc default.
+
 ## Considered options
 
 - **Fire-fast at the 90ms capture onset** — rejected; every backchannel would kill the Agent mid-sentence. The second (confirm) knob exists precisely to separate capture from floor-yielding.

--- a/internal/wirenpc/bargetiming_test.go
+++ b/internal/wirenpc/bargetiming_test.go
@@ -1,0 +1,113 @@
+package wirenpc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// These tests relate the production barge and VAD constants (#431): the
+// Silero end-of-speech hangover (vadMinSilenceFrames × vadFrameMs = 384 ms)
+// is LONGER than the Barge-in Confirm Window (bargeConfirmWindow = 250 ms),
+// so the segment-final VADSpeechEnd for ANY burst arrives after the window's
+// timer has fired — a reactor that disarms only on speech_end can never save
+// a backchannel, and Soft-overlap (CONTEXT.md) is unreachable. The disarm
+// must ride the provisional VADVoicingStopped, which the VAD emits one frame
+// after voicing actually stops. The tests replay that production event timing
+// in real time against a real BargeIn, so a regression back to
+// "disarm only on speech_end" — or a constants change that silently
+// re-creates the trap — fails here.
+
+// prodHangover is the end-of-speech detection lag wirenpc configures Silero
+// with; prodFrame is one VAD frame, the provisional stop's detection lag.
+const (
+	prodHangover = vadMinSilenceFrames * vadFrameMs * time.Millisecond
+	prodFrame    = vadFrameMs * time.Millisecond
+)
+
+// TestBargeTiming_SoftOverlapReachableUnderProductionHangover replays a short
+// backchannel ("mhm", ~100 ms voiced) over an audibly-speaking Agent with the
+// event timing production produces: speech_start at onset, voicing_stopped
+// one frame after the voicing ends, speech_end only after the full hangover —
+// i.e. well AFTER the confirm window would have fired. The turn must survive
+// and no BargeDetected may be announced.
+func TestBargeTiming_SoftOverlapReachableUnderProductionHangover(t *testing.T) {
+	// The premises that make this scenario THE production trap. If a constants
+	// change breaks either, this test must be revisited deliberately rather
+	// than silently keep passing a weaker scenario.
+	const burst = 100 * time.Millisecond // voiced duration of the backchannel
+	if prodHangover <= bargeConfirmWindow {
+		t.Fatalf("premise changed: hangover %v ≤ confirm window %v — speech_end can now disarm the window itself; revisit this test and the VADVoicingStopped disarm (#431)",
+			prodHangover, bargeConfirmWindow)
+	}
+	if burst+prodFrame >= bargeConfirmWindow {
+		t.Fatalf("premise broken: the provisional stop (%v) would land after the window (%v) — pick a shorter burst",
+			burst+prodFrame, bargeConfirmWindow)
+	}
+	if burst+prodHangover <= bargeConfirmWindow {
+		t.Fatalf("premise broken: the speech_end (%v) would land inside the window (%v), so the test would not exercise the hangover trap",
+			burst+prodHangover, bargeConfirmWindow)
+	}
+
+	bus := voiceevent.NewBus()
+	var barges atomic.Int32
+	voiceevent.On(bus, func(voiceevent.BargeDetected) { barges.Add(1) })
+
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "bart")
+	defer release()
+	t.Cleanup(orchestrator.NewBargeIn(floor, bargeConfirmWindow).Bind(context.Background(), bus))
+
+	bus.Publish(voiceevent.FirstOpus{TurnID: "T1"}) // the Agent is audibly speaking
+
+	bus.Publish(voiceevent.VADSpeechStart{At: time.Now()}) // backchannel onset: window arms
+	time.Sleep(burst + prodFrame)                          // Silero flags the pause one frame after voicing stops…
+	bus.Publish(voiceevent.VADVoicingStopped{At: time.Now()})
+	time.Sleep(prodHangover - prodFrame) // …and leaves the speaking state only after the full hangover.
+	bus.Publish(voiceevent.VADSpeechEnd{At: time.Now()})
+
+	time.Sleep(bargeConfirmWindow + 100*time.Millisecond) // well past any still-armed window
+	if turnCtx.Err() != nil {
+		t.Fatal("a backchannel shorter than the confirm window cancelled the Agent under production timing: Soft-overlap is unreachable again (#431)")
+	}
+	if n := barges.Load(); n != 0 {
+		t.Fatalf("BargeDetected fired %d time(s) for a sub-window backchannel, want 0", n)
+	}
+}
+
+// TestBargeTiming_SustainedInterruptionFiresNearWindow is the counterpart: a
+// participant who keeps voicing past the confirm window still barges, with
+// latency close to the window (ADR-0027) — the soft-overlap fix must not have
+// deferred the decision to the hangover.
+func TestBargeTiming_SustainedInterruptionFiresNearWindow(t *testing.T) {
+	bus := voiceevent.NewBus()
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "bart")
+	defer release()
+	t.Cleanup(orchestrator.NewBargeIn(floor, bargeConfirmWindow).Bind(context.Background(), bus))
+
+	bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	start := time.Now()
+	bus.Publish(voiceevent.VADSpeechStart{At: start}) // continuous voicing: no stop, no end
+
+	select {
+	case <-turnCtx.Done():
+	case <-time.After(bargeConfirmWindow + 2*time.Second):
+		t.Fatal("continuous voiced speech past the confirm window must cancel the Agent")
+	}
+	latency := time.Since(start)
+	if latency < bargeConfirmWindow-20*time.Millisecond {
+		t.Errorf("barge fired after %v, before the %v confirm window elapsed", latency, bargeConfirmWindow)
+	}
+	// Generous scheduling slack: the property is "≈ window", i.e. NOT deferred
+	// by anything like the 384 ms hangover on top.
+	if latency > bargeConfirmWindow+prodHangover/2 {
+		t.Errorf("barge latency %v is far past the %v confirm window — the decision looks deferred to the hangover", latency, bargeConfirmWindow)
+	}
+}

--- a/pkg/voice/orchestrator/address.go
+++ b/pkg/voice/orchestrator/address.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"context"
+	"log/slog"
+	"strings"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -127,6 +129,24 @@ func (d *AddressDetector) Bind(_ context.Context, bus *voiceevent.Bus) (cancel f
 	// below is retained belt-and-braces either way.
 	sam, speakerAware := d.matcher.(SpeakerAwareMatcher)
 	return voiceevent.On(bus, func(final voiceevent.STTFinal) {
+		// An empty or whitespace-only final routes NOWHERE (#434). The STT stage
+		// publishes empties by pinned contract — "downstream consumers, not this
+		// stage, decide" — and this detector is that consumer: the recognizer
+		// authoritatively heard nothing, so there is no utterance to address. Left
+		// unfiltered, the ambient heuristics (sole-NPC, last-speaker) would route
+		// the nothing and the Agent would speak unprompted off a noise burst —
+		// polluting its history with an empty user message and spending real
+		// LLM+TTS money. The empty final stays observable on the bus for
+		// metrics/diagnostics (and the Transcript keeps its own semantics); only
+		// address routing drops it. Logged so live sessions show how often noise
+		// crosses VAD onset yet transcribes to nothing.
+		if strings.TrimSpace(final.Text) == "" {
+			slog.Default().Info("orchestrator: empty STT final, routing nowhere",
+				slog.String("speaker", final.SpeakerID),
+				slog.String("turn", final.TurnID),
+			)
+			return
+		}
 		// Route via the SpeakerID-aware call when the matcher supports it (#256), so
 		// the matcher-side Butler GM-gate drops an ineligible Butler PRE-CAP — before
 		// the ensemble set below is built — then collect the survivors and decide the

--- a/pkg/voice/orchestrator/address_emptyfinal_test.go
+++ b/pkg/voice/orchestrator/address_emptyfinal_test.go
@@ -1,0 +1,65 @@
+package orchestrator_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
+)
+
+// These tests pin the consuming half of the STT stage's publish-everything
+// contract (#434): an STTFinal whose text is empty or whitespace-only is "the
+// recognizer authoritatively heard nothing" — a noise burst that crossed VAD
+// onset (cough, breath, chair) — and must route NOWHERE. Zero AddressRouted /
+// EnsembleRouted is the whole downstream story: the Replier wakes only on
+// those events, so no route means no turn, no history/Hot-Context append, no
+// LLM+TTS call, no spend — the Agent never speaks unprompted at a cough. The
+// empty final itself stays on the bus (observability and Transcript semantics
+// are unchanged).
+
+// TestAddressDetector_EmptyFinal_NoSoleNPCRoute is the one-NPC roster case:
+// the sole-active-NPC fallback (weight ≥ threshold with the production
+// defaults) is the ambient heuristic that would otherwise route an empty
+// utterance. Empty and whitespace-only finals must produce zero routes.
+func TestAddressDetector_EmptyFinal_NoSoleNPCRoute(t *testing.T) {
+	h := voicetest.New(t)
+	butlerAg, bartAg, _ := scoringAgents()
+	// Bart is the only non-AddressOnly Agent: the sole-NPC fallback is live.
+	d := newScoringDetector(butlerAg, bartAg)
+	t.Cleanup(d.Bind(t.Context(), h.Bus))
+
+	for _, text := range []string{"", "   ", " \t\n"} {
+		h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: text, TurnID: "T-noise"})
+	}
+
+	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 0)
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 0)
+}
+
+// TestAddressDetector_EmptyFollowUp_NoLastAddressedRoute is the two-NPC
+// roster case: after a normally-routed named turn, the last-addressed
+// heuristic would route an empty follow-up back to the same NPC. The named
+// utterance must route exactly as before (the non-empty path is untouched)
+// and the empty follow-up must add nothing.
+func TestAddressDetector_EmptyFollowUp_NoLastAddressedRoute(t *testing.T) {
+	h := voicetest.New(t)
+	butlerAg, bartAg, goblinAg := scoringAgents()
+	d := newScoringDetector(butlerAg, bartAg, goblinAg)
+	t.Cleanup(d.Bind(t.Context(), h.Bus))
+
+	// A real, named utterance routes to Bart and makes him last-addressed.
+	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "Bart, what's the special tonight?", TurnID: "T-1"})
+	voicetest.AssertEvent(t, h,
+		func(e voiceevent.AddressRouted) bool {
+			return e.Target.AgentID == bartTarget.AgentID && e.TurnID == "T-1"
+		},
+		"address.routed → Bart for the named utterance (non-empty finals route exactly as before)",
+	)
+
+	// The cough that follows transcribes to nothing: no last-speaker route.
+	h.Bus.Publish(voiceevent.STTFinal{At: time.Now(), Text: "  ", TurnID: "T-2"})
+
+	voicetest.AssertEventCount[voiceevent.AddressRouted](t, h, 1) // still only the named one
+	voicetest.AssertEventCount[voiceevent.EnsembleRouted](t, h, 0)
+}

--- a/pkg/voice/orchestrator/barge.go
+++ b/pkg/voice/orchestrator/barge.go
@@ -10,33 +10,48 @@ import (
 
 // BargeIn is the [Reactor] that yields the conversational floor when a human
 // reclaims it while an Agent is speaking (ADR-0027). It subscribes to the VAD
-// stage's speech transitions and, on a confirmed barge, calls [Floor.Yield] —
-// cancelling the Agent's turn — and publishes [voiceevent.BargeDetected].
+// stage's speech transitions and, on a confirmed barge, calls [Floor.YieldTurn]
+// — cancelling the Agent's turn — and publishes [voiceevent.BargeDetected].
 //
 // Trigger has two gates. First, the Agent must be AUDIBLY speaking: a barge can
 // only fire once the held turn has produced its first audible frame
-// ([voiceevent.FirstOpus] → [Floor.MarkSpeaking] → [Floor.Speaking]), never
+// ([voiceevent.FirstOpus] → [Floor.MarkSpeaking] → [Floor.SpeakingTurn]), never
 // during its held-but-silent pre-audio LLM phase. Cancelling a silent turn was
 // the no-NPC-response self-cancel — the addressing user's own continued/over-split
 // speech, under the single shared VAD session, looked like a barge against a turn
-// that had made no sound (ADR-0027). Second, given a speaking Agent, floor-yielding
-// waits for the speech to persist for confirmWindow continuous milliseconds,
-// separating a genuine interruption from a sub-threshold backchannel ("mhm", a
-// cough), which is left to run the normal transcription path and never cancels the
-// Agent. A confirmWindow of 0 yields instantly once speech onsets over a speaking
-// Agent — the simplest form, used to validate the async-turn plumbing before the
-// window is tuned in.
+// that had made no sound (ADR-0027). Gate 1 is re-checked when the confirm window
+// EXPIRES, not only when it arms (#432): the window captures the speaking turn's
+// id at arm time and only that same, still-speaking turn is cancellable at fire
+// time — if the turn ended naturally inside the window and a new pre-audio turn
+// took the floor, the expiry is a no-op instead of killing a turn the human never
+// heard. Second, given a speaking Agent, floor-yielding waits for the speech to
+// persist for confirmWindow continuous milliseconds, separating a genuine
+// interruption from a sub-threshold backchannel ("mhm", a cough), which is left
+// to run the normal transcription path and never cancels the Agent. A
+// confirmWindow of 0 yields instantly once speech onsets over a speaking Agent —
+// the simplest form, used to validate the async-turn plumbing before the window
+// is tuned in.
+//
+// Soft-overlap is decided on VOICED duration, not on the segment boundary
+// (#431): the production VAD leaves its speaking state only after a min-silence
+// hangover LONGER than the confirm window, so the segment-final
+// [voiceevent.VADSpeechEnd] can never beat the timer — disarming only on it
+// would make every backchannel a barge. The reactor therefore disarms on the
+// provisional [voiceevent.VADVoicingStopped] (the first sub-threshold frame,
+// published as soon as the speaker actually falls silent) and re-arms on
+// [voiceevent.VADVoicingResumed] (voicing picking back up inside the still-open
+// utterance, which fires no fresh speech_start). VADSpeechEnd still disarms as a
+// belt-and-braces fallback for VAD sources that emit no provisional transitions.
 //
 // Per ADR-0027 an Agent's own TTS never triggers a barge: only inbound
 // participant audio is VAD'd, so every speech_start here is a human's.
 //
-// Per-speaker confirm windows (ADR-0050): [voiceevent.VADSpeechStart] /
-// [voiceevent.VADSpeechEnd] now carry a SpeakerID (the Speaker Lane the transition
-// came off), so a confirm window is armed and disarmed PER speaker — a speech_end
-// from speaker B no longer disarms the window speaker A's interruption armed (the
-// pre-lane caveat this fixes). Single-lane wiring runs one "" key, so the behaviour
-// is identical to before lanes existed. The fired [voiceevent.BargeDetected] names
-// the barging speaker.
+// Per-speaker confirm windows (ADR-0050): the VAD speech transitions carry a
+// SpeakerID (the Speaker Lane the transition came off), so a confirm window is
+// armed and disarmed PER speaker — a speech_end from speaker B no longer disarms
+// the window speaker A's interruption armed (the pre-lane caveat this fixes).
+// Single-lane wiring runs one "" key, so the behaviour is identical to before
+// lanes existed. The fired [voiceevent.BargeDetected] names the barging speaker.
 type BargeIn struct {
 	floor   *Floor
 	confirm time.Duration
@@ -78,35 +93,62 @@ func (b *BargeIn) Bind(_ context.Context, bus *voiceevent.Bus) (cancel func()) {
 		b.floor.MarkSpeaking(e.TurnID)
 	})
 	unsubStart := voiceevent.On(bus, func(e voiceevent.VADSpeechStart) {
-		// Only fight for the floor if an Agent is AUDIBLY speaking (ADR-0027);
-		// otherwise this is the user's own utterance — the onset of a new turn, or
-		// the continuation of the one that holds the still-silent floor — and the
-		// normal STT → AddressRouted → Floor.Take path (coalesce/supersede) handles
-		// it without cancelling a turn that has produced no audio.
-		if !b.floor.Speaking() {
-			return
-		}
-		if b.confirm <= 0 {
-			b.fire(bus, e.SpeakerID)
-			return
-		}
-		b.arm(bus, e.SpeakerID)
+		b.onVoicing(bus, e.SpeakerID)
+	})
+	unsubResumed := voiceevent.On(bus, func(e voiceevent.VADVoicingResumed) {
+		// Voicing picked back up inside a still-open utterance (#431): the VAD
+		// fires no fresh speech_start (the hangover never elapsed), so this is the
+		// only onset a pause-and-keep-talking interruption produces. Treated
+		// exactly like a speech_start: the window (re-)arms from now, so only
+		// confirmWindow of CONTINUOUS voicing fires the barge.
+		b.onVoicing(bus, e.SpeakerID)
+	})
+	unsubStopped := voiceevent.On(bus, func(e voiceevent.VADVoicingStopped) {
+		// This speaker actually fell silent before their window elapsed: a
+		// soft-overlap backchannel, no cancel (#431). This — not the segment-final
+		// speech_end below, which the production hangover delays past any sane
+		// confirm window — is the disarm that makes Soft-overlap reachable.
+		b.disarm(e.SpeakerID)
 	})
 	unsubEnd := voiceevent.On(bus, func(e voiceevent.VADSpeechEnd) {
-		b.disarm(e.SpeakerID) // this speaker's speech ended before its window: soft overlap, no cancel
+		// Belt-and-braces: a VAD source that publishes no provisional voicing
+		// transitions still disarms at its segment boundary.
+		b.disarm(e.SpeakerID)
 	})
 
 	return func() {
 		unsubSpeaking()
 		unsubStart()
+		unsubResumed()
+		unsubStopped()
 		unsubEnd()
 		b.disarmAll()
 	}
 }
 
-// arm starts (or restarts) speaker sp's confirm-window timer. When it elapses
-// without an intervening speech_end from the SAME speaker, the barge fires.
-func (b *BargeIn) arm(bus *voiceevent.Bus, sp string) {
+// onVoicing is the shared onset path for a speech_start and an in-utterance
+// voicing_resumed from speaker sp: only fight for the floor if an Agent is
+// AUDIBLY speaking (ADR-0027) — otherwise this is the user's own utterance and
+// the normal STT → AddressRouted → Floor.Take path (coalesce/supersede) handles
+// it without cancelling a turn that has produced no audio. The speaking turn's
+// id is captured HERE, so the eventual fire can only ever cancel this turn
+// (#432), never whichever turn happens to hold the floor by then.
+func (b *BargeIn) onVoicing(bus *voiceevent.Bus, sp string) {
+	turnID, speaking := b.floor.SpeakingTurn()
+	if !speaking {
+		return
+	}
+	if b.confirm <= 0 {
+		b.fire(bus, sp, turnID)
+		return
+	}
+	b.arm(bus, sp, turnID)
+}
+
+// arm starts (or restarts) speaker sp's confirm-window timer against the
+// speaking turn turnID. When it elapses without an intervening voicing_stopped /
+// speech_end from the SAME speaker, the barge fires — against turnID only.
+func (b *BargeIn) arm(bus *voiceevent.Bus, sp, turnID string) {
 	done := make(chan struct{})
 	b.mu.Lock()
 	if prev := b.pending[sp]; prev != nil {
@@ -128,7 +170,7 @@ func (b *BargeIn) arm(bus *voiceevent.Bus, sp string) {
 			}
 			b.mu.Unlock()
 			if current {
-				b.fire(bus, sp)
+				b.fire(bus, sp, turnID)
 			}
 		case <-done:
 		}
@@ -156,14 +198,18 @@ func (b *BargeIn) disarmAll() {
 	b.mu.Unlock()
 }
 
-// fire yields the floor and, if a turn was actually cancelled, announces it: the
-// BargeDetected observability signal (ADR-0027) carrying the barging speaker (sp,
-// ADR-0050) and a TurnEnded carrying the cut turn's TurnID + the barge reason, so
-// the metrics subscriber attributes this turn's death to the barge rather than the
-// coarse no-first-audio catch-all.
-func (b *BargeIn) fire(bus *voiceevent.Bus, sp string) {
-	turnID, yielded := b.floor.Yield()
-	if !yielded {
+// fire re-validates Gate 1 and yields the floor: [Floor.YieldTurn] cancels the
+// turn ONLY if turnID — the turn that was audibly speaking when the window
+// armed — still holds the floor and is still speaking (#432). A holder change
+// inside the window (the turn ended naturally; a new, possibly still-silent
+// turn took the floor) or an already-free floor makes the expiry a silent
+// no-op: no cancel, no BargeDetected. On a real cut it announces the barge —
+// the BargeDetected observability signal (ADR-0027) carrying the barging
+// speaker (sp, ADR-0050) and a TurnEnded carrying the cut turn's TurnID + the
+// barge reason, so the metrics subscriber attributes this turn's death to the
+// barge rather than the coarse no-first-audio catch-all.
+func (b *BargeIn) fire(bus *voiceevent.Bus, sp, turnID string) {
+	if !b.floor.YieldTurn(turnID) {
 		return
 	}
 	now := time.Now()

--- a/pkg/voice/orchestrator/barge_test.go
+++ b/pkg/voice/orchestrator/barge_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/orchestrator"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/vad"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voicetest"
 )
@@ -238,4 +239,227 @@ func TestBargeIn_SameSpeakerSoftOverlapDisarms(t *testing.T) {
 	if turnCtx.Err() != nil {
 		t.Fatal("a same-speaker soft-overlap backchannel must not cancel the turn")
 	}
+}
+
+// TestBargeIn_VoicingStoppedDisarms is the #431 core: the PROVISIONAL
+// voicing_stopped — published as soon as the speaker actually falls silent,
+// long before the hangover-delayed segment speech_end — disarms the window, so
+// a backchannel burst shorter than the window never cancels the Agent even
+// though its speech_end arrives (hangover) after the window would have fired.
+// The test waits out the window to prove the timer really was disarmed, not
+// merely not-yet-fired, then delivers the late speech_end as production would.
+func TestBargeIn_VoicingStoppedDisarms(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	const window = 60 * time.Millisecond
+	t.Cleanup(orchestrator.NewBargeIn(floor, window).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	h.Bus.Publish(voiceevent.VADVoicingStopped{SpeakerID: "A"}) // the burst really ended
+
+	time.Sleep(3 * window) // the armed timer would have fired by now
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	if turnCtx.Err() != nil {
+		t.Fatal("a voicing_stopped inside the window must disarm it: the burst was a soft-overlap backchannel")
+	}
+
+	// The segment-final speech_end lands only after the hangover — far too late
+	// to have been the disarm — and must stay a harmless no-op.
+	h.Bus.Publish(voiceevent.VADSpeechEnd{SpeakerID: "A"})
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	if turnCtx.Err() != nil {
+		t.Fatal("the hangover-delayed speech_end must not cancel anything")
+	}
+}
+
+// TestBargeIn_VoicingResumedReArms pins the onset half of #431: a speaker who
+// pauses briefly (voicing_stopped disarms) and then KEEPS TALKING inside the
+// still-open utterance fires no fresh speech_start — voicing_resumed is the
+// only onset signal — so it must re-arm the window, and the now-continuous
+// speech must still barge the Agent.
+func TestBargeIn_VoicingResumedReArms(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	t.Cleanup(orchestrator.NewBargeIn(floor, 30*time.Millisecond).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	h.Bus.Publish(voiceevent.VADVoicingStopped{SpeakerID: "A"}) // brief pause: disarm
+	h.Bus.Publish(voiceevent.VADVoicingResumed{SpeakerID: "A"}) // keeps talking: re-arm
+
+	voicetest.WaitEvent(t, h, 2*time.Second,
+		func(e voiceevent.BargeDetected) bool { return e.SpeakerID == "A" },
+		"barge.detected for A's resumed, sustained speech (voicing_resumed must re-arm the window)",
+	)
+	if turnCtx.Err() == nil {
+		t.Fatal("resumed sustained speech must cancel the turn")
+	}
+}
+
+// TestBargeIn_VoicingStoppedOtherSpeakerKeepsWindow extends the ADR-0050
+// per-speaker keying to the provisional transitions: B's voicing_stopped must
+// not disarm A's window — A's sustained interruption still fires.
+func TestBargeIn_VoicingStoppedOtherSpeakerKeepsWindow(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	t.Cleanup(orchestrator.NewBargeIn(floor, 40*time.Millisecond).Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	h.Bus.Publish(voiceevent.VADVoicingStopped{SpeakerID: "B"}) // only B paused
+
+	voicetest.WaitEvent(t, h, 2*time.Second,
+		func(e voiceevent.BargeDetected) bool { return e.SpeakerID == "A" },
+		"barge.detected attributed to A (B's voicing_stopped must not disarm A's window)",
+	)
+	if turnCtx.Err() == nil {
+		t.Fatal("A's sustained interruption must cancel the turn")
+	}
+}
+
+// TestBargeIn_ExpiryAfterHolderChange_DoesNotCancelNewTurn is the #432
+// regression: Gate 1 must hold at window EXPIRY, not only at arm. The window
+// arms against speaking turn T1; T1 ends naturally inside the window and a
+// NEW turn T2 takes the floor, still silent in its pre-audio LLM phase. The
+// expiring timer must not cancel T2 — the human's overlapping speech was
+// aimed at T1, and killing a turn that has produced no audio is exactly the
+// `no_audio` self-cancel class ADR-0027's Gate 1 exists to prevent.
+func TestBargeIn_ExpiryAfterHolderChange_DoesNotCancelNewTurn(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+
+	const window = 60 * time.Millisecond
+	t.Cleanup(orchestrator.NewBargeIn(floor, window).Bind(t.Context(), h.Bus))
+
+	// T1 speaks; a participant starts talking over it: the window arms on T1.
+	parent1 := voiceevent.WithTurnID(context.Background(), "T1")
+	_, release1, _ := floor.Take(parent1, "")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+
+	// T1 finishes naturally inside the window; T2 takes the floor, pre-audio.
+	release1()
+	parent2 := voiceevent.WithTurnID(context.Background(), "T2")
+	turnCtx2, release2, _ := floor.Take(parent2, "")
+	defer release2()
+
+	time.Sleep(3 * window) // let the armed timer expire
+	if turnCtx2.Err() != nil {
+		t.Fatal("the expiring window armed on T1 must not cancel the new, not-yet-audible turn T2")
+	}
+	if !floor.Active() {
+		t.Fatal("T2 must still hold the floor")
+	}
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
+}
+
+// TestBargeIn_ExpiryAfterHolderChange_SparesNewSpeakingTurn pins the STRICT
+// identity reading of the Gate-1 re-check (#432): even when the replacement
+// turn T2 has begun speaking by expiry, the window armed against T1 must not
+// cut it — the human started talking before they had heard a word of T2, so
+// their speech cannot have been an interruption of it. T2's own barge window
+// arms on the human's next voicing onset, not this stale one.
+func TestBargeIn_ExpiryAfterHolderChange_SparesNewSpeakingTurn(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+
+	const window = 60 * time.Millisecond
+	t.Cleanup(orchestrator.NewBargeIn(floor, window).Bind(t.Context(), h.Bus))
+
+	parent1 := voiceevent.WithTurnID(context.Background(), "T1")
+	_, release1, _ := floor.Take(parent1, "")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+
+	// T1 ends; T2 takes the floor AND becomes audible inside the window.
+	release1()
+	parent2 := voiceevent.WithTurnID(context.Background(), "T2")
+	turnCtx2, release2, _ := floor.Take(parent2, "")
+	defer release2()
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T2"})
+
+	time.Sleep(3 * window)
+	if turnCtx2.Err() != nil {
+		t.Fatal("a window armed on T1 must not cancel T2, even though T2 is speaking at expiry")
+	}
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+}
+
+// TestBargeIn_SoftOverlapBurst_StillTranscribed closes #431's remaining half:
+// the backchannel burst that must NOT barge must still run the normal
+// transcription path (Soft-overlap per CONTEXT.md is "transcribed and
+// committed normally — it just doesn't cancel the Agent"). A scripted VAD
+// drives the segmenter through start → voicing_stopped (disarm) → the
+// hangover → speech_end on the SAME bus a BargeIn is bound to: the turn
+// survives the window expiry, and the utterance still reaches the recognizer
+// and publishes its STTFinal.
+func TestBargeIn_SoftOverlapBurst_StillTranscribed(t *testing.T) {
+	h := voicetest.New(t)
+	rec := &recordingRecognizer{}
+	vadStage := orchestrator.NewVAD(h.Bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart,    // burst onset: window arms
+		vad.VADVoicingStopped, // burst really ended: window disarms
+		vad.VADSpeechContinue, // hangover still counting
+		vad.VADSpeechEnd,      // segment closes: transcription dispatches
+	}})
+	sttStage := orchestrator.NewSTT(h.Bus, rec)
+	seg := orchestrator.NewSegmenter(vadStage, sttStage)
+
+	floor := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	turnCtx, release, _ := floor.Take(parent, "")
+	defer release()
+
+	const window = 50 * time.Millisecond
+	t.Cleanup(orchestrator.NewBargeIn(floor, window).Bind(t.Context(), h.Bus))
+	t.Cleanup(seg.Bind(t.Context(), h.Bus))
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"}) // the Agent is audibly speaking
+
+	feed(t, seg, 2)        // start + voicing_stopped: armed, then disarmed
+	time.Sleep(3 * window) // the window would have fired had the stop not disarmed it
+	feed(t, seg, 2)        // hangover frame + speech_end: the burst commits to STT
+
+	if err := seg.Flush(); err != nil {
+		t.Fatalf("seg.Flush: %v", err)
+	}
+	if got := len(rec.batches()); got != 1 {
+		t.Fatalf("recognizer saw %d segments, want 1: the soft-overlap burst must still be transcribed", got)
+	}
+	voicetest.AssertEventCount[voiceevent.STTFinal](t, h, 1)
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	if turnCtx.Err() != nil {
+		t.Fatal("the soft-overlap burst must not cancel the Agent's turn")
+	}
+}
+
+// TestBargeIn_ExpiryOnFreeFloor_NoSpuriousEvent: the window arms on a speaking
+// turn which then ends naturally, leaving the floor free at expiry. Nothing is
+// cancelled and no BargeDetected/TurnEnded is announced (#432 AC3).
+func TestBargeIn_ExpiryOnFreeFloor_NoSpuriousEvent(t *testing.T) {
+	h := voicetest.New(t)
+	floor := orchestrator.NewFloor()
+
+	const window = 60 * time.Millisecond
+	t.Cleanup(orchestrator.NewBargeIn(floor, window).Bind(t.Context(), h.Bus))
+
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	_, release, _ := floor.Take(parent, "")
+	h.Bus.Publish(voiceevent.FirstOpus{TurnID: "T1"})
+	h.Bus.Publish(voiceevent.VADSpeechStart{SpeakerID: "A"})
+	release() // T1 finishes on its own; floor is free
+
+	time.Sleep(3 * window)
+	voicetest.AssertNoEvent[voiceevent.BargeDetected](t, h)
+	voicetest.AssertNoEvent[voiceevent.TurnEnded](t, h)
 }

--- a/pkg/voice/orchestrator/floor.go
+++ b/pkg/voice/orchestrator/floor.go
@@ -168,6 +168,50 @@ func (f *Floor) Yield() (turnID string, yielded bool) {
 	return turnID, true
 }
 
+// YieldTurn cancels the turn holding the floor ONLY when turnID is that turn
+// AND it is audibly speaking ([Floor.Speaking]), reporting whether it did. It
+// is the barge fire path's Gate-1 re-check (#432, ADR-0027): the confirm
+// window captures the speaking holder's TurnID when it arms
+// ([Floor.SpeakingTurn]), and when the timer expires this re-validates that
+// the SAME turn still holds the floor and is still speaking. A holder change
+// inside the window — the speaking turn ended naturally and a new, not-yet-
+// audible turn took the floor — makes this a no-op: the human's overlapping
+// speech was aimed at a turn that no longer exists, and cancelling the new
+// turn would be exactly the pre-audio self-cancel Gate 1 exists to prevent
+// (`no_audio` turns must not be cancellable). An empty floor is likewise a
+// no-op. Mechanically identical to [Floor.Yield] once the guard passes.
+func (f *Floor) YieldTurn(turnID string) (yielded bool) {
+	f.mu.Lock()
+	if f.cancel == nil || f.holderTurn != turnID || !f.speaking {
+		f.mu.Unlock()
+		return false
+	}
+	c := f.cancel
+	f.cancel = nil
+	f.holderTurn = ""
+	f.holderAgent = ""
+	f.speaking = false
+	f.mu.Unlock()
+	c()
+	return true
+}
+
+// SpeakingTurn reports the TurnID of the floor's current holder when — and
+// only when — that holder is audibly speaking ([Floor.Speaking]). It is the
+// arm-time Gate-1 read of the [BargeIn] confirm window (#432): the captured
+// id is what [Floor.YieldTurn] re-validates at window expiry, so a barge can
+// only ever cancel the turn the human was actually talking over. speaking is
+// false when the floor is free or the holder is still in its silent pre-audio
+// phase (turnID is then empty). Point-in-time, like [Floor.Speaking].
+func (f *Floor) SpeakingTurn() (turnID string, speaking bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cancel == nil || !f.speaking {
+		return "", false
+	}
+	return f.holderTurn, true
+}
+
 // YieldAgent cancels the turn holding the floor ONLY when agentID is that turn's
 // target Agent, reporting the cut turn's TurnID and yielded=true; otherwise it is
 // a no-op reporting ("", false) and the floor is left untouched. It is the

--- a/pkg/voice/orchestrator/floor_test.go
+++ b/pkg/voice/orchestrator/floor_test.go
@@ -384,3 +384,93 @@ func TestFloor_SetHolderAgentRetargetsMuteCut(t *testing.T) {
 		t.Fatal("the retargeted mute cut must cancel the turn ctx")
 	}
 }
+
+// TestFloor_SpeakingTurn pins the arm-time Gate-1 read of the barge window
+// (#432): a free floor and a held-but-silent (pre-audio) holder both report
+// not-speaking, and only once the holder is marked speaking does its TurnID
+// come back — the id [Floor.YieldTurn] later re-validates at window expiry.
+func TestFloor_SpeakingTurn(t *testing.T) {
+	f := orchestrator.NewFloor()
+	if id, speaking := f.SpeakingTurn(); speaking || id != "" {
+		t.Fatalf("free floor: SpeakingTurn = (%q, %v), want (\"\", false)", id, speaking)
+	}
+
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	_, release, _ := f.Take(parent, "bart")
+	defer release()
+	if id, speaking := f.SpeakingTurn(); speaking || id != "" {
+		t.Fatalf("held-but-silent holder: SpeakingTurn = (%q, %v), want (\"\", false)", id, speaking)
+	}
+
+	f.MarkSpeaking("T1")
+	if id, speaking := f.SpeakingTurn(); !speaking || id != "T1" {
+		t.Fatalf("speaking holder: SpeakingTurn = (%q, %v), want (\"T1\", true)", id, speaking)
+	}
+}
+
+// TestFloor_YieldTurnCutsMatchingSpeakingHolder is the happy barge path: the
+// turn captured at arm time still holds the floor and is still speaking, so
+// YieldTurn cancels it and frees the floor.
+func TestFloor_YieldTurnCutsMatchingSpeakingHolder(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	ctx, release, _ := f.Take(parent, "bart")
+	defer release()
+	f.MarkSpeaking("T1")
+
+	if !f.YieldTurn("T1") {
+		t.Fatal("YieldTurn(T1) must cut the speaking holder T1")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("YieldTurn must cancel the turn ctx")
+	}
+	if f.Active() {
+		t.Fatal("YieldTurn must free the floor")
+	}
+	if f.YieldTurn("T1") {
+		t.Fatal("a second YieldTurn(T1) must report false: the floor is free")
+	}
+}
+
+// TestFloor_YieldTurnSparesDifferentHolder is the #432 Gate-1 re-check: the
+// armed-on turn ended and a NEW turn holds the floor — YieldTurn for the old
+// id must be a no-op, even when the new holder is itself speaking.
+func TestFloor_YieldTurnSparesDifferentHolder(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent1 := voiceevent.WithTurnID(context.Background(), "T1")
+	_, release1, _ := f.Take(parent1, "bart")
+	f.MarkSpeaking("T1")
+	release1() // T1 ends naturally
+
+	parent2 := voiceevent.WithTurnID(context.Background(), "T2")
+	ctx2, release2, _ := f.Take(parent2, "bart")
+	defer release2()
+	f.MarkSpeaking("T2") // even audible: still not the armed-on turn
+
+	if f.YieldTurn("T1") {
+		t.Fatal("YieldTurn(T1) must be a no-op once T2 holds the floor")
+	}
+	if ctx2.Err() != nil {
+		t.Fatal("YieldTurn(T1) must not cancel T2's ctx")
+	}
+	if !f.Active() {
+		t.Fatal("T2 must still hold the floor")
+	}
+}
+
+// TestFloor_YieldTurnSparesSilentHolder: YieldTurn requires the holder to be
+// audibly speaking — a held-but-silent (pre-audio) turn is never barge-cut,
+// even under its own TurnID (the `no_audio` protection, ADR-0027).
+func TestFloor_YieldTurnSparesSilentHolder(t *testing.T) {
+	f := orchestrator.NewFloor()
+	parent := voiceevent.WithTurnID(context.Background(), "T1")
+	ctx, release, _ := f.Take(parent, "bart")
+	defer release()
+
+	if f.YieldTurn("T1") {
+		t.Fatal("YieldTurn must not cut a held-but-silent (pre-audio) holder")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("the silent holder's ctx must stay alive")
+	}
+}

--- a/pkg/voice/orchestrator/vad.go
+++ b/pkg/voice/orchestrator/vad.go
@@ -26,7 +26,9 @@ import (
 // The wrapped session is synchronous and frame-driven; callers feed PCM
 // frames via [VAD.Process] in the audio loop. Per-frame "still speaking"
 // and "still silent" states are not republished — only the transitions
-// (speech_start, speech_end) cross the bus boundary.
+// (speech_start, speech_end, and the provisional voicing_stopped /
+// voicing_resumed pair inside an open utterance, #431) cross the bus
+// boundary.
 type VAD struct {
 	bus     *voiceevent.Bus
 	session vad.SessionHandle
@@ -80,8 +82,9 @@ func NewVAD(bus *voiceevent.Bus, session vad.SessionHandle, opts ...VADOption) *
 // Process feeds one PCM frame through the underlying VAD session and
 // republishes the per-frame transitions onto the bus: speech_start at the
 // onset of an utterance, speech_end when the speaker has been quiet for the
-// session's silence-frame threshold. Per-frame "still speaking" / "still
-// silent" states stay inside the session and are not published.
+// session's silence-frame threshold, and the provisional in-utterance
+// voicing_stopped / voicing_resumed pair (#431). Per-frame "still speaking" /
+// "still silent" states stay inside the session and are not published.
 func (v *VAD) Process(frame audio.Frame) error {
 	evt, err := v.session.ProcessFrame(frame)
 	if err != nil {
@@ -107,6 +110,21 @@ func (v *VAD) Process(frame audio.Frame) error {
 		})
 		// #125: stamp the fixed end-of-speech detection lag once per speech_end.
 		v.rec.VADHangover(v.hangover)
+	case vad.VADVoicingStopped:
+		// Provisional in-utterance voicing pause (#431): published so the barge-in
+		// confirm window can disarm at the real end of voicing instead of waiting
+		// out the hangover; the Segmenter does not subscribe to it.
+		v.bus.Publish(voiceevent.VADVoicingStopped{
+			At:          time.Now(),
+			Probability: evt.Probability,
+			SpeakerID:   speaker,
+		})
+	case vad.VADVoicingResumed:
+		v.bus.Publish(voiceevent.VADVoicingResumed{
+			At:          time.Now(),
+			Probability: evt.Probability,
+			SpeakerID:   speaker,
+		})
 	}
 	return nil
 }

--- a/pkg/voice/orchestrator/vad_test.go
+++ b/pkg/voice/orchestrator/vad_test.go
@@ -166,6 +166,41 @@ func TestVAD_TwoUtteranceTest_EmitsTwoSpeechStarts(t *testing.T) {
 	voicetest.AssertEventCount[voiceevent.VADSpeechStart](t, h, 2)
 }
 
+// TestVAD_PublishesVoicingTransitions pins the #431 publish path: the stage
+// republishes the session's provisional VADVoicingStopped / VADVoicingResumed
+// transitions onto the bus, stamped with the frame's Speaker() like every
+// other transition (ADR-0050) — these are what let the barge-in confirm
+// window observe the real end of voicing instead of the hangover-delayed
+// speech_end.
+func TestVAD_PublishesVoicingTransitions(t *testing.T) {
+	bus := voiceevent.NewBus()
+	var stopped []voiceevent.VADVoicingStopped
+	var resumed []voiceevent.VADVoicingResumed
+	voiceevent.On(bus, func(e voiceevent.VADVoicingStopped) { stopped = append(stopped, e) })
+	voiceevent.On(bus, func(e voiceevent.VADVoicingResumed) { resumed = append(resumed, e) })
+
+	stage := orchestrator.NewVAD(bus, &scriptedVAD{events: []vad.VADEventType{
+		vad.VADSpeechStart, vad.VADVoicingStopped, vad.VADVoicingResumed, vad.VADSpeechEnd,
+	}})
+
+	base, err := audio.NewFrame(make([]int16, 512), 16000, 32)
+	if err != nil {
+		t.Fatalf("audio.NewFrame: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if err := stage.Process(base.WithSpeaker("42")); err != nil {
+			t.Fatalf("frame %d: Process: %v", i, err)
+		}
+	}
+
+	if len(stopped) != 1 || stopped[0].SpeakerID != "42" {
+		t.Errorf("VADVoicingStopped = %+v, want exactly one with SpeakerID \"42\"", stopped)
+	}
+	if len(resumed) != 1 || resumed[0].SpeakerID != "42" {
+		t.Errorf("VADVoicingResumed = %+v, want exactly one with SpeakerID \"42\"", resumed)
+	}
+}
+
 // TestVAD_StampsSpeakerIDFromFrame pins that the VAD stage stamps each published
 // speech transition with the processed frame's Speaker() (ADR-0050): an attributed
 // frame yields VADSpeechStart/End carrying that SpeakerID, and an unattributed ("")

--- a/pkg/voice/vad/silero/silero.go
+++ b/pkg/voice/vad/silero/silero.go
@@ -419,8 +419,22 @@ func (s *session) step(prob float64) vad.VADEvent {
 				s.silenceCount = 0
 				return vad.VADEvent{Type: vad.VADSpeechEnd, Probability: prob}
 			}
-		} else {
+			if s.silenceCount == 1 {
+				// First sub-threshold frame after voiced frames: the speaker just
+				// fell silent, though the utterance stays open until the hangover
+				// elapses. Surfaced so the barge-in confirm window can disarm on the
+				// real end of voicing instead of the hangover-delayed speech_end
+				// (#431); segmentation semantics are untouched.
+				return vad.VADEvent{Type: vad.VADVoicingStopped, Probability: prob}
+			}
+			return vad.VADEvent{Type: vad.VADSpeechContinue, Probability: prob}
+		}
+		if s.silenceCount > 0 {
 			s.silenceCount = 0
+			// Voicing picked back up before the hangover elapsed: no new
+			// speech_start fires (the utterance never closed), so this is the
+			// only onset signal a mid-utterance resumption produces (#431).
+			return vad.VADEvent{Type: vad.VADVoicingResumed, Probability: prob}
 		}
 		return vad.VADEvent{Type: vad.VADSpeechContinue, Probability: prob}
 	}

--- a/pkg/voice/vad/silero/silero_test.go
+++ b/pkg/voice/vad/silero/silero_test.go
@@ -364,7 +364,8 @@ func TestProcessFrame_SilenceCountResetOnHighProb(t *testing.T) {
 		t.Fatalf("silenceCount = %d, want %d", sess.silenceCount, minSilence-1)
 	}
 
-	// One high-prob frame should reset silence count.
+	// One high-prob frame resets the silence count; the transition out of the
+	// provisional pause surfaces as VADVoicingResumed (#431).
 	m.mu.Lock()
 	m.prob = 0.9
 	m.mu.Unlock()
@@ -372,11 +373,20 @@ func TestProcessFrame_SilenceCountResetOnHighProb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProcessFrame: %v", err)
 	}
-	if evt.Type != vad.VADSpeechContinue {
-		t.Errorf("expected VADSpeechContinue, got %v", evt.Type)
+	if evt.Type != vad.VADVoicingResumed {
+		t.Errorf("expected VADVoicingResumed, got %v", evt.Type)
 	}
 	if sess.silenceCount != 0 {
 		t.Errorf("silenceCount = %d, want 0 after reset", sess.silenceCount)
+	}
+
+	// The frame after the resumption is plain ongoing speech again.
+	evt, err = sess.ProcessFrame(frame)
+	if err != nil {
+		t.Fatalf("ProcessFrame: %v", err)
+	}
+	if evt.Type != vad.VADSpeechContinue {
+		t.Errorf("expected VADSpeechContinue after resumption, got %v", evt.Type)
 	}
 }
 
@@ -667,8 +677,9 @@ func TestProcessFrame_StateTransitions(t *testing.T) {
 		{0.8, vad.VADSpeechStart},
 		// Ongoing speech.
 		{0.8, vad.VADSpeechContinue},
-		// Silence count builds up (below SilenceThreshold=0.35).
-		{0.1, vad.VADSpeechContinue},
+		// First sub-threshold frame (below SilenceThreshold=0.35): the speaker
+		// provisionally fell silent (#431); the hangover keeps counting.
+		{0.1, vad.VADVoicingStopped},
 		{0.1, vad.VADSpeechContinue},
 		// Speech ends on third consecutive low-prob frame.
 		{0.1, vad.VADSpeechEnd},
@@ -694,6 +705,96 @@ func TestProcessFrame_StateTransitions(t *testing.T) {
 		if evt.Type != s.wantType {
 			t.Errorf("step %d (prob=%.2f): got %v, want %v", i, s.prob, evt.Type, s.wantType)
 		}
+	}
+}
+
+// TestProcessFrame_VoicingPauseResumeCycle pins the provisional voicing
+// transitions (#431): inside one open utterance, every dip below the silence
+// threshold emits exactly one VADVoicingStopped on its first frame, and every
+// pickup before the hangover elapses emits exactly one VADVoicingResumed —
+// repeatedly, without ever closing the segment (no VADSpeechEnd, no fresh
+// VADSpeechStart). These are the signals the barge-in confirm window keys on:
+// stopped = the burst really ended (soft overlap, disarm), resumed = the
+// speaker is talking again (re-arm).
+func TestProcessFrame_VoicingPauseResumeCycle(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	const minSpeech, minSilence = 2, 5
+
+	m := &mockInferencer{prob: 0.9}
+	sess := makeSession(t, cfg, m, minSpeech, minSilence)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	frame := silenceFrame(t, cfg)
+	setProb := func(p float32) {
+		m.mu.Lock()
+		m.prob = p
+		m.mu.Unlock()
+	}
+	next := func() vad.VADEventType {
+		t.Helper()
+		evt, err := sess.ProcessFrame(frame)
+		if err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
+		}
+		return evt.Type
+	}
+
+	// Enter the speaking state.
+	for range minSpeech {
+		next()
+	}
+	if sess.state != stateSpeaking {
+		t.Fatalf("expected stateSpeaking, got %v", sess.state)
+	}
+
+	// Two pause/resume cycles, each shorter than the hangover.
+	for cycle := range 2 {
+		setProb(0.1)
+		if got := next(); got != vad.VADVoicingStopped {
+			t.Fatalf("cycle %d: first sub-threshold frame: got %v, want VADVoicingStopped", cycle, got)
+		}
+		if got := next(); got != vad.VADSpeechContinue {
+			t.Fatalf("cycle %d: second sub-threshold frame: got %v, want VADSpeechContinue (stopped fires once per pause)", cycle, got)
+		}
+		setProb(0.9)
+		if got := next(); got != vad.VADVoicingResumed {
+			t.Fatalf("cycle %d: first voiced frame after pause: got %v, want VADVoicingResumed", cycle, got)
+		}
+		if got := next(); got != vad.VADSpeechContinue {
+			t.Fatalf("cycle %d: frame after resumption: got %v, want VADSpeechContinue (resumed fires once per pickup)", cycle, got)
+		}
+	}
+	if sess.state != stateSpeaking {
+		t.Fatalf("utterance must still be open after pause/resume cycles, got state %v", sess.state)
+	}
+}
+
+// TestProcessFrame_MinSilenceOne_NoProvisionalStop pins the degenerate hangover:
+// with minSilenceFrames=1 the first sub-threshold frame IS the segment boundary,
+// so it emits VADSpeechEnd directly and never a provisional VADVoicingStopped.
+func TestProcessFrame_MinSilenceOne_NoProvisionalStop(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	m := &mockInferencer{prob: 0.9}
+	sess := makeSession(t, cfg, m, 2, 1)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	frame := silenceFrame(t, cfg)
+	for range 2 { // enter speaking
+		sess.ProcessFrame(frame) //nolint:errcheck
+	}
+	m.mu.Lock()
+	m.prob = 0.1
+	m.mu.Unlock()
+	evt, err := sess.ProcessFrame(frame)
+	if err != nil {
+		t.Fatalf("ProcessFrame: %v", err)
+	}
+	if evt.Type != vad.VADSpeechEnd {
+		t.Errorf("minSilenceFrames=1: got %v, want VADSpeechEnd on the first sub-threshold frame", evt.Type)
 	}
 }
 

--- a/pkg/voice/vad/types.go
+++ b/pkg/voice/vad/types.go
@@ -24,4 +24,19 @@ const (
 
 	// VADSilence indicates no speech detected.
 	VADSilence
+
+	// VADVoicingStopped indicates voicing has provisionally paused inside a
+	// still-open utterance: the first sub-threshold frame after voiced frames,
+	// while the end-of-speech hangover is still counting down. It is NOT a
+	// segment boundary — the utterance stays open and either resumes
+	// (VADVoicingResumed) or ends for real (VADSpeechEnd) once the hangover
+	// elapses. It exists so latency-sensitive consumers (the barge-in confirm
+	// window, #431) can observe when a speaker actually fell silent without
+	// waiting out the hangover, whose job is utterance merging for STT.
+	VADVoicingStopped
+
+	// VADVoicingResumed indicates voicing picked back up inside the utterance
+	// after a VADVoicingStopped, before the hangover elapsed — so no new
+	// VADSpeechStart fires, but the speaker is audibly talking again.
+	VADVoicingResumed
 )

--- a/pkg/voice/voiceevent/event.go
+++ b/pkg/voice/voiceevent/event.go
@@ -52,6 +52,40 @@ type VADSpeechEnd struct {
 // EventName implements [Event].
 func (VADSpeechEnd) EventName() string { return "vad.speech_end" }
 
+// VADVoicingStopped marks the PROVISIONAL end of voicing inside a still-open
+// utterance: the VAD saw its first sub-threshold frame after voiced frames,
+// but the end-of-speech hangover has not elapsed, so no [VADSpeechEnd] fires
+// yet. It is not a segment boundary — the Segmenter ignores it and keeps
+// buffering — but it is the earliest "the speaker actually fell silent"
+// signal, which the [BargeIn] confirm window disarms on (#431): under the
+// production hangover (longer than the confirm window) the segment-final
+// speech_end always arrives too late to disarm, so Soft-overlap (CONTEXT.md)
+// would otherwise be unreachable. SpeakerID attribution as in [VADSpeechEnd].
+type VADVoicingStopped struct {
+	At          time.Time
+	Probability float64
+	SpeakerID   string
+}
+
+// EventName implements [Event].
+func (VADVoicingStopped) EventName() string { return "vad.voicing_stopped" }
+
+// VADVoicingResumed marks voicing picking back up inside a still-open
+// utterance after a [VADVoicingStopped], before the hangover elapsed. Because
+// the utterance never closed, no fresh [VADSpeechStart] fires — this is the
+// only onset signal a mid-utterance resumption produces, and the [BargeIn]
+// reactor re-arms its confirm window on it (#431): a participant who pauses
+// briefly and then keeps talking over the Agent is still interrupting.
+// SpeakerID attribution as in [VADSpeechStart].
+type VADVoicingResumed struct {
+	At          time.Time
+	Probability float64
+	SpeakerID   string
+}
+
+// EventName implements [Event].
+func (VADVoicingResumed) EventName() string { return "vad.voicing_resumed" }
+
 // STTPartial is the MUTABLE interim hypothesis of the in-progress utterance
 // (ADR-0042/0020). Text REPLACES all previous partials for the same UtteranceID —
 // it is not cumulative. Only [STTFinal] reaches Address Detection and the


### PR DESCRIPTION
## What does this PR do?

Closes #431, closes #432, closes #434 — the three conversation-UX defects from the 2026-07-14 review. Together they make talking over an Agent behave like talking over a (politely deferential) human: it yields the moment you genuinely interrupt, keeps talking through your "mhm", and never pipes up uninvited at a cough.

**#431 — Soft-overlap is now reachable in production.** The confirm window used to disarm only on `vad.speech_end`, which Silero delays by its min-silence hangover (12 × 32 ms = 384 ms) — longer than the 250 ms window — so the timer always won and *every* backchannel cancelled the Agent's whole turn. The Silero session now surfaces its provisional in-utterance transitions — `VADVoicingStopped` on the first sub-threshold frame (the speaker actually fell silent) and `VADVoicingResumed` on pickup before the hangover elapses — the VAD stage republishes them (`vad.voicing_stopped` / `vad.voicing_resumed`, SpeakerID-stamped per ADR-0050), and `BargeIn` disarms on the stop and (re-)arms on the resume. The hangover keeps its one job (utterance merging for STT); segmentation is untouched, and `speech_end` still disarms as a fallback for VAD sources without provisional transitions.

**#432 — Gate 1 is re-validated at window expiry.** Arming now captures the speaking turn's TurnID (`Floor.SpeakingTurn`), and the expiring timer yields via `Floor.YieldTurn`, which atomically re-checks that the *same* turn still holds the floor and is still audibly speaking. A new pre-audio turn that took the floor mid-window is spared (the `no_audio` self-cancel class Gate 1 exists to prevent), as is — deliberately, the strict reading — a *different* turn that started speaking mid-window: the human hadn't heard it when they began talking. Expiry on a free floor stays a silent no-op.

**#434 — Empty finals route nowhere.** The `AddressDetector` drops an `STTFinal` whose text is empty/whitespace-only before matching: no `AddressRouted`/`EnsembleRouted`, hence no turn, no history/Hot-Context append, no LLM+TTS spend. The STT stage's publish-everything contract and Transcript semantics are unchanged; each drop logs an INFO line so live sessions show noise-trigger frequency.

ADR-0027 is amended with the two barge mechanics. The per-Agent confirm-window tunable stays out of scope (unimplemented, as before).

## Why is this change needed?

Every live Voice Session hit all three: a "ja", cough, or chair creak ≥ ~96 ms of voiced audio killed the Agent mid-sentence (the effective backchannel filter was the undocumented VAD onset, not the documented confirm window); an expiring window could cancel a brand-new turn that had never made a sound; and a noise burst the recognizer heard as nothing made an NPC speak unprompted while polluting its history and spending provider money. All three defeat documented core conversation behaviour (CONTEXT.md Soft-overlap / Barge-in Confirm Window, ADR-0027).

## How was this tested?

TDD: every new test was verified red against the pre-fix reactor/detector, then green with the fix.

- `internal/wirenpc/bargetiming_test.go` replays the **production constants** (250 ms window vs 384 ms hangover) with real event timing: a ~100 ms backchannel whose `speech_end` lands at burst+384 ms does **not** cancel; sustained voicing barges with latency ≈ window. In-test premise guards fail loudly if a constants change ever silently re-creates the trap (#431 AC "relate the two constants").
- `barge_test.go`: voicing_stopped disarms (and the late speech_end stays a no-op); voicing_resumed re-arms and still barges; per-speaker keying extends to the provisional transitions (ADR-0050); holder-change/speaking-holder-change/free-floor at expiry all spared with zero spurious events; a segmenter-driven pipeline test proves the spared burst is **still transcribed and committed** (one recognizer segment, one `STTFinal`).
- `floor_test.go`: `SpeakingTurn` / `YieldTurn` unit contracts (identity match, audibility requirement, idempotence).
- `silero_test.go`: stop/resume cycle fires exactly once per pause/pickup, segment stays open, `minSilenceFrames=1` degenerates straight to `speech_end`; existing state-transition tables updated to the richer taxonomy.
- `address_emptyfinal_test.go`: sole-NPC and last-addressed rosters route nothing for `""`/whitespace finals; named utterances route exactly as before.

- [x] `make check` passes (`go build`, `go vet`, `golangci-lint`: 0 issues; full `go test ./...` — the only failures are the pre-existing ONNX-runtime-download failures this sandbox cannot avoid, identical set on `main`)
- [x] New/updated tests cover the change (`go test -race` on all touched packages)
- [ ] Manual testing (not possible in this environment — no live Discord/provider access)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [x] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (modulo the pre-existing sandbox ONNX-download failures, same on `main`)
- [x] I have updated documentation if needed (ADR-0027 amendment)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **New event taxonomy is additive**: `vad.voicing_stopped` / `vad.voicing_resumed` are extra bus events; the Segmenter, Transcript, and metrics subscribers don't subscribe to them, and the `vad.VADEventType` enum appends (no renumbering). Any SSE consumer sees two new self-describing event names.
- **Design choice on resumption**: a pause + resume restarts the confirm window (CONTEXT.md's "continuous voiced speech"), and the provisional stop fires on the *first* sub-threshold frame — Silero's LSTM smoothing keeps intra-phrase dips rare, so a determined interrupter still lands ≈ window latency (pinned by the wirenpc timing test), while the disarm gets the earliest possible signal.
- The interplay the review called out — a backchannel that both cancels the turn (#431) and triggers a spurious follow-up (#434) — is now closed at both ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DgVjpU8X4msnVMPNsxxLQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011DgVjpU8X4msnVMPNsxxLQ)_