### PR TITLE
fix(#505): heartbeat during voice-session wind-down (no mid-drain reap)

### DIFF
--- a/docs/devs/2026-07-20-voice-fleet-rollout.md
+++ b/docs/devs/2026-07-20-voice-fleet-rollout.md
@@ -99,12 +99,19 @@ is sized to cover a DAVE/MLS wind-down before SIGKILL.
 
 ### Known windows (documented, accepted)
 
-- **Heartbeat during drain (#505).** A draining worker stops heartbeating while it
-  winds its sessions down; a drain longer than `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY`
-  (30s default) lets another worker's reaper mark the still-draining intent
-  `dead` mid-drain (its final finish then lands superseded, harmless but the
-  history reads `dead` instead of `done`). Tracked in #505; keep the expiry above
-  the realistic wind-down or accept the mislabel.
+- **Heartbeat during drain — CLOSED by #505.** A draining worker now keeps
+  heartbeating while it winds its sessions down: `endSession` runs a drain-beat
+  goroutine (every `GLYPHOXA_VOICE_HEARTBEAT_INTERVAL`, on detached bounded
+  ctxs) for the whole `Manager.Stop` window, on BOTH the SIGTERM drain and the
+  stop_requested wind-down, so a clean drain within budget is never reaped
+  `dead` and reconcile cannot race an in-flight CloseVoiceSession (the intent
+  stays non-terminal until the close landed). Residual: a sustained DB outage
+  spanning multiple missed beats past `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` still
+  reaps mid-drain — the drain-beat goroutine then stops stamping (ADR-0006:
+  never re-claim), the wind-down completes, the superseded finish is swallowed,
+  and the history reads `dead`. Accepted: that now requires an outage, not
+  merely a slow finalizer. `voice.terminationGracePeriodSeconds` (300) still
+  bounds the worst-case wind-down and stays above every finalizer budget.
 - **Reaped-but-alive overlap.** A worker that is merely SLOW (not dead) can be
   reaped: it learns of the supersede only on its next heartbeat (ErrNotFound) and
   then kills its local session — until that beat, its gateway/voice connection

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -322,12 +322,61 @@ func (l *ClaimLoop) finishSelfExit(intent storage.VoiceSessionIntent) {
 
 // endSession stops the Manager's session for the tenant (blocking until its loop
 // ends and the voice_sessions row lands) and finishes the intent, both on a
-// detached ctx so a cancelled run ctx cannot abort the clean wind-down.
+// detached ctx so a cancelled run ctx cannot abort the clean wind-down. While
+// Stop blocks — finalizers + CloseVoiceSession can take several seconds — a
+// drain heartbeat keeps the claim fresh (#505): winding down is ALIVE, and
+// without it a clean drain inside the budget could cross Expiry unheartbeated
+// and be reaped 'dead' mid-drain. Beats end BEFORE the finish (stopBeat waits
+// out the goroutine), so no beat is ever ordered after the terminal write.
 func (l *ClaimLoop) endSession(tenant uuid.UUID, intentID uuid.UUID, status storage.VoiceSessionIntentStatus, lastError string) {
+	stopBeat := l.startDrainHeartbeat(intentID)
 	if _, err := l.mgr.Stop(l.detached(), tenant); err != nil && !errors.Is(err, ErrNoActiveSession) {
 		l.log.Warn("claim loop: stop session", "intent", intentID, "err", err)
 	}
+	stopBeat()
 	l.finish(intentID, status, lastError)
+}
+
+// startDrainHeartbeat keeps intentID's heartbeat fresh while endSession blocks
+// in Manager.Stop (#505): it beats every cfg.Heartbeat on detached bounded ctxs
+// (the run ctx may already be cancelled — SIGTERM — and one beat may never eat
+// more than dbOpTimeout(Heartbeat)). ErrNotFound means the claim was reaped
+// anyway (a multi-beat DB outage crossed Expiry): log and stop beating — the
+// wind-down itself continues, and this goroutine NEVER calls mgr.Stop (the
+// session is already stopping; ADR-0006: superseded-mid-drain means stop
+// stamping and let the wind-down finish, never re-claim). stop_requested is
+// ignored — the session is already ending. The returned func cancels the
+// goroutine and waits for it to exit.
+func (l *ClaimLoop) startDrainHeartbeat(intentID uuid.UUID) (stop func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(l.cfg.Heartbeat)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				hbCtx, cancelHB := context.WithTimeout(context.Background(), dbOpTimeout(l.cfg.Heartbeat))
+				_, err := l.store.HeartbeatVoiceSessionIntent(hbCtx, intentID, l.instanceID)
+				cancelHB()
+				if errors.Is(err, storage.ErrNotFound) {
+					l.log.Warn("claim loop: drain heartbeat superseded (claim reaped); letting wind-down finish",
+						"intent", intentID)
+					return
+				}
+				if err != nil {
+					l.log.Warn("claim loop: drain heartbeat", "intent", intentID, "err", err)
+				}
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 // finish writes the intent's terminal state on a detached, bounded ctx. A

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -148,11 +148,23 @@ func (f *fakeIntentStore) FinishVoiceSessionIntent(_ context.Context, id uuid.UU
 	return *i, nil
 }
 
-func (f *fakeIntentStore) ReapDeadVoiceSessionIntents(_ context.Context, _ time.Duration) (int64, error) {
+// ReapDeadVoiceSessionIntents models the real reaper (#505): a claimed/live row
+// whose heartbeat is staler than expiry flips 'dead'. reapReturns is added to
+// the reported count (drives the reconcile-after-reap logging path).
+func (f *fakeIntentStore) ReapDeadVoiceSessionIntents(_ context.Context, expiry time.Duration) (int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.reaped++
-	return f.reapReturns, nil
+	var n int64
+	now := time.Now()
+	for _, i := range f.intents {
+		if (i.Status == storage.VoiceIntentClaimed || i.Status == storage.VoiceIntentLive) &&
+			i.HeartbeatAt != nil && now.Sub(*i.HeartbeatAt) > expiry {
+			i.Status = storage.VoiceIntentDead
+			n++
+		}
+	}
+	return n + f.reapReturns, nil
 }
 
 func (f *fakeIntentStore) ReconcileWorkerOrphanedVoiceSessions(_ context.Context) (int64, error) {
@@ -625,6 +637,67 @@ func TestClaimLoop_DrainHeartbeatSupersededStopsBeating(t *testing.T) {
 	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDead {
 		t.Fatalf("intent status = %q, want dead (superseded-mid-drain never resurrected)", got)
 	}
+}
+
+// TestClaimLoop_ReaperNeverKillsCleanDrain covers #505 AC1+AC2 against the REAL
+// reaper semantics (the fake reaps rows with heartbeats staler than Expiry): a
+// clean wind-down that is SLOWER than Expiry (gate held >> Expiry) but keeps
+// drain-beating is never marked 'dead' by concurrent reap/reconcile ticks — the
+// intent stays live (non-terminal) the whole time CloseVoiceSession is
+// in-flight, so neither ReconcileWorkerOrphanedVoiceSessions arm (both require
+// a terminal/absent intent) can race the Close; then it finishes 'done'.
+func TestClaimLoop_ReaperNeverKillsCleanDrain(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	// Scaled intervals: drain beats every 2ms, Expiry 20ms, gate held ~100ms —
+	// several Expiry windows pass while the wind-down is in-flight.
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: 2 * time.Millisecond, Expiry: 20 * time.Millisecond})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// Enter the drain and park on the gate; meanwhile keep reap+reconcile ticks
+	// running concurrently (another worker's reaper never sleeps).
+	istore.requestStop(intent.ID)
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+	reapStop := make(chan struct{})
+	reapDone := make(chan struct{})
+	go func() {
+		defer close(reapDone)
+		for {
+			select {
+			case <-reapStop:
+				return
+			default:
+				loop.TickForTest(context.Background())
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Hold the drain open for ~5x Expiry: the intent must stay live throughout —
+	// never 'dead' (AC1), never terminal while Close is in-flight (AC2).
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := istore.get(intent.ID).Status; got != storage.VoiceIntentLive {
+			t.Fatalf("intent status = %q mid-drain under a live reaper, want live", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(closeGate)
+	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
+	close(reapStop)
+	<-reapDone
+	loop.DrainForTest()
 }
 
 // TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -584,6 +584,49 @@ func TestClaimLoop_DrainHeartbeatDuringStopRequested(t *testing.T) {
 	loop.DrainForTest()
 }
 
+// TestClaimLoop_DrainHeartbeatSupersededStopsBeating covers #505's reaped-anyway
+// arm (ADR-0006 superseded-mid-drain): if the claim is reaped DURING the drain
+// (a multi-beat DB outage crossed Expiry), the drain-beat goroutine stops
+// stamping — it never re-claims and never calls mgr.Stop again — while the
+// wind-down itself completes; the finish is fenced NotFound and swallowed, the
+// row stays 'dead', and the goroutine exits (DrainForTest returns — no leak).
+func TestClaimLoop_DrainHeartbeatSupersededStopsBeating(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// Enter the drain (stop_requested) and let it park on the close gate.
+	istore.requestStop(intent.ID)
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+
+	// The reaper wins mid-drain: the next drain beat NotFounds and stops beating.
+	istore.markDead(intent.ID)
+	waitFor(t, time.Second, func() bool {
+		before := istore.heartbeatCount()
+		time.Sleep(10 * time.Millisecond)
+		return istore.heartbeatCount() == before
+	})
+
+	// The wind-down still completes; the finish is swallowed (row stays 'dead')
+	// and every goroutine exits.
+	close(closeGate)
+	loop.DrainForTest()
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDead {
+		t.Fatalf("intent status = %q, want dead (superseded-mid-drain never resurrected)", got)
+	}
+}
+
 // TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the
 // Manager is at capacity (single-session default): a second pending intent is
 // left pending while the first runs.

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -548,6 +548,42 @@ func TestClaimLoop_DrainHeartbeatDuringSigterm(t *testing.T) {
 	}
 }
 
+// TestClaimLoop_DrainHeartbeatDuringStopRequested covers #505's second call
+// site: a stop_requested wind-down has the SAME unheartbeated window as the
+// SIGTERM drain (endSession blocks in Manager.Stop through the finalizers), so
+// beats must keep landing there too, and the intent finishes 'done' only after
+// the slow finalizer releases.
+func TestClaimLoop_DrainHeartbeatDuringStopRequested(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// stop_requested → runSession's ticker branch enters endSession →
+	// Manager.Stop parks on the close gate. Beats must continue.
+	istore.requestStop(intent.ID)
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+	before := istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return istore.heartbeatCount() > before+2 })
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentLive {
+		t.Fatalf("intent status = %q during the stop wind-down, want still live (heartbeating)", got)
+	}
+
+	close(closeGate)
+	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
+	loop.DrainForTest()
+}
+
 // TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the
 // Manager is at capacity (single-session default): a second pending intent is
 // left pending while the first runs.

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -25,8 +25,19 @@ type fakeIntentStore struct {
 	reapReturns int64 // how many rows ReapDead reports this tick (drives reconcile-after-reap)
 	reconciled  int   // ReconcileWorkerOrphanedVoiceSessions call count
 	heartbeats  int   // HeartbeatVoiceSessionIntent call count (#506 finalize-heartbeat test)
+	// timeline records the order of claim-plane calls ("hb" / "finish") with
+	// timestamps — the #505 drain-heartbeat tests assert beats keep landing
+	// through a slow wind-down and that no beat is ordered after the finish.
+	timeline []timelineEvent
 	// sessionOutcome scripts GetVoiceSession — the self-exit outcome read (#483 L4).
 	sessionOutcome func(uuid.UUID) (storage.VoiceSession, error)
+}
+
+// timelineEvent is one recorded claim-plane call: kind "hb" (heartbeat) or
+// "finish", stamped when the call landed.
+type timelineEvent struct {
+	kind string
+	at   time.Time
 }
 
 func newFakeIntentStore() *fakeIntentStore {
@@ -104,6 +115,7 @@ func (f *fakeIntentStore) HeartbeatVoiceSessionIntent(_ context.Context, id uuid
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.heartbeats++
+	f.timeline = append(f.timeline, timelineEvent{kind: "hb", at: time.Now()})
 	i, ok := f.intents[id]
 	if !ok || i.InstanceID != instanceID ||
 		(i.Status != storage.VoiceIntentClaimed && i.Status != storage.VoiceIntentLive) {
@@ -123,6 +135,7 @@ func (f *fakeIntentStore) heartbeatCount() int {
 func (f *fakeIntentStore) FinishVoiceSessionIntent(_ context.Context, id uuid.UUID, instanceID string, status storage.VoiceSessionIntentStatus, lastError string) (storage.VoiceSessionIntent, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.timeline = append(f.timeline, timelineEvent{kind: "finish", at: time.Now()})
 	i, ok := f.intents[id]
 	if !ok || i.InstanceID != instanceID ||
 		(i.Status != storage.VoiceIntentClaimed && i.Status != storage.VoiceIntentLive) {
@@ -159,6 +172,12 @@ func (f *fakeIntentStore) GetVoiceSession(_ context.Context, id uuid.UUID) (stor
 		return storage.VoiceSession{}, storage.ErrNotFound
 	}
 	return hook(id)
+}
+
+func (f *fakeIntentStore) timelineCopy() []timelineEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]timelineEvent(nil), f.timeline...)
 }
 
 func (f *fakeIntentStore) reconcileCount() int {
@@ -478,6 +497,55 @@ func TestClaimLoop_HeartbeatsThroughSlowFinalize(t *testing.T) {
 	close(closeGate)
 	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
 	loop.DrainForTest()
+}
+
+// TestClaimLoop_DrainHeartbeatDuringSigterm covers #505 AC1/AC3: a SIGTERM drain
+// whose CloseVoiceSession runs slowly (the slow-finalizer window, parked on the
+// gate) must KEEP heartbeating while endSession blocks in Manager.Stop — before
+// #505 the drain window (up to the Manager's end budgets) went unheartbeated, so
+// a clean wind-down could cross Expiry and be reaped 'dead' mid-drain. Assert
+// beats keep landing during the Stop window, the intent stays live (not
+// terminal) until the finalizer releases, and only THEN finishes 'done'.
+func TestClaimLoop_DrainHeartbeatDuringSigterm(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate // parks CloseVoiceSession → the slow wind-down
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { loop.Run(ctx); close(done) }()
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// SIGTERM: runSession's ctx.Done branch enters endSession → Manager.Stop
+	// parks on the close gate. Beats must continue through that window.
+	cancel()
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+	before := istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return istore.heartbeatCount() > before+2 })
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentLive {
+		t.Fatalf("intent status = %q during the drain window, want still live (heartbeating)", got)
+	}
+
+	// Release the slow finalizer: the wind-down completes and the intent
+	// finishes 'done' — a clean drain within budget is never 'dead'.
+	close(closeGate)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not drain after the finalizer released")
+	}
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDone {
+		t.Fatalf("intent status after drain = %q, want done", got)
+	}
 }
 
 // TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -700,6 +700,53 @@ func TestClaimLoop_ReaperNeverKillsCleanDrain(t *testing.T) {
 	loop.DrainForTest()
 }
 
+// TestClaimLoop_DrainBeatsEndBeforeFinish covers #505's ordering contract:
+// endSession waits the drain-beat goroutine out (stopBeat) BEFORE writing the
+// terminal state, so the recorded call timeline never shows a heartbeat ordered
+// after the finish — a late stray beat would be fenced NotFound on a real
+// store, but the loop must not rely on that fence.
+func TestClaimLoop_DrainBeatsEndBeforeFinish(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	istore.requestStop(intent.ID)
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+	before := istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return istore.heartbeatCount() > before+2 })
+	close(closeGate)
+	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
+	loop.DrainForTest()
+
+	events := istore.timelineCopy()
+	finishAt := -1
+	for i, e := range events {
+		if e.kind == "finish" {
+			finishAt = i
+			break
+		}
+	}
+	if finishAt < 0 {
+		t.Fatal("no finish recorded in the call timeline")
+	}
+	for _, e := range events[finishAt+1:] {
+		if e.kind == "hb" {
+			t.Fatal("a heartbeat was ordered AFTER the finish — drain beats must end before the terminal write")
+		}
+	}
+}
+
 // TestClaimLoop_NoCapacityNoClaim asserts the loop does not claim when the
 // Manager is at capacity (single-session default): a second pending intent is
 // left pending while the first runs.


### PR DESCRIPTION
Closes #505

**Merge order: merges AFTER #503's PR** (fix/503-cross-pod-voice-controls lands first; rebase surface here is the endSession body + test-fake additions only, per the shared contract).

## What

A draining Voice Instance stopped heartbeating while `endSession` blocked in `Manager.Stop` (finalizers + CloseVoiceSession, up to several seconds) — on BOTH the SIGTERM drain and the stop_requested wind-down. A slow-but-clean wind-down could cross `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` and be reaped `dead` mid-drain.

Fix (per architect plan): `endSession` now runs a drain-phase heartbeat goroutine (`startDrainHeartbeat`) for the whole Stop window — beats every `cfg.Heartbeat` on detached bounded ctxs, stops on ErrNotFound (reaped anyway; ADR-0006 — never re-claim, let the wind-down finish), and is waited out BEFORE the terminal finish write.

- Heartbeat 5s / Expiry 30s defaults unchanged (ADR-0057 — crash detection stays fast); drain beat is the owner refreshing its OWN claim, never adoption.
- AC2 falls out: the intent stays non-terminal until Close landed, so neither `ReconcileWorkerOrphanedVoiceSessions` arm can race an in-flight CloseVoiceSession. No reconcile change; test proves it.
- `finishSelfExit` / #483 L3 / #506 L5 paths untouched.
- Residual (documented, accepted): a sustained DB outage spanning multiple missed beats past Expiry still reaps mid-drain — now requires an outage, not merely a slow finalizer. `terminationGracePeriodSeconds` (300) unchanged.

## Tests (5 added, all with -race)

- `TestClaimLoop_DrainHeartbeatDuringSigterm` — slow-finalizer SIGTERM drain: beats continue, intent stays live, finishes `done` only after finalizer releases (AC1/AC3)
- `TestClaimLoop_DrainHeartbeatDuringStopRequested` — same for the stop_requested call site
- `TestClaimLoop_DrainHeartbeatSupersededStopsBeating` — reaped mid-drain: beats stop, no second `mgr.Stop`, wind-down completes, finish swallowed, no goroutine leak
- `TestClaimLoop_ReaperNeverKillsCleanDrain` — real reaper semantics in the fake (stale-heartbeat reap), concurrent reap+reconcile ticks during a drain 5x Expiry: intent never `dead`, never terminal while Close in-flight (AC1+AC2)
- `TestClaimLoop_DrainBeatsEndBeforeFinish` — recorded call timeline: no heartbeat ordered after the finish

Fake IntentStore gains only heartbeat/finish call-timeline recording + real expiry-based reap (contract-compliant; control methods land with #503).

Docs: `docs/devs/2026-07-20-voice-fleet-rollout.md` "Known windows" — heartbeat-during-drain marked CLOSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)