### PR TITLE
refactor(#447): one busproject scaffold under the Relay and Chunker bus projections

### DIFF
--- a/internal/busproject/projection.go
+++ b/internal/busproject/projection.go
@@ -1,0 +1,170 @@
+// Package busproject is the shared scaffold under the process's Voice-Session
+// bus projections (#447): the transcript Relay (ADR-0040, Line grain) and the
+// Chunker (ADR-0011, Chunk grain) fold the same voiceevent.Bus into different
+// records of the same speech, and everything around their fold rules is
+// identical plumbing. The scaffold owns that plumbing exactly once:
+//
+//   - the subscribe-once-for-the-process subscription (single active Voice
+//     Session across reconnects and sessions, ADR-0039);
+//   - the one-Snapshot-per-event session rollover (#149): ONE Sessions.Snapshot
+//     serves both the active-id comparison and the typed-FK capture, so a
+//     Voice Session change between two reads can never mis-attribute the
+//     triggering event to the previous session or to uuid.Nil;
+//   - the per-TurnID coalescing state map: lazy creation on first sight,
+//     wholesale reset at rollover;
+//   - the async write queue ([Queue]): non-blocking tee, ONE writer goroutine,
+//     drop-on-overflow, and the flush barrier that makes drain-at-Stop
+//     authoritative.
+//
+// Hosts supply only their genuinely distinct parts: the fold rules (which
+// events mutate which turn state and what gets emitted), the flush sink, and
+// their session-finalize hooks. ADR-0040/ADR-0011 guardrail: this scaffold
+// merges PLUMBING only — the Transcript Line and Transcript Chunk grains, their
+// schemas, and their fold semantics stay separate and must not converge here.
+//
+// The observe StageSubscriber is deliberately NOT on this scaffold: it shares
+// the subscription and turn-map coalescing but reaps by TTL sweep instead of
+// Snapshot rollover, and forcing it on would bend the rollover contract.
+package busproject
+
+import (
+	"sync"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// Sessions is the narrow read a projection needs from the SessionManager:
+// which Voice Session (if any) is currently active. *session.Manager satisfies
+// it via Snapshot; tests fake it. It is the same seam the hosts already expose
+// — deliberately kept this thin (#447).
+type Sessions interface {
+	Snapshot() (storage.VoiceSession, bool)
+}
+
+// Hooks are the host's callbacks into the projection lifecycle. Every hook runs
+// with the shared lock HELD (the bus delivers synchronously, so none of them
+// may block or re-lock).
+type Hooks struct {
+	// Fold applies one attributed event to the host's projection state — the
+	// genuinely distinct part of each projector (Relay: display text at
+	// TTSInvoked per ADR-0040; Chunker: delivered-only at FirstAudio per
+	// ADR-0012). Required.
+	Fold func(e voiceevent.Event)
+	// FinishSession closes out the OUTGOING session's state on a rollover,
+	// BEFORE the active FKs repoint and the turn map resets: Session() still
+	// returns the previous Voice Session, so a stale open chunk flushed here
+	// keeps the OLD session's ids. Optional; also fires on the first rollover
+	// (from the process-start idle state), where hosts have nothing to close.
+	FinishSession func()
+	// StartSession initializes the host's state for the newly-active session,
+	// AFTER the FKs repoint and the turn map resets: Session() returns the new
+	// Voice Session. Optional.
+	StartSession func()
+}
+
+// Projection is the scaffold under one bus projector. It attributes every bus
+// event to the active Voice Session under the host's own lock, rolls over on a
+// session change, and owns the per-TurnID coalescing map. The type parameter T
+// is the host's per-turn state; new turns are created as new(T).
+//
+// The lock is BORROWED from the host (mu), not owned: the host's fold state and
+// the scaffold's session state form one consistency domain, and the host's
+// other entry points (HTTP handlers, window timers, flush hooks) keep taking
+// the same mutex they always did.
+type Projection[T any] struct {
+	sessions Sessions
+	mu       sync.Locker
+	hooks    Hooks
+
+	// activeID is the active Voice Session id string ("" before the first
+	// attributed event); active is the FULL Snapshot captured at rollover — the
+	// SAME read that won the id comparison (#149), so the typed FKs can never
+	// belong to a different session than activeID.
+	activeID string
+	active   storage.VoiceSession
+	turns    map[string]*T
+}
+
+// New returns a Projection guarding its state with the host's mu and calling
+// back through hooks. It does not subscribe; the host calls Subscribe once its
+// own construction is complete.
+func New[T any](sessions Sessions, mu sync.Locker, hooks Hooks) *Projection[T] {
+	return &Projection[T]{
+		sessions: sessions,
+		mu:       mu,
+		hooks:    hooks,
+		turns:    map[string]*T{},
+	}
+}
+
+// Subscribe registers the projection on bus once, for the life of the process:
+// the same bus persists across reconnect cycles AND across sessions (single
+// active Voice Session, ADR-0039), so the projector sees every event without
+// re-subscribing. A nil bus subscribes nothing (event-less unit-test hosts).
+func (p *Projection[T]) Subscribe(bus *voiceevent.Bus) {
+	if bus == nil {
+		return
+	}
+	bus.Subscribe(p.project)
+}
+
+// project is the bus callback: it attributes the event to the active Voice
+// Session (rolling over on a session change) and folds it into the host's
+// state. It must not block — the bus delivers synchronously.
+func (p *Projection[T]) project(e voiceevent.Event) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// ONE Snapshot serves both the id comparison and the rollover's FK capture
+	// (#149): the manager's mutex is independent of mu, so a second read could
+	// see the session already ended and leave the FKs pointing at the previous
+	// session (or uuid.Nil at process start).
+	vs, active := p.sessions.Snapshot()
+	if !active {
+		return // no active Voice Session — drop the event (ADR-0039)
+	}
+	if vs.ID.String() != p.activeID {
+		if p.hooks.FinishSession != nil {
+			p.hooks.FinishSession()
+		}
+		p.activeID = vs.ID.String()
+		p.active = vs
+		p.turns = map[string]*T{}
+		if p.hooks.StartSession != nil {
+			p.hooks.StartSession()
+		}
+	}
+	p.hooks.Fold(e)
+}
+
+// Session returns the Voice Session captured by the rollover's Snapshot — the
+// typed FKs (ID, CampaignID) persistence attributes rows to. The zero value
+// before the first attributed event. Caller must hold the shared lock.
+func (p *Projection[T]) Session() storage.VoiceSession {
+	return p.active
+}
+
+// ActiveID returns the active Voice Session id string, "" before the first
+// attributed event. Caller must hold the shared lock.
+func (p *Projection[T]) ActiveID() string {
+	return p.activeID
+}
+
+// Turn returns the coalescing state for a turn id, creating it on first sight.
+// Caller must hold the shared lock.
+func (p *Projection[T]) Turn(id string) *T {
+	t := p.turns[id]
+	if t == nil {
+		t = new(T)
+		p.turns[id] = t
+	}
+	return t
+}
+
+// Lookup returns the coalescing state for a turn id WITHOUT creating it — nil
+// when the turn has never been seen (or the map has since rolled over). Caller
+// must hold the shared lock.
+func (p *Projection[T]) Lookup(id string) *T {
+	return p.turns[id]
+}

--- a/internal/busproject/projection_test.go
+++ b/internal/busproject/projection_test.go
@@ -1,0 +1,301 @@
+package busproject
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// scriptedSessions is a Sessions fake whose Snapshot answer the test scripts
+// per call — the tool for pinning interleavings where the Voice Session state
+// changes BETWEEN two Snapshot reads inside one projection (#149).
+type scriptedSessions struct {
+	mu    sync.Mutex
+	fn    func(call int) (storage.VoiceSession, bool)
+	calls int
+}
+
+func (s *scriptedSessions) set(fn func(call int) (storage.VoiceSession, bool)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fn = fn
+	s.calls = 0
+}
+
+func (s *scriptedSessions) Snapshot() (storage.VoiceSession, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.fn(s.calls)
+}
+
+func (s *scriptedSessions) snapshotCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// testTurn is a minimal per-turn state for the scaffold tests.
+type testTurn struct {
+	text string
+}
+
+func event(sec int) voiceevent.Event {
+	return voiceevent.STTFinal{At: time.Date(2026, 6, 27, 18, 0, sec, 0, time.UTC), Text: "x", TurnID: "t"}
+}
+
+// TestProjection_OneSnapshotPerEvent is the #149 invariant, mid-event session
+// change: the Voice Session ends between the event's projection and any
+// hypothetical second capture read. The scaffold must take exactly ONE
+// Snapshot per event — serving both the id comparison and the FK capture — so
+// the triggering event is attributed to the session that Snapshot returned,
+// never to uuid.Nil and never dropped.
+func TestProjection_OneSnapshotPerEvent(t *testing.T) {
+	sessB := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	ss := &scriptedSessions{}
+	// The FIRST Snapshot of the event sees B active; any LATER Snapshot sees no
+	// active session (B ended mid-projection).
+	ss.set(func(call int) (storage.VoiceSession, bool) {
+		if call == 1 {
+			return sessB, true
+		}
+		return storage.VoiceSession{}, false
+	})
+
+	var mu sync.Mutex
+	var folded []storage.VoiceSession
+	var p *Projection[testTurn]
+	p = New[testTurn](ss, &mu, Hooks{
+		Fold: func(voiceevent.Event) { folded = append(folded, p.Session()) },
+	})
+	bus := voiceevent.NewBus()
+	p.Subscribe(bus)
+
+	bus.Publish(event(1))
+
+	if got := ss.snapshotCalls(); got != 1 {
+		t.Fatalf("projection took %d Snapshots for one event, want exactly 1 (#149)", got)
+	}
+	if len(folded) != 1 {
+		t.Fatalf("folded %d events, want 1", len(folded))
+	}
+	if folded[0].ID != sessB.ID || folded[0].CampaignID != sessB.CampaignID {
+		t.Errorf("event attributed to %+v, want session B (%s/%s) — never uuid.Nil", folded[0], sessB.ID, sessB.CampaignID)
+	}
+	if folded[0].ID == uuid.Nil {
+		t.Errorf("event attributed to uuid.Nil")
+	}
+}
+
+// TestProjection_RolloverAttribution is the stale-snapshot attribution half of
+// #149 plus the rollover hook contract: FinishSession observes the OUTGOING
+// session's FKs (a stale flush there must keep the OLD session's ids —
+// TestChunker_RolloverFlushKeepsOldSessionIDs depends on this), StartSession
+// and Fold observe the new session's, and the turn map resets wholesale.
+func TestProjection_RolloverAttribution(t *testing.T) {
+	sessA := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	sessB := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return sessA, true })
+
+	var mu sync.Mutex
+	var finishSaw, startSaw, foldSaw []storage.VoiceSession
+	var p *Projection[testTurn]
+	p = New[testTurn](ss, &mu, Hooks{
+		Fold:          func(voiceevent.Event) { foldSaw = append(foldSaw, p.Session()) },
+		FinishSession: func() { finishSaw = append(finishSaw, p.Session()) },
+		StartSession:  func() { startSaw = append(startSaw, p.Session()) },
+	})
+	bus := voiceevent.NewBus()
+	p.Subscribe(bus)
+
+	// First event under A: the first rollover fires FinishSession with the
+	// process-start zero state, then StartSession + Fold under A.
+	bus.Publish(event(1))
+	mu.Lock()
+	p.Turn("t1").text = "under A"
+	mu.Unlock()
+
+	// A ends, B starts: FinishSession must still see A (old FKs), everything
+	// after must see B, and A's turn state must be gone.
+	ss.set(func(int) (storage.VoiceSession, bool) { return sessB, true })
+	bus.Publish(event(2))
+
+	if len(finishSaw) != 2 || finishSaw[0].ID != uuid.Nil || finishSaw[1].ID != sessA.ID {
+		t.Errorf("FinishSession saw %+v, want [zero, session A] (old FKs at flush time)", finishSaw)
+	}
+	if len(startSaw) != 2 || startSaw[0].ID != sessA.ID || startSaw[1].ID != sessB.ID {
+		t.Errorf("StartSession saw %+v, want [A, B]", startSaw)
+	}
+	if len(foldSaw) != 2 || foldSaw[0].ID != sessA.ID || foldSaw[1].ID != sessB.ID {
+		t.Errorf("Fold saw %+v, want [A, B]", foldSaw)
+	}
+	if foldSaw[1].CampaignID != sessB.CampaignID {
+		t.Errorf("post-rollover fold campaign = %s, want B's %s", foldSaw[1].CampaignID, sessB.CampaignID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := p.Lookup("t1"); got != nil {
+		t.Errorf("turn map survived the rollover: %+v", got)
+	}
+	if got := p.ActiveID(); got != sessB.ID.String() {
+		t.Errorf("ActiveID = %q, want session B", got)
+	}
+}
+
+// TestProjection_InactiveDropsEvent: with no active Voice Session the event is
+// dropped (ADR-0039) — no rollover, no fold, no state change.
+func TestProjection_InactiveDropsEvent(t *testing.T) {
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return storage.VoiceSession{}, false })
+
+	var mu sync.Mutex
+	folds := 0
+	p := New[testTurn](ss, &mu, Hooks{
+		Fold:          func(voiceevent.Event) { folds++ },
+		FinishSession: func() { t.Error("FinishSession fired with no active session") },
+		StartSession:  func() { t.Error("StartSession fired with no active session") },
+	})
+	bus := voiceevent.NewBus()
+	p.Subscribe(bus)
+
+	bus.Publish(event(1))
+
+	if folds != 0 {
+		t.Errorf("folded %d events with no active session, want 0", folds)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if p.ActiveID() != "" {
+		t.Errorf("ActiveID = %q after dropped event, want \"\"", p.ActiveID())
+	}
+}
+
+// TestProjection_InactiveStragglerKeepsState: an event arriving AFTER the
+// active Voice Session ended (Snapshot flips inactive between the session's
+// last fold and Finalize) is dropped WITHOUT touching the captured state — the
+// relay's endSession guard compares against ActiveID, so a straggler that
+// cleared it would suppress the terminal `status: idle` frame (#144), and a
+// cleared turn map would break a same-session resume.
+func TestProjection_InactiveStragglerKeepsState(t *testing.T) {
+	sess := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return sess, true })
+
+	var mu sync.Mutex
+	folds := 0
+	var p *Projection[testTurn]
+	p = New[testTurn](ss, &mu, Hooks{
+		Fold: func(voiceevent.Event) { folds++; p.Turn("t1").text = "kept" },
+	})
+	bus := voiceevent.NewBus()
+	p.Subscribe(bus)
+
+	bus.Publish(event(1)) // attributed to sess; creates turn t1
+
+	// The session ends; a straggler event is dropped, state untouched.
+	ss.set(func(int) (storage.VoiceSession, bool) { return storage.VoiceSession{}, false })
+	bus.Publish(event(2))
+
+	if folds != 1 {
+		t.Fatalf("folded %d events, want 1 (straggler dropped)", folds)
+	}
+	mu.Lock()
+	if got := p.ActiveID(); got != sess.ID.String() {
+		t.Errorf("ActiveID = %q after dropped straggler, want the ended session's id retained", got)
+	}
+	if got := p.Session(); got.ID != sess.ID || got.CampaignID != sess.CampaignID {
+		t.Errorf("Session = %+v after dropped straggler, want the captured FKs retained", got)
+	}
+	if turn := p.Lookup("t1"); turn == nil || turn.text != "kept" {
+		t.Errorf("turn state = %+v after dropped straggler, want it retained", turn)
+	}
+	mu.Unlock()
+
+	// The SAME session reported active again (Snapshot raced, not a new
+	// session): no rollover — folding resumes on the retained turn state.
+	ss.set(func(int) (storage.VoiceSession, bool) { return sess, true })
+	bus.Publish(event(3))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if folds != 2 {
+		t.Fatalf("folded %d events, want 2", folds)
+	}
+	if turn := p.Lookup("t1"); turn == nil || turn.text != "kept" {
+		t.Errorf("turn state = %+v after resume, want no rollover for the same session id", turn)
+	}
+}
+
+// TestProjection_SameSessionNoRollover: consecutive events under one session
+// fold without re-firing the rollover hooks, and turn state persists.
+func TestProjection_SameSessionNoRollover(t *testing.T) {
+	sess := storage.VoiceSession{ID: uuid.New(), CampaignID: uuid.New()}
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return sess, true })
+
+	var mu sync.Mutex
+	rollovers := 0
+	var p *Projection[testTurn]
+	p = New[testTurn](ss, &mu, Hooks{
+		Fold:         func(voiceevent.Event) { p.Turn("t1").text += "." },
+		StartSession: func() { rollovers++ },
+	})
+	bus := voiceevent.NewBus()
+	p.Subscribe(bus)
+
+	bus.Publish(event(1))
+	bus.Publish(event(2))
+	bus.Publish(event(3))
+
+	if rollovers != 1 {
+		t.Errorf("rolled over %d times for one session, want 1", rollovers)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got := p.Turn("t1").text; got != "..." {
+		t.Errorf("turn state = %q, want it to coalesce across the session's events", got)
+	}
+}
+
+// TestProjection_TurnLifecycle: Turn lazy-creates exactly once per id and
+// Lookup never creates.
+func TestProjection_TurnLifecycle(t *testing.T) {
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return storage.VoiceSession{}, false })
+	var mu sync.Mutex
+	p := New[testTurn](ss, &mu, Hooks{Fold: func(voiceevent.Event) {}})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := p.Lookup("t1"); got != nil {
+		t.Fatalf("Lookup created a turn: %+v", got)
+	}
+	first := p.Turn("t1")
+	if first == nil {
+		t.Fatal("Turn returned nil")
+	}
+	first.text = "kept"
+	if again := p.Turn("t1"); again != first {
+		t.Errorf("Turn returned a fresh state for a seen id")
+	}
+	if got := p.Lookup("t1"); got != first {
+		t.Errorf("Lookup = %+v, want the created turn", got)
+	}
+}
+
+// TestProjection_NilBusSubscribeNoop: an event-less host (unit tests driving
+// the fold directly) subscribes nothing and does not panic.
+func TestProjection_NilBusSubscribeNoop(t *testing.T) {
+	ss := &scriptedSessions{}
+	ss.set(func(int) (storage.VoiceSession, bool) { return storage.VoiceSession{}, false })
+	var mu sync.Mutex
+	p := New[testTurn](ss, &mu, Hooks{Fold: func(voiceevent.Event) {}})
+	p.Subscribe(nil)
+}

--- a/internal/busproject/queue.go
+++ b/internal/busproject/queue.go
@@ -1,0 +1,101 @@
+package busproject
+
+import "context"
+
+// Queue is the async write queue shared by the bus projections (#447, mined
+// from #74/#104): a bounded channel drained by ONE writer goroutine. The bus
+// delivers project synchronously and must not block, so Enqueue is
+// non-blocking — an overflow is DROPPED (reported to the caller, who logs it)
+// rather than ever calling the DB inline; durability is best-effort while
+// live. Flush sends a barrier through the SAME channel, so FIFO ordering
+// guarantees every item enqueued before it has been written when the barrier
+// runs — that is what makes a drain-at-Stop count authoritative (ADR-0040).
+//
+// A nil *Queue is the persistence-disabled projector: Enqueue accepts (and
+// discards) silently, Flush returns immediately without running its barrier.
+// The writer goroutine lives for the process, like the subscription it drains.
+type Queue[T any] struct {
+	ch chan queueOp[T]
+}
+
+// queueOp is one item on the writer channel: an item to write, or a flush
+// barrier. Exactly one is set; barrier != nil discriminates.
+type queueOp[T any] struct {
+	item    T
+	barrier *flushBarrier
+}
+
+// flushBarrier is the Flush marker: the writer runs fn (if any) only after
+// every item enqueued before it has been written, then closes done.
+type flushBarrier struct {
+	fn   func()
+	done chan struct{}
+}
+
+// NewQueue starts the single writer goroutine draining a channel of the given
+// capacity into write. write is called serially, one item at a time; it owns
+// its own timeout and error handling (a failed write must not stop the loop —
+// the queue has no opinion on durability beyond FIFO).
+func NewQueue[T any](capacity int, write func(T)) *Queue[T] {
+	q := &Queue[T]{ch: make(chan queueOp[T], capacity)}
+	go q.loop(write)
+	return q
+}
+
+// loop is the single writer goroutine: it serially writes queued items and
+// services flush barriers.
+func (q *Queue[T]) loop(write func(T)) {
+	for op := range q.ch {
+		if op.barrier != nil {
+			if op.barrier.fn != nil {
+				op.barrier.fn()
+			}
+			close(op.barrier.done)
+			continue
+		}
+		write(op.item)
+	}
+}
+
+// Enqueue tees one item onto the writer channel with a non-blocking send — the
+// bus must not block — and reports false when the queue is full: the item is
+// dropped and the CALLER logs it (it holds the item's identifying context).
+// A nil Queue (persistence disabled) accepts silently: nothing was dropped,
+// there is just nowhere to write.
+func (q *Queue[T]) Enqueue(item T) bool {
+	if q == nil {
+		return true
+	}
+	select {
+	case q.ch <- queueOp[T]{item: item}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Flush drains the queue via a barrier riding the SAME channel as the items:
+// when it returns nil, every item enqueued before the call has been written.
+// fn (optional) runs in the writer goroutine after that drain and before Flush
+// returns — the seam for an authoritative post-drain read like the Relay's
+// COUNT(*) (ADR-0040). ctx bounds both the enqueue (the channel may be full of
+// items) and the wait; on expiry Flush returns ctx.Err() — an already-queued
+// barrier still runs, its result discarded. A nil Queue returns nil without
+// running fn.
+func (q *Queue[T]) Flush(ctx context.Context, fn func()) error {
+	if q == nil {
+		return nil
+	}
+	b := &flushBarrier{fn: fn, done: make(chan struct{})}
+	select {
+	case q.ch <- queueOp[T]{barrier: b}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-b.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/busproject/queue_test.go
+++ b/internal/busproject/queue_test.go
@@ -1,0 +1,235 @@
+package busproject
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingSink is a write sink the test can pin: the first write signals
+// entered and parks on release, so the queue's backlog fills deterministically.
+type blockingSink struct {
+	entered chan struct{}
+	release chan struct{}
+
+	mu      sync.Mutex
+	written []int
+}
+
+func newBlockingSink() *blockingSink {
+	return &blockingSink{entered: make(chan struct{}, 1), release: make(chan struct{})}
+}
+
+func (s *blockingSink) write(n int) {
+	select {
+	case s.entered <- struct{}{}:
+	default:
+	}
+	<-s.release
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.written = append(s.written, n)
+}
+
+func (s *blockingSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.written)
+}
+
+func (s *blockingSink) items() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.written...)
+}
+
+// eventually polls fn until it returns true or the deadline passes.
+func eventually(t *testing.T, within time.Duration, fn func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return fn()
+}
+
+// TestQueue_OverflowDrops: the enqueue is non-blocking — with the writer pinned
+// and the channel full, Enqueue reports the drop instead of ever blocking, and
+// exactly in-flight + capacity items survive.
+func TestQueue_OverflowDrops(t *testing.T) {
+	const cap = 4
+	sink := newBlockingSink()
+	q := NewQueue(cap, sink.write)
+
+	// First item: the writer dequeues it and parks — the channel is drained to
+	// empty, so the accepted count below is exact.
+	if !q.Enqueue(0) {
+		t.Fatal("first Enqueue dropped on an empty queue")
+	}
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer never reached the sink")
+	}
+
+	accepted, dropped := 0, 0
+	for i := 1; i <= cap+3; i++ {
+		if q.Enqueue(i) {
+			accepted++
+		} else {
+			dropped++
+		}
+	}
+	if accepted != cap || dropped != 3 {
+		t.Fatalf("accepted %d dropped %d, want %d accepted (capacity) and 3 dropped", accepted, dropped, cap)
+	}
+
+	close(sink.release)
+	want := 1 + cap
+	if !eventually(t, 3*time.Second, func() bool { return sink.count() == want }) {
+		t.Fatalf("writer wrote %d items, want %d (in-flight + queue; overflow dropped)", sink.count(), want)
+	}
+}
+
+// TestQueue_FlushDrainsBeforeBarrier: the barrier rides the SAME channel as the
+// items, so FIFO guarantees every item enqueued before Flush has been written
+// when the barrier fn runs — even when the writer was parked mid-item at flush
+// time. This is what makes the Relay's post-drain COUNT(*) authoritative
+// (ADR-0040).
+func TestQueue_FlushDrainsBeforeBarrier(t *testing.T) {
+	sink := newBlockingSink()
+	q := NewQueue(8, sink.write)
+
+	// Writer parks on item 1; items 2 and 3 queue behind it.
+	q.Enqueue(1)
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer never reached the sink")
+	}
+	q.Enqueue(2)
+	q.Enqueue(3)
+
+	barrierSaw := make(chan int, 1)
+	flushed := make(chan error, 1)
+	go func() {
+		flushed <- q.Flush(context.Background(), func() { barrierSaw <- sink.count() })
+	}()
+
+	close(sink.release)
+	select {
+	case err := <-flushed:
+		if err != nil {
+			t.Fatalf("Flush: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush never returned after release")
+	}
+	if saw := <-barrierSaw; saw != 3 {
+		t.Errorf("barrier ran with %d items written, want all 3 enqueued before it", saw)
+	}
+	if got := sink.items(); len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("items written %v, want FIFO [1 2 3]", got)
+	}
+}
+
+// TestQueue_FlushCtxBoundsEnqueue: with the channel full of items, the barrier
+// send blocks — an expired ctx aborts it with ctx.Err() instead of hanging.
+func TestQueue_FlushCtxBoundsEnqueue(t *testing.T) {
+	sink := newBlockingSink()
+	q := NewQueue(1, sink.write)
+
+	q.Enqueue(1) // writer parks on it
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer never reached the sink")
+	}
+	q.Enqueue(2) // fills the channel
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := q.Flush(ctx, nil); err != context.Canceled {
+		t.Fatalf("Flush on a full queue with expired ctx = %v, want context.Canceled", err)
+	}
+	close(sink.release)
+}
+
+// TestQueue_FlushCtxBoundsWait: a barrier already enqueued keeps its FIFO slot,
+// but the caller stops waiting on ctx expiry; the barrier still runs later and
+// its result is discarded.
+func TestQueue_FlushCtxBoundsWait(t *testing.T) {
+	sink := newBlockingSink()
+	q := NewQueue(8, sink.write)
+
+	q.Enqueue(1) // writer parks; the barrier below sits queued behind it
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer never reached the sink")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ran := make(chan struct{})
+	flushed := make(chan error, 1)
+	go func() {
+		flushed <- q.Flush(ctx, func() { close(ran) })
+	}()
+	// Wait for the barrier to actually sit in the channel — cancelling before
+	// the enqueue would abort the send instead of abandoning the wait.
+	if !eventually(t, 2*time.Second, func() bool { return len(q.ch) == 1 }) {
+		t.Fatal("barrier never reached the queue")
+	}
+	// The barrier is queued but cannot run; cancel makes Flush return now.
+	cancel()
+	select {
+	case err := <-flushed:
+		if err != context.Canceled {
+			t.Fatalf("Flush = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush did not honor ctx cancellation while waiting")
+	}
+
+	// The abandoned barrier still drains — the writer never wedges on it.
+	close(sink.release)
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("abandoned barrier never ran")
+	}
+}
+
+// TestQueue_FlushNilFn: a barrier with no fn is a pure drain.
+func TestQueue_FlushNilFn(t *testing.T) {
+	sink := newBlockingSink()
+	close(sink.release) // sink never parks
+	q := NewQueue(8, sink.write)
+
+	q.Enqueue(1)
+	q.Enqueue(2)
+	if err := q.Flush(context.Background(), nil); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := sink.count(); got != 2 {
+		t.Errorf("flushed with %d items written, want 2", got)
+	}
+}
+
+// TestQueue_NilQueueIsDisabledPersistence: the nil Queue is the
+// persistence-disabled projector — Enqueue accepts silently (nothing to log as
+// dropped), Flush returns nil WITHOUT running the barrier fn (the Relay's
+// disabled Finalize reports count 0 without touching the store).
+func TestQueue_NilQueueIsDisabledPersistence(t *testing.T) {
+	var q *Queue[int]
+	if !q.Enqueue(1) {
+		t.Error("nil queue reported a drop; disabled persistence must be silent")
+	}
+	if err := q.Flush(context.Background(), func() { t.Error("nil queue ran the barrier fn") }); err != nil {
+		t.Errorf("nil queue Flush = %v, want nil", err)
+	}
+}

--- a/internal/transcript/chunker.go
+++ b/internal/transcript/chunker.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/busproject"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
 )
@@ -27,11 +28,12 @@ import (
 // transcript_line grain (ADR-0040): the two are independent records of the same
 // speech.
 //
-// Concurrency mirrors the relay (#74): the bus delivers project SYNCHRONOUSLY and
-// must not block, so a closed chunk is teed onto a bounded queue drained by ONE
-// writer goroutine, and an overflow drops + logs rather than ever calling the DB
-// inline. FlushSession (the Manager's loop-exit hook) closes the open chunk and
-// rides a flush barrier through the SAME queue, so FIFO guarantees every prior
+// Concurrency mirrors the relay (#74) through the SAME busproject scaffold
+// (#447): the bus delivers project SYNCHRONOUSLY and must not block, so a
+// closed chunk is teed onto a bounded queue drained by ONE writer goroutine,
+// and an overflow drops + logs rather than ever calling the DB inline.
+// FlushSession (the Manager's loop-exit hook) closes the open chunk and rides
+// a flush barrier through the SAME queue, so FIFO guarantees every prior
 // insert has landed when it returns.
 
 const (
@@ -118,39 +120,30 @@ type openChunk struct {
 
 // Chunker projects bus events into Transcript Chunks and writes them async. Safe
 // for concurrent use: the bus callback, the window timer and FlushSession all take
-// the same lock.
+// the same lock — c.mu, shared with the busproject scaffold that owns the
+// subscription, the session rollover, and the turn map (#447).
 type Chunker struct {
-	sessions Sessions
-	store    ChunkStore
-	gauge    BacklogGauge
-	log      *slog.Logger
-	window   time.Duration
-	maxUtt   int
+	store  ChunkStore
+	gauge  BacklogGauge
+	log    *slog.Logger
+	window time.Duration
+	maxUtt int
 
 	resolver SpeakerResolver // resolves SpeakerID → name for the line prefix (#281); nil = generic label
 
-	mu               sync.Mutex
-	activeID         string // current session id; "" at process start
-	activeUUID       uuid.UUID
-	activeCampaignID uuid.UUID
-	open             *openChunk
-	turns            map[string]*chunkTurn // per-session, reset on rollover
+	// proj is the shared projection scaffold (#447): it attributes every bus
+	// event to the active session under c.mu (ONE Snapshot per event, like the
+	// relay, #149), flushes a stale open chunk via finishSession BEFORE the FKs
+	// repoint on a session change, and owns the per-turn coalescing map. The
+	// chunker keeps only its fold rules (delivered-only, ADR-0012).
+	proj *busproject.Projection[chunkTurn]
 
-	// writeCh is the non-blocking queue draining into the single writer goroutine;
-	// nil when persistence is disabled (store == nil).
-	writeCh chan chunkOp
-}
+	mu   sync.Mutex
+	open *openChunk
 
-// chunkOp is one item on the writer queue: a chunk to insert, or a flush barrier.
-type chunkOp struct {
-	chunk *storage.TranscriptChunk
-	flush *chunkFlush
-}
-
-// chunkFlush is the FlushSession barrier: the writer replies on result once every
-// insert enqueued before it has landed (FIFO).
-type chunkFlush struct {
-	result chan error
+	// queue is the non-blocking write queue draining into the single writer
+	// goroutine; nil when persistence is disabled (store == nil).
+	queue *busproject.Queue[*storage.TranscriptChunk]
 }
 
 // NewChunker subscribes to the bus once and returns a Chunker ready to fold
@@ -170,21 +163,21 @@ func NewChunker(bus *voiceevent.Bus, sessions Sessions, store ChunkStore, gauge 
 		maxUtt = defaultMaxUtterances
 	}
 	c := &Chunker{
-		sessions: sessions,
-		store:    store,
-		gauge:    gauge,
-		log:      log,
-		window:   window,
-		maxUtt:   maxUtt,
-		turns:    map[string]*chunkTurn{},
+		store:  store,
+		gauge:  gauge,
+		log:    log,
+		window: window,
+		maxUtt: maxUtt,
 	}
 	if store != nil {
-		c.writeCh = make(chan chunkOp, chunkQueue)
-		go c.writeLoop()
+		c.queue = busproject.NewQueue(chunkQueue, c.writeChunk)
 	}
-	if bus != nil {
-		bus.Subscribe(c.project)
-	}
+	c.proj = busproject.New[chunkTurn](sessions, &c.mu, busproject.Hooks{
+		Fold:          c.fold,
+		FinishSession: c.finishSession,
+		StartSession:  c.startSession,
+	})
+	c.proj.Subscribe(bus)
 	return c
 }
 
@@ -198,27 +191,18 @@ func (c *Chunker) SetResolver(res SpeakerResolver) {
 	c.mu.Unlock()
 }
 
-// project is the bus callback: it attributes the event to the active session
-// (rolling over on a session change, one Snapshot per event like the relay) and
-// folds it into the open chunk. It must not block (the bus delivers
-// synchronously): the only outward call, closeChunk's enqueue, is non-blocking.
-func (c *Chunker) project(e voiceevent.Event) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	vs, active := c.sessions.Snapshot()
-	if !active {
-		return // no active session — drop the event (ADR-0039)
-	}
-	if vs.ID.String() != c.activeID {
-		c.rollover(vs)
-	}
-
+// fold applies one attributed event to the open chunk — the chunker's fold
+// rules (ADR-0012: delivered-only, commit at FirstAudio). The scaffold has
+// already taken the event's ONE session Snapshot (like the relay, #149) and
+// rolled over on a session change; fold runs under c.mu and must not block
+// (the bus delivers synchronously): the only outward call, closeChunk's
+// enqueue, is non-blocking.
+func (c *Chunker) fold(e voiceevent.Event) {
 	switch ev := e.(type) {
 	case voiceevent.STTFinal:
 		c.appendHuman(ev)
 	case voiceevent.AddressRouted:
-		c.turn(ev.TurnID).target = ev.Target
+		c.proj.Turn(ev.TurnID).target = ev.Target
 	case voiceevent.TTSInvoked:
 		c.bufferAgentSentence(ev)
 	case voiceevent.FirstAudio:
@@ -228,25 +212,28 @@ func (c *Chunker) project(e voiceevent.Event) {
 	case voiceevent.TurnEnded:
 		// The turn is finalized: drop its undelivered tail (ADR-0012 — the room
 		// never heard those sentences) and refuse late dispatches.
-		t := c.turn(ev.TurnID)
+		t := c.proj.Turn(ev.TurnID)
 		t.ended = true
 		t.pending = nil
 	}
 }
 
-// rollover switches to the newly-active session vs. Any stale open chunk from the
-// previous session is enqueue-flushed as a safety net (a session that ended
-// without a FlushSession still persists its last chunk), BEFORE the active FKs are
-// repointed so the flushed chunk keeps the OLD session's ids.
-func (c *Chunker) rollover(vs storage.VoiceSession) {
+// finishSession is the scaffold's pre-rollover hook: any stale open chunk from
+// the outgoing session is enqueue-flushed as a safety net (a session that ended
+// without a FlushSession still persists its last chunk). It runs BEFORE the
+// scaffold repoints the active FKs, so the flushed chunk keeps the OLD
+// session's ids.
+func (c *Chunker) finishSession() {
 	if c.open != nil {
 		c.closeChunk(c.open)
 	}
-	c.activeID = vs.ID.String()
-	c.activeUUID = vs.ID
-	c.activeCampaignID = vs.CampaignID
+}
+
+// startSession is the scaffold's post-rollover hook: the scaffold has repointed
+// the FKs and reset the turn map; clearing open here is defensive (finishSession's
+// closeChunk already detached it).
+func (c *Chunker) startSession() {
 	c.open = nil
-	c.turns = map[string]*chunkTurn{}
 }
 
 // appendHuman folds one human utterance (one STTFinal, attributed to its Speaker
@@ -271,7 +258,7 @@ func (c *Chunker) humanPrefix(speakerID string) string {
 	if c.resolver == nil || speakerID == "" {
 		return "Player / DM"
 	}
-	if name := c.resolver.Lookup(c.activeCampaignID, speakerID).Name; name != "" {
+	if name := c.resolver.Lookup(c.proj.Session().CampaignID, speakerID).Name; name != "" {
 		return name
 	}
 	return "Player / DM"
@@ -306,7 +293,7 @@ func (c *Chunker) recordSpeaker(oc *openChunk, speakerID string) {
 // start-error the turn recovers from would commit the lost sentence AND shift the
 // FirstAudio pairing of every later sentence by one.
 func (c *Chunker) bufferAgentSentence(ev voiceevent.TTSInvoked) {
-	t := c.turn(ev.TurnID)
+	t := c.proj.Turn(ev.TurnID)
 	if t.ended {
 		c.log.Warn("transcript: chunk sentence after turn ended, dropping", "turn", ev.TurnID)
 		return
@@ -326,7 +313,7 @@ func (c *Chunker) bufferAgentSentence(ev voiceevent.TTSInvoked) {
 // count); later delivered sentences append to that same line. A FirstAudio with
 // nothing pending — a straggler after TurnEnded cleared the buffer — is a no-op.
 func (c *Chunker) commitDelivered(ev voiceevent.FirstAudio) {
-	t := c.turn(ev.TurnID)
+	t := c.proj.Turn(ev.TurnID)
 	if len(t.pending) == 0 {
 		c.log.Debug("transcript: first audio with no pending sentence, ignoring", "turn", ev.TurnID)
 		return
@@ -373,7 +360,7 @@ func (c *Chunker) commitDelivered(ev voiceevent.FirstAudio) {
 //     accepted (the close raced the failure; rare by construction since the
 //     dispatch is serial single-in-flight).
 func (c *Chunker) abortSentence(ev voiceevent.TTSStreamFailed) {
-	t := c.turn(ev.TurnID)
+	t := c.proj.Turn(ev.TurnID)
 	if t.ended {
 		return
 	}
@@ -503,7 +490,7 @@ func (c *Chunker) closeChunk(oc *openChunk) {
 		c.open = nil
 	}
 	for _, id := range oc.turnIDs {
-		if t := c.turns[id]; t != nil {
+		if t := c.proj.Lookup(id); t != nil {
 			t.line = nil
 		}
 	}
@@ -518,65 +505,40 @@ func (c *Chunker) closeChunk(oc *openChunk) {
 	if speakers == nil {
 		speakers = []string{} // scan contract: non-nil empty when no attributed speaker
 	}
+	sess := c.proj.Session()
 	chunk := storage.TranscriptChunk{
-		CampaignID:            c.activeCampaignID,
-		VoiceSessionID:        c.activeUUID,
+		CampaignID:            sess.CampaignID,
+		VoiceSessionID:        sess.ID,
 		Content:               strings.Join(texts, "\n"),
 		SpeakerDiscordUserIDs: speakers,
 		ParticipatedAgentIDs:  oc.agents,
 		StartedAt:             oc.startedAt,
 	}
-	c.enqueue(chunkOp{chunk: &chunk})
-}
-
-// enqueue tees an op onto the writer queue with a non-blocking send — the bus must
-// not block, so an overflow drops + logs. No-op when persistence is disabled.
-func (c *Chunker) enqueue(op chunkOp) {
-	if c.writeCh == nil {
-		return
-	}
-	select {
-	case c.writeCh <- op:
-	default:
+	// The tee is non-blocking (the bus must not block), so an overflow drops +
+	// logs; a nil queue (persistence disabled) accepts silently.
+	if !c.queue.Enqueue(&chunk) {
 		c.log.Warn("transcript: chunk queue full, dropping chunk")
 	}
 }
 
-// turn returns the coalescing state for a turn id, creating it on first sight.
-func (c *Chunker) turn(id string) *chunkTurn {
-	t := c.turns[id]
-	if t == nil {
-		t = &chunkTurn{}
-		c.turns[id] = t
+// writeChunk is the Chunker's flush sink — the write half of the single writer
+// goroutine: one serial, bounded Insert+Count per closed chunk, refreshing the
+// backlog gauge (Set-from-COUNT, ADR-0032). An insert/count failure is logged
+// but does not stop the loop — durability is best-effort.
+func (c *Chunker) writeChunk(chunk *storage.TranscriptChunk) {
+	ctx, cancel := context.WithTimeout(context.Background(), chunkWriteTimeout)
+	defer cancel()
+	if _, err := c.store.InsertTranscriptChunk(ctx, *chunk); err != nil {
+		c.log.Warn("transcript: insert chunk", "err", err)
+		return
 	}
-	return t
-}
-
-// writeLoop is the single writer goroutine: it serially inserts closed chunks and
-// refreshes the backlog gauge, and services flush barriers. An insert/count
-// failure is logged but does not stop the loop — durability is best-effort.
-func (c *Chunker) writeLoop() {
-	for op := range c.writeCh {
-		switch {
-		case op.chunk != nil:
-			ctx, cancel := context.WithTimeout(context.Background(), chunkWriteTimeout)
-			if _, err := c.store.InsertTranscriptChunk(ctx, *op.chunk); err != nil {
-				c.log.Warn("transcript: insert chunk", "err", err)
-				cancel()
-				continue
-			}
-			n, err := c.store.CountUnembeddedChunks(ctx)
-			cancel()
-			if err != nil {
-				c.log.Warn("transcript: count unembedded chunks", "err", err)
-				continue
-			}
-			if c.gauge != nil {
-				c.gauge.SetEmbeddingBacklog(n)
-			}
-		case op.flush != nil:
-			op.flush.result <- nil // FIFO: every prior insert has landed
-		}
+	n, err := c.store.CountUnembeddedChunks(ctx)
+	if err != nil {
+		c.log.Warn("transcript: count unembedded chunks", "err", err)
+		return
+	}
+	if c.gauge != nil {
+		c.gauge.SetEmbeddingBacklog(n)
 	}
 }
 
@@ -587,25 +549,10 @@ func (c *Chunker) writeLoop() {
 // store) or a mismatched session id is a no-op.
 func (c *Chunker) FlushSession(ctx context.Context, sessionID uuid.UUID) error {
 	c.mu.Lock()
-	if c.open != nil && c.activeUUID == sessionID {
+	if c.open != nil && c.proj.Session().ID == sessionID {
 		c.closeChunk(c.open)
 	}
-	ch := c.writeCh
 	c.mu.Unlock()
 
-	if ch == nil {
-		return nil
-	}
-	res := make(chan error, 1)
-	select {
-	case ch <- chunkOp{flush: &chunkFlush{result: res}}:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	select {
-	case err := <-res:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return c.queue.Flush(ctx, nil)
 }

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -37,7 +37,7 @@ type subscriber struct {
 // so the send is non-blocking.
 func (r *Relay) push(f Frame) {
 	for s := range r.subs {
-		if s.id != r.activeID {
+		if s.id != r.proj.ActiveID() {
 			continue
 		}
 		select {
@@ -62,7 +62,7 @@ func (r *Relay) attach(id string, lastID uint64) (*subscriber, []Frame) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var replay []Frame
-	if id == r.activeID {
+	if id == r.proj.ActiveID() {
 		for _, f := range r.buf {
 			if f.Seq > lastID {
 				replay = append(replay, f)

--- a/internal/transcript/persist.go
+++ b/internal/transcript/persist.go
@@ -10,12 +10,14 @@ import (
 )
 
 // Incremental async persistence (#74, ADR-0040): the projection tees each emitted
-// Line into a buffered queue drained by ONE writer goroutine that UPSERTs it. The
-// bus delivers project SYNCHRONOUSLY and must not block, so the tee is
-// non-blocking (drop + log on overflow) — durability is best-effort while live.
-// On Stop the Manager calls Finalize, which sends a flush barrier through the SAME
-// queue: the writer processes it only after every line enqueued before it has
-// landed, then returns COUNT(*) — the authoritative line_count (rows == lines).
+// Line into a busproject.Queue — a buffered queue drained by ONE writer goroutine
+// that UPSERTs it. The bus delivers project SYNCHRONOUSLY and must not block, so
+// the tee is non-blocking (drop + log on overflow) — durability is best-effort
+// while live. On Stop the Manager calls Finalize, which sends a flush barrier
+// through the SAME queue: the writer processes it only after every line enqueued
+// before it has landed, then returns COUNT(*) — the authoritative line_count
+// (rows == lines). The queue/barrier mechanics live in the shared scaffold
+// (#447); this file keeps only the Relay's tee and flush sink.
 
 const (
 	// persistQueue bounds the writer's backlog. Tees past this are dropped (logged)
@@ -27,37 +29,15 @@ const (
 	writeTimeout = 5 * time.Second
 )
 
-// writeOp is one item on the writer queue: a line to UPSERT, or a flush barrier.
-// Exactly one field is set.
-type writeOp struct {
-	line  *storage.TranscriptLine
-	flush *flushReq
-}
-
-// flushReq is the Finalize barrier: the writer drains every line before it, then
-// counts the session's persisted rows and replies on result.
-type flushReq struct {
-	ctx       context.Context
-	sessionID uuid.UUID
-	result    chan flushResult
-}
-
-type flushResult struct {
-	count int
-	err   error
-}
-
 // persist tees one emitted Line onto the writer queue, keyed for the coalescing
 // UPSERT and carrying seq as the ordering key. Caller holds r.mu; the send is
 // non-blocking (the bus must not block) so an overflow drops + logs. No-op when
-// persistence is disabled.
+// persistence is disabled (nil queue).
 func (r *Relay) persist(l Line, seq uint64) {
-	if r.writeCh == nil {
-		return
-	}
-	op := writeOp{line: &storage.TranscriptLine{
-		VoiceSessionID:       r.activeUUID,
-		CampaignID:           r.activeCampaignID,
+	sess := r.proj.Session()
+	line := &storage.TranscriptLine{
+		VoiceSessionID:       sess.ID,
+		CampaignID:           sess.CampaignID,
 		LineID:               l.ID,
 		Seq:                  int64(seq), //nolint:gosec // seq is a small monotonic counter
 		Who:                  l.Who,
@@ -66,31 +46,21 @@ func (r *Relay) persist(l Line, seq uint64) {
 		TS:                   l.TS,
 		Text:                 l.Text,
 		SpeakerDiscordUserID: l.SpeakerID, // #278: "" (unattributed / Agent) → NULLIF → NULL in storage
-	}}
-	select {
-	case r.writeCh <- op:
-	default:
+	}
+	if !r.queue.Enqueue(line) {
 		r.log.Warn("transcript: persist queue full, dropping line", "line_id", l.ID)
 	}
 }
 
-// writeLoop is the single writer goroutine (#74): it serially UPSERTs queued lines
-// and services flush barriers. A line write failure is logged but does not stop
-// the loop — durability is best-effort and the next Stop's COUNT(*) is still
-// authoritative over whatever landed.
-func (r *Relay) writeLoop() {
-	for op := range r.writeCh {
-		switch {
-		case op.line != nil:
-			ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
-			if err := r.store.UpsertTranscriptLine(ctx, *op.line); err != nil {
-				r.log.Warn("transcript: persist line", "err", err, "line_id", op.line.LineID)
-			}
-			cancel()
-		case op.flush != nil:
-			n, err := r.store.CountTranscriptLines(op.flush.ctx, op.flush.sessionID)
-			op.flush.result <- flushResult{count: n, err: err}
-		}
+// writeLine is the Relay's flush sink — the write half of the single writer
+// goroutine (#74): one serial, bounded UPSERT per queued line. A write failure
+// is logged but does not stop the loop — durability is best-effort and the next
+// Stop's COUNT(*) is still authoritative over whatever landed.
+func (r *Relay) writeLine(l *storage.TranscriptLine) {
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	defer cancel()
+	if err := r.store.UpsertTranscriptLine(ctx, *l); err != nil {
+		r.log.Warn("transcript: persist line", "err", err, "line_id", l.LineID)
 	}
 }
 
@@ -109,19 +79,12 @@ func (r *Relay) writeLoop() {
 // silent and the screen "Live" forever.
 func (r *Relay) Finalize(ctx context.Context, id uuid.UUID) (int, error) {
 	r.endSession(id)
-	if r.writeCh == nil {
-		return 0, nil
+	var (
+		n   int
+		err error
+	)
+	if ferr := r.queue.Flush(ctx, func() { n, err = r.store.CountTranscriptLines(ctx, id) }); ferr != nil {
+		return 0, ferr
 	}
-	res := make(chan flushResult, 1)
-	select {
-	case r.writeCh <- writeOp{flush: &flushReq{ctx: ctx, sessionID: id, result: res}}:
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	}
-	select {
-	case fr := <-res:
-		return fr.count, fr.err
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	}
+	return n, err
 }

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/busproject"
 	"github.com/MrWong99/Glyphoxa/internal/speaker"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -210,7 +211,8 @@ type turn struct {
 
 // Relay projects bus events into transcript lines and serves them over SSE +
 // JSON. Safe for concurrent use: the bus callback, the HTTP handlers and View
-// all take the same lock.
+// all take the same lock — r.mu, shared with the busproject scaffold that owns
+// the subscription, the session rollover, and the turn map (#447).
 type Relay struct {
 	sessions Sessions
 	store    LineStore       // persists projected lines (#74); nil disables persistence
@@ -218,26 +220,26 @@ type Relay struct {
 	scope    TenantScope     // tenant-ownership gate for the HTTP mounts (#439); nil = unscoped
 	log      *slog.Logger
 
-	mu       sync.Mutex
-	activeID string // current session id; "" when idle
-	// activeUUID / activeCampaignID mirror activeID as the typed FKs persistence
-	// needs; captured from the active session's Snapshot at rollover.
-	activeUUID       uuid.UUID
-	activeCampaignID uuid.UUID
-	buf              []Frame
-	lines            []Line
-	typing           Typing
-	connection       string // latest gateway connection state for the live session (#123); "" until the first transition
-	turns            map[string]*turn
-	nextSeq          uint64
-	humanSeq         uint64
-	subs             map[*subscriber]struct{}
+	// proj is the shared projection scaffold (#447): it attributes every bus
+	// event to the active session under r.mu (ONE Snapshot per event, #149),
+	// rolls the buffer over on a session change via startSession, and owns the
+	// per-turn coalescing map. The relay keeps only its fold rules.
+	proj *busproject.Projection[turn]
 
-	// writeCh is the non-blocking queue draining into the single writer goroutine
-	// (#74): emitLine tees each Line in here under r.mu, the bus contract forbids
-	// blocking so the send drops on overflow, and Finalize sends a flush barrier.
-	// nil when persistence is disabled (store == nil).
-	writeCh chan writeOp
+	mu         sync.Mutex
+	buf        []Frame
+	lines      []Line
+	typing     Typing
+	connection string // latest gateway connection state for the live session (#123); "" until the first transition
+	nextSeq    uint64
+	humanSeq   uint64
+	subs       map[*subscriber]struct{}
+
+	// queue is the non-blocking write queue draining into the single writer
+	// goroutine (#74): emitLine tees each Line in here under r.mu, the bus
+	// contract forbids blocking so the send drops on overflow, and Finalize
+	// sends a flush barrier. nil when persistence is disabled (store == nil).
+	queue *busproject.Queue[*storage.TranscriptLine]
 
 	// writeTimeout bounds each SSE frame write/flush (#148 Defect B): a client
 	// that stops reading makes the blocked write fail instead of parking the
@@ -265,7 +267,6 @@ func NewRelay(bus *voiceevent.Bus, sessions Sessions, store LineStore, log *slog
 		sessions:     sessions,
 		store:        store,
 		log:          log,
-		turns:        map[string]*turn{},
 		subs:         map[*subscriber]struct{}{},
 		writeTimeout: defaultWriteTimeout,
 		closing:      make(chan struct{}),
@@ -274,10 +275,13 @@ func NewRelay(bus *voiceevent.Bus, sessions Sessions, store LineStore, log *slog
 	// when persistence is enabled, so the live-only relay keeps its single-state
 	// behaviour and unit tests with a nil store spawn nothing.
 	if store != nil {
-		r.writeCh = make(chan writeOp, persistQueue)
-		go r.writeLoop()
+		r.queue = busproject.NewQueue(persistQueue, r.writeLine)
 	}
-	bus.Subscribe(r.project)
+	r.proj = busproject.New[turn](sessions, &r.mu, busproject.Hooks{
+		Fold:         r.fold,
+		StartSession: r.startSession,
+	})
+	r.proj.Subscribe(bus)
 	return r
 }
 
@@ -317,26 +321,13 @@ func (r *Relay) tenantScope() TenantScope {
 	return r.scope
 }
 
-// project is the bus callback: it attributes the event to the active session,
-// rolling the buffer over on a session change, and folds the event into the
-// transcript. It must not block (the bus delivers synchronously): all sends to
-// live subscribers are non-blocking.
-func (r *Relay) project(e voiceevent.Event) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// ONE Snapshot serves both the id comparison and the rollover's UUID/campaign
-	// capture (#149): the manager's mutex is independent of r.mu, so a second read
-	// could see the session already ended and leave the FKs pointing at the
-	// previous session (or uuid.Nil at process start).
-	vs, active := r.sessions.Snapshot()
-	if !active {
-		return // no active session — drop the event (ADR-0039)
-	}
-	if vs.ID.String() != r.activeID {
-		r.rollover(vs)
-	}
-
+// fold applies one attributed event to the transcript — the relay's projection
+// rules (ADR-0040: display text enters the line at TTSInvoked). The scaffold
+// has already taken the event's ONE session Snapshot (#149) and rolled the
+// buffer over on a session change; fold runs under r.mu and must not block
+// (the bus delivers synchronously): all sends to live subscribers are
+// non-blocking.
+func (r *Relay) fold(e voiceevent.Event) {
 	switch ev := e.(type) {
 	case voiceevent.VADSpeechStart:
 		// A human opened their mouth: warm the speaker resolver NOW (#281) so the
@@ -347,7 +338,7 @@ func (r *Relay) project(e voiceevent.Event) {
 		// TurnEnded, so without this the last agent line keeps the label through
 		// the following silence. Also correct for a barge (human over the Agent).
 		if r.resolver != nil && ev.SpeakerID != "" {
-			r.resolver.Warm(r.activeCampaignID, ev.SpeakerID)
+			r.resolver.Warm(r.proj.Session().CampaignID, ev.SpeakerID)
 		}
 		r.setTyping(r.liveTyping())
 	case voiceevent.STTFinal:
@@ -368,7 +359,7 @@ func (r *Relay) project(e voiceevent.Event) {
 		})
 	case voiceevent.AddressRouted:
 		// Records WHO answers this turn; no line yet (no text).
-		t := r.turn(ev.TurnID)
+		t := r.proj.Turn(ev.TurnID)
 		t.target = ev.Target
 	case voiceevent.SpeakRequested:
 		// A GM /say (#295): like AddressRouted it records WHO speaks this turn (no line
@@ -376,7 +367,7 @@ func (r *Relay) project(e voiceevent.Event) {
 		// path below, so the /say line is assembled and persisted exactly like an LLM
 		// reply (ID "a:<turn>", NPC kind + pill) — no hand-crafted transcript row
 		// (ADR-0012/0040).
-		t := r.turn(ev.TurnID)
+		t := r.proj.Turn(ev.TurnID)
 		t.target = ev.Target
 	case voiceevent.EnsembleLead:
 		// An Ensemble Turn's elected Lead (#301, ADR-0025): the Lead speaks under the
@@ -384,7 +375,7 @@ func (r *Relay) project(e voiceevent.Event) {
 		// the coalescing TTSInvoked line is attributed to the Lead (a:<turn>, its name +
 		// NPC pill). The losing candidates publish no EnsembleLead and no TTSInvoked, so
 		// they leave no line.
-		t := r.turn(ev.TurnID)
+		t := r.proj.Turn(ev.TurnID)
 		t.target = ev.Target
 	case voiceevent.EnsembleReaction:
 		// An Ensemble Turn's Cross-talk Reaction (#302, ADR-0025): the reactor speaks
@@ -393,11 +384,11 @@ func (r *Relay) project(e voiceevent.Event) {
 		// lands as a SEPARATE line (a:<rID>, the reactor's name + NPC pill) beneath the
 		// Lead's rather than coalescing into it. A declined Reaction publishes no
 		// EnsembleReaction and no TTSInvoked, so it leaves no line.
-		t := r.turn(ev.TurnID)
+		t := r.proj.Turn(ev.TurnID)
 		t.target = ev.Target
 	case voiceevent.TTSInvoked:
 		// One sentence of the Agent's reply — coalesced into the turn's line.
-		t := r.turn(ev.TurnID)
+		t := r.proj.Turn(ev.TurnID)
 		if t.ended {
 			// A barge can deliver a sentence after TurnEnded; ignore it so the
 			// finalized reply is not clobbered (FIX 2). typing already cleared.
@@ -429,7 +420,7 @@ func (r *Relay) project(e voiceevent.Event) {
 		// Mark the turn finalized (keep the entry so a late sentence is dropped,
 		// FIX 2) and fall back to listening — correct for a barge that cut the
 		// Agent off mid-reply.
-		r.turn(ev.TurnID).ended = true
+		r.proj.Turn(ev.TurnID).ended = true
 		r.setTyping(r.liveTyping())
 	case voiceevent.MuteChanged:
 		// One Agent's mute flipped (#211): forward a "mute" frame so the web Voice
@@ -474,18 +465,16 @@ func (r *Relay) currentSessionID() string {
 	return vs.ID.String()
 }
 
-// rollover starts a fresh buffer for the newly-active session vs — the SAME
-// snapshot the caller compared ids against (#149), so the typed FKs persistence
-// needs can never belong to a different session than activeID — and seeds it
-// with the initial live/listening status frame, so a client connecting
-// mid-session replays a coherent state.
-func (r *Relay) rollover(vs storage.VoiceSession) {
-	r.activeID = vs.ID.String()
-	r.activeUUID = vs.ID
-	r.activeCampaignID = vs.CampaignID
+// startSession is the scaffold's rollover hook: it starts a fresh buffer for
+// the newly-active session — whose typed FKs the scaffold captured from the
+// SAME snapshot it compared ids against (#149), so persistence can never
+// attribute a line to a different session than the buffer — and seeds it with
+// the initial live/listening status frame, so a client connecting mid-session
+// replays a coherent state. Runs under r.mu; the scaffold has already reset
+// the turn map.
+func (r *Relay) startSession() {
 	r.buf = nil
 	r.lines = nil
-	r.turns = map[string]*turn{}
 	r.nextSeq = 0
 	r.humanSeq = 0
 	r.typing = r.liveTyping()
@@ -500,7 +489,7 @@ func (r *Relay) rollover(vs storage.VoiceSession) {
 func (r *Relay) endSession(id uuid.UUID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if id.String() != r.activeID {
+	if id.String() != r.proj.ActiveID() {
 		// The relay never rolled over to this session (zero bus events) — there is
 		// no buffer to close, and emitting here would inject a spurious idle frame
 		// into the CURRENT session's stream.
@@ -508,16 +497,6 @@ func (r *Relay) endSession(id uuid.UUID) {
 	}
 	r.typing = Typing{}
 	r.emit(Frame{Event: "status", Data: mustJSON(status{Status: "idle", Typing: Typing{}})})
-}
-
-// turn returns the coalescing state for a turn id, creating it on first sight.
-func (r *Relay) turn(id string) *turn {
-	t := r.turns[id]
-	if t == nil {
-		t = &turn{}
-		r.turns[id] = t
-	}
-	return t
 }
 
 // liveTyping is the indicator while a session is live but no Agent is mid-reply.
@@ -586,7 +565,7 @@ func (r *Relay) emit(f Frame) {
 func (r *Relay) View(id string) View {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.currentSessionID() != id || id != r.activeID {
+	if r.currentSessionID() != id || id != r.proj.ActiveID() {
 		return View{Lines: []Line{}, Status: "idle", Typing: Typing{}}
 	}
 	return View{
@@ -610,7 +589,7 @@ func copyLines(lines []Line) []Line {
 // reconnect/reload history for an ended session.
 func (r *Relay) snapshot(ctx context.Context, id string) View {
 	r.mu.Lock()
-	live := r.currentSessionID() == id && id == r.activeID
+	live := r.currentSessionID() == id && id == r.proj.ActiveID()
 	if live {
 		v := View{Lines: copyLines(r.lines), Status: "live", Typing: r.typing, Connection: r.connection}
 		r.mu.Unlock()
@@ -656,7 +635,7 @@ func (r *Relay) persistedView(ctx context.Context, id string) View {
 func (r *Relay) Frames(id string, afterSeq uint64) []Frame {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if id != r.activeID {
+	if id != r.proj.ActiveID() {
 		return nil
 	}
 	var out []Frame
@@ -678,7 +657,7 @@ func (r *Relay) resolveHuman(speakerID string) (string, Kind) {
 	if r.resolver == nil || speakerID == "" {
 		return "Player / DM", KindPlayer
 	}
-	res := r.resolver.Lookup(r.activeCampaignID, speakerID)
+	res := r.resolver.Lookup(r.proj.Session().CampaignID, speakerID)
 	kind := KindPlayer
 	if res.GM {
 		kind = KindGM


### PR DESCRIPTION
## What does this PR do?

Closes #447.

Extracts the projection scaffolding that the transcript Relay (ADR-0040, Line grain) and the Chunker (ADR-0011, Chunk grain) each implemented independently into one shared package, `internal/busproject`:

- **`Projection[T]`** owns the subscribe-once bus subscription, the one-Snapshot-per-event session rollover (the #149 FK-mismatch invariant — ONE `Sessions.Snapshot()` serves both the active-id comparison and the typed-FK capture), and the per-TurnID coalescing map (lazy creation, wholesale reset at rollover). It **borrows the host's mutex** (`sync.Locker`), so the Relay's HTTP handlers and the Chunker's window timer keep taking the exact lock they always did, and calls back through `Hooks{Fold, FinishSession, StartSession}`. `FinishSession` fires **before** the FKs repoint — that ordering is what lets the Chunker's stale-chunk safety-net flush keep the OLD session's ids (pinned by `TestChunker_RolloverFlushKeepsOldSessionIDs` and now also by a dedicated scaffold test).
- **`Queue[T]`** owns the non-blocking tee → single-writer goroutine → flush-barrier write queue: `Enqueue` reports drop-on-overflow to the caller (log messages stay byte-identical), `Flush(ctx, fn)` rides a barrier through the same channel and runs `fn` in the writer after every prior item lands — the Relay's authoritative post-drain `COUNT(*)` travels as that closure. A nil `*Queue` is the persistence-disabled projector (Relay's `Finalize` returns `0, nil` without touching the store, exactly as before).

`relay.go`/`persist.go` and `chunker.go` shrink to their genuinely distinct fold rules (display text at `TTSInvoked` per ADR-0040 vs delivered-only at `FirstAudio` per ADR-0012), their flush sinks (`writeLine` UPSERT / `writeChunk` Insert+Count+gauge), and their session hooks. A future third projection costs a fold, not a file.

**ADR guardrail respected:** this merges plumbing only — Transcript Line and Transcript Chunk remain separate records of the same speech; neither grain's schema nor fold semantics moved. The observe `StageSubscriber` (TTL reaping, not Snapshot rollover) deliberately stays off the scaffold, per the issue's out-of-scope note.

## Why is this change needed?

The #149-class rollover invariant — a subtle rule — was re-proven independently in both files, and the write-queue/drain contract had two homes that could drift. Issue #447 (from the 2026-07-14 architecture review, candidate C4) agreed on a single scaffold so the invariant is implemented and tested once, and the drop-on-overflow/drain contract has one home.

## How was this tested?

- `go test -race ./...` — full suite passes (also run at `-count=3`/`-count=5` on the touched packages for flake hunting). The only failures are pre-existing environmental ones in `pkg/voice/{orchestrator,vad/silero,wire}`: the ONNX Runtime binary download is blocked by this environment's proxy (HTTP 403); they fail identically on a clean checkout of `main`.
- Both existing `internal/transcript` suites pass **unchanged** (zero test-file edits), including the behavior pins for #149 (`TestPersist_RolloverTakesOneSnapshot`), the never-block bus contract (`TestChunker_BusCallbackNeverBlocks`, which asserts exact accepted/dropped counts against `chunkQueue`), and the old-FK rollover flush.
- New dedicated scaffold tests: mid-event session change takes exactly ONE Snapshot; stale-snapshot attribution across the rollover hooks (FinishSession sees old FKs, Fold sees new); straggler-event state retention after the session goes inactive; turn-map lifecycle; overflow drop with exact in-flight+capacity accounting; drain-on-flush FIFO with barrier ordering; ctx bounds on both barrier enqueue and wait; nil-queue disabled-persistence semantics.
- The straggler-retention and barrier-ordering pins were validated by **mutation testing** (a mutant clearing state in the `!active` branch now fails the suite; it survived before the pin was added).
- An adversarial multi-agent parity review of the diff (4 independent review dimensions, every finding cross-examined by 3 refuting verifiers against the pre-refactor `HEAD` sources) confirmed zero behavior changes on any reachable path.
- `go vet` and `golangci-lint run` clean on the touched packages; `gofmt` clean.

- [x] `make check` passes (modulo the pre-existing ONNX-download environment failures above)
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Behavior-parity details a reviewer may want to double-check:

- **Lock discipline is unchanged by design:** the scaffold locks the host's own mutex for the bus callback, so lock ordering (`r.mu`/`c.mu` → manager's mutex via `Snapshot`) is identical to before; hooks and the `Session()`/`ActiveID()`/`Turn()`/`Lookup()` accessors run under that held lock, mirroring the old "caller holds r.mu" comments.
- **One deliberate non-behavioral unification:** `NewRelay` with a nil bus previously nil-panicked (incidentally); it now no-ops like `NewChunker` always did. No caller in the tree (production or tests) passes a nil bus.
- The pre-existing `gofmt` drift in `internal/storage/highlight_enrich_reconcile_test.go` (a comment quote) is untouched to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxSxCGz3859VWEfEfeYs8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxSxCGz3859VWEfEfeYs8p)_