### PR TITLE
fix(chart): stop requiring the three provider keys for a BYOK install

### DIFF
--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -153,8 +153,15 @@ cross-template `include` of the whole Secret file is not visible to a
 single-template helm-unittest suite, but a named partial always is. Keys are
 unindented here; the caller applies `nindent 2`. The DB + cipher keys are
 unconditional; the shared credential keys are gated on voice-or-web and the web
-OAuth keys on web, each `required` under its gate so a deploy can never start
-with an empty credential.
+OAuth keys on web. The bot token and the OAuth keys are `required` under their
+gates so a deploy can never start without a working gateway login. The three
+provider keys are NOT required: they are only the env fallback of the hybrid
+BYOK policy (ADR-0004/ADR-0039) — a BYOK deployment leaves them empty and
+Tenants bring their own keys via Provider Configs; only a deployment providing
+managed provider usage (platform keys, ADR-0054) fills them. They still always
+render under the gate, possibly empty, because the voice/web Deployments
+reference them by secretKeyRef unconditionally — omitting the keys would
+dead-end the pods at CreateContainerConfigError.
 */}}
 {{- define "glyphoxa.secretStringData" -}}
 database-url: {{ include "glyphoxa.databaseURL" . | quote }}
@@ -164,9 +171,9 @@ database: {{ .Values.database.name | quote }}
 app-secret: {{ required "appSecret is required: a base64-encoded 32-byte credential-cipher key (ADR-0004) the seed Job uses to seal placeholder provider credentials. Generate one with `openssl rand -base64 32`." .Values.appSecret | quote }}
 {{- if or .Values.voice.enabled .Values.web.enabled }}
 discord-bot-token: {{ required "discordBotToken is required when voice.enabled or web.enabled: the Discord bot token the voice pod joins the gateway with (and the web tier's base session bot)." .Values.discordBotToken | quote }}
-elevenlabs-api-key: {{ required "elevenLabsApiKey is required when voice.enabled or web.enabled: the ElevenLabs API key the STT/TTS adapters read." .Values.elevenLabsApiKey | quote }}
-gemini-api-key: {{ required "geminiApiKey is required when voice.enabled or web.enabled: the Gemini API key." .Values.geminiApiKey | quote }}
-groq-api-key: {{ required "groqApiKey is required when voice.enabled or web.enabled: the Groq API key the LLM adapter reads." .Values.groqApiKey | quote }}
+elevenlabs-api-key: {{ .Values.elevenLabsApiKey | quote }}
+gemini-api-key: {{ .Values.geminiApiKey | quote }}
+groq-api-key: {{ .Values.groqApiKey | quote }}
 {{- end }}
 {{- if .Values.web.enabled }}
 discord-oauth-client-id: {{ required "web.oauth.clientId is required when web.enabled: the Discord OAuth application's Client ID (ADR-0016/0039). A Web Instance refuses to boot without a usable login (ADR-0041)." .Values.web.oauth.clientId | quote }}

--- a/deploy/charts/glyphoxa/tests/secret_test.yaml
+++ b/deploy/charts/glyphoxa/tests/secret_test.yaml
@@ -8,10 +8,12 @@ templates:
   - templates/secret.yaml
 # appSecret has no default (an unset value fails the render so a deploy can never
 # silently run on a weak key); supply a placeholder for every render here. The
-# shared credential keys (DISCORD_BOT_TOKEN + the three provider keys) are
-# required when EITHER voice.enabled or web.enabled — both on by default — and the
-# web keys (the three Discord OAuth credentials + the operator allowlist) are
-# required when web.enabled, so supply placeholders for them too. Every fixture is
+# shared credential keys (DISCORD_BOT_TOKEN + the three provider keys) render
+# when EITHER voice.enabled or web.enabled — both on by default. Of those only
+# the bot token is required; the provider keys are the BYOK env fallback
+# (ADR-0004) and may stay empty. The web keys (the three Discord OAuth
+# credentials + the operator allowlist) are required when web.enabled, so supply
+# placeholders for them too. Every fixture is
 # deliberately plain low-entropy ASCII, NOT a base64 32-byte key or a real token —
 # the template stores them verbatim in stringData, and a random blob here only
 # trips secret scanners. Production still requires real values (see values.yaml).
@@ -88,7 +90,8 @@ tests:
   - it: carries the shared credential keys when voice is enabled
     # The DISCORD_BOT_TOKEN + the three provider keys are shared by the voice
     # Deployment (#36) and the web Deployment (#118); they are emitted when
-    # EITHER is enabled and each is required then.
+    # EITHER is enabled — the bot token required, the provider keys optional
+    # (BYOK env fallback, tested below).
     asserts:
       - isNotNullOrEmpty:
           path: stringData["discord-bot-token"]
@@ -110,6 +113,48 @@ tests:
           path: stringData["discord-bot-token"]
       - isNotNullOrEmpty:
           path: stringData["groq-api-key"]
+
+  - it: renders empty provider keys for a BYOK web-only install
+    # The three provider keys are only the env FALLBACK of the hybrid BYOK
+    # policy (ADR-0004/ADR-0039): a BYOK deployment leaves them empty and
+    # Tenants bring their own keys via Provider Configs, so an empty value must
+    # render, not fail — this is the exact values posture documented in
+    # docs/deploy/k3s-proxmox.md §5. The keys still exist (empty) because the
+    # voice/web Deployments reference them by secretKeyRef unconditionally;
+    # omitting them would dead-end the pod at CreateContainerConfigError. Only
+    # a managed/platform-key deployment (ADR-0054) fills them.
+    set:
+      voice:
+        enabled: false
+      elevenLabsApiKey: ""
+      geminiApiKey: ""
+      groqApiKey: ""
+    asserts:
+      - equal:
+          path: stringData["elevenlabs-api-key"]
+          value: ""
+      - equal:
+          path: stringData["gemini-api-key"]
+          value: ""
+      - equal:
+          path: stringData["groq-api-key"]
+          value: ""
+      # The bot token is NOT part of the BYOK relaxation — the web tier still
+      # joins the gateway with it.
+      - isNotNullOrEmpty:
+          path: stringData["discord-bot-token"]
+
+  - it: still requires the bot token when the provider keys are relaxed
+    # Pins the boundary of the BYOK relaxation: the provider keys may be empty,
+    # the Discord bot token may not — no gateway login, no deployment.
+    set:
+      discordBotToken: ""
+      elevenLabsApiKey: ""
+      geminiApiKey: ""
+      groqApiKey: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "discordBotToken is required"
 
   - it: carries the web keys — the three OAuth credentials + the operator allowlist — when web is enabled
     # The web Deployment (#118) reads the Discord OAuth trio + GLYPHOXA_OPERATOR_IDS

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -23,10 +23,14 @@ appSecret: ""
 # voice pod reads DISCORD_BOT_TOKEN to join the gateway and the three provider
 # keys at request time (BYOK, ADR-0004): ELEVENLABS_API_KEY (STT + TTS),
 # GEMINI_API_KEY, and GROQ_API_KEY (LLM). They are stored in the Secret, never
-# baked into the image (ADR-0034). Defaults are empty: voice mode fails without a
-# real Discord token, and a migrate/seed-only install (voice.enabled=false) needs
-# none of them. For real deploys, prefer templating them from an external Secret
-# over committing them to values.
+# baked into the image (ADR-0034). The bot token is required whenever voice or
+# web is enabled — the pod joins the gateway with it. The three provider keys
+# are only the env FALLBACK of the hybrid BYOK policy (ADR-0004/ADR-0039):
+# leave them empty for a BYOK deployment where Tenants bring their own keys via
+# Provider Configs; fill them only if this deployment itself provides managed
+# provider usage (platform keys, ADR-0054). A migrate/seed-only install
+# (voice + web disabled) needs none of them. For real deploys, prefer
+# templating them from an external Secret over committing them to values.
 discordBotToken: ""
 elevenLabsApiKey: ""
 geminiApiKey: ""


### PR DESCRIPTION
## Problem

[docs/deploy/k3s-proxmox.md §5](https://github.com/MrWong99/Glyphoxa/blob/main/docs/deploy/k3s-proxmox.md) documents the BYOK deployment posture — `elevenLabsApiKey: ""`, `geminiApiKey: ""`, `groqApiKey: ""` with `web.enabled=true` — but the app Secret partial (`glyphoxa.secretStringData` in `_helpers.tpl`) wrapped all three in Helm `required` whenever `voice.enabled` or `web.enabled`. The documented values file therefore failed `helm install` with `elevenLabsApiKey is required when voice.enabled or web.enabled`.

## Decision: the chart was wrong, not the doc

The three provider keys are only the **env fallback** of the hybrid BYOK policy (ADR-0004/ADR-0039): tenant Provider Configs are the primary path, and every adapter (`pkg/voice/stt/elevenlabs`, `pkg/voice/llm/gemini`, `pkg/voice/llm/groq`) explicitly degrades gracefully on an empty key. Filled env keys are the managed/platform-key posture (ADR-0054). The Discord bot token is different in kind — the pod joins the gateway with it — so it stays `required`, as do the OAuth keys.

## Changes

- `_helpers.tpl`: drop `required` from the three provider keys. They still always render under the voice-or-web gate (possibly `""`) because the voice/web Deployments reference them by `secretKeyRef` unconditionally — omitting the keys would dead-end the pods at `CreateContainerConfigError`. Partial doc comment updated with the required/optional split.
- `values.yaml`: credentials comment now states the posture (bot token required; provider keys empty for BYOK, filled for platform keys).
- `tests/secret_test.yaml`: two new tests — the doc's exact BYOK web-only posture renders with empty provider keys, and an empty `discordBotToken` still fails the render — plus updated stale "each is required" comments.

## Verification

- `helm unittest deploy/charts/glyphoxa`: 139 tests, 9 suites, all pass
- The exact render from the report that previously failed at `web-deployment.yaml:82` now succeeds; rendered Secret shows the bot token populated and the three provider keys as `""`
- `helm lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)