### PR TITLE
feat(#491): voice session claim plane — intent rows claimed by a -mode voice worker

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -7,11 +7,14 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
@@ -384,6 +387,64 @@ func maxVoiceSessions(getenv func(string) string) int {
 		return defaultMaxVoiceSessions
 	}
 	return n
+}
+
+// Claim-plane cadence defaults (#491, ADR-0057 (b)): the -mode voice worker polls
+// every 2s, heartbeats a live claim every 5s, and a claim goes stale (worker
+// presumed dead) after 30s. Heartbeat must sit well under Expiry so a healthy
+// worker never trips the reaper. The web tier's IntentControl reuses the same
+// env knobs for its Start/Stop poll cadence.
+const (
+	defaultVoiceClaimPoll         = 2 * time.Second
+	defaultVoiceHeartbeatInterval = 5 * time.Second
+	defaultVoiceHeartbeatExpiry   = 30 * time.Second
+)
+
+// envDuration parses a Go duration env var, falling back to def on a blank,
+// unparsable or non-positive value — a mis-set knob must never wedge the claim
+// loop at zero or flip it negative.
+func envDuration(getenv func(string) string, key string, def time.Duration) time.Duration {
+	d, err := time.ParseDuration(strings.TrimSpace(getenv(key)))
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+// voiceClaimLoopConfig reads the -mode voice worker's claim-loop cadence from the
+// GLYPHOXA_VOICE_CLAIM_POLL / _HEARTBEAT_INTERVAL / _HEARTBEAT_EXPIRY env vars
+// (#491). Parsed HERE in the composition root, never in internal/session, so the
+// cadence stays a deployment knob.
+func voiceClaimLoopConfig(getenv func(string) string) session.ClaimLoopConfig {
+	return session.ClaimLoopConfig{
+		Poll:      envDuration(getenv, "GLYPHOXA_VOICE_CLAIM_POLL", defaultVoiceClaimPoll),
+		Heartbeat: envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_INTERVAL", defaultVoiceHeartbeatInterval),
+		Expiry:    envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+	}
+}
+
+// voiceIntentControlConfig reads the web tier's IntentControl poll cadence from
+// the same claim-poll env var (#491): its Start/Stop poll the claim plane at the
+// claim-poll interval, with fixed 20s/30s budgets for the queue-until-live and
+// wind-down waits. The budgets are internal defaults (IntentControl clamps them),
+// so a blank cadence env still yields sane behaviour.
+func voiceIntentControlConfig(getenv func(string) string) session.IntentControlConfig {
+	return session.IntentControlConfig{
+		Poll: envDuration(getenv, "GLYPHOXA_VOICE_CLAIM_POLL", defaultVoiceClaimPoll),
+	}
+}
+
+// newVoiceInstanceID mints this Voice Instance's identity for the claim plane
+// (#491): hostname + "-" + the first 8 hex of a fresh uuid, minted once per boot.
+// It fences the worker's claim/heartbeat/finish writes and is the natural handle
+// the presence-owner election (#492) will reuse. A hostname read failure falls
+// back to "voice".
+func newVoiceInstanceID() string {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "voice"
+	}
+	return host + "-" + uuid.NewString()[:8]
 }
 
 // forceLoopback rewrites a listen address to bind 127.0.0.1, preserving the port

--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -431,6 +431,26 @@ func voiceClaimLoopConfig(getenv func(string) string) session.ClaimLoopConfig {
 func voiceIntentControlConfig(getenv func(string) string) session.IntentControlConfig {
 	return session.IntentControlConfig{
 		Poll: envDuration(getenv, "GLYPHOXA_VOICE_CLAIM_POLL", defaultVoiceClaimPoll),
+		// Matches the worker's reaper horizon so Start's zero-worker escape (review
+		// item 4) judges a blocking claim stale on the same clock the worker would.
+		Expiry: envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+	}
+}
+
+// warnClaimCadence checks the claim-plane cadence has sane headroom (#491 review
+// item 9): the heartbeat expiry must sit comfortably above one heartbeat interval
+// plus a session's wind-down, or a healthy-but-slow worker risks being reaped
+// mid-drain. It warns (never clamps — an operator may know their timing) when the
+// margin above one heartbeat interval is under 10s.
+func warnClaimCadence(cfg session.ClaimLoopConfig, log *slog.Logger) {
+	if cfg.Expiry <= cfg.Heartbeat {
+		log.Warn("GLYPHOXA_VOICE_HEARTBEAT_EXPIRY <= _HEARTBEAT_INTERVAL: a live worker will be reaped between beats",
+			"expiry", cfg.Expiry, "interval", cfg.Heartbeat)
+		return
+	}
+	if cfg.Expiry-cfg.Heartbeat < 10*time.Second {
+		log.Warn("thin claim-plane headroom: HEARTBEAT_EXPIRY minus HEARTBEAT_INTERVAL is under 10s; a slow drain may trip the reaper",
+			"expiry", cfg.Expiry, "interval", cfg.Heartbeat)
 	}
 }
 

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
@@ -1054,3 +1055,35 @@ func TestNewVoiceInstanceID(t *testing.T) {
 		t.Fatalf("instance id %q is not <host>-<8hex>", a)
 	}
 }
+
+// TestWarnClaimCadence pins the headroom guard (#491 item 9): healthy defaults
+// stay quiet; expiry at/below the heartbeat interval, or under 10s headroom, warns.
+func TestWarnClaimCadence(t *testing.T) {
+	countWarns := func(cfg session.ClaimLoopConfig) int {
+		h := &countingHandler{}
+		warnClaimCadence(cfg, slog.New(h))
+		return h.warns
+	}
+	if n := countWarns(session.ClaimLoopConfig{Poll: 2 * time.Second, Heartbeat: 5 * time.Second, Expiry: 30 * time.Second}); n != 0 {
+		t.Errorf("healthy defaults warned %d times, want 0", n)
+	}
+	if n := countWarns(session.ClaimLoopConfig{Heartbeat: 5 * time.Second, Expiry: 3 * time.Second}); n != 1 {
+		t.Errorf("expiry below interval warned %d times, want 1", n)
+	}
+	if n := countWarns(session.ClaimLoopConfig{Heartbeat: 5 * time.Second, Expiry: 12 * time.Second}); n != 1 {
+		t.Errorf("thin headroom warned %d times, want 1", n)
+	}
+}
+
+// countingHandler is a minimal slog.Handler that counts WARN records.
+type countingHandler struct{ warns int }
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		h.warns++
+	}
+	return nil
+}
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -993,3 +993,64 @@ func TestArmVoiceGMGate(t *testing.T) {
 		}
 	}
 }
+
+// TestEnvDuration pins the claim-plane duration parse (#491): a valid Go duration
+// wins; blank, unparsable, zero and negative values fall back to the default —
+// a mis-set knob must never wedge the claim loop at zero or flip it negative.
+func TestEnvDuration(t *testing.T) {
+	const def = 7 * time.Second
+	cases := []struct {
+		val  string
+		want time.Duration
+	}{
+		{"", def},
+		{"   ", def},
+		{"nope", def},
+		{"0s", def},
+		{"-3s", def},
+		{"2s", 2 * time.Second},
+		{"500ms", 500 * time.Millisecond},
+	}
+	for _, c := range cases {
+		if got := envDuration(envMap(map[string]string{"K": c.val}), "K", def); got != c.want {
+			t.Errorf("envDuration(%q) = %v, want %v", c.val, got, c.want)
+		}
+	}
+}
+
+// TestVoiceClaimLoopConfig pins the three claim-loop cadence knobs (#491): unset
+// yields the 2s/5s/30s defaults, and each env var overrides its field.
+func TestVoiceClaimLoopConfig(t *testing.T) {
+	def := voiceClaimLoopConfig(envMap(nil))
+	if def.Poll != defaultVoiceClaimPoll || def.Heartbeat != defaultVoiceHeartbeatInterval || def.Expiry != defaultVoiceHeartbeatExpiry {
+		t.Fatalf("defaults = %+v, want 2s/5s/30s", def)
+	}
+	got := voiceClaimLoopConfig(envMap(map[string]string{
+		"GLYPHOXA_VOICE_CLAIM_POLL":         "1s",
+		"GLYPHOXA_VOICE_HEARTBEAT_INTERVAL": "3s",
+		"GLYPHOXA_VOICE_HEARTBEAT_EXPIRY":   "20s",
+	}))
+	if got.Poll != time.Second || got.Heartbeat != 3*time.Second || got.Expiry != 20*time.Second {
+		t.Fatalf("overridden = %+v, want 1s/3s/20s", got)
+	}
+}
+
+// TestNewVoiceInstanceID pins the instance-id shape (#491): hostname + "-" +
+// 8 hex, distinct per call (the uuid suffix), never empty.
+func TestNewVoiceInstanceID(t *testing.T) {
+	a, b := newVoiceInstanceID(), newVoiceInstanceID()
+	if a == "" || b == "" {
+		t.Fatal("instance id is empty")
+	}
+	if a == b {
+		t.Fatalf("instance ids not distinct: %q == %q", a, b)
+	}
+	var host, suffix string
+	if i := strings.LastIndex(a, "-"); i >= 0 {
+		host = a[:i]
+		suffix = a[i+1:]
+	}
+	if host == "" || len(suffix) != 8 {
+		t.Fatalf("instance id %q is not <host>-<8hex>", a)
+	}
+}

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spa"
 	"github.com/MrWong99/Glyphoxa/internal/speaker"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
 	"github.com/MrWong99/Glyphoxa/internal/transcript"
@@ -183,6 +184,14 @@ func main() {
 // orchestrator stage/turn latency + provider series (Config.StageMetrics →
 // buildConversation: the bus subscriber + the agenttool provider adapter).
 func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *observe.PrometheusRecorder, metricsAddr string) error {
+	// #491 (ADR-0057): -mode voice WITHOUT -guild/-channel and WITH a database is
+	// the claim-plane worker — DB-driven assignment, no static target flags. WITH
+	// -guild/-channel (or -hardcoded) it stays the legacy standalone node below,
+	// byte-for-byte unchanged.
+	if !hardcoded && cfg.Guild == "" && cfg.Channel == "" && databaseURL() != "" {
+		return runVoiceWorker(log, cfg, metrics, metricsAddr)
+	}
+
 	cfg.Token = os.Getenv("DISCORD_BOT_TOKEN")
 	if cfg.Token == "" {
 		return fmt.Errorf("DISCORD_BOT_TOKEN is not set")
@@ -282,6 +291,190 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 	log.Info("standalone voice mode: knowledge Tools (transcript_search, kg_query) are unavailable; run -mode all or web to enable them")
 
 	return wirenpc.RunFromDB(ctx, cfg, pool, cipher)
+}
+
+// runVoiceWorker is the -mode voice claim-plane worker (#491, ADR-0057): instead
+// of a single static guild/channel it polls the voice_session_intents table,
+// claims the oldest pending intent (FOR UPDATE SKIP LOCKED, ADR-0049), runs it
+// through the tenant-aware Manager (#488) over the per-Tenant Discord client
+// registry (#489), heartbeats while live, and finishes the row on end. No
+// mid-session takeover (ADR-0006): a stale heartbeat marks the claim dead and the
+// Tenant restarts. SIGTERM stops claiming and drains live sessions cleanly within
+// the window. The voice role reads $GLYPHOXA_SECRET to decrypt BYOK Tenant tokens
+// (ADR-0057 (d)).
+//
+// This process is the single interim claimer (#492 elects the presence owner when
+// replicas > 1): the presence Registry is active so the worker registers the
+// tenant command surface, and the per-Tenant clients drive voice.
+func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRecorder, metricsAddr string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg.Logger = log
+	cfg.Metrics = metrics
+	cfg.StageMetrics = metrics
+	cfg.Token = os.Getenv("DISCORD_BOT_TOKEN") // central-token fallback; BYOK tenants override per-session
+
+	dsn := databaseURL()
+	// ADR-0031: the worker never migrates (only -mode all does); verify the schema
+	// is current and fail loud with the actionable message if behind.
+	if err := wirenpc.EnsureSchemaCurrent(ctx, dsn); err != nil {
+		return err
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("voice worker: open db pool: %w", err)
+	}
+	defer pool.Close()
+	store := storage.New(pool)
+	blobStore := blob.NewPostgres(pool)
+
+	// The BYOK credential cipher (ADR-0004/0057 (d)): the voice role now decrypts
+	// per-Tenant Bot tokens itself. Best-effort — a worker with no $GLYPHOXA_SECRET
+	// still serves central-token Tenants on the env fallback.
+	cipher, err := appCipher()
+	if err != nil {
+		log.Warn("provider credential decryption disabled; the worker serves only env-token tenants until $GLYPHOXA_SECRET is set", "err", err)
+		cipher = nil
+	}
+
+	if metricsAddr != "" {
+		observe.NewMetricsServer(metricsAddr, metrics, observe.ReadinessProbe(pool.Ping), log).Start(ctx)
+	}
+
+	// Worker-scoped boot reconciliation (#491, reviewer-flagged): a plain
+	// ReconcileOrphanedVoiceSessions is process-blind — two workers booting would
+	// close each other's live 'running' rows. Close ONLY rows whose owning intent
+	// went terminal (a crashed worker's leftovers), never one an intent still holds
+	// live. Required before replicas > 1 (#492).
+	if n, err := store.ReconcileWorkerOrphanedVoiceSessions(ctx); err != nil {
+		return fmt.Errorf("voice worker: reconcile orphaned sessions: %w", err)
+	} else if n > 0 {
+		log.Warn("voice worker: closed orphaned voice sessions behind terminal intents", "count", n)
+	}
+
+	instanceID := newVoiceInstanceID()
+	log.Info("voice worker starting", "instance", instanceID)
+
+	// ONE process bus; each session gets its own bus Forwarded onto this (#487).
+	eventBus := voiceevent.NewBus()
+	cfg.Bus = eventBus
+	sessions := session.NewRegistry()
+
+	// GM identity (ADR-0055): the per-Tenant Butler voice-address gate + transcript
+	// GM labels. A failed load degrades to the env allowlist alone, never a boot
+	// failure.
+	allow := auth.ParseOperatorAllowlist(os.Getenv("GLYPHOXA_OPERATOR_IDS"))
+	gmID := auth.NewGMIdentity(store, allow, log)
+	if err := gmID.Refresh(ctx); err != nil {
+		log.Warn("voice worker: loading tenant-operator GM bindings failed; falling back to the allowlist", "err", err)
+	}
+	cfg.GMSpeaker = gmSpeakerGate(false, gmID.IsGM)
+
+	// Effective Admission Mode (ADR-0055) drives the plan-allowance + platform-key
+	// entitlement gates the session Manager applies at Start — the worker READS the
+	// posture the web tier records; it does not record it.
+	admission := auth.AdmissionAllowlist
+	if res, aerr := resolveAdmissionMode(ctx, store, os.Getenv); aerr != nil {
+		log.Warn("voice worker: resolve admission mode; defaulting to allowlist gates", "err", aerr)
+	} else {
+		admission = res.Effective
+	}
+	keyEnt := entitlementForMode(admission, store)
+	cfg.KeyEntitlement = keyEnt
+
+	// Per-Tenant Discord client registry (#489): the standing client keyed by each
+	// Tenant's resolved Bot token, plus the tenant command surface. The worker IS
+	// the active presence owner in the single-worker interim (#492 flips this to an
+	// elector when replicas > 1).
+	gate := presence.NewGate(gmID, presence.NewStorageTenantResolver(store))
+	reg := presence.NewRegistry(gate, log)
+	reg.Register(presence.RollCommand(tool.NewDice()))
+	reg.RegisterComponentHandler(presence.NewConsentButtons(store, sessions, log).HandleComponent)
+	clients := presence.NewClients(store, cipher, reg, cfg.Token, log)
+	clients.SetGatewayBudget(cfg.GatewayBudget)
+
+	// The Manager's persistence deps (the buildVoiceDeps set, #491): the relay's
+	// headless line writer/finalizer, the chunk writer, the Highlight saver, NPC
+	// recall + KG-facts, the knowledge Tools, the durable Usage ledger, the
+	// plan-allowance gate, and the per-Campaign speaker resolver. The relay is
+	// headless here — no SSE mounts (ADR-0014 Hop-A stays deferred on the voice
+	// tier); it exists only to persist transcript lines and finalize them at Stop.
+	recapEngine := recap.NewEngine(store, cipher, metrics, log, recap.WithKeyEntitlement(keyEnt))
+	speakerResolver := speaker.NewResolver(store, clients, gmID, log)
+	relay := transcript.NewRelay(eventBus, sessions, store, log)
+	relay.SetResolver(speakerResolver)
+	chunker := transcript.NewChunker(eventBus, sessions, store, metrics, log, transcript.ChunkerConfig{})
+	chunker.SetResolver(speakerResolver)
+	highlightSaver := highlight.NewSaver(store, blobStore, jobEnqueuer{store}, log)
+	knowledgeAdapter := knowledge.New(store, store.PromptKG())
+
+	deps := session.Deps{
+		Registry:   sessions,
+		Transcript: relay,
+		Chunker:    chunker,
+		Highlights: highlightSaver,
+		Clients:    clients,
+		SpeakerNameForCampaign: func(campaignID uuid.UUID, speakerID string) string {
+			return speakerResolver.Lookup(campaignID, speakerID).Name
+		},
+		GMSpeakerForTenant: func(tenantID uuid.UUID, discordUserID string) bool {
+			return discordUserID != "" && gmID.IsGMInTenant(tenantID, discordUserID)
+		},
+		MaxSessions: maxVoiceSessions(os.Getenv),
+		Usage:       store,
+		Allowance:   allowanceForMode(admission, store),
+		Facts:       kgfacts.New(store.PromptKG(), metrics, log, kgfacts.Config{}),
+		Tools: tool.Deps{
+			Transcripts: knowledgeAdapter,
+			KG:          knowledgeAdapter,
+			KGW:         knowledgeAdapter,
+			Recap:       knowledge.NewRecap(recapEngine, store),
+		},
+	}
+
+	// NPC memory recall (#122): resolved once over the shared embeddings provider.
+	// An unavailable provider leaves recall off (loud-but-non-fatal), exactly as in
+	// the web/all boot.
+	if provider, _, err := embedworker.ResolveProvider(ctx, store); err != nil {
+		log.Error("voice worker: embeddings provider unavailable; NPC memory recall disabled", "err", err)
+	} else {
+		recaller := recall.New(provider, store, sessions, eventBus, metrics, log, recall.Config{})
+		context.AfterFunc(ctx, recaller.Close)
+		deps.Memory = recaller
+	}
+
+	runner := func(rctx context.Context, c wirenpc.Config) error {
+		return wirenpc.RunFromDB(rctx, c, pool, cipher)
+	}
+	mgr := session.NewManager(store, runner, cfg, cipher, log, true, deps)
+
+	// Register the full tenant command surface (start/end/search/mute/say/recap),
+	// then seed the standing clients so the commands appear with no session live.
+	reg.Register(
+		presence.UseCommand(store),
+		presence.StartCommand(store, mgr),
+		presence.EndCommand(mgr),
+		presence.SearchCommand(store, mgr),
+		presence.RecapCommand(store, mgr, recapEngine, mgr),
+		presence.MuteCommand(mgr, store),
+		presence.MuteAllCommand(mgr, store),
+		presence.SayCommand(mgr, store),
+	)
+	if err := clients.EnsureAll(ctx); err != nil {
+		log.Warn("voice worker: initial presence seed failed; retries on the next Discord settings save", "err", err)
+	}
+	go clients.Run(ctx)
+
+	// Run the claim loop until SIGTERM. It stops claiming on ctx cancel and drains
+	// its live sessions cleanly (AC5); then tear down the Manager (a no-op backstop
+	// after the drain) and close the standing clients.
+	loop := session.NewClaimLoop(store, mgr, instanceID, log, voiceClaimLoopConfig(os.Getenv))
+	loop.Run(ctx)
+	mgr.Shutdown()
+	clients.Close()
+	return nil
 }
 
 // ensureSchemaReady runs the boot schema preflight for the web/all entrypoint
@@ -836,6 +1029,19 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 		return fmt.Errorf("web: %w", err)
 	}
 
+	// Web-tier Voice-Session control (#491, ADR-0057): -mode all drives the
+	// in-process Manager directly (byte-identical to today — NO intent rows). A
+	// split -mode web tier instead drives the Postgres claim plane through
+	// IntentControl: its StartSession writes a voice_session_intents row a -mode
+	// voice worker claims and runs, and the live-only controls (mute/say/replay/
+	// spend) degrade with CodeFailedPrecondition because that state lives in the
+	// worker, not here (the ADR-0057 consequence). The choice pivots on withVoice:
+	// an all-mode process owns the loop; a web-only one delegates to the plane.
+	var sessionCtl sessionControl = mgr
+	if !withVoice {
+		sessionCtl = session.NewIntentControl(store, log, voiceIntentControlConfig(os.Getenv))
+	}
+
 	// Background job runner (#286, ADR-0049): one DB-backed generic runner over the
 	// `job` table, safe across web/all replicas by construction (the claim is a
 	// FOR UPDATE SKIP LOCKED, ADR-0039). It runs in web AND all mode (the
@@ -1012,7 +1218,7 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 			return clients.VoiceChannelMembers(ctx, tenantID, channelID)
 		}
 	}
-	mounts := managementMounts(store, blobStore, cipher, metrics, log, mgr, relay, speakerResolver, recapEngine, assistEngine, presenceRefresh, integrationStatus, memberLister, embedProvider, admission, signupPlanSlug, keyEnt)
+	mounts := managementMounts(store, blobStore, cipher, metrics, log, sessionCtl, relay, speakerResolver, recapEngine, assistEngine, presenceRefresh, integrationStatus, memberLister, embedProvider, admission, signupPlanSlug, keyEnt)
 	root := spa.Handler()
 	// GLYPHOXA_DEV_MODE opt-out (ADR-0041): seed + auto-authenticate the synthetic
 	// operator on every request and pin the bind to loopback, so a dev instance
@@ -1126,7 +1332,25 @@ var plainMountPolicy = map[string]auth.TenantMode{
 // its two plain net/http reads mount OUTSIDE the Connect /api prefix at
 // /api/v1/sessions/{id}[/events], each a row in the guarded mount table
 // (#446 — the Connect interceptor chain does not cover them).
-func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr *session.Manager, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, assistEngine *assist.Engine, presenceRefresh func(tenantID uuid.UUID), integrationStatus func(tenantID uuid.UUID) (string, string), memberLister func(context.Context) ([]presence.Member, error), embedProvider embeddings.Provider, admission auth.AdmissionMode, signupPlanSlug string, keyEnt llmbuild.PlatformKeyEntitlement) []web.Mount {
+// sessionControl is the web tier's Voice-Session control surface (#491): the RPC
+// SessionManager plus the campaign/health/replay seams the mounts wire. BOTH
+// *session.Manager (in-process, -mode all) and *session.IntentControl (claim-plane
+// driven, -mode web of a split deployment) satisfy it, so managementMounts is
+// mode-agnostic — runWeb picks which one to pass.
+type sessionControl interface {
+	Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error)
+	Stop(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSession, error)
+	Active(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSession, bool, error)
+	SetAgentMute(ctx context.Context, tenantID uuid.UUID, agentID string, muted bool) ([]string, error)
+	SetAllMute(ctx context.Context, tenantID uuid.UUID, muted bool) ([]string, error)
+	MutedAgentIDs(tenantID uuid.UUID) []string
+	Spend(tenantID uuid.UUID) spend.Status
+	IsCampaignLive(campaignID uuid.UUID) bool
+	AnyLive() bool
+	ReplayHighlight(ctx context.Context, tenantID uuid.UUID, clipKey string) error
+}
+
+func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto.Cipher, metrics observe.StageRecorder, log *slog.Logger, mgr sessionControl, relay *transcript.Relay, speakerResolver *speaker.Resolver, recapEngine *recap.Engine, assistEngine *assist.Engine, presenceRefresh func(tenantID uuid.UUID), integrationStatus func(tenantID uuid.UUID) (string, string), memberLister func(context.Context) ([]presence.Member, error), embedProvider embeddings.Provider, admission auth.AdmissionMode, signupPlanSlug string, keyEnt llmbuild.PlatformKeyEntitlement) []web.Mount {
 	// OAuth credentials are enforced at boot by requireWebEnv (ADR-0041, issue
 	// #112): a non-dev web/all Instance never reaches here without all three set,
 	// and GLYPHOXA_DEV_MODE serves an auto-authenticated session that never uses

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -450,12 +450,23 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	}
 	mgr := session.NewManager(store, runner, cfg, cipher, log, true, deps)
 
+	// The claim-plane session control (#491 review item 1): in WORKER mode
+	// /glyphoxa start and end must NOT drive the Manager directly — that would run a
+	// slash-started session with NO intent row (no heartbeat, the one-live-per-tenant
+	// invariant false, IntentControl/archive guards blind, an unreconcilable crash
+	// row). Route them through IntentControl so /glyphoxa start writes an intent this
+	// same worker's loop claims (typically within one poll) and /glyphoxa end
+	// requests the stop the loop honors — exactly the plane the web tier uses. The
+	// live controls (search/recap/mute/say) still drive the Manager, which holds the
+	// live session this worker is running.
+	intentControl := session.NewIntentControl(store, log, voiceIntentControlConfig(os.Getenv))
+
 	// Register the full tenant command surface (start/end/search/mute/say/recap),
 	// then seed the standing clients so the commands appear with no session live.
 	reg.Register(
 		presence.UseCommand(store),
-		presence.StartCommand(store, mgr),
-		presence.EndCommand(mgr),
+		presence.StartCommand(store, intentControl),
+		presence.EndCommand(intentControl),
 		presence.SearchCommand(store, mgr),
 		presence.RecapCommand(store, mgr, recapEngine, mgr),
 		presence.MuteCommand(mgr, store),
@@ -470,7 +481,9 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	// Run the claim loop until SIGTERM. It stops claiming on ctx cancel and drains
 	// its live sessions cleanly (AC5); then tear down the Manager (a no-op backstop
 	// after the drain) and close the standing clients.
-	loop := session.NewClaimLoop(store, mgr, instanceID, log, voiceClaimLoopConfig(os.Getenv))
+	claimCfg := voiceClaimLoopConfig(os.Getenv)
+	warnClaimCadence(claimCfg, log)
+	loop := session.NewClaimLoop(store, mgr, instanceID, log, claimCfg)
 	loop.Run(ctx)
 	mgr.Shutdown()
 	clients.Close()

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -87,10 +87,20 @@ spec:
           args:
             - -mode
             - voice
+            # -guild/-channel render ONLY when set (#491, ADR-0057): with both set
+            # this is the legacy standalone node joining one static channel; with
+            # both empty it is the claim-plane worker, which takes its guild/channel
+            # per-session from each Tenant's saved deployment config and needs no
+            # static target. Setting one without the other is a misconfiguration the
+            # binary rejects at boot.
+            {{- with .Values.voice.guild }}
             - -guild
-            - {{ include "glyphoxa.voice.snowflake" (required "voice.guild is required when voice.enabled: the Discord guild (server) snowflake ID the bot joins." .Values.voice.guild) | quote }}
+            - {{ include "glyphoxa.voice.snowflake" . | quote }}
+            {{- end }}
+            {{- with .Values.voice.channel }}
             - -channel
-            - {{ include "glyphoxa.voice.snowflake" (required "voice.channel is required when voice.enabled: the Discord voice channel snowflake ID the bot joins." .Values.voice.channel) | quote }}
+            - {{ include "glyphoxa.voice.snowflake" . | quote }}
+            {{- end }}
             - -metrics-addr
             - {{ $metricsAddr | quote }}
           env:

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -83,6 +83,24 @@ tests:
             - -metrics-addr
             - ":9090"
 
+  - it: drops -guild/-channel in claim-plane worker mode (empty values)
+    # #491 (ADR-0057): with voice.guild/voice.channel empty the pod is the
+    # claim-plane worker — DB-driven assignment, no static target flags. The arg
+    # vector is mode + metrics-addr only; the worker takes each session's channel
+    # from the Tenant's saved deployment config.
+    set:
+      voice:
+        guild: ""
+        channel: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - -mode
+            - voice
+            - -metrics-addr
+            - ":9090"
+
   - it: rejects a numeric guild rather than deploying a truncated snowflake
     # A snowflake passed as a NUMBER is already truncated by float64 before the
     # template runs (111111111111111111 -> 111111111111111104), and int64 can't

--- a/docs/devs/2026-07-19-voice-claim-plane-rollout.md
+++ b/docs/devs/2026-07-19-voice-claim-plane-rollout.md
@@ -1,0 +1,55 @@
+# Voice claim plane rollout (#491, ADR-0057)
+
+Session start is decoupled from the in-process Manager so a separate voice
+worker can run it. This note records the operator-facing behaviour and the known
+gaps a split deployment inherits.
+
+## Modes
+
+- **`-mode all` (self-host default) — unchanged.** The web tier drives the voice
+  loop in-process via the Manager. It writes **no** `voice_session_intents` rows
+  and behaves byte-for-byte as before.
+- **`-mode voice` WITH `-guild`/`-channel`** — the legacy standalone node,
+  unchanged: it joins one static channel.
+- **`-mode voice` WITHOUT `-guild`/`-channel` (+ a database URL)** — the new
+  **claim-plane worker**. It polls `voice_session_intents`, claims the oldest
+  pending intent (`FOR UPDATE SKIP LOCKED`, ADR-0049), runs it through the
+  tenant-aware Manager over the per-Tenant Discord client registry, heartbeats
+  while live, and finishes the row on end. It takes each session's guild/channel
+  from the Tenant's saved deployment config — the static flags are not required.
+- **`-mode web` (split)** — the web tier's `StartSession`/`StopSession` write and
+  flag intent rows via `IntentControl` instead of driving a loop. `GetSession`
+  shows the session as *live* only once a worker has driven the intent live.
+
+## Claim-plane knobs (env)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `GLYPHOXA_VOICE_CLAIM_POLL` | `2s` | worker claim tick / web poll cadence |
+| `GLYPHOXA_VOICE_HEARTBEAT_INTERVAL` | `5s` | live-session heartbeat stamp interval |
+| `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` | `30s` | staleness before a claim is reaped dead |
+
+## Worker death
+
+A worker crash stops its heartbeats; after `HEARTBEAT_EXPIRY` the reaper marks
+the intent **dead** and the Tenant sees it as such and can restart. There is
+**no mid-session takeover** — DAVE/MLS state cannot migrate (ADR-0006/0057 (e)),
+so a stale claim is a death, never a hand-off to another worker. A worker's boot
+reconciliation closes only `voice_sessions` rows whose owning intent has gone
+terminal, so two workers booting never close each other's live rows.
+
+## Known gaps in split mode (pre-existing, unchanged by this slice)
+
+- **No live SSE transcript on the web tier.** ADR-0014's Hop-A relay is still
+  deferred: the worker persists transcript lines to Postgres, but the split web
+  tier does not stream them live. Reload shows the persisted transcript.
+- **`mute` / `say` / `replay` / spend-meter web RPCs are unavailable in split
+  mode.** That live state lives in the worker, so the web tier degrades these
+  with `CodeFailedPrecondition` ("not available in a split deployment") rather
+  than lie. `-mode all` retains all of them.
+
+## Scaling note
+
+Running more than one worker replica is **not** enabled here: this is the
+single-worker interim. Concurrent workers on the central token still need the
+elected presence owner (#492) and the DAVE soak test (#493) before `replicas > 1`.

--- a/docs/devs/2026-07-19-voice-claim-plane-rollout.md
+++ b/docs/devs/2026-07-19-voice-claim-plane-rollout.md
@@ -34,9 +34,33 @@ gaps a split deployment inherits.
 A worker crash stops its heartbeats; after `HEARTBEAT_EXPIRY` the reaper marks
 the intent **dead** and the Tenant sees it as such and can restart. There is
 **no mid-session takeover** — DAVE/MLS state cannot migrate (ADR-0006/0057 (e)),
-so a stale claim is a death, never a hand-off to another worker. A worker's boot
-reconciliation closes only `voice_sessions` rows whose owning intent has gone
-terminal, so two workers booting never close each other's live rows.
+so a stale claim is a death, never a hand-off to another worker.
+
+Two reconcile paths close a crashed worker's leftover `running` `voice_sessions`
+rows, both scoped to rows behind a **terminal** intent (never a live worker's
+row): once at each worker boot, and inside the claim tick immediately after any
+reap — so a fast pod restart never leaves those rows stranded until the next boot.
+
+### Zero healthy workers
+
+The reaper runs inside worker ticks, so with **no** running worker a `claimed`/
+`live` intent's heartbeat never expires on its own and its Tenant would be blocked
+(`AlreadyExists`) indefinitely. To escape this, the web tier's `StartSession`, on
+hitting the one-live-per-tenant collision, reaps that specific blocking intent
+**if its heartbeat is already stale** before failing — so a Tenant whose only
+worker died can restart as soon as the expiry window passes, even before a new
+worker boots.
+
+### Start / Stop outcomes (split mode)
+
+- **Start queued past its budget** — the pending intent is **cancelled** (→ `done`)
+  and `StartSession` returns `CodeUnavailable` ("try again shortly"); the retry
+  writes a fresh intent rather than colliding, and no worker booting later claims
+  a stale row nobody is watching.
+- **Start cancelled before a worker claimed it** — `CodeAborted` ("start was
+  cancelled"), distinct from the still-queued Unavailable.
+- **Stop unconfirmed within its budget** — `CodeUnavailable` (retry), never a
+  false success carrying a still-`running` row.
 
 ## Known gaps in split mode (pre-existing, unchanged by this slice)
 
@@ -47,6 +71,27 @@ terminal, so two workers booting never close each other's live rows.
   mode.** That live state lives in the worker, so the web tier degrades these
   with `CodeFailedPrecondition` ("not available in a split deployment") rather
   than lie. `-mode all` retains all of them.
+
+## Do NOT point `-mode all` at a worker's database
+
+`-mode all` drives sessions in-process with **no** intent rows and runs the
+**broad** boot reconcile (`ReconcileOrphanedVoiceSessions`), which closes *every*
+`running` `voice_sessions` row it finds — including live rows a `-mode voice`
+worker owns against the same DB. An all-mode process sharing a claim-plane
+database would therefore both (a) close live workers' sessions on its boot and
+(b) start intent-less sessions that break the one-live-per-tenant invariant.
+Split (`-mode web` + `-mode voice`) and single (`-mode all`) are **distinct
+deployments**; never mix them on one database.
+
+## Slash commands in worker mode
+
+`/glyphoxa start` and `/glyphoxa end` go through the claim plane, exactly like the
+web tier: start writes an intent this worker's loop claims (typically within one
+poll), end requests the stop the loop honors. They never drive the Manager
+directly, so a slash-started session always has an intent row (heartbeat,
+reconcilable, visible to `GetSession` and the archive guard). The live controls
+(`/glyphoxa search`/`recap`/`mute`/`say`) still drive the Manager — the worker
+holds that live session.
 
 ## Scaling note
 

--- a/internal/rpc/highlight_share.go
+++ b/internal/rpc/highlight_share.go
@@ -243,6 +243,9 @@ func (s *SessionServer) replayToVoice(
 	// already campaign-ownership-checked to the caller's Tenant, so h.TenantID is the
 	// operator's Tenant — the session the clip belongs in.
 	if err := s.replayer.ReplayHighlight(ctx, h.TenantID, h.ClipKey); err != nil {
+		if errors.Is(err, session.ErrSplitMode) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errSplitMode)
+		}
 		if errors.Is(err, session.ErrNoActiveSession) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no live Voice Session to replay into"))
 		}

--- a/internal/rpc/highlight_share_test.go
+++ b/internal/rpc/highlight_share_test.go
@@ -343,6 +343,23 @@ func TestShareHighlight_VoiceReplayNoSession(t *testing.T) {
 	}
 }
 
+// TestShareHighlight_VoiceReplaySplitMode pins ErrSplitMode → FailedPrecondition:
+// a live-channel replay needs the worker's outbound pump, so it degrades on the
+// web tier of a split deployment (#491 item 6).
+func TestShareHighlight_VoiceReplaySplitMode(t *testing.T) {
+	tenantID := uuid.New()
+	campaignID := uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+	replayer := &fakeReplayer{err: session.ErrSplitMode}
+
+	client := newShareClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), &fakeSharer{}, replayer, newFakeShareStore())
+	_, err := client.ShareHighlight(context.Background(), connect.NewRequest(shareReplayReq(h.ID.String())))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("split mode: want CodeFailedPrecondition, got %v", err)
+	}
+}
+
 // TestListShareChannels_ChannelsAndLast pins the dialog source: the guild's channels
 // plus the campaign's remembered channel.
 func TestListShareChannels_ChannelsAndLast(t *testing.T) {

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -79,6 +79,12 @@ type RecapEngine interface {
 	Recap(ctx context.Context, sessionIDs []uuid.UUID) (recap.Result, error)
 }
 
+// errSplitMode is the static client message for a live-session control invoked on
+// the web tier of a split (-mode web + -mode voice) deployment (#491): the live
+// state lives in the worker, so mute/say/replay/spend degrade with
+// CodeFailedPrecondition rather than lie (ADR-0057 consequence).
+var errSplitMode = errors.New("not available in a split deployment (the voice worker holds the live session)")
+
 // searchTranscriptLimit caps a transcript search result set (#120). It is a fixed
 // server policy for the single-operator web tier (ADR-0039), mirroring
 // searchNodesLimit; the client sends no limit.
@@ -287,6 +293,11 @@ func (s *SessionServer) startError(err error) error {
 		// The manager is in its terminal closed state (#157): the process is
 		// shutting down. Unavailable, so the client retries the restarted process.
 		return connect.NewError(connect.CodeUnavailable, errors.New("the server is shutting down; try again shortly"))
+	case errors.Is(err, session.ErrIntentPending):
+		// Split mode (#491): the intent is written but no -mode voice worker has
+		// claimed and driven it live within the Start budget. Unavailable, so the
+		// operator retries — the worker picks it up on its next poll.
+		return connect.NewError(connect.CodeUnavailable, errors.New("voice worker has not claimed the session yet; try again shortly"))
 	default:
 		s.log.Error("StartSession: manager start failed", "err", err)
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
@@ -337,6 +348,8 @@ func (s *SessionServer) SetAgentMute(
 
 	ids, err := s.mgr.SetAgentMute(ctx, tenantID, req.Msg.GetAgentId(), req.Msg.GetMuted())
 	switch {
+	case errors.Is(err, session.ErrSplitMode):
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errSplitMode)
 	case errors.Is(err, session.ErrNoActiveSession):
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
 	case errors.Is(err, session.ErrAgentNotInCampaign):
@@ -360,6 +373,9 @@ func (s *SessionServer) SetAllMute(
 		return nil, err
 	}
 	ids, err := s.mgr.SetAllMute(ctx, tenantID, req.Msg.GetMuted())
+	if errors.Is(err, session.ErrSplitMode) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errSplitMode)
+	}
 	if errors.Is(err, session.ErrNoActiveSession) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
 	}

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -294,10 +294,15 @@ func (s *SessionServer) startError(err error) error {
 		// shutting down. Unavailable, so the client retries the restarted process.
 		return connect.NewError(connect.CodeUnavailable, errors.New("the server is shutting down; try again shortly"))
 	case errors.Is(err, session.ErrIntentPending):
-		// Split mode (#491): the intent is written but no -mode voice worker has
-		// claimed and driven it live within the Start budget. Unavailable, so the
-		// operator retries — the worker picks it up on its next poll.
+		// Split mode (#491): the intent was written but no -mode voice worker claimed
+		// and drove it live within the Start budget, so IntentControl CANCELLED the
+		// pending row before returning. Unavailable, so the operator's retry starts a
+		// fresh intent rather than colliding — the worker picks it up on its next poll.
 		return connect.NewError(connect.CodeUnavailable, errors.New("voice worker has not claimed the session yet; try again shortly"))
+	case errors.Is(err, session.ErrIntentCancelled):
+		// Split mode (#491): the queued start was stopped before any worker claimed
+		// it — a distinct cancelled outcome, not a fault and not still-pending.
+		return connect.NewError(connect.CodeAborted, errors.New("the voice session start was cancelled before it began"))
 	default:
 		s.log.Error("StartSession: manager start failed", "err", err)
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
@@ -316,6 +321,12 @@ func (s *SessionServer) StopSession(
 	vs, err := s.mgr.Stop(ctx, tenantID)
 	if errors.Is(err, session.ErrNoActiveSession) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
+	}
+	if errors.Is(err, session.ErrStopPending) {
+		// Split mode (#491): the worker has not confirmed the wind-down within the
+		// Stop budget. Unavailable so the operator retries — never a false success
+		// carrying a still-'running' row.
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("the voice worker has not confirmed the stop yet; try again shortly"))
 	}
 	if err != nil {
 		s.log.Error("StopSession: manager stop failed", "err", err)

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -32,6 +32,7 @@ type fakeSessionManager struct {
 	current          storage.VoiceSession
 	startErr         error
 	stopErr          error
+	muteErr          error // injected mute failure (e.g. session.ErrSplitMode, #491)
 	startCalls       int
 	muted            map[string]struct{}
 	rosterIDs        []string     // ids SetAllMute mutes (the campaign roster the real Manager lists)
@@ -117,6 +118,9 @@ func (f *fakeSessionManager) AnyLive() bool {
 func (f *fakeSessionManager) SetAgentMute(_ context.Context, tenantID uuid.UUID, agentID string, muted bool) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.muteErr != nil {
+		return nil, f.muteErr
+	}
 	if !f.active || !f.matchesTenant(tenantID) {
 		return nil, session.ErrNoActiveSession
 	}
@@ -146,6 +150,9 @@ func (f *fakeSessionManager) inRoster(agentID string) bool {
 func (f *fakeSessionManager) SetAllMute(_ context.Context, tenantID uuid.UUID, muted bool) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.muteErr != nil {
+		return nil, f.muteErr
+	}
 	if !f.active || !f.matchesTenant(tenantID) {
 		return nil, session.ErrNoActiveSession
 	}
@@ -1480,5 +1487,55 @@ func TestStartSessionTenantCampaignCoherence(t *testing.T) {
 	}
 	if mgr.startCampaign != campaign.ID {
 		t.Errorf("session started for campaign %s, want %s", mgr.startCampaign, campaign.ID)
+	}
+}
+
+// TestSplitModeStartPending maps IntentControl's queue-timeout (ErrIntentPending)
+// to CodeUnavailable so the operator retries (#491).
+func TestSplitModeStartPending(t *testing.T) {
+	t.Parallel()
+	client := newSessionClient(t, &fakeSessionManager{startErr: session.ErrIntentPending}, activeStore())
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("ErrIntentPending code = %v, want Unavailable", got)
+	}
+}
+
+// TestSplitModeStartCancelled maps a start cancelled before any worker claimed it
+// (ErrIntentCancelled) to CodeAborted — distinct from still-pending (#491 item 7).
+func TestSplitModeStartCancelled(t *testing.T) {
+	t.Parallel()
+	client := newSessionClient(t, &fakeSessionManager{startErr: session.ErrIntentCancelled}, activeStore())
+	_, err := client.StartSession(context.Background(), connect.NewRequest(&managementv1.StartSessionRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeAborted {
+		t.Errorf("ErrIntentCancelled code = %v, want Aborted", got)
+	}
+}
+
+// TestSplitModeStopPending maps a Stop the worker did not confirm within budget
+// (ErrStopPending) to CodeUnavailable — never a false success (#491 item 7).
+func TestSplitModeStopPending(t *testing.T) {
+	t.Parallel()
+	client := newSessionClient(t, &fakeSessionManager{stopErr: session.ErrStopPending}, activeStore())
+	_, err := client.StopSession(context.Background(), connect.NewRequest(&managementv1.StopSessionRequest{}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("ErrStopPending code = %v, want Unavailable", got)
+	}
+}
+
+// TestSplitModeMuteDegrades maps the Manager-only mute controls' ErrSplitMode to
+// CodeFailedPrecondition on the web tier of a split deployment (#491 item 6).
+func TestSplitModeMuteDegrades(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{muteErr: session.ErrSplitMode}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.SetAgentMute(context.Background(), connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: uuid.NewString(), Muted: true}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("SetAgentMute ErrSplitMode code = %v, want FailedPrecondition", got)
+	}
+	_, err = client.SetAllMute(context.Background(), connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: true}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Errorf("SetAllMute ErrSplitMode code = %v, want FailedPrecondition", got)
 	}
 }

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -33,6 +33,11 @@ type IntentStore interface {
 	HeartbeatVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string) (bool, error)
 	FinishVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string, status storage.VoiceSessionIntentStatus, lastError string) (storage.VoiceSessionIntent, error)
 	ReapDeadVoiceSessionIntents(ctx context.Context, expiry time.Duration) (int64, error)
+	// ReconcileWorkerOrphanedVoiceSessions closes 'running' voice_sessions rows
+	// behind a NOW-terminal intent (#491): run in the tick right after a reap so a
+	// fast pod restart's leftover rows are closed the moment their intent is reaped
+	// dead, not only at the next boot (review item 2).
+	ReconcileWorkerOrphanedVoiceSessions(ctx context.Context) (int64, error)
 }
 
 // ClaimLoopConfig carries the claim loop's three poll durations (#491), read
@@ -115,6 +120,15 @@ func (l *ClaimLoop) tick(ctx context.Context) {
 		l.log.Warn("claim loop: reap dead intents", "err", err)
 	} else if n > 0 {
 		l.log.Warn("claim loop: reaped dead voice session intents (worker heartbeats expired)", "count", n)
+		// A reap just made some intents terminal: close any 'running' voice_sessions
+		// rows behind them NOW (review item 2), so a crashed worker's leftover row is
+		// reconciled the moment its intent expires — not only at the next boot, which
+		// a fast pod restart could postpone indefinitely.
+		if rn, err := l.store.ReconcileWorkerOrphanedVoiceSessions(ctx); err != nil {
+			l.log.Warn("claim loop: reconcile orphaned sessions after reap", "err", err)
+		} else if rn > 0 {
+			l.log.Warn("claim loop: closed orphaned voice sessions behind reaped intents", "count", rn)
+		}
 	}
 
 	for l.mgr.HasCapacity() {
@@ -149,15 +163,23 @@ func (l *ClaimLoop) startClaimed(ctx context.Context, intent storage.VoiceSessio
 
 	live, err := l.store.MarkVoiceSessionIntentLive(ctx, intent.ID, l.instanceID, vs.ID)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			l.log.Warn("claim loop: claim superseded before live (reaped); stopping the started session",
-				"intent", intent.ID)
-		} else {
-			l.log.Warn("claim loop: mark intent live", "intent", intent.ID, "err", err)
-		}
+		// Stop the just-started session either way. NotFound means the row was
+		// already reaped dead (a superseded claim) — the row is terminal, so no
+		// finish. Any OTHER error (a DB blip, or a SIGTERM cancelling ctx between
+		// Claim and MarkLive) left the row 'claimed' with no heartbeat goroutine, so
+		// finish it 'failed' on a detached ctx (mirroring the Start-refusal path) —
+		// otherwise it lingers 'claimed' until the reaper marks it the wrong state
+		// (review item 5, AC5's claimed-not-yet-live SIGTERM case).
 		if _, serr := l.mgr.Stop(l.detached(), intent.TenantID); serr != nil && !errors.Is(serr, ErrNoActiveSession) {
 			l.log.Warn("claim loop: stop after failed mark-live", "intent", intent.ID, "err", serr)
 		}
+		if errors.Is(err, storage.ErrNotFound) {
+			l.log.Warn("claim loop: claim superseded before live (reaped); stopped the started session",
+				"intent", intent.ID)
+			return
+		}
+		l.log.Warn("claim loop: mark intent live; finishing failed", "intent", intent.ID, "err", err)
+		l.finish(intent.ID, storage.VoiceIntentFailed, "mark-live failed: "+err.Error())
 		return
 	}
 

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -1,0 +1,245 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// The -mode voice claim loop (#491, ADR-0057 (b)): a Voice Instance polls the
+// voice_session_intents claim plane, claims the oldest pending intent with the
+// FOR UPDATE SKIP LOCKED idiom (ADR-0049), runs it through the tenant-aware
+// Manager (#488), heartbeats while live, and finishes the row on end. No
+// mid-session takeover (ADR-0006/0057 (e)): a claim's heartbeat going stale is
+// the OWNING worker's death — the reaper marks that row 'dead' and the Tenant
+// restarts; this loop never re-claims another worker's claimed/live intent.
+
+// intentEndTimeout bounds a detached terminal write (Finish) after the run ctx
+// is cancelled, mirroring the Manager's endTimeout so a shutdown can't hang on a
+// slow DB.
+const intentEndTimeout = 5 * time.Second
+
+// IntentStore is the claim-plane surface the ClaimLoop needs (#491). *storage.Store
+// satisfies it; tests use a fake so the loop is exercised without Postgres.
+type IntentStore interface {
+	ClaimVoiceSessionIntent(ctx context.Context, instanceID string) (storage.VoiceSessionIntent, error)
+	MarkVoiceSessionIntentLive(ctx context.Context, id uuid.UUID, instanceID string, voiceSessionID uuid.UUID) (storage.VoiceSessionIntent, error)
+	HeartbeatVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string) (bool, error)
+	FinishVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string, status storage.VoiceSessionIntentStatus, lastError string) (storage.VoiceSessionIntent, error)
+	ReapDeadVoiceSessionIntents(ctx context.Context, expiry time.Duration) (int64, error)
+}
+
+// ClaimLoopConfig carries the claim loop's three poll durations (#491), read
+// from GLYPHOXA_VOICE_CLAIM_POLL / _HEARTBEAT_INTERVAL / _HEARTBEAT_EXPIRY. A
+// non-positive value falls back to its default in NewClaimLoop.
+type ClaimLoopConfig struct {
+	// Poll is the claim-tick interval: each tick reaps stale claims then claims
+	// pending intents while the Manager has capacity. Default 2s.
+	Poll time.Duration
+	// Heartbeat is how often a live session's goroutine stamps heartbeat_at (and
+	// reads stop_requested). Default 5s. Must be well under Expiry.
+	Heartbeat time.Duration
+	// Expiry is how stale a heartbeat may get before the reaper marks the claim
+	// dead (the owning worker is presumed crashed). Default 30s.
+	Expiry time.Duration
+}
+
+// ClaimLoop drives the -mode voice worker's DB-driven session assignment (#491).
+type ClaimLoop struct {
+	store      IntentStore
+	mgr        *Manager
+	instanceID string
+	log        *slog.Logger
+	cfg        ClaimLoopConfig
+
+	wg sync.WaitGroup // tracks live per-session goroutines for the graceful drain
+}
+
+// NewClaimLoop builds a claim loop over the intent store and the tenant-aware
+// Manager. instanceID is this Voice Instance's identity (hostname-uuid8, minted
+// per boot in cmd/glyphoxa) — the fence for its heartbeat/finish writes. A
+// non-positive config duration takes its default.
+func NewClaimLoop(store IntentStore, mgr *Manager, instanceID string, log *slog.Logger, cfg ClaimLoopConfig) *ClaimLoop {
+	if log == nil {
+		log = slog.Default()
+	}
+	if cfg.Poll <= 0 {
+		cfg.Poll = 2 * time.Second
+	}
+	if cfg.Heartbeat <= 0 {
+		cfg.Heartbeat = 5 * time.Second
+	}
+	if cfg.Expiry <= 0 {
+		cfg.Expiry = 30 * time.Second
+	}
+	return &ClaimLoop{store: store, mgr: mgr, instanceID: instanceID, log: log, cfg: cfg}
+}
+
+// Run polls the claim plane until ctx is cancelled, then drains: SIGTERM stops
+// claiming and waits for every live session's goroutine to end its session
+// cleanly and finish its row within the drain window (AC5). Each tick reaps stale
+// claims then claims-and-starts while the Manager has capacity.
+func (l *ClaimLoop) Run(ctx context.Context) {
+	ticker := time.NewTicker(l.cfg.Poll)
+	defer ticker.Stop()
+	// One immediate tick so a pending intent written just before boot is claimed
+	// without waiting a full poll interval.
+	l.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			// Stop claiming; the per-session goroutines observe the same ctx and each
+			// ends its session cleanly + finishes its row. Wait for them (the drain).
+			l.wg.Wait()
+			return
+		case <-ticker.C:
+			l.tick(ctx)
+		}
+	}
+}
+
+// tick reaps stale claims, then claims and starts pending intents while the
+// Manager has a free slot (#491). Capacity is checked BEFORE each claim so the
+// loop never claims work it cannot run.
+func (l *ClaimLoop) tick(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	if n, err := l.store.ReapDeadVoiceSessionIntents(ctx, l.cfg.Expiry); err != nil {
+		l.log.Warn("claim loop: reap dead intents", "err", err)
+	} else if n > 0 {
+		l.log.Warn("claim loop: reaped dead voice session intents (worker heartbeats expired)", "count", n)
+	}
+
+	for l.mgr.HasCapacity() {
+		intent, err := l.store.ClaimVoiceSessionIntent(ctx, l.instanceID)
+		if errors.Is(err, storage.ErrNotFound) {
+			return // nothing pending to claim this tick
+		}
+		if err != nil {
+			l.log.Warn("claim loop: claim intent", "err", err)
+			return
+		}
+		l.startClaimed(ctx, intent)
+	}
+}
+
+// startClaimed drives a freshly-claimed intent to live: Manager.Start, MarkLive,
+// then spawn the per-session heartbeat goroutine. A Start refusal finishes the
+// intent 'failed' with the reason (so it is never stranded 'claimed'); a MarkLive
+// that finds no row (the reaper already marked it dead) stops the session it just
+// started (ADR-0006 — no running a session the plane believes dead).
+func (l *ClaimLoop) startClaimed(ctx context.Context, intent storage.VoiceSessionIntent) {
+	vs, err := l.mgr.Start(ctx, intent.TenantID, intent.CampaignID)
+	if err != nil {
+		// ErrSessionLimit should not occur (tick gates on HasCapacity), but finishing
+		// 'failed' rather than leaving the row 'claimed' guarantees no strand either
+		// way. ErrSessionActive means the Tenant is somehow already live in THIS
+		// worker — also a failed duplicate.
+		l.log.Warn("claim loop: manager start refused claimed intent", "intent", intent.ID, "err", err)
+		l.finish(intent.ID, storage.VoiceIntentFailed, err.Error())
+		return
+	}
+
+	live, err := l.store.MarkVoiceSessionIntentLive(ctx, intent.ID, l.instanceID, vs.ID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			l.log.Warn("claim loop: claim superseded before live (reaped); stopping the started session",
+				"intent", intent.ID)
+		} else {
+			l.log.Warn("claim loop: mark intent live", "intent", intent.ID, "err", err)
+		}
+		if _, serr := l.mgr.Stop(l.detached(), intent.TenantID); serr != nil && !errors.Is(serr, ErrNoActiveSession) {
+			l.log.Warn("claim loop: stop after failed mark-live", "intent", intent.ID, "err", serr)
+		}
+		return
+	}
+
+	l.wg.Add(1)
+	go l.runSession(ctx, live)
+}
+
+// runSession owns a live intent's heartbeat lifecycle (#491): each Heartbeat tick
+// it stamps the row and reads stop_requested, and detects the session ending on
+// its own. It exits — finishing the intent — on a requested stop, a superseded
+// claim (reaped: kill the local session, the row is already terminal), the loop
+// self-exiting, or ctx cancellation (graceful shutdown).
+func (l *ClaimLoop) runSession(ctx context.Context, intent storage.VoiceSessionIntent) {
+	defer l.wg.Done()
+	tenant := intent.TenantID
+	ticker := time.NewTicker(l.cfg.Heartbeat)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Graceful shutdown (SIGTERM): end the session cleanly and finish the row
+			// on a detached ctx (the run ctx is already cancelled).
+			l.endSession(tenant, intent.ID, storage.VoiceIntentDone, "")
+			return
+		case <-ticker.C:
+			if _, live, _ := l.mgr.Active(ctx, tenant); !live {
+				// The loop self-exited (or was stopped elsewhere): the Manager already
+				// wrote the terminal voice_sessions row; finish the intent 'done'.
+				l.finish(intent.ID, storage.VoiceIntentDone, "")
+				return
+			}
+			stop, err := l.store.HeartbeatVoiceSessionIntent(ctx, intent.ID, l.instanceID)
+			if errors.Is(err, storage.ErrNotFound) {
+				// Superseded — the reaper marked this claim dead (this worker was judged
+				// stale). Kill the local session; the row is already terminal, so no
+				// finish (ADR-0006: never keep running a session the plane calls dead).
+				l.log.Warn("claim loop: heartbeat superseded (claim reaped dead); stopping local session",
+					"intent", intent.ID)
+				if _, serr := l.mgr.Stop(l.detached(), tenant); serr != nil && !errors.Is(serr, ErrNoActiveSession) {
+					l.log.Warn("claim loop: stop after superseded heartbeat", "intent", intent.ID, "err", serr)
+				}
+				return
+			}
+			if err != nil {
+				l.log.Warn("claim loop: heartbeat", "intent", intent.ID, "err", err)
+				continue // a transient DB hiccup: retry next tick, don't kill a live session
+			}
+			if stop {
+				// The web tier flagged a stop: wind the session down and finish 'done'.
+				l.endSession(tenant, intent.ID, storage.VoiceIntentDone, "")
+				return
+			}
+		}
+	}
+}
+
+// endSession stops the Manager's session for the tenant (blocking until its loop
+// ends and the voice_sessions row lands) and finishes the intent, both on a
+// detached ctx so a cancelled run ctx cannot abort the clean wind-down.
+func (l *ClaimLoop) endSession(tenant uuid.UUID, intentID uuid.UUID, status storage.VoiceSessionIntentStatus, lastError string) {
+	if _, err := l.mgr.Stop(l.detached(), tenant); err != nil && !errors.Is(err, ErrNoActiveSession) {
+		l.log.Warn("claim loop: stop session", "intent", intentID, "err", err)
+	}
+	l.finish(intentID, status, lastError)
+}
+
+// finish writes the intent's terminal state on a detached, bounded ctx. A
+// superseded write (the reaper won the race) is expected and swallowed.
+func (l *ClaimLoop) finish(intentID uuid.UUID, status storage.VoiceSessionIntentStatus, lastError string) {
+	ctx, cancel := context.WithTimeout(context.Background(), intentEndTimeout)
+	defer cancel()
+	if _, err := l.store.FinishVoiceSessionIntent(ctx, intentID, l.instanceID, status, lastError); err != nil && !errors.Is(err, storage.ErrNotFound) {
+		l.log.Warn("claim loop: finish intent", "intent", intentID, "status", status, "err", err)
+	}
+}
+
+// detached returns a background context for the clean wind-down (Manager.Stop)
+// that a cancelled run ctx must not abort — Stop blocks until the loop ends and
+// the voice_sessions row lands, itself bounded by the Manager's endTimeout
+// budget, so no timeout is needed here (mirrors the Manager's WithoutCancel
+// end-write posture).
+func (l *ClaimLoop) detached() context.Context {
+	return context.Background()
+}

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -1,0 +1,272 @@
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeIntentStore is an in-memory session.IntentStore: it models the claim-plane
+// semantics (pending → claimed → live → terminal, instance fencing, reap) so the
+// ClaimLoop is exercised without Postgres.
+type fakeIntentStore struct {
+	mu      sync.Mutex
+	intents map[uuid.UUID]*storage.VoiceSessionIntent
+	reaped  int
+}
+
+func newFakeIntentStore() *fakeIntentStore {
+	return &fakeIntentStore{intents: map[uuid.UUID]*storage.VoiceSessionIntent{}}
+}
+
+func (f *fakeIntentStore) add(tenantID, campaignID uuid.UUID) *storage.VoiceSessionIntent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i := &storage.VoiceSessionIntent{
+		ID:         uuid.New(),
+		TenantID:   tenantID,
+		CampaignID: campaignID,
+		Status:     storage.VoiceIntentPending,
+		CreatedAt:  time.Now(),
+	}
+	f.intents[i.ID] = i
+	return i
+}
+
+func (f *fakeIntentStore) get(id uuid.UUID) storage.VoiceSessionIntent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return *f.intents[id]
+}
+
+func (f *fakeIntentStore) requestStop(id uuid.UUID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.intents[id].StopRequested = true
+}
+
+func (f *fakeIntentStore) markDead(id uuid.UUID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.intents[id].Status = storage.VoiceIntentDead
+}
+
+func (f *fakeIntentStore) ClaimVoiceSessionIntent(_ context.Context, instanceID string) (storage.VoiceSessionIntent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var oldest *storage.VoiceSessionIntent
+	for _, i := range f.intents {
+		if i.Status != storage.VoiceIntentPending {
+			continue
+		}
+		if oldest == nil || i.CreatedAt.Before(oldest.CreatedAt) {
+			oldest = i
+		}
+	}
+	if oldest == nil {
+		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	now := time.Now()
+	oldest.Status = storage.VoiceIntentClaimed
+	oldest.InstanceID = instanceID
+	oldest.ClaimedAt = &now
+	oldest.HeartbeatAt = &now
+	return *oldest, nil
+}
+
+func (f *fakeIntentStore) MarkVoiceSessionIntentLive(_ context.Context, id uuid.UUID, instanceID string, vsID uuid.UUID) (storage.VoiceSessionIntent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i, ok := f.intents[id]
+	if !ok || i.InstanceID != instanceID || i.Status != storage.VoiceIntentClaimed {
+		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	i.Status = storage.VoiceIntentLive
+	i.VoiceSessionID = uuid.NullUUID{UUID: vsID, Valid: true}
+	return *i, nil
+}
+
+func (f *fakeIntentStore) HeartbeatVoiceSessionIntent(_ context.Context, id uuid.UUID, instanceID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i, ok := f.intents[id]
+	if !ok || i.InstanceID != instanceID ||
+		(i.Status != storage.VoiceIntentClaimed && i.Status != storage.VoiceIntentLive) {
+		return false, storage.ErrNotFound
+	}
+	now := time.Now()
+	i.HeartbeatAt = &now
+	return i.StopRequested, nil
+}
+
+func (f *fakeIntentStore) FinishVoiceSessionIntent(_ context.Context, id uuid.UUID, instanceID string, status storage.VoiceSessionIntentStatus, lastError string) (storage.VoiceSessionIntent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i, ok := f.intents[id]
+	if !ok || i.InstanceID != instanceID ||
+		(i.Status != storage.VoiceIntentClaimed && i.Status != storage.VoiceIntentLive) {
+		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	now := time.Now()
+	i.Status = status
+	i.LastError = lastError
+	i.EndedAt = &now
+	return *i, nil
+}
+
+func (f *fakeIntentStore) ReapDeadVoiceSessionIntents(_ context.Context, _ time.Duration) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reaped++
+	return 0, nil
+}
+
+func newClaimLoop(t *testing.T, store session.IntentStore, mgr *session.Manager) *session.ClaimLoop {
+	t.Helper()
+	return session.NewClaimLoop(store, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: 2 * time.Millisecond, Expiry: 30 * time.Second})
+}
+
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within", d)
+}
+
+// TestClaimLoop_ClaimStartLiveEndDone covers sequence (6): one tick claims a
+// pending intent, starts the Manager session, marks it live, heartbeats; a
+// requested stop winds it down and the intent lands 'done'.
+func TestClaimLoop_ClaimStartLiveEndDone(t *testing.T) {
+	mstore := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	intent := istore.add(tenantID, campaignID)
+
+	loop.TickForTest(context.Background())
+
+	// The session started (blocking runner is executing) and the intent is live.
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("manager session never started")
+	}
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+	if _, live, _ := mgr.Active(context.Background(), tenantID); !live {
+		t.Fatal("manager reports no live session after claim")
+	}
+
+	// Sequence (7): a requested stop → the heartbeat goroutine stops the manager
+	// session and finishes the intent 'done'.
+	istore.requestStop(intent.ID)
+	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
+	if !runner.wasCancelled() {
+		t.Fatal("manager loop was not cancelled on stop_requested")
+	}
+	if _, live, _ := mgr.Active(context.Background(), tenantID); live {
+		t.Fatal("manager still reports a live session after stop")
+	}
+	loop.DrainForTest()
+}
+
+// TestClaimLoop_HeartbeatSupersededStopsSession covers the reaped-claim path
+// (sequence 9 worker-death sibling, in-process): when a heartbeat returns
+// ErrNotFound (the reaper marked the claim dead), the loop stops its local
+// session and does NOT resurrect the terminal row (ADR-0006 no takeover).
+func TestClaimLoop_HeartbeatSupersededStopsSession(t *testing.T) {
+	mstore := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	intent := istore.add(tenantID, campaignID)
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// Simulate the reaper marking this claim dead: the next heartbeat is superseded.
+	istore.markDead(intent.ID)
+	waitFor(t, 2*time.Second, func() bool { return runner.wasCancelled() })
+	if _, live, _ := mgr.Active(context.Background(), tenantID); live {
+		t.Fatal("session still live after superseded heartbeat")
+	}
+	// The row stays 'dead' — no finish resurrected it.
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDead {
+		t.Fatalf("intent status = %q, want dead (no takeover / resurrection)", got)
+	}
+	loop.DrainForTest()
+}
+
+// TestClaimLoop_GracefulDrain covers sequence (5)/AC5: ctx cancellation stops
+// claiming and each live session ends cleanly, its intent finished 'done'.
+func TestClaimLoop_GracefulDrain(t *testing.T) {
+	mstore := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	intent := istore.add(tenantID, campaignID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { loop.Run(ctx); close(done) }()
+
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not drain within the window")
+	}
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDone {
+		t.Fatalf("intent status after drain = %q, want done", got)
+	}
+	if !runner.wasCancelled() {
+		t.Fatal("session loop not cancelled on graceful shutdown")
+	}
+}
+
+// TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the
+// Manager is at capacity (single-session default): a second pending intent is
+// left pending while the first runs.
+func TestClaimLoop_NoCapacityNoClaim(t *testing.T) {
+	mstore := newFakeStore()
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true) // MaxSessions defaults to 1
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	first := istore.add(uuid.New(), uuid.New())
+	second := istore.add(uuid.New(), uuid.New())
+
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(first.ID).Status == storage.VoiceIntentLive })
+
+	// Capacity is 1 and taken; the tick above must not have claimed the second.
+	if got := istore.get(second.ID).Status; got != storage.VoiceIntentPending {
+		t.Fatalf("second intent status = %q, want pending (no capacity)", got)
+	}
+}

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -17,9 +17,11 @@ import (
 // semantics (pending → claimed → live → terminal, instance fencing, reap) so the
 // ClaimLoop is exercised without Postgres.
 type fakeIntentStore struct {
-	mu      sync.Mutex
-	intents map[uuid.UUID]*storage.VoiceSessionIntent
-	reaped  int
+	mu          sync.Mutex
+	intents     map[uuid.UUID]*storage.VoiceSessionIntent
+	reaped      int
+	reapReturns int64 // how many rows ReapDead reports this tick (drives reconcile-after-reap)
+	reconciled  int   // ReconcileWorkerOrphanedVoiceSessions call count
 }
 
 func newFakeIntentStore() *fakeIntentStore {
@@ -125,7 +127,20 @@ func (f *fakeIntentStore) ReapDeadVoiceSessionIntents(_ context.Context, _ time.
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reaped++
+	return f.reapReturns, nil
+}
+
+func (f *fakeIntentStore) ReconcileWorkerOrphanedVoiceSessions(_ context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reconciled++
 	return 0, nil
+}
+
+func (f *fakeIntentStore) reconcileCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reconciled
 }
 
 func newClaimLoop(t *testing.T, store session.IntentStore, mgr *session.Manager) *session.ClaimLoop {
@@ -245,6 +260,31 @@ func TestClaimLoop_GracefulDrain(t *testing.T) {
 	}
 	if !runner.wasCancelled() {
 		t.Fatal("session loop not cancelled on graceful shutdown")
+	}
+}
+
+// TestClaimLoop_ReconcileAfterReap covers review item 2: a tick that reaps stale
+// intents (reap > 0) also runs the worker-orphan reconcile, so a fast restart's
+// leftover 'running' rows are closed the moment their intent expires — not only
+// at the next boot. A tick with no reap does NOT reconcile (cheap).
+func TestClaimLoop_ReconcileAfterReap(t *testing.T) {
+	mstore := newFakeStore()
+	mgr := newManager(t, mstore, newBlockingRunner().run, true)
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	// No reap this tick → no reconcile.
+	istore.reapReturns = 0
+	loop.TickForTest(context.Background())
+	if got := istore.reconcileCount(); got != 0 {
+		t.Fatalf("reconcile ran %d times with no reap, want 0", got)
+	}
+
+	// A reap → reconcile runs.
+	istore.reapReturns = 2
+	loop.TickForTest(context.Background())
+	if got := istore.reconcileCount(); got != 1 {
+		t.Fatalf("reconcile ran %d times after a reap, want 1", got)
 	}
 }
 

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -1,10 +1,20 @@
 package session
 
 import (
+	"context"
 	"time"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 )
+
+// TickForTest runs one claim-loop tick synchronously (reap → claim-and-start
+// while capacity), so a test can drive assignment deterministically without the
+// poll timer (#491). Test-only.
+func (l *ClaimLoop) TickForTest(ctx context.Context) { l.tick(ctx) }
+
+// DrainForTest waits for every live per-session goroutine to finish — the same
+// wait Run does on ctx cancellation (the graceful drain, #491). Test-only.
+func (l *ClaimLoop) DrainForTest() { l.wg.Wait() }
 
 // SetEndTimeoutForTest shrinks the per-step end budget (Finalize / end-write)
 // so the #143 budget-separation tests run in milliseconds instead of the

--- a/internal/session/intentcontrol.go
+++ b/internal/session/intentcontrol.go
@@ -32,6 +32,11 @@ type IntentControlStore interface {
 	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
 	IsCampaignLiveIntent(ctx context.Context, campaignID uuid.UUID) (bool, error)
 	AnyLiveVoiceSessionIntent(ctx context.Context) (bool, error)
+	// ReapVoiceSessionIntentIfExpired marks the given claimed/live intent dead when
+	// its heartbeat is stale — the zero-worker escape (#491 review item 4): Start
+	// unblocks a Tenant whose prior worker died and left a claimed/live row no tick
+	// will ever sweep. Returns whether it reaped.
+	ReapVoiceSessionIntentIfExpired(ctx context.Context, id uuid.UUID, expiry time.Duration) (bool, error)
 }
 
 // IntentControlConfig carries IntentControl's poll cadence and budgets (#491). A
@@ -43,8 +48,13 @@ type IntentControlConfig struct {
 	// before returning ErrIntentPending (the operator retries). Default 20s.
 	StartBudget time.Duration
 	// StopBudget bounds how long Stop waits for the worker to wind the session down
-	// before returning the intent's last-known row. Default 30s.
+	// before returning ErrStopPending. Default 30s.
 	StopBudget time.Duration
+	// Expiry is the heartbeat-staleness horizon (matching the worker's
+	// GLYPHOXA_VOICE_HEARTBEAT_EXPIRY): Start reaps a blocking claimed/live intent
+	// whose heartbeat is older than this before failing ErrSessionActive — the
+	// zero-worker escape (review item 4). Default 30s.
+	Expiry time.Duration
 }
 
 // IntentControl drives voice sessions through the Postgres claim plane (#491).
@@ -69,6 +79,9 @@ func NewIntentControl(store IntentControlStore, log *slog.Logger, cfg IntentCont
 	if cfg.StopBudget <= 0 {
 		cfg.StopBudget = 30 * time.Second
 	}
+	if cfg.Expiry <= 0 {
+		cfg.Expiry = 30 * time.Second
+	}
 	return &IntentControl{store: store, log: log, cfg: cfg}
 }
 
@@ -82,7 +95,16 @@ func NewIntentControl(store IntentControlStore, log *slog.Logger, cfg IntentCont
 func (c *IntentControl) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error) {
 	intent, err := c.store.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
 	if errors.Is(err, storage.ErrIntentActive) {
-		return storage.VoiceSession{}, ErrSessionActive
+		// Zero-worker escape (review item 4): the blocking intent may be a dead
+		// worker's claimed/live row that no tick will ever sweep. Reap it if its
+		// heartbeat is stale, then retry the create ONCE. A still-live row (fresh
+		// beat) or an in-flight pending Start is left alone → ErrSessionActive.
+		if reaped, rerr := c.reapBlockingIfExpired(ctx, tenantID); rerr == nil && reaped {
+			intent, err = c.store.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
+		}
+		if errors.Is(err, storage.ErrIntentActive) {
+			return storage.VoiceSession{}, ErrSessionActive
+		}
 	}
 	if err != nil {
 		return storage.VoiceSession{}, fmt.Errorf("session: create voice session intent: %w", err)
@@ -98,22 +120,31 @@ func (c *IntentControl) Start(ctx context.Context, tenantID, campaignID uuid.UUI
 		}
 		switch cur.Status {
 		case storage.VoiceIntentLive:
-			if !cur.VoiceSessionID.Valid {
-				break // live but the id has not landed yet — keep polling
+			if cur.VoiceSessionID.Valid {
+				vs, err := c.store.GetVoiceSession(ctx, cur.VoiceSessionID.UUID)
+				if err != nil {
+					return storage.VoiceSession{}, fmt.Errorf("session: load live voice session: %w", err)
+				}
+				return vs, nil
 			}
-			vs, err := c.store.GetVoiceSession(ctx, cur.VoiceSessionID.UUID)
-			if err != nil {
-				return storage.VoiceSession{}, fmt.Errorf("session: load live voice session: %w", err)
-			}
-			return vs, nil
+			// live but the id has not landed yet — keep polling.
 		case storage.VoiceIntentFailed, storage.VoiceIntentDead:
 			return storage.VoiceSession{}, fmt.Errorf("session: voice worker could not start the session: %s", intentReason(cur))
 		case storage.VoiceIntentDone:
-			// Stopped before it ever went live (a stop hit the pending row): treat as
-			// a benign no-session outcome, not a fault.
-			return storage.VoiceSession{}, ErrIntentPending
+			// Stopped before it ever went live (an external stop hit the pending row):
+			// a distinct cancelled outcome, NOT the still-queued ErrIntentPending
+			// (review item 7).
+			return storage.VoiceSession{}, ErrIntentCancelled
 		}
 		if time.Now().After(deadline) {
+			// Budget spent and still not live: CANCEL the pending intent so a retry
+			// does not 23505 into a dead-end AlreadyExists and a worker booting later
+			// does not claim a stale row nobody is watching (review item 3). Then
+			// "try again shortly" is honest. A concurrent claim turns the cancel into
+			// a stop_requested the claiming worker honors — also correct.
+			if _, cerr := c.store.RequestVoiceSessionStop(ctx, intent.ID); cerr != nil && !errors.Is(cerr, storage.ErrNotFound) {
+				c.log.Warn("intent control: cancel pending intent after start timeout", "intent", intent.ID, "err", cerr)
+			}
 			return storage.VoiceSession{}, ErrIntentPending
 		}
 		select {
@@ -122,6 +153,25 @@ func (c *IntentControl) Start(ctx context.Context, tenantID, campaignID uuid.UUI
 		case <-ticker.C:
 		}
 	}
+}
+
+// reapBlockingIfExpired reaps the Tenant's current blocking intent when it is a
+// claimed/live row whose heartbeat is stale (its worker died) — the single-row
+// zero-worker escape (review item 4). A pending or fresh row is left untouched
+// (false). It is best-effort: any error is returned so Start falls back to the
+// plain ErrSessionActive.
+func (c *IntentControl) reapBlockingIfExpired(ctx context.Context, tenantID uuid.UUID) (bool, error) {
+	blocking, err := c.store.GetLiveVoiceSessionIntentForTenant(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return false, nil // it already cleared — the retry will succeed
+	}
+	if err != nil {
+		return false, err
+	}
+	if blocking.Status != storage.VoiceIntentClaimed && blocking.Status != storage.VoiceIntentLive {
+		return false, nil // pending: an in-flight Start owns it, not a dead worker
+	}
+	return c.store.ReapVoiceSessionIntentIfExpired(ctx, blocking.ID, c.cfg.Expiry)
 }
 
 // Stop flags the Tenant's live intent for the owning worker to wind down and
@@ -153,9 +203,10 @@ func (c *IntentControl) Stop(ctx context.Context, tenantID uuid.UUID) (storage.V
 			return c.loadRow(ctx, cur)
 		}
 		if time.Now().After(deadline) {
-			// The worker has not confirmed within the budget; return the last-known
-			// row (still running) so the caller can re-poll GetSession.
-			return c.loadRow(ctx, cur)
+			// The worker has not confirmed within the budget: the session may still be
+			// running, so surface an error (→ CodeUnavailable, retry) rather than a
+			// false success carrying a still-'running' row (review item 7).
+			return storage.VoiceSession{}, ErrStopPending
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/session/intentcontrol.go
+++ b/internal/session/intentcontrol.go
@@ -1,0 +1,276 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// IntentControl is the web tier's split-mode SessionManager (#491, ADR-0057): in
+// a -mode web + -mode voice deployment the web tier does NOT drive the voice loop
+// in-process. Instead Start writes a voice_session_intents row and polls the
+// claim plane until a -mode voice worker claims and drives it live; Stop flags
+// the intent and polls until the worker winds the session down; Active reads the
+// Tenant's live intent. It is a drop-in for *Manager on the web tier's RPC
+// surface: the mgr-only live controls (mute/say/replay/spend) degrade with
+// ErrSplitMode because the live session state lives in the worker, not here.
+
+// IntentControlStore is the claim-plane + voice_sessions surface IntentControl
+// needs. *storage.Store satisfies it; tests use a fake.
+type IntentControlStore interface {
+	CreateVoiceSessionIntent(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSessionIntent, error)
+	RequestVoiceSessionStop(ctx context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error)
+	GetVoiceSessionIntent(ctx context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error)
+	GetLiveVoiceSessionIntentForTenant(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSessionIntent, error)
+	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
+	IsCampaignLiveIntent(ctx context.Context, campaignID uuid.UUID) (bool, error)
+	AnyLiveVoiceSessionIntent(ctx context.Context) (bool, error)
+}
+
+// IntentControlConfig carries IntentControl's poll cadence and budgets (#491). A
+// non-positive value takes its default.
+type IntentControlConfig struct {
+	// Poll is the tick between claim-plane reads while Start/Stop wait. Default 1s.
+	Poll time.Duration
+	// StartBudget bounds how long Start waits for a worker to drive the intent live
+	// before returning ErrIntentPending (the operator retries). Default 20s.
+	StartBudget time.Duration
+	// StopBudget bounds how long Stop waits for the worker to wind the session down
+	// before returning the intent's last-known row. Default 30s.
+	StopBudget time.Duration
+}
+
+// IntentControl drives voice sessions through the Postgres claim plane (#491).
+type IntentControl struct {
+	store IntentControlStore
+	log   *slog.Logger
+	cfg   IntentControlConfig
+}
+
+// NewIntentControl builds the web tier's split-mode session control over the
+// claim-plane store. A non-positive config duration takes its default.
+func NewIntentControl(store IntentControlStore, log *slog.Logger, cfg IntentControlConfig) *IntentControl {
+	if log == nil {
+		log = slog.Default()
+	}
+	if cfg.Poll <= 0 {
+		cfg.Poll = time.Second
+	}
+	if cfg.StartBudget <= 0 {
+		cfg.StartBudget = 20 * time.Second
+	}
+	if cfg.StopBudget <= 0 {
+		cfg.StopBudget = 30 * time.Second
+	}
+	return &IntentControl{store: store, log: log, cfg: cfg}
+}
+
+// Start writes a pending intent for the Tenant's Campaign and polls the claim
+// plane until a worker drives it live (returning the loaded voice_sessions row),
+// it fails/dies (an error carrying the recorded last_error), or the Start budget
+// elapses (ErrIntentPending → the RPC's CodeUnavailable, the operator retries).
+// A duplicate live-per-tenant intent (storage.ErrIntentActive) surfaces as
+// ErrSessionActive so the RPC maps it to CodeAlreadyExists exactly like the
+// in-process Manager's per-Tenant guard.
+func (c *IntentControl) Start(ctx context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	intent, err := c.store.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
+	if errors.Is(err, storage.ErrIntentActive) {
+		return storage.VoiceSession{}, ErrSessionActive
+	}
+	if err != nil {
+		return storage.VoiceSession{}, fmt.Errorf("session: create voice session intent: %w", err)
+	}
+
+	deadline := time.Now().Add(c.cfg.StartBudget)
+	ticker := time.NewTicker(c.cfg.Poll)
+	defer ticker.Stop()
+	for {
+		cur, err := c.store.GetVoiceSessionIntent(ctx, intent.ID)
+		if err != nil {
+			return storage.VoiceSession{}, fmt.Errorf("session: poll voice session intent: %w", err)
+		}
+		switch cur.Status {
+		case storage.VoiceIntentLive:
+			if !cur.VoiceSessionID.Valid {
+				break // live but the id has not landed yet — keep polling
+			}
+			vs, err := c.store.GetVoiceSession(ctx, cur.VoiceSessionID.UUID)
+			if err != nil {
+				return storage.VoiceSession{}, fmt.Errorf("session: load live voice session: %w", err)
+			}
+			return vs, nil
+		case storage.VoiceIntentFailed, storage.VoiceIntentDead:
+			return storage.VoiceSession{}, fmt.Errorf("session: voice worker could not start the session: %s", intentReason(cur))
+		case storage.VoiceIntentDone:
+			// Stopped before it ever went live (a stop hit the pending row): treat as
+			// a benign no-session outcome, not a fault.
+			return storage.VoiceSession{}, ErrIntentPending
+		}
+		if time.Now().After(deadline) {
+			return storage.VoiceSession{}, ErrIntentPending
+		}
+		select {
+		case <-ctx.Done():
+			return storage.VoiceSession{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// Stop flags the Tenant's live intent for the owning worker to wind down and
+// polls until the intent goes terminal (done/dead/failed) or the Stop budget
+// elapses, returning the closed voice_sessions row when one is bound. No live
+// intent for the Tenant is ErrNoActiveSession.
+func (c *IntentControl) Stop(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSession, error) {
+	live, err := c.store.GetLiveVoiceSessionIntentForTenant(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, ErrNoActiveSession
+	}
+	if err != nil {
+		return storage.VoiceSession{}, fmt.Errorf("session: load live intent: %w", err)
+	}
+
+	if _, err := c.store.RequestVoiceSessionStop(ctx, live.ID); err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, fmt.Errorf("session: request voice session stop: %w", err)
+	}
+
+	deadline := time.Now().Add(c.cfg.StopBudget)
+	ticker := time.NewTicker(c.cfg.Poll)
+	defer ticker.Stop()
+	for {
+		cur, err := c.store.GetVoiceSessionIntent(ctx, live.ID)
+		if err != nil {
+			return storage.VoiceSession{}, fmt.Errorf("session: poll intent on stop: %w", err)
+		}
+		if isIntentTerminal(cur.Status) {
+			return c.loadRow(ctx, cur)
+		}
+		if time.Now().After(deadline) {
+			// The worker has not confirmed within the budget; return the last-known
+			// row (still running) so the caller can re-poll GetSession.
+			return c.loadRow(ctx, cur)
+		}
+		select {
+		case <-ctx.Done():
+			return storage.VoiceSession{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// Active reports the Tenant's LIVE Voice Session (the split-mode read backing
+// GetSession / searchCampaign): a live intent with its voice_sessions row loaded.
+// A pending/claimed intent (not yet live) reports no active session — the screen
+// shows idle until the worker joins. No intent at all is likewise not-active.
+func (c *IntentControl) Active(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSession, bool, error) {
+	live, err := c.store.GetLiveVoiceSessionIntentForTenant(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, false, nil
+	}
+	if err != nil {
+		return storage.VoiceSession{}, false, err
+	}
+	if live.Status != storage.VoiceIntentLive || !live.VoiceSessionID.Valid {
+		return storage.VoiceSession{}, false, nil
+	}
+	vs, err := c.store.GetVoiceSession(ctx, live.VoiceSessionID.UUID)
+	if err != nil {
+		return storage.VoiceSession{}, false, err
+	}
+	return vs, true, nil
+}
+
+// IsCampaignLive reports whether campaignID has a live intent anywhere in the
+// pool — the split-mode archive/delete guard (#491). Errors degrade to false
+// (the guard is a safety net; a DB blip should not falsely block, and the RPC
+// re-reads). ctx-free to match the *Manager seam the web servers wire.
+func (c *IntentControl) IsCampaignLive(campaignID uuid.UUID) bool {
+	live, err := c.store.IsCampaignLiveIntent(context.Background(), campaignID)
+	if err != nil {
+		c.log.Warn("intent control: campaign live-guard read", "campaign", campaignID, "err", err)
+		return false
+	}
+	return live
+}
+
+// AnyLive reports whether any intent is live in the pool — the split-mode Discord
+// health short-circuit (#491, the claim-plane sibling of Manager.AnyLive).
+func (c *IntentControl) AnyLive() bool {
+	live, err := c.store.AnyLiveVoiceSessionIntent(context.Background())
+	if err != nil {
+		c.log.Warn("intent control: any-live health read", "err", err)
+		return false
+	}
+	return live
+}
+
+// The live-session controls below are Manager-only: their state (the mute set,
+// the spend meter, the outbound pump for say/replay) lives in the -mode voice
+// worker, unreachable from the web tier. In a split deployment they degrade with
+// ErrSplitMode (→ CodeFailedPrecondition) rather than lie (ADR-0057 consequence:
+// no mute/say RPCs on the web tier of a split deployment).
+
+// SetAgentMute is Manager-only (#491): ErrSplitMode in a split deployment.
+func (c *IntentControl) SetAgentMute(context.Context, uuid.UUID, string, bool) ([]string, error) {
+	return nil, ErrSplitMode
+}
+
+// SetAllMute is Manager-only (#491): ErrSplitMode in a split deployment.
+func (c *IntentControl) SetAllMute(context.Context, uuid.UUID, bool) ([]string, error) {
+	return nil, ErrSplitMode
+}
+
+// MutedAgentIDs is Manager-only (#491): nil on the web tier of a split deployment.
+func (c *IntentControl) MutedAgentIDs(uuid.UUID) []string { return nil }
+
+// Spend is Manager-only (#491): the zero Status on the web tier of a split
+// deployment (the live meter rides the worker; the durable ledger is the truth).
+func (c *IntentControl) Spend(uuid.UUID) spend.Status { return spend.Status{} }
+
+// ReplayHighlight is Manager-only (#491): a live-channel replay needs the worker's
+// outbound pump, so it is ErrSplitMode on the web tier of a split deployment.
+func (c *IntentControl) ReplayHighlight(context.Context, uuid.UUID, string) error {
+	return ErrSplitMode
+}
+
+// loadRow loads the voice_sessions row an intent bound, or the zero VoiceSession
+// (nil id) when the intent never went live (no worker claimed it).
+func (c *IntentControl) loadRow(ctx context.Context, intent storage.VoiceSessionIntent) (storage.VoiceSession, error) {
+	if !intent.VoiceSessionID.Valid {
+		return storage.VoiceSession{}, nil
+	}
+	vs, err := c.store.GetVoiceSession(ctx, intent.VoiceSessionID.UUID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return storage.VoiceSession{}, nil
+	}
+	if err != nil {
+		return storage.VoiceSession{}, fmt.Errorf("session: load voice session row: %w", err)
+	}
+	return vs, nil
+}
+
+// isIntentTerminal reports whether a status is a settled end state.
+func isIntentTerminal(s storage.VoiceSessionIntentStatus) bool {
+	switch s {
+	case storage.VoiceIntentDone, storage.VoiceIntentDead, storage.VoiceIntentFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// intentReason renders an intent's failure cause for the Start error: its
+// recorded last_error, or a generic phrase naming the terminal status.
+func intentReason(intent storage.VoiceSessionIntent) string {
+	if intent.LastError != "" {
+		return intent.LastError
+	}
+	return string(intent.Status)
+}

--- a/internal/session/intentcontrol_test.go
+++ b/internal/session/intentcontrol_test.go
@@ -1,0 +1,261 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// fakeControlStore is an in-memory session.IntentControlStore built on top of a
+// fakeIntentStore's claim-plane semantics plus a voice_sessions map — the union a
+// real *storage.Store presents to BOTH IntentControl (web tier) and ClaimLoop
+// (worker), so the end-to-end test wires the two halves through one store exactly
+// as production does through one DB.
+type fakeControlStore struct {
+	*fakeIntentStore
+	mu       sync.Mutex
+	sessions map[uuid.UUID]storage.VoiceSession
+}
+
+func newFakeControlStore() *fakeControlStore {
+	return &fakeControlStore{
+		fakeIntentStore: newFakeIntentStore(),
+		sessions:        map[uuid.UUID]storage.VoiceSession{},
+	}
+}
+
+// putSession records a voice_sessions row the worker's Manager created, so
+// IntentControl can load it once the intent goes live.
+func (f *fakeControlStore) putSession(vs storage.VoiceSession) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sessions[vs.ID] = vs
+}
+
+func (f *fakeControlStore) CreateVoiceSessionIntent(_ context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSessionIntent, error) {
+	f.fakeIntentStore.mu.Lock()
+	for _, i := range f.fakeIntentStore.intents {
+		if i.TenantID == tenantID &&
+			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
+			f.fakeIntentStore.mu.Unlock()
+			return storage.VoiceSessionIntent{}, storage.ErrIntentActive
+		}
+	}
+	f.fakeIntentStore.mu.Unlock()
+	return *f.add(tenantID, campaignID), nil
+}
+
+func (f *fakeControlStore) GetVoiceSessionIntent(_ context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error) {
+	f.fakeIntentStore.mu.Lock()
+	defer f.fakeIntentStore.mu.Unlock()
+	i, ok := f.fakeIntentStore.intents[id]
+	if !ok {
+		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	return *i, nil
+}
+
+func (f *fakeControlStore) RequestVoiceSessionStop(_ context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error) {
+	f.fakeIntentStore.mu.Lock()
+	defer f.fakeIntentStore.mu.Unlock()
+	i, ok := f.fakeIntentStore.intents[id]
+	if !ok {
+		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	if i.Status == storage.VoiceIntentPending {
+		now := time.Now()
+		i.Status = storage.VoiceIntentDone
+		i.EndedAt = &now
+	}
+	i.StopRequested = true
+	return *i, nil
+}
+
+func (f *fakeControlStore) GetLiveVoiceSessionIntentForTenant(_ context.Context, tenantID uuid.UUID) (storage.VoiceSessionIntent, error) {
+	f.fakeIntentStore.mu.Lock()
+	defer f.fakeIntentStore.mu.Unlock()
+	for _, i := range f.fakeIntentStore.intents {
+		if i.TenantID == tenantID &&
+			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
+			return *i, nil
+		}
+	}
+	return storage.VoiceSessionIntent{}, storage.ErrNotFound
+}
+
+func (f *fakeControlStore) GetVoiceSession(_ context.Context, id uuid.UUID) (storage.VoiceSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	vs, ok := f.sessions[id]
+	if !ok {
+		return storage.VoiceSession{}, storage.ErrNotFound
+	}
+	return vs, nil
+}
+
+func (f *fakeControlStore) IsCampaignLiveIntent(_ context.Context, campaignID uuid.UUID) (bool, error) {
+	f.fakeIntentStore.mu.Lock()
+	defer f.fakeIntentStore.mu.Unlock()
+	for _, i := range f.fakeIntentStore.intents {
+		if i.CampaignID == campaignID &&
+			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeControlStore) AnyLiveVoiceSessionIntent(_ context.Context) (bool, error) {
+	f.fakeIntentStore.mu.Lock()
+	defer f.fakeIntentStore.mu.Unlock()
+	for _, i := range f.fakeIntentStore.intents {
+		switch i.Status {
+		case storage.VoiceIntentPending, storage.VoiceIntentClaimed, storage.VoiceIntentLive:
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func newIntentControl(t *testing.T, store session.IntentControlStore) *session.IntentControl {
+	t.Helper()
+	return session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: 100 * time.Millisecond, StopBudget: time.Second})
+}
+
+// TestIntentControl_StartTimesOutPending covers sequence (10) timeout leg: no
+// worker claims the intent, so Start returns ErrIntentPending (→ CodeUnavailable).
+func TestIntentControl_StartTimesOutPending(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := newIntentControl(t, store)
+	_, err := ctl.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrIntentPending) {
+		t.Fatalf("Start err = %v, want ErrIntentPending", err)
+	}
+}
+
+// TestIntentControl_StartDuplicateActive covers the per-tenant guard: a second
+// Start while an intent is non-terminal maps to ErrSessionActive.
+func TestIntentControl_StartDuplicateActive(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := newIntentControl(t, store)
+	tenantID := uuid.New()
+	store.add(tenantID, uuid.New()) // a standing pending intent for the tenant
+	_, err := ctl.Start(context.Background(), tenantID, uuid.New())
+	if !errors.Is(err, session.ErrSessionActive) {
+		t.Fatalf("duplicate Start err = %v, want ErrSessionActive", err)
+	}
+}
+
+// TestIntentControl_ActiveOnlyWhenLive asserts Active reports false for a
+// pending/claimed intent and true (with the row) once live.
+func TestIntentControl_ActiveOnlyWhenLive(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := newIntentControl(t, store)
+	tenantID, campaignID := uuid.New(), uuid.New()
+	intent := store.add(tenantID, campaignID)
+
+	if _, active, _ := ctl.Active(context.Background(), tenantID); active {
+		t.Fatal("Active true for a pending intent")
+	}
+
+	// Drive it live with a bound voice_sessions row (as the worker would).
+	claimed, _ := store.ClaimVoiceSessionIntent(context.Background(), "worker-1")
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionRunning}
+	store.putSession(vs)
+	if _, err := store.MarkVoiceSessionIntentLive(context.Background(), claimed.ID, "worker-1", vs.ID); err != nil {
+		t.Fatalf("mark live: %v", err)
+	}
+	got, active, err := ctl.Active(context.Background(), tenantID)
+	if err != nil || !active || got.ID != vs.ID {
+		t.Fatalf("Active = (%s,%v,%v), want live row %s", got.ID, active, err, vs.ID)
+	}
+	_ = intent
+}
+
+// TestIntentControl_EndToEndWithClaimLoop covers sequence (10) end-to-end: the
+// web tier's IntentControl.Start and a worker's in-process ClaimLoop wired
+// through ONE store — Start writes the intent, the loop claims + starts + marks
+// live, Start returns the live row; then Stop flags it, the loop winds down, Stop
+// returns the closed row.
+func TestIntentControl_EndToEndWithClaimLoop(t *testing.T) {
+	store := newFakeControlStore()
+
+	// The worker half: a Manager over a fake voice-loop, and a ClaimLoop that
+	// records the voice_sessions rows the Manager creates into the shared store so
+	// IntentControl can load them (mirroring one *storage.Store serving both).
+	mstore := &recordingStore{fakeStore: newFakeStore(), control: store}
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	loop := newClaimLoop(t, store, mgr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	loopDone := make(chan struct{})
+	go func() { loop.Run(ctx); close(loopDone) }()
+
+	ctl := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: 3 * time.Second, StopBudget: 3 * time.Second})
+
+	tenantID, campaignID := uuid.New(), uuid.New()
+	vs, err := ctl.Start(ctx, tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("Start end-to-end: %v", err)
+	}
+	if vs.CampaignID != campaignID || vs.Status != storage.VoiceSessionRunning {
+		t.Fatalf("Start returned %+v, want a running row for campaign %s", vs, campaignID)
+	}
+
+	// The web tier now sees the live session.
+	if _, active, _ := ctl.Active(ctx, tenantID); !active {
+		t.Fatal("Active false after Start went live")
+	}
+
+	// Stop from the web tier: flag the intent, the loop winds the session down.
+	closed, err := ctl.Stop(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("Stop end-to-end: %v", err)
+	}
+	if closed.ID != vs.ID {
+		t.Fatalf("Stop returned session %s, want %s", closed.ID, vs.ID)
+	}
+	if !runner.wasCancelled() {
+		t.Fatal("worker loop not cancelled by the stop flag")
+	}
+
+	cancel()
+	<-loopDone
+}
+
+// recordingStore adapts a fakeStore (the Manager's session.Store) so every
+// voice_sessions row it creates/closes is also mirrored into the shared
+// fakeControlStore, so IntentControl reads the same rows the worker's Manager
+// wrote — as one *storage.Store would.
+type recordingStore struct {
+	*fakeStore
+	control *fakeControlStore
+}
+
+func (r *recordingStore) CreateVoiceSession(ctx context.Context, campaignID uuid.UUID) (storage.VoiceSession, error) {
+	vs, err := r.fakeStore.CreateVoiceSession(ctx, campaignID)
+	if err == nil {
+		r.control.putSession(vs)
+	}
+	return vs, err
+}
+
+func (r *recordingStore) CloseVoiceSession(ctx context.Context, id uuid.UUID, status storage.VoiceSessionStatus, lineCount int, endReason *string) (storage.VoiceSession, error) {
+	vs, err := r.fakeStore.CloseVoiceSession(ctx, id, status, lineCount, endReason)
+	if err == nil {
+		r.control.putSession(vs)
+	}
+	return vs, err
+}

--- a/internal/session/intentcontrol_test.go
+++ b/internal/session/intentcontrol_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -23,6 +24,10 @@ type fakeControlStore struct {
 	*fakeIntentStore
 	mu       sync.Mutex
 	sessions map[uuid.UUID]storage.VoiceSession
+	// onGet, when set, runs against an intent on each GetVoiceSessionIntent — a hook
+	// to simulate an external transition (e.g. a stop landing on a pending row) mid
+	// Start poll. Guarded by the fakeIntentStore mutex the caller already holds.
+	onGet func(*storage.VoiceSessionIntent)
 }
 
 func newFakeControlStore() *fakeControlStore {
@@ -59,6 +64,9 @@ func (f *fakeControlStore) GetVoiceSessionIntent(_ context.Context, id uuid.UUID
 	i, ok := f.intents[id]
 	if !ok {
 		return storage.VoiceSessionIntent{}, storage.ErrNotFound
+	}
+	if f.onGet != nil {
+		f.onGet(i)
 	}
 	return *i, nil
 }
@@ -112,6 +120,38 @@ func (f *fakeControlStore) IsCampaignLiveIntent(_ context.Context, campaignID uu
 	}
 	return false, nil
 }
+
+// reapExpiry is the age threshold the test uses; a heartbeat older than now minus
+// this is stale. Tests set an intent's heartbeat via markStaleHeartbeat.
+func (f *fakeControlStore) ReapVoiceSessionIntentIfExpired(_ context.Context, id uuid.UUID, expiry time.Duration) (bool, error) {
+	f.intents_mu().Lock()
+	defer f.intents_mu().Unlock()
+	i, ok := f.intents[id]
+	if !ok || (i.Status != storage.VoiceIntentClaimed && i.Status != storage.VoiceIntentLive) {
+		return false, nil
+	}
+	if i.HeartbeatAt == nil || time.Since(*i.HeartbeatAt) < expiry {
+		return false, nil
+	}
+	now := time.Now()
+	i.Status = storage.VoiceIntentDead
+	i.LastError = "worker heartbeat expired"
+	i.EndedAt = &now
+	return true, nil
+}
+
+// markStaleHeartbeat ages an intent's heartbeat so ReapVoiceSessionIntentIfExpired
+// treats it as a dead worker's row.
+func (f *fakeControlStore) markStaleHeartbeat(id uuid.UUID) {
+	f.intents_mu().Lock()
+	defer f.intents_mu().Unlock()
+	old := time.Now().Add(-time.Hour)
+	f.intents[id].HeartbeatAt = &old
+}
+
+// intents_mu exposes the embedded fakeIntentStore mutex for the control-store
+// methods that touch the shared intent map.
+func (f *fakeControlStore) intents_mu() *sync.Mutex { return &f.fakeIntentStore.mu }
 
 func (f *fakeControlStore) AnyLiveVoiceSessionIntent(_ context.Context) (bool, error) {
 	f.fakeIntentStore.mu.Lock()
@@ -258,4 +298,117 @@ func (r *recordingStore) CloseVoiceSession(ctx context.Context, id uuid.UUID, st
 		r.control.putSession(vs)
 	}
 	return vs, err
+}
+
+// TestIntentControl_StartCancelsPendingOnTimeout covers review item 3: when no
+// worker claims within the Start budget, IntentControl cancels the pending intent
+// (so a retry does not 23505) and returns ErrIntentPending.
+func TestIntentControl_StartCancelsPendingOnTimeout(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: 20 * time.Millisecond, StopBudget: time.Second, Expiry: 30 * time.Second})
+	tenantID, campaignID := uuid.New(), uuid.New()
+
+	_, err := ctl.Start(context.Background(), tenantID, campaignID)
+	if !errors.Is(err, session.ErrIntentPending) {
+		t.Fatalf("Start err = %v, want ErrIntentPending", err)
+	}
+	// The pending intent was cancelled to 'done', so a fresh Start does not collide.
+	if _, err := ctl.Start(context.Background(), tenantID, campaignID); !errors.Is(err, session.ErrIntentPending) {
+		t.Fatalf("retry Start err = %v, want ErrIntentPending (no 23505 dead-end)", err)
+	}
+}
+
+// TestIntentControl_StartCancelledOutcome covers review item 7: an external stop
+// landing on the still-pending row is a distinct ErrIntentCancelled, not
+// ErrIntentPending.
+func TestIntentControl_StartCancelledOutcome(t *testing.T) {
+	store := newFakeControlStore()
+	// On the first poll, flip the pending intent straight to done (an external stop).
+	store.onGet = func(i *storage.VoiceSessionIntent) {
+		if i.Status == storage.VoiceIntentPending {
+			now := time.Now()
+			i.Status = storage.VoiceIntentDone
+			i.EndedAt = &now
+		}
+	}
+	ctl := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: time.Second, StopBudget: time.Second, Expiry: 30 * time.Second})
+	_, err := ctl.Start(context.Background(), uuid.New(), uuid.New())
+	if !errors.Is(err, session.ErrIntentCancelled) {
+		t.Fatalf("Start err = %v, want ErrIntentCancelled", err)
+	}
+}
+
+// TestIntentControl_ZeroWorkerReapsStaleBlocker covers review item 4: a Start
+// blocked by a dead worker's stale claimed/live intent reaps it and proceeds
+// (no worker present, so it then times out) — never a permanent AlreadyExists.
+func TestIntentControl_ZeroWorkerReapsStaleBlocker(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: 20 * time.Millisecond, StopBudget: time.Second, Expiry: time.Millisecond})
+	tenantID, campaignID := uuid.New(), uuid.New()
+
+	old := store.add(tenantID, campaignID)
+	claimed, _ := store.ClaimVoiceSessionIntent(context.Background(), "dead-worker")
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionRunning}
+	store.putSession(vs)
+	if _, err := store.MarkVoiceSessionIntentLive(context.Background(), claimed.ID, "dead-worker", vs.ID); err != nil {
+		t.Fatalf("mark live: %v", err)
+	}
+	store.markStaleHeartbeat(claimed.ID)
+
+	_, err := ctl.Start(context.Background(), tenantID, campaignID)
+	if !errors.Is(err, session.ErrIntentPending) {
+		t.Fatalf("Start err = %v, want ErrIntentPending (reaped then queued)", err)
+	}
+	if got := store.get(old.ID).Status; got != storage.VoiceIntentDead {
+		t.Fatalf("stale blocker status = %q, want dead (reaped)", got)
+	}
+}
+
+// TestIntentControl_StopBudgetError covers review item 7: a Stop whose worker
+// never confirms within the budget returns ErrStopPending, not a false success.
+func TestIntentControl_StopBudgetError(t *testing.T) {
+	store := newFakeControlStore()
+	ctl := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, StartBudget: time.Second, StopBudget: 20 * time.Millisecond, Expiry: 30 * time.Second})
+	tenantID, campaignID := uuid.New(), uuid.New()
+
+	store.add(tenantID, campaignID)
+	claimed, _ := store.ClaimVoiceSessionIntent(context.Background(), "worker-1")
+	vs := storage.VoiceSession{ID: uuid.New(), CampaignID: campaignID, Status: storage.VoiceSessionRunning}
+	store.putSession(vs)
+	if _, err := store.MarkVoiceSessionIntentLive(context.Background(), claimed.ID, "worker-1", vs.ID); err != nil {
+		t.Fatalf("mark live: %v", err)
+	}
+
+	// The worker never winds down (no loop), so Stop only flags and polls to budget.
+	_, err := ctl.Stop(context.Background(), tenantID)
+	if !errors.Is(err, session.ErrStopPending) {
+		t.Fatalf("Stop err = %v, want ErrStopPending", err)
+	}
+}
+
+// TestIntentControl_MgrOnlyDegrade covers review item 6: the Manager-only live
+// controls degrade with ErrSplitMode on the web tier of a split deployment.
+func TestIntentControl_MgrOnlyDegrade(t *testing.T) {
+	ctl := session.NewIntentControl(newFakeControlStore(), slog.New(slog.DiscardHandler), session.IntentControlConfig{})
+	tenantID := uuid.New()
+
+	if _, err := ctl.SetAgentMute(context.Background(), tenantID, uuid.NewString(), true); !errors.Is(err, session.ErrSplitMode) {
+		t.Errorf("SetAgentMute err = %v, want ErrSplitMode", err)
+	}
+	if _, err := ctl.SetAllMute(context.Background(), tenantID, true); !errors.Is(err, session.ErrSplitMode) {
+		t.Errorf("SetAllMute err = %v, want ErrSplitMode", err)
+	}
+	if err := ctl.ReplayHighlight(context.Background(), tenantID, "clip-key"); !errors.Is(err, session.ErrSplitMode) {
+		t.Errorf("ReplayHighlight err = %v, want ErrSplitMode", err)
+	}
+	if ids := ctl.MutedAgentIDs(tenantID); ids != nil {
+		t.Errorf("MutedAgentIDs = %v, want nil", ids)
+	}
+	if sp := ctl.Spend(tenantID); sp != (spend.Status{}) {
+		t.Errorf("Spend = %+v, want zero", sp)
+	}
 }

--- a/internal/session/intentcontrol_test.go
+++ b/internal/session/intentcontrol_test.go
@@ -42,7 +42,7 @@ func (f *fakeControlStore) putSession(vs storage.VoiceSession) {
 
 func (f *fakeControlStore) CreateVoiceSessionIntent(_ context.Context, tenantID, campaignID uuid.UUID) (storage.VoiceSessionIntent, error) {
 	f.fakeIntentStore.mu.Lock()
-	for _, i := range f.fakeIntentStore.intents {
+	for _, i := range f.intents {
 		if i.TenantID == tenantID &&
 			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
 			f.fakeIntentStore.mu.Unlock()
@@ -56,7 +56,7 @@ func (f *fakeControlStore) CreateVoiceSessionIntent(_ context.Context, tenantID,
 func (f *fakeControlStore) GetVoiceSessionIntent(_ context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error) {
 	f.fakeIntentStore.mu.Lock()
 	defer f.fakeIntentStore.mu.Unlock()
-	i, ok := f.fakeIntentStore.intents[id]
+	i, ok := f.intents[id]
 	if !ok {
 		return storage.VoiceSessionIntent{}, storage.ErrNotFound
 	}
@@ -66,7 +66,7 @@ func (f *fakeControlStore) GetVoiceSessionIntent(_ context.Context, id uuid.UUID
 func (f *fakeControlStore) RequestVoiceSessionStop(_ context.Context, id uuid.UUID) (storage.VoiceSessionIntent, error) {
 	f.fakeIntentStore.mu.Lock()
 	defer f.fakeIntentStore.mu.Unlock()
-	i, ok := f.fakeIntentStore.intents[id]
+	i, ok := f.intents[id]
 	if !ok {
 		return storage.VoiceSessionIntent{}, storage.ErrNotFound
 	}
@@ -82,7 +82,7 @@ func (f *fakeControlStore) RequestVoiceSessionStop(_ context.Context, id uuid.UU
 func (f *fakeControlStore) GetLiveVoiceSessionIntentForTenant(_ context.Context, tenantID uuid.UUID) (storage.VoiceSessionIntent, error) {
 	f.fakeIntentStore.mu.Lock()
 	defer f.fakeIntentStore.mu.Unlock()
-	for _, i := range f.fakeIntentStore.intents {
+	for _, i := range f.intents {
 		if i.TenantID == tenantID &&
 			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
 			return *i, nil
@@ -104,7 +104,7 @@ func (f *fakeControlStore) GetVoiceSession(_ context.Context, id uuid.UUID) (sto
 func (f *fakeControlStore) IsCampaignLiveIntent(_ context.Context, campaignID uuid.UUID) (bool, error) {
 	f.fakeIntentStore.mu.Lock()
 	defer f.fakeIntentStore.mu.Unlock()
-	for _, i := range f.fakeIntentStore.intents {
+	for _, i := range f.intents {
 		if i.CampaignID == campaignID &&
 			(i.Status == storage.VoiceIntentPending || i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) {
 			return true, nil
@@ -116,7 +116,7 @@ func (f *fakeControlStore) IsCampaignLiveIntent(_ context.Context, campaignID uu
 func (f *fakeControlStore) AnyLiveVoiceSessionIntent(_ context.Context) (bool, error) {
 	f.fakeIntentStore.mu.Lock()
 	defer f.fakeIntentStore.mu.Unlock()
-	for _, i := range f.fakeIntentStore.intents {
+	for _, i := range f.intents {
 		switch i.Status {
 		case storage.VoiceIntentPending, storage.VoiceIntentClaimed, storage.VoiceIntentLive:
 			return true, nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1024,6 +1024,18 @@ func (m *Manager) IsCampaignLive(campaignID uuid.UUID) bool {
 	return false
 }
 
+// HasCapacity reports whether the Manager can accept another Voice Session — its
+// live + reserving count is below MaxSessions (#491). The -mode voice claim loop
+// consults it before claiming an intent, so it never claims work it cannot run
+// (avoiding an ErrSessionLimit strand): claim only while there is a free slot. A
+// snapshot under the lock; in the single-worker interim (#492 elects the sole
+// claimer) nothing else fills a slot between this read and the following Start.
+func (m *Manager) HasCapacity() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.active)+len(m.reservations) < m.maxSessions
+}
+
 // AnyLive reports whether ANY Voice Session is currently running in this process
 // (#150, #488): the tenant-agnostic health signal the Discord probe reads. A
 // session in its end window (as.ended) no longer counts. Correct at any cap.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -82,6 +82,19 @@ var (
 	// session's mute set. Mapped to CodeNotFound.
 	ErrAgentNotInCampaign = errors.New("session: no such Agent in the Active Campaign")
 
+	// ErrIntentPending is returned by IntentControl.Start when the claim plane wrote
+	// the intent but no -mode voice worker claimed and drove it live within the Start
+	// budget (#491, split mode): the session is queued, not failed. The RPC layer
+	// maps it to CodeUnavailable ("voice worker has not claimed the session yet") so
+	// the operator retries.
+	ErrIntentPending = errors.New("session: voice worker has not claimed the session yet")
+	// ErrSplitMode is returned by the IntentControl methods that only the in-process
+	// Manager can serve — live mute/say/replay/spend reads (#491): in a split
+	// (-mode web + -mode voice) deployment the web tier holds no live session state,
+	// so these degrade rather than lie. The RPC layer maps it to
+	// CodeFailedPrecondition ("not available in a split deployment").
+	ErrSplitMode = errors.New("session: not available in a split deployment")
+
 	// ErrButlerVoiceless is returned by SpeakAsButler when the Active Campaign's
 	// Butler has no synthesizable Voice (empty VoiceID — the default auto-Butler is
 	// voiceless). Voicing it would publish a KindButler transcript line that never

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -88,6 +88,17 @@ var (
 	// maps it to CodeUnavailable ("voice worker has not claimed the session yet") so
 	// the operator retries.
 	ErrIntentPending = errors.New("session: voice worker has not claimed the session yet")
+	// ErrIntentCancelled is returned by IntentControl.Start when the intent it was
+	// waiting on went to a terminal 'done' WITHOUT ever going live (#491 review item
+	// 7): a stop landed on the still-pending row, so the start was cancelled — a
+	// distinct outcome from ErrIntentPending (still queued). The RPC maps it to
+	// CodeAborted so the operator sees "start was cancelled", not "not claimed yet".
+	ErrIntentCancelled = errors.New("session: the voice session start was cancelled before a worker claimed it")
+	// ErrStopPending is returned by IntentControl.Stop when the owning worker did not
+	// confirm the wind-down within the Stop budget (#491 review item 7): the session
+	// may still be running, so it is surfaced as an error (→ CodeUnavailable, retry)
+	// rather than a false success carrying a still-'running' row.
+	ErrStopPending = errors.New("session: the voice worker has not confirmed the stop yet")
 	// ErrSplitMode is returned by the IntentControl methods that only the in-process
 	// Manager can serve — live mute/say/replay/spend reads (#491): in a split
 	// (-mode web + -mode voice) deployment the web tier holds no live session state,

--- a/internal/storage/migrations/00035_voice_session_intents.sql
+++ b/internal/storage/migrations/00035_voice_session_intents.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+
+-- Voice-session claim plane (#491, ADR-0057 (b)): a start writes an INTENT row
+-- here instead of driving the in-process Manager directly, and a -mode voice
+-- worker claims it with the SAME FOR UPDATE SKIP LOCKED + heartbeat idiom the
+-- job runner proves (ADR-0049, internal/storage/job.go). Poll only — no
+-- LISTEN/NOTIFY (ADR-0057 (b)). Tenant-keyed: multi-guild tenant mapping is
+-- deferred at the epic level, so one live intent per Tenant is the invariant.
+--
+-- No mid-session takeover (ADR-0006/0057 (e)): a claim's heartbeat going stale
+-- means the owning Voice Instance is DEAD, so the row is marked 'dead' and the
+-- Tenant restarts — the session is NEVER handed to another instance (DAVE/MLS
+-- state cannot migrate). ClaimVoiceSessionIntent therefore claims 'pending' rows
+-- ONLY; it never re-claims a 'claimed'/'live' one whose worker crashed.
+CREATE TABLE voice_session_intents (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        uuid NOT NULL REFERENCES tenant (id) ON DELETE CASCADE,
+    campaign_id      uuid NOT NULL REFERENCES campaign (id) ON DELETE CASCADE,
+    -- pending | claimed | live | done | dead | failed. Text, not an enum: the app
+    -- validates the vocabulary and an older binary reading a future value must not
+    -- fail at the type layer (mirrors deployment_settings.admission_mode).
+    status           text NOT NULL DEFAULT 'pending',
+    -- The Voice Instance that holds the claim: hostname-uuid8, minted per boot in
+    -- cmd/glyphoxa. Empty until claimed; the fence for heartbeat/finish writes.
+    instance_id      text NOT NULL DEFAULT '',
+    -- The voice_sessions row the worker created once it went live. SET NULL if that
+    -- lifecycle row is ever deleted — the intent's own lifecycle is authoritative.
+    voice_session_id uuid REFERENCES voice_sessions (id) ON DELETE SET NULL,
+    -- The web tier flags this to wind a live session down; the owning worker sees it
+    -- on the next heartbeat and stops its local session (ADR-0057 (b) release).
+    stop_requested   boolean NOT NULL DEFAULT false,
+    last_error       text NOT NULL DEFAULT '',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    claimed_at       timestamptz,
+    heartbeat_at     timestamptz,
+    ended_at         timestamptz
+);
+
+-- One live intent per Tenant (the tenant-keyed invariant): a second start while a
+-- pending/claimed/live intent exists trips 23505 → ErrIntentActive. Terminal rows
+-- (done/dead/failed) fall out of the predicate, so a Tenant can start again once
+-- its prior intent finished.
+CREATE UNIQUE INDEX voice_session_intents_one_live_per_tenant
+    ON voice_session_intents (tenant_id)
+    WHERE status IN ('pending', 'claimed', 'live');
+
+-- The claim scan: oldest pending first (ORDER BY created_at), and the reaper's
+-- stale-heartbeat sweep both ride this.
+CREATE INDEX voice_session_intents_claim_idx
+    ON voice_session_intents (status, created_at);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS voice_session_intents;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -147,6 +147,54 @@ type VoiceSession struct {
 	EndReason  *string
 }
 
+// VoiceSessionIntentStatus is a Voice Session Intent's lifecycle state (#491,
+// ADR-0057 (b)): the claim-plane row a web-tier Start writes and a -mode voice
+// worker claims. 'pending' → 'claimed' (a worker took it) → 'live' (its loop is
+// up) → 'done' (clean end) / 'failed' (loop fault) / 'dead' (the worker's
+// heartbeat went stale — no takeover, ADR-0006). The three non-terminal states
+// share the one-live-per-tenant partial UNIQUE index.
+type VoiceSessionIntentStatus string
+
+const (
+	// VoiceIntentPending: written by Start, not yet claimed by any worker.
+	VoiceIntentPending VoiceSessionIntentStatus = "pending"
+	// VoiceIntentClaimed: a worker won the FOR UPDATE SKIP LOCKED claim and stamped
+	// its instance_id; its loop is starting but not yet live.
+	VoiceIntentClaimed VoiceSessionIntentStatus = "claimed"
+	// VoiceIntentLive: the worker's voice loop is up and the voice_sessions row is
+	// bound; the worker heartbeats while in this state.
+	VoiceIntentLive VoiceSessionIntentStatus = "live"
+	// VoiceIntentDone: terminal clean end (Stop honored, or the loop self-exited).
+	VoiceIntentDone VoiceSessionIntentStatus = "done"
+	// VoiceIntentDead: terminal — the owning worker's heartbeat went stale, so the
+	// reaper marked it dead. No mid-session takeover (ADR-0006/0057 (e)): the Tenant
+	// restarts; the session is NEVER handed to another Voice Instance.
+	VoiceIntentDead VoiceSessionIntentStatus = "dead"
+	// VoiceIntentFailed: terminal — the claiming worker could not run the session
+	// (e.g. the Manager refused it), last_error carries the readable cause.
+	VoiceIntentFailed VoiceSessionIntentStatus = "failed"
+)
+
+// VoiceSessionIntent is one row of the voice-session claim plane (#491): a
+// tenant-keyed intent a web Start writes and a -mode voice worker claims, runs,
+// and heartbeats. VoiceSessionID is set once the worker goes live; ClaimedAt /
+// HeartbeatAt / EndedAt track the claim lifecycle; LastError carries a fault's
+// readable cause. Mirrors the storage.Job shape (ADR-0049).
+type VoiceSessionIntent struct {
+	ID             uuid.UUID
+	TenantID       uuid.UUID
+	CampaignID     uuid.UUID
+	Status         VoiceSessionIntentStatus
+	InstanceID     string
+	VoiceSessionID uuid.NullUUID
+	StopRequested  bool
+	LastError      string
+	CreatedAt      time.Time
+	ClaimedAt      *time.Time
+	HeartbeatAt    *time.Time
+	EndedAt        *time.Time
+}
+
 // Agent is an AI-controlled persona — Butler or Character NPC (ADR-0009).
 type Agent struct {
 	ID         uuid.UUID

--- a/internal/storage/voiceintent.go
+++ b/internal/storage/voiceintent.go
@@ -240,6 +240,29 @@ func (s *Store) ReconcileWorkerOrphanedVoiceSessions(ctx context.Context) (int64
 	return tag.RowsAffected(), nil
 }
 
+// ReapVoiceSessionIntentIfExpired marks ONE claimed/live intent dead when its
+// heartbeat is older than expiry — the zero-worker escape (#491 review item 4):
+// the reaper otherwise runs only inside a worker's claim tick, so with NO healthy
+// worker a dead claimed/live intent would never expire and its Tenant would stay
+// blocked (ErrIntentActive) forever. IntentControl.Start calls this on the exact
+// row blocking a retry. Fenced by id + a stale heartbeat, so a live row (fresh
+// beat) or a foreign status is untouched. Returns whether it reaped a row.
+func (s *Store) ReapVoiceSessionIntentIfExpired(ctx context.Context, id uuid.UUID, expiry time.Duration) (bool, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_session_intents
+		    SET status = 'dead',
+		        last_error = CASE WHEN last_error = '' THEN 'worker heartbeat expired' ELSE last_error END,
+		        ended_at = now()
+		  WHERE id = $1
+		    AND status IN ('claimed', 'live')
+		    AND heartbeat_at < now() - make_interval(secs => $2)`,
+		id, expiry.Seconds())
+	if err != nil {
+		return false, fmt.Errorf("storage: reap voice session intent %s if expired: %w", id, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // GetVoiceSessionIntent loads one intent by id, or ErrNotFound. It backs the
 // IntentControl poll (the web tier watching a Start it wrote) and tests.
 func (s *Store) GetVoiceSessionIntent(ctx context.Context, id uuid.UUID) (VoiceSessionIntent, error) {

--- a/internal/storage/voiceintent.go
+++ b/internal/storage/voiceintent.go
@@ -227,6 +227,43 @@ func (s *Store) GetVoiceSessionIntent(ctx context.Context, id uuid.UUID) (VoiceS
 	return v, nil
 }
 
+// IsCampaignLiveIntent reports whether campaignID has any non-terminal
+// (pending/claimed/live) intent — the split-mode archive/delete live-guard
+// (#491): the web tier drives no in-process session, so "is this Campaign live"
+// is a claim-plane read rather than a Manager scan. Correct across the worker
+// pool.
+func (s *Store) IsCampaignLiveIntent(ctx context.Context, campaignID uuid.UUID) (bool, error) {
+	var one int
+	err := s.db.QueryRow(ctx,
+		`SELECT 1 FROM voice_session_intents
+		  WHERE campaign_id = $1 AND status IN ('pending', 'claimed', 'live')
+		  LIMIT 1`, campaignID).Scan(&one)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("storage: campaign %s live-intent check: %w", campaignID, err)
+	}
+	return true, nil
+}
+
+// AnyLiveVoiceSessionIntent reports whether ANY non-terminal intent exists — the
+// split-mode health signal (#491, the claim-plane sibling of Manager.AnyLive) the
+// web tier reads for the Discord health short-circuit.
+func (s *Store) AnyLiveVoiceSessionIntent(ctx context.Context) (bool, error) {
+	var one int
+	err := s.db.QueryRow(ctx,
+		`SELECT 1 FROM voice_session_intents
+		  WHERE status IN ('pending', 'claimed', 'live') LIMIT 1`).Scan(&one)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("storage: any-live-intent check: %w", err)
+	}
+	return true, nil
+}
+
 // GetLiveVoiceSessionIntentForTenant returns the Tenant's current non-terminal
 // (pending/claimed/live) intent, or ErrNotFound when the Tenant has none — the
 // per-Tenant read backing IntentControl.Active (the split-mode sibling of

--- a/internal/storage/voiceintent.go
+++ b/internal/storage/voiceintent.go
@@ -1,0 +1,250 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Voice-session claim-plane persistence (#491, ADR-0057 (b)): the web tier writes
+// an INTENT row on Start, a -mode voice worker claims the oldest pending one with
+// the FOR UPDATE SKIP LOCKED idiom the job runner proves (ADR-0049,
+// internal/storage/job.go), heartbeats while its loop is live, and finishes it on
+// end. No mid-session takeover (ADR-0006/0057 (e)): a stale heartbeat marks the
+// row 'dead' — the Tenant restarts, the session is never handed to another
+// instance. These queries mirror the job.go idiom: SKIP-LOCKED claim, instance
+// fencing on every terminal/heartbeat write, ErrNotFound for a superseded caller.
+
+// ErrIntentActive is returned by CreateVoiceSessionIntent when the Tenant already
+// has a non-terminal (pending/claimed/live) intent — the one-live-per-tenant
+// partial UNIQUE index (23505). The RPC layer maps it to CodeAlreadyExists,
+// mirroring session.ErrSessionActive.
+var ErrIntentActive = errors.New("storage: a voice session intent is already active for this tenant")
+
+const voiceIntentColumns = `
+	id, tenant_id, campaign_id, status, instance_id, voice_session_id,
+	stop_requested, last_error, created_at, claimed_at, heartbeat_at, ended_at`
+
+func scanVoiceSessionIntent(row pgx.Row) (VoiceSessionIntent, error) {
+	var v VoiceSessionIntent
+	err := row.Scan(
+		&v.ID, &v.TenantID, &v.CampaignID, &v.Status, &v.InstanceID, &v.VoiceSessionID,
+		&v.StopRequested, &v.LastError, &v.CreatedAt, &v.ClaimedAt, &v.HeartbeatAt, &v.EndedAt,
+	)
+	return v, err
+}
+
+// CreateVoiceSessionIntent writes a 'pending' claim-plane row for a Tenant's
+// Campaign and returns it. A second create while the Tenant already has a
+// non-terminal (pending/claimed/live) intent trips the one-live-per-tenant
+// partial UNIQUE index (23505) and yields ErrIntentActive — the per-Tenant
+// single-active guard, now durable in the DB rather than the in-process Manager.
+func (s *Store) CreateVoiceSessionIntent(ctx context.Context, tenantID, campaignID uuid.UUID) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO voice_session_intents (tenant_id, campaign_id)
+		 VALUES ($1, $2)
+		 RETURNING `+voiceIntentColumns,
+		tenantID, campaignID)
+	v, err := scanVoiceSessionIntent(row)
+	if err != nil {
+		if code, ok := pgErrCode(err); ok && code == "23505" {
+			return VoiceSessionIntent{}, ErrIntentActive
+		}
+		return VoiceSessionIntent{}, fmt.Errorf("storage: create voice session intent for tenant %s: %w", tenantID, err)
+	}
+	return v, nil
+}
+
+// ClaimVoiceSessionIntent atomically claims the single oldest PENDING intent for
+// instanceID and returns it in its post-claim state (status='claimed',
+// instance_id set, claimed_at/heartbeat_at = now()). No pending intent yields
+// ErrNotFound.
+//
+// The claim is ONE atomic UPDATE whose target is chosen by a `SELECT … FOR UPDATE
+// SKIP LOCKED LIMIT 1` subquery, so two concurrent workers skip each other's
+// locked candidates and claim two DISTINCT intents (never the same one) — exactly
+// the job-runner idiom (ADR-0049). It claims 'pending' ONLY: a 'claimed'/'live'
+// row whose worker crashed is NEVER re-claimed here (ADR-0006/0057 (e) — no
+// mid-session takeover); ReapDeadVoiceSessionIntents marks such a row 'dead'
+// instead, and the Tenant restarts.
+func (s *Store) ClaimVoiceSessionIntent(ctx context.Context, instanceID string) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_intents
+		    SET status = 'claimed',
+		        instance_id = $1,
+		        claimed_at = now(),
+		        heartbeat_at = now()
+		  WHERE id = (
+		        SELECT id FROM voice_session_intents
+		         WHERE status = 'pending'
+		         ORDER BY created_at, id
+		         FOR UPDATE SKIP LOCKED
+		         LIMIT 1
+		  )
+		 RETURNING `+voiceIntentColumns,
+		instanceID)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: claim voice session intent: %w", err)
+	}
+	return v, nil
+}
+
+// MarkVoiceSessionIntentLive flips instanceID's claimed intent to 'live' and
+// binds the voice_sessions row the worker created, stamping a fresh heartbeat. It
+// is fenced by (id, instance_id, status='claimed'): a superseded caller (a reaper
+// already marked it dead, or a different instance owns it) matches no row and
+// yields ErrNotFound.
+func (s *Store) MarkVoiceSessionIntentLive(ctx context.Context, id uuid.UUID, instanceID string, voiceSessionID uuid.UUID) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_intents
+		    SET status = 'live',
+		        voice_session_id = $3,
+		        heartbeat_at = now()
+		  WHERE id = $1 AND instance_id = $2 AND status = 'claimed'
+		 RETURNING `+voiceIntentColumns,
+		id, instanceID, voiceSessionID)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: mark voice session intent %s live: %w", id, err)
+	}
+	return v, nil
+}
+
+// HeartbeatVoiceSessionIntent stamps heartbeat_at = now() for instanceID's live
+// (or claimed) intent and reports whether a stop was requested, so the owning
+// worker learns on each beat whether the web tier asked it to wind down. It is
+// fenced WHERE instance_id=$2 AND status IN ('claimed','live'): a row the reaper
+// already marked dead (worker declared stale), or one now owned by another
+// instance, matches nothing and yields ErrNotFound — the caller reads that as
+// "my claim was superseded" and kills its local session (ADR-0006: it must not
+// keep running a session the plane believes is dead).
+func (s *Store) HeartbeatVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string) (stopRequested bool, err error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_intents
+		    SET heartbeat_at = now()
+		  WHERE id = $1 AND instance_id = $2 AND status IN ('claimed', 'live')
+		 RETURNING stop_requested`,
+		id, instanceID)
+	if serr := row.Scan(&stopRequested); serr != nil {
+		if errors.Is(serr, pgx.ErrNoRows) {
+			return false, ErrNotFound
+		}
+		return false, fmt.Errorf("storage: heartbeat voice session intent %s: %w", id, serr)
+	}
+	return stopRequested, nil
+}
+
+// RequestVoiceSessionStop asks the claim plane to wind an intent down. A still
+// 'pending' intent (no worker has claimed it) is taken straight to 'done' with
+// ended_at set — there is no worker to honor a flag, so the stop resolves
+// immediately. A claimed/live intent instead sets stop_requested=true, which the
+// owning worker sees on its next heartbeat and acts on. A missing id, or an
+// already-terminal intent, yields ErrNotFound. Returns the updated row.
+func (s *Store) RequestVoiceSessionStop(ctx context.Context, id uuid.UUID) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_intents
+		    SET status = CASE WHEN status = 'pending' THEN 'done' ELSE status END,
+		        stop_requested = true,
+		        ended_at = CASE WHEN status = 'pending' THEN now() ELSE ended_at END
+		  WHERE id = $1 AND status IN ('pending', 'claimed', 'live')
+		 RETURNING `+voiceIntentColumns,
+		id)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: request voice session intent %s stop: %w", id, err)
+	}
+	return v, nil
+}
+
+// FinishVoiceSessionIntent writes a terminal state (done/failed/dead) for
+// instanceID's intent with a recorded last_error and ended_at = now(). Fenced by
+// (id, instance_id) and a non-terminal current status so a superseded caller
+// (the reaper already marked it dead) matches no row and yields ErrNotFound. The
+// worker calls it once its local session has fully wound down.
+func (s *Store) FinishVoiceSessionIntent(ctx context.Context, id uuid.UUID, instanceID string, status VoiceSessionIntentStatus, lastError string) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_intents
+		    SET status = $3, last_error = $4, ended_at = now()
+		  WHERE id = $1 AND instance_id = $2 AND status IN ('claimed', 'live')
+		 RETURNING `+voiceIntentColumns,
+		id, instanceID, status, lastError)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: finish voice session intent %s: %w", id, err)
+	}
+	return v, nil
+}
+
+// ReapDeadVoiceSessionIntents marks 'dead' every claimed/live intent whose
+// heartbeat is older than expiry — the owning Voice Instance is presumed crashed
+// (ADR-0006/0057 (e): no takeover, so a stale claim is a death, not a hand-off).
+// The Tenant sees the dead state and can restart. A fresh heartbeat (within
+// expiry) is untouched. Returns how many rows were reaped. Called once per claim
+// loop tick before claiming, mirroring SweepExpiredJobs (ADR-0049).
+func (s *Store) ReapDeadVoiceSessionIntents(ctx context.Context, expiry time.Duration) (int64, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_session_intents
+		    SET status = 'dead',
+		        last_error = CASE WHEN last_error = '' THEN 'worker heartbeat expired' ELSE last_error END,
+		        ended_at = now()
+		  WHERE status IN ('claimed', 'live')
+		    AND heartbeat_at < now() - make_interval(secs => $1)`,
+		expiry.Seconds())
+	if err != nil {
+		return 0, fmt.Errorf("storage: reap dead voice session intents: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// GetVoiceSessionIntent loads one intent by id, or ErrNotFound. It backs the
+// IntentControl poll (the web tier watching a Start it wrote) and tests.
+func (s *Store) GetVoiceSessionIntent(ctx context.Context, id uuid.UUID) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx, `SELECT `+voiceIntentColumns+` FROM voice_session_intents WHERE id = $1`, id)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: get voice session intent %s: %w", id, err)
+	}
+	return v, nil
+}
+
+// GetLiveVoiceSessionIntentForTenant returns the Tenant's current non-terminal
+// (pending/claimed/live) intent, or ErrNotFound when the Tenant has none — the
+// per-Tenant read backing IntentControl.Active (the split-mode sibling of
+// Manager.Active). The one-live-per-tenant index guarantees at most one row
+// matches.
+func (s *Store) GetLiveVoiceSessionIntentForTenant(ctx context.Context, tenantID uuid.UUID) (VoiceSessionIntent, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+voiceIntentColumns+`
+		   FROM voice_session_intents
+		  WHERE tenant_id = $1 AND status IN ('pending', 'claimed', 'live')
+		  ORDER BY created_at DESC
+		  LIMIT 1`, tenantID)
+	v, err := scanVoiceSessionIntent(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionIntent{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionIntent{}, fmt.Errorf("storage: get live voice session intent for tenant %s: %w", tenantID, err)
+	}
+	return v, nil
+}

--- a/internal/storage/voiceintent.go
+++ b/internal/storage/voiceintent.go
@@ -213,6 +213,33 @@ func (s *Store) ReapDeadVoiceSessionIntents(ctx context.Context, expiry time.Dur
 	return tag.RowsAffected(), nil
 }
 
+// ReconcileWorkerOrphanedVoiceSessions closes 'running' voice_sessions rows that
+// a -mode voice worker left behind on a crash — but ONLY those whose owning intent
+// has gone terminal (dead/done/failed), NEVER a row an intent still holds
+// live/claimed (#491, the reviewer-flagged process-blindness): a plain
+// ReconcileOrphanedVoiceSessions is process-blind, so two workers booting would
+// close each other's live 'running' rows. Scoping the sweep to rows behind a
+// terminal intent makes it safe for a pool: a live worker's row (its intent still
+// live) is untouched, while a crashed worker's row (its intent reaped dead, or
+// finished done/failed) is closed. Returns how many rows were closed. The -mode
+// all path keeps the broad [ReconcileOrphanedVoiceSessions] (it writes no intents).
+func (s *Store) ReconcileWorkerOrphanedVoiceSessions(ctx context.Context) (int64, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_sessions vs
+		    SET ended_at = now(), status = $1, end_reason = $2
+		  WHERE vs.status = $3
+		    AND EXISTS (
+		          SELECT 1 FROM voice_session_intents i
+		           WHERE i.voice_session_id = vs.id
+		             AND i.status IN ('dead', 'done', 'failed')
+		    )`,
+		VoiceSessionEnded, VoiceSessionReasonOrphaned, VoiceSessionRunning)
+	if err != nil {
+		return 0, fmt.Errorf("storage: reconcile worker-orphaned voice sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // GetVoiceSessionIntent loads one intent by id, or ErrNotFound. It backs the
 // IntentControl poll (the web tier watching a Start it wrote) and tests.
 func (s *Store) GetVoiceSessionIntent(ctx context.Context, id uuid.UUID) (VoiceSessionIntent, error) {

--- a/internal/storage/voiceintent_test.go
+++ b/internal/storage/voiceintent_test.go
@@ -1,0 +1,332 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// secondCampaign inserts a second tenant + campaign alongside seedCampaign's, so
+// the two-tenant claim tests exercise distinct tenants (the one-live-per-tenant
+// index is per-tenant, so two tenants each hold their own live intent).
+func secondCampaign(t *testing.T, pool *pgxpool.Pool) (tenantID, campaignID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO tenant (name) VALUES ('Beta TTRPG') RETURNING id`).Scan(&tenantID); err != nil {
+		t.Fatalf("insert second tenant: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO campaign (tenant_id, name, system, language)
+		 VALUES ($1, 'Second Camp', 'dnd5e', 'en') RETURNING id`, tenantID).Scan(&campaignID); err != nil {
+		t.Fatalf("insert second campaign: %v", err)
+	}
+	return tenantID, campaignID
+}
+
+// TestCreateVoiceSessionIntent covers sequence (1): a pending intent is created,
+// and a duplicate live-per-tenant create trips ErrIntentActive.
+func TestCreateVoiceSessionIntent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	intent, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("create intent: %v", err)
+	}
+	if intent.Status != storage.VoiceIntentPending {
+		t.Fatalf("status = %q, want pending", intent.Status)
+	}
+	if intent.TenantID != tenantID || intent.CampaignID != campaignID {
+		t.Fatalf("owning ids = (%s,%s), want (%s,%s)", intent.TenantID, intent.CampaignID, tenantID, campaignID)
+	}
+	if intent.InstanceID != "" || intent.ClaimedAt != nil || intent.HeartbeatAt != nil {
+		t.Fatalf("fresh intent should be unclaimed: %+v", intent)
+	}
+
+	// A second create for the SAME tenant while the first is non-terminal collides.
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID); !errors.Is(err, storage.ErrIntentActive) {
+		t.Fatalf("duplicate create err = %v, want ErrIntentActive", err)
+	}
+
+	// Once the first finishes, the tenant can start again.
+	if _, err := st.RequestVoiceSessionStop(ctx, intent.ID); err != nil {
+		t.Fatalf("stop pending intent: %v", err)
+	}
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID); err != nil {
+		t.Fatalf("create after prior done: %v", err)
+	}
+}
+
+// TestConcurrentClaimersDistinctIntents covers sequence (2): two concurrent
+// claimers get DISTINCT pending intents and never the same one, and neither ever
+// re-claims a claimed/live intent (no takeover, ADR-0006).
+func TestConcurrentClaimersDistinctIntents(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantA, campA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	tenantB, campB := secondCampaign(t, pool)
+
+	iA, err := st.CreateVoiceSessionIntent(ctx, tenantA, campA)
+	if err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	iB, err := st.CreateVoiceSessionIntent(ctx, tenantB, campB)
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	// Two workers claim concurrently; each must win a distinct intent.
+	var wg sync.WaitGroup
+	claimed := make([]storage.VoiceSessionIntent, 2)
+	errs := make([]error, 2)
+	for i, inst := range []string{"worker-1", "worker-2"} {
+		wg.Add(1)
+		go func(i int, inst string) {
+			defer wg.Done()
+			claimed[i], errs[i] = st.ClaimVoiceSessionIntent(ctx, inst)
+		}(i, inst)
+	}
+	wg.Wait()
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("claim %d: %v", i, e)
+		}
+	}
+	if claimed[0].ID == claimed[1].ID {
+		t.Fatalf("both workers claimed the same intent %s", claimed[0].ID)
+	}
+	got := map[uuid.UUID]bool{claimed[0].ID: true, claimed[1].ID: true}
+	if !got[iA.ID] || !got[iB.ID] {
+		t.Fatalf("claimed set %v does not cover both intents %s,%s", got, iA.ID, iB.ID)
+	}
+	for _, c := range claimed {
+		if c.Status != storage.VoiceIntentClaimed || c.InstanceID == "" || c.ClaimedAt == nil || c.HeartbeatAt == nil {
+			t.Fatalf("claimed intent not stamped: %+v", c)
+		}
+	}
+
+	// No pending intents remain: a third claim finds nothing (never re-claims a
+	// claimed/live row — no takeover).
+	if _, err := st.ClaimVoiceSessionIntent(ctx, "worker-3"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("third claim err = %v, want ErrNotFound (no takeover of claimed rows)", err)
+	}
+}
+
+// TestHeartbeatFencing covers sequence (3): heartbeat is fenced by instance +
+// status, and after the row is marked dead a heartbeat returns ErrNotFound.
+func TestHeartbeatFencing(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	intent, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	claimed, err := st.ClaimVoiceSessionIntent(ctx, "worker-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	// The owning instance heartbeats fine; stop not requested.
+	stop, err := st.HeartbeatVoiceSessionIntent(ctx, claimed.ID, "worker-1")
+	if err != nil || stop {
+		t.Fatalf("heartbeat by owner = (%v,%v), want (false,nil)", stop, err)
+	}
+
+	// A DIFFERENT instance is fenced out.
+	if _, err := st.HeartbeatVoiceSessionIntent(ctx, claimed.ID, "worker-2"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("heartbeat by foreign instance err = %v, want ErrNotFound", err)
+	}
+
+	// Mark the row dead (reap with zero expiry), then the owner's heartbeat is
+	// superseded → ErrNotFound (caller kills its local session).
+	if _, err := st.ReapDeadVoiceSessionIntents(ctx, 0); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if _, err := st.HeartbeatVoiceSessionIntent(ctx, claimed.ID, "worker-1"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("heartbeat after dead err = %v, want ErrNotFound", err)
+	}
+	_ = intent
+}
+
+// TestReapMarksStaleDead covers sequence (4): reap marks stale claimed/live
+// intents dead and leaves a fresh one untouched.
+func TestReapMarksStaleDead(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantA, campA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	tenantB, campB := secondCampaign(t, pool)
+
+	// Stale: claimed, then heartbeat forced into the past.
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantA, campA); err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	stale, err := st.ClaimVoiceSessionIntent(ctx, "dead-worker")
+	if err != nil {
+		t.Fatalf("claim A: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE voice_session_intents SET heartbeat_at = now() - interval '10 minutes' WHERE id = $1`, stale.ID); err != nil {
+		t.Fatalf("age heartbeat: %v", err)
+	}
+
+	// Fresh: claimed just now.
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantB, campB); err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+	fresh, err := st.ClaimVoiceSessionIntent(ctx, "live-worker")
+	if err != nil {
+		t.Fatalf("claim B: %v", err)
+	}
+
+	n, err := st.ReapDeadVoiceSessionIntents(ctx, 30*time.Second)
+	if err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("reaped %d, want 1 (only the stale one)", n)
+	}
+
+	gotStale, err := st.GetVoiceSessionIntent(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("get stale: %v", err)
+	}
+	if gotStale.Status != storage.VoiceIntentDead || gotStale.LastError == "" || gotStale.EndedAt == nil {
+		t.Fatalf("stale not reaped: %+v", gotStale)
+	}
+	gotFresh, err := st.GetVoiceSessionIntent(ctx, fresh.ID)
+	if err != nil {
+		t.Fatalf("get fresh: %v", err)
+	}
+	if gotFresh.Status != storage.VoiceIntentClaimed {
+		t.Fatalf("fresh intent disturbed: %+v", gotFresh)
+	}
+}
+
+// TestRequestStop covers sequence (5): a pending intent stops directly to done;
+// a live intent only gets the flag set (its worker winds it down).
+func TestRequestStop(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantA, campA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	tenantB, campB := secondCampaign(t, pool)
+
+	// pending → done directly.
+	pending, err := st.CreateVoiceSessionIntent(ctx, tenantA, campA)
+	if err != nil {
+		t.Fatalf("create pending: %v", err)
+	}
+	stopped, err := st.RequestVoiceSessionStop(ctx, pending.ID)
+	if err != nil {
+		t.Fatalf("stop pending: %v", err)
+	}
+	if stopped.Status != storage.VoiceIntentDone || stopped.EndedAt == nil {
+		t.Fatalf("pending stop = %+v, want done+ended", stopped)
+	}
+
+	// live → flag only.
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantB, campB); err != nil {
+		t.Fatalf("create live: %v", err)
+	}
+	claimed, err := st.ClaimVoiceSessionIntent(ctx, "worker-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	vsID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO voice_sessions (id, campaign_id, status) VALUES ($1, $2, 'running')`, vsID, campB); err != nil {
+		t.Fatalf("insert voice session: %v", err)
+	}
+	if _, err := st.MarkVoiceSessionIntentLive(ctx, claimed.ID, "worker-1", vsID); err != nil {
+		t.Fatalf("mark live: %v", err)
+	}
+	flagged, err := st.RequestVoiceSessionStop(ctx, claimed.ID)
+	if err != nil {
+		t.Fatalf("stop live: %v", err)
+	}
+	if flagged.Status != storage.VoiceIntentLive || !flagged.StopRequested {
+		t.Fatalf("live stop = %+v, want still-live + stop_requested", flagged)
+	}
+	// The worker's next heartbeat reports the requested stop.
+	stop, err := st.HeartbeatVoiceSessionIntent(ctx, claimed.ID, "worker-1")
+	if err != nil || !stop {
+		t.Fatalf("heartbeat after stop req = (%v,%v), want (true,nil)", stop, err)
+	}
+}
+
+// TestGetLiveVoiceSessionIntentForTenant covers the per-tenant read backing
+// IntentControl.Active: it returns the non-terminal intent, ErrNotFound once
+// terminal.
+func TestGetLiveVoiceSessionIntentForTenant(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.GetLiveVoiceSessionIntentForTenant(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("idle tenant err = %v, want ErrNotFound", err)
+	}
+	created, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := st.GetLiveVoiceSessionIntentForTenant(ctx, tenantID)
+	if err != nil || got.ID != created.ID {
+		t.Fatalf("live read = (%s,%v), want %s", got.ID, err, created.ID)
+	}
+	if _, err := st.RequestVoiceSessionStop(ctx, created.ID); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if _, err := st.GetLiveVoiceSessionIntentForTenant(ctx, tenantID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("after done err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestFinishVoiceSessionIntent covers the terminal write fencing: a foreign
+// instance cannot finish, and once dead the owner cannot finish either.
+func TestFinishVoiceSessionIntent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantID, campaignID); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	claimed, err := st.ClaimVoiceSessionIntent(ctx, "worker-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	if _, err := st.FinishVoiceSessionIntent(ctx, claimed.ID, "worker-2", storage.VoiceIntentDone, ""); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("finish by foreign instance err = %v, want ErrNotFound", err)
+	}
+	done, err := st.FinishVoiceSessionIntent(ctx, claimed.ID, "worker-1", storage.VoiceIntentDone, "")
+	if err != nil {
+		t.Fatalf("finish by owner: %v", err)
+	}
+	if done.Status != storage.VoiceIntentDone || done.EndedAt == nil {
+		t.Fatalf("finished = %+v, want done+ended", done)
+	}
+	// A second finish on a terminal row is a no-op → ErrNotFound.
+	if _, err := st.FinishVoiceSessionIntent(ctx, claimed.ID, "worker-1", storage.VoiceIntentFailed, "boom"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("re-finish terminal err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/storage/voiceintent_test.go
+++ b/internal/storage/voiceintent_test.go
@@ -299,6 +299,80 @@ func TestGetLiveVoiceSessionIntentForTenant(t *testing.T) {
 	}
 }
 
+// TestReconcileWorkerOrphanedScoping covers sequence (9) orphan-reconcile
+// scoping: a worker boot closes a 'running' voice_sessions row whose intent went
+// dead, but NEVER one whose intent is still live (another worker owns it) — the
+// reviewer-flagged process-blindness fix.
+func TestReconcileWorkerOrphanedScoping(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantA, campA := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	tenantB, campB := secondCampaign(t, pool)
+
+	// Crashed worker: a live intent (heartbeat aged) + its running voice_sessions
+	// row, then reaped dead — this row is a true orphan to close.
+	deadVS := uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO voice_sessions (id, campaign_id, status) VALUES ($1,$2,'running')`, deadVS, campA); err != nil {
+		t.Fatalf("insert dead vs: %v", err)
+	}
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantA, campA); err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	deadClaim, err := st.ClaimVoiceSessionIntent(ctx, "dead-worker")
+	if err != nil {
+		t.Fatalf("claim A: %v", err)
+	}
+	if _, err := st.MarkVoiceSessionIntentLive(ctx, deadClaim.ID, "dead-worker", deadVS); err != nil {
+		t.Fatalf("mark A live: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE voice_session_intents SET heartbeat_at = now() - interval '10 minutes' WHERE id=$1`, deadClaim.ID); err != nil {
+		t.Fatalf("age A: %v", err)
+	}
+	if _, err := st.ReapDeadVoiceSessionIntents(ctx, 30*time.Second); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+
+	// Live worker: a live intent + its running voice_sessions row, fresh heartbeat
+	// — another worker owns it, must NOT be closed.
+	liveVS := uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO voice_sessions (id, campaign_id, status) VALUES ($1,$2,'running')`, liveVS, campB); err != nil {
+		t.Fatalf("insert live vs: %v", err)
+	}
+	if _, err := st.CreateVoiceSessionIntent(ctx, tenantB, campB); err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+	liveClaim, err := st.ClaimVoiceSessionIntent(ctx, "live-worker")
+	if err != nil {
+		t.Fatalf("claim B: %v", err)
+	}
+	if _, err := st.MarkVoiceSessionIntentLive(ctx, liveClaim.ID, "live-worker", liveVS); err != nil {
+		t.Fatalf("mark B live: %v", err)
+	}
+
+	n, err := st.ReconcileWorkerOrphanedVoiceSessions(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("reconciled %d, want 1 (only the dead-intent row)", n)
+	}
+	gotDead, err := st.GetVoiceSession(ctx, deadVS)
+	if err != nil {
+		t.Fatalf("get dead vs: %v", err)
+	}
+	if gotDead.Status != storage.VoiceSessionEnded {
+		t.Fatalf("dead worker's row not closed: %+v", gotDead)
+	}
+	gotLive, err := st.GetVoiceSession(ctx, liveVS)
+	if err != nil {
+		t.Fatalf("get live vs: %v", err)
+	}
+	if gotLive.Status != storage.VoiceSessionRunning {
+		t.Fatalf("live worker's row wrongly closed: %+v", gotLive)
+	}
+}
+
 // TestFinishVoiceSessionIntent covers the terminal write fencing: a foreign
 // instance cannot finish, and once dead the owner cannot finish either.
 func TestFinishVoiceSessionIntent(t *testing.T) {


### PR DESCRIPTION
## What

Decouples voice-session start from the in-process Manager so a separate `-mode
voice` worker can run it via a Postgres claim plane (ADR-0057 (b), the job-runner
SKIP-LOCKED idiom from ADR-0049). Poll-only, tenant-keyed, no LISTEN/NOTIFY. No
mid-session takeover (ADR-0006): a stale heartbeat marks the claim dead and the
Tenant restarts.

Closes #491.

## Slices (all TDD)

1. **Storage claim plane** — migration `00035_voice_session_intents.sql`
   (one-live-per-tenant partial UNIQUE, claim index) + `voiceintent.go`:
   Create (23505 → `ErrIntentActive`), Claim (`FOR UPDATE SKIP LOCKED`, pending
   only — never re-claims a live/claimed row), MarkLive, Heartbeat (instance+status
   fenced), RequestStop (pending→done direct, else flag), Finish, Reap, per-tenant
   + per-campaign reads. Integration tests cover architect sequence 1–5 + fencing.
2. **`session.ClaimLoop`** — reap → claim while `Manager.HasCapacity` → Start →
   MarkLive → per-session heartbeat goroutine (stop_requested → Stop; reaped →
   stop local, no takeover; self-exit; graceful drain). Fake-Manager tests cover
   sequence 6,7 + drain + no-capacity.
3. **`session.IntentControl`** — web-tier split-mode SessionManager: Start writes
   an intent and polls to live (`ErrIntentPending`→CodeUnavailable), Stop flags +
   polls to closed, Active reads the live intent; mute/say/replay/spend degrade
   with `ErrSplitMode`→CodeFailedPrecondition. Unit + end-to-end (IntentControl +
   in-process ClaimLoop through one store) tests cover sequence 10.
4. **cmd wiring** — `runVoiceWorker` (claim loop over the tenant Manager + per-tenant
   Discord clients, reads GLYPHOXA_SECRET); `runWeb` wires IntentControl in web-only
   mode, `-mode all` byte-identical (no intent rows). Instance id (host-uuid8) +
   `GLYPHOXA_VOICE_CLAIM_POLL/_HEARTBEAT_INTERVAL/_HEARTBEAT_EXPIRY` parse (tested).
5. **Reviewer pre-flag resolved** — worker boot reconcile
   (`ReconcileWorkerOrphanedVoiceSessions`) closes ONLY rows whose owning intent
   is terminal, never a live worker's row. Integration-tested (sequence 9).
6. **Chart + docs** — voice args drop `-guild/-channel` when empty (helm test);
   split-mode rollout note (no SSE relay, mute/say unavailable on web tier).

## Local gates
`gofmt`/`go vet`/`golangci-lint` clean; `go test ./...` green; full
`go test -race -tags=integration -timeout 25m` green on session/storage/rpc/cmd;
`helm unittest` 153/153.

## Open questions / follow-ups
- `buildVoiceDeps` is not yet extracted as a shared helper — `runVoiceWorker`
  constructs its Manager deps directly (mirrors `runWeb`); a later cleanup can
  dedupe. Functionally complete.
- Chart does not yet mount `GLYPHOXA_SECRET` on the voice pod for worker mode
  (ADR-0057 (d)/ADR-0034 amendment) — the worker still serves central-token
  tenants without it; the BYOK secret mount is a small follow-up.
- Multi-replica (`replicas > 1`) stays gated on the presence-owner election (#492)
  and the DAVE soak (#493), as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
