### PR TITLE
fix(#504): guild-ownership proof for Discord settings + release path

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -1487,6 +1487,12 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// (#110). Empty when DISCORD_OAUTH_CLIENT_ID is unset — the screen's disabled
 	// fallback.
 	providerSrv.SetDiscordApplicationID(clientID)
+	// The central DISCORD_BOT_TOKEN is the last rung of the #504 guild-admin
+	// proof's check-token ladder (request plaintext > stored BYOK > this), so
+	// central-token tenants without a saved BYOK bot token can still prove they
+	// administer a guild before binding it. Empty when unset (BYOK-only web
+	// deployments): the proof then requires a saved/request token.
+	providerSrv.SetEnvBotToken(os.Getenv("DISCORD_BOT_TOKEN"))
 	providerPath, providerHandler := providerSrv.Handler(stack.HandlerOptions()...)
 	voicePath, voiceHandler := voiceSrv.Handler(stack.HandlerOptions()...)
 	// The recap engine regenerates Butler-flavoured Session recaps on demand

--- a/docs/adr/0058-guild-ownership-proof.md
+++ b/docs/adr/0058-guild-ownership-proof.md
@@ -1,0 +1,98 @@
+# Guild-ownership proof for Discord settings and the guild release path
+
+#483 made guild binding first-registrar-wins (a partial UNIQUE index on
+`deployment_config.guild_id`), which closed silent rebinding but opened a squat:
+any authenticated tenant could bind a guild_id it does not administer — first,
+before the legitimate owner — and the owner then hit "already linked by another
+tenant" with no recourse. #504 closes both halves: a proof that the saver
+administers the guild before it binds, and a release path so a legitimate
+transfer between tenants is possible without DB surgery.
+
+## What this decides
+
+- **SaveDiscordSettings proves guild administration before ANY write.** Binding
+  a guild_id requires the authenticated saver (`auth.CurrentUser`'s session
+  principal — never an env allowlist, ADR-0055) to be the guild's owner or hold
+  a role carrying ADMINISTRATOR (0x8) or MANAGE_GUILD (0x20). The proof runs
+  before the token save too, so a rejected request mutates nothing — and the
+  `ErrGuildTaken` "another tenant" message is only reachable by PROVEN guild
+  admins, so it leaks no cross-tenant existence to strangers.
+- **`internal/discordguild` mirrors `internal/discordinvite` exactly**
+  (ADR-0047 pattern reuse, amendment noted there in spirit): plain `net/http`
+  (never disgo's rest client — goroutine leak per call), 15s client timeout,
+  `Bot` auth header, package-private `checkAdmin` with a base-URL +
+  `export_test.go` seam. Two REST calls: `GET /guilds/{id}` (owner_id + role
+  table; owner short-circuits — owners may hold no explicit role) and
+  `GET /guilds/{id}/members/{userID}` (role ids; the implicit @everyone role —
+  id == guild id — is unioned in). The `permissions` field is a decimal STRING
+  (`strconv.ParseUint(.., 10, 64)`). No third REST call: the role table already
+  rides the guild read.
+- **The check token is the same token that will serve the guild.** Ladder:
+  request-plaintext `bot_token` (pre-seal) > stored BYOK token (decrypted
+  server-side only, ADR-0004) > the central `DISCORD_BOT_TOKEN` env token
+  (`SetEnvBotToken`, wired at boot) — so BYOK and central-token tenants are both
+  covered. All empty → `FailedPrecondition` "save the Discord bot token first".
+  There is deliberately NO user-OAuth-token path: the auth tier discards the
+  Discord access token after login, and the Bot must be in the guild anyway to
+  serve it.
+- **Error granularity avoids a membership oracle.** Bot cannot read the guild
+  (403 *or* 404 — Discord is inconsistent for a non-member Bot, ADR-0047
+  precedent) → `FailedPrecondition` "the Bot is not a member of that server".
+  User-not-in-guild and member-without-permission collapse to ONE
+  `PermissionDenied` message ("you need the Manage Server permission in that
+  Discord server to link it"), so the RPC cannot be used to probe who is in
+  which guild.
+- **Release is a dedicated RPC, not an empty-ID save.** `ReleaseDiscordGuild`
+  frees the caller's own binding; present-but-empty IDs on Save stay rejected
+  (#142 posture: an empty ID on the wire is an accident). The request must echo
+  the currently-bound guild_id and storage does an atomic compare-and-clear
+  (`WHERE tenant_id = $1 AND guild_id = $2 AND guild_id <> ''`) — no
+  read-then-write race, no schema change (guild_id `''` is already the
+  unconfigured state, migration 00037). Mismatch or no binding →
+  `FailedPrecondition`. **No Discord proof on release**: the operator may have
+  lost guild access entirely, and release only touches the caller's own
+  tenant-local row. A transfer is: A releases, B saves with proof.
+- **Release reconciles the standing presence.** After a successful release the
+  health cache is busted and `refreshPresence` fires (ADR-0057: the guild
+  binding is the Guild→Tenant routing truth), tearing down the freed guild's
+  standing client — otherwise the old tenant's presence squats the guild the
+  next tenant just claimed. A release during a live Voice Session rides the
+  existing reconcile semantics; no new handling.
+- **SaaS-first: the proof is enforced in BOTH Admission Modes, no self-host or
+  dev bypass.** Where ADR-0039's single-operator convenience implied "the
+  operator configures their own deployment, no proof needed", this narrows it:
+  a single-operator self-host must also have the Bot in the guild and hold
+  Manage Server there to bind it. This is deliberate — multi-tenant SaaS is the
+  standard posture, and mode-conditional security checks are how bypasses ship.
+  (Under `GLYPHOXA_DEV_MODE` the synthetic dev operator has no real Discord
+  snowflake, so an ID-binding save fails the proof; dev flows that need a bound
+  guild seed the DB directly, as the k3d scripts already do via Helm values.)
+- **TOCTOU accepted.** The proof is checked at save time; a saver who later
+  loses Manage Server keeps the binding until released. Discord permissions are
+  live state — continuous re-verification would mean polling every bound guild
+  forever for marginal gain. The victim's recourse is Discord-side (kick the
+  Bot) plus release/rebind, which the proof now protects.
+
+## Considered and rejected
+
+- **Proof via the saver's OAuth access token** (`GET /users/@me/guilds`) — the
+  auth tier deliberately discards the Discord access token after login
+  (cookie-session posture, ADR-0016); persisting user tokens to check guilds
+  widens the secret surface for a check the Bot token already serves.
+- **Release as SaveDiscordSettings with empty IDs** — reopens the #142
+  silent-wipe accident class; an explicit, echo-confirmed RPC cannot fire from
+  a half-loaded form.
+- **Proof on release too** — locks out any operator whose guild access was
+  revoked (the exact moment they should clean up), for no security gain: release
+  only clears the caller's own row.
+- **Self-host / allowlist-mode bypass** — see SaaS-first above; rejected per
+  operator directive (2026-07-20).
+
+## Relationship to other ADRs
+
+ADR-0047 (client shape, error-collapse precedent, no-disgo rule — reused
+verbatim), ADR-0004 (Bot token decrypted server-side only, never on the wire),
+ADR-0055 (saver identity = session principal; enforced in both Admission
+Modes), ADR-0057 (guild binding is routing truth; release refreshes presence),
+ADR-0033 (all Discord behind seams; the default suite stays keyless), ADR-0039
+(single-operator convenience narrowed as recorded above).

--- a/internal/discordguild/discordguild.go
+++ b/internal/discordguild/discordguild.go
@@ -1,0 +1,175 @@
+// Package discordguild proves a Discord User administers a Guild (#504,
+// ADR-0058): the guild-ownership proof SaveDiscordSettings runs before binding a
+// guild_id to a Tenant, so a squat-first attacker cannot bind a guild they do
+// not administer. It makes at most two REST calls with the deployment Bot token:
+// `GET /guilds/{id}` for the owner + role table, and — when the user is not the
+// owner — `GET /guilds/{id}/members/{userID}` for the user's roles. "Administers"
+// means: guild owner, or any held role (the @everyone role included) carrying
+// ADMINISTRATOR (0x8) or MANAGE_GUILD (0x20).
+//
+// Like internal/discordinvite and internal/discordtag, the calls are plain
+// net/http GETs, deliberately NOT disgo's rest.NewClient: that client's rate
+// limiter starts a cleanup goroutine its Close never stops, leaking one
+// goroutine + ticker per call (ADR-0047).
+//
+// These are LIVE network calls. The RPC layer hides CheckAdmin behind a seam so
+// unit tests fake the checker and never touch the network; offline tests drive
+// the package-private base-URL seam ([CheckAdminAt]) at a fake HTTP server.
+package discordguild
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// liveAPIBaseURL is Discord's REST API root, matching internal/discordinvite.
+const liveAPIBaseURL = "https://discord.com/api/v10"
+
+// userAgent is the DiscordBot form Discord requires of bot REST callers.
+const userAgent = "DiscordBot (https://github.com/MrWong99/Glyphoxa, v2)"
+
+// Discord permission bits that count as "administers the guild": either grants
+// full guild-settings control, which is the bar for binding the guild to a
+// Tenant (#504).
+const (
+	permAdministrator uint64 = 0x8
+	permManageGuild   uint64 = 0x20
+)
+
+// guildClient is shared across calls (http.Client is safe for concurrent use);
+// its Timeout is a belt on top of the caller's ctx deadline (ADR-0047).
+var guildClient = &http.Client{Timeout: 15 * time.Second}
+
+// ErrBotNotInGuild means the Bot itself cannot read the guild: the guild read
+// (or the member read) came back 403 or 404 — Discord is inconsistent about
+// which for a non-member Bot, so both map here (ADR-0047 precedent).
+var ErrBotNotInGuild = errors.New("discordguild: the Bot is not a member of that guild")
+
+// ErrUserNotInGuild means the guild resolved but the user is not a member of it
+// (member read 404 while the guild read succeeded).
+var ErrUserNotInGuild = errors.New("discordguild: user is not a member of that guild")
+
+// ErrNoPermission means the user is a member but none of their roles carries
+// ADMINISTRATOR or MANAGE_GUILD.
+var ErrNoPermission = errors.New("discordguild: user lacks Manage Guild")
+
+// CheckAdmin proves userID administers guildID using token (a Discord Bot
+// token): nil when the user is the guild owner or holds a role with
+// ADMINISTRATOR/MANAGE_GUILD, else one of the sentinel errors above. An empty
+// token fails fast (no dial). A ctx deadline bounds each call. log may be nil.
+func CheckAdmin(ctx context.Context, token, guildID, userID string, log *slog.Logger) error {
+	return checkAdmin(ctx, token, guildID, userID, "", log)
+}
+
+// checkAdmin is CheckAdmin with a base-URL seam: "" means the live Discord API,
+// tests point it at a fake HTTP server.
+func checkAdmin(ctx context.Context, token, guildID, userID, baseURL string, log *slog.Logger) error {
+	if token == "" {
+		return errors.New("discordguild: empty bot token")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	if baseURL == "" {
+		baseURL = liveAPIBaseURL
+	}
+
+	// GET /guilds/{id} → owner_id + the guild's role table. The Bot must be a
+	// member to read this; 403/404 both mean it is not (Discord is inconsistent).
+	var guild struct {
+		OwnerID string `json:"owner_id"`
+		Roles   []struct {
+			ID          string `json:"id"`
+			Permissions string `json:"permissions"` // decimal STRING per Discord API
+		} `json:"roles"`
+	}
+	status, err := getJSON(ctx, token, baseURL+"/guilds/"+url.PathEscape(guildID), &guild)
+	if err != nil {
+		return fmt.Errorf("discordguild: GET /guilds: %w", err)
+	}
+	if status == http.StatusForbidden || status == http.StatusNotFound {
+		return ErrBotNotInGuild
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("discordguild: GET /guilds: HTTP %d", status)
+	}
+	if guild.OwnerID == userID {
+		log.Debug("guild-admin proof: user is the guild owner", "guild", guildID)
+		return nil
+	}
+
+	// GET /guilds/{id}/members/{userID} → the user's role ids. 404 here means
+	// the user is not a member (the guild itself resolved above); 403 means the
+	// Bot lost read access between the two calls — collapse to not-in-guild.
+	var member struct {
+		Roles []string `json:"roles"`
+	}
+	status, err = getJSON(ctx, token,
+		baseURL+"/guilds/"+url.PathEscape(guildID)+"/members/"+url.PathEscape(userID), &member)
+	if err != nil {
+		return fmt.Errorf("discordguild: GET /guilds/members: %w", err)
+	}
+	if status == http.StatusNotFound {
+		return ErrUserNotInGuild
+	}
+	if status == http.StatusForbidden {
+		return ErrBotNotInGuild
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("discordguild: GET /guilds/members: HTTP %d", status)
+	}
+
+	// Union of the member's roles plus @everyone (role id == guild id, held by
+	// every member implicitly). Any role carrying ADMINISTRATOR or MANAGE_GUILD
+	// proves administration. Permissions is a decimal string.
+	held := map[string]bool{guildID: true}
+	for _, id := range member.Roles {
+		held[id] = true
+	}
+	for _, role := range guild.Roles {
+		if !held[role.ID] {
+			continue
+		}
+		perms, err := strconv.ParseUint(role.Permissions, 10, 64)
+		if err != nil {
+			return fmt.Errorf("discordguild: parse role %s permissions %q: %w", role.ID, role.Permissions, err)
+		}
+		if perms&(permAdministrator|permManageGuild) != 0 {
+			log.Debug("guild-admin proof: role grants Manage Guild", "guild", guildID, "role", role.ID)
+			return nil
+		}
+	}
+	return ErrNoPermission
+}
+
+// getJSON issues an authenticated Bot GET and, on 200, decodes the body into
+// out. It returns the HTTP status (so the caller maps 403/404 to sentinels) and
+// an error only for transport or decode failures.
+func getJSON(ctx context.Context, token, rawURL string, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+token)
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := guildClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return resp.StatusCode, fmt.Errorf("decode: %w", err)
+	}
+	return resp.StatusCode, nil
+}

--- a/internal/discordguild/discordguild_test.go
+++ b/internal/discordguild/discordguild_test.go
@@ -1,0 +1,75 @@
+package discordguild_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/discordguild"
+)
+
+// fakeGuildAPI is a scripted Discord REST fake for the two CheckAdmin reads:
+// GET /guilds/{id} and GET /guilds/{id}/members/{userID}. It counts requests so
+// tests can assert short-circuits (owner never fetches the member).
+type fakeGuildAPI struct {
+	guildStatus  int
+	guild        map[string]any
+	memberStatus int
+	member       map[string]any
+
+	guildCalls  atomic.Int64
+	memberCalls atomic.Int64
+}
+
+func (f *fakeGuildAPI) server(t *testing.T, guildID, userID string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/guilds/"+guildID+"/members/"+userID, func(w http.ResponseWriter, _ *http.Request) {
+		f.memberCalls.Add(1)
+		w.WriteHeader(f.memberStatus)
+		if f.memberStatus == http.StatusOK {
+			_ = json.NewEncoder(w).Encode(f.member)
+		}
+	})
+	mux.HandleFunc("/guilds/"+guildID, func(w http.ResponseWriter, _ *http.Request) {
+		f.guildCalls.Add(1)
+		w.WriteHeader(f.guildStatus)
+		if f.guildStatus == http.StatusOK {
+			_ = json.NewEncoder(w).Encode(f.guild)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const (
+	testGuildID = "472093001100000000"
+	testUserID  = "555000000000000000"
+)
+
+// TestCheckAdmin_OwnerShortCircuits: the guild owner passes on the guild read
+// alone — the member endpoint is never called (owners may hold no explicit role).
+func TestCheckAdmin_OwnerShortCircuits(t *testing.T) {
+	t.Parallel()
+	fake := &fakeGuildAPI{
+		guildStatus: http.StatusOK,
+		guild: map[string]any{
+			"id": testGuildID, "owner_id": testUserID,
+			"roles": []map[string]any{},
+		},
+		memberStatus: http.StatusOK,
+	}
+	srv := fake.server(t, testGuildID, testUserID)
+
+	err := discordguild.CheckAdminAt(context.Background(), "tok", testGuildID, testUserID, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("CheckAdmin(owner) = %v, want nil", err)
+	}
+	if got := fake.memberCalls.Load(); got != 0 {
+		t.Errorf("member endpoint called %d times for the owner, want 0", got)
+	}
+}

--- a/internal/discordguild/discordguild_test.go
+++ b/internal/discordguild/discordguild_test.go
@@ -3,6 +3,7 @@ package discordguild_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -71,5 +72,154 @@ func TestCheckAdmin_OwnerShortCircuits(t *testing.T) {
 	}
 	if got := fake.memberCalls.Load(); got != 0 {
 		t.Errorf("member endpoint called %d times for the owner, want 0", got)
+	}
+}
+
+// TestCheckAdmin_RoleBits: a member passes when any held role — the implicit
+// @everyone role (id == guild id) included — carries MANAGE_GUILD (0x20) or
+// ADMINISTRATOR (0x8); without either bit the proof fails with ErrNoPermission.
+// The permissions field is a decimal STRING per the Discord API.
+func TestCheckAdmin_RoleBits(t *testing.T) {
+	t.Parallel()
+
+	roleID := "600000000000000001"
+	for name, tc := range map[string]struct {
+		roles       []map[string]any // guild role table
+		memberRoles []string
+		wantErr     error
+	}{
+		"manage guild bit": {
+			roles:       []map[string]any{{"id": roleID, "permissions": "32"}},
+			memberRoles: []string{roleID},
+		},
+		"administrator bit": {
+			roles:       []map[string]any{{"id": roleID, "permissions": "8"}},
+			memberRoles: []string{roleID},
+		},
+		"everyone role grants": {
+			// @everyone's id equals the guild id and is held implicitly: empty
+			// member roles still pass.
+			roles:       []map[string]any{{"id": testGuildID, "permissions": "32"}},
+			memberRoles: []string{},
+		},
+		"no bits": {
+			roles: []map[string]any{
+				{"id": testGuildID, "permissions": "1049600"}, // speak/view, no manage
+				{"id": roleID, "permissions": "3146752"},
+			},
+			memberRoles: []string{roleID},
+			wantErr:     discordguild.ErrNoPermission,
+		},
+		"unheld admin role does not grant": {
+			roles:       []map[string]any{{"id": roleID, "permissions": "8"}},
+			memberRoles: []string{},
+			wantErr:     discordguild.ErrNoPermission,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeGuildAPI{
+				guildStatus: http.StatusOK,
+				guild: map[string]any{
+					"id": testGuildID, "owner_id": "othr0000000000000000",
+					"roles": tc.roles,
+				},
+				memberStatus: http.StatusOK,
+				member:       map[string]any{"roles": tc.memberRoles},
+			}
+			srv := fake.server(t, testGuildID, testUserID)
+			err := discordguild.CheckAdminAt(context.Background(), "tok", testGuildID, testUserID, srv.URL, nil)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("CheckAdmin = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckAdmin_GuildReadDenied: the guild read failing 403 OR 404 means the
+// Bot is not a member of that guild (Discord is inconsistent about which code) —
+// both collapse to ErrBotNotInGuild, and the member endpoint is never reached.
+func TestCheckAdmin_GuildReadDenied(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
+		fake := &fakeGuildAPI{guildStatus: status, memberStatus: http.StatusOK}
+		srv := fake.server(t, testGuildID, testUserID)
+		err := discordguild.CheckAdminAt(context.Background(), "tok", testGuildID, testUserID, srv.URL, nil)
+		if !errors.Is(err, discordguild.ErrBotNotInGuild) {
+			t.Errorf("guild read %d: err = %v, want ErrBotNotInGuild", status, err)
+		}
+		if got := fake.memberCalls.Load(); got != 0 {
+			t.Errorf("guild read %d: member endpoint called %d times, want 0", status, got)
+		}
+	}
+}
+
+// TestCheckAdmin_MemberRead: member 404 = the user is not in the (resolvable)
+// guild → ErrUserNotInGuild; member 403 = the Bot lost access → ErrBotNotInGuild.
+func TestCheckAdmin_MemberRead(t *testing.T) {
+	t.Parallel()
+	for status, want := range map[int]error{
+		http.StatusNotFound:  discordguild.ErrUserNotInGuild,
+		http.StatusForbidden: discordguild.ErrBotNotInGuild,
+	} {
+		fake := &fakeGuildAPI{
+			guildStatus: http.StatusOK,
+			guild: map[string]any{
+				"id": testGuildID, "owner_id": "othr0000000000000000",
+				"roles": []map[string]any{},
+			},
+			memberStatus: status,
+		}
+		srv := fake.server(t, testGuildID, testUserID)
+		err := discordguild.CheckAdminAt(context.Background(), "tok", testGuildID, testUserID, srv.URL, nil)
+		if !errors.Is(err, want) {
+			t.Errorf("member read %d: err = %v, want %v", status, err, want)
+		}
+	}
+}
+
+// TestCheckAdmin_EmptyTokenFailsFast: no token, no dial — zero HTTP requests.
+func TestCheckAdmin_EmptyTokenFailsFast(t *testing.T) {
+	t.Parallel()
+	fake := &fakeGuildAPI{guildStatus: http.StatusOK, memberStatus: http.StatusOK}
+	srv := fake.server(t, testGuildID, testUserID)
+
+	err := discordguild.CheckAdminAt(context.Background(), "", testGuildID, testUserID, srv.URL, nil)
+	if err == nil {
+		t.Fatal("CheckAdmin with empty token = nil, want error")
+	}
+	if got := fake.guildCalls.Load() + fake.memberCalls.Load(); got != 0 {
+		t.Errorf("empty token dialed %d times, want 0", got)
+	}
+}
+
+// TestCheckAdmin_UnexpectedStatusIsGenericError: a 500 from either read is a
+// plain error, never one of the sentinels (the RPC layer maps it to Internal).
+func TestCheckAdmin_UnexpectedStatusIsGenericError(t *testing.T) {
+	t.Parallel()
+	for name, fake := range map[string]*fakeGuildAPI{
+		"guild 500": {guildStatus: http.StatusInternalServerError, memberStatus: http.StatusOK},
+		"member 500": {
+			guildStatus: http.StatusOK,
+			guild: map[string]any{
+				"id": testGuildID, "owner_id": "othr0000000000000000",
+				"roles": []map[string]any{},
+			},
+			memberStatus: http.StatusInternalServerError,
+		},
+	} {
+		srv := fake.server(t, testGuildID, testUserID)
+		err := discordguild.CheckAdminAt(context.Background(), "tok", testGuildID, testUserID, srv.URL, nil)
+		if err == nil {
+			t.Errorf("%s: err = nil, want generic error", name)
+			continue
+		}
+		for _, sentinel := range []error{
+			discordguild.ErrBotNotInGuild, discordguild.ErrUserNotInGuild, discordguild.ErrNoPermission,
+		} {
+			if errors.Is(err, sentinel) {
+				t.Errorf("%s: err = %v, must not be sentinel %v", name, err, sentinel)
+			}
+		}
 	}
 }

--- a/internal/discordguild/export_test.go
+++ b/internal/discordguild/export_test.go
@@ -1,0 +1,5 @@
+package discordguild
+
+// CheckAdminAt exposes the base-URL seam so tests can point the checker at a
+// fake Discord REST server instead of the live API.
+var CheckAdminAt = checkAdmin

--- a/internal/rpc/export_test.go
+++ b/internal/rpc/export_test.go
@@ -16,3 +16,10 @@ func (d *DeploymentSharer) SetShareSeamsForTest(
 	d.listFn = list
 	d.postFn = post
 }
+
+// SetGuildProofForTest overrides the #504 guild-admin proof seam so unit tests
+// drive SaveDiscordSettings without dialing Discord, mirroring the resolveInvite
+// seam pattern.
+func (s *ProviderServer) SetGuildProofForTest(fn func(ctx context.Context, token, guildID, userID string) error) {
+	s.checkGuildAdmin = fn
+}

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -16,6 +16,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/discordguild"
 	"github.com/MrWong99/Glyphoxa/internal/discordinvite"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
@@ -43,6 +44,9 @@ type providerStore interface {
 	GetDeploymentConfig(ctx context.Context, tenantID uuid.UUID) (storage.DeploymentConfig, error)
 	SaveDiscordBotToken(ctx context.Context, tenantID uuid.UUID, ciphertext []byte, last4 string) (storage.DeploymentConfig, error)
 	SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error)
+	// ReleaseDiscordGuild frees the Tenant's bound guild via an atomic
+	// compare-and-clear (#504): the echoed guild_id must match the binding.
+	ReleaseDiscordGuild(ctx context.Context, tenantID uuid.UUID, guildID string) (storage.DeploymentConfig, error)
 	// GetTenantSpendCaps / SetTenantSpendCaps back the per-Tenant spend caps
 	// Configuration surface (#130, ADR-0046).
 	GetTenantSpendCaps(ctx context.Context, tenantID uuid.UUID) (storage.SpendCaps, error)
@@ -117,6 +121,19 @@ type ProviderServer struct {
 	// defaults it to the live discordinvite.Resolve, and unit tests override it
 	// with a fake so ResolveGuildInvite never touches the network.
 	resolveInvite func(ctx context.Context, token, code string) (discordinvite.Resolved, error)
+
+	// checkGuildAdmin proves the saver administers the guild being bound (#504,
+	// ADR-0058): guild owner or a role with ADMINISTRATOR/MANAGE_GUILD. It is a
+	// seam mirroring resolveInvite: NewProviderServer defaults it to the live
+	// discordguild.CheckAdmin, and unit tests override it so SaveDiscordSettings
+	// never touches the network (ADR-0033 keyless suite).
+	checkGuildAdmin func(ctx context.Context, token, guildID, userID string) error
+
+	// envBotToken is the deployment's central DISCORD_BOT_TOKEN (SetEnvBotToken),
+	// the last rung of the proof's check-token ladder: request plaintext > stored
+	// BYOK token > this. Used ONLY to authenticate the guild-admin REST reads —
+	// it is never persisted or returned (ADR-0004 posture).
+	envBotToken string
 }
 
 var _ managementv1connect.ProviderServiceHandler = (*ProviderServer)(nil)
@@ -132,7 +149,18 @@ func NewProviderServer(store providerStore, cipher *crypto.Cipher, log *slog.Log
 	s.resolveInvite = func(ctx context.Context, token, code string) (discordinvite.Resolved, error) {
 		return discordinvite.Resolve(ctx, token, code, log)
 	}
+	s.checkGuildAdmin = func(ctx context.Context, token, guildID, userID string) error {
+		return discordguild.CheckAdmin(ctx, token, guildID, userID, log)
+	}
 	return s
+}
+
+// SetEnvBotToken wires the deployment's central DISCORD_BOT_TOKEN as the final
+// fallback for the guild-admin proof's check token (#504), so central-token
+// tenants (no BYOK bot token saved) can still prove guild administration.
+// Called once at boot, before the server serves, so no lock is needed.
+func (s *ProviderServer) SetEnvBotToken(token string) {
+	s.envBotToken = token
 }
 
 // SetHealthInvalidator wires the health-cache buster called after a successful
@@ -381,21 +409,35 @@ func (s *ProviderServer) SaveDiscordSettings(
 		return nil, connect.NewError(connect.CodeInvalidArgument,
 			errors.New("guild_id and voice_channel_id must both be non-empty when provided"))
 	}
+	if req.Msg.BotToken != nil {
+		if s.cipher == nil {
+			return nil, connect.NewError(connect.CodeFailedPrecondition,
+				errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
+		}
+		if req.Msg.GetBotToken() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument,
+				errors.New("bot_token must not be empty when provided"))
+		}
+	}
+
+	// Guild-ownership proof (#504, ADR-0058): binding a guild_id requires the
+	// saver to prove they administer that guild, enforced in BOTH admission
+	// modes with no self-host bypass. The proof runs BEFORE any write (the token
+	// save included), so a rejected request mutates nothing — and the
+	// ErrGuildTaken message below is only ever reachable by proven guild admins,
+	// closing the cross-tenant existence oracle.
+	if hasIDs {
+		if err := s.proveGuildAdmin(ctx, tenantID, req.Msg.GetBotToken(), req.Msg.GetGuildId()); err != nil {
+			return nil, err
+		}
+	}
 
 	var dep storage.DeploymentConfig
 
 	// Bot token first (when the client sent one), so the IDs upsert below returns
 	// the row with the freshly-saved token last4.
 	if req.Msg.BotToken != nil {
-		if s.cipher == nil {
-			return nil, connect.NewError(connect.CodeFailedPrecondition,
-				errors.New("credential encryption is not configured ($GLYPHOXA_SECRET)"))
-		}
 		token := req.Msg.GetBotToken()
-		if token == "" {
-			return nil, connect.NewError(connect.CodeInvalidArgument,
-				errors.New("bot_token must not be empty when provided"))
-		}
 		sealed, last4, err := s.seal(token)
 		if err != nil {
 			s.log.Error("SaveDiscordSettings: seal failed", "err", err)
@@ -413,11 +455,11 @@ func (s *ProviderServer) SaveDiscordSettings(
 	if hasIDs {
 		dep, err = s.store.SaveDiscordChannels(ctx, tenantID, req.Msg.GetGuildId(), req.Msg.GetVoiceChannelId())
 		if errors.Is(err, storage.ErrGuildTaken) {
-			// First-registrar-wins guild binding (#483; the full guild-permission
-			// proof — verifying the saver actually administers the guild — is #504).
-			// A deliberate precondition refusal, never a silent rebind: the old
-			// newest-wins read let a second Tenant hijack the first's guild and with
-			// it the victim's voice-channel member reads + command routing.
+			// First-registrar-wins guild binding (#483) + the #504 proof above:
+			// only a PROVEN admin of the guild can even reach this message, so it
+			// leaks no cross-tenant existence to strangers. A deliberate
+			// precondition refusal, never a silent rebind; the release path for a
+			// legitimate transfer is ReleaseDiscordGuild.
 			return nil, connect.NewError(connect.CodeFailedPrecondition,
 				errors.New("this Discord server is already linked by another tenant; it must unlink there first"))
 		}
@@ -444,6 +486,105 @@ func (s *ProviderServer) SaveDiscordSettings(
 
 	return connect.NewResponse(&managementv1.SaveDiscordSettingsResponse{
 		Credential:     discordCredential(dep),
+		GuildId:        dep.GuildID,
+		VoiceChannelId: dep.VoiceChannelID,
+	}), nil
+}
+
+// proveGuildAdmin runs the #504 guild-ownership proof for a SaveDiscordSettings
+// that binds guildID: the authenticated saver (auth.CurrentUser — the session
+// principal, ADR-0055, never an env allowlist) must administer the guild per
+// the checkGuildAdmin seam. reqToken is the request's plaintext Bot token when
+// one rode along (pre-seal), else the check-token ladder falls back to the
+// stored BYOK token and finally the central env token — the same token that
+// will serve the guild (BYOK + central-token tenants both covered). Error
+// granularity (no membership oracle): Bot-cannot-see-guild is FailedPrecondition
+// "not a member"; user-not-in-guild and member-without-perms collapse to ONE
+// PermissionDenied message.
+func (s *ProviderServer) proveGuildAdmin(ctx context.Context, tenantID uuid.UUID, reqToken, guildID string) error {
+	user, ok := auth.CurrentUser(ctx)
+	if !ok || user.DiscordUserID == "" {
+		return connect.NewError(connect.CodeUnauthenticated,
+			errors.New("no authenticated Discord user to verify guild permissions for"))
+	}
+
+	token := reqToken
+	if token == "" {
+		stored, err := s.resolveBotToken(ctx, tenantID)
+		if err != nil {
+			return err
+		}
+		token = stored
+	}
+	if token == "" {
+		token = s.envBotToken
+	}
+	if token == "" {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("save the Discord bot token first"))
+	}
+
+	switch err := s.checkGuildAdmin(ctx, token, guildID, user.DiscordUserID); {
+	case err == nil:
+		return nil
+	case errors.Is(err, discordguild.ErrBotNotInGuild):
+		return connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("the Bot is not a member of that server"))
+	case errors.Is(err, discordguild.ErrUserNotInGuild), errors.Is(err, discordguild.ErrNoPermission):
+		return connect.NewError(connect.CodePermissionDenied,
+			errors.New("you need the Manage Server permission in that Discord server to link it"))
+	default:
+		s.log.Error("SaveDiscordSettings: guild-admin proof failed", "err", err)
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// ReleaseDiscordGuild frees this Tenant's bound Guild (#504, ADR-0058) — the
+// supported path for a legitimate guild transfer (A releases, B saves with
+// proof). The request must echo the currently-bound guild_id; storage does an
+// atomic compare-and-clear, so a stale echo mutates nothing. NO Discord proof is
+// required here: the operator may have lost guild access, and release is
+// tenant-local cleanup of the caller's OWN binding. On success the health cache
+// is busted and the standing presence reconciled (tears down the freed guild's
+// presence — required before the next tenant claims it).
+func (s *ProviderServer) ReleaseDiscordGuild(
+	ctx context.Context,
+	req *connect.Request[managementv1.ReleaseDiscordGuildRequest],
+) (*connect.Response[managementv1.ReleaseDiscordGuildResponse], error) {
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	guildID := req.Msg.GetGuildId()
+	if guildID == "" {
+		// Present-but-empty is an accident (mirrors #142's posture), never a
+		// wildcard release.
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("guild_id must be the currently linked Discord server"))
+	}
+
+	dep, err := s.store.ReleaseDiscordGuild(ctx, tenantID, guildID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("that Discord server is not the one currently linked; reload and try again"))
+	}
+	if err != nil {
+		s.log.Error("ReleaseDiscordGuild: store release failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// The binding changed: bust the cached health verdict and reconcile the
+	// standing presence so the freed guild's client tears down (#489 semantics —
+	// critical for a transfer, or the old presence squats the guild).
+	if s.invalidateHealth != nil {
+		s.invalidateHealth(tenantID)
+	}
+	if s.refreshPresence != nil {
+		go s.refreshPresence(tenantID)
+	}
+
+	return connect.NewResponse(&managementv1.ReleaseDiscordGuildResponse{
 		GuildId:        dep.GuildID,
 		VoiceChannelId: dep.VoiceChannelID,
 	}), nil

--- a/internal/rpc/provider_guildproof_test.go
+++ b/internal/rpc/provider_guildproof_test.go
@@ -1,0 +1,352 @@
+package rpc_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/discordguild"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+)
+
+// proofRecorder captures every checkGuildAdmin invocation so tests assert the
+// checker receives the resolved token + guild + the saver's Discord snowflake.
+type proofRecorder struct {
+	mu    sync.Mutex
+	calls []proofCall
+	err   error
+}
+
+type proofCall struct{ token, guildID, userID string }
+
+func (p *proofRecorder) check(_ context.Context, token, guildID, userID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, proofCall{token: token, guildID: guildID, userID: userID})
+	return p.err
+}
+
+func (p *proofRecorder) snapshot() []proofCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]proofCall(nil), p.calls...)
+}
+
+// TestProviderDiscordSettings_ProofReceivesSaverIdentity pins the #504 proof
+// wiring: an IDs save invokes the guild-admin checker with the resolved Bot
+// token (here the request's plaintext), the guild being bound, and the
+// authenticated saver's Discord snowflake (auth.CurrentUser — never an env
+// allowlist, ADR-0055).
+func TestProviderDiscordSettings_ProofReceivesSaverIdentity(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	rec := &proofRecorder{}
+	client, _ := clientForServer(t, srv)
+	srv.SetGuildProofForTest(rec.check)
+
+	const token = "test-discord-bot-token-3333"
+	if _, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr(token),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	})); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("checker called %d times, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.token != token {
+		t.Errorf("checker token = %q, want the request plaintext", got.token)
+	}
+	if got.guildID != "472093001100" {
+		t.Errorf("checker guild = %q, want 472093001100", got.guildID)
+	}
+	if got.userID != testSaverDiscordID {
+		t.Errorf("checker user = %q, want the saver's snowflake %q", got.userID, testSaverDiscordID)
+	}
+}
+
+// TestProviderDiscordSettings_SquatterRejected is the #504 squat regression: a
+// saver who cannot prove guild administration (ErrNoPermission) gets
+// PermissionDenied and the binding write NEVER happens — a squat-first attacker
+// cannot bind an unowned guild. ErrUserNotInGuild collapses to the same single
+// message (no membership-probing oracle).
+func TestProviderDiscordSettings_SquatterRejected(t *testing.T) {
+	t.Parallel()
+	for name, proofErr := range map[string]error{
+		"member without perms": discordguild.ErrNoPermission,
+		"user not in guild":    discordguild.ErrUserNotInGuild,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := newFakeProviderStore()
+			srv := rpc.NewProviderServer(store, testCipher(t), nil)
+			client, _ := clientForServer(t, srv)
+			srv.SetGuildProofForTest((&proofRecorder{err: proofErr}).check)
+
+			_, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+				BotToken: strPtr("test-discord-bot-token-3333"),
+				GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+			}))
+			if connect.CodeOf(err) != connect.CodePermissionDenied {
+				t.Fatalf("code = %v (err %v), want PermissionDenied", connect.CodeOf(err), err)
+			}
+			if !strings.Contains(err.Error(), "Manage Server") {
+				t.Errorf("err = %v, want the Manage Server message", err)
+			}
+			if store.channelsCalls != 0 {
+				t.Errorf("SaveDiscordChannels called %d times after failed proof, want 0", store.channelsCalls)
+			}
+			// The proof runs BEFORE any write: the token save must not have
+			// happened either (no partial write).
+			if store.dep != nil {
+				t.Errorf("rejected save mutated deployment_config: %+v", store.dep)
+			}
+		})
+	}
+}
+
+// TestProviderDiscordSettings_BotNotInGuild: the Bot being unable to see the
+// guild is FailedPrecondition "not a member" (403/404 collapse — no cross-guild
+// existence leak), and nothing is written.
+func TestProviderDiscordSettings_BotNotInGuild(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	client, _ := clientForServer(t, srv)
+	srv.SetGuildProofForTest((&proofRecorder{err: discordguild.ErrBotNotInGuild}).check)
+
+	_, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr("test-discord-bot-token-3333"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("code = %v (err %v), want FailedPrecondition", connect.CodeOf(err), err)
+	}
+	if !strings.Contains(err.Error(), "not a member") {
+		t.Errorf("err = %v, want the not-a-member message", err)
+	}
+	if store.dep != nil || store.channelsCalls != 0 {
+		t.Errorf("rejected save wrote: dep=%+v channelsCalls=%d", store.dep, store.channelsCalls)
+	}
+}
+
+// TestProviderDiscordSettings_ProofTokenResolution pins the check-token ladder
+// (#504): request plaintext > stored BYOK token (decrypted) > central env token
+// (SetEnvBotToken); all three empty is FailedPrecondition "save the ... token
+// first" and the checker never runs.
+func TestProviderDiscordSettings_ProofTokenResolution(t *testing.T) {
+	t.Parallel()
+
+	idsReq := func() *managementv1.SaveDiscordSettingsRequest {
+		return &managementv1.SaveDiscordSettingsRequest{
+			GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+		}
+	}
+
+	t.Run("stored BYOK token decrypted", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeProviderStore()
+		cipher := testCipher(t)
+		srv := rpc.NewProviderServer(store, cipher, nil)
+		rec := &proofRecorder{}
+		client, _ := clientForServer(t, srv)
+		srv.SetGuildProofForTest(rec.check)
+
+		const token = "test-discord-bot-token-7777"
+		if _, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+			BotToken: strPtr(token),
+			GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+		})); err != nil {
+			t.Fatalf("seed token+ids: %v", err)
+		}
+		// IDs-only save: the stored sealed token is decrypted for the check.
+		if _, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(idsReq())); err != nil {
+			t.Fatalf("ids-only save: %v", err)
+		}
+		calls := rec.snapshot()
+		if len(calls) != 2 || calls[1].token != token {
+			t.Fatalf("checker calls = %+v, want 2nd with decrypted stored token", calls)
+		}
+	})
+
+	t.Run("central env token", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeProviderStore() // no deployment row at all
+		srv := rpc.NewProviderServer(store, testCipher(t), nil)
+		rec := &proofRecorder{}
+		client, _ := clientForServer(t, srv)
+		srv.SetGuildProofForTest(rec.check)
+		srv.SetEnvBotToken("central-env-token")
+
+		if _, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(idsReq())); err != nil {
+			t.Fatalf("ids save: %v", err)
+		}
+		calls := rec.snapshot()
+		if len(calls) != 1 || calls[0].token != "central-env-token" {
+			t.Fatalf("checker calls = %+v, want the env token", calls)
+		}
+	})
+
+	t.Run("no token anywhere", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeProviderStore()
+		srv := rpc.NewProviderServer(store, testCipher(t), nil)
+		rec := &proofRecorder{}
+		client, _ := clientForServer(t, srv)
+		srv.SetGuildProofForTest(rec.check)
+
+		_, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(idsReq()))
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Fatalf("code = %v (err %v), want FailedPrecondition", connect.CodeOf(err), err)
+		}
+		if !strings.Contains(err.Error(), "save the Discord bot token first") {
+			t.Errorf("err = %v, want the save-token-first message", err)
+		}
+		if len(rec.snapshot()) != 0 {
+			t.Error("checker ran without any token")
+		}
+	})
+}
+
+// TestProviderDiscordSettings_TokenOnlySaveSkipsProof: a token-only save binds
+// no guild, so the proof is not invoked (#504).
+func TestProviderDiscordSettings_TokenOnlySaveSkipsProof(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	rec := &proofRecorder{}
+	client, _ := clientForServer(t, srv)
+	srv.SetGuildProofForTest(rec.check)
+
+	if _, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr("test-discord-bot-token-3333"),
+	})); err != nil {
+		t.Fatalf("token-only save: %v", err)
+	}
+	if got := len(rec.snapshot()); got != 0 {
+		t.Errorf("checker called %d times on a token-only save, want 0", got)
+	}
+}
+
+// TestProviderDiscordSettings_ProofRequiresSaverIdentity: an IDs save with no
+// authenticated user in context (or one without a Discord snowflake) is
+// Unauthenticated — the proof needs a saver identity to check (ADR-0055: the
+// session principal, never an env allowlist).
+func TestProviderDiscordSettings_ProofRequiresSaverIdentity(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	srv.SetGuildProofForTest((&proofRecorder{}).check)
+	client, _ := clientForServerNoUser(t, srv)
+
+	_, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr("test-discord-bot-token-3333"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	}))
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("code = %v (err %v), want Unauthenticated", connect.CodeOf(err), err)
+	}
+	if store.dep != nil {
+		t.Errorf("unauthenticated save wrote deployment_config: %+v", store.dep)
+	}
+}
+
+// TestProviderReleaseDiscordGuild pins the #504 release RPC: echoing the bound
+// guild clears the binding (response echoes empty IDs) and fires the
+// invalidateHealth + refreshPresence hooks (the standing presence for the freed
+// guild must tear down — critical for transfer); a mismatched echo is
+// FailedPrecondition with NO hooks fired; an empty guild_id is InvalidArgument.
+func TestProviderReleaseDiscordGuild(t *testing.T) {
+	t.Parallel()
+	store := newFakeProviderStore()
+	srv := rpc.NewProviderServer(store, testCipher(t), nil)
+	srv.SetGuildProofForTest((&proofRecorder{}).check)
+
+	var mu sync.Mutex
+	var invalidated, refreshed []uuid.UUID
+	refreshDone := make(chan struct{}, 8)
+	srv.SetHealthInvalidator(func(id uuid.UUID) {
+		mu.Lock()
+		invalidated = append(invalidated, id)
+		mu.Unlock()
+	})
+	srv.SetPresenceRefresher(func(id uuid.UUID) {
+		mu.Lock()
+		refreshed = append(refreshed, id)
+		mu.Unlock()
+		refreshDone <- struct{}{}
+	})
+	client, tenantID := clientForServer(t, srv)
+	ctx := context.Background()
+
+	// Empty guild_id → InvalidArgument.
+	_, err := client.ReleaseDiscordGuild(ctx, connect.NewRequest(&managementv1.ReleaseDiscordGuildRequest{}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("empty guild_id code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+
+	// Nothing bound yet → FailedPrecondition, no hooks.
+	_, err = client.ReleaseDiscordGuild(ctx, connect.NewRequest(&managementv1.ReleaseDiscordGuildRequest{GuildId: "472093001100"}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("unbound release code = %v (err %v), want FailedPrecondition", connect.CodeOf(err), err)
+	}
+
+	// Bind, then release with the wrong echo → FailedPrecondition, binding stays.
+	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+		BotToken: strPtr("test-discord-bot-token-3333"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+	})); err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	// Drain the save's own hook firings so the mismatch assertion below is clean.
+	<-refreshDone
+	mu.Lock()
+	invalidated, refreshed = nil, nil
+	mu.Unlock()
+
+	_, err = client.ReleaseDiscordGuild(ctx, connect.NewRequest(&managementv1.ReleaseDiscordGuildRequest{GuildId: "999"}))
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("mismatched release code = %v (err %v), want FailedPrecondition", connect.CodeOf(err), err)
+	}
+	mu.Lock()
+	if len(invalidated) != 0 || len(refreshed) != 0 {
+		t.Errorf("mismatched release fired hooks: invalidated=%v refreshed=%v", invalidated, refreshed)
+	}
+	mu.Unlock()
+	if store.dep.GuildID != "472093001100" {
+		t.Fatalf("mismatched release mutated binding: %q", store.dep.GuildID)
+	}
+
+	// Correct echo → cleared response + both hooks for THIS tenant.
+	resp, err := client.ReleaseDiscordGuild(ctx, connect.NewRequest(&managementv1.ReleaseDiscordGuildRequest{GuildId: "472093001100"}))
+	if err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if resp.Msg.GetGuildId() != "" || resp.Msg.GetVoiceChannelId() != "" {
+		t.Errorf("release response = %q/%q, want both empty", resp.Msg.GetGuildId(), resp.Msg.GetVoiceChannelId())
+	}
+	<-refreshDone
+	mu.Lock()
+	defer mu.Unlock()
+	if len(invalidated) != 1 || invalidated[0] != tenantID {
+		t.Errorf("invalidateHealth = %v, want [%s]", invalidated, tenantID)
+	}
+	if len(refreshed) != 1 || refreshed[0] != tenantID {
+		t.Errorf("refreshPresence = %v, want [%s]", refreshed, tenantID)
+	}
+	if store.dep.GuildID != "" || store.dep.VoiceChannelID != "" {
+		t.Errorf("store after release = %q/%q, want cleared", store.dep.GuildID, store.dep.VoiceChannelID)
+	}
+	if store.dep.DiscordBotTokenLast4 != crypto.Last4("test-discord-bot-token-3333") {
+		t.Errorf("release wiped the bot token: %q", store.dep.DiscordBotTokenLast4)
+	}
+}

--- a/internal/rpc/provider_integration_test.go
+++ b/internal/rpc/provider_integration_test.go
@@ -61,11 +61,18 @@ func providerClient(t *testing.T, store *storage.Store, cipher *crypto.Cipher, t
 	t.Helper()
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			return next(auth.WithTenant(ctx, tenantID), req)
+			// The #504 guild-admin proof needs an authenticated saver identity.
+			ctx = auth.WithUser(auth.WithTenant(ctx, tenantID),
+				storage.User{ID: uuid.New(), DiscordUserID: testSaverDiscordID})
+			return next(ctx, req)
 		}
 	})
+	srvImpl := rpc.NewProviderServer(store, cipher, nil)
+	// Always-pass proof stub: this suite exercises the STORAGE boundary; the
+	// live Discord proof stays behind its seam (ADR-0033).
+	srvImpl.SetGuildProofForTest(func(context.Context, string, string, string) error { return nil })
 	mux := http.NewServeMux()
-	mux.Handle(rpc.NewProviderServer(store, cipher, nil).Handler(connect.WithInterceptors(inject)))
+	mux.Handle(srvImpl.Handler(connect.WithInterceptors(inject)))
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return managementv1connect.NewProviderServiceClient(http.DefaultClient, srv.URL, connect.WithProtoJSON())

--- a/internal/rpc/provider_invite_test.go
+++ b/internal/rpc/provider_invite_test.go
@@ -54,6 +54,10 @@ func (f *fakeInviteStore) SaveDiscordChannels(context.Context, uuid.UUID, string
 	return storage.DeploymentConfig{}, nil
 }
 
+func (f *fakeInviteStore) ReleaseDiscordGuild(context.Context, uuid.UUID, string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, storage.ErrNotFound
+}
+
 func (f *fakeInviteStore) GetTenantSpendCaps(context.Context, uuid.UUID) (storage.SpendCaps, error) {
 	return storage.SpendCaps{}, nil
 }

--- a/internal/rpc/provider_presence_test.go
+++ b/internal/rpc/provider_presence_test.go
@@ -2,8 +2,6 @@ package rpc_test
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -11,8 +9,6 @@ import (
 	"github.com/google/uuid"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
-	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
-	"github.com/MrWong99/Glyphoxa/internal/auth"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 )
 
@@ -23,20 +19,9 @@ func TestProviderPresenceRefresher(t *testing.T) {
 	t.Parallel()
 	store := newFakeProviderStore()
 	srv := rpc.NewProviderServer(store, testCipher(t), nil)
-	tenantID := uuid.New()
 	fired := make(chan uuid.UUID, 4)
 	srv.SetPresenceRefresher(func(id uuid.UUID) { fired <- id })
-
-	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			return next(auth.WithTenant(ctx, tenantID), req)
-		}
-	})
-	mux := http.NewServeMux()
-	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
-	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
-	client := managementv1connect.NewProviderServiceClient(http.DefaultClient, ts.URL, connect.WithProtoJSON())
+	client, tenantID := clientForServer(t, srv)
 	ctx := context.Background()
 
 	// Successful save (token + channels) → refresher fires.

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -29,6 +29,10 @@ type fakeProviderStore struct {
 	caps        storage.SpendCaps // per-Tenant spend caps (#130)
 	capsSet     bool
 	channelsErr error // scripted SaveDiscordChannels failure (#483 guild collision)
+
+	// channelsCalls counts SaveDiscordChannels invocations so #504 tests assert
+	// a failed guild-admin proof never reaches the binding write.
+	channelsCalls int
 }
 
 func newFakeProviderStore() *fakeProviderStore {
@@ -94,6 +98,7 @@ func (f *fakeProviderStore) SaveDiscordBotToken(_ context.Context, tenantID uuid
 }
 
 func (f *fakeProviderStore) SaveDiscordChannels(_ context.Context, tenantID uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error) {
+	f.channelsCalls++
 	if f.channelsErr != nil {
 		return storage.DeploymentConfig{}, f.channelsErr
 	}
@@ -102,6 +107,18 @@ func (f *fakeProviderStore) SaveDiscordChannels(_ context.Context, tenantID uuid
 	}
 	f.dep.GuildID = guildID
 	f.dep.VoiceChannelID = voiceChannelID
+	f.dep.UpdatedAt = f.now()
+	return *f.dep, nil
+}
+
+// ReleaseDiscordGuild mirrors the storage compare-and-clear (#504): only a
+// matching tenant-held binding clears; anything else is ErrNotFound.
+func (f *fakeProviderStore) ReleaseDiscordGuild(_ context.Context, _ uuid.UUID, guildID string) (storage.DeploymentConfig, error) {
+	if f.dep == nil || f.dep.GuildID == "" || f.dep.GuildID != guildID {
+		return storage.DeploymentConfig{}, storage.ErrNotFound
+	}
+	f.dep.GuildID = ""
+	f.dep.VoiceChannelID = ""
 	f.dep.UpdatedAt = f.now()
 	return *f.dep, nil
 }
@@ -136,17 +153,43 @@ func newProviderClient(t *testing.T, store *fakeProviderStore, cipher *crypto.Ci
 	return clientForServer(t, rpc.NewProviderServer(store, cipher, nil))
 }
 
-// clientForServer mounts a PRE-BUILT ProviderServer behind the fixed-tenant
-// interceptor and returns a Connect-JSON client + the injected tenant. Callers
-// that must configure the server before it serves (e.g. SetDiscordApplicationID,
-// #110) build it and pass it in; newProviderClient is the common store+cipher
-// shortcut over this.
+// testSaverDiscordID is the Discord snowflake of the fixed operator the test
+// interceptor injects — the saver identity the #504 guild-admin proof checks.
+const testSaverDiscordID = "555000000000000000"
+
+// clientForServer mounts a PRE-BUILT ProviderServer behind the fixed-tenant +
+// fixed-user interceptor and returns a Connect-JSON client + the injected
+// tenant. Callers that must configure the server before it serves (e.g.
+// SetDiscordApplicationID, #110) build it and pass it in; newProviderClient is
+// the common store+cipher shortcut over this.
+//
+// The guild-admin proof (#504) is stubbed to always-pass so pre-#504 ID-save
+// tests stay green and never dial Discord; tests exercising the proof override
+// it via SetGuildProofForTest AFTER this call (requests only start later).
 func clientForServer(t *testing.T, server *rpc.ProviderServer) (managementv1connect.ProviderServiceClient, uuid.UUID) {
+	t.Helper()
+	server.SetGuildProofForTest(func(context.Context, string, string, string) error { return nil })
+	return mountProviderServer(t, server, true)
+}
+
+// clientForServerNoUser mounts a server whose interceptor injects a tenant but
+// NO authenticated user — the #504 missing-principal path.
+func clientForServerNoUser(t *testing.T, server *rpc.ProviderServer) (managementv1connect.ProviderServiceClient, uuid.UUID) {
+	t.Helper()
+	server.SetGuildProofForTest(func(context.Context, string, string, string) error { return nil })
+	return mountProviderServer(t, server, false)
+}
+
+func mountProviderServer(t *testing.T, server *rpc.ProviderServer, withUser bool) (managementv1connect.ProviderServiceClient, uuid.UUID) {
 	t.Helper()
 	tenantID := uuid.New()
 	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			return next(auth.WithTenant(ctx, tenantID), req)
+			ctx = auth.WithTenant(ctx, tenantID)
+			if withUser {
+				ctx = auth.WithUser(ctx, storage.User{ID: uuid.New(), DiscordUserID: testSaverDiscordID})
+			}
+			return next(ctx, req)
 		}
 	})
 	mux := http.NewServeMux()
@@ -473,8 +516,12 @@ func TestProviderDiscordSettings_GuildOwnedByOtherTenant(t *testing.T) {
 	store.channelsErr = storage.ErrGuildTaken
 	client, _ := newProviderClient(t, store, testCipher(t))
 
+	// Since #504 the guild-admin proof runs first; the always-pass test stub
+	// stands in for a proven admin, and the request token feeds the check —
+	// ErrGuildTaken must still surface for a PROVEN admin of a taken guild.
 	_, err := client.SaveDiscordSettings(context.Background(), connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+		BotToken: strPtr("test-discord-bot-token-3333"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
 	}))
 	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
 		t.Fatalf("save owned guild code = %v (err %v), want CodeFailedPrecondition", connect.CodeOf(err), err)
@@ -494,9 +541,11 @@ func TestProviderDiscordSettings_TokenOnlySaveKeepsIDs(t *testing.T) {
 	client, _ := newProviderClient(t, store, testCipher(t))
 	ctx := context.Background()
 
-	// Operator has IDs saved.
+	// Operator has a token + IDs saved (the token also feeds the #504 proof's
+	// check-token ladder).
 	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+		BotToken: strPtr("test-discord-bot-token-0000"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
 	})); err != nil {
 		t.Fatalf("save ids: %v", err)
 	}
@@ -530,7 +579,8 @@ func TestProviderDiscordSettings_EmptyIDsRejected(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
-		GuildId: strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
+		BotToken: strPtr("test-discord-bot-token-0000"),
+		GuildId:  strPtr("472093001100"), VoiceChannelId: strPtr("472093774421"),
 	})); err != nil {
 		t.Fatalf("save ids: %v", err)
 	}

--- a/internal/rpc/voice_test.go
+++ b/internal/rpc/voice_test.go
@@ -774,8 +774,12 @@ func TestSaveCredentials_InvalidateHealthCache(t *testing.T) {
 
 	providerSrv := NewProviderServer(&stubProviderStore{}, cipher, nil)
 	providerSrv.SetHealthInvalidator(voiceSrv.InvalidateHealth)
+	// The #504 guild-admin proof is out of scope here: stub it to pass, give the
+	// check-token ladder an env token, and put a saver identity in the context.
+	providerSrv.checkGuildAdmin = func(context.Context, string, string, string) error { return nil }
+	providerSrv.SetEnvBotToken("env-bot-token")
 
-	ctx := tenantCtx() // same tenant drives saves and health calls
+	ctx := auth.WithUser(tenantCtx(), storage.User{ID: uuid.New(), DiscordUserID: "555000000000000000"})
 	health := func(label string) {
 		t.Helper()
 		if _, err := voiceSrv.GetProviderHealth(ctx, connect.NewRequest(&managementv1.GetProviderHealthRequest{})); err != nil {
@@ -845,6 +849,10 @@ func (stubProviderStore) SaveDiscordBotToken(context.Context, uuid.UUID, []byte,
 
 func (stubProviderStore) SaveDiscordChannels(_ context.Context, _ uuid.UUID, guildID, voiceChannelID string) (storage.DeploymentConfig, error) {
 	return storage.DeploymentConfig{GuildID: guildID, VoiceChannelID: voiceChannelID}, nil
+}
+
+func (stubProviderStore) ReleaseDiscordGuild(context.Context, uuid.UUID, string) (storage.DeploymentConfig, error) {
+	return storage.DeploymentConfig{}, storage.ErrNotFound
 }
 
 func (stubProviderStore) GetTenantSpendCaps(context.Context, uuid.UUID) (storage.SpendCaps, error) {

--- a/internal/storage/deployment.go
+++ b/internal/storage/deployment.go
@@ -159,3 +159,28 @@ func (s *Store) SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, gui
 	}
 	return d, nil
 }
+
+// ReleaseDiscordGuild frees a Tenant's bound guild (#504): an atomic
+// compare-and-clear — the caller echoes the guild_id it believes is bound, and
+// the row is cleared only when tenant AND guild match (no read-then-write race).
+// guild_id = '' is the unconfigured state (migration 00037), so release needs no
+// schema change and frees the first-registrar-wins index slot for the next
+// binder (legit transfer: A releases, B saves with proof). The Bot token is
+// untouched. No matching bound row — wrong echo, already released, or no config
+// at all — returns ErrNotFound.
+func (s *Store) ReleaseDiscordGuild(ctx context.Context, tenantID uuid.UUID, guildID string) (DeploymentConfig, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE deployment_config
+		    SET guild_id = '', voice_channel_id = '', updated_at = now()
+		  WHERE tenant_id = $1 AND guild_id = $2 AND guild_id <> ''
+		 RETURNING `+deploymentConfigColumns,
+		tenantID, guildID)
+	d, err := scanDeploymentConfig(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return DeploymentConfig{}, ErrNotFound
+	}
+	if err != nil {
+		return DeploymentConfig{}, fmt.Errorf("storage: release discord guild for tenant %s: %w", tenantID, err)
+	}
+	return d, nil
+}

--- a/internal/storage/deployment.go
+++ b/internal/storage/deployment.go
@@ -163,7 +163,7 @@ func (s *Store) SaveDiscordChannels(ctx context.Context, tenantID uuid.UUID, gui
 // ReleaseDiscordGuild frees a Tenant's bound guild (#504): an atomic
 // compare-and-clear — the caller echoes the guild_id it believes is bound, and
 // the row is cleared only when tenant AND guild match (no read-then-write race).
-// guild_id = '' is the unconfigured state (migration 00037), so release needs no
+// guild_id = ” is the unconfigured state (migration 00037), so release needs no
 // schema change and frees the first-registrar-wins index slot for the next
 // binder (legit transfer: A releases, B saves with proof). The Bot token is
 // untouched. No matching bound row — wrong echo, already released, or no config

--- a/internal/storage/deployment_test.go
+++ b/internal/storage/deployment_test.go
@@ -96,6 +96,105 @@ func TestSaveDiscordChannelsGuildCollision(t *testing.T) {
 	}
 }
 
+// TestReleaseDiscordGuild pins the #504 release path: the owning Tenant frees
+// its bound guild via an atomic compare-and-clear (WHERE tenant_id AND guild_id
+// match), so a stale/mismatched echo mutates nothing (ErrNotFound), and the
+// cleared row keeps the Bot token.
+func TestReleaseDiscordGuild(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	a, err := st.CreateTenant(ctx, "A")
+	if err != nil {
+		t.Fatalf("CreateTenant A: %v", err)
+	}
+
+	const guild = "555000000000000000"
+	if _, err := st.SaveDiscordBotToken(ctx, a, []byte("sealed"), "3333"); err != nil {
+		t.Fatalf("SaveDiscordBotToken A: %v", err)
+	}
+	if _, err := st.SaveDiscordChannels(ctx, a, guild, "chanA"); err != nil {
+		t.Fatalf("SaveDiscordChannels A: %v", err)
+	}
+
+	// Mismatched guild echo → ErrNotFound, row untouched.
+	if _, err := st.ReleaseDiscordGuild(ctx, a, "999000000000000000"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("ReleaseDiscordGuild(mismatch) err = %v, want ErrNotFound", err)
+	}
+	dep, err := st.GetDeploymentConfig(ctx, a)
+	if err != nil {
+		t.Fatalf("GetDeploymentConfig after mismatch: %v", err)
+	}
+	if dep.GuildID != guild || dep.VoiceChannelID != "chanA" {
+		t.Errorf("mismatched release mutated row: guild=%q voice=%q", dep.GuildID, dep.VoiceChannelID)
+	}
+
+	// Matching guild → cleared row returned; Bot token untouched.
+	cleared, err := st.ReleaseDiscordGuild(ctx, a, guild)
+	if err != nil {
+		t.Fatalf("ReleaseDiscordGuild: %v", err)
+	}
+	if cleared.GuildID != "" || cleared.VoiceChannelID != "" {
+		t.Errorf("released row = guild %q voice %q, want both empty", cleared.GuildID, cleared.VoiceChannelID)
+	}
+	if cleared.DiscordBotTokenLast4 != "3333" {
+		t.Errorf("release wiped the bot token: last4 = %q", cleared.DiscordBotTokenLast4)
+	}
+
+	// Already-released (guild_id = '') → ErrNotFound (nothing bound to release).
+	if _, err := st.ReleaseDiscordGuild(ctx, a, guild); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("ReleaseDiscordGuild(twice) err = %v, want ErrNotFound", err)
+	}
+	// No row at all → ErrNotFound.
+	b, err := st.CreateTenant(ctx, "B")
+	if err != nil {
+		t.Fatalf("CreateTenant B: %v", err)
+	}
+	if _, err := st.ReleaseDiscordGuild(ctx, b, guild); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("ReleaseDiscordGuild(no row) err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestReleaseDiscordGuildTransfer pins the #504 legit-transfer regression: A
+// binds, A releases, B claims the freed guild — while a bind-during-hold still
+// fails ErrGuildTaken (the squat window never opens).
+func TestReleaseDiscordGuildTransfer(t *testing.T) {
+	st := migrated(t)
+	ctx := context.Background()
+
+	a, err := st.CreateTenant(ctx, "A")
+	if err != nil {
+		t.Fatalf("CreateTenant A: %v", err)
+	}
+	b, err := st.CreateTenant(ctx, "B")
+	if err != nil {
+		t.Fatalf("CreateTenant B: %v", err)
+	}
+
+	const guild = "666000000000000000"
+	if _, err := st.SaveDiscordChannels(ctx, a, guild, "chanA"); err != nil {
+		t.Fatalf("SaveDiscordChannels A: %v", err)
+	}
+	// While A holds it, B still cannot bind.
+	if _, err := st.SaveDiscordChannels(ctx, b, guild, "chanB"); !errors.Is(err, storage.ErrGuildTaken) {
+		t.Fatalf("SaveDiscordChannels B while A holds err = %v, want ErrGuildTaken", err)
+	}
+	// A releases, B claims.
+	if _, err := st.ReleaseDiscordGuild(ctx, a, guild); err != nil {
+		t.Fatalf("ReleaseDiscordGuild A: %v", err)
+	}
+	if _, err := st.SaveDiscordChannels(ctx, b, guild, "chanB"); err != nil {
+		t.Fatalf("SaveDiscordChannels B after release: %v", err)
+	}
+	got, err := st.GetTenantIDByGuildID(ctx, guild)
+	if err != nil {
+		t.Fatalf("GetTenantIDByGuildID after transfer: %v", err)
+	}
+	if got != b {
+		t.Errorf("guild owner after transfer = %s, want B %s", got, b)
+	}
+}
+
 // TestListTenantOperatorBindings is the per-Tenant GM-identity source (#490): each
 // binding pairs a Tenant with its operator's Discord snowflake, so GMIdentity can
 // scope GM standing to the owning Tenant instead of deployment-wide. The synthetic

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -1111,6 +1111,14 @@ service ProviderService {
   // channel IDs. An omitted bot_token leaves the stored token unchanged, so the
   // IDs can be saved without re-entering the secret. State-changing.
   rpc SaveDiscordSettings(SaveDiscordSettingsRequest) returns (SaveDiscordSettingsResponse);
+  // ReleaseDiscordGuild frees this Tenant's bound Guild (#504, ADR-0058) — the
+  // supported path for a legitimate guild transfer: A releases, B saves with
+  // proof. The request must echo the currently-bound guild_id (an atomic
+  // compare-and-clear; a mismatch or no binding is FailedPrecondition, an empty
+  // guild_id InvalidArgument). No Discord proof is required to release — the
+  // operator may have lost guild access; release is tenant-local cleanup. The
+  // Bot token is untouched. State-changing: auth + CSRF guard it.
+  rpc ReleaseDiscordGuild(ReleaseDiscordGuildRequest) returns (ReleaseDiscordGuildResponse);
   // ResolveGuildInvite resolves a pasted Discord invite code to its Guild and
   // that Guild's voice channels, using the decrypted saved deployment Bot token
   // server-side (#105, ADR-0047). The SPA extracts the bare code from the pasted
@@ -1266,6 +1274,22 @@ message SaveDiscordSettingsResponse {
   ProviderCredential credential = 1;
   string guild_id = 2;
   string voice_channel_id = 3;
+}
+
+// ReleaseDiscordGuildRequest frees the Tenant's bound Guild (#504). guild_id
+// must equal the currently-bound Guild — a confirmation echo, so a stale form
+// cannot release a binding the operator was not looking at. Empty is rejected
+// (InvalidArgument): present-but-empty is an accident, never a clear.
+message ReleaseDiscordGuildRequest {
+  // guild_id is the bound Guild snowflake being released.
+  string guild_id = 1;
+}
+
+// ReleaseDiscordGuildResponse returns the cleared binding — both fields empty
+// after a successful release (mirrors SaveDiscordSettingsResponse's ID echo).
+message ReleaseDiscordGuildResponse {
+  string guild_id = 1;
+  string voice_channel_id = 2;
 }
 
 // ResolveGuildInviteRequest carries the bare Discord invite code the SPA

--- a/web/src/screens/configuration/Configuration.test.tsx
+++ b/web/src/screens/configuration/Configuration.test.tsx
@@ -16,6 +16,7 @@ import {
   ProviderCredentialSchema,
   SaveProviderConfigResponseSchema,
   SaveDiscordSettingsResponseSchema,
+  ReleaseDiscordGuildResponseSchema,
   GetProviderHealthResponseSchema,
   ProviderHealthSchema,
   ListModelsResponseSchema,
@@ -71,7 +72,16 @@ function mockBackend(
     discordSaves?: SaveDiscordSettingsRequest[];
     // discordSaveError makes SaveDiscordSettings fail (simulates a server-side
     // failure) so tests can pin that the screen surfaces the rejection.
+    // discordSaveCode overrides its Connect code (default Internal) — #504 pins
+    // that the server's PermissionDenied proof message reaches the operator.
     discordSaveError?: string;
+    discordSaveCode?: Code;
+    // boundGuild seeds an already-linked guild + voice channel, the state the
+    // #504 unlink control acts on. releaseCalls captures every
+    // ReleaseDiscordGuild request's guild_id; releaseError fails the release.
+    boundGuild?: { guildId: string; voiceChannelId: string };
+    releaseCalls?: string[];
+    releaseError?: string;
     // providerSaves captures every SaveProviderConfig request so tests can pin
     // the model-only wire shape (#227: secret "" + model).
     providerSaves?: Array<{ provider: string; secret: string; model: string }>;
@@ -111,8 +121,8 @@ function mockBackend(
     elevenlabs: opts.saved?.elevenlabs,
     gemini: opts.saved?.gemini,
     discord: opts.saved?.discord,
-    guildId: "",
-    voiceChannelId: "",
+    guildId: opts.boundGuild?.guildId ?? "",
+    voiceChannelId: opts.boundGuild?.voiceChannelId ?? "",
     spendSoft: opts.spendCaps?.softUsd,
     spendHard: opts.spendCaps?.hardUsd,
   };
@@ -172,7 +182,8 @@ function mockBackend(
       },
       saveDiscordSettings: (req) => {
         opts.discordSaves?.push(req);
-        if (opts.discordSaveError) throw new ConnectError(opts.discordSaveError, Code.Internal);
+        if (opts.discordSaveError)
+          throw new ConnectError(opts.discordSaveError, opts.discordSaveCode ?? Code.Internal);
         // Presence semantics mirror the real server (#142): omitted IDs leave
         // the stored ones untouched, and present-but-empty is REJECTED exactly
         // like internal/rpc/provider.go — so a client that regresses into
@@ -192,6 +203,20 @@ function mockBackend(
           guildId: state.guildId,
           voiceChannelId: state.voiceChannelId,
         });
+      },
+      releaseDiscordGuild: (req) => {
+        opts.releaseCalls?.push(req.guildId);
+        if (opts.releaseError) throw new ConnectError(opts.releaseError, Code.FailedPrecondition);
+        // Mirror the server (#504): the echo must match the bound guild.
+        if (!req.guildId || req.guildId !== state.guildId) {
+          throw new ConnectError(
+            "that Discord server is not the one currently linked; reload and try again",
+            Code.FailedPrecondition,
+          );
+        }
+        state.guildId = "";
+        state.voiceChannelId = "";
+        return create(ReleaseDiscordGuildResponseSchema, { guildId: "", voiceChannelId: "" });
       },
       resolveGuildInvite: async (req) => {
         opts.inviteCodes?.push(req.inviteCode);
@@ -987,5 +1012,69 @@ describe("Configuration first-run (#267)", () => {
 
     expect(await screen.findByText(/could not load the active campaign/i)).toBeInTheDocument();
     expect(screen.queryByText(/create your first campaign/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the server's PermissionDenied guild-proof message on a rejected save (#504)", async () => {
+    renderScreen(
+      mockBackend({
+        discordSaveError: "you need the Manage Server permission in that Discord server to link it",
+        discordSaveCode: Code.PermissionDenied,
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText("Guild ID"), { target: { value: "472093001100" } });
+    fireEvent.change(screen.getByLabelText("Voice channel ID"), { target: { value: "472093774421" } });
+    fireEvent.click(screen.getByRole("button", { name: /save discord settings/i }));
+
+    // The operator must see the server's actionable proof message, not a
+    // generic failure toast.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/manage server permission/i);
+  });
+
+  it("unlinks the bound guild only after an explicit confirm (#504)", async () => {
+    const releaseCalls: string[] = [];
+    renderScreen(
+      mockBackend({
+        boundGuild: { guildId: "472093001100", voiceChannelId: "472093774421" },
+        releaseCalls,
+      }),
+    );
+
+    // A bound guild offers the unlink control; first click only arms it.
+    fireEvent.click(await screen.findByRole("button", { name: /unlink server/i }));
+    expect(releaseCalls).toHaveLength(0);
+
+    // The confirm step names the consequence and needs its own click.
+    fireEvent.click(screen.getByRole("button", { name: /confirm unlink/i }));
+    await waitFor(() => expect(releaseCalls).toEqual(["472093001100"]));
+
+    // The refetched config comes back unbound: fields empty, control gone.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Guild ID") as HTMLInputElement).value).toBe(""),
+    );
+    expect((screen.getByLabelText("Voice channel ID") as HTMLInputElement).value).toBe("");
+    expect(screen.queryByRole("button", { name: /unlink server/i })).not.toBeInTheDocument();
+  });
+
+  it("offers no unlink control while no guild is bound (#504)", async () => {
+    renderScreen();
+    await screen.findByLabelText("Guild ID");
+    expect(screen.queryByRole("button", { name: /unlink server/i })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a failed release as a visible alert (#504)", async () => {
+    renderScreen(
+      mockBackend({
+        boundGuild: { guildId: "472093001100", voiceChannelId: "472093774421" },
+        releaseError: "that Discord server is not the one currently linked; reload and try again",
+      }),
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /unlink server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm unlink/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/not the one currently linked/i);
   });
 });

--- a/web/src/screens/configuration/Configuration.tsx
+++ b/web/src/screens/configuration/Configuration.tsx
@@ -84,6 +84,23 @@ export function Configuration() {
   // Separate mutation instance for the IDs form so its error/pending state is
   // its own — a bot-token failure paints the SecretRow, not this form (#142).
   const saveDiscordIds = useMutation(ProviderService.method.saveDiscordSettings, { onSuccess: invalidateList });
+  // Unlink (#504): frees this tenant's guild binding so another tenant can
+  // claim it (legit transfer: we release, they save with proof). The request
+  // echoes the bound guild_id — the server compare-and-clears atomically.
+  const releaseGuild = useMutation(ProviderService.method.releaseDiscordGuild, {
+    onSuccess: () => {
+      // The binding is gone server-side: clear the local fields and drop the
+      // dirty guard so the refetch reseeds the (now empty) stored state.
+      idsDirty.current = false;
+      setGuildId("");
+      setVoiceChannelId("");
+      setConfirmUnlink(false);
+      invalidateList();
+    },
+  });
+  // Two-step unlink: the first click only arms the confirm — releasing a guild
+  // hands it to whoever binds next, so it must never ride a single misclick.
+  const [confirmUnlink, setConfirmUnlink] = useState(false);
 
   // Guild / Voice channel IDs are controlled, seeded from the RPC. A `dirty` ref
   // guards the seed so a slow first load (or a post-save refetch) can never
@@ -245,6 +262,42 @@ export function Configuration() {
               </span>
             )}
           </div>
+          {/* Unlink (#504): offered only while a guild is actually bound
+              (stored state, not the form fields). Releasing frees the guild for
+              another tenant — the supported transfer path — so it takes an
+              explicit confirm, and a failed release stays visible. */}
+          {config.isSuccess && config.data.guildId !== "" && (
+            <div className="gx-discord__unlink">
+              {confirmUnlink ? (
+                <>
+                  <span className="gx-discord__unlink-note">
+                    Unlink this Discord server? Sessions stop working until a server is linked
+                    again, and another tenant can then link it.
+                  </span>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={releaseGuild.isPending}
+                    onClick={() => releaseGuild.mutate({ guildId: config.data.guildId })}
+                  >
+                    Confirm unlink
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setConfirmUnlink(false)}>
+                    Cancel
+                  </Button>
+                </>
+              ) : (
+                <Button variant="secondary" size="sm" onClick={() => setConfirmUnlink(true)}>
+                  Unlink server
+                </Button>
+              )}
+              {releaseGuild.isError && (
+                <span className="gx-discord__error" role="alert">
+                  Couldn&apos;t unlink: {releaseGuild.error.message}
+                </span>
+              )}
+            </div>
+          )}
           {/* Authorizing the Bot into the Guild is a separate, prerequisite step
               from saving the IDs — neither pasted-link format joins the Bot (#110).
               Gated on a resolved read so the "no application id" note can't flash

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -87,6 +87,23 @@
   gap: var(--spacing-md);
 }
 
+/* Unlink control (#504): a right-aligned row under the IDs form. The confirm
+ * step swaps in a consequence note + danger button, so a release never rides a
+ * single misclick. */
+.gx-discord__unlink {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+}
+
+.gx-discord__unlink-note {
+  font-size: var(--body-sm);
+  color: var(--text-secondary);
+  max-width: 46ch;
+}
+
 /* Inline save-failure cue for the IDs form, mirroring the SecretRow error
  * treatment (#142 / #154). */
 .gx-discord__error {


### PR DESCRIPTION
Closes #504.

## What

- **New `internal/discordguild`**: proves a Discord user administers a guild (owner short-circuit, or any held role — @everyone included — with ADMINISTRATOR/MANAGE_GUILD). Mirrors `internal/discordinvite` exactly per ADR-0047: plain net/http (no disgo), 15s timeout, Bot auth header, base-URL + export_test seam. `permissions` parsed as decimal string.
- **SaveDiscordSettings**: guild-admin proof runs BEFORE any write (token save included) — a squat-first attacker cannot bind an unowned guild, and the "another tenant" ErrGuildTaken message is only reachable by proven admins (no existence oracle). Check-token ladder: request plaintext > stored BYOK (decrypted server-side, ADR-0004) > central `DISCORD_BOT_TOKEN` env token — BYOK + central-token tenants both covered. Enforced in BOTH admission modes, no self-host/dev bypass (recorded in ADR-0058).
- **New `ReleaseDiscordGuild` RPC**: the legit-transfer path (A releases, B saves with proof). Echo-confirmed atomic compare-and-clear in storage (no schema change; `guild_id=''` is the unconfigured state). No Discord proof on release (operator may have lost guild access). Fires invalidateHealth + refreshPresence so the freed guild's standing presence tears down (ADR-0057).
- **Web**: two-step Unlink control on the Configuration screen; server proof/release error messages surface verbatim (no generic toast).
- **ADR-0058** records the proof + release contract, the TOCTOU acceptance, and the SaaS-first no-bypass narrowing of ADR-0039.

## Error mapping

| condition | code | message |
|---|---|---|
| Bot can't read guild (403/404) | FailedPrecondition | "the Bot is not a member of that server" |
| user not in guild / no Manage Guild | PermissionDenied | "you need the Manage Server permission in that Discord server to link it" |
| no token anywhere | FailedPrecondition | "save the Discord bot token first" |
| release echo mismatch / unbound | FailedPrecondition | "not the one currently linked" |

## Tests

TDD red→green throughout: 8 discordguild unit tests (owner short-circuit, role-bit table, 403/404 collapse, member 404/403, empty-token fail-fast, generic-500), 2 storage integration tests (compare-and-clear + full A-releases-B-claims transfer regression incl. bind-while-held still ErrGuildTaken), 7 RPC tests (proof wiring/identity, squat regression with write-count assertion, token ladder, token-only skip, missing principal, release hooks), 4 web vitest tests (PermissionDenied message rendered, confirm-gated unlink, no control when unbound, failed release alert). Existing #142/#483 tests updated to ride the new proof stub. All Discord stays behind seams — default suite keyless (ADR-0033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)