### PR TITLE
feat(#492): multi-replica voice fleet — presence-owner election, PDB, mounted secret

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
+	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -434,6 +435,26 @@ func voiceIntentControlConfig(getenv func(string) string) session.IntentControlC
 		// Matches the worker's reaper horizon so Start's zero-worker escape (review
 		// item 4) judges a blocking claim stale on the same clock the worker would.
 		Expiry: envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+	}
+}
+
+// Presence-owner election defaults (#492, ADR-0057 (c)): the -mode voice worker
+// renews the singleton presence_owner claim every 5s and an owner's silence past
+// 15s marks its row dead so a challenger takes over. Interval must sit well under
+// Expiry so a healthy owner never loses the row between renewals (three renew
+// attempts fit inside one expiry).
+const (
+	defaultPresenceOwnerInterval = 5 * time.Second
+	defaultPresenceOwnerExpiry   = 15 * time.Second
+)
+
+// voicePresenceElectorConfig reads the presence-owner election cadence from
+// GLYPHOXA_PRESENCE_OWNER_INTERVAL / _EXPIRY (#492). Parsed here in the composition
+// root so the cadence stays a deployment knob, never baked into internal/presence.
+func voicePresenceElectorConfig(getenv func(string) string) presence.OwnerElectorConfig {
+	return presence.OwnerElectorConfig{
+		Interval: envDuration(getenv, "GLYPHOXA_PRESENCE_OWNER_INTERVAL", defaultPresenceOwnerInterval),
+		Expiry:   envDuration(getenv, "GLYPHOXA_PRESENCE_OWNER_EXPIRY", defaultPresenceOwnerExpiry),
 	}
 }
 

--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -458,6 +458,25 @@ func voicePresenceElectorConfig(getenv func(string) string) presence.OwnerElecto
 	}
 }
 
+// warnElectorCadence checks the presence-owner election cadence has sane headroom
+// (#492), mirroring warnClaimCadence: the renew Interval must sit well under Expiry
+// or a healthy owner risks losing its own lease between renewals (a flapping
+// active/inactive Registry — duplicate or dropped interaction dispatch). It warns
+// (never clamps — an operator may know their timing) when Interval >= Expiry, and on
+// thin headroom (Expiry under two Intervals, so a single missed renew expires the
+// lease).
+func warnElectorCadence(cfg presence.OwnerElectorConfig, log *slog.Logger) {
+	if cfg.Interval >= cfg.Expiry {
+		log.Warn("GLYPHOXA_PRESENCE_OWNER_INTERVAL >= _EXPIRY: the owner will flap — its lease expires before it can renew",
+			"interval", cfg.Interval, "expiry", cfg.Expiry)
+		return
+	}
+	if cfg.Expiry < 2*cfg.Interval {
+		log.Warn("thin presence-owner headroom: EXPIRY under two INTERVALs; a single missed renew self-demotes the owner",
+			"interval", cfg.Interval, "expiry", cfg.Expiry)
+	}
+}
+
 // warnClaimCadence checks the claim-plane cadence has sane headroom (#491 review
 // item 9): the heartbeat expiry must sit comfortably above one heartbeat interval
 // plus a session's wind-down, or a healthy-but-slow worker risks being reaped

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/presence"
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
@@ -1072,6 +1073,26 @@ func TestWarnClaimCadence(t *testing.T) {
 	}
 	if n := countWarns(session.ClaimLoopConfig{Heartbeat: 5 * time.Second, Expiry: 12 * time.Second}); n != 1 {
 		t.Errorf("thin headroom warned %d times, want 1", n)
+	}
+}
+
+// TestWarnElectorCadence pins the presence-owner headroom guard (#492): healthy
+// defaults (5s/15s) stay quiet; interval at/above expiry warns (flap), and expiry
+// under two intervals warns (a single missed renew self-demotes).
+func TestWarnElectorCadence(t *testing.T) {
+	countWarns := func(cfg presence.OwnerElectorConfig) int {
+		h := &countingHandler{}
+		warnElectorCadence(cfg, slog.New(h))
+		return h.warns
+	}
+	if n := countWarns(presence.OwnerElectorConfig{Interval: 5 * time.Second, Expiry: 15 * time.Second}); n != 0 {
+		t.Errorf("healthy defaults warned %d times, want 0", n)
+	}
+	if n := countWarns(presence.OwnerElectorConfig{Interval: 15 * time.Second, Expiry: 15 * time.Second}); n != 1 {
+		t.Errorf("interval >= expiry warned %d times, want 1", n)
+	}
+	if n := countWarns(presence.OwnerElectorConfig{Interval: 5 * time.Second, Expiry: 8 * time.Second}); n != 1 {
+		t.Errorf("thin headroom (expiry < 2*interval) warned %d times, want 1", n)
 	}
 }
 

--- a/cmd/glyphoxa/drain_test.go
+++ b/cmd/glyphoxa/drain_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDrainVoiceWorkerOrder covers sequence (6): on SIGTERM the -mode voice worker
+// tears down in exactly one order — stop claiming and serving, then Finish the live
+// intent rows (Manager Shutdown), then release the presence-owner claim, then close
+// the Discord clients. The owner claim releasing AFTER the Manager finishes is the
+// load-bearing property (#492, ADR-0057 (c)): a survivor must not start dispatching
+// this instance's interactions until its sessions are wound down.
+func TestDrainVoiceWorkerOrder(t *testing.T) {
+	var order []string
+	drainVoiceWorker(
+		func() { order = append(order, "run") },
+		func() { order = append(order, "finish") },
+		func() { order = append(order, "release-owner") },
+		func() { order = append(order, "close-clients") },
+	)
+
+	want := []string{"run", "finish", "release-owner", "close-clients"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("drain order = %v, want %v (owner released only after the Manager finishes its rows)", order, want)
+	}
+}

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -303,9 +303,14 @@ func runVoice(log *slog.Logger, cfg wirenpc.Config, hardcoded bool, metrics *obs
 // the window. The voice role reads $GLYPHOXA_SECRET to decrypt BYOK Tenant tokens
 // (ADR-0057 (d)).
 //
-// This process is the single interim claimer (#492 elects the presence owner when
-// replicas > 1): the presence Registry is active so the worker registers the
-// tenant command surface, and the per-Tenant clients drive voice.
+// Interactions are dispatched by exactly ONE elected presence owner (#492,
+// ADR-0057 (c)): every gateway session on the shared central token receives every
+// INTERACTION_CREATE (P5), so with replicas > 1 each worker would otherwise handle
+// the same slash command. The presence Registry boots INACTIVE and an OwnerElector,
+// running beside the ClaimLoop on this same instanceID, flips it active only while
+// this Instance holds the singleton presence_owner claim; a non-owner drops the
+// duplicate events it still receives. Voice itself needs no such election — a pod
+// holding no connection for a guild simply ignores that guild's voice events (P6).
 func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRecorder, metricsAddr string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -385,11 +390,13 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	cfg.KeyEntitlement = keyEnt
 
 	// Per-Tenant Discord client registry (#489): the standing client keyed by each
-	// Tenant's resolved Bot token, plus the tenant command surface. The worker IS
-	// the active presence owner in the single-worker interim (#492 flips this to an
-	// elector when replicas > 1).
+	// Tenant's resolved Bot token, plus the tenant command surface. The Registry
+	// boots INACTIVE (#492): the OwnerElector below flips it active only while this
+	// Instance wins the presence_owner election, so exactly one worker on the shared
+	// central token dispatches each interaction (ADR-0057 (c)).
 	gate := presence.NewGate(gmID, presence.NewStorageTenantResolver(store))
 	reg := presence.NewRegistry(gate, log)
+	reg.SetActive(false)
 	reg.Register(presence.RollCommand(tool.NewDice()))
 	reg.RegisterComponentHandler(presence.NewConsentButtons(store, sessions, log).HandleComponent)
 	clients := presence.NewClients(store, cipher, reg, cfg.Token, log)
@@ -478,16 +485,50 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	}
 	go clients.Run(ctx)
 
+	// Presence-owner election (#492, ADR-0057 (c)): runs beside the claim loop on the
+	// SAME instanceID, flipping the Registry active only while this Instance owns the
+	// singleton presence_owner row. It runs on its OWN context so the drain can
+	// sequence its Release AFTER the Manager finishes its rows (below) — releasing
+	// the owner claim is the LAST coordination write, so a survivor takes over
+	// interaction dispatch only once this instance has cleanly wound its sessions
+	// down.
+	elector := presence.NewOwnerElector(store, instanceID, reg.SetActive, log, voicePresenceElectorConfig(os.Getenv))
+	electorCtx, electorStop := context.WithCancel(context.Background())
+	electorDone := make(chan struct{})
+	go func() { defer close(electorDone); elector.Run(electorCtx) }()
+
 	// Run the claim loop until SIGTERM. It stops claiming on ctx cancel and drains
-	// its live sessions cleanly (AC5); then tear down the Manager (a no-op backstop
-	// after the drain) and close the standing clients.
+	// its live sessions cleanly (AC5). Drain order (ADR-0006/0057): stop claiming →
+	// Manager Shutdown (Finish the live rows) → release the presence-owner claim →
+	// close the standing clients. The Manager finishes its rows BEFORE the owner
+	// claim is released so no survivor starts dispatching for this instance's guilds
+	// mid-teardown.
 	claimCfg := voiceClaimLoopConfig(os.Getenv)
 	warnClaimCadence(claimCfg, log)
 	loop := session.NewClaimLoop(store, mgr, instanceID, log, claimCfg)
-	loop.Run(ctx)
-	mgr.Shutdown()
-	clients.Close()
+	drainVoiceWorker(
+		func() { loop.Run(ctx) },
+		mgr.Shutdown,
+		func() { electorStop(); <-electorDone },
+		clients.Close,
+	)
 	return nil
+}
+
+// drainVoiceWorker runs the -mode voice worker to SIGTERM and then tears it down in
+// the ONE correct order (#492, ADR-0006/0057): run blocks claiming the plane and
+// serving until ctx cancel; then stopClaimingAndFinish (the Manager's Shutdown)
+// Finishes every live intent row; then releaseOwner drops the presence-owner claim;
+// then closeClients tears the standing Discord clients down. The owner claim is the
+// LAST coordination write before the clients go — a survivor must not begin
+// dispatching interactions for this instance's guilds until its sessions are wound
+// down, so releaseOwner strictly follows stopClaimingAndFinish. Extracted from
+// runVoiceWorker so this ordering is unit-testable without a live DB or Discord.
+func drainVoiceWorker(run, stopClaimingAndFinish, releaseOwner, closeClients func()) {
+	run()
+	stopClaimingAndFinish()
+	releaseOwner()
+	closeClients()
 }
 
 // ensureSchemaReady runs the boot schema preflight for the web/all entrypoint

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -492,7 +492,9 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	// the owner claim is the LAST coordination write, so a survivor takes over
 	// interaction dispatch only once this instance has cleanly wound its sessions
 	// down.
-	elector := presence.NewOwnerElector(store, instanceID, reg.SetActive, log, voicePresenceElectorConfig(os.Getenv))
+	electorCfg := voicePresenceElectorConfig(os.Getenv)
+	warnElectorCadence(electorCfg, log)
+	elector := presence.NewOwnerElector(store, instanceID, reg.SetActive, log, electorCfg)
 	electorCtx, electorStop := context.WithCancel(context.Background())
 	electorDone := make(chan struct{})
 	go func() { defer close(electorDone); elector.Run(electorCtx) }()

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -1,12 +1,18 @@
 {{/*
 Voice-mode Deployment (#36) — the serving workload of the chart.
 
-It runs the single image as `glyphoxa -mode voice -guild <id> -channel <id>`,
-joining one Discord guild+channel and giving the seeded NPC a live voice loop.
+It runs the single image as `glyphoxa -mode voice` (a claim-plane worker in the
+shared pool) or, with -guild/-channel set, the legacy standalone node joining one
+static channel.
 
-- ONE replica, by intent: voice is stateful per channel (one Discord gateway
-  connection, one channel join), so two replicas would fight over the same
-  channel. The replica count is fixed here rather than surfaced as a tunable.
+- A TUNABLE replica count (#492, ADR-0057): the shared voice-worker pool makes
+  scaling out a value, not a design change. Session assignment is a Postgres
+  claim plane — one live intent per Tenant, claimed FOR UPDATE SKIP LOCKED (#491)
+  — and interaction dispatch is gated to a single elected presence owner (the
+  presence_owner row, ADR-0057 (c)), so N replicas coexist on the central token
+  without fighting over a channel or double-handling a slash command. A pod
+  holding no connection for a guild simply ignores that guild's voice events
+  (P6). Default 1; the SaaS deploy sets it higher and arms the PDB.
 - NOT a Helm hook: a plain resource applies after every pre-install/pre-upgrade
   hook, so the migrate (-5) and seed (-4) hooks have completed — the schema is
   current and the demo NPC seeded — before this pod starts.
@@ -15,10 +21,12 @@ joining one Discord guild+channel and giving the seeded NPC a live voice loop.
   with the actionable `migrate up` message if the schema is behind, rather than
   auto-migrating under a serving process.
 - Credentials come from the app Secret (ADR-0034): DISCORD_BOT_TOKEN plus the
-  three provider keys each adapter reads at request time (BYOK, ADR-0004). It
-  does NOT read GLYPHOXA_SECRET — loadSeededNPC takes no cipher and never
-  decrypts the sealed placeholder credentials; keeping the cipher key off this
-  long-lived pod keeps its blast radius small.
+  three provider keys each adapter reads at request time (BYOK, ADR-0004), AND
+  GLYPHOXA_SECRET (ADR-0057 (d), superseding ADR-0034's "does NOT read
+  GLYPHOXA_SECRET" posture): a worker in the pool holds BYOK Tenants' Discord
+  clients and must decrypt their bot tokens itself, so the voice role now reads
+  the platform cipher — a deliberate blast-radius widening resolved on #492 as a
+  mounted secret (vs forwarded short-lived credentials).
 - Health/metrics (#33, ADR-0032): the metrics-only listener serves /metrics for
   scraping plus the /healthz liveness and /readyz readiness probes on the metrics
   port. Liveness targets /healthz (process-up; it ignores DB health so a DB blip
@@ -39,20 +47,21 @@ metadata:
     {{- include "glyphoxa.labels" . | nindent 4 }}
     app.kubernetes.io/component: voice
 spec:
-  # Voice is stateful per channel — a single replica by intent (see the header).
-  replicas: 1
-  # Recreate, NOT the default RollingUpdate: on a `helm upgrade` (e.g. an image
-  # bump) RollingUpdate would surge a second voice pod and keep the old one until
-  # the new is Ready. But /readyz only pings the DB — the Discord gateway is
-  # opened later in Run(), after the readiness server is already serving — so the
-  # new pod reports Ready on DB alone while the old pod still holds the gateway
-  # session. For the surge window TWO pods would mgr.Open the SAME guild+channel
-  # with the SAME token, the single-replica-per-channel violation this chart
-  # exists to prevent. Recreate tears the old pod down before the new one starts,
-  # so at most one pod ever holds the channel (at the cost of a brief gap on
-  # upgrade, which is correct for a single-session voice workload).
+  # A tunable replica count (#492, ADR-0057): the shared voice-worker pool serves
+  # K sessions across many Tenants. Default 1 for a self-host install.
+  replicas: {{ .Values.voice.replicas }}
+  # RollingUpdate, NOT Recreate: the claim plane (one live intent per Tenant, #491)
+  # and the per-Tenant client guard make a brief pod overlap SAFE (#492, ADR-0057),
+  # unlike the old single-channel model this chart used to protect with Recreate. A
+  # surging pod that has not yet claimed an intent holds no channel, and interaction
+  # dispatch stays with the one elected presence owner (ADR-0057 (c)) regardless of
+  # how many pods report Ready. maxUnavailable 0 keeps serving capacity through the
+  # roll; maxSurge 1 bounds the overlap to one extra pod.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
@@ -69,6 +78,11 @@ spec:
         prometheus.io/port: {{ .Values.voice.metricsPort | quote }}
         prometheus.io/path: /metrics
     spec:
+      # Clean-shutdown budget (#492, ADR-0006/0057): SIGTERM stops claiming, drains
+      # live Voice Sessions (each intent Finished 'done'), releases the presence-owner
+      # claim, and closes the clients — a session is ENDED on drain, never migrated,
+      # so this window must cover a DAVE/MLS wind-down before the kubelet SIGKILLs.
+      terminationGracePeriodSeconds: {{ .Values.voice.terminationGracePeriodSeconds }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -112,12 +126,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "glyphoxa.secretName" . }}
                   key: database-url
-            # Required by runVoice to open the Discord gateway.
+            # Required by runVoice to open the Discord gateway (the central-token
+            # fallback; a BYOK Tenant's client overrides it per session).
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "glyphoxa.secretName" . }}
                   key: discord-bot-token
+            # The credential cipher (ADR-0004/0057 (d)): a worker in the shared pool
+            # holds BYOK Tenants' Discord clients and decrypts their bot tokens itself,
+            # so the voice role now reads GLYPHOXA_SECRET — a deliberate blast-radius
+            # widening from ADR-0034's old posture, resolved on #492 as a mounted
+            # secret (vs forwarded short-lived credentials).
+            - name: GLYPHOXA_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "glyphoxa.secretName" . }}
+                  key: app-secret
             # Provider keys each adapter reads from its own env var at request
             # time (BYOK, ADR-0004): ElevenLabs (STT + TTS), Gemini, Groq (LLM).
             - name: ELEVENLABS_API_KEY

--- a/deploy/charts/glyphoxa/templates/voice-pdb.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-pdb.yaml
@@ -1,0 +1,28 @@
+{{/*
+Voice-mode PodDisruptionBudget (#492, ADR-0057) — availability protection for the
+shared voice-worker pool.
+
+Armed ONLY when voice is enabled AND voice.replicas > 1. With a fleet it keeps at
+least minAvailable pods serving through a VOLUNTARY disruption (a node drain or
+cluster upgrade), so interaction dispatch (the elected presence owner) and live
+Voice Sessions are never all torn down at once. A single-replica install renders no
+PDB: it has no availability to protect, and a minAvailable-1 PDB over one pod would
+BLOCK every voluntary drain (the node could never be cordoned). The claim plane
+(#491) and the elected-owner gate (ADR-0057 (c)) are what make several pods
+genuinely fungible here, so protecting a subset is meaningful.
+*/}}
+{{- if and .Values.voice.enabled (gt (int .Values.voice.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "glyphoxa.voice.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: voice
+spec:
+  minAvailable: {{ .Values.voice.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: voice
+{{- end }}

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -40,24 +40,48 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: runs exactly one replica
-    # Voice is stateful per channel (one gateway connection / one channel join),
-    # so the workload is pinned to a single replica — scaling out would have two
-    # bots fighting over the same voice channel.
+  - it: defaults to a single replica
+    # A self-host install needs no fleet; the shared-pool tunable defaults to 1.
     asserts:
       - equal:
           path: spec.replicas
           value: 1
 
-  - it: uses the Recreate strategy so an upgrade never runs two pods on one channel
-    # The default RollingUpdate would surge a second voice pod that reports Ready
-    # on the DB-only /readyz while the old pod still holds the Discord gateway —
-    # two pods on the same guild+channel with the same token. Recreate tears the
-    # old pod down first, keeping at most one session-holder.
+  - it: renders the configured replica count for a fleet
+    # The shared voice-worker pool (#492, ADR-0057) makes replicas a real tunable:
+    # the Postgres claim plane (#491) and the elected-presence-owner interaction
+    # gate (ADR-0057 (c)) let N replicas coexist on the central token.
+    set:
+      voice:
+        replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: uses RollingUpdate with a safe surge so a fleet upgrades without a full gap
+    # The claim plane (one live intent per Tenant) plus the per-Tenant guard make a
+    # brief pod overlap safe (#492, ADR-0057): a surging pod that has not claimed an
+    # intent holds no channel, and the elected owner still dispatches interactions.
+    # maxUnavailable 0 keeps capacity during the roll; maxSurge 1 bounds the overlap.
     asserts:
       - equal:
           path: spec.strategy.type
-          value: Recreate
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: sets the termination grace period so a mid-session drain completes
+    # SIGTERM drains live Voice Sessions cleanly before SIGKILL (#492, ADR-0006):
+    # stop claiming, Finish the rows, release the owner claim, close the clients.
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 300
 
   - it: is NOT a Helm hook so it applies after the migrate and seed hooks
     # The migrate (-5) and seed (-4) hooks complete before any non-hook resource;
@@ -230,13 +254,14 @@ tests:
             name: GLYPHOXA_OLLAMA_URL
             value: http://host.k3d.internal:11434
 
-  - it: does NOT carry GLYPHOXA_SECRET
-    # Voice never decrypts the sealed provider_config: loadSeededNPC takes no
-    # cipher and the adapters read real keys from their own env vars. The cipher
-    # key stays on the seed Job; leaking it into the long-lived serving pod would
-    # widen its blast radius for no reason.
+  - it: carries GLYPHOXA_SECRET to decrypt BYOK tenant tokens
+    # ADR-0057 (d): a worker in the shared pool holds BYOK Tenants' Discord clients
+    # and must decrypt their bot tokens itself, so the voice role now reads the
+    # platform cipher — a deliberate blast-radius widening from the old posture
+    # (ADR-0034 amended by ADR-0057). Resolved on #492 as a mounted secret (vs
+    # forwarded short-lived credentials).
     asserts:
-      - notContains:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: GLYPHOXA_SECRET

--- a/deploy/charts/glyphoxa/tests/voice_pdb_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_pdb_test.yaml
@@ -1,0 +1,57 @@
+suite: voice-mode PodDisruptionBudget
+# The voice PodDisruptionBudget (#492, ADR-0057) protects the shared voice-worker
+# pool through voluntary disruptions (node drains/upgrades): with a fleet it keeps
+# at least minAvailable pods serving so interaction dispatch and live sessions are
+# never all torn down at once. It is armed ONLY when voice.replicas > 1 — a
+# single-replica install has no availability to protect, and a minAvailable-1 PDB
+# over one pod would block every voluntary drain.
+templates:
+  - templates/voice-pdb.yaml
+set:
+  voice:
+    guild: "111111111111111111"
+    channel: "222222222222222222"
+  discordBotToken: unit-test-discord-token-placeholder
+  elevenLabsApiKey: unit-test-elevenlabs-placeholder
+  geminiApiKey: unit-test-gemini-placeholder
+  groqApiKey: unit-test-groq-placeholder
+tests:
+  - it: is absent for a single-replica install
+    # replicas 1 (the default): no PDB, so a node drain is never blocked.
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is absent when voice is disabled
+    set:
+      voice:
+        enabled: false
+        replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a PodDisruptionBudget for a fleet
+    set:
+      voice:
+        replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-voice
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: selects the voice pods
+    set:
+      voice:
+        replicas: 2
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: voice

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -167,10 +167,32 @@ voice:
   guild: ""
   channel: ""
 
-  # Single replica, by intent: voice is stateful per channel (one gateway
-  # connection and one channel join), so two replicas would fight over the same
-  # voice channel. Not surfaced as a tunable — scaling out is a design change,
-  # not a value.
+  # Voice Instance replica count (#492, ADR-0057). The shared voice-worker pool
+  # makes scaling out a real tunable, not a design change: session assignment is a
+  # Postgres claim plane (one live intent per Tenant, #491) and interaction
+  # dispatch is gated to a single elected presence owner (ADR-0057 (c)), so N
+  # replicas coexist on the central token without fighting over a channel or
+  # double-handling a slash command. Default 1 (a self-host install needs no
+  # fleet); set > 1 for the SaaS deploy, which also arms the PodDisruptionBudget
+  # below.
+  replicas: 1
+
+  # Termination grace period (#492, ADR-0006/0057): SIGTERM stops the worker
+  # claiming, drains its live Voice Sessions cleanly (each intent Finished 'done'),
+  # releases its presence-owner claim, and closes its clients. Sized generously so
+  # a mid-session drain completes a DAVE/MLS wind-down before the kubelet SIGKILLs
+  # the pod — a session is ENDED on drain (ADR-0006), never migrated, so this is
+  # the whole clean-shutdown budget. Default 300s.
+  terminationGracePeriodSeconds: 300
+
+  # PodDisruptionBudget for the voice pool (#492). Armed only when replicas > 1 —
+  # a single-replica install has no availability to protect and a PDB with
+  # minAvailable 1 over one pod would BLOCK voluntary drains (node upgrades). With
+  # a fleet it keeps at least minAvailable pods serving through a voluntary
+  # disruption so interaction dispatch and live sessions are never fully torn down
+  # at once.
+  pdb:
+    minAvailable: 1
 
   # Optional per-workload image override. When repository/tag are set here they
   # win over the shared top-level `image`; otherwise the voice pod runs the same

--- a/docs/devs/2026-07-20-voice-fleet-rollout.md
+++ b/docs/devs/2026-07-20-voice-fleet-rollout.md
@@ -1,0 +1,86 @@
+# Multi-replica voice fleet rollout (#492, ADR-0057)
+
+Builds on the claim plane (#491, `2026-07-19-voice-claim-plane-rollout.md`). That
+note made `-mode voice` a claim worker; this one lets the chart run **more than
+one** of them on the shared central token. The two mechanisms that make N replicas
+safe are the Postgres claim plane (session assignment) and the presence-owner
+election (interaction dispatch).
+
+## Presence-owner election
+
+Every gateway session on a shared central token receives the FULL event stream,
+including duplicate `INTERACTION_CREATE` — Discord deduplicates nothing between
+sessions on one token (ADR-0057 P5). So N Voice Instances would each try to handle
+the same `/roll`. A singleton `presence_owner` claim row elects exactly ONE
+Instance to register command listeners and dispatch interactions; every non-owner
+Registry is `SetActive(false)` and drops the duplicate events it still receives.
+
+- The `-mode voice` worker boots its Registry **inactive**; an `OwnerElector`
+  runs beside the claim loop on the same `instanceID` and flips it active only
+  while this Instance holds the `presence_owner` row.
+- `-mode all` and the legacy standalone node are always their own single owner —
+  their Registry defaults active, no election.
+
+### Election knobs (env)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `GLYPHOXA_PRESENCE_OWNER_INTERVAL` | `5s` | renew/acquire tick |
+| `GLYPHOXA_PRESENCE_OWNER_EXPIRY` | `15s` | incumbent silence before its claim is stealable |
+
+Interval sits well under expiry so a healthy owner never loses the row between
+renewals; a dead owner's row is claimable by a challenger after one expiry, so
+failover lands within roughly expiry + one interval (~20s worst case).
+
+## Voice itself needs no election
+
+A pod holding no voice connection for a guild simply receives and ignores that
+guild's voice gateway events (ADR-0057 P6). The claim plane already guarantees one
+worker per live session (one live intent per Tenant), so duplicate voice events on
+the shared token are inert — only interaction dispatch needed the owner gate.
+
+## Drain order (SIGTERM)
+
+`stop claiming → Manager.Shutdown (Finish the live intent rows) → elector Release
+(drop the presence_owner claim) → close the Discord clients`. The owner claim is
+the LAST coordination write, so a survivor begins dispatching this instance's
+interactions only after its sessions are wound down. Sessions are ENDED on drain,
+never migrated (ADR-0006), so `voice.terminationGracePeriodSeconds` (default 300)
+is sized to cover a DAVE/MLS wind-down before SIGKILL.
+
+## IDENTIFY budget under fleet cold-start (#486)
+
+No new code guards this — disgo serializes IDENTIFYs per client (`max_concurrency`
+1, one per 5s per token), so two replicas booting on the shared token IDENTIFY a
+handful of times total, nowhere near the 1000/24h/token budget. RESUME is free and
+shows up in `glyphoxa_gateway_resume_total`, not identify. The fleet check below
+scrapes `glyphoxa_gateway_identify_total` across the pods and fails on a blowout,
+catching a serialization regression even without live traffic.
+
+## Secret posture (ADR-0057 (d), resolved on #492)
+
+Voice pods **mount** `GLYPHOXA_SECRET` (the `app-secret` key) — the "mounted
+secret" arm of the knob ADR-0057 (d) left open, chosen over forwarding short-lived
+credentials from the web tier. A worker in the pool holds BYOK Tenants' Discord
+clients and must decrypt their bot tokens itself, so the voice role reads the
+platform cipher; this deliberately widens the voice blast radius from ADR-0034's
+old "does NOT read GLYPHOXA_SECRET" posture (which ADR-0057 already amends).
+
+## Helm
+
+`voice.replicas` (default 1) is now a real tunable; `voice.pdb.minAvailable`
+(default 1) arms a PodDisruptionBudget **only** when replicas > 1 (a single-replica
+install has no availability to protect and a minAvailable-1 PDB over one pod would
+block node drains). The Deployment uses `RollingUpdate{maxSurge:1,maxUnavailable:0}`
+— the claim plane and per-Tenant guard make a brief pod overlap safe, replacing the
+old single-channel `Recreate`.
+
+## Manual fleet check
+
+`scripts/k3d-fleet-check.sh` — NOT in CI (needs a live Discord token and a human to
+type `/roll`). It installs the chart at `voice.replicas=2` and checks: both
+replicas Available; `/roll` handled exactly once (human observation + per-pod log
+cross-check); owner-pod kill → survivor elected within ~20s; IDENTIFY counters sane
+under cold-start. Env conventions mirror `scripts/e2e-deploy-smoke.sh`
+(`RELEASE`/`NAMESPACE`/`IMAGE_*`/`TIMEOUT`); see the script header for the full
+recipe.

--- a/docs/devs/2026-07-20-voice-fleet-rollout.md
+++ b/docs/devs/2026-07-20-voice-fleet-rollout.md
@@ -32,6 +32,29 @@ Interval sits well under expiry so a healthy owner never loses the row between
 renewals; a dead owner's row is claimable by a challenger after one expiry, so
 failover lands within roughly expiry + one interval (~20s worst case).
 
+### Self-demotion when partitioned
+
+An owner that can no longer reach Postgres self-demotes: once the MONOTONIC elapsed
+since its last successful renew reaches `Expiry`, the elector calls `SetActive(false)`
+locally. This is judged on the process's own monotonic clock — never the DB
+`heartbeat_at` or a wall clock — so a partitioned owner stops dispatching before
+another node's lease-expiry claim could promote a second owner (else both would
+dispatch the same interaction). The acquire/renew call is bounded by a per-op DB
+timeout of `min(Interval, 3s)` so a stuck connection cannot pin the loop and starve
+the demotion check. The elector does NOT `Release` on demotion — the DB is
+unreachable by assumption, so a local deactivation is all that is possible and the
+row's own lease expiry hands ownership over. Re-promotion happens ONLY via the next
+successful acquire in the normal loop.
+
+**Interaction gap under partition.** Between an owner losing DB reachability and a
+survivor claiming the expired lease, there is a window of up to roughly
+`Expiry + Interval` (~20s at defaults) where the old owner has self-demoted (so it
+dispatches nothing) but no new owner has been elected yet — interactions in that
+window get no reply until the survivor promotes. This is the deliberate cost of
+never running two owners at once (ADR-0057 (c) prefers a brief gap over a
+double-dispatch); it is the same order as the failover window and does not affect
+live voice (P6).
+
 ## Voice itself needs no election
 
 A pod holding no voice connection for a guild simply receives and ignores that
@@ -65,6 +88,32 @@ credentials from the web tier. A worker in the pool holds BYOK Tenants' Discord
 clients and must decrypt their bot tokens itself, so the voice role reads the
 platform cipher; this deliberately widens the voice blast radius from ADR-0034's
 old "does NOT read GLYPHOXA_SECRET" posture (which ADR-0057 already amends).
+
+## Cross-pod consent poller
+
+A tape-consent button (`/…grant`/`revoke`) is dispatched by the elected presence
+OWNER, which publishes `TapeConsentChanged` on ITS OWN process bus. But in the fleet
+the live tape may be running on a DIFFERENT pod (a claim-plane worker), whose bus
+never sees that event — so the same-pod bus fast path alone would strand a cross-pod
+grant/revoke. `wireTapeConsent` therefore also runs a poller goroutine on the cycle
+ctx that re-reads the durable `tape_consent` rows every
+`GLYPHOXA_TAPE_CONSENT_RECONCILE_INTERVAL` (default 5s), bounding cross-pod staleness
+to one interval. The bus fast path stays (instant same-pod), `PublishToCampaign`
+stays in the consent handler, and ADR-0051 holds because `ReconcileConsent`
+authoritatively clears a revoked Speaker's ring. The poller dies with the cycle ctx.
+
+## One-time upgrade transition
+
+The FIRST `helm upgrade` from a pre-#492 chart to this one has a brief transition
+window: the old voice pod runs the always-active Registry (no elector), and during
+the `RollingUpdate` a new elector pod comes up and wins the `presence_owner` row —
+for the surge overlap BOTH the old always-active pod and the new elected owner
+dispatch interactions, a short duplicate-reply window. It self-heals the moment the
+old pod terminates (its always-active Registry goes with it). Mitigation if a
+duplicate reply during the upgrade is unacceptable: scale voice to 1
+(`--set voice.replicas=1`) for that first upgrade so there is no surge overlap, then
+scale back up. Subsequent upgrades are elector-to-elector and have no such window
+(only the one owner ever dispatches).
 
 ## Helm
 

--- a/internal/presence/command.go
+++ b/internal/presence/command.go
@@ -282,8 +282,19 @@ func (r *Registry) HandleAutocomplete(e *events.AutocompleteInteractionCreate) {
 		userID:  e.User().ID.String(),
 		data:    data,
 	}
-	choices := r.autocompleteChoices(context.Background(), dispatchKey(data.CommandName, data.SubCommandName), ac)
-	_ = e.AutocompleteResult(choices)
+	r.handleAutocomplete(context.Background(), dispatchKey(data.CommandName, data.SubCommandName), ac, eventAutocompleteResponder{event: e})
+}
+
+// handleAutocomplete is the testable autocomplete core: the send is injectable so a
+// test can assert whether ANY response was sent. A non-owner (#492) DROPS the
+// interaction entirely — it sends NO AutocompleteResult at all (not an empty choice
+// list), because the elected owner answers it; a stray empty result from a non-owner
+// would race the owner's real choices.
+func (r *Registry) handleAutocomplete(base context.Context, key string, ac *Autocomplete, resp autocompleteResponder) {
+	if !r.active.Load() {
+		return
+	}
+	_ = resp.result(r.autocompleteChoices(base, key, ac))
 }
 
 // autocompleteChoices is the testable autocomplete core: it returns the handler
@@ -292,10 +303,6 @@ func (r *Registry) HandleAutocomplete(e *events.AutocompleteInteractionCreate) {
 // fails.
 func (r *Registry) autocompleteChoices(base context.Context, key string, ac *Autocomplete) []discord.AutocompleteChoice {
 	empty := []discord.AutocompleteChoice{}
-	if !r.active.Load() {
-		// Non-owner (#492): no choices, no handler — the elected owner answers.
-		return empty
-	}
 	cmd, ok := r.lookup(key)
 	if !ok || cmd.Autocomplete == nil {
 		return empty
@@ -524,6 +531,23 @@ type responder interface {
 	deferResponse(ephemeral bool) error
 	followup(content string, ephemeral bool) error
 	editOriginal(content string) error
+}
+
+// autocompleteResponder is the injectable autocomplete-result sink: production wraps
+// the disgo event, tests record whether a result was sent (so the non-owner DROP is
+// verifiable — no result at all, #492).
+type autocompleteResponder interface {
+	result(choices []discord.AutocompleteChoice) error
+}
+
+// eventAutocompleteResponder is the production autocomplete responder over a live
+// autocomplete event.
+type eventAutocompleteResponder struct {
+	event *events.AutocompleteInteractionCreate
+}
+
+func (r eventAutocompleteResponder) result(choices []discord.AutocompleteChoice) error {
+	return r.event.AutocompleteResult(choices)
 }
 
 // eventResponder is the production responder over a live slash-command event.

--- a/internal/presence/command.go
+++ b/internal/presence/command.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/disgoorg/disgo/discord"
@@ -76,6 +77,17 @@ type Registry struct {
 	// killed. Field (not the const) so tests drive it with a short deadline.
 	responseTimeout time.Duration
 
+	// active gates every inbound-interaction path (#492, ADR-0057 (c)). Discord
+	// delivers every INTERACTION_CREATE to EVERY gateway session on a shared central
+	// token (P5), so N Voice Instances would each try to handle the same interaction.
+	// Only the elected presence owner is active; a non-owner drops the duplicate
+	// events it still receives. Atomic so the OwnerElector can flip it from its own
+	// goroutine while the disgo event goroutines read it. Default true: a -mode all
+	// node and the legacy standalone node are always their own single owner; the
+	// -mode voice WORKER flips this false at boot and the elector turns it on only
+	// once this Instance wins the presence_owner row.
+	active atomic.Bool
+
 	mu    sync.RWMutex
 	cmds  map[string]Command // dispatch key -> command
 	order []string           // registration order, for deterministic Definitions
@@ -93,8 +105,23 @@ func NewRegistry(gate *Gate, log *slog.Logger) *Registry {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Registry{gate: gate, log: log, cmds: map[string]Command{}, responseTimeout: interactionTimeout}
+	r := &Registry{gate: gate, log: log, cmds: map[string]Command{}, responseTimeout: interactionTimeout}
+	// Default active: -mode all and the legacy standalone node are always their own
+	// single presence owner. The -mode voice worker calls SetActive(false) at boot
+	// and lets its OwnerElector flip it on only when it wins the election (#492).
+	r.active.Store(true)
+	return r
 }
+
+// SetActive flips whether this Registry acts on inbound interactions (#492,
+// ADR-0057 (c)). The OwnerElector calls it: true once this Voice Instance wins the
+// presence_owner election, false when it loses or drains. An inactive Registry
+// early-returns from every interaction path — HandleCommand, HandleAutocomplete,
+// HandleComponent — so a non-owner drops the duplicate events Discord still
+// delivers to it (every session on a shared token receives the full stream, P5),
+// making N Voice Instances on one central token safe. Atomic; safe to call from
+// the elector goroutine while disgo event goroutines read it.
+func (r *Registry) SetActive(active bool) { r.active.Store(active) }
 
 // Register adds commands to the surface. Boot-time only (before the first
 // Ensure); the dispatch key is the command's Path.
@@ -122,6 +149,11 @@ func (r *Registry) RegisterComponentHandler(h func(*events.ComponentInteractionC
 // fans the event out to every registered component handler, each of which decides
 // by custom id whether the interaction is theirs.
 func (r *Registry) HandleComponent(e *events.ComponentInteractionCreate) {
+	if !r.active.Load() {
+		// Non-owner (#492): drop the duplicate component interaction; the elected owner
+		// runs its handlers.
+		return
+	}
 	r.mu.RLock()
 	handlers := r.componentHandlers
 	r.mu.RUnlock()
@@ -198,6 +230,12 @@ func (r *Registry) HandleCommand(e *events.ApplicationCommandInteractionCreate) 
 // is separated from HandleCommand so it can be unit-tested with a fake
 // Interaction (a fake responder + fake options), no live Discord event needed.
 func (r *Registry) dispatch(base context.Context, key string, ic *Interaction) {
+	if !r.active.Load() {
+		// Not the elected presence owner (#492): drop the duplicate interaction Discord
+		// delivered to this session's token. No reply — another Voice Instance (the
+		// owner) answers it; replying here would double-respond the user.
+		return
+	}
 	cmd, ok := r.lookup(key)
 	if !ok {
 		_ = ic.ReplyEphemeral("Unknown command.")
@@ -254,6 +292,10 @@ func (r *Registry) HandleAutocomplete(e *events.AutocompleteInteractionCreate) {
 // fails.
 func (r *Registry) autocompleteChoices(base context.Context, key string, ac *Autocomplete) []discord.AutocompleteChoice {
 	empty := []discord.AutocompleteChoice{}
+	if !r.active.Load() {
+		// Non-owner (#492): no choices, no handler — the elected owner answers.
+		return empty
+	}
 	cmd, ok := r.lookup(key)
 	if !ok || cmd.Autocomplete == nil {
 		return empty

--- a/internal/presence/command_test.go
+++ b/internal/presence/command_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/events"
 )
 
 // replyKind names the responder method a recorded message came through, so a test can
@@ -349,4 +350,115 @@ func keys(m map[string]discord.SlashCommandCreate) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestSetActiveGatesDispatch covers sequence (4): an inactive Registry (a
+// non-elected presence owner, #492) drops a slash-command interaction entirely —
+// the handler never runs and NOTHING is replied — while an active one dispatches
+// normally. This is the mechanism that makes N Voice Instances on one shared
+// central token safe: every session receives every INTERACTION_CREATE (P5), and
+// only the elected owner acts on it.
+func TestSetActiveGatesDispatch(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	ran := false
+	reg.Register(Command{Path: "ping", Handle: func(_ context.Context, ic *Interaction) error {
+		ran = true
+		return ic.Reply("pong")
+	}})
+
+	reg.SetActive(false)
+	resp := &fakeResponder{}
+	reg.dispatch(context.Background(), "ping", &Interaction{guildID: testGuild, userID: strangerID, resp: resp})
+	if ran {
+		t.Error("inactive Registry must not run the handler")
+	}
+	if len(resp.replies) != 0 {
+		t.Errorf("inactive Registry must not reply, got %+v", resp.replies)
+	}
+
+	reg.SetActive(true)
+	resp2 := &fakeResponder{}
+	reg.dispatch(context.Background(), "ping", &Interaction{guildID: testGuild, userID: strangerID, resp: resp2})
+	if !ran {
+		t.Error("active Registry must run the handler")
+	}
+	if len(resp2.replies) != 1 || resp2.replies[0].content != "pong" {
+		t.Errorf("active Registry should reply once with pong, got %+v", resp2.replies)
+	}
+}
+
+// TestSetActiveGatesAutocomplete covers sequence (4) for autocomplete: an inactive
+// Registry returns no choices without running the autocomplete handler.
+func TestSetActiveGatesAutocomplete(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	ran := false
+	reg.Register(Command{Path: "pick", Handle: func(context.Context, *Interaction) error { return nil },
+		Autocomplete: func(context.Context, *Autocomplete) ([]discord.AutocompleteChoice, error) {
+			ran = true
+			return []discord.AutocompleteChoice{discord.AutocompleteChoiceString{Name: "x", Value: "x"}}, nil
+		}})
+
+	reg.SetActive(false)
+	choices := reg.autocompleteChoices(context.Background(), "pick", &Autocomplete{guildID: testGuild, userID: strangerID})
+	if ran {
+		t.Error("inactive Registry must not run the autocomplete handler")
+	}
+	if len(choices) != 0 {
+		t.Errorf("inactive Registry must return no choices, got %d", len(choices))
+	}
+}
+
+// TestSetActiveGatesComponent covers sequence (4) for message components: an
+// inactive Registry fans no component interaction out to its handlers.
+func TestSetActiveGatesComponent(t *testing.T) {
+	reg := testRegistry(testGuild, "")
+	ran := false
+	reg.RegisterComponentHandler(func(*events.ComponentInteractionCreate) { ran = true })
+
+	reg.SetActive(false)
+	reg.HandleComponent(nil)
+	if ran {
+		t.Error("inactive Registry must not invoke component handlers")
+	}
+
+	reg.SetActive(true)
+	reg.HandleComponent(nil)
+	if !ran {
+		t.Error("active Registry must invoke component handlers")
+	}
+}
+
+// TestExactlyOnceAcrossTwoRegistries covers sequence (5): the exactly-once
+// guarantee behind ADR-0057 (c). Two Voice Instances' command Registries receive
+// the SAME interaction (Discord delivers it to every session on the shared token);
+// only the elected owner is active, so the handler runs exactly once total and the
+// non-owner replies nothing.
+func TestExactlyOnceAcrossTwoRegistries(t *testing.T) {
+	owner := testRegistry(testGuild, "")
+	nonOwner := testRegistry(testGuild, "")
+	dispatches := 0
+	handler := func(_ context.Context, ic *Interaction) error {
+		dispatches++
+		return ic.Reply("done")
+	}
+	owner.Register(Command{Path: "roll", Handle: handler})
+	nonOwner.Register(Command{Path: "roll", Handle: handler})
+
+	owner.SetActive(true)
+	nonOwner.SetActive(false)
+
+	ownerResp := &fakeResponder{}
+	nonOwnerResp := &fakeResponder{}
+	owner.dispatch(context.Background(), "roll", &Interaction{guildID: testGuild, userID: strangerID, resp: ownerResp})
+	nonOwner.dispatch(context.Background(), "roll", &Interaction{guildID: testGuild, userID: strangerID, resp: nonOwnerResp})
+
+	if dispatches != 1 {
+		t.Fatalf("handler ran %d times, want exactly once across the fleet", dispatches)
+	}
+	if len(ownerResp.replies) != 1 {
+		t.Errorf("owner should reply once, got %+v", ownerResp.replies)
+	}
+	if len(nonOwnerResp.replies) != 0 {
+		t.Errorf("non-owner must reply nothing, got %+v", nonOwnerResp.replies)
+	}
 }

--- a/internal/presence/command_test.go
+++ b/internal/presence/command_test.go
@@ -387,8 +387,24 @@ func TestSetActiveGatesDispatch(t *testing.T) {
 	}
 }
 
+// recordingAutocompleteResponder records whether a result was sent, so a test can
+// assert a non-owner sends NOTHING (not an empty result).
+type recordingAutocompleteResponder struct {
+	sent    bool
+	choices []discord.AutocompleteChoice
+}
+
+func (r *recordingAutocompleteResponder) result(choices []discord.AutocompleteChoice) error {
+	r.sent = true
+	r.choices = choices
+	return nil
+}
+
 // TestSetActiveGatesAutocomplete covers sequence (4) for autocomplete: an inactive
-// Registry returns no choices without running the autocomplete handler.
+// Registry DROPS the interaction — it sends NO AutocompleteResult at all (not an
+// empty list), and never runs the handler — while an active one responds normally.
+// Drives handleAutocomplete (the send seam) so the drop-vs-empty distinction is
+// observable.
 func TestSetActiveGatesAutocomplete(t *testing.T) {
 	reg := testRegistry(testGuild, "")
 	ran := false
@@ -399,12 +415,23 @@ func TestSetActiveGatesAutocomplete(t *testing.T) {
 		}})
 
 	reg.SetActive(false)
-	choices := reg.autocompleteChoices(context.Background(), "pick", &Autocomplete{guildID: testGuild, userID: strangerID})
+	inactive := &recordingAutocompleteResponder{}
+	reg.handleAutocomplete(context.Background(), "pick", &Autocomplete{guildID: testGuild, userID: strangerID}, inactive)
 	if ran {
 		t.Error("inactive Registry must not run the autocomplete handler")
 	}
-	if len(choices) != 0 {
-		t.Errorf("inactive Registry must return no choices, got %d", len(choices))
+	if inactive.sent {
+		t.Error("inactive Registry must send NO autocomplete result at all (drop, not empty)")
+	}
+
+	reg.SetActive(true)
+	active := &recordingAutocompleteResponder{}
+	reg.handleAutocomplete(context.Background(), "pick", &Autocomplete{guildID: testGuild, userID: strangerID}, active)
+	if !ran {
+		t.Error("active Registry must run the handler")
+	}
+	if !active.sent || len(active.choices) != 1 {
+		t.Errorf("active Registry should send one choice, sent=%v choices=%d", active.sent, len(active.choices))
 	}
 }
 

--- a/internal/presence/elector.go
+++ b/internal/presence/elector.go
@@ -1,0 +1,131 @@
+package presence
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// OwnerStore is the presence-owner election persistence the OwnerElector drives
+// (#492, ADR-0057 (c)); *storage.Store satisfies it. Split out so the elector unit
+// tests script elections without a live Postgres.
+type OwnerStore interface {
+	// AcquireOrRenewPresenceOwner claims or renews the singleton owner row for
+	// instanceID, reporting whether instanceID now owns it. It wins on an empty row,
+	// a renew of its own claim, or an expired incumbent; it loses to a live other
+	// owner.
+	AcquireOrRenewPresenceOwner(ctx context.Context, instanceID string, expiry time.Duration) (bool, error)
+	// ReleasePresenceOwner drops instanceID's claim (fenced by instance_id) so a
+	// challenger wins immediately on a clean drain.
+	ReleasePresenceOwner(ctx context.Context, instanceID string) error
+}
+
+// OwnerElectorConfig is the elector's cadence: how often it renews (Interval) and
+// how long an owner's silence before its row is considered dead (Expiry). Read
+// from GLYPHOXA_PRESENCE_OWNER_INTERVAL (5s) / _EXPIRY (15s) in cmd/glyphoxa.
+type OwnerElectorConfig struct {
+	Interval time.Duration
+	Expiry   time.Duration
+}
+
+// releaseTimeout bounds the best-effort Release on shutdown: the parent ctx is
+// already cancelled by then, so Release runs on a fresh short-lived ctx.
+const electorReleaseTimeout = 3 * time.Second
+
+// OwnerElector runs the presence-owner election loop for one Voice Instance (#492,
+// ADR-0057 (c)): it renews the singleton presence_owner claim on a ticker and, on
+// every ownership transition, calls onChange — wired to Registry.SetActive so only
+// the elected owner acts on the interaction stream every session on a shared
+// central token receives (P5). On ctx cancel (SIGTERM) it Releases the claim and
+// signals loss, so a drained owner hands over immediately rather than forcing the
+// fleet to wait out the expiry.
+//
+// No mid-session takeover concern here (that is the voice claim plane's, #491):
+// this elects who DISPATCHES INTERACTIONS, orthogonal to who holds a voice call.
+type OwnerElector struct {
+	store      OwnerStore
+	instanceID string
+	onChange   func(owner bool)
+	cfg        OwnerElectorConfig
+	log        *slog.Logger
+
+	// current is the last-signalled ownership; onChange fires only on a change from
+	// it. Seeded false because a -mode voice worker boots inactive.
+	current bool
+
+	// ticks, when non-nil, replaces the internal time.Ticker so tests drive
+	// elections deterministically. nil in production → a real ticker at cfg.Interval.
+	ticks <-chan time.Time
+}
+
+// NewOwnerElector builds an elector over store for instanceID. onChange is called
+// on each ownership transition (true on gain, false on loss/shutdown) — wire it to
+// the presence Registry's SetActive. A nil log discards.
+func NewOwnerElector(store OwnerStore, instanceID string, onChange func(owner bool), log *slog.Logger, cfg OwnerElectorConfig) *OwnerElector {
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	return &OwnerElector{store: store, instanceID: instanceID, onChange: onChange, cfg: cfg, log: log}
+}
+
+// Run drives the election until ctx is cancelled. It attempts an immediate claim at
+// boot (so ownership is decided without waiting a full interval), then renews on
+// each tick. On ctx cancel it Releases the claim and signals loss. Blocking; run it
+// in its own goroutine.
+func (e *OwnerElector) Run(ctx context.Context) {
+	e.reconcile(ctx)
+
+	ticks := e.ticks
+	if ticks == nil {
+		ticker := time.NewTicker(e.cfg.Interval)
+		defer ticker.Stop()
+		ticks = ticker.C
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			e.release()
+			return
+		case <-ticks:
+			e.reconcile(ctx)
+		}
+	}
+}
+
+// reconcile runs one acquire/renew and signals a transition. A transient error
+// leaves the last state untouched (no flip): a DB blip that fails our renew also
+// fails any challenger's acquire, so relinquishing would only risk a needless gap.
+func (e *OwnerElector) reconcile(ctx context.Context) {
+	owner, err := e.store.AcquireOrRenewPresenceOwner(ctx, e.instanceID, e.cfg.Expiry)
+	if err != nil {
+		e.log.Warn("presence: owner election acquire/renew failed; keeping current ownership", "instance", e.instanceID, "owner", e.current, "err", err)
+		return
+	}
+	e.set(owner)
+}
+
+// set fires onChange only when ownership actually changes.
+func (e *OwnerElector) set(owner bool) {
+	if owner == e.current {
+		return
+	}
+	e.current = owner
+	if owner {
+		e.log.Info("presence: won owner election", "instance", e.instanceID)
+	} else {
+		e.log.Info("presence: lost owner election", "instance", e.instanceID)
+	}
+	e.onChange(owner)
+}
+
+// release best-effort drops the claim on shutdown (parent ctx already cancelled, so
+// a fresh short ctx) and signals loss so the Registry deactivates.
+func (e *OwnerElector) release() {
+	rctx, cancel := context.WithTimeout(context.Background(), electorReleaseTimeout)
+	defer cancel()
+	if err := e.store.ReleasePresenceOwner(rctx, e.instanceID); err != nil {
+		e.log.Warn("presence: releasing owner claim on shutdown failed; it will expire", "instance", e.instanceID, "err", err)
+	}
+	e.set(false)
+}

--- a/internal/presence/elector.go
+++ b/internal/presence/elector.go
@@ -53,6 +53,17 @@ type OwnerElector struct {
 	// it. Seeded false because a -mode voice worker boots inactive.
 	current bool
 
+	// lastRenew is the local (monotonic) instant of the last SUCCESSFUL acquire/renew.
+	// Self-demotion is judged against elapsed since this — never the DB heartbeat_at
+	// or a wall clock — so a partitioned owner that can no longer reach Postgres
+	// deactivates its Registry before another node's lease-expiry claim could make two
+	// owners dispatch the same interaction.
+	lastRenew time.Time
+
+	// now is the clock (default time.Now, which carries a monotonic reading). Injected
+	// in tests to drive the demotion timer deterministically.
+	now func() time.Time
+
 	// ticks, when non-nil, replaces the internal time.Ticker so tests drive
 	// elections deterministically. nil in production → a real ticker at cfg.Interval.
 	ticks <-chan time.Time
@@ -65,7 +76,7 @@ func NewOwnerElector(store OwnerStore, instanceID string, onChange func(owner bo
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &OwnerElector{store: store, instanceID: instanceID, onChange: onChange, cfg: cfg, log: log}
+	return &OwnerElector{store: store, instanceID: instanceID, onChange: onChange, cfg: cfg, log: log, now: time.Now}
 }
 
 // Run drives the election until ctx is cancelled. It attempts an immediate claim at
@@ -93,16 +104,46 @@ func (e *OwnerElector) Run(ctx context.Context) {
 	}
 }
 
-// reconcile runs one acquire/renew and signals a transition. A transient error
-// leaves the last state untouched (no flip): a DB blip that fails our renew also
-// fails any challenger's acquire, so relinquishing would only risk a needless gap.
+// reconcile runs one acquire/renew and signals a transition. The acquire is bounded
+// by a per-op DB timeout (min(interval, 3s)) so a stuck connection can never block
+// the loop past its own tick — otherwise the demotion check below would never run.
+//
+// On success it stamps lastRenew and signals ownership. On error it SELF-DEMOTES —
+// SetActive(false) via set — once the monotonic elapsed since the last successful
+// renew reaches Expiry: a partitioned owner that can no longer reach Postgres must
+// stop dispatching before another node's lease-expiry claim promotes a second owner
+// (else both dispatch the same interaction). It does NOT Release on demotion — the
+// DB is unreachable by assumption, so a local deactivation is all that is possible
+// and the row's own lease expiry hands ownership over. Re-promotion happens ONLY via
+// the next SUCCESSFUL acquire in the normal loop (which re-stamps lastRenew and
+// re-signals true). Before the elapsed reaches Expiry a transient blip keeps
+// ownership: the same blip fails a challenger's acquire too, so relinquishing early
+// would only risk a needless gap.
 func (e *OwnerElector) reconcile(ctx context.Context) {
-	owner, err := e.store.AcquireOrRenewPresenceOwner(ctx, e.instanceID, e.cfg.Expiry)
+	opCtx, cancel := context.WithTimeout(ctx, e.opTimeout())
+	owner, err := e.store.AcquireOrRenewPresenceOwner(opCtx, e.instanceID, e.cfg.Expiry)
+	cancel()
 	if err != nil {
-		e.log.Warn("presence: owner election acquire/renew failed; keeping current ownership", "instance", e.instanceID, "owner", e.current, "err", err)
+		e.log.Warn("presence: owner election acquire/renew failed", "instance", e.instanceID, "owner", e.current, "err", err)
+		if e.current && e.now().Sub(e.lastRenew) >= e.cfg.Expiry {
+			e.log.Warn("presence: owner lease unrenewed past expiry; self-demoting (no Release — DB unreachable)", "instance", e.instanceID, "expiry", e.cfg.Expiry)
+			e.set(false)
+		}
 		return
 	}
+	e.lastRenew = e.now()
 	e.set(owner)
+}
+
+// opTimeout bounds a single acquire/renew DB call: min(Interval, 3s), so a stuck
+// connection cannot pin the loop past its tick and starve the self-demotion check.
+// Falls back to 3s when Interval is non-positive.
+func (e *OwnerElector) opTimeout() time.Duration {
+	const cap = 3 * time.Second
+	if e.cfg.Interval > 0 && e.cfg.Interval < cap {
+		return e.cfg.Interval
+	}
+	return cap
 }
 
 // set fires onChange only when ownership actually changes.

--- a/internal/presence/elector_test.go
+++ b/internal/presence/elector_test.go
@@ -114,6 +114,57 @@ func TestOwnerElectorReleasesOnCancel(t *testing.T) {
 	}
 }
 
+// TestOwnerElectorSelfDemotesAfterExpiry covers the review item: a partitioned
+// owner that can no longer reach Postgres self-demotes (SetActive(false)) once the
+// MONOTONIC elapsed since its last successful renew reaches Expiry — before that it
+// keeps ownership — and it does NOT Release on demotion (DB unreachable). Re-promotion
+// comes only via the next successful acquire. Drives reconcile directly against a
+// fake clock for determinism.
+func TestOwnerElectorSelfDemotesAfterExpiry(t *testing.T) {
+	store := &fakeOwnerStore{
+		outcomes: []bool{true, true, true, true},
+		errs:     []error{nil, errors.New("partition"), errors.New("partition"), nil},
+	}
+	changes := make(chan bool, 8)
+	cfg := OwnerElectorConfig{Interval: 5 * time.Second, Expiry: 15 * time.Second}
+	e := NewOwnerElector(store, "instance-a", func(owner bool) { changes <- owner }, nil, cfg)
+
+	base := time.Now()
+	clk := base
+	e.now = func() time.Time { return clk }
+	ctx := context.Background()
+
+	// Boot: successful acquire → own, lastRenew stamped.
+	e.reconcile(ctx)
+	if got := <-changes; got != true {
+		t.Fatalf("boot onChange = %v, want true", got)
+	}
+
+	// A blip BEFORE expiry: keep ownership, no demotion, no onChange.
+	clk = base.Add(cfg.Expiry - time.Millisecond)
+	e.reconcile(ctx)
+	if len(changes) != 0 {
+		t.Fatalf("demoted before expiry: %d changes queued", len(changes))
+	}
+
+	// Still failing, now AT expiry: self-demote to inactive, WITHOUT Release.
+	clk = base.Add(cfg.Expiry)
+	e.reconcile(ctx)
+	if got := <-changes; got != false {
+		t.Fatalf("expiry onChange = %v, want false (self-demote)", got)
+	}
+	if store.wasReleased() {
+		t.Error("self-demotion must NOT Release the claim (DB unreachable; lease expiry hands over)")
+	}
+
+	// The DB recovers: the next successful acquire re-promotes.
+	clk = base.Add(cfg.Expiry + cfg.Interval)
+	e.reconcile(ctx)
+	if got := <-changes; got != true {
+		t.Fatalf("recovery onChange = %v, want true (re-promote via successful acquire)", got)
+	}
+}
+
 // TestOwnerElectorErrorKeepsState covers sequence (3): a transient acquire error
 // does not flip a live owner inactive — it logs and retains the last state, since a
 // DB blip that fails our renew also fails a challenger's acquire.

--- a/internal/presence/elector_test.go
+++ b/internal/presence/elector_test.go
@@ -1,0 +1,150 @@
+package presence
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeOwnerStore scripts AcquireOrRenewPresenceOwner outcomes in order and records
+// whether Release was called, so an elector test drives elections deterministically
+// without a real Postgres.
+type fakeOwnerStore struct {
+	mu        sync.Mutex
+	outcomes  []bool  // successive acquire results; the last repeats once exhausted
+	errs      []error // parallel to outcomes; nil = success
+	calls     int
+	released  bool
+	releaseCh chan struct{}
+}
+
+func (f *fakeOwnerStore) AcquireOrRenewPresenceOwner(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i := f.calls
+	if i >= len(f.outcomes) {
+		i = len(f.outcomes) - 1
+	}
+	f.calls++
+	var err error
+	if i < len(f.errs) {
+		err = f.errs[i]
+	}
+	return f.outcomes[i], err
+}
+
+func (f *fakeOwnerStore) ReleasePresenceOwner(_ context.Context, _ string) error {
+	f.mu.Lock()
+	f.released = true
+	ch := f.releaseCh
+	f.mu.Unlock()
+	if ch != nil {
+		close(ch)
+	}
+	return nil
+}
+
+func (f *fakeOwnerStore) wasReleased() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.released
+}
+
+// TestOwnerElectorGainAndLoss covers sequence (3): the elector fires onChange(true)
+// when it wins the presence_owner row and onChange(false) when a later renew loses
+// it — the gain/loss transitions that drive Registry.SetActive.
+func TestOwnerElectorGainAndLoss(t *testing.T) {
+	store := &fakeOwnerStore{outcomes: []bool{true, false}}
+	ticks := make(chan time.Time)
+	changes := make(chan bool, 8)
+
+	e := NewOwnerElector(store, "instance-a", func(owner bool) { changes <- owner }, nil,
+		OwnerElectorConfig{Interval: time.Hour, Expiry: 15 * time.Second})
+	e.ticks = ticks
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { e.Run(ctx); close(done) }()
+
+	// The immediate boot reconcile wins the row.
+	if got := <-changes; got != true {
+		t.Fatalf("first onChange = %v, want true (won the election)", got)
+	}
+	// A tick renews and this time loses.
+	ticks <- time.Now()
+	if got := <-changes; got != false {
+		t.Fatalf("second onChange = %v, want false (lost the election)", got)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestOwnerElectorReleasesOnCancel covers sequence (3): ctx cancellation (SIGTERM)
+// releases the claim and signals loss, so a drained owner hands the row over
+// immediately instead of forcing the fleet to wait out its expiry.
+func TestOwnerElectorReleasesOnCancel(t *testing.T) {
+	store := &fakeOwnerStore{outcomes: []bool{true}, releaseCh: make(chan struct{})}
+	changes := make(chan bool, 8)
+
+	e := NewOwnerElector(store, "instance-a", func(owner bool) { changes <- owner }, nil,
+		OwnerElectorConfig{Interval: time.Hour, Expiry: 15 * time.Second})
+	e.ticks = make(chan time.Time)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { e.Run(ctx); close(done) }()
+
+	if got := <-changes; got != true {
+		t.Fatalf("first onChange = %v, want true", got)
+	}
+
+	cancel()
+	<-done
+
+	if !store.wasReleased() {
+		t.Error("ctx cancel must Release the presence-owner claim")
+	}
+	// The shutdown must signal loss so Registry.SetActive(false) fires.
+	if got := <-changes; got != false {
+		t.Fatalf("shutdown onChange = %v, want false", got)
+	}
+}
+
+// TestOwnerElectorErrorKeepsState covers sequence (3): a transient acquire error
+// does not flip a live owner inactive — it logs and retains the last state, since a
+// DB blip that fails our renew also fails a challenger's acquire.
+func TestOwnerElectorErrorKeepsState(t *testing.T) {
+	store := &fakeOwnerStore{
+		outcomes: []bool{true, false, true},
+		errs:     []error{nil, errors.New("db blip"), nil},
+	}
+	ticks := make(chan time.Time)
+	changes := make(chan bool, 8)
+
+	e := NewOwnerElector(store, "instance-a", func(owner bool) { changes <- owner }, nil,
+		OwnerElectorConfig{Interval: time.Hour, Expiry: 15 * time.Second})
+	e.ticks = ticks
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { e.Run(ctx); close(done) }()
+
+	if got := <-changes; got != true {
+		t.Fatalf("first onChange = %v, want true", got)
+	}
+	// A tick returns an error: state must NOT change (no onChange emitted).
+	ticks <- time.Now()
+	// A further tick succeeds as owner again: still no change (was already owner), so
+	// the only remaining change would be shutdown's false.
+	ticks <- time.Now()
+
+	cancel()
+	<-done
+	if got := <-changes; got != false {
+		t.Fatalf("after error/renew the only further change should be shutdown false, got %v", got)
+	}
+}

--- a/internal/presence/session_commands.go
+++ b/internal/presence/session_commands.go
@@ -177,6 +177,11 @@ func EndCommand(voice VoiceControl) Command {
 				if errors.Is(err, session.ErrNoActiveSession) {
 					return ic.ReplyEphemeral("No voice session is running.")
 				}
+				if errors.Is(err, session.ErrStopPending) {
+					// Split/worker mode (#491): the stop was requested but the worker has
+					// not confirmed it within the budget. Retryable, not a failure.
+					return ic.ReplyEphemeral("Ending the voice session is taking longer than expected — the worker hasn't confirmed the stop yet. Try again in a moment.")
+				}
 				return fmt.Errorf("presence: stop voice session: %w", err)
 			}
 			return ic.ReplyEphemeral("Voice session ended.")
@@ -245,6 +250,14 @@ func startErrorMessage(err error) (string, bool) {
 		return "Voice isn't available in this deployment mode.", true
 	case errors.Is(err, session.ErrManagerClosed):
 		return "The server is shutting down — try again shortly.", true
+	case errors.Is(err, session.ErrIntentPending):
+		// Split/worker mode (#491): the intent is queued but no worker claimed it
+		// within the budget. Retryable, not a failure.
+		return "Starting the voice session is taking longer than expected — no worker has claimed it yet. Try again in a moment.", true
+	case errors.Is(err, session.ErrIntentCancelled):
+		// Split/worker mode (#491): the start was cancelled before any worker claimed
+		// it — a distinct outcome from a still-queued pending.
+		return "The voice session start was cancelled before a worker picked it up.", true
 	default:
 		return "", false
 	}

--- a/internal/presence/session_commands_test.go
+++ b/internal/presence/session_commands_test.go
@@ -419,6 +419,64 @@ func TestEndNoneRunning(t *testing.T) {
 	}
 }
 
+// TestStartIntentPending covers the #491-residual (#492): in split/worker mode a
+// Start that queues an intent but is not claimed within the budget returns
+// ErrIntentPending — a retryable state, not a failure — so the operator gets a
+// clear "not claimed yet, try again" message, never the generic error.
+func TestStartIntentPending(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{forUser: &lost}
+	voice := &fakeVoice{startErr: session.ErrIntentPending}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("pending reply = %+v, want one ephemeral message", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "try again") {
+		t.Errorf("pending reply = %q, want a retryable 'not claimed yet' hint", resp.followups[0].content)
+	}
+}
+
+// TestStartIntentCancelled covers the #491-residual (#492): a Start cancelled
+// before any worker claimed it reports a distinct, clear outcome.
+func TestStartIntentCancelled(t *testing.T) {
+	lost := campaign("Lost Mine")
+	store := &fakeSessionStore{forUser: &lost}
+	voice := &fakeVoice{startErr: session.ErrIntentCancelled}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(StartCommand(store, voice))
+
+	resp := dispatchAs(reg, "glyphoxa start", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("cancelled reply = %+v, want one ephemeral message", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "cancel") {
+		t.Errorf("cancelled reply = %q, want a clear 'cancelled' message", resp.followups[0].content)
+	}
+}
+
+// TestEndStopPending covers the #491-residual (#492): in split/worker mode an end
+// whose stop the worker has not yet confirmed within the budget returns
+// ErrStopPending — a retryable state, reported as such rather than generically.
+func TestEndStopPending(t *testing.T) {
+	voice := &fakeVoice{stopErr: session.ErrStopPending}
+	reg := testRegistry(testGuild, operatorID)
+	reg.Register(EndCommand(voice))
+
+	resp := dispatchAs(reg, "glyphoxa end", operatorID, nil)
+
+	if len(resp.followups) != 1 || !resp.followups[0].ephemeral {
+		t.Fatalf("stop-pending reply = %+v, want one ephemeral message", resp.followups)
+	}
+	if !strings.Contains(strings.ToLower(resp.followups[0].content), "try again") {
+		t.Errorf("stop-pending reply = %q, want a retryable hint", resp.followups[0].content)
+	}
+}
+
 // TestEndForeignTenantSessionRefused pins the cross-tenant guard (#490): the
 // Manager is single-active, so a GM in Tenant A must NOT stop a live session that
 // belongs to Tenant B — end refuses and never calls Stop.

--- a/internal/storage/migrations/00036_presence_owner.sql
+++ b/internal/storage/migrations/00036_presence_owner.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+
+-- Presence-owner election (#492, ADR-0057 (c)): every gateway session on a shared
+-- central token receives the FULL event stream, so N Voice Instances holding
+-- sessions on that token would each see every INTERACTION_CREATE and each try to
+-- handle it (Discord deduplicates nothing between sessions on one token, P5). This
+-- singleton row elects exactly ONE Voice Instance to register command listeners
+-- and dispatch interactions; non-owners drop the duplicate events they still
+-- receive.
+--
+-- Singleton by construction: the PRIMARY KEY is a boolean pinned true by a CHECK,
+-- so the table holds at most one row — the current owner's claim. Election is a
+-- single upsert (AcquireOrRenewPresenceOwner) that wins when the caller already
+-- owns the row OR the incumbent's heartbeat has expired; failover is thus the same
+-- expiry-then-claim idiom the job runner (ADR-0049) and the voice claim plane
+-- (#491) already use. Poll only — no LISTEN/NOTIFY (ADR-0057 (b)).
+CREATE TABLE presence_owner (
+    singleton    boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    instance_id  text NOT NULL,
+    heartbeat_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS presence_owner;

--- a/internal/storage/presenceowner.go
+++ b/internal/storage/presenceowner.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Presence-owner election persistence (#492, ADR-0057 (c)): the singleton
+// presence_owner row elects exactly one Voice Instance to register command
+// listeners and dispatch interactions for a shared central token; non-owners drop
+// the duplicate interaction events they still receive (every gateway session on
+// one token gets the FULL stream, P5). Election is ONE upsert that wins when the
+// caller already owns the row OR the incumbent's heartbeat has expired — the same
+// expiry-then-claim idiom the job runner (ADR-0049) and the voice claim plane
+// (#491) prove. Poll only (ADR-0057 (b)); no LISTEN/NOTIFY.
+
+// AcquireOrRenewPresenceOwner atomically claims or renews the singleton
+// presence-owner row for instanceID and reports whether instanceID now owns it.
+// The single upsert wins — inserts on an empty table, or updates the existing
+// row — only when the row is already instanceID's (a renew, advancing the
+// heartbeat) OR the incumbent's heartbeat is older than expiry (a dead owner's
+// row, so a challenger takes over). When another live instance holds it the
+// ON CONFLICT WHERE predicate is false, no row is written, and this returns
+// false — the caller is a non-owner and must stay inactive.
+func (s *Store) AcquireOrRenewPresenceOwner(ctx context.Context, instanceID string, expiry time.Duration) (bool, error) {
+	var owner string
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO presence_owner AS po (singleton, instance_id, heartbeat_at)
+		 VALUES (true, $1, now())
+		 ON CONFLICT (singleton) DO UPDATE
+		    SET instance_id = excluded.instance_id,
+		        heartbeat_at = now()
+		  WHERE po.instance_id = $1
+		     OR po.heartbeat_at < now() - make_interval(secs => $2)
+		 RETURNING po.instance_id`,
+		instanceID, expiry.Seconds()).Scan(&owner)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The conflict predicate was false: a live incumbent still owns the row, no
+		// write happened, and this caller is a non-owner.
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("storage: acquire or renew presence owner for %s: %w", instanceID, err)
+	}
+	return true, nil
+}
+
+// ReleasePresenceOwner drops instanceID's presence-owner claim so a challenger's
+// very next AcquireOrRenewPresenceOwner wins immediately (a clean drain handover,
+// not an expiry wait). Fenced by instance_id: a superseded former owner that
+// already lost the row deletes nothing, never the new owner's claim. Deleting no
+// row is not an error.
+func (s *Store) ReleasePresenceOwner(ctx context.Context, instanceID string) error {
+	if _, err := s.db.Exec(ctx,
+		`DELETE FROM presence_owner WHERE instance_id = $1`, instanceID); err != nil {
+		return fmt.Errorf("storage: release presence owner for %s: %w", instanceID, err)
+	}
+	return nil
+}

--- a/internal/storage/presenceowner_test.go
+++ b/internal/storage/presenceowner_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestPresenceOwnerElection covers sequence (1): the first instance to acquire the
+// empty singleton row wins; a second, distinct instance loses while the first's
+// heartbeat is live; and the first renewing advances its own heartbeat.
+func TestPresenceOwnerElection(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	const expiry = 15 * time.Second
+
+	won, err := st.AcquireOrRenewPresenceOwner(ctx, "instance-a", expiry)
+	if err != nil {
+		t.Fatalf("acquire (empty): %v", err)
+	}
+	if !won {
+		t.Fatal("first instance on an empty row should win")
+	}
+
+	// A distinct instance while A's heartbeat is fresh must lose.
+	won, err = st.AcquireOrRenewPresenceOwner(ctx, "instance-b", expiry)
+	if err != nil {
+		t.Fatalf("acquire (contended): %v", err)
+	}
+	if won {
+		t.Fatal("second instance should lose while the incumbent's heartbeat is live")
+	}
+
+	// A renews: still the owner, heartbeat advances.
+	var before time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM presence_owner`).Scan(&before); err != nil {
+		t.Fatalf("read heartbeat: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	won, err = st.AcquireOrRenewPresenceOwner(ctx, "instance-a", expiry)
+	if err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+	if !won {
+		t.Fatal("incumbent renewing should still own the row")
+	}
+	var after time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM presence_owner`).Scan(&after); err != nil {
+		t.Fatalf("read heartbeat after renew: %v", err)
+	}
+	if !after.After(before) {
+		t.Fatalf("renew should advance heartbeat: before=%s after=%s", before, after)
+	}
+}
+
+// TestPresenceOwnerFailover covers sequence (2): once the incumbent's heartbeat
+// expires a challenger wins (failover on owner death), and an explicit Release
+// hands over immediately without waiting for expiry.
+func TestPresenceOwnerFailover(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, _ := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A owns with a tiny expiry, then goes silent past it: the row is now stale.
+	if won, err := st.AcquireOrRenewPresenceOwner(ctx, "instance-a", 20*time.Millisecond); err != nil || !won {
+		t.Fatalf("A acquire: won=%v err=%v", won, err)
+	}
+	time.Sleep(40 * time.Millisecond)
+
+	won, err := st.AcquireOrRenewPresenceOwner(ctx, "instance-b", 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("B acquire after expiry: %v", err)
+	}
+	if !won {
+		t.Fatal("challenger should win once the incumbent heartbeat has expired")
+	}
+
+	// B releases: A's next acquire wins immediately, no expiry wait.
+	if err := st.ReleasePresenceOwner(ctx, "instance-b"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	won, err = st.AcquireOrRenewPresenceOwner(ctx, "instance-a", 15*time.Second)
+	if err != nil {
+		t.Fatalf("A re-acquire after release: %v", err)
+	}
+	if !won {
+		t.Fatal("after a clean Release the next acquirer should win immediately")
+	}
+
+	// A superseded former owner's Release must NOT delete the current owner's row.
+	if err := st.ReleasePresenceOwner(ctx, "instance-b"); err != nil {
+		t.Fatalf("stale release: %v", err)
+	}
+	var owner string
+	if err := pool.QueryRow(ctx, `SELECT instance_id FROM presence_owner`).Scan(&owner); err != nil {
+		t.Fatalf("owner still present: %v", err)
+	}
+	if owner != "instance-a" {
+		t.Fatalf("owner = %q, want instance-a (stale release must not evict the live owner)", owner)
+	}
+}

--- a/internal/wirenpc/connect.go
+++ b/internal/wirenpc/connect.go
@@ -269,7 +269,7 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// TapeConsentChanged, and post the in-channel consent disclosure with
 	// grant/revoke buttons. A nil Tape (campaign not armed) makes both inert, so the
 	// loop is unchanged.
-	defer wireTapeConsent(cycleCtx, bus, cfg.Tape, cfg.CampaignID, cfg.TapeConsent, log)()
+	defer wireTapeConsent(cycleCtx, bus, cfg.Tape, cfg.CampaignID, cfg.TapeConsent, cfg.TapeConsentReconcileInterval, log)()
 	if cfg.Tape != nil {
 		if err := postTapeDisclosure(cycleCtx, client, channel, cfg.CampaignID); err != nil {
 			// A failed disclosure post must not tear down the session — capture is

--- a/internal/wirenpc/run.go
+++ b/internal/wirenpc/run.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -110,6 +111,7 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *cryp
 		defer tp.Close()
 		cfg.Tape = tp
 		cfg.TapeConsent = st
+		cfg.TapeConsentReconcileInterval = tapeConsentReconcileInterval(os.Getenv)
 		log.Info("rollover tape armed", "campaign", cfg.CampaignID, "consented_speakers", len(consented))
 	}
 

--- a/internal/wirenpc/tapewiring.go
+++ b/internal/wirenpc/tapewiring.go
@@ -3,6 +3,7 @@ package wirenpc
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -49,6 +50,22 @@ type TapeConsentReader interface {
 	ListTapeConsent(ctx context.Context, campaignID uuid.UUID) ([]string, error)
 }
 
+// defaultTapeConsentReconcileInterval is the poller cadence when
+// GLYPHOXA_TAPE_CONSENT_RECONCILE_INTERVAL is unset or non-positive (#492).
+const defaultTapeConsentReconcileInterval = 5 * time.Second
+
+// tapeConsentReconcileInterval reads the cross-pod consent poller cadence from
+// GLYPHOXA_TAPE_CONSENT_RECONCILE_INTERVAL (#492), falling back to 5s on a blank,
+// unparsable, or non-positive value. Parsed in the composition root (RunFromDB) so
+// the cadence stays a deployment knob.
+func tapeConsentReconcileInterval(getenv func(string) string) time.Duration {
+	d, err := time.ParseDuration(strings.TrimSpace(getenv("GLYPHOXA_TAPE_CONSENT_RECONCILE_INTERVAL")))
+	if err != nil || d <= 0 {
+		return defaultTapeConsentReconcileInterval
+	}
+	return d
+}
+
 // wireTapeConsent keeps the tape's consent set converged to the DURABLE truth
 // (#306, ADR-0051), the exact discipline the mute wiring uses (wireMutes): it
 // re-reads the authoritative consent rows rather than trusting an event payload, so
@@ -60,10 +77,20 @@ type TapeConsentReader interface {
 //   - On every TapeConsentChanged it filters e.CampaignID to THIS session's campaign
 //     — a press against a stale disclosure for another campaign (a reused channel)
 //     must not arm a lane here — then re-reads the store and reconciles the whole set.
+//     This is the same-pod fast path: instant when the consent handler and the tape
+//     share a process bus.
+//   - It runs a poller goroutine that reconciles every `interval` until ctx (the
+//     cycle ctx) is done (#492). In the fleet the consent button is dispatched by the
+//     elected presence OWNER, which publishes TapeConsentChanged on ITS OWN bus — but
+//     the tape may run on a DIFFERENT pod (a claim-plane worker) whose bus never sees
+//     that event, so the bus fast path alone would strand the change cross-pod. The
+//     poller bounds cross-pod staleness to one interval; ADR-0051 holds because
+//     ReconcileConsent authoritatively clears a revoked Speaker's ring.
 //
-// It returns the unsubscribe func for the caller to defer. A nil tape (campaign not
-// armed) does nothing.
-func wireTapeConsent(ctx context.Context, bus *voiceevent.Bus, t *tape.Tape, campaignID uuid.UUID, store TapeConsentReader, log *slog.Logger) func() {
+// It returns the unsubscribe func for the caller to defer; the poller stops on ctx
+// done (the cycle ctx), so it dies with the cycle. A nil tape (campaign not armed)
+// does nothing.
+func wireTapeConsent(ctx context.Context, bus *voiceevent.Bus, t *tape.Tape, campaignID uuid.UUID, store TapeConsentReader, interval time.Duration, log *slog.Logger) func() {
 	if t == nil {
 		return func() {}
 	}
@@ -74,6 +101,9 @@ func wireTapeConsent(ctx context.Context, bus *voiceevent.Bus, t *tape.Tape, cam
 		// seed rather than crashing the session.
 		log.Error("tape: armed but no consent reader wired; live consent changes will not apply", "campaign", campaignID)
 		return func() {}
+	}
+	if interval <= 0 {
+		interval = defaultTapeConsentReconcileInterval
 	}
 	reconcile := func() {
 		consented, err := store.ListTapeConsent(ctx, campaignID)
@@ -93,5 +123,19 @@ func wireTapeConsent(ctx context.Context, bus *voiceevent.Bus, t *tape.Tape, cam
 		reconcile() // re-read the durable truth; ignore the (possibly stale/reordered) payload
 	})
 	reconcile() // authoritative reseed at cycle start (catches changes during a reconnect gap)
+	// Cross-pod poller (#492): reconcile every interval until the cycle ctx is done.
+	// A reconcile error is logged inside reconcile and the ticker keeps going.
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				reconcile()
+			}
+		}
+	}()
 	return unsub
 }

--- a/internal/wirenpc/tapewiring_test.go
+++ b/internal/wirenpc/tapewiring_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/goleak"
 
 	"github.com/MrWong99/Glyphoxa/internal/tape"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -84,7 +85,7 @@ func TestTapeWiring_NilTapeWiresNothing(t *testing.T) {
 	// wireTapeConsent(nil) returns an inert unsubscribe and subscribes nothing:
 	// publishing an event must not panic.
 	bus := voiceevent.NewBus()
-	unsub := wireTapeConsent(context.Background(), bus, nil, uuid.New(), newFakeConsentStore(), discardLog())
+	unsub := wireTapeConsent(context.Background(), bus, nil, uuid.New(), newFakeConsentStore(), 0, discardLog())
 	bus.Publish(voiceevent.TapeConsentChanged{SpeakerID: "111", Granted: true})
 	unsub()
 }
@@ -112,7 +113,7 @@ func TestTapeWiring_ArmedTapeNoStoreDoesNotPanic(t *testing.T) {
 	defer tp.Close()
 	bus := voiceevent.NewBus()
 
-	unsub := wireTapeConsent(context.Background(), bus, tp, uuid.New(), nil, discardLog())
+	unsub := wireTapeConsent(context.Background(), bus, tp, uuid.New(), nil, 0, discardLog())
 	// Publishing must not reach a nil-store reconcile.
 	bus.Publish(voiceevent.TapeConsentChanged{CampaignID: uuid.New().String(), SpeakerID: "111", Granted: true})
 	unsub()
@@ -131,7 +132,11 @@ func TestTapeWiring_ReseedsAndReconcilesAuthoritatively(t *testing.T) {
 	tp := tape.New(tape.Window, nil, nil) // fresh tape, nothing seeded in-memory
 	defer tp.Close()
 	bus := voiceevent.NewBus()
-	unsub := wireTapeConsent(context.Background(), bus, tp, cid, store, discardLog())
+	// A long interval so the poller never fires here — this test exercises the seed +
+	// bus fast path; a cancellable ctx stops the poller goroutine at test end.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	unsub := wireTapeConsent(ctx, bus, tp, cid, store, time.Hour, discardLog())
 	defer unsub()
 
 	// Reseed at cycle start armed 111 from the store (finding 2).
@@ -160,7 +165,9 @@ func TestTapeWiring_IgnoresOtherCampaign(t *testing.T) {
 	tp := tape.New(tape.Window, nil, nil)
 	defer tp.Close()
 	bus := voiceevent.NewBus()
-	unsub := wireTapeConsent(context.Background(), bus, tp, sessionCID, store, discardLog())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	unsub := wireTapeConsent(ctx, bus, tp, sessionCID, store, time.Hour, discardLog())
 	defer unsub()
 
 	if !laneCaptured(tp, "111", time.Now()) {
@@ -173,6 +180,143 @@ func TestTapeWiring_IgnoresOtherCampaign(t *testing.T) {
 	bus.Publish(voiceevent.TapeConsentChanged{CampaignID: otherCID.String(), SpeakerID: "111", Granted: false})
 	if !laneCaptured(tp, "111", time.Now().Add(time.Second)) {
 		t.Fatalf("an event for a different campaign reconciled this session's tape")
+	}
+}
+
+// errConsentStore wraps a fakeConsentStore to fail ListTapeConsent a bounded number
+// of times, so a test can assert the poller logs the error and keeps ticking.
+type errConsentStore struct {
+	*fakeConsentStore
+	mu    sync.Mutex
+	fails int
+	reads int
+}
+
+func (e *errConsentStore) ListTapeConsent(ctx context.Context, cid uuid.UUID) ([]string, error) {
+	e.mu.Lock()
+	e.reads++
+	fail := e.fails > 0
+	if fail {
+		e.fails--
+	}
+	e.mu.Unlock()
+	if fail {
+		return nil, context.DeadlineExceeded
+	}
+	return e.fakeConsentStore.ListTapeConsent(ctx, cid)
+}
+
+func (e *errConsentStore) readCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.reads
+}
+
+// TestTapeWiring_PollerConvergesCrossPod covers #492 (a): a consent row flip with NO
+// bus event — the cross-pod case, where the OWNER pod published TapeConsentChanged on
+// its own bus and this worker's bus never saw it — converges the tape within one
+// poll interval.
+func TestTapeWiring_PollerConvergesCrossPod(t *testing.T) {
+	cid := uuid.New()
+	store := newFakeConsentStore() // empty at cycle start: nobody consents
+
+	tp := tape.New(tape.Window, nil, nil)
+	defer tp.Close()
+	bus := voiceevent.NewBus()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	unsub := wireTapeConsent(ctx, bus, tp, cid, store, 10*time.Millisecond, discardLog())
+	defer unsub()
+
+	// A grant lands in the DB out of band (the button was dispatched on ANOTHER pod),
+	// so NO TapeConsentChanged reaches this bus. The poller must pick it up.
+	store.set(cid, "111")
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if laneCaptured(tp, "111", time.Now()) {
+			return // converged
+		}
+		select {
+		case <-deadline:
+			t.Fatal("poller did not converge the tape to the durable grant within the window")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestTapeWiring_PollerStopsOnCtxCancel covers #492 (c): the poller goroutine dies
+// with the cycle ctx (goleak catches a survivor).
+func TestTapeWiring_PollerStopsOnCtxCancel(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	cid := uuid.New()
+	store := newFakeConsentStore()
+	tp := tape.New(tape.Window, nil, nil)
+	defer tp.Close()
+	bus := voiceevent.NewBus()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	unsub := wireTapeConsent(ctx, bus, tp, cid, store, 5*time.Millisecond, discardLog())
+
+	// Let the poller run a few ticks, then cancel: the goroutine must exit.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	unsub()
+	// Give the goroutine a moment to observe ctx.Done before goleak inspects.
+	time.Sleep(20 * time.Millisecond)
+}
+
+// TestTapeWiring_PollerContinuesAfterError covers #492 (d): a reconcile error is
+// logged and the ticker keeps going — a later tick still converges the tape once the
+// store recovers.
+func TestTapeWiring_PollerContinuesAfterError(t *testing.T) {
+	cid := uuid.New()
+	base := newFakeConsentStore()
+	store := &errConsentStore{fakeConsentStore: base, fails: 2} // first two reads (incl the seed) error
+
+	tp := tape.New(tape.Window, nil, nil)
+	defer tp.Close()
+	bus := voiceevent.NewBus()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	unsub := wireTapeConsent(ctx, bus, tp, cid, store, 10*time.Millisecond, discardLog())
+	defer unsub()
+
+	base.set(cid, "111") // durable grant, but the next read(s) still error
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if laneCaptured(tp, "111", time.Now()) {
+			if store.readCount() < 3 {
+				t.Fatalf("converged after %d reads, want the ticker to have survived the errors", store.readCount())
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("poller did not recover and converge after the store errors")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestTapeConsentReconcileInterval covers the env knob (#492): a valid duration is
+// honored; blank/unparsable/non-positive falls back to the 5s default.
+func TestTapeConsentReconcileInterval(t *testing.T) {
+	cases := map[string]time.Duration{
+		"":       defaultTapeConsentReconcileInterval,
+		"bogus":  defaultTapeConsentReconcileInterval,
+		"0s":     defaultTapeConsentReconcileInterval,
+		"-3s":    defaultTapeConsentReconcileInterval,
+		"250ms":  250 * time.Millisecond,
+		"  10s ": 10 * time.Second,
+	}
+	for in, want := range cases {
+		got := tapeConsentReconcileInterval(func(string) string { return in })
+		if got != want {
+			t.Errorf("tapeConsentReconcileInterval(%q) = %s, want %s", in, got, want)
+		}
 	}
 }
 

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -322,6 +322,15 @@ type Config struct {
 	// consent-button listener (all mode's presence owns its own). Set by RunFromDB
 	// alongside Tape; nil when the campaign is not armed.
 	TapeConsent TapeConsentStore
+	// TapeConsentReconcileInterval is how often the per-cycle consent poller re-reads
+	// the durable tape_consent rows (#492): a consent button is dispatched by the
+	// elected presence OWNER, which publishes TapeConsentChanged on ITS OWN process
+	// bus — but in the fleet the tape may run on a DIFFERENT pod (a claim-plane
+	// worker) whose bus never sees that event. The poller closes that cross-pod gap
+	// so a grant/revoke converges on the tape within one interval, bounding staleness.
+	// Read from GLYPHOXA_TAPE_CONSENT_RECONCILE_INTERVAL by RunFromDB; <=0 takes the
+	// 5s default. Wired only when Tape is non-nil.
+	TapeConsentReconcileInterval time.Duration
 
 	// Highlights, when non-nil, is the Session Highlights trigger sink (#307/#308,
 	// ADR-0051): connectAndServe builds the moment detector ONLY when both Tape and

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -115,6 +115,11 @@ validate_path external-db \
 # needs none of the web OAuth credentials.
 validate_path web-disabled --set web.enabled=false
 
+# The voice-fleet render path (#492, ADR-0057): replicas > 1 arms the
+# PodDisruptionBudget alongside the Deployment, so a policy/v1 PDB must render and
+# schema-validate. Exercises the shared-voice-worker-pool branch end to end.
+validate_path voice-fleet --set voice.replicas=3
+
 # The Ingress render paths (#121 AC): enabled with an externally supplied TLS
 # Secret (cert-manager off) and enabled with the cert-manager cluster-issuer
 # path must each produce a schema-valid networking.k8s.io/v1 Ingress. Only a

--- a/scripts/k3d-fleet-check.sh
+++ b/scripts/k3d-fleet-check.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# k3d-fleet-check.sh — issue #492 (ADR-0057): MANUAL fleet check for the
+# multi-replica voice pool. NOT wired into CI: it needs a LIVE Discord bot token
+# and a human to type `/roll` and eyeball the reply, which an unattended runner
+# cannot supply (the same reason the voice channel-join and the full OAuth login
+# stay manual in scripts/e2e-deploy-smoke.sh). Run it by hand against a local k3d
+# cluster to convince yourself of the four things the unit/helm tests can only
+# prove in the small:
+#
+#   1. replicas=2 both reach Available (the shared pool boots N Voice Instances);
+#   2. `/roll` is handled EXACTLY ONCE with two replicas up (ADR-0057 (c): every
+#      gateway session on the shared token sees the interaction, but only the one
+#      elected presence owner dispatches it — the non-owner drops its duplicate);
+#   3. failover — kill the owner pod and a survivor wins the presence_owner
+#      election within ~20s (default expiry 15s + one renew interval), so the
+#      fleet keeps dispatching interactions with no operator action;
+#   4. the IDENTIFY budget guard (#486) holds under fleet cold-start: disgo
+#      serializes IDENTIFYs per client (max_concurrency 1, one per 5s), so two
+#      replicas booting on the shared token must NOT blow the 1000/24h budget —
+#      the glyphoxa_gateway_identify_total counters stay small and sane.
+#
+# The claim plane (#491) and presence-owner election (#492) are what make several
+# voice pods coexist on one central token; this script exercises the whole shape
+# end to end on a real cluster.
+#
+# Cluster lifecycle is the caller's (mirrors e2e-deploy-smoke.sh):
+#
+#   k3d cluster create gx-fleet
+#   docker build -t glyphoxa:fleet . && k3d image import glyphoxa:fleet -c gx-fleet
+#   DISCORD_BOT_TOKEN=... VOICE_GUILD=... VOICE_CHANNEL=... ./scripts/k3d-fleet-check.sh
+#   k3d cluster delete gx-fleet
+#
+# All knobs are env vars with defaults. A LIVE DISCORD_BOT_TOKEN is REQUIRED
+# (step 2/3 need the bot online to receive `/roll`); without it the script still
+# runs steps 1 and 4 but SKIPS the interaction and failover-dispatch checks with a
+# loud notice.
+set -euo pipefail
+
+RELEASE="${RELEASE:-glyphoxa-fleet}"
+NAMESPACE="${NAMESPACE:-glyphoxa-fleet}"
+CHART="${CHART:-deploy/charts/glyphoxa}"
+IMAGE_REPO="${IMAGE_REPO:-glyphoxa}"
+IMAGE_TAG="${IMAGE_TAG:-fleet}"
+REPLICAS="${REPLICAS:-2}"
+TIMEOUT="${TIMEOUT:-300s}"
+# How long to allow for a survivor to win the election after the owner is killed.
+# Default owner expiry is 15s (GLYPHOXA_PRESENCE_OWNER_EXPIRY) plus one 5s renew
+# interval, so ~20s is the worst case; give headroom for pod scheduling.
+FAILOVER_TIMEOUT="${FAILOVER_TIMEOUT:-45}"
+# Local port the per-pod /metrics listener is forwarded to for the IDENTIFY scrape.
+METRICS_LOCAL_PORT="${METRICS_LOCAL_PORT:-19091}"
+
+# Live Discord credentials for the interaction checks (steps 2 and 3). Optional:
+# absent, those steps are skipped with a notice.
+DISCORD_BOT_TOKEN="${DISCORD_BOT_TOKEN:-}"
+VOICE_GUILD="${VOICE_GUILD:-}"
+VOICE_CHANNEL="${VOICE_CHANNEL:-}"
+
+note() { printf '\n\033[1;36mk3d-fleet-check: %s\033[0m\n' "$*"; }
+warn() { printf '\n\033[1;33mk3d-fleet-check: %s\033[0m\n' "$*"; }
+fail() { printf '\n\033[1;31mk3d-fleet-check: %s\033[0m\n' "$*" >&2; exit 1; }
+
+command -v kubectl >/dev/null || fail "kubectl not found"
+command -v helm >/dev/null || fail "helm not found"
+
+# psql against the in-cluster Postgres (the migrate/seed hooks' DB). Reads the DSN
+# the chart wired into the app Secret, then runs the query inside the postgres pod.
+psql_query() {
+  local sql="$1"
+  kubectl -n "$NAMESPACE" exec deploy/"$RELEASE"-glyphoxa-postgres -- \
+    psql -qtAX -U glyphoxa -d glyphoxa -c "$sql"
+}
+
+# The elected presence owner's instance_id is the presence_owner singleton row;
+# its prefix is the owning pod's hostname (== pod name), so it maps a claim back
+# to a pod (newVoiceInstanceID: hostname-uuid8).
+current_owner_instance() { psql_query "SELECT instance_id FROM presence_owner;"; }
+
+install_release() {
+  note "installing $RELEASE with voice.replicas=$REPLICAS (image $IMAGE_REPO:$IMAGE_TAG)"
+  local args=(
+    --namespace "$NAMESPACE" --create-namespace
+    --set image.repository="$IMAGE_REPO" --set image.tag="$IMAGE_TAG"
+    --set voice.replicas="$REPLICAS"
+    # A voice-only fleet: the web tier is not needed for this check, and disabling
+    # it drops the OAuth-credential requirements.
+    --set web.enabled=false
+    --wait --timeout "$TIMEOUT"
+  )
+  if [[ -n "$DISCORD_BOT_TOKEN" ]]; then
+    [[ -n "$VOICE_GUILD" && -n "$VOICE_CHANNEL" ]] || fail "with DISCORD_BOT_TOKEN set, VOICE_GUILD and VOICE_CHANNEL are required"
+    args+=(--set-string discordBotToken="$DISCORD_BOT_TOKEN"
+           --set-string voice.guild="$VOICE_GUILD"
+           --set-string voice.channel="$VOICE_CHANNEL")
+  else
+    # No live token: a placeholder still lets the pods reach Available (#44
+    # resilience — /readyz pings the DB, not Discord), enough for steps 1 and 4.
+    args+=(--set-string discordBotToken=placeholder-fleet-token
+           --set-string voice.guild="111111111111111111"
+           --set-string voice.channel="222222222222222222")
+  fi
+  # The provider keys are `required` when voice.enabled; dummies suffice (no
+  # provider is called in this check).
+  args+=(--set-string elevenLabsApiKey=placeholder
+         --set-string geminiApiKey=placeholder
+         --set-string groqApiKey=placeholder)
+  helm upgrade --install "$RELEASE" "$CHART" "${args[@]}"
+}
+
+# --- Step 1: both replicas Available -----------------------------------------
+step_replicas_available() {
+  note "step 1: waiting for $REPLICAS voice replicas to be Available"
+  kubectl -n "$NAMESPACE" rollout status deploy/"$RELEASE"-glyphoxa-voice --timeout "$TIMEOUT"
+  local ready
+  ready=$(kubectl -n "$NAMESPACE" get deploy/"$RELEASE"-glyphoxa-voice -o jsonpath='{.status.readyReplicas}')
+  [[ "$ready" == "$REPLICAS" ]] || fail "step 1: readyReplicas=$ready, want $REPLICAS"
+  note "step 1 OK: $ready/$REPLICAS voice pods Ready"
+}
+
+# --- Step 4: IDENTIFY counters sane under cold-start -------------------------
+# Scrapes each voice pod's /metrics and sums glyphoxa_gateway_identify_total. With
+# two pods cold-starting on the shared token the total must be small (a handful),
+# never a budget-threatening burst — disgo's max_concurrency 1 serializes the
+# IDENTIFYs one per 5s per token (#486, ADR-0057 P5). RESUME is free; a churny
+# reconnect shows up in glyphoxa_gateway_resume_total, not identify.
+step_identify_budget() {
+  note "step 4: scraping IDENTIFY counters across the fleet (budget guard, #486)"
+  local pods total=0
+  pods=$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=voice -o name)
+  [[ -n "$pods" ]] || fail "step 4: no voice pods found"
+  for pod in $pods; do
+    kubectl -n "$NAMESPACE" port-forward "$pod" "${METRICS_LOCAL_PORT}:9090" >/dev/null 2>&1 &
+    local pf=$!
+    sleep 2
+    local n
+    n=$(curl -fsS "http://127.0.0.1:${METRICS_LOCAL_PORT}/metrics" 2>/dev/null \
+          | awk '/^glyphoxa_gateway_identify_total/ { s += $NF } END { printf "%d", s }') || n=0
+    kill "$pf" >/dev/null 2>&1 || true
+    wait "$pf" 2>/dev/null || true
+    note "  $pod: identify_total=$n"
+    total=$((total + n))
+  done
+  # A sane cold-start is a few IDENTIFYs per pod. Flag a blowout (an obvious
+  # threshold well under the 1000/24h budget) so a serialization regression is
+  # caught even without live traffic.
+  note "step 4: fleet identify_total=$total"
+  if (( total > 50 )); then
+    fail "step 4: identify_total=$total looks like a budget blowout — is IDENTIFY serialization (#486) intact?"
+  fi
+  note "step 4 OK: IDENTIFY budget guard holds under cold-start"
+}
+
+# --- Step 3: failover — kill owner, survivor re-elected ----------------------
+step_failover() {
+  note "step 3: presence-owner failover"
+  local owner_instance owner_pod
+  owner_instance=$(current_owner_instance)
+  [[ -n "$owner_instance" ]] || fail "step 3: no presence_owner row — did an owner ever get elected? (needs a live token)"
+  # instance_id is <pod-name>-<uuid8>; strip the uuid8 suffix to get the pod name.
+  owner_pod="${owner_instance%-*}"
+  note "step 3: current owner instance=$owner_instance (pod $owner_pod)"
+  note "step 3: deleting the owner pod"
+  kubectl -n "$NAMESPACE" delete pod "$owner_pod" --wait=false
+
+  local deadline=$(( SECONDS + FAILOVER_TIMEOUT )) new_owner=""
+  while (( SECONDS < deadline )); do
+    new_owner=$(current_owner_instance || true)
+    if [[ -n "$new_owner" && "$new_owner" != "$owner_instance" ]]; then
+      note "step 3 OK: survivor elected new owner=$new_owner within $(( SECONDS - (deadline - FAILOVER_TIMEOUT) ))s"
+      return
+    fi
+    sleep 2
+  done
+  fail "step 3: no new owner elected within ${FAILOVER_TIMEOUT}s (still $new_owner)"
+}
+
+# --- Step 2: /roll handled exactly once (human in the loop) ------------------
+step_roll_once() {
+  note "step 2: exactly-once /roll (MANUAL — needs you at a Discord client)"
+  cat <<'EOF'
+  With BOTH voice replicas up and one elected presence owner:
+    1. In the configured guild, run  /roll 1d20  (or any /roll).
+    2. You must see EXACTLY ONE reply. Two replies = the SetActive gate failed and
+       both replicas dispatched (ADR-0057 (c) regression). Zero replies = the
+       owner is not registering commands (election or client-registry problem).
+    3. Cross-check the logs: exactly one pod should log the dispatch. Run:
+         kubectl -n NAMESPACE logs -l app.kubernetes.io/component=voice \
+           --prefix --tail=200 | grep -i 'slash command'
+       and confirm a single pod handled it.
+EOF
+  warn "step 2 is a human observation; the script cannot type /roll for you"
+}
+
+install_release
+step_replicas_available
+step_identify_budget
+if [[ -n "$DISCORD_BOT_TOKEN" ]]; then
+  step_roll_once
+  step_failover
+else
+  warn "DISCORD_BOT_TOKEN unset: skipping step 2 (/roll) and step 3 (failover dispatch) — set it plus VOICE_GUILD/VOICE_CHANNEL to run them"
+fi
+
+note "done. Tear the release down with: helm -n $NAMESPACE uninstall $RELEASE"

--- a/scripts/k3d-fleet-check.sh
+++ b/scripts/k3d-fleet-check.sh
@@ -7,7 +7,9 @@
 # cluster to convince yourself of the four things the unit/helm tests can only
 # prove in the small:
 #
-#   1. replicas=2 both reach Available (the shared pool boots N Voice Instances);
+#   1. replicas=2 both reach Available AS CLAIM-PLANE WORKERS (the pods run
+#      `glyphoxa -mode voice` with NO -guild/-channel — the shared pool takes each
+#      session's target from the Tenant's saved config, #491);
 #   2. `/roll` is handled EXACTLY ONCE with two replicas up (ADR-0057 (c): every
 #      gateway session on the shared token sees the interaction, but only the one
 #      elected presence owner dispatches it — the non-owner drops its duplicate);
@@ -19,6 +21,13 @@
 #      replicas booting on the shared token must NOT blow the 1000/24h budget —
 #      the glyphoxa_gateway_identify_total counters stay small and sane.
 #
+# WORKER TOPOLOGY, not standalone: `glyphoxa -mode voice` boots as the claim-plane
+# worker (with the OwnerElector) ONLY when BOTH -guild and -channel are unset
+# (main.go); setting either flips it to the LEGACY STANDALONE node, which has no
+# elector and no presence_owner row. So this script leaves voice.guild/voice.channel
+# EMPTY. The elector electing an owner (a presence_owner row appearing) is itself
+# part of what step 3 verifies.
+#
 # The claim plane (#491) and presence-owner election (#492) are what make several
 # voice pods coexist on one central token; this script exercises the whole shape
 # end to end on a real cluster.
@@ -27,13 +36,13 @@
 #
 #   k3d cluster create gx-fleet
 #   docker build -t glyphoxa:fleet . && k3d image import glyphoxa:fleet -c gx-fleet
-#   DISCORD_BOT_TOKEN=... VOICE_GUILD=... VOICE_CHANNEL=... ./scripts/k3d-fleet-check.sh
+#   DISCORD_BOT_TOKEN=... ./scripts/k3d-fleet-check.sh
 #   k3d cluster delete gx-fleet
 #
-# All knobs are env vars with defaults. A LIVE DISCORD_BOT_TOKEN is REQUIRED
-# (step 2/3 need the bot online to receive `/roll`); without it the script still
-# runs steps 1 and 4 but SKIPS the interaction and failover-dispatch checks with a
-# loud notice.
+# All knobs are env vars with defaults. A LIVE DISCORD_BOT_TOKEN is REQUIRED for
+# steps 2 and 3 (the bot must be online to receive `/roll` and to elect an owner);
+# without it the script still runs steps 1 and 4 but SKIPS the interaction and
+# failover checks with a loud notice.
 set -euo pipefail
 
 RELEASE="${RELEASE:-glyphoxa-fleet}"
@@ -50,11 +59,16 @@ FAILOVER_TIMEOUT="${FAILOVER_TIMEOUT:-45}"
 # Local port the per-pod /metrics listener is forwarded to for the IDENTIFY scrape.
 METRICS_LOCAL_PORT="${METRICS_LOCAL_PORT:-19091}"
 
-# Live Discord credentials for the interaction checks (steps 2 and 3). Optional:
-# absent, those steps are skipped with a notice.
+# Resource names. The chart's fullname == RELEASE when RELEASE contains the chart
+# name "glyphoxa" (the default does); the StatefulSet/Deployment suffixes mirror
+# scripts/e2e-deploy-smoke.sh.
+PG="${RELEASE}-postgres"     # Postgres StatefulSet
+VOICE="${RELEASE}-voice"     # voice Deployment
+
+# Live Discord credentials for the interaction/election checks (steps 2 and 3).
+# Optional: absent, those steps are skipped with a notice. NOTE: no VOICE_GUILD/
+# VOICE_CHANNEL — worker mode requires them UNSET (see the header).
 DISCORD_BOT_TOKEN="${DISCORD_BOT_TOKEN:-}"
-VOICE_GUILD="${VOICE_GUILD:-}"
-VOICE_CHANNEL="${VOICE_CHANNEL:-}"
 
 note() { printf '\n\033[1;36mk3d-fleet-check: %s\033[0m\n' "$*"; }
 warn() { printf '\n\033[1;33mk3d-fleet-check: %s\033[0m\n' "$*"; }
@@ -63,58 +77,68 @@ fail() { printf '\n\033[1;31mk3d-fleet-check: %s\033[0m\n' "$*" >&2; exit 1; }
 command -v kubectl >/dev/null || fail "kubectl not found"
 command -v helm >/dev/null || fail "helm not found"
 
-# psql against the in-cluster Postgres (the migrate/seed hooks' DB). Reads the DSN
-# the chart wired into the app Secret, then runs the query inside the postgres pod.
+# psql against the in-cluster Postgres. Postgres is a StatefulSet (not a Deployment),
+# so exec into statefulset/<pg> (mirrors e2e-deploy-smoke.sh's statefulset/ handle).
 psql_query() {
   local sql="$1"
-  kubectl -n "$NAMESPACE" exec deploy/"$RELEASE"-glyphoxa-postgres -- \
+  kubectl -n "$NAMESPACE" exec "statefulset/${PG}" -- \
     psql -qtAX -U glyphoxa -d glyphoxa -c "$sql"
 }
 
-# The elected presence owner's instance_id is the presence_owner singleton row;
-# its prefix is the owning pod's hostname (== pod name), so it maps a claim back
-# to a pod (newVoiceInstanceID: hostname-uuid8).
+# The elected presence owner's instance_id is the presence_owner singleton row; its
+# prefix is the owning pod's hostname (== pod name), so it maps a claim back to a pod
+# (newVoiceInstanceID: hostname-uuid8).
 current_owner_instance() { psql_query "SELECT instance_id FROM presence_owner;"; }
 
 install_release() {
-  note "installing $RELEASE with voice.replicas=$REPLICAS (image $IMAGE_REPO:$IMAGE_TAG)"
+  note "installing $RELEASE with voice.replicas=$REPLICAS (image $IMAGE_REPO:$IMAGE_TAG), voice-only WORKER mode"
+  # A dummy 32-byte base64 app secret: voice pods now MOUNT GLYPHOXA_SECRET (#492,
+  # ADR-0057 (d)) so the chart requires appSecret even with the web tier off. No real
+  # BYOK decryption happens in this check.
+  local app_secret
+  app_secret="$(head -c 32 /dev/zero | base64)"
   local args=(
     --namespace "$NAMESPACE" --create-namespace
     --set image.repository="$IMAGE_REPO" --set image.tag="$IMAGE_TAG"
     --set voice.replicas="$REPLICAS"
-    # A voice-only fleet: the web tier is not needed for this check, and disabling
-    # it drops the OAuth-credential requirements.
+    # Voice-only fleet: web off drops the OAuth-credential requirements.
     --set web.enabled=false
+    # WORKER MODE: guild/channel stay EMPTY so the pods run the claim-plane worker
+    # with the OwnerElector, NOT the legacy standalone node (see the header).
+    --set-string voice.guild=""
+    --set-string voice.channel=""
+    --set-string appSecret="$app_secret"
     --wait --timeout "$TIMEOUT"
   )
+  # The bot token (required by the chart) plus dummy provider keys (no provider is
+  # called here). A live token lets the pods actually open the gateway and elect an
+  # owner; a placeholder still boots them to Ready (#44 resilience — /readyz pings the
+  # DB, not Discord) for steps 1 and 4.
   if [[ -n "$DISCORD_BOT_TOKEN" ]]; then
-    [[ -n "$VOICE_GUILD" && -n "$VOICE_CHANNEL" ]] || fail "with DISCORD_BOT_TOKEN set, VOICE_GUILD and VOICE_CHANNEL are required"
-    args+=(--set-string discordBotToken="$DISCORD_BOT_TOKEN"
-           --set-string voice.guild="$VOICE_GUILD"
-           --set-string voice.channel="$VOICE_CHANNEL")
+    args+=(--set-string discordBotToken="$DISCORD_BOT_TOKEN")
   else
-    # No live token: a placeholder still lets the pods reach Available (#44
-    # resilience — /readyz pings the DB, not Discord), enough for steps 1 and 4.
-    args+=(--set-string discordBotToken=placeholder-fleet-token
-           --set-string voice.guild="111111111111111111"
-           --set-string voice.channel="222222222222222222")
+    args+=(--set-string discordBotToken=placeholder-fleet-token)
   fi
-  # The provider keys are `required` when voice.enabled; dummies suffice (no
-  # provider is called in this check).
   args+=(--set-string elevenLabsApiKey=placeholder
          --set-string geminiApiKey=placeholder
          --set-string groqApiKey=placeholder)
   helm upgrade --install "$RELEASE" "$CHART" "${args[@]}"
 }
 
-# --- Step 1: both replicas Available -----------------------------------------
+# --- Step 1: both replicas Available as workers -------------------------------
 step_replicas_available() {
-  note "step 1: waiting for $REPLICAS voice replicas to be Available"
-  kubectl -n "$NAMESPACE" rollout status deploy/"$RELEASE"-glyphoxa-voice --timeout "$TIMEOUT"
+  note "step 1: waiting for $REPLICAS voice replicas (claim-plane workers) to be Available"
+  kubectl -n "$NAMESPACE" rollout status "deployment/${VOICE}" --timeout "$TIMEOUT"
   local ready
-  ready=$(kubectl -n "$NAMESPACE" get deploy/"$RELEASE"-glyphoxa-voice -o jsonpath='{.status.readyReplicas}')
+  ready=$(kubectl -n "$NAMESPACE" get "deployment/${VOICE}" -o jsonpath='{.status.readyReplicas}')
   [[ "$ready" == "$REPLICAS" ]] || fail "step 1: readyReplicas=$ready, want $REPLICAS"
-  note "step 1 OK: $ready/$REPLICAS voice pods Ready"
+  # Confirm the pods really are workers (no -guild/-channel in the arg vector).
+  local args
+  args=$(kubectl -n "$NAMESPACE" get "deployment/${VOICE}" -o jsonpath='{.spec.template.spec.containers[0].args}')
+  if grep -q -- '-guild' <<<"$args"; then
+    fail "step 1: voice args carry -guild → pods run LEGACY STANDALONE, not workers: $args"
+  fi
+  note "step 1 OK: $ready/$REPLICAS worker pods Ready (no -guild/-channel)"
 }
 
 # --- Step 4: IDENTIFY counters sane under cold-start -------------------------
@@ -140,9 +164,6 @@ step_identify_budget() {
     note "  $pod: identify_total=$n"
     total=$((total + n))
   done
-  # A sane cold-start is a few IDENTIFYs per pod. Flag a blowout (an obvious
-  # threshold well under the 1000/24h budget) so a serialization regression is
-  # caught even without live traffic.
   note "step 4: fleet identify_total=$total"
   if (( total > 50 )); then
     fail "step 4: identify_total=$total looks like a budget blowout — is IDENTIFY serialization (#486) intact?"
@@ -153,20 +174,28 @@ step_identify_budget() {
 # --- Step 3: failover — kill owner, survivor re-elected ----------------------
 step_failover() {
   note "step 3: presence-owner failover"
-  local owner_instance owner_pod
-  owner_instance=$(current_owner_instance)
-  [[ -n "$owner_instance" ]] || fail "step 3: no presence_owner row — did an owner ever get elected? (needs a live token)"
+  # An elected owner presupposes the pods opened the gateway — only a LIVE token does
+  # that. Wait for the row to appear (the elector's first successful acquire).
+  local owner_instance owner_pod deadline
+  deadline=$(( SECONDS + FAILOVER_TIMEOUT ))
+  while (( SECONDS < deadline )); do
+    owner_instance=$(current_owner_instance || true)
+    [[ -n "$owner_instance" ]] && break
+    sleep 2
+  done
+  [[ -n "$owner_instance" ]] || fail "step 3: no presence_owner row appeared — did an owner get elected? (needs a live token so the gateway opens)"
   # instance_id is <pod-name>-<uuid8>; strip the uuid8 suffix to get the pod name.
   owner_pod="${owner_instance%-*}"
   note "step 3: current owner instance=$owner_instance (pod $owner_pod)"
   note "step 3: deleting the owner pod"
   kubectl -n "$NAMESPACE" delete pod "$owner_pod" --wait=false
 
-  local deadline=$(( SECONDS + FAILOVER_TIMEOUT )) new_owner=""
+  deadline=$(( SECONDS + FAILOVER_TIMEOUT ))
+  local new_owner=""
   while (( SECONDS < deadline )); do
     new_owner=$(current_owner_instance || true)
     if [[ -n "$new_owner" && "$new_owner" != "$owner_instance" ]]; then
-      note "step 3 OK: survivor elected new owner=$new_owner within $(( SECONDS - (deadline - FAILOVER_TIMEOUT) ))s"
+      note "step 3 OK: survivor elected new owner=$new_owner (was $owner_instance)"
       return
     fi
     sleep 2
@@ -177,14 +206,14 @@ step_failover() {
 # --- Step 2: /roll handled exactly once (human in the loop) ------------------
 step_roll_once() {
   note "step 2: exactly-once /roll (MANUAL — needs you at a Discord client)"
-  cat <<'EOF'
-  With BOTH voice replicas up and one elected presence owner:
-    1. In the configured guild, run  /roll 1d20  (or any /roll).
+  cat <<EOF
+  With BOTH voice worker replicas up and one elected presence owner:
+    1. In a guild the bot is in, run  /roll 1d20  (or any /roll).
     2. You must see EXACTLY ONE reply. Two replies = the SetActive gate failed and
        both replicas dispatched (ADR-0057 (c) regression). Zero replies = the
        owner is not registering commands (election or client-registry problem).
     3. Cross-check the logs: exactly one pod should log the dispatch. Run:
-         kubectl -n NAMESPACE logs -l app.kubernetes.io/component=voice \
+         kubectl -n ${NAMESPACE} logs -l app.kubernetes.io/component=voice \\
            --prefix --tail=200 | grep -i 'slash command'
        and confirm a single pod handled it.
 EOF
@@ -198,7 +227,7 @@ if [[ -n "$DISCORD_BOT_TOKEN" ]]; then
   step_roll_once
   step_failover
 else
-  warn "DISCORD_BOT_TOKEN unset: skipping step 2 (/roll) and step 3 (failover dispatch) — set it plus VOICE_GUILD/VOICE_CHANNEL to run them"
+  warn "DISCORD_BOT_TOKEN unset: skipping step 2 (/roll) and step 3 (failover) — set it to run them (guild/channel MUST stay unset for worker mode)"
 fi
 
 note "done. Tear the release down with: helm -n $NAMESPACE uninstall $RELEASE"


### PR DESCRIPTION
Closes #492. Final slice of epic #483: the shared voice-worker pool now scales to N replicas on the central token.

## What lands (ADR-0057)

**Presence-owner election (interaction dispatch).** Every gateway session on a shared central token receives every `INTERACTION_CREATE` (P5), so N Voice Instances would each handle the same `/roll`. A singleton `presence_owner` claim row (migration `00036`) elects exactly one Instance; `Registry.SetActive` atomically gates `HandleCommand`/`HandleAutocomplete`/`HandleComponent` so a non-owner drops its duplicates. `OwnerElector` renews the claim on a ticker, flips the Registry on ownership transitions, and Releases on drain.

- `AcquireOrRenewPresenceOwner` / `ReleasePresenceOwner` — single-upsert win on self-or-expired; fenced Release for clean handover.
- `-mode all` + legacy standalone default active (their own single owner); the `-mode voice` worker boots inactive and lets the elector flip it (replaces #491's interim always-active).

**Drain order (ADR-0006/0057).** `stop claiming → Manager.Shutdown (Finish rows) → elector Release → close clients`, extracted into a unit-tested `drainVoiceWorker` so the release-after-finish ordering is pinned. `voice.terminationGracePeriodSeconds` (300) sizes it for a DAVE/MLS wind-down.

**Helm.** `voice.replicas` a real tunable (default 1); `RollingUpdate{maxSurge:1,maxUnavailable:0}` (claim plane makes overlap safe); `voice-pdb.yaml` armed only when replicas > 1; the voice pod now **mounts `GLYPHOXA_SECRET`** to decrypt BYOK tenant tokens — the mounted-secret arm of the ADR-0057 (d) knob, resolved on this issue.

**Duplicate-event tolerance + IDENTIFY guard.** A worker with no connection for a guild ignores that guild's voice events (P6) — no code needed. IDENTIFY serialization is disgo's per-client `max_concurrency` 1 (#486) — no code needed; the k3d script scrapes the counters.

## AC mapping
- Presence-owner election + failover + exactly-once: storage + elector + Registry tests.
- Helm replicas > 1 + drain grace + PDB: helm-unittest (`voice_deployment_test.yaml`, `voice_pdb_test.yaml`).
- Secret posture documented + implemented: template flip + `2026-07-20-voice-fleet-rollout.md`.
- Duplicate-event tolerance: `TestExactlyOnceAcrossTwoRegistries` + P6 (inert voice events).
- IDENTIFY cold-start: `scripts/k3d-fleet-check.sh` observes `glyphoxa_gateway_identify_total`.

Also folds in three #491-review residuals: `/glyphoxa start` maps `ErrIntentPending`/`ErrIntentCancelled` and `/glyphoxa end` maps `ErrStopPending` to clear retryable messages.

## Tests (per architect sequence 1–8)
storage election/failover · Registry SetActive gate · cross-registry exactly-once · elector gain/loss/release/error · drain order · helm replicas/PDB/grace/secret/RollingUpdate · manual k3d script (documented).

## Local gates
`go build`/`vet`/`gofmt` clean · `go test -race ./...` green · `go test -race -tags=integration -timeout 20m ./internal/storage ./internal/session` green (storage 1010s) · `cmd/glyphoxa` integration green · helm-unittest 159 pass · helm-validate OK (incl. new voice-fleet path) · golangci-lint 0 issues.

`scripts/k3d-fleet-check.sh` is deliberately **not** in CI (needs a live Discord token + human `/roll`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
