### PR TITLE
feat: SaaS foundation — Plans, Subscriptions, Usage Ledger, platform keys + k3s/cloud deployment docs (ADR-0054)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,17 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 | **MCP Server** | An out-of-process backing that exposes one or more Tools over the Model Context Protocol (stdio or streamable-HTTP). A Tool source differentiated from built-ins by running in a separate process; pays serialization/IPC cost in exchange for isolation and third-party extensibility. | External tool, Plugin, MCP Tool |
 | **Hot Context** | The recent-Transcript + KG-facts + Persona bundle assembled per-utterance to prime an Agent's LLM call (target <50ms). | Context, Prompt context |
 
+## Billing & SaaS
+
+| Term | Definition | Aliases to avoid |
+|------|------------|------------------|
+| **Plan** | A subscription tier in the deployment's catalog: slug (stable handle), monthly price, Key Source, optional included-usage allowance, and an extensible limits bag. Synced as data from the operator's declarative catalog (ADR-0054); archived, never deleted. | Tier (reserved for prose only), Package, SKU |
+| **Plan Catalog** | The operator's declarative JSON (or Helm values) list of Plans, synced into the DB via `glyphoxa billing plans-sync` / the chart's plans hook Job. | Pricing table, Config |
+| **Subscription** | A Tenant's binding to a Plan, snapshotting the Plan's slug and monthly price at bind time; at most one active per Tenant, with ended rows as history. The revenue record. | Membership, License |
+| **Key Source** | Where a Plan's provider keys come from: `byok` (the Tenant's own keys, ADR-0004) or `platform` (the deployment's env keys, included in the price). | Key mode, Pooling |
+| **Platform Keys** | The deployment-operated provider credentials (env `*_API_KEY`) serving `platform`-Plan Tenants via the existing env-fallback path (ADR-0039/0054). | Pooled keys, Shared keys, Operator keys (prose ok) |
+| **Usage Ledger** | The durable per-Tenant record of metered provider usage: daily buckets per (component, provider, model) with quantities and a priced ESTIMATE, flushed at Voice Session end (`usage_ledger`). The cost side of billing; never a gate, never billing truth. | Billing log, Meter (the in-memory ADR-0046 accumulator), Invoice |
+
 ## Process & Deployment
 
 | Term | Definition | Aliases to avoid |
@@ -101,6 +112,7 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 ## Relationships
 
 - A **Tenant** has many **Members** with a **Member Role**, many **Campaigns**, many linked **Guilds**, and one or more **Provider Configs** per **Component**.
+- A **Tenant** has at most one active **Subscription**, which references a **Plan** and snapshots its price; a Tenant's metered usage accumulates in the **Usage Ledger**.
 - A **Campaign** has one **GM** (a Member of its Tenant), many **Characters**, one **Knowledge Graph**, exactly one **Butler**,many **Character NPCs**, and many **Transcripts**.
 - A **Character** belongs to exactly one **Campaign** and is bound to exactly one **Discord User**; the Discord User may also be a **Linked Player**.
 - A **Character NPC** belongs to exactly one **Campaign**.
@@ -135,5 +147,6 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 - **"Bot"** refers to the *single* Glyphoxa Discord bot identity (one token, shared across all Tenants). Don't say "the Tenant's bot" — say "the Bot acting on behalf of the Tenant."
 - **"Worker"** is a v1 term for what v2 calls a **Voice Instance**. Do not use "worker" in v2 — it implies the gateway/worker split that was explicitly removed.
 - **"Role"** is overloaded between **Member Role** (`owner`/`admin`/`gm`) and **Agent Role** (`butler`/`character`). Always qualify.
+- **"Tier"** in prose means a **Plan** (the subscription catalog entry); the schema/API term is always Plan. Never use "tier" for a **Member Role** (already an alias to avoid there).
 - **"Player role"** is *not* a Member Role — Players are not Tenant Members. Don't add `player` to the Member Role enum.
 - **"Barge-in" vs "Cross-talk"** — **Barge-in** is a *human* interrupting a speaking Agent (VAD-triggered via the Barge-in Confirm Window; cancels the Agent's whole turn — see ADR-0026). **Cross-talk** is one Agent's already-delivered text being fed to another addressed Agent during an Ensemble Turn — the second Agent has not spoken yet, so nothing is interrupted. Never use "barge-in" for the Agent-to-Agent case, and never use "cross-talk" for a human interruption.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,6 +61,7 @@ Resume-from-here doc for the interactive design grilling. Decisions are recorded
 | [0051](docs/adr/0051-rollover-tape-consent-retention.md) | Rollover tape: all-participant consent, bounded retention, GM-gated sharing | #303 |
 | [0052](docs/adr/0052-kg-write-proposals.md) | Agent KG writes land as GM-reviewed Knowledge Proposals | #298 |
 | [0053](docs/adr/0053-campaign-bundle-format.md) | Campaign Bundle: versioned gzipped-JSON export with mandatory secrets exclusion | #287 |
+| [0054](docs/adr/0054-saas-plans-platform-keys-usage-ledger.md) | SaaS foundation: Plans as synced data, Subscriptions with price snapshots, Usage Ledger, platform keys | SaaS request 2026-07-17 |
 
 ## Open questions
 

--- a/cmd/glyphoxa/billing.go
+++ b/cmd/glyphoxa/billing.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/Glyphoxa/internal/billing"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// billingUsage documents the `glyphoxa billing` subcommand (ADR-0054): the
+// operator surface for the Plan catalog, Tenant subscriptions, and the cost +
+// revenue report. There is deliberately NO payment-processor integration here —
+// the operator collects money out of band and records the resulting plan
+// binding; automated billing is a later layer.
+const billingUsage = `usage: glyphoxa billing <plans-sync|plans-list|tenants|subscribe|cancel|report>
+
+  plans-sync -file <plans.json> [-archive-missing]
+           sync the declarative plan catalog into the DB (upsert by slug;
+           -archive-missing archives plans absent from the file)
+  plans-list
+           list the plan catalog (archived plans flagged)
+  tenants  list tenants with their active plan
+  subscribe -tenant <uuid> -plan <slug>
+           bind a tenant to a plan (snapshots the current price; ends any
+           previous subscription)
+  cancel -tenant <uuid>
+           end a tenant's active subscription
+  report [-month YYYY-MM]
+           per-tenant revenue (subscription price snapshots, un-prorated) and
+           estimated provider cost (usage ledger) for one calendar month (UTC);
+           defaults to the current month
+
+Connection string is read from $GLYPHOXA_DATABASE_URL (or $DATABASE_URL).
+Every cost figure is an ESTIMATE from the static price map (ADR-0046), never
+billing truth.`
+
+// RunBilling is the entry point for the `billing` subcommand. args are the
+// arguments after "billing".
+func RunBilling(ctx context.Context, args []string) error {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, billingUsage)
+		return fmt.Errorf("billing: missing subcommand")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		fmt.Println(billingUsage)
+		return nil
+	}
+
+	dsn := databaseURL()
+	if dsn == "" {
+		return fmt.Errorf("billing: set $GLYPHOXA_DATABASE_URL (or $DATABASE_URL)")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("billing: open db: %w", err)
+	}
+	defer pool.Close()
+	st := storage.New(pool)
+
+	switch args[0] {
+	case "plans-sync":
+		return runPlansSync(ctx, st, args[1:])
+	case "plans-list":
+		return runPlansList(ctx, st)
+	case "tenants":
+		return runBillingTenants(ctx, st)
+	case "subscribe":
+		return runSubscribe(ctx, st, args[1:])
+	case "cancel":
+		return runCancel(ctx, st, args[1:])
+	case "report":
+		return runBillingReport(ctx, st, args[1:])
+	default:
+		fmt.Fprintln(os.Stderr, billingUsage)
+		return fmt.Errorf("billing: unknown subcommand %q", args[0])
+	}
+}
+
+func runPlansSync(ctx context.Context, st *storage.Store, args []string) error {
+	fs := flag.NewFlagSet("billing plans-sync", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "path to the plan catalog JSON file")
+	archiveMissing := fs.Bool("archive-missing", false, "archive plans absent from the file (never deletes)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *file == "" {
+		return fmt.Errorf("billing plans-sync: -file is required")
+	}
+
+	data, err := os.ReadFile(*file)
+	if err != nil {
+		return fmt.Errorf("billing plans-sync: %w", err)
+	}
+	catalog, err := billing.ParseCatalog(data)
+	if err != nil {
+		return err
+	}
+
+	specs := make([]storage.PlanSpec, 0, len(catalog.Plans))
+	for _, p := range catalog.Plans {
+		limits, err := p.LimitsJSON()
+		if err != nil {
+			return err
+		}
+		specs = append(specs, storage.PlanSpec{
+			Slug:             p.Slug,
+			DisplayName:      p.DisplayName,
+			Description:      p.Description,
+			MonthlyPriceUSD:  p.MonthlyPriceUSD,
+			KeySource:        string(p.KeySource),
+			IncludedUsageUSD: p.IncludedUsageUSD,
+			Limits:           limits,
+		})
+	}
+
+	res, err := st.SyncPlans(ctx, specs, *archiveMissing)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("billing: plans synced — %d upserted, %d archived\n", res.Upserted, res.Archived)
+	return nil
+}
+
+func runPlansList(ctx context.Context, st *storage.Store) error {
+	plans, err := st.ListPlans(ctx)
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "SLUG\tNAME\tPRICE/MO\tKEYS\tINCLUDED USAGE\tSTATE")
+	for _, p := range plans {
+		included := "-"
+		if p.IncludedUsageUSD != nil {
+			included = fmt.Sprintf("$%.2f", *p.IncludedUsageUSD)
+		}
+		state := "active"
+		if p.Archived {
+			state = "archived"
+		}
+		fmt.Fprintf(w, "%s\t%s\t$%.2f\t%s\t%s\t%s\n",
+			p.Slug, p.DisplayName, p.MonthlyPriceUSD, p.KeySource, included, state)
+	}
+	return w.Flush()
+}
+
+func runBillingTenants(ctx context.Context, st *storage.Store) error {
+	tenants, err := st.ListTenantsWithPlan(ctx)
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "TENANT ID\tNAME\tPLAN\tCREATED")
+	for _, t := range tenants {
+		plan := t.PlanSlug
+		if plan == "" {
+			plan = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.ID, t.Name, plan, t.CreatedAt.Format(time.DateOnly))
+	}
+	return w.Flush()
+}
+
+func runSubscribe(ctx context.Context, st *storage.Store, args []string) error {
+	fs := flag.NewFlagSet("billing subscribe", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	tenant := fs.String("tenant", "", "tenant id (see `glyphoxa billing tenants`)")
+	plan := fs.String("plan", "", "plan slug (see `glyphoxa billing plans-list`)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *tenant == "" || *plan == "" {
+		return fmt.Errorf("billing subscribe: -tenant and -plan are required")
+	}
+	tenantID, err := uuid.Parse(*tenant)
+	if err != nil {
+		return fmt.Errorf("billing subscribe: bad tenant id: %w", err)
+	}
+
+	sub, err := st.SetTenantPlan(ctx, tenantID, *plan)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("billing: tenant %s subscribed to %q at $%.2f/mo (snapshot)\n",
+		sub.TenantID, sub.PlanSlug, sub.MonthlyPriceUSD)
+	return nil
+}
+
+func runCancel(ctx context.Context, st *storage.Store, args []string) error {
+	fs := flag.NewFlagSet("billing cancel", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	tenant := fs.String("tenant", "", "tenant id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *tenant == "" {
+		return fmt.Errorf("billing cancel: -tenant is required")
+	}
+	tenantID, err := uuid.Parse(*tenant)
+	if err != nil {
+		return fmt.Errorf("billing cancel: bad tenant id: %w", err)
+	}
+	if err := st.EndTenantPlan(ctx, tenantID); err != nil {
+		return err
+	}
+	fmt.Printf("billing: tenant %s subscription ended\n", tenantID)
+	return nil
+}
+
+func runBillingReport(ctx context.Context, st *storage.Store, args []string) error {
+	fs := flag.NewFlagSet("billing report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	month := fs.String("month", "", "calendar month YYYY-MM (UTC); defaults to the current month")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var from time.Time
+	if *month == "" {
+		now := time.Now().UTC()
+		from = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		var err error
+		from, err = time.Parse("2006-01", *month)
+		if err != nil {
+			return fmt.Errorf("billing report: bad -month (want YYYY-MM): %w", err)
+		}
+	}
+	to := from.AddDate(0, 1, 0)
+
+	lines, err := st.BillingReport(ctx, from, to)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Billing report %s (UTC month). Revenue = subscription price snapshots,\n", from.Format("2006-01"))
+	fmt.Println("un-prorated; cost = usage-ledger ESTIMATES (ADR-0046), never billing truth.")
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "TENANT\tPLAN\tREVENUE/MO\tEST. COST\tLLM TOK (IN/OUT)\tTTS CHARS\tSTT SEC")
+	var revenue, cost float64
+	for _, l := range lines {
+		plan := l.PlanSlug
+		if plan == "" {
+			plan = "- (BYOK, unsubscribed)"
+		}
+		fmt.Fprintf(w, "%s\t%s\t$%.2f\t$%.4f\t%d/%d\t%d\t%.0f\n",
+			l.TenantName, plan, l.MonthlyPriceUSD, l.EstimatedUSD,
+			l.LLMInputTokens, l.LLMOutputTokens, l.TTSCharacters, l.STTAudioSeconds)
+		revenue += l.MonthlyPriceUSD
+		cost += l.EstimatedUSD
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	fmt.Printf("\nTOTAL revenue $%.2f, estimated provider cost $%.4f, margin $%.4f\n",
+		revenue, cost, revenue-cost)
+	return nil
+}

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -102,6 +102,12 @@ func main() {
 				os.Exit(1)
 			}
 			return
+		case "billing":
+			if err := RunBilling(context.Background(), os.Args[2:]); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return
 		}
 	}
 
@@ -590,6 +596,11 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		Transcript: relay,
 		Chunker:    chunker,
 		Highlights: highlightSaver,
+		// Durable Usage Ledger (ADR-0054): every manager-started session's metered
+		// usage lands in the usage_ledger table at loop exit, attributed to its
+		// Tenant — the cost side of the SaaS billing report. Attribution only;
+		// gating stays with the spend meter (ADR-0046).
+		Usage: store,
 		// NPC KG-facts recall (#126, ADR-0008): the reserved Hot Context KG-facts
 		// slot, filled per turn from the active Campaign's gm-public Nodes.
 		// UNCONDITIONAL — unlike Memory below — because it needs no embeddings

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -60,6 +60,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-seed" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.plans.fullname" -}}
+{{- printf "%s-plans" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "glyphoxa.voice.fullname" -}}
 {{- printf "%s-voice" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/deploy/charts/glyphoxa/templates/plans-configmap.yaml
+++ b/deploy/charts/glyphoxa/templates/plans-configmap.yaml
@@ -1,0 +1,29 @@
+{{/*
+Plan-catalog ConfigMap (ADR-0054) — the declarative subscription-tier catalog
+the plans-sync hook Job feeds to `glyphoxa billing plans-sync`.
+
+The catalog is authored directly in values (`plans.catalog`, YAML) and rendered
+to the JSON shape the CLI parses, so tiers live in the same values file (or
+GitOps overlay) as the rest of the deploy — editing a price is a `helm upgrade`,
+no image or code change (the tiers-are-config requirement).
+
+Hook + weight: pre-install,pre-upgrade at the plans Job's weight minus one, so
+the ConfigMap exists before the Job that mounts it runs (Helm orders hooks by
+weight; nothing needs to "complete" for a ConfigMap).
+*/}}
+{{- if .Values.plans.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "glyphoxa.plans.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: plans
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ sub (int .Values.plans.hookWeight) 1 | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  plans.json: |
+    {{- toPrettyJson .Values.plans.catalog | nindent 4 }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/plans-sync-job.yaml
+++ b/deploy/charts/glyphoxa/templates/plans-sync-job.yaml
@@ -1,0 +1,96 @@
+{{/*
+Plans-sync hook Job (ADR-0054) — syncs the declarative plan catalog into the DB.
+
+It runs `glyphoxa billing plans-sync -file /etc/glyphoxa/plans/plans.json` ONCE
+per install/upgrade as a Helm pre-install/pre-upgrade hook, after the migrate
+(-5) and seed (-4) hooks so the plan/tenant_subscription tables exist, and
+before any serving workload. The sync is an upsert-by-slug (idempotent), so the
+pre-upgrade run neither errors nor duplicates plans on a chart bump; with
+`plans.archiveMissing` it also archives tiers removed from the catalog (never
+deletes — subscriptions reference them, ADR-0054).
+
+Mirrors the seed hook's structure: before-hook-creation delete policy, the
+pg_isready initContainer when the in-cluster Postgres is enabled, and the
+database URL from the app Secret. It does NOT read GLYPHOXA_SECRET — the plan
+catalog carries no credentials.
+*/}}
+{{- if .Values.plans.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "glyphoxa.plans.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: plans
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ .Values.plans.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: plans
+    spec:
+      restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.postgres.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: {{ include "glyphoxa.postgres.image" . }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              until pg_isready -h {{ include "glyphoxa.postgres.fullname" . }} -p {{ .Values.postgres.service.port }} -U {{ .Values.database.user | quote }};
+              do echo "waiting for postgres at {{ include "glyphoxa.postgres.fullname" . }}:{{ .Values.postgres.service.port }}"; sleep 2; done
+      {{- end }}
+      containers:
+        - name: plans-sync
+          image: {{ include "glyphoxa.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - billing
+            - plans-sync
+            - -file
+            - /etc/glyphoxa/plans/plans.json
+            {{- if .Values.plans.archiveMissing }}
+            - -archive-missing
+            {{- end }}
+          env:
+            - name: GLYPHOXA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: database-url
+          volumeMounts:
+            - name: plans-catalog
+              mountPath: /etc/glyphoxa/plans
+              readOnly: true
+          {{- with .Values.plans.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: plans-catalog
+          configMap:
+            name: {{ include "glyphoxa.plans.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/tests/plans_test.yaml
+++ b/deploy/charts/glyphoxa/tests/plans_test.yaml
@@ -1,0 +1,176 @@
+suite: plans-sync hook Job + catalog ConfigMap
+# The plan catalog (ADR-0054) ships as declarative chart values: a ConfigMap
+# renders `plans.catalog` to the plans.json shape and a hook Job feeds it to
+# `glyphoxa billing plans-sync`, ordered after migrate (-5) and seed (-4) so the
+# plan tables exist. OFF by default — a pure-BYOK self-host renders neither.
+templates:
+  - templates/plans-sync-job.yaml
+  - templates/plans-configmap.yaml
+tests:
+  - it: renders nothing when plans are disabled (the default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the Job and ConfigMap when enabled
+    set:
+      plans:
+        enabled: true
+        catalog:
+          plans:
+            - slug: all-inclusive
+              display_name: All Inclusive
+              monthly_price_usd: 20
+              key_source: platform
+              included_usage_usd: 15
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-plans
+
+  - it: renders the catalog values as JSON in the ConfigMap
+    set:
+      plans:
+        enabled: true
+        catalog:
+          plans:
+            - slug: all-inclusive
+              display_name: All Inclusive
+              monthly_price_usd: 20
+              key_source: platform
+    template: templates/plans-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"slug": "all-inclusive"'
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"key_source": "platform"'
+
+  - it: is a pre-install AND pre-upgrade hook ordered after migrate and seed
+    # plans-sync at -3 sorts after migrate (-5) and seed (-4) — the plan tables
+    # must exist — yet ahead of the serving workloads at weight 0. The ConfigMap
+    # renders one weight earlier so the Job can mount it.
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-3"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: orders the ConfigMap one hook-weight ahead of the Job
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-configmap.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-4"
+
+  - it: runs `glyphoxa billing plans-sync` against the mounted catalog
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - billing
+            - plans-sync
+            - -file
+            - /etc/glyphoxa/plans/plans.json
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: RELEASE-NAME-glyphoxa-plans
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /etc/glyphoxa/plans
+
+  - it: appends -archive-missing only when opted in
+    set:
+      plans:
+        enabled: true
+        archiveMissing: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - billing
+            - plans-sync
+            - -file
+            - /etc/glyphoxa/plans/plans.json
+            - -archive-missing
+
+  - it: sources GLYPHOXA_DATABASE_URL from the DB Secret and reads NO app-secret
+    # The catalog carries no credentials, so unlike the seed hook this Job must
+    # not mount GLYPHOXA_SECRET.
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: app-secret
+
+  - it: waits for the in-cluster Postgres before syncing
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[-1]
+          pattern: pg_isready.*RELEASE-NAME-glyphoxa-postgres
+
+  - it: skips the wait initContainer against an external database
+    set:
+      plans:
+        enabled: true
+      postgres:
+        enabled: false
+      database:
+        url: postgres://u:p@external.example.com:5432/glyphoxa?sslmode=require
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: never restarts a completed plans-sync pod
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-sync-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -84,6 +84,47 @@ seed:
   hookWeight: -4
   resources: {}
 
+# Plan-catalog sync hook Job (ADR-0054): the SaaS subscription tiers as
+# declarative chart values, synced into the DB by `glyphoxa billing plans-sync`
+# on every install/upgrade. OFF by default — a pure-BYOK self-host needs no
+# plans. Enabling it makes tiers pure config: edit `catalog`, `helm upgrade`,
+# done. Tenants are bound to plans with `glyphoxa billing subscribe`, and cost/
+# revenue read out via `glyphoxa billing report` (docs/deploy/saas-operations.md).
+plans:
+  enabled: false
+  # -3 sorts AFTER migrate (-5) and seed (-4), so the plan tables exist and any
+  # demo data is in place, yet still ahead of the serving workloads at weight 0.
+  # The catalog ConfigMap renders at this weight minus one.
+  hookWeight: -3
+  # Archive plans absent from the catalog on sync (never deletes — running
+  # subscriptions keep resolving their plan). Leave false to let removed tiers
+  # linger active until explicitly archived.
+  archiveMissing: false
+  resources: {}
+  # The catalog itself, in the `glyphoxa billing plans-sync` JSON shape
+  # (authored as YAML here, rendered to JSON in the ConfigMap). slug is the
+  # stable handle syncs upsert by; key_source 'platform' marks a tier whose
+  # subscription includes provider usage on the DEPLOYMENT's keys (the
+  # elevenLabsApiKey/groqApiKey/geminiApiKey values above — ADR-0054), 'byok'
+  # (the default) a tier where Tenants bring their own. included_usage_usd is
+  # the monthly estimated-USD allowance a platform tier includes; limits is a
+  # free-form knob bag consumers read known keys from. Example:
+  #   catalog:
+  #     plans:
+  #       - slug: byok-free
+  #         display_name: BYOK Free
+  #         monthly_price_usd: 0
+  #       - slug: all-inclusive
+  #         display_name: All Inclusive
+  #         description: Groq + ElevenLabs usage included
+  #         monthly_price_usd: 20
+  #         key_source: platform
+  #         included_usage_usd: 15
+  #         limits:
+  #           max_campaigns: 10
+  catalog:
+    plans: []
+
 # Voice-mode Deployment (#36): the single image run as `glyphoxa -mode voice`,
 # joining one Discord guild+channel and giving the seeded NPC a live voice loop.
 # It is a plain (non-hook) workload, so it applies after the migrate (-5) and

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,10 +20,22 @@ Start here — these describe the system as it ships today.
 - **[quickstart-gm.md](quickstart-gm.md)** — GM quickstart: from a fresh clone
   to a talking Character NPC in a Discord voice channel.
 
+### [deploy/](deploy/) — hosted-deployment runbooks (ADR-0054)
+
+Running Glyphoxa **for others**, beyond the single-machine self-host:
+
+- **[deploy/k3s-proxmox.md](deploy/k3s-proxmox.md)** — the Helm chart on a k3s
+  cluster in a Proxmox VM, exposed via DynDNS with Let's Encrypt TLS.
+- **[deploy/cloud-providers.md](deploy/cloud-providers.md)** — moving that
+  deployment to a paid cloud: provider suggestions and cost estimates.
+- **[deploy/saas-operations.md](deploy/saas-operations.md)** — subscription
+  Plans, platform keys, and the cost/revenue report
+  (`glyphoxa billing`).
+
 ### [adr/](adr/) — Architecture Decision Records
 
-The 53 ADRs (`0001`…`0053`) recording the decisions behind the system, from
-multi-GM self-hosting through the Campaign Bundle format. Where an ADR and the
+The 54 ADRs (`0001`…`0054`) recording the decisions behind the system, from
+multi-GM self-hosting through the SaaS billing foundation. Where an ADR and the
 shipped tree disagree, `architecture.md` follows the tree and says so.
 
 ### [agents/](agents/) — agent & contributor conventions

--- a/docs/adr/0054-saas-plans-platform-keys-usage-ledger.md
+++ b/docs/adr/0054-saas-plans-platform-keys-usage-ledger.md
@@ -1,0 +1,106 @@
+# SaaS foundation: Plans as synced data, Subscriptions with price snapshots, a durable Usage Ledger, and platform keys on the env-fallback path
+
+Glyphoxa's next deployment target after the proven self-host on-ramp (ADR-0034)
+is a hosted SaaS: first on a k3s cluster in the operator's home network
+(exposed via DynDNS), later on a cloud provider. BYOK (ADR-0004) stays fully
+supported; additionally a subscription may **include** Groq/ElevenLabs usage on
+the deployment's own keys. Tier structure is undecided by design, so tiers must
+be pure configuration — easy to add, edit, and retire — and their **cost and
+revenue must be measurable**. Decided with the operator 2026-07-17; this ADR
+records the shape. Payment-processor integration is explicitly OUT of this
+slice.
+
+## What this decides
+
+- **Plans are data, not code: a `plan` table synced from a declarative JSON
+  catalog.** `glyphoxa billing plans-sync -file plans.json` upserts tiers by
+  `slug` (the stable handle) inside one transaction; `-archive-missing`
+  archives tiers absent from the file. Plans are **never deleted** — archived
+  ones accept no new subscriptions but keep resolving for history. A plan
+  carries `display_name`, `description`, `monthly_price_usd`,
+  `key_source ('byok'|'platform')`, `included_usage_usd` (platform-only monthly
+  estimated-USD allowance), and a free-form `limits` jsonb bag so future knobs
+  (max campaigns, feature flags) need no schema churn. The Helm chart renders
+  the same catalog from values into a ConfigMap and syncs it via a hook Job
+  (weight -3, after migrate/seed) — editing a tier is a `helm upgrade`.
+- **Subscriptions snapshot price at bind time.** `tenant_subscription` binds a
+  Tenant to a plan with `plan_slug` + `monthly_price_usd` copied onto the row;
+  a partial unique index enforces at most one active (ended_at IS NULL)
+  subscription per tenant, and switching plans ends the old row — the row
+  history IS the revenue record, immune to later catalog edits. Binding is
+  operator-CLI (`glyphoxa billing subscribe|cancel|tenants`): money changes
+  hands out of band (payment links, bank transfer) and the operator records
+  the result; automating that with a processor (Stripe webhooks → subscribe)
+  is a later layer that slots in above these tables without changing them.
+- **A durable per-Tenant Usage Ledger is the cost side.** `internal/billing.
+  Ledger` implements `observe.UsageSink` and tees beside the recorder and the
+  in-memory spend meter at session Start (`observe.TeeUsage` composes; zero new
+  pipeline plumbing, the ADR-0045 capture points are untouched). It buckets
+  usage by `(tenant, day UTC, component, provider, model)` with quantities AND
+  an `estimated_usd` priced at capture time from the ADR-0046 price map
+  (exported as `spend.Estimate*USD`), and is flushed once at loop exit through
+  the session Manager's new optional `UsageWriter` seam
+  (`storage.Store.AddUsage`, upsert-accumulate). Attribution only — it never
+  gates; gating stays with the spend meter. Accepted losses, documented:
+  a crash loses the unflushed session remainder, and every figure is an
+  ESTIMATE (never billing truth). Off-session usage (Recap, Highlight
+  enrichment — the `spend.PriceOnly` sites) is **not yet** tenant-attributed;
+  it logs per-call spend today and joins the ledger as a follow-up.
+- **`glyphoxa billing report [-month YYYY-MM]` is the measurement surface:**
+  per tenant, the subscription price snapshot(s) overlapping the month
+  (un-prorated, labelled as such) against the ledger's summed quantities and
+  estimated cost, with totals and margin. It is deliberately a CLI + SQL story
+  for now; RPC/console surfaces come with the multi-tenant web tier.
+- **Platform keys ride the existing env-fallback path.** The hybrid BYOK
+  policy (ADR-0039: `credentials_last4 = "env"` ⇒ adapter falls back to its
+  `*_API_KEY` env var) is mechanically already "the deployment's pooled keys" —
+  a `key_source='platform'` plan makes that arrangement a *product*: the
+  operator sets GROQ_API_KEY/ELEVENLABS_API_KEY on the deployment (the chart's
+  existing Secret values) and subscribed Tenants use env-placeholder Provider
+  Configs. **Entitlement enforcement is deferred, deliberately:** in the v1.0
+  single-operator web tier (ADR-0039/0041) every Tenant is the operator, so
+  there is nothing to enforce against yet. When self-signup lands, enforcement
+  belongs at (a) Provider-Config save/resolve — a tenant without a platform
+  plan cannot hold an env-placeholder config — and (b) a monthly allowance
+  gate over the ledger patterned on the spend-cap mechanics (ADR-0046), both
+  reading `included_usage_usd`.
+- **Deployment path:** the same Helm chart serves the whole ladder — Docker
+  Compose/systemd self-host (unchanged), k3s-on-Proxmox home SaaS
+  (docs/deploy/k3s-proxmox.md), cloud k8s later
+  (docs/deploy/cloud-providers.md). The known scale ceiling is unchanged and
+  honest: one `all`-mode web pod (session backplane deferred, ADR-0039).
+
+## Considered and rejected
+
+- **Plans as code constants** (the prices.go pattern) — rejected: the whole
+  point is editing tiers without a deploy; a declarative file syncs from
+  GitOps and the DB row is the runtime read.
+- **Plan CRUD via RPC/console** — deferred, not rejected: a file + hook Job is
+  versionable and reviewable; a UI adds surface before there is a second
+  operator to use it.
+- **Per-event usage rows** — rejected: unbounded growth for no attribution
+  gain; daily (tenant, component, provider, model) buckets answer every
+  cost question the report asks. Quantities are stored beside the priced
+  estimate so a price-map change never rewrites history.
+- **Prometheus as the ledger** — rejected: counters are process-lifetime,
+  deliberately tenant-unlabelled (ADR-0032 cardinality bound), and not
+  durable. The ledger is a table; the counters remain the live ops view.
+- **A `key_source` column on usage_ledger rows** — deferred until per-component
+  mixed sourcing (one tenant BYOK for LLM, platform for TTS) needs attribution;
+  today the tenant's plan classifies its usage at report time.
+- **Stripe (or any processor) in this slice** — rejected for now: it would
+  force tier structure decisions the operator has explicitly not made, and the
+  snapshot tables are exactly the substrate a processor integration writes to
+  later.
+- **Enforcing platform-plan entitlement now** — rejected as dead code: the
+  single-operator tier has no non-operator tenants to refuse. The enforcement
+  seams are named above so the self-signup epic can land it deliberately.
+
+## Relationship to other ADRs
+
+ADR-0004 (BYOK; "operator-pooled keys are a future-additive path" — this is
+that path), ADR-0039 (hybrid env-fallback policy; single-operator ceiling),
+ADR-0045 (usage capture points the ledger tees into), ADR-0046 (price map,
+estimate posture, cap mechanics the future allowance gate mirrors), ADR-0031/
+0034 (migration + Helm hook conventions the plans-sync Job follows), ADR-0041
+(operator allowlist — the current SaaS admission control).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,4 +340,5 @@ used provider needs are required.
 - [ADR-0016](adr/0016-cookies-discord-only-oauth.md) — cookies + Discord-only OAuth.
 - [ADR-0004](adr/0004-byok-provider-key-matrix.md) — BYOK provider key matrix.
 - [ADR-0034](adr/0034-deployment-artifacts.md) — deployment artifacts (container/Helm).
+- [deploy/k3s-proxmox.md](deploy/k3s-proxmox.md) — hosting Glyphoxa on a k3s cluster (Proxmox home lab, DynDNS + TLS); [deploy/saas-operations.md](deploy/saas-operations.md) — subscription Plans, platform keys, and the `glyphoxa billing` cost/revenue surface (ADR-0054).
 - [docs/agents/live-npc-run.md](agents/live-npc-run.md) — the `voice`-mode live NPC run guide.

--- a/docs/deploy/cloud-providers.md
+++ b/docs/deploy/cloud-providers.md
@@ -1,0 +1,114 @@
+# Moving Glyphoxa to the cloud: provider suggestions & cost estimates
+
+The home-lab k3s deployment ([k3s-proxmox.md](k3s-proxmox.md)) and a cloud
+deployment run the **same chart with the same values** — the move is a DNS
+change and a `helm install` on a different cluster, plus a `pg_dump`/
+`pg_restore`. This doc is about picking where, cheaply.
+
+All prices are **approximate, captured 2026-07**, and change; treat them as
+order-of-magnitude for comparison, and check current pricing before deciding.
+
+## What Glyphoxa actually needs
+
+- **One always-on amd64 node**, 2–4 vCPU / 4–8 GiB — the `all`-mode web pod +
+  Postgres fit comfortably (the voice pipeline is pure Go, no GPU). The web
+  tier is single-replica by design (ADR-0039), so a multi-node HA cluster buys
+  you nothing yet — don't pay for it.
+- **Postgres with pgvector** — in-chart StatefulSet (default) or a managed DB
+  *that supports the pgvector extension* (verify before committing; most
+  managed Postgres offerings support it now, but plans/regions differ).
+- **Ingress + TLS** on 80/443 — the chart's existing Traefik/nginx +
+  cert-manager path.
+- **Modest, latency-sensitive traffic** — Discord voice is ~50–100 kbps Opus
+  per active speaker plus provider API calls; a month of heavy sessions is a
+  few tens of GB. What matters is round-trip latency to Discord's voice edge
+  and to Groq/ElevenLabs/Deepgram — for European players pick an EU region,
+  for US players a US one. Egress-metered hyperscalers are fine on volume but
+  overpriced anyway (below).
+
+## Recommendations
+
+### 1. Hetzner Cloud + self-managed k3s — the price/performance pick
+
+- **CX32** (4 vCPU shared, 8 GiB, 80 GB NVMe): **~€7–8/mo**; a **CX22**
+  (2 vCPU/4 GiB, ~€4/mo) runs it for light use. 20 TB traffic included.
+- EU (DE/FI) and US regions; excellent latency to both Discord and the
+  provider APIs from either.
+- You run k3s exactly as on the Proxmox VM — the entire §2–§7 of the home-lab
+  guide applies verbatim, minus DynDNS (you get a stable public IP; point a
+  normal A record at it).
+- Add-ons worth it: automated snapshots (~20% of the server price), a
+  separate volume for Postgres if you outgrow the root disk.
+- Caveat: their ARM instances (CAX) are cheaper still, but the published
+  Glyphoxa image is **amd64-only** today — stick to CX/CPX, or build your own
+  arm64 image (the binary is pure Go and cross-compiles trivially; the
+  Dockerfile just isn't multi-arch yet).
+
+**Total: ~€5–10/mo.** This is the natural first step off the home lab: same
+operational model, real IP, real uptime, no CG-NAT worries.
+
+### 2. netcup (or similar EU VPS: Contabo, IONOS) — cheapest raw compute
+
+Root/VPS servers with generous specs (~€5–8/mo for 4 vCPU/8 GiB) and no hourly
+billing. Same self-managed k3s story as Hetzner. Fine choice if you already
+have an account; Hetzner's API/tooling and snapshot story are better.
+
+### 3. Managed Kubernetes with a free control plane — less ops, a bit more €
+
+If you'd rather not own the k3s node itself:
+
+| Provider | Control plane | Cheapest sensible node | Ballpark total |
+|----------|--------------|------------------------|----------------|
+| **Civo** (k3s-based) | free | ~$10–20/mo (2 vCPU/4 GiB) | ~$15–25/mo |
+| **Scaleway Kapsule** | free (mutualized) | DEV1-M ~€10/mo | ~€10–15/mo |
+| **DigitalOcean DOKS** | free | $12–24/mo (2–4 GiB) | ~$15–30/mo |
+| **OVHcloud MKS** | free | ~€10–15/mo | ~€12–20/mo |
+
+All four hand you a kubeconfig; from there it's the identical
+`helm install` + cert-manager + ingress flow. Watch for: forced load-balancer
+charges (a cloud LB adds $5–15/mo — on a single-node cluster you can often
+use the ingress controller's hostPort/NodePort instead), and block-storage
+minimums for the Postgres PVC.
+
+### 4. The hyperscalers (AWS/GCP/Azure) — not recommended at this scale
+
+EKS charges ~$70+/mo for the control plane alone; GKE/AKS have free tiers but
+node, LB, and **egress** pricing still lands you at several times the options
+above for one small always-on service. Choose them only if you're already
+there (credits, existing infra, compliance).
+
+## Managed Postgres, or keep it in-chart?
+
+The in-chart pgvector StatefulSet is fine well past hobby scale **if you keep
+backups honest** (nightly `pg_dump` + off-box copy — the CronJob from the
+home-lab guide §8). Move to managed Postgres when backups/failover become the
+thing you worry about:
+
+- DigitalOcean Managed PG (~$15/mo) and Scaleway both support pgvector.
+- Point the chart at it with `postgres.enabled=false` +
+  `database.url=postgres://...` — that render path is CI-validated already.
+- Check extension support explicitly (`CREATE EXTENSION vector`) before
+  migrating; it's the first migration and fails loudly without it.
+
+## Migration from the home lab, concretely
+
+1. Stand up the new cluster; install cert-manager + issuer (home-lab guide §4).
+2. `helm install` with your existing values file (new host in `ingress.host`).
+3. `pg_dump -Fc` on the old cluster → `pg_restore` into the new DB **before**
+   first login (fresh visits would otherwise seed state you'd then collide
+   with; restoring over the migrate-hook schema with `--clean` is the easy
+   path).
+4. Update the DNS record and the Discord OAuth redirect URL to the new host.
+5. Keep the old deployment stopped-but-intact for a week before deleting.
+
+Voice Sessions don't survive the move (they're bound to a live process —
+ADR-0006 explicitly rejects mid-session migration); schedule the cutover
+between game nights.
+
+## See also
+
+- [k3s-proxmox.md](k3s-proxmox.md) — the home-lab deployment and the install
+  steps every option above reuses.
+- [saas-operations.md](saas-operations.md) — plans, platform keys, and the
+  cost report that tells you when hosting bills are covered by subscriptions.
+- ADR-0034 (deployment artifacts), ADR-0054 (SaaS foundation).

--- a/docs/deploy/k3s-proxmox.md
+++ b/docs/deploy/k3s-proxmox.md
@@ -1,0 +1,342 @@
+# Deploying Glyphoxa on k3s (Proxmox home lab, DynDNS + TLS)
+
+This runbook takes the Helm chart (ADR-0034) from "works on a dev cluster" to
+an **internet-reachable deployment on a k3s cluster inside a Proxmox VM**,
+exposed via DynDNS with Let's Encrypt TLS. It is the first stop on the SaaS
+path (ADR-0054): the same chart, values, and operational habits carry over
+unchanged to a cloud provider later — see
+[cloud-providers.md](cloud-providers.md) for that step.
+
+For plain single-machine self-hosting, Docker Compose or systemd
+([configuration.md §9–§10](../configuration.md)) remain simpler and fully
+supported; this guide is for running Glyphoxa **as a service for others**.
+
+## Topology
+
+```
+Internet ──▶ router (DynDNS name, forwards 80/443)
+                 │
+                 ▼
+   Proxmox VM (Ubuntu 24.04, k3s single node)
+                 │
+        Traefik (k3s built-in ingress, TLS via cert-manager)
+                 │
+        ┌────────┴─────────┐
+        ▼                  ▼
+  glyphoxa-web        glyphoxa-postgres
+  (-mode all,         (pgvector StatefulSet,
+   1 replica)          local-path PV)
+```
+
+Notes on the shape, so nothing here surprises you later:
+
+- **One web pod, `-mode all`, by design.** The v1.0 web tier holds Voice
+  Sessions in-process and cross-pod session control is deferred (ADR-0039), so
+  the chart pins one replica with a `Recreate` strategy. Scaling out is a
+  design change (a session backplane), not a values tweak — don't set
+  `replicas: 2` and expect it to work.
+- **The chart's voice Deployment stays off.** `voice.enabled=true` runs a
+  fixed-guild/channel NPC loop (the demo path); in an `all`-mode deployment the
+  web pod drives the voice loop itself, so enable only one of the two.
+- **TLS terminates at Traefik** (ADR-0039); the app behind it speaks plain
+  HTTP in-cluster.
+
+## Prerequisites
+
+- A Proxmox host with capacity for the VM below.
+- A DNS name you control. Either a DynDNS provider (DuckDNS, deSEC,
+  dynv6, your registrar's API) or a real domain with a DynDNS-updatable
+  record. You need **one hostname**, e.g. `glyphoxa.example.dedyn.io`.
+- Router access to forward TCP **80 and 443** to the VM. (80 is needed for
+  Let's Encrypt HTTP-01 renewal, not just the first issue.)
+- A Discord application for OAuth (and the Bot token) —
+  [configuration.md §5](../configuration.md) walks through registering it.
+- `kubectl` and `helm` (v3.14+) on your workstation.
+
+## 1. Create the VM
+
+A single k3s node running Glyphoxa (web `all` mode + Postgres) is comfortable
+at:
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| vCPU | 2 | 4 |
+| RAM | 4 GiB | 8 GiB |
+| Disk | 20 GiB | 40+ GiB (Postgres + transcripts/blobs grow) |
+
+In Proxmox: Ubuntu Server 24.04 (or Debian 13) cloud image or ISO, VirtIO
+disk/NIC, `qemu-guest-agent` installed, and a **static IP or DHCP
+reservation** — the router's port forward must keep pointing at it. Enable
+"Start at boot".
+
+```sh
+# inside the VM
+sudo apt-get update && sudo apt-get install -y qemu-guest-agent curl
+sudo systemctl enable --now qemu-guest-agent
+```
+
+## 2. Install k3s
+
+k3s ships Traefik as the bundled ingress controller and `local-path` as the
+default StorageClass — both are exactly what this deployment uses, so a stock
+install is fine:
+
+```sh
+curl -sfL https://get.k3s.io | sh -
+# kubeconfig for your workstation:
+sudo cat /etc/rancher/k3s/k3s.yaml   # copy to ~/.kube/config, replace 127.0.0.1 with the VM IP
+kubectl get nodes                    # want: Ready
+```
+
+Traefik listens on the node's 80/443 out of the box (ServiceLB), so the
+router's port forward terminates at the VM with nothing else to install.
+
+## 3. DynDNS and port forwarding
+
+1. Point your hostname at your public IP and keep it updated. Prefer the
+   **router's built-in DynDNS client** (Fritz!Box, OpenWrt, UniFi all have
+   one); otherwise run `ddclient` on the VM or a tiny CronJob in the cluster.
+2. Forward **TCP 80 → VM:80** and **TCP 443 → VM:443** on the router.
+3. Verify from outside your LAN (e.g. phone hotspot):
+   `curl -I http://glyphoxa.example.dedyn.io` should reach Traefik (a 404 is
+   fine at this point — it means Traefik answered).
+
+> **CG-NAT / DS-Lite warning:** if your ISP doesn't give you a public IPv4,
+> inbound port forwarding won't work. Options: ask the ISP for real dual
+> stack, use an IPv6-only setup (works if all your users have IPv6), or relay
+> through a cheap VPS/Cloudflare Tunnel. This is the single most common
+> home-lab blocker — check it before anything else.
+
+## 4. cert-manager + Let's Encrypt
+
+The chart has an opt-in cert-manager path (`ingress.certManager.*`); install
+cert-manager and a ClusterIssuer once per cluster:
+
+```sh
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true
+```
+
+```yaml
+# clusterissuer.yaml — HTTP-01 through the Traefik ingress class
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com          # expiry notices
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: traefik
+```
+
+```sh
+kubectl apply -f clusterissuer.yaml
+```
+
+## 5. Values
+
+Create a namespace and a values file. Secrets belong in a proper secret
+manager eventually; for a home lab, a **non-committed** values file with
+tight permissions is the pragmatic start (the chart also supports templating
+everything from external Secrets — see the comments in `values.yaml`).
+
+```sh
+kubectl create namespace glyphoxa
+```
+
+```yaml
+# glyphoxa-values.yaml — chmod 0600, NEVER commit this file
+image:
+  tag: v0.2.0                # pin the release you deploy
+
+# openssl rand -base64 32
+appSecret: "<base64-32-bytes>"
+
+discordBotToken: "<bot token>"
+# BYOK deployment: leave the provider keys empty — Tenants bring their own
+# (ADR-0004). Fill them only if this deployment itself provides managed
+# provider usage (platform keys, ADR-0054 / saas-operations.md).
+elevenLabsApiKey: ""
+geminiApiKey: ""
+groqApiKey: ""
+
+database:
+  password: "<generate a real one; URL-safe characters>"
+
+postgres:
+  persistence:
+    size: 20Gi               # local-path StorageClass by default on k3s
+
+seed:
+  enabled: false             # no demo data on a real deployment
+
+voice:
+  enabled: false             # the web pod drives the voice loop in `all` mode
+
+web:
+  enabled: true
+  mode: all                  # web console + in-process voice loop (ADR-0039)
+  oauth:
+    clientId: "<discord client id>"
+    clientSecret: "<discord client secret>"
+    # leave redirectUrl empty: with the Ingress enabled it is DERIVED from
+    # ingress.host + /auth/discord/callback, so it can never drift
+  operatorIds: "<your discord snowflake>"
+  resources:                 # `all` mode runs the voice loop in-process
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+
+ingress:
+  enabled: true
+  host: glyphoxa.example.dedyn.io
+  className: traefik
+  certManager:
+    enabled: true
+    clusterIssuer: letsencrypt-prod
+```
+
+Register the derived redirect URL on the Discord application **exactly**:
+`https://glyphoxa.example.dedyn.io/auth/discord/callback`.
+
+## 6. Install
+
+```sh
+helm install glyphoxa deploy/charts/glyphoxa \
+  --namespace glyphoxa \
+  --values glyphoxa-values.yaml
+```
+
+What happens, in order: the migrate hook Job applies the embedded schema
+(ADR-0031), then the web Deployment starts and `EnsureCurrent` confirms the
+schema before serving.
+
+Verify:
+
+```sh
+kubectl -n glyphoxa get pods                      # web Running, migrate Completed
+kubectl -n glyphoxa get certificate               # READY True (first issue ~1 min)
+curl -I https://glyphoxa.example.dedyn.io/        # 200, valid certificate
+```
+
+Then open the host in a browser, **Sign in with Discord**, and configure
+Provider Configs in the console.
+
+## 7. Upgrades
+
+```sh
+# bump image.tag in glyphoxa-values.yaml to the new release, then:
+helm upgrade glyphoxa deploy/charts/glyphoxa \
+  --namespace glyphoxa --values glyphoxa-values.yaml
+```
+
+The migrate hook runs before the new pod rolls (pre-upgrade hook, ADR-0034);
+`all` mode uses a `Recreate` strategy, so expect a brief (seconds) outage per
+upgrade — schedule around live Voice Sessions.
+
+## 8. Backups
+
+The in-chart Postgres is a plain StatefulSet on a local-path PV — **one disk,
+one VM**. Two layers, use both:
+
+1. **Proxmox level:** schedule VM backups (vzdump) or ZFS snapshots of the VM
+   disk. Crash-consistent, catches everything.
+2. **Logical dumps** for point-in-time restore and migration off the VM:
+
+```yaml
+# pgdump-cronjob.yaml — nightly logical dump into its own PVC
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: glyphoxa-pgdump
+  namespace: glyphoxa
+spec:
+  schedule: "15 4 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: pgvector/pgvector:pg17
+              command: ["/bin/sh", "-c"]
+              args:
+                - pg_dump "$GLYPHOXA_DATABASE_URL" -Fc
+                  -f "/backup/glyphoxa-$(date +%F).dump"
+                  && find /backup -name '*.dump' -mtime +14 -delete
+              env:
+                - name: GLYPHOXA_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: glyphoxa        # the chart's app Secret
+                      key: database-url
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: glyphoxa-pgdump
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: glyphoxa-pgdump
+  namespace: glyphoxa
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+Copy the dumps off the VM regularly (rsync to a NAS, restic to any S3) — a
+backup on the same physical disk is not a backup. Restore with
+`pg_restore -d "$DSN" --clean --if-exists <file>.dump`.
+
+## 9. Monitoring
+
+Both workloads expose `/metrics` on an internal port with `prometheus.io/*`
+scrape annotations (ADR-0032) — a stock kube-prometheus-stack or a lone
+Prometheus with annotation discovery picks them up with zero chart changes.
+Useful once you host other people: the per-provider usage counters
+(`glyphoxa_voice_llm_tokens_total`, `…_tts_characters_total`,
+`…_stt_audio_seconds_total`) are the live view of what your platform keys are
+burning; the durable per-Tenant ledger is the billing-grade view
+([saas-operations.md](saas-operations.md)).
+
+## 10. Security posture for an internet-facing home lab
+
+- The operator allowlist (ADR-0041) is your admission control: nobody outside
+  `GLYPHOXA_OPERATOR_IDS` can complete a login, even with the console reachable
+  from the internet. Keep it tight.
+- Keep the VM patched (`unattended-upgrades`) and k3s current
+  (`curl -sfL https://get.k3s.io | sh -` re-runs are in-place upgrades).
+- The container is `FROM scratch`, static binary, non-root, read-only rootfs
+  (ADR-0034) — the app surface is small; the router and VM are your real
+  perimeter. Don't forward anything but 80/443.
+- Never set `GLYPHOXA_DEV_MODE` here.
+
+## See also
+
+- [configuration.md](../configuration.md) — every environment variable; the
+  chart sets them for you but the reference is there.
+- [cloud-providers.md](cloud-providers.md) — moving this exact setup to a paid
+  cloud, with provider suggestions and monthly cost estimates.
+- [saas-operations.md](saas-operations.md) — running Glyphoxa for paying
+  users: Plans, platform keys, cost & revenue measurement.
+- ADR-0034 (deployment artifacts), ADR-0039 (web tier), ADR-0041 (allowlist),
+  ADR-0054 (SaaS path).

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -1,0 +1,191 @@
+# Running Glyphoxa as a SaaS: Plans, platform keys, cost & revenue
+
+This runbook covers operating a Glyphoxa deployment that hosts **paying
+users**: defining subscription tiers (Plans), including provider usage in a
+subscription (platform keys), binding Tenants to Plans, and reading cost and
+revenue out. The design and its deliberate boundaries are
+[ADR-0054](../adr/0054-saas-plans-platform-keys-usage-ledger.md).
+
+**Current honest scope, before you sell anything:**
+
+- The web tier is still the single-operator tier (ADR-0039/0041): every login
+  must be on the operator allowlist, and each allowlisted Discord User gets an
+  isolated Tenant. "SaaS" today means *you onboard each customer by adding
+  their snowflake to `GLYPHOXA_OPERATOR_IDS` and assigning a Plan*. Self-signup
+  is the next epic, not this one.
+- There is **no payment processor integration**. You collect money out of band
+  (PayPal, bank transfer, Stripe payment links) and record the result with
+  `glyphoxa billing subscribe`. The tables are processor-ready (price
+  snapshots, subscription history), so automation can land later without a
+  migration.
+- Every cost figure is an **estimate** from the static price map (ADR-0046) —
+  good for attribution and margin sanity, never an invoice.
+
+## 1. Plans (tiers)
+
+Tiers are pure configuration: a JSON catalog synced into the `plan` table.
+Nothing about their structure is hardcoded — add, edit, or retire tiers by
+editing the file and re-syncing.
+
+```json
+{
+  "plans": [
+    {
+      "slug": "byok-free",
+      "display_name": "BYOK Free",
+      "description": "Bring your own Groq/ElevenLabs keys.",
+      "monthly_price_usd": 0
+    },
+    {
+      "slug": "all-inclusive",
+      "display_name": "All Inclusive",
+      "description": "Groq + ElevenLabs usage included, on our keys.",
+      "monthly_price_usd": 20,
+      "key_source": "platform",
+      "included_usage_usd": 15,
+      "limits": { "max_campaigns": 10 }
+    }
+  ]
+}
+```
+
+Field notes:
+
+- `slug` — the stable handle; syncs upsert by it, subscriptions snapshot it.
+  Lowercase alphanumerics + hyphens.
+- `key_source` — `byok` (default): the Tenant saves its own provider keys.
+  `platform`: the Tenant runs on the deployment's env keys (§2) and the
+  subscription price covers the usage.
+- `included_usage_usd` — the monthly estimated-USD usage allowance a platform
+  tier includes. Today this is **reporting information** (the report shows
+  usage against it); automated gating on it is a named follow-up (ADR-0054).
+- `limits` — a free-form bag for future per-tier knobs. Consumers read the
+  keys they know; unknown keys are inert, so you can annotate tiers ahead of
+  enforcement.
+
+Sync and inspect:
+
+```sh
+glyphoxa billing plans-sync -file plans.json            # upsert by slug
+glyphoxa billing plans-sync -file plans.json -archive-missing
+glyphoxa billing plans-list
+```
+
+`-archive-missing` archives tiers you removed from the file. Archived plans
+accept no new subscriptions but existing ones keep running — plans are never
+deleted, so revenue history always resolves.
+
+**On Kubernetes**, the chart does this for you: put the same catalog under
+`plans.catalog` in your values file and set `plans.enabled=true` — a hook Job
+runs the sync on every `helm upgrade` (see `deploy/charts/glyphoxa/values.yaml`
+for the annotated example). Tier edits become values edits.
+
+## 2. Platform keys ("usage included")
+
+Mechanically, platform keys are the **env-fallback path** that already exists
+(ADR-0039's hybrid policy): a Provider Config whose credential is the `env`
+placeholder makes the adapter read the deployment's own `GROQ_API_KEY` /
+`ELEVENLABS_API_KEY` / `GEMINI_API_KEY`. For a SaaS deployment:
+
+1. Set the provider keys on the deployment (the chart's
+   `groqApiKey`/`elevenLabsApiKey`/`geminiApiKey` values, or the env of the
+   systemd/compose service). These are YOUR keys — the platform pool.
+2. Give paying Tenants a `key_source: "platform"` plan.
+3. Their env-placeholder Provider Configs (the seeded default) now run on your
+   pool; the Usage Ledger (§3) attributes every token/character/second they
+   burn to their Tenant, so you can see each subscription's real cost.
+
+BYOK Tenants coexist on the same deployment: they save real keys in the
+console (encrypted with `GLYPHOXA_SECRET`, ADR-0004), and a real saved key
+always wins over the env fallback.
+
+> **Deferred, deliberately:** nothing yet *prevents* a Tenant without a
+> platform plan from using env-placeholder configs — in the single-operator
+> tier every Tenant is you, so there is nobody to refuse. Before opening
+> self-signup, the entitlement checks land at Provider-Config save/resolve and
+> as a monthly allowance gate (ADR-0054 names the seams). Until then, don't
+> hand out logins you wouldn't trust with your keys.
+
+Per-session guardrails already exist today: set per-Tenant **spend caps**
+(soft/hard, ADR-0046) so a runaway Voice Session stops itself.
+
+## 3. Cost: the Usage Ledger
+
+Every Voice Session started from the web tier accumulates its metered usage
+(LLM tokens, TTS characters, STT seconds — ADR-0045) into per-Tenant daily
+buckets and flushes them to the `usage_ledger` table at session end. This is
+automatic — no configuration. Notes:
+
+- Buckets are `(tenant, day UTC, component, provider, model)` with raw
+  quantities AND a USD estimate priced at capture time; price-map updates
+  never rewrite history.
+- A crash loses the unflushed remainder of a live session (estimates-only
+  posture; the Prometheus counters still moved).
+- Off-session LLM spend (Recap, Highlight enrichment) is logged per call but
+  not yet in the ledger — a named follow-up.
+
+Ad-hoc SQL is fair game for anything the report doesn't cover, e.g. platform
+cost by provider for a month:
+
+```sql
+SELECT provider, component,
+       SUM(estimated_usd)     AS est_usd,
+       SUM(llm_input_tokens)  AS in_tok,
+       SUM(llm_output_tokens) AS out_tok
+  FROM usage_ledger
+ WHERE day >= '2026-07-01' AND day < '2026-08-01'
+ GROUP BY provider, component
+ ORDER BY est_usd DESC;
+```
+
+## 4. Revenue: subscriptions
+
+```sh
+glyphoxa billing tenants                                  # find tenant ids + current plans
+glyphoxa billing subscribe -tenant <uuid> -plan all-inclusive
+glyphoxa billing cancel -tenant <uuid>
+```
+
+`subscribe` snapshots the plan's slug and current price onto the subscription
+row and ends any previous subscription — the row history is the revenue
+record. Editing a plan's price later affects only *new* subscriptions; if you
+want existing customers on the new price, re-`subscribe` them (that's a
+deliberate, visible act, not a silent repricing).
+
+## 5. The monthly report
+
+```sh
+glyphoxa billing report -month 2026-07
+```
+
+Per tenant: plan, revenue (price snapshot, un-prorated), estimated provider
+cost, and the usage quantities behind it; then totals and margin. Use it to
+answer the two questions that decide tier structure: *what does a typical
+campaign's month actually cost me* and *which tiers are underwater*. Because
+plans are data, adjusting a tier in response is a catalog edit + sync.
+
+A tenant that switched plans mid-month shows one line per subscription (usage
+attached to the first, so totals never double-count). Un-prorated revenue is a
+deliberate simplification for now — the subscription rows carry exact
+started_at/ended_at timestamps, so proration is a query change later, not a
+schema change.
+
+## 6. Operational checklist for going paid
+
+- [ ] Spend caps set for every hosted Tenant (ADR-0046) — your hard backstop.
+- [ ] Provider dashboards (Groq/ElevenLabs) checked against the ledger's
+      estimates for the first month — calibrate expectations; the price map is
+      an estimate by design.
+- [ ] Backups running and restore-tested ([k3s-proxmox.md §8](k3s-proxmox.md))
+      — the ledger and subscription history are now business records.
+- [ ] `plans.json` (or the Helm values catalog) in version control.
+- [ ] Terms with your users about recording/consent (the Rollover Tape is
+      consent-gated by design, ADR-0051 — point users at it).
+
+## See also
+
+- [ADR-0054](../adr/0054-saas-plans-platform-keys-usage-ledger.md) — the
+  design, its boundaries, and the named follow-ups.
+- [k3s-proxmox.md](k3s-proxmox.md) — the home-lab deployment this operates on.
+- [cloud-providers.md](cloud-providers.md) — moving to a paid cloud.
+- [configuration.md](../configuration.md) — env vars, OAuth, allowlist.

--- a/internal/billing/catalog.go
+++ b/internal/billing/catalog.go
@@ -1,0 +1,126 @@
+// Package billing is the SaaS subscription foundation (ADR-0054): the
+// declarative Plan catalog the operator syncs into the plan table, and the
+// Usage Ledger sink that persists per-Tenant metered usage for cost
+// attribution. It deliberately contains NO payment-processor integration —
+// collecting money is a later, separate layer; this package makes tiers
+// configurable and cost + revenue measurable.
+package billing
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// KeySource is where a Plan's provider keys come from (ADR-0004 / ADR-0054).
+type KeySource string
+
+const (
+	// KeySourceBYOK: the Tenant supplies its own provider credentials — the v1.0
+	// default and the self-host posture (ADR-0004).
+	KeySourceBYOK KeySource = "byok"
+	// KeySourcePlatform: the deployment's own provider keys (the env-fallback
+	// path the hybrid policy already supports, ADR-0039) serve the Tenant's
+	// usage; the subscription price covers it.
+	KeySourcePlatform KeySource = "platform"
+)
+
+// slugPattern keeps slugs URL- and CLI-safe: lowercase alphanumerics and
+// hyphens, starting alphanumeric.
+var slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// Plan is one subscription tier as declared in the operator's catalog file.
+// The slug is the stable handle: syncs upsert by it, subscriptions snapshot it.
+type Plan struct {
+	Slug        string `json:"slug"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description,omitempty"`
+	// MonthlyPriceUSD is the tier's monthly list price (0 for a free tier).
+	MonthlyPriceUSD float64 `json:"monthly_price_usd"`
+	// KeySource defaults to "byok" when omitted.
+	KeySource KeySource `json:"key_source,omitempty"`
+	// IncludedUsageUSD is the monthly estimated-USD provider-usage allowance a
+	// 'platform' plan includes; nil = no configured allowance. Meaningless (and
+	// rejected) on a 'byok' plan.
+	IncludedUsageUSD *float64 `json:"included_usage_usd,omitempty"`
+	// Limits is the extensible per-tier knob bag (max campaigns, feature flags,
+	// …): stored as-is, consumers read the keys they know (ADR-0054).
+	Limits map[string]any `json:"limits,omitempty"`
+}
+
+// Catalog is the top-level shape of the plans file (`plans.json`).
+type Catalog struct {
+	Plans []Plan `json:"plans"`
+}
+
+// ParseCatalog strictly decodes and validates a catalog file. Unknown JSON
+// fields are rejected (a typoed key must fail the sync, not silently vanish),
+// as are duplicate or malformed slugs, negative prices/allowances, unknown key
+// sources, and an allowance on a BYOK plan. An empty plan list is valid — it
+// only does something when paired with -archive-missing.
+func ParseCatalog(data []byte) (Catalog, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var c Catalog
+	if err := dec.Decode(&c); err != nil {
+		return Catalog{}, fmt.Errorf("billing: parse catalog: %w", err)
+	}
+	if dec.More() {
+		return Catalog{}, fmt.Errorf("billing: parse catalog: trailing data after the catalog object")
+	}
+
+	seen := map[string]struct{}{}
+	for i := range c.Plans {
+		p := &c.Plans[i]
+		if p.KeySource == "" {
+			p.KeySource = KeySourceBYOK
+		}
+		if err := p.validate(); err != nil {
+			return Catalog{}, fmt.Errorf("billing: plan %d (%q): %w", i, p.Slug, err)
+		}
+		if _, dup := seen[p.Slug]; dup {
+			return Catalog{}, fmt.Errorf("billing: duplicate plan slug %q", p.Slug)
+		}
+		seen[p.Slug] = struct{}{}
+	}
+	return c, nil
+}
+
+// validate checks one plan's invariants (KeySource already defaulted).
+func (p *Plan) validate() error {
+	if !slugPattern.MatchString(p.Slug) {
+		return fmt.Errorf("slug must match %s", slugPattern)
+	}
+	if p.DisplayName == "" {
+		return fmt.Errorf("display_name is required")
+	}
+	if p.MonthlyPriceUSD < 0 {
+		return fmt.Errorf("monthly_price_usd must be >= 0 (got %v)", p.MonthlyPriceUSD)
+	}
+	switch p.KeySource {
+	case KeySourceBYOK:
+		if p.IncludedUsageUSD != nil {
+			return fmt.Errorf("included_usage_usd is only valid on a %q plan", KeySourcePlatform)
+		}
+	case KeySourcePlatform:
+		if p.IncludedUsageUSD != nil && *p.IncludedUsageUSD < 0 {
+			return fmt.Errorf("included_usage_usd must be >= 0 (got %v)", *p.IncludedUsageUSD)
+		}
+	default:
+		return fmt.Errorf("key_source must be %q or %q (got %q)", KeySourceBYOK, KeySourcePlatform, p.KeySource)
+	}
+	return nil
+}
+
+// LimitsJSON marshals the plan's limits bag for storage ('{}' when empty).
+func (p *Plan) LimitsJSON() (json.RawMessage, error) {
+	if len(p.Limits) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	b, err := json.Marshal(p.Limits)
+	if err != nil {
+		return nil, fmt.Errorf("billing: marshal limits for plan %q: %w", p.Slug, err)
+	}
+	return b, nil
+}

--- a/internal/billing/catalog_test.go
+++ b/internal/billing/catalog_test.go
@@ -1,0 +1,84 @@
+package billing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCatalogValid(t *testing.T) {
+	data := []byte(`{
+	  "plans": [
+	    {"slug": "free", "display_name": "Free", "monthly_price_usd": 0},
+	    {"slug": "byok-pro", "display_name": "BYOK Pro", "monthly_price_usd": 5,
+	     "key_source": "byok", "limits": {"max_campaigns": 10}},
+	    {"slug": "all-inclusive", "display_name": "All Inclusive",
+	     "description": "Groq + ElevenLabs usage included",
+	     "monthly_price_usd": 20, "key_source": "platform", "included_usage_usd": 15}
+	  ]
+	}`)
+	c, err := ParseCatalog(data)
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	if len(c.Plans) != 3 {
+		t.Fatalf("plans = %d, want 3", len(c.Plans))
+	}
+	// key_source defaults to byok when omitted.
+	if c.Plans[0].KeySource != KeySourceBYOK {
+		t.Errorf("free key_source = %q, want %q", c.Plans[0].KeySource, KeySourceBYOK)
+	}
+	if c.Plans[2].KeySource != KeySourcePlatform {
+		t.Errorf("all-inclusive key_source = %q, want %q", c.Plans[2].KeySource, KeySourcePlatform)
+	}
+	if c.Plans[2].IncludedUsageUSD == nil || *c.Plans[2].IncludedUsageUSD != 15 {
+		t.Errorf("all-inclusive included_usage_usd = %v, want 15", c.Plans[2].IncludedUsageUSD)
+	}
+	limits, err := c.Plans[1].LimitsJSON()
+	if err != nil {
+		t.Fatalf("LimitsJSON: %v", err)
+	}
+	if string(limits) != `{"max_campaigns":10}` {
+		t.Errorf("limits JSON = %s", limits)
+	}
+	empty, _ := c.Plans[0].LimitsJSON()
+	if string(empty) != `{}` {
+		t.Errorf("empty limits JSON = %s, want {}", empty)
+	}
+}
+
+func TestParseCatalogRejects(t *testing.T) {
+	cases := []struct {
+		name, data, wantErr string
+	}{
+		{"unknown field", `{"plans":[{"slug":"a","display_name":"A","monthly_price":1}]}`, "unknown field"},
+		{"duplicate slug", `{"plans":[{"slug":"a","display_name":"A"},{"slug":"a","display_name":"B"}]}`, "duplicate plan slug"},
+		{"bad slug", `{"plans":[{"slug":"Not A Slug","display_name":"A"}]}`, "slug must match"},
+		{"missing display name", `{"plans":[{"slug":"a"}]}`, "display_name is required"},
+		{"negative price", `{"plans":[{"slug":"a","display_name":"A","monthly_price_usd":-1}]}`, "monthly_price_usd"},
+		{"allowance on byok", `{"plans":[{"slug":"a","display_name":"A","included_usage_usd":5}]}`, "only valid on"},
+		{"negative allowance", `{"plans":[{"slug":"a","display_name":"A","key_source":"platform","included_usage_usd":-5}]}`, "included_usage_usd"},
+		{"unknown key source", `{"plans":[{"slug":"a","display_name":"A","key_source":"pooled"}]}`, "key_source must be"},
+		{"trailing data", `{"plans":[]} {"more": true}`, "trailing data"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseCatalog([]byte(tc.data))
+			if err == nil {
+				t.Fatalf("ParseCatalog accepted %s", tc.data)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseCatalogEmptyList(t *testing.T) {
+	c, err := ParseCatalog([]byte(`{"plans": []}`))
+	if err != nil {
+		t.Fatalf("ParseCatalog: %v", err)
+	}
+	if len(c.Plans) != 0 {
+		t.Fatalf("plans = %d, want 0", len(c.Plans))
+	}
+}

--- a/internal/billing/ledger.go
+++ b/internal/billing/ledger.go
@@ -1,0 +1,150 @@
+package billing
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// FlushFunc persists accumulated ledger rows; [storage.Store.AddUsage] satisfies
+// it. Rows commute (upsert-accumulate), so callers only guarantee each buffered
+// batch is sent once.
+type FlushFunc func(ctx context.Context, rows []storage.UsageRow) error
+
+// Ledger is the durable-usage counterpart of the in-memory spend meter
+// (ADR-0054): an [observe.UsageSink] that buckets a session's metered usage by
+// (day, component, provider, model) with a priced estimate, for the session
+// Manager to flush into the usage_ledger table at session end. Like the meter
+// it rides [observe.TeeUsage] beside the production recorder — zero new
+// pipeline plumbing — and it never gates anything: attribution only.
+//
+// Buffering is in-memory until Flush: a crash loses the unflushed remainder of
+// the session, which the ADR accepts for an estimates-only ledger (the
+// Prometheus counters still moved).
+type Ledger struct {
+	tenantID uuid.UUID
+	now      func() time.Time
+
+	mu   sync.Mutex
+	rows map[ledgerKey]*storage.UsageRow
+}
+
+type ledgerKey struct {
+	day       string // yyyy-mm-dd (UTC)
+	component storage.Component
+	provider  observe.Provider
+	model     string
+}
+
+// NewLedger builds a ledger for one Tenant's session. now is injectable for
+// tests; nil uses time.Now.
+func NewLedger(tenantID uuid.UUID, now func() time.Time) *Ledger {
+	if now == nil {
+		now = time.Now
+	}
+	return &Ledger{
+		tenantID: tenantID,
+		now:      now,
+		rows:     map[ledgerKey]*storage.UsageRow{},
+	}
+}
+
+// LLMTokens accumulates one completion's tokens (implements
+// [observe.UsageSink]). Image generation rides this sink too (Gemini meters a
+// generated image as output tokens, ADR-0045), so its usage lands under the llm
+// component with the model distinguishing it.
+func (l *Ledger) LLMTokens(provider observe.Provider, model string, inputTokens, outputTokens int) {
+	row := func(r *storage.UsageRow) {
+		r.LLMInputTokens += int64(inputTokens)
+		r.LLMOutputTokens += int64(outputTokens)
+		r.EstimatedUSD += spend.EstimateLLMUSD(provider, model, inputTokens, outputTokens)
+	}
+	l.accumulate(storage.ComponentLLM, provider, model, row)
+}
+
+// TTSCharacters accumulates one synthesis's characters (implements
+// [observe.UsageSink]).
+func (l *Ledger) TTSCharacters(provider observe.Provider, chars int) {
+	l.accumulate(storage.ComponentTTS, provider, "", func(r *storage.UsageRow) {
+		r.TTSCharacters += int64(chars)
+		r.EstimatedUSD += spend.EstimateTTSUSD(provider, chars)
+	})
+}
+
+// STTAudioSeconds accumulates one recognition's audio duration (implements
+// [observe.UsageSink]).
+func (l *Ledger) STTAudioSeconds(provider observe.Provider, d time.Duration) {
+	l.accumulate(storage.ComponentSTT, provider, "", func(r *storage.UsageRow) {
+		r.STTAudioSeconds += d.Seconds()
+		r.EstimatedUSD += spend.EstimateSTTUSD(provider, d)
+	})
+}
+
+// accumulate applies fold to the bucket for (today, component, provider, model),
+// creating it on first use.
+func (l *Ledger) accumulate(component storage.Component, provider observe.Provider, model string, fold func(*storage.UsageRow)) {
+	day := l.now().UTC().Truncate(24 * time.Hour)
+	key := ledgerKey{day: day.Format(time.DateOnly), component: component, provider: provider, model: model}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	r, ok := l.rows[key]
+	if !ok {
+		r = &storage.UsageRow{
+			TenantID:  l.tenantID,
+			Day:       day,
+			Component: component,
+			Provider:  string(provider),
+			Model:     model,
+		}
+		l.rows[key] = r
+	}
+	fold(r)
+}
+
+// Flush drains the buffered buckets through flush. The buffer is snapshotted
+// and cleared BEFORE calling flush (usage arriving during a flush lands in the
+// next batch); on error the snapshot is merged back so a later Flush retries —
+// rows commute, so re-merging never mis-counts.
+func (l *Ledger) Flush(ctx context.Context, flush FlushFunc) error {
+	l.mu.Lock()
+	if len(l.rows) == 0 {
+		l.mu.Unlock()
+		return nil
+	}
+	snapshot := l.rows
+	l.rows = map[ledgerKey]*storage.UsageRow{}
+	l.mu.Unlock()
+
+	rows := make([]storage.UsageRow, 0, len(snapshot))
+	for _, r := range snapshot {
+		rows = append(rows, *r)
+	}
+	if err := flush(ctx, rows); err != nil {
+		// Merge the failed snapshot back under the CURRENT buffer (which may have
+		// gained rows meanwhile): quantities and estimates are additive.
+		l.mu.Lock()
+		for k, r := range snapshot {
+			if cur, ok := l.rows[k]; ok {
+				cur.LLMInputTokens += r.LLMInputTokens
+				cur.LLMOutputTokens += r.LLMOutputTokens
+				cur.TTSCharacters += r.TTSCharacters
+				cur.STTAudioSeconds += r.STTAudioSeconds
+				cur.EstimatedUSD += r.EstimatedUSD
+			} else {
+				l.rows[k] = r
+			}
+		}
+		l.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+var _ observe.UsageSink = (*Ledger)(nil)

--- a/internal/billing/ledger_test.go
+++ b/internal/billing/ledger_test.go
@@ -1,0 +1,126 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fixedNow pins the ledger's clock so day bucketing is deterministic.
+func fixedNow(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func TestLedgerAccumulatesAndBuckets(t *testing.T) {
+	tenant := uuid.New()
+	at := time.Date(2026, 7, 17, 21, 30, 0, 0, time.UTC)
+	l := NewLedger(tenant, fixedNow(at))
+
+	// Two LLM calls on the same (provider, model) fold into ONE bucket; a second
+	// model and the TTS/STT components get buckets of their own.
+	l.LLMTokens(observe.ProviderGroq, "openai/gpt-oss-120b", 1000, 500)
+	l.LLMTokens(observe.ProviderGroq, "openai/gpt-oss-120b", 200, 100)
+	l.LLMTokens(observe.ProviderGroq, "qwen/qwen3-32b", 10, 10)
+	l.TTSCharacters(observe.ProviderElevenLabs, 400)
+	l.STTAudioSeconds(observe.ProviderElevenLabs, 90*time.Second)
+
+	var got []storage.UsageRow
+	err := l.Flush(context.Background(), func(_ context.Context, rows []storage.UsageRow) error {
+		got = rows
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("rows = %d, want 4 buckets", len(got))
+	}
+
+	byKey := map[string]storage.UsageRow{}
+	for _, r := range got {
+		if r.TenantID != tenant {
+			t.Errorf("row tenant = %s, want %s", r.TenantID, tenant)
+		}
+		wantDay := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+		if !r.Day.Equal(wantDay) {
+			t.Errorf("row day = %v, want %v", r.Day, wantDay)
+		}
+		byKey[string(r.Component)+"/"+r.Provider+"/"+r.Model] = r
+	}
+
+	llm := byKey["llm/groq/openai/gpt-oss-120b"]
+	if llm.LLMInputTokens != 1200 || llm.LLMOutputTokens != 600 {
+		t.Errorf("llm tokens = %d/%d, want 1200/600", llm.LLMInputTokens, llm.LLMOutputTokens)
+	}
+	wantUSD := spend.EstimateLLMUSD(observe.ProviderGroq, "openai/gpt-oss-120b", 1000, 500) +
+		spend.EstimateLLMUSD(observe.ProviderGroq, "openai/gpt-oss-120b", 200, 100)
+	if diff := llm.EstimatedUSD - wantUSD; diff > 1e-12 || diff < -1e-12 {
+		t.Errorf("llm estimated USD = %v, want %v", llm.EstimatedUSD, wantUSD)
+	}
+
+	tts := byKey["tts/elevenlabs/"]
+	if tts.TTSCharacters != 400 {
+		t.Errorf("tts chars = %d, want 400", tts.TTSCharacters)
+	}
+	stt := byKey["stt/elevenlabs/"]
+	if stt.STTAudioSeconds != 90 {
+		t.Errorf("stt seconds = %v, want 90", stt.STTAudioSeconds)
+	}
+	if stt.EstimatedUSD <= 0 || tts.EstimatedUSD <= 0 {
+		t.Errorf("estimates must be positive: tts=%v stt=%v", tts.EstimatedUSD, stt.EstimatedUSD)
+	}
+}
+
+func TestLedgerFlushDrainsBuffer(t *testing.T) {
+	l := NewLedger(uuid.New(), fixedNow(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)))
+	l.TTSCharacters(observe.ProviderElevenLabs, 100)
+
+	calls := 0
+	flush := func(_ context.Context, rows []storage.UsageRow) error {
+		calls++
+		return nil
+	}
+	if err := l.Flush(context.Background(), flush); err != nil {
+		t.Fatalf("first Flush: %v", err)
+	}
+	// Empty buffer: no second call.
+	if err := l.Flush(context.Background(), flush); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("flush calls = %d, want 1 (empty buffer must not flush)", calls)
+	}
+}
+
+func TestLedgerFlushErrorRetainsRows(t *testing.T) {
+	l := NewLedger(uuid.New(), fixedNow(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)))
+	l.TTSCharacters(observe.ProviderElevenLabs, 100)
+
+	boom := errors.New("db down")
+	if err := l.Flush(context.Background(), func(context.Context, []storage.UsageRow) error { return boom }); !errors.Is(err, boom) {
+		t.Fatalf("Flush err = %v, want %v", err, boom)
+	}
+
+	// More usage lands after the failed flush; the retry must carry BOTH the
+	// merged-back snapshot and the new usage.
+	l.TTSCharacters(observe.ProviderElevenLabs, 50)
+
+	var got []storage.UsageRow
+	if err := l.Flush(context.Background(), func(_ context.Context, rows []storage.UsageRow) error {
+		got = rows
+		return nil
+	}); err != nil {
+		t.Fatalf("retry Flush: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("rows = %d, want 1", len(got))
+	}
+	if got[0].TTSCharacters != 150 {
+		t.Fatalf("tts chars after retry = %d, want 150 (100 merged back + 50 new)", got[0].TTSCharacters)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/billing"
 	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
@@ -100,6 +101,14 @@ type Store interface {
 	GetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID) (storage.SpendCaps, error)
 }
 
+// UsageWriter persists a session's accumulated Usage Ledger rows at loop exit
+// (ADR-0054). It is a SEPARATE optional seam from [Store] — a deployment that
+// wires no UsageWriter (voice-standalone, tests) records no durable usage, and
+// nothing else changes. [*storage.Store] satisfies it (AddUsage).
+type UsageWriter interface {
+	AddUsage(ctx context.Context, rows []storage.UsageRow) error
+}
+
 // TranscriptFinalizer drains the live transcript's writer queue for a session and
 // returns the authoritative persisted line_count (#74, ADR-0040). The Manager
 // calls it on Stop / loop exit BEFORE EndVoiceSession so the recorded count
@@ -166,6 +175,11 @@ type activeSession struct {
 	// Tenant configured at least one cap at Start. It is the cfg.Gate and rides the
 	// teed StageMetrics, and backs Manager.Spend(). Dies with the session.
 	meter *spend.Meter
+	// ledger is the session's durable Usage Ledger sink (ADR-0054), non-nil only
+	// when the Manager was wired a UsageWriter. It rides the teed StageMetrics
+	// beside the meter (attribution only, never a gate) and is flushed into the
+	// usage_ledger table at loop exit.
+	ledger *billing.Ledger
 	// endReasonOverride records a deliberate policy end_reason for a session that
 	// ended cleanly (status 'ended') rather than by a fault — set by the hard-cap
 	// trip before it cancels the run ctx (#130). runLoop reads it under Manager.mu
@@ -189,6 +203,7 @@ type Manager struct {
 	transcript TranscriptFinalizer // finalizes persisted lines on Stop (#74); nil keeps line_count at 0
 	chunker    ChunkFinalizer      // closes the open Transcript Chunk on Stop (#104); nil = no chunking
 	highlights Highlighter         // persists Session Highlights + schedules purge on Stop (#308); nil = highlights off
+	usage      UsageWriter         // persists the Usage Ledger at loop exit (ADR-0054); nil = no durable usage
 	log        *slog.Logger
 	enabled    bool          // false in web-only mode: Start is rejected (ADR-0039)
 	endTimeout time.Duration // per-step end budget (Finalize, end-write); endTimeout in prod, shrunk in tests
@@ -252,6 +267,11 @@ type Deps struct {
 	// registered but unavailable at Execute (the prompt/loop still behave, the
 	// model just gets an "unavailable" tool result).
 	Tools tool.Deps
+	// Usage, when non-nil, persists each session's accumulated Usage Ledger rows
+	// at loop exit (ADR-0054): per-Tenant durable usage for SaaS cost attribution.
+	// [*storage.Store] satisfies it. nil = no durable usage (voice-standalone /
+	// test posture), byte-for-byte today's behavior.
+	Usage UsageWriter
 	// View, when non-nil, is bound to the new Manager so the collaborators above —
 	// constructed against it BEFORE the Manager existed — read this Manager's
 	// active session. Binding inside NewManager is what makes the wiring order
@@ -284,6 +304,7 @@ func NewManager(store Store, run LoopRunner, base wirenpc.Config, cipher *crypto
 		transcript: deps.Transcript,
 		chunker:    deps.Chunker,
 		highlights: deps.Highlights,
+		usage:      deps.Usage,
 		log:        log,
 		enabled:    enabled,
 		endTimeout: endTimeout,
@@ -423,6 +444,22 @@ func (m *Manager) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (st
 		as.meter = meter
 	}
 
+	// Usage Ledger (ADR-0054): when a UsageWriter is wired, the session's metered
+	// usage is additionally bucketed per (day, component, provider, model) for
+	// durable per-Tenant cost attribution — flushed at loop exit, never a gate.
+	// It tees onto whatever StageMetrics already is (the recorder, or the
+	// recorder+meter tee above — TeeUsage composes), so the capture points are
+	// unchanged. No UsageWriter ⇒ no ledger, byte-for-byte today's behavior.
+	if m.usage != nil {
+		ledger := billing.NewLedger(tenantID, nil)
+		base := cfg.StageMetrics
+		if base == nil {
+			base = observe.Discard{}
+		}
+		cfg.StageMetrics = observe.TeeUsage(base, ledger)
+		as.ledger = ledger
+	}
+
 	// Bind the Highlights pipeline to this session before the loop (and its
 	// detector) can fire a Trigger (#308): Begin records the owning ids the Saver
 	// stamps onto every candidate row + its blob key. Finalize (runLoop) unbinds and
@@ -558,6 +595,18 @@ func (m *Manager) runLoop(ctx context.Context, as *activeSession, cfg wirenpc.Co
 			m.log.Warn("flush transcript chunk before end", "err", err, "voice_session", as.session.ID)
 		}
 		chunkCancel()
+	}
+
+	// Flush the session's Usage Ledger into the usage_ledger table (ADR-0054).
+	// Best-effort with its OWN budget, like the finalizers above: a flush failure
+	// loses only this session's usage attribution (an estimates-only ledger) and
+	// never blocks the row from ending.
+	if as.ledger != nil {
+		usageCtx, usageCancel := context.WithTimeout(base, m.endTimeout)
+		if err := as.ledger.Flush(usageCtx, m.usage.AddUsage); err != nil {
+			m.log.Warn("flush usage ledger before end", "err", err, "voice_session", as.session.ID)
+		}
+		usageCancel()
 	}
 
 	// A hard-cap trip records a deliberate end_reason override before it cancels the

--- a/internal/spend/prices.go
+++ b/internal/spend/prices.go
@@ -82,6 +82,29 @@ const (
 	defaultSTTPerHour = 1.00
 )
 
+// EstimateLLMUSD estimates the USD cost of one completion's tokens from the
+// static price map, exported for the Usage Ledger (ADR-0054). Same figures the
+// Meter accumulates; an unknown (provider, model) silently uses the conservative
+// default — the live Meter owns the warn-once, the ledger just prices.
+func EstimateLLMUSD(provider observe.Provider, model string, inputTokens, outputTokens int) float64 {
+	usd, _ := llmCostUSD(provider, model, inputTokens, outputTokens)
+	return usd
+}
+
+// EstimateTTSUSD estimates the USD cost of chars submitted to a TTS synthesizer
+// (exported for the Usage Ledger, ADR-0054).
+func EstimateTTSUSD(provider observe.Provider, chars int) float64 {
+	usd, _ := ttsCostUSD(provider, chars)
+	return usd
+}
+
+// EstimateSTTUSD estimates the USD cost of audio submitted to an STT recognizer
+// (exported for the Usage Ledger, ADR-0054).
+func EstimateSTTUSD(provider observe.Provider, d time.Duration) float64 {
+	usd, _ := sttCostUSD(provider, d)
+	return usd
+}
+
 // llmCostUSD estimates the USD cost of one completion's tokens. known is false
 // when the (provider, model) key had no entry and the conservative default was
 // used (the caller warns once).

--- a/internal/storage/billing.go
+++ b/internal/storage/billing.go
@@ -1,0 +1,390 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// SaaS billing foundation (ADR-0054): the Plan catalog, per-Tenant Subscriptions
+// with price snapshots, and the durable per-Tenant Usage Ledger. Storage stays a
+// faithful persistence layer — catalog validation lives in internal/billing, and
+// pricing happens in the ledger sink before rows reach AddUsage.
+
+// ErrPlanArchived is returned by SetTenantPlan for an archived plan slug: an
+// archived tier accepts no NEW subscriptions (existing ones keep running).
+var ErrPlanArchived = errors.New("storage: plan is archived")
+
+// PlanSpec is the write shape SyncPlans upserts from the operator's catalog file
+// (ADR-0054). Limits is raw JSON (validated upstream); nil stores '{}'.
+type PlanSpec struct {
+	Slug             string
+	DisplayName      string
+	Description      string
+	MonthlyPriceUSD  float64
+	KeySource        string // 'byok' | 'platform' (plan_key_source enum)
+	IncludedUsageUSD *float64
+	Limits           json.RawMessage
+}
+
+// Plan is a catalog row.
+type Plan struct {
+	ID               uuid.UUID
+	Slug             string
+	DisplayName      string
+	Description      string
+	MonthlyPriceUSD  float64
+	KeySource        string
+	IncludedUsageUSD *float64
+	Limits           json.RawMessage
+	Archived         bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// Subscription is a Tenant's binding to a Plan. PlanSlug and MonthlyPriceUSD are
+// snapshots taken at subscribe time (revenue history survives catalog edits);
+// EndedAt is nil while the subscription is active.
+type Subscription struct {
+	ID              uuid.UUID
+	TenantID        uuid.UUID
+	PlanID          uuid.UUID
+	PlanSlug        string
+	MonthlyPriceUSD float64
+	StartedAt       time.Time
+	EndedAt         *time.Time
+}
+
+// UsageRow is one daily-bucketed usage accumulation the ledger sink flushes
+// (ADR-0054). Day is a calendar date (UTC); only its date part is stored.
+// EstimatedUSD is priced from the static map at capture time — an ESTIMATE,
+// never billing truth (ADR-0046 posture).
+type UsageRow struct {
+	TenantID        uuid.UUID
+	Day             time.Time
+	Component       Component
+	Provider        string
+	Model           string
+	LLMInputTokens  int64
+	LLMOutputTokens int64
+	TTSCharacters   int64
+	STTAudioSeconds float64
+	EstimatedUSD    float64
+}
+
+// PlanSyncResult reports what one SyncPlans call changed.
+type PlanSyncResult struct {
+	Upserted int
+	Archived int
+}
+
+// SyncPlans upserts the catalog specs by slug (reviving a previously archived
+// slug) and, when archiveMissing is set, archives every plan whose slug is
+// absent from specs. Runs in one transaction: a partially applied catalog is
+// never visible. Plans are never deleted — subscriptions reference them.
+func (s *Store) SyncPlans(ctx context.Context, specs []PlanSpec, archiveMissing bool) (PlanSyncResult, error) {
+	var res PlanSyncResult
+	err := s.InTx(ctx, func(tx *Store) error {
+		slugs := make([]string, 0, len(specs))
+		for _, spec := range specs {
+			limits := spec.Limits
+			if len(limits) == 0 {
+				limits = json.RawMessage(`{}`)
+			}
+			_, err := tx.db.Exec(ctx,
+				`INSERT INTO plan (slug, display_name, description, monthly_price_usd,
+				                   key_source, included_usage_usd, limits, archived)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, false)
+				 ON CONFLICT (slug) DO UPDATE SET
+				     display_name = EXCLUDED.display_name,
+				     description = EXCLUDED.description,
+				     monthly_price_usd = EXCLUDED.monthly_price_usd,
+				     key_source = EXCLUDED.key_source,
+				     included_usage_usd = EXCLUDED.included_usage_usd,
+				     limits = EXCLUDED.limits,
+				     archived = false,
+				     updated_at = now()`,
+				spec.Slug, spec.DisplayName, spec.Description, spec.MonthlyPriceUSD,
+				spec.KeySource, spec.IncludedUsageUSD, limits)
+			if err != nil {
+				return fmt.Errorf("storage: sync plan %q: %w", spec.Slug, err)
+			}
+			res.Upserted++
+			slugs = append(slugs, spec.Slug)
+		}
+		if archiveMissing {
+			tag, err := tx.db.Exec(ctx,
+				`UPDATE plan SET archived = true, updated_at = now()
+				  WHERE NOT archived AND slug <> ALL($1)`, slugs)
+			if err != nil {
+				return fmt.Errorf("storage: archive missing plans: %w", err)
+			}
+			res.Archived = int(tag.RowsAffected())
+		}
+		return nil
+	})
+	if err != nil {
+		return PlanSyncResult{}, err
+	}
+	return res, nil
+}
+
+// ListPlans returns the full catalog (archived included, flagged), stable-ordered
+// by slug.
+func (s *Store) ListPlans(ctx context.Context) ([]Plan, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT id, slug, display_name, description, monthly_price_usd,
+		        key_source, included_usage_usd, limits, archived, created_at, updated_at
+		   FROM plan ORDER BY slug`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list plans: %w", err)
+	}
+	defer rows.Close()
+
+	var plans []Plan
+	for rows.Next() {
+		var p Plan
+		if err := rows.Scan(&p.ID, &p.Slug, &p.DisplayName, &p.Description,
+			&p.MonthlyPriceUSD, &p.KeySource, &p.IncludedUsageUSD, &p.Limits,
+			&p.Archived, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("storage: scan plan: %w", err)
+		}
+		plans = append(plans, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list plans: %w", err)
+	}
+	return plans, nil
+}
+
+// SetTenantPlan subscribes a Tenant to the plan with slug, snapshotting the
+// plan's current slug + monthly price onto the new subscription row. Any active
+// subscription is ended first (its EndedAt set), so the partial unique index
+// keeps at most one active row per tenant. ErrNotFound for an unknown slug or
+// tenant; ErrPlanArchived for an archived one.
+func (s *Store) SetTenantPlan(ctx context.Context, tenantID uuid.UUID, slug string) (Subscription, error) {
+	var sub Subscription
+	err := s.InTx(ctx, func(tx *Store) error {
+		var planID uuid.UUID
+		var price float64
+		var archived bool
+		err := tx.db.QueryRow(ctx,
+			`SELECT id, monthly_price_usd, archived FROM plan WHERE slug = $1`, slug).
+			Scan(&planID, &price, &archived)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("storage: load plan %q: %w", slug, err)
+		}
+		if archived {
+			return fmt.Errorf("%w: %q", ErrPlanArchived, slug)
+		}
+
+		if _, err := tx.db.Exec(ctx,
+			`UPDATE tenant_subscription SET ended_at = now()
+			  WHERE tenant_id = $1 AND ended_at IS NULL`, tenantID); err != nil {
+			return fmt.Errorf("storage: end active subscription for tenant %s: %w", tenantID, err)
+		}
+
+		err = tx.db.QueryRow(ctx,
+			`INSERT INTO tenant_subscription (tenant_id, plan_id, plan_slug, monthly_price_usd)
+			 VALUES ($1, $2, $3, $4)
+			 RETURNING id, tenant_id, plan_id, plan_slug, monthly_price_usd, started_at, ended_at`,
+			tenantID, planID, slug, price).
+			Scan(&sub.ID, &sub.TenantID, &sub.PlanID, &sub.PlanSlug,
+				&sub.MonthlyPriceUSD, &sub.StartedAt, &sub.EndedAt)
+		if err != nil {
+			// The tenant FK is the only constraint an unknown tenant trips here.
+			return fmt.Errorf("storage: subscribe tenant %s to %q: %w", tenantID, slug, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Subscription{}, err
+	}
+	return sub, nil
+}
+
+// EndTenantPlan ends a Tenant's active subscription (cancellation). ErrNotFound
+// when the tenant has no active subscription.
+func (s *Store) EndTenantPlan(ctx context.Context, tenantID uuid.UUID) error {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE tenant_subscription SET ended_at = now()
+		  WHERE tenant_id = $1 AND ended_at IS NULL`, tenantID)
+	if err != nil {
+		return fmt.Errorf("storage: end subscription for tenant %s: %w", tenantID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ActiveSubscription returns a Tenant's active subscription, ErrNotFound when
+// none (an unsubscribed tenant — the BYOK self-host default).
+func (s *Store) ActiveSubscription(ctx context.Context, tenantID uuid.UUID) (Subscription, error) {
+	var sub Subscription
+	err := s.db.QueryRow(ctx,
+		`SELECT id, tenant_id, plan_id, plan_slug, monthly_price_usd, started_at, ended_at
+		   FROM tenant_subscription
+		  WHERE tenant_id = $1 AND ended_at IS NULL`, tenantID).
+		Scan(&sub.ID, &sub.TenantID, &sub.PlanID, &sub.PlanSlug,
+			&sub.MonthlyPriceUSD, &sub.StartedAt, &sub.EndedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Subscription{}, ErrNotFound
+	}
+	if err != nil {
+		return Subscription{}, fmt.Errorf("storage: active subscription for tenant %s: %w", tenantID, err)
+	}
+	return sub, nil
+}
+
+// AddUsage upsert-accumulates ledger rows: an existing (tenant, day, component,
+// provider, model) bucket has the quantities and estimate ADDED, a new bucket is
+// inserted. Idempotence is NOT promised — the flush path must not double-send —
+// but ordering is irrelevant and rows commute, so concurrent sessions of one
+// tenant simply accumulate.
+func (s *Store) AddUsage(ctx context.Context, usageRows []UsageRow) error {
+	if len(usageRows) == 0 {
+		return nil
+	}
+	return s.InTx(ctx, func(tx *Store) error {
+		for _, r := range usageRows {
+			_, err := tx.db.Exec(ctx,
+				`INSERT INTO usage_ledger (tenant_id, day, component, provider, model,
+				                           llm_input_tokens, llm_output_tokens,
+				                           tts_characters, stt_audio_seconds, estimated_usd)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+				 ON CONFLICT (tenant_id, day, component, provider, model) DO UPDATE SET
+				     llm_input_tokens = usage_ledger.llm_input_tokens + EXCLUDED.llm_input_tokens,
+				     llm_output_tokens = usage_ledger.llm_output_tokens + EXCLUDED.llm_output_tokens,
+				     tts_characters = usage_ledger.tts_characters + EXCLUDED.tts_characters,
+				     stt_audio_seconds = usage_ledger.stt_audio_seconds + EXCLUDED.stt_audio_seconds,
+				     estimated_usd = usage_ledger.estimated_usd + EXCLUDED.estimated_usd,
+				     updated_at = now()`,
+				r.TenantID, r.Day, r.Component, r.Provider, r.Model,
+				r.LLMInputTokens, r.LLMOutputTokens, r.TTSCharacters,
+				r.STTAudioSeconds, r.EstimatedUSD)
+			if err != nil {
+				return fmt.Errorf("storage: add usage for tenant %s: %w", r.TenantID, err)
+			}
+		}
+		return nil
+	})
+}
+
+// TenantBillingLine is one tenant's row in the billing report window: the active
+// or overlapping subscription snapshot(s) plus the ledger's summed estimated
+// cost. A tenant that switched plans mid-window appears once per subscription
+// (revenue is per subscription row); usage is attached to the FIRST line only so
+// summing the report never double-counts cost.
+type TenantBillingLine struct {
+	TenantID        uuid.UUID
+	TenantName      string
+	PlanSlug        string  // empty: no subscription overlapped the window
+	MonthlyPriceUSD float64 // 0 when PlanSlug is empty
+	EstimatedUSD    float64
+	LLMInputTokens  int64
+	LLMOutputTokens int64
+	TTSCharacters   int64
+	STTAudioSeconds float64
+}
+
+// BillingReport aggregates revenue and estimated cost per tenant over [from, to)
+// (ADR-0054): every subscription overlapping the window contributes its monthly
+// price snapshot un-prorated (label it as such when surfacing), and the usage
+// ledger contributes summed quantities + estimated USD. Tenants with usage but
+// no subscription (BYOK) appear with an empty PlanSlug.
+func (s *Store) BillingReport(ctx context.Context, from, to time.Time) ([]TenantBillingLine, error) {
+	rows, err := s.db.Query(ctx,
+		`WITH usage_sums AS (
+		     SELECT tenant_id,
+		            SUM(estimated_usd) AS estimated_usd,
+		            SUM(llm_input_tokens) AS llm_input_tokens,
+		            SUM(llm_output_tokens) AS llm_output_tokens,
+		            SUM(tts_characters) AS tts_characters,
+		            SUM(stt_audio_seconds) AS stt_audio_seconds
+		       FROM usage_ledger
+		      WHERE day >= $1::date AND day < $2::date
+		      GROUP BY tenant_id
+		 ), subs AS (
+		     SELECT tenant_id, plan_slug, monthly_price_usd, started_at,
+		            ROW_NUMBER() OVER (PARTITION BY tenant_id ORDER BY started_at) AS rn
+		       FROM tenant_subscription
+		      WHERE started_at < $2 AND (ended_at IS NULL OR ended_at >= $1)
+		 )
+		 SELECT t.id, t.name,
+		        COALESCE(s.plan_slug, ''), COALESCE(s.monthly_price_usd, 0),
+		        CASE WHEN COALESCE(s.rn, 1) = 1 THEN COALESCE(u.estimated_usd, 0) ELSE 0 END,
+		        CASE WHEN COALESCE(s.rn, 1) = 1 THEN COALESCE(u.llm_input_tokens, 0) ELSE 0 END,
+		        CASE WHEN COALESCE(s.rn, 1) = 1 THEN COALESCE(u.llm_output_tokens, 0) ELSE 0 END,
+		        CASE WHEN COALESCE(s.rn, 1) = 1 THEN COALESCE(u.tts_characters, 0) ELSE 0 END,
+		        CASE WHEN COALESCE(s.rn, 1) = 1 THEN COALESCE(u.stt_audio_seconds, 0) ELSE 0 END
+		   FROM tenant t
+		   LEFT JOIN subs s ON s.tenant_id = t.id
+		   LEFT JOIN usage_sums u ON u.tenant_id = t.id
+		  WHERE s.tenant_id IS NOT NULL OR u.tenant_id IS NOT NULL
+		  ORDER BY t.name, t.id, s.started_at NULLS FIRST`,
+		from, to)
+	if err != nil {
+		return nil, fmt.Errorf("storage: billing report: %w", err)
+	}
+	defer rows.Close()
+
+	var lines []TenantBillingLine
+	for rows.Next() {
+		var l TenantBillingLine
+		if err := rows.Scan(&l.TenantID, &l.TenantName, &l.PlanSlug, &l.MonthlyPriceUSD,
+			&l.EstimatedUSD, &l.LLMInputTokens, &l.LLMOutputTokens,
+			&l.TTSCharacters, &l.STTAudioSeconds); err != nil {
+			return nil, fmt.Errorf("storage: scan billing line: %w", err)
+		}
+		lines = append(lines, l)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: billing report: %w", err)
+	}
+	return lines, nil
+}
+
+// ListTenantsWithPlan lists every tenant with its active plan slug (empty when
+// unsubscribed) — the operator's `billing tenants` view for finding tenant ids.
+func (s *Store) ListTenantsWithPlan(ctx context.Context) ([]TenantPlanRow, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT t.id, t.name, t.created_at, COALESCE(s.plan_slug, '')
+		   FROM tenant t
+		   LEFT JOIN tenant_subscription s
+		          ON s.tenant_id = t.id AND s.ended_at IS NULL
+		  ORDER BY t.created_at, t.id`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list tenants: %w", err)
+	}
+	defer rows.Close()
+
+	var out []TenantPlanRow
+	for rows.Next() {
+		var r TenantPlanRow
+		if err := rows.Scan(&r.ID, &r.Name, &r.CreatedAt, &r.PlanSlug); err != nil {
+			return nil, fmt.Errorf("storage: scan tenant: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list tenants: %w", err)
+	}
+	return out, nil
+}
+
+// TenantPlanRow is one line of ListTenantsWithPlan.
+type TenantPlanRow struct {
+	ID        uuid.UUID
+	Name      string
+	CreatedAt time.Time
+	PlanSlug  string // empty: no active subscription
+}

--- a/internal/storage/billing_test.go
+++ b/internal/storage/billing_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// billingSpecs is a small two-tier catalog used across the billing tests.
+func billingSpecs() []storage.PlanSpec {
+	allowance := 15.0
+	return []storage.PlanSpec{
+		{Slug: "byok-free", DisplayName: "BYOK Free", KeySource: "byok"},
+		{Slug: "all-inclusive", DisplayName: "All Inclusive", Description: "usage included",
+			MonthlyPriceUSD: 20, KeySource: "platform", IncludedUsageUSD: &allowance,
+			Limits: []byte(`{"max_campaigns":10}`)},
+	}
+}
+
+// TestSyncPlansUpsertArchiveRevive proves the catalog sync lifecycle (ADR-0054):
+// insert, update-by-slug, archive-missing, and revival of an archived slug.
+func TestSyncPlansUpsertArchiveRevive(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	res, err := st.SyncPlans(ctx, billingSpecs(), false)
+	if err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	if res.Upserted != 2 || res.Archived != 0 {
+		t.Fatalf("initial sync = %+v, want 2 upserted, 0 archived", res)
+	}
+
+	// Re-sync with an edited price and one plan missing + archiveMissing: the
+	// edit lands, the missing plan archives, nothing is deleted.
+	edited := billingSpecs()[1:]
+	edited[0].MonthlyPriceUSD = 25
+	res, err = st.SyncPlans(ctx, edited, true)
+	if err != nil {
+		t.Fatalf("re-sync: %v", err)
+	}
+	if res.Upserted != 1 || res.Archived != 1 {
+		t.Fatalf("re-sync = %+v, want 1 upserted, 1 archived", res)
+	}
+
+	plans, err := st.ListPlans(ctx)
+	if err != nil {
+		t.Fatalf("list plans: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %d, want 2 (archived kept)", len(plans))
+	}
+	bykSlug := map[string]storage.Plan{}
+	for _, p := range plans {
+		bykSlug[p.Slug] = p
+	}
+	if !bykSlug["byok-free"].Archived {
+		t.Errorf("byok-free should be archived after archive-missing sync")
+	}
+	if got := bykSlug["all-inclusive"]; got.Archived || got.MonthlyPriceUSD != 25 {
+		t.Errorf("all-inclusive = archived=%v price=%v, want active price 25", got.Archived, got.MonthlyPriceUSD)
+	}
+	if got := bykSlug["all-inclusive"]; got.IncludedUsageUSD == nil || *got.IncludedUsageUSD != 15 {
+		t.Errorf("all-inclusive allowance = %v, want 15", got.IncludedUsageUSD)
+	}
+
+	// Syncing the full catalog again revives the archived slug.
+	if _, err := st.SyncPlans(ctx, billingSpecs(), false); err != nil {
+		t.Fatalf("revive sync: %v", err)
+	}
+	plans, _ = st.ListPlans(ctx)
+	for _, p := range plans {
+		if p.Archived {
+			t.Errorf("plan %q still archived after revive sync", p.Slug)
+		}
+	}
+}
+
+// TestSubscriptionLifecycle proves subscribe → snapshot → switch → cancel, the
+// one-active-subscription invariant, and the archived-plan refusal.
+func TestSubscriptionLifecycle(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.SyncPlans(ctx, billingSpecs(), false); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	// Unsubscribed tenant: ErrNotFound.
+	if _, err := st.ActiveSubscription(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("active subscription before subscribe err = %v, want ErrNotFound", err)
+	}
+
+	sub, err := st.SetTenantPlan(ctx, tenantID, "all-inclusive")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if sub.PlanSlug != "all-inclusive" || sub.MonthlyPriceUSD != 20 || sub.EndedAt != nil {
+		t.Fatalf("subscription = %+v, want active all-inclusive @ 20", sub)
+	}
+
+	// A price edit after subscribing must NOT rewrite the snapshot.
+	edited := billingSpecs()
+	edited[1].MonthlyPriceUSD = 99
+	if _, err := st.SyncPlans(ctx, edited, false); err != nil {
+		t.Fatalf("price edit sync: %v", err)
+	}
+	got, err := st.ActiveSubscription(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("active subscription: %v", err)
+	}
+	if got.MonthlyPriceUSD != 20 {
+		t.Fatalf("snapshot price after catalog edit = %v, want 20", got.MonthlyPriceUSD)
+	}
+
+	// Switching plans ends the old subscription and starts a new one.
+	if _, err := st.SetTenantPlan(ctx, tenantID, "byok-free"); err != nil {
+		t.Fatalf("switch plan: %v", err)
+	}
+	got, err = st.ActiveSubscription(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("active after switch: %v", err)
+	}
+	if got.PlanSlug != "byok-free" {
+		t.Fatalf("active plan after switch = %q, want byok-free", got.PlanSlug)
+	}
+
+	// Archived plans accept no new subscriptions.
+	if _, err := st.SyncPlans(ctx, billingSpecs()[1:], true); err != nil { // archives byok-free
+		t.Fatalf("archive sync: %v", err)
+	}
+	if _, err := st.SetTenantPlan(ctx, uuid.New(), "byok-free"); !errors.Is(err, storage.ErrPlanArchived) {
+		t.Fatalf("subscribe to archived err = %v, want ErrPlanArchived", err)
+	}
+
+	// Unknown slug and unknown tenant.
+	if _, err := st.SetTenantPlan(ctx, tenantID, "no-such-plan"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("unknown slug err = %v, want ErrNotFound", err)
+	}
+
+	// Cancel.
+	if err := st.EndTenantPlan(ctx, tenantID); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if _, err := st.ActiveSubscription(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("active after cancel err = %v, want ErrNotFound", err)
+	}
+	if err := st.EndTenantPlan(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("double cancel err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestAddUsageAccumulatesAndReports proves the upsert-accumulate ledger write
+// and the per-tenant billing report window.
+func TestAddUsageAccumulatesAndReports(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.SyncPlans(ctx, billingSpecs(), false); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if _, err := st.SetTenantPlan(ctx, tenantID, "all-inclusive"); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	day := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	row := storage.UsageRow{
+		TenantID: tenantID, Day: day,
+		Component: storage.ComponentLLM, Provider: "groq", Model: "openai/gpt-oss-120b",
+		LLMInputTokens: 1000, LLMOutputTokens: 500, EstimatedUSD: 0.10,
+	}
+	if err := st.AddUsage(ctx, []storage.UsageRow{row}); err != nil {
+		t.Fatalf("first AddUsage: %v", err)
+	}
+	// Same bucket again: must accumulate, not duplicate or overwrite.
+	if err := st.AddUsage(ctx, []storage.UsageRow{row}); err != nil {
+		t.Fatalf("second AddUsage: %v", err)
+	}
+	// A different day, outside the report window below.
+	outside := row
+	outside.Day = day.AddDate(0, 2, 0)
+	if err := st.AddUsage(ctx, []storage.UsageRow{outside}); err != nil {
+		t.Fatalf("outside AddUsage: %v", err)
+	}
+
+	from := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 1, 0)
+	lines, err := st.BillingReport(ctx, from, to)
+	if err != nil {
+		t.Fatalf("BillingReport: %v", err)
+	}
+	// Filter to THIS test's tenant: on a shared GLYPHOXA_TEST_DSN database the
+	// report legitimately includes other tests' tenants.
+	var mine []storage.TenantBillingLine
+	for _, line := range lines {
+		if line.TenantID == tenantID {
+			mine = append(mine, line)
+		}
+	}
+	if len(mine) != 1 {
+		t.Fatalf("report lines for tenant = %d, want 1", len(mine))
+	}
+	l := mine[0]
+	if l.PlanSlug != "all-inclusive" || l.MonthlyPriceUSD != 20 {
+		t.Fatalf("line = %+v, want all-inclusive @ 20", l)
+	}
+	if l.LLMInputTokens != 2000 || l.LLMOutputTokens != 1000 {
+		t.Fatalf("tokens = %d/%d, want 2000/1000 (accumulated, window-scoped)", l.LLMInputTokens, l.LLMOutputTokens)
+	}
+	if l.EstimatedUSD < 0.199 || l.EstimatedUSD > 0.201 {
+		t.Fatalf("estimated USD = %v, want ~0.20", l.EstimatedUSD)
+	}
+
+	// Tenant listing shows the active plan.
+	tenants, err := st.ListTenantsWithPlan(ctx)
+	if err != nil {
+		t.Fatalf("ListTenantsWithPlan: %v", err)
+	}
+	found := false
+	for _, tr := range tenants {
+		if tr.ID == tenantID {
+			found = true
+			if tr.PlanSlug != "all-inclusive" {
+				t.Fatalf("tenant plan = %q, want all-inclusive", tr.PlanSlug)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("tenant %s missing from ListTenantsWithPlan", tenantID)
+	}
+
+	// Empty AddUsage is a no-op, never an error.
+	if err := st.AddUsage(ctx, nil); err != nil {
+		t.Fatalf("empty AddUsage: %v", err)
+	}
+}

--- a/internal/storage/migrations/00033_billing_plans.sql
+++ b/internal/storage/migrations/00033_billing_plans.sql
@@ -1,0 +1,96 @@
+-- +goose Up
+
+-- SaaS billing foundation (ADR-0054): a configurable Plan catalog, per-Tenant
+-- Subscriptions with price snapshots, and a durable per-Tenant Usage Ledger.
+--
+-- Everything here is deployment-optional: a pure-BYOK self-host never syncs a
+-- plan, never subscribes a tenant, and the ledger simply accumulates rows the
+-- operator can ignore. Nothing in the voice path reads these tables.
+
+-- Where a Plan's provider keys come from (ADR-0004 / ADR-0054):
+--   'byok'     — the Tenant supplies its own provider credentials (v1.0 default).
+--   'platform' — the deployment's own provider keys (the env-fallback path) serve
+--                the Tenant's usage; the subscription price covers it.
+CREATE TYPE plan_key_source AS ENUM ('byok', 'platform');
+
+-- The Plan catalog: one row per subscription tier. Rows are synced from the
+-- operator's declarative catalog file (`glyphoxa billing plans-sync`, ADR-0054),
+-- never hand-edited by the app. `slug` is the stable configuration handle;
+-- everything else may change between syncs. Removed tiers are ARCHIVED, never
+-- deleted — subscriptions reference them and revenue history must keep resolving.
+CREATE TABLE plan (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug text NOT NULL UNIQUE,
+    display_name text NOT NULL,
+    description text NOT NULL DEFAULT '',
+    -- The tier's monthly list price. double precision holds a currency estimate
+    -- consistent with the spend-cap columns (ADR-0046); authoritative invoicing
+    -- (a payment processor) is a later layer (ADR-0054).
+    monthly_price_usd double precision NOT NULL DEFAULT 0
+        CHECK (monthly_price_usd >= 0),
+    key_source plan_key_source NOT NULL DEFAULT 'byok',
+    -- Monthly estimated-USD provider-usage allowance included in a 'platform'
+    -- plan. NULL = no configured allowance (unbounded, or BYOK where it is moot).
+    included_usage_usd double precision
+        CHECK (included_usage_usd IS NULL OR included_usage_usd >= 0),
+    -- Extensible per-tier knobs (max campaigns, max concurrent sessions, feature
+    -- flags, …) without schema churn: consumers read the keys they know.
+    limits jsonb NOT NULL DEFAULT '{}'::jsonb,
+    -- Archived plans accept no NEW subscriptions; existing ones keep working.
+    archived boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- A Tenant's binding to a Plan. plan_slug and monthly_price_usd are SNAPSHOTS
+-- taken at subscribe time: editing a plan's price in the catalog never rewrites
+-- what running subscriptions are worth, so revenue stays measurable from these
+-- rows alone. At most one ACTIVE (ended_at IS NULL) subscription per tenant;
+-- ended rows are the subscription history.
+CREATE TABLE tenant_subscription (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenant (id) ON DELETE CASCADE,
+    plan_id uuid NOT NULL REFERENCES plan (id),
+    plan_slug text NOT NULL,
+    monthly_price_usd double precision NOT NULL,
+    started_at timestamptz NOT NULL DEFAULT now(),
+    ended_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX tenant_subscription_active_uq
+    ON tenant_subscription (tenant_id)
+    WHERE ended_at IS NULL;
+CREATE INDEX tenant_subscription_tenant_idx
+    ON tenant_subscription (tenant_id);
+
+-- The durable per-Tenant Usage Ledger (ADR-0054): daily-bucketed accumulation of
+-- the same metered usage the in-memory spend meter reads (ADR-0045/0046), keyed
+-- (tenant, day, component, provider, model) and upsert-accumulated. estimated_usd
+-- is priced at write time from the static price map — a persisted ESTIMATE for
+-- cost attribution, never billing truth (ADR-0046 posture). Quantities are kept
+-- alongside so a price-map change never rewrites history.
+CREATE TABLE usage_ledger (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES tenant (id) ON DELETE CASCADE,
+    day date NOT NULL,
+    component provider_component NOT NULL,
+    provider text NOT NULL,
+    model text NOT NULL DEFAULT '',
+    llm_input_tokens bigint NOT NULL DEFAULT 0,
+    llm_output_tokens bigint NOT NULL DEFAULT 0,
+    tts_characters bigint NOT NULL DEFAULT 0,
+    stt_audio_seconds double precision NOT NULL DEFAULT 0,
+    estimated_usd double precision NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, day, component, provider, model)
+);
+
+CREATE INDEX usage_ledger_tenant_day_idx ON usage_ledger (tenant_id, day);
+
+-- +goose Down
+
+DROP TABLE usage_ledger;
+DROP TABLE tenant_subscription;
+DROP TABLE plan;
+DROP TYPE plan_key_source;

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -133,6 +133,15 @@ validate_path ingress-cert-manager \
   --set ingress.certManager.clusterIssuer=letsencrypt-prod \
   --set web.oauth.redirectUrl=null
 
+# The plan-catalog render path (ADR-0054): plans.enabled with a catalog entry
+# must produce a schema-valid ConfigMap + hook Job alongside the defaults.
+validate_path plans-sync \
+  --set plans.enabled=true \
+  --set-string plans.catalog.plans[0].slug=all-inclusive \
+  --set-string 'plans.catalog.plans[0].display_name=All Inclusive' \
+  --set plans.catalog.plans[0].monthly_price_usd=20 \
+  --set-string plans.catalog.plans[0].key_source=platform
+
 # Reserved-character credentials (issue #151): the same raw values feed
 # POSTGRES_USER/POSTGRES_PASSWORD, so the assembled DSN must percent-encode
 # them or the migrate hook and the app parse a different credential than the


### PR DESCRIPTION
## What does this PR do?

Makes Glyphoxa deployable as a hosted SaaS while keeping BYOK and the self-host on-ramp untouched, per [ADR-0054](docs/adr/0054-saas-plans-platform-keys-usage-ledger.md) (new):

**Subscription tiers as configuration (not code):**
- New migration `00033`: `plan`, `tenant_subscription`, `usage_ledger` tables.
- Plans sync from a declarative JSON catalog via `glyphoxa billing plans-sync` — upsert by slug, archive-never-delete, extensible per-tier `limits` jsonb. Editing a tier is a file edit + sync (or a `helm upgrade`).
- Subscriptions snapshot the plan slug + monthly price at bind time (`glyphoxa billing subscribe|cancel|tenants`), so **revenue** stays measurable after any catalog edit; at most one active subscription per tenant, history kept.

**Cost measurement (durable Usage Ledger):**
- `internal/billing.Ledger` — an `observe.UsageSink` teed beside the recorder and the in-memory spend meter per Voice Session (zero new pipeline plumbing; ADR-0045 capture points untouched). Buckets usage by (tenant, day UTC, component, provider, model) with quantities and a USD estimate priced from the ADR-0046 map (newly exported `spend.Estimate*USD`), flushed at loop exit through a new optional `session.Deps.Usage` seam. Attribution only, never a gate.
- `glyphoxa billing report -month YYYY-MM` — per-tenant revenue vs estimated provider cost + margin.

**"Subscription includes Groq/ElevenLabs" (platform keys):**
- `key_source: platform` plans ride the existing env-fallback hybrid policy (ADR-0039): the deployment's own `GROQ_API_KEY`/`ELEVENLABS_API_KEY` serve subscribed tenants, and the ledger attributes what they burn. Entitlement *enforcement* is deliberately deferred (single-operator tier has nobody to refuse); the seams are named in the ADR for the self-signup epic.

**Helm chart:**
- Opt-in `plans.*` values: catalog authored in values → ConfigMap → pre-install/pre-upgrade sync hook Job (weight -3, after migrate/seed). Off by default; a pure-BYOK install renders nothing new.

**Docs (new `docs/deploy/`):**
- [k3s-proxmox.md](docs/deploy/k3s-proxmox.md) — full runbook: Proxmox VM sizing, k3s, DynDNS + port forwarding (incl. the CG-NAT trap), cert-manager/Let's Encrypt, values, backups, monitoring.
- [cloud-providers.md](docs/deploy/cloud-providers.md) — provider suggestions with cost estimates (Hetzner ~€5–10/mo recommended; Civo/Scaleway/DO/OVH managed-k8s comparison; why not hyperscalers) and a concrete home-lab → cloud migration checklist.
- [saas-operations.md](docs/deploy/saas-operations.md) — operating plans, platform keys, and the cost/revenue report; honest current-scope caveats (single-operator onboarding, no payment processor yet).
- CONTEXT.md gains the Billing & SaaS vocabulary; DESIGN.md ledger + docs index updated.

## Why is this change needed?

Glyphoxa is proven in Docker Compose self-host; the next step is a SaaS deployment — first on a k3s cluster on a Proxmox VM behind DynDNS, later on a cloud provider. Tier structure is intentionally undecided, so tiers must be easily configurable/extensible, and their cost + revenue measurable from day one. BYOK must keep working alongside subscriptions that include provider usage.

## How was this tested?

- [x] `make check` passes (gofmt clean, `go vet ./...`, full `go test -race -count=1 ./...` green)
- [x] New/updated tests cover the change
- [x] Manual testing (describe below if applicable)

- New unit tests: `internal/billing` (catalog validation, ledger bucketing/flush/retry-merge).
- New integration tests (tag `integration`): plan sync lifecycle (upsert/archive/revive), subscription lifecycle (snapshot immunity to catalog edits, one-active invariant, archived-plan refusal), ledger upsert-accumulate + report window — **run against a real Postgres**, including a `migrate down`/`up` roundtrip of the new migration.
- Chart: new helm-unittest suite (11 tests, all 137 chart tests pass) + a new `plans-sync` render path in `scripts/helm-validate.sh` (full gate run locally with kubeconform: OK).
- End-to-end CLI smoke against a live DB: `plans-sync → plans-list → tenants → subscribe → seeded ledger rows → report` produced correct revenue/cost/margin.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [x] Documentation update
- [ ] Refactor / code cleanup
- [x] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **No payment processor in this slice, deliberately** — money is collected out of band and recorded via CLI; the snapshot tables are the substrate a Stripe integration writes to later without a migration.
- **Named follow-ups** (in ADR-0054): platform-key entitlement enforcement + monthly allowance gate (land with self-signup), off-session usage (Recap/Highlight enrichment) joining the ledger, proration in the report, multi-arch image for ARM cloud nodes.
- Migration numbering: `00033` (the `00029` gap in the sequence is pre-existing).
- All ledger figures are ESTIMATES (ADR-0046 posture) and labelled as such everywhere they surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcUcvJz2xaA89ui9wDdGs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcUcvJz2xaA89ui9wDdGs7)_