### PR TITLE
feat(#486): gateway IDENTIFY-budget observability (identify vs resume)

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -342,6 +343,26 @@ func sttStreaming(getenv func(string) string) bool {
 		return false
 	}
 	return true
+}
+
+// defaultGatewayIdentifyWarn is the per-application 24h IDENTIFY count above which
+// the gateway-budget observer warns (#486). It sits well below Discord's
+// 1000/token/24h hard limit — exhausting that budget resets the token and drops
+// every session (a central-token outage) — so an operator sees the trend with
+// head-room to react.
+const defaultGatewayIdentifyWarn = 500
+
+// gatewayIdentifyWarnThreshold reads the GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD
+// override for the IDENTIFY-budget alarm (#486). A blank, non-numeric, zero or
+// negative value falls back to [defaultGatewayIdentifyWarn], so a mis-set env var
+// never silently disables the alarm.
+func gatewayIdentifyWarnThreshold(getenv func(string) string) int {
+	v := strings.TrimSpace(getenv("GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD"))
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return defaultGatewayIdentifyWarn
+	}
+	return n
 }
 
 // forceLoopback rewrites a listen address to bind 127.0.0.1, preserving the port

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -673,6 +673,32 @@ func TestSTTStreaming(t *testing.T) {
 	}
 }
 
+// TestGatewayIdentifyWarnThreshold: the IDENTIFY-budget warning threshold (#486)
+// defaults to 500 (well below Discord's 1000/token/24h reset limit) and accepts a
+// positive integer override; blank, non-numeric, zero and negative values fall
+// back to the default so a fat-fingered env var never disables the alarm.
+func TestGatewayIdentifyWarnThreshold(t *testing.T) {
+	const def = 500
+	cases := []struct {
+		val  string
+		want int
+	}{
+		{"", def},
+		{"   ", def},
+		{"abc", def},
+		{"0", def},
+		{"-5", def},
+		{"1", 1},
+		{"250", 250},
+		{" 900 ", 900},
+	}
+	for _, c := range cases {
+		if got := gatewayIdentifyWarnThreshold(envMap(map[string]string{"GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD": c.val})); got != c.want {
+			t.Errorf("gatewayIdentifyWarnThreshold(%q) = %d, want %d", c.val, got, c.want)
+		}
+	}
+}
+
 // TestForceLoopback pins the listen host to 127.0.0.1 while preserving the port,
 // so a GLYPHOXA_DEV_MODE instance is structurally unreachable from a container
 // port-mapping (ADR-0041) regardless of the configured -web-addr.

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -78,6 +78,13 @@ func main() {
 	log := observe.NewLogger(os.Stderr, format, slog.LevelInfo, metrics.DAVEDecryptHook())
 	slog.SetDefault(log)
 
+	// Gateway IDENTIFY-budget observer (#486): registers the identify/resume
+	// counters on the metrics registry and warns when one bot application's 24h
+	// IDENTIFYs cross the configured threshold (default 500, below Discord's
+	// 1000/token/24h token-reset limit). Attached to the standing presence client
+	// and to per-cycle voice clients below.
+	gatewayBudget := observe.NewGatewayBudget(metrics.Registry(), gatewayIdentifyWarnThreshold(os.Getenv), log)
+
 	// `migrate` and `seed` are subcommands with their own argument grammar,
 	// dispatched before flag parsing. `voice`, `web`, and `all` are the Modes
 	// (ADR-0005). The default Mode is now `all` (ADR-0005/ADR-0034 self-host
@@ -130,6 +137,12 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9090", "address for the /metrics + /healthz + /readyz listener (all Modes; kept off the public web API port, ADR-0032); empty disables it")
 	webAddr := flag.String("web-addr", ":8080", "address for the web/all-mode Connect RPC API listener (ADR-0039); observability is on -metrics-addr")
 	flag.Parse()
+
+	// Instrument per-cycle (owned) voice clients with the IDENTIFY-budget observer
+	// (#486). In `all` mode the voice loop borrows the standing presence client
+	// (instrumented in runWeb), so this only bites in standalone `voice` mode where
+	// each cycle dials its own client; the borrow path leaves it unused.
+	cfg.GatewayBudget = gatewayBudget
 
 	switch *mode {
 	case "voice":
@@ -575,6 +588,12 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		// a live tape arms or clears that Speaker's lane.
 		reg.RegisterComponentHandler(presence.NewConsentButtons(store, eventBus, log).HandleComponent)
 		pres = presence.New(store, cipher, reg, cfg.Token, log)
+		// Instrument the standing client's gateway session establishments for the
+		// IDENTIFY-budget metrics (#486). Set before the first Ensure (below) so the
+		// initial gateway open already carries the identify/resume listeners. The
+		// voice-cycle clients borrow this same instrumented client, so they need no
+		// per-cycle listeners (cfg.GatewayBudget is used only on the owned path).
+		pres.SetGatewayBudget(cfg.GatewayBudget)
 		// The voice loop borrows this one client instead of dialing its own per
 		// session; set BEFORE the Manager copies cfg into its base config. Note:
 		// pres.Ensure is deliberately NOT called here — it opens the gateway, whose

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -334,6 +334,7 @@ server (the Helm chart's `ollamaUrl` value renders it), or semantic memory
 | `GLYPHOXA_OPERATOR_IDS` | `web`/`all` | Allowlisted Discord snowflakes (comma/whitespace-separated, digits only). Empty, separators-only, or non-numeric entries ⇒ fatal. |
 | `GLYPHOXA_DEV_MODE` | never in prod | Non-empty (except `0`/`false`/`no`/`off`) ⇒ OAuth-less local dev on `127.0.0.1` with auto-auth. |
 | `GLYPHOXA_LOG_FORMAT` | optional | `json`, or `text` (the default for any other value). |
+| `GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD` | optional | Per-application 24h Discord gateway IDENTIFY count above which a structured warning fires (token-reset early-warning, #486). Positive integer; blank/non-numeric/≤0 ⇒ default `500` (below Discord's 1000/token/24h limit). See [deploy/saas-operations.md §7](deploy/saas-operations.md). |
 | `GLYPHOXA_OLLAMA_URL` | optional | Ollama embeddings endpoint override; default `http://127.0.0.1:11434`. v1.0 embeddings are **Ollama-only** (ADR-0011), so set it wherever the process has no local Ollama — containers and k8s pods (k3d: `http://host.k3d.internal:11434`). The server must serve `nomic-embed-text`. Unreachable ⇒ semantic memory (L2) stalls loudly; nothing else breaks. |
 | `GROQ_API_KEY` | if Groq used | LLM provider key. |
 | `ELEVENLABS_API_KEY` | if ElevenLabs used | STT/TTS provider key. |

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -217,10 +217,14 @@ Two Prometheus counters on `/metrics` (the `-metrics-addr` listener, default
 `:9090`) make this observable, labelled by the non-secret bot **application id**
 (never the token):
 
-- `glyphoxa_gateway_identify_total{application_id="…"}` — fresh sessions
-  (budget-consuming).
+- `glyphoxa_gateway_identify_total{application_id="…"}` — **IDENTIFYs sent**
+  (budget-consuming). Counted at the point the gateway sends the IDENTIFY, not
+  when a session reaches `Ready` — so a connect that spends the budget but never
+  succeeds (an `InvalidSession` reply, a close before dispatch, a reconnect loop
+  that keeps re-identifying) is still counted. That is the whole point: a silent
+  connect-fail loop is the fastest way to burn the budget.
 - `glyphoxa_gateway_resume_total{application_id="…"}` — reattached sessions
-  (budget-free).
+  (budget-free), counted on the `Resumed` event.
 
 **What to watch.** A rising `identify_total` rate — especially a reconnect loop
 that identifies instead of resuming — is the early sign of budget burn. Alert on

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -203,6 +203,39 @@ schema change.
 - [ ] Terms with your users about recording/consent (the Rollover Tape is
       consent-gated by design, ADR-0051 — point users at it).
 
+## 7. Gateway IDENTIFY budget (token-reset alarm)
+
+Discord allows a bot token **1000 IDENTIFYs per 24 hours**. Blowing that budget
+terminates every session **and resets the token** — in central-token mode (one
+shared Bot across all Tenants) that is a platform-wide outage, not a single
+Tenant's problem. A RESUME reattaches an existing session and does **not** spend
+the budget; only a fresh IDENTIFY does. So a healthy deployment resumes across
+brief network blips and identifies rarely (a restart, a token change, a long
+disconnect).
+
+Two Prometheus counters on `/metrics` (the `-metrics-addr` listener, default
+`:9090`) make this observable, labelled by the non-secret bot **application id**
+(never the token):
+
+- `glyphoxa_gateway_identify_total{application_id="…"}` — fresh sessions
+  (budget-consuming).
+- `glyphoxa_gateway_resume_total{application_id="…"}` — reattached sessions
+  (budget-free).
+
+**What to watch.** A rising `identify_total` rate — especially a reconnect loop
+that identifies instead of resuming — is the early sign of budget burn. Alert on
+`increase(glyphoxa_gateway_identify_total[24h])` approaching 1000 per
+application id; investigate well before it, because a reset is an outage you
+cannot undo (you wait it out or rotate the token).
+
+The process also logs a structured **warning** (`application_id`,
+`identifies_24h`, `threshold`) when one application crosses a configurable 24h
+IDENTIFY count. It defaults to **500** — half the hard limit, for head-room —
+and is tuned with `GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD` (a positive
+integer; a blank, non-numeric, zero or negative value keeps the default, so a
+fat-fingered override never silently disables the alarm). Both the standing
+presence gateway and the per-session voice clients are counted.
+
 ## See also
 
 - [ADR-0054](../adr/0054-saas-plans-platform-keys-usage-ledger.md) — the

--- a/internal/observe/gateway.go
+++ b/internal/observe/gateway.go
@@ -15,17 +15,22 @@ import (
 const identifyWindow = 24 * time.Hour
 
 // GatewayBudget observes Discord gateway session establishments, classifying each
-// as an IDENTIFY (a fresh session, budget-consuming) or a RESUME (budget-free),
-// exporting Prometheus counters labeled by the non-secret bot application id, and
-// logging a structured warning when one application's IDENTIFYs cross a
-// configurable threshold inside the rolling 24h window (#486, ADR-0032).
+// as an IDENTIFY (budget-consuming) or a RESUME (budget-free), exporting Prometheus
+// counters labeled by the non-secret bot application id, and logging a structured
+// warning when one application's IDENTIFYs cross a configurable threshold inside
+// the rolling 24h window (#486, ADR-0032).
+//
+// IDENTIFY is counted at SEND time (the wirenpc identify rate-limiter wrapper), not
+// when a session reaches Ready, so a connect that spends the budget but never
+// succeeds still counts — that is the exact failure mode this metric pre-warns.
+// RESUME is counted on the Resumed dispatch.
 //
 // The token is NEVER a label or a log field — only the application id, which is a
 // public, bounded identifier (one per bot; a handful across tenants), so the
 // series stays within the ADR-0032 cardinality bounds.
 //
-// Its Record* methods fire from disgo's gateway read goroutines (the Ready /
-// Resumed dispatch), so all state is mutex-guarded.
+// Its Record* methods fire from disgo's gateway read goroutines (the identify send
+// path / the Resumed dispatch), so all state is mutex-guarded.
 type GatewayBudget struct {
 	identify *prometheus.CounterVec // application_id
 	resume   *prometheus.CounterVec // application_id

--- a/internal/observe/gateway.go
+++ b/internal/observe/gateway.go
@@ -1,0 +1,121 @@
+package observe
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// identifyWindow is the rolling span Discord meters IDENTIFYs over: a bot token
+// is allowed 1000 IDENTIFYs per 24h, and exhausting that budget terminates every
+// session and RESETS the token — an operator outage in central-token mode where
+// all tenants share one budget (#486). RESUME does not consume it.
+const identifyWindow = 24 * time.Hour
+
+// GatewayBudget observes Discord gateway session establishments, classifying each
+// as an IDENTIFY (a fresh session, budget-consuming) or a RESUME (budget-free),
+// exporting Prometheus counters labeled by the non-secret bot application id, and
+// logging a structured warning when one application's IDENTIFYs cross a
+// configurable threshold inside the rolling 24h window (#486, ADR-0032).
+//
+// The token is NEVER a label or a log field — only the application id, which is a
+// public, bounded identifier (one per bot; a handful across tenants), so the
+// series stays within the ADR-0032 cardinality bounds.
+//
+// Its Record* methods fire from disgo's gateway read goroutines (the Ready /
+// Resumed dispatch), so all state is mutex-guarded.
+type GatewayBudget struct {
+	identify *prometheus.CounterVec // application_id
+	resume   *prometheus.CounterVec // application_id
+
+	threshold int
+	log       *slog.Logger
+	now       func() time.Time
+
+	mu      sync.Mutex
+	windows map[string][]time.Time // appID -> IDENTIFY timestamps within the window
+	warned  map[string]bool        // appID -> already warned while over threshold
+}
+
+// NewGatewayBudget builds the observer and registers its two counters on reg.
+// threshold is the per-application 24h IDENTIFY count above which a warning fires;
+// it should sit well below Discord's 1000/day hard limit so an operator sees the
+// trend before the token is reset.
+func NewGatewayBudget(reg prometheus.Registerer, threshold int, log *slog.Logger) *GatewayBudget {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	b := &GatewayBudget{
+		// Process-level gateway health (namespace only, no voice subsystem), like
+		// embedding_backlog / jobs_total: a gateway connect is not a voice-pipeline
+		// stage. application_id is the sole, bounded label (ADR-0032).
+		identify: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "gateway_identify_total",
+			Help:      "Discord gateway IDENTIFYs (fresh sessions) per bot application id. Discord allows 1000/token/24h; exhaustion resets the token (#486).",
+		}, []string{"application_id"}),
+		resume: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "gateway_resume_total",
+			Help:      "Discord gateway RESUMEs (reattached sessions) per bot application id. RESUME does not consume the IDENTIFY budget (#486).",
+		}, []string{"application_id"}),
+		threshold: threshold,
+		log:       log,
+		now:       time.Now,
+		windows:   map[string][]time.Time{},
+		warned:    map[string]bool{},
+	}
+	reg.MustRegister(b.identify, b.resume)
+	return b
+}
+
+// RecordIdentify counts one IDENTIFY for appID and, if that pushes the
+// application's rolling-24h count past the threshold, logs a structured warning
+// once until the window drains back under it (so a churning gateway warns on the
+// crossing, not on every reconnect).
+func (b *GatewayBudget) RecordIdentify(appID string) {
+	b.identify.WithLabelValues(appID).Inc()
+
+	b.mu.Lock()
+	now := b.now()
+	w := prune(b.windows[appID], now.Add(-identifyWindow))
+	w = append(w, now)
+	b.windows[appID] = w
+
+	over := len(w) > b.threshold
+	warn := over && !b.warned[appID]
+	if over {
+		b.warned[appID] = true
+	} else {
+		b.warned[appID] = false
+	}
+	count := len(w)
+	b.mu.Unlock()
+
+	if warn {
+		b.log.Warn("gateway IDENTIFY budget threshold exceeded for a bot application; approaching Discord's 1000/24h token-reset limit",
+			"application_id", appID,
+			"identifies_24h", count,
+			"threshold", b.threshold,
+		)
+	}
+}
+
+// RecordResume counts one RESUME for appID. RESUME does not consume the IDENTIFY
+// budget, so it never trips the threshold — it is exported purely to show that a
+// reconnect reattached rather than re-identified.
+func (b *GatewayBudget) RecordResume(appID string) {
+	b.resume.WithLabelValues(appID).Inc()
+}
+
+// prune returns ts with every timestamp at or before cutoff dropped. The slice is
+// append-ordered (oldest first), so it trims a leading run.
+func prune(ts []time.Time, cutoff time.Time) []time.Time {
+	i := 0
+	for i < len(ts) && !ts[i].After(cutoff) {
+		i++
+	}
+	return ts[i:]
+}

--- a/internal/observe/gateway_test.go
+++ b/internal/observe/gateway_test.go
@@ -1,0 +1,110 @@
+package observe
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// counterValue gathers reg and returns the sample for series `name` at the given
+// application_id label, or -1 if that series has no sample yet.
+func counterValue(t *testing.T, reg *prometheus.Registry, name, appID string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "application_id" && l.GetValue() == appID {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// TestGatewayBudgetClassifiesIdentifyVsResume proves the two session-establishment
+// paths land on SEPARATE series, each labeled by the non-secret application id.
+func TestGatewayBudgetClassifiesIdentifyVsResume(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	b := NewGatewayBudget(reg, 500, slog.New(slog.DiscardHandler))
+
+	b.RecordIdentify("app-1")
+	b.RecordIdentify("app-1")
+	b.RecordResume("app-1")
+	b.RecordIdentify("app-2")
+
+	if got := counterValue(t, reg, "glyphoxa_gateway_identify_total", "app-1"); got != 2 {
+		t.Fatalf("identify{app-1} = %v, want 2", got)
+	}
+	if got := counterValue(t, reg, "glyphoxa_gateway_resume_total", "app-1"); got != 1 {
+		t.Fatalf("resume{app-1} = %v, want 1", got)
+	}
+	if got := counterValue(t, reg, "glyphoxa_gateway_identify_total", "app-2"); got != 1 {
+		t.Fatalf("identify{app-2} = %v, want 1", got)
+	}
+}
+
+// TestGatewayBudgetWarnsWhenIdentifiesExceedThreshold proves a per-application
+// rolling window warns once when identifies cross the configured threshold, and
+// stays quiet below it.
+func TestGatewayBudgetWarnsWhenIdentifiesExceedThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	b := NewGatewayBudget(prometheus.NewRegistry(), 3, log)
+
+	// Three identifies is AT the threshold — no warning yet.
+	for range 3 {
+		b.RecordIdentify("app-1")
+	}
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Fatalf("warned at threshold, want quiet:\n%s", buf.String())
+	}
+
+	// The fourth crosses it — exactly one warning naming the application id.
+	b.RecordIdentify("app-1")
+	out := buf.String()
+	if n := strings.Count(out, "level=WARN"); n != 1 {
+		t.Fatalf("warnings = %d, want 1:\n%s", n, out)
+	}
+	if !strings.Contains(out, "application_id=app-1") {
+		t.Fatalf("warning missing application_id:\n%s", out)
+	}
+
+	// A fifth while still over threshold must not spam a second warning.
+	b.RecordIdentify("app-1")
+	if n := strings.Count(buf.String(), "level=WARN"); n != 1 {
+		t.Fatalf("warnings after fifth = %d, want 1 (de-duped)", n)
+	}
+}
+
+// TestGatewayBudgetWindowRollsOff proves identifies older than 24h leave the
+// window, so a slow trickle never trips the alarm.
+func TestGatewayBudgetWindowRollsOff(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	b := NewGatewayBudget(prometheus.NewRegistry(), 2, log)
+
+	now := time.Now()
+	b.now = func() time.Time { return now }
+
+	b.RecordIdentify("app-1")
+	b.RecordIdentify("app-1")
+	// Advance past the 24h window: the earlier two roll off.
+	now = now.Add(25 * time.Hour)
+	b.RecordIdentify("app-1")
+	b.RecordIdentify("app-1")
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Fatalf("warned though old identifies rolled off:\n%s", buf.String())
+	}
+}

--- a/internal/observe/gateway_test.go
+++ b/internal/observe/gateway_test.go
@@ -88,6 +88,37 @@ func TestGatewayBudgetWarnsWhenIdentifiesExceedThreshold(t *testing.T) {
 	}
 }
 
+// TestGatewayBudgetWarnRefiresAfterWindowDrains proves the warning is not latched
+// forever: once the window drains back under the threshold, a fresh crossing warns
+// again (a regression that leaves warned=true permanently must fail here).
+func TestGatewayBudgetWarnRefiresAfterWindowDrains(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	b := NewGatewayBudget(prometheus.NewRegistry(), 2, log)
+
+	now := time.Now()
+	b.now = func() time.Time { return now }
+
+	// First crossing: 3 > 2 → one warning.
+	for range 3 {
+		b.RecordIdentify("app-1")
+	}
+	if n := strings.Count(buf.String(), "level=WARN"); n != 1 {
+		t.Fatalf("first-crossing warnings = %d, want 1", n)
+	}
+
+	// Drain the window past 24h so the earlier three roll off and the alarm rearms.
+	now = now.Add(25 * time.Hour)
+
+	// Second crossing after the drain: another 3 → a SECOND warning.
+	for range 3 {
+		b.RecordIdentify("app-1")
+	}
+	if n := strings.Count(buf.String(), "level=WARN"); n != 2 {
+		t.Fatalf("warnings after second crossing = %d, want 2 (alarm must rearm, not latch)", n)
+	}
+}
+
 // TestGatewayBudgetWindowRollsOff proves identifies older than 24h leave the
 // window, so a slow trickle never trips the alarm.
 func TestGatewayBudgetWindowRollsOff(t *testing.T) {

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -86,6 +86,13 @@ type Presence struct {
 	token   string                     // token the current client was built with
 	client  atomic.Pointer[bot.Client] // nil = wait-state
 	guildID atomic.Value               // string; last-ensured configured Guild ("" in wait-state)
+
+	// budget observes the standing client's gateway session establishments for the
+	// IDENTIFY-budget metrics (#486). Set once at boot via SetGatewayBudget before
+	// the first Ensure; read lazily by the default client builder, so a nil budget
+	// (never set) simply attaches no listeners. Not mu-guarded: it is written once
+	// before any Ensure and only read thereafter.
+	budget wirenpc.GatewayBudgetRecorder
 }
 
 // New builds a Presence. envToken is the DISCORD_BOT_TOKEN fallback (the
@@ -103,12 +110,24 @@ func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log
 		log:      log,
 	}
 	p.guildID.Store("")
-	p.build = defaultClientBuilder(reg, log, p.invalidate)
+	// The listener provider is read at build time (each Ensure that rebuilds the
+	// client), so a SetGatewayBudget between New and the first Ensure still lands.
+	p.build = defaultClientBuilder(reg, log, p.invalidate, func() []bot.EventListener {
+		return wirenpc.GatewayBudgetListeners(p.budget)
+	})
 	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
 	p.register = restRegister
 	p.closeClient = func(client *bot.Client) { client.Close(context.Background()) }
 	p.fetchMember = p.restGetMember
 	return p
+}
+
+// SetGatewayBudget installs the IDENTIFY-budget observer (#486) the default
+// client builder attaches to the standing gateway client. Call it once at boot
+// before the first Ensure; a later Ensure that rebuilds the client (token change)
+// re-reads it, so a mid-life set also takes effect on the next rebuild.
+func (p *Presence) SetGatewayBudget(b wirenpc.GatewayBudgetRecorder) {
+	p.budget = b
 }
 
 // Ensure reconciles the standing client and command registration against the
@@ -272,7 +291,7 @@ func (p *Presence) Close() {
 // disgo client with the SAME options the per-session voice wiring used (so a
 // shared-client Voice Session keeps its DAVE encryption and voice-state intents,
 // ADR-0006) plus the interaction listeners and async event delivery.
-func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot.Client, cause error)) ClientBuilder {
+func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot.Client, cause error), budgetListeners func() []bot.EventListener) ClientBuilder {
 	return func(token string) (*bot.Client, error) {
 		// client is captured by the close handler below; disgo.New assigns it
 		// before any gateway open, so it is non-nil by the time a close can fire.
@@ -300,6 +319,12 @@ func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot
 			// Message-component (button) interactions: the rollover-tape consent
 			// buttons (#306) and any future component surface fan out from here.
 			bot.WithEventListenerFunc(reg.HandleComponent),
+			// Gateway IDENTIFY-budget observability (#486): classify the standing
+			// client's session establishments (Ready→identify, Resumed→resume). Empty
+			// when no budget is set. The voice-cycle clients that BORROW this client
+			// (wirenpc.Config.Client) inherit these listeners, so they are not
+			// re-instrumented on the borrow path — no double-counting.
+			bot.WithEventListeners(budgetListeners()...),
 			// Deliver events asynchronously so an interaction handler never runs on
 			// the gateway read goroutine and starves voice events (ADR-0010).
 			bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled()),

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -90,8 +90,13 @@ type Presence struct {
 	// budget observes the standing client's gateway session establishments for the
 	// IDENTIFY-budget metrics (#486). Set once at boot via SetGatewayBudget before
 	// the first Ensure; read lazily by the default client builder, so a nil budget
-	// (never set) simply attaches no listeners. Not mu-guarded: it is written once
-	// before any Ensure and only read thereafter.
+	// (never set) simply attaches no instrumentation.
+	//
+	// This write is intentionally NOT mu-guarded: SetGatewayBudget must be called on
+	// the boot goroutine BEFORE the first Ensure — which is what spawns the gateway
+	// read goroutines that (indirectly) read it — so boot ordering, not a mutex,
+	// establishes the happens-before edge. Calling SetGatewayBudget after a gateway
+	// is open would be a data race.
 	budget wirenpc.GatewayBudgetRecorder
 }
 
@@ -110,10 +115,10 @@ func New(store Store, cipher *crypto.Cipher, reg *Registry, envToken string, log
 		log:      log,
 	}
 	p.guildID.Store("")
-	// The listener provider is read at build time (each Ensure that rebuilds the
+	// The budget opts are read at build time (each Ensure that rebuilds the
 	// client), so a SetGatewayBudget between New and the first Ensure still lands.
-	p.build = defaultClientBuilder(reg, log, p.invalidate, func() []bot.EventListener {
-		return wirenpc.GatewayBudgetListeners(p.budget)
+	p.build = defaultClientBuilder(reg, log, p.invalidate, func(token string) []bot.ConfigOpt {
+		return wirenpc.GatewayBudgetClientOpts(token, p.budget)
 	})
 	p.open = func(ctx context.Context, client *bot.Client) error { return client.OpenGateway(ctx) }
 	p.register = restRegister
@@ -291,13 +296,13 @@ func (p *Presence) Close() {
 // disgo client with the SAME options the per-session voice wiring used (so a
 // shared-client Voice Session keeps its DAVE encryption and voice-state intents,
 // ADR-0006) plus the interaction listeners and async event delivery.
-func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot.Client, cause error), budgetListeners func() []bot.EventListener) ClientBuilder {
+func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot.Client, cause error), budgetOpts func(token string) []bot.ConfigOpt) ClientBuilder {
 	return func(token string) (*bot.Client, error) {
 		// client is captured by the close handler below; disgo.New assigns it
 		// before any gateway open, so it is non-nil by the time a close can fire.
 		var client *bot.Client
 		var err error
-		client, err = disgo.New(token,
+		opts := []bot.ConfigOpt{
 			bot.WithLogger(log),
 			bot.WithDefaultGateway(),
 			// Guilds + GuildVoiceStates are the minimum for the voice join path
@@ -319,16 +324,17 @@ func defaultClientBuilder(reg *Registry, log *slog.Logger, onDead func(dead *bot
 			// Message-component (button) interactions: the rollover-tape consent
 			// buttons (#306) and any future component surface fan out from here.
 			bot.WithEventListenerFunc(reg.HandleComponent),
-			// Gateway IDENTIFY-budget observability (#486): classify the standing
-			// client's session establishments (Ready→identify, Resumed→resume). Empty
-			// when no budget is set. The voice-cycle clients that BORROW this client
-			// (wirenpc.Config.Client) inherit these listeners, so they are not
-			// re-instrumented on the borrow path — no double-counting.
-			bot.WithEventListeners(budgetListeners()...),
 			// Deliver events asynchronously so an interaction handler never runs on
 			// the gateway read goroutine and starves voice events (ADR-0010).
 			bot.WithEventManagerConfigOpts(bot.WithAsyncEventsEnabled()),
-		)
+		}
+		// Gateway IDENTIFY-budget observability (#486): count the standing client's
+		// IDENTIFYs at send time (identify rate-limiter wrapper) and RESUMEs on the
+		// Resumed event. Empty when no budget is set. The voice-cycle clients that
+		// BORROW this client (wirenpc.Config.Client) inherit this instrumentation, so
+		// they are NOT re-instrumented on the borrow path — no double-counting.
+		opts = append(opts, budgetOpts(token)...)
+		client, err = disgo.New(token, opts...)
 		return client, err
 	}
 }

--- a/internal/wirenpc/connect.go
+++ b/internal/wirenpc/connect.go
@@ -77,14 +77,13 @@ func acquireClient(ctx context.Context, cfg Config, bus *voiceevent.Bus, log *sl
 		)),
 		gxvoice.DaveOption(),
 	}
-	// Gateway IDENTIFY-budget observability (#486): classify this per-cycle client's
-	// session establishments (Ready→identify, Resumed→resume) onto the Prometheus
-	// counters and the threshold warning. Only the OWNED client is instrumented here;
-	// the borrowed standing client (handled above) is instrumented by the presence,
-	// so no session is double-counted. A nil budget yields no listeners.
-	if ls := GatewayBudgetListeners(cfg.GatewayBudget); len(ls) > 0 {
-		opts = append(opts, bot.WithEventListeners(ls...))
-	}
+	// Gateway IDENTIFY-budget observability (#486): count this per-cycle client's
+	// IDENTIFYs at send time (via the identify rate-limiter wrapper, so a connect
+	// that burns budget without reaching Ready still counts) and its RESUMEs on the
+	// Resumed event. Only the OWNED client is instrumented here; the borrowed
+	// standing client (handled above) is instrumented by the presence, so no
+	// establishment is double-counted. A nil budget yields no opts.
+	opts = append(opts, GatewayBudgetClientOpts(cfg.Token, cfg.GatewayBudget)...)
 	// Standalone voice mode has no boot-owned presence to answer the tape consent
 	// disclosure's buttons (#306, finding 5), so THIS per-cycle client must carry
 	// the listener itself — otherwise every Consent/Revoke press fails. The all-mode

--- a/internal/wirenpc/connect.go
+++ b/internal/wirenpc/connect.go
@@ -77,6 +77,14 @@ func acquireClient(ctx context.Context, cfg Config, bus *voiceevent.Bus, log *sl
 		)),
 		gxvoice.DaveOption(),
 	}
+	// Gateway IDENTIFY-budget observability (#486): classify this per-cycle client's
+	// session establishments (Ready→identify, Resumed→resume) onto the Prometheus
+	// counters and the threshold warning. Only the OWNED client is instrumented here;
+	// the borrowed standing client (handled above) is instrumented by the presence,
+	// so no session is double-counted. A nil budget yields no listeners.
+	if ls := GatewayBudgetListeners(cfg.GatewayBudget); len(ls) > 0 {
+		opts = append(opts, bot.WithEventListeners(ls...))
+	}
 	// Standalone voice mode has no boot-owned presence to answer the tape consent
 	// disclosure's buttons (#306, finding 5), so THIS per-cycle client must carry
 	// the listener itself — otherwise every Consent/Revoke press fails. The all-mode

--- a/internal/wirenpc/gatewaybudget.go
+++ b/internal/wirenpc/gatewaybudget.go
@@ -1,8 +1,14 @@
 package wirenpc
 
 import (
+	"context"
+	"encoding/base64"
+	"strings"
+
 	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/snowflake/v2"
 )
 
 // GatewayBudgetRecorder classifies Discord gateway session establishments so the
@@ -10,27 +16,91 @@ import (
 // declared here as a narrow interface so this package (and internal/presence,
 // which reuses it) never imports the concrete recorder just to name it.
 type GatewayBudgetRecorder interface {
-	// RecordIdentify counts one fresh session (IDENTIFY) for the bot application.
+	// RecordIdentify counts one IDENTIFY sent for the bot application.
 	RecordIdentify(appID string)
 	// RecordResume counts one reattached session (RESUME) for the bot application.
 	RecordResume(appID string)
 }
 
-// GatewayBudgetListeners returns disgo event listeners that classify each gateway
-// session establishment: a Ready dispatch is a fresh IDENTIFY (consumes Discord's
-// 1000/token/24h budget), a Resumed dispatch is a RESUME (does not). Both are
-// labeled by the client's application id — a public identifier, never the token.
-// Returns nil when b is nil so a caller can splat the result unconditionally.
-func GatewayBudgetListeners(b GatewayBudgetRecorder) []bot.EventListener {
+// GatewayBudgetClientOpts returns the disgo options that instrument a client's
+// gateway session establishments for the IDENTIFY-budget metrics (#486):
+//
+//   - an identify rate-limiter wrapper that counts each IDENTIFY at SEND time
+//     (when disgo admits the identify, before any Ready), so a connect that burns
+//     the 1000/token/24h budget but never reaches Ready — an InvalidSession reply,
+//     a pre-dispatch close, a reconnect loop that keeps re-identifying — is still
+//     counted and can trip the alarm. Discord spends the budget on the IDENTIFY it
+//     receives, not on the session we establish, so this is where the count belongs.
+//   - a Resumed event listener that counts each budget-free RESUME.
+//
+// Returns nil when b is nil so a caller (the borrowed standing-client path, or an
+// env-only bench) can splat the result unconditionally and attach nothing — a
+// borrowed client is instrumented by the presence that owns it, never twice.
+func GatewayBudgetClientOpts(token string, b GatewayBudgetRecorder) []bot.ConfigOpt {
 	if b == nil {
 		return nil
 	}
-	return []bot.EventListener{
-		bot.NewListenerFunc(func(e *events.Ready) {
-			b.RecordIdentify(e.Client().ApplicationID.String())
-		}),
-		bot.NewListenerFunc(func(e *events.Resumed) {
-			b.RecordResume(e.Client().ApplicationID.String())
-		}),
+	appID := applicationIDFromToken(token)
+	return []bot.ConfigOpt{
+		bot.WithGatewayConfigOpts(gateway.WithIdentifyRateLimiter(newIdentifyCounter(appID, b))),
+		bot.WithEventListeners(resumeListener(b)),
 	}
+}
+
+// resumeListener counts one RESUME per disgo Resumed dispatch, labeled by the
+// client's application id (never the token).
+func resumeListener(b GatewayBudgetRecorder) bot.EventListener {
+	return bot.NewListenerFunc(func(e *events.Resumed) {
+		b.RecordResume(e.Client().ApplicationID.String())
+	})
+}
+
+// identifyCounter wraps a gateway.IdentifyRateLimiter and counts one IDENTIFY each
+// time the wrapped limiter admits a send (Wait returns nil). The inner limiter is
+// disgo's Noop by default, so wrapping it counts without changing the identify
+// pacing — the reconnect behavior (backoff) is unchanged.
+type identifyCounter struct {
+	inner  gateway.IdentifyRateLimiter
+	appID  string
+	budget GatewayBudgetRecorder
+}
+
+func newIdentifyCounter(appID string, b GatewayBudgetRecorder) gateway.IdentifyRateLimiter {
+	return &identifyCounter{
+		inner:  gateway.NewNoopIdentifyRateLimiter(),
+		appID:  appID,
+		budget: b,
+	}
+}
+
+func (c *identifyCounter) Close(ctx context.Context) { c.inner.Close(ctx) }
+
+// Wait counts an IDENTIFY only when the inner limiter admits the send: on a
+// context-cancelled Wait no identify is sent, so nothing is counted.
+func (c *identifyCounter) Wait(ctx context.Context, shardID int) error {
+	if err := c.inner.Wait(ctx, shardID); err != nil {
+		return err
+	}
+	c.budget.RecordIdentify(c.appID)
+	return nil
+}
+
+func (c *identifyCounter) Unlock(shardID int) { c.inner.Unlock(shardID) }
+
+// applicationIDFromToken derives the public application id from a Discord bot
+// token's first dot-segment (base64 of the snowflake id), mirroring disgo's own
+// derivation so the send-side IDENTIFY label matches the Resumed-event label. It
+// returns "" for an unparseable token rather than panicking — the token itself is
+// NEVER used as a label or logged.
+func applicationIDFromToken(token string) string {
+	first, _, _ := strings.Cut(token, ".")
+	raw, err := base64.RawStdEncoding.DecodeString(first)
+	if err != nil {
+		return ""
+	}
+	id, err := snowflake.Parse(string(raw))
+	if err != nil {
+		return ""
+	}
+	return id.String()
 }

--- a/internal/wirenpc/gatewaybudget.go
+++ b/internal/wirenpc/gatewaybudget.go
@@ -1,0 +1,36 @@
+package wirenpc
+
+import (
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/events"
+)
+
+// GatewayBudgetRecorder classifies Discord gateway session establishments so the
+// IDENTIFY budget (#486) is observable. It is satisfied by observe.GatewayBudget;
+// declared here as a narrow interface so this package (and internal/presence,
+// which reuses it) never imports the concrete recorder just to name it.
+type GatewayBudgetRecorder interface {
+	// RecordIdentify counts one fresh session (IDENTIFY) for the bot application.
+	RecordIdentify(appID string)
+	// RecordResume counts one reattached session (RESUME) for the bot application.
+	RecordResume(appID string)
+}
+
+// GatewayBudgetListeners returns disgo event listeners that classify each gateway
+// session establishment: a Ready dispatch is a fresh IDENTIFY (consumes Discord's
+// 1000/token/24h budget), a Resumed dispatch is a RESUME (does not). Both are
+// labeled by the client's application id — a public identifier, never the token.
+// Returns nil when b is nil so a caller can splat the result unconditionally.
+func GatewayBudgetListeners(b GatewayBudgetRecorder) []bot.EventListener {
+	if b == nil {
+		return nil
+	}
+	return []bot.EventListener{
+		bot.NewListenerFunc(func(e *events.Ready) {
+			b.RecordIdentify(e.Client().ApplicationID.String())
+		}),
+		bot.NewListenerFunc(func(e *events.Resumed) {
+			b.RecordResume(e.Client().ApplicationID.String())
+		}),
+	}
+}

--- a/internal/wirenpc/gatewaybudget_test.go
+++ b/internal/wirenpc/gatewaybudget_test.go
@@ -1,6 +1,8 @@
 package wirenpc
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/disgoorg/disgo/bot"
@@ -17,28 +19,85 @@ type budgetSpy struct {
 func (s *budgetSpy) RecordIdentify(appID string) { s.identifies = append(s.identifies, appID) }
 func (s *budgetSpy) RecordResume(appID string)   { s.resumes = append(s.resumes, appID) }
 
-// TestGatewayBudgetListenersClassify proves the disgo Ready dispatch is recorded
-// as an IDENTIFY and the Resumed dispatch as a RESUME, each labeled by the
-// client's application id (never the token).
-func TestGatewayBudgetListenersClassify(t *testing.T) {
+// denyLimiter is an inner rate-limiter whose Wait always denies (as a real
+// identify limiter does on a cancelled/deadline-exceeded context), so no identify
+// is sent.
+type denyLimiter struct{ err error }
+
+func (d denyLimiter) Close(context.Context)           {}
+func (d denyLimiter) Wait(context.Context, int) error { return d.err }
+func (denyLimiter) Unlock(int)                        {}
+
+// TestIdentifyCounterCountsAtSend proves an IDENTIFY is counted when the gateway's
+// identify rate-limiter admits a send — BEFORE any Ready — so a connect that
+// burns the budget but never reaches Ready (InvalidSession, pre-dispatch close)
+// is still counted. When the inner limiter denies the send (cancelled/deadline
+// ctx), no identify goes out, so it counts nothing.
+func TestIdentifyCounterCountsAtSend(t *testing.T) {
 	spy := &budgetSpy{}
-	listeners := GatewayBudgetListeners(spy)
+	appID := snowflake.ID(42).String()
+	rl := newIdentifyCounter(appID, spy)
 
-	appID := snowflake.ID(42)
-	client := &bot.Client{ApplicationID: appID}
-	gen := events.NewGenericEvent(client, 0, 0)
-
-	ready := &events.Ready{GenericEvent: gen}
-	resumed := &events.Resumed{GenericEvent: gen}
-	for _, l := range listeners {
-		l.OnEvent(ready)
-		l.OnEvent(resumed)
+	// Admitted send (default Noop inner admits) → counted.
+	if err := rl.Wait(context.Background(), 0); err != nil {
+		t.Fatalf("Wait = %v, want nil", err)
 	}
-
-	if len(spy.identifies) != 1 || spy.identifies[0] != appID.String() {
+	if len(spy.identifies) != 1 || spy.identifies[0] != appID {
 		t.Fatalf("identifies = %v, want [%s]", spy.identifies, appID)
 	}
+
+	// Denied send → no identify sent → no count.
+	denied := &identifyCounter{inner: denyLimiter{err: context.Canceled}, appID: appID, budget: spy}
+	if err := denied.Wait(context.Background(), 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait(denied) = %v, want context.Canceled", err)
+	}
+	if len(spy.identifies) != 1 {
+		t.Fatalf("identifies after denied Wait = %v, want unchanged (1)", spy.identifies)
+	}
+}
+
+// TestResumeListenerCounts proves a disgo Resumed dispatch is classified as a
+// RESUME labeled by the client's application id, and a Ready dispatch is NOT
+// counted here (identify is counted at send time, not on Ready).
+func TestResumeListenerCounts(t *testing.T) {
+	spy := &budgetSpy{}
+	l := resumeListener(spy)
+
+	appID := snowflake.ID(7)
+	client := &bot.Client{ApplicationID: appID}
+	gen := events.NewGenericEvent(client, 0, 0)
+	l.OnEvent(&events.Resumed{GenericEvent: gen})
+	l.OnEvent(&events.Ready{GenericEvent: gen})
+
 	if len(spy.resumes) != 1 || spy.resumes[0] != appID.String() {
 		t.Fatalf("resumes = %v, want [%s]", spy.resumes, appID)
+	}
+	if len(spy.identifies) != 0 {
+		t.Fatalf("identifies = %v, want none (identify is send-side)", spy.identifies)
+	}
+}
+
+// TestGatewayBudgetClientOptsBranching proves the borrowed path (nil budget)
+// attaches NOTHING, while the owned path (budget set) attaches the instrumentation
+// opts — so a borrowed standing client is never double-counted.
+func TestGatewayBudgetClientOptsBranching(t *testing.T) {
+	if got := GatewayBudgetClientOpts("tok", nil); got != nil {
+		t.Fatalf("GatewayBudgetClientOpts(nil budget) = %d opts, want 0 (borrowed client attaches nothing)", len(got))
+	}
+	if got := GatewayBudgetClientOpts("tok", &budgetSpy{}); len(got) == 0 {
+		t.Fatalf("GatewayBudgetClientOpts(budget) attached nothing, want the instrumentation opts (owned client)")
+	}
+}
+
+// TestApplicationIDFromToken proves the application id is derived from the token's
+// first segment (base64 of the snowflake), matching disgo's own derivation, and
+// degrades to "" for an unparseable token rather than panicking.
+func TestApplicationIDFromToken(t *testing.T) {
+	// snowflake 42 → base64("42") = "NDI"; a real token is "<appid-b64>.<ts>.<hmac>".
+	if got := applicationIDFromToken("NDI.abc.def"); got != "42" {
+		t.Fatalf("applicationIDFromToken = %q, want %q", got, "42")
+	}
+	if got := applicationIDFromToken("!!!not-base64"); got != "" {
+		t.Fatalf("applicationIDFromToken(bad) = %q, want empty", got)
 	}
 }

--- a/internal/wirenpc/gatewaybudget_test.go
+++ b/internal/wirenpc/gatewaybudget_test.go
@@ -1,0 +1,44 @@
+package wirenpc
+
+import (
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/events"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// budgetSpy captures the classified session-establishment calls.
+type budgetSpy struct {
+	identifies []string
+	resumes    []string
+}
+
+func (s *budgetSpy) RecordIdentify(appID string) { s.identifies = append(s.identifies, appID) }
+func (s *budgetSpy) RecordResume(appID string)   { s.resumes = append(s.resumes, appID) }
+
+// TestGatewayBudgetListenersClassify proves the disgo Ready dispatch is recorded
+// as an IDENTIFY and the Resumed dispatch as a RESUME, each labeled by the
+// client's application id (never the token).
+func TestGatewayBudgetListenersClassify(t *testing.T) {
+	spy := &budgetSpy{}
+	listeners := GatewayBudgetListeners(spy)
+
+	appID := snowflake.ID(42)
+	client := &bot.Client{ApplicationID: appID}
+	gen := events.NewGenericEvent(client, 0, 0)
+
+	ready := &events.Ready{GenericEvent: gen}
+	resumed := &events.Resumed{GenericEvent: gen}
+	for _, l := range listeners {
+		l.OnEvent(ready)
+		l.OnEvent(resumed)
+	}
+
+	if len(spy.identifies) != 1 || spy.identifies[0] != appID.String() {
+		t.Fatalf("identifies = %v, want [%s]", spy.identifies, appID)
+	}
+	if len(spy.resumes) != 1 || spy.resumes[0] != appID.String() {
+		t.Fatalf("resumes = %v, want [%s]", spy.resumes, appID)
+	}
+}

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -181,6 +181,13 @@ type Config struct {
 	// runWithReconnect backs off and retries — self-healing across presence
 	// rebuilds. nil keeps today's per-cycle client (env-only voice mode, unchanged).
 	Client ClientProvider
+	// GatewayBudget observes this loop's gateway session establishments, classifying
+	// IDENTIFY vs RESUME and warning as the per-application IDENTIFY budget nears
+	// Discord's 1000/token/24h limit (#486). It is attached ONLY to a per-cycle
+	// (owned) client this loop builds; the borrowed standing client (Client != nil)
+	// is instrumented by the presence that owns it, so it is not double-counted. nil
+	// disables the observation (env-only bench paths).
+	GatewayBudget GatewayBudgetRecorder
 	// Logger receives structured logs; nil discards them.
 	Logger *slog.Logger
 	// Metrics receives the hot-path voice counters/gauges (A2): inbound frame


### PR DESCRIPTION
## What

Instruments the Discord gateway connect path so every session establishment is classified as **IDENTIFY** (budget-consuming) vs **RESUME** (budget-free) and exported as Prometheus counters, with a threshold warning as one bot application nears Discord's 1000-IDENTIFY/token/24h limit — exhausting which **resets the token** and drops every session (a platform outage in central-token mode).

Closes #486.

## How

- **`observe.GatewayBudget`** (`internal/observe/gateway.go`): registers `glyphoxa_gateway_identify_total` / `glyphoxa_gateway_resume_total`, labeled by the non-secret `application_id` only (never the token — ADR-0032 bounded cardinality). A concurrent-safe rolling-24h per-application window logs one structured `slog` warning (`application_id`, `identifies_24h`, `threshold`) when identifies cross the threshold, de-duped until the window drains back under it.
- **`wirenpc.GatewayBudgetListeners`** (`internal/wirenpc/gatewaybudget.go`): disgo `Ready`→identify, `Resumed`→resume adapter (disgo's own identify/resume classification), behind a narrow `GatewayBudgetRecorder` interface so neither wirenpc nor presence import the concrete recorder.
- Wired into **both** gateway build paths (AC): the standing presence client (`Presence.SetGatewayBudget`) and per-cycle voice clients (`Config.GatewayBudget`, **owned path only** — the borrowed standing client is already instrumented, so no double-count).
- **`GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD`** (default **500**, well below 1000); blank/non-numeric/≤0 keeps the default so a mis-set var never silently disables the alarm.
- Operator note in `docs/deploy/saas-operations.md` §7 (identify vs resume, the 1000/24h budget, token-reset risk, the alarm) + `docs/configuration.md` env table.

## Tests (TDD, vertical slices)

- `TestGatewayBudgetClassifiesIdentifyVsResume` — identify vs resume land on separate series per application id.
- `TestGatewayBudgetWarnsWhenIdentifiesExceedThreshold` — quiet at threshold, exactly one warning on crossing, no spam after.
- `TestGatewayBudgetWindowRollsOff` — identifies older than 24h leave the window.
- `TestGatewayBudgetListenersClassify` — disgo `Ready`/`Resumed` map to identify/resume with the client's application id.
- `TestGatewayIdentifyWarnThreshold` — env default/override/guard parsing.

Local: `go vet ./...`, `golangci-lint`, and `gofmt` clean; touched-package tests green. No new module dependencies (counters read via registry gather, house style).