### PR TITLE
fix(#484): bump disgo past the DAVE-session leak fix (disgoorg/disgo#568)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/antzucaro/matchr v0.0.0-20221106193745-7bed6ef61ef9
-	github.com/disgoorg/disgo v0.19.6 // pinned: pkg/voice depends on the voice.Conn/OpusFrame* API; bump deliberately
+	github.com/disgoorg/disgo v0.19.7-0.20260716190728-6298d75ebc8e // pinned: pkg/voice depends on the voice.Conn/OpusFrame* API; pseudo-version = PR #568 merge (DAVE session close on conn discard, #484) — move to the next tagged release containing it, otherwise bump deliberately
 	github.com/disgoorg/snowflake/v2 v2.0.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -40,7 +40,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/disgoorg/godave v0.2.0 // indirect
+	github.com/disgoorg/godave v0.3.0 // indirect
 	github.com/disgoorg/json/v2 v2.0.0 // indirect
 	github.com/disgoorg/omit v1.0.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,10 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/disgoorg/disgo v0.19.6 h1:1xJQt6KZgiqvBOnjuziG1gE4Iqd0aJn8DNfE6eE+0qw=
-github.com/disgoorg/disgo v0.19.6/go.mod h1:NnV63iw4lJdF1fnV0gX27XR43ZgRGqnL122svRMTgTE=
-github.com/disgoorg/godave v0.2.0 h1:BB6cc09UXml8yP9K2TZUADyiUF0Oosg1Pfzw1vfQGAc=
-github.com/disgoorg/godave v0.2.0/go.mod h1:OreAC3hpabr39bMVA+jwOVDq1EUPXH5A0XUBiZaDI1Y=
+github.com/disgoorg/disgo v0.19.7-0.20260716190728-6298d75ebc8e h1:xE9rUv0wiEUgaagdNaHltaJ6ZFkeG/svxfnpxUcDxbU=
+github.com/disgoorg/disgo v0.19.7-0.20260716190728-6298d75ebc8e/go.mod h1:ZMGQXsHdnrc7rIgcugi6Ht8sSPOKXwy7WKeNlDGfgKg=
+github.com/disgoorg/godave v0.3.0 h1:37F3ZuiMd8/EXeoCtTeE8iP2eT2nWsfEa4/ITwoKfe4=
+github.com/disgoorg/godave v0.3.0/go.mod h1:OreAC3hpabr39bMVA+jwOVDq1EUPXH5A0XUBiZaDI1Y=
 github.com/disgoorg/json/v2 v2.0.0 h1:U16yy/ARK7/aEpzjjqK1b/KaqqGHozUdeVw/DViEzQI=
 github.com/disgoorg/json/v2 v2.0.0/go.mod h1:jZTBC0nIE1WeetSEI3/Dka8g+qglb4FPVmp5I5HpEfI=
 github.com/disgoorg/omit v1.0.0 h1:y0LkVUOyUHT8ZlnhIAeOZEA22UYykeysK8bLJ0SfT78=


### PR DESCRIPTION
Closes #484 (slice of epic #483).

## What

Bumps `github.com/disgoorg/disgo` from v0.19.6 to the pseudo-version at the disgoorg/disgo#568 merge commit (`6298d75`, 2026-07-16), which closes a conn's DAVE session in `connImpl.Close`. Pulls `github.com/disgoorg/godave` v0.2.0 → v0.3.0 (indirect). Pin comment updated with the new reason and the next deliberate-bump condition (first tagged release containing #568).

## Why

v0.19.6 never closes the DAVE session when a voice conn is discarded (disgoorg/disgo#566). Our voice path creates a fresh conn per reconnect cycle, so every cycle leaks the DAVE session's goroutines — survivable at one session per process, not at the concurrent-sessions-per-pod target of epic #483.

## Verification

- `dave.Close()` confirmed present in the pinned module source (`voice/conn.go:339` at `6298d75`)
- `go build ./...` and `go build -tags dave ./...` both pass — the `voice.Conn`/`OpusFrame*` API surface we pin for is unchanged; no call-site changes needed
- `go test -race -count=1 ./...` passes (full unit suite)
- `go test -race -count=1 -tags dave ./pkg/voice/...` passes — thomas-vilte/dave-go v0.5.1 satisfies godave v0.3.0's `Session` interface (the `Ready()` contract added for the disgo#555 passthrough semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)