### PR TITLE
feat(deploy): scripted Hetzner SaaS install + update (k3s, backups, migrations)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,17 @@ jobs:
       - name: helm-validate self-test
         run: scripts/helm-validate-test.sh
 
+      # The SaaS install/update scripts (deploy/saas/): their --dry-run paths
+      # generate the values file the chart is installed with, so their
+      # self-tests belong with the chart gates — they helm-template the
+      # generated values against the local chart (both admission modes) and
+      # pin the version-decision logic. Offline: no cluster, no network.
+      - name: saas install script self-test
+        run: deploy/saas/install-test.sh
+
+      - name: saas update script self-test
+        run: deploy/saas/update-test.sh
+
   e2e:
     name: deploy e2e (k3d smoke)
     # Wait for the `image` job so its cache-to (mode=max) has populated the gha

--- a/deploy/saas/install-test.sh
+++ b/deploy/saas/install-test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Self-test for deploy/saas/install.sh — offline, no cluster, no root: runs the
+# script's --dry-run path (which gathers parameters and writes values/state/
+# backup files but touches nothing else) and asserts the properties the real
+# install depends on. Same discipline as the scripts/ self-tests
+# (helm-validate-test.sh &c): each case pins one property, so a lost check
+# re-opens exactly one hole.
+#
+# Needs bash + openssl (like the script itself) and helm for the render cases
+# (present wherever the chart gates run).
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+INSTALL=deploy/saas/install.sh
+CHART=deploy/charts/glyphoxa
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+pass() { echo "install-test: PASS — $*"; }
+fail() { echo "install-test: FAIL — $*" >&2; exit 1; }
+
+# base_env emits the full non-interactive parameter set; callers override
+# single vars per case. Dummy-but-shaped values, never deployed.
+base_env() {
+  cat <<EOF
+GX_CONFIG_DIR=$1
+GX_VERSION=v9.9.9-selftest
+GX_HOST=glyphoxa.selftest.example
+GX_TLS=letsencrypt
+GX_ACME_EMAIL=selftest@example.com
+GX_DISCORD_CLIENT_ID=000000000000000001
+GX_DISCORD_CLIENT_SECRET=selftest-not-a-real-secret
+GX_DISCORD_BOT_TOKEN=selftest-not-a-real-token
+GX_OPERATOR_IDS=111111111111111111
+GX_ADMISSION_MODE=allowlist
+GX_OLLAMA_URL=
+GX_GROQ_API_KEY=
+GX_ELEVENLABS_API_KEY=
+GX_GEMINI_API_KEY=
+GX_BACKUP_DIR=
+EOF
+}
+
+# run_dry CONFIG_DIR [VAR=VAL ...] — dry-run the installer non-interactively
+# (stdin </dev/null, so prompts are impossible) with the base env + overrides.
+run_dry() {
+  local dir="$1"; shift
+  # The unquoted expansion IS the point: base_env emits one KEY=value token
+  # per line (no spaces in base values), overrides arrive quoted via "$@".
+  # shellcheck disable=SC2046
+  env -i PATH="$PATH" HOME="$workdir" $(base_env "$dir" | xargs) "$@" \
+    bash "$INSTALL" --dry-run </dev/null
+}
+
+# --- 1. a run without a TTY and a missing required var must fail, naming it --
+d="$workdir/missing-required"; mkdir -p "$d"
+if out="$(env -i PATH="$PATH" HOME="$workdir" GX_CONFIG_DIR="$d" GX_VERSION=v9.9.9-selftest \
+    bash "$INSTALL" --dry-run </dev/null 2>&1)"; then
+  fail "dry-run with no parameters succeeded; it must refuse without GX_HOST"
+fi
+grep -q 'GX_HOST' <<<"$out" || fail "the missing-parameter error does not name GX_HOST: $out"
+pass "non-interactive run without GX_HOST refuses and names the variable"
+
+# --- 2. dry-run writes values/state with tight permissions and sane content --
+d="$workdir/happy"; mkdir -p "$d"
+run_dry "$d" >/dev/null 2>&1 || fail "happy-path dry-run failed"
+[ -f "$d/values.yaml" ] || fail "no values.yaml written"
+[ -f "$d/install.env" ] || fail "no install.env written"
+perms="$(stat -c '%a' "$d/values.yaml")"
+[ "$perms" = "600" ] || fail "values.yaml permissions are ${perms}, want 600"
+grep -q 'host: "glyphoxa.selftest.example"' "$d/values.yaml" || fail "values.yaml lacks the ingress host"
+grep -q 'operatorIds: "111111111111111111"' "$d/values.yaml" || fail "operatorIds not a quoted string (snowflake precision, values.yaml docs)"
+grep -q '^GX_VERSION=v9.9.9-selftest$' "$d/install.env" || fail "install.env lacks the pinned version"
+# The generated DB password must be generated, not the chart's static default.
+grep -q 'password: "glyphoxa"' "$d/values.yaml" && fail "values.yaml carries the chart's default DB password"
+# appSecret must decode to exactly 32 bytes (ADR-0004).
+secret="$(sed -n 's/^appSecret: "\(.*\)"$/\1/p' "$d/values.yaml")"
+[ "$(printf '%s' "$secret" | base64 -d 2>/dev/null | wc -c)" = "32" ] \
+  || fail "generated appSecret is not base64 of 32 bytes"
+pass "dry-run writes 0600 values.yaml + install.env with generated secrets"
+
+# --- 3. the generated values must actually render against the local chart ---
+if command -v helm >/dev/null 2>&1; then
+  helm template gx-selftest "$CHART" --values "$d/values.yaml" \
+    --set-string image.tag=v9.9.9-selftest >"$workdir/render.yaml" \
+    || fail "the chart does not render with the generated values"
+  grep -q 'kind: Deployment' "$workdir/render.yaml" || fail "render has no Deployment"
+  grep -q 'kind: Ingress' "$workdir/render.yaml" || fail "render has no Ingress (ingress.enabled expected)"
+  pass "generated values render against the local chart (allowlist mode)"
+
+  # open-admission variant: plans catalog + signup slug must render too
+  d2="$workdir/open"; mkdir -p "$d2"
+  run_dry "$d2" GX_ADMISSION_MODE=open GX_SIGNUP_PLAN_SLUG=byok-free GX_OPERATOR_IDS= \
+    >/dev/null 2>&1 || fail "open-admission dry-run failed"
+  helm template gx-selftest "$CHART" --values "$d2/values.yaml" \
+    --set-string image.tag=v9.9.9-selftest >"$workdir/render-open.yaml" \
+    || fail "the chart does not render with the open-admission values"
+  grep -q 'byok-free' "$workdir/render-open.yaml" || fail "open-admission render lacks the signup plan slug"
+  pass "open-admission values (plans catalog + signup slug) render against the local chart"
+else
+  echo "install-test: SKIP — helm not found; render cases not run" >&2
+fi
+
+# --- 4. a re-run must NOT rotate appSecret (sealed creds die with it) -------
+before="$(grep '^appSecret:' "$d/values.yaml")"
+run_dry "$d" >/dev/null 2>&1 || fail "re-run dry-run failed"
+after="$(grep '^appSecret:' "$d/values.yaml")"
+[ "$before" = "$after" ] || fail "re-run regenerated appSecret — sealed BYOK credentials would be undecryptable (ADR-0004)"
+pass "re-run reuses the existing values file (appSecret stable)"
+
+# --- 5. the backup option must emit a correct CronJob manifest --------------
+# A NON-default schedule, so the round-trip assertion below cannot pass by
+# falling back to the script's default.
+d3="$workdir/backup"; mkdir -p "$d3"
+run_dry "$d3" GX_BACKUP_DIR=/var/lib/glyphoxa-backups \
+  GX_BACKUP_SCHEDULE='30 2 * * 1' GX_BACKUP_RETENTION_DAYS=21 \
+  >/dev/null 2>&1 || fail "backup dry-run failed"
+m="$d3/backup-cronjob.yaml"
+[ -f "$m" ] || fail "no backup-cronjob.yaml written"
+grep -q 'schedule: "30 2 \* \* 1"' "$m" || fail "manifest lacks the schedule"
+grep -q 'path: /var/lib/glyphoxa-backups' "$m" || fail "manifest lacks the hostPath"
+# The chart's app Secret is <fullname>-db (glyphoxa.secretName) — the doc's
+# old example used the bare release name and dangled.
+grep -q 'name: glyphoxa-db' "$m" || fail "manifest does not reference the chart Secret glyphoxa-db"
+grep -q 'mtime +21' "$m" || fail "manifest lacks the retention sweep"
+if command -v kubeconform >/dev/null 2>&1; then
+  kubeconform -strict "$m" || fail "kubeconform rejects the backup CronJob"
+fi
+# The custom schedule must survive a state-file round-trip (spaces + globs):
+# a re-run WITHOUT the env override must regenerate the same manifest, not
+# fall back to the default or mangle the globs.
+grep -q '^GX_BACKUP_SCHEDULE=30 2 \* \* 1$' "$d3/install.env" || fail "install.env mangles the cron schedule"
+run_dry "$d3" GX_BACKUP_DIR=/var/lib/glyphoxa-backups >/dev/null 2>&1 \
+  || fail "backup re-run dry-run failed"
+grep -q 'schedule: "30 2 \* \* 1"' "$m" || fail "re-run lost the custom schedule (state prefill must beat the default)"
+pass "backup CronJob manifest is correct and the schedule round-trips the state file"
+
+# --- 6. quoting: a secret with YAML-hostile characters must still render ----
+if command -v helm >/dev/null 2>&1; then
+  d4="$workdir/quoting"; mkdir -p "$d4"
+  # Literal $ and backtick are the case under test — no expansion wanted.
+  # shellcheck disable=SC2016
+  run_dry "$d4" 'GX_DISCORD_CLIENT_SECRET=we"ird\pass$word`x' >/dev/null 2>&1 \
+    || fail "dry-run with a YAML-hostile secret failed"
+  helm template gx-selftest "$CHART" --values "$d4/values.yaml" \
+    --set-string image.tag=v9.9.9-selftest >/dev/null \
+    || fail "the chart does not render when a secret contains quotes/backslashes/dollars"
+  pass "YAML-hostile characters in secrets survive values generation"
+fi
+
+# --- 7. invalid parameter values must be refused ----------------------------
+d5="$workdir/invalid"; mkdir -p "$d5"
+run_dry "$d5" GX_ADMISSION_MODE=wide-open >/dev/null 2>&1 \
+  && fail "GX_ADMISSION_MODE=wide-open was accepted"
+run_dry "$d5" GX_OPERATOR_IDS=not-a-snowflake >/dev/null 2>&1 \
+  && fail "non-numeric GX_OPERATOR_IDS was accepted"
+run_dry "$d5" GX_BACKUP_DIR=relative/path >/dev/null 2>&1 \
+  && fail "relative GX_BACKUP_DIR was accepted"
+run_dry "$d5" GX_ACME_EMAIL=not-an-email >/dev/null 2>&1 \
+  && fail "implausible GX_ACME_EMAIL was accepted"
+run_dry "$d5" GX_BACKUP_DIR=/var/lib/x GX_BACKUP_SCHEDULE='not a schedule' >/dev/null 2>&1 \
+  && fail "non-cron GX_BACKUP_SCHEDULE was accepted"
+pass "invalid admission mode / operator ids / backup dir / email / schedule are refused"
+
+# --- 8. an explicitly EMPTY env var clears a recorded choice on re-run ------
+# d3's state records a backup dir; base_env passes GX_BACKUP_DIR= (set but
+# empty), which must win over the state (set-but-empty counts as set).
+run_dry "$d3" >/dev/null 2>&1 || fail "explicit-empty backup re-run failed"
+grep -q '^GX_BACKUP_CRONJOB=$' "$d3/install.env" \
+  || fail "GX_BACKUP_DIR= did not clear the recorded backup (state prefill beat an explicit empty env var)"
+pass "an explicitly empty env var clears the recorded backup choice"
+
+# --- 9. reuse-run host handling: env conflict refused, hand-edit adopted ----
+# d holds the happy-path install (host glyphoxa.selftest.example). An env
+# override that contradicts the reused values file must be refused…
+if run_dry "$d" GX_HOST=other.selftest.example >/dev/null 2>&1; then
+  fail "a GX_HOST env override conflicting with the reused values file was silently accepted"
+fi
+# …while a hand-EDITED values file (no env override) is adopted as authority.
+sed -i 's/^  host: "glyphoxa.selftest.example"$/  host: "edited.selftest.example"/' "$d/values.yaml"
+# shellcheck disable=SC2046
+env -i PATH="$PATH" HOME="$workdir" $(base_env "$d" | grep -v '^GX_HOST=' | xargs) \
+  bash "$INSTALL" --dry-run </dev/null >/dev/null 2>&1 \
+  || fail "reuse-run with a hand-edited values host failed"
+grep -q '^GX_HOST=edited.selftest.example$' "$d/install.env" \
+  || fail "hand-edited values host was not adopted into the state"
+pass "reuse-run refuses a conflicting GX_HOST env override and adopts a hand-edited values host"
+
+echo "install-test: OK"

--- a/deploy/saas/install.sh
+++ b/deploy/saas/install.sh
@@ -1,0 +1,651 @@
+#!/usr/bin/env bash
+# deploy/saas/install.sh — stand up a complete single-box Glyphoxa SaaS server
+# on k3s, from a bare Linux host (the Hetzner path of
+# docs/deploy/cloud-providers.md; every step mirrors docs/deploy/k3s-proxmox.md
+# §2–§8, which stays the reference for what each piece is and why).
+#
+# What it does, in order:
+#   1. asks for the parameters it needs (DNS name, ACME email, Discord OAuth +
+#      bot credentials, operator allowlist, Admission Mode, Ollama URL,
+#      optional platform provider keys, optional on-disk backup) — every
+#      prompt can be pre-answered with the GX_* env var it names, and a
+#      non-interactive run (no TTY) requires exactly those vars;
+#   2. installs k3s (skipped when already present, or with --skip-k3s to
+#      target the current kubeconfig context instead) and helm if missing;
+#   3. installs cert-manager + a Let's Encrypt ClusterIssuer (unless GX_TLS=none);
+#   4. resolves the latest released version (or --version), downloads that
+#      release's source tarball, and installs ITS chart with the image tag
+#      pinned to the same release — chart and image can never drift;
+#   5. writes the values file (0600) and an install-state file the companion
+#      update script (deploy/saas/update.sh) reads;
+#   6. optionally applies a nightly pg_dump CronJob writing to a path on the
+#      node's disk, with retention.
+#
+# Re-running is safe: an existing values file is REUSED (never regenerated —
+# rotating appSecret would make every sealed BYOK credential undecryptable,
+# ADR-0004), k3s/helm/cert-manager installs are skipped when present, and the
+# chart install is `helm upgrade --install`.
+#
+# --dry-run gathers parameters, writes the values/state/backup files and
+# prints the plan, but touches neither the host nor any cluster — the
+# self-test (install-test.sh) runs entirely through it.
+set -euo pipefail
+
+# --------------------------------------------------------------- defaults --
+# Only what is needed to FIND the state file is defaulted here; everything
+# else defaults after the state-file prefill below, so a re-run keeps a
+# previous install's choices instead of silently resetting them.
+GX_CONFIG_DIR="${GX_CONFIG_DIR:-/etc/glyphoxa}"
+GX_ACME_SERVER="${GX_ACME_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+
+DRY_RUN=""
+SKIP_K3S="${GX_SKIP_K3S:-}"
+FRESH_VALUES=""
+
+usage() {
+  cat <<'EOF'
+usage: install.sh [options]
+
+Options:
+  --version vX.Y.Z   install this released version (default: latest release on
+                     a FIRST install; a re-run keeps the version recorded in
+                     install.env — upgrading is deploy/saas/update.sh's job)
+  --config-dir DIR   where values/state live (default: /etc/glyphoxa)
+  --skip-k3s         do not install/use k3s; deploy to the CURRENT kubeconfig
+                     context (for existing clusters and local testing)
+  --fresh-values     regenerate the values file even if one exists. DANGER:
+                     rotates appSecret — sealed BYOK provider credentials
+                     become undecryptable (ADR-0004). Never use on a live box.
+  --dry-run          gather parameters + write values/state, touch nothing else
+  -h, --help         this text
+
+Every prompt reads its GX_* env var first (GX_HOST, GX_ACME_EMAIL,
+GX_DISCORD_CLIENT_ID, GX_DISCORD_CLIENT_SECRET, GX_DISCORD_BOT_TOKEN,
+GX_OPERATOR_IDS, GX_ADMISSION_MODE, GX_SIGNUP_PLAN_SLUG, GX_OLLAMA_URL,
+GX_GROQ_API_KEY, GX_ELEVENLABS_API_KEY, GX_GEMINI_API_KEY, GX_TLS,
+GX_BACKUP_DIR, GX_BACKUP_SCHEDULE, GX_BACKUP_RETENTION_DAYS, GX_PG_DISK);
+a run without a TTY takes ONLY the env vars and fails naming any missing
+required one, so unattended installs are reproducible.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) GX_VERSION="${2:?--version needs a tag}"; shift 2 ;;
+    --config-dir) GX_CONFIG_DIR="${2:?--config-dir needs a path}"; shift 2 ;;
+    --skip-k3s) SKIP_K3S=1; shift ;;
+    --fresh-values) FRESH_VALUES=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "install.sh: unknown option '$1' (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+die()  { echo "install.sh: ERROR: $*" >&2; exit 1; }
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found"; }
+
+# yesc escapes a value for a double-quoted YAML scalar (backslash, then quote).
+yesc() { local s="${1-}"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
+
+# ask VAR "prompt" ["default"]: keep an env-provided value; otherwise prompt
+# (with default), or fail actionably when there is no TTY. Three-arg form is
+# optional (empty default allowed); two-arg form is required (loops until
+# non-empty).
+ask() {
+  local var="$1" text="$2" def="${3-__REQUIRED__}" val
+  if [ -n "${!var-}" ]; then return 0; fi
+  if [ ! -t 0 ]; then
+    if [ "$def" != "__REQUIRED__" ]; then printf -v "$var" '%s' "$def"; return 0; fi
+    die "no TTY and \$$var is unset — set $var (see --help)"
+  fi
+  while :; do
+    if [ "$def" != "__REQUIRED__" ]; then
+      read -r -p "$text [${def}]: " val || die "input aborted"
+      val="${val:-$def}"
+    else
+      read -r -p "$text: " val || die "input aborted"
+    fi
+    if [ -n "$val" ] || [ "$def" != "__REQUIRED__" ]; then break; fi
+    echo "  (required)"
+  done
+  printf -v "$var" '%s' "$val"
+}
+
+# ask_secret VAR "prompt": like required ask, but no echo.
+ask_secret() {
+  local var="$1" text="$2" val
+  if [ -n "${!var-}" ]; then return 0; fi
+  [ -t 0 ] || die "no TTY and \$$var is unset — set $var (see --help)"
+  while :; do
+    read -r -s -p "$text: " val || die "input aborted"
+    echo
+    [ -n "$val" ] && break
+    echo "  (required)"
+  done
+  printf -v "$var" '%s' "$val"
+}
+
+# ask_secret_optional VAR "prompt": no echo, empty allowed (Enter to skip).
+ask_secret_optional() {
+  local var="$1" text="$2" val
+  if [ -n "${!var-}" ]; then return 0; fi
+  if [ ! -t 0 ]; then printf -v "$var" '%s' ""; return 0; fi
+  read -r -s -p "$text: " val || die "input aborted"
+  echo
+  printf -v "$var" '%s' "$val"
+}
+
+# ----------------------------------------------------------------- preflight --
+need_cmd curl
+need_cmd tar
+need_cmd openssl
+
+if [ -z "$DRY_RUN" ] && [ -z "$SKIP_K3S" ] && [ "$(id -u)" -ne 0 ]; then
+  die "installing k3s needs root — re-run with sudo (or use --skip-k3s to target an existing cluster)"
+fi
+
+VALUES_FILE="${GX_CONFIG_DIR}/values.yaml"
+STATE_FILE="${GX_CONFIG_DIR}/install.env"
+BACKUP_MANIFEST="${GX_CONFIG_DIR}/backup-cronjob.yaml"
+
+# Remember which of the two deploy-shaping parameters arrived via the REAL
+# environment (before the state prefill), so a reuse-run can tell an explicit
+# override (a conflict to refuse) from a state echo (nothing to do) below.
+ENV_GX_HOST="${GX_HOST-}"
+ENV_GX_TLS="${GX_TLS-}"
+
+# A previous install's state prefills GX_* the caller did not set, so a re-run
+# only prompts for what it cannot know. Set-but-EMPTY counts as set (an
+# explicit `GX_BACKUP_DIR=` must be able to clear a recorded choice), hence
+# the +x test. Parsed line-wise, NOT sourced: values like a cron schedule
+# contain spaces/globs that `source` would mangle.
+if [ -f "$STATE_FILE" ]; then
+  while IFS='=' read -r k v; do
+    case "$k" in
+      GX_*) [ -n "${!k+x}" ] || printf -v "$k" '%s' "$v" ;;
+    esac
+  done <"$STATE_FILE"
+fi
+
+# Hard defaults for whatever neither the env nor a previous state provided.
+GX_REPO="${GX_REPO:-MrWong99/Glyphoxa}"
+GX_RELEASE="${GX_RELEASE:-glyphoxa}"
+GX_NAMESPACE="${GX_NAMESPACE:-glyphoxa}"
+GX_VERSION="${GX_VERSION:-}"                 # empty = latest published release
+GX_TLS="${GX_TLS:-}"                         # letsencrypt | none (prompted)
+GX_PG_DISK="${GX_PG_DISK:-20Gi}"
+GX_TIMEOUT="${GX_TIMEOUT:-600s}"
+GX_BACKUP_SCHEDULE="${GX_BACKUP_SCHEDULE:-15 4 * * *}"
+GX_BACKUP_RETENTION_DAYS="${GX_BACKUP_RETENTION_DAYS:-14}"
+
+REUSE_VALUES=""
+[ -f "$VALUES_FILE" ] && [ -z "$FRESH_VALUES" ] && REUSE_VALUES=1
+
+# ---------------------------------------------------------------- parameters --
+log "Glyphoxa SaaS install — parameters"
+
+ask GX_HOST "Public DNS name the console will be served on (e.g. glyphoxa.example.com)"
+case "$GX_HOST" in
+  *[!a-zA-Z0-9.-]*|"") die "GX_HOST '$GX_HOST' is not a plausible DNS name" ;;
+esac
+
+ask GX_TLS "TLS: 'letsencrypt' (cert-manager + HTTP-01, needs the DNS name pointing here) or 'none' (plain HTTP / TLS terminated elsewhere)" "letsencrypt"
+case "$GX_TLS" in
+  letsencrypt)
+    ask GX_ACME_EMAIL "Email for Let's Encrypt expiry notices"
+    # Shape check before the value is interpolated into the ClusterIssuer
+    # manifest (same discipline as the GX_HOST check above).
+    case "$GX_ACME_EMAIL" in
+      *[!A-Za-z0-9._%+@-]*|*@*@*|*@|@*|"") die "GX_ACME_EMAIL '$GX_ACME_EMAIL' is not a plausible email" ;;
+      *@*) : ;;
+      *) die "GX_ACME_EMAIL '$GX_ACME_EMAIL' is not a plausible email" ;;
+    esac
+    ;;
+  none) GX_ACME_EMAIL="" ;;
+  *) die "GX_TLS must be 'letsencrypt' or 'none', got '$GX_TLS'" ;;
+esac
+
+if [ -n "$REUSE_VALUES" ]; then
+  note "existing ${VALUES_FILE} found — credentials, admission mode and provider"
+  note "keys are taken from it (edit that file to change them; --fresh-values regenerates)."
+else
+  note "Discord application (docs/configuration.md §5: OAuth2 client + bot token)."
+  ask GX_DISCORD_CLIENT_ID "Discord OAuth client id"
+  ask_secret GX_DISCORD_CLIENT_SECRET "Discord OAuth client secret"
+  ask_secret GX_DISCORD_BOT_TOKEN "Discord bot token"
+
+  ask GX_ADMISSION_MODE "Admission Mode (ADR-0055): 'allowlist' (only the operators below may log in) or 'open' (any Discord user founds a Tenant)" "allowlist"
+  case "$GX_ADMISSION_MODE" in
+    allowlist)
+      ask GX_OPERATOR_IDS "Operator Discord snowflake(s), comma-separated (Discord: Settings > Advanced > Developer Mode, then Copy ID)"
+      GX_SIGNUP_PLAN_SLUG=""
+      ;;
+    open)
+      ask GX_OPERATOR_IDS "Platform-admin Discord snowflake(s), comma-separated (may be empty; the pod then warns 'no platform admins')" ""
+      ask GX_SIGNUP_PLAN_SLUG "Plan slug every signup is bound to (synced into the DB as a \$0 BYOK tier; edit the values file later for real tiers — docs/deploy/saas-operations.md §1)" "byok-free"
+      case "$GX_SIGNUP_PLAN_SLUG" in
+        *[!a-z0-9-]*|"") die "GX_SIGNUP_PLAN_SLUG must be lowercase alphanumerics + hyphens" ;;
+      esac
+      ;;
+    *) die "GX_ADMISSION_MODE must be 'allowlist' or 'open', got '$GX_ADMISSION_MODE'" ;;
+  esac
+  case "${GX_OPERATOR_IDS//[0-9, ]/}" in
+    "") : ;;
+    *) die "GX_OPERATOR_IDS must be numeric Discord snowflakes (comma/space separated)" ;;
+  esac
+
+  ask GX_OLLAMA_URL "Ollama URL for embeddings (serving nomic-embed-text; empty disables semantic memory L2 with a WARN loop — docs/configuration.md)" ""
+
+  note "Platform provider keys (ADR-0054): leave empty for a pure-BYOK deployment;"
+  note "fill to sell 'usage included' tiers on YOUR keys (saas-operations.md §2)."
+  ask_secret_optional GX_GROQ_API_KEY "Groq API key (optional, hidden; Enter to skip)"
+  ask_secret_optional GX_ELEVENLABS_API_KEY "ElevenLabs API key (optional, hidden; Enter to skip)"
+  ask_secret_optional GX_GEMINI_API_KEY "Gemini API key (optional, hidden; Enter to skip)"
+fi
+
+ask GX_BACKUP_DIR "Nightly pg_dump backup directory on the node's disk (empty to skip backups)" ""
+if [ -n "$GX_BACKUP_DIR" ]; then
+  case "$GX_BACKUP_DIR" in
+    /*) : ;;
+    *) die "GX_BACKUP_DIR must be an absolute path" ;;
+  esac
+  ask GX_BACKUP_SCHEDULE "Backup cron schedule (UTC)" "$GX_BACKUP_SCHEDULE"
+  case "$GX_BACKUP_SCHEDULE" in
+    *[!0-9\*/,\ -]*|"") die "GX_BACKUP_SCHEDULE '$GX_BACKUP_SCHEDULE' is not a plausible cron schedule" ;;
+  esac
+  ask GX_BACKUP_RETENTION_DAYS "Days of dumps to keep" "$GX_BACKUP_RETENTION_DAYS"
+  case "$GX_BACKUP_RETENTION_DAYS" in
+    *[!0-9]*|"") die "GX_BACKUP_RETENTION_DAYS must be a number" ;;
+  esac
+fi
+
+# On a reuse-run the values FILE is what deploys (only image.tag is passed on
+# top), so the effective host/TLS must agree with it. An explicit env override
+# is a conflict to refuse (the file wins, silently ignoring the operator would
+# be worse); a drift the other way — the operator hand-edited the values file —
+# is adopted, since the file is authoritative.
+if [ -n "$REUSE_VALUES" ]; then
+  FILE_HOST="$(sed -n 's/^  host: "\(.*\)"$/\1/p' "$VALUES_FILE" | head -n1)"
+  if [ -n "$FILE_HOST" ] && [ "$FILE_HOST" != "$GX_HOST" ]; then
+    if [ -n "$ENV_GX_HOST" ]; then
+      die "GX_HOST '$GX_HOST' conflicts with the reused ${VALUES_FILE} (ingress.host '$FILE_HOST') — edit that file, or --fresh-values (DANGER: rotates appSecret)"
+    fi
+    note "adopting host '$FILE_HOST' from the values file (it is what deploys)"
+    GX_HOST="$FILE_HOST"
+  fi
+  # The only 4-space-indented enabled: in the generated file is
+  # ingress.certManager.enabled (the ingress block closes the file).
+  FILE_CM="$(grep -E '^    enabled: (true|false)$' "$VALUES_FILE" | tail -n1 | awk '{print $2}')"
+  FILE_TLS=none; [ "$FILE_CM" = "true" ] && FILE_TLS=letsencrypt
+  if [ -n "$FILE_CM" ] && [ "$FILE_TLS" != "$GX_TLS" ]; then
+    if [ -n "$ENV_GX_TLS" ]; then
+      die "GX_TLS '$GX_TLS' conflicts with the reused ${VALUES_FILE} (certManager.enabled ${FILE_CM}) — edit that file, or --fresh-values (DANGER: rotates appSecret)"
+    fi
+    note "adopting TLS mode '$FILE_TLS' from the values file (it is what deploys)"
+    GX_TLS="$FILE_TLS"
+    [ "$GX_TLS" = "letsencrypt" ] && [ -z "$GX_ACME_EMAIL" ] \
+      && ask GX_ACME_EMAIL "Email for Let's Encrypt expiry notices"
+  fi
+fi
+
+# ------------------------------------------------------------ resolve version --
+log "Resolving version"
+if [ -z "$GX_VERSION" ]; then
+  # `|| true` so a curl failure reaches the actionable die below instead of
+  # errexit killing the script with only curl's terse stderr.
+  GX_VERSION="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/${GX_REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1 || true)"
+  [ -n "$GX_VERSION" ] || die "could not resolve the latest release of ${GX_REPO} (network? rate limit?) — pin one with --version"
+fi
+note "installing Glyphoxa ${GX_VERSION}"
+
+# The chart names objects <fullname>-<component>, where fullname is the
+# release name when it already contains 'glyphoxa' and <release>-glyphoxa
+# otherwise (templates/_helpers.tpl). The web Deployment and the app Secret
+# (-db) are addressed by that name below and in update.sh.
+FULLNAME="$GX_RELEASE"
+case "$GX_RELEASE" in
+  *glyphoxa*) : ;;
+  *) FULLNAME="${GX_RELEASE}-glyphoxa" ;;
+esac
+
+# --------------------------------------------------------------- write config --
+log "Config in ${GX_CONFIG_DIR}"
+mkdir -p "$GX_CONFIG_DIR"
+chmod 700 "$GX_CONFIG_DIR" 2>/dev/null || true
+
+if [ -n "$REUSE_VALUES" ]; then
+  note "reusing existing ${VALUES_FILE} (secrets kept; --fresh-values to regenerate)"
+else
+  [ -f "$VALUES_FILE" ] && note "REGENERATING ${VALUES_FILE} — appSecret rotates, sealed BYOK credentials become undecryptable (ADR-0004)"
+  APP_SECRET="$(openssl rand -base64 32)"
+  DB_PASSWORD="$(openssl rand -hex 24)"   # hex: URL-safe by construction
+
+  PLANS_BLOCK=""
+  ADMISSION_BLOCK=""
+  if [ "$GX_ADMISSION_MODE" = "open" ]; then
+    ADMISSION_BLOCK="
+  admissionMode: open
+  signupPlanSlug: \"$(yesc "$GX_SIGNUP_PLAN_SLUG")\""
+    PLANS_BLOCK="
+# Signup tier catalog (ADR-0054/0055): the slug open-mode signups bind to.
+# Add real tiers here and re-run install.sh (or a 'helm upgrade' with
+# --set-string image.tag pinned) — see docs/deploy/saas-operations.md §1.
+plans:
+  enabled: true
+  catalog:
+    plans:
+      - slug: \"$(yesc "$GX_SIGNUP_PLAN_SLUG")\"
+        display_name: \"BYOK Free\"
+        description: \"Bring your own provider keys.\"
+        monthly_price_usd: 0"
+  fi
+
+  CERTMANAGER_ENABLED=false
+  [ "$GX_TLS" = "letsencrypt" ] && CERTMANAGER_ENABLED=true
+
+  umask 077
+  cat >"$VALUES_FILE" <<EOF
+# Generated by deploy/saas/install.sh — keep 0600, NEVER commit.
+# Edit + re-run install.sh (it reuses this file), or run deploy/saas/update.sh.
+# The image tag is NOT pinned here: install.sh/update.sh pass it via
+# --set-string image.tag=vX.Y.Z (recorded in ${STATE_FILE}). A direct
+# 'helm upgrade' MUST do the same — without it the chart falls back to its
+# appVersion, which does not track releases.
+
+appSecret: "$(yesc "$APP_SECRET")"
+
+discordBotToken: "$(yesc "$GX_DISCORD_BOT_TOKEN")"
+# Platform provider keys (ADR-0054): empty = pure BYOK.
+elevenLabsApiKey: "$(yesc "$GX_ELEVENLABS_API_KEY")"
+geminiApiKey: "$(yesc "$GX_GEMINI_API_KEY")"
+groqApiKey: "$(yesc "$GX_GROQ_API_KEY")"
+
+ollamaUrl: "$(yesc "$GX_OLLAMA_URL")"
+
+database:
+  password: "$(yesc "$DB_PASSWORD")"
+
+postgres:
+  persistence:
+    size: ${GX_PG_DISK}
+
+seed:
+  enabled: false             # no demo data on a real deployment
+
+voice:
+  enabled: false             # the web pod drives the voice loop in 'all' mode
+
+web:
+  enabled: true
+  mode: all
+  oauth:
+    clientId: "$(yesc "$GX_DISCORD_CLIENT_ID")"
+    clientSecret: "$(yesc "$GX_DISCORD_CLIENT_SECRET")"
+    # redirectUrl stays empty: it is DERIVED from ingress.host so it can
+    # never drift (docs/deploy/k3s-proxmox.md §5).
+  operatorIds: "$(yesc "$GX_OPERATOR_IDS")"${ADMISSION_BLOCK}
+  resources:                 # 'all' mode runs the voice loop in-process
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+${PLANS_BLOCK}
+ingress:
+  enabled: true
+  host: "$(yesc "$GX_HOST")"
+  className: traefik
+  certManager:
+    enabled: ${CERTMANAGER_ENABLED}
+    clusterIssuer: letsencrypt-prod
+EOF
+fi
+
+BACKUP_CRONJOB=""
+if [ -n "$GX_BACKUP_DIR" ]; then
+  BACKUP_CRONJOB="${FULLNAME}-pgdump"
+  # The chart's app Secret is <release>-db (glyphoxa.secretName); its
+  # database-url key is the same DSN every workload uses (ADR-0031).
+  umask 077
+  cat >"$BACKUP_MANIFEST" <<EOF
+# Generated by deploy/saas/install.sh — nightly logical pg_dump to a path on
+# the NODE's disk (single-box deployment). Restore:
+#   pg_restore -d "\$DSN" --clean --if-exists <file>.dump
+# Copy dumps off the box regularly — a backup on the same disk is not a
+# backup (docs/deploy/k3s-proxmox.md §8).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ${BACKUP_CRONJOB}
+  namespace: ${GX_NAMESPACE}
+spec:
+  schedule: "${GX_BACKUP_SCHEDULE}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: pgvector/pgvector:pg17
+              command: ["/bin/sh", "-c"]
+              # umask + chmod: dumps carry the DB, so neither the directory
+              # nor the files may be world-readable regardless of who created
+              # the hostPath (DirectoryOrCreate makes it 0755).
+              args:
+                - umask 077 && chmod 700 /backup
+                  && pg_dump "\$GLYPHOXA_DATABASE_URL" -Fc
+                  -f "/backup/glyphoxa-\$(date +%F-%H%M%S).dump"
+                  && find /backup -name 'glyphoxa-*.dump'
+                  -mtime +${GX_BACKUP_RETENTION_DAYS} -delete
+              env:
+                - name: GLYPHOXA_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${FULLNAME}-db
+                      key: database-url
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+          volumes:
+            - name: backup
+              hostPath:
+                path: ${GX_BACKUP_DIR}
+                type: DirectoryOrCreate
+EOF
+fi
+
+# State the companion update script (and a re-run of this one) reads.
+# KUBECONFIG is recorded so update runs against the same cluster the install
+# targeted. Parsed line-wise (KEY=raw value, no quoting) — never `source`d.
+# On the REAL path this is written only after the install converged, so a
+# failed install never leaves state claiming a version that never deployed
+# (--dry-run writes it immediately: the files ARE its output).
+write_state() {
+  local kubeconfig_record="${KUBECONFIG-}"
+  [ -z "$SKIP_K3S" ] && kubeconfig_record="/etc/rancher/k3s/k3s.yaml"
+  umask 077
+  cat >"$STATE_FILE" <<EOF
+# Generated by deploy/saas/install.sh — read by deploy/saas/update.sh.
+# KEY=raw-value per line; parsed line-wise, never source'd.
+GX_REPO=${GX_REPO}
+GX_RELEASE=${GX_RELEASE}
+GX_FULLNAME=${FULLNAME}
+GX_NAMESPACE=${GX_NAMESPACE}
+GX_VERSION=${GX_VERSION}
+GX_HOST=${GX_HOST}
+GX_TLS=${GX_TLS}
+GX_ACME_EMAIL=${GX_ACME_EMAIL}
+GX_VALUES_FILE=${VALUES_FILE}
+GX_BACKUP_DIR=${GX_BACKUP_DIR}
+GX_BACKUP_CRONJOB=${BACKUP_CRONJOB}
+GX_BACKUP_SCHEDULE=${GX_BACKUP_SCHEDULE}
+GX_BACKUP_RETENTION_DAYS=${GX_BACKUP_RETENTION_DAYS}
+GX_KUBECONFIG=${kubeconfig_record}
+GX_TIMEOUT=${GX_TIMEOUT}
+EOF
+}
+
+if [ -n "$DRY_RUN" ]; then
+  write_state
+  log "DRY RUN — plan"
+  note "would install: k3s $([ -n "$SKIP_K3S" ] && echo '(skipped — current context)' || echo '(if missing)'), helm (if missing)"
+  [ "$GX_TLS" = "letsencrypt" ] && note "would install: cert-manager + ClusterIssuer letsencrypt-prod (${GX_ACME_SERVER})"
+  note "would deploy: Glyphoxa ${GX_VERSION} as release '${GX_RELEASE}' in namespace '${GX_NAMESPACE}', host ${GX_HOST}"
+  [ -n "$GX_BACKUP_DIR" ] && note "would apply: backup CronJob '${BACKUP_CRONJOB}' -> ${GX_BACKUP_DIR} (schedule '${GX_BACKUP_SCHEDULE}', keep ${GX_BACKUP_RETENTION_DAYS}d)"
+  note "wrote: ${VALUES_FILE}, ${STATE_FILE}$([ -n "$GX_BACKUP_DIR" ] && echo ", ${BACKUP_MANIFEST}")"
+  exit 0
+fi
+
+# ------------------------------------------------------------------- k3s --
+if [ -n "$SKIP_K3S" ]; then
+  log "Using the current kubeconfig context (--skip-k3s)"
+  need_cmd kubectl
+  note "context: $(kubectl config current-context 2>/dev/null || echo '<none>')"
+  if [ -t 0 ]; then
+    read -r -p "Deploy to this context? [y/N] " yn
+    case "$yn" in [yY]*) : ;; *) die "aborted" ;; esac
+  fi
+else
+  log "k3s"
+  if command -v k3s >/dev/null 2>&1 && systemctl is-active --quiet k3s 2>/dev/null; then
+    note "k3s already installed and running — skipping install"
+  else
+    note "installing k3s (https://get.k3s.io)"
+    curl -sfL https://get.k3s.io | sh -
+  fi
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+  export PATH="/usr/local/bin:$PATH"   # k3s symlinks kubectl here
+  need_cmd kubectl
+  # The k3s unit reports ready before the kubelet registers the Node object,
+  # and `kubectl wait` errors immediately on zero matching resources — so wait
+  # for the node to EXIST before waiting for Ready.
+  note "waiting for the node to register"
+  for _ in $(seq 1 60); do
+    kubectl get nodes --no-headers 2>/dev/null | grep -q . && break
+    sleep 2
+  done
+  kubectl wait --for=condition=Ready node --all --timeout=180s
+fi
+
+# ------------------------------------------------------------------- helm --
+if ! command -v helm >/dev/null 2>&1; then
+  log "Installing helm"
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+need_cmd helm
+
+# ------------------------------------------------------------------ chart --
+log "Fetching the ${GX_VERSION} chart"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+curl -fsSL "https://github.com/${GX_REPO}/archive/refs/tags/${GX_VERSION}.tar.gz" \
+  | tar -xz -C "$WORKDIR"
+CHART_DIR="$(echo "$WORKDIR"/*/deploy/charts/glyphoxa)"
+[ -d "$CHART_DIR" ] || die "release ${GX_VERSION} has no deploy/charts/glyphoxa — too old for a chart install?"
+
+# ----------------------------------------------------------- cert-manager --
+if [ "$GX_TLS" = "letsencrypt" ]; then
+  log "cert-manager + Let's Encrypt ClusterIssuer"
+  # Three cases: (a) a release WE manage exists (even failed/half-installed
+  # after an aborted --wait) — converge it with upgrade --install; (b) no
+  # release but the CRDs exist — cert-manager is managed by someone else,
+  # leave it alone; (c) neither — first install.
+  if helm status cert-manager -n cert-manager >/dev/null 2>&1; then
+    note "converging the cert-manager release (repairs a half-install; no-op when healthy)"
+    helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+    helm upgrade --install cert-manager jetstack/cert-manager \
+      --namespace cert-manager --create-namespace \
+      --set crds.enabled=true --wait --timeout "$GX_TIMEOUT"
+  elif kubectl get crd clusterissuers.cert-manager.io >/dev/null 2>&1; then
+    note "cert-manager CRDs present but not helm-managed by this script — leaving it alone"
+  else
+    helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+    helm upgrade --install cert-manager jetstack/cert-manager \
+      --namespace cert-manager --create-namespace \
+      --set crds.enabled=true --wait --timeout "$GX_TIMEOUT"
+  fi
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: ${GX_ACME_SERVER}
+    email: "${GX_ACME_EMAIL}"
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: traefik
+EOF
+  # Best-effort DNS sanity: HTTP-01 issuance can only succeed once GX_HOST
+  # resolves to this box. A mismatch is a warning, not a failure — DNS may
+  # still be propagating, and the Certificate retries on its own.
+  PUB_IP="$(curl -fsS -4 --max-time 5 https://ifconfig.me 2>/dev/null || true)"
+  DNS_IP="$(getent ahostsv4 "$GX_HOST" 2>/dev/null | awk '{print $1; exit}' || true)"
+  if [ -n "$PUB_IP" ] && [ "$DNS_IP" != "$PUB_IP" ]; then
+    note "WARNING: ${GX_HOST} resolves to '${DNS_IP:-<nothing>}' but this box's public IP looks like ${PUB_IP}."
+    note "Point an A record at ${PUB_IP}; the certificate will issue once it propagates."
+  fi
+fi
+
+# ---------------------------------------------------------------- install --
+# Freshly generated secrets against a cluster that already holds release data
+# would rotate appSecret (stranding every sealed BYOK credential, ADR-0004)
+# AND mismatch the Postgres password persisted on its PVC. The values file is
+# the only key to that data — refuse to overwrite what we cannot decrypt.
+if [ -z "$REUSE_VALUES" ] \
+  && kubectl -n "$GX_NAMESPACE" get secret "${FULLNAME}-db" >/dev/null 2>&1; then
+  die "the values file was (re)generated with FRESH secrets, but namespace '${GX_NAMESPACE}' \
+already holds release data (Secret ${FULLNAME}-db). Installing would strand the sealed BYOK \
+credentials (ADR-0004) and mismatch the Postgres password on its PVC. Restore the previous \
+values.yaml into ${GX_CONFIG_DIR}, or for a TRUE fresh start remove the old release first: \
+helm -n ${GX_NAMESPACE} uninstall ${GX_RELEASE} && kubectl -n ${GX_NAMESPACE} delete pvc,secret,job --all"
+fi
+
+log "Installing Glyphoxa ${GX_VERSION} (release '${GX_RELEASE}', namespace '${GX_NAMESPACE}')"
+kubectl get namespace "$GX_NAMESPACE" >/dev/null 2>&1 \
+  || kubectl create namespace "$GX_NAMESPACE"
+helm upgrade --install "$GX_RELEASE" "$CHART_DIR" \
+  --namespace "$GX_NAMESPACE" \
+  --values "$VALUES_FILE" \
+  --set-string "image.tag=${GX_VERSION}" \
+  --wait --timeout "$GX_TIMEOUT"
+
+log "Verifying"
+kubectl -n "$GX_NAMESPACE" rollout status "deployment/${FULLNAME}-web" --timeout "$GX_TIMEOUT"
+
+# ----------------------------------------------------------------- backup --
+if [ -n "$GX_BACKUP_DIR" ]; then
+  log "Backup CronJob (${BACKUP_CRONJOB} -> ${GX_BACKUP_DIR}, '${GX_BACKUP_SCHEDULE}' UTC, keep ${GX_BACKUP_RETENTION_DAYS}d)"
+  [ -z "$SKIP_K3S" ] && { mkdir -p "$GX_BACKUP_DIR"; chmod 700 "$GX_BACKUP_DIR"; }
+  kubectl apply -f "$BACKUP_MANIFEST"
+  note "first dump runs on schedule; run one now with:"
+  note "  kubectl -n ${GX_NAMESPACE} create job --from=cronjob/${BACKUP_CRONJOB} ${BACKUP_CRONJOB}-manual-\$(date +%s)"
+  note "copy dumps OFF this box regularly (rsync/restic) — same-disk backups don't count."
+fi
+
+# ---------------------------------------------------------------- summary --
+write_state
+SCHEME=https; [ "$GX_TLS" = "none" ] && SCHEME=http
+log "Done — Glyphoxa ${GX_VERSION} is up"
+note "console:        ${SCHEME}://${GX_HOST}/"
+note "OAuth redirect: register ${SCHEME}://${GX_HOST}/auth/discord/callback on the Discord application (exactly)"
+[ "$GX_TLS" = "letsencrypt" ] && note "certificate:    kubectl -n ${GX_NAMESPACE} get certificate   (READY True once DNS points here)"
+note "values:         ${VALUES_FILE} (0600 — edit + re-run install.sh; a direct helm upgrade needs --set-string image.tag=${GX_VERSION})"
+note "state:          ${STATE_FILE}"
+note "update later:   deploy/saas/update.sh   (docs/deploy/cloud-providers.md)"
+note "going paid:     docs/deploy/saas-operations.md (plans, platform keys, cost report)"

--- a/deploy/saas/update-test.sh
+++ b/deploy/saas/update-test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Self-test for deploy/saas/update.sh — offline, no cluster: exercises the
+# version-decision logic through --dry-run against a synthetic install state,
+# pinning the target with GX_TARGET_VERSION so no network is touched. Each
+# case pins one property (the scripts/ self-test discipline).
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+UPDATE=deploy/saas/update.sh
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+pass() { echo "update-test: PASS — $*"; }
+fail() { echo "update-test: FAIL — $*" >&2; exit 1; }
+
+# make_state DIR VERSION [extra lines...] — a minimal plausible install state.
+make_state() {
+  local dir="$1" version="$2"; shift 2
+  mkdir -p "$dir"
+  : >"$dir/values.yaml"
+  {
+    echo "GX_RELEASE=glyphoxa"
+    echo "GX_FULLNAME=glyphoxa"
+    echo "GX_NAMESPACE=glyphoxa"
+    echo "GX_VERSION=${version}"
+    echo "GX_VALUES_FILE=${dir}/values.yaml"
+    printf '%s\n' "$@"
+  } >"$dir/install.env"
+}
+
+run_update() { # DIR [args...]
+  local dir="$1"; shift
+  env -i PATH="$PATH" HOME="$workdir" bash "$UPDATE" --config-dir "$dir" "$@" </dev/null
+}
+
+# --- 1. no install state must fail, pointing at install.sh -----------------
+if out="$(run_update "$workdir/nowhere" --dry-run 2>&1)"; then
+  fail "update without install state succeeded"
+fi
+grep -q 'install.sh' <<<"$out" || fail "the no-state error does not point at install.sh: $out"
+pass "missing install state refuses and points at install.sh"
+
+# --- 2. same version is a no-op ---------------------------------------------
+d="$workdir/uptodate"; make_state "$d" v1.2.3
+out="$(run_update "$d" --dry-run --version v1.2.3 2>&1)" \
+  || fail "same-version dry-run exited non-zero: $out"
+grep -qi 'up to date' <<<"$out" || fail "same-version run does not say 'up to date': $out"
+pass "same-version target is a clean no-op"
+
+# --- 3. downgrades are refused, citing the ADR-0055 caveat ------------------
+d="$workdir/downgrade"; make_state "$d" v1.2.3
+if out="$(run_update "$d" --dry-run --version v1.1.0 2>&1)"; then
+  fail "downgrade v1.2.3 -> v1.1.0 was accepted"
+fi
+grep -q 'ADR-0055' <<<"$out" || fail "the downgrade refusal does not cite ADR-0055: $out"
+pass "downgrade is refused with the ADR-0055 caveat"
+
+# --- 4. --force overrides the downgrade refusal -----------------------------
+out="$(run_update "$d" --dry-run --version v1.1.0 --force 2>&1)" \
+  || fail "forced downgrade dry-run failed: $out"
+grep -q 'v1.2.3 -> v1.1.0' <<<"$out" || fail "forced downgrade plan does not show the version change: $out"
+pass "--force allows the downgrade and the plan names both versions"
+
+# --- 5. an upgrade prints a plan naming both versions and the backup posture -
+d="$workdir/upgrade"; make_state "$d" v1.2.3 "GX_BACKUP_CRONJOB=glyphoxa-pgdump"
+out="$(run_update "$d" --dry-run --version v1.3.0 2>&1)" \
+  || fail "upgrade dry-run failed: $out"
+grep -q 'v1.2.3 -> v1.3.0' <<<"$out" || fail "plan does not show the version change: $out"
+grep -q 'glyphoxa-pgdump' <<<"$out" || fail "plan does not mention the pre-upgrade backup CronJob: $out"
+out="$(run_update "$d" --dry-run --version v1.3.0 --skip-backup 2>&1)" \
+  || fail "upgrade --skip-backup dry-run failed: $out"
+grep -q 'NO pre-upgrade backup' <<<"$out" || fail "--skip-backup plan does not admit skipping the backup: $out"
+pass "upgrade plan names both versions and the backup posture"
+
+# --- 6. a pre-release-style tag sorts correctly (no false downgrade) --------
+d="$workdir/prerelease"; make_state "$d" v1.2.3
+out="$(run_update "$d" --dry-run --version v1.2.10 2>&1)" \
+  || fail "v1.2.3 -> v1.2.10 was treated as a downgrade (string compare instead of version sort): $out"
+pass "version comparison is numeric (v1.2.10 > v1.2.3)"
+
+# --- 7. semver prerelease ordering: rc -> GA is an UPGRADE, GA -> rc is not --
+# GNU sort -V alone gets this backwards (v1.3.0 < v1.3.0-rc1); the guard maps
+# '-' to '~' to restore semver order (.goreleaser.yml cuts prerelease tags).
+d="$workdir/rc-to-ga"; make_state "$d" v1.3.0-rc1
+out="$(run_update "$d" --dry-run --version v1.3.0 2>&1)" \
+  || fail "the routine rc -> GA update (v1.3.0-rc1 -> v1.3.0) was refused as a downgrade: $out"
+grep -q 'v1.3.0-rc1 -> v1.3.0' <<<"$out" || fail "rc -> GA plan does not show the version change: $out"
+d="$workdir/ga-to-rc"; make_state "$d" v1.3.0
+if out="$(run_update "$d" --dry-run --version v1.3.0-rc1 2>&1)"; then
+  fail "the GA -> rc DOWNGRADE (v1.3.0 -> v1.3.0-rc1) was waved through"
+fi
+grep -q 'ADR-0055' <<<"$out" || fail "the GA -> rc refusal does not cite ADR-0055: $out"
+pass "prerelease ordering is semver-correct in both directions"
+
+echo "update-test: OK"

--- a/deploy/saas/update.sh
+++ b/deploy/saas/update.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# deploy/saas/update.sh — update a deploy/saas/install.sh deployment to the
+# latest released Glyphoxa version (or a pinned one) and migrate the schema.
+#
+# What it does, in order:
+#   1. loads the install state (/etc/glyphoxa/install.env, or --config-dir)
+#      and targets the same cluster the install did;
+#   2. resolves the latest published release (or --version vX.Y.Z);
+#   3. refuses same-version re-runs and DOWNGRADES — rolling an open-admission
+#      deployment back across the ADR-0055 boundary boots in allowlist posture
+#      and evicts every signup (saas-operations.md's rollback caveat); --force
+#      overrides both refusals once you have read that caveat;
+#   4. when a backup CronJob is configured, takes a pre-upgrade pg_dump and
+#      waits for it — an upgrade without a fresh dump is a bet, not an update;
+#   5. downloads the target release's source tarball and `helm upgrade`s with
+#      ITS chart and its image tag — chart and image move in lockstep, and the
+#      chart's pre-upgrade migrate hook brings the schema current BEFORE the
+#      new pod rolls (ADR-0031/0034; `all` mode uses a Recreate strategy, so
+#      expect a brief outage — schedule around live Voice Sessions);
+#   6. verifies the rollout and records the new version in the state file.
+#
+# --dry-run resolves + prints the plan without touching the cluster.
+set -euo pipefail
+
+GX_CONFIG_DIR="${GX_CONFIG_DIR:-/etc/glyphoxa}"
+GX_TARGET_VERSION="${GX_TARGET_VERSION:-}"   # empty = latest published release
+FORCE=""
+SKIP_BACKUP=""
+DRY_RUN=""
+
+usage() {
+  cat <<'EOF'
+usage: update.sh [options]
+
+Options:
+  --version vX.Y.Z   update to this released version (default: latest release)
+  --config-dir DIR   where install.sh put values/state (default: /etc/glyphoxa)
+  --skip-backup      skip the pre-upgrade pg_dump (NOT recommended)
+  --force            proceed on same-version re-runs and downgrades. A
+                     downgrade across the ADR-0055 boundary boots an open
+                     deployment in allowlist posture and evicts every signup —
+                     read docs/deploy/saas-operations.md first.
+  --dry-run          resolve versions + print the plan, touch nothing
+  -h, --help         this text
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) GX_TARGET_VERSION="${2:?--version needs a tag}"; shift 2 ;;
+    --config-dir) GX_CONFIG_DIR="${2:?--config-dir needs a path}"; shift 2 ;;
+    --skip-backup) SKIP_BACKUP=1; shift ;;
+    --force) FORCE=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "update.sh: unknown option '$1' (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+die()  { echo "update.sh: ERROR: $*" >&2; exit 1; }
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found"; }
+
+need_cmd curl
+need_cmd tar
+
+# ------------------------------------------------------------------- state --
+STATE_FILE="${GX_CONFIG_DIR}/install.env"
+[ -f "$STATE_FILE" ] \
+  || die "no install state at ${STATE_FILE} — run deploy/saas/install.sh first (or pass --config-dir)"
+
+# Parsed line-wise (KEY=raw value), NOT sourced — values like a cron schedule
+# contain spaces/globs that `source` would mangle. install.sh writes the file.
+while IFS='=' read -r k v; do
+  case "$k" in
+    GX_*) printf -v "$k" '%s' "$v" ;;
+  esac
+done <"$STATE_FILE"
+
+for req in GX_RELEASE GX_NAMESPACE GX_VERSION GX_VALUES_FILE; do
+  [ -n "${!req-}" ] || die "${STATE_FILE} is missing ${req} — re-run deploy/saas/install.sh"
+done
+GX_FULLNAME="${GX_FULLNAME:-$GX_RELEASE}"
+GX_REPO="${GX_REPO:-MrWong99/Glyphoxa}"
+GX_TIMEOUT="${GX_TIMEOUT:-600s}"
+[ -f "$GX_VALUES_FILE" ] || die "values file ${GX_VALUES_FILE} (from state) does not exist"
+
+# Target the cluster the install recorded, unless the caller already exported
+# a KUBECONFIG of their own.
+if [ -z "${KUBECONFIG-}" ] && [ -n "${GX_KUBECONFIG-}" ] && [ -f "$GX_KUBECONFIG" ]; then
+  export KUBECONFIG="$GX_KUBECONFIG"
+fi
+export PATH="/usr/local/bin:$PATH"   # k3s symlinks kubectl here
+
+# ---------------------------------------------------------------- versions --
+log "Resolving versions"
+
+# Deployed version: what the web Deployment actually runs beats the state
+# record (someone may have helm-upgraded by hand); fall back to the state.
+CURRENT="$GX_VERSION"
+if [ -z "$DRY_RUN" ]; then
+  need_cmd kubectl
+  live="$(kubectl -n "$GX_NAMESPACE" get "deployment/${GX_FULLNAME}-web" \
+      -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+  case "$live" in
+    *:*) CURRENT="${live##*:}" ;;
+  esac
+fi
+
+TARGET="$GX_TARGET_VERSION"
+if [ -z "$TARGET" ]; then
+  # `|| true` so a curl failure reaches the actionable die below instead of
+  # errexit killing the script with only curl's terse stderr.
+  TARGET="$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+      "https://api.github.com/repos/${GX_REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1 || true)"
+  [ -n "$TARGET" ] || die "could not resolve the latest release of ${GX_REPO} (network? rate limit?) — pin one with --version"
+fi
+
+note "deployed: ${CURRENT}"
+note "target:   ${TARGET}"
+
+if [ "$TARGET" = "$CURRENT" ] && [ -z "$FORCE" ]; then
+  log "Already up to date (${CURRENT}) — nothing to do"
+  exit 0
+fi
+
+# Refuse when the target is the LOWER version. Plain `sort -V` alone is wrong
+# for prerelease tags (GNU version sort puts v1.3.0 BEFORE v1.3.0-rc1 — the
+# inverse of semver, so an rc→GA update would be refused and a GA→rc downgrade
+# waved through); mapping the semver '-' to dpkg-style '~' (which sorts before
+# the bare version) restores semver order for the v1.2.3[-suffix] tags this
+# repo cuts (.goreleaser.yml: prerelease auto). Downgrades are not a symmetric
+# operation here: an open-admission deployment rolled back across the ADR-0055
+# boundary boots in allowlist posture and evicts every signup (see
+# saas-operations.md, rollback caveat).
+LOWER="$(printf '%s\n%s\n' "$CURRENT" "$TARGET" | sed 's/-/~/' | sort -V | head -n1 | tr '~' '-')"
+if [ "$TARGET" != "$CURRENT" ] \
+  && [ "$LOWER" = "$TARGET" ] \
+  && [ -z "$FORCE" ]; then
+  die "refusing to DOWNGRADE ${CURRENT} -> ${TARGET}: across the ADR-0055 boundary this \
+boots an open deployment in allowlist posture and evicts every signup \
+(docs/deploy/saas-operations.md). --force if you have read that and mean it."
+fi
+
+if [ -n "$DRY_RUN" ]; then
+  log "DRY RUN — plan"
+  note "would update ${CURRENT} -> ${TARGET} (release '${GX_RELEASE}', namespace '${GX_NAMESPACE}')"
+  if [ -n "${GX_BACKUP_CRONJOB-}" ] && [ -z "$SKIP_BACKUP" ]; then
+    note "would take a pre-upgrade pg_dump via CronJob '${GX_BACKUP_CRONJOB}'"
+  else
+    note "would take NO pre-upgrade backup ($([ -n "$SKIP_BACKUP" ] && echo '--skip-backup' || echo 'none configured'))"
+  fi
+  note "would helm upgrade with the ${TARGET} chart + image (migrate hook runs first)"
+  exit 0
+fi
+
+need_cmd helm
+need_cmd kubectl
+
+# ------------------------------------------------------------------ backup --
+if [ -n "${GX_BACKUP_CRONJOB-}" ] && [ -z "$SKIP_BACKUP" ]; then
+  log "Pre-upgrade backup (CronJob ${GX_BACKUP_CRONJOB})"
+  if cj_err="$(kubectl -n "$GX_NAMESPACE" get "cronjob/${GX_BACKUP_CRONJOB}" -o name 2>&1)"; then
+    JOB="${GX_BACKUP_CRONJOB}-pre-$(date +%Y%m%d%H%M%S)"
+    kubectl -n "$GX_NAMESPACE" create job --from="cronjob/${GX_BACKUP_CRONJOB}" "$JOB"
+    # A failed dump ABORTS the update: upgrading without the backup you
+    # configured is exactly the surprise this step exists to prevent. Poll
+    # both terminal conditions so a deterministic pg_dump failure surfaces in
+    # seconds instead of eating the whole timeout.
+    t="${GX_TIMEOUT%s}"; case "$t" in *[!0-9]*|"") t=600 ;; esac
+    deadline=$((SECONDS + t))
+    while :; do
+      cond="$(kubectl -n "$GX_NAMESPACE" get "job/${JOB}" \
+        -o jsonpath='{range .status.conditions[?(@.status=="True")]}{.type}{end}' 2>/dev/null || true)"
+      case "$cond" in
+        *Complete*) break ;;
+        *Failed*) die "pre-upgrade backup Job ${JOB} FAILED — fix the backup (kubectl -n ${GX_NAMESPACE} logs job/${JOB}), or --skip-backup at your own risk" ;;
+      esac
+      [ "$SECONDS" -lt "$deadline" ] \
+        || die "pre-upgrade backup Job ${JOB} did not complete within ${GX_TIMEOUT} — fix the backup (or --skip-backup at your own risk)"
+      sleep 5
+    done
+    note "dump written under ${GX_BACKUP_DIR:-<backup dir>} on the node"
+  elif grep -qi 'notfound' <<<"$cj_err"; then
+    # The state promises a backup that is not there — that is a broken backup,
+    # not a missing feature: refuse rather than silently update without one.
+    die "state names backup CronJob '${GX_BACKUP_CRONJOB}' but namespace '${GX_NAMESPACE}' has none — \
+restore it (kubectl apply -f ${GX_CONFIG_DIR}/backup-cronjob.yaml) or pass --skip-backup to update without a backup"
+  else
+    die "cannot check the backup CronJob: ${cj_err}"
+  fi
+elif [ -n "$SKIP_BACKUP" ]; then
+  note "skipping the pre-upgrade backup (--skip-backup)"
+else
+  note "WARNING: no backup configured (install.sh's backup option was declined) — updating without one"
+fi
+
+# ------------------------------------------------------------------- chart --
+log "Fetching the ${TARGET} chart"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+curl -fsSL "https://github.com/${GX_REPO}/archive/refs/tags/${TARGET}.tar.gz" \
+  | tar -xz -C "$WORKDIR"
+CHART_DIR="$(echo "$WORKDIR"/*/deploy/charts/glyphoxa)"
+[ -d "$CHART_DIR" ] || die "release ${TARGET} has no deploy/charts/glyphoxa"
+
+# ----------------------------------------------------------------- upgrade --
+log "Upgrading ${CURRENT} -> ${TARGET}"
+if ! helm upgrade "$GX_RELEASE" "$CHART_DIR" \
+  --namespace "$GX_NAMESPACE" \
+  --values "$GX_VALUES_FILE" \
+  --set-string "image.tag=${TARGET}" \
+  --wait --timeout "$GX_TIMEOUT"; then
+  log "UPGRADE FAILED — diagnostics"
+  kubectl -n "$GX_NAMESPACE" get pods -o wide 2>/dev/null || true
+  kubectl -n "$GX_NAMESPACE" logs "job/${GX_FULLNAME}-migrate" --tail=40 2>/dev/null || true
+  note "roll back with:  helm -n ${GX_NAMESPACE} rollback ${GX_RELEASE}"
+  note "                 (then restore the pre-upgrade dump if the migrate hook already ran:"
+  note "                  pg_restore -d \"\$DSN\" --clean --if-exists <dump>)"
+  note "NOTE the ADR-0055 rollback caveat before rolling an open deployment back."
+  die "helm upgrade to ${TARGET} failed"
+fi
+
+kubectl -n "$GX_NAMESPACE" rollout status "deployment/${GX_FULLNAME}-web" --timeout "$GX_TIMEOUT"
+
+# ------------------------------------------------------------------- state --
+# Record the deployed version (line-rewrite, keeping the rest of the file).
+tmp="$(mktemp)"
+sed "s/^GX_VERSION=.*/GX_VERSION=${TARGET}/" "$STATE_FILE" >"$tmp"
+chmod 600 "$tmp"
+mv "$tmp" "$STATE_FILE"
+
+log "Done — ${GX_RELEASE} is on ${TARGET}"
+note "deployed image: $(kubectl -n "$GX_NAMESPACE" get "deployment/${GX_FULLNAME}-web" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo '<unknown>')"
+note "state updated:  ${STATE_FILE}"

--- a/docs/deploy/cloud-providers.md
+++ b/docs/deploy/cloud-providers.md
@@ -54,6 +54,40 @@ order-of-magnitude for comparison, and check current pricing before deciding.
 **Total: ~€5–10/mo.** This is the natural first step off the home lab: same
 operational model, real IP, real uptime, no CG-NAT worries.
 
+#### Scripted install & updates
+
+Two scripts automate this exact single-box path (they are generic k3s, but
+Hetzner is the deployment they were written for):
+
+- [`deploy/saas/install.sh`](../../deploy/saas/install.sh) — the whole of
+  the home-lab guide's §2–§8 on a bare box: prompts for the DNS name, ACME
+  email, Discord credentials, Admission Mode and (optionally) a nightly
+  `pg_dump` backup directory on disk; installs k3s + helm + cert-manager;
+  installs the **latest released** version with chart and image pinned to the
+  same tag. Every prompt can be pre-answered with the `GX_*` env var it
+  names, so unattended installs work too.
+- [`deploy/saas/update.sh`](../../deploy/saas/update.sh) — updates a scripted
+  install to the latest release (or `--version vX.Y.Z`): takes a pre-upgrade
+  dump when backups are configured, then `helm upgrade`s with the target
+  release's own chart — the pre-upgrade migrate hook brings the schema
+  current before the new pod rolls. Downgrades are refused (ADR-0055's
+  rollback caveat) unless forced.
+
+```sh
+# on the fresh server, as root
+curl -fsSLO https://raw.githubusercontent.com/MrWong99/Glyphoxa/main/deploy/saas/install.sh
+chmod +x install.sh && ./install.sh        # prompts for everything it needs
+
+# any later day
+curl -fsSLO https://raw.githubusercontent.com/MrWong99/Glyphoxa/main/deploy/saas/update.sh
+chmod +x update.sh && ./update.sh          # latest release + schema migration
+```
+
+State lands in `/etc/glyphoxa/` (values file `0600`, install state, backup
+manifest); re-running the installer reuses it — secrets, notably
+`appSecret`, are never rotated on a re-run (ADR-0004: rotating it strands
+every sealed BYOK credential).
+
 ### 2. netcup (or similar EU VPS: Contabo, IONOS) — cheapest raw compute
 
 Root/VPS servers with generous specs (~€5–8/mo for 4 vCPU/8 GiB) and no hourly

--- a/docs/deploy/k3s-proxmox.md
+++ b/docs/deploy/k3s-proxmox.md
@@ -247,6 +247,12 @@ helm upgrade glyphoxa deploy/charts/glyphoxa \
   --namespace glyphoxa --values glyphoxa-values.yaml
 ```
 
+> On a cloud box installed with
+> [`deploy/saas/install.sh`](../../deploy/saas/install.sh), use
+> [`deploy/saas/update.sh`](../../deploy/saas/update.sh) instead — it resolves
+> the latest release, takes a pre-upgrade dump, and upgrades with that
+> release's own chart ([cloud-providers.md](cloud-providers.md)).
+
 The migrate hook runs before the new pod rolls (pre-upgrade hook, ADR-0034);
 `all` mode uses a `Recreate` strategy, so expect a brief (seconds) outage per
 upgrade — schedule around live Voice Sessions.
@@ -287,7 +293,7 @@ spec:
                 - name: GLYPHOXA_DATABASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: glyphoxa        # the chart's app Secret
+                      name: glyphoxa-db     # the chart's app Secret: <fullname>-db
                       key: database-url
               volumeMounts:
                 - name: backup
@@ -312,6 +318,12 @@ spec:
 Copy the dumps off the VM regularly (rsync to a NAS, restic to any S3) — a
 backup on the same physical disk is not a backup. Restore with
 `pg_restore -d "$DSN" --clean --if-exists <file>.dump`.
+
+[`deploy/saas/install.sh`](../../deploy/saas/install.sh) sets up an
+equivalent CronJob for you (writing to a host path instead of a PVC — on a
+single cloud box that is the disk you have), and
+[`deploy/saas/update.sh`](../../deploy/saas/update.sh) triggers a run of it
+before every upgrade.
 
 ## 9. Monitoring
 

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -195,8 +195,10 @@ schema change.
 - [ ] Provider dashboards (Groq/ElevenLabs) checked against the ledger's
       estimates for the first month — calibrate expectations; the price map is
       an estimate by design.
-- [ ] Backups running and restore-tested ([k3s-proxmox.md §8](k3s-proxmox.md))
-      — the ledger and subscription history are now business records.
+- [ ] Backups running and restore-tested ([k3s-proxmox.md §8](k3s-proxmox.md);
+      on a scripted cloud install, `deploy/saas/install.sh`'s backup option +
+      the pre-upgrade dump `deploy/saas/update.sh` takes) — the ledger and
+      subscription history are now business records.
 - [ ] `plans.json` (or the Helm values catalog) in version control.
 - [ ] Terms with your users about recording/consent (the Rollover Tape is
       consent-gated by design, ADR-0051 — point users at it).


### PR DESCRIPTION
## What

Two self-contained operator scripts for the single-box cloud path of [cloud-providers.md](docs/deploy/cloud-providers.md) (Hetzner being the recommended target; generic k3s otherwise), linked from the deploy docs:

- **`deploy/saas/install.sh`** — stands up the entire SaaS server on a bare box: prompts for DNS name, ACME email, Discord OAuth/bot credentials, Admission Mode (ADR-0055, including an open-mode signup plan catalog), Ollama URL, optional platform provider keys, and an **optional nightly `pg_dump` backup to a path on the node's disk** (schedule + retention). Installs **k3s**, helm, and cert-manager + ClusterIssuer as needed, resolves the **latest published release** and installs *that release's own chart* with `image.tag` pinned to the same tag (the chart's appVersion doesn't track releases, so chart and image can never drift). Every prompt is pre-answerable via the `GX_*` env var it names — a no-TTY run is env-only and fails naming the missing variable, so unattended installs are reproducible. `--skip-k3s` targets an existing kubeconfig context; `--dry-run` writes config only.
- **`deploy/saas/update.sh`** — update + migrate to the latest published release (or `--version vX.Y.Z`): triggers a **pre-upgrade dump** through the backup CronJob (a failed — or configured-but-missing — backup aborts the update), then `helm upgrade`s with the target release's chart so the pre-upgrade **migrate hook brings the schema current** before the pod rolls. Same-version runs are a clean no-op; **downgrades are refused citing the ADR-0055 rollback caveat** unless `--force`.

## Safety properties worth reviewing

- Re-runs **reuse the values file — `appSecret` never rotates** (rotating it strands every sealed BYOK credential, ADR-0004); `--fresh-values` is the explicit, loudly-warned escape hatch, and a guard refuses freshly generated secrets against a namespace that already holds release data (`<fullname>-db`).
- The downgrade guard is **semver-correct for prerelease tags**: plain `sort -V` orders `v1.3.0` *before* `v1.3.0-rc1`, which would refuse rc→GA updates and wave GA→rc downgrades through; the guard maps `-` → `~` (dpkg rule) before sorting.
- The state file is `KEY=raw-value`, parsed line-wise and never `source`d (cron schedules contain globs/spaces); an explicitly empty env var (`GX_BACKUP_DIR=`) clears a recorded choice, and a `GX_HOST`/`GX_TLS` env override that conflicts with the reused values file is refused rather than silently ignored (hand-edits to the values file are adopted — the file is what deploys).
- Dumps are written `0600` in a `0700` dir (umask set inside the CronJob container, independent of who created the hostPath).

## Tests

- `deploy/saas/install-test.sh` + `update-test.sh` (17 offline cases, no cluster) follow the `scripts/` "the gate must gate" discipline: they helm-template the generated values against the local chart in **both admission modes**, pin the appSecret-stability/state-round-trip/quoting properties, and the version-decision logic including both prerelease directions. Wired into ci.yml's helm job (the workflow-invariant test in `internal/ci` passes).
- **Live e2e on a throwaway k3d cluster**: v0.2.1 install (cert-manager + staging ACME), a real `pg_dump` custom-format dump landing on the host-mapped backup path, `update.sh` → v0.3.0 with pre-upgrade dump + completed migrate hook + console serving 200 after the roll, downgrade refusal, same-version no-op, reuse re-run, and the interactive prompt flow via a pty. The one path not literally executed is `curl get.k3s.io | sh` itself (needs a real systemd box); everything downstream ran against real k3s.
- All four scripts are shellcheck-clean.

## Docs

Scripts linked from the Hetzner section of cloud-providers.md (with curl-and-run usage), k3s-proxmox.md §7 (upgrades) and §8 (backups), and the saas-operations.md go-paid checklist. Drive-by fix: the §8 CronJob example referenced Secret `glyphoxa`, but the chart names it **`glyphoxa-db`** (`glyphoxa.secretName` = `<fullname>-db`) — the example as written dangled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)