### PR TITLE
docs+build: retire whisper.cpp; ElevenLabs quality bar for future TTS/STT providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,8 +302,8 @@ jobs:
           name: spa-dist
           path: internal/spa/dist
 
-      # buildx + layer caching keeps the slow native build (whisper.cpp +
-      # CGO) off the critical path on warm caches. This is a
+      # buildx + layer caching keeps the CGO image build off the critical
+      # path on warm caches. This is a
       # SEPARATE job from the fast `test` gate (ADR-0033): the heavy image build
       # must not slow an unrelated PR's unit feedback.
       - name: Set up Docker Buildx
@@ -396,7 +396,7 @@ jobs:
     name: deploy e2e (k3d smoke)
     # Wait for the `image` job so its cache-to (mode=max) has populated the gha
     # cache: this job's build is then a cache HIT (load layers, no recompile)
-    # rather than a second full native build of the slow whisper/libdave/CGO
+    # rather than a second full CGO image build
     # image. The serialization costs a little wall-time but halves the expensive
     # build per run. The real cluster e2e is issue #37's gate — deliberately a
     # SEPARATE job from the fast `test` suite (ADR-0033) so the heavy image build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,6 @@ builds:
       - -tags=opus,dave
     env:
       - CGO_ENABLED=1
-      - CGO_CFLAGS=-I/tmp/whisper/include
     goos:
       - linux
     goarch:
@@ -26,13 +25,11 @@ builds:
         env:
           - CC=x86_64-linux-gnu-gcc
           - CXX=x86_64-linux-gnu-g++
-          - CGO_LDFLAGS=-L/tmp/whisper/amd64/lib
       - goos: linux
         goarch: arm64
         env:
           - CC=aarch64-linux-gnu-gcc
           - CXX=aarch64-linux-gnu-g++
-          - CGO_LDFLAGS=-L/tmp/whisper/arm64/lib -lm
     ldflags:
       - -s -w
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@
 # channel, etc.) are supplied at RUNTIME via args/env — there are no per-mode
 # images. The build stage compiles the live binary with the production tags
 # (`opus dave` — both pure Go since the pion/opus + dave-go migration; CGO
-# remains only for the ONNX/silero binding) after building the whisper.cpp
-# static lib, exactly as the Makefile / CI do. The runtime stage is a slim glibc
+# remains only for the ONNX/silero binding), exactly as the Makefile / CI do.
+# The runtime stage is a slim glibc
 # base (distroless deferred, ADR-0034) carrying the binary plus its one native
 # runtime dep: a bundled libonnxruntime (the version the Silero VAD pins in
 # pkg/voice/vad/silero/runtime.go — dlopen'd at runtime, not linked).
@@ -40,35 +40,14 @@ ARG ONNX_VERSION
 ENV CGO_ENABLED=1
 
 # Build/runtime native deps:
-#   - cmake/git/build-essential: build whisper.cpp (static).
+#   - build-essential: the C compiler CGO needs for the ONNX/silero binding.
 #   - curl/unzip: fetch the ONNX runtime tarball.
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
-		git \
-		cmake \
 		build-essential \
 		curl \
 		unzip \
 	&& rm -rf /var/lib/apt/lists/*
-
-# --- whisper.cpp static library (mirrors Makefile `whisper-libs`) ----------
-# Static (BUILD_SHARED_LIBS=OFF) so the .a is linked into the binary; nothing
-# from whisper needs to ship in the runtime image. GGML_NATIVE=OFF here (unlike
-# the Makefile's ON): the image must run on hosts other than the builder, so we
-# must NOT bake in -march=native instructions the runtime CPU may lack.
-ARG WHISPER_DEST=/tmp/whisper-install
-RUN git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git /tmp/whisper-src \
-	&& cmake -B /tmp/whisper-src/build -S /tmp/whisper-src \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DBUILD_SHARED_LIBS=OFF \
-		-DGGML_NATIVE=OFF \
-		-DWHISPER_BUILD_TESTS=OFF \
-		-DWHISPER_BUILD_SERVER=OFF \
-	&& cmake --build /tmp/whisper-src/build --config Release -j"$(nproc)" \
-	&& mkdir -p "${WHISPER_DEST}/include" "${WHISPER_DEST}/lib" \
-	&& cp /tmp/whisper-src/include/whisper.h "${WHISPER_DEST}/include/" \
-	&& cp -r /tmp/whisper-src/ggml/include/* "${WHISPER_DEST}/include/" \
-	&& find /tmp/whisper-src/build -name '*.a' -exec cp {} "${WHISPER_DEST}/lib/" \;
 
 # --- ONNX Runtime (the exact version the Silero VAD pins) ------------------
 # Bundled so GLYPHOXA_ONNX_LIB can point at it and the VAD never reaches the
@@ -97,11 +76,9 @@ RUN go mod download
 # gen/, so this COPY brings them in; the go build below then compiles them.
 COPY . .
 
-# Compile the live binary with the production tags and the whisper env the
-# Makefile + .goreleaser.yml use. Both tags are pure Go now; CGO stays on for
-# the ONNX/silero binding. ldflags `-s -w` strip debug info, matching goreleaser.
-ENV C_INCLUDE_PATH=${WHISPER_DEST}/include
-ENV LIBRARY_PATH=${WHISPER_DEST}/lib
+# Compile the live binary with the production tags. Both tags are pure Go;
+# CGO stays on for the ONNX/silero binding. ldflags `-s -w` strip debug info,
+# matching goreleaser.
 RUN go build -tags "opus dave" -ldflags "-s -w" \
 		-o /out/glyphoxa ./cmd/glyphoxa
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 export CGO_ENABLED := 1
 
-.PHONY: build test lint vet fmt check clean whisper-libs refresh-silero-model install-lint proto proto-check proto-lint spa docker-build docker-smoke docker-smoke-test helm-lint helm-test helm-validate helm-validate-test
+.PHONY: build test lint vet fmt check clean refresh-silero-model install-lint proto proto-check proto-lint spa docker-build docker-smoke docker-smoke-test helm-lint helm-test helm-validate helm-validate-test
 
 # Build voice engine
 build:
@@ -44,40 +44,6 @@ fmt:
 check: fmt vet test
 	@echo "All checks passed ✓"
 
-# Build whisper.cpp static library for local CGO compilation.
-# After running this, set the environment before other targets:
-#   export C_INCLUDE_PATH=/tmp/whisper-install/include
-#   export LIBRARY_PATH=/tmp/whisper-install/lib
-#   export CGO_ENABLED=1
-WHISPER_SRC  := /tmp/whisper-src
-WHISPER_DEST := /tmp/whisper-install
-
-whisper-libs:
-	@if [ -f "$(WHISPER_DEST)/include/whisper.h" ]; then \
-		echo "whisper.cpp already built at $(WHISPER_DEST)"; \
-	else \
-		echo "Cloning whisper.cpp..."; \
-		git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git $(WHISPER_SRC); \
-		echo "Building whisper.cpp..."; \
-		cmake -B $(WHISPER_SRC)/build -S $(WHISPER_SRC) \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DBUILD_SHARED_LIBS=OFF \
-			-DGGML_NATIVE=ON \
-			-DWHISPER_BUILD_TESTS=OFF \
-			-DWHISPER_BUILD_SERVER=OFF; \
-		cmake --build $(WHISPER_SRC)/build --config Release -j$$(nproc); \
-		mkdir -p $(WHISPER_DEST)/include $(WHISPER_DEST)/lib; \
-		cp $(WHISPER_SRC)/include/whisper.h $(WHISPER_DEST)/include/; \
-		cp -r $(WHISPER_SRC)/ggml/include/* $(WHISPER_DEST)/include/ 2>/dev/null || true; \
-		find $(WHISPER_SRC)/build -name '*.a' -exec cp {} $(WHISPER_DEST)/lib/ \;; \
-		echo "whisper.cpp installed to $(WHISPER_DEST)"; \
-	fi
-	@echo ""
-	@echo "Run the following to enable whisper CGO builds:"
-	@echo "  export C_INCLUDE_PATH=$(WHISPER_DEST)/include"
-	@echo "  export LIBRARY_PATH=$(WHISPER_DEST)/lib"
-	@echo "  export CGO_ENABLED=1"
-
 # Refresh the embedded Silero VAD ONNX model from upstream. Run when bumping
 # silero versions; commit the updated file and the new SHA-256 in
 # pkg/voice/vad/silero/data/README.md.
@@ -114,9 +80,8 @@ clean:
 
 # --- Container image (ADR-0034) --------------------------------------------
 # One multi-stage image for the single binary; `mode`/config are runtime args.
-# The native build (whisper.cpp + CGO) is SLOW on a cold layer cache — expect
-# several minutes on first build. (libopus and libdave are gone: the codec and
-# DAVE are pure Go since the pion/opus + dave-go migration.)
+# The only native piece left is CGO for the ONNX/silero binding (the codec,
+# DAVE, and the retired whisper.cpp build are gone — see ADR-0004 amendment).
 DOCKER_IMAGE ?= glyphoxa:smoke
 
 # Depends on `proto`: gen/ is gitignored and NOT generated inside the image

--- a/docs/adr/0004-byok-provider-key-matrix.md
+++ b/docs/adr/0004-byok-provider-key-matrix.md
@@ -21,3 +21,29 @@ Tenant admins paste a key, pick a model from the provider's list-models endpoint
 ## Amendment: `image` Component via Gemini (2026-07-07, #311)
 
 The `provider_component` enum gains **`image`** (enum migration). v1 matrix entry: **Gemini** is the sole image-generation adapter — the provider already exists in the matrix for LLM, so the operator manages no new vendor/key family. The Component gets its own BYOK Configuration slot + health check, and ADR-0046 price-map entries (per-image estimates). Scope is image-only; video generation is explicitly out of v1. ElevenLabs sound generation (deferred, #312) will ride the existing `tts` Provider Config with a distinct usage kind rather than a new Component.
+
+## Amendment: whisper.cpp retired; quality bar for future local/drop-in providers (2026-07-16)
+
+**whisper.cpp is out.** It was under consideration as the second STT provider
+(local, key-free) since v1, and the build plumbing (Makefile `whisper-libs`,
+Dockerfile static-lib stage, goreleaser flags) existed ahead of any Go binding —
+nothing ever linked it. Evaluation concluded its performance is too poor for
+Glyphoxa's live loop: transcription latency on self-host-class hardware is far
+from the ~1.7 s STT-bound turn latency the hosted providers deliver, and it
+would have re-added a heavy CGO dependency just as the codec and DAVE went pure
+Go (ADR-0006/0033/0034 amendments). The vestigial build steps are removed with
+this amendment.
+
+**Quality bar for any future replacement:** a drop-in TTS or STT alternative
+(local or hosted) may be evaluated later **only if its actual audio quality is
+roughly comparable to the ElevenLabs API** — that is the reference bar for both
+synthesis quality (TTS) and transcription fidelity on live Discord speech
+(STT). Candidates below that bar are not worth the integration surface,
+whatever their cost or locality advantages. If a local provider is adopted, it
+must run out-of-process (sidecar/server mode) rather than as an in-process CGO
+binding, to preserve the pure-Go binary (see the ONNX exit, #468).
+
+The matrix's second-provider slots (STT: whisper.cpp, TTS: Coqui XTTS — also
+never implemented) are accordingly **vacant by policy**, not TODO: Deepgram and
+ElevenLabs remain the implemented reference providers, alongside the
+OpenAI-compatible surfaces already in the codebase.

--- a/pkg/voice/stt/stt.go
+++ b/pkg/voice/stt/stt.go
@@ -1,7 +1,8 @@
 // Package stt defines the Speech-to-Text provider surface consumed by the
 // orchestrator (ADR-0019).
 //
-// Real providers (Deepgram, whisper.cpp — see ADR-0004) and the cassette
+// Real providers (see the ADR-0004 matrix and its 2026-07-16 amendment on
+// local STT) and the cassette
 // replayer (see [github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette]) both
 // implement [Recognizer]. The orchestrator's STT stage is provider-agnostic:
 // it forwards [audio.Frame]s and republishes the final transcript onto the


### PR DESCRIPTION
**Stacked on #467** — merge that first; GitHub will retarget this PR to `main` automatically. **Do not delete the `feat/dave-go-pion-opus` branch until this PR has retargeted** (the stacked-PR delete-branch trap).

## What

whisper.cpp was staged as ADR-0004's second (local) STT provider, and the build plumbing existed ahead of any Go binding — the Dockerfile compiled a whisper.cpp static lib on every cold image build that **nothing links** (no binding in go.mod, no build tag, no call site). Decision: retire it — its performance is too poor for the live voice loop.

- **ADR-0004 amendment** records the rejection and sets the bar for any future drop-in TTS/STT alternative: *actual audio quality roughly comparable to the ElevenLabs API* — below that bar, candidates aren't worth the integration surface regardless of cost/locality. If a local provider is ever adopted, it runs out-of-process (sidecar/server mode), never as an in-process CGO binding — protecting the pure-Go binary path (#468). The matrix's never-implemented second slots (whisper.cpp, Coqui XTTS) are now *vacant by policy*, not TODO.
- **Deletes** the Makefile `whisper-libs` target, the Dockerfile whisper.cpp build stage (+ cmake/git from build deps — cold image builds get several minutes faster), and the goreleaser whisper CFLAGS/LDFLAGS. `build-essential` stays: CGO still compiles the ONNX/silero binding.
- Updates CI comments and the `pkg/voice/stt` package doc.

## Validation

`go build -tags "opus dave" ./...`, `go vet ./...`, gofmt — clean. Docker image covered by the CI `image` job (the Dockerfile only gets simpler here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)