### PR TITLE
fix(#427,#438) + refactor(#449,#450): degrade-chain tool strip, dice-gate residuals, kgvocab, PromptKG seam

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -726,7 +726,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// Manager (the active Campaign). Gating it on the provider would silently lose
 	// the feature on keyless deployments. It owns no goroutine/subscription, so
 	// there is nothing to Close.
-	mgr.SetFacts(kgfacts.New(store, mgr, metrics, log, kgfacts.Config{}))
+	mgr.SetFacts(kgfacts.New(store.PromptKG(), mgr, metrics, log, kgfacts.Config{}))
 
 	// Knowledge Tools' read sources (#296, S1): the storage-backed adapter behind
 	// the read-only transcript_search and kg_query built-ins. UNCONDITIONAL — like
@@ -735,7 +735,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// granted NPC recall the transcript and its own Node neighbourhood. It flows onto
 	// the base voice config every session copies; in web-only mode the Manager starts
 	// no sessions, so the Tools stay dormant. SearchFacts drops gm_private (ADR-0008).
-	knowledgeAdapter := knowledge.New(store, mgr)
+	knowledgeAdapter := knowledge.New(store, store.PromptKG(), mgr)
 	mgr.SetToolDeps(tool.Deps{
 		Transcripts: knowledgeAdapter,
 		KG:          knowledgeAdapter,

--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -63,13 +63,20 @@ const factsHeader = "## What you know about the world"
 // in the agent's rendered block. Reserved in the block-budget accounting.
 const blockJoin = "\n\n"
 
-// Nodes is the narrow storage read kgfacts needs: the Agent's edge-aware Node
-// neighbourhood — its own linked Node plus its single-hop neighbours (both edge
-// directions), gm-public only, bounded (the prompt-injection read, #133).
-// *storage.Store satisfies it.
-type Nodes interface {
+// PromptKG is the prompt-facing KG read seam kgfacts needs (#450): the Agent's
+// edge-aware Node neighbourhood — its own linked Node plus its single-hop
+// neighbours (both edge directions), gm-public only, bounded (the
+// prompt-injection read, #133). It deliberately declares NO unfiltered KG read:
+// what this interface returns lands in an NPC's Hot Context, so gm_private
+// filtering is enforced by the seam (see the gm_private seam test in
+// internal/storage), not by call-site discipline. storage's PromptKG() view
+// satisfies it.
+type PromptKG interface {
 	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
 }
+
+// Compile-time assertion: the storage prompt view satisfies the seam.
+var _ PromptKG = storage.PromptKGView{}
 
 // Sessions is the narrow read kgfacts needs from the SessionManager: whether a
 // Voice Session is active this turn — the guard that keeps Facts a no-op when idle
@@ -103,17 +110,17 @@ func (c Config) withDefaults() Config {
 // subscription (unlike recall) — the read is inline per turn. Safe for concurrent
 // use (its deps are).
 type Recaller struct {
-	nodes    Nodes
+	nodes    PromptKG
 	sessions Sessions
 	metrics  Metrics
 	log      *slog.Logger
 	budget   time.Duration
 }
 
-// New builds a Recaller wired to the public-Node read, the session source (for the
-// active Campaign), and the metrics sink. Unlike recall it starts nothing and owns
-// no resources to release.
-func New(nodes Nodes, sessions Sessions, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
+// New builds a Recaller wired to the prompt-facing KG read seam (pass storage's
+// PromptKG() view), the session source (for the active Campaign), and the
+// metrics sink. Unlike recall it starts nothing and owns no resources to release.
+func New(nodes PromptKG, sessions Sessions, metrics Metrics, log *slog.Logger, cfg Config) *Recaller {
 	cfg = cfg.withDefaults()
 	if log == nil {
 		log = slog.Default()

--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 )
 
@@ -231,27 +232,11 @@ func renderFact(n storage.KGNode) string {
 	return head + "\n" + body
 }
 
-// typeLabel maps a Node type onto its GM-facing label (#126 test contract). An
-// unknown type falls back to "Note" defensively (the DB enum keeps this exhaustive).
+// typeLabel maps a Node type onto its GM-facing label (#126 test contract) via
+// the single label map in pkg/kgvocab (#449); an unknown type falls back to
+// "Note" there.
 func typeLabel(t storage.KGNodeType) string {
-	switch t {
-	case storage.KGNodeCharacter:
-		return "Character"
-	case storage.KGNodeNPC:
-		return "NPC"
-	case storage.KGNodeLocation:
-		return "Location"
-	case storage.KGNodeFaction:
-		return "Faction"
-	case storage.KGNodeItem:
-		return "Item"
-	case storage.KGNodePlotThread:
-		return "Plot thread"
-	case storage.KGNodeNote:
-		return "Note"
-	default:
-		return "Note"
-	}
+	return kgvocab.NodeTypeLabel(string(t))
 }
 
 // truncateRunes trims s to at most max runes, appending an ellipsis when it cut —

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -19,7 +19,7 @@ import (
 // agentID string, so the render/cap tests must pass a real uuid to reach the read.
 var testAgent = uuid.New()
 
-// fakeNodes is a scripted kgfacts.Nodes: it returns fixed Nodes or an error, and
+// fakeNodes is a scripted kgfacts.PromptKG: it returns fixed Nodes or an error, and
 // can block until ctx is cancelled to exercise the budget timeout.
 type fakeNodes struct {
 	nodes    []storage.KGNode
@@ -64,7 +64,7 @@ func activeSessions(campaignID uuid.UUID) fakeSessions {
 	return fakeSessions{vs: storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID}, ok: true}
 }
 
-func newRecaller(t *testing.T, nodes kgfacts.Nodes, sessions kgfacts.Sessions, m kgfacts.Metrics) *kgfacts.Recaller {
+func newRecaller(t *testing.T, nodes kgfacts.PromptKG, sessions kgfacts.Sessions, m kgfacts.Metrics) *kgfacts.Recaller {
 	t.Helper()
 	return kgfacts.New(nodes, sessions, m, nil, kgfacts.Config{})
 }

--- a/internal/knowledge/dedup_test.go
+++ b/internal/knowledge/dedup_test.go
@@ -34,7 +34,7 @@ func TestExistingKnowledge_OwnNodeGathersPendingAndEstablished(t *testing.T) {
 			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: uuid.New().String(), Subject: "Arturus", Fact: "ist ein Ritter"}), // different target
 		},
 	}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	w := tool.ProposedWrite{Kind: "fact", NodeID: ownNodeID.String(), Subject: "Gesa", Fact: "something new"}
 	known, err := adapter.ExistingKnowledge(context.Background(), aid.String(), w)
@@ -65,7 +65,7 @@ func TestExistingKnowledge_CampaignBySubjectName(t *testing.T) {
 			pendingRow(cid, tool.ProposedWrite{Kind: "fact", Subject: "the duke", Fact: "is old"}),
 		},
 	}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	w := tool.ProposedWrite{Kind: "fact", Subject: "The Duke", Fact: "new fact"}
 	known, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), w)
@@ -94,7 +94,7 @@ func TestExistingKnowledge_UnifiesOwnNodeAndCampaignKeys(t *testing.T) {
 			pendingRow(cid, tool.ProposedWrite{Kind: "fact", NodeID: gesaID.String(), Subject: "Gesa", Fact: "ist die Schwester von Arturus"}),
 		},
 	}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	// The Butler now re-proposes the same fact campaign-scoped (no node id, subject
 	// by name) — it must see the NPC's pending row via the unified key.
@@ -116,7 +116,7 @@ func TestExistingKnowledge_SkipsGMPrivateEstablished(t *testing.T) {
 	store := &fakeStore{
 		allNodes: []storage.KGNode{{ID: secretID, Name: "The Traitor", Body: "is secretly the spy", GMPrivate: true}},
 	}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 	w := tool.ProposedWrite{Kind: "fact", Subject: "The Traitor", Fact: "is secretly the spy"}
 	known, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), w)
 	if err != nil {
@@ -129,7 +129,7 @@ func TestExistingKnowledge_SkipsGMPrivateEstablished(t *testing.T) {
 
 // No active session is a clean error the handler can fail open on.
 func TestExistingKnowledge_NoSessionErrors(t *testing.T) {
-	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	adapter := knowledge.New(&fakeStore{}, &fakeStore{}, fakeSessions{live: false})
 	if _, err := adapter.ExistingKnowledge(context.Background(), uuid.New().String(), tool.ProposedWrite{Kind: "fact", Subject: "X", Fact: "y"}); err == nil {
 		t.Error("want error with no active session")
 	}

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/textnorm"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
@@ -174,27 +175,10 @@ func toFacts(nodes []storage.KGNode) []tool.KGFact {
 	return out
 }
 
-// typeLabel maps a Node type onto its GM-facing label, mirroring kgfacts. An
-// unknown type falls back to "Note" (the DB enum keeps this exhaustive).
+// typeLabel maps a Node type onto its GM-facing label via the single label map
+// in pkg/kgvocab (#449); an unknown type falls back to "Note" there.
 func typeLabel(t storage.KGNodeType) string {
-	switch t {
-	case storage.KGNodeCharacter:
-		return "Character"
-	case storage.KGNodeNPC:
-		return "NPC"
-	case storage.KGNodeLocation:
-		return "Location"
-	case storage.KGNodeFaction:
-		return "Faction"
-	case storage.KGNodeItem:
-		return "Item"
-	case storage.KGNodePlotThread:
-		return "Plot thread"
-	case storage.KGNodeNote:
-		return "Note"
-	default:
-		return "Note"
-	}
+	return kgvocab.NodeTypeLabel(string(t))
 }
 
 // proposalWriteTimeout bounds the cancel-immune proposal INSERT: ADR-0052 barge

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -9,9 +9,9 @@
 // It mirrors the kgfacts pattern (internal/kgfacts): a Store for the reads plus a
 // Sessions source for the active Campaign, with "no active session → error" so a
 // Tool called outside a live turn reports it cleanly rather than reading nothing.
-// The load-bearing invariant is SearchFacts DROPPING gm_private rows:
-// storage.SearchNodes is the GM-facing wiki search and does NOT filter them
-// (ADR-0008), so an unfiltered pass would leak a GM secret into an NPC's prompt.
+// The prompt-facing KG fact reads run exclusively through the [PromptKG] seam,
+// which has no method that can return a gm_private row (#450) — filtering is
+// enforced by that interface, see the gm_private seam test in internal/storage.
 package knowledge
 
 import (
@@ -37,19 +37,33 @@ import (
 // panic or a silent empty read against the wrong Campaign.
 var ErrNoActiveSession = errors.New("knowledge: no active voice session")
 
-// Store is the narrow set of storage reads the adapter needs. *storage.Store
-// satisfies it. Kept local (not the whole *storage.Store) so the adapter's
-// contract is explicit and unit-fakeable.
-type Store interface {
+// PromptKG is the prompt-facing KG read seam (#450): the ONLY surface the
+// adapter's fact reads (OwnNodeFacts, SearchFacts — both of which land in an
+// Agent's prompt) may touch. Every method is gm_private-filtered in storage and
+// the interface deliberately declares NO unfiltered read, so wiring a GM-facing
+// read into prompt assembly is unrepresentable here — the guard is the type, not
+// a per-call-site comment. storage.PromptKGView satisfies it.
+type PromptKG interface {
 	// SearchPublicNodes is the prompt-facing KG search: gm_private Nodes are
 	// EXCLUDED in the query (before the LIMIT), so a GM-only Node never reaches a
 	// prompt and a public match is not starved by top-ranked private hits (ADR-0008).
 	SearchPublicNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
-	// SearchTranscriptLines is the campaign-scoped transcript search (#120).
-	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
 	// AgentNodeFacts is the Agent's own edge-aware neighbourhood, already
 	// gm_private-filtered (#133).
 	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
+}
+
+// Compile-time assertion: the storage prompt view satisfies the seam.
+var _ PromptKG = storage.PromptKGView{}
+
+// Store is the narrow set of NON-prompt storage reads/writes the adapter needs —
+// the transcript search plus the Knowledge Proposal write path (ADR-0052, already
+// GM-gated). *storage.Store satisfies it. Kept local (not the whole
+// *storage.Store) so the adapter's contract is explicit and unit-fakeable. The
+// prompt-facing KG fact reads live on [PromptKG] instead (#450).
+type Store interface {
+	// SearchTranscriptLines is the campaign-scoped transcript search (#120).
+	SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.TranscriptLine, error)
 	// AgentLinkedNode is the Agent's own linked Node (the NPC-Node↔Agent link),
 	// the anchor an own_node-scoped remember_knowledge proposal attaches to (#300,
 	// ADR-0052). ok=false means the Agent has no linked entry.
@@ -62,7 +76,8 @@ type Store interface {
 	// queue a re-proposal is checked against.
 	ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error)
 	// ListNodes resolves a campaign-scoped proposal's subject Node by name so its
-	// established body facts can be dedup candidates (#411).
+	// established body facts can be dedup candidates (#411, write path — its output
+	// is Go-filtered for gm_private before any echo, see ExistingKnowledge).
 	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
 }
 
@@ -74,20 +89,24 @@ type Sessions interface {
 }
 
 // Adapter implements both tool.TranscriptSearcher and tool.KGReader over a
-// storage Store and the active-session source. Safe for concurrent use (its deps
-// are). Build it once at web boot and set it on the session Manager's base config.
+// storage Store, the prompt-facing [PromptKG] read seam, and the active-session
+// source. Safe for concurrent use (its deps are). Build it once at web boot and
+// set it on the session Manager's base config.
 type Adapter struct {
 	store    Store
+	kg       PromptKG // prompt-facing KG fact reads ONLY (#450)
 	sessions Sessions
 }
 
-// New builds the adapter. Both deps must be non-nil — they are wiring
-// requirements, so a nil is a boot bug, not a runtime condition.
-func New(store Store, sessions Sessions) *Adapter {
-	if store == nil || sessions == nil {
-		panic("knowledge: New: nil store or sessions")
+// New builds the adapter over the non-prompt store reads, the prompt-facing KG
+// read seam (pass storage's PromptKG() view), and the session source. All deps
+// must be non-nil — they are wiring requirements, so a nil is a boot bug, not a
+// runtime condition.
+func New(store Store, kg PromptKG, sessions Sessions) *Adapter {
+	if store == nil || kg == nil || sessions == nil {
+		panic("knowledge: New: nil store, prompt KG, or sessions")
 	}
-	return &Adapter{store: store, sessions: sessions}
+	return &Adapter{store: store, kg: kg, sessions: sessions}
 }
 
 // activeCampaign resolves the Campaign the live session scopes reads to, or
@@ -127,16 +146,17 @@ func (a *Adapter) SearchTranscript(ctx context.Context, query string, limit int)
 }
 
 // OwnNodeFacts implements [tool.KGReader]. It returns the Agent's own linked Node
-// plus its single-hop neighbourhood (#133), already gm_private-filtered and
-// edge-aware by storage. The agentID is the caller identity threaded from the
-// turn ctx (never the LLM args); an empty or unparseable id has no neighbourhood
-// to scope to and yields no facts (never a wider fallback).
+// plus its single-hop neighbourhood (#133), read through the [PromptKG] seam
+// (gm_private filtering enforced by that interface, #450). The agentID is the
+// caller identity threaded from the turn ctx (never the LLM args); an empty or
+// unparseable id has no neighbourhood to scope to and yields no facts (never a
+// wider fallback).
 func (a *Adapter) OwnNodeFacts(ctx context.Context, agentID string) ([]tool.KGFact, error) {
 	aid, err := uuid.Parse(agentID)
 	if err != nil || aid == uuid.Nil {
 		return nil, nil
 	}
-	nodes, err := a.store.AgentNodeFacts(ctx, aid)
+	nodes, err := a.kg.AgentNodeFacts(ctx, aid)
 	if err != nil {
 		return nil, fmt.Errorf("knowledge: own node facts: %w", err)
 	}
@@ -144,17 +164,16 @@ func (a *Adapter) OwnNodeFacts(ctx context.Context, agentID string) ([]tool.KGFa
 }
 
 // SearchFacts implements [tool.KGReader]. It runs the campaign-wide KG search for
-// the Butler's grant over SearchPublicNodes, which EXCLUDES gm_private Nodes in
-// the query itself — the load-bearing ADR-0008 guard. The exclusion must be in
-// the query, not a post-fetch Go filter: filtering after the SQL LIMIT would drop
-// the top-N ranked hits when they are all gm_private and starve a public match
-// ranked just past the limit. No session yields ErrNoActiveSession.
+// the Butler's grant through the [PromptKG] seam, whose SearchPublicNodes
+// EXCLUDES gm_private Nodes in the query itself, before the LIMIT (gm_private
+// filtering enforced by that interface, #450 — see the seam test in
+// internal/storage). No session yields ErrNoActiveSession.
 func (a *Adapter) SearchFacts(ctx context.Context, query string, limit int) ([]tool.KGFact, error) {
 	campaignID, err := a.activeCampaign()
 	if err != nil {
 		return nil, err
 	}
-	nodes, err := a.store.SearchPublicNodes(ctx, campaignID, query, limit)
+	nodes, err := a.kg.SearchPublicNodes(ctx, campaignID, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("knowledge: search facts: %w", err)
 	}

--- a/internal/knowledge/knowledge_integration_test.go
+++ b/internal/knowledge/knowledge_integration_test.go
@@ -120,7 +120,7 @@ func TestAdapter_SearchFactsDropsGMPrivate_RealDB(t *testing.T) {
 		}
 	}
 
-	adapter := knowledge.New(store, staticSession{sess: storage.VoiceSession{CampaignID: campaignID}, live: true})
+	adapter := knowledge.New(store, store.PromptKG(), staticSession{sess: storage.VoiceSession{CampaignID: campaignID}, live: true})
 
 	// LIMIT 1 is the discriminating case: the private rows out-rank the public one,
 	// so only a BEFORE-LIMIT exclusion can return the public fact.
@@ -154,7 +154,7 @@ func TestAdapter_SearchTranscriptCampaignScoped_RealDB(t *testing.T) {
 		t.Fatalf("upsert transcript line: %v", err)
 	}
 
-	adapter := knowledge.New(store, staticSession{sess: sess, live: true})
+	adapter := knowledge.New(store, store.PromptKG(), staticSession{sess: sess, live: true})
 
 	hits, err := adapter.SearchTranscript(ctx, "promise", 10)
 	if err != nil {
@@ -165,7 +165,7 @@ func TestAdapter_SearchTranscriptCampaignScoped_RealDB(t *testing.T) {
 	}
 
 	// No active session → the campaign-scoped reads error, never read cross-campaign.
-	idle := knowledge.New(store, staticSession{live: false})
+	idle := knowledge.New(store, store.PromptKG(), staticSession{live: false})
 	if _, err := idle.SearchTranscript(ctx, "promise", 10); !errors.Is(err, knowledge.ErrNoActiveSession) {
 		t.Errorf("SearchTranscript idle = %v, want ErrNoActiveSession", err)
 	}

--- a/internal/knowledge/knowledge_proposal_integration_test.go
+++ b/internal/knowledge/knowledge_proposal_integration_test.go
@@ -80,7 +80,7 @@ func TestRememberKnowledge_OwnNodeProposal_RealDB(t *testing.T) {
 	store, pool, campaignID, agentID, nodeID := seedProposalWorld(t, dsn)
 	ctx := context.Background()
 
-	adapter := knowledge.New(store, staticSession{
+	adapter := knowledge.New(store, store.PromptKG(), staticSession{
 		sess: storage.VoiceSession{CampaignID: campaignID}, live: true,
 	})
 	rk := tool.NewRememberKnowledge(adapter)
@@ -160,7 +160,7 @@ func TestRememberKnowledge_DoubleRememberOneRow_RealDB(t *testing.T) {
 	store, _, campaignID, agentID, _ := seedProposalWorld(t, dsn)
 	ctx := context.Background()
 
-	adapter := knowledge.New(store, staticSession{
+	adapter := knowledge.New(store, store.PromptKG(), staticSession{
 		sess: storage.VoiceSession{CampaignID: campaignID}, live: true,
 	})
 	rk := tool.NewRememberKnowledge(adapter)

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -107,7 +107,7 @@ func TestSearchFactsUsesPublicSearchScoped(t *testing.T) {
 	store := &fakeStore{nodes: []storage.KGNode{
 		{Name: "Public Duke", Type: storage.KGNodeNPC, Body: "rules openly"},
 	}}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	facts, err := adapter.SearchFacts(context.Background(), "duke", 5)
 	if err != nil {
@@ -123,7 +123,7 @@ func TestSearchFactsUsesPublicSearchScoped(t *testing.T) {
 
 // TestSearchFactsNoSessionErrors pins the no-active-session error path.
 func TestSearchFactsNoSessionErrors(t *testing.T) {
-	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	adapter := knowledge.New(&fakeStore{}, &fakeStore{}, fakeSessions{live: false})
 	if _, err := adapter.SearchFacts(context.Background(), "x", 5); !errors.Is(err, knowledge.ErrNoActiveSession) {
 		t.Errorf("SearchFacts with no session = %v, want ErrNoActiveSession", err)
 	}
@@ -136,7 +136,7 @@ func TestSearchTranscriptCampaignScoped(t *testing.T) {
 	store := &fakeStore{lines: []storage.TranscriptLine{
 		{Who: "Bart", Kind: "npc", Text: "I remember."},
 	}}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	hits, err := adapter.SearchTranscript(context.Background(), "remember", 5)
 	if err != nil {
@@ -149,7 +149,7 @@ func TestSearchTranscriptCampaignScoped(t *testing.T) {
 		t.Errorf("hits = %+v, want the one Bart line", hits)
 	}
 
-	idle := knowledge.New(store, fakeSessions{live: false})
+	idle := knowledge.New(store, store, fakeSessions{live: false})
 	if _, err := idle.SearchTranscript(context.Background(), "x", 5); !errors.Is(err, knowledge.ErrNoActiveSession) {
 		t.Errorf("SearchTranscript with no session = %v, want ErrNoActiveSession", err)
 	}
@@ -163,7 +163,7 @@ func TestOwnNodeFactsResolvesAgent(t *testing.T) {
 	store := &fakeStore{agentNodes: []storage.KGNode{
 		{Name: "Mara", Type: storage.KGNodeCharacter, Body: "owes you"},
 	}}
-	adapter := knowledge.New(store, liveSession(uuid.New()))
+	adapter := knowledge.New(store, store, liveSession(uuid.New()))
 
 	facts, err := adapter.OwnNodeFacts(context.Background(), aid.String())
 	if err != nil {
@@ -197,7 +197,7 @@ func TestOwnNodeResolvesLinkedNode(t *testing.T) {
 	aid := uuid.New()
 	nid := uuid.New()
 	store := &fakeStore{linkedNode: storage.KGNode{ID: nid, Name: "Bartholomew"}, linkedOK: true}
-	adapter := knowledge.New(store, liveSession(uuid.New()))
+	adapter := knowledge.New(store, store, liveSession(uuid.New()))
 
 	ref, ok, err := adapter.OwnNode(context.Background(), aid.String())
 	if err != nil || !ok {
@@ -228,7 +228,7 @@ func TestCreateProposalShapeAndScope(t *testing.T) {
 	cid := uuid.New()
 	aid := uuid.New()
 	store := &fakeStore{}
-	adapter := knowledge.New(store, liveSession(cid))
+	adapter := knowledge.New(store, store, liveSession(cid))
 
 	// The turn ctx is ALREADY cancelled (barge) when the write starts; the store's
 	// write ctx must NOT observe it (context.WithoutCancel).
@@ -264,7 +264,7 @@ func TestCreateProposalShapeAndScope(t *testing.T) {
 // TestCreateProposalNoSessionErrors pins the no-active-session error path for the
 // write seam.
 func TestCreateProposalNoSessionErrors(t *testing.T) {
-	adapter := knowledge.New(&fakeStore{}, fakeSessions{live: false})
+	adapter := knowledge.New(&fakeStore{}, &fakeStore{}, fakeSessions{live: false})
 	err := adapter.CreateProposal(context.Background(), uuid.New().String(),
 		tool.ProposedWrite{V: 1, Kind: "fact", Fact: "x"})
 	if !errors.Is(err, knowledge.ErrNoActiveSession) {

--- a/internal/observe/recorder.go
+++ b/internal/observe/recorder.go
@@ -177,9 +177,8 @@ const (
 
 // MalformedPath is the bounded label naming WHICH detection site caught a
 // malformed tool generation on the [StageRecorder.MalformedToolGen] counter
-// (#398/#399/#410). All three values are reserved now so the series' label space
-// is fixed from the first slice (ADR-0032 bounded labels); #398 emits only
-// [MalformedStreamError], with #399/#410 lighting up the other two.
+// (#398/#399/#410/#438). The value set is closed so the series' label space is
+// fixed (ADR-0032 bounded labels).
 type MalformedPath string
 
 const (
@@ -193,6 +192,10 @@ const (
 	// MalformedRollClaim: the model narrated a dice result it never actually rolled
 	// via the tool, caught by the roll-claim guard (#399).
 	MalformedRollClaim MalformedPath = "roll_claim"
+	// MalformedRegenMismatch: the forced dice regeneration (#399) narrated a roll
+	// value contradicting the dice Tool's ACTUAL result, caught by the regen
+	// consistency check (#438). The contradicting draft was discarded.
+	MalformedRegenMismatch MalformedPath = "regen_mismatch"
 )
 
 // StageRecorder records the orchestrator's per-stage / per-turn latency

--- a/internal/rpc/knowledge_proposal.go
+++ b/internal/rpc/knowledge_proposal.go
@@ -14,14 +14,10 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 )
-
-// proposalWriteVersion mirrors the storage/tool ProposedWrite schema version
-// (ADR-0052 "v":1). A row whose version differs is unreadable and listed with an
-// unset write oneof.
-const proposalWriteVersion = 1
 
 // Knowledge Proposal review handlers (#300, ADR-0052) on CampaignServer: the GM
 // review surface for the pending queue an Agent's remember_knowledge call files
@@ -224,11 +220,11 @@ func similarityQueryText(raw json.RawMessage) string {
 		return ""
 	}
 	switch w.Kind {
-	case "fact":
+	case kgvocab.KindFact:
 		return w.Subject + ": " + w.Fact
-	case "edge":
+	case kgvocab.KindEdge:
 		return w.Subject + " " + w.Relation + " " + w.Target
-	case "node":
+	case kgvocab.KindNode:
 		return w.Name + "\n\n" + w.Body
 	default:
 		return ""
@@ -248,27 +244,27 @@ func toProtoKnowledgeProposal(p storage.KnowledgeProposal) *managementv1.Knowled
 	}
 
 	var w tool.ProposedWrite
-	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil || w.V != proposalWriteVersion {
+	if err := json.Unmarshal(p.ProposedWrite, &w); err != nil || w.V != kgvocab.ProposalWriteVersion {
 		slog.Default().Warn("KnowledgeProposal: unparseable proposed_write; listing with unset write",
 			"proposal_id", p.ID, "err", err)
 		return out // write oneof left unset → UI renders "unreadable — reject"
 	}
 
 	switch w.Kind {
-	case "fact":
+	case kgvocab.KindFact:
 		out.Write = &managementv1.KnowledgeProposal_Fact{Fact: &managementv1.ProposedFact{
 			NodeId:  w.NodeID,
 			Subject: w.Subject,
 			Fact:    w.Fact,
 		}}
-	case "edge":
+	case kgvocab.KindEdge:
 		out.Write = &managementv1.KnowledgeProposal_Edge{Edge: &managementv1.ProposedEdge{
 			NodeId:   w.NodeID,
 			Subject:  w.Subject,
 			Relation: toProtoEdgeType(storage.KGEdgeType(w.Relation)),
 			Target:   w.Target,
 		}}
-	case "node":
+	case kgvocab.KindNode:
 		out.Write = &managementv1.KnowledgeProposal_Node{Node: &managementv1.ProposedNode{
 			NodeType: toProtoNodeType(storage.KGNodeType(w.NodeType)),
 			Name:     w.Name,

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // Knowledge Graph Edge persistence (#132, ADR-0008 v1.0 + 2026-07-04 amendment):
@@ -28,19 +30,21 @@ var ErrInvalidEdge = errors.New("storage: invalid edge")
 var ErrConflict = errors.New("storage: conflict")
 
 // KGEdgeType is a Knowledge Graph Edge's type (CONTEXT.md "Edge", ADR-0008). It
-// mirrors the kg_edge_type Postgres enum.
+// mirrors the kg_edge_type Postgres enum. The values are compiler-linked to the
+// single relation vocabulary in pkg/kgvocab (#449), which the remember_knowledge
+// Tool's schema/validation also derives from.
 type KGEdgeType string
 
 const (
-	KGEdgeResidesIn      KGEdgeType = "resides_in"
-	KGEdgeMemberOf       KGEdgeType = "member_of"
-	KGEdgeOwns           KGEdgeType = "owns"
-	KGEdgeKnows          KGEdgeType = "knows"
-	KGEdgeEnemyOf        KGEdgeType = "enemy_of"
-	KGEdgeAllyOf         KGEdgeType = "ally_of"
-	KGEdgeParentOf       KGEdgeType = "parent_of"
-	KGEdgeParticipatedIn KGEdgeType = "participated_in"
-	KGEdgeMentionedIn    KGEdgeType = "mentioned_in"
+	KGEdgeResidesIn      KGEdgeType = kgvocab.RelationResidesIn
+	KGEdgeMemberOf       KGEdgeType = kgvocab.RelationMemberOf
+	KGEdgeOwns           KGEdgeType = kgvocab.RelationOwns
+	KGEdgeKnows          KGEdgeType = kgvocab.RelationKnows
+	KGEdgeEnemyOf        KGEdgeType = kgvocab.RelationEnemyOf
+	KGEdgeAllyOf         KGEdgeType = kgvocab.RelationAllyOf
+	KGEdgeParentOf       KGEdgeType = kgvocab.RelationParentOf
+	KGEdgeParticipatedIn KGEdgeType = kgvocab.RelationParticipatedIn
+	KGEdgeMentionedIn    KGEdgeType = kgvocab.RelationMentionedIn
 )
 
 // KGEdge is one persisted typed directional Edge between two Nodes in a Campaign.

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // Knowledge Graph Node persistence (#126, ADR-0008 v1.0): the structured wiki /
@@ -17,16 +19,19 @@ import (
 
 // KGNodeType is a Knowledge Graph Node's type (CONTEXT.md "Node", ADR-0008). It
 // mirrors the kg_node_type Postgres enum; the value is immutable after create.
+// The values are compiler-linked to the single node-type vocabulary in
+// pkg/kgvocab (#449), which the remember_knowledge Tool's schema/validation and
+// the GM-facing label map also derive from.
 type KGNodeType string
 
 const (
-	KGNodeCharacter  KGNodeType = "character"
-	KGNodeNPC        KGNodeType = "npc"
-	KGNodeLocation   KGNodeType = "location"
-	KGNodeFaction    KGNodeType = "faction"
-	KGNodeItem       KGNodeType = "item"
-	KGNodePlotThread KGNodeType = "plot_thread"
-	KGNodeNote       KGNodeType = "note"
+	KGNodeCharacter  KGNodeType = kgvocab.NodeTypeCharacter
+	KGNodeNPC        KGNodeType = kgvocab.NodeTypeNPC
+	KGNodeLocation   KGNodeType = kgvocab.NodeTypeLocation
+	KGNodeFaction    KGNodeType = kgvocab.NodeTypeFaction
+	KGNodeItem       KGNodeType = kgvocab.NodeTypeItem
+	KGNodePlotThread KGNodeType = kgvocab.NodeTypePlotThread
+	KGNodeNote       KGNodeType = kgvocab.NodeTypeNote
 )
 
 // KGNode is one persisted Knowledge Graph Node in a Campaign. GMPrivate hides the

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -249,9 +249,8 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 // hint the GM review surface shows beside a Knowledge Proposal (#300, ADR-0052).
 // NULL-embedding rows are excluded (the partial HNSW index). Unlike the
 // prompt-facing searches this INCLUDES gm_private Nodes: it is GM-facing review
-// only, so the exclusion that guards NPC prompts does not apply here. NEVER reuse
-// this for NPC prompt assembly — it would leak GM secrets. k <= 0 is a caller bug
-// and errors. The query vector reuses encodeVector + a server-side ::vector cast,
+// only, and it is deliberately NOT part of [PromptKGView] — prompt assembly
+// cannot reach it (#450). k <= 0 is a caller bug and errors. The query vector reuses encodeVector + a server-side ::vector cast,
 // so storage carries no pgvector-go dependency.
 func (s *Store) SimilarNodes(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]KGNode, error) {
 	if k <= 0 {

--- a/internal/storage/kg_prompt.go
+++ b/internal/storage/kg_prompt.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// PromptKGView is the prompt-facing Knowledge Graph read surface (#450,
+// ADR-0008): the type prompt-assembly code (Hot Context fact recall, the
+// kg_query Tool adapter) holds for KG reads. Every method filters gm_private
+// rows inside its SQL, and the type exposes NO unfiltered read — "reaches a
+// prompt" and "may see gm_private" are separated by the type system instead of
+// by remembering the right *Store method name at each call site. GM and web
+// review surfaces keep the full-KG reads on *Store (SearchNodes, SimilarNodes,
+// ListNodes), which never flow into prompt assembly.
+//
+// The zero-lag filtering semantics are those of the underlying *Store reads;
+// the gm_private exclusion is pinned by the seam integration test
+// (TestPromptKG_NeverReturnsGMPrivate).
+type PromptKGView struct{ s *Store }
+
+// PromptKG returns the prompt-facing read view of this Store — the ONLY KG
+// handle prompt-assembly wiring should be given (#450).
+func (s *Store) PromptKG() PromptKGView { return PromptKGView{s: s} }
+
+// SearchPublicNodes is the prompt-facing KG search: gm_private Nodes are
+// excluded in the query, before the LIMIT (see [Store.SearchPublicNodes]).
+func (v PromptKGView) SearchPublicNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]KGNode, error) {
+	return v.s.SearchPublicNodes(ctx, campaignID, query, limit)
+}
+
+// AgentNodeFacts is the Agent's own edge-aware Node neighbourhood, gm-public
+// only (see [Store.AgentNodeFacts]).
+func (v PromptKGView) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode, error) {
+	return v.s.AgentNodeFacts(ctx, agentID)
+}

--- a/internal/storage/kg_prompt_test.go
+++ b/internal/storage/kg_prompt_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestPromptKG_NeverReturnsGMPrivate is the #450 seam pin: it seeds gm_private
+// Nodes right where each prompt-facing read would surface them — a top-ranked
+// private search hit and a private edge-neighbour — and drives EVERY read the
+// [storage.PromptKGView] exposes, asserting zero leakage. Prompt assembly holds
+// only this view (kgfacts Hot Context, the knowledge Tool adapter), so this test
+// is the one place the "no gm_private row can reach a prompt" invariant is
+// proven against a real DB; the per-call-site warning comments point here.
+func TestPromptKG_NeverReturnsGMPrivate(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	view := st.PromptKG()
+
+	// Public and private Nodes sharing search terms, so the private one would
+	// rank in an unfiltered search.
+	pub := mkNode(t, st, campaignID, storage.KGNodeLocation, "Harbor of Silverport")
+	secret, err := st.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: storage.KGNodeLocation, Name: "Harbor smugglers' cache",
+		Body: "GM only: the harbor cache holds the stolen crown.", GMPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateNode secret: %v", err)
+	}
+
+	// An NPC linked to an Agent, with one public and one gm_private neighbour.
+	own := mkNode(t, st, campaignID, storage.KGNodeNPC, "Dockmaster Ilva")
+	agentID := linkAgent(t, st, campaignID, own.ID, "Ilva")
+	mkEdge(t, st, campaignID, own.ID, pub.ID, storage.KGEdgeResidesIn)
+	mkEdge(t, st, campaignID, own.ID, secret.ID, storage.KGEdgeKnows)
+
+	assertNoPrivate := func(op string, nodes []storage.KGNode, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		for _, n := range nodes {
+			if n.GMPrivate {
+				t.Errorf("%s leaked gm_private node %q through the prompt seam", op, n.Name)
+			}
+			if n.ID == secret.ID {
+				t.Errorf("%s returned the seeded secret node %q", op, n.Name)
+			}
+		}
+	}
+
+	// Seam read 1: the prompt-facing search. The private Node matches "harbor"
+	// too and must be excluded in the query, not post-hoc.
+	hits, err := view.SearchPublicNodes(ctx, campaignID, "harbor", 10)
+	assertNoPrivate("SearchPublicNodes", hits, err)
+	if len(hits) != 1 || hits[0].ID != pub.ID {
+		t.Errorf("SearchPublicNodes = %d hits, want exactly the public harbor node", len(hits))
+	}
+
+	// Seam read 2: the Agent's Hot Context neighbourhood. The private neighbour's
+	// Edge exists but the Node must not surface.
+	facts, err := view.AgentNodeFacts(ctx, agentID)
+	assertNoPrivate("AgentNodeFacts", facts, err)
+	got := nodeIDSet(facts)
+	if got[own.ID] != 1 || got[pub.ID] != 1 || len(facts) != 2 {
+		t.Errorf("AgentNodeFacts = %+v, want exactly own node + public neighbour", facts)
+	}
+
+	// Contrast: the GM-facing reads on *Store still see the private Node — the
+	// filter lives in the seam, not in the data.
+	gmHits, err := st.SearchNodes(ctx, campaignID, "harbor", 10)
+	if err != nil {
+		t.Fatalf("SearchNodes: %v", err)
+	}
+	if nodeIDSet(gmHits)[secret.ID] != 1 {
+		t.Errorf("GM-facing SearchNodes no longer sees the gm_private node — the seam must filter, not the table")
+	}
+}

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
@@ -165,25 +166,23 @@ func (s *Store) ApproveKnowledgeProposal(ctx context.Context, campaignID, id uui
 		if err := json.Unmarshal(raw, &w); err != nil {
 			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
 		}
-		if w.V != proposalWriteVersion {
+		// The approve side checks the SAME version and kind identifiers the create
+		// side stamped — both from pkg/kgvocab (#449), so they cannot drift.
+		if w.V != kgvocab.ProposalWriteVersion {
 			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
 		}
 		switch w.Kind {
-		case "fact":
+		case kgvocab.KindFact:
 			return tx.applyProposedFact(ctx, campaignID, w)
-		case "edge":
+		case kgvocab.KindEdge:
 			return tx.applyProposedEdge(ctx, campaignID, w)
-		case "node":
+		case kgvocab.KindNode:
 			return tx.applyProposedNode(ctx, campaignID, w)
 		default:
 			return &ProposalBlockedError{Reason: "unreadable proposal — reject it"}
 		}
 	})
 }
-
-// proposalWriteVersion mirrors tool's stamped schema version (ADR-0052 "v":1). An
-// approved row whose version differs is unreadable and must be rejected.
-const proposalWriteVersion = 1
 
 // applyProposedFact appends the proposal's fact sentence to the target Node's body
 // (blank body → the fact alone; non-blank → separated by a blank line) and resets

--- a/pkg/kgvocab/kgvocab.go
+++ b/pkg/kgvocab/kgvocab.go
@@ -1,0 +1,128 @@
+// Package kgvocab is the single home of the Knowledge Proposal write-contract
+// vocabulary (#449, ADR-0052/ADR-0008): the proposal write version, the proposal
+// kind identifiers, the closed Edge relation and Node type vocabularies, and the
+// GM-facing Node type labels.
+//
+// It is a LEAF package — it imports nothing from this repository — so both sides
+// of the write contract can consume one definition: pkg/tool (the create path,
+// which must stay storage-free) declares its JSON-schema enums and validates
+// arguments from it, and internal/storage (the approve path), internal/rpc (the
+// review surface), internal/kgfacts and internal/knowledge (the label renderers)
+// re-check the same shapes against the same values. Adding a relation or node
+// type is therefore ONE edit here: every validator, schema enum, and typed
+// constant is compiler-linked to these declarations, so the create and approve
+// sides cannot drift apart and label drift is impossible.
+//
+// The wire/DB representations are exactly these strings (lowercase snake_case);
+// the Postgres kg_edge_type / kg_node_type enums mirror them.
+package kgvocab
+
+// ProposalWriteVersion is the schema version stamped onto every ProposedWrite
+// ("v":1, ADR-0052), so a later shape change is detectable on the stored jsonb.
+// The create path stamps it; the approve and review paths reject a row whose
+// version differs as unreadable.
+const ProposalWriteVersion = 1
+
+// Proposal kinds (ADR-0052): the tagged-union discriminator of a ProposedWrite.
+// fact/edge may be proposed own_node or campaign; node (a brand-new wiki entry)
+// is Butler-only (campaign scope).
+const (
+	KindFact = "fact"
+	KindEdge = "edge"
+	KindNode = "node"
+)
+
+// The closed Edge relation vocabulary (ADR-0008): every relation an Edge can
+// carry and an Agent may propose.
+const (
+	RelationResidesIn      = "resides_in"
+	RelationMemberOf       = "member_of"
+	RelationOwns           = "owns"
+	RelationKnows          = "knows"
+	RelationEnemyOf        = "enemy_of"
+	RelationAllyOf         = "ally_of"
+	RelationParentOf       = "parent_of"
+	RelationParticipatedIn = "participated_in"
+	RelationMentionedIn    = "mentioned_in"
+)
+
+// relations is the relation vocabulary in its canonical (schema enum) order.
+var relations = []string{
+	RelationResidesIn,
+	RelationMemberOf,
+	RelationOwns,
+	RelationKnows,
+	RelationEnemyOf,
+	RelationAllyOf,
+	RelationParentOf,
+	RelationParticipatedIn,
+	RelationMentionedIn,
+}
+
+// Relations returns the closed relation vocabulary in canonical order, as a
+// fresh slice the caller may keep.
+func Relations() []string { return append([]string(nil), relations...) }
+
+// ValidRelation reports whether s is one of the closed relation vocabulary.
+func ValidRelation(s string) bool {
+	for _, r := range relations {
+		if s == r {
+			return true
+		}
+	}
+	return false
+}
+
+// The closed Node type vocabulary (ADR-0008): the kg_node_type values.
+const (
+	NodeTypeCharacter  = "character"
+	NodeTypeNPC        = "npc"
+	NodeTypeLocation   = "location"
+	NodeTypeFaction    = "faction"
+	NodeTypeItem       = "item"
+	NodeTypePlotThread = "plot_thread"
+	NodeTypeNote       = "note"
+)
+
+// nodeTypes is the node-type vocabulary in its canonical (enum / schema) order.
+var nodeTypes = []string{
+	NodeTypeCharacter,
+	NodeTypeNPC,
+	NodeTypeLocation,
+	NodeTypeFaction,
+	NodeTypeItem,
+	NodeTypePlotThread,
+	NodeTypeNote,
+}
+
+// NodeTypes returns the closed node-type vocabulary in canonical order, as a
+// fresh slice the caller may keep.
+func NodeTypes() []string { return append([]string(nil), nodeTypes...) }
+
+// ValidNodeType reports whether s is one of the closed node-type vocabulary.
+func ValidNodeType(s string) bool {
+	_, ok := nodeTypeLabels[s]
+	return ok
+}
+
+// nodeTypeLabels maps each node type to its GM-facing label — the one label map
+// kgfacts and knowledge used to duplicate.
+var nodeTypeLabels = map[string]string{
+	NodeTypeCharacter:  "Character",
+	NodeTypeNPC:        "NPC",
+	NodeTypeLocation:   "Location",
+	NodeTypeFaction:    "Faction",
+	NodeTypeItem:       "Item",
+	NodeTypePlotThread: "Plot thread",
+	NodeTypeNote:       "Note",
+}
+
+// NodeTypeLabel returns the GM-facing label for a node type ("Character",
+// "Plot thread", …). An unknown type falls back to "Note" defensively — the DB
+// enum keeps the input exhaustive in practice.
+func NodeTypeLabel(t string) string {
+	if l, ok := nodeTypeLabels[t]; ok {
+		return l
+	}
+	return "Note"
+}

--- a/pkg/kgvocab/kgvocab_test.go
+++ b/pkg/kgvocab/kgvocab_test.go
@@ -1,0 +1,95 @@
+package kgvocab_test
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
+)
+
+// TestRelations pins the closed relation vocabulary: canonical order, validity,
+// and the returned slice being a private copy.
+func TestRelations(t *testing.T) {
+	want := []string{
+		kgvocab.RelationResidesIn, kgvocab.RelationMemberOf, kgvocab.RelationOwns,
+		kgvocab.RelationKnows, kgvocab.RelationEnemyOf, kgvocab.RelationAllyOf,
+		kgvocab.RelationParentOf, kgvocab.RelationParticipatedIn, kgvocab.RelationMentionedIn,
+	}
+	got := kgvocab.Relations()
+	if len(got) != len(want) {
+		t.Fatalf("Relations() has %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Relations()[%d] = %q, want %q", i, got[i], want[i])
+		}
+		if !kgvocab.ValidRelation(want[i]) {
+			t.Errorf("ValidRelation(%q) = false, want true", want[i])
+		}
+	}
+	if kgvocab.ValidRelation("loves") || kgvocab.ValidRelation("") {
+		t.Error("ValidRelation accepted a value outside the closed vocabulary")
+	}
+
+	got[0] = "mutated"
+	if kgvocab.Relations()[0] != kgvocab.RelationResidesIn {
+		t.Error("Relations() must return a copy; mutating the result changed the vocabulary")
+	}
+}
+
+// TestNodeTypes pins the closed node-type vocabulary and its validity check.
+func TestNodeTypes(t *testing.T) {
+	want := []string{
+		kgvocab.NodeTypeCharacter, kgvocab.NodeTypeNPC, kgvocab.NodeTypeLocation,
+		kgvocab.NodeTypeFaction, kgvocab.NodeTypeItem, kgvocab.NodeTypePlotThread,
+		kgvocab.NodeTypeNote,
+	}
+	got := kgvocab.NodeTypes()
+	if len(got) != len(want) {
+		t.Fatalf("NodeTypes() has %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("NodeTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+		if !kgvocab.ValidNodeType(want[i]) {
+			t.Errorf("ValidNodeType(%q) = false, want true", want[i])
+		}
+	}
+	if kgvocab.ValidNodeType("dragon") || kgvocab.ValidNodeType("") {
+		t.Error("ValidNodeType accepted a value outside the closed vocabulary")
+	}
+}
+
+// TestNodeTypeLabel pins the GM-facing label for EVERY node type — the one map
+// kgfacts and knowledge consume — plus the defensive "Note" fallback.
+func TestNodeTypeLabel(t *testing.T) {
+	want := map[string]string{
+		kgvocab.NodeTypeCharacter:  "Character",
+		kgvocab.NodeTypeNPC:        "NPC",
+		kgvocab.NodeTypeLocation:   "Location",
+		kgvocab.NodeTypeFaction:    "Faction",
+		kgvocab.NodeTypeItem:       "Item",
+		kgvocab.NodeTypePlotThread: "Plot thread",
+		kgvocab.NodeTypeNote:       "Note",
+	}
+	for typ, label := range want {
+		if got := kgvocab.NodeTypeLabel(typ); got != label {
+			t.Errorf("NodeTypeLabel(%q) = %q, want %q", typ, got, label)
+		}
+	}
+	if got := kgvocab.NodeTypeLabel("dragon"); got != "Note" {
+		t.Errorf("NodeTypeLabel(unknown) = %q, want the defensive Note fallback", got)
+	}
+}
+
+// TestKindsAndVersion pins the proposal kind identifiers and the write version —
+// the values the create path stamps and the approve/review paths check.
+func TestKindsAndVersion(t *testing.T) {
+	if kgvocab.KindFact != "fact" || kgvocab.KindEdge != "edge" || kgvocab.KindNode != "node" {
+		t.Errorf("kinds = %q/%q/%q, want fact/edge/node (the on-disk contract)",
+			kgvocab.KindFact, kgvocab.KindEdge, kgvocab.KindNode)
+	}
+	if kgvocab.ProposalWriteVersion != 1 {
+		t.Errorf("ProposalWriteVersion = %d, want 1 (ADR-0052)", kgvocab.ProposalWriteVersion)
+	}
+}

--- a/pkg/tool/loop.go
+++ b/pkg/tool/loop.go
@@ -49,6 +49,15 @@ type Loop struct {
 	// called" recorder must learn about a RECOVERED pseudo-dice call, which never
 	// surfaced as a provider-native ToolCall.
 	OnPseudoCall func(ctx context.Context, name string, recovered bool)
+
+	// OnToolResult fires once per executed tool call with the [ToolResult] fed
+	// back to the model: name is the Tool's name, content the result text, isErr
+	// whether it is an error result. nil is a no-op. Like OnPseudoCall it is a
+	// wiring seam kept OUT of this vendor-agnostic package (ADR-0028): the
+	// agenttool bridge uses it to record the dice Tool's ACTUAL result so the
+	// invented-roll guard can verify a regenerated narration against what was
+	// really rolled (#438).
+	OnToolResult func(ctx context.Context, name, content string, isErr bool)
 }
 
 // NewLoop builds a Loop over provider and the Agent's grants. Both must be
@@ -170,6 +179,7 @@ func (l *Loop) RunStream(ctx context.Context, messages []Message, onText func(de
 		results := make([]ToolResult, len(asst.ToolCalls))
 		for i, call := range asst.ToolCalls {
 			results[i] = l.execute(ctx, call)
+			l.fireToolResult(ctx, call.Name, results[i])
 		}
 		convo = append(convo, Message{Role: RoleTool, ToolResults: results})
 	}
@@ -235,6 +245,7 @@ func (l *Loop) Run(ctx context.Context, messages []Message) (string, error) {
 		results := make([]ToolResult, len(asst.ToolCalls))
 		for i, call := range asst.ToolCalls {
 			results[i] = l.execute(ctx, call)
+			l.fireToolResult(ctx, call.Name, results[i])
 		}
 		convo = append(convo, Message{Role: RoleTool, ToolResults: results})
 	}
@@ -335,5 +346,11 @@ func inlineEligible(t Tool) bool {
 func (l *Loop) firePseudoCall(ctx context.Context, name string, recovered bool) {
 	if l.OnPseudoCall != nil {
 		l.OnPseudoCall(ctx, name, recovered)
+	}
+}
+
+func (l *Loop) fireToolResult(ctx context.Context, name string, r ToolResult) {
+	if l.OnToolResult != nil {
+		l.OnToolResult(ctx, name, r.Content, r.IsError)
 	}
 }

--- a/pkg/tool/remember_dedup.go
+++ b/pkg/tool/remember_dedup.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/MrWong99/Glyphoxa/internal/textnorm"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // Write-time dedup for remember_knowledge (#411, ADR-0052 mechanism a): before a
@@ -21,11 +22,11 @@ import (
 // and punctuation here do not matter.
 func ProposalSalient(w ProposedWrite) string {
 	switch w.Kind {
-	case proposalKindFact:
+	case kgvocab.KindFact:
 		return w.Fact
-	case proposalKindEdge:
+	case kgvocab.KindEdge:
 		return strings.TrimSpace(w.Relation + " " + w.Target)
-	case proposalKindNode:
+	case kgvocab.KindNode:
 		return strings.TrimSpace(w.Name + " " + w.Body)
 	default:
 		return strings.TrimSpace(w.Fact + " " + w.Name + " " + w.Body)
@@ -45,7 +46,7 @@ func ProposalTargetKey(w ProposedWrite) string {
 	if s := textnorm.Normalize(w.Subject); s != "" {
 		return "subj:" + s
 	}
-	if w.Kind == proposalKindNode {
+	if w.Kind == kgvocab.KindNode {
 		if n := textnorm.Normalize(w.Name); n != "" {
 			return "name:" + n
 		}

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // MaxProposalTextRunes caps the free-text (prose) fields a remember_knowledge
@@ -17,54 +19,22 @@ import (
 // handler, per-field, before the writer is ever called.
 const MaxProposalTextRunes = 2000
 
-// Proposal kinds (ADR-0052). fact/edge may be proposed own_node or campaign;
-// node (a brand-new wiki entry) is Butler-only (campaign scope).
-const (
-	proposalKindFact = "fact"
-	proposalKindEdge = "edge"
-	proposalKindNode = "node"
-)
-
-// proposalWriteVersion is the schema version stamped onto every ProposedWrite
-// (ADR-0052 "v":1), so a later shape change is detectable on the stored jsonb.
-const proposalWriteVersion = 1
-
-// relationValues is the closed set of Edge relations an Agent may propose,
-// mirroring the kg_edge relation vocabulary (ADR-0008). Exact lowercase
-// snake_case — the review surface and the eventual approved write depend on it.
-var relationValues = map[string]bool{
-	"resides_in":      true,
-	"member_of":       true,
-	"owns":            true,
-	"knows":           true,
-	"enemy_of":        true,
-	"ally_of":         true,
-	"parent_of":       true,
-	"participated_in": true,
-	"mentioned_in":    true,
-}
-
-// nodeTypeValues is the closed set of Node types a Butler may propose for a new
-// entry, mirroring storage.KGNodeType (ADR-0008). Exact lowercase snake_case.
-var nodeTypeValues = map[string]bool{
-	"character":   true,
-	"npc":         true,
-	"location":    true,
-	"faction":     true,
-	"item":        true,
-	"plot_thread": true,
-	"note":        true,
-}
+// The proposal kinds, the write version, and the closed relation / node-type
+// vocabularies all live in ONE place — pkg/kgvocab (#449) — consumed here by the
+// create path and by internal/storage (approve), internal/rpc (review), and the
+// label renderers, so the write contract cannot drift between its sides.
 
 // rememberKnowledgeInputSchema is the JSON Schema declared to the LLM. Scope is
 // NEVER an argument (ADR-0029: it lives in the grant, enforced in the handler);
 // the model only ever names WHAT it wants to remember, never on whose authority.
+// The enum lists are built from the kgvocab vocabulary at package init (#449), so
+// the declared schema and the handler's validation cannot diverge.
 var rememberKnowledgeInputSchema = json.RawMessage(`{
   "type": "object",
   "properties": {
     "kind": {
       "type": "string",
-      "enum": ["fact", "edge", "node"],
+      "enum": ` + enumJSON(kgvocab.KindFact, kgvocab.KindEdge, kgvocab.KindNode) + `,
       "description": "fact: a statement about an entity. edge: a relationship between two entities. node: a brand-new entry for the world."
     },
     "subject": {
@@ -77,7 +47,7 @@ var rememberKnowledgeInputSchema = json.RawMessage(`{
     },
     "relation": {
       "type": "string",
-      "enum": ["resides_in", "member_of", "owns", "knows", "enemy_of", "ally_of", "parent_of", "participated_in", "mentioned_in"],
+      "enum": ` + enumJSON(kgvocab.Relations()...) + `,
       "description": "The relationship type (kind=edge)."
     },
     "target": {
@@ -86,7 +56,7 @@ var rememberKnowledgeInputSchema = json.RawMessage(`{
     },
     "node_type": {
       "type": "string",
-      "enum": ["character", "npc", "location", "faction", "item", "plot_thread", "note"],
+      "enum": ` + enumJSON(kgvocab.NodeTypes()...) + `,
       "description": "The type of the new entry (kind=node)."
     },
     "name": {
@@ -100,6 +70,16 @@ var rememberKnowledgeInputSchema = json.RawMessage(`{
   },
   "required": ["kind"]
 }`)
+
+// enumJSON renders vals as the JSON array a schema enum declares — the seam that
+// derives the declared enums from the kgvocab vocabulary (#449).
+func enumJSON(vals ...string) string {
+	b, err := json.Marshal(vals)
+	if err != nil {
+		panic(err) // marshaling a []string cannot fail
+	}
+	return string(b)
+}
 
 // rememberArgs is the decoded LLM argument set. Scope is absent by design.
 type rememberArgs struct {
@@ -290,7 +270,7 @@ func withPendingEcho(lead string, pending []string) string {
 // body must be rejected the same way for a Butler and an NPC.
 func validateArgs(a rememberArgs) error {
 	switch a.Kind {
-	case proposalKindFact:
+	case kgvocab.KindFact:
 		if strings.TrimSpace(a.Fact) == "" {
 			return fmt.Errorf("remember_knowledge: a fact requires the 'fact' text")
 		}
@@ -300,8 +280,8 @@ func validateArgs(a rememberArgs) error {
 		if err := capName("subject", a.Subject); err != nil {
 			return err
 		}
-	case proposalKindEdge:
-		if !relationValues[a.Relation] {
+	case kgvocab.KindEdge:
+		if !kgvocab.ValidRelation(a.Relation) {
 			return fmt.Errorf("remember_knowledge: %q is not a known relation", a.Relation)
 		}
 		if strings.TrimSpace(a.Target) == "" {
@@ -313,11 +293,11 @@ func validateArgs(a rememberArgs) error {
 		if err := capName("target", a.Target); err != nil {
 			return err
 		}
-	case proposalKindNode:
+	case kgvocab.KindNode:
 		if strings.TrimSpace(a.Name) == "" {
 			return fmt.Errorf("remember_knowledge: a new entry requires a 'name'")
 		}
-		if !nodeTypeValues[a.NodeType] {
+		if !kgvocab.ValidNodeType(a.NodeType) {
 			return fmt.Errorf("remember_knowledge: %q is not a known node_type", a.NodeType)
 		}
 		if err := capText("name", a.Name); err != nil {
@@ -357,7 +337,7 @@ func capName(field, s string) error {
 // supplied, and an Agent with no linked entry is refused with the writer never
 // called.
 func (rk *RememberKnowledge) ownNodeWrite(ctx context.Context, a rememberArgs) (ProposedWrite, error) {
-	if a.Kind == proposalKindNode {
+	if a.Kind == kgvocab.KindNode {
 		return ProposedWrite{}, fmt.Errorf("remember_knowledge: you may not create new entries; you can only remember facts about yourself")
 	}
 	ref, ok, err := rk.dst.OwnNode(ctx, CallerID(ctx))
@@ -367,11 +347,11 @@ func (rk *RememberKnowledge) ownNodeWrite(ctx context.Context, a rememberArgs) (
 	if !ok {
 		return ProposedWrite{}, fmt.Errorf("remember_knowledge: you have no linked wiki entry to remember facts about")
 	}
-	w := ProposedWrite{V: proposalWriteVersion, Kind: a.Kind, NodeID: ref.ID, Subject: ref.Name}
+	w := ProposedWrite{V: kgvocab.ProposalWriteVersion, Kind: a.Kind, NodeID: ref.ID, Subject: ref.Name}
 	switch a.Kind {
-	case proposalKindFact:
+	case kgvocab.KindFact:
 		w.Fact = a.Fact
-	case proposalKindEdge:
+	case kgvocab.KindEdge:
 		w.Relation = a.Relation
 		w.Target = a.Target
 	}
@@ -382,22 +362,22 @@ func (rk *RememberKnowledge) ownNodeWrite(ctx context.Context, a rememberArgs) (
 // kinds are allowed, the subject is preserved from the args, and there is no
 // anchor node_id (the review surface resolves the subject by name).
 func campaignWrite(a rememberArgs) (ProposedWrite, error) {
-	w := ProposedWrite{V: proposalWriteVersion, Kind: a.Kind}
+	w := ProposedWrite{V: kgvocab.ProposalWriteVersion, Kind: a.Kind}
 	switch a.Kind {
-	case proposalKindFact:
+	case kgvocab.KindFact:
 		if strings.TrimSpace(a.Subject) == "" {
 			return ProposedWrite{}, fmt.Errorf("remember_knowledge: a fact requires a 'subject'")
 		}
 		w.Subject = a.Subject
 		w.Fact = a.Fact
-	case proposalKindEdge:
+	case kgvocab.KindEdge:
 		if strings.TrimSpace(a.Subject) == "" {
 			return ProposedWrite{}, fmt.Errorf("remember_knowledge: an edge requires a 'subject'")
 		}
 		w.Subject = a.Subject
 		w.Relation = a.Relation
 		w.Target = a.Target
-	case proposalKindNode:
+	case kgvocab.KindNode:
 		w.NodeType = a.NodeType
 		w.Name = a.Name
 		w.Body = a.Body

--- a/pkg/tool/remember_knowledge_schema_test.go
+++ b/pkg/tool/remember_knowledge_schema_test.go
@@ -1,0 +1,58 @@
+package tool
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
+)
+
+// TestRememberKnowledgeSchema_EnumsEqualVocabulary is the #449 drift pin: the
+// JSON schema remember_knowledge DECLARES to the LLM must carry exactly the
+// kgvocab vocabularies — kinds, relations, node types — in canonical order. The
+// schema is built from the vocabulary at package init, so this asserts the
+// derivation stays wired (a hand-edited enum string would fail here).
+func TestRememberKnowledgeSchema_EnumsEqualVocabulary(t *testing.T) {
+	var schema struct {
+		Properties map[string]struct {
+			Enum []string `json:"enum"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(NewRememberKnowledge(nil).InputSchema(), &schema); err != nil {
+		t.Fatalf("declared input schema is not valid JSON: %v", err)
+	}
+
+	want := map[string][]string{
+		"kind":      {kgvocab.KindFact, kgvocab.KindEdge, kgvocab.KindNode},
+		"relation":  kgvocab.Relations(),
+		"node_type": kgvocab.NodeTypes(),
+	}
+	for field, wantEnum := range want {
+		prop, ok := schema.Properties[field]
+		if !ok {
+			t.Errorf("schema has no %q property", field)
+			continue
+		}
+		if !slices.Equal(prop.Enum, wantEnum) {
+			t.Errorf("schema %q enum = %v, want the kgvocab vocabulary %v", field, prop.Enum, wantEnum)
+		}
+	}
+}
+
+// TestRememberKnowledgeSchema_ValidationMatchesVocabulary closes the other half
+// of the #449 loop: every value the schema advertises is accepted by the
+// handler's validation, so the declared contract and the enforced one are the
+// same set (adding a relation/node type in kgvocab flips both at once).
+func TestRememberKnowledgeSchema_ValidationMatchesVocabulary(t *testing.T) {
+	for _, r := range kgvocab.Relations() {
+		if err := validateArgs(rememberArgs{Kind: kgvocab.KindEdge, Subject: "A", Relation: r, Target: "B"}); err != nil {
+			t.Errorf("validateArgs rejected advertised relation %q: %v", r, err)
+		}
+	}
+	for _, nt := range kgvocab.NodeTypes() {
+		if err := validateArgs(rememberArgs{Kind: kgvocab.KindNode, Name: "X", NodeType: nt}); err != nil {
+			t.Errorf("validateArgs rejected advertised node_type %q: %v", nt, err)
+		}
+	}
+}

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -249,10 +249,14 @@ type attemptResult struct {
 // provider's tool_use_failed class and has NOT yet forwarded any prose is retried
 // once with the same tools+choice (no backoff); a second failure of the same class
 // regenerates tool-less (tools stay DECLARED, tool_choice none — the conversation
-// may hold prior tool_call/tool messages). A round that already forwarded a delta is
-// never retried (ADR-0044 mid-stream rule), and a ctx cancellation between attempts
-// aborts. Every malformed generation increments MalformedToolGen so provider flake
-// stays visible even when the turn fully recovers.
+// may hold prior tool_call/tool messages). If the tool-less attempt ALSO fails with
+// the same class (#427: some models call a tool despite tool_choice none) and the
+// conversation holds no prior tool messages, one final attempt strips the tool
+// declarations entirely; with prior tool messages the failure propagates. A round
+// that already forwarded a delta is never retried (ADR-0044 mid-stream rule), and a
+// ctx cancellation between attempts aborts. Every malformed generation increments
+// MalformedToolGen so provider flake stays visible even when the turn fully
+// recovers.
 func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, tools []tool.Decl, onText func(delta string) error) (tool.AssistantMessage, error) {
 	round := nextRound(ctx)
 	start := time.Now()
@@ -289,6 +293,29 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 					return a.abortBetweenAttempts(ctx, err)
 				}
 				res = a.attempt(ctx, messages, tools, llm.ToolChoice{Mode: llm.ToolChoiceNone}, onText)
+
+				if a.isToolSyntax(res) {
+					// Attempt 4 (#427): some models ignore tool_choice none and call a
+					// tool anyway, which the provider rejects at the wire — so the #398
+					// fallback itself failed. The third malformed generation is counted
+					// either way. When the conversation holds NO prior tool_call/tool
+					// messages, ONE final attempt is made with the tool declarations
+					// stripped entirely: with nothing declared there is nothing to call,
+					// so this failure class is impossible. With prior tool messages the
+					// error propagates as before — stripping the declarations there
+					// risks a provider 400 on the now-dangling tool references (the
+					// reason #420 kept tools declared on the none-attempt).
+					a.rec.MalformedToolGen(a.provName, observe.MalformedStreamError)
+					a.recordReportedUsage(res.haveUsage, res.usage)
+					if !hasToolHistory(messages) {
+						slog.Warn("agenttool: tool-less fallback still failed tool-syntax; regenerating with tools stripped",
+							"provider", string(a.provName), "round", round)
+						if err := ctx.Err(); err != nil {
+							return a.abortBetweenAttempts(ctx, err)
+						}
+						res = a.attempt(ctx, messages, nil, llm.ToolChoice{}, onText)
+					}
+				}
 			}
 		}
 	}
@@ -297,6 +324,20 @@ func (a providerAdapter) complete(ctx context.Context, messages []tool.Message, 
 	// invented-roll guard; a no-op unless this turn installed a [calledTools] set.
 	recordCalledTools(ctx, res.msg.ToolCalls)
 	return a.recordOutcome(ctx, round, start, messages, res)
+}
+
+// hasToolHistory reports whether the conversation already carries a tool_call or
+// tool-result message — the #427 guard condition: only a tool-history-free
+// conversation may have its tool declarations stripped on the final degrade
+// attempt (a prior tool reference with no matching declaration risks a provider
+// 400).
+func hasToolHistory(messages []tool.Message) bool {
+	for _, m := range messages {
+		if len(m.ToolCalls) > 0 || len(m.ToolResults) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // isToolSyntax reports whether res failed with the provider's tool-syntax class AND

--- a/pkg/voice/agenttool/agenttool.go
+++ b/pkg/voice/agenttool/agenttool.go
@@ -110,15 +110,21 @@ func consumeForcedChoice(ctx context.Context) (llm.ToolChoice, bool) {
 type calledToolsKey struct{}
 
 // calledTools is the per-turn recorder behind [calledToolsKey]: the adapter marks
-// every Tool the model emitted a call for; the guard queries it with [has]. Safe
-// for the loop's single goroutine plus the race detector.
+// every Tool the model emitted a call for, and the loop's OnToolResult wiring
+// records each executed Tool's result content (#438) so the regen guard can
+// verify a narration against what was actually rolled. The guard queries it with
+// [has] / [resultsFor]. Safe for the loop's single goroutine plus the race
+// detector.
 type calledTools struct {
-	mu    sync.Mutex
-	names map[string]bool
+	mu      sync.Mutex
+	names   map[string]bool
+	results map[string][]string
 }
 
 // newCalledTools builds an empty per-turn called-Tools recorder.
-func newCalledTools() *calledTools { return &calledTools{names: map[string]bool{}} }
+func newCalledTools() *calledTools {
+	return &calledTools{names: map[string]bool{}, results: map[string][]string{}}
+}
 
 // withCalledTools returns ctx carrying c, so the adapter records executed tool-call
 // names into it as the turn runs.
@@ -131,6 +137,15 @@ func (c *calledTools) has(name string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.names[name]
+}
+
+// resultsFor returns the executed-result contents recorded for name this turn
+// (#438) — the dice Tool's actual result lines the regen consistency check
+// verifies the narration against.
+func (c *calledTools) resultsFor(name string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.results[name]...)
 }
 
 // recordCalledTools marks every tool-call name in calls on the per-turn recorder
@@ -159,6 +174,21 @@ func markCalledTool(ctx context.Context, name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.names[name] = true
+}
+
+// markToolResult records one executed Tool's result content on the per-turn
+// recorder ctx carries, if any (#438). An executed result implies the Tool was
+// called, so the name is marked too — the loop's OnToolResult wiring feeds this
+// regardless of whether the call was provider-native or pseudo-recovered.
+func markToolResult(ctx context.Context, name, content string) {
+	c, _ := ctx.Value(calledToolsKey{}).(*calledTools)
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.names[name] = true
+	c.results[name] = append(c.results[name], content)
 }
 
 // providerAdapter makes a streaming [llm.Provider] usable as the non-streaming
@@ -666,6 +696,15 @@ func NewEngine(provider llm.Provider, grants *tool.GrantSet, agentID, model stri
 				markCalledTool(ctx, name)
 			}
 		}
+		// #438: record every executed Tool's result on the turn's recorder (a
+		// no-op without one) so the invented-roll guard can verify a forced
+		// regeneration's narration against the dice Tool's ACTUAL result. Error
+		// results are skipped — a refused roll yields no legitimate number.
+		l.OnToolResult = func(ctx context.Context, name, content string, isErr bool) {
+			if !isErr {
+				markToolResult(ctx, name, content)
+			}
+		}
 		return l
 	}
 	// Two loops over the same adapter: full grants, and grants with dice dropped.
@@ -749,20 +788,21 @@ func (e *Engine) generate(ctx context.Context, messages []llm.Message, onText fu
 
 	// Post-hoc guard (Option C): dice was armed, the dice Tool was never actually
 	// called, and the reply narrates a numeric roll result → the model invented it.
-	// Regenerate ONCE with the dice Tool forced; the forced round's provider failures
-	// flow into the #398 policy (no new retry). The discarded draft is NEVER
-	// delivered — on a regeneration error the turn fails rather than speak the
-	// invented number (ADR-0030: a discarded draft must not surface).
+	// Regenerate with the dice Tool forced and the narration VERIFIED against the
+	// Tool's actual result (#438, see [Engine.regenWithForcedDice]); the forced
+	// rounds' provider failures flow into the #398 policy (no new retry). The
+	// discarded draft is NEVER delivered — on a regeneration error the turn fails
+	// rather than speak the invented number (ADR-0030: a discarded draft must not
+	// surface).
 	if !called.has(diceToolName) && claimsRollResult(text) {
 		e.rec.MalformedToolGen(e.provName, observe.MalformedRollClaim)
 		slog.Warn("agenttool: dice armed but model narrated an unrolled result; regenerating with forced dice tool",
 			"provider", string(e.provName))
-		forced := withForcedToolChoice(withRoundCounter(ctx), llm.ToolChoice{Mode: llm.ToolChoiceTool, Tool: diceToolName})
-		regen, rerr := e.full.Run(forced, msgs)
+		regen, rerr := e.regenWithForcedDice(ctx, msgs)
 		if rerr != nil {
 			return "", rerr
 		}
-		text = regen // deliver the regenerated reply as-is — the guard fires at most once
+		text = regen
 	}
 
 	// Deliver the (possibly regenerated) whole text once — same whole-text push the
@@ -774,6 +814,41 @@ func (e *Engine) generate(ctx context.Context, messages []llm.Message, onText fu
 		}
 	}
 	return text, nil
+}
+
+// maxForcedRegens bounds the invented-roll escalation: the #399 forced
+// regeneration plus ONE #438 consistency retry — never an unbounded loop.
+const maxForcedRegens = 2
+
+// regenWithForcedDice re-runs the buffered turn with the dice Tool forced on the
+// opening round (#399) and verifies the regenerated narration against the dice
+// Tool's ACTUAL result (#438): a regen that claims a roll value contradicting
+// what the Tool returned — or that claims a value without the Tool having run at
+// all — is discarded and retried once; a second contradiction fails the turn
+// (ADR-0012/ADR-0030: a contradicting number must never be spoken, a discarded
+// draft must never surface). A claim-free regen, or one whose claim matches the
+// rolled result, is returned unchanged. Each attempt runs with a fresh
+// [calledTools] recorder so the consistency check sees only THAT attempt's rolls,
+// and each mismatch is counted on the bounded regen_mismatch label.
+func (e *Engine) regenWithForcedDice(ctx context.Context, msgs []tool.Message) (string, error) {
+	for attempt := 1; ; attempt++ {
+		called := newCalledTools()
+		forced := withForcedToolChoice(withCalledTools(withRoundCounter(ctx), called),
+			llm.ToolChoice{Mode: llm.ToolChoiceTool, Tool: diceToolName})
+		regen, err := e.full.Run(forced, msgs)
+		if err != nil {
+			return "", err
+		}
+		if rollClaimConsistent(regen, called.resultsFor(diceToolName)) {
+			return regen, nil
+		}
+		e.rec.MalformedToolGen(e.provName, observe.MalformedRegenMismatch)
+		slog.Warn("agenttool: forced regen narrated a roll contradicting the dice result; draft discarded",
+			"provider", string(e.provName), "attempt", attempt)
+		if attempt >= maxForcedRegens {
+			return "", errors.New("agenttool: regenerated reply kept contradicting the actual dice result")
+		}
+	}
 }
 
 // withDiceHardening returns messages with [diceHardeningInstruction] appended to

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -1517,6 +1517,9 @@ func TestEngine_DiceHardening_ArmedTurnAppendsInstruction(t *testing.T) {
 // the model narrates a roll result WITHOUT calling the tool → the reply is discarded
 // and regenerated with the dice tool FORCED; the delivered reply reflects the
 // actually executed roll, and exactly one roll-claim malformed-gen is counted.
+//
+// The seeded diceGrants rng rolls a 16 first — the regen narrates that same 16, so
+// the #438 consistency check sees a matching claim and the reply ships unchanged.
 func TestEngine_InventedRoll_RegeneratesWithForcedDice(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{
 		// Run 1 (buffered): invents a result, no tool call.
@@ -1524,7 +1527,7 @@ func TestEngine_InventedRoll_RegeneratesWithForcedDice(t *testing.T) {
 		// Forced regen round 0: now it calls the dice tool.
 		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
 		// Forced regen round 1: answers with the real result in context.
-		{text: "The bones show an 8, traveler.", stop: "end_turn"},
+		{text: "The bones show a 16, traveler.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
 	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
@@ -1537,7 +1540,7 @@ func TestEngine_InventedRoll_RegeneratesWithForcedDice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if strings.TrimSpace(got) != "The bones show an 8, traveler." {
+	if strings.TrimSpace(got) != "The bones show a 16, traveler." {
 		t.Errorf("delivered = %q, want the regenerated reply reflecting the executed roll", got)
 	}
 	if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedRollClaim {
@@ -1619,13 +1622,19 @@ func TestEngine_NotArmed_GuardNeverFires(t *testing.T) {
 	}
 }
 
-// TestEngine_InventedRoll_SingleEscalation is AC "guard fires at most once per
-// turn": if the FORCED regeneration still narrates a bare number, it is delivered
-// as-is — the guard does not loop. Exactly two loop runs (buffered + one regen).
-func TestEngine_InventedRoll_SingleEscalation(t *testing.T) {
+// TestEngine_RegenMismatch_RetriesOnceThenDelivers is #438 AC "regen narrating a
+// value ≠ actual Tool result does not ship as-is": the first forced regen claims a
+// 17 without the dice Tool ever running, so it contradicts (no Tool result at all)
+// and is discarded; the ONE bounded retry does a proper round-trip narrating the
+// actual roll (the seeded 16) and ships. Counted: one roll_claim + one
+// regen_mismatch, both bounded labels (#430).
+func TestEngine_RegenMismatch_RetriesOnceThenDelivers(t *testing.T) {
 	prov := &scriptedProvider{steps: []step{
 		{text: "Ah, eine 19!", stop: "end_turn"},          // run 1: invented
-		{text: "Trust me, a solid 17.", stop: "end_turn"}, // forced regen: still a bare number, no tool call
+		{text: "Trust me, a solid 17.", stop: "end_turn"}, // regen 1: claims a number, tool never ran → contradiction
+		// Regen 2 (the one bounded retry): proper dice round-trip.
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "A 16! The bones favor you.", stop: "end_turn"},
 	}}
 	rec := &recordingStage{}
 	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
@@ -1635,14 +1644,130 @@ func TestEngine_InventedRoll_SingleEscalation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if strings.TrimSpace(got) != "Trust me, a solid 17." {
-		t.Errorf("delivered = %q, want the single regeneration delivered as-is", got)
+	if strings.TrimSpace(got) != "A 16! The bones favor you." {
+		t.Errorf("delivered = %q, want the consistent retry's reply", got)
 	}
-	if paths := rec.malformedPaths(); len(paths) != 1 {
-		t.Errorf("MalformedToolGen count = %d, want 1 (guard fires at most once)", len(paths))
+	if paths := rec.malformedPaths(); len(paths) != 2 ||
+		paths[0] != observe.MalformedRollClaim || paths[1] != observe.MalformedRegenMismatch {
+		t.Errorf("MalformedToolGen paths = %v, want [roll_claim regen_mismatch]", paths)
+	}
+	if n := len(prov.requests()); n != 4 {
+		t.Errorf("Complete calls = %d, want 4 (buffered run + contradicting regen + retry round-trip)", n)
+	}
+}
+
+// TestEngine_RegenMismatch_ContradictsRealRollRetries is the #438 headline: the
+// forced regen DOES call the dice Tool (it rolls the seeded 16) but narrates a 20 —
+// the invented-number-despite-rolling case. The contradicting draft is discarded
+// and the bounded retry's consistent narration ships.
+func TestEngine_RegenMismatch_ContradictsRealRollRetries(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "Ah, eine 19!", stop: "end_turn"}, // run 1: invented
+		// Regen 1: calls dice (rolls 16)... then narrates a 20 anyway.
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "A natural 20! Incredible!", stop: "end_turn"},
+		// Regen 2: rolls again (13) and narrates it faithfully.
+		{calls: []llm.ToolCall{{ID: "t2", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "The bones show a 13.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "The bones show a 13." {
+		t.Errorf("delivered = %q, want the retry's faithful narration (the 20-claim must not ship)", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 2 ||
+		paths[0] != observe.MalformedRollClaim || paths[1] != observe.MalformedRegenMismatch {
+		t.Errorf("MalformedToolGen paths = %v, want [roll_claim regen_mismatch]", paths)
+	}
+}
+
+// TestEngine_RegenMismatch_BoundedThenFailsTurn pins the #438 bound: when the
+// retry ALSO contradicts, the turn fails — never an unbounded loop, and the
+// contradicting draft is NEVER delivered (ADR-0030). Exactly three loop runs
+// (buffered + regen + one retry) and three bounded malformed labels.
+func TestEngine_RegenMismatch_BoundedThenFailsTurn(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "Ah, eine 19!", stop: "end_turn"},          // run 1: invented
+		{text: "Trust me, a solid 17.", stop: "end_turn"}, // regen 1: contradicts (no roll)
+		{text: "Fine — an 11 then.", stop: "end_turn"},    // regen 2: still contradicts (no roll)
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err == nil {
+		t.Fatal("Generate = nil error; want the turn to fail rather than speak a contradicting roll")
+	}
+	if got != "" {
+		t.Errorf("delivered = %q; a contradicting draft must never surface", got)
+	}
+	if n := len(prov.requests()); n != 3 {
+		t.Errorf("Complete calls = %d, want 3 (buffered + regen + ONE bounded retry)", n)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 3 ||
+		paths[0] != observe.MalformedRollClaim ||
+		paths[1] != observe.MalformedRegenMismatch || paths[2] != observe.MalformedRegenMismatch {
+		t.Errorf("MalformedToolGen paths = %v, want [roll_claim regen_mismatch regen_mismatch]", paths)
+	}
+}
+
+// TestEngine_RegenWithoutClaim_ShipsUnchanged: a forced regen that makes NO
+// numeric claim has nothing to contradict — it ships as-is even though the model
+// (still) never called the dice Tool. The guard escalates on invented numbers,
+// not on a number-free deflection.
+func TestEngine_RegenWithoutClaim_ShipsUnchanged(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "Ah, eine 19!", stop: "end_turn"},                  // run 1: invented
+		{text: "The fates keep their counsel.", stop: "end_turn"}, // regen: no claim, no roll
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "The fates keep their counsel." {
+		t.Errorf("delivered = %q, want the claim-free regen unchanged", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedRollClaim {
+		t.Errorf("MalformedToolGen paths = %v, want exactly [roll_claim]", paths)
 	}
 	if n := len(prov.requests()); n != 2 {
 		t.Errorf("Complete calls = %d, want 2 (buffered run + exactly one regeneration)", n)
+	}
+}
+
+// TestEngine_InventedRoll_SpelledOutNumber is #438 item 1 at the engine level: a
+// spelled-out invented result ("a natural twenty", no tool call) trips the guard
+// exactly like a digit claim, and the forced regen's faithful narration ships.
+func TestEngine_InventedRoll_SpelledOutNumber(t *testing.T) {
+	prov := &scriptedProvider{steps: []step{
+		{text: "You rolled a natural twenty! Astounding!", stop: "end_turn"}, // invented, spelled out
+		{calls: []llm.ToolCall{{ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}, stop: "tool_use"},
+		{text: "The bones show a 16, traveler.", stop: "end_turn"},
+	}}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20."}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.TrimSpace(got) != "The bones show a 16, traveler." {
+		t.Errorf("delivered = %q, want the regenerated faithful narration", got)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 1 || paths[0] != observe.MalformedRollClaim {
+		t.Errorf("MalformedToolGen paths = %v, want exactly [roll_claim]", paths)
 	}
 }
 

--- a/pkg/voice/agenttool/agenttool_test.go
+++ b/pkg/voice/agenttool/agenttool_test.go
@@ -1189,6 +1189,111 @@ func TestEngine_ToolSyntax_FallsBackToolLessAfterTwoFailures(t *testing.T) {
 	}
 }
 
+// TestEngine_ToolSyntax_StripsToolsWhenNoneAttemptFails is AC 1 (#427): when the
+// tool-less fallback attempt (tool_choice none, tools still declared) ALSO fails
+// with the tool-syntax class and the conversation holds NO prior tool_call/tool
+// messages, ONE final attempt is made with the tool declarations stripped entirely
+// (nothing to call → the wire error is impossible). Its text is delivered and the
+// turn is NOT abandoned. All three malformed generations are counted.
+func TestEngine_ToolSyntax_StripsToolsWhenNoneAttemptFails(t *testing.T) {
+	prov := &toolSyntaxProvider{fails: 3, answer: "The bones stay silent, but your hands are steady."}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	got, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err != nil {
+		t.Fatalf("Generate after three tool_use_failed: %v (turn must NOT be abandoned)", err)
+	}
+	if strings.TrimSpace(got) != "The bones stay silent, but your hands are steady." {
+		t.Errorf("final text = %q, want the tool-stripped attempt's answer", got)
+	}
+	if prov.calls != 4 {
+		t.Errorf("Complete calls = %d, want 4 (attempt, retry, tool-less, tool-stripped)", prov.calls)
+	}
+
+	reqs := prov.requests()
+	if len(reqs) != 4 {
+		t.Fatalf("recorded %d requests, want 4", len(reqs))
+	}
+	// The third request is the #398 fallback: tools declared, tool_choice none.
+	if len(reqs[2].Tools) == 0 || reqs[2].ToolChoice.Mode != llm.ToolChoiceNone {
+		t.Errorf("none-attempt tools=%d choice=%q, want declared tools with choice none",
+			len(reqs[2].Tools), reqs[2].ToolChoice.Mode)
+	}
+	// The fourth request must carry NO tool declarations at all.
+	if len(reqs[3].Tools) != 0 {
+		t.Errorf("final attempt declared %d tools, want none (stripped entirely)", len(reqs[3].Tools))
+	}
+	if reqs[3].ToolChoice.Mode == llm.ToolChoiceNone || reqs[3].ToolChoice.Mode == llm.ToolChoiceTool {
+		t.Errorf("final attempt tool_choice = %q, want the default (no tools to steer)", reqs[3].ToolChoice.Mode)
+	}
+
+	// All THREE malformed generations counted (#427: the third occurrence too).
+	if paths := rec.malformedPaths(); len(paths) != 3 {
+		t.Errorf("MalformedToolGen count = %d, want 3 (every failure counted)", len(paths))
+	}
+	rounds, callsOK, callsErr := rec.snapshot()
+	if len(rounds) != 1 || callsOK != 1 || callsErr != 0 {
+		t.Errorf("final metrics rounds=%d ok=%d err=%d, want 1/1/0 (recovered, final-outcome-only)", len(rounds), callsOK, callsErr)
+	}
+}
+
+// toolHistoryThenSyntaxProvider emits one successful dice tool-call round, then
+// fails every later Complete with the tool-syntax class — so the failing round's
+// conversation carries prior tool_call/tool messages (#427's guard condition).
+type toolHistoryThenSyntaxProvider struct {
+	mu    sync.Mutex
+	reqs  []llm.Request
+	calls int
+}
+
+func (p *toolHistoryThenSyntaxProvider) Complete(_ context.Context, req llm.Request) (<-chan llm.StreamEvent, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	p.reqs = append(p.reqs, req)
+	p.mu.Unlock()
+
+	if n == 1 {
+		ch := make(chan llm.StreamEvent, 2)
+		ch <- llm.StreamEvent{Type: llm.EventToolCall, ToolCall: llm.ToolCall{
+			ID: "t1", Name: "dice", Input: json.RawMessage(`{"count":1,"sides":20}`)}}
+		ch <- llm.StreamEvent{Type: llm.EventDone, StopReason: "tool_use"}
+		close(ch)
+		return ch, nil
+	}
+	return nil, &providererr.ToolSyntaxError{Op: "test.Complete", Msg: "tool_use_failed"}
+}
+
+// TestEngine_ToolSyntax_PriorToolHistoryPropagates is AC 2 (#427): when the
+// conversation already holds tool_call/tool messages (a dice round completed
+// earlier in the turn), the tool-stripped final attempt is NOT made — stripping
+// there risks a provider 400 on the dangling tool references (#420) — and the
+// none-attempt's failure propagates as today. The third malformed generation is
+// still counted.
+func TestEngine_ToolSyntax_PriorToolHistoryPropagates(t *testing.T) {
+	prov := &toolHistoryThenSyntaxProvider{}
+	rec := &recordingStage{}
+	eng := agenttool.NewEngine(prov, diceGrants(t), "", "m", 256, 0,
+		agenttool.WithMetrics(rec, observe.ProviderGroq),
+		agenttool.WithRetry(instantAgentRetry()))
+
+	_, err := eng.Generate(context.Background(), []llm.Message{{Role: llm.RoleUser, Text: "Roll a d20 for me."}})
+	if err == nil {
+		t.Fatal("Generate = nil, want the propagated tool-syntax error (prior tool history pins today's behaviour)")
+	}
+	// 1 successful dice round + attempt/retry/none on the follow-up round — and NO
+	// fifth, tool-stripped attempt.
+	if prov.calls != 4 {
+		t.Errorf("Complete calls = %d, want 4 (dice round + 3 failed attempts, no stripped attempt)", prov.calls)
+	}
+	if paths := rec.malformedPaths(); len(paths) != 3 {
+		t.Errorf("MalformedToolGen count = %d, want 3 (the third occurrence is counted too)", len(paths))
+	}
+}
+
 // TestEngine_NonToolSyntaxError_NotRetried is AC 3 (#398): a mid-stream provider
 // error of a DIFFERENT class (not tool_use_failed) on a tool-armed round is NOT
 // retried by the tool-syntax path — it propagates on the first call, and no

--- a/pkg/voice/agenttool/dicegate.go
+++ b/pkg/voice/agenttool/dicegate.go
@@ -33,14 +33,18 @@ var diceNotation = regexp.MustCompile(`(?i)\b\d*[dw](\d+\b|%)`)
 //   - en: \b-anchored PREFIX so inflections stay armed ("rolls", "rolling") while
 //     the "die" substring no longer trips inside unrelated words ("studied") —
 //     the substring false-positive class #226 also flags in the other direction.
+//     The named-check phrasings (perception/insight/investigation check, #438)
+//     cover the common GM "make a … check" cues the generic set missed.
 //   - de: bare substrings, because the roll cue lives inside compounds
 //     ("Würfelwerkzeug", "Rettungswurf", "Fertigkeitsprobe") that word anchors
 //     would miss. würf/wurf/wirf/werf cover würfeln + the werfen ("throw a die")
-//     verb family (imperative „wirf", „werft", „werfen wir"). This deliberately
-//     accepts rare compound false positives (Entwurf, Vorwurf, verwerfen) — the
-//     recall bias above makes that the cheap side.
+//     verb family (imperative „wirf", „werft", „werfen wir"), and the bare "probe"
+//     substring covers every named -probe check compound (Wahrnehmungsprobe,
+//     Nachforschungsprobe — the #438 DE cues) as "wurf" covers the -rettungswurf
+//     saves. This deliberately accepts rare compound false positives (Entwurf,
+//     Vorwurf, verwerfen) — the recall bias above makes that the cheap side.
 var diceKeywords = map[string]*regexp.Regexp{
-	"en": regexp.MustCompile(`(?i)\b(roll|dice|die|d20|d6|d100|saving throw|initiative|advantage|disadvantage|to hit|attack roll|ability check|skill check)`),
+	"en": regexp.MustCompile(`(?i)\b(roll|dice|die|d20|d6|d100|saving throw|initiative|advantage|disadvantage|to hit|attack roll|ability check|skill check|perception check|insight check|investigation check)`),
 	"de": regexp.MustCompile(`(?i)(würf|wurf|wirf|werf|probe|initiative)`),
 }
 

--- a/pkg/voice/agenttool/dicegate_test.go
+++ b/pkg/voice/agenttool/dicegate_test.go
@@ -32,6 +32,12 @@ func TestNeedsDice(t *testing.T) {
 		// \b-anchored prefix keeps inflections (rolls/rolling) armed.
 		{"en rolling", "en", "He keeps rolling his eyes.", true},
 
+		// --- English: common named-check phrasings (#438) — must arm dice. ---
+		{"en perception check", "en", "Make a perception check.", true},
+		{"en insight check", "en", "Give me an insight check on the merchant.", true},
+		{"en investigation check", "en", "I'd like an investigation check on the desk.", true},
+		{"en wisdom saving throw", "en", "Make a wisdom saving throw.", true},
+
 		// --- English: plain conversation — must NOT arm dice. ---
 		{"en room price", "en", "How much for a room and a pint?", false},
 		{"en greeting", "en", "Hello Bart, how are you?", false},
@@ -52,7 +58,13 @@ func TestNeedsDice(t *testing.T) {
 		{"de w20 notation", "de", "würfle zwei w20", true},
 		{"de bare notation", "de", "nimm zwei w20", true},
 		{"de Probe", "de", "mach eine Probe", true},
+		// German named checks are compounds on -probe, so the bare "probe" substring
+		// covers them all (#438) — pinned here so a keyword-set edit cannot drop them.
+		{"de Wahrnehmungsprobe", "de", "Mach eine Wahrnehmungsprobe.", true},
+		{"de Motiv-erkennen Probe", "de", "Würfle eine Probe auf Motiv erkennen.", true},
+		{"de Nachforschungen-Probe", "de", "Eine Nachforschungsprobe, bitte.", true},
 		{"de Rettungswurf", "de", "mach einen Rettungswurf gegen das Gift", true},
+		{"de Weisheitsrettungswurf", "de", "Mach einen Weisheitsrettungswurf.", true},
 		{"de Initiative", "de", "alle würfeln Initiative", true},
 		// werfen ("throw a die") verb family — imperative „wirf", „werfen" (#226).
 		{"de wirf imperative", "de", "Wirf noch einmal!", true},

--- a/pkg/voice/agenttool/rollclaim.go
+++ b/pkg/voice/agenttool/rollclaim.go
@@ -1,6 +1,10 @@
 package agenttool
 
-import "regexp"
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
 
 // diceHardeningInstruction is appended to the system prompt on dice-armed turns
 // (#399, Option B): cheap prompt hardening that tells the model to call the dice
@@ -22,13 +26,116 @@ const diceHardeningInstruction = "When asked to roll dice, call the dice tool an
 // above 100 (e.g. "3d100") without calling the tool.
 var standaloneRollNumber = regexp.MustCompile(`\b([1-9][0-9]?|100)\b`)
 
+// enNumberWord / deNumberWord are the spelled-out number vocabularies the #438
+// spelled-claim patterns capture: 1–20 plus the tens up to 100, in the two
+// campaign languages currently supported. Longer alternatives come first so the
+// capture prefers "fourteen" over "four" and "one hundred" over "one".
+const (
+	enNumberWord = `one\s+hundred|hundred|seventeen|thirteen|fourteen|eighteen|nineteen|sixteen|fifteen|seventy|twenty|thirty|eleven|twelve|eighty|ninety|forty|fifty|sixty|three|seven|eight|four|five|nine|one|two|six|ten`
+	deNumberWord = `einhundert|hundert|siebzehn|dreizehn|vierzehn|fünfzehn|sechzehn|achtzehn|neunzehn|dreißig|dreissig|siebzig|zwanzig|vierzig|fünfzig|sechzig|achtzig|neunzig|sieben|zwölf|zwei|drei|vier|fünf|sechs|acht|neun|zehn|eins|elf`
+)
+
+// spelledRollClaims match a spelled-out number word IN A ROLL-CLAIM CONTEXT
+// (#438): "you rolled a natural twenty", "a roll of ninety", "eine Zwanzig",
+// "gewürfelt: siebzehn". Unlike the digit form, a bare number word is everyday
+// prose ("twenty paces", "zwanzig Schritte"), so the spelled detector requires a
+// claim cue — a roll verb, "natural"/"nat", a German article (number-as-noun), or
+// a würfeln/Wurf cue — as its precision guard. Both languages are checked
+// unconditionally, keeping [claimsRollResult] language-free like the digit path.
+// Capture group 1 is the number word [claimedRollValues] maps to its value.
+var spelledRollClaims = []*regexp.Regexp{
+	// EN: a roll verb (with optional article/of) or "natural"/"nat", then the word.
+	regexp.MustCompile(`(?i)\b(?:roll(?:ed|s|ing)?(?:\s+(?:a|an|of))?|natural|nat)\s+(?:an?\s+)?(?:natural\s+|nat\s+)?(` + enNumberWord + `)\b`),
+	// DE: an article (optionally "natürliche") — the number-as-noun form „eine
+	// Zwanzig" — or a würfeln/Wurf cue, then the word.
+	regexp.MustCompile(`(?i)\b(?:ein(?:e|en|er)?\s+(?:natürliche[nrs]?\s+)?|gewürfelt[:,]?\s+|würfel(?:st|t)?\s+|wurf(?:s|es)?\s+(?:von\s+)?)(` + deNumberWord + `)\b`),
+}
+
+// numberWordValues maps a normalized (lowercased, whitespace-collapsed) captured
+// number word to its integer value — EN and DE, 1–20 plus the tens up to 100.
+var numberWordValues = map[string]int{
+	"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7,
+	"eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13,
+	"fourteen": 14, "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18,
+	"nineteen": 19, "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+	"sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
+	"hundred": 100, "one hundred": 100,
+
+	"eins": 1, "zwei": 2, "drei": 3, "vier": 4, "fünf": 5, "sechs": 6, "sieben": 7,
+	"acht": 8, "neun": 9, "zehn": 10, "elf": 11, "zwölf": 12, "dreizehn": 13,
+	"vierzehn": 14, "fünfzehn": 15, "sechzehn": 16, "siebzehn": 17, "achtzehn": 18,
+	"neunzehn": 19, "zwanzig": 20, "dreißig": 30, "dreissig": 30, "vierzig": 40,
+	"fünfzig": 50, "sechzig": 60, "siebzig": 70, "achtzig": 80, "neunzig": 90,
+	"hundert": 100, "einhundert": 100,
+}
+
 // claimsRollResult reports whether text reads as a narrated die result (#399,
 // Option C): explicit die notation ("d20", "2w6", "d%") is stripped first — those
 // are the request, not a result — and what remains is checked for a standalone
-// 1..100 integer. Language-free and recall-biased: a false positive only costs one
-// regeneration on a turn where the dice Tool was already armed, whereas a false
-// negative would ship an invented number, so the detector leans toward firing.
+// 1..100 integer or a spelled-out number word in a roll-claim context (#438).
+// Language-free and recall-biased: a false positive only costs one regeneration on
+// a turn where the dice Tool was already armed, whereas a false negative would
+// ship an invented number, so the detector leans toward firing.
 func claimsRollResult(text string) bool {
+	return len(claimedRollValues(text)) > 0
+}
+
+// claimedRollValues extracts the roll values text claims (#438): every standalone
+// 1..100 integer (after die notation is stripped) plus every spelled-out number
+// word in a roll-claim context, mapped to its integer. The values feed the
+// regen-consistency check ([rollClaimConsistent]); an empty result means text
+// makes no roll claim.
+func claimedRollValues(text string) []int {
 	stripped := diceNotation.ReplaceAllString(text, " ")
-	return standaloneRollNumber.MatchString(stripped)
+	var vals []int
+	for _, m := range standaloneRollNumber.FindAllString(stripped, -1) {
+		if n, err := strconv.Atoi(m); err == nil {
+			vals = append(vals, n)
+		}
+	}
+	for _, re := range spelledRollClaims {
+		for _, m := range re.FindAllStringSubmatch(stripped, -1) {
+			word := strings.Join(strings.Fields(strings.ToLower(m[1])), " ")
+			if v, ok := numberWordValues[word]; ok {
+				vals = append(vals, v)
+			}
+		}
+	}
+	return vals
+}
+
+// integerToken matches any run of digits — the loose extraction for the dice
+// Tool's own result line, where every number (individual rolls AND totals, which
+// can exceed 100) is a legitimate value for the narration to repeat.
+var integerToken = regexp.MustCompile(`\d+`)
+
+// rollClaimConsistent reports whether a regenerated reply's narrated roll claim is
+// consistent with the dice Tool's actual results (#438): a reply claiming no value
+// is trivially consistent; a claimed value is consistent when it matches ANY
+// number the Tool reported (individual rolls or totals — die notation in the
+// result line is stripped first so "1d20" never legitimizes a 20). The any-match
+// rule is deliberate: narration legitimately mixes the roll with derived numbers
+// (modifiers, totals), and a false contradiction would burn the one bounded retry
+// — while the flagship failure (Tool rolled 7, reply claims 20 and never mentions
+// the 7) can never pass. A claim with NO Tool result at all always contradicts.
+func rollClaimConsistent(text string, results []string) bool {
+	claims := claimedRollValues(text)
+	if len(claims) == 0 {
+		return true
+	}
+	actual := map[int]bool{}
+	for _, r := range results {
+		stripped := diceNotation.ReplaceAllString(r, " ")
+		for _, m := range integerToken.FindAllString(stripped, -1) {
+			if n, err := strconv.Atoi(m); err == nil {
+				actual[n] = true
+			}
+		}
+	}
+	for _, c := range claims {
+		if actual[c] {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/voice/agenttool/rollclaim_internal_test.go
+++ b/pkg/voice/agenttool/rollclaim_internal_test.go
@@ -1,12 +1,20 @@
 package agenttool
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // TestClaimsRollResult pins the recall-biased invented-roll detector (#399): after
 // stripping explicit die notation (so "W20"/"d20" tokens do not count as a claimed
 // result), a standalone 1..100 integer in the reply reads as a narrated roll result.
 // The detector is language-free and deliberately over-triggers — a false positive
 // only costs one regeneration on a turn where dice was already armed.
+//
+// #438 extends it to SPELLED-OUT numbers (EN + DE, 1–20 plus the tens up to 100),
+// but only in roll-claim contexts (a roll verb, "natural"/"nat", a German article
+// or würfeln/Wurf cue) — unlike the digit form, a bare number word is common prose
+// ("twenty paces"), so the spelled form carries a precision guard.
 func TestClaimsRollResult(t *testing.T) {
 	cases := []struct {
 		name string
@@ -20,11 +28,86 @@ func TestClaimsRollResult(t *testing.T) {
 		{"recall bias: non-roll number still fires", "Das macht 20 Goldstücke.", true},
 		{"three-digit non-roll number ignored", "Es kostet 250 Gold.", false},
 		{"hundred is a valid result", "A perfect 100 on the nose.", true},
+
+		// --- #438: spelled-out numbers in claim contexts (EN). ---
+		{"en natural twenty", "You rolled a natural twenty!", true},
+		{"en natural without roll verb", "A natural twenty! Incredible.", true},
+		{"en nat twenty", "Nat twenty, well done.", true},
+		{"en rolled a seven", "He rolled a seven, alas.", true},
+		{"en rolls a three", "The die rolls a three.", true},
+		{"en roll of ninety", "A roll of ninety on the percentile dice.", true},
+		{"en rolled a one hundred", "You rolled a one hundred!", true},
+
+		// --- #438: spelled-out numbers in claim contexts (DE). ---
+		{"de eine Zwanzig", "Ah, eine Zwanzig! Du hast Glück.", true},
+		{"de natürliche Zwanzig", "Eine natürliche Zwanzig!", true},
+		{"de eine Dreißig gewürfelt", "Du hast eine Dreißig gewürfelt.", true},
+		{"de gewürfelt: siebzehn", "Gewürfelt: siebzehn.", true},
+		{"de eine Eins", "Oh nein, eine Eins.", true},
+
+		// --- #438: precision guard — plain narrative number words do NOT fire. ---
+		{"en twenty paces", "You walk twenty paces down the corridor.", false},
+		{"en seven travelers", "Seven travelers sit by the fire.", false},
+		{"de zwanzig Schritte", "Du gehst zwanzig Schritte weiter.", false},
+		{"de vier Gäste", "Vier Gäste sitzen am Feuer.", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := claimsRollResult(tc.text); got != tc.want {
 				t.Errorf("claimsRollResult(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClaimedRollValues pins the VALUE extraction the #438 regen-consistency check
+// compares against the dice Tool's actual result: digit claims parse to their
+// integer, spelled-out claims map through the number-word tables, and die notation
+// never contributes a value.
+func TestClaimedRollValues(t *testing.T) {
+	cases := []struct {
+		text string
+		want []int
+	}{
+		{"Ah, eine 19!", []int{19}},
+		{"You rolled a natural twenty!", []int{20}},
+		{"Du hast eine Dreißig gewürfelt.", []int{30}},
+		{"I roll the d20... a 7! With +3 that's 10.", []int{7, 3, 10}},
+		{"Let me roll a d20 for you.", nil},
+		{"The bones are silent.", nil},
+	}
+	for _, tc := range cases {
+		if got := claimedRollValues(tc.text); !slices.Equal(got, tc.want) {
+			t.Errorf("claimedRollValues(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+// TestRollClaimConsistent pins the #438 regen-verification rule: a reply claiming
+// no value is trivially consistent; a claimed value is consistent when it matches
+// ANY number the dice Tool actually reported (rolls or totals — narration mixes
+// the roll with derived numbers); a claim with NO matching Tool number — including
+// no Tool result at all — contradicts.
+func TestRollClaimConsistent(t *testing.T) {
+	cases := []struct {
+		name    string
+		text    string
+		results []string
+		want    bool
+	}{
+		{"claim matches the single roll", "The bones show a 16, traveler.", []string{"Rolled 1d20: 16."}, true},
+		{"claim contradicts the roll", "A perfect 20!", []string{"Rolled 1d20: 7."}, false},
+		{"spelled claim contradicts", "You rolled a natural twenty!", []string{"Rolled 1d20: 7."}, false},
+		{"spelled claim matches", "You rolled a natural twenty!", []string{"Rolled 1d20: 20."}, true},
+		{"claim with no tool result at all", "Trust me, a solid 17.", nil, false},
+		{"no claim is trivially consistent", "The fates stay silent tonight.", nil, true},
+		{"derived total counts as consistent", "That's 3 and 4 — 7 total!", []string{"Rolled 2d6: [3 4] (total 7)."}, true},
+		{"notation in the result never legitimizes", "A 20, I swear!", []string{"Rolled 1d20: 7."}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rollClaimConsistent(tc.text, tc.results); got != tc.want {
+				t.Errorf("rollClaimConsistent(%q, %v) = %v, want %v", tc.text, tc.results, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Four fixes, one focused commit each:

Closes #427 — **Tool-less fallback dies when the model calls a tool despite tool_choice=none.** When the #398 fallback attempt (tool_choice none, tools still declared) itself fails with the tool-syntax class and the conversation holds no prior tool_call/tool messages, the adapter now makes one final attempt with the tool declarations stripped entirely — nothing to call, so the wire error is impossible and the reply delivers instead of the turn abandoning. With prior tool messages the failure propagates as before (stripping there risks a provider 400 on dangling tool references, the #420 rationale). The third malformed occurrence now increments `MalformedToolGen` too.

Closes #438 — **Dice-gate residual bypasses.**
1. *Spelled-out numbers:* `claimsRollResult` now recognizes spelled-out number words (EN + DE, 1–20 plus tens to 100) in roll-claim contexts ("rolled a natural twenty", "eine Zwanzig"), with a precision guard so narrative numbers ("twenty paces") stay unflagged.
2. *Regen verification:* `tool.Loop` gains an `OnToolResult` seam; the bridge records the dice Tool's actual results and the forced regeneration only ships when its narrated value matches a number the Tool really reported. A contradiction discards the draft and retries once (bounded); a second contradiction fails the turn — a contradicting number is never spoken. New bounded `regen_mismatch` metric label.
3. *Keyword gaps:* EN `needsDice` gains perception/insight/investigation check phrasings; the DE compounds were already covered by the `probe`/`wurf` substrings and are now pinned by tests.

Closes #449 — **One home for the Knowledge Proposal write-contract vocabulary.** New leaf package `pkg/kgvocab` owns the write version, kind identifiers, relation and node-type vocabularies, and the GM-facing labels. The remember_knowledge JSON-schema enums are derived from it at package init (drift pinned by test), the storage `KGEdgeType`/`KGNodeType` constants are compiler-linked to it, the storage/rpc approve/review paths share its kinds/version, and the duplicated 7-case label switch in kgfacts/knowledge collapses into `kgvocab.NodeTypeLabel`. No behavior change — same strings, same version, same payloads.

Closes #450 — **Type-guard the gm_private seam.** Prompt-assembly code now obtains KG facts only through a seam with no method that can return a gm_private row: `storage.PromptKGView` (via `Store.PromptKG()`) exposes only `SearchPublicNodes` and `AgentNodeFacts`; the kgfacts and knowledge consumer interfaces declare only those filtered reads, and the knowledge adapter's fact reads are separated from the (already GM-gated, out-of-scope) proposal write path. The heavy warning comments shrink to pointers at the seam. GM/web review surfaces keep the unfiltered `*Store` reads unchanged.

## Why is this change needed?

- #427 reproduced live (2026-07-12, Groq openai/gpt-oss-120b): the degrade chain's final attempt failed at the wire and the NPC went silent — the exact outcome #398 exists to prevent.
- #438's three bypasses each let an invented roll ship despite the #399/#425 enforcement core being sound.
- #449/#450 are maintainer-approved architecture-review findings (2026-07-14): the write contract was held together by matching literals across 4–5 files, and a security invariant was guarded by comments instead of types.

## How was this tested?

TDD throughout: failing tests written first for each behavior change, then the fix.

- [x] `make check` passes for all touched packages (`go test -race` on agenttool, tool, observe, kgvocab, storage, rpc, kgfacts, knowledge, plus full `./...`; the only failures are pre-existing ONNX-Runtime download blocks in the VAD packages on this sandbox, untouched by this PR)
- [x] New/updated tests cover the change: #427 strip/propagate + metric tests; #438 spelled-out claim, claimed-value, consistency, keyword, and four engine-level regen tests; #449 vocabulary tests + schema-enum drift pin; #450 seam integration test (`TestPromptKG_NeverReturnsGMPrivate`, tagged `integration`) seeding gm_private rows and driving every seam read
- [ ] Manual testing (not applicable — no live provider in the sandbox)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — #427, #438
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [x] Refactor / code cleanup — #449, #450 (no behavior change)
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (VAD packages excepted — pre-existing sandbox ONNX download block)
- [x] I have updated documentation if needed (doc comments updated at every touched seam)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages (one commit per issue)

## Additional Notes

- **#438 changes one pinned behavior on purpose:** the old `TestEngine_InventedRoll_SingleEscalation` asserted a regen narrating an unrolled number ships as-is — exactly the bug #438 item 2 describes. It is replaced by bounded-verification tests (mismatch → one retry → fail-rather-than-ship). The headline #399 test also scripted a regen narrating "an 8" while the seeded roll is 16; it now narrates the real roll, which the new consistency check enforces.
- **#438 consistency rule is any-match:** narration legitimately mixes the roll with derived numbers (modifiers, totals), so a claim is consistent when *any* claimed value matches *any* Tool-reported number. Precision-biased so a false contradiction can't burn the bounded retry; the flagship failure (rolled 7, narrates 20, never mentions 7) can never pass.
- **#450 scope:** the Knowledge Proposal dedup read (`ListNodes`, write path) stays on the adapter's non-prompt `Store` interface per the issue's out-of-scope note; its gm_private Go-filter is unchanged.
- `knowledge.New` gained a `PromptKG` parameter (internal wiring; the only caller is `cmd/glyphoxa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Twe1C84RcetQS7JR7nS6RF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twe1C84RcetQS7JR7nS6RF)_