### PR TITLE
fix(web): knowledge panel rows overflow and clip their controls off-screen

### DIFF
--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -76,6 +76,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  /* Grid items default to min-width:auto, so a long unwrappable draft snippet
+     would widen this column past its 1fr track and push row controls
+     off-screen. */
+  min-width: 0;
 }
 
 /* Each node type is its own titled group in the list. */
@@ -94,8 +98,13 @@
   color: var(--text-subtle);
 }
 
-.gx-kg-card {
+/* The gx-card base is a column; this card is an icon | text | actions row.
+   Row direction is also what lets __meta shrink and the snippet ellipsize
+   instead of pushing the card wider than the list. The compound selector
+   outranks the base rule, which the bundle emits after this file. */
+.gx-card.gx-kg-card {
   display: flex;
+  flex-direction: row;
   align-items: flex-start;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);


### PR DESCRIPTION
Two compounding layout bugs in the Campaign → Knowledge panel, surfaced by #480's LLM-drafted entries (their one-line snippets are far longer than hand-written ones):

1. **Draft rows pushed their remove buttons ~1100px off-screen.** `.gx-kg-list` is a grid item, so its default `min-width: auto` let a long unwrappable snippet widen the `1fr` column to ~2200px. Fixed by clamping the grid item with `min-width: 0`.

2. **Wiki entry cards overflowed the same way — and were silently rendering as columns.** `.gx-kg-card` was written as an icon | text | actions row (`align-items: flex-start`, actions with `margin-left: auto`), but the `gx-card` base rule (`flex-direction: column`) is emitted **after** campaign.css in the production bundle and won the same-specificity tie. As a column with left alignment, children take content width, so the snippet's ellipsis never engaged. Fixed by winning the cascade with a `.gx-card.gx-kg-card` compound selector and stating `flex-direction: row` explicitly.

**Verification** — live against the local k3d deployment on the rebuilt image: draft rows and wiki cards clamp to the list column (card `scrollWidth` 610 vs. 2196 before), snippets ellipsize, every remove/edit control stays on-screen, and the cascade prune + atomic apply flow from #480 was exercised end-to-end on the fixed layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)