### PR TITLE
refactor(#448): deepen session.Manager — lease core + LiveSession handle + construction-time deps

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -500,63 +500,21 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	runner := func(rctx context.Context, c wirenpc.Config) error {
 		return wirenpc.RunFromDB(rctx, c, pool, cipher)
 	}
-	mgr := session.NewManager(store, runner, cfg, cipher, log, withVoice)
-	// Boot-time reconciliation (#143): close voice_sessions rows a previous run
-	// left 'running' (crash / failed end-write). No loop is live yet, so every
-	// such row is an orphan; done before the web tier serves so GetSession never
-	// reports a dead session as live. Web-only mode skips inside (it owns no
-	// rows). A failure here is a broken DB — fail the boot loudly.
-	if err := mgr.ReconcileOrphans(ctx); err != nil {
-		return fmt.Errorf("web: %w", err)
-	}
+	// The Manager's collaborators below (transcript projectors, highlight saver,
+	// recallers, knowledge Tools adapter) are its construction-time deps (#448),
+	// so they are built FIRST — against this pre-constructed View, the narrow
+	// active-session read they all consume — and NewManager then binds the View.
+	// A Manager cannot exist without its deps already wired, so the old "built
+	// first, back-wired after" ordering comments are gone with the setters.
+	sessions := session.NewView()
 
-	// The one-shot recap Engine (#272) is constructed ONCE here so both consumers can
-	// share it: the /glyphoxa recap slash command (#273, registered below) and the
-	// GenerateRecap RPC (#274, wired through managementMounts). It reads transcripts
-	// via the store, decrypts a BYOK LLM key with cipher, meters usage into the process
+	// The one-shot recap Engine (#272) is constructed ONCE here so its consumers
+	// can share it: the /glyphoxa recap slash command (#273, registered below),
+	// the GenerateRecap RPC (#274, wired through managementMounts), and the recap
+	// knowledge Tool (Deps.Tools below). It reads transcripts via the store,
+	// decrypts a BYOK LLM key with cipher, meters usage into the process
 	// metrics, and logs attribution — but never persists a recap (ADR-0040).
 	recapEngine := recap.NewEngine(store, cipher, metrics, log)
-
-	if withVoice {
-		// The GM admin/session commands (#108, ADR-0010): /glyphoxa use sets the
-		// durable Active Campaign; start/end drive the SAME in-process Manager the
-		// web Session screen uses, so the two surfaces share one session record and
-		// never diverge (AC4). Registered here (not in the presence block above)
-		// because they need the Manager, and BEFORE Ensure so they land in the one
-		// per-Guild registration alongside /roll. /glyphoxa search (#120) joins them:
-		// it resolves the Active Campaign through the SAME shared slash resolver
-		// (resolveActiveCampaign over the store + Manager), so it can never diverge
-		// from /glyphoxa start.
-		reg.Register(
-			presence.UseCommand(store),
-			presence.StartCommand(store, mgr),
-			presence.EndCommand(mgr),
-			presence.SearchCommand(store, mgr),
-			// /glyphoxa recap (#273): recaps the Active Campaign's latest ended Voice
-			// Session via the SAME shared slash resolver, delivered per the invoker's
-			// choice (voiced/public/ephemeral, #271). The Manager is the ButlerVoicer
-			// (#365): the now-voiced Butler (ADR-0009 #299) speaks a `voiced` recap via
-			// SpeakAsButler → SayAs, so it lands as a KindButler transcript line; with no
-			// live session OR a voiceless Butler a voiced request degrades to public text.
-			presence.RecapCommand(store, mgr, recapEngine, mgr),
-			// /glyphoxa mute <npc> + muteall (#211): the Manager is their SessionMuter
-			// and the mute view the live loop reads (NewManager wired cfg.Mutes = mgr).
-			presence.MuteCommand(mgr, store),
-			presence.MuteAllCommand(mgr),
-			// /say <text> as:<agent> (#295, ADR-0010): GM puppeteering. The Manager is the
-			// SayControl (its SayAs publishes SpeakRequested on the shared bus, which the
-			// live loop's DirectSpeech reactor renders in the NPC's Voice); store lists the
-			// voiced roster for the resolver + autocomplete.
-			presence.SayCommand(mgr, store),
-		)
-		// Bring the presence up at boot (AC: the commands appear with no Voice
-		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier
-		// — it stays in the wait-state and the RPC refresher retries on the next save.
-		if err := pres.Ensure(ctx); err != nil {
-			log.Warn("presence: initial ensure failed; the slash-command surface "+
-				"will retry when Discord settings are next saved", "err", err)
-		}
-	}
 
 	// The speaker resolver (#281, E4) resolves a Speaker Lane snowflake to its
 	// Character/GM display name for the relay + chunk prefix. It reads Characters
@@ -573,42 +531,38 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS")), log)
 
 	// The SSE transcript relay (issue #73, ADR-0014 Hop-B) subscribes to the
-	// process bus once and reads the active session from the manager (Snapshot).
+	// process bus once and reads the active session from the session View (#448).
 	// The store backs incremental line persistence + replay-on-reload (#74,
-	// ADR-0040); the manager finalizes the relay's writer queue on Stop (below).
-	relay := transcript.NewRelay(eventBus, mgr, store, log)
+	// ADR-0040); the manager finalizes the relay's writer queue on Stop
+	// (Deps.Transcript below).
+	relay := transcript.NewRelay(eventBus, sessions, store, log)
 	relay.SetResolver(speakerResolver) // #281: resolve who/GM per line (nil-safe, off if unset)
 	// #439: the snapshot/SSE mounts are tenant-scoped — a session outside the
 	// caller's Tenant is 404 (session → campaign → tenant), enforced before the
 	// SSE stream opens. The guarded mount table below declares TenantRequired
 	// to inject the tenant this check reads.
 	relay.SetTenantScope(store.VoiceSessionInTenant)
-	// Back-wire the finalizer so Stop drains the relay's writer queue and records
-	// the authoritative line_count (#74). Done after the relay exists because the
-	// relay needs the manager (Snapshot), so the manager is built first.
-	mgr.SetTranscript(relay)
 
 	// The Transcript Chunk writer (#104, ADR-0011) subscribes to the SAME process
 	// bus and folds utterances into 3–6-utterance chunks written with embedding
 	// NULL (the async embedding pipeline, #116, fills them later); it refreshes the
 	// embedding-backlog gauge from the DB after each write. The manager closes its
-	// open chunk on Stop / loop exit. This CHUNK grain is independent of the relay's
-	// line grain (ADR-0040). Voice-standalone mode does not chunk (same posture as
-	// line persistence).
-	chunker := transcript.NewChunker(eventBus, mgr, store, metrics, log, transcript.ChunkerConfig{})
+	// open chunk on Stop / loop exit (Deps.Chunker below). This CHUNK grain is
+	// independent of the relay's line grain (ADR-0040). Voice-standalone mode does
+	// not chunk (same posture as line persistence).
+	chunker := transcript.NewChunker(eventBus, sessions, store, metrics, log, transcript.ChunkerConfig{})
 	chunker.SetResolver(speakerResolver) // #281: resolved name as each human line's chunk prefix
-	mgr.SetChunkFlusher(chunker)
 
 	// Session Highlights persistence (#308, Epic 8, ADR-0051): the Saver is #307's
 	// detector Sink — it encodes each Trigger's tape snapshot to a clip (behind the
 	// blob seam), writes a 'candidate' highlight row, and on session end schedules
 	// the 7-day candidate purge job. It rides the SAME base voice config the manager
 	// copies per session (cfg.Highlights = the Saver), and the manager Begins/
-	// Finalizes it per session (beside transcript.Finalize). In web-only mode the
-	// manager starts no sessions, so it stays dormant; the RPC read side + clip serve
-	// (below) reach the same rows through Postgres regardless.
+	// Finalizes it per session (beside transcript.Finalize) — both via
+	// Deps.Highlights below. In web-only mode the manager starts no sessions, so it
+	// stays dormant; the RPC read side + clip serve (below) reach the same rows
+	// through Postgres regardless.
 	highlightSaver := highlight.NewSaver(store, blobStore, jobEnqueuer{store}, log)
-	mgr.SetHighlights(highlightSaver)
 	// Seed the backlog gauge from the DB at boot so it reads the true count before
 	// the first chunk is written (idempotent Set-from-COUNT, ADR-0032). A read
 	// failure logs and leaves the gauge at 0 rather than failing the boot.
@@ -616,6 +570,90 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		log.Warn("seed embedding-backlog gauge", "err", err)
 	} else {
 		metrics.SetEmbeddingBacklog(n)
+	}
+
+	// Knowledge Tools' read sources (#296, S1): the storage-backed adapter behind
+	// the read-only transcript_search and kg_query built-ins. UNCONDITIONAL — like
+	// KG-facts recall it needs only the process store + the session View (for the
+	// active Campaign), no embeddings provider — so a keyless deployment still lets a
+	// granted NPC recall the transcript and its own Node neighbourhood. It flows onto
+	// the base voice config every session copies; in web-only mode the Manager starts
+	// no sessions, so the Tools stay dormant. SearchFacts drops gm_private (ADR-0008).
+	knowledgeAdapter := knowledge.New(store, store.PromptKG(), sessions)
+
+	// The Manager's construction-time deps (#448): the finalizers/pipelines it
+	// drives per session and the collaborators riding its base voice config — one
+	// immutable struct instead of six back-wired setters. Everything here was
+	// constructed against the View that NewManager binds below.
+	deps := session.Deps{
+		View:       sessions,
+		Transcript: relay,
+		Chunker:    chunker,
+		Highlights: highlightSaver,
+		// NPC KG-facts recall (#126, ADR-0008): the reserved Hot Context KG-facts
+		// slot, filled per turn from the active Campaign's gm-public Nodes.
+		// UNCONDITIONAL — unlike Memory below — because it needs no embeddings
+		// provider, only the process store (an indexed OLTP read) and the session
+		// View (the active Campaign). Gating it on the provider would silently lose
+		// the feature on keyless deployments. It owns no goroutine/subscription, so
+		// there is nothing to Close.
+		Facts: kgfacts.New(store.PromptKG(), sessions, metrics, log, kgfacts.Config{}),
+		Tools: tool.Deps{
+			Transcripts: knowledgeAdapter,
+			KG:          knowledgeAdapter,
+			KGW:         knowledgeAdapter,
+			Recap:       knowledge.NewRecap(recapEngine, store, sessions),
+		},
+	}
+
+	// Resolve the process embeddings provider ONCE and share it across the two
+	// consumers (#122): the async backfill worker (#116) drains the NULL-embedding
+	// backlog, and the NPC memory recaller (#122) embeds utterances for Hot Context
+	// retrieval. Resolving it twice would open two independent clients. A resolve
+	// failure (an unsupported provider OR a config-read error) is loud-but-non-fatal
+	// for BOTH: the backlog gauge exposes the permanent stall and NPC memory recall
+	// stays disabled (AC6 — Agent turns behave exactly as before), rather than
+	// crashing the process.
+	// embedProvider is hoisted out of the resolve branch so the Knowledge Proposal
+	// review surface's similarity hint (#300) can share the SAME resolved provider:
+	// nil (an unsupported provider or a config-read error) leaves the hint on its
+	// fulltext fallback, exactly as the backfill worker stalls loudly.
+	var embedProvider embeddings.Provider
+	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
+		log.Error("embeddings provider unavailable; embedding backfill and NPC memory recall disabled", "err", err)
+	} else {
+		embedProvider = provider
+		// Backfill worker (#116, ADR-0011): claims chunks written with embedding NULL,
+		// embeds their text, and UPDATEs each row — draining the gauge toward zero and
+		// making the chunks returnable by embedding-filtered retrieval. It needs only
+		// the DB + provider (not the voice loop), so it runs in web AND all mode. It
+		// rides the process signal ctx, so SIGTERM stops it and any in-flight provider
+		// call aborts with the same context.
+		go embedworker.New(store, provider, model, metrics, log, embedworker.Config{}).Run(ctx)
+
+		// NPC memory recall (#122, ADR-0011/0042): one recaller over the shared
+		// provider + the process store (ANN retriever, #119) + the session View
+		// (the active Campaign) + the process bus (STTPartial speculation). Wired as
+		// Deps.Memory so every manager-started session's Agent loops fill the
+		// reserved Hot Context memory slot; a slow/unavailable path degrades
+		// to no-memory within the turn budget. Bound to the run ctx — AfterFunc drops
+		// the bus subscription and stops the speculator on shutdown. In web-only mode
+		// the Manager starts no sessions, so the recaller stays dormant (bus idle).
+		// Set only in this branch so a keyless deployment leaves Memory a true nil
+		// (recall off), never a typed-nil interface.
+		recaller := recall.New(provider, store, sessions, eventBus, metrics, log, recall.Config{})
+		context.AfterFunc(ctx, recaller.Close)
+		deps.Memory = recaller
+	}
+
+	mgr := session.NewManager(store, runner, cfg, cipher, log, withVoice, deps)
+	// Boot-time reconciliation (#143): close voice_sessions rows a previous run
+	// left 'running' (crash / failed end-write). No loop is live yet, so every
+	// such row is an orphan; done before the web tier serves so GetSession never
+	// reports a dead session as live. Web-only mode skips inside (it owns no
+	// rows). A failure here is a broken DB — fail the boot loudly.
+	if err := mgr.ReconcileOrphans(ctx); err != nil {
+		return fmt.Errorf("web: %w", err)
 	}
 
 	// Background job runner (#286, ADR-0049): one DB-backed generic runner over the
@@ -670,9 +708,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 
 	// Boot-time retention backstop (#308, ADR-0051, the ReconcileOrphans/#184 spirit):
 	// a crash between a session ending and the Saver scheduling its 7-day candidate
-	// purge would strand those candidates. At boot, enqueue a purge for every ended
-	// session that has candidates but no live purge job. Loud-but-non-fatal: a failure
-	// logs and boot continues (the next boot retries).
+	// purge would strand those candidates. At boot — AFTER ReconcileOrphans above, so
+	// crash-orphaned sessions count as ended and their candidates are swept THIS
+	// boot, not the next — enqueue a purge for every ended session that has
+	// candidates but no live purge job. Loud-but-non-fatal: a failure logs and boot
+	// continues (the next boot retries).
 	if err := highlight.SweepMissingCandidatePurges(ctx, store, jobEnqueuer{store}, log); err != nil {
 		log.Warn("highlight purge backstop sweep failed at boot", "err", err)
 	}
@@ -688,67 +728,46 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		log.Warn("highlight enrichment reconciliation sweep failed at boot", "err", err)
 	}
 
-	// Resolve the process embeddings provider ONCE and share it across the two
-	// consumers (#122): the async backfill worker (#116) drains the NULL-embedding
-	// backlog, and the NPC memory recaller (#122) embeds utterances for Hot Context
-	// retrieval. Resolving it twice would open two independent clients. A resolve
-	// failure (an unsupported provider OR a config-read error) is loud-but-non-fatal
-	// for BOTH: the backlog gauge exposes the permanent stall and NPC memory recall
-	// stays disabled (AC6 — Agent turns behave exactly as before), rather than
-	// crashing the process.
-	// embedProvider is hoisted out of the resolve branch so the Knowledge Proposal
-	// review surface's similarity hint (#300) can share the SAME resolved provider:
-	// nil (an unsupported provider or a config-read error) leaves the hint on its
-	// fulltext fallback, exactly as the backfill worker stalls loudly.
-	var embedProvider embeddings.Provider
-	if provider, model, err := embedworker.ResolveProvider(ctx, store); err != nil {
-		log.Error("embeddings provider unavailable; embedding backfill and NPC memory recall disabled", "err", err)
-	} else {
-		embedProvider = provider
-		// Backfill worker (#116, ADR-0011): claims chunks written with embedding NULL,
-		// embeds their text, and UPDATEs each row — draining the gauge toward zero and
-		// making the chunks returnable by embedding-filtered retrieval. It needs only
-		// the DB + provider (not the voice loop), so it runs in web AND all mode. It
-		// rides the process signal ctx, so SIGTERM stops it and any in-flight provider
-		// call aborts with the same context.
-		go embedworker.New(store, provider, model, metrics, log, embedworker.Config{}).Run(ctx)
-
-		// NPC memory recall (#122, ADR-0011/0042): one recaller over the shared
-		// provider + the process store (ANN retriever, #119) + the session Manager
-		// (the active Campaign) + the process bus (STTPartial speculation). Set on the
-		// Manager's base voice config so every manager-started session's Agent loops
-		// fill the reserved Hot Context memory slot; a slow/unavailable path degrades
-		// to no-memory within the turn budget. Bound to the run ctx — AfterFunc drops
-		// the bus subscription and stops the speculator on shutdown. In web-only mode
-		// the Manager starts no sessions, so the recaller stays dormant (bus idle).
-		recaller := recall.New(provider, store, mgr, eventBus, metrics, log, recall.Config{})
-		context.AfterFunc(ctx, recaller.Close)
-		mgr.SetMemory(recaller)
+	if withVoice {
+		// The GM admin/session commands (#108, ADR-0010): /glyphoxa use sets the
+		// durable Active Campaign; start/end drive the SAME in-process Manager the
+		// web Session screen uses, so the two surfaces share one session record and
+		// never diverge (AC4). Registered here (not in the presence block above)
+		// because they need the Manager, and BEFORE Ensure so they land in the one
+		// per-Guild registration alongside /roll. /glyphoxa search (#120) joins them:
+		// it resolves the Active Campaign through the SAME shared slash resolver
+		// (resolveActiveCampaign over the store + Manager), so it can never diverge
+		// from /glyphoxa start.
+		reg.Register(
+			presence.UseCommand(store),
+			presence.StartCommand(store, mgr),
+			presence.EndCommand(mgr),
+			presence.SearchCommand(store, mgr),
+			// /glyphoxa recap (#273): recaps the Active Campaign's latest ended Voice
+			// Session via the SAME shared slash resolver, delivered per the invoker's
+			// choice (voiced/public/ephemeral, #271). The Manager is the ButlerVoicer
+			// (#365): the now-voiced Butler (ADR-0009 #299) speaks a `voiced` recap via
+			// SpeakAsButler → SayAs, so it lands as a KindButler transcript line; with no
+			// live session OR a voiceless Butler a voiced request degrades to public text.
+			presence.RecapCommand(store, mgr, recapEngine, mgr),
+			// /glyphoxa mute <npc> + muteall (#211): the Manager is their SessionMuter
+			// and the mute view the live loop reads (NewManager wired cfg.Mutes = mgr).
+			presence.MuteCommand(mgr, store),
+			presence.MuteAllCommand(mgr),
+			// /say <text> as:<agent> (#295, ADR-0010): GM puppeteering. The Manager is the
+			// SayControl (its SayAs publishes SpeakRequested on the shared bus, which the
+			// live loop's DirectSpeech reactor renders in the NPC's Voice); store lists the
+			// voiced roster for the resolver + autocomplete.
+			presence.SayCommand(mgr, store),
+		)
+		// Bring the presence up at boot (AC: the commands appear with no Voice
+		// Session). Non-fatal: a bad or absent Bot token must not kill the web tier
+		// — it stays in the wait-state and the RPC refresher retries on the next save.
+		if err := pres.Ensure(ctx); err != nil {
+			log.Warn("presence: initial ensure failed; the slash-command surface "+
+				"will retry when Discord settings are next saved", "err", err)
+		}
 	}
-
-	// NPC KG-facts recall (#126, ADR-0008): the reserved Hot Context KG-facts slot,
-	// filled per turn from the active Campaign's gm-public Nodes. UNCONDITIONAL —
-	// OUTSIDE the embeddings-provider branch above — because it needs no embeddings
-	// provider, only the process store (an indexed OLTP read) and the session
-	// Manager (the active Campaign). Gating it on the provider would silently lose
-	// the feature on keyless deployments. It owns no goroutine/subscription, so
-	// there is nothing to Close.
-	mgr.SetFacts(kgfacts.New(store.PromptKG(), mgr, metrics, log, kgfacts.Config{}))
-
-	// Knowledge Tools' read sources (#296, S1): the storage-backed adapter behind
-	// the read-only transcript_search and kg_query built-ins. UNCONDITIONAL — like
-	// KG-facts recall it needs only the process store + the session Manager (for the
-	// active Campaign), no embeddings provider — so a keyless deployment still lets a
-	// granted NPC recall the transcript and its own Node neighbourhood. It flows onto
-	// the base voice config every session copies; in web-only mode the Manager starts
-	// no sessions, so the Tools stay dormant. SearchFacts drops gm_private (ADR-0008).
-	knowledgeAdapter := knowledge.New(store, store.PromptKG(), mgr)
-	mgr.SetToolDeps(tool.Deps{
-		Transcripts: knowledgeAdapter,
-		KG:          knowledgeAdapter,
-		KGW:         knowledgeAdapter,
-		Recap:       knowledge.NewRecap(recapEngine, store, mgr),
-	})
 
 	// The web tier serves the auth-guarded Connect API under /api, the Discord
 	// OAuth carve-out under /auth (ADR-0015/0016), and the embedded SPA at /

--- a/internal/presence/mute.go
+++ b/internal/presence/mute.go
@@ -180,8 +180,8 @@ func resolveAgent(roster []storage.Agent, input string) (agent storage.Agent, fo
 // now (ADR-0009 #299 amendment), but it stays Address-Only and mute is
 // matcher-owned and Character-only, so muting it would be an inert control — it is
 // neither offered by the autocomplete nor resolvable by name/UUID here. The
-// manager rejects it too (see session.SetAgentMute); this just keeps the /glyphoxa
-// surface from ever presenting a mute target that does nothing.
+// manager rejects it too (see session.LiveSession.SetAgentMute); this just keeps
+// the /glyphoxa surface from ever presenting a mute target that does nothing.
 func voiced(agents []storage.Agent) []storage.Agent {
 	out := make([]storage.Agent, 0, len(agents))
 	for _, a := range agents {

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -29,8 +29,9 @@ type SessionManager interface {
 	Snapshot() (storage.VoiceSession, bool)
 	// SetAgentMute / SetAllMute toggle the live per-Agent mute set (#211), returning
 	// the resulting sorted muted-id set; both fail ErrNoActiveSession when idle. The
-	// set is the VOICED Character NPCs only — the Address-Only Butler is never voiced
-	// (ADR-0009/ADR-0024), so SetAllMute skips it and SetAgentMute fails
+	// set is the Character NPCs only — the Address-Only Butler is not a mute target
+	// (voiced since the ADR-0009 #299 amendment, but mute is matcher-owned and
+	// Character-only), so SetAllMute skips it and SetAgentMute fails
 	// ErrAgentNotInCampaign for it, just as for an agent outside the active session's
 	// Campaign (all validated atomically against that session).
 	SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error)

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -14,7 +14,7 @@ func (m *Manager) SetEndTimeoutForTest(d time.Duration) {
 }
 
 // BaseFactsForTest returns the FactsRecaller threaded onto the base voice config,
-// so a test can assert SetFacts wired it (#126). Test-only.
+// so a test can assert Deps.Facts wired it (#126, #448). Test-only.
 func (m *Manager) BaseFactsForTest() agent.FactsRecaller {
 	return m.base.Facts
 }

--- a/internal/session/livesession.go
+++ b/internal/session/livesession.go
@@ -1,0 +1,421 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// LiveSession is a handle to ONE live Voice Session (#448), carrying the
+// session-scoped operations — the mute set, GM puppeteering (SayAs /
+// SpeakAsButler) and Highlight replay — that the lease/lifecycle [Manager] hands
+// out via [Manager.Live]. The handle is pinned to the session that was active
+// when it was obtained: every operation revalidates that its session is STILL
+// the active one (the one revalidate implementation) and fails
+// [ErrNoActiveSession] once stale — after the session ended, or after a new one
+// started. A handle is cheap, safe for concurrent use, and never outlives its
+// usefulness silently: staleness surfaces as ErrNoActiveSession (the idle nil
+// for the MutedAgentIDs read), never as a misdirected write.
+type LiveSession struct {
+	m  *Manager
+	as *activeSession
+}
+
+// Live returns a handle to the currently active Voice Session, or nil when idle
+// (the caller's ErrNoActiveSession moment). The handle stays valid only while
+// that same session is the active one; see [LiveSession].
+func (m *Manager) Live() *LiveSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.active == nil {
+		return nil
+	}
+	return &LiveSession{m: m, as: m.active}
+}
+
+// revalidate is THE one implementation of the capture → drop-lock → revalidate
+// dance the session-scoped ops share (#448): it re-locks Manager.mu, confirms
+// this handle's session is still the active one, runs fn (which may be nil for
+// pure liveness checks) under the lock, and unlocks. A stale handle — its
+// session ended or another one started between the capture and now — fails
+// ErrNoActiveSession without running fn, so an op can never mutate or publish
+// into a session it was not obtained from.
+func (l *LiveSession) revalidate(fn func()) error {
+	l.m.mu.Lock()
+	defer l.m.mu.Unlock()
+	if l.m.active != l.as {
+		return ErrNoActiveSession
+	}
+	if fn != nil {
+		fn()
+	}
+	return nil
+}
+
+// MutedAgentIDs is a sorted snapshot of the session's currently-muted Agent ids,
+// or nil when the handle is stale — the same shape as the idle Manager read
+// backing GetSession's reload truth (AC5).
+func (l *LiveSession) MutedAgentIDs() []string {
+	var ids []string
+	if err := l.revalidate(func() { ids = mutedIDsLocked(l.as.muted) }); err != nil {
+		return nil
+	}
+	return ids
+}
+
+// SetAgentMute mutes or unmutes one voiced Agent in this session, returning the
+// resulting sorted muted-id set (#211). It rejects an agentID that is not a
+// VOICED Agent of the session's Campaign — a foreign agent, an unknown id, or
+// the Address-Only Butler (never a mute target, ADR-0009/ADR-0024) — with
+// ErrAgentNotInCampaign, and fails ErrNoActiveSession once the handle is stale.
+//
+// Validation and the write are SESSION-ATOMIC (mirrors SetAllMute): the Campaign
+// is listed with no lock held (the store read may block), then the set is
+// written only if this handle's session is still active (revalidate) — so a
+// session swap between the roster read and the write can never sneak a foreign
+// agent (valid in the old Campaign, not the new) into the new session's mute
+// set. The write-then-publish runs under pubMu so it is globally ordered against
+// a concurrent SetAllMute (no reverse-order events).
+func (l *LiveSession) SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error) {
+	// Fail a stale handle BEFORE the roster read (the shape the pre-handle ops
+	// had: active-session check first), so no store round-trip runs — and no
+	// store error masks the staleness — for a session that is already gone. The
+	// authoritative check is the one under pubMu below; this one only fails fast.
+	if err := l.revalidate(nil); err != nil {
+		return nil, err
+	}
+	agents, err := l.m.store.ListAgents(ctx, l.as.campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("session: list agents for mute: %w", err)
+	}
+	if !agentInList(voicedAgents(agents), agentID) {
+		return nil, ErrAgentNotInCampaign
+	}
+
+	l.m.pubMu.Lock()
+	defer l.m.pubMu.Unlock()
+
+	var (
+		changed bool
+		ids     []string
+	)
+	if err := l.revalidate(func() {
+		changed = applyMuteLocked(l.as.muted, agentID, muted)
+		ids = mutedIDsLocked(l.as.muted)
+	}); err != nil {
+		return nil, err
+	}
+	// base is immutable after NewManager (#448), so the Bus read needs no lock;
+	// the publish itself runs outside Manager.mu (subscribers re-read Muted) but
+	// inside pubMu (the #211 ordering).
+	if changed && l.m.base.Bus != nil {
+		l.m.base.Bus.Publish(voiceevent.MuteChanged{At: time.Now(), AgentID: agentID, Muted: muted})
+	}
+	return ids, nil
+}
+
+// SetAllMute mutes or unmutes every mutable Agent of the session's Campaign (the
+// Character NPCs from store.ListAgents, minus the Address-Only Butler — which is
+// voiced now (ADR-0009 #299 amendment) but is not a mute target, mute being
+// matcher-owned and Character-only), returning the resulting sorted muted-id set
+// (#211). The roster is listed with no lock held (the store read may block),
+// then the set is applied only if this handle's session is still active
+// (revalidate) — a session that ended (or a new one that started) while listing
+// fails ErrNoActiveSession. The apply + its per-change MuteChanged burst run
+// under pubMu, so the whole mute-all is ordered atomically against a concurrent
+// per-Agent toggle.
+func (l *LiveSession) SetAllMute(ctx context.Context, muted bool) ([]string, error) {
+	// Stale-fast before the roster read; the authoritative check runs under
+	// pubMu below (mirrors SetAgentMute).
+	if err := l.revalidate(nil); err != nil {
+		return nil, err
+	}
+	agents, err := l.m.store.ListAgents(ctx, l.as.campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("session: list agents for mute-all: %w", err)
+	}
+
+	l.m.pubMu.Lock()
+	defer l.m.pubMu.Unlock()
+
+	var (
+		changes []voiceevent.MuteChanged
+		ids     []string
+	)
+	if err := l.revalidate(func() {
+		changes = make([]voiceevent.MuteChanged, 0, len(agents))
+		for _, a := range voicedAgents(agents) {
+			id := a.ID.String()
+			if applyMuteLocked(l.as.muted, id, muted) {
+				changes = append(changes, voiceevent.MuteChanged{AgentID: id, Muted: muted})
+			}
+		}
+		ids = mutedIDsLocked(l.as.muted)
+	}); err != nil {
+		return nil, err
+	}
+	if l.m.base.Bus != nil {
+		now := time.Now()
+		for _, c := range changes {
+			c.At = now
+			l.m.base.Bus.Publish(c)
+		}
+	}
+	return ids, nil
+}
+
+// SayAs publishes a GM-puppeteered direct-speech request (#295, ADR-0010): the
+// voiced Agent with agentID speaks text verbatim in this Voice Session. It
+// rejects an agentID that is not an Agent of the session's Campaign — a foreign
+// agent or an unknown id — with ErrAgentNotInCampaign. The now-voiced Butler
+// (ADR-0009 #299 amendment) IS a valid target reached via
+// [LiveSession.SpeakAsButler]; the Discord /say roster still excludes it
+// (say.go's voiced filter), so a GM cannot puppet it by hand.
+//
+// Validation and the publish are SESSION-ATOMIC (mirrors SetAgentMute): the
+// Campaign is listed with no lock held (the store read may block), then the
+// event is published only if this handle's session is still active (revalidate)
+// — so a session swap between the roster read and the publish can never voice a
+// foreign agent into the new session. It publishes [voiceevent.SpeakRequested]
+// carrying the agent's Target (id + the Agent's OWN role + display name — a
+// butler-role Target projects a KindButler line, ADR-0040), a fresh TurnID, and
+// the text — NOT [voiceevent.AddressRouted], which would trigger the LLM Replier
+// (ADR-0024). The GM mute is deliberately NOT consulted here (puppeteering is a
+// GM override, so a muted NPC still speaks a /say — the DirectSpeech reactor
+// bypasses the mute gate).
+func (l *LiveSession) SayAs(ctx context.Context, agentID, text string) error {
+	// Stale-fast before the roster read (the pre-handle SayAs checked the active
+	// session first, so an ended session never reached the store and a store
+	// error could never mask ErrNoActiveSession); the publish-guarding check
+	// below stays the authoritative one.
+	if err := l.revalidate(nil); err != nil {
+		return err
+	}
+	agents, err := l.m.store.ListAgents(ctx, l.as.campaignID)
+	if err != nil {
+		return fmt.Errorf("session: list agents for say: %w", err)
+	}
+	var target storage.Agent
+	found := false
+	for _, a := range agents {
+		if a.ID.String() == agentID {
+			target = a
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrAgentNotInCampaign
+	}
+
+	if err := l.revalidate(nil); err != nil {
+		return err
+	}
+	if l.m.base.Bus != nil {
+		l.m.base.Bus.Publish(voiceevent.SpeakRequested{
+			At:     time.Now(),
+			TurnID: voiceevent.NewTurnID(),
+			Target: voiceevent.AddressTarget{
+				AgentID:   agentID,
+				AgentRole: sayRole(target.Role),
+				Name:      target.Name,
+			},
+			Text: text,
+		})
+	}
+	return nil
+}
+
+// SpeakAsButler voices text verbatim as the session Campaign's Butler (#365) —
+// the recap decision-6a voiced on-ramp. It resolves the Butler from the roster
+// and delegates to [LiveSession.SayAs] ON THE SAME HANDLE (so a session that
+// rolled over between the two roster reads is refused rather than voiced into
+// the successor), and the published SpeakRequested carries the Butler's
+// butler-role Target — the transcript projects a KindButler line through the
+// NORMAL relay projection (no hand-crafted row). A campaign with no Butler
+// yields ErrAgentNotInCampaign, and a VOICELESS Butler (empty VoiceID — the
+// default auto-Butler) yields ErrButlerVoiceless BEFORE any publish, so the
+// recap surface can degrade to text rather than persist a phantom line for
+// unsynthesizable speech (AC1, ADR-0012).
+func (l *LiveSession) SpeakAsButler(ctx context.Context, text string) error {
+	// Stale-fast before the roster read (mirrors SayAs, which re-checks before
+	// the publish).
+	if err := l.revalidate(nil); err != nil {
+		return err
+	}
+	agents, err := l.m.store.ListAgents(ctx, l.as.campaignID)
+	if err != nil {
+		return fmt.Errorf("session: list agents for butler say: %w", err)
+	}
+	for _, a := range agents {
+		if a.Role != storage.AgentRoleButler {
+			continue
+		}
+		// The default auto-Butler is voiceless (empty VoiceID). Refuse BEFORE SayAs
+		// publishes anything, so no phantom KindButler line is persisted for speech the
+		// room can never hear (AC1: "when a live session has a VOICED Butler").
+		voice, err := storage.VoiceFromJSON(a.Voice)
+		if err != nil {
+			return fmt.Errorf("session: decode butler voice: %w", err)
+		}
+		if voice.VoiceID == "" {
+			return ErrButlerVoiceless
+		}
+		return l.SayAs(ctx, a.ID.String(), text)
+	}
+	return ErrAgentNotInCampaign
+}
+
+// ReplayHighlight publishes a [voiceevent.ReplayRequested] so the orchestrator's
+// ClipReplay reactor plays a promoted Session Highlight's clip into this
+// session's voice channel (#310, Epic 8, ADR-0051 GM-only sharing). The clipKey
+// is the blob key the ShareHighlight RPC already resolved (and
+// campaign-ownership-checked) — the handle only gates on its session still being
+// live (revalidate, so a session that ended is refused rather than replayed
+// into) and mints the turn (ADR-0005: the event carries the KEY, never audio).
+func (l *LiveSession) ReplayHighlight(_ context.Context, clipKey string) error {
+	if err := l.revalidate(nil); err != nil {
+		return err
+	}
+	if l.m.base.Bus != nil {
+		l.m.base.Bus.Publish(voiceevent.ReplayRequested{
+			At:      time.Now(),
+			TurnID:  voiceevent.NewTurnID(),
+			ClipKey: clipKey,
+		})
+	}
+	return nil
+}
+
+// The session-scoped ops below stay reachable on the Manager as one-line routes
+// through the CURRENT LiveSession (#448): the existing consumer seams
+// (rpc.SessionManager, rpc.HighlightReplayer, presence.SessionMuter,
+// presence.SayControl, presence.ButlerVoicer) are satisfied by *Manager and
+// resolve the live Voice Session per call — a handle captured at boot would be
+// forever stale. Idle maps to the same ErrNoActiveSession a stale handle
+// reports, so callers see one error contract either way.
+
+// SetAgentMute routes to [LiveSession.SetAgentMute] on the current session;
+// idle is ErrNoActiveSession (AC4).
+func (m *Manager) SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error) {
+	l := m.Live()
+	if l == nil {
+		return nil, ErrNoActiveSession
+	}
+	return l.SetAgentMute(ctx, agentID, muted)
+}
+
+// SetAllMute routes to [LiveSession.SetAllMute] on the current session; idle is
+// ErrNoActiveSession.
+func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) {
+	l := m.Live()
+	if l == nil {
+		return nil, ErrNoActiveSession
+	}
+	return l.SetAllMute(ctx, muted)
+}
+
+// SayAs routes to [LiveSession.SayAs] on the current session; idle is
+// ErrNoActiveSession (refused before any roster lookup).
+func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
+	l := m.Live()
+	if l == nil {
+		return ErrNoActiveSession
+	}
+	return l.SayAs(ctx, agentID, text)
+}
+
+// SpeakAsButler routes to [LiveSession.SpeakAsButler] on the current session
+// (satisfies presence.ButlerVoicer structurally); idle is ErrNoActiveSession.
+func (m *Manager) SpeakAsButler(ctx context.Context, text string) error {
+	l := m.Live()
+	if l == nil {
+		return ErrNoActiveSession
+	}
+	return l.SpeakAsButler(ctx, text)
+}
+
+// ReplayHighlight routes to [LiveSession.ReplayHighlight] on the current
+// session; idle is ErrNoActiveSession and publishes nothing.
+func (m *Manager) ReplayHighlight(ctx context.Context, clipKey string) error {
+	l := m.Live()
+	if l == nil {
+		return ErrNoActiveSession
+	}
+	return l.ReplayHighlight(ctx, clipKey)
+}
+
+// sayRole maps an Agent's storage Role to the [voiceevent.AddressTarget] role
+// string the transcript relay keys its Line Kind off (ADR-0040): the Butler yields
+// the butler role (→ KindButler pill), every other Agent the character role. The two
+// vocabularies share their underlying strings, but mapping explicitly keeps SayAs
+// decoupled from that coincidence.
+func sayRole(r storage.AgentRole) string {
+	if r == storage.AgentRoleButler {
+		return voiceevent.AgentRoleButler
+	}
+	return voiceevent.AgentRoleCharacter
+}
+
+// agentInList reports whether agentID (a UUID string) names an Agent in agents.
+func agentInList(agents []storage.Agent, agentID string) bool {
+	for _, a := range agents {
+		if a.ID.String() == agentID {
+			return true
+		}
+	}
+	return false
+}
+
+// voicedAgents returns only the Agents the mute subsystem can act on — the
+// Character NPCs. The auto-created Butler (agent_role='butler') now enters the
+// voiced wirenpc Roster/Matcher/Cast (ADR-0009 #299 amendment), but it stays
+// Address-Only and mute is matcher-owned and Character-only: muting the Butler is
+// refused, so filtering it here could only ever record a phantom id that silences
+// nothing. Filtering it here is the single chokepoint both SetAgentMute (which
+// then rejects the Butler with ErrAgentNotInCampaign) and SetAllMute (which then
+// skips it) share, so the live mute set is exactly the set of Character Agents —
+// and GetSession's reload truth (muted_agent_ids) never lists the Butler.
+func voicedAgents(agents []storage.Agent) []storage.Agent {
+	out := make([]storage.Agent, 0, len(agents))
+	for _, a := range agents {
+		if a.Role == storage.AgentRoleButler {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// applyMuteLocked sets or clears agentID in the mute set, reporting whether the
+// set actually changed (so an idempotent re-mute publishes nothing). Caller holds
+// Manager.mu.
+func applyMuteLocked(set map[string]struct{}, agentID string, muted bool) bool {
+	_, was := set[agentID]
+	if muted == was {
+		return false
+	}
+	if muted {
+		set[agentID] = struct{}{}
+	} else {
+		delete(set, agentID)
+	}
+	return true
+}
+
+// mutedIDsLocked returns the muted ids as a sorted slice. Caller holds Manager.mu.
+func mutedIDsLocked(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/session/livesession_test.go
+++ b/internal/session/livesession_test.go
@@ -1,0 +1,248 @@
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// TestLive_IdleReturnsNil pins the handle's idle contract (#448): with no active
+// Voice Session there is nothing to hand out, so Live returns nil and the caller
+// maps that to the same ErrNoActiveSession the Manager pass-throughs report.
+func TestLive_IdleReturnsNil(t *testing.T) {
+	mgr, _ := muteManager(t, newFakeStore())
+	if l := mgr.Live(); l != nil {
+		t.Fatalf("Live() while idle = %v, want nil", l)
+	}
+}
+
+// TestLiveSession_StaleAfterStopRefused pins the stale-handle error contract
+// (#448): a handle obtained from a session that has since ENDED fails every
+// operation with the existing ErrNoActiveSession semantics — nothing is
+// published, nothing is mutated.
+func TestLiveSession_StaleAfterStopRefused(t *testing.T) {
+	store := newFakeStore()
+	bart := seedAgents(store, 1)[0]
+	mgr, bus := muteManager(t, store)
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	live := mgr.Live()
+	if live == nil {
+		t.Fatal("Live() during an active session = nil, want a handle")
+	}
+
+	var spoke []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { spoke = append(spoke, e) }))
+	var replayed []voiceevent.ReplayRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.ReplayRequested) { replayed = append(replayed, e) }))
+	var muteEvents []voiceevent.MuteChanged
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { muteEvents = append(muteEvents, e) }))
+
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if _, err := live.SetAgentMute(context.Background(), bart.ID.String(), true); err != session.ErrNoActiveSession {
+		t.Errorf("stale SetAgentMute = %v, want ErrNoActiveSession", err)
+	}
+	if _, err := live.SetAllMute(context.Background(), true); err != session.ErrNoActiveSession {
+		t.Errorf("stale SetAllMute = %v, want ErrNoActiveSession", err)
+	}
+	if err := live.SayAs(context.Background(), bart.ID.String(), "hello"); err != session.ErrNoActiveSession {
+		t.Errorf("stale SayAs = %v, want ErrNoActiveSession", err)
+	}
+	if err := live.SpeakAsButler(context.Background(), "hello"); err != session.ErrNoActiveSession {
+		t.Errorf("stale SpeakAsButler = %v, want ErrNoActiveSession", err)
+	}
+	if err := live.ReplayHighlight(context.Background(), "clip/abc"); err != session.ErrNoActiveSession {
+		t.Errorf("stale ReplayHighlight = %v, want ErrNoActiveSession", err)
+	}
+	if got := live.MutedAgentIDs(); got != nil {
+		t.Errorf("stale MutedAgentIDs = %v, want nil", got)
+	}
+	if len(spoke) != 0 || len(replayed) != 0 || len(muteEvents) != 0 {
+		t.Errorf("a stale handle published %d SpeakRequested / %d ReplayRequested / %d MuteChanged, want none",
+			len(spoke), len(replayed), len(muteEvents))
+	}
+}
+
+// TestLiveSession_MidOpRolloverRefused pins the AUTHORITATIVE revalidation — the
+// one under pubMu, after the roster read (#448): the handle passes its stale-fast
+// entry check while the session is live, then the session ends DURING ListAgents
+// (the fake store's mid-op hook), so only the second check can catch it. The op
+// must refuse ErrNoActiveSession and publish nothing — deleting the inner
+// revalidate would fail this test.
+func TestLiveSession_MidOpRolloverRefused(t *testing.T) {
+	store := newFakeStore()
+	bart := seedAgents(store, 1)[0]
+	mgr, bus := muteManager(t, store)
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	live := mgr.Live()
+
+	var muteEvents []voiceevent.MuteChanged
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.MuteChanged) { muteEvents = append(muteEvents, e) }))
+	var spoke []voiceevent.SpeakRequested
+	t.Cleanup(voiceevent.On(bus, func(e voiceevent.SpeakRequested) { spoke = append(spoke, e) }))
+
+	// End the session from inside the roster read: after the entry check, before
+	// the write/publish. Disarm after one shot so the Stop itself can't recurse.
+	store.mu.Lock()
+	store.onListAgents = func() {
+		store.mu.Lock()
+		store.onListAgents = nil
+		store.mu.Unlock()
+		if _, err := mgr.Stop(context.Background()); err != nil {
+			t.Errorf("mid-op Stop: %v", err)
+		}
+	}
+	store.mu.Unlock()
+
+	if _, err := live.SetAgentMute(context.Background(), bart.ID.String(), true); err != session.ErrNoActiveSession {
+		t.Fatalf("mid-op-rollover SetAgentMute = %v, want ErrNoActiveSession", err)
+	}
+	if len(muteEvents) != 0 {
+		t.Fatalf("mid-op-rollover SetAgentMute published %d MuteChanged, want none", len(muteEvents))
+	}
+
+	// Same window for SayAs: entry check passes, the session ends during the
+	// roster read, the publish-guarding revalidate must refuse.
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start 2: %v", err)
+	}
+	t.Cleanup(mgr.Shutdown)
+	live = mgr.Live()
+	store.mu.Lock()
+	store.onListAgents = func() {
+		store.mu.Lock()
+		store.onListAgents = nil
+		store.mu.Unlock()
+		if _, err := mgr.Stop(context.Background()); err != nil {
+			t.Errorf("mid-op Stop 2: %v", err)
+		}
+	}
+	store.mu.Unlock()
+	if err := live.SayAs(context.Background(), bart.ID.String(), "hello"); err != session.ErrNoActiveSession {
+		t.Fatalf("mid-op-rollover SayAs = %v, want ErrNoActiveSession", err)
+	}
+	if len(spoke) != 0 {
+		t.Fatalf("mid-op-rollover SayAs published %d SpeakRequested, want none", len(spoke))
+	}
+}
+
+// TestLiveSession_StaleAfterRolloverRefused pins the sharper half of the stale
+// contract (#448): a handle from session 1 stays stale even while session 2 IS
+// active — the revalidation is same-session, not merely any-session — so a
+// racing op can never mutate or voice into a successor session's state.
+func TestLiveSession_StaleAfterRolloverRefused(t *testing.T) {
+	store := newFakeStore()
+	bart := seedAgents(store, 1)[0]
+	mgr, _ := muteManager(t, store)
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start 1: %v", err)
+	}
+	stale := mgr.Live()
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("Start 2: %v", err)
+	}
+	t.Cleanup(mgr.Shutdown)
+
+	if _, err := stale.SetAgentMute(context.Background(), bart.ID.String(), true); err != session.ErrNoActiveSession {
+		t.Errorf("rolled-over SetAgentMute = %v, want ErrNoActiveSession", err)
+	}
+	if got := mgr.MutedAgentIDs(); len(got) != 0 {
+		t.Errorf("session 2 mute set = %v after a stale handle's write, want empty", got)
+	}
+	if err := stale.SayAs(context.Background(), bart.ID.String(), "hi"); err != session.ErrNoActiveSession {
+		t.Errorf("rolled-over SayAs = %v, want ErrNoActiveSession", err)
+	}
+
+	// A FRESH handle to session 2 works: the staleness is per-handle, not sticky.
+	fresh := mgr.Live()
+	if fresh == nil {
+		t.Fatal("Live() during session 2 = nil, want a handle")
+	}
+	ids, err := fresh.SetAgentMute(context.Background(), bart.ID.String(), true)
+	if err != nil {
+		t.Fatalf("fresh SetAgentMute: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != bart.ID.String() {
+		t.Fatalf("fresh handle muted ids = %v, want [%s]", ids, bart.ID)
+	}
+}
+
+// TestView_SnapshotTracksBoundManager pins the View seam (#448): unbound (the
+// projectors' state between their construction and NewManager) it reports no
+// active session; bound via Deps.View it mirrors the Manager's Snapshot through
+// the whole lifecycle.
+func TestView_SnapshotTracksBoundManager(t *testing.T) {
+	view := session.NewView()
+	if _, ok := view.Snapshot(); ok {
+		t.Fatal("an unbound View reports an active session, want idle")
+	}
+
+	store := newFakeStore()
+	bus := voiceeventBusForView()
+	mgr := newViewManager(t, store, bus, view)
+	if _, ok := view.Snapshot(); ok {
+		t.Fatal("a bound-but-idle View reports an active session, want idle")
+	}
+
+	started, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(mgr.Shutdown)
+	vs, ok := view.Snapshot()
+	if !ok || vs.ID != started.ID {
+		t.Fatalf("bound View snapshot = (%v, %v), want the started session %s", vs.ID, ok, started.ID)
+	}
+
+	if _, err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if _, ok := view.Snapshot(); ok {
+		t.Fatal("View still reports an active session after Stop, want idle")
+	}
+}
+
+// TestView_SecondBindPanics pins the bind-once guard (#448): two Managers
+// sharing one View would silently split the active-session truth, so the second
+// NewManager panics loudly at boot instead.
+func TestView_SecondBindPanics(t *testing.T) {
+	view := session.NewView()
+	store := newFakeStore()
+	bus := voiceeventBusForView()
+	newViewManager(t, store, bus, view)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("binding a View to a second Manager did not panic")
+		}
+	}()
+	newViewManager(t, store, bus, view)
+}
+
+// voiceeventBusForView keeps the View tests' Manager construction shaped like
+// muteManager without threading its return pair around.
+func voiceeventBusForView() *voiceevent.Bus { return voiceevent.NewBus() }
+
+// newViewManager builds a Manager bound to view over store, mirroring
+// muteManager's config.
+func newViewManager(t *testing.T, store session.Store, bus *voiceevent.Bus, view *session.View) *session.Manager {
+	t.Helper()
+	return session.NewManager(store, reRunnableRunner,
+		wirenpc.Config{Token: "test-token", Bus: bus}, nil, slog.New(slog.DiscardHandler), true,
+		session.Deps{View: view})
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 	"time"
 
@@ -106,8 +105,9 @@ type Store interface {
 // calls it on Stop / loop exit BEFORE EndVoiceSession so the recorded count
 // matches the persisted rows. *transcript.Relay satisfies it; defined here (not
 // imported) so the manager does NOT depend on the relay — the relay already
-// depends on the manager via Sessions, and the reverse import would cycle. nil
-// (not wired / persistence off) leaves line_count at the in-memory default.
+// depends on the active-session read via its Sessions seam (a [View], #448), and
+// the reverse import would cycle. nil (not wired / persistence off) leaves
+// line_count at the in-memory default.
 type TranscriptFinalizer interface {
 	Finalize(ctx context.Context, id uuid.UUID) (int, error)
 }
@@ -130,8 +130,9 @@ type Highlighter interface {
 // (#104, ADR-0011): a lone trailing utterance is flushed ONLY here, at session
 // end. *transcript.Chunker satisfies it; defined here (not imported) so the
 // manager does NOT depend on the transcript package — the chunker already depends
-// on the manager via Sessions, and the reverse import would cycle (mirrors
-// TranscriptFinalizer). nil (no chunking / voice-standalone) is a no-op.
+// on the active-session read via its Sessions seam (a [View], #448), and the
+// reverse import would cycle (mirrors TranscriptFinalizer). nil (no chunking /
+// voice-standalone) is a no-op.
 type ChunkFinalizer interface {
 	FlushSession(ctx context.Context, sessionID uuid.UUID) error
 }
@@ -183,7 +184,7 @@ const spendHardReason = "spend_cap_hard: estimated spend crossed the hard cap"
 type Manager struct {
 	store      Store
 	run        LoopRunner
-	base       wirenpc.Config      // Token (env fallback)/Logger/Metrics template; Guild/Channel come from saved config
+	base       wirenpc.Config      // Token (env fallback)/Logger/Metrics template; Guild/Channel come from saved config. Immutable after NewManager (#448), so lock-free reads (e.g. base.Bus) are safe.
 	cipher     *crypto.Cipher      // decrypts the saved deployment Bot token (#87); nil without $GLYPHOXA_SECRET
 	transcript TranscriptFinalizer // finalizes persisted lines on Stop (#74); nil keeps line_count at 0
 	chunker    ChunkFinalizer      // closes the open Transcript Chunk on Stop (#104); nil = no chunking
@@ -197,99 +198,111 @@ type Manager struct {
 	closed bool // terminal: set by Shutdown; Start refuses with ErrManagerClosed (#157)
 
 	// pubMu serializes the whole write-set→publish-MuteChanged sequence across the
-	// mute ops (#211), so two overlapping ops (a per-Agent toggle racing a mute-all)
-	// can never publish events in the reverse order of their set writes — which
-	// would let a stale event de-sync the wirenpc matcher from the authoritative
-	// set. Ordered AFTER m.mu: an op takes pubMu, then m.mu for the set write, drops
-	// m.mu, publishes while still holding pubMu, then drops pubMu. Muted() (the
-	// re-read subscribers do during that publish) takes only m.mu, which is free —
-	// no inversion.
+	// [LiveSession] mute ops (#211), so two overlapping ops (a per-Agent toggle
+	// racing a mute-all) can never publish events in the reverse order of their set
+	// writes — which would let a stale event de-sync the wirenpc matcher from the
+	// authoritative set. Ordered AFTER m.mu: an op takes pubMu, then m.mu for the
+	// set write, drops m.mu, publishes while still holding pubMu, then drops pubMu.
+	// Muted() (the re-read subscribers do during that publish) takes only m.mu,
+	// which is free — no inversion. It lives on the Manager (not the handle) so the
+	// ordering is global across ALL handles to the session.
 	pubMu sync.Mutex
 }
 
-// NewManager wraps the store, loop runner and base config in a Manager. base
-// carries the env-fallback Discord token, logger and metrics recorders; Start
-// overlays the saved guild/channel onto a copy and resolves the Bot token (the
-// saved deployment token decrypted via cipher, else the base env token — #87).
-// cipher may be nil (boot without $GLYPHOXA_SECRET): the env-fallback path still
-// works, but a real saved token then fails Start with a clear precondition
-// (ErrDiscordTokenUndecryptable). enabled is false in
+// Deps are the Manager's construction-time collaborator seams (#448): the six
+// formerly post-construction setters folded into one struct, so "wired before
+// the first Start" is structural — the Manager (and its base voice config) is
+// immutable after NewManager returns — instead of comment-enforced call
+// ordering in the composition root. Every field is optional; the zero value is
+// a Manager with every collaborator off (the voice-standalone / test posture).
+//
+// Five of the collaborators themselves need the active-session read (the
+// Manager's Snapshot) — the old Manager ↔ projector construction cycle that
+// forced the setters. The cycle breaks at its true seam: they depend only on a
+// narrow Sessions{Snapshot} interface, so they are constructed FIRST against a
+// [View], and the View is bound to the Manager here at construction.
+type Deps struct {
+	// Transcript is the finalizer that drains the live transcript's writer queue on
+	// Stop / loop exit and returns the authoritative persisted line_count (#74,
+	// ADR-0040). nil (not wired / persistence off) keeps line_count at the
+	// in-memory default.
+	Transcript TranscriptFinalizer
+	// Chunker closes the session's open Transcript Chunk on Stop / loop exit
+	// (#104, ADR-0011). nil = no chunking (voice-standalone, same posture as line
+	// persistence).
+	Chunker ChunkFinalizer
+	// Highlights is the Session Highlights persistence pipeline (#308): the
+	// Manager Begins/Finalizes it per session, and the SAME value flows onto the
+	// base voice config as cfg.Highlights (the detector's Sink) every session
+	// copies. nil = highlights off (the detector, if any, gets a nil Sink).
+	Highlights Highlighter
+	// Memory is the NPC memory recaller wired onto the base voice config every
+	// manager-started session copies (#122): it flows through Start → RunFromDB →
+	// connectAndServe → buildConversation into each NPC's Agent loop. nil (an
+	// unavailable embeddings/DB path) leaves recall off (AC6).
+	Memory agent.MemoryRecaller
+	// Facts is the NPC KG-facts recaller wired onto the base voice config (#126),
+	// filling the reserved Hot Context KG-facts slot per turn. nil leaves facts
+	// off (the prompt stays byte-identical).
+	Facts agent.FactsRecaller
+	// Tools are the built-in knowledge Tools' backing sources wired onto the base
+	// voice config (#296): the adapters behind transcript_search, kg_query, the
+	// remember_knowledge proposal writer and the recap Tool, flowing through
+	// buildConversation → tool.BuiltinRegistry. The zero value leaves the Tools
+	// registered but unavailable at Execute (the prompt/loop still behave, the
+	// model just gets an "unavailable" tool result).
+	Tools tool.Deps
+	// View, when non-nil, is bound to the new Manager so the collaborators above —
+	// constructed against it BEFORE the Manager existed — read this Manager's
+	// active session. Binding inside NewManager is what makes the wiring order
+	// un-breakable (#448). A View binds to exactly one Manager.
+	View *View
+}
+
+// NewManager wraps the store, loop runner, base config and collaborator deps in
+// a Manager. base carries the env-fallback Discord token, logger and metrics
+// recorders; Start overlays the saved guild/channel onto a copy and resolves
+// the Bot token (the saved deployment token decrypted via cipher, else the base
+// env token — #87). cipher may be nil (boot without $GLYPHOXA_SECRET): the
+// env-fallback path still works, but a real saved token then fails Start with a
+// clear precondition (ErrDiscordTokenUndecryptable). enabled is false in
 // web-only mode, where the process does not drive voice (Start fails
 // ErrVoiceUnavailable).
-func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto.Cipher, log *slog.Logger, enabled bool) *Manager {
+//
+// The Manager and its base config are immutable once NewManager returns (#448):
+// every collaborator arrives via deps, so nothing needs a lock to read base and
+// no wiring can land after the first Start.
+func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto.Cipher, log *slog.Logger, enabled bool, deps Deps) *Manager {
 	if log == nil {
 		log = slog.Default()
 	}
-	m := &Manager{store: store, run: run, base: base, cipher: cipher, log: log, enabled: enabled, endTimeout: endTimeout}
+	m := &Manager{
+		store:      store,
+		run:        run,
+		base:       base,
+		cipher:     cipher,
+		transcript: deps.Transcript,
+		chunker:    deps.Chunker,
+		highlights: deps.Highlights,
+		log:        log,
+		enabled:    enabled,
+		endTimeout: endTimeout,
+	}
 	// The Manager IS the live mute view (#211): it owns the session-local mute set,
 	// so wire it as the base voice config's MuteView. Every session Start copies
 	// base, so each session's Conversation reads this Manager's set.
 	m.base.Mutes = m
+	m.base.Memory = deps.Memory
+	m.base.Facts = deps.Facts
+	m.base.ToolDeps = deps.Tools
+	// The SAME Highlighter the Manager Begins/Finalizes per session is the base
+	// config's detector Sink (#308), so triggers land in the pipeline the Manager
+	// owns the lifecycle of.
+	m.base.Highlights = deps.Highlights
+	if deps.View != nil {
+		deps.View.bind(m)
+	}
 	return m
-}
-
-// SetTranscript wires the transcript finalizer the Manager calls on Stop / loop
-// exit (#74). It is set once at boot — after both the Manager and the relay are
-// built (the relay needs the Manager via Sessions, so the Manager is built first
-// and the finalizer back-wired) — before any session can start, so no lock is
-// needed.
-func (m *Manager) SetTranscript(t TranscriptFinalizer) {
-	m.transcript = t
-}
-
-// SetChunkFlusher wires the chunk finalizer the Manager calls on Stop / loop exit
-// (#104). Like SetTranscript it is set once at boot, after the chunker is built
-// (the chunker needs the Manager via Sessions), before any session can start, so
-// no lock is needed. nil leaves chunking off (voice-standalone, same posture as
-// line persistence).
-func (m *Manager) SetChunkFlusher(f ChunkFinalizer) {
-	m.chunker = f
-}
-
-// SetMemory wires the NPC memory recaller onto the base voice config every
-// manager-started session copies (#122): it flows through Start → RunFromDB →
-// connectAndServe → buildConversation into each NPC's Agent loop. Like
-// SetTranscript / SetChunkFlusher it is set once at boot — the recaller needs the
-// Manager as its Sessions source (the active Campaign), so the Manager is built
-// first and the recaller back-wired — before any session can start, so no lock is
-// needed. nil (an unavailable embeddings/DB path) leaves recall off (AC6).
-func (m *Manager) SetMemory(r agent.MemoryRecaller) {
-	m.base.Memory = r
-}
-
-// SetFacts wires the NPC KG-facts recaller onto the base voice config every
-// manager-started session copies (#126): it flows through Start → RunFromDB →
-// connectAndServe → buildConversation into each NPC's Agent loop, filling the
-// reserved Hot Context KG-facts slot. Like SetMemory it is set once at boot — the
-// recaller needs the Manager as its Sessions source (the active Campaign), so the
-// Manager is built first and the recaller back-wired — before any session can
-// start, so no lock is needed. nil leaves facts off (the prompt stays byte-identical).
-func (m *Manager) SetFacts(f agent.FactsRecaller) {
-	m.base.Facts = f
-}
-
-// SetToolDeps wires the built-in knowledge Tools' read sources onto the base
-// voice config every manager-started session copies (#296, S1): the adapter
-// backing transcript_search and kg_query. Like SetFacts it flows through Start →
-// RunFromDB → connectAndServe → buildConversation → tool.BuiltinRegistry, so a
-// live NPC granted a knowledge Tool actually reaches the DB. The adapter needs
-// the Manager as its active-session source, so the Manager is built first and the
-// deps back-wired before any session starts — no lock needed. The zero value
-// leaves the Tools registered but unavailable at Execute (the prompt/loop still
-// behave, the model just gets an "unavailable" tool result).
-func (m *Manager) SetToolDeps(d tool.Deps) {
-	m.base.ToolDeps = d
-}
-
-// SetHighlights wires the Session Highlights persistence pipeline (#308): the
-// Manager Begins/Finalizes it per session, and the SAME value flows onto the base
-// voice config as cfg.Highlights (the detector's Sink) every session copies. Like
-// SetTranscript it is set once at boot — the Saver needs the store + blob backend,
-// built alongside the Manager — before any session can start, so no lock is
-// needed. nil leaves highlights off (the detector, if any, gets a nil Sink).
-func (m *Manager) SetHighlights(h Highlighter) {
-	m.highlights = h
-	m.base.Highlights = h
 }
 
 // ReconcileOrphans closes voice_sessions rows still marked 'running' that no
@@ -672,337 +685,12 @@ func (m *Manager) Muted(agentID string) bool {
 
 // MutedAgentIDs is a sorted snapshot of the currently-muted Agent ids, or nil when
 // idle. It backs GetSession's reload truth (AC5): a mid-session page reload reads
-// the true current mute state from here.
+// the true current mute state from here. It routes through the current
+// [LiveSession] (#448).
 func (m *Manager) MutedAgentIDs() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.active == nil {
+	l := m.Live()
+	if l == nil {
 		return nil
 	}
-	return mutedIDsLocked(m.active.muted)
-}
-
-// SetAgentMute mutes or unmutes one voiced Agent in the live session, returning
-// the resulting sorted muted-id set (#211). It refuses when idle
-// (ErrNoActiveSession, AC4) and rejects an agentID that is not a VOICED Agent of
-// the active session's Campaign — a foreign agent, an unknown id, or the
-// Address-Only Butler (never voiced, ADR-0009/ADR-0024) — with
-// ErrAgentNotInCampaign.
-//
-// Validation and the write are SESSION-ATOMIC (mirrors SetAllMute): the active
-// session is captured, its Campaign is listed with m.mu released (the store read
-// may block), then the set is written only if the SAME session is still active —
-// so a session swap between the roster read and the write can never sneak a
-// foreign agent (valid in the old Campaign, not the new) into the new session's
-// mute set. The write-then-publish runs under pubMu so it is globally ordered
-// against a concurrent SetAllMute (no reverse-order events).
-func (m *Manager) SetAgentMute(ctx context.Context, agentID string, muted bool) ([]string, error) {
-	m.mu.Lock()
-	as := m.active
-	if as == nil {
-		m.mu.Unlock()
-		return nil, ErrNoActiveSession
-	}
-	campaignID := as.campaignID
-	m.mu.Unlock()
-
-	agents, err := m.store.ListAgents(ctx, campaignID)
-	if err != nil {
-		return nil, fmt.Errorf("session: list agents for mute: %w", err)
-	}
-	if !agentInList(voicedAgents(agents), agentID) {
-		return nil, ErrAgentNotInCampaign
-	}
-
-	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
-
-	m.mu.Lock()
-	if m.active != as {
-		// The session ended or rolled over between the roster read and the write:
-		// abort rather than mutate a set that belongs to a different session.
-		m.mu.Unlock()
-		return nil, ErrNoActiveSession
-	}
-	changed := applyMuteLocked(m.active.muted, agentID, muted)
-	ids := mutedIDsLocked(m.active.muted)
-	bus := m.base.Bus
-	m.mu.Unlock()
-
-	if changed && bus != nil {
-		bus.Publish(voiceevent.MuteChanged{At: time.Now(), AgentID: agentID, Muted: muted})
-	}
-	return ids, nil
-}
-
-// SetAllMute mutes or unmutes every mutable Agent of the Active Campaign (the
-// Character NPCs from store.ListAgents, minus the Address-Only Butler — which is
-// voiced now (ADR-0009 #299 amendment) but is not a mute target, mute being
-// matcher-owned and Character-only), returning the resulting sorted muted-id set
-// (#211). It refuses when idle
-// (ErrNoActiveSession). The campaign is captured under m.mu, the roster is listed
-// with m.mu released (the store read may block), then the set is re-locked and
-// applied only if the SAME session is still active — a session that ended (or a
-// new one that started) while listing aborts with ErrNoActiveSession. The apply +
-// its per-change MuteChanged burst run under pubMu, so the whole mute-all is
-// ordered atomically against a concurrent per-Agent toggle.
-func (m *Manager) SetAllMute(ctx context.Context, muted bool) ([]string, error) {
-	m.mu.Lock()
-	as := m.active
-	if as == nil {
-		m.mu.Unlock()
-		return nil, ErrNoActiveSession
-	}
-	campaignID := as.campaignID
-	m.mu.Unlock()
-
-	agents, err := m.store.ListAgents(ctx, campaignID)
-	if err != nil {
-		return nil, fmt.Errorf("session: list agents for mute-all: %w", err)
-	}
-
-	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
-
-	m.mu.Lock()
-	if m.active != as {
-		// The session ended or rolled over while we listed agents: abort rather than
-		// mutate a set that no longer belongs to this session.
-		m.mu.Unlock()
-		return nil, ErrNoActiveSession
-	}
-	changes := make([]voiceevent.MuteChanged, 0, len(agents))
-	for _, a := range voicedAgents(agents) {
-		id := a.ID.String()
-		if applyMuteLocked(m.active.muted, id, muted) {
-			changes = append(changes, voiceevent.MuteChanged{AgentID: id, Muted: muted})
-		}
-	}
-	ids := mutedIDsLocked(m.active.muted)
-	bus := m.base.Bus
-	m.mu.Unlock()
-
-	if bus != nil {
-		now := time.Now()
-		for _, c := range changes {
-			c.At = now
-			bus.Publish(c)
-		}
-	}
-	return ids, nil
-}
-
-// SayAs publishes a GM-puppeteered direct-speech request (#295, ADR-0010): the
-// voiced Agent with agentID speaks text verbatim in the live Voice Session. It
-// refuses when idle (ErrNoActiveSession) and rejects an agentID that is not an
-// Agent of the active session's Campaign — a foreign agent or an unknown id — with
-// ErrAgentNotInCampaign. The now-voiced Butler (ADR-0009 #299 amendment) IS a valid
-// target reached via [Manager.SpeakAsButler]; the Discord /say roster still excludes
-// it (say.go's voiced filter), so a GM cannot puppet it by hand.
-//
-// Validation and the publish are SESSION-ATOMIC (mirrors SetAgentMute): the active
-// session is captured, its Campaign is listed with m.mu released (the store read may
-// block), then the event is published only if the SAME session is still active — so
-// a session swap between the roster read and the publish can never voice a foreign
-// agent into the new session. It publishes [voiceevent.SpeakRequested] carrying the
-// agent's Target (id + the Agent's OWN role + display name — a butler-role Target
-// projects a KindButler line, ADR-0040), a fresh TurnID, and the text — NOT
-// [voiceevent.AddressRouted], which would trigger the LLM Replier (ADR-0024). The GM
-// mute is deliberately NOT consulted here (puppeteering is a GM override, so a muted
-// NPC still speaks a /say — the DirectSpeech reactor bypasses the mute gate).
-func (m *Manager) SayAs(ctx context.Context, agentID, text string) error {
-	m.mu.Lock()
-	as := m.active
-	if as == nil {
-		m.mu.Unlock()
-		return ErrNoActiveSession
-	}
-	campaignID := as.campaignID
-	m.mu.Unlock()
-
-	agents, err := m.store.ListAgents(ctx, campaignID)
-	if err != nil {
-		return fmt.Errorf("session: list agents for say: %w", err)
-	}
-	var target storage.Agent
-	found := false
-	for _, a := range agents {
-		if a.ID.String() == agentID {
-			target = a
-			found = true
-			break
-		}
-	}
-	if !found {
-		return ErrAgentNotInCampaign
-	}
-
-	m.mu.Lock()
-	if m.active != as {
-		// The session ended or rolled over between the roster read and the publish:
-		// abort rather than voice into a different (or no) session.
-		m.mu.Unlock()
-		return ErrNoActiveSession
-	}
-	bus := m.base.Bus
-	m.mu.Unlock()
-
-	if bus != nil {
-		bus.Publish(voiceevent.SpeakRequested{
-			At:     time.Now(),
-			TurnID: voiceevent.NewTurnID(),
-			Target: voiceevent.AddressTarget{
-				AgentID:   agentID,
-				AgentRole: sayRole(target.Role),
-				Name:      target.Name,
-			},
-			Text: text,
-		})
-	}
-	return nil
-}
-
-// ReplayHighlight publishes a [voiceevent.ReplayRequested] so the orchestrator's
-// ClipReplay reactor plays a promoted Session Highlight's clip into the live voice
-// channel (#310, Epic 8, ADR-0051 GM-only sharing). It mirrors [Manager.SayAs]'s
-// active-session guard: with no live Voice Session it is refused ErrNoActiveSession
-// and publishes nothing. The clipKey is the blob key the ShareHighlight RPC already
-// resolved (and campaign-ownership-checked) — the Manager only gates on a live
-// session and mints the turn (ADR-0005: the event carries the KEY, never audio).
-//
-// The active session is captured under m.mu and the publish happens only if a
-// session is still live (session-atomic, mirroring SayAs), so a session that ended
-// between the check and the publish can never replay into a dead session.
-func (m *Manager) ReplayHighlight(_ context.Context, clipKey string) error {
-	m.mu.Lock()
-	as := m.active
-	if as == nil {
-		m.mu.Unlock()
-		return ErrNoActiveSession
-	}
-	bus := m.base.Bus
-	m.mu.Unlock()
-
-	if bus != nil {
-		bus.Publish(voiceevent.ReplayRequested{
-			At:      time.Now(),
-			TurnID:  voiceevent.NewTurnID(),
-			ClipKey: clipKey,
-		})
-	}
-	return nil
-}
-
-// sayRole maps an Agent's storage Role to the [voiceevent.AddressTarget] role
-// string the transcript relay keys its Line Kind off (ADR-0040): the Butler yields
-// the butler role (→ KindButler pill), every other Agent the character role. The two
-// vocabularies share their underlying strings, but mapping explicitly keeps SayAs
-// decoupled from that coincidence.
-func sayRole(r storage.AgentRole) string {
-	if r == storage.AgentRoleButler {
-		return voiceevent.AgentRoleButler
-	}
-	return voiceevent.AgentRoleCharacter
-}
-
-// SpeakAsButler voices text verbatim as the Active Campaign's Butler in the live
-// Voice Session (#365) — the recap decision-6a voiced on-ramp (satisfies
-// presence.ButlerVoicer structurally). It resolves the session's Butler from the
-// roster and delegates to [Manager.SayAs], so the published SpeakRequested carries
-// the Butler's butler-role Target and the transcript projects a KindButler line
-// through the NORMAL relay projection (no hand-crafted row). It refuses when idle
-// (ErrNoActiveSession), a campaign with no Butler yields ErrAgentNotInCampaign, and
-// a VOICELESS Butler (empty VoiceID — the default auto-Butler) yields
-// ErrButlerVoiceless BEFORE any publish, so the recap surface can degrade to text
-// rather than persist a phantom line for unsynthesizable speech (AC1, ADR-0012).
-func (m *Manager) SpeakAsButler(ctx context.Context, text string) error {
-	m.mu.Lock()
-	as := m.active
-	if as == nil {
-		m.mu.Unlock()
-		return ErrNoActiveSession
-	}
-	campaignID := as.campaignID
-	m.mu.Unlock()
-
-	agents, err := m.store.ListAgents(ctx, campaignID)
-	if err != nil {
-		return fmt.Errorf("session: list agents for butler say: %w", err)
-	}
-	for _, a := range agents {
-		if a.Role != storage.AgentRoleButler {
-			continue
-		}
-		// The default auto-Butler is voiceless (empty VoiceID). Refuse BEFORE SayAs
-		// publishes anything, so no phantom KindButler line is persisted for speech the
-		// room can never hear (AC1: "when a live session has a VOICED Butler").
-		voice, err := storage.VoiceFromJSON(a.Voice)
-		if err != nil {
-			return fmt.Errorf("session: decode butler voice: %w", err)
-		}
-		if voice.VoiceID == "" {
-			return ErrButlerVoiceless
-		}
-		return m.SayAs(ctx, a.ID.String(), text)
-	}
-	return ErrAgentNotInCampaign
-}
-
-// agentInList reports whether agentID (a UUID string) names an Agent in agents.
-func agentInList(agents []storage.Agent, agentID string) bool {
-	for _, a := range agents {
-		if a.ID.String() == agentID {
-			return true
-		}
-	}
-	return false
-}
-
-// voicedAgents returns only the Agents the mute subsystem can act on — the
-// Character NPCs. The auto-created Butler (agent_role='butler') now enters the
-// voiced wirenpc Roster/Matcher/Cast (ADR-0009 #299 amendment), but it stays
-// Address-Only and mute is matcher-owned and Character-only: muting the Butler is
-// refused, so filtering it here could only ever record a phantom id that silences
-// nothing. Filtering it here is the single chokepoint both SetAgentMute (which
-// then rejects the Butler with ErrAgentNotInCampaign) and SetAllMute (which then
-// skips it) share, so the live mute set is exactly the set of Character Agents —
-// and GetSession's reload truth (muted_agent_ids) never lists the Butler.
-func voicedAgents(agents []storage.Agent) []storage.Agent {
-	out := make([]storage.Agent, 0, len(agents))
-	for _, a := range agents {
-		if a.Role == storage.AgentRoleButler {
-			continue
-		}
-		out = append(out, a)
-	}
-	return out
-}
-
-// applyMuteLocked sets or clears agentID in the mute set, reporting whether the
-// set actually changed (so an idempotent re-mute publishes nothing). Caller holds
-// Manager.mu.
-func applyMuteLocked(set map[string]struct{}, agentID string, muted bool) bool {
-	_, was := set[agentID]
-	if muted == was {
-		return false
-	}
-	if muted {
-		set[agentID] = struct{}{}
-	} else {
-		delete(set, agentID)
-	}
-	return true
-}
-
-// mutedIDsLocked returns the muted ids as a sorted slice. Caller holds Manager.mu.
-func mutedIDsLocked(set map[string]struct{}) []string {
-	if len(set) == 0 {
-		return nil
-	}
-	ids := make([]string, 0, len(set))
-	for id := range set {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids
+	return l.MutedAgentIDs()
 }

--- a/internal/session/manager_mute_test.go
+++ b/internal/session/manager_mute_test.go
@@ -29,7 +29,7 @@ func muteManager(t *testing.T, store session.Store) (*session.Manager, *voiceeve
 	t.Helper()
 	bus := voiceevent.NewBus()
 	mgr := session.NewManager(store, reRunnableRunner,
-		wirenpc.Config{Token: "test-token", Bus: bus}, nil, slog.New(slog.DiscardHandler), true)
+		wirenpc.Config{Token: "test-token", Bus: bus}, nil, slog.New(slog.DiscardHandler), true, session.Deps{})
 	return mgr, bus
 }
 

--- a/internal/session/manager_spend_test.go
+++ b/internal/session/manager_spend_test.go
@@ -85,7 +85,7 @@ func spendManager(t *testing.T, store session.Store, run session.LoopRunner, bus
 	t.Helper()
 	return session.NewManager(store, run,
 		wirenpc.Config{Token: "test-token", Bus: bus, StageMetrics: spy}, nil,
-		slog.New(slog.DiscardHandler), true)
+		slog.New(slog.DiscardHandler), true, session.Deps{})
 }
 
 // collectSpendCaps subscribes a collector for SpendCapReached events on bus.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -24,19 +24,20 @@ import (
 // (guild/channel source, #72) and records the voice_sessions Create/End calls so
 // the lifecycle can be asserted without Postgres.
 type fakeStore struct {
-	mu         sync.Mutex
-	dep        storage.DeploymentConfig
-	depErr     error
-	sessions   map[uuid.UUID]storage.VoiceSession
-	created    int
-	ended      int
-	depReads   int
-	reconciles int
-	tick       int
-	endErr     error           // injected EndVoiceSession failure (#143 Defect A)
-	agents     []storage.Agent // the Active Campaign's roster for ListAgents (#211 mute-all)
-	caps       storage.SpendCaps
-	capsErr    error // injected GetTenantSpendCaps failure (#130)
+	mu           sync.Mutex
+	dep          storage.DeploymentConfig
+	depErr       error
+	sessions     map[uuid.UUID]storage.VoiceSession
+	created      int
+	ended        int
+	depReads     int
+	reconciles   int
+	tick         int
+	endErr       error           // injected EndVoiceSession failure (#143 Defect A)
+	agents       []storage.Agent // the Active Campaign's roster for ListAgents (#211 mute-all)
+	onListAgents func()          // mid-op hook: runs during ListAgents, no store lock held (#448)
+	caps         storage.SpendCaps
+	capsErr      error // injected GetTenantSpendCaps failure (#130)
 }
 
 func newFakeStore() *fakeStore {
@@ -128,11 +129,20 @@ func (f *fakeStore) ReconcileOrphanedVoiceSessions(ctx context.Context) (int64, 
 	return n, nil
 }
 
-// ListAgents serves the campaign's roster for the mute-all path (#211).
+// ListAgents serves the campaign's roster for the mute-all path (#211). A test
+// may set onListAgents to run mid-op — after the ops' stale-fast entry check but
+// before their authoritative revalidation — to open the #448 race window (the
+// session ending between the roster read and the write/publish). It runs with
+// no fake-store lock held, so it may drive the Manager (e.g. Stop).
 func (f *fakeStore) ListAgents(_ context.Context, _ uuid.UUID) ([]storage.Agent, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
-	return append([]storage.Agent(nil), f.agents...), nil
+	hook := f.onListAgents
+	roster := append([]storage.Agent(nil), f.agents...)
+	f.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	return roster, nil
 }
 
 // GetTenantSpendCaps serves the canned per-Tenant spend caps snapshot at Start
@@ -200,27 +210,34 @@ func (r *blockingRunner) wasCancelled() bool {
 
 func newManager(t *testing.T, store session.Store, run session.LoopRunner, enabled bool) *session.Manager {
 	t.Helper()
-	return session.NewManager(store, run, wirenpc.Config{Token: "test-token"}, nil,
-		slog.New(slog.DiscardHandler), enabled)
+	return newManagerDeps(t, store, run, enabled, session.Deps{})
 }
 
-// fakeFactsRecaller is a no-op agent.FactsRecaller for the SetFacts wiring test.
+// newManagerDeps is newManager with explicit construction-time deps (#448): the
+// tests that used to back-wire a finalizer/pipeline via a setter now pass it
+// here, the same way the composition root does.
+func newManagerDeps(t *testing.T, store session.Store, run session.LoopRunner, enabled bool, deps session.Deps) *session.Manager {
+	t.Helper()
+	return session.NewManager(store, run, wirenpc.Config{Token: "test-token"}, nil,
+		slog.New(slog.DiscardHandler), enabled, deps)
+}
+
+// fakeFactsRecaller is a no-op agent.FactsRecaller for the Deps.Facts wiring test.
 type fakeFactsRecaller struct{}
 
 func (fakeFactsRecaller) Facts(context.Context, string) []string { return nil }
 
-// TestSetFacts_ThreadsOntoBaseConfig mirrors the SetMemory/SetChunkFlusher wiring
-// (#126): SetFacts sets the recaller on the base voice config every session copies,
+// TestDepsFacts_ThreadsOntoBaseConfig mirrors the Memory/Chunker wiring (#126):
+// Deps.Facts lands the recaller on the base voice config every session copies,
 // so it flows through Start → RunFromDB → buildConversation into each NPC's loop.
-func TestSetFacts_ThreadsOntoBaseConfig(t *testing.T) {
-	mgr := newManager(t, newFakeStore(), newBlockingRunner().run, true)
-	if mgr.BaseFactsForTest() != nil {
-		t.Fatal("base Facts should start nil")
+func TestDepsFacts_ThreadsOntoBaseConfig(t *testing.T) {
+	if mgr := newManager(t, newFakeStore(), newBlockingRunner().run, true); mgr.BaseFactsForTest() != nil {
+		t.Fatal("base Facts should be nil with zero Deps")
 	}
 	rec := fakeFactsRecaller{}
-	mgr.SetFacts(rec)
+	mgr := newManagerDeps(t, newFakeStore(), newBlockingRunner().run, true, session.Deps{Facts: rec})
 	if mgr.BaseFactsForTest() != rec {
-		t.Errorf("SetFacts did not thread the recaller onto the base config: got %v", mgr.BaseFactsForTest())
+		t.Errorf("Deps.Facts did not thread the recaller onto the base config: got %v", mgr.BaseFactsForTest())
 	}
 }
 
@@ -372,7 +389,7 @@ func TestStartUsesSavedToken(t *testing.T) {
 
 	runner := newBlockingRunner()
 	mgr := session.NewManager(store, runner.run, wirenpc.Config{}, cipher,
-		slog.New(slog.DiscardHandler), true)
+		slog.New(slog.DiscardHandler), true, session.Deps{})
 
 	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -397,7 +414,7 @@ func TestStartFallsBackToEnvToken(t *testing.T) {
 	store.dep.DiscordBotTokenLast4 = "env" // seeded placeholder: no real token in the DB
 	runner := newBlockingRunner()
 	mgr := session.NewManager(store, runner.run, wirenpc.Config{Token: "env-bot-token"}, nil,
-		slog.New(slog.DiscardHandler), true)
+		slog.New(slog.DiscardHandler), true, session.Deps{})
 
 	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -419,7 +436,7 @@ func TestStartFallsBackToEnvToken(t *testing.T) {
 func TestStartMissingToken(t *testing.T) {
 	store := newFakeStore() // guild/channel set, no token saved
 	mgr := session.NewManager(store, newBlockingRunner().run, wirenpc.Config{}, nil,
-		slog.New(slog.DiscardHandler), true)
+		slog.New(slog.DiscardHandler), true, session.Deps{})
 
 	_, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
 	if !errors.Is(err, session.ErrDiscordTokenMissing) {
@@ -447,7 +464,7 @@ func TestStartUndecryptableToken(t *testing.T) {
 
 	// nil cipher: a real saved token can no longer be opened.
 	mgr := session.NewManager(store, newBlockingRunner().run, wirenpc.Config{}, nil,
-		slog.New(slog.DiscardHandler), true)
+		slog.New(slog.DiscardHandler), true, session.Deps{})
 
 	_, err = mgr.Start(context.Background(), uuid.New(), uuid.New())
 	if !errors.Is(err, session.ErrDiscordTokenUndecryptable) {
@@ -487,9 +504,8 @@ func (f *fakeFinalizer) seen() (uuid.UUID, int) {
 func TestStopFinalizesTranscriptCount(t *testing.T) {
 	store := newFakeStore()
 	runner := newBlockingRunner()
-	mgr := newManager(t, store, runner.run, true)
 	fin := &fakeFinalizer{count: 9}
-	mgr.SetTranscript(fin)
+	mgr := newManagerDeps(t, store, runner.run, true, session.Deps{Transcript: fin})
 
 	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
 	if err != nil {
@@ -550,9 +566,8 @@ func (s *spyHighlighter) seen() (begins, finals int) {
 func TestManagerBeginsAndFinalizesHighlights(t *testing.T) {
 	store := newFakeStore()
 	runner := newBlockingRunner()
-	mgr := newManager(t, store, runner.run, true)
 	spy := &spyHighlighter{}
-	mgr.SetHighlights(spy)
+	mgr := newManagerDeps(t, store, runner.run, true, session.Deps{Highlights: spy})
 
 	tenantID, campaignID := uuid.New(), uuid.New()
 	vs, err := mgr.Start(context.Background(), tenantID, campaignID)
@@ -595,9 +610,8 @@ func (slowFinalizer) Finalize(ctx context.Context, _ uuid.UUID) (int, error) {
 func TestSlowFinalizeStillEndsRow(t *testing.T) {
 	store := newFakeStore()
 	runner := newBlockingRunner()
-	mgr := newManager(t, store, runner.run, true)
+	mgr := newManagerDeps(t, store, runner.run, true, session.Deps{Transcript: slowFinalizer{}})
 	mgr.SetEndTimeoutForTest(50 * time.Millisecond)
-	mgr.SetTranscript(slowFinalizer{})
 
 	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
 	if err != nil {
@@ -956,9 +970,8 @@ func (f *fakeChunkFinalizer) seen() (uuid.UUID, int, int) {
 func TestStopFlushesChunkBeforeEnd(t *testing.T) {
 	store := newFakeStore()
 	runner := newBlockingRunner()
-	mgr := newManager(t, store, runner.run, true)
 	flusher := &fakeChunkFinalizer{store: store}
-	mgr.SetChunkFlusher(flusher)
+	mgr := newManagerDeps(t, store, runner.run, true, session.Deps{Chunker: flusher})
 
 	vs, err := mgr.Start(context.Background(), uuid.New(), uuid.New())
 	if err != nil {
@@ -988,8 +1001,8 @@ func TestStopFlushesChunkBeforeEnd(t *testing.T) {
 func TestStopSucceedsDespiteChunkFlushError(t *testing.T) {
 	store := newFakeStore()
 	runner := newBlockingRunner()
-	mgr := newManager(t, store, runner.run, true)
-	mgr.SetChunkFlusher(&fakeChunkFinalizer{store: store, err: errors.New("chunk writer wedged")})
+	mgr := newManagerDeps(t, store, runner.run, true,
+		session.Deps{Chunker: &fakeChunkFinalizer{store: store, err: errors.New("chunk writer wedged")}})
 
 	if _, err := mgr.Start(context.Background(), uuid.New(), uuid.New()); err != nil {
 		t.Fatalf("Start: %v", err)

--- a/internal/session/view.go
+++ b/internal/session/view.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"sync/atomic"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// View is the pre-constructible active-session read (#448): the narrow
+// Sessions{Snapshot} seam the transcript projectors (relay, chunker), the
+// recallers (memory, KG facts) and the knowledge Tools adapter consume. Those
+// collaborators are the Manager's construction-time [Deps], so they must exist
+// BEFORE the Manager and cannot take the Manager itself — the old cycle the
+// post-construction setters papered over. They take a View instead; NewManager
+// binds it (Deps.View), which is what makes the wiring order un-breakable:
+// until a Manager is bound — and no session can run before its Manager exists —
+// and while the bound Manager is idle, Snapshot truthfully reports no active
+// session. A View binds to exactly one Manager; a second bind is a boot bug and
+// panics.
+type View struct {
+	mgr atomic.Pointer[Manager]
+}
+
+// NewView returns an unbound View: Snapshot reports no active session until
+// NewManager binds a Manager to it via [Deps].
+func NewView() *View {
+	return &View{}
+}
+
+// Snapshot reports the bound Manager's active Voice Session and true, or the
+// zero value and false when unbound or idle — the same contract as
+// [Manager.Snapshot], which every consumer's Sessions seam was written against.
+func (v *View) Snapshot() (storage.VoiceSession, bool) {
+	m := v.mgr.Load()
+	if m == nil {
+		return storage.VoiceSession{}, false
+	}
+	return m.Snapshot()
+}
+
+// bind attaches the one Manager this View reads, called by NewManager
+// (Deps.View). The CompareAndSwap makes double-wiring loud: two Managers
+// sharing a View would silently split the active-session truth.
+func (v *View) bind(m *Manager) {
+	if !v.mgr.CompareAndSwap(nil, m) {
+		panic("session: View is already bound to a Manager")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #448.

Deepens `session.Manager` into the lease/lifecycle core the issue describes, extracting the other three concepts it carried:

- **`LiveSession` handle** (`internal/session/livesession.go`): `Manager.Live()` returns a handle pinned to the one active Voice Session (or nil when idle). The session-scoped operations — `SetAgentMute`, `SetAllMute`, `MutedAgentIDs`, `SayAs`, `SpeakAsButler`, `ReplayHighlight` — live on the handle, and the capture → drop-lock → revalidate-same-session dance is implemented **exactly once** (`LiveSession.revalidate`), replacing the 3× duplicated guard plus the partial 4th in `SpeakAsButler`. Stale handles (session ended or rolled over) fail with the existing `ErrNoActiveSession` semantics, including a fail-fast *before* the roster read so a stale handle never does a wasted store round-trip and a store error can never mask staleness. The Manager keeps one-line routes through the current handle, so the existing consumer seams (`rpc.SessionManager`, `rpc.HighlightReplayer`, `presence.SessionMuter`/`SayControl`/`ButlerVoicer`) still see `*Manager` — per the agent brief, "their calls route through the handle or Manager equivalently".
- **Construction-time deps** (`session.Deps` on `NewManager`): the six post-construction setters (`SetTranscript`/`SetChunkFlusher`/`SetHighlights`/`SetMemory`/`SetFacts`/`SetToolDeps`) are gone. The Manager and its base voice config are immutable after `NewManager` returns, so "wired before first Start" is structural — which also makes the previously lock-guarded `base.Bus` reads safely lock-free.
- **`session.View`** (`internal/session/view.go`): the construction cycle breaks at its true seam. The projectors/recallers (relay, chunker, memory recall, KG facts, knowledge Tools adapter) depend only on `Sessions{Snapshot}`, so the composition root now builds them first against a pre-constructed `View`, then `NewManager` binds it (`Deps.View`, bind-once with a loud panic on double-wiring). Unbound or idle, `Snapshot` truthfully reports no active session. The "must run AFTER mgr is assigned to establish the happens-before edge" back-wiring comments in `cmd/glyphoxa/main.go` are deleted because the constraint no longer exists.

One deliberate tightening: `SpeakAsButler` now delegates to `SayAs` **on the same handle**, so a session that rolls over between its two roster reads is refused instead of voiced into the successor session (the old code re-captured whatever session was current).

Boot order note: the highlight purge backstop sweep still runs **after** `ReconcileOrphans` (as on `main`), so crash-orphaned sessions' candidates get their 7-day purge horizon the same boot — caught and fixed during an adversarial review pass on this diff.

## Why is this change needed?

`internal/session/manager.go` (1006 lines, ~20 public methods) carried four concepts on one struct; every caller had to know the single-active invariant and the mu/pubMu lock order, the revalidate guard was duplicated 3.5×, and the composition root back-wired six dependencies in a comment-enforced order (2026-07-14 architecture review, candidate C5; approved in #448).

## How was this tested?

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test -race -count=1` passes for `internal/session`, `internal/rpc`, `internal/presence`, `internal/transcript`, `internal/recall`, `internal/kgfacts`, `internal/knowledge`, `internal/busproject`.
- Full `go test ./...` passes except `pkg/voice/{orchestrator,vad/silero,wire}`, which fail **on `main` too** in this sandbox: they download ONNX Runtime at test time and the egress proxy returns HTTP 403. Untouched by this diff.
- The existing session suite (lifecycle, mute, say, spend, replay, reconcile) passes with its behavioral assertions unchanged; only construction call sites changed (setter → `Deps`). rpc + presence suites are untouched.
- New tests: `Live()` nil when idle; every op refused `ErrNoActiveSession` on a stale handle after Stop *and* after rollover (with no `MuteChanged`/`SpeakRequested`/`ReplayRequested` published); the **authoritative mid-op revalidation** (session ends during the roster read, via a `fakeStore.ListAgents` hook — deleting the inner revalidate fails this test); `View` unbound/bound/second-bind-panics semantics.

- [x] `make check` passes (modulo the pre-existing ONNX-download failures above)
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (except the pre-existing ONNX-runtime download failures noted above)
- [x] I have updated documentation if needed (godoc; no docs/ pages reference the old setters)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Acceptance criteria from the agent brief:

- ✅ Exactly one implementation of the active-session revalidation; the 3+1 duplicated guards are gone (`grep -n 'm.active != as' internal/session` → only `revalidate`).
- ✅ No post-construction setters remain on Manager; the construction-ordering comments in `cmd/glyphoxa/main.go` are deleted.
- ✅ Full existing session suite passes with unchanged assertions; #433's caps-before-insert Start ordering is preserved untouched.
- ✅ rpc + presence suites pass unchanged — their interfaces are still satisfied by `*Manager`, whose ops now route through the handle.

Two comment-only corrections rode along where this refactor's docs touched them: `presence/mute.go`'s pointer now names `session.LiveSession.SetAgentMute`, and `rpc/session.go`'s interface doc no longer claims the Butler is "never voiced" (stale since the ADR-0009 #299 amendment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WygW9eUbm3XzMWB9VLdeEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WygW9eUbm3XzMWB9VLdeEe)_