### PR TITLE
refactor(#446): one auth policy behind the Connect and net/http adapters

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -143,7 +143,8 @@ var proxyHeaders = []string{"X-Forwarded-For", "X-Forwarded-Proto", "Forwarded"}
 // (ADR-0041 GLYPHOXA_DEV_MODE). It upserts the fixed synthetic operator
 // ([storage.DevOperatorDiscordID]), binds/creates its tenant, and mints a
 // session + CSRF token — the same row shape the OAuth callback produces — so the
-// existing interceptor stack + RequireSession + CSRF gate accept the injected
+// existing policy gate (the Connect stack and the guarded mount table, #446)
+// accepts the injected
 // cookies unchanged (see [devAuthMiddleware]). The store is the same
 // auth.OAuthStore the OAuth callback uses; now is injected for tests.
 func seedDevSession(ctx context.Context, store auth.OAuthStore, now func() time.Time) (sessionToken, csrfToken string, err error) {
@@ -213,8 +214,8 @@ func (d *devSessions) tokens(ctx context.Context) (session, csrf string, err err
 
 // devAuthMiddleware makes every request arrive already authenticated as the
 // dev operator (ADR-0041 GLYPHOXA_DEV_MODE). It stamps the glyphoxa_session
-// cookie (satisfying both the Connect auth interceptor and the plain-read
-// RequireSession guard) and BOTH the glyphoxa_csrf cookie AND a matching
+// cookie (satisfying the session check on both the Connect stack and the
+// guarded plain mounts, #446) and BOTH the glyphoxa_csrf cookie AND a matching
 // X-CSRF-Token header (satisfying the double-submit CSRF interceptor) onto every
 // inbound request, replacing any cookies the client sent. This reuses the whole
 // existing gate unchanged — nothing is special-cased downstream. Requests

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -12,9 +12,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -578,8 +580,8 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	relay.SetResolver(speakerResolver) // #281: resolve who/GM per line (nil-safe, off if unset)
 	// #439: the snapshot/SSE mounts are tenant-scoped — a session outside the
 	// caller's Tenant is 404 (session → campaign → tenant), enforced before the
-	// SSE stream opens. The mounts below compose auth.RequireTenant to inject
-	// the tenant this check reads.
+	// SSE stream opens. The guarded mount table below declares TenantRequired
+	// to inject the tenant this check reads.
 	relay.SetTenantScope(store.VoiceSessionInTenant)
 	// Back-wire the finalizer so Stop drains the relay's writer queue and records
 	// the authoritative line_count (#74). Done after the relay exists because the
@@ -790,7 +792,8 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// operator on every request and pin the bind to loopback, so a dev instance
 	// needs no OAuth and a mis-set flag in production is structurally unreachable.
 	// Wrapping the mounts + SPA root routes every request through the existing
-	// interceptor stack / RequireSession / CSRF gate already authenticated. This
+	// policy gate (the Connect interceptor stack and the guarded mount table,
+	// #446) already authenticated. This
 	// replaces the manual DB-session-insert dev flow.
 	if dev {
 		forced, wrap, err := enableDevMode(ctx, store, store, webAddr, log, time.Now)
@@ -871,10 +874,32 @@ func (s highlightClipSweeper) DeleteClip(ctx context.Context, key string) error 
 	return s.blobs.Delete(ctx, key)
 }
 
+// plainMountPolicy is the declarative auth table for every plain (non-Connect)
+// mount (#446): each pattern's tenant posture, enforced by auth.MustGuardMounts
+// with the same auth.Policy the Connect stack runs. Every row is operator-gated
+// (session, ADR-0041) and CSRF derives from the method (POST ⇒ double-submit,
+// ADR-0016), so the tenant mode is the one explicit per-mount decision.
+//
+// TestPlainMountPolicy pins these declarations: downgrading a byte mount's
+// posture (the #408 regression shape — e.g. clip losing TenantRequired) fails
+// the suite, so a change here must be made deliberately, in both places.
+var plainMountPolicy = map[string]auth.TenantMode{
+	// The SSE relay + snapshot and the byte streams (clip/image/export) all
+	// need the caller's Tenant to scope their reads (#439): session AND tenant.
+	"GET /api/v1/sessions/{id}/events":  auth.TenantRequired,
+	"GET /api/v1/sessions/{id}":         auth.TenantRequired,
+	"GET /api/v1/highlights/{id}/clip":  auth.TenantRequired,
+	"GET /api/v1/highlights/{id}/image": auth.TenantRequired,
+	"GET /api/v1/campaigns/{id}/export": auth.TenantRequired,
+	// TenantNone: ServeImport resolves the tenant off the session itself
+	// (#291); the POST method already makes the guard demand the CSRF pair.
+	"POST /api/v1/campaigns/import": auth.TenantNone,
+}
+
 // relay serves the live transcript over SSE + a JSON snapshot (#73, ADR-0014):
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
-// /api/v1/sessions/{id}[/events], each guarded by auth.RequireSession (the
-// Connect interceptor chain does not cover them).
+// /api/v1/sessions/{id}[/events], each a row in the guarded mount table
+// (#446 — the Connect interceptor chain does not cover them).
 func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, presenceRefresh func(), memberLister func(context.Context) ([]presence.Member, error), embedProvider embeddings.Provider) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
@@ -895,8 +920,13 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	authServer := auth.NewAuthServer(store, log)
 
 	// The store satisfies both Authenticator (AuthenticateSession) and
-	// TenantResolver (TenantForUser); GetCurrentUser is the only public procedure.
-	stack := auth.NewStack(store, store, managementv1connect.AuthServiceGetCurrentUserProcedure)
+	// TenantResolver (TenantForUser). ONE policy gates both transports (#446):
+	// the Connect interceptor stack and the plain-mount table below are thin
+	// adapters over the same auth.Policy, so the session/CSRF/tenant gate
+	// cannot drift between them again (#408). GetCurrentUser is the only
+	// public procedure.
+	policy := auth.NewPolicy(store, store)
+	stack := policy.Stack(managementv1connect.AuthServiceGetCurrentUserProcedure)
 
 	campaignSrv := rpc.NewCampaignServer(store)
 	// While a session is live, the roster/mute panel scopes to that session's
@@ -972,9 +1002,9 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	sessionPath, sessionHandler := sessionSrv.Handler(stack.HandlerOptions()...)
 
 	// Session Highlight clip serve (#308/#309): GET /api/v1/highlights/{id}/clip, a
-	// plain net/http byte stream (ADR-0015) beside the SSE relay, operator-gated by
-	// auth.RequireSession. Tenant-scoped row load + blob.Get + http.ServeContent
-	// (Range → scrub).
+	// plain net/http byte stream (ADR-0015) beside the SSE relay, operator-gated
+	// via the guarded mount table. Tenant-scoped row load + blob.Get +
+	// http.ServeContent (Range → scrub).
 	// The clip route scopes to the Active Campaign server-side (#308), sharing the
 	// SessionServer's read-side resolution so a foreign-campaign clip id is 404 just
 	// like the Highlight RPCs.
@@ -982,47 +1012,75 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 
 	// The campaign-bundle transport (#290, ADR-0053) is a PLAIN net/http mount
 	// beside the SSE relay, not a Connect service (ADR-0015): a streamed gzip
-	// download does not fit Connect's message model. Operator-only via
-	// auth.RequireSession, the same gate the relay reads (ADR-0041). The GET export
-	// (#290) and the POST import (#291) share this handler.
+	// download does not fit Connect's message model. Operator-only via the
+	// guarded mount table, the same gate the relay reads (ADR-0041). The GET
+	// export (#290) and the POST import (#291) share this handler.
 	bundleHandler := &bundle.Handler{Store: store, Log: log}
 
-	return []web.Mount{
+	// The plain (non-Connect) mounts bind their handlers here; their auth
+	// posture is declared separately in [plainMountPolicy] (#446), and the two
+	// maps are zipped below. MustGuardMounts enforces the result with the SAME
+	// policy the Connect stack runs and panics the boot on an under-declared
+	// row — a mount can no longer silently compose the wrapper subset that
+	// shipped #408.
+	plainHandlers := map[string]http.Handler{
+		// The SSE relay + snapshot are PLAIN mounts (not web.APIMount): they want
+		// the full /api/v1/... path, not the /api-stripped Connect method path.
+		// Go 1.22 method+wildcard patterns keep them off the Connect mounts
+		// (/api/glyphoxa.management.v1.*) and the SPA root. Session AND tenant
+		// (#439, the post-#408 discipline) — the relay's TenantScope (wired
+		// above) 404s a session outside the caller's Tenant before the SSE
+		// stream opens.
+		"GET /api/v1/sessions/{id}/events": http.HandlerFunc(relay.ServeEvents),
+		"GET /api/v1/sessions/{id}":        http.HandlerFunc(relay.ServeSnapshot),
+		// Session Highlight clip (#308): operator-gated audio byte stream with
+		// Range. ServeClip/ServeImage require the tenant (#408), resolved
+		// server-side off the operator; without it TenantID always missed and
+		// every request 401'd.
+		"GET /api/v1/highlights/{id}/clip": http.HandlerFunc(clipServer.ServeClip),
+		// Session Highlight AI image (#311): operator-gated image byte stream, same
+		// tenant + Active-Campaign 404 posture as the clip; no image yet → 404.
+		"GET /api/v1/highlights/{id}/image": http.HandlerFunc(clipServer.ServeImage),
+		// Campaign bundle export (#290): streamed gzip download, operator-gated,
+		// session AND tenant (#439) — a foreign-tenant campaign id is 404.
+		"GET /api/v1/campaigns/{id}/export": http.HandlerFunc(bundleHandler.ServeExport),
+		// Campaign bundle import (#291): multipart upload, operator-gated; the
+		// POST method makes the guard demand the CSRF double-submit (ADR-0016)
+		// the SPA satisfies with the script-readable glyphoxa_csrf cookie.
+		"POST /api/v1/campaigns/import": http.HandlerFunc(bundleHandler.ServeImport),
+	}
+	if len(plainHandlers) != len(plainMountPolicy) {
+		panic(fmt.Sprintf("plain mounts and plainMountPolicy disagree: %d handlers, %d policy rows — every plain mount must declare its posture (#446)",
+			len(plainHandlers), len(plainMountPolicy)))
+	}
+	rows := make([]auth.GuardedMount, 0, len(plainHandlers))
+	for _, pattern := range slices.Sorted(maps.Keys(plainHandlers)) {
+		// A handler missing from plainMountPolicy yields the zero TenantMode,
+		// which MustGuardMounts rejects loudly.
+		rows = append(rows, auth.GuardedMount{
+			Pattern: pattern,
+			Tenant:  plainMountPolicy[pattern],
+			Handler: plainHandlers[pattern],
+		})
+	}
+	guarded := auth.MustGuardMounts(policy, rows)
+
+	mounts := []web.Mount{
 		web.APIMount(campaignPath, campaignHandler),
 		web.APIMount(authPath, authHandler),
 		web.APIMount(providerPath, providerHandler),
 		web.APIMount(voicePath, voiceHandler),
 		web.APIMount(sessionPath, sessionHandler),
-		// The SSE relay + snapshot are PLAIN mounts (not web.APIMount): they want
-		// the full /api/v1/... path, not the /api-stripped Connect method path.
-		// Go 1.22 method+wildcard patterns keep them off the Connect mounts
-		// (/api/glyphoxa.management.v1.*) and the SPA root. auth.RequireSession
-		// validates the glyphoxa_session cookie the EventSource/fetch send; the
-		// mounts are session AND tenant (#439, the post-#408 discipline) — the
-		// relay's TenantScope (wired above) 404s a session outside the caller's
-		// Tenant before the SSE stream opens.
-		{Path: "GET /api/v1/sessions/{id}/events", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(relay.ServeEvents)))},
-		{Path: "GET /api/v1/sessions/{id}", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(relay.ServeSnapshot)))},
-		// Session Highlight clip (#308): operator-gated audio byte stream with Range.
-		// ServeClip/ServeImage require the tenant, so the mount is session AND tenant
-		// (#408): RequireTenant (inside RequireSession) resolves it server-side off the
-		// operator — the plain-HTTP mirror of the Connect tenant interceptor. Without it
-		// TenantID always missed and every request 401'd.
-		{Path: "GET /api/v1/highlights/{id}/clip", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(clipServer.ServeClip)))},
-		// Session Highlight AI image (#311): operator-gated image byte stream, same
-		// tenant + Active-Campaign 404 posture as the clip; no image yet → 404.
-		{Path: "GET /api/v1/highlights/{id}/image", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(clipServer.ServeImage)))},
-		// Campaign bundle export (#290): streamed gzip download, operator-gated,
-		// session AND tenant (#439) — a foreign-tenant campaign id is 404.
-		{Path: "GET /api/v1/campaigns/{id}/export", Handler: auth.RequireSession(store, auth.RequireTenant(store, http.HandlerFunc(bundleHandler.ServeExport)))},
-		// Campaign bundle import (#291): multipart upload, operator-gated, plus the
-		// plain-HTTP CSRF double-submit (ADR-0016) the SPA satisfies with the
-		// script-readable glyphoxa_csrf cookie — a state-changing POST outside the
-		// Connect chain needs it (RequireSession alone gates only the session).
-		{Path: "POST /api/v1/campaigns/import", Handler: auth.RequireSession(store, auth.RequireCSRF(http.HandlerFunc(bundleHandler.ServeImport)))},
-		{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
-		{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
 	}
+	for _, g := range guarded {
+		mounts = append(mounts, web.Mount{Path: g.Pattern, Handler: g.Handler})
+	}
+	return append(mounts,
+		// The OAuth redirects are the login carve-out (ADR-0015): public by
+		// design, no session to require yet.
+		web.Mount{Path: "/auth/discord/login", Handler: http.HandlerFunc(oauth.Login)},
+		web.Mount{Path: "/auth/discord/callback", Handler: http.HandlerFunc(oauth.Callback)},
+	)
 }
 
 // runWebTier starts the web API server on ctx and blocks until it has fully shut

--- a/cmd/glyphoxa/mount_policy_test.go
+++ b/cmd/glyphoxa/mount_policy_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+)
+
+// TestPlainMountPolicy pins the PRODUCTION plain-mount auth table (#446).
+// auth.MustGuardMounts already makes an UNDECLARED row fail the boot, but a
+// MIS-declared one — a byte mount downgraded from TenantRequired, the exact
+// #408 regression shape — would otherwise ship with every test green (the
+// review's mutation check proved it: flipping the clip row to TenantNone
+// changed no test outcome). This literal restatement turns that one-line
+// downgrade into a loud failure: changing a mount's posture now requires
+// touching this test too, i.e. doing it deliberately.
+func TestPlainMountPolicy(t *testing.T) {
+	t.Parallel()
+	want := map[string]auth.TenantMode{
+		"GET /api/v1/sessions/{id}/events":  auth.TenantRequired,
+		"GET /api/v1/sessions/{id}":         auth.TenantRequired,
+		"GET /api/v1/highlights/{id}/clip":  auth.TenantRequired,
+		"GET /api/v1/highlights/{id}/image": auth.TenantRequired,
+		"GET /api/v1/campaigns/{id}/export": auth.TenantRequired,
+		"POST /api/v1/campaigns/import":     auth.TenantNone,
+	}
+	if !maps.Equal(plainMountPolicy, want) {
+		t.Fatalf("plainMountPolicy drifted from the pinned #446 table:\n got  %v\n want %v\n"+
+			"If this change is intentional, update BOTH maps — a silent posture downgrade is the #408 class.",
+			plainMountPolicy, want)
+	}
+	// Belt and braces: every GET byte/SSE mount must stay tenant-scoped (#439).
+	for pattern, mode := range plainMountPolicy {
+		if len(pattern) > 4 && pattern[:4] == "GET " && mode != auth.TenantRequired {
+			t.Errorf("GET mount %q is not TenantRequired — the #408 subset", pattern)
+		}
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -433,7 +433,15 @@ The carve-outs are plain `net/http`, deliberately outside Connect (ADR-0015):
 - `GET /api/v1/sessions/{id}` — the snapshot (`transcript.Relay.ServeSnapshot`)
 - `/auth/discord/login`, `/auth/discord/callback` — OAuth redirects
 
-Both session reads are wrapped in `auth.RequireSession`. Connect server-streaming
+Every plain mount except the OAuth redirects is a row in the guarded mount
+table (`auth.MustGuardMounts`): one transport-agnostic policy
+(`auth.Policy`) makes the session/CSRF/tenant decisions for BOTH the Connect
+interceptor stack and these plain mounts, and each row declares its tenant
+posture explicitly — an undeclared row fails the boot. The table replaced
+per-mount hand-composition of `auth.RequireSession`/`RequireTenant`/
+`RequireCSRF`, whose drift shipped #408 (clip/image mounts composed
+session-only, so they 401'd in production while the Connect RPCs passed on
+the same cookie). Connect server-streaming
 lacks EventSource semantics (`Last-Event-ID`, proxy compatibility); the browser has
 no bidirectional need on the Session screen, so WebSocket was rejected. SSE frames
 call `queryClient.setQueryData(...)` to amend the cached snapshot rather than

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,10 +1,10 @@
 // Package auth is the single-operator authentication tier (ADR-0016 / ADR-0039):
 // the net/http Discord OAuth carve-out (ADR-0015), the opaque cookie session it
-// issues, and the Connect interceptor stack + context accessors that gate the
-// management RPCs. The stacked Configuration (#68) and Campaign (#71) PRs reuse
-// this package's exported seam: [NewStack] for the interceptor options and
-// [CurrentUser] / [TenantID] to read the resolved principal out of a handler's
-// context.
+// issues, and ONE transport-agnostic policy (#446, policy.go) that gates both
+// transports — the Connect interceptor stack ([NewStack]) over the management
+// RPCs and the guarded plain-mount table ([MustGuardMounts]) over the byte
+// endpoints. [CurrentUser] / [TenantID] read the resolved principal out of a
+// handler's context.
 package auth
 
 import (

--- a/internal/auth/drift_test.go
+++ b/internal/auth/drift_test.go
@@ -1,0 +1,388 @@
+package auth_test
+
+// The #446 drift regression test: drive the Connect adapter (the interceptor
+// stack) and the plain-HTTP adapter (the guarded mount table) with the SAME
+// session/CSRF input matrix and assert they reach IDENTICAL decisions. This is
+// the test that makes the #408 class visible: there, the two hand-synced
+// copies of the gate diverged (a mount composed session-only, no tenant) and
+// nothing failed until production.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// outcome is the transport-free decision class both adapters must agree on.
+type outcome string
+
+const (
+	allowed         outcome = "allowed"
+	unauthenticated outcome = "unauthenticated" // CodeUnauthenticated / 401
+	forbidden       outcome = "forbidden"       // CodePermissionDenied / 403
+)
+
+func connectOutcome(err error) outcome {
+	if err == nil {
+		return allowed
+	}
+	switch connect.CodeOf(err) {
+	case connect.CodeUnauthenticated:
+		return unauthenticated
+	case connect.CodePermissionDenied:
+		return forbidden
+	default:
+		return outcome(fmt.Sprintf("unexpected connect code %v", connect.CodeOf(err)))
+	}
+}
+
+func httpOutcome(status int) outcome {
+	switch {
+	case status >= 200 && status < 300:
+		return allowed
+	case status == http.StatusUnauthorized:
+		return unauthenticated
+	case status == http.StatusForbidden:
+		return forbidden
+	default:
+		return outcome(fmt.Sprintf("unexpected http status %d", status))
+	}
+}
+
+// driftCell is one point of the principal/cookie/CSRF matrix plus the outcome
+// the shared policy defines for it. The expectation is stated per cell so a
+// bug that shifts BOTH adapters the same way still fails the test.
+type driftCell struct {
+	name          string
+	sessionCookie string // "" = no cookie sent
+	csrfCookie    string
+	csrfHeader    string
+	wantRead      outcome // CSRF-exempt path (NO_SIDE_EFFECTS RPC / GET mount)
+	wantWrite     outcome // state-changing path (mutating RPC / POST mount)
+}
+
+const driftCSRF = "csrf-double-submit-token"
+
+// denialText pins the exact rejection text per denial class. The strings live
+// once in the policy (Denial.Message) and ride both transports verbatim; a
+// silent reword would otherwise ship green on every test.
+var denialText = map[outcome]string{
+	unauthenticated: "please sign in",
+	forbidden:       "csrf check failed, retry",
+}
+
+// assertDenialText asserts a denied request carried the pinned text on both
+// transports: the connect.Error message and the HTTP body (http.Error appends
+// a trailing newline).
+func assertDenialText(t *testing.T, path string, want outcome, connectErr error, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	wantText, denied := denialText[want]
+	if !denied {
+		return
+	}
+	var cerr *connect.Error
+	if !errors.As(connectErr, &cerr) {
+		t.Errorf("%s via Connect: want *connect.Error, got %v", path, connectErr)
+	} else if cerr.Message() != wantText {
+		t.Errorf("%s via Connect: denial text = %q, want %q", path, cerr.Message(), wantText)
+	}
+	if got := strings.TrimSuffix(rec.Body.String(), "\n"); got != wantText {
+		t.Errorf("%s via HTTP mount: denial body = %q, want %q", path, got, wantText)
+	}
+}
+
+func driftMatrix() []driftCell {
+	return []driftCell{
+		{name: "no session, no csrf", wantRead: unauthenticated, wantWrite: unauthenticated},
+		{name: "no session, valid csrf", csrfCookie: driftCSRF, csrfHeader: driftCSRF,
+			wantRead: unauthenticated, wantWrite: unauthenticated},
+		{name: "invalid session, valid csrf", sessionCookie: "expired-or-unknown",
+			csrfCookie: driftCSRF, csrfHeader: driftCSRF,
+			wantRead: unauthenticated, wantWrite: unauthenticated},
+		{name: "valid session, matching csrf", sessionCookie: validToken,
+			csrfCookie: driftCSRF, csrfHeader: driftCSRF,
+			wantRead: allowed, wantWrite: allowed},
+		{name: "valid session, mismatched csrf", sessionCookie: validToken,
+			csrfCookie: driftCSRF, csrfHeader: "attacker-guess",
+			wantRead: allowed, wantWrite: forbidden},
+		{name: "valid session, missing csrf header", sessionCookie: validToken,
+			csrfCookie: driftCSRF,
+			wantRead:   allowed, wantWrite: forbidden},
+		{name: "valid session, missing csrf cookie", sessionCookie: validToken,
+			csrfHeader: driftCSRF,
+			wantRead:   allowed, wantWrite: forbidden},
+		{name: "valid session, no csrf at all", sessionCookie: validToken,
+			wantRead: allowed, wantWrite: forbidden},
+	}
+}
+
+// connectAdapter stands up the real AuthService behind the real interceptor
+// stack with NO public procedures, so GetCurrentUser behaves as a gated
+// NO_SIDE_EFFECTS read and Logout as a gated mutation — the same Check shapes
+// the guarded mounts use.
+func connectAdapter(t *testing.T, authn auth.Authenticator, tenants auth.TenantResolver) managementv1connect.AuthServiceClient {
+	t.Helper()
+	stack := auth.NewStack(authn, tenants)
+	server := auth.NewAuthServer(&fakeDeleter{}, nil)
+	mux := http.NewServeMux()
+	mux.Handle(server.Handler(stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())
+}
+
+// recordingAuthService is an AuthService whose GetCurrentUser records what the
+// REAL interceptor stack put into the request context — the Connect-side
+// mirror of the guarded mounts' ctxSeen handler. The real AuthServer never
+// reads TenantID, so without this the tenant half of the Connect injection
+// would go unasserted (an interceptor that stopped resolving tenants — the
+// #408 injection drift — would break every tenant-scoped RPC with the suite
+// green).
+type recordingAuthService struct {
+	managementv1connect.UnimplementedAuthServiceHandler
+	seen *ctxSeen
+}
+
+func (s *recordingAuthService) GetCurrentUser(ctx context.Context, _ *connect.Request[managementv1.GetCurrentUserRequest]) (*connect.Response[managementv1.GetCurrentUserResponse], error) {
+	s.seen.user, s.seen.hasUser = auth.CurrentUser(ctx)
+	s.seen.tenant, s.seen.hasTenant = auth.TenantID(ctx)
+	return connect.NewResponse(&managementv1.GetCurrentUserResponse{}), nil
+}
+
+// recordingConnectAdapter mounts recordingAuthService behind the real stack.
+func recordingConnectAdapter(t *testing.T, authn auth.Authenticator, tenants auth.TenantResolver) (managementv1connect.AuthServiceClient, *ctxSeen) {
+	t.Helper()
+	seen := &ctxSeen{}
+	stack := auth.NewStack(authn, tenants)
+	mux := http.NewServeMux()
+	mux.Handle(managementv1connect.NewAuthServiceHandler(&recordingAuthService{seen: seen}, stack.HandlerOptions()...))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return managementv1connect.NewAuthServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON()), seen
+}
+
+// httpAdapter builds a guarded GET (read) and POST (write) mount off the same
+// policy inputs, recording what the inner handler observed in ctx.
+type ctxSeen struct {
+	user      storage.User
+	hasUser   bool
+	tenant    uuid.UUID
+	hasTenant bool
+}
+
+func httpAdapter(t *testing.T, authn auth.Authenticator, tenants auth.TenantResolver, mode auth.TenantMode) (read, write http.Handler, seen *ctxSeen) {
+	t.Helper()
+	seen = &ctxSeen{}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen.user, seen.hasUser = auth.CurrentUser(r.Context())
+		seen.tenant, seen.hasTenant = auth.TenantID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	guarded := auth.MustGuardMounts(auth.NewPolicy(authn, tenants), []auth.GuardedMount{
+		{Pattern: "GET /read", Tenant: mode, Handler: inner},
+		{Pattern: "POST /write", Tenant: mode, Handler: inner},
+	})
+	return guarded[0].Handler, guarded[1].Handler, seen
+}
+
+func applyCell(h http.Header, c driftCell) {
+	cookies := ""
+	if c.sessionCookie != "" {
+		cookies = auth.SessionCookieName + "=" + c.sessionCookie
+	}
+	if c.csrfCookie != "" {
+		if cookies != "" {
+			cookies += "; "
+		}
+		cookies += auth.CSRFCookieName + "=" + c.csrfCookie
+	}
+	if cookies != "" {
+		h.Set("Cookie", cookies)
+	}
+	if c.csrfHeader != "" {
+		h.Set("X-CSRF-Token", c.csrfHeader)
+	}
+}
+
+// TestAdapterParity_NoDrift is the #446 drift regression: for every cell of
+// the session×CSRF matrix, the Connect interceptor and the guarded plain
+// mount must produce the same decision class on both the read (CSRF-exempt)
+// and write (CSRF-gated) paths — and that class must be the one the policy
+// defines. Both sides run the tenant resolver successfully, isolating the
+// session/CSRF gate that drifted in #408.
+func TestAdapterParity_NoDrift(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	tenantID := uuid.New()
+
+	for _, cell := range driftMatrix() {
+		t.Run(cell.name, func(t *testing.T) {
+			authn := fakeAuthN{users: map[string]storage.User{validToken: op}}
+			tenants := fakeTenant{id: tenantID}
+			client := connectAdapter(t, authn, tenants)
+			// The Connect stack's tenant mode is TenantOptional; declare the
+			// mounts the same so the whole Check matches, not just parts.
+			readMount, writeMount, _ := httpAdapter(t, authn, tenants, auth.TenantOptional)
+
+			// Read path: GetCurrentUser (NO_SIDE_EFFECTS) vs the GET mount.
+			readReq := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+			applyCell(readReq.Header(), cell)
+			_, readErr := client.GetCurrentUser(context.Background(), readReq)
+
+			httpRead := httptest.NewRequest(http.MethodGet, "/read", nil)
+			applyCell(httpRead.Header, cell)
+			readRec := httptest.NewRecorder()
+			readMount.ServeHTTP(readRec, httpRead)
+
+			if got, want := connectOutcome(readErr), cell.wantRead; got != want {
+				t.Errorf("read via Connect = %s, want %s (err=%v)", got, want, readErr)
+			}
+			if got, want := httpOutcome(readRec.Code), cell.wantRead; got != want {
+				t.Errorf("read via HTTP mount = %s, want %s (status=%d)", got, want, readRec.Code)
+			}
+			if connectOutcome(readErr) != httpOutcome(readRec.Code) {
+				t.Errorf("READ DRIFT: Connect=%s HTTP=%s for the same inputs",
+					connectOutcome(readErr), httpOutcome(readRec.Code))
+			}
+			assertDenialText(t, "read", cell.wantRead, readErr, readRec)
+
+			// Write path: Logout (mutating) vs the POST mount.
+			writeReq := connect.NewRequest(&managementv1.LogoutRequest{})
+			applyCell(writeReq.Header(), cell)
+			_, writeErr := client.Logout(context.Background(), writeReq)
+
+			httpWrite := httptest.NewRequest(http.MethodPost, "/write", nil)
+			applyCell(httpWrite.Header, cell)
+			writeRec := httptest.NewRecorder()
+			writeMount.ServeHTTP(writeRec, httpWrite)
+
+			if got, want := connectOutcome(writeErr), cell.wantWrite; got != want {
+				t.Errorf("write via Connect = %s, want %s (err=%v)", got, want, writeErr)
+			}
+			if got, want := httpOutcome(writeRec.Code), cell.wantWrite; got != want {
+				t.Errorf("write via HTTP mount = %s, want %s (status=%d)", got, want, writeRec.Code)
+			}
+			if connectOutcome(writeErr) != httpOutcome(writeRec.Code) {
+				t.Errorf("WRITE DRIFT: Connect=%s HTTP=%s for the same inputs",
+					connectOutcome(writeErr), httpOutcome(writeRec.Code))
+			}
+			assertDenialText(t, "write", cell.wantWrite, writeErr, writeRec)
+		})
+	}
+}
+
+// TestAdapterParity_PrincipalInjection proves both adapters inject the SAME
+// resolved principal AND tenant into the request context — the injection half
+// of the gate, which #408 showed can drift independently of the reject half
+// (there, one transport's handlers saw a TenantID the other's never got).
+func TestAdapterParity_PrincipalInjection(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	tenantID := uuid.New()
+	authn := fakeAuthN{users: map[string]storage.User{validToken: op}}
+	tenants := fakeTenant{id: tenantID}
+
+	// Connect side: a recording handler behind the REAL stack observes the
+	// injected operator and tenant.
+	client, connectSeen := recordingConnectAdapter(t, authn, tenants)
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken)
+	if _, err := client.GetCurrentUser(context.Background(), req); err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if !connectSeen.hasUser || connectSeen.user.ID != op.ID {
+		t.Errorf("Connect-injected principal = %+v (hasUser=%t), want %s",
+			connectSeen.user, connectSeen.hasUser, op.ID)
+	}
+	if !connectSeen.hasTenant || connectSeen.tenant != tenantID {
+		t.Errorf("Connect-injected tenant = %s (hasTenant=%t), want %s",
+			connectSeen.tenant, connectSeen.hasTenant, tenantID)
+	}
+
+	// HTTP side: the guarded mount injects the same operator and tenant.
+	readMount, _, seen := httpAdapter(t, authn, tenants, auth.TenantRequired)
+	httpReq := httptest.NewRequest(http.MethodGet, "/read", nil)
+	httpReq.Header.Set("Cookie", auth.SessionCookieName+"="+validToken)
+	rec := httptest.NewRecorder()
+	readMount.ServeHTTP(rec, httpReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("guarded mount status = %d, want 200", rec.Code)
+	}
+	if !seen.hasUser || seen.user.ID != op.ID {
+		t.Errorf("HTTP-injected principal = %+v (hasUser=%t), want %s", seen.user, seen.hasUser, op.ID)
+	}
+	if !seen.hasTenant || seen.tenant != tenantID {
+		t.Errorf("HTTP-injected tenant = %s (hasTenant=%t), want %s", seen.tenant, seen.hasTenant, tenantID)
+	}
+
+	// The two transports observed the SAME injection.
+	if connectSeen.user.ID != seen.user.ID || connectSeen.tenant != seen.tenant {
+		t.Errorf("INJECTION DRIFT: Connect saw (user=%s tenant=%s), HTTP saw (user=%s tenant=%s)",
+			connectSeen.user.ID, connectSeen.tenant, seen.user.ID, seen.tenant)
+	}
+}
+
+// TestAdapterTenantPosture documents the ONE deliberate divergence between
+// the transports, now expressed as declared data instead of hand-synced code:
+// the Connect stack runs TenantOptional (tenant-agnostic procedures proceed
+// on a resolve failure), while the byte mounts declare TenantRequired (their
+// handlers always need a tenant, so an unresolvable one fails fast with 401).
+func TestAdapterTenantPosture(t *testing.T) {
+	t.Parallel()
+	op := operator()
+	authn := fakeAuthN{users: map[string]storage.User{validToken: op}}
+	broken := fakeTenant{err: storage.ErrNotFound}
+
+	// Connect / TenantOptional: the call proceeds — authenticated but
+	// tenantless, observed through the real stack.
+	client, connectSeen := recordingConnectAdapter(t, authn, broken)
+	req := connect.NewRequest(&managementv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.SessionCookieName+"="+validToken)
+	if _, err := client.GetCurrentUser(context.Background(), req); err != nil {
+		t.Errorf("TenantOptional (Connect): resolve failure must proceed tenantless, got %v", err)
+	}
+	if !connectSeen.hasUser || connectSeen.hasTenant {
+		t.Errorf("TenantOptional (Connect): want principal without tenant, got hasUser=%t hasTenant=%t",
+			connectSeen.hasUser, connectSeen.hasTenant)
+	}
+
+	// Guarded mount / TenantRequired: the same failure rejects 401 before the
+	// handler runs.
+	readMount, _, seen := httpAdapter(t, authn, broken, auth.TenantRequired)
+	httpReq := httptest.NewRequest(http.MethodGet, "/read", nil)
+	httpReq.Header.Set("Cookie", auth.SessionCookieName+"="+validToken)
+	rec := httptest.NewRecorder()
+	readMount.ServeHTTP(rec, httpReq)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("TenantRequired (mount): resolve failure status = %d, want 401", rec.Code)
+	}
+	if seen.hasUser || seen.hasTenant {
+		t.Error("TenantRequired (mount): handler ran despite an unresolvable tenant")
+	}
+
+	// Guarded mount / TenantOptional mirrors the Connect posture exactly.
+	optMount, _, optSeen := httpAdapter(t, authn, broken, auth.TenantOptional)
+	rec = httptest.NewRecorder()
+	optReq := httptest.NewRequest(http.MethodGet, "/read", nil)
+	optReq.Header.Set("Cookie", auth.SessionCookieName+"="+validToken)
+	optMount.ServeHTTP(rec, optReq)
+	if rec.Code != http.StatusOK {
+		t.Errorf("TenantOptional (mount): resolve failure must proceed tenantless, got %d", rec.Code)
+	}
+	if !optSeen.hasUser || optSeen.hasTenant {
+		t.Errorf("TenantOptional (mount): want principal without tenant, got hasUser=%t hasTenant=%t",
+			optSeen.hasUser, optSeen.hasTenant)
+	}
+}

--- a/internal/auth/interceptors.go
+++ b/internal/auth/interceptors.go
@@ -2,120 +2,162 @@ package auth
 
 import (
 	"context"
-	"crypto/subtle"
 	"errors"
-	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/google/uuid"
-
-	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// Authenticator validates a session token and resolves the owning operator.
-// *storage.Store satisfies it via AuthenticateSession.
-type Authenticator interface {
-	AuthenticateSession(ctx context.Context, token string) (storage.User, error)
-}
+// This file is the Connect ADAPTER over the shared auth policy (policy.go,
+// issue #446). It contains no auth decisions of its own: it maps the Connect
+// transport — request headers, the procedure's public/read markers, connect
+// error codes — onto [Policy.Evaluate], whose verdict it enforces. The plain
+// net/http mounts get the same policy through middleware.go / mounts.go.
 
-// TenantResolver resolves the tenant bound to an operator (ADR-0039 thin
-// pass-through). *storage.Store satisfies it via TenantForUser.
-type TenantResolver interface {
-	TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error)
-}
-
-// NewAuthInterceptor validates the glyphoxa_session cookie on every Connect call
-// and puts the resolved operator into the request context ([CurrentUser]).
+// NewPolicyInterceptor gates every Connect call with the shared [Policy]:
+// session (who) → CSRF (anti-forgery, ADR-0016) → tenant (which tenant,
+// ADR-0039), injecting the resolved operator ([CurrentUser]) and tenant
+// ([TenantID]) into the request context.
+//
 // Unauthenticated requests are rejected with CodeUnauthenticated — INCLUDING
 // reads, so the whole API is gated — EXCEPT procedures named in public, which
 // are allowed through unauthenticated so they can self-handle the missing
 // session (AuthService.GetCurrentUser returns CodeUnauthenticated itself, the
-// SPA's 401 → /login probe).
-func NewAuthInterceptor(a Authenticator, public ...string) connect.UnaryInterceptorFunc {
+// SPA's 401 → /login probe). CSRF applies to state-changing calls only:
+// NO_SIDE_EFFECTS reads (e.g. GetActiveCampaign / GetCurrentUser) mutate
+// nothing, and the CSRF cookie is not guaranteed present before the first
+// login. The tenant is [TenantOptional]: some Connect procedures are
+// tenant-agnostic, so a resolve failure proceeds tenantless (logged) and each
+// handler fails on its own terms — unlike the byte mounts (mounts.go), which
+// declare [TenantRequired].
+func NewPolicyInterceptor(p *Policy, public ...string) connect.UnaryInterceptorFunc {
 	publicSet := make(map[string]struct{}, len(public))
-	for _, p := range public {
-		publicSet[p] = struct{}{}
+	for _, proc := range public {
+		publicSet[proc] = struct{}{}
 	}
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			if token := cookieValue(req.Header(), SessionCookieName); token != "" {
-				if u, err := a.AuthenticateSession(ctx, token); err == nil {
-					return next(WithUser(ctx, u), req)
-				}
+			_, isPublic := publicSet[req.Spec().Procedure]
+			v := p.Evaluate(ctx, InputFromHeader(req.Header()), Check{
+				Public: isPublic,
+				CSRF:   req.Spec().IdempotencyLevel != connect.IdempotencyNoSideEffects,
+				Tenant: TenantOptional,
+			})
+			if v.Deny != DenyNone {
+				return nil, denialError(v.Deny)
 			}
-			if _, ok := publicSet[req.Spec().Procedure]; ok {
-				return next(ctx, req)
-			}
-			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authentication required"))
+			return next(v.Context(ctx), req)
 		}
 	}
 }
 
-// NewCSRFInterceptor enforces the double-submit CSRF check (ADR-0016) on
-// state-changing calls: the X-CSRF-Token header must match the glyphoxa_csrf
-// cookie, else CodePermissionDenied. Reads (NO_SIDE_EFFECTS, e.g.
-// GetActiveCampaign / GetCurrentUser) are exempt — they mutate nothing, and the
-// CSRF cookie is not guaranteed present before the first login.
-func NewCSRFInterceptor() connect.UnaryInterceptorFunc {
+// connectCode maps a policy [Denial] onto the Connect transport — the
+// interceptor-side mirror of middleware.go's [WriteDenial].
+func connectCode(d Denial) connect.Code {
+	if d == DenyCSRF {
+		return connect.CodePermissionDenied
+	}
+	return connect.CodeUnauthenticated
+}
+
+// denialError builds the connect error for a policy [Denial].
+func denialError(d Denial) *connect.Error {
+	return connect.NewError(connectCode(d), errors.New(d.Message()))
+}
+
+// The three single-check interceptors below expose ONE policy check each —
+// the Connect mirrors of middleware.go's RequireSession / RequireCSRF /
+// RequireTenant. Production handlers never compose them by hand: [NewStack]
+// runs the full policy in one interceptor. They remain the exported seam for
+// mounting an isolated check around a service in tests (e.g. proving a
+// mutation is CSRF-gated without standing up the whole stack).
+
+// NewAuthInterceptor enforces only the session check: the glyphoxa_session
+// cookie must resolve to an operator, else CodeUnauthenticated — except for
+// procedures named in public, which pass through unauthenticated so they can
+// self-handle the missing session. A resolved operator rides the context
+// ([CurrentUser]).
+func NewAuthInterceptor(a Authenticator, public ...string) connect.UnaryInterceptorFunc {
+	publicSet := make(map[string]struct{}, len(public))
+	for _, proc := range public {
+		publicSet[proc] = struct{}{}
+	}
+	p := NewPolicy(a, nil)
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			if req.Spec().IdempotencyLevel == connect.IdempotencyNoSideEffects {
-				return next(ctx, req)
+			_, isPublic := publicSet[req.Spec().Procedure]
+			u, hasUser, deny := p.evaluateSession(ctx, cookieValue(req.Header(), SessionCookieName), isPublic)
+			if deny != DenyNone {
+				return nil, denialError(deny)
 			}
-			cookie := cookieValue(req.Header(), CSRFCookieName)
-			header := req.Header().Get("X-CSRF-Token")
-			if cookie == "" || header == "" ||
-				subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
-				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("CSRF token mismatch"))
+			if hasUser {
+				ctx = WithUser(ctx, u)
 			}
 			return next(ctx, req)
 		}
 	}
 }
 
-// NewTenantInterceptor resolves the authenticated operator's bound tenant and
-// puts it in the context ([TenantID]). For the single operator this is the thin
-// X-Tenant-Id pass-through (ADR-0039): the tenant is resolved server-side from
-// the operator, not trusted from a client header, so the multi-tenant
-// membership check fills in here later without a rewrite. Unauthenticated reads
-// (no operator in ctx) pass through untouched; a resolve failure is logged and
-// the request proceeds without a tenant (handlers that need one fail on their
-// own terms).
-func NewTenantInterceptor(tr TenantResolver) connect.UnaryInterceptorFunc {
+// NewCSRFInterceptor enforces only the double-submit CSRF check (ADR-0016) on
+// state-changing calls; NO_SIDE_EFFECTS reads are exempt.
+func NewCSRFInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			u, ok := CurrentUser(ctx)
-			if !ok {
-				return next(ctx, req)
+			deny := evaluateCSRF(
+				cookieValue(req.Header(), CSRFCookieName),
+				req.Header().Get("X-CSRF-Token"),
+				req.Spec().IdempotencyLevel != connect.IdempotencyNoSideEffects,
+			)
+			if deny != DenyNone {
+				return nil, denialError(deny)
 			}
-			tenantID, err := tr.TenantForUser(ctx, u.ID)
-			if err != nil {
-				slog.Default().Warn("tenant interceptor: no tenant for operator",
-					"user_id", u.ID, "err", err)
-				return next(ctx, req)
-			}
-			return next(WithTenant(ctx, tenantID), req)
+			return next(ctx, req)
 		}
 	}
 }
 
-// Stack is the ordered Connect interceptor stack the web tier mounts on every
-// management handler: auth (who) → CSRF (anti-forgery) → tenant (which tenant).
-// Build it with [NewStack] and apply it with [Stack.HandlerOptions]. The stacked
-// #68/#71 PRs reuse the same Stack so the gate is identical across services.
+// NewTenantInterceptor enforces only the [TenantOptional] tenant resolution:
+// an authenticated operator's bound tenant is resolved server-side (ADR-0039)
+// and injected ([TenantID]); an unauthenticated context or a resolve failure
+// (logged) proceeds without one.
+func NewTenantInterceptor(tr TenantResolver) connect.UnaryInterceptorFunc {
+	p := NewPolicy(nil, tr)
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			u, hasUser := CurrentUser(ctx)
+			id, hasTenant, deny := p.evaluateTenant(ctx, u, hasUser, TenantOptional)
+			if deny != DenyNone {
+				return nil, denialError(deny)
+			}
+			if hasTenant {
+				ctx = WithTenant(ctx, id)
+			}
+			return next(ctx, req)
+		}
+	}
+}
+
+// Stack is the Connect interceptor stack the web tier mounts on every
+// management handler. Build it with [NewStack] and apply it with
+// [Stack.HandlerOptions]. Every service reuses the same Stack so the gate is
+// identical across services.
 type Stack struct {
 	interceptors []connect.Interceptor
 }
 
-// NewStack assembles the interceptor stack. public lists the fully-qualified
-// procedures reachable without a valid session (the SPA's
-// AuthService.GetCurrentUser boot probe).
+// NewStack assembles the interceptor stack over a fresh [Policy]. public
+// lists the fully-qualified procedures reachable without a valid session (the
+// SPA's AuthService.GetCurrentUser boot probe). The composition root, which
+// also feeds the plain-mount table, builds the policy once and uses
+// [Policy.Stack] instead.
 func NewStack(a Authenticator, tr TenantResolver, public ...string) *Stack {
-	return &Stack{interceptors: []connect.Interceptor{
-		NewAuthInterceptor(a, public...),
-		NewCSRFInterceptor(),
-		NewTenantInterceptor(tr),
-	}}
+	return NewPolicy(a, tr).Stack(public...)
+}
+
+// Stack assembles the Connect interceptor stack over this policy — the same
+// policy instance the plain-mount table ([MustGuardMounts]) enforces, so the
+// two transports cannot gate differently.
+func (p *Policy) Stack(public ...string) *Stack {
+	return &Stack{interceptors: []connect.Interceptor{NewPolicyInterceptor(p, public...)}}
 }
 
 // HandlerOptions returns the connect.HandlerOption that installs the stack on a

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,97 +1,85 @@
 package auth
 
 import (
-	"crypto/subtle"
-	"log/slog"
 	"net/http"
 )
 
-// RequireSession is the net/http guard for the plain (non-Connect) read
-// endpoints — the SSE transcript relay and its snapshot (ADR-0014 Hop-B) — and
-// the plain import POST (#291). Those handlers live OUTSIDE the Connect
-// interceptor chain ([NewAuthInterceptor]), so they would be unauthenticated
-// without this. It mirrors the interceptor's gate: the glyphoxa_session cookie
-// must resolve to an operator via [Authenticator], else the request is rejected
-// 401. On success it injects the resolved operator into the request context
-// ([CurrentUser]) — a pure addition mirroring the interceptor's WithUser, so a
-// downstream handler (ServeImport) resolves the tenant off the session; the relay
-// handlers that ignore it are unaffected.
-//
-// EventSource and same-origin fetch send the cookie automatically, so no custom
-// header is needed; GET reads need no CSRF check (ADR-0016 exempts NO_SIDE_EFFECTS
-// reads). A state-changing POST additionally wraps in [RequireCSRF].
+// This file is the plain net/http ADAPTER over the shared auth policy
+// (policy.go, issue #446). Like interceptors.go it contains no auth decisions:
+// each wrapper maps one policy check onto the HTTP transport. Production
+// mounts do not compose these by hand anymore — they declare a row in the
+// guarded mount table ([MustGuardMounts], mounts.go), which runs the full
+// [Policy.Evaluate] per request. The wrappers remain the exported seam for
+// composing a single check around a handler in tests and one-off tools.
+
+// WriteDenial maps a policy [Denial] onto the HTTP transport — 401 for a
+// missing/invalid session (or an unresolvable required tenant), 403 for a
+// CSRF failure — with the same message text the Connect adapter returns.
+// Call it only with a real denial, never [DenyNone].
+func WriteDenial(w http.ResponseWriter, d Denial) {
+	status := http.StatusUnauthorized
+	if d == DenyCSRF {
+		status = http.StatusForbidden
+	}
+	http.Error(w, d.Message(), status)
+}
+
+// RequireSession is the net/http session guard: the glyphoxa_session cookie
+// must resolve to an operator via [Authenticator], else 401. On success it
+// injects the resolved operator into the request context ([CurrentUser]) — a
+// pure addition, so handlers that ignore it are unaffected. EventSource and
+// same-origin fetch send the cookie automatically, so no custom header is
+// needed; GET reads need no CSRF check (ADR-0016 exempts reads).
 func RequireSession(a Authenticator, next http.Handler) http.Handler {
+	p := NewPolicy(a, nil)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := cookieValue(r.Header, SessionCookieName)
-		if token == "" {
-			http.Error(w, "authentication required", http.StatusUnauthorized)
-			return
-		}
-		u, err := a.AuthenticateSession(r.Context(), token)
-		if err != nil {
-			http.Error(w, "authentication required", http.StatusUnauthorized)
+		u, _, deny := p.evaluateSession(r.Context(), cookieValue(r.Header, SessionCookieName), false)
+		if deny != DenyNone {
+			WriteDenial(w, deny)
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(WithUser(r.Context(), u)))
 	})
 }
 
-// RequireTenant is the net/http mirror of [NewTenantInterceptor] for the plain
-// (non-Connect) byte endpoints whose handlers require a tenant — the Session
-// Highlight clip (#308) and image (#311) mounts. It MUST be composed INSIDE
-// [RequireSession] (session first, then tenant): it reads the operator that guard
-// injected ([CurrentUser]) and resolves the bound tenant SERVER-SIDE via
-// [TenantResolver] (ADR-0039 thin pass-through) — never from a client header —
-// then injects it ([WithTenant]) so the handler's [TenantID] read hits.
+// RequireTenant applies the [TenantRequired] posture: it reads the operator an
+// upstream [RequireSession] injected ([CurrentUser]), resolves the bound
+// tenant SERVER-SIDE via [TenantResolver] (ADR-0039 — never from a client
+// header), and injects it ([WithTenant]) so the handler's [TenantID] read
+// hits. A missing operator or an unresolved tenant rejects 401 — the byte
+// handlers ALWAYS need a tenant, so this fails fast with the same code the
+// handler would return anyway (the deliberate contrast with the Connect
+// stack's [TenantOptional], where tenant-agnostic procedures proceed).
 //
-// This closes #408: those mounts previously wrapped only RequireSession (user,
-// no tenant), so the handlers' TenantID lookup always missed and every clip/image
-// request 401'd in production, while the Connect RPCs (which carry the tenant
-// interceptor) returned 200 with the same cookie.
-//
-// Failure posture differs from the Connect interceptor deliberately. The
-// interceptor proceeds tenantless and lets each handler fail on its own terms
-// (some Connect procedures are tenant-agnostic). These byte handlers ALWAYS need
-// a tenant, so a missing operator or an unresolved tenant rejects 401 here —
-// fail-fast with the same code the handler would return anyway. Since #439 the
-// SSE relay + snapshot (relay.ServeEvents/ServeSnapshot) and the bundle export
-// (bundle.ServeExport) compose this wrapper too and 404 a resource outside the
-// injected tenant; the import POST (bundle.ServeImport) remains the one plain
-// mount without it — a write that resolves the tenant off the session itself.
+// This gate closes #408: the clip/image mounts previously composed only the
+// session check (user, no tenant), so the handlers' TenantID lookup always
+// missed and every request 401'd in production, while the Connect RPCs
+// returned 200 with the same cookie. The guarded mount table (mounts.go) now
+// makes that subset impossible to compose silently.
 func RequireTenant(tr TenantResolver, next http.Handler) http.Handler {
+	p := NewPolicy(nil, tr)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		u, ok := CurrentUser(r.Context())
-		if !ok {
-			http.Error(w, "authentication required", http.StatusUnauthorized)
+		u, hasUser := CurrentUser(r.Context())
+		id, _, deny := p.evaluateTenant(r.Context(), u, hasUser, TenantRequired)
+		if deny != DenyNone {
+			WriteDenial(w, deny)
 			return
 		}
-		tenantID, err := tr.TenantForUser(r.Context(), u.ID)
-		if err != nil {
-			// Mirror NewTenantInterceptor's log (interceptors.go) so a 401 here is
-			// never a blind wall — the exact debugging pain that made #408 need a live
-			// repro. The byte handlers require a tenant, so we reject rather than proceed.
-			slog.Default().Warn("require tenant: no tenant for operator", "user_id", u.ID, "err", err)
-			http.Error(w, "authentication required", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r.WithContext(WithTenant(r.Context(), tenantID)))
+		next.ServeHTTP(w, r.WithContext(WithTenant(r.Context(), id)))
 	})
 }
 
-// RequireCSRF is the plain-HTTP double-submit CSRF guard (ADR-0016): the mirror
-// of [NewCSRFInterceptor] for a state-changing net/http POST that bypasses the
-// Connect chain (the import upload). The glyphoxa_csrf cookie must
-// constant-time-match the X-CSRF-Token header, else 403. RequireSession alone is
-// insufficient — a same-origin cookie rides along on a cross-site POST, so the
-// header the SPA sets from the script-readable cookie is what proves intent.
-// Compose it INSIDE RequireSession (auth first, then anti-forgery).
+// RequireCSRF is the plain-HTTP double-submit guard (ADR-0016): the
+// glyphoxa_csrf cookie must constant-time-match the X-CSRF-Token header, else
+// 403. A session alone is insufficient for a state-changing POST — a
+// same-origin cookie rides along on a cross-site POST, so the header the SPA
+// sets from the script-readable cookie is what proves intent. Compose it
+// INSIDE RequireSession (auth first, then anti-forgery).
 func RequireCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cookie := cookieValue(r.Header, CSRFCookieName)
-		header := r.Header.Get("X-CSRF-Token")
-		if cookie == "" || header == "" ||
-			subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
-			http.Error(w, "CSRF token mismatch", http.StatusForbidden)
+		deny := evaluateCSRF(cookieValue(r.Header, CSRFCookieName), r.Header.Get("X-CSRF-Token"), true)
+		if deny != DenyNone {
+			WriteDenial(w, deny)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/internal/auth/mounts.go
+++ b/internal/auth/mounts.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// This file is the declarative policy table for the plain (non-Connect)
+// net/http mounts (issue #446) — the SSE relay + snapshot, the highlight
+// clip/image byte streams, and the campaign bundle export/import. Which
+// checks each mount requires is declared as data in ONE place (the
+// composition root's []GuardedMount) and enforced by [MustGuardMounts], so a
+// mount cannot silently compose a wrapper subset that differs from the
+// Connect gate — the drift that shipped #408.
+
+// GuardedMount is one row of the plain-mount policy table: a Go 1.22
+// method+path ServeMux pattern, the tenant posture the handler needs, and the
+// handler itself. The session check is unconditional — every guarded mount is
+// operator-only (ADR-0041) — and the CSRF check derives from the request
+// method (see [MustGuardMounts]), so the tenant mode is the only per-mount
+// decision left to declare. Its zero value is invalid on purpose: a row that
+// forgets to declare it fails loudly at startup instead of shipping the #408
+// subset.
+type GuardedMount struct {
+	Pattern string
+	Tenant  TenantMode
+	Handler http.Handler
+}
+
+// guardedMethods are the method verbs a guarded pattern must lead with. The
+// method requirement keeps the table honest: every row states what it serves,
+// and the ServeMux registration then enforces it.
+var guardedMethods = map[string]struct{}{
+	http.MethodGet:    {},
+	http.MethodHead:   {},
+	http.MethodPost:   {},
+	http.MethodPut:    {},
+	http.MethodPatch:  {},
+	http.MethodDelete: {},
+}
+
+// validate rejects a row that under-declares its policy. Returned errors are
+// programmer errors — MustGuardMounts turns them into a boot panic.
+func (g GuardedMount) validate() error {
+	if g.Pattern == "" {
+		return fmt.Errorf("auth: guarded mount with empty pattern")
+	}
+	method, _, ok := strings.Cut(g.Pattern, " ")
+	if _, known := guardedMethods[method]; !ok || !known {
+		return fmt.Errorf("auth: guarded mount %q must lead with an explicit method (e.g. %q)", g.Pattern, "GET "+g.Pattern)
+	}
+	if g.Handler == nil {
+		return fmt.Errorf("auth: guarded mount %q has a nil handler", g.Pattern)
+	}
+	switch g.Tenant {
+	case TenantNone, TenantOptional, TenantRequired:
+		return nil
+	case tenantUnspecified:
+		return fmt.Errorf("auth: guarded mount %q does not declare a tenant mode — set Tenant to TenantNone, TenantOptional or TenantRequired (the undeclared-subset drift is what shipped #408)", g.Pattern)
+	default:
+		return fmt.Errorf("auth: guarded mount %q has an unknown tenant mode %d", g.Pattern, g.Tenant)
+	}
+}
+
+// MustGuardMounts validates the plain-mount policy table and returns a copy
+// with every handler wrapped in the shared policy gate ([Policy.Evaluate] —
+// the same evaluation the Connect interceptor runs). It panics on an invalid
+// table (undeclared tenant mode, missing method, nil handler, duplicate
+// pattern): the table is static boot configuration, and a mount without a
+// declared policy must fail the boot, not serve.
+//
+// Per request the guard requires a valid session, requires the CSRF
+// double-submit pair for state-changing methods (everything but GET/HEAD/
+// OPTIONS — the plain-HTTP spelling of the Connect NO_SIDE_EFFECTS
+// exemption, ADR-0016), and applies the row's declared [TenantMode]. Denials
+// map to 401/403 via [WriteDenial]; on success the resolved operator and
+// tenant ride the request context ([CurrentUser] / [TenantID]).
+func MustGuardMounts(p *Policy, rows []GuardedMount) []GuardedMount {
+	if p == nil {
+		panic("auth: MustGuardMounts requires a non-nil Policy")
+	}
+	seen := make(map[string]struct{}, len(rows))
+	guarded := make([]GuardedMount, 0, len(rows))
+	for _, row := range rows {
+		if err := row.validate(); err != nil {
+			panic(err.Error())
+		}
+		if _, dup := seen[row.Pattern]; dup {
+			panic(fmt.Sprintf("auth: guarded mount %q declared twice", row.Pattern))
+		}
+		seen[row.Pattern] = struct{}{}
+		guarded = append(guarded, GuardedMount{
+			Pattern: row.Pattern,
+			Tenant:  row.Tenant,
+			Handler: p.guard(row),
+		})
+	}
+	return guarded
+}
+
+// guard wraps one row's handler in the policy gate.
+func (p *Policy) guard(row GuardedMount) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := p.Evaluate(r.Context(), InputFromHeader(r.Header), Check{
+			CSRF:   !safeMethod(r.Method),
+			Tenant: row.Tenant,
+		})
+		if v.Deny != DenyNone {
+			WriteDenial(w, v.Deny)
+			return
+		}
+		row.Handler.ServeHTTP(w, r.WithContext(v.Context(r.Context())))
+	})
+}
+
+// safeMethod reports whether the request method is read-only in the ADR-0016
+// sense — exempt from the CSRF double-submit exactly like a NO_SIDE_EFFECTS
+// Connect procedure. Derived at request time from the live method (not the
+// pattern), so a future state-changing mount cannot forget its CSRF gate.
+func safeMethod(m string) bool {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return false
+}

--- a/internal/auth/mounts_test.go
+++ b/internal/auth/mounts_test.go
@@ -1,0 +1,149 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func testPolicy() *auth.Policy {
+	return auth.NewPolicy(
+		fakeAuthN{users: map[string]storage.User{validToken: operator()}},
+		fakeTenant{id: uuid.New()},
+	)
+}
+
+// mustPanic asserts fn panics — the "loudly fails at startup" contract of the
+// mount table (#446): an under-declared row must kill the boot, not serve.
+func mustPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Errorf("%s: MustGuardMounts did not panic", name)
+		}
+	}()
+	fn()
+}
+
+func TestMustGuardMounts_RejectsUnderDeclaredRows(t *testing.T) {
+	t.Parallel()
+	p := testPolicy()
+
+	mustPanic(t, "undeclared tenant mode", func() {
+		auth.MustGuardMounts(p, []auth.GuardedMount{
+			{Pattern: "GET /x", Handler: okHandler()}, // Tenant omitted — the #408 shape
+		})
+	})
+	mustPanic(t, "nil handler", func() {
+		auth.MustGuardMounts(p, []auth.GuardedMount{
+			{Pattern: "GET /x", Tenant: auth.TenantNone},
+		})
+	})
+	mustPanic(t, "empty pattern", func() {
+		auth.MustGuardMounts(p, []auth.GuardedMount{
+			{Tenant: auth.TenantNone, Handler: okHandler()},
+		})
+	})
+	mustPanic(t, "pattern without method", func() {
+		auth.MustGuardMounts(p, []auth.GuardedMount{
+			{Pattern: "/api/v1/x", Tenant: auth.TenantNone, Handler: okHandler()},
+		})
+	})
+	mustPanic(t, "duplicate pattern", func() {
+		auth.MustGuardMounts(p, []auth.GuardedMount{
+			{Pattern: "GET /x", Tenant: auth.TenantNone, Handler: okHandler()},
+			{Pattern: "GET /x", Tenant: auth.TenantRequired, Handler: okHandler()},
+		})
+	})
+	mustPanic(t, "nil policy", func() {
+		auth.MustGuardMounts(nil, []auth.GuardedMount{
+			{Pattern: "GET /x", Tenant: auth.TenantNone, Handler: okHandler()},
+		})
+	})
+}
+
+// TestGuardedMount_CSRFDerivesFromMethod proves the table's CSRF rule is
+// structural, not per-row: a state-changing method demands the double-submit
+// pair (the plain-HTTP spelling of the Connect NO_SIDE_EFFECTS exemption,
+// ADR-0016) without any mount having to remember to compose it — the class of
+// omission the hand-built wrapper chains allowed.
+func TestGuardedMount_CSRFDerivesFromMethod(t *testing.T) {
+	t.Parallel()
+	guarded := auth.MustGuardMounts(testPolicy(), []auth.GuardedMount{
+		{Pattern: "GET /read", Tenant: auth.TenantNone, Handler: okHandler()},
+		{Pattern: "POST /write", Tenant: auth.TenantNone, Handler: okHandler()},
+	})
+	read, write := guarded[0].Handler, guarded[1].Handler
+
+	authedReq := func(method, path string) *http.Request {
+		r := httptest.NewRequest(method, path, nil)
+		r.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: validToken})
+		return r
+	}
+
+	// GET passes with a session alone — reads are CSRF-exempt.
+	rec := httptest.NewRecorder()
+	read.ServeHTTP(rec, authedReq(http.MethodGet, "/read"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET without CSRF pair: status = %d, want 200", rec.Code)
+	}
+
+	// POST with a session but no CSRF pair is 403 — no row declared this;
+	// the method did. The body text is pinned: it is the policy's single
+	// denial message, shared verbatim with the Connect transport.
+	rec = httptest.NewRecorder()
+	write.ServeHTTP(rec, authedReq(http.MethodPost, "/write"))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("POST without CSRF pair: status = %d, want 403", rec.Code)
+	}
+	if got := rec.Body.String(); got != "csrf check failed, retry\n" {
+		t.Errorf("POST without CSRF pair: body = %q, want the pinned denial text", got)
+	}
+
+	// POST with the double-submit pair passes.
+	req := authedReq(http.MethodPost, "/write")
+	req.AddCookie(&http.Cookie{Name: auth.CSRFCookieName, Value: "tok123"})
+	req.Header.Set("X-CSRF-Token", "tok123")
+	rec = httptest.NewRecorder()
+	write.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("POST with CSRF pair: status = %d, want 200", rec.Code)
+	}
+}
+
+// TestGuardedMount_SessionAlwaysRequired: every table row is operator-only
+// (ADR-0041) — there is no way to declare a session-exempt guarded mount.
+func TestGuardedMount_SessionAlwaysRequired(t *testing.T) {
+	t.Parallel()
+	guarded := auth.MustGuardMounts(testPolicy(), []auth.GuardedMount{
+		{Pattern: "GET /read", Tenant: auth.TenantNone, Handler: okHandler()},
+	})
+
+	rec := httptest.NewRecorder()
+	guarded[0].Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/read", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("cookieless request: status = %d, want 401", rec.Code)
+	}
+	if got := rec.Body.String(); got != "please sign in\n" {
+		t.Errorf("cookieless request: body = %q, want the pinned denial text", got)
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/read", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: "nope"})
+	guarded[0].Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("invalid session: status = %d, want 401", rec.Code)
+	}
+}

--- a/internal/auth/policy.go
+++ b/internal/auth/policy.go
@@ -1,0 +1,255 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// This file is the single transport-agnostic auth policy (issue #446): session
+// authentication, the double-submit CSRF check (ADR-0016), tenant resolution
+// (ADR-0039), and the denial posture for each — decided ONCE, here. The Connect
+// interceptor (interceptors.go) and the plain net/http guards (middleware.go,
+// mounts.go) are thin adapters that map transport specifics (headers, connect
+// codes vs HTTP statuses) onto [Policy.Evaluate]. Before this seam the two
+// transports hand-synced copies of the same gate, and they drifted: #408
+// shipped because the clip/image mounts composed only the session check (no
+// tenant), so those endpoints 401'd in production while the Connect RPCs
+// passed on the same cookie.
+
+// Authenticator validates a session token and resolves the owning operator.
+// *storage.Store satisfies it via AuthenticateSession.
+type Authenticator interface {
+	AuthenticateSession(ctx context.Context, token string) (storage.User, error)
+}
+
+// TenantResolver resolves the tenant bound to an operator (ADR-0039 thin
+// pass-through). *storage.Store satisfies it via TenantForUser.
+type TenantResolver interface {
+	TenantForUser(ctx context.Context, userID uuid.UUID) (uuid.UUID, error)
+}
+
+// Policy owns the auth decisions both transports enforce. Construct with
+// [NewPolicy]; evaluate with [Policy.Evaluate].
+type Policy struct {
+	authn   Authenticator
+	tenants TenantResolver
+}
+
+// NewPolicy builds the shared policy. tr may be nil only when every evaluation
+// uses [TenantNone] (a nil resolver fails tenant resolution closed).
+func NewPolicy(a Authenticator, tr TenantResolver) *Policy {
+	return &Policy{authn: a, tenants: tr}
+}
+
+// Input is the transport-free request evidence the policy inspects: the two
+// cookie values and the CSRF echo header. Adapters build it with
+// [InputFromHeader]; tests may construct it directly.
+type Input struct {
+	SessionToken string // glyphoxa_session cookie value, "" when absent
+	CSRFCookie   string // glyphoxa_csrf cookie value, "" when absent
+	CSRFHeader   string // X-CSRF-Token header value, "" when absent
+}
+
+// InputFromHeader extracts the policy [Input] from a header set. It works for
+// both a net/http request's Header and a Connect request's Header() (which
+// carries the inbound Cookie header), so cookie extraction cannot drift
+// between the transports either.
+func InputFromHeader(h http.Header) Input {
+	return Input{
+		SessionToken: cookieValue(h, SessionCookieName),
+		CSRFCookie:   cookieValue(h, CSRFCookieName),
+		CSRFHeader:   h.Get("X-CSRF-Token"),
+	}
+}
+
+// TenantMode declares what a mount/procedure needs from tenant resolution.
+// The zero value is deliberately NOT a valid mode: a [GuardedMount] row that
+// forgets to declare one fails [MustGuardMounts] at startup instead of
+// silently composing the subset that caused #408.
+type TenantMode int
+
+const (
+	tenantUnspecified TenantMode = iota // zero value — rejected loudly, fails closed
+	// TenantNone skips tenant resolution entirely. The import POST uses it:
+	// its handler resolves the tenant off the session itself (#291).
+	TenantNone
+	// TenantOptional resolves the operator's tenant when authenticated and
+	// proceeds tenantless on failure (logged) — the Connect posture, where
+	// some procedures are tenant-agnostic and each handler fails on its own
+	// terms.
+	TenantOptional
+	// TenantRequired rejects as unauthenticated when the tenant cannot be
+	// resolved — the byte-mount posture (clip/image/SSE/snapshot/export):
+	// those handlers ALWAYS need a tenant, so this fails fast with the same
+	// code the handler would return anyway.
+	TenantRequired
+)
+
+// Check declares which checks one mount or procedure requires. The Connect
+// adapter derives CSRF from the procedure's IdempotencyLevel; the plain-HTTP
+// guard derives it from the request method — both are transport spellings of
+// the one rule "state-changing requires the double-submit pair".
+type Check struct {
+	// Public marks a procedure reachable without a valid session so it can
+	// self-handle the missing principal (AuthService.GetCurrentUser, the
+	// SPA's 401 → /login probe). A valid session still injects the operator.
+	Public bool
+	// CSRF requires the double-submit pair (ADR-0016).
+	CSRF bool
+	// Tenant is the tenant-resolution posture. Must be set explicitly.
+	Tenant TenantMode
+}
+
+// Denial classifies why the policy rejected a request. Adapters map it onto
+// their transport: connect codes (interceptors.go) or HTTP statuses
+// (middleware.go WriteDenial).
+type Denial int
+
+const (
+	// DenyNone means the request passed every required check.
+	DenyNone Denial = iota
+	// DenyUnauthenticated is the missing/invalid-session (or unresolvable
+	// required tenant) rejection: CodeUnauthenticated / 401.
+	DenyUnauthenticated
+	// DenyCSRF is the double-submit failure: CodePermissionDenied / 403.
+	DenyCSRF
+)
+
+// Message is the user-facing rejection text, identical on both transports.
+func (d Denial) Message() string {
+	switch d {
+	case DenyCSRF:
+		return "csrf check failed, retry"
+	default:
+		return "please sign in"
+	}
+}
+
+// Verdict is the policy outcome for one request: either a [Denial], or the
+// resolved principal/tenant to inject into the request context via
+// [Verdict.Context].
+type Verdict struct {
+	Deny      Denial
+	User      storage.User
+	HasUser   bool
+	Tenant    uuid.UUID
+	HasTenant bool
+}
+
+// Context injects the verdict's resolved operator ([WithUser]) and tenant
+// ([WithTenant]) into ctx. Both adapters call it, so context injection cannot
+// drift between the transports.
+func (v Verdict) Context(ctx context.Context) context.Context {
+	if v.HasUser {
+		ctx = WithUser(ctx, v.User)
+	}
+	if v.HasTenant {
+		ctx = WithTenant(ctx, v.Tenant)
+	}
+	return ctx
+}
+
+// Evaluate runs the full gate in the canonical order — session (who) → CSRF
+// (anti-forgery) → tenant (which tenant) — and returns the verdict. It is the
+// ONLY decision path: the Connect interceptor and the plain-mount guard both
+// call it per request, so a check cannot exist on one transport and not the
+// other (the #408 drift class).
+func (p *Policy) Evaluate(ctx context.Context, in Input, c Check) Verdict {
+	u, hasUser, deny := p.evaluateSession(ctx, in.SessionToken, c.Public)
+	if deny != DenyNone {
+		return Verdict{Deny: deny}
+	}
+	// CSRF applies regardless of authentication state: a public state-changing
+	// procedure still needs the double-submit pair.
+	if deny := evaluateCSRF(in.CSRFCookie, in.CSRFHeader, c.CSRF); deny != DenyNone {
+		return Verdict{Deny: deny}
+	}
+	tenant, hasTenant, deny := p.evaluateTenant(ctx, u, hasUser, c.Tenant)
+	if deny != DenyNone {
+		return Verdict{Deny: deny}
+	}
+	return Verdict{User: u, HasUser: hasUser, Tenant: tenant, HasTenant: hasTenant}
+}
+
+// evaluateSession validates the session token and resolves the operator. A
+// missing/invalid token on a non-public check denies; on a public check the
+// request proceeds without a principal (the procedure self-handles it).
+func (p *Policy) evaluateSession(ctx context.Context, token string, public bool) (storage.User, bool, Denial) {
+	if token != "" && p.authn != nil {
+		if u, err := p.authn.AuthenticateSession(ctx, token); err == nil {
+			return u, true, DenyNone
+		}
+	}
+	if public {
+		return storage.User{}, false, DenyNone
+	}
+	return storage.User{}, false, DenyUnauthenticated
+}
+
+// evaluateCSRF is the double-submit check (ADR-0016): the glyphoxa_csrf cookie
+// must constant-time-match the X-CSRF-Token header. The cookie is not
+// guaranteed present before the first login, which is why reads are exempt
+// (required=false) rather than treating an absent pair as a match.
+func evaluateCSRF(cookie, header string, required bool) Denial {
+	if !required {
+		return DenyNone
+	}
+	if cookie == "" || header == "" ||
+		subtle.ConstantTimeCompare([]byte(cookie), []byte(header)) != 1 {
+		return DenyCSRF
+	}
+	return DenyNone
+}
+
+// evaluateTenant applies the declared [TenantMode]. An unspecified (zero)
+// mode fails CLOSED — [MustGuardMounts] rejects it at startup, but if one
+// slips through a hand-built [Check] it must deny everything, never silently
+// skip the tenant gate.
+func (p *Policy) evaluateTenant(ctx context.Context, u storage.User, hasUser bool, mode TenantMode) (uuid.UUID, bool, Denial) {
+	switch mode {
+	case TenantNone:
+		return uuid.Nil, false, DenyNone
+	case TenantOptional:
+		if !hasUser {
+			return uuid.Nil, false, DenyNone
+		}
+		if id, ok := p.resolveTenant(ctx, u); ok {
+			return id, true, DenyNone
+		}
+		return uuid.Nil, false, DenyNone
+	case TenantRequired:
+		if !hasUser {
+			return uuid.Nil, false, DenyUnauthenticated
+		}
+		if id, ok := p.resolveTenant(ctx, u); ok {
+			return id, true, DenyNone
+		}
+		return uuid.Nil, false, DenyUnauthenticated
+	default:
+		return uuid.Nil, false, DenyUnauthenticated
+	}
+}
+
+// resolveTenant resolves the operator's bound tenant SERVER-SIDE (ADR-0039
+// thin pass-through) — never from a client header — so the multi-tenant
+// membership check fills in here later without a rewrite. A failure is warned
+// so a downstream 401 is never a blind wall — the exact debugging pain that
+// made #408 need a live repro.
+func (p *Policy) resolveTenant(ctx context.Context, u storage.User) (uuid.UUID, bool) {
+	if p.tenants == nil {
+		slog.Default().Warn("auth policy: tenant check declared but no TenantResolver wired", "user_id", u.ID)
+		return uuid.Nil, false
+	}
+	id, err := p.tenants.TenantForUser(ctx, u.ID)
+	if err != nil {
+		slog.Default().Warn("auth policy: no tenant for operator", "user_id", u.ID, "err", err)
+		return uuid.Nil, false
+	}
+	return id, true
+}

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -18,8 +18,8 @@ import (
 // net/http endpoints mounted beside the SSE relay, NOT Connect RPCs (ADR-0015) —
 // the bundle is a file a human inspects, and a streamed gzip download / multipart
 // upload do not fit the Connect message-size model. The operator-only auth
-// posture (ADR-0041) is applied at the mount by wrapping in auth.RequireSession;
-// this type invents no auth of its own.
+// posture (ADR-0041) is applied at the mount via the guarded mount table
+// (auth.MustGuardMounts, #446); this type invents no auth of its own.
 //
 // #290 owns ServeExport (the GET download); #291 adds ServeImport (the POST
 // upload) to this same type.
@@ -34,9 +34,9 @@ type Handler struct {
 // transcript payload (ADR-0053 §1, default off). Archived campaigns are
 // exportable — a backup must still capture a campaign after it is archived.
 //
-// Tenant posture (#439): the mount composes auth.RequireSession +
-// auth.RequireTenant (session AND tenant, the post-#408 discipline), and this
-// handler 404s a campaign outside the injected tenant BEFORE any bytes are
+// Tenant posture (#439): the mount declares TenantRequired (session AND
+// tenant, the post-#408 discipline), and this handler 404s a campaign
+// outside the injected tenant BEFORE any bytes are
 // written — foreign and nonexistent campaigns are indistinguishable, matching
 // the Highlight mounts' don't-reveal-existence posture. A missing context
 // tenant is a miswired mount and rejects 401, fail-closed.
@@ -114,9 +114,10 @@ type importResponse struct {
 }
 
 // ServeImport ingests an uploaded campaign bundle: POST /api/v1/campaigns/import,
-// multipart form field "bundle". The mount wraps it in auth.RequireSession (401
-// gate + operator injected) THEN auth.RequireCSRF (403 double-submit, ADR-0016) —
-// this handler assumes both have passed and reads the operator from the context.
+// multipart form field "bundle". The guarded mount (#446) gates the session
+// (401 + operator injected) and, because POST is state-changing, the CSRF
+// double-submit (403, ADR-0016) — this handler assumes both have passed and
+// reads the operator from the context.
 //
 // The request body is capped by http.MaxBytesReader at [blob.MaxSize] (ADR-0048's
 // 32 MiB constant used purely as a request cap — blob.Store is NOT involved, the

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -29,8 +29,8 @@ type ClipStore interface {
 type CampaignResolver func(ctx context.Context) (uuid.UUID, bool, error)
 
 // ClipServer serves a Highlight's audio clip over plain HTTP (#308/#309): GET
-// /api/v1/highlights/{id}/clip, mounted behind auth.RequireSession +
-// auth.RequireTenant (#408 — session AND tenant) beside the SSE relay (ADR-0015 —
+// /api/v1/highlights/{id}/clip, a TenantRequired row in the guarded mount
+// table (#408/#446 — session AND tenant) beside the SSE relay (ADR-0015 —
 // a byte stream, not a Connect unary). It loads the row
 // tenant-scoped, fetches the clip through the blob seam (ADR-0048), and streams
 // it with http.ServeContent so the browser <audio> scrubber's Range requests
@@ -52,10 +52,11 @@ func NewClipServer(store ClipStore, blobs blob.Store, resolve CampaignResolver, 
 }
 
 // ServeClip streams one Highlight's clip. CONTRACT (#408): the mount must be
-// "session AND tenant", not just session — auth.RequireSession authenticates the
-// operator, and auth.RequireTenant (composed inside it) resolves and injects the
-// tenant server-side. RequireSession ALONE injects only the user, so TenantID
-// misses and this handler 401s every request (the production bug #408 fixed). This
+// "session AND tenant", not just session — its table row declares
+// TenantRequired (#446), so the guard authenticates the operator AND resolves
+// and injects the tenant server-side. A session-only gate injects just the
+// user, so TenantID misses and this handler 401s every request (the
+// production bug #408 fixed). This
 // handler re-reads that injected tenant to scope the row load, so a foreign-tenant
 // id (or an unparsable one) is 404 — existence is never leaked. A missing blob is also 404
 // (the row and clip should agree, but a purge race must not 500). http.ServeContent
@@ -125,8 +126,8 @@ func (c *ClipServer) ServeClip(w http.ResponseWriter, req *http.Request) {
 }
 
 // ServeImage streams one Highlight's AI-generated image (#311), mirroring
-// ServeClip: GET /api/v1/highlights/{id}/image behind auth.RequireSession +
-// auth.RequireTenant (session AND tenant, per #408 — see ServeClip). It
+// ServeClip: GET /api/v1/highlights/{id}/image, a TenantRequired guarded
+// mount (session AND tenant, per #408 — see ServeClip). It
 // applies the same tenant + Active-Campaign 404 posture (existence never leaked)
 // and serves through http.ServeContent (Range/conditional). A Highlight with no
 // image yet (image_key == "") is 404 — the enrichment has not run, is not

--- a/internal/transcript/http.go
+++ b/internal/transcript/http.go
@@ -177,8 +177,9 @@ func (r *Relay) ServeSnapshot(w http.ResponseWriter, req *http.Request) {
 
 // authorizeTenant enforces the tenant-ownership gate (#439) on a session
 // endpoint. With no scope installed it is a no-op (unscoped, pre-#439
-// behavior). Otherwise the request must carry the tenant auth.RequireTenant
-// injected — a miss is a miswired mount (the #408 class) and rejects 401,
+// behavior). Otherwise the request must carry the tenant the TenantRequired
+// guarded mount (#446) injected — a miss is a miswired mount (the #408 class)
+// and rejects 401,
 // fail-closed. A session outside the tenant — including one that does not
 // exist at all, so absence and foreignness are indistinguishable — is 404,
 // matching the Highlight mounts' don't-reveal-existence posture. A check

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -304,8 +304,9 @@ type TenantScope func(ctx context.Context, tenantID, sessionID uuid.UUID) (bool,
 // SetTenantScope wires the tenant-ownership check (#439) after construction,
 // mirroring SetResolver so NewRelay call sites stay byte-identical. With a
 // scope installed, ServeSnapshot and ServeEvents 404 any session outside the
-// request's Tenant (auth.RequireTenant injects it) — the same don't-reveal
-// posture as the Highlight mounts — and the SSE rejection happens before the
+// request's Tenant (the TenantRequired guarded mount injects it) — the same
+// don't-reveal posture as the Highlight mounts — and the SSE rejection
+// happens before the
 // stream opens. nil leaves the endpoints unscoped (voice-standalone builds,
 // unit-test relays). Called once at boot; guarded by r.mu.
 func (r *Relay) SetTenantScope(scope TenantScope) {


### PR DESCRIPTION
## What does this PR do?

Closes #446.

Hoists the duplicated session → CSRF → tenant gate into **one transport-agnostic `auth.Policy`** (`internal/auth/policy.go`) that both transports consume as thin adapters:

- **Connect**: `NewStack` now installs a single `NewPolicyInterceptor` that runs `Policy.Evaluate` per call (public procedures, `NO_SIDE_EFFECTS` CSRF exemption, and `TenantOptional` posture are mapped from Connect specifics onto the shared `Check`).
- **Plain net/http**: the SSE relay/snapshot, highlight clip/image, and bundle export/import mounts route through a **declarative table** (`auth.MustGuardMounts`). The session check is unconditional, CSRF derives from the request method (the plain-HTTP spelling of the `NO_SIDE_EFFECTS` exemption), and the tenant posture is the one explicit per-mount declaration. `TenantMode`'s zero value is invalid, so an under-declared row **panics the boot** instead of silently composing the #408 subset.
- The production declarations live in `plainMountPolicy` (`cmd/glyphoxa/main.go`) and are pinned by `TestPlainMountPolicy`, so a posture downgrade (e.g. a byte mount losing `TenantRequired`) fails the suite.
- `RequireSession`/`RequireTenant`/`RequireCSRF` and the single-check interceptors remain as exported one-check adapters over the same policy helpers — no decision logic is duplicated between the interceptor and middleware files, and existing suites pass unchanged.
- Denial texts now live once on `Denial.Message()` and were reworded to "please sign in" (401) / "csrf check failed, retry" (403), identical on both transports and pinned by tests.

## Why is this change needed?

The two hand-synced copies of the gate had already drifted in production: #408 shipped because the clip/image mounts composed only `RequireSession` (no tenant), so those endpoints 401'd while the Connect RPCs passed on the same cookie. With one policy behind both adapters and a checked mount table, that drift class is structurally impossible; #439's tenant parity hardening (already landed) is absorbed as `TenantRequired` declarations.

## How was this tested?

- New **drift regression tests** (`internal/auth/drift_test.go`): drive the real Connect stack and the guarded mounts with the same principal/cookie/CSRF matrix and assert identical decision classes, identical pinned denial texts, and identical context injection (operator **and** tenant, observed by recording handlers on both transports). `TestAdapterTenantPosture` documents the one deliberate divergence (`TenantOptional` on Connect vs `TenantRequired` on byte mounts) as declared data.
- New mount-table tests (`internal/auth/mounts_test.go`): loud boot failure on under-declared/duplicate/nil/method-less rows; CSRF derived from method; session always required.
- `TestPlainMountPolicy` (`cmd/glyphoxa`) pins the production table. Both new guards were **mutation-verified**: flipping the interceptor's tenant mode or a production table row now fails tests (previously stayed green).
- Existing auth, rpc, transcript, highlight, bundle, and boot suites pass unchanged; `go vet -tags=integration` compiles the integration suites.

- [x] `make check` passes (`fmt` + `vet` + `test`; also `golangci-lint run ./...` clean and `go test -race` on all `internal`/`cmd` packages — the only repo failures are pre-existing environmental ONNX-download failures in `pkg/voice`, present on `main`)
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (modulo the pre-existing `pkg/voice` ONNX environment failures, unchanged from `main`)
- [x] I have updated documentation if needed (`docs/architecture.md` §4.3, package/mount doc comments in `auth`, `bundle`, `highlight`, `transcript`, dev-mode comments in `cmd/glyphoxa`)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- The 401/403 response **status codes** and connect codes are byte-identical to the old gate; the response **body texts** changed as noted above (single source on `Denial.Message()`). Nothing in the repo (SPA included) matched on the old texts.
- An adversarial multi-lens review (behavior parity, security, API compatibility, test quality, policy internals) was run on the diff; all confirmed findings — Connect-side tenant-injection coverage, production-table pinning, denial-text pinning, and stale dev-mode comments — are addressed in this PR. The tenant-resolve-failure log now emits once as `"auth policy: no tenant for operator"` for both transports (previously two near-identical messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL9FbugGWKk3L1DaCzjmgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL9FbugGWKk3L1DaCzjmgn)_