### PR TITLE
refactor(#445): split the Campaign RPC surface into feature modules over narrow store slices

### DIFF
--- a/internal/rpc/active_campaign.go
+++ b/internal/rpc/active_campaign.go
@@ -65,3 +65,36 @@ func resolveActiveCampaign(ctx context.Context, live func() (uuid.UUID, bool), s
 	}
 	return store.GetActiveCampaign(ctx)
 }
+
+// activeCampaignSource is the ONE Active-Campaign resolution every CampaignServer
+// feature module shares (#445): the live Voice Session closure SetSessions wires
+// plus the 3-method resolver slice. The modules hold a pointer to the same
+// instance, so the header, CRUD, KG, proposal, and grant surfaces always resolve
+// the same campaign — and SetSessions wiring the closure once at boot reaches all
+// of them.
+type activeCampaignSource struct {
+	// live reports the live Voice Session's campaign id, if any. Nil until
+	// SetSessions wires it (keyless deployments and most unit tests leave it nil,
+	// which skips the live-first step). Set once at boot before serving, so no
+	// lock is needed.
+	live  func() (uuid.UUID, bool)
+	store activeCampaignResolver
+}
+
+// resolve resolves the operator's Active Campaign via the one shared
+// resolveActiveCampaign policy (live Voice Session → durable /glyphoxa use
+// selection → most-recent fallback, #222).
+func (a *activeCampaignSource) resolve(ctx context.Context) (storage.Campaign, error) {
+	return resolveActiveCampaign(ctx, a.live, a.store)
+}
+
+// liveID reports the LIVE Voice Session's campaign id, nil-safe for an unwired
+// source. The archive/delete live-guard reads it directly — the campaign that is
+// currently voicing must not be archived or deleted, whether or not it is the
+// resolved Active Campaign (#265).
+func (a *activeCampaignSource) liveID() (uuid.UUID, bool) {
+	if a.live == nil {
+		return uuid.Nil, false
+	}
+	return a.live()
+}

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -3,7 +3,8 @@
 // and the generated wire types in gen/glyphoxa/management/v1, and the
 // translation of storage errors into Connect status codes. Handlers depend on
 // narrow reader interfaces (not *storage.Store) so they unit-test keyless with
-// a fake and integration-test against a real store.
+// a fake and integration-test against a real store; CampaignServer composes
+// per-feature modules, each over its own 3–6-method store slice (#445).
 package rpc
 
 import (
@@ -22,159 +23,96 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
-// campaignStore is the narrow storage surface CampaignServer needs — the active
-// campaign read, the roster reads and agent CRUD writes (#71), and the campaign
-// management reads/writes (#264). *storage.Store satisfies it, so handlers can be
-// driven by a fake in unit tests and the real store in integration tests.
-type campaignStore interface {
-	// GetActiveCampaignForUser + GetActiveCampaign are the profile-first resolution
-	// (durable /glyphoxa use selection → most-recent fallback) the header + CRUD +
-	// KG reads scope through instead of the plain most-recent read (#222).
-	GetActiveCampaignForUser(ctx context.Context, discordUserID string) (storage.Campaign, error)
-	GetActiveCampaign(ctx context.Context) (storage.Campaign, error)
-	// GetCampaign loads a campaign by id: the roster/mute panel resolves the LIVE
-	// Voice Session's campaign first (#222), so it fetches that specific row rather
-	// than the profile default. UpdateAgent also uses it to read the owning
-	// campaign's language for a first-save voice default (#224).
-	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
-	// ListCampaigns/CreateCampaign/UpdateCampaign/SetActiveCampaign back the
-	// campaign management RPCs (#264): the name-ordered picker list, the tenant-
-	// scoped create (auto-Butler fires), the opaque name/system/language write, and
-	// the durable /glyphoxa use selection shared with the slash-command surface.
-	ListCampaigns(ctx context.Context) ([]storage.Campaign, error)
-	CreateCampaign(ctx context.Context, c storage.NewCampaign) (uuid.UUID, error)
-	UpdateCampaign(ctx context.Context, c storage.CampaignUpdate) (storage.Campaign, error)
-	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
-	// The campaign archive lifecycle (#269): ListAllCampaigns is the archive-
-	// inclusive list the include_archived flag routes to; Archive/Unarchive/Delete
-	// are the lifecycle writes. Delete cascades in one statement; Archive clears any
-	// durable selection pointing at the campaign.
-	ListAllCampaigns(ctx context.Context) ([]storage.Campaign, error)
-	ArchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
-	UnarchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
-	DeleteCampaign(ctx context.Context, id uuid.UUID) error
-	// DeleteCampaignWithJob hard-deletes AND enqueues a follow-up job atomically
-	// (#308): the campaign hard delete uses it to schedule the Highlight-clip blob
-	// sweep in the delete's own transaction, so the sweep exists iff the delete
-	// committed (no orphan sweep of a surviving campaign, no lost sweep on a crash).
-	DeleteCampaignWithJob(ctx context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error
-	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
-	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
-	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
-	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
-	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
-	DeleteAgent(ctx context.Context, campaignID, id uuid.UUID) error
-	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
-	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
-	UpdateNode(ctx context.Context, u storage.KGNodeUpdate) (storage.KGNode, error)
-	DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error
-	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
-	DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error
-	NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
-	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
-	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
-	// Knowledge Proposal review (#300, ADR-0052): the GM review surface's list of
-	// pending proposals, the single-proposal read the similarity hint keys off, the
-	// atomic approve/reject writes, and the embedding-vector nearest-neighbour search
-	// the similarity hint runs.
-	ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error)
-	GetPendingKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) (storage.KnowledgeProposal, error)
-	ApproveKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
-	RejectKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
-	SimilarNodes(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.KGNode, error)
-	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
-	UpsertToolGrant(ctx context.Context, g storage.NewToolGrant) error
-	DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error
-	// Player Character (PC) CRUD (#276, E4): the campaign-scoped roster read plus
-	// create/update (incl. Discord-User rebind)/delete. All resolve the active
-	// campaign server-side like the Agent CRUD, so another campaign's Characters
-	// are never returned nor mutable.
-	ListCharacters(ctx context.Context, campaignID uuid.UUID) ([]storage.Character, error)
-	CreateCharacter(ctx context.Context, c storage.NewCharacter) (uuid.UUID, error)
-	UpdateCharacter(ctx context.Context, c storage.CharacterUpdate) (storage.Character, error)
-	DeleteCharacter(ctx context.Context, campaignID, id uuid.UUID) error
-}
-
-// CampaignServer implements managementv1connect.CampaignServiceHandler over a
-// campaignStore. tools is the built-in Tool catalog the grant editor lists
-// (ADR-0028) — the available-Tools source for ListToolGrants and the registry
-// UpdateToolGrant validates tool_name against (#117).
+// CampaignServer implements managementv1connect.CampaignServiceHandler as a
+// composition of feature modules (#445): campaign management, the archive
+// lifecycle, the Agent roster, Player Characters, KG Nodes/Edges, Knowledge
+// Proposals, and Tool Grants. Each module declares the minimal store slice it
+// consumes (all satisfied structurally by *storage.Store) and its RPC methods
+// promote onto this struct, so the wire surface — one CampaignService behind
+// one interceptor stack — is unchanged while a unit test fakes only the slice
+// its feature reads.
 type CampaignServer struct {
-	store campaignStore
-	tools *tool.Registry
-	// liveCampaign reports the live Voice Session's campaign id, if any. Nil until
-	// SetSessions wires it; the roster/mute panel resolves through it so it scopes
-	// to the campaign actually voicing, not a durable selection changed mid-session
-	// (#222). Set once at boot before serving, so no lock is needed.
-	liveCampaign func() (uuid.UUID, bool)
-	// memberLister lists the Discord Users currently in the operator's voice
-	// channel for the Players panel picker (#279). Nil until SetMemberLister wires
-	// it (a keyless / bot-offline deployment leaves it nil); the handler then
-	// returns an empty list so the UI falls back to free-text snowflake entry. Set
-	// once at boot before serving, so no lock is needed.
-	memberLister voiceMemberLister
-	// speakerInv drops a campaign's cached speaker→name resolutions after a Character
-	// mutation (#281, ADR-0039 in-proc direct-method invalidation), so the live relay
-	// re-resolves future lines with the new mapping. Nil disables (feature off / no
-	// live resolver); set once at boot before serving.
-	speakerInv SpeakerInvalidator
-	// clips sweeps a campaign's Session Highlight clips out of blob storage on hard
-	// delete (#308, ADR-0048): highlight rows cascade with the campaign, but the
-	// clip blobs have NO FK and must be dropped through the seam. Nil disables the
-	// sweep (web-only / no blob backend); set once at boot before serving.
-	clips HighlightClipSweeper
-	// embedder embeds a proposal's subject text for the ListSimilarKnowledge vector
-	// hint (#300, ADR-0011/0052). Nil (no embeddings provider wired, or a keyless
-	// deployment) makes the hint degrade silently to fulltext SearchNodes. Set once
-	// at boot before serving, so no lock is needed.
-	embedder Embedder
+	// active is the ONE live-first Active-Campaign resolution every module
+	// shares (#222): SetSessions wires its live closure once at boot, and every
+	// surface (header, roster/mute panel, campaign CRUD, KG wiki, review queue)
+	// scopes through it, so a screen's reads and writes always agree.
+	active *activeCampaignSource
+
+	*campaignManagement
+	*campaignArchive
+	*agentRoster
+	*characterRoster
+	*kgNodes
+	*kgEdges
+	*knowledgeProposals
+	*toolGrants
 }
 
-// Embedder embeds short texts to query vectors for the Knowledge Proposal
-// similarity hint (#300, ADR-0052). The resolved embeddings provider satisfies it;
-// nil disables the vector path (the hint falls back to fulltext search).
-type Embedder interface {
-	Embed(ctx context.Context, texts []string) ([][]float32, error)
+// CampaignStores groups the per-feature store slices CampaignServer composes
+// (#445). One *storage.Store satisfies every field structurally — that is what
+// NewCampaignServer wires — while a unit test fills ONLY the slice its feature
+// under test reads (plus Active for handlers that resolve the Active Campaign)
+// and leaves the rest nil.
+type CampaignStores struct {
+	// Active backs the shared live-first Active-Campaign resolution (#222)
+	// every scoped handler walks before touching its feature slice.
+	Active activeCampaignResolver
+	// Campaigns backs the campaign management surface: list/create/update and
+	// the durable /glyphoxa use selection (#264).
+	Campaigns campaignManagementStore
+	// Archive backs the archive/hard-delete lifecycle (#269).
+	Archive campaignArchiveStore
+	// Agents backs the roster read and the Agent (NPC) CRUD (#71).
+	Agents agentStore
+	// Characters backs the Player Character CRUD (#276).
+	Characters characterStore
+	// KGNodes backs the Knowledge Graph Node CRUD + wiki search (#126, #131).
+	KGNodes kgNodeStore
+	// KGEdges backs the Knowledge Graph Edge CRUD + the voiced-by link (#132).
+	KGEdges kgEdgeStore
+	// Proposals backs the Knowledge Proposal review queue + similarity hint
+	// (#300, ADR-0052).
+	Proposals knowledgeProposalStore
+	// Grants backs the Tool Grant editor (#117).
+	Grants toolGrantStore
 }
 
-// SetEmbedder wires the embeddings provider the ListSimilarKnowledge vector hint
-// uses (#300). Called once at boot before serving; nil leaves the hint on the
-// fulltext fallback only.
-func (s *CampaignServer) SetEmbedder(e Embedder) {
-	s.embedder = e
+// NewCampaignServer wires every feature module over the one concrete store —
+// the production composition (cmd/glyphoxa) and the integration tests use it.
+// The available-Tools catalog is the shared built-in Registry (ADR-0028), so
+// the grants a GM can toggle are exactly the Tools a Voice Session runs;
+// nothing external configures it.
+func NewCampaignServer(s *storage.Store) *CampaignServer {
+	return NewCampaignServerWith(CampaignStores{
+		Active:     s,
+		Campaigns:  s,
+		Archive:    s,
+		Agents:     s,
+		Characters: s,
+		KGNodes:    s,
+		KGEdges:    s,
+		Proposals:  s,
+		Grants:     s,
+	})
 }
 
-// HighlightClipSweeper drops a campaign's Session Highlight clips through the blob
-// seam on hard delete (#308, ADR-0048). main.go wires it over
-// storage.ListCampaignHighlightClipKeys + blob.Delete. The keys are listed BEFORE
-// the campaign row delete (which cascades the highlight rows away) and the blobs
-// are dropped AFTER the delete succeeds, so a refused delete never orphans a live
-// campaign's clips.
-type HighlightClipSweeper interface {
-	CampaignClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error)
-	DeleteClip(ctx context.Context, key string) error
-}
-
-// SetHighlightClipSweeper wires the highlight-clip blob sweep the campaign hard
-// delete runs (#308). Called once at boot before serving; nil leaves the sweep
-// off (the highlight rows still cascade, only their blobs would linger).
-func (s *CampaignServer) SetHighlightClipSweeper(sw HighlightClipSweeper) {
-	s.clips = sw
-}
-
-// SpeakerInvalidator drops a campaign's cached speaker→name resolutions. The live
-// *speaker.Resolver satisfies it; the Character CRUD handlers call it on
-// create/update/delete so a rebind takes effect on the next projected line (#281).
-type SpeakerInvalidator interface {
-	InvalidateCampaign(campaignID uuid.UUID)
-}
-
-// NewCampaignServer wraps a campaignStore (e.g. *storage.Store) in a
-// CampaignServer. The available-Tools catalog is the shared built-in Registry
-// (ADR-0028), so the grants a GM can toggle are exactly the Tools a Voice Session
-// runs; nothing external configures it.
-func NewCampaignServer(s campaignStore) *CampaignServer {
-	return &CampaignServer{store: s, tools: tool.BuiltinRegistry(tool.Deps{})}
+// NewCampaignServerWith composes the feature modules over per-feature store
+// slices (#445), so a unit test drives one feature over the full Connect stack
+// while faking only that feature's slice. A nil slice leaves that feature's
+// handlers panicking on first use — fill exactly what the test exercises.
+func NewCampaignServerWith(stores CampaignStores) *CampaignServer {
+	active := &activeCampaignSource{store: stores.Active}
+	return &CampaignServer{
+		active:             active,
+		campaignManagement: &campaignManagement{store: stores.Campaigns, active: active},
+		campaignArchive:    &campaignArchive{store: stores.Archive, active: active},
+		agentRoster:        &agentRoster{store: stores.Agents, active: active},
+		characterRoster:    &characterRoster{store: stores.Characters, active: active},
+		kgNodes:            &kgNodes{store: stores.KGNodes, active: active},
+		kgEdges:            &kgEdges{store: stores.KGEdges, active: active},
+		knowledgeProposals: &knowledgeProposals{store: stores.Proposals, active: active},
+		toolGrants:         &toolGrants{store: stores.Grants, active: active, tools: tool.BuiltinRegistry(tool.Deps{})},
+	}
 }
 
 // compile-time assertion that CampaignServer satisfies the generated handler.
@@ -187,7 +125,7 @@ var _ managementv1connect.CampaignServiceHandler = (*CampaignServer)(nil)
 // mid-session. Called once at boot, after the session manager exists and before
 // the server serves, so no lock is needed — mirrors VoiceServer.SetSessions.
 func (s *CampaignServer) SetSessions(src activeSessionSource) {
-	s.liveCampaign = func() (uuid.UUID, bool) {
+	s.active.live = func() (uuid.UUID, bool) {
 		vs, active := src.Snapshot()
 		return vs.CampaignID, active
 	}
@@ -197,23 +135,49 @@ func (s *CampaignServer) SetSessions(src activeSessionSource) {
 // (#281). Called once at boot before serving, so no lock is needed; nil-safe at the
 // call sites (invalidateSpeakers). A nil resolver leaves the hook off.
 func (s *CampaignServer) SetSpeakerInvalidator(inv SpeakerInvalidator) {
-	s.speakerInv = inv
+	s.characterRoster.speakerInv = inv
 }
 
-// invalidateSpeakers drops a campaign's cached speaker resolutions after a
-// Character mutation, if a resolver is wired (#281). Nil-safe.
-func (s *CampaignServer) invalidateSpeakers(campaignID uuid.UUID) {
-	if s.speakerInv != nil {
-		s.speakerInv.InvalidateCampaign(campaignID)
-	}
+// SetEmbedder wires the embeddings provider the ListSimilarKnowledge vector hint
+// uses (#300). Called once at boot before serving; nil leaves the hint on the
+// fulltext fallback only.
+func (s *CampaignServer) SetEmbedder(e Embedder) {
+	s.knowledgeProposals.embedder = e
 }
 
-// activeCampaign resolves the campaign every CampaignService handler scopes to,
-// via the one shared resolveActiveCampaign policy (live Voice Session → durable
-// /glyphoxa use selection → most-recent fallback, #222). Reads and writes on the
-// same screen therefore always name the same campaign.
-func (s *CampaignServer) activeCampaign(ctx context.Context) (storage.Campaign, error) {
-	return resolveActiveCampaign(ctx, s.liveCampaign, s.store)
+// SetHighlightClipSweeper wires the highlight-clip blob sweep the campaign hard
+// delete runs (#308). Called once at boot before serving; nil leaves the sweep
+// off (the highlight rows still cascade, only their blobs would linger).
+func (s *CampaignServer) SetHighlightClipSweeper(sw HighlightClipSweeper) {
+	s.campaignArchive.clips = sw
+}
+
+// campaignManagement is the campaign lifecycle feature module (#264, #222): the
+// Session-screen header's Active-Campaign read, the campaign list/create/update
+// management surface, the durable /glyphoxa use selection, and the Campaign
+// Language catalog (#268 — a pure registry read).
+type campaignManagement struct {
+	store  campaignManagementStore
+	active *activeCampaignSource
+}
+
+// campaignManagementStore is the narrow campaign-management surface the module
+// needs (#264); *storage.Store satisfies it, so the handlers unit-test keyless
+// with a fake.
+type campaignManagementStore interface {
+	// ListCampaigns is the name-ordered ACTIVE-only picker list; ListAllCampaigns
+	// is the archive-inclusive variant the include_archived flag routes to (#269).
+	ListCampaigns(ctx context.Context) ([]storage.Campaign, error)
+	ListAllCampaigns(ctx context.Context) ([]storage.Campaign, error)
+	// CreateCampaign is the tenant-scoped create (the ADR-0009 auto-Butler trigger
+	// fires on the insert); GetCampaign backs its read-back and SetActiveCampaign's
+	// pre-write validation.
+	CreateCampaign(ctx context.Context, c storage.NewCampaign) (uuid.UUID, error)
+	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	UpdateCampaign(ctx context.Context, c storage.CampaignUpdate) (storage.Campaign, error)
+	// SetActiveCampaign records the durable /glyphoxa use selection shared with the
+	// slash-command surface (migration 00014).
+	SetActiveCampaign(ctx context.Context, discordUserID string, campaignID uuid.UUID) error
 }
 
 // GetActiveCampaign resolves the operator's active campaign and maps it onto the
@@ -222,11 +186,11 @@ func (s *CampaignServer) activeCampaign(ctx context.Context) (storage.Campaign, 
 // Session-screen header names the same campaign the roster, transcript, and Start
 // do (#222). A storage.ErrNotFound (no campaign exists) becomes CodeNotFound; any
 // other failure becomes CodeInternal.
-func (s *CampaignServer) GetActiveCampaign(
+func (s *campaignManagement) GetActiveCampaign(
 	ctx context.Context,
 	_ *connect.Request[managementv1.GetActiveCampaignRequest],
 ) (*connect.Response[managementv1.GetActiveCampaignResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -135,21 +135,21 @@ func (s *CampaignServer) SetSessions(src activeSessionSource) {
 // (#281). Called once at boot before serving, so no lock is needed; nil-safe at the
 // call sites (invalidateSpeakers). A nil resolver leaves the hook off.
 func (s *CampaignServer) SetSpeakerInvalidator(inv SpeakerInvalidator) {
-	s.characterRoster.speakerInv = inv
+	s.speakerInv = inv
 }
 
 // SetEmbedder wires the embeddings provider the ListSimilarKnowledge vector hint
 // uses (#300). Called once at boot before serving; nil leaves the hint on the
 // fulltext fallback only.
 func (s *CampaignServer) SetEmbedder(e Embedder) {
-	s.knowledgeProposals.embedder = e
+	s.embedder = e
 }
 
 // SetHighlightClipSweeper wires the highlight-clip blob sweep the campaign hard
 // delete runs (#308). Called once at boot before serving; nil leaves the sweep
 // off (the highlight rows still cascade, only their blobs would linger).
 func (s *CampaignServer) SetHighlightClipSweeper(sw HighlightClipSweeper) {
-	s.campaignArchive.clips = sw
+	s.clips = sw
 }
 
 // campaignManagement is the campaign lifecycle feature module (#264, #222): the

--- a/internal/rpc/campaign_archive.go
+++ b/internal/rpc/campaign_archive.go
@@ -13,29 +13,60 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Campaign archive/delete lifecycle handlers (#269, decided on #265) on
-// CampaignServer. Archive is the primary flow; hard delete is only for
+// campaignArchive is the campaign archive/delete lifecycle feature module
+// (#269, decided on #265). Archive is the primary flow; hard delete is only for
 // already-archived campaigns. Archive and Delete refuse the campaign backing the
-// LIVE Voice Session (the same in-process liveCampaign truth resolveActiveCampaign
+// LIVE Voice Session (the same in-process live truth resolveActiveCampaign
 // consults, ADR-0039 — no second session-truth source). Error mapping mirrors the
 // campaign management handlers: ErrNotFound→CodeNotFound, ErrNotArchived→
 // CodeFailedPrecondition, an unparsable id→CodeInvalidArgument, generic
 // CodeInternal with a server-side slog.
+type campaignArchive struct {
+	store  campaignArchiveStore
+	active *activeCampaignSource
+	// clips sweeps a campaign's Session Highlight clips out of blob storage on hard
+	// delete (#308, ADR-0048): highlight rows cascade with the campaign, but the
+	// clip blobs have NO FK and must be dropped through the seam. Nil disables the
+	// sweep (web-only / no blob backend); set once at boot before serving.
+	clips HighlightClipSweeper
+}
+
+// campaignArchiveStore is the narrow archive-lifecycle surface the module needs
+// (#269); *storage.Store satisfies it. Delete cascades in one statement; Archive
+// clears any durable selection pointing at the campaign.
+type campaignArchiveStore interface {
+	ArchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	UnarchiveCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	DeleteCampaign(ctx context.Context, id uuid.UUID) error
+	// DeleteCampaignWithJob hard-deletes AND enqueues a follow-up job atomically
+	// (#308): the campaign hard delete uses it to schedule the Highlight-clip blob
+	// sweep in the delete's own transaction, so the sweep exists iff the delete
+	// committed (no orphan sweep of a surviving campaign, no lost sweep on a crash).
+	DeleteCampaignWithJob(ctx context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error
+}
+
+// HighlightClipSweeper drops a campaign's Session Highlight clips through the blob
+// seam on hard delete (#308, ADR-0048). main.go wires it over
+// storage.ListCampaignHighlightClipKeys + blob.Delete. The keys are listed BEFORE
+// the campaign row delete (which cascades the highlight rows away) and the blobs
+// are dropped AFTER the delete succeeds, so a refused delete never orphans a live
+// campaign's clips.
+type HighlightClipSweeper interface {
+	CampaignClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error)
+	DeleteClip(ctx context.Context, key string) error
+}
 
 // liveGuard refuses an operation on the campaign backing the LIVE Voice Session
 // (#265): the campaign that is currently voicing can be neither archived nor
-// deleted out from under it. It consults the SAME liveCampaign closure
+// deleted out from under it. It consults the SAME live closure
 // resolveActiveCampaign uses, so there is one source of session truth (ADR-0039).
 // It returns nil when no session is live, the source is unwired (keyless tests),
-// or a DIFFERENT campaign is live. Note the inherent TOCTOU: liveCampaign is
+// or a DIFFERENT campaign is live. Note the inherent TOCTOU: the live closure is
 // in-process manager state and a session could end (or start) in the millisecond
 // after this check — accepted for the single-operator web tier, where the window
 // is negligible and the DB cascade is still safe either way.
-func (s *CampaignServer) liveGuard(id uuid.UUID, verb string) error {
-	if s.liveCampaign == nil {
-		return nil
-	}
-	if lid, active := s.liveCampaign(); active && lid == id {
+func (s *campaignArchive) liveGuard(id uuid.UUID, verb string) error {
+	if lid, active := s.active.liveID(); active && lid == id {
 		return connect.NewError(connect.CodeFailedPrecondition,
 			errors.New("campaign backs the live Voice Session and cannot be "+verb+" while it runs"))
 	}
@@ -47,7 +78,7 @@ func (s *CampaignServer) liveGuard(id uuid.UUID, verb string) error {
 // Voice Session (#269). It refuses the live session's campaign
 // (CodeFailedPrecondition) and an unknown id (CodeNotFound); the store write is
 // idempotent, so re-archiving is a no-op returning the same campaign.
-func (s *CampaignServer) ArchiveCampaign(
+func (s *campaignArchive) ArchiveCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.ArchiveCampaignRequest],
 ) (*connect.Response[managementv1.ArchiveCampaignResponse], error) {
@@ -73,7 +104,7 @@ func (s *CampaignServer) ArchiveCampaign(
 // UnarchiveCampaign returns an archived campaign to the active set (#269). There
 // is no live-guard: a live session's campaign is never archived, so it can never
 // be a target here. An unknown id is CodeNotFound.
-func (s *CampaignServer) UnarchiveCampaign(
+func (s *campaignArchive) UnarchiveCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.UnarchiveCampaignRequest],
 ) (*connect.Response[managementv1.UnarchiveCampaignResponse], error) {
@@ -99,7 +130,7 @@ func (s *CampaignServer) UnarchiveCampaign(
 // archive first), and an unknown id (CodeNotFound). The re-typed name confirmation
 // is a UI-only guard (the request carries only the id); the server precondition is
 // purely "already archived".
-func (s *CampaignServer) DeleteCampaign(
+func (s *campaignArchive) DeleteCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteCampaignRequest],
 ) (*connect.Response[managementv1.DeleteCampaignResponse], error) {

--- a/internal/rpc/campaign_archive_test.go
+++ b/internal/rpc/campaign_archive_test.go
@@ -10,20 +10,29 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
+// archiveClient composes the slices the archive panel drives — Active +
+// Campaigns + Archive, all served by the one fakeArchiveStore (#445) — behind
+// campaignClientAs with the given operator, tenant, and live-session source.
+func archiveClient(t *testing.T, store *fakeArchiveStore, user storage.User, tenantID uuid.UUID, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClientAs(t, rpc.CampaignStores{Active: store, Campaigns: store, Archive: store}, user, tenantID, sessions)
+}
+
 // TestArchiveCampaign_HappyPath: a valid, non-live campaign archives and the
 // archived_at timestamp maps onto the wire.
 func TestArchiveCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	id := uuid.New()
 	archivedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
 	store.archiveResult = storage.Campaign{ID: id, TenantID: uuid.New(), Name: "Old One", ArchivedAt: &archivedAt}
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	resp, err := client.ArchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: id.String()}))
@@ -40,7 +49,7 @@ func TestArchiveCampaign_HappyPath(t *testing.T) {
 
 func TestArchiveCampaign_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, newFakeArchiveStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.ArchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: "nope"}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -50,9 +59,9 @@ func TestArchiveCampaign_InvalidID(t *testing.T) {
 
 func TestArchiveCampaign_UnknownIDNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.archiveErr = storage.ErrNotFound
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.ArchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: uuid.New().String()}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -65,8 +74,8 @@ func TestArchiveCampaign_UnknownIDNotFound(t *testing.T) {
 func TestArchiveCampaign_LiveSessionRefused(t *testing.T) {
 	t.Parallel()
 	live := uuid.New()
-	store := newFakeStore()
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+	store := newFakeArchiveStore()
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
 
 	_, err := client.ArchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: live.String()}))
@@ -85,9 +94,9 @@ func TestArchiveCampaign_OtherCampaignWhileLiveAllowed(t *testing.T) {
 	t.Parallel()
 	live := uuid.New()
 	other := uuid.New()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.archiveResult = storage.Campaign{ID: other, Name: "Other"}
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
 
 	if _, err := client.ArchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.ArchiveCampaignRequest{Id: other.String()})); err != nil {
@@ -102,10 +111,10 @@ func TestArchiveCampaign_OtherCampaignWhileLiveAllowed(t *testing.T) {
 // (archived_at unset) with no live-guard.
 func TestUnarchiveCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	id := uuid.New()
 	store.unarchiveResult = storage.Campaign{ID: id, Name: "Back"}
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	resp, err := client.UnarchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.UnarchiveCampaignRequest{Id: id.String()}))
@@ -122,9 +131,9 @@ func TestUnarchiveCampaign_HappyPath(t *testing.T) {
 
 func TestUnarchiveCampaign_UnknownIDNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.unarchiveErr = storage.ErrNotFound
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.UnarchiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.UnarchiveCampaignRequest{Id: uuid.New().String()}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -135,9 +144,9 @@ func TestUnarchiveCampaign_UnknownIDNotFound(t *testing.T) {
 // TestDeleteCampaign_HappyPath: a valid, archived, non-live campaign deletes.
 func TestDeleteCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	id := uuid.New()
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	if _, err := client.DeleteCampaign(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: id.String()})); err != nil {
@@ -171,10 +180,10 @@ func (f *fakeClipSweeper) DeleteClip(_ context.Context, key string) error {
 // highlight clip through the blob seam (#308, ADR-0048).
 func TestDeleteCampaign_SweepsHighlightClips(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	id := uuid.New()
 	sweeper := &fakeClipSweeper{keys: []string{"k1", "k2"}}
-	srv := rpc.NewCampaignServer(store)
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Campaigns: store, Archive: store})
 	srv.SetHighlightClipSweeper(sweeper)
 
 	if _, err := srv.DeleteCampaign(context.Background(),
@@ -194,10 +203,10 @@ func TestDeleteCampaign_SweepsHighlightClips(t *testing.T) {
 // (#308, ADR-0049) — the backstop that survives a crash after the row cascade.
 func TestDeleteCampaign_EnqueuesDurableClipSweep(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	id := uuid.New()
 	sweeper := &fakeClipSweeper{keys: []string{"k1", "k2"}}
-	srv := rpc.NewCampaignServer(store)
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Campaigns: store, Archive: store})
 	srv.SetHighlightClipSweeper(sweeper)
 
 	if _, err := srv.DeleteCampaign(context.Background(),
@@ -223,9 +232,9 @@ func TestDeleteCampaign_EnqueuesDurableClipSweep(t *testing.T) {
 // plain delete path (no sweep job to enqueue).
 func TestDeleteCampaign_NoClipsNoJob(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	sweeper := &fakeClipSweeper{} // no keys
-	srv := rpc.NewCampaignServer(store)
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Campaigns: store, Archive: store})
 	srv.SetHighlightClipSweeper(sweeper)
 
 	if _, err := srv.DeleteCampaign(context.Background(),
@@ -244,10 +253,10 @@ func TestDeleteCampaign_NoClipsNoJob(t *testing.T) {
 // drop any clips (the campaign is still live).
 func TestDeleteCampaign_RefusedKeepsClips(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.deleteCampaignErr = storage.ErrNotArchived
 	sweeper := &fakeClipSweeper{keys: []string{"k1"}}
-	srv := rpc.NewCampaignServer(store)
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Campaigns: store, Archive: store})
 	srv.SetHighlightClipSweeper(sweeper)
 
 	_, err := srv.DeleteCampaign(context.Background(),
@@ -262,7 +271,7 @@ func TestDeleteCampaign_RefusedKeepsClips(t *testing.T) {
 
 func TestDeleteCampaign_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, newFakeArchiveStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.DeleteCampaign(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: "nope"}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -274,9 +283,9 @@ func TestDeleteCampaign_InvalidID(t *testing.T) {
 // FailedPrecondition (archive first, #265).
 func TestDeleteCampaign_NotArchivedRefused(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.deleteCampaignErr = storage.ErrNotArchived
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.DeleteCampaign(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()}))
 	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
@@ -286,9 +295,9 @@ func TestDeleteCampaign_NotArchivedRefused(t *testing.T) {
 
 func TestDeleteCampaign_UnknownIDNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.deleteCampaignErr = storage.ErrNotFound
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 	_, err := client.DeleteCampaign(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: uuid.New().String()}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -301,8 +310,8 @@ func TestDeleteCampaign_UnknownIDNotFound(t *testing.T) {
 func TestDeleteCampaign_LiveSessionRefused(t *testing.T) {
 	t.Parallel()
 	live := uuid.New()
-	store := newFakeStore()
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
+	store := newFakeArchiveStore()
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live))
 
 	_, err := client.DeleteCampaign(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCampaignRequest{Id: live.String()}))
@@ -320,13 +329,13 @@ func TestDeleteCampaign_LiveSessionRefused(t *testing.T) {
 func TestListCampaigns_IncludeArchivedRouting(t *testing.T) {
 	t.Parallel()
 	archivedAt := time.Date(2026, 7, 9, 8, 0, 0, 0, time.UTC)
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.campaignList = []storage.Campaign{{ID: uuid.New(), Name: "Active"}}
 	store.allCampaignList = []storage.Campaign{
 		{ID: uuid.New(), Name: "Active"},
 		{ID: uuid.New(), Name: "Archived", ArchivedAt: &archivedAt},
 	}
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	// Default (false) → active only.
 	activeResp, err := client.ListCampaigns(context.Background(),
@@ -363,9 +372,9 @@ func TestSetActiveCampaign_ArchivedRefused(t *testing.T) {
 	t.Parallel()
 	archivedAt := time.Date(2026, 7, 9, 8, 0, 0, 0, time.UTC)
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeArchiveStore()
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{id: {ID: id, Name: "Archived", ArchivedAt: &archivedAt}}
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := archiveClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.SetActiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: id.String()}))

--- a/internal/rpc/campaign_crud.go
+++ b/internal/rpc/campaign_crud.go
@@ -14,11 +14,31 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 )
 
-// Campaign-screen CRUD handlers (#71) on CampaignServer: the roster read plus
-// agent create/update/delete over the polymorphic agents table (ADR-0009).
-// Reads/writes resolve the single operator's active campaign server-side, the
-// same single-tenant pass-through GetActiveCampaign uses (ADR-0039); per-tenant
-// scoping fills in behind the X-Tenant-Id interceptor later.
+// agentRoster is the Campaign-screen Agent CRUD feature module (#71): the
+// roster read plus agent create/update/delete over the polymorphic agents table
+// (ADR-0009). Reads/writes resolve the single operator's active campaign
+// server-side, the same single-tenant pass-through GetActiveCampaign uses
+// (ADR-0039); per-tenant scoping fills in behind the X-Tenant-Id interceptor
+// later.
+type agentRoster struct {
+	store  agentStore
+	active *activeCampaignSource
+}
+
+// agentStore is the narrow roster + Agent CRUD surface the module needs (#71);
+// *storage.Store satisfies it, so the handlers unit-test keyless with a fake.
+type agentStore interface {
+	// GetButler + CharacterAgents are the ordered roster read (the Butler is
+	// auto-created with the campaign, ADR-0009).
+	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
+	CharacterAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	// GetAgent backs the create read-back and UpdateAgent's campaign-scoped
+	// pre-read (#356) that preserves persisted voice tuning (#224).
+	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
+	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
+	DeleteAgent(ctx context.Context, campaignID, id uuid.UUID) error
+}
 
 // GetCampaignRoster returns the active campaign with its ordered roster: the
 // Butler first, then the Character NPCs. The campaign is resolved live-first
@@ -27,11 +47,11 @@ import (
 // actually voicing, not a durable selection changed mid-session (#222). No
 // campaign yields CodeNotFound; a missing Butler is an ADR-0009 invariant
 // violation (logged, CodeInternal).
-func (s *CampaignServer) GetCampaignRoster(
+func (s *agentRoster) GetCampaignRoster(
 	ctx context.Context,
 	_ *connect.Request[managementv1.GetCampaignRosterRequest],
 ) (*connect.Response[managementv1.GetCampaignRosterResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -72,11 +92,11 @@ func (s *CampaignServer) GetCampaignRoster(
 // /glyphoxa use selection → most-recent fallback), the SAME resolution the roster
 // read uses, so mid-session a new NPC lands in the campaign the screen shows —
 // never a silent cross-campaign write (#222).
-func (s *CampaignServer) CreateAgent(
+func (s *agentRoster) CreateAgent(
 	ctx context.Context,
 	req *connect.Request[managementv1.CreateAgentRequest],
 ) (*connect.Response[managementv1.CreateAgentResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -116,7 +136,7 @@ func (s *CampaignServer) CreateAgent(
 // UpdateAgent saves an agent's editor fields and returns the updated agent. The
 // store force-keeps a Butler's role and Address-Only (ADR-0009 / ADR-0024). An
 // unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
-func (s *CampaignServer) UpdateAgent(
+func (s *agentRoster) UpdateAgent(
 	ctx context.Context,
 	req *connect.Request[managementv1.UpdateAgentRequest],
 ) (*connect.Response[managementv1.UpdateAgentResponse], error) {
@@ -128,7 +148,7 @@ func (s *CampaignServer) UpdateAgent(
 	// Resolve the active campaign the SAME live-first way the roster/create paths do
 	// (#222/#229) — its language seeds a first-save voice default (#224). Reusing the
 	// unified resolver avoids a second, divergent campaign-resolution path.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -179,7 +199,7 @@ func (s *CampaignServer) UpdateAgent(
 
 // DeleteAgent removes a Character NPC. Deleting the Butler is CodeFailedPrecondition
 // (ADR-0009); an unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
-func (s *CampaignServer) DeleteAgent(
+func (s *agentRoster) DeleteAgent(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteAgentRequest],
 ) (*connect.Response[managementv1.DeleteAgentResponse], error) {
@@ -192,7 +212,7 @@ func (s *CampaignServer) DeleteAgent(
 	// DELETE matches (id, campaign_id), so an Agent in another campaign is never
 	// removable through this session — it reads back as CodeNotFound, and the Butler
 	// guard still fires for the active campaign's own Butler.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/campaign_crud_test.go
+++ b/internal/rpc/campaign_crud_test.go
@@ -3,10 +3,6 @@ package rpc_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -14,534 +10,16 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
-	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	ttseleven "github.com/MrWong99/Glyphoxa/pkg/voice/tts/elevenlabs"
 )
 
-// errAny is an opaque storage failure the fake returns to force the Internal path.
-var errAny = errors.New("kg fake failure")
-
-// fakeCampaignStore is a small in-memory campaignStore for the CRUD handlers'
-// keyless unit tests. Error hooks (campErr/butlerErr/…) force the failure paths;
-// the agents map backs GetAgent/Create/Update/Delete so happy paths round-trip
-// without a database.
-type fakeCampaignStore struct {
-	campaign  storage.Campaign
-	campErr   error
-	butler    storage.Agent
-	butlerErr error
-	chars     []storage.Agent
-	charsErr  error
-
-	// forUser/forUserErr back the durable /glyphoxa use selection the profile-first
-	// resolution reads first (#222); campaign is the most-recent fallback.
-	forUser    storage.Campaign
-	forUserErr error
-	// campaignsByID backs GetCampaign, the live-first roster path's per-id load
-	// (#222); getCampaignErr forces its failure path.
-	campaignsByID  map[uuid.UUID]storage.Campaign
-	getCampaignErr error
-
-	// Campaign management state (#264): campaignList backs ListCampaigns;
-	// createdCampaigns records CreateCampaign inputs (created rows also land in
-	// campaignsByID so a read-back resolves); updatedCampaigns records
-	// UpdateCampaign inputs; setActiveCalls records SetActiveCampaign inputs. The
-	// *Err hooks force each failure path.
-	campaignList      []storage.Campaign
-	listCampaignErr   error
-	createdCampaigns  []storage.NewCampaign
-	createCampaignErr error
-	updatedCampaigns  []storage.CampaignUpdate
-	updateCampaignErr error
-	setActiveCalls    []setActiveCall
-	setActiveErr      error
-	// Archive lifecycle state (#269): allCampaignList backs ListAllCampaigns;
-	// archiveCalls/unarchiveCalls/deleteCalls record the ids each handler passed;
-	// the *Result campaigns are returned on the happy path, and the *Err hooks force
-	// each failure path (e.g. storage.ErrNotFound, storage.ErrNotArchived).
-	allCampaignList   []storage.Campaign
-	listAllErr        error
-	archiveCalls      []uuid.UUID
-	archiveResult     storage.Campaign
-	archiveErr        error
-	unarchiveCalls    []uuid.UUID
-	unarchiveResult   storage.Campaign
-	unarchiveErr      error
-	deleteCalls       []uuid.UUID
-	deleteCampaignErr error
-	deleteJobKind     string // the follow-up job kind DeleteCampaignWithJob enqueued (#308)
-	deleteJobPayload  []byte // the follow-up job payload (the clip keys to sweep)
-	// listNodesCampaign/searchNodesCampaign record the campaign id ListNodes /
-	// SearchNodes resolved so the scope precedence can be asserted (#222).
-	listNodesCampaign   uuid.UUID
-	searchNodesCampaign uuid.UUID
-
-	agents    map[uuid.UUID]storage.Agent
-	createErr error
-	updateErr error
-	deleteErr error
-	nextColor int
-	// updateAgentCampaign/deleteAgentCampaign record the campaign id the agent
-	// mutations were scoped to (#342), so a unit test can assert the handler passed
-	// the resolved active campaign down to storage.
-	updateAgentCampaign uuid.UUID
-	deleteAgentCampaign uuid.UUID
-
-	created []storage.NewAgent
-
-	// KG Node state (#126, #129): nodes backs ListNodes/Update/Delete; nodesCreated
-	// records the storage inputs; the *Err hooks force each failure path.
-	nodes         []storage.KGNode
-	nodesCreated  []storage.NewKGNode
-	nodeCreateErr error
-	nodeListErr   error
-	nodeUpdateErr error
-	nodeDeleteErr error
-	// updateNodeCampaign/deleteNodeCampaign record the campaign id the KG-Node
-	// mutations were scoped to (#342), so a unit test can assert the handler passed
-	// the resolved active campaign down to storage.
-	updateNodeCampaign uuid.UUID
-	deleteNodeCampaign uuid.UUID
-
-	// KG Edge state (#132): edgesCreated records CreateEdge inputs; edgesOut/edgesIn
-	// back NodeEdges; setAgentCalls records SetNodeAgent inputs; setAgentNode is the
-	// happy-path node it returns (with AgentID overridden per call); the *Err hooks
-	// force each failure path.
-	edgesCreated  []storage.NewKGEdge
-	edgeCreateErr error
-	edgeDeleteErr error
-	edgesOut      []storage.KGEdgeWithNodes
-	edgesIn       []storage.KGEdgeWithNodes
-	nodeEdgesErr  error
-	// nodeEdgesCampaign records the campaign id ListNodeEdges resolved (#356), so a
-	// unit test can assert the read was scoped to the active campaign.
-	nodeEdgesCampaign uuid.UUID
-	setAgentCalls     []setAgentCall
-	setAgentNode      storage.KGNode
-	setAgentErr       error
-	// deleteEdgeCampaign/setAgentCampaign record the campaign id the Edge-delete /
-	// voiced-by link were scoped to (#342), so a unit test can assert the handler
-	// passed the resolved active campaign down.
-	deleteEdgeCampaign uuid.UUID
-	setAgentCampaign   uuid.UUID
-
-	// KG Node search state (#131): searchResults is returned verbatim so the
-	// handler's 1:1 rank-order mapping is asserted; searchQuery/searchLimit/searchCalls
-	// record what reached storage; nodeSearchErr forces the Internal path.
-	searchResults []storage.KGNode
-	searchQuery   string
-	searchLimit   int
-	searchCalls   int
-	nodeSearchErr error
-
-	// Tool Grant state (#117): grants maps agent_id → tool_name → config blob (nil
-	// = no scope), backing the upsert/delete/list round-trip; the *Err hooks force
-	// each failure path.
-	grants         map[uuid.UUID]map[string]json.RawMessage
-	grantListErr   error
-	grantUpsertErr error
-	grantDeleteErr error
-
-	// Knowledge Proposal review state (#300): pendingProposals backs the list read;
-	// getProposal/getProposalErr back GetPendingKnowledgeProposal; approve/reject
-	// record calls and force error paths; similarResults/similarErr back SimilarNodes
-	// and similarQueryVec records the vector it was queried with.
-	pendingProposals      []storage.KnowledgeProposal
-	listProposalsErr      error
-	listProposalsCampaign uuid.UUID
-	getProposal           storage.KnowledgeProposal
-	getProposalErr        error
-	getProposalCampaign   uuid.UUID
-	approveErr            error
-	approveCalls          []uuid.UUID
-	approveCampaign       uuid.UUID
-	rejectErr             error
-	rejectCalls           []uuid.UUID
-	rejectCampaign        uuid.UUID
-	similarResults        []storage.KGNode
-	similarErr            error
-	similarCalls          int
-	similarQueryVec       []float32
-
-	// Player Character state (#276): characters backs ListCharacters/Update/Delete;
-	// charsCreated records CreateCharacter inputs; charsListCampaign records the
-	// campaign id ListCharacters resolved (scope assertion); the *Err hooks force
-	// each failure path (e.g. storage.ErrConflict, storage.ErrNotFound).
-	characters        []storage.Character
-	charsCreated      []storage.NewCharacter
-	charsListCampaign uuid.UUID
-	charCreateErr     error
-	charListErr       error
-	charUpdateErr     error
-	charDeleteErr     error
-	// charUpdateCampaign/charDeleteCampaign record the campaign id the Character
-	// mutations were scoped to (#342): the handler resolves the active campaign and
-	// passes it down, so another campaign's Character is never mutable.
-	charUpdateCampaign uuid.UUID
-	charDeleteCampaign uuid.UUID
-}
-
-// setAgentCall records one SetNodeAgent invocation for assertions.
-type setAgentCall struct {
-	nodeID  uuid.UUID
-	agentID uuid.NullUUID
-}
-
-// setActiveCall records one SetActiveCampaign invocation for assertions (#264).
-type setActiveCall struct {
-	discordUserID string
-	campaignID    uuid.UUID
-}
-
-func newFakeStore() *fakeCampaignStore {
-	return &fakeCampaignStore{
-		agents:        map[uuid.UUID]storage.Agent{},
-		campaignsByID: map[uuid.UUID]storage.Campaign{},
-	}
-}
-
-func (f *fakeCampaignStore) GetActiveCampaign(context.Context) (storage.Campaign, error) {
-	return f.campaign, f.campErr
-}
-
-func (f *fakeCampaignStore) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
-	if f.forUserErr != nil {
-		return storage.Campaign{}, f.forUserErr
-	}
-	if f.forUser.ID == uuid.Nil {
-		return storage.Campaign{}, storage.ErrNotFound
-	}
-	return f.forUser, nil
-}
-
-func (f *fakeCampaignStore) GetCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
-	if f.getCampaignErr != nil {
-		return storage.Campaign{}, f.getCampaignErr
-	}
-	c, ok := f.campaignsByID[id]
-	if !ok {
-		return storage.Campaign{}, storage.ErrNotFound
-	}
-	return c, nil
-}
-
-func (f *fakeCampaignStore) ListCampaigns(context.Context) ([]storage.Campaign, error) {
-	return f.campaignList, f.listCampaignErr
-}
-
-func (f *fakeCampaignStore) CreateCampaign(_ context.Context, c storage.NewCampaign) (uuid.UUID, error) {
-	if f.createCampaignErr != nil {
-		return uuid.Nil, f.createCampaignErr
-	}
-	f.createdCampaigns = append(f.createdCampaigns, c)
-	id := uuid.New()
-	// Land the row so CreateCampaign's read-back (GetCampaign) resolves it.
-	f.campaignsByID[id] = storage.Campaign{
-		ID:       id,
-		TenantID: c.TenantID,
-		Name:     c.Name,
-		System:   c.System,
-		Language: c.Language,
-	}
-	return id, nil
-}
-
-func (f *fakeCampaignStore) UpdateCampaign(_ context.Context, c storage.CampaignUpdate) (storage.Campaign, error) {
-	if f.updateCampaignErr != nil {
-		return storage.Campaign{}, f.updateCampaignErr
-	}
-	f.updatedCampaigns = append(f.updatedCampaigns, c)
-	existing, ok := f.campaignsByID[c.ID]
-	if !ok {
-		return storage.Campaign{}, storage.ErrNotFound
-	}
-	existing.Name = c.Name
-	existing.System = c.System
-	existing.Language = c.Language
-	if c.TapeArmed != nil { // optional: nil leaves it unchanged (COALESCE semantics)
-		existing.TapeArmed = *c.TapeArmed
-	}
-	f.campaignsByID[c.ID] = existing
-	return existing, nil
-}
-
-func (f *fakeCampaignStore) SetActiveCampaign(_ context.Context, discordUserID string, campaignID uuid.UUID) error {
-	if f.setActiveErr != nil {
-		return f.setActiveErr
-	}
-	f.setActiveCalls = append(f.setActiveCalls, setActiveCall{discordUserID: discordUserID, campaignID: campaignID})
-	return nil
-}
-
-func (f *fakeCampaignStore) ListAllCampaigns(context.Context) ([]storage.Campaign, error) {
-	return f.allCampaignList, f.listAllErr
-}
-
-func (f *fakeCampaignStore) ArchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
-	f.archiveCalls = append(f.archiveCalls, id)
-	if f.archiveErr != nil {
-		return storage.Campaign{}, f.archiveErr
-	}
-	return f.archiveResult, nil
-}
-
-func (f *fakeCampaignStore) UnarchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
-	f.unarchiveCalls = append(f.unarchiveCalls, id)
-	if f.unarchiveErr != nil {
-		return storage.Campaign{}, f.unarchiveErr
-	}
-	return f.unarchiveResult, nil
-}
-
-func (f *fakeCampaignStore) DeleteCampaign(_ context.Context, id uuid.UUID) error {
-	f.deleteCalls = append(f.deleteCalls, id)
-	return f.deleteCampaignErr
-}
-
-func (f *fakeCampaignStore) DeleteCampaignWithJob(_ context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error {
-	f.deleteCalls = append(f.deleteCalls, id)
-	if f.deleteCampaignErr != nil {
-		// Delete refused inside the tx: nothing committed, so no job is recorded — the
-		// real store enqueues in the SAME tx that rolls back.
-		return f.deleteCampaignErr
-	}
-	f.deleteJobKind = jobKind
-	f.deleteJobPayload = jobPayload
-	return nil
-}
-
-func (f *fakeCampaignStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
-	return f.butler, f.butlerErr
-}
-
-func (f *fakeCampaignStore) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
-	return f.chars, f.charsErr
-}
-
-func (f *fakeCampaignStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
-	a, ok := f.agents[id]
-	if !ok {
-		return storage.Agent{}, storage.ErrNotFound
-	}
-	return a, nil
-}
-
-func (f *fakeCampaignStore) CreateAgent(_ context.Context, a storage.NewAgent) (uuid.UUID, error) {
-	if f.createErr != nil {
-		return uuid.Nil, f.createErr
-	}
-	f.created = append(f.created, a)
-	id := uuid.New()
-	f.agents[id] = storage.Agent{
-		ID:           id,
-		CampaignID:   a.CampaignID,
-		Role:         a.Role,
-		Name:         a.Name,
-		Title:        a.Title,
-		Persona:      a.Persona,
-		Voice:        a.Voice,
-		AddressOnly:  a.AddressOnly,
-		SpeakerColor: f.nextColor,
-		Aliases:      a.Aliases,
-	}
-	f.nextColor++
-	return id, nil
-}
-
-func (f *fakeCampaignStore) UpdateAgent(_ context.Context, u storage.AgentUpdate) (storage.Agent, error) {
-	f.updateAgentCampaign = u.CampaignID
-	if f.updateErr != nil {
-		return storage.Agent{}, f.updateErr
-	}
-	a, ok := f.agents[u.ID]
-	if !ok {
-		return storage.Agent{}, storage.ErrNotFound
-	}
-	a.Name = u.Name
-	a.Title = u.Title
-	a.Persona = u.Persona
-	a.Voice = u.Voice
-	a.AddressOnly = u.AddressOnly
-	a.Aliases = u.Aliases
-	f.agents[u.ID] = a
-	return a, nil
-}
-
-func (f *fakeCampaignStore) DeleteAgent(_ context.Context, campaignID, id uuid.UUID) error {
-	f.deleteAgentCampaign = campaignID
-	if f.deleteErr != nil {
-		return f.deleteErr
-	}
-	if _, ok := f.agents[id]; !ok {
-		return storage.ErrNotFound
-	}
-	delete(f.agents, id)
-	return nil
-}
-
-func (f *fakeCampaignStore) CreateNode(_ context.Context, n storage.NewKGNode) (storage.KGNode, error) {
-	if f.nodeCreateErr != nil {
-		return storage.KGNode{}, f.nodeCreateErr
-	}
-	f.nodesCreated = append(f.nodesCreated, n)
-	created := storage.KGNode{
-		ID:         uuid.New(),
-		CampaignID: n.CampaignID,
-		Type:       n.Type,
-		Name:       n.Name,
-		Body:       n.Body,
-		GMPrivate:  n.GMPrivate,
-	}
-	f.nodes = append(f.nodes, created)
-	return created, nil
-}
-
-func (f *fakeCampaignStore) ListNodes(_ context.Context, campaignID uuid.UUID) ([]storage.KGNode, error) {
-	f.listNodesCampaign = campaignID
-	return f.nodes, f.nodeListErr
-}
-
-func (f *fakeCampaignStore) UpdateNode(_ context.Context, u storage.KGNodeUpdate) (storage.KGNode, error) {
-	f.updateNodeCampaign = u.CampaignID
-	if f.nodeUpdateErr != nil {
-		return storage.KGNode{}, f.nodeUpdateErr
-	}
-	for i := range f.nodes {
-		if f.nodes[i].ID == u.ID {
-			f.nodes[i].Name = u.Name
-			f.nodes[i].Body = u.Body
-			f.nodes[i].GMPrivate = u.GMPrivate
-			return f.nodes[i], nil
-		}
-	}
-	return storage.KGNode{}, storage.ErrNotFound
-}
-
-func (f *fakeCampaignStore) DeleteNode(_ context.Context, campaignID, id uuid.UUID) error {
-	f.deleteNodeCampaign = campaignID
-	if f.nodeDeleteErr != nil {
-		return f.nodeDeleteErr
-	}
-	for i := range f.nodes {
-		if f.nodes[i].ID == id {
-			f.nodes = append(f.nodes[:i], f.nodes[i+1:]...)
-			return nil
-		}
-	}
-	return storage.ErrNotFound
-}
-
-func (f *fakeCampaignStore) CreateEdge(_ context.Context, e storage.NewKGEdge) (storage.KGEdge, error) {
-	if f.edgeCreateErr != nil {
-		return storage.KGEdge{}, f.edgeCreateErr
-	}
-	f.edgesCreated = append(f.edgesCreated, e)
-	return storage.KGEdge{
-		ID:         uuid.New(),
-		CampaignID: e.CampaignID,
-		FromNodeID: e.FromNodeID,
-		ToNodeID:   e.ToNodeID,
-		Type:       e.Type,
-	}, nil
-}
-
-func (f *fakeCampaignStore) DeleteEdge(_ context.Context, campaignID, _ uuid.UUID) error {
-	f.deleteEdgeCampaign = campaignID
-	return f.edgeDeleteErr
-}
-
-func (f *fakeCampaignStore) NodeEdges(_ context.Context, campaignID, _ uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
-	f.nodeEdgesCampaign = campaignID
-	return f.edgesOut, f.edgesIn, f.nodeEdgesErr
-}
-
-func (f *fakeCampaignStore) SetNodeAgent(_ context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error) {
-	f.setAgentCampaign = campaignID
-	if f.setAgentErr != nil {
-		return storage.KGNode{}, f.setAgentErr
-	}
-	f.setAgentCalls = append(f.setAgentCalls, setAgentCall{nodeID: nodeID, agentID: agentID})
-	n := f.setAgentNode
-	n.ID = nodeID
-	n.AgentID = agentID
-	return n, nil
-}
-
-func (f *fakeCampaignStore) SearchNodes(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error) {
-	f.searchCalls++
-	f.searchNodesCampaign = campaignID
-	f.searchQuery = query
-	f.searchLimit = limit
-	if f.nodeSearchErr != nil {
-		return nil, f.nodeSearchErr
-	}
-	return f.searchResults, nil
-}
-
-func (f *fakeCampaignStore) ListToolGrants(_ context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error) {
-	if f.grantListErr != nil {
-		return nil, f.grantListErr
-	}
-	var out []storage.ToolGrant
-	for tool, cfg := range f.grants[agentID] {
-		out = append(out, storage.ToolGrant{AgentID: agentID, ToolName: tool, Config: cfg})
-	}
-	return out, nil
-}
-
-func (f *fakeCampaignStore) UpsertToolGrant(_ context.Context, g storage.NewToolGrant) error {
-	if f.grantUpsertErr != nil {
-		return f.grantUpsertErr
-	}
-	if f.grants == nil {
-		f.grants = map[uuid.UUID]map[string]json.RawMessage{}
-	}
-	if f.grants[g.AgentID] == nil {
-		f.grants[g.AgentID] = map[string]json.RawMessage{}
-	}
-	f.grants[g.AgentID][g.ToolName] = g.Config
-	return nil
-}
-
-func (f *fakeCampaignStore) DeleteToolGrant(_ context.Context, agentID uuid.UUID, toolName string) error {
-	if f.grantDeleteErr != nil {
-		return f.grantDeleteErr
-	}
-	if _, ok := f.grants[agentID][toolName]; !ok {
-		return storage.ErrNotFound
-	}
-	delete(f.grants[agentID], toolName)
-	return nil
-}
-
-// crudClient stands up the full CampaignService handler over an httptest server
-// and returns a Connect-JSON client.
-func crudClient(t *testing.T, store *fakeCampaignStore) managementv1connect.CampaignServiceClient {
+// crudClient stands up the CampaignService handler over the Agent-roster fake
+// (the Active + Agents slices, #445) and returns a Connect-JSON client.
+func crudClient(t *testing.T, store *fakeAgentStore) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(store).Handler())
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
-	)
-}
-
-// crudClientWithEmbedder is crudClient with a wired Embedder so the
-// ListSimilarKnowledge vector path (#300) is exercised.
-func crudClientWithEmbedder(t *testing.T, store *fakeCampaignStore, emb rpc.Embedder) managementv1connect.CampaignServiceClient {
-	t.Helper()
-	srv := rpc.NewCampaignServer(store)
-	srv.SetEmbedder(emb)
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler())
-	s := httptest.NewServer(mux)
-	t.Cleanup(s.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, s.URL, connect.WithProtoJSON(),
-	)
+	return campaignClient(t, rpc.CampaignStores{Active: store, Agents: store})
 }
 
 // crudClientAs is crudClient plus an injected authenticated operator (so the
@@ -549,34 +27,16 @@ func crudClientWithEmbedder(t *testing.T, store *fakeCampaignStore, emb rpc.Embe
 // #222) and an optional live Voice Session source (so the roster/mute panel's
 // live-first scope can be exercised). A zero user injects nothing; a nil
 // sessions leaves the server with no live source.
-func crudClientAs(t *testing.T, store *fakeCampaignStore, user storage.User, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+func crudClientAs(t *testing.T, store *fakeAgentStore, user storage.User, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	srv := rpc.NewCampaignServer(store)
-	if sessions != nil {
-		srv.SetSessions(sessions)
-	}
-	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			if user.DiscordUserID != "" {
-				ctx = auth.WithUser(ctx, user)
-			}
-			return next(ctx, req)
-		}
-	})
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
-	s := httptest.NewServer(mux)
-	t.Cleanup(s.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, s.URL, connect.WithProtoJSON(),
-	)
+	return campaignClientAs(t, rpc.CampaignStores{Active: store, Agents: store}, user, uuid.Nil, sessions)
 }
 
 func TestGetCampaignRoster_Order(t *testing.T) {
 	t.Parallel()
 
 	campID := uuid.New()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine", System: "dnd5e", Language: "en"}
 	store.butler = storage.Agent{ID: uuid.New(), CampaignID: campID, Role: storage.AgentRoleButler, Name: "Glyphoxa", AddressOnly: true, SpeakerColor: 0}
 	store.chars = []storage.Agent{
@@ -613,7 +73,7 @@ func TestGetCampaignRoster_Order(t *testing.T) {
 
 func TestGetCampaignRoster_NoCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campErr = storage.ErrNotFound
 	client := crudClient(t, store)
 
@@ -628,7 +88,7 @@ func TestGetCampaignRoster_ButlerMissingIsInternal(t *testing.T) {
 	t.Parallel()
 	// A campaign with no Butler is an ADR-0009 invariant violation, not a client
 	// error: it maps to Internal, not NotFound.
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.butlerErr = storage.ErrNotFound
 	client := crudClient(t, store)
@@ -640,11 +100,11 @@ func TestGetCampaignRoster_ButlerMissingIsInternal(t *testing.T) {
 	}
 }
 
-// rosterStore builds a fake whose Butler + one Character resolve for ANY campaign
-// id (the fake ignores the id on those reads), so the roster tests can assert
-// purely on which campaign GetCampaignRoster resolved.
-func rosterStore() *fakeCampaignStore {
-	store := newFakeStore()
+// rosterStore builds an Agent fake whose Butler + one Character resolve for ANY
+// campaign id (the fake ignores the id on those reads), so the roster tests can
+// assert purely on which campaign GetCampaignRoster resolved.
+func rosterStore() *fakeAgentStore {
+	store := newFakeAgentStore()
 	store.butler = storage.Agent{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Glyphoxa", AddressOnly: true}
 	store.chars = []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleCharacter, Name: "Ana"}}
 	return store
@@ -729,7 +189,7 @@ func TestCreateAgentHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.forUser = durable
 	store.campaign = newer
 	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
@@ -746,13 +206,6 @@ func TestCreateAgentHonorsDurableSelection(t *testing.T) {
 	}
 }
 
-// liveMgr returns a fakeSessionManager reporting an active Voice Session bound to
-// campaignID — the live-first input every CampaignService surface resolves through
-// (#222). The Manager enforces single-active, so one live campaign is enough.
-func liveMgr(campaignID uuid.UUID) *fakeSessionManager {
-	return &fakeSessionManager{active: true, current: storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID}}
-}
-
 // TestGetActiveCampaignHonorsLiveSession is #222 finding 2: the header resolves the
 // LIVE Voice Session's campaign (L), not the durable selection (D) or the newest
 // (N), so it never names a different campaign than the roster/transcript on the
@@ -762,7 +215,7 @@ func TestGetActiveCampaignHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
@@ -787,7 +240,7 @@ func TestCreateAgentHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
@@ -842,7 +295,7 @@ func TestGetCampaignRosterLiveCampaignMissingIsNotFound(t *testing.T) {
 
 func TestCreateAgent_IsCharacterWithColor(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.nextColor = 2
 	client := crudClient(t, store)
@@ -875,7 +328,7 @@ func TestCreateAgent_IsCharacterWithColor(t *testing.T) {
 
 func TestCreateAgent_NoCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campErr = storage.ErrNotFound
 	client := crudClient(t, store)
 
@@ -888,7 +341,7 @@ func TestCreateAgent_NoCampaign(t *testing.T) {
 
 func TestUpdateAgent_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := crudClient(t, newFakeAgentStore())
 
 	_, err := client.UpdateAgent(context.Background(),
 		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: "not-a-uuid", Name: "x"}))
@@ -899,7 +352,7 @@ func TestUpdateAgent_InvalidID(t *testing.T) {
 
 func TestUpdateAgent_NotFound(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := crudClient(t, newFakeAgentStore())
 
 	_, err := client.UpdateAgent(context.Background(),
 		connect.NewRequest(&managementv1.UpdateAgentRequest{Id: uuid.New().String(), Name: "x"}))
@@ -910,7 +363,7 @@ func TestUpdateAgent_NotFound(t *testing.T) {
 
 func TestUpdateAgent_HappyPathRoundTrips(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	id := uuid.New()
 	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Old", SpeakerColor: 3}
 	client := crudClient(t, store)
@@ -943,7 +396,7 @@ func TestUpdateAgent_HappyPathRoundTrips(t *testing.T) {
 // clobbered the whole blob to {"voice_id":…} and the NPC went silent.
 func TestUpdateAgent_PreservesExistingVoiceTuning(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	campID := uuid.New()
 	store.campaign = storage.Campaign{ID: campID, Language: "de"}
 	id := uuid.New()
@@ -988,7 +441,7 @@ func TestUpdateAgent_PreservesExistingVoiceTuning(t *testing.T) {
 // same ErrNotFound discipline as the scoped store UPDATE (#353).
 func TestUpdateAgent_CrossCampaignPreReadIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	// The Agent exists, but in ANOTHER campaign, with a tuned voice that must not leak.
@@ -1020,7 +473,7 @@ func TestUpdateAgent_CrossCampaignPreReadIsNotFound(t *testing.T) {
 
 func TestDeleteAgent_ButlerIsFailedPrecondition(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.deleteErr = storage.ErrButlerUndeletable
 	client := crudClient(t, store)
 
@@ -1033,7 +486,7 @@ func TestDeleteAgent_ButlerIsFailedPrecondition(t *testing.T) {
 
 func TestDeleteAgent_NotFound(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := crudClient(t, newFakeAgentStore())
 
 	_, err := client.DeleteAgent(context.Background(),
 		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: uuid.New().String()}))
@@ -1044,7 +497,7 @@ func TestDeleteAgent_NotFound(t *testing.T) {
 
 func TestDeleteAgent_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := crudClient(t, newFakeAgentStore())
 
 	_, err := client.DeleteAgent(context.Background(),
 		connect.NewRequest(&managementv1.DeleteAgentRequest{Id: "nope"}))
@@ -1055,7 +508,7 @@ func TestDeleteAgent_InvalidID(t *testing.T) {
 
 func TestDeleteAgent_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	id := uuid.New()
 	store.agents[id] = storage.Agent{ID: id, Role: storage.AgentRoleCharacter, Name: "Doomed"}
 	client := crudClient(t, store)
@@ -1074,7 +527,7 @@ func TestDeleteAgent_HappyPath(t *testing.T) {
 // and a cross-campaign write is refused server-side.
 func TestUpdateAgent_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
@@ -1094,7 +547,7 @@ func TestUpdateAgent_ScopesToActiveCampaign(t *testing.T) {
 // resolved active campaign, so another campaign's Agent is never removable.
 func TestDeleteAgent_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
@@ -1115,7 +568,7 @@ func TestDeleteAgent_ScopesToActiveCampaign(t *testing.T) {
 // rather than deleting by bare id.
 func TestDeleteAgent_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeAgentStore()
 	store.campErr = storage.ErrNotFound
 	client := crudClient(t, store)
 

--- a/internal/rpc/campaign_grant.go
+++ b/internal/rpc/campaign_grant.go
@@ -11,9 +11,10 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/tool"
 )
 
-// Campaign-screen Tool Grant handlers (#117) on CampaignServer: list every
+// toolGrants is the Campaign-screen Tool Grant feature module (#117): list every
 // built-in Tool with an Agent's current grant state, and toggle a grant on/off
 // (editing its scope config) for an Agent. The available-Tools catalog is the
 // built-in Registry (ADR-0028), so the toggles a GM sees are exactly the Tools a
@@ -23,11 +24,29 @@ import (
 // UpdateToolGrant is state-changing so the auth + CSRF interceptors guard it —
 // identical to the sibling agent CRUD mutations (AC5), inherited from the shared
 // interceptor stack the web tier mounts, not re-implemented here.
+type toolGrants struct {
+	store  toolGrantStore
+	active *activeCampaignSource
+	// tools is the built-in Tool catalog the grant editor lists (ADR-0028) — the
+	// available-Tools source for ListToolGrants and the registry UpdateToolGrant
+	// validates tool_name against (#117). Always non-nil (set by the constructor).
+	tools *tool.Registry
+}
+
+// toolGrantStore is the narrow Tool-Grant surface the module needs (#117);
+// *storage.Store satisfies it. GetAgent backs the campaign-ownership check both
+// handlers run before a grant read or write keyed on agent_id alone (#342/#356).
+type toolGrantStore interface {
+	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
+	UpsertToolGrant(ctx context.Context, g storage.NewToolGrant) error
+	DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error
+}
 
 // ListToolGrants returns, for one Agent, every registered Tool paired with the
 // Agent's grant state (granted, scope config, whether the Tool supports a scope).
 // An unparsable agent_id is CodeInvalidArgument.
-func (s *CampaignServer) ListToolGrants(
+func (s *toolGrants) ListToolGrants(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListToolGrantsRequest],
 ) (*connect.Response[managementv1.ListToolGrantsResponse], error) {
@@ -41,7 +60,7 @@ func (s *CampaignServer) ListToolGrants(
 	// cross-campaign (or deleted, issue #215) target as CodeNotFound — a clean
 	// missing-Agent instead of a fabricated full-catalog-ungranted list — mirroring
 	// the sibling UpdateToolGrant write guard.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -67,7 +86,7 @@ func (s *CampaignServer) ListToolGrants(
 // registered and any config is valid JSON, then reads the resulting state back so
 // the response is the persisted truth. An unparsable agent_id, an unknown Tool, or
 // invalid config is CodeInvalidArgument.
-func (s *CampaignServer) UpdateToolGrant(
+func (s *toolGrants) UpdateToolGrant(
 	ctx context.Context,
 	req *connect.Request[managementv1.UpdateToolGrantRequest],
 ) (*connect.Response[managementv1.UpdateToolGrantResponse], error) {
@@ -88,7 +107,7 @@ func (s *CampaignServer) UpdateToolGrant(
 	// campaign A could grant/revoke Tools on campaign B's Agent (incl. B's Butler).
 	// The scoped check refuses a cross-campaign target as CodeNotFound before any
 	// write — and still maps a deleted Agent to CodeNotFound (issue #215).
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -147,7 +166,7 @@ func (s *CampaignServer) UpdateToolGrant(
 // or mutation keyed on agent_id alone can reach another campaign's Agent. Any
 // other lookup failure is CodeInternal. Shared by ListToolGrants (#356) and
 // UpdateToolGrant (#342).
-func (s *CampaignServer) requireAgentInCampaign(ctx context.Context, campaignID, agentID uuid.UUID) error {
+func (s *toolGrants) requireAgentInCampaign(ctx context.Context, campaignID, agentID uuid.UUID) error {
 	a, err := s.store.GetAgent(ctx, agentID)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
@@ -167,7 +186,7 @@ func (s *CampaignServer) requireAgentInCampaign(ctx context.Context, campaignID,
 // rows into the wire list: one entry per registered Tool (Name order), each
 // carrying its description, the Agent's granted bit + scope config, and whether
 // the Tool supports a scope. It is the shared body of both grant handlers.
-func (s *CampaignServer) toolGrantsFor(ctx context.Context, agentID uuid.UUID) ([]*managementv1.ToolGrant, error) {
+func (s *toolGrants) toolGrantsFor(ctx context.Context, agentID uuid.UUID) ([]*managementv1.ToolGrant, error) {
 	rows, err := s.store.ListToolGrants(ctx, agentID)
 	if err != nil {
 		return nil, err

--- a/internal/rpc/campaign_grant_integration_test.go
+++ b/internal/rpc/campaign_grant_integration_test.go
@@ -226,47 +226,6 @@ func TestToolGrants_CrossCampaign_Integration(t *testing.T) {
 	}
 }
 
-// TestListToolGrants_CrossCampaign_Integration is #356: the READ is scoped too.
-// With a live Voice Session pinning the active campaign to A, an operator must not
-// be able to READ campaign B's Butler grant configs by id — ListToolGrants is
-// CodeNotFound, not a leaked catalog of B's grants.
-func TestListToolGrants_CrossCampaign_Integration(t *testing.T) {
-	dsn := startPostgres(t)
-	store, campaignA := seedStore(t, dsn) // A + its auto-Butler (seeded dice grant)
-	ctx := context.Background()
-
-	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
-	if err != nil {
-		t.Fatalf("GetActiveCampaign: %v", err)
-	}
-	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
-		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
-	})
-	if err != nil {
-		t.Fatalf("CreateCampaign B: %v", err)
-	}
-	butlerB, err := store.GetButler(ctx, campaignB)
-	if err != nil {
-		t.Fatalf("GetButler B: %v", err)
-	}
-
-	// Pin the active campaign to A via a live Voice Session, then mount the server.
-	srv := rpc.NewCampaignServer(store)
-	srv.SetSessions(liveMgr(campaignA))
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler())
-	s := httptest.NewServer(mux)
-	t.Cleanup(s.Close)
-	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, s.URL, connect.WithProtoJSON())
-
-	_, err = client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{
-		AgentId: butlerB.ID.String(),
-	}))
-	if got := connect.CodeOf(err); got != connect.CodeNotFound {
-		t.Fatalf("cross-campaign ListToolGrants code = %v, want NotFound", got)
-	}
-}
-
 // listGrants is a small helper that lists an Agent's grant states or fails the test.
 func listGrants(t *testing.T, client managementv1connect.CampaignServiceClient, agentID string) []*managementv1.ToolGrant {
 	t.Helper()

--- a/internal/rpc/campaign_grant_test.go
+++ b/internal/rpc/campaign_grant_test.go
@@ -3,8 +3,6 @@ package rpc_test
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -17,9 +15,25 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
+// grantStores composes the Tool-Grant slice plus the shared active-campaign
+// resolver (#445) — one fakeGrantStore serves both fields because it embeds
+// *fakeActive, which is all the grant RPCs under test resolve through.
+func grantStores(store *fakeGrantStore) rpc.CampaignStores {
+	return rpc.CampaignStores{Active: store, Grants: store}
+}
+
+// grantClient is campaignClient over the grant composition — the plumbing the
+// former crudClient(t, fakeCampaignStore) call sites in this file used.
+func grantClient(t *testing.T, store *fakeGrantStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, grantStores(store))
+}
+
 // registerAgent seeds a bare Agent row so the grant handlers' existence pre-check
 // (issue #215) passes; these tests only need the Agent to exist, not its fields.
-func registerAgent(store *fakeCampaignStore) uuid.UUID {
+// The Agent's zero CampaignID matches the fake's zero active campaign, so the
+// ownership check (#342/#356) resolves it as in-campaign.
+func registerAgent(store *fakeGrantStore) uuid.UUID {
 	id := uuid.New()
 	store.agents[id] = storage.Agent{ID: id}
 	return id
@@ -34,9 +48,9 @@ func registerAgent(store *fakeCampaignStore) uuid.UUID {
 // transcript_search do not.
 func TestListToolGrants_CatalogWithState(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	// No grant rows: every built-in is listed but not granted.
 	resp, err := client.ListToolGrants(context.Background(),
@@ -100,7 +114,7 @@ func TestListToolGrants_CatalogWithState(t *testing.T) {
 // missing-Agent mapping.
 func TestToolGrant_GhostAgentNotFound(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore()) // empty store → no Agent exists
+	client := grantClient(t, newFakeGrantStore()) // empty store → no Agent exists
 	ghost := uuid.New().String()
 
 	_, listErr := client.ListToolGrants(context.Background(),
@@ -122,13 +136,13 @@ func TestToolGrant_GhostAgentNotFound(t *testing.T) {
 // CodeNotFound and nothing is written.
 func TestUpdateToolGrant_CrossCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	// The Agent exists, but in ANOTHER campaign.
 	foreignAgent := uuid.New()
 	store.agents[foreignAgent] = storage.Agent{ID: foreignAgent, CampaignID: uuid.New()}
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
@@ -143,10 +157,10 @@ func TestUpdateToolGrant_CrossCampaignIsNotFound(t *testing.T) {
 // campaign the grant write cannot resolve an owning campaign and is CodeNotFound.
 func TestUpdateToolGrant_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	store.campErr = storage.ErrNotFound
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
@@ -163,13 +177,13 @@ func TestUpdateToolGrant_NoActiveCampaignIsNotFound(t *testing.T) {
 // active campaign, so a mismatch is CodeNotFound, not a leaked catalog.
 func TestListToolGrants_CrossCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	// The Agent exists, but in ANOTHER campaign.
 	foreignAgent := uuid.New()
 	store.agents[foreignAgent] = storage.Agent{ID: foreignAgent, CampaignID: uuid.New()}
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	_, err := client.ListToolGrants(context.Background(),
 		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: foreignAgent.String()}))
@@ -182,10 +196,10 @@ func TestListToolGrants_CrossCampaignIsNotFound(t *testing.T) {
 // campaign the read cannot resolve an owning campaign and is CodeNotFound.
 func TestListToolGrants_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	store.campErr = storage.ErrNotFound
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	_, err := client.ListToolGrants(context.Background(),
 		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: agentID.String()}))
@@ -196,7 +210,7 @@ func TestListToolGrants_NoActiveCampaignIsNotFound(t *testing.T) {
 
 func TestListToolGrants_InvalidAgentID(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := grantClient(t, newFakeGrantStore())
 	_, err := client.ListToolGrants(context.Background(),
 		connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: "not-a-uuid"}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -209,9 +223,9 @@ func TestListToolGrants_InvalidAgentID(t *testing.T) {
 // AC2 persist-and-reload contract at the handler seam.
 func TestUpdateToolGrant_ToggleRoundTrips(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	on, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
@@ -247,9 +261,9 @@ func TestUpdateToolGrant_ToggleRoundTrips(t *testing.T) {
 // no scope editor (AC3): the API is scope-capable regardless of the Tool's editor.
 func TestUpdateToolGrant_ConfigRoundTrips(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 
 	scope := `{"scope":"self"}`
 	resp, err := client.UpdateToolGrant(context.Background(),
@@ -287,7 +301,7 @@ func assertScopeSelf(t *testing.T, cfg string) {
 
 func TestUpdateToolGrant_UnknownToolRejected(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := grantClient(t, newFakeGrantStore())
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
 			AgentId: uuid.New().String(), ToolName: "not_a_tool", Granted: true,
@@ -299,9 +313,9 @@ func TestUpdateToolGrant_UnknownToolRejected(t *testing.T) {
 
 func TestUpdateToolGrant_InvalidConfigRejected(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
 			AgentId: agentID.String(), ToolName: "dice", Granted: true, Config: "{not json",
@@ -313,7 +327,7 @@ func TestUpdateToolGrant_InvalidConfigRejected(t *testing.T) {
 
 func TestUpdateToolGrant_InvalidAgentID(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := grantClient(t, newFakeGrantStore())
 	_, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{AgentId: "nope", ToolName: "dice", Granted: true}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -326,9 +340,9 @@ func TestUpdateToolGrant_InvalidAgentID(t *testing.T) {
 // errors.
 func TestUpdateToolGrant_RevokeIsIdempotent(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeGrantStore()
 	agentID := registerAgent(store)
-	client := crudClient(t, store)
+	client := grantClient(t, store)
 	if _, err := client.UpdateToolGrant(context.Background(),
 		connect.NewRequest(&managementv1.UpdateToolGrantRequest{
 			AgentId: agentID.String(), ToolName: "dice", Granted: false,
@@ -351,13 +365,9 @@ func (denyAuth) AuthenticateSession(context.Context, string) (storage.User, erro
 // side-effect-free exempts it from CSRF, not from auth.
 func TestToolGrant_AuthGatesBothLikeSiblings(t *testing.T) {
 	t.Parallel()
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(newFakeStore()).Handler(
+	client := campaignClientServe(t, rpc.NewCampaignServerWith(grantStores(newFakeGrantStore())),
 		connect.WithInterceptors(auth.NewAuthInterceptor(denyAuth{})),
-	))
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	)
 	ctx := context.Background()
 
 	_, listErr := client.ListToolGrants(ctx, connect.NewRequest(&managementv1.ListToolGrantsRequest{AgentId: uuid.New().String()}))
@@ -378,13 +388,9 @@ func TestToolGrant_AuthGatesBothLikeSiblings(t *testing.T) {
 // is exempt and reaches the handler.
 func TestToolGrant_CSRFGuardsMutationNotRead(t *testing.T) {
 	t.Parallel()
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(newFakeStore()).Handler(
+	client := campaignClientServe(t, rpc.NewCampaignServerWith(grantStores(newFakeGrantStore())),
 		connect.WithInterceptors(auth.NewCSRFInterceptor()),
-	))
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+	)
 	ctx := context.Background()
 
 	// The write is CSRF-guarded — no token → PermissionDenied, like the sibling.

--- a/internal/rpc/campaign_integration_test.go
+++ b/internal/rpc/campaign_integration_test.go
@@ -1,24 +1,23 @@
 //go:build integration
 
-// This test drives the CampaignService handler against a real *storage.Store
-// backed by a testcontainers Postgres, end to end over Connect-JSON. It is
-// tag-isolated behind `integration` so the default `go test ./...` stays
-// Docker-free (ADR-0021 / ADR-0033). The Postgres harness is duplicated here in
+// The shared Postgres harness for internal/rpc's integration suites: the
+// pgvector testcontainer + the seeded store the suites drive real handlers
+// against, tag-isolated behind `integration` so the default `go test ./...`
+// stays Docker-free (ADR-0021 / ADR-0033). The harness is duplicated here in
 // miniature because internal/storage's harness_test.go is package-private to
-// storage_test.
+// storage_test. The plain GetActiveCampaign round-trip that used to live here
+// is unit coverage now (#445) — the handlers' mapping is proven keyless over
+// per-feature fakes, and only SQL-shaped behavior stays DB-bound.
 
 package rpc_test
 
 import (
 	"context"
 	"database/sql"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
-	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -26,9 +25,6 @@ import (
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
-	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
-	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -109,43 +105,4 @@ func seedStore(t *testing.T, dsn string) (st *storage.Store, campaignID uuid.UUI
 		t.Fatalf("insert campaign: %v", err)
 	}
 	return storage.New(pool), campaignID
-}
-
-func TestGetActiveCampaign_Integration(t *testing.T) {
-	dsn := startPostgres(t)
-	store, campaignID := seedStore(t, dsn)
-
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(store).Handler())
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	client := managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
-	)
-
-	resp, err := client.GetActiveCampaign(
-		context.Background(),
-		connect.NewRequest(&managementv1.GetActiveCampaignRequest{}),
-	)
-	if err != nil {
-		t.Fatalf("GetActiveCampaign: %v", err)
-	}
-
-	got := resp.Msg.GetCampaign()
-	if got == nil {
-		t.Fatal("response campaign is nil")
-	}
-	if got.GetId() != campaignID.String() {
-		t.Errorf("id = %q, want %q", got.GetId(), campaignID.String())
-	}
-	if got.GetName() != "Lost Mine" {
-		t.Errorf("name = %q, want %q", got.GetName(), "Lost Mine")
-	}
-	if got.GetSystem() != "dnd5e" {
-		t.Errorf("system = %q, want %q", got.GetSystem(), "dnd5e")
-	}
-	if got.GetLanguage() != "en" {
-		t.Errorf("language = %q, want %q", got.GetLanguage(), "en")
-	}
 }

--- a/internal/rpc/campaign_language.go
+++ b/internal/rpc/campaign_language.go
@@ -16,7 +16,7 @@ import (
 // appears here automatically and no language is hardcoded outside phonetic.go.
 // It is a pure read over the default registry: no store, no auth scope, and no
 // failure path.
-func (s *CampaignServer) ListSupportedLanguages(
+func (s *campaignManagement) ListSupportedLanguages(
 	_ context.Context,
 	_ *connect.Request[managementv1.ListSupportedLanguagesRequest],
 ) (*connect.Response[managementv1.ListSupportedLanguagesResponse], error) {

--- a/internal/rpc/campaign_language_test.go
+++ b/internal/rpc/campaign_language_test.go
@@ -8,17 +8,18 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
 // TestListSupportedLanguages proves the handler reports the Campaign Language
 // choices as the registered phonetic-encoder codes, sorted (ADR-0024). The
 // registry is the sole language-truth source, so the shipped en/de matrix comes
-// back as ["de","en"] with no store read and no auth needed.
+// back as ["de","en"] with no store read and no auth needed — an all-nil
+// CampaignStores composition suffices (#445).
 func TestListSupportedLanguages(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := campaignClientAs(t, rpc.CampaignStores{}, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	resp, err := client.ListSupportedLanguages(context.Background(),
 		connect.NewRequest(&managementv1.ListSupportedLanguagesRequest{}))

--- a/internal/rpc/campaign_management.go
+++ b/internal/rpc/campaign_management.go
@@ -14,7 +14,8 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Campaign management handlers (#264, Epic 2/8) on CampaignServer: list, create,
+// Campaign management handlers (#264, Epic 2/8) on the campaignManagement module:
+// list, create,
 // update, and durable-select the operator's campaigns. They follow the same error
 // mapping the agent CRUD uses (ErrNotFound→CodeNotFound, empty name→
 // CodeInvalidArgument, generic CodeInternal with a server-side slog). Reads are
@@ -24,7 +25,7 @@ import (
 // name-then-id ordering). By default only ACTIVE campaigns are returned; when
 // include_archived is set the archived ones are included too — the archive-
 // management panel's view (#269). A storage failure is CodeInternal.
-func (s *CampaignServer) ListCampaigns(
+func (s *campaignManagement) ListCampaigns(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListCampaignsRequest],
 ) (*connect.Response[managementv1.ListCampaignsResponse], error) {
@@ -52,7 +53,7 @@ func (s *CampaignServer) ListCampaigns(
 // auto-Butler trigger fires on the insert, so the new campaign gets its Butler
 // (with the dice grant) as a database invariant. The created row is read back so
 // the response carries the server-assigned id and timestamps.
-func (s *CampaignServer) CreateCampaign(
+func (s *campaignManagement) CreateCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.CreateCampaignRequest],
 ) (*connect.Response[managementv1.CreateCampaignResponse], error) {
@@ -93,7 +94,7 @@ func (s *CampaignServer) CreateCampaign(
 // non-empty (CodeInvalidArgument). System/Language are written opaquely, exactly
 // as stored today — no validation, no vocabulary curation (that is the settings
 // editor slice's call). An unknown id is CodeNotFound.
-func (s *CampaignServer) UpdateCampaign(
+func (s *campaignManagement) UpdateCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.UpdateCampaignRequest],
 ) (*connect.Response[managementv1.UpdateCampaignResponse], error) {
@@ -135,7 +136,7 @@ func (s *CampaignServer) UpdateCampaign(
 // The resolved campaign is read back through the shared live-first policy, so while
 // a Voice Session is live its campaign still wins (#222) and the returned campaign
 // may differ from the one just selected.
-func (s *CampaignServer) SetActiveCampaign(
+func (s *campaignManagement) SetActiveCampaign(
 	ctx context.Context,
 	req *connect.Request[managementv1.SetActiveCampaignRequest],
 ) (*connect.Response[managementv1.SetActiveCampaignResponse], error) {
@@ -179,7 +180,7 @@ func (s *CampaignServer) SetActiveCampaign(
 
 	// Return the resolved Active Campaign via the one shared live-first policy, so
 	// this surface agrees with GetActiveCampaign/GetCampaignRoster/ListNodes (#222).
-	resolved, err := s.activeCampaign(ctx)
+	resolved, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/campaign_management_integration_test.go
+++ b/internal/rpc/campaign_management_integration_test.go
@@ -4,9 +4,15 @@
 // Connect-JSON against a real *storage.Store (testcontainers Postgres): list,
 // create (auto-Butler + dice grant invariant, ADR-0009), the opaque
 // name/system/language update, and the durable Active Campaign selection shared
-// with `/glyphoxa use` (migration 00014), including the live-first resolution
-// rule (#222). Tag-isolated behind `integration`; reuses startPostgres/seedStore
-// from campaign_integration_test.go.
+// with `/glyphoxa use` (migration 00014). Only the SQL-shaped behavior lives
+// here (#445) — the triggers, seed migrations, ORDER BY, and the shared
+// selection row. The live-first precedence is unit coverage
+// (TestSetActiveCampaignLiveFirstWins), and the #268 language-edit/voice
+// separation is covered twice elsewhere: structurally at the handler layer (the
+// management store slice cannot even name an Agent write) and at the SQL layer
+// by internal/storage's TestUpdateCampaignLanguageLeavesAgentVoiceUntouched.
+// Tag-isolated behind `integration`; reuses startPostgres/seedStore from
+// campaign_integration_test.go.
 
 package rpc_test
 
@@ -213,127 +219,5 @@ func TestCampaignManagement_Integration(t *testing.T) {
 	}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {
 		t.Errorf("SetActiveCampaign(unknown) code = %v, want NotFound", got)
-	}
-}
-
-// TestUpdateCampaignLanguage_LeavesAgentVoiceUntouched pins the #268 decision that
-// a Campaign Language change mutates NOTHING downstream: existing Agents' voice
-// settings stay byte-identical (ADR-0009, #224). The first-save voice seeding
-// (applyVoiceSelection) lives ONLY on the agent-write path (UpdateAgent) and must
-// never fire from UpdateCampaign — this guards against a future re-seed regression
-// that would re-derive every Agent's voice from the new language.
-func TestUpdateCampaignLanguage_LeavesAgentVoiceUntouched(t *testing.T) {
-	dsn := startPostgres(t)
-	store, seededID := seedStore(t, dsn)
-	ctx := context.Background()
-
-	seeded, err := store.GetCampaign(ctx, seededID)
-	if err != nil {
-		t.Fatalf("GetCampaign(seeded): %v", err)
-	}
-	const operator = "operator-268"
-	client := mgmtIntegrationClient(t, store, seeded.TenantID, operator, nil)
-
-	// A fresh campaign in language "en" with its auto-Butler (ADR-0009), made the
-	// durable Active Campaign so the agent-write path resolves it (#222).
-	created, err := client.CreateCampaign(ctx, connect.NewRequest(&managementv1.CreateCampaignRequest{
-		Name: "Voice Guard", System: "dnd5e", Language: "en",
-	}))
-	if err != nil {
-		t.Fatalf("CreateCampaign: %v", err)
-	}
-	campID := created.Msg.GetCampaign().GetId()
-	if _, err := client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
-		CampaignId: campID,
-	})); err != nil {
-		t.Fatalf("SetActiveCampaign: %v", err)
-	}
-
-	butler, err := store.GetButler(ctx, uuid.MustParse(campID))
-	if err != nil {
-		t.Fatalf("GetButler: %v", err)
-	}
-
-	// Give the Butler a concrete voice via the agent-write path — this is where the
-	// language legitimately seeds the first-save voice default (#224).
-	if _, err := client.UpdateAgent(ctx, connect.NewRequest(&managementv1.UpdateAgentRequest{
-		Id: butler.ID.String(), Name: butler.Name, Title: butler.Title, Persona: butler.Persona,
-		Voice: "voice-en-123", AddressOnly: butler.AddressOnly,
-	})); err != nil {
-		t.Fatalf("UpdateAgent(seed voice): %v", err)
-	}
-	before, err := store.GetAgent(ctx, butler.ID)
-	if err != nil {
-		t.Fatalf("GetAgent(before): %v", err)
-	}
-	if len(before.Voice) == 0 {
-		t.Fatalf("precondition: Butler voice not seeded, got %q", string(before.Voice))
-	}
-
-	// The change under test: Campaign Language en -> de.
-	if _, err := client.UpdateCampaign(ctx, connect.NewRequest(&managementv1.UpdateCampaignRequest{
-		Id: campID, Name: "Voice Guard", System: "dnd5e", Language: "de",
-	})); err != nil {
-		t.Fatalf("UpdateCampaign(lang en->de): %v", err)
-	}
-
-	// The language column moved…
-	after, err := store.GetCampaign(ctx, uuid.MustParse(campID))
-	if err != nil {
-		t.Fatalf("GetCampaign(after): %v", err)
-	}
-	if after.Language != "de" {
-		t.Fatalf("campaign language = %q, want de", after.Language)
-	}
-	// …but the Butler's voice blob is byte-identical: a language change mutates no
-	// Agent voice (the #268 decision; applyVoiceSelection stays unused here).
-	agentAfter, err := store.GetAgent(ctx, butler.ID)
-	if err != nil {
-		t.Fatalf("GetAgent(after): %v", err)
-	}
-	if string(agentAfter.Voice) != string(before.Voice) {
-		t.Errorf("Butler voice changed on a language edit:\n before = %s\n after  = %s",
-			string(before.Voice), string(agentAfter.Voice))
-	}
-}
-
-// TestSetActiveCampaignLiveFirst_Integration pins the live-first resolution rule
-// (#222, #264) end to end: with a live Voice Session bound to campaign L, a
-// durable selection of a DIFFERENT campaign D is still written (both surfaces in
-// lockstep) but the resolved Active Campaign is L — the live session wins.
-func TestSetActiveCampaignLiveFirst_Integration(t *testing.T) {
-	dsn := startPostgres(t)
-	store, liveID := seedStore(t, dsn) // "Lost Mine" is the live campaign L
-	ctx := context.Background()
-
-	seeded, err := store.GetCampaign(ctx, liveID)
-	if err != nil {
-		t.Fatalf("GetCampaign(seeded): %v", err)
-	}
-	// A second campaign D in the same tenant to durably select.
-	durableID, err := store.CreateCampaign(ctx, storage.NewCampaign{
-		TenantID: seeded.TenantID, Name: "Durable D", System: "dnd5e", Language: "en",
-	})
-	if err != nil {
-		t.Fatalf("CreateCampaign(D): %v", err)
-	}
-
-	// A live session bound to L.
-	client := mgmtIntegrationClient(t, store, seeded.TenantID, "operator-live", liveMgr(liveID))
-
-	setResp, err := client.SetActiveCampaign(ctx, connect.NewRequest(&managementv1.SetActiveCampaignRequest{
-		CampaignId: durableID.String(),
-	}))
-	if err != nil {
-		t.Fatalf("SetActiveCampaign(D): %v", err)
-	}
-	// Resolved Active Campaign is the LIVE one, not the just-selected D.
-	if got := setResp.Msg.GetCampaign().GetId(); got != liveID.String() {
-		t.Errorf("resolved = %s, want the LIVE campaign %s (not the selected %s)", got, liveID, durableID)
-	}
-	// ...but the durable selection D was still written (lockstep with /glyphoxa use).
-	forUser, err := store.GetActiveCampaignForUser(ctx, "operator-live")
-	if err != nil || forUser.ID != durableID {
-		t.Errorf("durable selection = %+v, %v, want D %s", forUser, err, durableID)
 	}
 }

--- a/internal/rpc/campaign_management_test.go
+++ b/internal/rpc/campaign_management_test.go
@@ -2,8 +2,6 @@ package rpc_test
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -11,47 +9,27 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
-	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// mgmtClient stands up the CampaignService handler with an injected operator +
-// tenant (the auth interceptor stack's resolved principal, ADR-0039) and an
-// optional live Voice Session source, returning a Connect-JSON client. The
-// management RPCs (#264) need both: CreateCampaign resolves the tenant, and
-// SetActiveCampaign resolves the operator's DiscordUserID.
-func mgmtClient(t *testing.T, store *fakeCampaignStore, user storage.User, tenantID uuid.UUID, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+// mgmtClient stands up the CampaignService handler over the management slice
+// (Active + Campaigns, one fakeManagementStore serves both, #445) with an
+// injected operator + tenant (the auth interceptor stack's resolved principal,
+// ADR-0039) and an optional live Voice Session source, returning a
+// Connect-JSON client. The management RPCs (#264) need both: CreateCampaign
+// resolves the tenant, and SetActiveCampaign resolves the operator's
+// DiscordUserID.
+func mgmtClient(t *testing.T, store *fakeManagementStore, user storage.User, tenantID uuid.UUID, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	srv := rpc.NewCampaignServer(store)
-	if sessions != nil {
-		srv.SetSessions(sessions)
-	}
-	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			if user.DiscordUserID != "" {
-				ctx = auth.WithUser(ctx, user)
-			}
-			if tenantID != uuid.Nil {
-				ctx = auth.WithTenant(ctx, tenantID)
-			}
-			return next(ctx, req)
-		}
-	})
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
-	s := httptest.NewServer(mux)
-	t.Cleanup(s.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, s.URL, connect.WithProtoJSON(),
-	)
+	return campaignClientAs(t, rpc.CampaignStores{Active: store, Campaigns: store}, user, tenantID, sessions)
 }
 
 func TestListCampaigns_NameOrdered(t *testing.T) {
 	t.Parallel()
 	// The store already returns name-ordered rows (ListCampaigns SQL); the handler
 	// maps them 1:1, so assert the order is preserved onto the wire.
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	store.campaignList = []storage.Campaign{
 		{ID: uuid.New(), TenantID: uuid.New(), Name: "Alpha Quest", System: "dnd5e", Language: "en"},
 		{ID: uuid.New(), TenantID: uuid.New(), Name: "Lost Mine", System: "pf2e", Language: "de"},
@@ -77,7 +55,7 @@ func TestListCampaigns_NameOrdered(t *testing.T) {
 
 func TestListCampaigns_Empty(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	resp, err := client.ListCampaigns(context.Background(),
 		connect.NewRequest(&managementv1.ListCampaignsRequest{}))
@@ -91,7 +69,7 @@ func TestListCampaigns_Empty(t *testing.T) {
 
 func TestListCampaigns_Internal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	store.listCampaignErr = errAny
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
@@ -104,7 +82,7 @@ func TestListCampaigns_Internal(t *testing.T) {
 
 func TestCreateCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	tenantID := uuid.New()
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, tenantID, nil)
 
@@ -134,7 +112,7 @@ func TestCreateCampaign_HappyPath(t *testing.T) {
 
 func TestCreateCampaign_EmptyNameInvalid(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	// Whitespace-only is treated as empty (trimmed), like CreateNode.
@@ -151,7 +129,7 @@ func TestCreateCampaign_EmptyNameInvalid(t *testing.T) {
 func TestCreateCampaign_NoTenantUnauthenticated(t *testing.T) {
 	t.Parallel()
 	// No tenant injected → the handler treats it as unauthenticated.
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.Nil, nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.Nil, nil)
 
 	_, err := client.CreateCampaign(context.Background(),
 		connect.NewRequest(&managementv1.CreateCampaignRequest{Name: "x"}))
@@ -162,7 +140,7 @@ func TestCreateCampaign_NoTenantUnauthenticated(t *testing.T) {
 
 func TestCreateCampaign_Internal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	store.createCampaignErr = errAny
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
@@ -175,7 +153,7 @@ func TestCreateCampaign_Internal(t *testing.T) {
 
 func TestUpdateCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	id := uuid.New()
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{
 		id: {ID: id, TenantID: uuid.New(), Name: "Old", System: "old-sys", Language: "en"},
@@ -209,7 +187,7 @@ func TestUpdateCampaign_HappyPath(t *testing.T) {
 // than silently disarming it.
 func TestUpdateCampaign_TapeArmed(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	id := uuid.New()
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{
 		id: {ID: id, TenantID: uuid.New(), Name: "Old", Language: "en"},
@@ -246,7 +224,7 @@ func TestUpdateCampaign_TapeArmed(t *testing.T) {
 // rejects it (curation is the settings-editor slice's call).
 func TestUpdateCampaign_OpaqueFreeText(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	id := uuid.New()
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{id: {ID: id, Name: "Old"}}
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
@@ -267,7 +245,7 @@ func TestUpdateCampaign_OpaqueFreeText(t *testing.T) {
 
 func TestUpdateCampaign_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.UpdateCampaign(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: "not-a-uuid", Name: "x"}))
@@ -278,7 +256,7 @@ func TestUpdateCampaign_InvalidID(t *testing.T) {
 
 func TestUpdateCampaign_EmptyNameInvalid(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.UpdateCampaign(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: uuid.New().String(), Name: "  "}))
@@ -290,7 +268,7 @@ func TestUpdateCampaign_EmptyNameInvalid(t *testing.T) {
 func TestUpdateCampaign_UnknownIDNotFound(t *testing.T) {
 	t.Parallel()
 	// campaignsByID is empty, so UpdateCampaign returns ErrNotFound.
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.UpdateCampaign(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCampaignRequest{Id: uuid.New().String(), Name: "x"}))
@@ -301,7 +279,7 @@ func TestUpdateCampaign_UnknownIDNotFound(t *testing.T) {
 
 func TestSetActiveCampaign_HappyPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	target := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Target"}
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{target.ID: target}
 	// No live session and no durable selection lookup wired: the resolved read
@@ -330,7 +308,7 @@ func TestSetActiveCampaign_HappyPath(t *testing.T) {
 
 func TestSetActiveCampaign_InvalidID(t *testing.T) {
 	t.Parallel()
-	client := mgmtClient(t, newFakeStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
+	client := mgmtClient(t, newFakeManagementStore(), storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.SetActiveCampaign(context.Background(),
 		connect.NewRequest(&managementv1.SetActiveCampaignRequest{CampaignId: "nope"}))
@@ -343,7 +321,7 @@ func TestSetActiveCampaign_UnknownIDNotFound(t *testing.T) {
 	t.Parallel()
 	// campaignsByID is empty → the pre-write GetCampaign validation returns
 	// ErrNotFound, and the selection is never persisted.
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), nil)
 
 	_, err := client.SetActiveCampaign(context.Background(),
@@ -365,7 +343,7 @@ func TestSetActiveCampaignLiveFirstWins(t *testing.T) {
 	t.Parallel()
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
-	store := newFakeStore()
+	store := newFakeManagementStore()
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live, durable.ID: durable}
 	store.forUser = durable // the durable selection, were live-first not in force
 	client := mgmtClient(t, store, storage.User{DiscordUserID: "999"}, uuid.New(), liveMgr(live.ID))

--- a/internal/rpc/campaign_test.go
+++ b/internal/rpc/campaign_test.go
@@ -3,8 +3,6 @@ package rpc_test
 import (
 	"context"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -13,12 +11,12 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
-	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// fakeReader is a keyless, deterministic campaignReader for the default gate.
+// fakeReader is a keyless, deterministic active-campaign resolver for the
+// default gate — it implements only the shared resolver slice (#445).
 // forUser/forUserErr back the durable /glyphoxa use selection the profile-first
 // resolution reads first (#222); campaign is the most-recent fallback.
 type fakeReader struct {
@@ -46,139 +44,14 @@ func (f fakeReader) GetCampaign(context.Context, uuid.UUID) (storage.Campaign, e
 	return f.campaign, f.err
 }
 
-// The campaign management half of campaignStore (#264) is unused by the
-// GetActiveCampaign tests; stub it so fakeReader still satisfies the widened
-// interface. The management handlers exercise it via fakeCampaignStore.
-func (fakeReader) ListCampaigns(context.Context) ([]storage.Campaign, error) {
-	return nil, nil
-}
-func (fakeReader) CreateCampaign(context.Context, storage.NewCampaign) (uuid.UUID, error) {
-	return uuid.Nil, nil
-}
-func (fakeReader) UpdateCampaign(context.Context, storage.CampaignUpdate) (storage.Campaign, error) {
-	return storage.Campaign{}, nil
-}
-func (fakeReader) SetActiveCampaign(context.Context, string, uuid.UUID) error {
-	return nil
-}
-
-// The archive lifecycle half of campaignStore (#269) is unused by the
-// GetActiveCampaign tests; stub it so fakeReader still satisfies the widened
-// interface. The archive handlers exercise it via fakeCampaignStore.
-func (fakeReader) ListAllCampaigns(context.Context) ([]storage.Campaign, error) {
-	return nil, nil
-}
-func (fakeReader) ArchiveCampaign(context.Context, uuid.UUID) (storage.Campaign, error) {
-	return storage.Campaign{}, nil
-}
-func (fakeReader) UnarchiveCampaign(context.Context, uuid.UUID) (storage.Campaign, error) {
-	return storage.Campaign{}, nil
-}
-func (fakeReader) DeleteCampaign(context.Context, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) DeleteCampaignWithJob(context.Context, uuid.UUID, string, []byte) error {
-	return nil
-}
-
-// The roster + CRUD half of campaignStore is unused by the GetActiveCampaign
-// tests; stub it so fakeReader still satisfies the widened interface. The CRUD
-// handlers have their own fake (campaign_crud_test.go).
-func (fakeReader) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
-	return storage.Agent{}, storage.ErrNotFound
-}
-func (fakeReader) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
-	return nil, nil
-}
-func (fakeReader) GetAgent(context.Context, uuid.UUID) (storage.Agent, error) {
-	return storage.Agent{}, storage.ErrNotFound
-}
-func (fakeReader) CreateAgent(context.Context, storage.NewAgent) (uuid.UUID, error) {
-	return uuid.Nil, nil
-}
-func (fakeReader) UpdateAgent(context.Context, storage.AgentUpdate) (storage.Agent, error) {
-	return storage.Agent{}, storage.ErrNotFound
-}
-func (fakeReader) DeleteAgent(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) CreateNode(context.Context, storage.NewKGNode) (storage.KGNode, error) {
-	return storage.KGNode{}, nil
-}
-func (fakeReader) ListNodes(context.Context, uuid.UUID) ([]storage.KGNode, error) {
-	return nil, nil
-}
-func (fakeReader) UpdateNode(context.Context, storage.KGNodeUpdate) (storage.KGNode, error) {
-	return storage.KGNode{}, nil
-}
-func (fakeReader) DeleteNode(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) CreateEdge(context.Context, storage.NewKGEdge) (storage.KGEdge, error) {
-	return storage.KGEdge{}, nil
-}
-func (fakeReader) DeleteEdge(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) NodeEdges(context.Context, uuid.UUID, uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
-	return nil, nil, nil
-}
-func (fakeReader) SetNodeAgent(context.Context, uuid.UUID, uuid.UUID, uuid.NullUUID) (storage.KGNode, error) {
-	return storage.KGNode{}, nil
-}
-func (fakeReader) SearchNodes(context.Context, uuid.UUID, string, int) ([]storage.KGNode, error) {
-	return nil, nil
-}
-func (fakeReader) ListPendingKnowledgeProposals(context.Context, uuid.UUID) ([]storage.KnowledgeProposal, error) {
-	return nil, nil
-}
-func (fakeReader) GetPendingKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) (storage.KnowledgeProposal, error) {
-	return storage.KnowledgeProposal{}, nil
-}
-func (fakeReader) ApproveKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) RejectKnowledgeProposal(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-func (fakeReader) SimilarNodes(context.Context, uuid.UUID, []float32, int) ([]storage.KGNode, error) {
-	return nil, nil
-}
-func (fakeReader) ListToolGrants(context.Context, uuid.UUID) ([]storage.ToolGrant, error) {
-	return nil, nil
-}
-func (fakeReader) UpsertToolGrant(context.Context, storage.NewToolGrant) error {
-	return nil
-}
-func (fakeReader) DeleteToolGrant(context.Context, uuid.UUID, string) error {
-	return nil
-}
-func (fakeReader) ListCharacters(context.Context, uuid.UUID) ([]storage.Character, error) {
-	return nil, nil
-}
-func (fakeReader) CreateCharacter(context.Context, storage.NewCharacter) (uuid.UUID, error) {
-	return uuid.Nil, nil
-}
-func (fakeReader) UpdateCharacter(context.Context, storage.CharacterUpdate) (storage.Character, error) {
-	return storage.Character{}, nil
-}
-func (fakeReader) DeleteCharacter(context.Context, uuid.UUID, uuid.UUID) error {
-	return nil
-}
-
-// newClient stands up the CampaignServer handler behind an httptest server and
-// returns a Connect-JSON client for it. WithProtoJSON forces the JSON codec on
-// the wire (the default is binary proto), so this also asserts the RPC is
-// reachable over Connect-JSON.
+// newClient stands up a CampaignServer composed from only the Active resolver
+// slice (the GetActiveCampaign RPC touches no other slice, #445) behind an
+// httptest server and returns a Connect-JSON client for it. WithProtoJSON
+// forces the JSON codec on the wire (the default is binary proto), so this
+// also asserts the RPC is reachable over Connect-JSON.
 func newClient(t *testing.T, reader fakeReader) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(reader).Handler())
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
-	)
+	return campaignClient(t, rpc.CampaignStores{Active: reader})
 }
 
 // newClientAs is newClient plus an injected authenticated operator, so the
@@ -186,21 +59,7 @@ func newClient(t *testing.T, reader fakeReader) managementv1connect.CampaignServ
 // (#222). A zero user injects nothing (the legacy no-user path).
 func newClientAs(t *testing.T, reader fakeReader, user storage.User) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			if user.DiscordUserID != "" {
-				ctx = auth.WithUser(ctx, user)
-			}
-			return next(ctx, req)
-		}
-	})
-	mux := http.NewServeMux()
-	mux.Handle(rpc.NewCampaignServer(reader).Handler(connect.WithInterceptors(inject)))
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, srv.URL, connect.WithProtoJSON(),
-	)
+	return campaignClientAs(t, rpc.CampaignStores{Active: reader}, user, uuid.Nil, nil)
 }
 
 // TestGetActiveCampaignHonorsDurableSelection is #222: the Session-screen header

--- a/internal/rpc/character.go
+++ b/internal/rpc/character.go
@@ -13,20 +13,61 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Player Character (PC) CRUD handlers (#276, E4) on CampaignServer. Like the Agent
-// CRUD they resolve the single operator's active campaign server-side (ADR-0039),
-// so another campaign's Characters are never returned nor mutable. discord_user_id
-// is mandatory (ADR-0003) and must be a Discord snowflake; a Discord User plays at
-// most one Character per campaign, so a duplicate is CodeAlreadyExists and a
-// rebind is an ordinary update of that column.
+// characterRoster is the Player Character (PC) feature module (#276, E4): the
+// PC CRUD plus the Players panel's voice-member picker (#279). Like the Agent
+// CRUD the PC handlers resolve the single operator's active campaign server-side
+// (ADR-0039), so another campaign's Characters are never returned nor mutable.
+// discord_user_id is mandatory (ADR-0003) and must be a Discord snowflake; a
+// Discord User plays at most one Character per campaign, so a duplicate is
+// CodeAlreadyExists and a rebind is an ordinary update of that column.
+type characterRoster struct {
+	store  characterStore
+	active *activeCampaignSource
+	// speakerInv drops a campaign's cached speaker→name resolutions after a Character
+	// mutation (#281, ADR-0039 in-proc direct-method invalidation), so the live relay
+	// re-resolves future lines with the new mapping. Nil disables (feature off / no
+	// live resolver); set once at boot before serving.
+	speakerInv SpeakerInvalidator
+	// memberLister lists the Discord Users currently in the operator's voice
+	// channel for the Players panel picker (#279). Nil until SetMemberLister wires
+	// it (a keyless / bot-offline deployment leaves it nil); the handler then
+	// returns an empty list so the UI falls back to free-text snowflake entry. Set
+	// once at boot before serving, so no lock is needed.
+	memberLister voiceMemberLister
+}
+
+// characterStore is the narrow Player Character surface the module needs
+// (#276); *storage.Store satisfies it. All writes are campaign-scoped (#342),
+// so another campaign's Characters are never mutable.
+type characterStore interface {
+	ListCharacters(ctx context.Context, campaignID uuid.UUID) ([]storage.Character, error)
+	CreateCharacter(ctx context.Context, c storage.NewCharacter) (uuid.UUID, error)
+	UpdateCharacter(ctx context.Context, c storage.CharacterUpdate) (storage.Character, error)
+	DeleteCharacter(ctx context.Context, campaignID, id uuid.UUID) error
+}
+
+// SpeakerInvalidator drops a campaign's cached speaker→name resolutions. The live
+// *speaker.Resolver satisfies it; the Character CRUD handlers call it on
+// create/update/delete so a rebind takes effect on the next projected line (#281).
+type SpeakerInvalidator interface {
+	InvalidateCampaign(campaignID uuid.UUID)
+}
+
+// invalidateSpeakers drops a campaign's cached speaker resolutions after a
+// Character mutation, if a resolver is wired (#281). Nil-safe.
+func (s *characterRoster) invalidateSpeakers(campaignID uuid.UUID) {
+	if s.speakerInv != nil {
+		s.speakerInv.InvalidateCampaign(campaignID)
+	}
+}
 
 // ListCharacters returns the active campaign's Player Characters in storage
 // display order. No campaign is CodeNotFound; a storage failure is CodeInternal.
-func (s *CampaignServer) ListCharacters(
+func (s *characterRoster) ListCharacters(
 	ctx context.Context,
 	_ *connect.Request[managementv1.ListCharactersRequest],
 ) (*connect.Response[managementv1.ListCharactersResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -52,7 +93,7 @@ func (s *CampaignServer) ListCharacters(
 // empty name or a non-snowflake discord_user_id is CodeInvalidArgument; a Discord
 // User already playing a Character in the campaign is CodeAlreadyExists; no
 // campaign is CodeNotFound.
-func (s *CampaignServer) CreateCharacter(
+func (s *characterRoster) CreateCharacter(
 	ctx context.Context,
 	req *connect.Request[managementv1.CreateCharacterRequest],
 ) (*connect.Response[managementv1.CreateCharacterResponse], error) {
@@ -63,7 +104,7 @@ func (s *CampaignServer) CreateCharacter(
 		return nil, err
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -104,7 +145,7 @@ func (s *CampaignServer) CreateCharacter(
 // update (it stays required). An unparsable id, empty name, or non-snowflake
 // discord_user_id is CodeInvalidArgument; an unknown id is CodeNotFound; a
 // collision with another Character's Discord User is CodeAlreadyExists.
-func (s *CampaignServer) UpdateCharacter(
+func (s *characterRoster) UpdateCharacter(
 	ctx context.Context,
 	req *connect.Request[managementv1.UpdateCharacterRequest],
 ) (*connect.Response[managementv1.UpdateCharacterResponse], error) {
@@ -122,7 +163,7 @@ func (s *CampaignServer) UpdateCharacter(
 	// Resolve the active campaign and scope the write to it (#342): the store's
 	// UPDATE matches (id, campaign_id), so a Character in another campaign is never
 	// mutable through this operator's session — it reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -158,7 +199,7 @@ func (s *CampaignServer) UpdateCharacter(
 // DeleteCharacter removes a Player Character by id. An unparsable id is
 // CodeInvalidArgument; a missing id is CodeNotFound; a storage failure is
 // CodeInternal.
-func (s *CampaignServer) DeleteCharacter(
+func (s *characterRoster) DeleteCharacter(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteCharacterRequest],
 ) (*connect.Response[managementv1.DeleteCharacterResponse], error) {
@@ -170,7 +211,7 @@ func (s *CampaignServer) DeleteCharacter(
 	// Resolve the active campaign and scope the delete to it (#342): the store's
 	// DELETE matches (id, campaign_id), so another campaign's Character is never
 	// removable through this session — it reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/character_invalidate_test.go
+++ b/internal/rpc/character_invalidate_test.go
@@ -37,11 +37,11 @@ func (s *spyInvalidator) calls() []uuid.UUID {
 // resolutions so the live relay re-resolves future lines with the new mapping.
 func TestCharacterMutations_InvalidateSpeakers(t *testing.T) {
 	campaign := storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = campaign
 	spy := &spyInvalidator{}
 
-	srv := rpc.NewCampaignServer(store)
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Characters: store})
 	srv.SetSpeakerInvalidator(spy)
 
 	ctx := context.Background()
@@ -79,9 +79,9 @@ func TestCharacterMutations_InvalidateSpeakers(t *testing.T) {
 // TestCharacterMutations_NilInvalidatorSafe: with no invalidator wired (feature
 // off / no live resolver) the mutations must not panic.
 func TestCharacterMutations_NilInvalidatorSafe(t *testing.T) {
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	srv := rpc.NewCampaignServer(store) // no SetSpeakerInvalidator
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{Active: store, Characters: store}) // no SetSpeakerInvalidator
 
 	ctx := context.Background()
 	resp, err := srv.CreateCharacter(ctx, connect.NewRequest(&managementv1.CreateCharacterRequest{

--- a/internal/rpc/character_test.go
+++ b/internal/rpc/character_test.go
@@ -8,69 +8,26 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// --- fakeCampaignStore Player Character methods (#276) ---
-
-func (f *fakeCampaignStore) ListCharacters(_ context.Context, campaignID uuid.UUID) ([]storage.Character, error) {
-	f.charsListCampaign = campaignID
-	return f.characters, f.charListErr
-}
-
-func (f *fakeCampaignStore) CreateCharacter(_ context.Context, c storage.NewCharacter) (uuid.UUID, error) {
-	if f.charCreateErr != nil {
-		return uuid.Nil, f.charCreateErr
-	}
-	f.charsCreated = append(f.charsCreated, c)
-	id := uuid.New()
-	f.characters = append(f.characters, storage.Character{
-		ID:            id,
-		CampaignID:    c.CampaignID,
-		Name:          c.Name,
-		Aliases:       c.Aliases,
-		DiscordUserID: c.DiscordUserID,
-	})
-	return id, nil
-}
-
-func (f *fakeCampaignStore) UpdateCharacter(_ context.Context, u storage.CharacterUpdate) (storage.Character, error) {
-	f.charUpdateCampaign = u.CampaignID
-	if f.charUpdateErr != nil {
-		return storage.Character{}, f.charUpdateErr
-	}
-	for i := range f.characters {
-		if f.characters[i].ID == u.ID {
-			f.characters[i].Name = u.Name
-			f.characters[i].Aliases = u.Aliases
-			f.characters[i].DiscordUserID = u.DiscordUserID
-			return f.characters[i], nil
-		}
-	}
-	return storage.Character{}, storage.ErrNotFound
-}
-
-func (f *fakeCampaignStore) DeleteCharacter(_ context.Context, campaignID, id uuid.UUID) error {
-	f.charDeleteCampaign = campaignID
-	if f.charDeleteErr != nil {
-		return f.charDeleteErr
-	}
-	for i := range f.characters {
-		if f.characters[i].ID == id {
-			f.characters = append(f.characters[:i], f.characters[i+1:]...)
-			return nil
-		}
-	}
-	return storage.ErrNotFound
+// characterClient composes a CampaignServer from the Player Character fake —
+// filling only the Active + Characters slices (#445) — and returns the
+// Connect-JSON client.
+func characterClient(t *testing.T, store *fakeCharacterStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, Characters: store})
 }
 
 // --- CreateCharacter ---
 
 func TestCreateCharacter_MapsAndPersists(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	resp, err := client.CreateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.CreateCharacterRequest{
@@ -108,9 +65,9 @@ func TestCreateCharacter_MapsAndPersists(t *testing.T) {
 
 func TestCreateCharacter_EmptyNameIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.CreateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.CreateCharacterRequest{
@@ -124,9 +81,9 @@ func TestCreateCharacter_EmptyNameIsInvalidArgument(t *testing.T) {
 func TestCreateCharacter_NonSnowflakeIsInvalidArgument(t *testing.T) {
 	t.Parallel()
 	for _, bad := range []string{"", "not-a-number", "123abc", "-5", "12 34", "12.3"} {
-		store := newFakeStore()
+		store := newFakeCharacterStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
-		client := crudClient(t, store)
+		client := characterClient(t, store)
 
 		_, err := client.CreateCharacter(context.Background(),
 			connect.NewRequest(&managementv1.CreateCharacterRequest{
@@ -143,10 +100,10 @@ func TestCreateCharacter_NonSnowflakeIsInvalidArgument(t *testing.T) {
 
 func TestCreateCharacter_DuplicateIsAlreadyExists(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.charCreateErr = storage.ErrConflict
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.CreateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.CreateCharacterRequest{
@@ -159,9 +116,9 @@ func TestCreateCharacter_DuplicateIsAlreadyExists(t *testing.T) {
 
 func TestCreateCharacter_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.CreateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.CreateCharacterRequest{
@@ -176,13 +133,13 @@ func TestCreateCharacter_NoCampaignIsNotFound(t *testing.T) {
 
 func TestListCharacters_ScopedToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	store.characters = []storage.Character{
 		{ID: uuid.New(), CampaignID: activeID, Name: "Aravel", DiscordUserID: "1"},
 	}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	resp, err := client.ListCharacters(context.Background(),
 		connect.NewRequest(&managementv1.ListCharactersRequest{}))
@@ -199,9 +156,9 @@ func TestListCharacters_ScopedToActiveCampaign(t *testing.T) {
 
 func TestListCharacters_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.ListCharacters(context.Background(),
 		connect.NewRequest(&managementv1.ListCharactersRequest{}))
@@ -214,14 +171,14 @@ func TestListCharacters_NoCampaignIsNotFound(t *testing.T) {
 
 func TestUpdateCharacter_Rebinds(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
 	store.characters = []storage.Character{
 		{ID: id, CampaignID: activeID, Name: "Old", DiscordUserID: "111111111111111111"},
 	}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	resp, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -241,9 +198,9 @@ func TestUpdateCharacter_Rebinds(t *testing.T) {
 
 func TestUpdateCharacter_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -256,9 +213,9 @@ func TestUpdateCharacter_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestUpdateCharacter_UnknownIdIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -271,10 +228,10 @@ func TestUpdateCharacter_UnknownIdIsNotFound(t *testing.T) {
 
 func TestUpdateCharacter_ConflictIsAlreadyExists(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.charUpdateErr = storage.ErrConflict
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -287,9 +244,9 @@ func TestUpdateCharacter_ConflictIsAlreadyExists(t *testing.T) {
 
 func TestUpdateCharacter_NonSnowflakeIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -305,9 +262,9 @@ func TestUpdateCharacter_NonSnowflakeIsInvalidArgument(t *testing.T) {
 // CodeNotFound rather than mutating by bare id.
 func TestUpdateCharacter_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -322,10 +279,10 @@ func TestUpdateCharacter_NoActiveCampaignIsNotFound(t *testing.T) {
 
 func TestDeleteCharacter_Removes(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	id := uuid.New()
 	store.characters = []storage.Character{{ID: id, Name: "Doomed", DiscordUserID: "1"}}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	if _, err := client.DeleteCharacter(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: id.String()})); err != nil {
@@ -338,8 +295,8 @@ func TestDeleteCharacter_Removes(t *testing.T) {
 
 func TestDeleteCharacter_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeCharacterStore()
+	client := characterClient(t, store)
 
 	_, err := client.DeleteCharacter(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: "bad"}))
@@ -350,8 +307,8 @@ func TestDeleteCharacter_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestDeleteCharacter_UnknownIdIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeCharacterStore()
+	client := characterClient(t, store)
 
 	_, err := client.DeleteCharacter(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: uuid.NewString()}))
@@ -365,14 +322,14 @@ func TestDeleteCharacter_UnknownIdIsNotFound(t *testing.T) {
 // campaign_id) and a cross-campaign write is refused server-side.
 func TestUpdateCharacter_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
 	store.characters = []storage.Character{
 		{ID: id, CampaignID: activeID, Name: "Old", DiscordUserID: "111111111111111111"},
 	}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	if _, err := client.UpdateCharacter(context.Background(),
 		connect.NewRequest(&managementv1.UpdateCharacterRequest{
@@ -389,12 +346,12 @@ func TestUpdateCharacter_ScopesToActiveCampaign(t *testing.T) {
 // resolved active campaign, so another campaign's Character is never removable.
 func TestDeleteCharacter_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	id := uuid.New()
 	store.characters = []storage.Character{{ID: id, CampaignID: activeID, Name: "Doomed", DiscordUserID: "1"}}
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	if _, err := client.DeleteCharacter(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: id.String()})); err != nil {
@@ -409,9 +366,9 @@ func TestDeleteCharacter_ScopesToActiveCampaign(t *testing.T) {
 // campaign the scoped delete cannot resolve an owner and returns CodeNotFound.
 func TestDeleteCharacter_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeCharacterStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := characterClient(t, store)
 
 	_, err := client.DeleteCharacter(context.Background(),
 		connect.NewRequest(&managementv1.DeleteCharacterRequest{Id: uuid.NewString()}))

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -1,0 +1,760 @@
+package rpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// Per-feature fakes for the CampaignServer feature modules (#445). Each fake
+// implements exactly ONE per-feature store slice (plus the shared 3-method
+// active-campaign resolver via the embedded *fakeActive), so a test composes
+// rpc.CampaignStores from only the slices its feature exercises. State fields
+// and semantics are carried over from the former 39-method fakeCampaignStore.
+
+// errAny is an opaque storage failure a fake returns to force the Internal path.
+var errAny = errors.New("fake storage failure")
+
+// fakeActive is the keyless, deterministic active-campaign resolver every
+// feature fake embeds. forUser/forUserErr back the durable /glyphoxa use
+// selection the profile-first resolution reads first (#222); campaign is the
+// most-recent fallback; campaignsByID backs GetCampaign, the live-first path's
+// per-id load (also the management pre-write validation and read-back).
+type fakeActive struct {
+	campaign   storage.Campaign
+	campErr    error
+	forUser    storage.Campaign
+	forUserErr error
+
+	campaignsByID  map[uuid.UUID]storage.Campaign
+	getCampaignErr error
+}
+
+func newFakeActive() *fakeActive {
+	return &fakeActive{campaignsByID: map[uuid.UUID]storage.Campaign{}}
+}
+
+func (f *fakeActive) GetActiveCampaign(context.Context) (storage.Campaign, error) {
+	return f.campaign, f.campErr
+}
+
+func (f *fakeActive) GetActiveCampaignForUser(context.Context, string) (storage.Campaign, error) {
+	if f.forUserErr != nil {
+		return storage.Campaign{}, f.forUserErr
+	}
+	if f.forUser.ID == uuid.Nil {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return f.forUser, nil
+}
+
+func (f *fakeActive) GetCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	if f.getCampaignErr != nil {
+		return storage.Campaign{}, f.getCampaignErr
+	}
+	c, ok := f.campaignsByID[id]
+	if !ok {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	return c, nil
+}
+
+// setActiveCall records one SetActiveCampaign invocation for assertions (#264).
+type setActiveCall struct {
+	discordUserID string
+	campaignID    uuid.UUID
+}
+
+// fakeManagementStore fakes the campaign-management slice (#264): campaignList
+// backs ListCampaigns; createdCampaigns records CreateCampaign inputs (created
+// rows also land in campaignsByID so a read-back resolves); updatedCampaigns
+// records UpdateCampaign inputs; setActiveCalls records SetActiveCampaign
+// inputs; allCampaignList backs the archive-inclusive list (#269). The *Err
+// hooks force each failure path.
+type fakeManagementStore struct {
+	*fakeActive
+
+	campaignList      []storage.Campaign
+	listCampaignErr   error
+	createdCampaigns  []storage.NewCampaign
+	createCampaignErr error
+	updatedCampaigns  []storage.CampaignUpdate
+	updateCampaignErr error
+	setActiveCalls    []setActiveCall
+	setActiveErr      error
+	allCampaignList   []storage.Campaign
+	listAllErr        error
+}
+
+func newFakeManagementStore() *fakeManagementStore {
+	return &fakeManagementStore{fakeActive: newFakeActive()}
+}
+
+func (f *fakeManagementStore) ListCampaigns(context.Context) ([]storage.Campaign, error) {
+	return f.campaignList, f.listCampaignErr
+}
+
+func (f *fakeManagementStore) CreateCampaign(_ context.Context, c storage.NewCampaign) (uuid.UUID, error) {
+	if f.createCampaignErr != nil {
+		return uuid.Nil, f.createCampaignErr
+	}
+	f.createdCampaigns = append(f.createdCampaigns, c)
+	id := uuid.New()
+	// Land the row so CreateCampaign's read-back (GetCampaign) resolves it.
+	f.campaignsByID[id] = storage.Campaign{
+		ID:       id,
+		TenantID: c.TenantID,
+		Name:     c.Name,
+		System:   c.System,
+		Language: c.Language,
+	}
+	return id, nil
+}
+
+func (f *fakeManagementStore) UpdateCampaign(_ context.Context, c storage.CampaignUpdate) (storage.Campaign, error) {
+	if f.updateCampaignErr != nil {
+		return storage.Campaign{}, f.updateCampaignErr
+	}
+	f.updatedCampaigns = append(f.updatedCampaigns, c)
+	existing, ok := f.campaignsByID[c.ID]
+	if !ok {
+		return storage.Campaign{}, storage.ErrNotFound
+	}
+	existing.Name = c.Name
+	existing.System = c.System
+	existing.Language = c.Language
+	if c.TapeArmed != nil { // optional: nil leaves it unchanged (COALESCE semantics)
+		existing.TapeArmed = *c.TapeArmed
+	}
+	f.campaignsByID[c.ID] = existing
+	return existing, nil
+}
+
+func (f *fakeManagementStore) SetActiveCampaign(_ context.Context, discordUserID string, campaignID uuid.UUID) error {
+	if f.setActiveErr != nil {
+		return f.setActiveErr
+	}
+	f.setActiveCalls = append(f.setActiveCalls, setActiveCall{discordUserID: discordUserID, campaignID: campaignID})
+	return nil
+}
+
+func (f *fakeManagementStore) ListAllCampaigns(context.Context) ([]storage.Campaign, error) {
+	return f.allCampaignList, f.listAllErr
+}
+
+// fakeArchiveStore fakes the archive-lifecycle slice (#269) on top of the full
+// management fake (the archive panel drives list + archive RPCs through one
+// store): archiveCalls/unarchiveCalls/deleteCalls record the ids each handler
+// passed; the *Result campaigns are returned on the happy path; the *Err hooks
+// force each failure path (e.g. storage.ErrNotFound, storage.ErrNotArchived);
+// deleteJobKind/deleteJobPayload capture the DeleteCampaignWithJob enqueue (#308).
+type fakeArchiveStore struct {
+	*fakeManagementStore
+
+	archiveCalls      []uuid.UUID
+	archiveResult     storage.Campaign
+	archiveErr        error
+	unarchiveCalls    []uuid.UUID
+	unarchiveResult   storage.Campaign
+	unarchiveErr      error
+	deleteCalls       []uuid.UUID
+	deleteCampaignErr error
+	deleteJobKind     string
+	deleteJobPayload  []byte
+}
+
+func newFakeArchiveStore() *fakeArchiveStore {
+	return &fakeArchiveStore{fakeManagementStore: newFakeManagementStore()}
+}
+
+func (f *fakeArchiveStore) ArchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	f.archiveCalls = append(f.archiveCalls, id)
+	if f.archiveErr != nil {
+		return storage.Campaign{}, f.archiveErr
+	}
+	return f.archiveResult, nil
+}
+
+func (f *fakeArchiveStore) UnarchiveCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	f.unarchiveCalls = append(f.unarchiveCalls, id)
+	if f.unarchiveErr != nil {
+		return storage.Campaign{}, f.unarchiveErr
+	}
+	return f.unarchiveResult, nil
+}
+
+func (f *fakeArchiveStore) DeleteCampaign(_ context.Context, id uuid.UUID) error {
+	f.deleteCalls = append(f.deleteCalls, id)
+	return f.deleteCampaignErr
+}
+
+func (f *fakeArchiveStore) DeleteCampaignWithJob(_ context.Context, id uuid.UUID, jobKind string, jobPayload []byte) error {
+	f.deleteCalls = append(f.deleteCalls, id)
+	if f.deleteCampaignErr != nil {
+		// Delete refused inside the tx: nothing committed, so no job is recorded — the
+		// real store enqueues in the SAME tx that rolls back.
+		return f.deleteCampaignErr
+	}
+	f.deleteJobKind = jobKind
+	f.deleteJobPayload = jobPayload
+	return nil
+}
+
+// fakeAgentStore fakes the Agent roster/CRUD slice (#71): the agents map backs
+// GetAgent/Create/Update/Delete so happy paths round-trip without a database;
+// butler/chars back the roster read; the *Err hooks force the failure paths.
+// updateAgentCampaign/deleteAgentCampaign record the campaign id the mutations
+// were scoped to (#342).
+type fakeAgentStore struct {
+	*fakeActive
+
+	butler    storage.Agent
+	butlerErr error
+	chars     []storage.Agent
+	charsErr  error
+
+	agents    map[uuid.UUID]storage.Agent
+	createErr error
+	updateErr error
+	deleteErr error
+	nextColor int
+
+	updateAgentCampaign uuid.UUID
+	deleteAgentCampaign uuid.UUID
+
+	created []storage.NewAgent
+}
+
+func newFakeAgentStore() *fakeAgentStore {
+	return &fakeAgentStore{fakeActive: newFakeActive(), agents: map[uuid.UUID]storage.Agent{}}
+}
+
+func (f *fakeAgentStore) GetButler(context.Context, uuid.UUID) (storage.Agent, error) {
+	return f.butler, f.butlerErr
+}
+
+func (f *fakeAgentStore) CharacterAgents(context.Context, uuid.UUID) ([]storage.Agent, error) {
+	return f.chars, f.charsErr
+}
+
+func (f *fakeAgentStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeAgentStore) CreateAgent(_ context.Context, a storage.NewAgent) (uuid.UUID, error) {
+	if f.createErr != nil {
+		return uuid.Nil, f.createErr
+	}
+	f.created = append(f.created, a)
+	id := uuid.New()
+	f.agents[id] = storage.Agent{
+		ID:           id,
+		CampaignID:   a.CampaignID,
+		Role:         a.Role,
+		Name:         a.Name,
+		Title:        a.Title,
+		Persona:      a.Persona,
+		Voice:        a.Voice,
+		AddressOnly:  a.AddressOnly,
+		SpeakerColor: f.nextColor,
+		Aliases:      a.Aliases,
+	}
+	f.nextColor++
+	return id, nil
+}
+
+func (f *fakeAgentStore) UpdateAgent(_ context.Context, u storage.AgentUpdate) (storage.Agent, error) {
+	f.updateAgentCampaign = u.CampaignID
+	if f.updateErr != nil {
+		return storage.Agent{}, f.updateErr
+	}
+	a, ok := f.agents[u.ID]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	a.Name = u.Name
+	a.Title = u.Title
+	a.Persona = u.Persona
+	a.Voice = u.Voice
+	a.AddressOnly = u.AddressOnly
+	a.Aliases = u.Aliases
+	f.agents[u.ID] = a
+	return a, nil
+}
+
+func (f *fakeAgentStore) DeleteAgent(_ context.Context, campaignID, id uuid.UUID) error {
+	f.deleteAgentCampaign = campaignID
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	if _, ok := f.agents[id]; !ok {
+		return storage.ErrNotFound
+	}
+	delete(f.agents, id)
+	return nil
+}
+
+// fakeCharacterStore fakes the Player Character slice (#276): characters backs
+// List/Update/Delete; charsCreated records CreateCharacter inputs;
+// charsListCampaign records the campaign id ListCharacters resolved (scope
+// assertion); the *Err hooks force each failure path (e.g. storage.ErrConflict,
+// storage.ErrNotFound). charUpdateCampaign/charDeleteCampaign record the
+// campaign id the mutations were scoped to (#342).
+type fakeCharacterStore struct {
+	*fakeActive
+
+	characters        []storage.Character
+	charsCreated      []storage.NewCharacter
+	charsListCampaign uuid.UUID
+	charCreateErr     error
+	charListErr       error
+	charUpdateErr     error
+	charDeleteErr     error
+
+	charUpdateCampaign uuid.UUID
+	charDeleteCampaign uuid.UUID
+}
+
+func newFakeCharacterStore() *fakeCharacterStore {
+	return &fakeCharacterStore{fakeActive: newFakeActive()}
+}
+
+func (f *fakeCharacterStore) ListCharacters(_ context.Context, campaignID uuid.UUID) ([]storage.Character, error) {
+	f.charsListCampaign = campaignID
+	return f.characters, f.charListErr
+}
+
+func (f *fakeCharacterStore) CreateCharacter(_ context.Context, c storage.NewCharacter) (uuid.UUID, error) {
+	if f.charCreateErr != nil {
+		return uuid.Nil, f.charCreateErr
+	}
+	f.charsCreated = append(f.charsCreated, c)
+	id := uuid.New()
+	f.characters = append(f.characters, storage.Character{
+		ID:            id,
+		CampaignID:    c.CampaignID,
+		Name:          c.Name,
+		Aliases:       c.Aliases,
+		DiscordUserID: c.DiscordUserID,
+	})
+	return id, nil
+}
+
+func (f *fakeCharacterStore) UpdateCharacter(_ context.Context, u storage.CharacterUpdate) (storage.Character, error) {
+	f.charUpdateCampaign = u.CampaignID
+	if f.charUpdateErr != nil {
+		return storage.Character{}, f.charUpdateErr
+	}
+	for i := range f.characters {
+		if f.characters[i].ID == u.ID {
+			f.characters[i].Name = u.Name
+			f.characters[i].Aliases = u.Aliases
+			f.characters[i].DiscordUserID = u.DiscordUserID
+			return f.characters[i], nil
+		}
+	}
+	return storage.Character{}, storage.ErrNotFound
+}
+
+func (f *fakeCharacterStore) DeleteCharacter(_ context.Context, campaignID, id uuid.UUID) error {
+	f.charDeleteCampaign = campaignID
+	if f.charDeleteErr != nil {
+		return f.charDeleteErr
+	}
+	for i := range f.characters {
+		if f.characters[i].ID == id {
+			f.characters = append(f.characters[:i], f.characters[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+// fakeKGNodeStore fakes the KG-Node slice (#126, #131): nodes backs
+// ListNodes/Update/Delete; nodesCreated records the storage inputs; the search
+// fields record what reached storage (#131) and searchResults is returned
+// verbatim so the handler's 1:1 rank-order mapping is asserted; the *Err hooks
+// force each failure path. listNodesCampaign/searchNodesCampaign and the
+// mutation-campaign fields record the resolved scope (#222/#342).
+type fakeKGNodeStore struct {
+	*fakeActive
+
+	nodes         []storage.KGNode
+	nodesCreated  []storage.NewKGNode
+	nodeCreateErr error
+	nodeListErr   error
+	nodeUpdateErr error
+	nodeDeleteErr error
+
+	listNodesCampaign  uuid.UUID
+	updateNodeCampaign uuid.UUID
+	deleteNodeCampaign uuid.UUID
+
+	searchResults       []storage.KGNode
+	searchQuery         string
+	searchLimit         int
+	searchCalls         int
+	searchNodesCampaign uuid.UUID
+	nodeSearchErr       error
+}
+
+func newFakeKGNodeStore() *fakeKGNodeStore {
+	return &fakeKGNodeStore{fakeActive: newFakeActive()}
+}
+
+func (f *fakeKGNodeStore) CreateNode(_ context.Context, n storage.NewKGNode) (storage.KGNode, error) {
+	if f.nodeCreateErr != nil {
+		return storage.KGNode{}, f.nodeCreateErr
+	}
+	f.nodesCreated = append(f.nodesCreated, n)
+	created := storage.KGNode{
+		ID:         uuid.New(),
+		CampaignID: n.CampaignID,
+		Type:       n.Type,
+		Name:       n.Name,
+		Body:       n.Body,
+		GMPrivate:  n.GMPrivate,
+	}
+	f.nodes = append(f.nodes, created)
+	return created, nil
+}
+
+func (f *fakeKGNodeStore) ListNodes(_ context.Context, campaignID uuid.UUID) ([]storage.KGNode, error) {
+	f.listNodesCampaign = campaignID
+	return f.nodes, f.nodeListErr
+}
+
+func (f *fakeKGNodeStore) UpdateNode(_ context.Context, u storage.KGNodeUpdate) (storage.KGNode, error) {
+	f.updateNodeCampaign = u.CampaignID
+	if f.nodeUpdateErr != nil {
+		return storage.KGNode{}, f.nodeUpdateErr
+	}
+	for i := range f.nodes {
+		if f.nodes[i].ID == u.ID {
+			f.nodes[i].Name = u.Name
+			f.nodes[i].Body = u.Body
+			f.nodes[i].GMPrivate = u.GMPrivate
+			return f.nodes[i], nil
+		}
+	}
+	return storage.KGNode{}, storage.ErrNotFound
+}
+
+func (f *fakeKGNodeStore) DeleteNode(_ context.Context, campaignID, id uuid.UUID) error {
+	f.deleteNodeCampaign = campaignID
+	if f.nodeDeleteErr != nil {
+		return f.nodeDeleteErr
+	}
+	for i := range f.nodes {
+		if f.nodes[i].ID == id {
+			f.nodes = append(f.nodes[:i], f.nodes[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeKGNodeStore) SearchNodes(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error) {
+	f.searchCalls++
+	f.searchNodesCampaign = campaignID
+	f.searchQuery = query
+	f.searchLimit = limit
+	if f.nodeSearchErr != nil {
+		return nil, f.nodeSearchErr
+	}
+	return f.searchResults, nil
+}
+
+// setAgentCall records one SetNodeAgent invocation for assertions.
+type setAgentCall struct {
+	nodeID  uuid.UUID
+	agentID uuid.NullUUID
+}
+
+// fakeKGEdgeStore fakes the KG-Edge slice (#132): edgesCreated records
+// CreateEdge inputs; edgesOut/edgesIn back NodeEdges; setAgentCalls records
+// SetNodeAgent inputs; setAgentNode is the happy-path node it returns (with
+// AgentID overridden per call); the *Err hooks force each failure path. The
+// *Campaign fields record the resolved scope (#342/#356).
+type fakeKGEdgeStore struct {
+	*fakeActive
+
+	edgesCreated  []storage.NewKGEdge
+	edgeCreateErr error
+	edgeDeleteErr error
+	edgesOut      []storage.KGEdgeWithNodes
+	edgesIn       []storage.KGEdgeWithNodes
+	nodeEdgesErr  error
+
+	nodeEdgesCampaign  uuid.UUID
+	deleteEdgeCampaign uuid.UUID
+	setAgentCampaign   uuid.UUID
+
+	setAgentCalls []setAgentCall
+	setAgentNode  storage.KGNode
+	setAgentErr   error
+}
+
+func newFakeKGEdgeStore() *fakeKGEdgeStore {
+	return &fakeKGEdgeStore{fakeActive: newFakeActive()}
+}
+
+func (f *fakeKGEdgeStore) CreateEdge(_ context.Context, e storage.NewKGEdge) (storage.KGEdge, error) {
+	if f.edgeCreateErr != nil {
+		return storage.KGEdge{}, f.edgeCreateErr
+	}
+	f.edgesCreated = append(f.edgesCreated, e)
+	return storage.KGEdge{
+		ID:         uuid.New(),
+		CampaignID: e.CampaignID,
+		FromNodeID: e.FromNodeID,
+		ToNodeID:   e.ToNodeID,
+		Type:       e.Type,
+	}, nil
+}
+
+func (f *fakeKGEdgeStore) DeleteEdge(_ context.Context, campaignID, _ uuid.UUID) error {
+	f.deleteEdgeCampaign = campaignID
+	return f.edgeDeleteErr
+}
+
+func (f *fakeKGEdgeStore) NodeEdges(_ context.Context, campaignID, _ uuid.UUID) ([]storage.KGEdgeWithNodes, []storage.KGEdgeWithNodes, error) {
+	f.nodeEdgesCampaign = campaignID
+	return f.edgesOut, f.edgesIn, f.nodeEdgesErr
+}
+
+func (f *fakeKGEdgeStore) SetNodeAgent(_ context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error) {
+	f.setAgentCampaign = campaignID
+	if f.setAgentErr != nil {
+		return storage.KGNode{}, f.setAgentErr
+	}
+	f.setAgentCalls = append(f.setAgentCalls, setAgentCall{nodeID: nodeID, agentID: agentID})
+	n := f.setAgentNode
+	n.ID = nodeID
+	n.AgentID = agentID
+	return n, nil
+}
+
+// fakeProposalStore fakes the Knowledge Proposal review slice (#300):
+// pendingProposals backs the list read; getProposal/getProposalErr back
+// GetPendingKnowledgeProposal; approve/reject record calls and force error
+// paths; similarResults/similarErr back SimilarNodes and similarQueryVec
+// records the vector it was queried with; the search fields back the fulltext
+// fallback of the similarity hint (ADR-0011).
+type fakeProposalStore struct {
+	*fakeActive
+
+	pendingProposals      []storage.KnowledgeProposal
+	listProposalsErr      error
+	listProposalsCampaign uuid.UUID
+	getProposal           storage.KnowledgeProposal
+	getProposalErr        error
+	getProposalCampaign   uuid.UUID
+	approveErr            error
+	approveCalls          []uuid.UUID
+	approveCampaign       uuid.UUID
+	rejectErr             error
+	rejectCalls           []uuid.UUID
+	rejectCampaign        uuid.UUID
+	similarResults        []storage.KGNode
+	similarErr            error
+	similarCalls          int
+	similarQueryVec       []float32
+
+	searchResults       []storage.KGNode
+	searchQuery         string
+	searchLimit         int
+	searchCalls         int
+	searchNodesCampaign uuid.UUID
+	nodeSearchErr       error
+}
+
+func newFakeProposalStore() *fakeProposalStore {
+	return &fakeProposalStore{fakeActive: newFakeActive()}
+}
+
+func (f *fakeProposalStore) ListPendingKnowledgeProposals(_ context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error) {
+	f.listProposalsCampaign = campaignID
+	return f.pendingProposals, f.listProposalsErr
+}
+
+func (f *fakeProposalStore) GetPendingKnowledgeProposal(_ context.Context, campaignID, _ uuid.UUID) (storage.KnowledgeProposal, error) {
+	f.getProposalCampaign = campaignID
+	if f.getProposalErr != nil {
+		return storage.KnowledgeProposal{}, f.getProposalErr
+	}
+	return f.getProposal, nil
+}
+
+func (f *fakeProposalStore) ApproveKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
+	f.approveCampaign = campaignID
+	f.approveCalls = append(f.approveCalls, id)
+	return f.approveErr
+}
+
+func (f *fakeProposalStore) RejectKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
+	f.rejectCampaign = campaignID
+	f.rejectCalls = append(f.rejectCalls, id)
+	return f.rejectErr
+}
+
+func (f *fakeProposalStore) SimilarNodes(_ context.Context, _ uuid.UUID, query []float32, _ int) ([]storage.KGNode, error) {
+	f.similarCalls++
+	f.similarQueryVec = query
+	if f.similarErr != nil {
+		return nil, f.similarErr
+	}
+	return f.similarResults, nil
+}
+
+func (f *fakeProposalStore) SearchNodes(_ context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error) {
+	f.searchCalls++
+	f.searchNodesCampaign = campaignID
+	f.searchQuery = query
+	f.searchLimit = limit
+	if f.nodeSearchErr != nil {
+		return nil, f.nodeSearchErr
+	}
+	return f.searchResults, nil
+}
+
+// fakeGrantStore fakes the Tool Grant slice (#117): grants maps agent_id →
+// tool_name → config blob (nil = no scope), backing the upsert/delete/list
+// round-trip; agents backs the campaign-ownership check's GetAgent (#342/#356);
+// the *Err hooks force each failure path.
+type fakeGrantStore struct {
+	*fakeActive
+
+	agents map[uuid.UUID]storage.Agent
+
+	grants         map[uuid.UUID]map[string]json.RawMessage
+	grantListErr   error
+	grantUpsertErr error
+	grantDeleteErr error
+}
+
+func newFakeGrantStore() *fakeGrantStore {
+	return &fakeGrantStore{fakeActive: newFakeActive(), agents: map[uuid.UUID]storage.Agent{}}
+}
+
+func (f *fakeGrantStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeGrantStore) ListToolGrants(_ context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error) {
+	if f.grantListErr != nil {
+		return nil, f.grantListErr
+	}
+	var out []storage.ToolGrant
+	for tool, cfg := range f.grants[agentID] {
+		out = append(out, storage.ToolGrant{AgentID: agentID, ToolName: tool, Config: cfg})
+	}
+	return out, nil
+}
+
+func (f *fakeGrantStore) UpsertToolGrant(_ context.Context, g storage.NewToolGrant) error {
+	if f.grantUpsertErr != nil {
+		return f.grantUpsertErr
+	}
+	if f.grants == nil {
+		f.grants = map[uuid.UUID]map[string]json.RawMessage{}
+	}
+	if f.grants[g.AgentID] == nil {
+		f.grants[g.AgentID] = map[string]json.RawMessage{}
+	}
+	f.grants[g.AgentID][g.ToolName] = g.Config
+	return nil
+}
+
+func (f *fakeGrantStore) DeleteToolGrant(_ context.Context, agentID uuid.UUID, toolName string) error {
+	if f.grantDeleteErr != nil {
+		return f.grantDeleteErr
+	}
+	if _, ok := f.grants[agentID][toolName]; !ok {
+		return storage.ErrNotFound
+	}
+	delete(f.grants[agentID], toolName)
+	return nil
+}
+
+// liveMgr returns a fakeSessionManager reporting an active Voice Session bound to
+// campaignID — the live-first input every CampaignService surface resolves through
+// (#222). The Manager enforces single-active, so one live campaign is enough.
+func liveMgr(campaignID uuid.UUID) *fakeSessionManager {
+	return &fakeSessionManager{active: true, current: storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID}}
+}
+
+// campaignClient stands up the CampaignService handler composed from the given
+// per-feature stores over an httptest server and returns a Connect-JSON client.
+// WithProtoJSON forces the JSON codec on the wire, so this also asserts the RPC
+// is reachable over Connect-JSON.
+func campaignClient(t *testing.T, stores rpc.CampaignStores) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClientServe(t, rpc.NewCampaignServerWith(stores))
+}
+
+// campaignClientWithEmbedder is campaignClient with a wired Embedder so the
+// ListSimilarKnowledge vector path (#300) is exercised.
+func campaignClientWithEmbedder(t *testing.T, stores rpc.CampaignStores, emb rpc.Embedder) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	srv := rpc.NewCampaignServerWith(stores)
+	srv.SetEmbedder(emb)
+	return campaignClientServe(t, srv)
+}
+
+// campaignClientAs is campaignClient plus an injected authenticated operator +
+// tenant (the auth interceptor stack's resolved principal, ADR-0039) and an
+// optional live Voice Session source (so the live-first scope can be
+// exercised). A zero user/tenant injects nothing; a nil sessions leaves the
+// server with no live source.
+func campaignClientAs(t *testing.T, stores rpc.CampaignStores, user storage.User, tenantID uuid.UUID, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	srv := rpc.NewCampaignServerWith(stores)
+	if sessions != nil {
+		srv.SetSessions(sessions)
+	}
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if user.DiscordUserID != "" {
+				ctx = auth.WithUser(ctx, user)
+			}
+			if tenantID != uuid.Nil {
+				ctx = auth.WithTenant(ctx, tenantID)
+			}
+			return next(ctx, req)
+		}
+	})
+	return campaignClientServe(t, srv, connect.WithInterceptors(inject))
+}
+
+// campaignClientServe mounts an already-composed CampaignServer behind an
+// httptest server and returns the Connect-JSON client.
+func campaignClientServe(t *testing.T, srv *rpc.CampaignServer, opts ...connect.HandlerOption) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(opts...))
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return managementv1connect.NewCampaignServiceClient(
+		http.DefaultClient, s.URL, connect.WithProtoJSON(),
+	)
+}

--- a/internal/rpc/highlight_test.go
+++ b/internal/rpc/highlight_test.go
@@ -175,7 +175,7 @@ func newHighlightClientEnq(t *testing.T, tenantID uuid.UUID, hstore rpc.Highligh
 	return managementv1connect.NewSessionServiceClient(http.DefaultClient, httpSrv.URL, connect.WithProtoJSON())
 }
 
-// campaignStore returns a fakeSessionStore whose resolved Active Campaign is
+// campaignSessionStore returns a fakeSessionStore whose resolved Active Campaign is
 // campaignID and that owns the given voice sessions (each mapped to campaignID), so
 // the highlight RPCs' cross-campaign checks have a session to look up.
 func campaignSessionStore(campaignID uuid.UUID, sessionIDs ...uuid.UUID) *fakeSessionStore {

--- a/internal/rpc/kg_edge.go
+++ b/internal/rpc/kg_edge.go
@@ -14,16 +14,32 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Knowledge Graph Edge handlers (#132, ADR-0008 v1.0 + amendment) on
-// CampaignServer: create/delete typed directional Edges, list a Node's incident
+// kgEdges is the Knowledge Graph Edge feature module (#132, ADR-0008 v1.0 +
+// amendment): create/delete typed directional Edges, list a Node's incident
 // Edges split by direction, and link/unlink an NPC Node's "voiced by" Agent. The
 // active campaign is resolved server-side (single operator, ADR-0039).
+type kgEdges struct {
+	store  kgEdgeStore
+	active *activeCampaignSource
+}
+
+// kgEdgeStore is the narrow KG-Edge surface the module needs (#132);
+// *storage.Store satisfies it. Every method is campaign-scoped (#342/#356), so
+// another campaign's Edges are neither readable nor mutable.
+type kgEdgeStore interface {
+	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
+	DeleteEdge(ctx context.Context, campaignID, id uuid.UUID) error
+	// NodeEdges returns a Node's incident Edges with joined endpoint name/type.
+	NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
+	// SetNodeAgent links/unlinks an NPC Node's "voiced by" Agent.
+	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
+}
 
 // CreateEdge adds a typed Edge between two same-campaign Nodes. An UNSPECIFIED
 // edge_type or an unparsable endpoint id is CodeInvalidArgument; an invalid
 // (type, from, to) combination or a self-edge is CodeInvalidArgument; a duplicate
 // is CodeAlreadyExists; a missing OR cross-campaign endpoint is CodeNotFound.
-func (s *CampaignServer) CreateEdge(
+func (s *kgEdges) CreateEdge(
 	ctx context.Context,
 	req *connect.Request[managementv1.CreateEdgeRequest],
 ) (*connect.Response[managementv1.CreateEdgeResponse], error) {
@@ -41,7 +57,7 @@ func (s *CampaignServer) CreateEdge(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("edge type must be specified"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -70,7 +86,7 @@ func (s *CampaignServer) CreateEdge(
 
 // DeleteEdge removes a typed Edge by id. An unparsable id is CodeInvalidArgument;
 // a missing id is CodeNotFound.
-func (s *CampaignServer) DeleteEdge(
+func (s *kgEdges) DeleteEdge(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteEdgeRequest],
 ) (*connect.Response[managementv1.DeleteEdgeResponse], error) {
@@ -81,7 +97,7 @@ func (s *CampaignServer) DeleteEdge(
 	// Resolve the active campaign and scope the delete to it (#342): the store's
 	// DELETE matches (id, campaign_id), so an Edge in another campaign is never
 	// removable through this session — it reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -107,7 +123,7 @@ func (s *CampaignServer) DeleteEdge(
 // joined endpoint name, incl. gm_private ones) is returned, leaking neither the
 // KG nor an existence oracle. No active campaign is CodeNotFound; a storage
 // failure is CodeInternal.
-func (s *CampaignServer) ListNodeEdges(
+func (s *kgEdges) ListNodeEdges(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListNodeEdgesRequest],
 ) (*connect.Response[managementv1.ListNodeEdgesResponse], error) {
@@ -115,7 +131,7 @@ func (s *CampaignServer) ListNodeEdges(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid node id"))
 	}
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -141,7 +157,7 @@ func (s *CampaignServer) ListNodeEdges(
 // unlinks. An unparsable node/agent id is CodeInvalidArgument; linking a non-NPC
 // Node is CodeInvalidArgument; an Agent already voicing another Node is
 // CodeAlreadyExists; a missing OR cross-campaign Node/Agent is CodeNotFound.
-func (s *CampaignServer) SetNodeAgent(
+func (s *kgEdges) SetNodeAgent(
 	ctx context.Context,
 	req *connect.Request[managementv1.SetNodeAgentRequest],
 ) (*connect.Response[managementv1.SetNodeAgentResponse], error) {
@@ -165,7 +181,7 @@ func (s *CampaignServer) SetNodeAgent(
 	// so another campaign's Node is never re-voiced nor unlinked through this
 	// session — and a link's Agent must also belong to the active campaign. A
 	// cross-campaign Node/Agent reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/kg_edge_integration_test.go
+++ b/internal/rpc/kg_edge_integration_test.go
@@ -22,58 +22,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// TestListNodeEdges_CrossCampaign_Integration is #356: the KG read is scoped. With
-// a live Voice Session pinning the active campaign to A, an operator must not be
-// able to READ campaign B's Node incident edges by id — ListNodeEdges is
-// CodeNotFound, leaking neither B's edges nor its joined endpoint names nor an
-// existence oracle, even though B's Node has a real incident Edge.
-func TestListNodeEdges_CrossCampaign_Integration(t *testing.T) {
-	dsn := startPostgres(t)
-	store, campaignA := seedStore(t, dsn)
-	ctx := context.Background()
-
-	a, err := store.GetActiveCampaign(ctx) // == A, carries the tenant id
-	if err != nil {
-		t.Fatalf("GetActiveCampaign: %v", err)
-	}
-	campaignB, err := store.CreateCampaign(ctx, storage.NewCampaign{
-		TenantID: a.TenantID, Name: "Other Table", System: "dnd5e", Language: "en",
-	})
-	if err != nil {
-		t.Fatalf("CreateCampaign B: %v", err)
-	}
-	// B's Node with a real incident Edge (so an unscoped read would return data).
-	bChar, err := store.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignB, Type: storage.KGNodeCharacter, Name: "Secret Aldric"})
-	if err != nil {
-		t.Fatalf("CreateNode B char: %v", err)
-	}
-	bLoc, err := store.CreateNode(ctx, storage.NewKGNode{CampaignID: campaignB, Type: storage.KGNodeLocation, Name: "Secret Keep"})
-	if err != nil {
-		t.Fatalf("CreateNode B loc: %v", err)
-	}
-	if _, err := store.CreateEdge(ctx, storage.NewKGEdge{
-		CampaignID: campaignB, FromNodeID: bChar.ID, ToNodeID: bLoc.ID, Type: storage.KGEdgeResidesIn,
-	}); err != nil {
-		t.Fatalf("CreateEdge B: %v", err)
-	}
-
-	// Pin the active campaign to A via a live Voice Session, then mount the server.
-	server := rpc.NewCampaignServer(store)
-	server.SetSessions(liveMgr(campaignA))
-	mux := http.NewServeMux()
-	mux.Handle(server.Handler())
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	client := managementv1connect.NewCampaignServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
-
-	_, err = client.ListNodeEdges(ctx, connect.NewRequest(&managementv1.ListNodeEdgesRequest{
-		NodeId: bChar.ID.String(),
-	}))
-	if got := connect.CodeOf(err); got != connect.CodeNotFound {
-		t.Fatalf("cross-campaign ListNodeEdges code = %v, want NotFound", got)
-	}
-}
-
 func TestKGEdge_Integration(t *testing.T) {
 	dsn := startPostgres(t)
 	store, campaignID := seedStore(t, dsn)

--- a/internal/rpc/kg_edge_test.go
+++ b/internal/rpc/kg_edge_test.go
@@ -8,16 +8,26 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
+
+// edgeClient stands up the CampaignService client with the KG-Edge slice and
+// the shared Active-Campaign resolution both served by the one fakeKGEdgeStore
+// (it embeds *fakeActive), the composition every test here exercises (#445).
+func edgeClient(t *testing.T, store *fakeKGEdgeStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, KGEdges: store})
+}
 
 func TestCreateEdge_MapsAndPersists(t *testing.T) {
 	t.Parallel()
 	campID := uuid.New()
 	from, to := uuid.New(), uuid.New()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	resp, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -46,9 +56,9 @@ func TestCreateEdge_MapsAndPersists(t *testing.T) {
 
 func TestCreateEdge_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -61,9 +71,9 @@ func TestCreateEdge_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
 
 func TestCreateEdge_InvalidEndpointIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -90,10 +100,10 @@ func TestCreateEdge_StorageErrorsMapToCodes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			store := newFakeStore()
+			store := newFakeKGEdgeStore()
 			store.campaign = storage.Campaign{ID: uuid.New()}
 			store.edgeCreateErr = tc.storErr
-			client := crudClient(t, store)
+			client := edgeClient(t, store)
 
 			_, err := client.CreateEdge(context.Background(),
 				connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -109,9 +119,9 @@ func TestCreateEdge_StorageErrorsMapToCodes(t *testing.T) {
 
 func TestCreateEdge_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -125,8 +135,8 @@ func TestCreateEdge_NoCampaignIsNotFound(t *testing.T) {
 
 func TestDeleteEdge_Deletes(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeKGEdgeStore()
+	client := edgeClient(t, store)
 
 	if _, err := client.DeleteEdge(context.Background(),
 		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()})); err != nil {
@@ -136,7 +146,7 @@ func TestDeleteEdge_Deletes(t *testing.T) {
 
 func TestDeleteEdge_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := edgeClient(t, newFakeKGEdgeStore())
 
 	_, err := client.DeleteEdge(context.Background(),
 		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: "nope"}))
@@ -147,9 +157,9 @@ func TestDeleteEdge_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestDeleteEdge_NotFoundIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.edgeDeleteErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.DeleteEdge(context.Background(),
 		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()}))
@@ -162,10 +172,10 @@ func TestDeleteEdge_NotFoundIsNotFound(t *testing.T) {
 // resolved active campaign, so another campaign's Edge is never removable.
 func TestDeleteEdge_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	if _, err := client.DeleteEdge(context.Background(),
 		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()})); err != nil {
@@ -180,9 +190,9 @@ func TestDeleteEdge_ScopesToActiveCampaign(t *testing.T) {
 // scoped delete cannot resolve an owner and returns CodeNotFound.
 func TestDeleteEdge_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.DeleteEdge(context.Background(),
 		connect.NewRequest(&managementv1.DeleteEdgeRequest{Id: uuid.NewString()}))
@@ -199,7 +209,7 @@ func TestListNodeEdges_SplitsAndJoins(t *testing.T) {
 	node := uuid.New()
 	barrow := uuid.New()
 	cyra := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.edgesOut = []storage.KGEdgeWithNodes{{
 		KGEdge:   storage.KGEdge{ID: uuid.New(), FromNodeID: node, ToNodeID: barrow, Type: storage.KGEdgeResidesIn},
 		FromName: "Aldric", FromType: storage.KGNodeCharacter,
@@ -210,7 +220,7 @@ func TestListNodeEdges_SplitsAndJoins(t *testing.T) {
 		FromName: "Cyra", FromType: storage.KGNodeCharacter,
 		ToName: "Aldric", ToType: storage.KGNodeCharacter,
 	}}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	resp, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: node.String()}))
@@ -238,10 +248,10 @@ func TestListNodeEdges_SplitsAndJoins(t *testing.T) {
 // verified there — another campaign's Node is never listable through this session.
 func TestListNodeEdges_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	if _, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()})); err != nil {
@@ -257,10 +267,10 @@ func TestListNodeEdges_ScopesToActiveCampaign(t *testing.T) {
 // CodeNotFound, never a leaked edge list or an existence oracle.
 func TestListNodeEdges_CrossCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.nodeEdgesErr = storage.ErrNotFound // the scoped store refuses a foreign anchor
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()}))
@@ -273,9 +283,9 @@ func TestListNodeEdges_CrossCampaignIsNotFound(t *testing.T) {
 // the read cannot resolve an owning campaign and is CodeNotFound.
 func TestListNodeEdges_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()}))
@@ -286,7 +296,7 @@ func TestListNodeEdges_NoActiveCampaignIsNotFound(t *testing.T) {
 
 func TestListNodeEdges_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	client := crudClient(t, newFakeStore())
+	client := edgeClient(t, newFakeKGEdgeStore())
 
 	_, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: "bad"}))
@@ -297,9 +307,9 @@ func TestListNodeEdges_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestListNodeEdges_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.nodeEdgesErr = errAny
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.ListNodeEdges(context.Background(),
 		connect.NewRequest(&managementv1.ListNodeEdgesRequest{NodeId: uuid.NewString()}))
@@ -312,9 +322,9 @@ func TestSetNodeAgent_LinksAndMapsAgentId(t *testing.T) {
 	t.Parallel()
 	node := uuid.New()
 	agent := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.setAgentNode = storage.KGNode{ID: node, Type: storage.KGNodeNPC, Name: "Bart"}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	resp, err := client.SetNodeAgent(context.Background(),
 		connect.NewRequest(&managementv1.SetNodeAgentRequest{
@@ -334,9 +344,9 @@ func TestSetNodeAgent_LinksAndMapsAgentId(t *testing.T) {
 func TestSetNodeAgent_EmptyAgentIdUnlinks(t *testing.T) {
 	t.Parallel()
 	node := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.setAgentNode = storage.KGNode{ID: node, Type: storage.KGNodeNPC, Name: "Bart"}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	resp, err := client.SetNodeAgent(context.Background(),
 		connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: node.String(), AgentId: ""}))
@@ -358,8 +368,8 @@ func TestSetNodeAgent_InvalidIdsAreInvalidArgument(t *testing.T) {
 		{uuid.NewString(), "bad"},
 	}
 	for _, tc := range cases {
-		store := newFakeStore()
-		client := crudClient(t, store)
+		store := newFakeKGEdgeStore()
+		client := edgeClient(t, store)
 		_, err := client.SetNodeAgent(context.Background(),
 			connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: tc.node, AgentId: tc.agent}))
 		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -383,9 +393,9 @@ func TestSetNodeAgent_StorageErrorsMapToCodes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			store := newFakeStore()
+			store := newFakeKGEdgeStore()
 			store.setAgentErr = tc.storErr
-			client := crudClient(t, store)
+			client := edgeClient(t, store)
 
 			_, err := client.SetNodeAgent(context.Background(),
 				connect.NewRequest(&managementv1.SetNodeAgentRequest{
@@ -405,11 +415,11 @@ func TestSetNodeAgent_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
 	node := uuid.New()
 	agent := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	store.setAgentNode = storage.KGNode{ID: node, Type: storage.KGNodeNPC, Name: "Bart"}
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	if _, err := client.SetNodeAgent(context.Background(),
 		connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: node.String(), AgentId: agent.String()})); err != nil {
@@ -424,9 +434,9 @@ func TestSetNodeAgent_ScopesToActiveCampaign(t *testing.T) {
 // the scoped link/unlink cannot resolve an owner and returns CodeNotFound.
 func TestSetNodeAgent_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := edgeClient(t, store)
 
 	_, err := client.SetNodeAgent(context.Background(),
 		connect.NewRequest(&managementv1.SetNodeAgentRequest{NodeId: uuid.NewString(), AgentId: uuid.NewString()}))
@@ -442,10 +452,11 @@ func TestCreateEdgeHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.forUser = durable
 	store.campaign = newer
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
+	client := campaignClientAs(t, rpc.CampaignStores{Active: store, KGEdges: store},
+		storage.User{DiscordUserID: "999"}, uuid.Nil, nil)
 
 	if _, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{
@@ -470,11 +481,12 @@ func TestCreateEdgeHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGEdgeStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
+	client := campaignClientAs(t, rpc.CampaignStores{Active: store, KGEdges: store},
+		storage.User{DiscordUserID: "999"}, uuid.Nil, liveMgr(live.ID))
 
 	if _, err := client.CreateEdge(context.Background(),
 		connect.NewRequest(&managementv1.CreateEdgeRequest{

--- a/internal/rpc/kg_node.go
+++ b/internal/rpc/kg_node.go
@@ -14,14 +14,30 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Knowledge Graph Node handlers (#126, ADR-0008 v1.0) on CampaignServer: create
-// and list the campaign's wiki Nodes. Like the agent CRUD they resolve the single
-// operator's active campaign server-side (ADR-0039).
+// kgNodes is the Knowledge Graph Node feature module (#126, ADR-0008 v1.0):
+// CRUD + wiki search over the campaign's Nodes. Like the agent CRUD the handlers
+// resolve the single operator's active campaign server-side (ADR-0039).
+type kgNodes struct {
+	store  kgNodeStore
+	active *activeCampaignSource
+}
+
+// kgNodeStore is the narrow KG-Node surface the module needs (#126, #131);
+// *storage.Store satisfies it. Mutations are campaign-scoped (#342), so another
+// campaign's Nodes are never mutable.
+type kgNodeStore interface {
+	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
+	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
+	UpdateNode(ctx context.Context, u storage.KGNodeUpdate) (storage.KGNode, error)
+	DeleteNode(ctx context.Context, campaignID, id uuid.UUID) error
+	// SearchNodes is the ranked fulltext wiki search (#131).
+	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+}
 
 // CreateNode adds a Knowledge Graph Node to the active campaign and returns it. An
 // UNSPECIFIED node_type or an empty name is CodeInvalidArgument; no campaign is
 // CodeNotFound; a storage failure is CodeInternal.
-func (s *CampaignServer) CreateNode(
+func (s *kgNodes) CreateNode(
 	ctx context.Context,
 	req *connect.Request[managementv1.CreateNodeRequest],
 ) (*connect.Response[managementv1.CreateNodeResponse], error) {
@@ -34,7 +50,7 @@ func (s *CampaignServer) CreateNode(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -60,11 +76,11 @@ func (s *CampaignServer) CreateNode(
 // ListNodes returns the active campaign's Knowledge Graph Nodes in the storage
 // display order (type, then case-insensitive name). No campaign is CodeNotFound;
 // a storage failure is CodeInternal.
-func (s *CampaignServer) ListNodes(
+func (s *kgNodes) ListNodes(
 	ctx context.Context,
 	_ *connect.Request[managementv1.ListNodesRequest],
 ) (*connect.Response[managementv1.ListNodesResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -89,7 +105,7 @@ func (s *CampaignServer) ListNodes(
 // UpdateNode saves a Node's editor fields (name/body/gm_private) and returns the
 // updated Node. node_type is immutable, so it is never sent nor changed. An empty
 // name or an unparsable id is CodeInvalidArgument; a missing id is CodeNotFound.
-func (s *CampaignServer) UpdateNode(
+func (s *kgNodes) UpdateNode(
 	ctx context.Context,
 	req *connect.Request[managementv1.UpdateNodeRequest],
 ) (*connect.Response[managementv1.UpdateNodeResponse], error) {
@@ -105,7 +121,7 @@ func (s *CampaignServer) UpdateNode(
 	// Resolve the active campaign and scope the write to it (#342): the store's
 	// UPDATE matches (id, campaign_id), so a Node in another campaign is never
 	// mutable through this session — it reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -133,7 +149,7 @@ func (s *CampaignServer) UpdateNode(
 
 // DeleteNode removes a Node by id. An unparsable id is CodeInvalidArgument; a
 // missing id is CodeNotFound; a storage failure is CodeInternal.
-func (s *CampaignServer) DeleteNode(
+func (s *kgNodes) DeleteNode(
 	ctx context.Context,
 	req *connect.Request[managementv1.DeleteNodeRequest],
 ) (*connect.Response[managementv1.DeleteNodeResponse], error) {
@@ -145,7 +161,7 @@ func (s *CampaignServer) DeleteNode(
 	// Resolve the active campaign and scope the delete to it (#342): the store's
 	// DELETE matches (id, campaign_id), so a Node in another campaign is never
 	// removable through this session — it reads back as CodeNotFound.
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -174,7 +190,7 @@ const searchNodesLimit = 50
 // Nodes are INCLUDED (GM-facing search). An empty/whitespace query is
 // CodeInvalidArgument; no campaign is CodeNotFound; a storage failure is
 // CodeInternal.
-func (s *CampaignServer) SearchNodes(
+func (s *kgNodes) SearchNodes(
 	ctx context.Context,
 	req *connect.Request[managementv1.SearchNodesRequest],
 ) (*connect.Response[managementv1.SearchNodesResponse], error) {
@@ -182,7 +198,7 @@ func (s *CampaignServer) SearchNodes(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("query must not be empty"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))

--- a/internal/rpc/kg_node_test.go
+++ b/internal/rpc/kg_node_test.go
@@ -8,14 +8,31 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
+// kgNodeClient composes a CampaignServer over just the KG-Node slice (#445):
+// one fakeKGNodeStore serves both Active (via the embedded *fakeActive) and
+// KGNodes.
+func kgNodeClient(t *testing.T, store *fakeKGNodeStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, KGNodes: store})
+}
+
+// kgNodeClientAs is kgNodeClient plus an injected authenticated user and an
+// optional live Voice Session source, for the #222 scope-resolution tests.
+func kgNodeClientAs(t *testing.T, store *fakeKGNodeStore, user storage.User, sessions *fakeSessionManager) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClientAs(t, rpc.CampaignStores{Active: store, KGNodes: store}, user, uuid.Nil, sessions)
+}
+
 func TestCreateNode_MapsAndPersists(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -51,9 +68,9 @@ func TestCreateNode_MapsAndPersists(t *testing.T) {
 
 func TestCreateNode_TrimsName(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -74,9 +91,9 @@ func TestCreateNode_TrimsName(t *testing.T) {
 
 func TestCreateNode_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{Name: "x"})) // type unset = UNSPECIFIED
@@ -87,9 +104,9 @@ func TestCreateNode_UnspecifiedTypeIsInvalidArgument(t *testing.T) {
 
 func TestCreateNode_EmptyNameIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -102,10 +119,10 @@ func TestCreateNode_EmptyNameIsInvalidArgument(t *testing.T) {
 
 func TestCreateNode_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.nodeCreateErr = errAny
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -119,14 +136,14 @@ func TestCreateNode_StorageErrorIsInternal(t *testing.T) {
 func TestListNodes_MapsInStorageOrder(t *testing.T) {
 	t.Parallel()
 	campID := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine"}
 	// The storage layer owns the ordering; the handler must preserve it 1:1.
 	store.nodes = []storage.KGNode{
 		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodeLocation, Name: "Barrow"},
 		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodeNote, Name: "Rumor", Body: "hush", GMPrivate: true},
 	}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.ListNodes(context.Background(),
 		connect.NewRequest(&managementv1.ListNodesRequest{}))
@@ -147,9 +164,9 @@ func TestListNodes_MapsInStorageOrder(t *testing.T) {
 
 func TestListNodes_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.ListNodes(context.Background(),
 		connect.NewRequest(&managementv1.ListNodesRequest{}))
@@ -160,10 +177,10 @@ func TestListNodes_NoCampaignIsNotFound(t *testing.T) {
 
 func TestListNodes_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.nodeListErr = errAny
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.ListNodes(context.Background(),
 		connect.NewRequest(&managementv1.ListNodesRequest{}))
@@ -175,11 +192,11 @@ func TestListNodes_StorageErrorIsInternal(t *testing.T) {
 func TestUpdateNode_MapsAndPersists(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodes = []storage.KGNode{
 		{ID: id, CampaignID: uuid.New(), Type: storage.KGNodeLocation, Name: "Harbor", Body: "old"},
 	}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{
@@ -205,9 +222,9 @@ func TestUpdateNode_MapsAndPersists(t *testing.T) {
 func TestUpdateNode_TrimsName(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "old"}}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "  Alice  "}))
@@ -225,9 +242,9 @@ func TestUpdateNode_TrimsName(t *testing.T) {
 func TestUpdateNode_EmptyNameIsInvalidArgument(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "x"}}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "   "}))
@@ -238,8 +255,8 @@ func TestUpdateNode_EmptyNameIsInvalidArgument(t *testing.T) {
 
 func TestUpdateNode_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeKGNodeStore()
+	client := kgNodeClient(t, store)
 
 	_, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: "not-a-uuid", Name: "x"}))
@@ -250,8 +267,8 @@ func TestUpdateNode_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestUpdateNode_NotFoundIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore() // no nodes seeded
-	client := crudClient(t, store)
+	store := newFakeKGNodeStore() // no nodes seeded
+	client := kgNodeClient(t, store)
 
 	_, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
@@ -265,9 +282,9 @@ func TestUpdateNode_NotFoundIsNotFound(t *testing.T) {
 // CodeNotFound rather than mutating by bare id.
 func TestUpdateNode_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
@@ -278,9 +295,9 @@ func TestUpdateNode_NoActiveCampaignIsNotFound(t *testing.T) {
 
 func TestUpdateNode_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodeUpdateErr = errAny
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: uuid.NewString(), Name: "x"}))
@@ -292,9 +309,9 @@ func TestUpdateNode_StorageErrorIsInternal(t *testing.T) {
 func TestDeleteNode_Deletes(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "gone soon"}}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	if _, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: id.String()})); err != nil {
@@ -307,8 +324,8 @@ func TestDeleteNode_Deletes(t *testing.T) {
 
 func TestDeleteNode_InvalidIdIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeKGNodeStore()
+	client := kgNodeClient(t, store)
 
 	_, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: "nope"}))
@@ -319,8 +336,8 @@ func TestDeleteNode_InvalidIdIsInvalidArgument(t *testing.T) {
 
 func TestDeleteNode_NotFoundIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
-	client := crudClient(t, store)
+	store := newFakeKGNodeStore()
+	client := kgNodeClient(t, store)
 
 	_, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
@@ -331,9 +348,9 @@ func TestDeleteNode_NotFoundIsNotFound(t *testing.T) {
 
 func TestDeleteNode_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.nodeDeleteErr = errAny
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
@@ -348,11 +365,11 @@ func TestDeleteNode_StorageErrorIsInternal(t *testing.T) {
 func TestUpdateNode_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "old"}}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	if _, err := client.UpdateNode(context.Background(),
 		connect.NewRequest(&managementv1.UpdateNodeRequest{Id: id.String(), Name: "New"})); err != nil {
@@ -368,11 +385,11 @@ func TestUpdateNode_ScopesToActiveCampaign(t *testing.T) {
 func TestDeleteNode_ScopesToActiveCampaign(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	activeID := uuid.New()
 	store.campaign = storage.Campaign{ID: activeID}
 	store.nodes = []storage.KGNode{{ID: id, Type: storage.KGNodeNote, Name: "gone soon"}}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	if _, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: id.String()})); err != nil {
@@ -387,9 +404,9 @@ func TestDeleteNode_ScopesToActiveCampaign(t *testing.T) {
 // scoped delete cannot resolve an owner and returns CodeNotFound.
 func TestDeleteNode_NoActiveCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.DeleteNode(context.Background(),
 		connect.NewRequest(&managementv1.DeleteNodeRequest{Id: uuid.NewString()}))
@@ -400,9 +417,9 @@ func TestDeleteNode_NoActiveCampaignIsNotFound(t *testing.T) {
 
 func TestSearchNodes_EmptyQueryIsInvalidArgument(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	for _, q := range []string{"", "   "} {
 		_, err := client.SearchNodes(context.Background(),
@@ -420,7 +437,7 @@ func TestSearchNodes_EmptyQueryIsInvalidArgument(t *testing.T) {
 func TestSearchNodes_PreservesRankOrderAndIncludesPrivate(t *testing.T) {
 	t.Parallel()
 	campID := uuid.New()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: campID, Name: "Lost Mine"}
 	// Storage owns the relevance ranking; the handler must preserve it 1:1 and must
 	// NOT drop the gm_private match (GM-facing search).
@@ -429,7 +446,7 @@ func TestSearchNodes_PreservesRankOrderAndIncludesPrivate(t *testing.T) {
 		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodePlotThread, Name: "The dragon's true name", GMPrivate: true},
 		{ID: uuid.New(), CampaignID: campID, Type: storage.KGNodeNote, Name: "Rumor", Body: "a dragon"},
 	}
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	resp, err := client.SearchNodes(context.Background(),
 		connect.NewRequest(&managementv1.SearchNodesRequest{Query: "dragon"}))
@@ -457,9 +474,9 @@ func TestSearchNodes_PreservesRankOrderAndIncludesPrivate(t *testing.T) {
 
 func TestSearchNodes_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.SearchNodes(context.Background(),
 		connect.NewRequest(&managementv1.SearchNodesRequest{Query: "x"}))
@@ -470,10 +487,10 @@ func TestSearchNodes_NoCampaignIsNotFound(t *testing.T) {
 
 func TestSearchNodes_StorageErrorIsInternal(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.nodeSearchErr = errAny
-	client := crudClient(t, store)
+	client := kgNodeClient(t, store)
 
 	_, err := client.SearchNodes(context.Background(),
 		connect.NewRequest(&managementv1.SearchNodesRequest{Query: "x"}))
@@ -490,10 +507,10 @@ func TestCreateNodeHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
 
 	if _, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -516,10 +533,10 @@ func TestListNodesHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
 
 	if _, err := client.ListNodes(context.Background(),
 		connect.NewRequest(&managementv1.ListNodesRequest{})); err != nil {
@@ -538,10 +555,10 @@ func TestSearchNodesHonorsDurableSelection(t *testing.T) {
 	t.Parallel()
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, nil)
 
 	if _, err := client.SearchNodes(context.Background(),
 		connect.NewRequest(&managementv1.SearchNodesRequest{Query: "vault"})); err != nil {
@@ -561,11 +578,11 @@ func TestCreateNodeHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
 
 	if _, err := client.CreateNode(context.Background(),
 		connect.NewRequest(&managementv1.CreateNodeRequest{
@@ -589,11 +606,11 @@ func TestListNodesHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
 
 	if _, err := client.ListNodes(context.Background(),
 		connect.NewRequest(&managementv1.ListNodesRequest{})); err != nil {
@@ -612,11 +629,11 @@ func TestSearchNodesHonorsLiveSession(t *testing.T) {
 	live := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Live L"}
 	durable := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Durable D"}
 	newer := storage.Campaign{ID: uuid.New(), TenantID: uuid.New(), Name: "Newer N"}
-	store := newFakeStore()
+	store := newFakeKGNodeStore()
 	store.forUser = durable
 	store.campaign = newer
 	store.campaignsByID = map[uuid.UUID]storage.Campaign{live.ID: live}
-	client := crudClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
+	client := kgNodeClientAs(t, store, storage.User{DiscordUserID: "999"}, liveMgr(live.ID))
 
 	if _, err := client.SearchNodes(context.Background(),
 		connect.NewRequest(&managementv1.SearchNodesRequest{Query: "vault"})); err != nil {

--- a/internal/rpc/knowledge_proposal.go
+++ b/internal/rpc/knowledge_proposal.go
@@ -19,13 +19,45 @@ import (
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 )
 
-// Knowledge Proposal review handlers (#300, ADR-0052) on CampaignServer: the GM
-// review surface for the pending queue an Agent's remember_knowledge call files
-// into. List renders each proposal (parsing the jsonb write into a oneof), approve
-// lands the write atomically, reject drops it, and the similarity hint surfaces
-// existing Nodes near a proposal's subject so the GM merges rather than duplicates
-// (similarity is a HINT — no auto-merge, ADR-0052). They resolve the single
-// operator's active campaign server-side (ADR-0039), like the KG Node handlers.
+// knowledgeProposals is the Knowledge Proposal review feature module (#300,
+// ADR-0052): the GM review surface for the pending queue an Agent's
+// remember_knowledge call files into. List renders each proposal (parsing the
+// jsonb write into a oneof), approve lands the write atomically, reject drops it,
+// and the similarity hint surfaces existing Nodes near a proposal's subject so
+// the GM merges rather than duplicates (similarity is a HINT — no auto-merge,
+// ADR-0052). The handlers resolve the single operator's active campaign
+// server-side (ADR-0039), like the KG Node handlers.
+type knowledgeProposals struct {
+	store  knowledgeProposalStore
+	active *activeCampaignSource
+	// embedder embeds a proposal's subject text for the ListSimilarKnowledge vector
+	// hint (#300, ADR-0011/0052). Nil (no embeddings provider wired, or a keyless
+	// deployment) makes the hint degrade silently to fulltext SearchNodes. Set once
+	// at boot before serving, so no lock is needed.
+	embedder Embedder
+}
+
+// knowledgeProposalStore is the narrow review-queue surface the module needs
+// (#300, ADR-0052); *storage.Store satisfies it: the pending list, the
+// single-proposal read the similarity hint keys off, the atomic approve/reject
+// writes, and the two similarity searches the hint runs.
+type knowledgeProposalStore interface {
+	ListPendingKnowledgeProposals(ctx context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error)
+	GetPendingKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) (storage.KnowledgeProposal, error)
+	ApproveKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
+	RejectKnowledgeProposal(ctx context.Context, campaignID, id uuid.UUID) error
+	// SimilarNodes is the embedding-vector nearest-neighbour search; SearchNodes is
+	// the fulltext fallback the hint degrades to without an embedder (ADR-0011).
+	SimilarNodes(ctx context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.KGNode, error)
+	SearchNodes(ctx context.Context, campaignID uuid.UUID, query string, limit int) ([]storage.KGNode, error)
+}
+
+// Embedder embeds short texts to query vectors for the Knowledge Proposal
+// similarity hint (#300, ADR-0052). The resolved embeddings provider satisfies it;
+// nil disables the vector path (the hint falls back to fulltext search).
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+}
 
 // similarEmbedTimeout bounds the ListSimilarKnowledge embedding call — the hint is
 // nice-to-have, so a slow provider must not hang the review surface; on timeout it
@@ -39,11 +71,11 @@ const similarNodesLimit = 5
 // oldest-first, each with its authoring Agent's name and its parsed write. An
 // unparseable jsonb row is still listed (write oneof left UNSET) so the GM can
 // reject it. No campaign is CodeNotFound; a storage failure is CodeInternal.
-func (s *CampaignServer) ListKnowledgeProposals(
+func (s *knowledgeProposals) ListKnowledgeProposals(
 	ctx context.Context,
 	_ *connect.Request[managementv1.ListKnowledgeProposalsRequest],
 ) (*connect.Response[managementv1.ListKnowledgeProposalsResponse], error) {
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -69,7 +101,7 @@ func (s *CampaignServer) ListKnowledgeProposals(
 // approved. An unparsable id is CodeInvalidArgument; a missing/already-reviewed id
 // is CodeNotFound; a refused write is CodeFailedPrecondition carrying the storage
 // reason verbatim so the GM sees exactly what to fix.
-func (s *CampaignServer) ApproveKnowledgeProposal(
+func (s *knowledgeProposals) ApproveKnowledgeProposal(
 	ctx context.Context,
 	req *connect.Request[managementv1.ApproveKnowledgeProposalRequest],
 ) (*connect.Response[managementv1.ApproveKnowledgeProposalResponse], error) {
@@ -78,7 +110,7 @@ func (s *CampaignServer) ApproveKnowledgeProposal(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -105,7 +137,7 @@ func (s *CampaignServer) ApproveKnowledgeProposal(
 // RejectKnowledgeProposal drops a pending proposal without touching the KG. An
 // unparsable id is CodeInvalidArgument; a missing/already-reviewed id is
 // CodeNotFound.
-func (s *CampaignServer) RejectKnowledgeProposal(
+func (s *knowledgeProposals) RejectKnowledgeProposal(
 	ctx context.Context,
 	req *connect.Request[managementv1.RejectKnowledgeProposalRequest],
 ) (*connect.Response[managementv1.RejectKnowledgeProposalResponse], error) {
@@ -114,7 +146,7 @@ func (s *CampaignServer) RejectKnowledgeProposal(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -141,7 +173,7 @@ func (s *CampaignServer) RejectKnowledgeProposal(
 // nearest-neighbour search; with no provider OR any failure (embed error/timeout)
 // it degrades SILENTLY to fulltext SearchNodes — the hint is best-effort and must
 // never fail the review.
-func (s *CampaignServer) ListSimilarKnowledge(
+func (s *knowledgeProposals) ListSimilarKnowledge(
 	ctx context.Context,
 	req *connect.Request[managementv1.ListSimilarKnowledgeRequest],
 ) (*connect.Response[managementv1.ListSimilarKnowledgeResponse], error) {
@@ -150,7 +182,7 @@ func (s *CampaignServer) ListSimilarKnowledge(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid proposal id"))
 	}
 
-	c, err := s.activeCampaign(ctx)
+	c, err := s.active.resolve(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
@@ -186,7 +218,7 @@ func (s *CampaignServer) ListSimilarKnowledge(
 // similarNodes runs the vector nearest-neighbour search when an embedder is wired
 // and the embed succeeds; otherwise it degrades silently to fulltext SearchNodes.
 // A whitespace-only query short-circuits to no hits (SearchNodes would reject it).
-func (s *CampaignServer) similarNodes(ctx context.Context, campaignID uuid.UUID, queryText string) ([]storage.KGNode, error) {
+func (s *knowledgeProposals) similarNodes(ctx context.Context, campaignID uuid.UUID, queryText string) ([]storage.KGNode, error) {
 	if strings.TrimSpace(queryText) == "" {
 		return nil, nil
 	}

--- a/internal/rpc/knowledge_proposal_test.go
+++ b/internal/rpc/knowledge_proposal_test.go
@@ -12,45 +12,26 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/tool"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/embeddings"
 )
 
-// --- fakeCampaignStore proposal-review methods (#300) ---
-
-func (f *fakeCampaignStore) ListPendingKnowledgeProposals(_ context.Context, campaignID uuid.UUID) ([]storage.KnowledgeProposal, error) {
-	f.listProposalsCampaign = campaignID
-	return f.pendingProposals, f.listProposalsErr
+// proposalClient composes a CampaignService client over the Knowledge Proposal
+// review slice (#300): one fakeProposalStore serves both Active (via the
+// embedded *fakeActive) and Proposals.
+func proposalClient(t *testing.T, store *fakeProposalStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, Proposals: store})
 }
 
-func (f *fakeCampaignStore) GetPendingKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) (storage.KnowledgeProposal, error) {
-	f.getProposalCampaign = campaignID
-	if f.getProposalErr != nil {
-		return storage.KnowledgeProposal{}, f.getProposalErr
-	}
-	return f.getProposal, nil
-}
-
-func (f *fakeCampaignStore) ApproveKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
-	f.approveCampaign = campaignID
-	f.approveCalls = append(f.approveCalls, id)
-	return f.approveErr
-}
-
-func (f *fakeCampaignStore) RejectKnowledgeProposal(_ context.Context, campaignID, id uuid.UUID) error {
-	f.rejectCampaign = campaignID
-	f.rejectCalls = append(f.rejectCalls, id)
-	return f.rejectErr
-}
-
-func (f *fakeCampaignStore) SimilarNodes(_ context.Context, campaignID uuid.UUID, query []float32, k int) ([]storage.KGNode, error) {
-	f.similarCalls++
-	f.similarQueryVec = query
-	if f.similarErr != nil {
-		return nil, f.similarErr
-	}
-	return f.similarResults, nil
+// proposalClientWithEmbedder is proposalClient with a wired Embedder so the
+// ListSimilarKnowledge vector path (#300) is exercised.
+func proposalClientWithEmbedder(t *testing.T, store *fakeProposalStore, emb rpc.Embedder) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClientWithEmbedder(t, rpc.CampaignStores{Active: store, Proposals: store}, emb)
 }
 
 // fakeEmbedder records its input texts and returns a fixed vector (or an error).
@@ -82,7 +63,7 @@ func proposalRaw(t *testing.T, w tool.ProposedWrite) json.RawMessage {
 // fact/edge/node and that an unparseable row is still listed with an unset write.
 func TestListKnowledgeProposals_MapsThreeKinds(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Lost Mine"}
 	store.pendingProposals = []storage.KnowledgeProposal{
 		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Bart", CreatedAt: time.Now(),
@@ -94,7 +75,7 @@ func TestListKnowledgeProposals_MapsThreeKinds(t *testing.T) {
 		{ID: uuid.New(), AuthoringAgentID: uuid.New(), AuthoringAgentName: "Glyphoxa", CreatedAt: time.Now(),
 			ProposedWrite: json.RawMessage(`{"garbage":true}`)},
 	}
-	client := crudClient(t, store)
+	client := proposalClient(t, store)
 
 	resp, err := client.ListKnowledgeProposals(context.Background(),
 		connect.NewRequest(&managementv1.ListKnowledgeProposalsRequest{}))
@@ -125,9 +106,9 @@ func TestListKnowledgeProposals_MapsThreeKinds(t *testing.T) {
 
 func TestListKnowledgeProposals_NoCampaignIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := proposalClient(t, store)
 	_, err := client.ListKnowledgeProposals(context.Background(),
 		connect.NewRequest(&managementv1.ListKnowledgeProposalsRequest{}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -140,9 +121,9 @@ func TestApproveKnowledgeProposal_ErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		_, err := client.ApproveKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: "not-a-uuid"}))
 		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -151,9 +132,9 @@ func TestApproveKnowledgeProposal_ErrorMapping(t *testing.T) {
 	})
 
 	t.Run("happy path scopes to active campaign", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		id := uuid.New()
 		if _, err := client.ApproveKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: id.String()})); err != nil {
@@ -165,10 +146,10 @@ func TestApproveKnowledgeProposal_ErrorMapping(t *testing.T) {
 	})
 
 	t.Run("not found is NotFound", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
 		store.approveErr = storage.ErrNotFound
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		_, err := client.ApproveKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: uuid.New().String()}))
 		if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -177,10 +158,10 @@ func TestApproveKnowledgeProposal_ErrorMapping(t *testing.T) {
 	})
 
 	t.Run("blocked is FailedPrecondition with verbatim reason", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
 		store.approveErr = &storage.ProposalBlockedError{Reason: `no wiki entry named "Waterdeep" — create it first, then approve; or reject`}
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		_, err := client.ApproveKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.ApproveKnowledgeProposalRequest{Id: uuid.New().String()}))
 		if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
@@ -196,9 +177,9 @@ func TestRejectKnowledgeProposal_ErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		_, err := client.RejectKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: "x"}))
 		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
@@ -207,10 +188,10 @@ func TestRejectKnowledgeProposal_ErrorMapping(t *testing.T) {
 	})
 
 	t.Run("not found is NotFound", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
 		store.rejectErr = storage.ErrNotFound
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		_, err := client.RejectKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: uuid.New().String()}))
 		if got := connect.CodeOf(err); got != connect.CodeNotFound {
@@ -219,9 +200,9 @@ func TestRejectKnowledgeProposal_ErrorMapping(t *testing.T) {
 	})
 
 	t.Run("happy path forwards id", func(t *testing.T) {
-		store := newFakeStore()
+		store := newFakeProposalStore()
 		store.campaign = storage.Campaign{ID: uuid.New()}
-		client := crudClient(t, store)
+		client := proposalClient(t, store)
 		id := uuid.New()
 		if _, err := client.RejectKnowledgeProposal(context.Background(),
 			connect.NewRequest(&managementv1.RejectKnowledgeProposalRequest{Id: id.String()})); err != nil {
@@ -237,14 +218,14 @@ func TestRejectKnowledgeProposal_ErrorMapping(t *testing.T) {
 // is embedded and SimilarNodes is queried with the resulting vector.
 func TestListSimilarKnowledge_EmbedderPath(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.getProposal = storage.KnowledgeProposal{
 		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"}),
 	}
 	store.similarResults = []storage.KGNode{{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}}
 	emb := &fakeEmbedder{vec: make([]float32, embeddings.Dim)} // correct dimension → vector path
-	client := crudClientWithEmbedder(t, store, emb)
+	client := proposalClientWithEmbedder(t, store, emb)
 
 	resp, err := client.ListSimilarKnowledge(context.Background(),
 		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
@@ -267,13 +248,13 @@ func TestListSimilarKnowledge_EmbedderPath(t *testing.T) {
 // on the ::vector cast.
 func TestListSimilarKnowledge_WrongDimFallsBackToFTS(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.getProposal = storage.KnowledgeProposal{
 		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "fact", Subject: "Bart", Fact: "Fears dark"}),
 	}
 	emb := &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}} // 3 dims, not embeddings.Dim
-	client := crudClientWithEmbedder(t, store, emb)
+	client := proposalClientWithEmbedder(t, store, emb)
 
 	if _, err := client.ListSimilarKnowledge(context.Background(),
 		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()})); err != nil {
@@ -291,13 +272,13 @@ func TestListSimilarKnowledge_WrongDimFallsBackToFTS(t *testing.T) {
 // runs SearchNodes with the subject text.
 func TestListSimilarKnowledge_NilEmbedderFallsBackToFTS(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.getProposal = storage.KnowledgeProposal{
 		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "node", Name: "Zhent", Body: "shadow"}),
 	}
 	store.searchResults = []storage.KGNode{{ID: uuid.New(), Type: storage.KGNodeFaction, Name: "Zhentarim"}}
-	client := crudClient(t, store) // no embedder
+	client := proposalClient(t, store) // no embedder
 
 	resp, err := client.ListSimilarKnowledge(context.Background(),
 		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
@@ -319,13 +300,13 @@ func TestListSimilarKnowledge_NilEmbedderFallsBackToFTS(t *testing.T) {
 // silently to fulltext search rather than failing the review.
 func TestListSimilarKnowledge_EmbedErrorFallsBackToFTS(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.getProposal = storage.KnowledgeProposal{
 		ID: uuid.New(), ProposedWrite: proposalRaw(t, tool.ProposedWrite{V: 1, Kind: "edge", Subject: "Bart", Relation: "knows", Target: "Gundren"}),
 	}
 	emb := &fakeEmbedder{err: errors.New("provider down")}
-	client := crudClientWithEmbedder(t, store, emb)
+	client := proposalClientWithEmbedder(t, store, emb)
 
 	if _, err := client.ListSimilarKnowledge(context.Background(),
 		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()})); err != nil {
@@ -343,10 +324,10 @@ func TestListSimilarKnowledge_EmbedErrorFallsBackToFTS(t *testing.T) {
 // proposal is CodeNotFound.
 func TestListSimilarKnowledge_MissingProposalIsNotFound(t *testing.T) {
 	t.Parallel()
-	store := newFakeStore()
+	store := newFakeProposalStore()
 	store.campaign = storage.Campaign{ID: uuid.New()}
 	store.getProposalErr = storage.ErrNotFound
-	client := crudClient(t, store)
+	client := proposalClient(t, store)
 	_, err := client.ListSimilarKnowledge(context.Background(),
 		connect.NewRequest(&managementv1.ListSimilarKnowledgeRequest{ProposalId: uuid.New().String()}))
 	if got := connect.CodeOf(err); got != connect.CodeNotFound {

--- a/internal/rpc/voice_members.go
+++ b/internal/rpc/voice_members.go
@@ -22,7 +22,7 @@ type voiceMemberLister func(ctx context.Context) ([]presence.Member, error)
 // needed. Left nil on a keyless / bot-offline deployment, in which case
 // ListDiscordVoiceMembers returns an empty list.
 func (s *CampaignServer) SetMemberLister(l voiceMemberLister) {
-	s.characterRoster.memberLister = l
+	s.memberLister = l
 }
 
 // ListDiscordVoiceMembers returns the Discord Users currently in the operator's

--- a/internal/rpc/voice_members.go
+++ b/internal/rpc/voice_members.go
@@ -22,7 +22,7 @@ type voiceMemberLister func(ctx context.Context) ([]presence.Member, error)
 // needed. Left nil on a keyless / bot-offline deployment, in which case
 // ListDiscordVoiceMembers returns an empty list.
 func (s *CampaignServer) SetMemberLister(l voiceMemberLister) {
-	s.memberLister = l
+	s.characterRoster.memberLister = l
 }
 
 // ListDiscordVoiceMembers returns the Discord Users currently in the operator's
@@ -32,7 +32,7 @@ func (s *CampaignServer) SetMemberLister(l voiceMemberLister) {
 // and never an error, so the picker degrades to free-text snowflake entry
 // (ADR-0003). No privileged intent is used — the members come from the
 // voice-state cache the Bot already receives.
-func (s *CampaignServer) ListDiscordVoiceMembers(
+func (s *characterRoster) ListDiscordVoiceMembers(
 	ctx context.Context,
 	_ *connect.Request[managementv1.ListDiscordVoiceMembersRequest],
 ) (*connect.Response[managementv1.ListDiscordVoiceMembersResponse], error) {

--- a/internal/rpc/voice_members_test.go
+++ b/internal/rpc/voice_members_test.go
@@ -3,8 +3,6 @@ package rpc_test
 import (
 	"context"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -20,22 +18,17 @@ import (
 // member lister wired (nil = no standing presence). The Players panel picker
 // (#279) reads ListDiscordVoiceMembers, which must degrade to an empty list — not
 // an error — whenever the Bot can't answer, so the UI falls back to free-text.
+// The RPC touches no store slice, so the server composes empty CampaignStores (#445).
 func voiceMembersClient(
 	t *testing.T,
 	lister func(ctx context.Context) ([]presence.Member, error),
 ) managementv1connect.CampaignServiceClient {
 	t.Helper()
-	srv := rpc.NewCampaignServer(newFakeStore())
+	srv := rpc.NewCampaignServerWith(rpc.CampaignStores{})
 	if lister != nil {
 		srv.SetMemberLister(lister)
 	}
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler())
-	s := httptest.NewServer(mux)
-	t.Cleanup(s.Close)
-	return managementv1connect.NewCampaignServiceClient(
-		http.DefaultClient, s.URL, connect.WithProtoJSON(),
-	)
+	return campaignClientServe(t, srv)
 }
 
 // A nil lister (no standing presence) or a lister failure (offline Bot) yields an

--- a/internal/storage/active_campaign_test.go
+++ b/internal/storage/active_campaign_test.go
@@ -256,3 +256,52 @@ func TestUpdateCampaign(t *testing.T) {
 		t.Errorf("UpdateCampaign(random) = %v, want ErrNotFound", err)
 	}
 }
+
+// TestUpdateCampaignLanguageLeavesAgentVoiceUntouched is the DB half of the #268
+// decision: a Campaign Language edit mutates NOTHING downstream — no statement or
+// trigger on the campaign UPDATE rewrites agents.voice, so an Agent's persisted
+// voice blob stays byte-identical. The handler half is structural since #445 (the
+// rpc management store slice cannot even name an Agent write); this pins the SQL
+// layer, guarding against a future migration/trigger that would re-derive every
+// Agent's voice from the new language (the first-save seeding lives ONLY on the
+// agent-write path, #224).
+func TestUpdateCampaignLanguageLeavesAgentVoiceUntouched(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campID := seedCampaign(t, dsn) // seeded in language "en", auto-Butler fired
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Give the auto-Butler a concrete voice via the agent-write path — the one
+	// place a language may legitimately seed voice defaults (#224).
+	butler, err := st.GetButler(ctx, campID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	seeded, err := st.UpdateAgent(ctx, storage.AgentUpdate{
+		ID: butler.ID, CampaignID: campID, Name: butler.Name, Title: butler.Title,
+		Persona: butler.Persona, AddressOnly: butler.AddressOnly, Aliases: butler.Aliases,
+		Voice: []byte(`{"provider_id":"elevenlabs","voice_id":"v-268","language":"en"}`),
+	})
+	if err != nil {
+		t.Fatalf("UpdateAgent(seed voice): %v", err)
+	}
+	if len(seeded.Voice) == 0 {
+		t.Fatalf("precondition: Butler voice not seeded, got %q", string(seeded.Voice))
+	}
+
+	// The change under test: Campaign Language en -> de.
+	if _, err := st.UpdateCampaign(ctx, storage.CampaignUpdate{
+		ID: campID, Name: "Lost Mine", System: "dnd5e", Language: "de",
+	}); err != nil {
+		t.Fatalf("UpdateCampaign(lang en->de): %v", err)
+	}
+
+	after, err := st.GetAgent(ctx, butler.ID)
+	if err != nil {
+		t.Fatalf("GetAgent(after): %v", err)
+	}
+	if string(after.Voice) != string(seeded.Voice) {
+		t.Errorf("Butler voice changed on a language edit:\n before = %s\n after  = %s",
+			string(seeded.Voice), string(after.Voice))
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #445.

Removes the 39-method `campaignStore` god-interface from `internal/rpc`. `CampaignServer` is now a composition of eight feature modules — `campaignManagement` (list/create/update, durable selection, header read, languages), `campaignArchive`, `agentRoster`, `characterRoster` (PC CRUD + voice-member picker), `kgNodes`, `kgEdges`, `knowledgeProposals`, `toolGrants` — each declaring the 3–6-method store slice it actually consumes (consumer-defined, satisfied structurally by `*storage.Store`, the same pattern `providerStore`/`voiceStore`/`SessionStore` already use). Module RPC methods promote onto the unchanged `managementv1connect.CampaignServiceHandler` via pointer embedding, so it is still one CampaignService behind one interceptor stack — **no proto/wire change**.

A shared `*activeCampaignSource` (in `active_campaign.go`) carries the live-Voice-Session closure plus the existing 3-method `activeCampaignResolver`, so `SetSessions` wires every surface at once, exactly as before; the archive live-guard reads the same single source of session truth. `NewCampaignServer(*storage.Store)` keeps its call shape (`cmd/glyphoxa/main.go` is untouched); the new `NewCampaignServerWith(CampaignStores{…})` lets a test compose only the slices its feature exercises.

Handler bodies moved verbatim — same store-call order, error codes, messages, and slog lines.

## Why is this change needed?

Per the 2026-07-14 architecture review (issue #445): every handler depended on the whole 39-method surface, so a unit-test fake needed all 39 methods, which is why 8 `*_integration_test.go` suites needed live Postgres and the package doc's "handlers depend on narrow reader interfaces" claim was aspirational. After this split:

- **Fakes are writable per feature** — `fakes_test.go` holds one small fake per slice (each embedding the 3-method `fakeActive`), replacing `fakeReader` (36 dead stubs) and the ~70-config-field `fakeCampaignStore`.
- **Locality returns** — a Character-CRUD change no longer touches KG fakes.
- **No interface in `internal/rpc` has more than 8 store methods** (largest campaign slice: 6; pre-existing `providerStore`: 8).
- A future regression like "campaign update re-seeds agent voices" (#268) is now **structurally impossible at the handler layer**: the management slice cannot even name an Agent write.

## How was this tested?

- All **170 unit tests preserved verbatim** (verified per-file test-count parity against `main`) — only construction plumbing changed to per-feature fakes.
- Postgres-bound integration tests shrink **15 → 10**, keeping every genuinely SQL-shaped suite (auto-Butler trigger, seed-migration grants, ORDER BY, archive resolution filters, FK cascades, unique constraints, KG joins, cross-campaign write scoping). Each deleted test has an executable twin:
  - `TestGetActiveCampaign_Integration` → keyless mapping suite in `campaign_test.go` (strictly stronger assertions).
  - `TestSetActiveCampaignLiveFirst_Integration` → `TestSetActiveCampaignLiveFirstWins` (asserts both the lockstep durable write and live-first resolution).
  - `TestListToolGrants_CrossCampaign_Integration` → `TestListToolGrants_CrossCampaignIsNotFound` (the scoping is handler-level; the write-side DB test remains).
  - `TestListNodeEdges_CrossCampaign_Integration` → `TestListNodeEdges_CrossCampaignIsNotFound` + storage-level `TestNodeEdgesCrossCampaignRefused`.
  - `TestUpdateCampaignLanguage_LeavesAgentVoiceUntouched` → the DB half moved to `internal/storage` as `TestUpdateCampaignLanguageLeavesAgentVoiceUntouched` (the SQL is the subject there); the handler half is structural as above.
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./internal/rpc/ ./internal/storage/`, `gofmt` all clean; `go test -race -count=1 ./...` green except the pre-existing `TestB3_HangoverTuning_CorpusSegmentation` ONNX-download failure, which fails identically on `main` in this sandbox (blocked network) and is unrelated.
- Integration suites compile under the tag but need Docker/Postgres, unavailable in this environment — please rely on CI for the tagged run.

- [x] `make check` passes (fmt/vet/test; see ONNX caveat above)
- [x] New/updated tests cover the change
- [ ] Manual testing (not applicable — behavior-preserving refactor pinned by the existing suites)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (pre-existing ONNX sandbox failure aside)
- [x] I have updated documentation if needed (package doc now states the per-feature-slice pattern; no Markdown docs referenced the old shape — the split stays inside `internal/rpc`, so `docs/architecture.md` §4.2 remains accurate)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- Slice method totals sum to 39 with three deliberate consumer-side duplications (`GetCampaign` in resolver + management, `GetAgent` in roster + grants, `SearchNodes` in KG nodes + proposals-fallback) — each consumer names what it reads, per the pattern.
- An adversarial multi-lens review of the diff (behavior preservation, composition/promotion correctness, fake fidelity, test fidelity, docs rot) confirmed no wire-behavior drift; its only findings were the #268 DB-guard gap (fixed by the new storage test) and one pre-existing stale doc comment in `highlight_test.go` (fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCtfaeoXU1CPZp1T2vhQKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCtfaeoXU1CPZp1T2vhQKc)_