### PR TITLE
refactor(#451): bundle-owned store seam — narrow interfaces, in-memory fake, DB-free import/export tests

### DIFF
--- a/cmd/glyphoxa/seed.go
+++ b/cmd/glyphoxa/seed.go
@@ -132,7 +132,7 @@ func runSeedBundle(ctx context.Context, log *slog.Logger, path string) error {
 		return fmt.Errorf("seed: check campaign %q: %w", b.Campaign.Name, err)
 	}
 
-	res, err := bundle.Import(ctx, st, tenantID, b)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tenantID, b)
 	if err != nil {
 		return fmt.Errorf("seed: import bundle: %w", err)
 	}

--- a/internal/bundle/export.go
+++ b/internal/bundle/export.go
@@ -20,13 +20,13 @@ type ExportOptions struct {
 }
 
 // Export serializes one Campaign into a [Bundle] (ADR-0053). It reads EXCLUSIVELY
-// through the storage layer's allowlisted read paths — GetCampaign, ListAgents,
-// per-agent ListToolGrants, ListNodes, ListEdges, ListCharacters, and (only when
+// through the [ExportStore] seam — GetCampaign, ListAgents, per-agent
+// ListToolGrants, ListNodes, ListEdges, ListCharacters, and (only when
 // opts.IncludeHistory) ListVoiceSessions + ListTranscriptLines +
 // ListTranscriptChunks. It NEVER touches provider_config, deployment_config,
 // users, or auth sessions: the secrets-exclusion property (ADR-0053 §2) holds by
-// construction because the bundle types carry no field for a secret and this
-// function reads no table that stores one.
+// construction because the bundle types carry no field for a secret and the
+// seam carries no method that reads a table storing one.
 //
 // Every entity reference in the produced bundle is the SOURCE row's UUID string
 // (ADR-0053 §4): agent ids, node ids, edge endpoints, and history session/agent
@@ -36,7 +36,7 @@ type ExportOptions struct {
 // voice carries the canonical shape minus provider bindings (the FK
 // voice_provider_config_id is an Agent column this never reads). A voice column
 // that does not parse is a hard error, never a silently dropped voice (#224).
-func Export(ctx context.Context, st *storage.Store, campaignID uuid.UUID, opts ExportOptions) (*Bundle, error) {
+func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts ExportOptions) (*Bundle, error) {
 	campaign, err := st.GetCampaign(ctx, campaignID)
 	if err != nil {
 		return nil, fmt.Errorf("bundle: export: get campaign %s: %w", campaignID, err)
@@ -140,7 +140,7 @@ func Export(ctx context.Context, st *storage.Store, campaignID uuid.UUID, opts E
 
 // exportGrants reads one Agent's persisted Tool Grants and maps them to bundle
 // grains. Config is carried verbatim (nil when the grant narrows nothing).
-func exportGrants(ctx context.Context, st *storage.Store, agentID uuid.UUID) ([]Grant, error) {
+func exportGrants(ctx context.Context, st ExportStore, agentID uuid.UUID) ([]Grant, error) {
 	rows, err := st.ListToolGrants(ctx, agentID)
 	if err != nil {
 		return nil, fmt.Errorf("bundle: export: list grants for agent %s: %w", agentID, err)
@@ -182,7 +182,7 @@ func exportVoice(raw []byte) ([]byte, error) {
 // (ListTranscriptChunks is called with includeVectors=false, ADR-0053 §3) — the
 // destination re-embeds. ListVoiceSessions has no all-rows overload, so the cap
 // is math.MaxInt32: a backup pulls every session, and no campaign approaches it.
-func exportHistory(ctx context.Context, st *storage.Store, campaignID uuid.UUID) (*History, error) {
+func exportHistory(ctx context.Context, st ExportStore, campaignID uuid.UUID) (*History, error) {
 	sessions, err := st.ListVoiceSessions(ctx, campaignID, math.MaxInt32)
 	if err != nil {
 		return nil, fmt.Errorf("bundle: export: list voice sessions: %w", err)

--- a/internal/bundle/export_fake_test.go
+++ b/internal/bundle/export_fake_test.go
@@ -1,0 +1,403 @@
+package bundle_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// This file is the DB-free half of the export suite (#451): Export runs
+// against the in-memory fakeStore through [bundle.ExportStore], so ref
+// emission, history grouping, and voice normalization are proven under plain
+// `go test`. SQL-shaped reads (real ordering collations, the raw-NULL chunk
+// legacy shape) stay in the integration suite.
+
+// seedFakeCampaign populates a fake with one campaign through the seam's own
+// write methods — the auto-Butler plus a voiced NPC (linked to its KG node),
+// a location, one edge, one player Character, and a terminal session with
+// out-of-order lines and one chunk naming the NPC.
+func seedFakeCampaign(t *testing.T, f *fakeStore) (campaignID, bartID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	campaignID, err := f.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: uuid.New(), Name: "Erebor Reclaimed", System: "dnd5e", Language: "en",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+	bartID, err = f.CreateAgent(ctx, storage.NewAgent{
+		CampaignID: campaignID, Role: storage.AgentRoleCharacter, Name: "Bart",
+		Title: "Innkeeper", Persona: "gruff but fair",
+		Voice: seamVoiceJSON(t, "elevenlabs", "bart-voice"), Aliases: []string{"Barkeep"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if _, err := f.CreateToolGrant(ctx, storage.NewToolGrant{AgentID: bartID, ToolName: "dice"}); err != nil {
+		t.Fatalf("CreateToolGrant: %v", err)
+	}
+
+	npc, err := f.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: "npc", Name: "Bart", Body: "keeps the inn",
+	})
+	if err != nil {
+		t.Fatalf("CreateNode npc: %v", err)
+	}
+	if _, err := f.SetNodeAgent(ctx, campaignID, npc.ID, uuid.NullUUID{UUID: bartID, Valid: true}); err != nil {
+		t.Fatalf("SetNodeAgent: %v", err)
+	}
+	loc, err := f.CreateNode(ctx, storage.NewKGNode{
+		CampaignID: campaignID, Type: "location", Name: "The Prancing Pony", GMPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateNode location: %v", err)
+	}
+	if _, err := f.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignID, FromNodeID: npc.ID, ToNodeID: loc.ID, Type: "resides_in",
+	}); err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	if _, err := f.CreateCharacter(ctx, storage.NewCharacter{
+		CampaignID: campaignID, Name: "Frodo", Aliases: []string{"Ringbearer"},
+		DiscordUserID: "199999999999999999",
+	}); err != nil {
+		t.Fatalf("CreateCharacter: %v", err)
+	}
+
+	started := time.Date(2026, 4, 20, 19, 0, 0, 0, time.UTC)
+	ended := started.Add(2 * time.Hour)
+	sid, err := f.ImportVoiceSession(ctx, storage.VoiceSession{
+		CampaignID: campaignID, StartedAt: started, EndedAt: &ended,
+		Status: storage.VoiceSessionEnded, LineCount: 2,
+	})
+	if err != nil {
+		t.Fatalf("ImportVoiceSession: %v", err)
+	}
+	for _, l := range []storage.TranscriptLine{
+		{VoiceSessionID: sid, CampaignID: campaignID, LineID: "l2", Seq: 5, Who: "Bart", Kind: "agent", TS: started.Add(time.Minute), Text: "Welcome back."},
+		{VoiceSessionID: sid, CampaignID: campaignID, LineID: "l1", Seq: 2, Who: "Frodo", Kind: "human", TS: started, Text: "Hello!", SpeakerDiscordUserID: "199999999999999999"},
+	} {
+		if err := f.UpsertTranscriptLine(ctx, l); err != nil {
+			t.Fatalf("UpsertTranscriptLine: %v", err)
+		}
+	}
+	if _, err := f.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
+		CampaignID: campaignID, VoiceSessionID: sid,
+		Content:               "Frodo: Hello!\nBart: Welcome back.",
+		SpeakerDiscordUserIDs: []string{"199999999999999999"},
+		ParticipatedAgentIDs:  []uuid.UUID{bartID},
+		StartedAt:             started,
+	}); err != nil {
+		t.Fatalf("InsertTranscriptChunk: %v", err)
+	}
+	return campaignID, bartID
+}
+
+// TestExportFake_RefsAreSourceUUIDs: ADR-0053 §4 over the fake — every
+// reference the bundle carries (agent ids, node ids, edge endpoints, chunk
+// participants) is the source row's UUID string, wired consistently.
+func TestExportFake_RefsAreSourceUUIDs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+	campaignID, bartID := seedFakeCampaign(t, f)
+
+	b, err := bundle.Export(ctx, f, campaignID, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if b.FormatVersion != bundle.FormatVersion || b.Campaign.Name != "Erebor Reclaimed" {
+		t.Errorf("envelope = v%d %q, want v%d Erebor Reclaimed", b.FormatVersion, b.Campaign.Name, bundle.FormatVersion)
+	}
+
+	// Agents: Butler first (role ordering), then Bart; ids are row UUIDs.
+	if len(b.Campaign.Agents) != 2 || b.Campaign.Agents[0].Role != "butler" || b.Campaign.Agents[1].Name != "Bart" {
+		t.Fatalf("agents = %+v, want [butler Glyphoxa, character Bart]", b.Campaign.Agents)
+	}
+	if b.Campaign.Agents[1].ID != bartID.String() {
+		t.Errorf("Bart ref = %q, want source uuid %s", b.Campaign.Agents[1].ID, bartID)
+	}
+	butler, _ := f.GetButler(ctx, campaignID)
+	if b.Campaign.Agents[0].ID != butler.ID.String() {
+		t.Errorf("butler ref = %q, want source uuid %s", b.Campaign.Agents[0].ID, butler.ID)
+	}
+	wantDefaults := []string{"dice", "kg_query", "recap", "transcript_search"}
+	if got := b.Campaign.Agents[0].Grants; len(got) != len(wantDefaults) {
+		t.Errorf("butler grants = %+v, want the trigger defaults %v", got, wantDefaults)
+	} else {
+		for i, g := range got {
+			if g.ToolName != wantDefaults[i] {
+				t.Errorf("butler grant[%d] = %q, want %q (tool-name order)", i, g.ToolName, wantDefaults[i])
+			}
+		}
+	}
+
+	// Nodes: node_type is a Postgres ENUM ordered by declaration, so 'npc'
+	// sorts BEFORE 'location'; the NPC node references Bart, and both refs
+	// are the fake's row UUIDs.
+	if len(b.Campaign.Nodes) != 2 || b.Campaign.Nodes[0].Type != "npc" || b.Campaign.Nodes[1].Type != "location" {
+		t.Fatalf("nodes = %+v, want [npc, location] in enum order", b.Campaign.Nodes)
+	}
+	npcNode, locNode := b.Campaign.Nodes[0], b.Campaign.Nodes[1]
+	if npcNode.ID != nodeNamed(t, f, campaignID, "Bart").ID.String() ||
+		locNode.ID != nodeNamed(t, f, campaignID, "The Prancing Pony").ID.String() {
+		t.Errorf("node refs = %q/%q, want the source row uuids", npcNode.ID, locNode.ID)
+	}
+	if npcNode.AgentID != bartID.String() {
+		t.Errorf("npc node agent link = %q, want %s", npcNode.AgentID, bartID)
+	}
+	if !locNode.GMPrivate {
+		t.Error("gm_private flag lost on export")
+	}
+
+	// Edge endpoints are the node UUID strings.
+	if len(b.Campaign.Edges) != 1 ||
+		b.Campaign.Edges[0].From != npcNode.ID || b.Campaign.Edges[0].To != locNode.ID {
+		t.Errorf("edge = %+v, want npc->location by node refs", b.Campaign.Edges)
+	}
+
+	// Character verbatim.
+	if len(b.Campaign.Characters) != 1 || b.Campaign.Characters[0].DiscordUserID != "199999999999999999" {
+		t.Errorf("characters = %+v, want Frodo's snowflake verbatim", b.Campaign.Characters)
+	}
+
+	// History: session ref is the row uuid, lines in seq order, chunk
+	// participants are agent UUID strings.
+	if b.Campaign.History == nil || len(b.Campaign.History.Sessions) != 1 {
+		t.Fatalf("history = %+v, want one session", b.Campaign.History)
+	}
+	s := b.Campaign.History.Sessions[0]
+	if s.ID != f.sessions[0].ID.String() {
+		t.Errorf("session ref = %q, want source uuid %s", s.ID, f.sessions[0].ID)
+	}
+	if len(s.Lines) != 2 || s.Lines[0].LineID != "l1" || s.Lines[1].LineID != "l2" {
+		t.Errorf("lines = %+v, want seq order l1,l2", s.Lines)
+	}
+	if len(s.Chunks) != 1 || len(s.Chunks[0].ParticipatedAgentIDs) != 1 ||
+		s.Chunks[0].ParticipatedAgentIDs[0] != bartID.String() {
+		t.Errorf("chunk participants = %+v, want [%s]", s.Chunks, bartID)
+	}
+}
+
+// TestExportFake_HistoryFlagGates: the default export is a SETUP share —
+// History stays nil even though the store holds sessions (ADR-0053 §1).
+func TestExportFake_HistoryFlagGates(t *testing.T) {
+	t.Parallel()
+	f := newFakeStore()
+	campaignID, _ := seedFakeCampaign(t, f)
+
+	b, err := bundle.Export(context.Background(), f, campaignID, bundle.ExportOptions{})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if b.Campaign.History != nil {
+		t.Errorf("default export carries history: %+v", b.Campaign.History)
+	}
+}
+
+// TestExportFake_SkipsSessionlessChunk: a chunk without a Voice Session
+// binding (legacy NULL column shape) has no session to nest under and is
+// skipped from the history payload rather than orphaned.
+func TestExportFake_SkipsSessionlessChunk(t *testing.T) {
+	t.Parallel()
+	f := newFakeStore()
+	campaignID, _ := seedFakeCampaign(t, f)
+	// Injected directly: the seam's writer always binds a session, so the
+	// legacy shape can only exist as a pre-seam row.
+	f.chunks = append(f.chunks, storage.TranscriptChunk{
+		ID: uuid.New(), CampaignID: campaignID, VoiceSessionID: uuid.Nil,
+		Content: "orphaned", StartedAt: time.Date(2026, 4, 21, 19, 0, 0, 0, time.UTC),
+	})
+
+	b, err := bundle.Export(context.Background(), f, campaignID, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	total := 0
+	for _, s := range b.Campaign.History.Sessions {
+		for _, c := range s.Chunks {
+			total++
+			if c.Content == "orphaned" {
+				t.Error("sessionless chunk leaked into a session")
+			}
+		}
+	}
+	if total != 1 {
+		t.Errorf("exported chunks = %d, want 1 (the session-bound one)", total)
+	}
+}
+
+// TestExportFake_VoiceHandling: a '{}' default voice exports as absent, a real
+// voice round-trips the canonical shape, and an unparsable column is a hard
+// error (#224) — never a silently dropped voice.
+func TestExportFake_VoiceHandling(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("zero voice exports absent", func(t *testing.T) {
+		t.Parallel()
+		f := newFakeStore()
+		campaignID, _ := seedFakeCampaign(t, f)
+		b, err := bundle.Export(ctx, f, campaignID, bundle.ExportOptions{})
+		if err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+		if voice := b.Campaign.Agents[0].Voice; len(voice) != 0 { // the un-voiced Butler
+			t.Errorf("butler voice = %s, want absent", voice)
+		}
+		got, err := storage.VoiceFromJSON(b.Campaign.Agents[1].Voice)
+		if err != nil || got.ProviderID != "elevenlabs" || got.VoiceID != "bart-voice" {
+			t.Errorf("Bart voice = %+v (err %v), want canonical elevenlabs/bart-voice", got, err)
+		}
+	})
+	t.Run("unparsable voice column fails loudly", func(t *testing.T) {
+		t.Parallel()
+		f := newFakeStore()
+		campaignID, _ := seedFakeCampaign(t, f)
+		for i := range f.agents {
+			if f.agents[i].Name == "Bart" {
+				f.agents[i].Voice = json.RawMessage(`{corrupt`)
+			}
+		}
+		if _, err := bundle.Export(ctx, f, campaignID, bundle.ExportOptions{}); err == nil ||
+			!strings.Contains(err.Error(), "voice") {
+			t.Fatalf("err = %v, want voice decode failure", err)
+		}
+	})
+}
+
+// TestExportFake_UnknownCampaign: an id the store has never seen surfaces the
+// storage sentinel, which the HTTP layer maps to 404.
+func TestExportFake_UnknownCampaign(t *testing.T) {
+	t.Parallel()
+	_, err := bundle.Export(context.Background(), newFakeStore(), uuid.New(), bundle.ExportOptions{})
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("err = %v, want storage.ErrNotFound", err)
+	}
+}
+
+// normalizeRefs rewrites every UUID-valued ref in b to a stable name-derived
+// key (agents/nodes by name, sessions by start time) and zeroes ExportedAt, so
+// two exports of semantically identical campaigns compare byte-equal even
+// though every minted UUID differs.
+func normalizeRefs(t *testing.T, b *bundle.Bundle) {
+	t.Helper()
+	key := make(map[string]string)
+	for i := range b.Campaign.Agents {
+		a := &b.Campaign.Agents[i]
+		key[a.ID] = "agent:" + a.Name
+		a.ID = key[a.ID]
+	}
+	for i := range b.Campaign.Nodes {
+		n := &b.Campaign.Nodes[i]
+		key[n.ID] = "node:" + n.Name
+		n.ID = key[n.ID]
+		if n.AgentID != "" {
+			n.AgentID = mustKey(t, key, n.AgentID)
+		}
+	}
+	for i := range b.Campaign.Edges {
+		e := &b.Campaign.Edges[i]
+		e.From = mustKey(t, key, e.From)
+		e.To = mustKey(t, key, e.To)
+	}
+	if b.Campaign.History != nil {
+		for i := range b.Campaign.History.Sessions {
+			s := &b.Campaign.History.Sessions[i]
+			s.ID = "session:" + s.StartedAt.UTC().Format(time.RFC3339)
+			for j := range s.Chunks {
+				refs := s.Chunks[j].ParticipatedAgentIDs
+				for k := range refs {
+					refs[k] = mustKey(t, key, refs[k])
+				}
+			}
+		}
+	}
+	b.ExportedAt = time.Time{}
+}
+
+func mustKey(t *testing.T, key map[string]string, ref string) string {
+	t.Helper()
+	mapped, ok := key[ref]
+	if !ok {
+		t.Fatalf("ref %q resolves to no exported entity", ref)
+	}
+	return mapped
+}
+
+// TestExportImportFake_RoundTrip is the seam-level parity proof: a campaign
+// exported from one fake, imported into a second, and re-exported yields the
+// SAME bundle modulo minted ids — names, personas, grants (including the
+// Butler merge), KG wiring, characters, and history all survive the trip.
+func TestExportImportFake_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	src := newFakeStore()
+	campaignID, _ := seedFakeCampaign(t, src)
+	original, err := bundle.Export(ctx, src, campaignID, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("export source: %v", err)
+	}
+
+	dst := newFakeStore()
+	res, err := bundle.Import(ctx, dst, uuid.New(), original)
+	if err != nil {
+		t.Fatalf("import into destination: %v", err)
+	}
+	roundTripped, err := bundle.Export(ctx, dst, res.CampaignID, bundle.ExportOptions{IncludeHistory: true})
+	if err != nil {
+		t.Fatalf("re-export destination: %v", err)
+	}
+
+	// Fresh mint before normalization: no destination ref of ANY kind (agent,
+	// node, session) may equal a source ref.
+	srcIDs := make(map[string]bool)
+	for _, a := range original.Campaign.Agents {
+		srcIDs[a.ID] = true
+	}
+	for _, n := range original.Campaign.Nodes {
+		srcIDs[n.ID] = true
+	}
+	for _, s := range original.Campaign.History.Sessions {
+		srcIDs[s.ID] = true
+	}
+	for _, a := range roundTripped.Campaign.Agents {
+		if srcIDs[a.ID] {
+			t.Errorf("agent ref %s survived the import un-minted", a.ID)
+		}
+	}
+	for _, n := range roundTripped.Campaign.Nodes {
+		if srcIDs[n.ID] {
+			t.Errorf("node ref %s survived the import un-minted", n.ID)
+		}
+	}
+	for _, s := range roundTripped.Campaign.History.Sessions {
+		if srcIDs[s.ID] {
+			t.Errorf("session ref %s survived the import un-minted", s.ID)
+		}
+	}
+
+	normalizeRefs(t, original)
+	normalizeRefs(t, roundTripped)
+	want, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal original: %v", err)
+	}
+	got, err := json.MarshalIndent(roundTripped, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal round-tripped: %v", err)
+	}
+	if string(want) != string(got) {
+		t.Errorf("round trip diverged:\n--- source export ---\n%s\n--- destination re-export ---\n%s", want, got)
+	}
+}

--- a/internal/bundle/fakes_test.go
+++ b/internal/bundle/fakes_test.go
@@ -1,0 +1,484 @@
+package bundle_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
+)
+
+// fakeStore is the in-memory adapter of the bundle store seam (#451): it
+// implements bundle.ExportStore + bundle.ImportStore + bundle.TxRunner over
+// plain slices, so the remap/codec/secrets logic of import and export runs
+// under `go test` with no Postgres. It emulates every adapter contract the
+// [bundle.ImportStore] doc enumerates — including the ADR-0009 auto-Butler
+// trigger, which no other fake in the repo needed before — because the
+// importer's Butler-merge path is built on them.
+//
+// What it deliberately does NOT emulate: transaction rollback. InTx runs the
+// function directly against the same state (the flatten shape of a tx-bound
+// store) and leaves any partial writes behind on error, so import atomicity
+// remains proven ONLY by the Postgres integration tests
+// (TestImportMidBundleFailureRollsBack, TestImportHistoryRollsBackWithPart1) —
+// a fake-backed test asserts returned errors and logic, never all-or-nothing
+// persistence. Also absent: the NPC-only node↔agent CHECK on SetNodeAgent's
+// link path, which stays integration-proven.
+//
+// Slices keep insertion order as a DETERMINISTIC stand-in for the real
+// (created_at, id) list orderings — a stand-in, not parity: Postgres now() is
+// the transaction timestamp, so every row one import writes shares a
+// created_at and the real tie-break is random-UUID order. Tests must not pin
+// the relative order of same-import edges or chunks beyond what the bundle
+// format itself guarantees.
+type fakeStore struct {
+	campaigns  []storage.Campaign
+	agents     []storage.Agent
+	grants     []storage.ToolGrant
+	nodes      []storage.KGNode
+	edges      []storage.KGEdge
+	characters []storage.Character
+	sessions   []storage.VoiceSession
+	lines      []storage.TranscriptLine
+	chunks     []storage.TranscriptChunk
+}
+
+// Compile-time proofs the fake satisfies the whole seam — the second adapter
+// that, with PGStore, makes the seam real (#451).
+var (
+	_ bundle.ExportStore = (*fakeStore)(nil)
+	_ bundle.ImportStore = (*fakeStore)(nil)
+	_ bundle.TxRunner    = (*fakeStore)(nil)
+)
+
+func newFakeStore() *fakeStore { return &fakeStore{} }
+
+// commitFailTx runs the tx body against the fake and then fails the way a
+// COMMIT can (serialization failure, dropped connection) — the only shape in
+// which Import errors while DroppedParticipantRefs is already nonzero, since
+// history is the last in-tx step.
+type commitFailTx struct{ *fakeStore }
+
+func (c commitFailTx) InTx(ctx context.Context, fn func(tx bundle.ImportStore) error) error {
+	if err := fn(c.fakeStore); err != nil {
+		return err
+	}
+	return errors.New("fake: commit failed")
+}
+
+// InTx implements [bundle.TxRunner] by flattening: fn runs directly against
+// the fake's state, mirroring how a tx-bound *storage.Store runs a nested InTx
+// in the ambient transaction. See the type comment for what that means for
+// rollback (nothing — atomicity is the integration suite's job).
+func (f *fakeStore) InTx(_ context.Context, fn func(tx bundle.ImportStore) error) error {
+	return fn(f)
+}
+
+// butlerDefaultGrants is the auto-Butler trigger's default grant set as of
+// migration 00027 (dice + the two knowledge tools + recap), tool names only —
+// every default grant carries a NULL config.
+var butlerDefaultGrants = []string{"dice", "transcript_search", "kg_query", "recap"}
+
+// CreateCampaign mints the campaign row and emulates the ADR-0009 auto-Butler
+// trigger: the campaign's 'Glyphoxa' Butler (address_only true, voice at the
+// '{}' column default) plus its default grants land as a side effect, exactly
+// like the Postgres trigger create_campaign_butler().
+func (f *fakeStore) CreateCampaign(_ context.Context, c storage.NewCampaign) (uuid.UUID, error) {
+	id := uuid.New()
+	f.campaigns = append(f.campaigns, storage.Campaign{
+		ID: id, TenantID: c.TenantID, Name: c.Name, System: c.System, Language: c.Language,
+	})
+	butlerID := uuid.New()
+	f.agents = append(f.agents, storage.Agent{
+		ID: butlerID, CampaignID: id, Role: storage.AgentRoleButler,
+		Name: "Glyphoxa", Voice: json.RawMessage(`{}`), AddressOnly: true, Aliases: []string{},
+	})
+	for _, tool := range butlerDefaultGrants {
+		f.grants = append(f.grants, storage.ToolGrant{ID: uuid.New(), AgentID: butlerID, ToolName: tool})
+	}
+	return id, nil
+}
+
+func (f *fakeStore) GetCampaign(_ context.Context, id uuid.UUID) (storage.Campaign, error) {
+	for _, c := range f.campaigns {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return storage.Campaign{}, storage.ErrNotFound
+}
+
+func (f *fakeStore) GetButler(_ context.Context, campaignID uuid.UUID) (storage.Agent, error) {
+	for _, a := range f.agents {
+		if a.CampaignID == campaignID && a.Role == storage.AgentRoleButler {
+			return a, nil
+		}
+	}
+	return storage.Agent{}, storage.ErrNotFound
+}
+
+// CreateAgent enforces the ADR-0009 partial unique index: a second Butler in a
+// Campaign is refused. A Character gets the next roster-index speaker slot
+// (the real store also wraps at the palette size — irrelevant here).
+func (f *fakeStore) CreateAgent(_ context.Context, a storage.NewAgent) (uuid.UUID, error) {
+	if a.Role == storage.AgentRoleButler {
+		for _, existing := range f.agents {
+			if existing.CampaignID == a.CampaignID && existing.Role == storage.AgentRoleButler {
+				return uuid.Nil, fmt.Errorf("fake: second butler in campaign %s violates unique index", a.CampaignID)
+			}
+		}
+	}
+	slot := 0
+	if a.Role == storage.AgentRoleCharacter {
+		for _, existing := range f.agents {
+			if existing.CampaignID == a.CampaignID && existing.Role == storage.AgentRoleCharacter {
+				slot++
+			}
+		}
+	}
+	id := uuid.New()
+	f.agents = append(f.agents, storage.Agent{
+		ID: id, CampaignID: a.CampaignID, Role: a.Role,
+		Name: a.Name, Title: a.Title, Persona: a.Persona,
+		Voice: defaultVoice(a.Voice), VoiceProviderConfigID: a.VoiceProviderConfigID,
+		LLMProviderConfigID: a.LLMProviderConfigID, AddressOnly: a.AddressOnly,
+		SpeakerColor: slot, Aliases: defaultAliases(a.Aliases),
+	})
+	return id, nil
+}
+
+// UpdateAgent scopes the write to (id, campaign_id) → storage.ErrNotFound on a
+// miss, never changes agent_role, and force-keeps a Butler's address_only true
+// (ADR-0024) — the seam contracts the Butler merge rides on.
+func (f *fakeStore) UpdateAgent(_ context.Context, a storage.AgentUpdate) (storage.Agent, error) {
+	for i := range f.agents {
+		ag := &f.agents[i]
+		if ag.ID != a.ID || ag.CampaignID != a.CampaignID {
+			continue
+		}
+		ag.Name, ag.Title, ag.Persona = a.Name, a.Title, a.Persona
+		ag.Voice = defaultVoice(a.Voice)
+		ag.VoiceProviderConfigID = a.VoiceProviderConfigID
+		ag.LLMProviderConfigID = a.LLMProviderConfigID
+		ag.AddressOnly = a.AddressOnly || ag.Role == storage.AgentRoleButler
+		ag.Aliases = defaultAliases(a.Aliases)
+		return *ag, nil
+	}
+	return storage.Agent{}, storage.ErrNotFound
+}
+
+func (f *fakeStore) ListAgents(_ context.Context, campaignID uuid.UUID) ([]storage.Agent, error) {
+	var out []storage.Agent
+	for _, a := range f.agents {
+		if a.CampaignID == campaignID {
+			out = append(out, a)
+		}
+	}
+	// ORDER BY agent_role, name — 'butler' sorts before 'character'.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Role != out[j].Role {
+			return out[i].Role < out[j].Role
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+func (f *fakeStore) ListToolGrants(_ context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error) {
+	var out []storage.ToolGrant
+	for _, g := range f.grants {
+		if g.AgentID == agentID {
+			out = append(out, g)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ToolName < out[j].ToolName })
+	return out, nil
+}
+
+// CreateToolGrant refuses a duplicate (agent, tool) like the UNIQUE index
+// (ADR-0029); an empty Config normalizes to nil, the shape a SQL NULL scans
+// back as.
+func (f *fakeStore) CreateToolGrant(_ context.Context, g storage.NewToolGrant) (uuid.UUID, error) {
+	for _, existing := range f.grants {
+		if existing.AgentID == g.AgentID && existing.ToolName == g.ToolName {
+			return uuid.Nil, fmt.Errorf("fake: duplicate tool grant (%s/%s) violates unique index", g.AgentID, g.ToolName)
+		}
+	}
+	id := uuid.New()
+	config := g.Config
+	if len(config) == 0 {
+		config = nil
+	}
+	f.grants = append(f.grants, storage.ToolGrant{ID: id, AgentID: g.AgentID, ToolName: g.ToolName, Config: config})
+	return id, nil
+}
+
+func (f *fakeStore) DeleteToolGrant(_ context.Context, agentID uuid.UUID, toolName string) error {
+	for i, g := range f.grants {
+		if g.AgentID == agentID && g.ToolName == toolName {
+			f.grants = append(f.grants[:i], f.grants[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+// nodeTypeRank orders node types the way Postgres orders the kg_node_type
+// ENUM — by declaration, not lexicographically (npc sorts before location).
+var nodeTypeRank = func() map[storage.KGNodeType]int {
+	m := make(map[storage.KGNodeType]int)
+	for i, tp := range kgvocab.NodeTypes() {
+		m[storage.KGNodeType(tp)] = i
+	}
+	return m
+}()
+
+// CreateNode refuses a node type outside the kg_node_type ENUM, like the
+// real INSERT's ::kg_node_type cast.
+func (f *fakeStore) CreateNode(_ context.Context, n storage.NewKGNode) (storage.KGNode, error) {
+	if _, ok := nodeTypeRank[n.Type]; !ok {
+		return storage.KGNode{}, fmt.Errorf("fake: invalid input value for enum kg_node_type: %q", n.Type)
+	}
+	node := storage.KGNode{
+		ID: uuid.New(), CampaignID: n.CampaignID, Type: n.Type,
+		Name: n.Name, Body: n.Body, GMPrivate: n.GMPrivate,
+	}
+	f.nodes = append(f.nodes, node)
+	return node, nil
+}
+
+// SetNodeAgent scopes to (campaign, node) → storage.ErrNotFound on a miss and
+// refuses linking an agent already linked to another node, like the
+// kg_node_agent_unique index (one node per agent) → storage.ErrConflict. The
+// real store's NPC-only CHECK on the link stays integration-proven; the fake
+// links any node type.
+func (f *fakeStore) SetNodeAgent(_ context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error) {
+	if agentID.Valid {
+		for _, n := range f.nodes {
+			if n.AgentID.Valid && n.AgentID.UUID == agentID.UUID && n.ID != nodeID {
+				return storage.KGNode{}, storage.ErrConflict
+			}
+		}
+	}
+	for i := range f.nodes {
+		if f.nodes[i].ID == nodeID && f.nodes[i].CampaignID == campaignID {
+			f.nodes[i].AgentID = agentID
+			return f.nodes[i], nil
+		}
+	}
+	return storage.KGNode{}, storage.ErrNotFound
+}
+
+func (f *fakeStore) ListNodes(_ context.Context, campaignID uuid.UUID) ([]storage.KGNode, error) {
+	var out []storage.KGNode
+	for _, n := range f.nodes {
+		if n.CampaignID == campaignID {
+			out = append(out, n)
+		}
+	}
+	// ORDER BY node_type, lower(name), id — node_type is a Postgres ENUM,
+	// ordered by declaration (npc before location), NOT lexicographically;
+	// insertion order stands in for the id tie-break.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Type != out[j].Type {
+			return nodeTypeRank[out[i].Type] < nodeTypeRank[out[j].Type]
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+// CreateEdge mirrors the real createEdgeTx's pure-Go gates — none of which
+// the import path satisfies by construction, since bundle edges travel
+// verbatim: a self-edge is storage.ErrInvalidEdge, a missing/cross-campaign
+// endpoint is storage.ErrNotFound, the ADR-0008 validity matrix and unknown
+// edge types are refused via the exported storage.ValidateEdge, and a
+// duplicate (from, to, type) is storage.ErrConflict like the UNIQUE index.
+func (f *fakeStore) CreateEdge(_ context.Context, e storage.NewKGEdge) (storage.KGEdge, error) {
+	if e.FromNodeID == e.ToNodeID {
+		return storage.KGEdge{}, storage.ErrInvalidEdge
+	}
+	var fromType, toType storage.KGNodeType
+	var okFrom, okTo bool
+	for _, n := range f.nodes {
+		if n.CampaignID != e.CampaignID {
+			continue
+		}
+		if n.ID == e.FromNodeID {
+			fromType, okFrom = n.Type, true
+		}
+		if n.ID == e.ToNodeID {
+			toType, okTo = n.Type, true
+		}
+	}
+	if !okFrom || !okTo {
+		return storage.KGEdge{}, storage.ErrNotFound
+	}
+	if err := storage.ValidateEdge(e.Type, fromType, toType); err != nil {
+		return storage.KGEdge{}, err
+	}
+	for _, existing := range f.edges {
+		if existing.FromNodeID == e.FromNodeID && existing.ToNodeID == e.ToNodeID && existing.Type == e.Type {
+			return storage.KGEdge{}, storage.ErrConflict
+		}
+	}
+	edge := storage.KGEdge{
+		ID: uuid.New(), CampaignID: e.CampaignID,
+		FromNodeID: e.FromNodeID, ToNodeID: e.ToNodeID, Type: e.Type,
+	}
+	f.edges = append(f.edges, edge)
+	return edge, nil
+}
+
+func (f *fakeStore) ListEdges(_ context.Context, campaignID uuid.UUID) ([]storage.KGEdge, error) {
+	var out []storage.KGEdge
+	for _, e := range f.edges {
+		if e.CampaignID == campaignID {
+			out = append(out, e)
+		}
+	}
+	// Insertion order — a deterministic stand-in for the real (created_at,
+	// id) read; same-import rows tie on created_at and order randomly by
+	// UUID on Postgres (see the type comment).
+	return out, nil
+}
+
+// CreateCharacter refuses a second Character for the same (campaign,
+// discord_user_id) like the character_campaign_discord_user_idx UNIQUE index
+// (one Character per Discord User per Campaign) → storage.ErrConflict.
+func (f *fakeStore) CreateCharacter(_ context.Context, c storage.NewCharacter) (uuid.UUID, error) {
+	for _, existing := range f.characters {
+		if existing.CampaignID == c.CampaignID && existing.DiscordUserID == c.DiscordUserID {
+			return uuid.Nil, storage.ErrConflict
+		}
+	}
+	id := uuid.New()
+	f.characters = append(f.characters, storage.Character{
+		ID: id, CampaignID: c.CampaignID, Name: c.Name,
+		Aliases: defaultAliases(c.Aliases), DiscordUserID: c.DiscordUserID,
+	})
+	return id, nil
+}
+
+func (f *fakeStore) ListCharacters(_ context.Context, campaignID uuid.UUID) ([]storage.Character, error) {
+	var out []storage.Character
+	for _, c := range f.characters {
+		if c.CampaignID == campaignID {
+			out = append(out, c)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out, nil
+}
+
+// ImportVoiceSession stores the given row VERBATIM (timestamps, status,
+// line_count, end_reason) under a minted id — the contract that distinguishes
+// it from the live CreateVoiceSession.
+func (f *fakeStore) ImportVoiceSession(_ context.Context, v storage.VoiceSession) (uuid.UUID, error) {
+	v.ID = uuid.New()
+	f.sessions = append(f.sessions, v)
+	return v.ID, nil
+}
+
+func (f *fakeStore) ListVoiceSessions(_ context.Context, campaignID uuid.UUID, limit int) ([]storage.VoiceSession, error) {
+	var out []storage.VoiceSession
+	// Reverse-insertion walk as a deterministic stand-in for the id DESC
+	// tie-break (random UUIDs carry no recency on Postgres — see the type
+	// comment); the load-bearing order is started_at DESC.
+	for i := len(f.sessions) - 1; i >= 0; i-- {
+		if f.sessions[i].CampaignID == campaignID {
+			out = append(out, f.sessions[i])
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].StartedAt.After(out[j].StartedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// UpsertTranscriptLine upserts on the (voice_session_id, line_id) replay key
+// (ADR-0040): a conflict updates who/tag/kind/ts/text/speaker but NEVER seq —
+// the replay ordering key is fixed at first insert.
+func (f *fakeStore) UpsertTranscriptLine(_ context.Context, l storage.TranscriptLine) error {
+	for i := range f.lines {
+		if f.lines[i].VoiceSessionID == l.VoiceSessionID && f.lines[i].LineID == l.LineID {
+			seq := f.lines[i].Seq
+			f.lines[i] = l
+			f.lines[i].Seq = seq
+			return nil
+		}
+	}
+	f.lines = append(f.lines, l)
+	return nil
+}
+
+func (f *fakeStore) ListTranscriptLines(_ context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error) {
+	var out []storage.TranscriptLine
+	for _, l := range f.lines {
+		if l.VoiceSessionID == sessionID {
+			out = append(out, l)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
+	return out, nil
+}
+
+// InsertTranscriptChunk never records an embedding or embedding_model
+// (ADR-0011) — like the real writer, which leaves the vector NULL for the
+// destination embedworker. Arrays default to empty, never nil.
+func (f *fakeStore) InsertTranscriptChunk(_ context.Context, c storage.TranscriptChunk) (uuid.UUID, error) {
+	c.ID = uuid.New()
+	c.EmbeddingModel = ""
+	if c.SpeakerDiscordUserIDs == nil {
+		c.SpeakerDiscordUserIDs = []string{}
+	}
+	if c.ParticipatedAgentIDs == nil {
+		c.ParticipatedAgentIDs = []uuid.UUID{}
+	}
+	f.chunks = append(f.chunks, c)
+	return c.ID, nil
+}
+
+// ListTranscriptChunks returns the campaign's chunks in insertion order — the
+// deterministic stand-in for the real (created_at, id) read; same-import rows
+// tie on created_at and order randomly by UUID on Postgres (see the type
+// comment). Embedding is always "": the fake never holds a vector, so
+// includeVectors has nothing to include — Export only ever passes false
+// anyway (ADR-0053 §3).
+func (f *fakeStore) ListTranscriptChunks(_ context.Context, campaignID uuid.UUID, _ bool) ([]storage.ExportChunk, error) {
+	var out []storage.ExportChunk
+	for _, c := range f.chunks {
+		if c.CampaignID == campaignID {
+			out = append(out, storage.ExportChunk{TranscriptChunk: c})
+		}
+	}
+	return out, nil
+}
+
+// defaultVoice mirrors the store's write-side default: an empty voice persists
+// as the '{}' column default.
+func defaultVoice(v []byte) json.RawMessage {
+	if len(v) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return v
+}
+
+// defaultAliases mirrors the store's write-side default: nil persists as '{}'
+// (empty array), never SQL NULL.
+func defaultAliases(a []string) []string {
+	if a == nil {
+		return []string{}
+	}
+	return a
+}

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -166,7 +166,7 @@ func (h *Handler) ServeImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := Import(r.Context(), h.Store, tenantID, b)
+	res, err := Import(r.Context(), PGStore{h.Store}, tenantID, b)
 	if err != nil {
 		if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) {
 			writeImportError(w, http.StatusBadRequest, importErrorMessage(err))

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -17,8 +17,9 @@ import (
 // feeds the ServeImport JSON response, always present so the response shape is
 // stable for clients.
 // DroppedParticipantRefs counts chunk participant refs that mapped to no imported
-// Agent and were dropped (not fatal); a nonzero value also emits a single
-// slog.Warn from importHistory (#381), so a lossy import is never silent.
+// Agent and were dropped (not fatal); a nonzero value also makes [Import] emit a
+// single slog.Warn after the commit succeeds (#381), so a lossy import is never
+// silent.
 type ImportResult struct {
 	CampaignID uuid.UUID
 	Name       string
@@ -35,7 +36,9 @@ type ImportResult struct {
 }
 
 // Import ingests a [Bundle] into a fresh Campaign under tenantID, in ONE
-// transaction (ADR-0049 synchronous; ADR-0053 §4/§5/§7). It mints fresh UUIDs for
+// transaction (ADR-0049 synchronous; ADR-0053 §4/§5/§7): st is the seam whose
+// [TxRunner.InTx] carries the all-or-nothing contract — production passes
+// [PGStore], unit tests an in-memory fake (#451). It mints fresh UUIDs for
 // every entity and remaps intra-bundle references, so the same bundle imported
 // twice yields two independent Campaigns (ADR-0053 §4: idempotent re-import is a
 // non-goal). Any unknown cross-reference (a node's agent link, an edge endpoint)
@@ -64,7 +67,7 @@ type ImportResult struct {
 // (ADR-0011) — a chunk's participated refs are remapped through AgentIDs and an
 // unmappable one is dropped and counted. A bundle with no History section imports
 // exactly as part 1 did (zero history counts).
-func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundle) (ImportResult, error) {
+func Import(ctx context.Context, st TxRunner, tenantID uuid.UUID, b *Bundle) (ImportResult, error) {
 	if err := CheckVersion(b.FormatVersion); err != nil {
 		return ImportResult{}, fmt.Errorf("bundle has format_version %d; this build supports %d: %w",
 			b.FormatVersion, FormatVersion, err)
@@ -75,7 +78,7 @@ func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundl
 		AgentIDs: make(map[string]uuid.UUID),
 	}
 
-	err := st.InTx(ctx, func(tx *storage.Store) error {
+	err := st.InTx(ctx, func(tx ImportStore) error {
 		return importInTx(ctx, tx, tenantID, b, &res)
 	})
 	if err != nil {
@@ -93,11 +96,11 @@ func Import(ctx context.Context, st *storage.Store, tenantID uuid.UUID, b *Bundl
 	return res, nil
 }
 
-// importInTx runs the whole ingest against a tx-bound Store (see [Import]). It is
+// importInTx runs the whole ingest against the tx-bound seam (see [Import]). It is
 // split out so the transaction body reads top-to-bottom: campaign → Butler merge
 // → character Agents → Nodes → node↔Agent links → Edges → Characters. Every step
 // records or consumes the ref→id remaps in res.AgentIDs and a local node map.
-func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *Bundle, res *ImportResult) error {
+func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bundle, res *ImportResult) error {
 	campaignID, err := tx.CreateCampaign(ctx, storage.NewCampaign{
 		TenantID: tenantID,
 		Name:     b.Campaign.Name,
@@ -218,7 +221,7 @@ func importInTx(ctx context.Context, tx *storage.Store, tenantID uuid.UUID, b *B
 // DROPPED and counted in DroppedParticipantRefs (not fatal — a foreign agent
 // simply carries no local knowledge), while speaker snowflakes travel verbatim
 // (ADR-0053 §6). A nil History section is a no-op: counts stay zero (part-1 parity).
-func importHistory(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, b *Bundle, res *ImportResult) error {
+func importHistory(ctx context.Context, tx ImportStore, campaignID uuid.UUID, b *Bundle, res *ImportResult) error {
 	if b.Campaign.History == nil {
 		return nil
 	}
@@ -322,7 +325,7 @@ func coerceTerminalStatus(status string) storage.VoiceSessionStatus {
 // are nulled (secrets never travel in a bundle, ADR-0053 §2); address_only is left
 // to the storage layer, which force-keeps a Butler's true (ADR-0024). The Butler
 // ref is recorded in AgentIDs so a node could link to it if the bundle so wires.
-func mergeButler(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
+func mergeButler(ctx context.Context, tx ImportStore, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
 	butler, err := tx.GetButler(ctx, campaignID)
 	if err != nil {
 		return fmt.Errorf("bundle: import: get trigger-created butler: %w", err)
@@ -370,7 +373,7 @@ func mergeButler(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, a
 // createCharacterAgent inserts one Character NPC Agent with NULL provider FKs and
 // its Tool Grants, recording the ref→id remap. Speaker-colour slot assignment is
 // server-side and depends on bundle order (deterministic).
-func createCharacterAgent(ctx context.Context, tx *storage.Store, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
+func createCharacterAgent(ctx context.Context, tx ImportStore, campaignID uuid.UUID, a *Agent, res *ImportResult) error {
 	if _, err := storage.VoiceFromJSON(a.Voice); err != nil {
 		return fmt.Errorf("bundle: import: agent %q voice: %w", a.Name, err)
 	}
@@ -399,7 +402,7 @@ func createCharacterAgent(ctx context.Context, tx *storage.Store, campaignID uui
 
 // createGrants creates one Tool Grant per bundle grant for an Agent, carrying the
 // scope Config verbatim (nil when the grant narrows nothing, e.g. dice).
-func createGrants(ctx context.Context, tx *storage.Store, agentID uuid.UUID, grants []Grant) error {
+func createGrants(ctx context.Context, tx ImportStore, agentID uuid.UUID, grants []Grant) error {
 	for _, g := range grants {
 		if _, err := tx.CreateToolGrant(ctx, storage.NewToolGrant{
 			AgentID:  agentID,

--- a/internal/bundle/import_fake_test.go
+++ b/internal/bundle/import_fake_test.go
@@ -1,0 +1,702 @@
+package bundle_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/tts"
+)
+
+// This file is the DB-free half of the import suite (#451): the same
+// remap/merge/counting logic the integration tests prove against Postgres,
+// exercised here through [bundle.TxRunner] over the in-memory fakeStore under
+// plain `go test`. What stays integration-only is exactly the SQL-shaped rest:
+// real rollback of a mid-bundle failure, FK/CHECK interactions, and the
+// genuine trigger.
+
+// seamVoiceJSON returns a canonical voice column value for the given provider
+// and voice id, via the same mapper the importer validates with.
+func seamVoiceJSON(t *testing.T, providerID, voiceID string) json.RawMessage {
+	t.Helper()
+	raw, err := storage.VoiceToJSON(tts.Voice{ProviderID: providerID, VoiceID: voiceID})
+	if err != nil {
+		t.Fatalf("VoiceToJSON: %v", err)
+	}
+	return raw
+}
+
+// remapBundle builds the reference bundle for the remap tests: a Butler, two
+// character NPCs, an agent-linked NPC node plus a plain location node, one
+// edge, one player Character, and a history session whose lines arrive out of
+// seq order and whose chunk names both NPC refs.
+func remapBundle(t *testing.T) *bundle.Bundle {
+	t.Helper()
+	started := time.Date(2026, 5, 1, 19, 0, 0, 0, time.UTC)
+	ended := started.Add(3 * time.Hour)
+	return &bundle.Bundle{
+		FormatVersion: bundle.FormatVersion,
+		ExportedAt:    started,
+		Campaign: bundle.Campaign{
+			Name: "Shadows over Innsmouth", System: "coc7e", Language: "de",
+			Agents: []bundle.Agent{
+				{
+					ID: "butler-ref", Role: "butler", Name: "Majordomus", Title: "Haushofmeister",
+					Persona: "stiff upper lip", AddressOnly: false, Aliases: []string{"Dom"},
+					Grants: []bundle.Grant{{ToolName: "rules_lookup", Config: json.RawMessage(`{"system":"coc7e"}`)}},
+				},
+				{
+					ID: "gesa-ref", Role: "character", Name: "Gesa",
+					Voice:  seamVoiceJSON(t, "elevenlabs", "gesa-voice"),
+					Grants: []bundle.Grant{{ToolName: "dice"}},
+				},
+				{ID: "bart-ref", Role: "character", Name: "Bart", Voice: seamVoiceJSON(t, "openai", "onyx")},
+			},
+			Nodes: []bundle.Node{
+				{ID: "n-gesa", Type: "npc", Name: "Gesa", Body: "innkeeper", AgentID: "gesa-ref"},
+				{ID: "n-inn", Type: "location", Name: "The Gilman House", GMPrivate: true},
+			},
+			Edges: []bundle.Edge{{From: "n-gesa", To: "n-inn", Type: "resides_in"}},
+			Characters: []bundle.Character{
+				{Name: "Frodo", Aliases: []string{"Ringbearer"}, DiscordUserID: "199999999999999999"},
+			},
+			History: &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: started, EndedAt: &ended, Status: "ended", LineCount: 2,
+				Lines: []bundle.Line{
+					{LineID: "l2", Seq: 7, Who: "Gesa", Kind: "agent", TS: started.Add(time.Minute), Text: "Willkommen."},
+					{LineID: "l1", Seq: 3, Who: "Frodo", Kind: "human", TS: started, Text: "Hallo?", SpeakerDiscordUserID: "199999999999999999"},
+				},
+				Chunks: []bundle.Chunk{{
+					Content:               "Frodo: Hallo?\nGesa: Willkommen.",
+					SpeakerDiscordUserIDs: []string{"199999999999999999"},
+					ParticipatedAgentIDs:  []string{"gesa-ref", "bart-ref"},
+					StartedAt:             started,
+				}},
+			}}},
+		},
+	}
+}
+
+// agentNamed / nodeNamed find a fake row by name within one campaign.
+func agentNamed(t *testing.T, f *fakeStore, campaignID uuid.UUID, name string) storage.Agent {
+	t.Helper()
+	for _, a := range f.agents {
+		if a.CampaignID == campaignID && a.Name == name {
+			return a
+		}
+	}
+	t.Fatalf("no agent %q in campaign %s", name, campaignID)
+	return storage.Agent{}
+}
+
+func nodeNamed(t *testing.T, f *fakeStore, campaignID uuid.UUID, name string) storage.KGNode {
+	t.Helper()
+	for _, n := range f.nodes {
+		if n.CampaignID == campaignID && n.Name == name {
+			return n
+		}
+	}
+	t.Fatalf("no node %q in campaign %s", name, campaignID)
+	return storage.KGNode{}
+}
+
+// grantNames returns the tool names of an agent's grants in the seam's
+// tool-name order.
+func grantNames(t *testing.T, f *fakeStore, agentID uuid.UUID) []string {
+	t.Helper()
+	grants, err := f.ListToolGrants(context.Background(), agentID)
+	if err != nil {
+		t.Fatalf("ListToolGrants: %v", err)
+	}
+	names := make([]string, 0, len(grants))
+	for _, g := range grants {
+		names = append(names, g.ToolName)
+	}
+	return names
+}
+
+// TestImportFake_MintsAndRemapsEveryReference is the heart of ADR-0053 §4 over
+// the fake: every entity lands under a minted UUID, and every intra-bundle
+// reference — the node→agent link, both edge endpoints, and the chunk's
+// participant refs — is remapped consistently onto those minted ids.
+func TestImportFake_MintsAndRemapsEveryReference(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+	tenantID := uuid.New()
+
+	res, err := bundle.Import(ctx, f, tenantID, remapBundle(t))
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Counts feed the ServeImport response verbatim — all sections landed.
+	if res.Agents != 3 || res.Nodes != 2 || res.Edges != 1 || res.Characters != 1 ||
+		res.Sessions != 1 || res.Lines != 2 || res.Chunks != 1 || res.DroppedParticipantRefs != 0 {
+		t.Fatalf("counts = %+v, want 3/2/1/1 agents/nodes/edges/characters, 1/2/1 sessions/lines/chunks, 0 dropped", res)
+	}
+
+	campaign, err := f.GetCampaign(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("campaign did not land: %v", err)
+	}
+	if campaign.TenantID != tenantID || campaign.Name != "Shadows over Innsmouth" ||
+		campaign.System != "coc7e" || campaign.Language != "de" {
+		t.Errorf("campaign = %+v, want tenant %s + bundle name/system/language", campaign, tenantID)
+	}
+
+	// Every bundle ref got a fresh, distinct minted id.
+	for _, ref := range []string{"butler-ref", "gesa-ref", "bart-ref"} {
+		if res.AgentIDs[ref] == uuid.Nil {
+			t.Errorf("AgentIDs[%q] not minted", ref)
+		}
+	}
+	seen := make(map[uuid.UUID]string, len(res.AgentIDs))
+	for ref, id := range res.AgentIDs {
+		if other, dup := seen[id]; dup {
+			t.Errorf("minted agent ids collide: %q and %q both got %s", ref, other, id)
+		}
+		seen[id] = ref
+	}
+
+	// Node→agent link remapped onto the minted Gesa id; the plain node stays
+	// unlinked.
+	gesaNode := nodeNamed(t, f, res.CampaignID, "Gesa")
+	if !gesaNode.AgentID.Valid || gesaNode.AgentID.UUID != res.AgentIDs["gesa-ref"] {
+		t.Errorf("node agent link = %+v, want minted id %s", gesaNode.AgentID, res.AgentIDs["gesa-ref"])
+	}
+	if inn := nodeNamed(t, f, res.CampaignID, "The Gilman House"); inn.AgentID.Valid {
+		t.Errorf("location node unexpectedly agent-linked: %+v", inn.AgentID)
+	}
+
+	// Edge endpoints remapped onto the minted node ids.
+	if len(f.edges) != 1 {
+		t.Fatalf("edges = %d, want 1", len(f.edges))
+	}
+	edge := f.edges[0]
+	innNode := nodeNamed(t, f, res.CampaignID, "The Gilman House")
+	if edge.FromNodeID != gesaNode.ID || edge.ToNodeID != innNode.ID {
+		t.Errorf("edge = %s->%s, want %s->%s", edge.FromNodeID, edge.ToNodeID, gesaNode.ID, innNode.ID)
+	}
+
+	// Character travels verbatim (ADR-0053 §6: snowflake kept).
+	if len(f.characters) != 1 || f.characters[0].DiscordUserID != "199999999999999999" {
+		t.Errorf("characters = %+v, want Frodo's snowflake verbatim", f.characters)
+	}
+
+	// History: session minted, lines listed in seq order with replay keys
+	// verbatim, chunk participants remapped in bundle order.
+	if len(f.sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(f.sessions))
+	}
+	lines, err := f.ListTranscriptLines(ctx, f.sessions[0].ID)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	if len(lines) != 2 || lines[0].LineID != "l1" || lines[0].Seq != 3 ||
+		lines[1].LineID != "l2" || lines[1].Seq != 7 {
+		t.Errorf("lines out of replay order or keys rewritten: %+v", lines)
+	}
+	if lines[0].SpeakerDiscordUserID != "199999999999999999" {
+		t.Errorf("speaker snowflake = %q, want verbatim", lines[0].SpeakerDiscordUserID)
+	}
+	if len(f.chunks) != 1 {
+		t.Fatalf("chunks = %d, want 1", len(f.chunks))
+	}
+	wantParticipants := []uuid.UUID{res.AgentIDs["gesa-ref"], res.AgentIDs["bart-ref"]}
+	if got := f.chunks[0].ParticipatedAgentIDs; len(got) != 2 ||
+		got[0] != wantParticipants[0] || got[1] != wantParticipants[1] {
+		t.Errorf("chunk participants = %v, want remapped %v", got, wantParticipants)
+	}
+}
+
+// TestImportFake_TwiceMintsIndependentCampaigns: ADR-0053 §4 — the importer
+// never dedups; the same bundle imported twice yields two fully independent
+// Campaigns with disjoint minted ids.
+func TestImportFake_TwiceMintsIndependentCampaigns(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+	tenantID := uuid.New()
+
+	first, err := bundle.Import(ctx, f, tenantID, remapBundle(t))
+	if err != nil {
+		t.Fatalf("first Import: %v", err)
+	}
+	second, err := bundle.Import(ctx, f, tenantID, remapBundle(t))
+	if err != nil {
+		t.Fatalf("second Import: %v", err)
+	}
+
+	if first.CampaignID == second.CampaignID {
+		t.Fatalf("both imports landed in campaign %s", first.CampaignID)
+	}
+	for ref, id := range first.AgentIDs {
+		if second.AgentIDs[ref] == id {
+			t.Errorf("agent ref %q reused id %s across imports", ref, id)
+		}
+	}
+	if len(f.campaigns) != 2 || len(f.agents) != 6 || len(f.nodes) != 4 ||
+		len(f.characters) != 2 || len(f.sessions) != 2 {
+		t.Errorf("fake holds %d/%d/%d/%d/%d campaigns/agents/nodes/characters/sessions, want 2/6/4/2/2",
+			len(f.campaigns), len(f.agents), len(f.nodes), len(f.characters), len(f.sessions))
+	}
+}
+
+// TestImportFake_RejectsDuplicateRefs: a repeated agent or node ref key would
+// clobber the remap and bind references to the wrong row, so it is a hard
+// error naming the offending ref.
+func TestImportFake_RejectsDuplicateRefs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("agent", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Agents = append(b.Campaign.Agents, bundle.Agent{ID: "gesa-ref", Role: "character", Name: "Impostor"})
+		_, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err == nil || !strings.Contains(err.Error(), `duplicate agent ref "gesa-ref"`) {
+			t.Fatalf("err = %v, want duplicate agent ref", err)
+		}
+	})
+	t.Run("node", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Nodes = append(b.Campaign.Nodes, bundle.Node{ID: "n-inn", Type: "location", Name: "Shadow Inn"})
+		_, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err == nil || !strings.Contains(err.Error(), `duplicate node ref "n-inn"`) {
+			t.Fatalf("err = %v, want duplicate node ref", err)
+		}
+	})
+}
+
+// TestImportFake_RejectsUnknownRefs: any cross-reference that resolves to no
+// bundle entity — a node's agent link or either edge endpoint — aborts the
+// import (all-or-nothing; only chunk participants are drop-not-fatal).
+func TestImportFake_RejectsUnknownRefs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("node agent link", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Nodes[0].AgentID = "nobody"
+		_, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err == nil || !strings.Contains(err.Error(), `unknown agent "nobody"`) {
+			t.Fatalf("err = %v, want unknown agent ref", err)
+		}
+	})
+	t.Run("edge from", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Edges[0].From = "n-ghost"
+		_, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err == nil || !strings.Contains(err.Error(), `unknown from-node "n-ghost"`) {
+			t.Fatalf("err = %v, want unknown from-node", err)
+		}
+	})
+	t.Run("edge to", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Edges[0].To = "n-ghost"
+		_, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err == nil || !strings.Contains(err.Error(), `unknown to-node "n-ghost"`) {
+			t.Fatalf("err = %v, want unknown to-node", err)
+		}
+	})
+}
+
+// TestImportFake_RejectsSecondButler: exactly one Butler per Campaign
+// (ADR-0009) — a second one in the bundle is refused, never last-wins merged.
+func TestImportFake_RejectsSecondButler(t *testing.T) {
+	t.Parallel()
+	b := remapBundle(t)
+	b.Campaign.Agents = append(b.Campaign.Agents, bundle.Agent{ID: "butler2", Role: "butler", Name: "Zweiter"})
+	_, err := bundle.Import(context.Background(), newFakeStore(), uuid.New(), b)
+	if err == nil || !strings.Contains(err.Error(), "more than one butler") {
+		t.Fatalf("err = %v, want more-than-one-butler refusal", err)
+	}
+}
+
+// TestImportFake_ButlerMergesOntoTriggerRow: the ADR-0009 merge — the bundle's
+// Butler UPDATEs the trigger-created row (same id, new editor fields), its
+// grants replace the trigger defaults EXACTLY, and provider FKs land NULL
+// (ADR-0053 §2). The address_only/role checks pin the SEAM contract the merge
+// rides on — UpdateAgent force-keeps a Butler's address_only true and never
+// changes agent_role — which the fake emulates here and storage proves for
+// real (TestUpdateButlerKeepsAddressOnly; the bundle deliberately says false).
+func TestImportFake_ButlerMergesOntoTriggerRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+
+	res, err := bundle.Import(ctx, f, uuid.New(), remapBundle(t))
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	butler, err := f.GetButler(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	if butler.ID != res.AgentIDs["butler-ref"] {
+		t.Errorf("AgentIDs[butler-ref] = %s, want the trigger row %s", res.AgentIDs["butler-ref"], butler.ID)
+	}
+	if butler.Name != "Majordomus" || butler.Title != "Haushofmeister" || butler.Persona != "stiff upper lip" {
+		t.Errorf("butler fields not merged: %+v", butler)
+	}
+	if len(butler.Aliases) != 1 || butler.Aliases[0] != "Dom" {
+		t.Errorf("butler aliases = %v, want [Dom]", butler.Aliases)
+	}
+	if !butler.AddressOnly {
+		t.Error("butler address_only unpinned — the UpdateAgent seam contract (ADR-0024) must keep it true against the bundle's false")
+	}
+	if butler.Role != storage.AgentRoleButler {
+		t.Errorf("butler role changed to %q — the UpdateAgent seam contract never changes agent_role", butler.Role)
+	}
+	if butler.VoiceProviderConfigID.Valid || butler.LLMProviderConfigID.Valid {
+		t.Errorf("butler provider FKs not NULL: %+v / %+v", butler.VoiceProviderConfigID, butler.LLMProviderConfigID)
+	}
+
+	// Grants replaced exactly: every trigger default gone, the bundle's one
+	// grant present with its scope Config verbatim.
+	if names := grantNames(t, f, butler.ID); len(names) != 1 || names[0] != "rules_lookup" {
+		t.Fatalf("butler grants = %v, want exactly [rules_lookup]", names)
+	}
+	grants, _ := f.ListToolGrants(ctx, butler.ID)
+	if string(grants[0].Config) != `{"system":"coc7e"}` {
+		t.Errorf("grant config = %s, want verbatim scope blob", grants[0].Config)
+	}
+}
+
+// TestImportFake_NoButlerKeepsTriggerDefaults: a bundle without a Butler
+// leaves the trigger-created row and its default grant set standing.
+func TestImportFake_NoButlerKeepsTriggerDefaults(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+
+	b := remapBundle(t)
+	b.Campaign.Agents = b.Campaign.Agents[1:] // drop the Butler, keep the NPCs
+	b.Campaign.History = nil                  // chunk participants reference NPCs only anyway
+	res, err := bundle.Import(ctx, f, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Agents != 2 {
+		t.Errorf("Agents = %d, want 2 (the Butler is not counted when not in the bundle)", res.Agents)
+	}
+
+	butler, err := f.GetButler(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("GetButler: %v", err)
+	}
+	if butler.Name != "Glyphoxa" || !butler.AddressOnly {
+		t.Errorf("trigger defaults disturbed: %+v", butler)
+	}
+	want := []string{"dice", "kg_query", "recap", "transcript_search"} // tool-name order
+	got := grantNames(t, f, butler.ID)
+	if len(got) != len(want) {
+		t.Fatalf("butler grants = %v, want defaults %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("butler grants = %v, want defaults %v", got, want)
+		}
+	}
+}
+
+// TestImportFake_CharacterAgentsLandClean: character NPCs are created with
+// provider FKs NULL (the exporter stripped bindings; the tenant-level fallback
+// resolves providers later) and their grants carried verbatim.
+func TestImportFake_CharacterAgentsLandClean(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+
+	res, err := bundle.Import(ctx, f, uuid.New(), remapBundle(t))
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	gesa := agentNamed(t, f, res.CampaignID, "Gesa")
+	if gesa.VoiceProviderConfigID.Valid || gesa.LLMProviderConfigID.Valid {
+		t.Errorf("NPC provider FKs not NULL: %+v / %+v", gesa.VoiceProviderConfigID, gesa.LLMProviderConfigID)
+	}
+	if names := grantNames(t, f, gesa.ID); len(names) != 1 || names[0] != "dice" {
+		t.Errorf("Gesa grants = %v, want [dice]", names)
+	}
+	voice, err := storage.VoiceFromJSON(gesa.Voice)
+	if err != nil || voice.ProviderID != "elevenlabs" || voice.VoiceID != "gesa-voice" {
+		t.Errorf("Gesa voice = %+v (err %v), want elevenlabs/gesa-voice", voice, err)
+	}
+}
+
+// TestImportFake_InvalidVoiceFails: a voice that does not parse through the
+// canonical mapper is a hard error naming the agent — never a silent NPC
+// (#224) — for the Butler and character paths alike.
+func TestImportFake_InvalidVoiceFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("butler", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Agents[0].Voice = json.RawMessage(`"not an object"`)
+		if _, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b); err == nil ||
+			!strings.Contains(err.Error(), "butler voice") {
+			t.Fatalf("err = %v, want butler voice failure", err)
+		}
+	})
+	t.Run("character", func(t *testing.T) {
+		t.Parallel()
+		b := remapBundle(t)
+		b.Campaign.Agents[1].Voice = json.RawMessage(`"not an object"`)
+		if _, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b); err == nil ||
+			!strings.Contains(err.Error(), `agent "Gesa" voice`) {
+			t.Fatalf("err = %v, want Gesa voice failure", err)
+		}
+	})
+}
+
+// TestImportFake_DropsUnmappableParticipants: a chunk participant ref that
+// maps to no imported Agent is dropped and counted — not fatal — while
+// mappable refs in the same chunk still remap.
+func TestImportFake_DropsUnmappableParticipants(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+
+	b := remapBundle(t)
+	b.Campaign.History.Sessions[0].Chunks[0].ParticipatedAgentIDs = []string{"ghost", "gesa-ref", "phantom"}
+	res, err := bundle.Import(ctx, f, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.DroppedParticipantRefs != 2 {
+		t.Errorf("DroppedParticipantRefs = %d, want 2", res.DroppedParticipantRefs)
+	}
+	if res.Chunks != 1 {
+		t.Errorf("Chunks = %d, want 1 — a lossy chunk still lands", res.Chunks)
+	}
+	got := f.chunks[0].ParticipatedAgentIDs
+	if len(got) != 1 || got[0] != res.AgentIDs["gesa-ref"] {
+		t.Errorf("chunk participants = %v, want just the remapped gesa-ref", got)
+	}
+}
+
+// TestImportFake_WarnsOnDroppedRefs is the #381 log contract, DB-free: one
+// WARN on the request-scoped logger carrying campaign_id and count, emitted
+// only after the import succeeded; a clean import stays silent.
+func TestImportFake_WarnsOnDroppedRefs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lossy import warns once", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := observe.WithLogger(context.Background(),
+			slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+		b := remapBundle(t)
+		b.Campaign.History.Sessions[0].Chunks[0].ParticipatedAgentIDs = []string{"ghost", "phantom"}
+		res, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+		if err != nil {
+			t.Fatalf("Import: %v", err)
+		}
+		logged := buf.String()
+		if !strings.Contains(logged, "level=WARN") ||
+			!strings.Contains(logged, res.CampaignID.String()) ||
+			!strings.Contains(logged, "count=2") {
+			t.Errorf("warn missing/incomplete: %q", logged)
+		}
+	})
+	t.Run("clean import is silent", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := observe.WithLogger(context.Background(),
+			slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+		if _, err := bundle.Import(ctx, newFakeStore(), uuid.New(), remapBundle(t)); err != nil {
+			t.Fatalf("Import: %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("clean import emitted: %q", buf.String())
+		}
+	})
+	t.Run("failed import is silent even with drops counted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ctx := observe.WithLogger(context.Background(),
+			slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+		// Drops are counted during the tx body; the commit then fails, so a
+		// warn here would log a campaign_id that never persisted.
+		b := remapBundle(t)
+		b.Campaign.History.Sessions[0].Chunks[0].ParticipatedAgentIDs = []string{"ghost"}
+		if _, err := bundle.Import(ctx, commitFailTx{newFakeStore()}, uuid.New(), b); err == nil {
+			t.Fatal("Import succeeded through a failing commit")
+		}
+		if buf.Len() != 0 {
+			t.Errorf("rolled-back import emitted: %q", buf.String())
+		}
+	})
+}
+
+// TestImportFake_CoercesSessionStatus: an imported Voice Session is never
+// revivable — 'failed' keeps its distinct terminal state, anything else
+// (including a stale 'running') lands 'ended', and a missing ended_at defaults
+// to started_at so no imported row ever looks live.
+func TestImportFake_CoercesSessionStatus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	started := time.Date(2026, 5, 2, 19, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		status string
+		want   storage.VoiceSessionStatus
+	}{
+		{"running coerces to ended", "running", storage.VoiceSessionEnded},
+		{"failed stays failed", "failed", storage.VoiceSessionFailed},
+		{"ended stays ended", "ended", storage.VoiceSessionEnded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newFakeStore()
+			b := remapBundle(t)
+			b.Campaign.History = &bundle.History{Sessions: []bundle.Session{{
+				ID: "s1", StartedAt: started, Status: tc.status, // no EndedAt on purpose
+			}}}
+			if _, err := bundle.Import(ctx, f, uuid.New(), b); err != nil {
+				t.Fatalf("Import: %v", err)
+			}
+			s := f.sessions[0]
+			if s.Status != tc.want {
+				t.Errorf("status = %q, want %q", s.Status, tc.want)
+			}
+			if s.EndedAt == nil || !s.EndedAt.Equal(started) {
+				t.Errorf("ended_at = %v, want defaulted to started_at %v", s.EndedAt, started)
+			}
+		})
+	}
+}
+
+// TestImportFake_DuplicateLineIDCoalesces pins the documented edge from
+// import.go: two bundle Lines sharing a line_id COALESCE at the replay-key
+// upsert — one row survives with the FIRST insert's seq and the LAST write's
+// text — while res.Lines still counts both inputs.
+func TestImportFake_DuplicateLineIDCoalesces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newFakeStore()
+	started := time.Date(2026, 5, 3, 19, 0, 0, 0, time.UTC)
+
+	b := remapBundle(t)
+	b.Campaign.History.Sessions[0].Chunks = nil
+	b.Campaign.History.Sessions[0].Lines = []bundle.Line{
+		{LineID: "dup", Seq: 1, Who: "Gesa", Kind: "agent", TS: started, Text: "first"},
+		{LineID: "dup", Seq: 9, Who: "Bart", Kind: "agent", TS: started, Text: "second"},
+	}
+	res, err := bundle.Import(ctx, f, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Lines != 2 {
+		t.Errorf("Lines = %d, want 2 — the count reports inputs, not rows", res.Lines)
+	}
+	lines, _ := f.ListTranscriptLines(ctx, f.sessions[0].ID)
+	if len(lines) != 1 {
+		t.Fatalf("rows = %d, want 1 coalesced", len(lines))
+	}
+	if lines[0].Seq != 1 || lines[0].Text != "second" || lines[0].Who != "Bart" {
+		t.Errorf("coalesced line = %+v, want seq 1 (first insert) with last write's text/who", lines[0])
+	}
+}
+
+// TestImportFake_NodeMayLinkButlerRef: mergeButler records the Butler's ref in
+// AgentIDs precisely so a node can link to it — the consumer path of that
+// remap entry.
+func TestImportFake_NodeMayLinkButlerRef(t *testing.T) {
+	t.Parallel()
+	f := newFakeStore()
+	b := remapBundle(t)
+	b.Campaign.Nodes = append(b.Campaign.Nodes,
+		bundle.Node{ID: "n-butler", Type: "npc", Name: "Majordomus", AgentID: "butler-ref"})
+
+	res, err := bundle.Import(context.Background(), f, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	node := nodeNamed(t, f, res.CampaignID, "Majordomus")
+	if !node.AgentID.Valid || node.AgentID.UUID != res.AgentIDs["butler-ref"] {
+		t.Errorf("node agent link = %+v, want the merged butler %s", node.AgentID, res.AgentIDs["butler-ref"])
+	}
+}
+
+// TestImportFake_DuplicateGrantFails: an Agent grants a Tool at most once
+// (ADR-0029, a seam contract) — a bundle granting the same tool twice to one
+// agent aborts the import.
+func TestImportFake_DuplicateGrantFails(t *testing.T) {
+	t.Parallel()
+	b := remapBundle(t)
+	b.Campaign.Agents[1].Grants = append(b.Campaign.Agents[1].Grants, bundle.Grant{ToolName: "dice"})
+
+	_, err := bundle.Import(context.Background(), newFakeStore(), uuid.New(), b)
+	if err == nil || !strings.Contains(err.Error(), `create grant "dice"`) {
+		t.Fatalf("err = %v, want duplicate-grant refusal", err)
+	}
+}
+
+// TestImportFake_RefusesNewerVersionBeforeAnyWrite: the compatibility gate
+// (ADR-0053 §7) runs before the transaction — a newer bundle is refused with
+// both versions named and the store is never touched.
+func TestImportFake_RefusesNewerVersionBeforeAnyWrite(t *testing.T) {
+	t.Parallel()
+	f := newFakeStore()
+	b := remapBundle(t)
+	b.FormatVersion = bundle.FormatVersion + 1
+
+	_, err := bundle.Import(context.Background(), f, uuid.New(), b)
+	if !errors.Is(err, bundle.ErrNewerFormat) {
+		t.Fatalf("err = %v, want ErrNewerFormat", err)
+	}
+	wantMsg := fmt.Sprintf("bundle has format_version %d; this build supports %d",
+		bundle.FormatVersion+1, bundle.FormatVersion)
+	if !strings.Contains(err.Error(), wantMsg) {
+		t.Errorf("refusal does not name both versions: %v, want %q", err, wantMsg)
+	}
+	if len(f.campaigns) != 0 || len(f.agents) != 0 {
+		t.Errorf("store touched before the version gate: %d campaigns, %d agents", len(f.campaigns), len(f.agents))
+	}
+}
+
+// TestImportFake_HistorylessBundleZeroCounts: no History section means a
+// part-1 import exactly — zero session/line/chunk counts, nothing dropped.
+func TestImportFake_HistorylessBundleZeroCounts(t *testing.T) {
+	t.Parallel()
+	f := newFakeStore()
+	b := remapBundle(t)
+	b.Campaign.History = nil
+
+	res, err := bundle.Import(context.Background(), f, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.Sessions != 0 || res.Lines != 0 || res.Chunks != 0 || res.DroppedParticipantRefs != 0 {
+		t.Errorf("history counts = %d/%d/%d/%d, want all zero", res.Sessions, res.Lines, res.Chunks, res.DroppedParticipantRefs)
+	}
+	if len(f.sessions) != 0 || len(f.lines) != 0 || len(f.chunks) != 0 {
+		t.Errorf("history rows landed from a history-less bundle")
+	}
+}

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -48,7 +48,7 @@ func TestImportRefusesNewerVersion(t *testing.T) {
 		FormatVersion: bundle.FormatVersion + 1,
 		Campaign:      bundle.Campaign{Name: "From The Future", System: "dnd5e", Language: "en"},
 	}
-	_, err := bundle.Import(ctx, st, tid, b)
+	_, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b)
 	if !errors.Is(err, bundle.ErrNewerFormat) {
 		t.Fatalf("Import err = %v, want ErrNewerFormat", err)
 	}
@@ -67,7 +67,7 @@ func TestImportMinimalCampaign(t *testing.T) {
 		FormatVersion: bundle.FormatVersion,
 		Campaign:      bundle.Campaign{Name: "Bare Campaign", System: "dnd5e", Language: "en"},
 	}
-	res, err := bundle.Import(ctx, st, tid, b)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -112,13 +112,16 @@ func TestImportButlerMerge(t *testing.T) {
 			Name: "Butler Merge", System: "dnd5e", Language: "en",
 			Agents: []bundle.Agent{{
 				ID: "butler-ref", Role: "butler", Name: "Alfred", Title: "The Butler",
-				Persona: "Impeccably dry.", Voice: voice, AddressOnly: true,
+				// AddressOnly deliberately false: the storage layer force-keeps a
+				// Butler's address_only true (ADR-0024), and this proves the pin
+				// through the real import path rather than merely echoing the bundle.
+				Persona: "Impeccably dry.", Voice: voice, AddressOnly: false,
 				Aliases: []string{"Al"},
 				Grants:  []bundle.Grant{{ToolName: "rules_lookup"}},
 			}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, b)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -148,7 +151,7 @@ func TestImportButlerMerge(t *testing.T) {
 		t.Errorf("butler fields not merged: %+v", butler)
 	}
 	if !butler.AddressOnly {
-		t.Error("butler address_only not pinned true")
+		t.Error("butler address_only not pinned true against the bundle's false (ADR-0024)")
 	}
 	if butler.VoiceProviderConfigID.Valid || butler.LLMProviderConfigID.Valid {
 		t.Error("butler provider FKs not NULL")
@@ -180,7 +183,7 @@ func TestImportRoundTrip(t *testing.T) {
 	}
 
 	dst, tid := freshTenant(t)
-	res, err := bundle.Import(ctx, dst, tid, b)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: dst}, tid, b)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -299,11 +302,11 @@ func TestImportTwiceMakesTwoCampaigns(t *testing.T) {
 	}
 
 	dst, tid := freshTenant(t)
-	first, err := bundle.Import(ctx, dst, tid, b)
+	first, err := bundle.Import(ctx, bundle.PGStore{Store: dst}, tid, b)
 	if err != nil {
 		t.Fatalf("Import #1: %v", err)
 	}
-	second, err := bundle.Import(ctx, dst, tid, b)
+	second, err := bundle.Import(ctx, bundle.PGStore{Store: dst}, tid, b)
 	if err != nil {
 		t.Fatalf("Import #2: %v", err)
 	}
@@ -326,7 +329,7 @@ func TestImportMidBundleFailureRollsBack(t *testing.T) {
 			Edges: []bundle.Edge{{From: "n1", To: "ghost", Type: "resides_in"}},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b); err == nil {
 		t.Fatal("Import with unknown edge ref succeeded; want error")
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Doomed Import"); !errors.Is(err, storage.ErrNotFound) {
@@ -352,7 +355,7 @@ func TestImportRejectsSecondButler(t *testing.T) {
 			},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b); err == nil {
 		t.Fatal("Import with two butlers succeeded; want error")
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Two Butlers"); !errors.Is(err, storage.ErrNotFound) {
@@ -377,7 +380,7 @@ func TestImportRejectsDuplicateNodeRef(t *testing.T) {
 			},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b); err == nil {
 		t.Fatal("Import with duplicate node ref succeeded; want error")
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Dup Node"); !errors.Is(err, storage.ErrNotFound) {
@@ -402,7 +405,7 @@ func TestImportRejectsDuplicateAgentRef(t *testing.T) {
 			},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, b); err == nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, b); err == nil {
 		t.Fatal("Import with duplicate agent ref succeeded; want error")
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Dup Agent"); !errors.Is(err, storage.ErrNotFound) {
@@ -434,7 +437,7 @@ func TestImportSessionWithLines(t *testing.T) {
 			}}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -492,7 +495,7 @@ func TestImportCoercesNonTerminalSession(t *testing.T) {
 			}}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -539,7 +542,7 @@ func TestImportChunksRemapAndEmbedNull(t *testing.T) {
 			}}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -611,7 +614,7 @@ func TestImportedChunksEmbedAndRecall(t *testing.T) {
 			}}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -725,7 +728,7 @@ func TestImportRoundTripWithHistory(t *testing.T) {
 	}
 
 	dst, tid := freshTenant(t)
-	res, err := bundle.Import(ctx, dst, tid, b)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: dst}, tid, b)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -810,7 +813,7 @@ func TestImportHistoryRollsBackWithPart1(t *testing.T) {
 			}}},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, bnd); err == nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd); err == nil {
 		t.Fatal("Import with bad edge succeeded; want error")
 	}
 	if _, err := st.FindCampaignByName(ctx, tid, "Doomed History"); !errors.Is(err, storage.ErrNotFound) {
@@ -847,7 +850,7 @@ func TestImportWarnsOnDroppedParticipantRefs(t *testing.T) {
 			}}},
 		},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
@@ -892,7 +895,7 @@ func TestImportSilentWhenNoDroppedRefs(t *testing.T) {
 			}}},
 		},
 	}
-	if _, err := bundle.Import(ctx, st, tid, bnd); err != nil {
+	if _, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd); err != nil {
 		t.Fatalf("Import: %v", err)
 	}
 	if buf.Len() != 0 {
@@ -911,7 +914,7 @@ func TestImportHistorylessBundleUnchanged(t *testing.T) {
 		FormatVersion: bundle.FormatVersion,
 		Campaign:      bundle.Campaign{Name: "No History", System: "dnd5e", Language: "en"},
 	}
-	res, err := bundle.Import(ctx, st, tid, bnd)
+	res, err := bundle.Import(ctx, bundle.PGStore{Store: st}, tid, bnd)
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}

--- a/internal/bundle/secrets_fake_test.go
+++ b/internal/bundle/secrets_fake_test.go
@@ -1,0 +1,106 @@
+package bundle_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+)
+
+// TestSecretsExclusionPropertyFake is the DB-free migration of the ADR-0053 §2
+// property test (#451). With the store seam in place, the heart of the
+// property is STRUCTURAL: [bundle.ExportStore] carries no method that reads
+// provider_config, deployment_config, users, or auth sessions, so ciphertext
+// can never reach Export at all — that end of the original test needs no
+// database to hold. What remains to guard here is the seam types themselves:
+// rows the seam DOES read carry secret-adjacent fields (an Agent's provider
+// FK ids, a Character's linked_user_id, a chunk's embedding_model), and none
+// of them may reach bundle bytes. Distinctive markers are planted in each
+// such field and the gunzipped output of both export variants is scanned —
+// alongside the schema words whose appearance would betray a forbidden field
+// joining the wire format.
+//
+// The markers are deliberately NON-hex-shaped (like the integration test's)
+// where they are free strings, and the provider FKs are full UUIDs matched by
+// their complete string form, so neither can collide with the legitimate UUID
+// refs a bundle carries. The integration TestSecretsExclusionProperty keeps
+// the true-ciphertext seeding against real tables.
+func TestSecretsExclusionPropertyFake(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	f := newFakeStore()
+	campaignID, _ := seedFakeCampaign(t, f)
+
+	// Plant markers in every secret-adjacent field the seam types expose.
+	voiceProviderFK := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	llmProviderFK := uuid.MustParse("ffffffff-0000-1111-2222-333333333333")
+	const linkedUserMarker = "linked-user-zqxw-marker"
+	const embedModelMarker = "text-embed-wqzx-marker"
+	for i := range f.agents {
+		f.agents[i].VoiceProviderConfigID = uuid.NullUUID{UUID: voiceProviderFK, Valid: true}
+		f.agents[i].LLMProviderConfigID = uuid.NullUUID{UUID: llmProviderFK, Valid: true}
+		f.agents[i].SpeakerColor = 7
+	}
+	for i := range f.characters {
+		marker := linkedUserMarker
+		f.characters[i].LinkedUserID = &marker
+	}
+	for i := range f.chunks {
+		f.chunks[i].EmbeddingModel = embedModelMarker
+	}
+
+	forbidden := [][]byte{
+		[]byte(voiceProviderFK.String()),
+		[]byte(llmProviderFK.String()),
+		[]byte(linkedUserMarker),
+		[]byte(embedModelMarker),
+		// Schema words a leaked field would carry onto the wire.
+		[]byte("ciphertext"),
+		[]byte("last4"),
+		[]byte("credentials"),
+		[]byte("provider_config"),
+		[]byte("deployment_config"),
+		[]byte("linked_user_id"),
+		[]byte("embedding"),
+		[]byte("speaker_color"),
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts bundle.ExportOptions
+	}{
+		{"no-history", bundle.ExportOptions{}},
+		{"history", bundle.ExportOptions{IncludeHistory: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b, err := bundle.Export(ctx, f, campaignID, tc.opts)
+			if err != nil {
+				t.Fatalf("Export: %v", err)
+			}
+			var buf bytes.Buffer
+			if err := bundle.Encode(&buf, b); err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			gz, err := gzip.NewReader(&buf)
+			if err != nil {
+				t.Fatalf("gzip reader: %v", err)
+			}
+			plain, err := io.ReadAll(gz)
+			if err != nil {
+				t.Fatalf("gunzip: %v", err)
+			}
+			for _, want := range forbidden {
+				if bytes.Contains(plain, want) {
+					t.Errorf("bundle leaked forbidden bytes %q", want)
+				}
+			}
+		})
+	}
+}

--- a/internal/bundle/store.go
+++ b/internal/bundle/store.go
@@ -1,0 +1,143 @@
+package bundle
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// This file is the bundle-owned store seam (#451): import and export depend on
+// these consumer-defined slices of the persistence layer instead of the
+// concrete *storage.Store, so the heart of ADR-0053 — fresh-ID minting,
+// cross-reference remapping, duplicate detection, secrets exclusion — runs
+// against an in-memory fake in unit tests, while the Postgres adapter keeps
+// the genuinely SQL-shaped behavior (real rollback, constraints, the
+// auto-Butler trigger) under the integration suite.
+
+// ExportStore is the narrow read surface [Export] serializes a Campaign from;
+// *storage.Store satisfies it structurally and tests fake it. It enumerates
+// EXACTLY the allowlisted reads (ADR-0053 §2): campaign, agents, per-agent
+// grants, KG nodes/edges, characters, and — only when history is requested —
+// voice sessions, transcript lines, and transcript chunks. The
+// secrets-exclusion property is visible ON this seam: there is no method that
+// could read provider_config, deployment_config, users, or auth sessions, so
+// no secret byte can reach a bundle through it. Never widen it with one.
+//
+// Read contracts Export relies on: bundle layout is list order, so a
+// deterministic bundle needs every List method to return a stable order. The
+// real store's orderings, which an adapter must reproduce, are: ListAgents
+// (agent_role, name) — also the order the importer re-creates agents in,
+// which assigns speaker-colour slots; ListToolGrants (tool_name); ListNodes
+// (node_type, lower(name), id) — node_type is a Postgres ENUM ordered by
+// declaration, npc before location; ListEdges and ListTranscriptChunks
+// (created_at, id); ListCharacters (lower(name), id); ListVoiceSessions
+// (started_at DESC, id DESC); ListTranscriptLines (seq — the ADR-0040 replay
+// order). ListTranscriptChunks with includeVectors=false returns Embedding ""
+// — Export always passes false (ADR-0053 §3, the destination re-embeds).
+type ExportStore interface {
+	GetCampaign(ctx context.Context, id uuid.UUID) (storage.Campaign, error)
+	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
+	ListNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGNode, error)
+	ListEdges(ctx context.Context, campaignID uuid.UUID) ([]storage.KGEdge, error)
+	ListCharacters(ctx context.Context, campaignID uuid.UUID) ([]storage.Character, error)
+	ListVoiceSessions(ctx context.Context, campaignID uuid.UUID, limit int) ([]storage.VoiceSession, error)
+	ListTranscriptLines(ctx context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error)
+	ListTranscriptChunks(ctx context.Context, campaignID uuid.UUID, includeVectors bool) ([]storage.ExportChunk, error)
+}
+
+// ImportStore is the tx-bound write surface one import runs against —
+// the campaign-aggregate methods [Import]'s transaction body actually uses;
+// *storage.Store satisfies it structurally and tests fake it. Callers only
+// ever receive one through [TxRunner.InTx], so every write lands inside the
+// single import transaction.
+//
+// Adapter contracts the importer leans on (an adapter that breaks one breaks
+// the import, so the fake emulates them all):
+//
+//   - CreateCampaign creates the campaign's Butler as a side effect — the
+//     ADR-0009 auto-Butler (name 'Glyphoxa', address_only true) with its
+//     default grant set — so GetButler right after CreateCampaign returns a
+//     row and a second Butler insert is impossible.
+//   - CreateAgent refuses a second Butler in a Campaign (the partial unique
+//     index behind ADR-0009).
+//   - UpdateAgent force-keeps a Butler's address_only true (ADR-0024), never
+//     changes agent_role, and yields storage.ErrNotFound for an (id,
+//     campaign) miss.
+//   - CreateToolGrant refuses a duplicate (agent, tool) — an Agent grants a
+//     Tool at most once (ADR-0029); DeleteToolGrant yields storage.ErrNotFound
+//     for a grant that was never there.
+//   - ImportVoiceSession writes the given timestamps/status/line_count
+//     VERBATIM (unlike the live CreateVoiceSession) and returns a minted id.
+//   - UpsertTranscriptLine upserts on the (voice_session_id, line_id) replay
+//     key (ADR-0040); on conflict seq is NOT updated — it is the replay
+//     ordering key, fixed at first insert.
+//   - InsertTranscriptChunk never writes an embedding or embedding_model
+//     (ADR-0011): imported chunks are always the destination embedworker's
+//     backlog.
+type ImportStore interface {
+	CreateCampaign(ctx context.Context, c storage.NewCampaign) (uuid.UUID, error)
+	GetButler(ctx context.Context, campaignID uuid.UUID) (storage.Agent, error)
+	CreateAgent(ctx context.Context, a storage.NewAgent) (uuid.UUID, error)
+	UpdateAgent(ctx context.Context, a storage.AgentUpdate) (storage.Agent, error)
+	ListToolGrants(ctx context.Context, agentID uuid.UUID) ([]storage.ToolGrant, error)
+	CreateToolGrant(ctx context.Context, g storage.NewToolGrant) (uuid.UUID, error)
+	DeleteToolGrant(ctx context.Context, agentID uuid.UUID, toolName string) error
+	CreateNode(ctx context.Context, n storage.NewKGNode) (storage.KGNode, error)
+	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
+	CreateEdge(ctx context.Context, e storage.NewKGEdge) (storage.KGEdge, error)
+	CreateCharacter(ctx context.Context, c storage.NewCharacter) (uuid.UUID, error)
+	ImportVoiceSession(ctx context.Context, v storage.VoiceSession) (uuid.UUID, error)
+	UpsertTranscriptLine(ctx context.Context, l storage.TranscriptLine) error
+	InsertTranscriptChunk(ctx context.Context, c storage.TranscriptChunk) (uuid.UUID, error)
+}
+
+// TxRunner is [Import]'s transaction entry point: InTx runs fn against a
+// tx-bound [ImportStore], committing when fn returns nil and rolling back when
+// it doesn't. The bundle atomicity requirement (#291/#292 — one transaction
+// for the whole ingest, domain grains and history alike; import stays a
+// synchronous RPC per ADR-0049) lives HERE: fn runs as ONE unit, so every row
+// an import writes lands together or not at all — a mid-bundle failure leaves
+// no partial Campaign.
+//
+// The flatten expectation — previously an implicit property of
+// *storage.Store.InTx this package silently relied on — is part of the seam
+// contract: an ImportStore method that internally opens its own transaction
+// (storage's CreateEdge does, via a nested InTx) must FLATTEN into the ambient
+// import transaction. It joins the outer transaction and gains NO independent
+// rollback boundary (#291): a later error still rolls back the whole import,
+// including such an inner "committed" call. An adapter giving nested calls
+// real savepoint semantics would not break the importer, but one giving them
+// independent COMMITs would — that is the contract violation this note
+// exists to forbid.
+type TxRunner interface {
+	InTx(ctx context.Context, fn func(tx ImportStore) error) error
+}
+
+// PGStore adapts *storage.Store to the bundle seam — the Postgres adapter the
+// production handler and the seed path pass to [Import]. The read/write
+// slices need no adapting (the embedded Store satisfies [ExportStore] and
+// [ImportStore] structurally, per the assertions below); this wrapper exists
+// only because the concrete InTx types its closure over *storage.Store, so
+// [TxRunner] needs the tx-bound store re-typed as the [ImportStore] slice.
+// Behavior is the embedded Store's exactly: one BEGIN/COMMIT with rollback on
+// error, and nested InTx calls flattening into the ambient transaction (#291).
+type PGStore struct{ *storage.Store }
+
+// InTx implements [TxRunner] over the embedded Store's single-transaction
+// runner.
+func (p PGStore) InTx(ctx context.Context, fn func(tx ImportStore) error) error {
+	return p.Store.InTx(ctx, func(tx *storage.Store) error { return fn(tx) })
+}
+
+// Compile-time proofs the Postgres adapter satisfies the whole seam: the
+// concrete store IS the read and write slices, and PGStore adds the
+// transaction entry point on top.
+var (
+	_ ExportStore = (*storage.Store)(nil)
+	_ ImportStore = (*storage.Store)(nil)
+	_ TxRunner    = PGStore{}
+	_ ExportStore = PGStore{}
+)


### PR DESCRIPTION
## What does this PR do?

Closes #451.

Gives `internal/bundle` its own consumer-defined store seam so the heart of ADR-0053 — fresh-ID minting, cross-reference remapping, duplicate detection, secrets exclusion — runs DB-free, while the genuinely SQL-shaped behavior stays under the integration suite.

**The seam** (`internal/bundle/store.go`):
- `ExportStore` — exactly the allowlisted reads `Export` performs, with the list-ordering contracts a deterministic bundle rests on enumerated. The secrets-exclusion property is now visible *on* the seam: there is no method that could read `provider_config`, `deployment_config`, `users`, or auth sessions.
- `ImportStore` — the campaign-aggregate writes one import runs against, with every adapter contract the importer leans on spelled out (auto-Butler trigger side effect on `CreateCampaign`, the Butler `address_only` pin, grant uniqueness, verbatim `ImportVoiceSession`, replay-key upsert with seq fixed at first insert, no-embedding chunks).
- `TxRunner` — the transaction entry point. The all-or-nothing import requirement **and the previously implicit InTx-flatten expectation** (#291: a nested `InTx` joins the ambient transaction with no independent rollback boundary) are documented at the seam (acceptance criterion 4).
- `PGStore` — the Postgres adapter. `*storage.Store` satisfies both slices structurally (compile-time asserted); only `InTx` needs the 3-line wrapper because the concrete closure is typed over `*storage.Store`.

**The fake** (`fakes_test.go`) is the second adapter that makes the seam real. It emulates every documented contract — including the ADR-0009 auto-Butler trigger (first fake in the repo to do so), the `kg_node_type` ENUM *declaration* order (npc before location — not lexicographic), edge validation via the exported `storage.ValidateEdge`, and the character/grant/node↔agent uniqueness rules. It deliberately does **not** emulate rollback: import atomicity stays proven only by the Postgres integration tests (`TestImportMidBundleFailureRollsBack`, `TestImportHistoryRollsBackWithPart1`), per criterion 2.

**23 new DB-free tests** (`import_fake_test.go`, `export_fake_test.go`, `secrets_fake_test.go`) cover the issue's checklist: minting + consistent remap of every intra-bundle reference (node agent links, edge endpoints, characters, chunk participants), duplicate-ref rejection, unknown-ref rejection, Butler merge-onto-trigger-row (grants replaced exactly, provider FKs NULL, `address_only` pinned), unmappable-participant drop counting + the #381 warn gating (including a new no-warn-after-failed-commit case), session status coercion, replay-key coalescing, history flag gating, voice normalization, a full export→import→re-export equivalence check, and the migrated secrets-exclusion byte-scan property.

Production behavior is unchanged on every path: `Export` call sites compile unchanged (structural satisfaction); `Import` call sites take the mechanical `bundle.PGStore{Store: st}` wrap (handler, seed, 19 integration test sites). One deliberate integration-test strengthening: `TestImportButlerMerge` now sends `address_only: false` so the storage-layer pin is proven through the real import path instead of echoing the bundle.

## Why is this change needed?

`internal/bundle` was the only consumer in the persistence area still threading the concrete `*storage.Store` through its logic (and relying on `InTx`'s undocumented flatten semantics), so even pure data transformation could only be tested against live Postgres. Every bundle test was DB-bound; now the remap/codec/secrets logic runs in ~20ms under plain `go test` (criterion 1), and the DB suite shrinks to genuinely SQL-shaped assertions (real rollback, constraints, the real trigger).

## How was this tested?

- `go test -race -count=1 ./internal/bundle/...` — 35 tests pass with no DB harness (23 new fake-backed + existing codec suite).
- `go vet ./...` and `go vet -tags=integration ./internal/bundle/...` — both builds clean; the tagged and untagged test files coexist.
- `go test -tags=integration ./internal/bundle/` — compiles; the 27 DB tests skip loudly in this environment (no Docker) and are unchanged in behavior aside from the mechanical adapter wrap (criterion 3 — please let CI/a Docker host confirm the parity run).
- Full `go test -race ./...`: bundle/storage/rpc all green; the only failures are the pre-existing voice-pipeline tests that need the ONNX Runtime download, which this environment's proxy blocks (unrelated to this change).
- An adversarial multi-agent review pass over the diff surfaced 18 findings (fake/Postgres divergences like the ENUM ordering, missing uniqueness emulation, doc mis-citations, test tautologies) — all fixed in this diff.

- [x] `make check` passes (modulo the pre-existing ONNX-dependent voice tests, blocked by this environment's proxy)
- [x] New/updated tests cover the change
- [ ] Manual testing (not applicable — refactor with parity tests)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (see caveat above on the pre-existing ONNX-blocked voice tests)
- [x] I have updated documentation if needed (the seam docs are the documentation deliverable)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Design choice worth a reviewer's eye: no interface in the repo exposed a tx-runner before, because `storage.Store.InTx` types its closure over the concrete store. Making the closure take the `ImportStore` slice keeps the fake honest but costs exact structural satisfaction for that one method — hence `PGStore`, which is nothing but that re-typing. The alternative (leaving `Import` on the concrete store) would have kept the Butler-merge/remap logic untestable without Postgres, which is the whole point of #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKC1KKXgA3Y2e415JNkbw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKC1KKXgA3Y2e415JNkbw8)_