### PR TITLE
feat(#503): cross-pod live voice controls via claim-plane requested-controls

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -435,8 +435,17 @@ func voiceIntentControlConfig(getenv func(string) string) session.IntentControlC
 		// Matches the worker's reaper horizon so Start's zero-worker escape (review
 		// item 4) judges a blocking claim stale on the same clock the worker would.
 		Expiry: envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+		// How long a relayed live control (mute/say/butler-say, #503) waits for the
+		// hosting worker's confirmation. Dispatch rides the worker's heartbeat tick
+		// (default 5s), so this knob must stay comfortably above heartbeat + one
+		// control execute + margin — the 15s default gives ~3 beats of headroom.
+		ControlBudget: envDuration(getenv, "GLYPHOXA_VOICE_CONTROL_BUDGET", defaultVoiceControlBudget),
 	}
 }
+
+// defaultVoiceControlBudget is the relayed-control confirmation budget (#503):
+// 15s = worker heartbeat (5s) + execute + generous margin.
+const defaultVoiceControlBudget = 15 * time.Second
 
 // Presence-owner election defaults (#492, ADR-0057 (c)): the -mode voice worker
 // renews the singleton presence_owner claim every 5s and an owner's silence past

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -436,15 +436,14 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 	// row). Route them through IntentControl so /glyphoxa start writes an intent this
 	// same worker's loop claims (typically within one poll) and /glyphoxa end
 	// requests the stop the loop honors — exactly the plane the web tier uses. The
-	// live controls (mute/say) still drive the LOCAL Manager, which holds a live
-	// session only when THIS worker is running it: at replicas > 1 the presence
-	// owner dispatching the interaction may not be the session's host, so those
-	// commands take intentControl as their PoolSession and reply the split-mode
-	// limitation (#483) when the session is live on another worker — the cross-pod
-	// control plane is #503. search and recap resolve their Active Campaign through
-	// intentControl (the pool-wide Active), so they work regardless of which worker
-	// hosts the session; a `voiced` recap still degrades to public text when the
-	// Butler isn't in THIS worker's session (decision 6a).
+	// live controls (mute/say) drive the LOCAL Manager when THIS worker hosts the
+	// session, and otherwise RELAY through intentControl's voice_session_controls
+	// queue (#503) to the hosting worker — so at replicas > 1 the presence owner
+	// dispatching the interaction controls a session it does not host. search and
+	// recap resolve their Active Campaign through intentControl (the pool-wide
+	// Active), so they work regardless of which worker hosts the session; a
+	// `voiced` recap speaks locally when this worker hosts the session and relays
+	// via the ButlerControl otherwise.
 	intentControl := session.NewIntentControl(store, log, voiceIntentControlConfig(os.Getenv))
 
 	// Register the full tenant command surface (start/end/search/mute/say/recap),
@@ -454,7 +453,7 @@ func runVoiceWorker(log *slog.Logger, cfg wirenpc.Config, metrics *observe.Prome
 		presence.StartCommand(store, intentControl),
 		presence.EndCommand(intentControl),
 		presence.SearchCommand(store, intentControl),
-		presence.RecapCommand(store, intentControl, recapEngine, mgr),
+		presence.RecapCommand(store, intentControl, recapEngine, session.NewButlerControl(mgr, intentControl)),
 		presence.MuteCommand(mgr, store, intentControl),
 		presence.MuteAllCommand(mgr, store, intentControl),
 		presence.SayCommand(mgr, store, intentControl),

--- a/docs/adr/0057-shared-voice-worker-pool-multi-tenant.md
+++ b/docs/adr/0057-shared-voice-worker-pool-multi-tenant.md
@@ -130,13 +130,27 @@ instance — the Tenant restarts the session.
   a shared token; only the elected presence owner dispatches them.
 - A voice pod split from the web tier still has no live SSE transcript relay
   (ADR-0014's Hop-A remains deferred) and no mute/say RPCs — those gaps are
-  pre-existing and unchanged by this ADR.
+  pre-existing and unchanged by this ADR. *(The mute/say half of this
+  consequence is superseded by #503 — see Amendments.)*
 - The secret blast radius is deliberately widened: the voice role now reads
   `GLYPHOXA_SECRET`, a posture change from today's chart (superseded below).
 - Running K concurrent DAVE sessions in one process is soak-unverified; #493
   tracks the load test that must precede committing to a K value.
 
 ## Amendments
+
+**Cross-pod live controls (2026-07-20, #503)** — the consequence above that a
+split deployment has "no mute/say" is SUPERSEDED per the SaaS directive on
+#503: mute / muteall / say / voiced-recap now RELAY through a
+`voice_session_controls` queue hanging off `voice_session_intents`
+(`internal/storage/voicecontrol.go`, `internal/session/intentcontrol.go`). The
+mechanism stays inside this ADR's own rules: DB-write-then-poll only, no
+LISTEN/NOTIFY (decision (b)); the control row never re-targets another
+instance and only the OWNING worker's own claim loop dispatches it against its
+local Manager (decision (e), ADR-0006); a confirmation is posted only after
+the worker's terminal row — a requester timeout is an error, never a claimed
+success (ADR-0012). Highlight replay and the web panel's muted-set read remain
+degraded in split mode (out of #503's scope).
 
 **ADR-0039** — its claim that "the `voice.v1 VoiceControlService` proto
 (`claim_session` / `release_session` / `push_event`) is authored now" is

--- a/internal/presence/mute.go
+++ b/internal/presence/mute.go
@@ -49,11 +49,12 @@ const maxAutocompleteChoices = 25
 // no/ambiguous match. A mute with no active Voice Session is refused ephemerally.
 // There is deliberately NO unmute command — the web panel owns un-muting.
 //
-// pool is the claim-plane read for the replicas>1 fleet (#483, nil in -mode all):
-// when the LOCAL Manager holds no session but the Tenant's session is live on
-// ANOTHER worker, the handler replies the split-mode limitation (#503) instead of
-// the false "No Voice Session is active."
-func MuteCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Command {
+// pool is the claim-plane control relay for the replicas>1 fleet (#503, nil in
+// -mode all): when the LOCAL Manager holds no session but the Tenant's session
+// is live on ANOTHER worker, the handler Defers and relays the mute through the
+// voice_session_controls queue, confirming only on the hosting worker's
+// terminal row (ADR-0012).
+func MuteCommand(mgr SessionMuter, agents AgentLister, pool PoolControl) Command {
 	return Command{
 		Path:        "glyphoxa mute",
 		Description: "Mute one NPC voice in the active Voice Session.",
@@ -69,7 +70,11 @@ func MuteCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Command
 		Autocomplete: func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
 			vs, active, err := mgr.Active(ctx, ac.TenantID())
 			if err != nil || !active {
-				return nil, nil // no session for this Tenant: nothing to mute, offer nothing
+				// No LOCAL session: fall back to the pool's Active (#503) so the roster
+				// still resolves for a session hosted by another worker.
+				if vs, active = poolActive(ctx, pool, ac.TenantID()); !active {
+					return nil, nil // no session anywhere: nothing to mute, offer nothing
+				}
 			}
 			roster, err := agents.ListAgents(ctx, vs.CampaignID)
 			if err != nil {
@@ -94,9 +99,9 @@ func MuteCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Command
 			if err != nil || !active {
 				// No session for THIS Tenant (#488): a session live for another Tenant is
 				// invisible here, so a GM can never mute a foreign Tenant's session. When
-				// the pool shows it live on ANOTHER worker the reply names the split-mode
-				// limitation instead (#483/#503).
-				return replyNoLocalSession(ctx, ic, pool)
+				// the pool shows it live on ANOTHER worker, relay the mute through the
+				// claim plane (#503); else the plain no-session guard.
+				return handleCrossPodMute(ctx, ic, agents, pool)
 			}
 			input, _ := ic.String("npc")
 			roster, err := agents.ListAgents(ctx, vs.CampaignID)
@@ -126,16 +131,26 @@ func MuteCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Command
 // voiced Agent of the Active Campaign (the Character NPCs; the Address-Only Butler
 // is excluded) in the live Voice Session, refused ephemerally when no Voice
 // Session is active. Un-muting everyone is the web panel's job. pool is the
-// claim-plane read for the replicas>1 fleet (#483/#503, nil in -mode all) —
+// claim-plane control relay for the replicas>1 fleet (#503, nil in -mode all) —
 // see MuteCommand.
-func MuteAllCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Command {
+func MuteAllCommand(mgr SessionMuter, agents AgentLister, pool PoolControl) Command {
 	return Command{
 		Path:        "glyphoxa muteall",
 		Description: "Mute every NPC voice in the active Voice Session.",
 		GMOnly:      true,
 		Handle: func(ctx context.Context, ic *Interaction) error {
 			if _, active, err := mgr.Active(ctx, ic.TenantID()); err != nil || !active {
-				return replyNoLocalSession(ctx, ic, pool)
+				// Cross-pod branch (#503): the session may be hosted by another worker.
+				if _, poolLive := poolActive(ctx, pool, ic.TenantID()); !poolLive {
+					return ic.ReplyEphemeral("No Voice Session is active.")
+				}
+				// Defer FIRST: the relay polls the hosting worker past Discord's 3s
+				// deadline. The confirmation lands only on the worker's terminal row.
+				if err := ic.Defer(true); err != nil {
+					return fmt.Errorf("presence: defer cross-pod muteall: %w", err)
+				}
+				ids, err := pool.SetAllMute(ctx, ic.TenantID(), true)
+				return replyControlOutcome(ic, err, fmt.Sprintf("Muted all %d Agent voices.", len(ids)))
 			}
 			ids, err := mgr.SetAllMute(ctx, ic.TenantID(), true)
 			if err != nil {
@@ -144,6 +159,36 @@ func MuteAllCommand(mgr SessionMuter, agents AgentLister, pool PoolSession) Comm
 			return ic.ReplyEphemeral(fmt.Sprintf("Muted all %d Agent voices.", len(ids)))
 		},
 	}
+}
+
+// handleCrossPodMute is /glyphoxa mute's cross-pod branch (#503): the LOCAL
+// Manager holds no session, so when the pool shows the Tenant live on another
+// worker the mute is relayed through the voice_session_controls queue — Defer
+// FIRST (the relay polls past Discord's 3s deadline), resolve the target against
+// the POOL session's Campaign roster, relay, then confirm/err ephemerally. No
+// pool session anywhere keeps the plain pre-#483 guard.
+func handleCrossPodMute(ctx context.Context, ic *Interaction, agents AgentLister, pool PoolControl) error {
+	vs, live := poolActive(ctx, pool, ic.TenantID())
+	if !live {
+		return ic.ReplyEphemeral("No Voice Session is active.")
+	}
+	if err := ic.Defer(true); err != nil {
+		return fmt.Errorf("presence: defer cross-pod mute: %w", err)
+	}
+	input, _ := ic.String("npc")
+	roster, err := agents.ListAgents(ctx, vs.CampaignID)
+	if err != nil {
+		return fmt.Errorf("presence: list agents for cross-pod mute: %w", err) // generic reply via the registry
+	}
+	agent, found, ambiguous := resolveAgent(voiced(roster), input)
+	if ambiguous {
+		return ic.ReplyEphemeral(fmt.Sprintf("%q matches more than one Agent — pick one from the list.", strings.TrimSpace(input)))
+	}
+	if !found {
+		return ic.ReplyEphemeral(fmt.Sprintf("No Agent named %q in the Active Campaign.", strings.TrimSpace(input)))
+	}
+	_, err = pool.SetAgentMute(ctx, ic.TenantID(), agent.ID.String(), true)
+	return replyControlOutcome(ic, err, fmt.Sprintf("%s is muted.", agent.Name))
 }
 
 // resolveAgent resolves a /glyphoxa mute npc value to a roster Agent (#211):

--- a/internal/presence/mute_test.go
+++ b/internal/presence/mute_test.go
@@ -3,12 +3,14 @@ package presence
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/disgoorg/disgo/discord"
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -117,51 +119,161 @@ func TestMuteCommand_IdleEphemeral(t *testing.T) {
 	}
 }
 
-// fakePool is a PoolSession for the split-mode guard tests (#483): it scripts the
-// claim plane's pool-wide Active answer.
-type fakePool struct{ live bool }
+// fakePool is a PoolControl for the cross-pod control tests (#503): it scripts
+// the claim plane's pool-wide Active answer and records the relayed controls.
+type fakePool struct {
+	live       bool
+	campaignID uuid.UUID
+	mutedIDs   []string
+	muteErr    error
+	sayErr     error
+	agentCalls []muteCall
+	allCalls   []bool
+	sayCalls   []poolSayCall
+}
+
+type poolSayCall struct {
+	id   string
+	text string
+}
 
 func (f *fakePool) Active(context.Context, uuid.UUID) (storage.VoiceSession, bool, error) {
-	return storage.VoiceSession{}, f.live, nil
+	if !f.live {
+		return storage.VoiceSession{}, false, nil
+	}
+	return storage.VoiceSession{CampaignID: f.campaignID}, true, nil
 }
 
-// TestMuteCommand_SessionOnAnotherWorker pins the #483 replicas>1 fix: the local
-// Manager holds no session but the claim plane says the Tenant's session is live
-// (hosted by ANOTHER worker in the pool) — the handler must reply the honest
-// split-mode limitation (#503), never the false "No Voice Session is active.",
-// and must mute nothing.
-func TestMuteCommand_SessionOnAnotherWorker(t *testing.T) {
-	mgr := &fakeMuter{active: false}
-	cmd := MuteCommand(mgr, &fakeLister{}, &fakePool{live: true})
+func (f *fakePool) SetAgentMute(_ context.Context, _ uuid.UUID, id string, muted bool) ([]string, error) {
+	f.agentCalls = append(f.agentCalls, muteCall{id, muted})
+	return f.mutedIDs, f.muteErr
+}
+
+func (f *fakePool) SetAllMute(_ context.Context, _ uuid.UUID, muted bool) ([]string, error) {
+	f.allCalls = append(f.allCalls, muted)
+	return f.mutedIDs, f.muteErr
+}
+
+func (f *fakePool) SayAs(_ context.Context, _ uuid.UUID, id, text string) error {
+	f.sayCalls = append(f.sayCalls, poolSayCall{id, text})
+	return f.sayErr
+}
+
+// TestMuteCommand_LocalPathNoDefer covers sequence (12)/AC3: with the session
+// live on THIS worker the old path runs byte-identically — an immediate
+// ephemeral reply, NO Defer, the pool never consulted.
+func TestMuteCommand_LocalPathNoDefer(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	mgr := &fakeMuter{active: true, campaignID: uuid.New()}
+	pool := &fakePool{live: true}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{bart}}, pool)
 	resp := &fakeResponder{}
-	if err := cmd.Handle(context.Background(), muteIC(resp, "Bart")); err != nil {
+	if err := cmd.Handle(context.Background(), muteIC(resp, bart.ID.String())); err != nil {
 		t.Fatalf("Handle: %v", err)
 	}
-	if len(resp.replies) != 1 || !resp.replies[0].ephemeral {
-		t.Fatalf("split reply = %+v, want one ephemeral", resp.replies)
+	if resp.deferred != nil {
+		t.Fatal("local path Deferred, want the pre-#503 immediate reply (AC3)")
 	}
-	if !strings.Contains(resp.replies[0].content, "another worker") {
-		t.Errorf("split reply = %q, want the hosted-by-another-worker message, not the false no-session guard", resp.replies[0].content)
+	if len(resp.replies) != 1 || resp.replies[0].content != "Bart is muted." || !resp.replies[0].ephemeral {
+		t.Fatalf("local reply = %+v, want the ephemeral 'Bart is muted.'", resp.replies)
 	}
-	if len(mgr.agentCalls) != 0 {
-		t.Fatalf("split handler muted %v, want nothing", mgr.agentCalls)
+	if len(pool.agentCalls) != 0 {
+		t.Fatalf("local path relayed %v, want the local Manager only", pool.agentCalls)
 	}
 }
 
-// TestMuteAllCommand_SessionOnAnotherWorker is the muteall sibling of the #483
-// split-mode guard.
+// TestMuteCommand_SessionOnAnotherWorker covers sequence (13)/#503: the local
+// Manager holds no session but the pool does — the handler Defers ephemerally,
+// relays the mute through the claim plane, and confirms with "X is muted."
+func TestMuteCommand_SessionOnAnotherWorker(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	mgr := &fakeMuter{active: false}
+	pool := &fakePool{live: true, campaignID: uuid.New()}
+	cmd := MuteCommand(mgr, &fakeLister{agents: []storage.Agent{bart}}, pool)
+	resp := &fakeResponder{}
+	if err := cmd.Handle(context.Background(), muteIC(resp, bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if resp.deferred == nil || !*resp.deferred {
+		t.Fatal("cross-pod mute did not Defer(true) — the relay can outlive Discord's 3s deadline")
+	}
+	if len(pool.agentCalls) != 1 || pool.agentCalls[0].id != bart.ID.String() || !pool.agentCalls[0].muted {
+		t.Fatalf("pool relay calls = %+v, want one {%s true}", pool.agentCalls, bart.ID)
+	}
+	if len(mgr.agentCalls) != 0 {
+		t.Fatalf("cross-pod path drove the LOCAL manager: %+v", mgr.agentCalls)
+	}
+	if len(resp.followups) != 1 || !strings.Contains(resp.followups[0].content, "Bart is muted.") || !resp.followups[0].ephemeral {
+		t.Fatalf("confirming followup = %+v, want ephemeral 'Bart is muted.'", resp.followups)
+	}
+}
+
+// TestMuteCommand_RelayFailureSurfaces covers sequence (14): a relay failure
+// posts the REAL error text — never a silent no-op — and an unconfirmed relay
+// (ErrControlPending) posts the honest not-confirmed wording, no phantom success.
+func TestMuteCommand_RelayFailureSurfaces(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	lister := &fakeLister{agents: []storage.Agent{bart}}
+
+	pool := &fakePool{live: true, muteErr: errors.New("worker could not apply control: tts exploded")}
+	resp := &fakeResponder{}
+	if err := MuteCommand(&fakeMuter{}, lister, pool).Handle(context.Background(), muteIC(resp, bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(resp.followups) != 1 || !strings.Contains(resp.followups[0].content, "tts exploded") {
+		t.Fatalf("failure followup = %+v, want the real error text", resp.followups)
+	}
+
+	pool = &fakePool{live: true, muteErr: session.ErrControlPending}
+	resp = &fakeResponder{}
+	if err := MuteCommand(&fakeMuter{}, lister, pool).Handle(context.Background(), muteIC(resp, bart.ID.String())); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(resp.followups) != 1 || !strings.Contains(resp.followups[0].content, "not confirmed") {
+		t.Fatalf("pending followup = %+v, want the honest not-confirmed wording", resp.followups)
+	}
+	if strings.Contains(resp.followups[0].content, "is muted.") {
+		t.Fatalf("pending followup %q claims success", resp.followups[0].content)
+	}
+}
+
+// TestMuteAllCommand_SessionOnAnotherWorker covers the muteall arm of sequence
+// (15): Defer + relay + confirming count followup.
 func TestMuteAllCommand_SessionOnAnotherWorker(t *testing.T) {
 	mgr := &fakeMuter{active: false}
+	pool := &fakePool{live: true, mutedIDs: []string{"a", "b"}}
 	resp := &fakeResponder{}
-	if err := MuteAllCommand(mgr, &fakeLister{}, &fakePool{live: true}).Handle(context.Background(),
+	if err := MuteAllCommand(mgr, &fakeLister{}, pool).Handle(context.Background(),
 		&Interaction{guildID: testGuild, userID: operatorID, resp: resp}); err != nil {
 		t.Fatalf("Handle: %v", err)
 	}
-	if len(resp.replies) != 1 || !strings.Contains(resp.replies[0].content, "another worker") {
-		t.Fatalf("split reply = %+v, want the hosted-by-another-worker message", resp.replies)
+	if resp.deferred == nil || !*resp.deferred {
+		t.Fatal("cross-pod muteall did not Defer(true)")
+	}
+	if len(pool.allCalls) != 1 || !pool.allCalls[0] {
+		t.Fatalf("pool muteall calls = %v, want one true", pool.allCalls)
 	}
 	if len(mgr.allCalls) != 0 {
-		t.Fatalf("split handler muted-all %v, want nothing", mgr.allCalls)
+		t.Fatalf("cross-pod muteall drove the LOCAL manager: %v", mgr.allCalls)
+	}
+	if len(resp.followups) != 1 || !strings.Contains(resp.followups[0].content, "Muted all 2 Agent voices.") {
+		t.Fatalf("confirming followup = %+v, want 'Muted all 2 Agent voices.'", resp.followups)
+	}
+}
+
+// TestMuteAutocomplete_PoolFallback: with no LOCAL session the mute autocomplete
+// falls back to the pool's Active for the roster campaign (#503), so a GM on the
+// presence owner still gets choices for a session hosted elsewhere.
+func TestMuteAutocomplete_PoolFallback(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
+	cmd := MuteCommand(&fakeMuter{active: false}, &fakeLister{agents: []storage.Agent{bart}},
+		&fakePool{live: true, campaignID: uuid.New()})
+	choices, err := cmd.Autocomplete(context.Background(), muteAC(""))
+	if err != nil {
+		t.Fatalf("Autocomplete: %v", err)
+	}
+	if len(choices) != 1 {
+		t.Fatalf("choices = %+v, want Bart via the pool fallback", choices)
 	}
 }
 

--- a/internal/presence/say.go
+++ b/internal/presence/say.go
@@ -46,9 +46,11 @@ type SayControl interface {
 // (ADR-0009/0024), so puppeteering it needs the Butler voicer on-ramp — the
 // #299-blocked follow-up (ButlerVoicer = SayAs(GetButler id)).
 //
-// pool is the claim-plane read for the replicas>1 fleet (#483/#503, nil in
-// -mode all) — see MuteCommand.
-func SayCommand(mgr SayControl, agents AgentLister, pool PoolSession) Command {
+// pool is the claim-plane control relay for the replicas>1 fleet (#503, nil in
+// -mode all) — see MuteCommand. The no-Defer note above holds for the LOCAL
+// path only: the cross-pod branch DOES Defer, since the relay polls the hosting
+// worker past Discord's 3s deadline.
+func SayCommand(mgr SayControl, agents AgentLister, pool PoolControl) Command {
 	return Command{
 		Path:        "say",
 		Description: "Make an NPC speak the given text in the active Voice Session.",
@@ -69,7 +71,11 @@ func SayCommand(mgr SayControl, agents AgentLister, pool PoolSession) Command {
 		Autocomplete: func(ctx context.Context, ac *Autocomplete) ([]discord.AutocompleteChoice, error) {
 			vs, active, err := mgr.Active(ctx, ac.TenantID())
 			if err != nil || !active {
-				return nil, nil // no session for this Tenant: nothing to puppet, offer nothing
+				// No LOCAL session: fall back to the pool's Active (#503) so the roster
+				// still resolves for a session hosted by another worker.
+				if vs, active = poolActive(ctx, pool, ac.TenantID()); !active {
+					return nil, nil // no session anywhere: nothing to puppet, offer nothing
+				}
 			}
 			roster, err := agents.ListAgents(ctx, vs.CampaignID)
 			if err != nil {
@@ -94,9 +100,9 @@ func SayCommand(mgr SayControl, agents AgentLister, pool PoolSession) Command {
 			if err != nil || !active {
 				// No session for THIS Tenant (#488): a session live for another Tenant is
 				// invisible here, so a GM can never puppet a foreign Tenant's session. When
-				// the pool shows it live on ANOTHER worker the reply names the split-mode
-				// limitation instead (#483/#503).
-				return replyNoLocalSession(ctx, ic, pool)
+				// the pool shows it live on ANOTHER worker, relay the say through the
+				// claim plane (#503); else the plain no-session guard.
+				return handleCrossPodSay(ctx, ic, agents, pool)
 			}
 			text, _ := ic.String("text")
 			input, _ := ic.String("as")
@@ -121,4 +127,32 @@ func SayCommand(mgr SayControl, agents AgentLister, pool PoolSession) Command {
 			return ic.ReplyEphemeral(fmt.Sprintf("Speaking as %s.", agent.Name))
 		},
 	}
+}
+
+// handleCrossPodSay is /say's cross-pod branch (#503) — the say sibling of
+// handleCrossPodMute: Defer FIRST, resolve the puppet target against the POOL
+// session's Campaign roster, relay through the claim plane, confirm/err.
+func handleCrossPodSay(ctx context.Context, ic *Interaction, agents AgentLister, pool PoolControl) error {
+	vs, live := poolActive(ctx, pool, ic.TenantID())
+	if !live {
+		return ic.ReplyEphemeral("No Voice Session is active.")
+	}
+	if err := ic.Defer(true); err != nil {
+		return fmt.Errorf("presence: defer cross-pod say: %w", err)
+	}
+	text, _ := ic.String("text")
+	input, _ := ic.String("as")
+	roster, err := agents.ListAgents(ctx, vs.CampaignID)
+	if err != nil {
+		return fmt.Errorf("presence: list agents for cross-pod say: %w", err) // generic reply via the registry
+	}
+	agent, found, ambiguous := resolveAgent(voiced(roster), input)
+	if ambiguous {
+		return ic.ReplyEphemeral(fmt.Sprintf("%q matches more than one Agent — pick one from the list.", strings.TrimSpace(input)))
+	}
+	if !found {
+		return ic.ReplyEphemeral(fmt.Sprintf("No Agent named %q in the Active Campaign.", strings.TrimSpace(input)))
+	}
+	err = pool.SayAs(ctx, ic.TenantID(), agent.ID.String(), text)
+	return replyControlOutcome(ic, err, fmt.Sprintf("Speaking as %s.", agent.Name))
 }

--- a/internal/presence/say_test.go
+++ b/internal/presence/say_test.go
@@ -103,21 +103,29 @@ func TestSayCommand_IsFlatGMOnlyWithAutocomplete(t *testing.T) {
 	}
 }
 
-// TestSayCommand_SessionOnAnotherWorker pins the #483 replicas>1 fix: the local
-// Manager holds no session but the claim plane says the Tenant's session is live
-// on ANOTHER worker — /say must reply the honest split-mode limitation (#503),
-// never the false "No Voice Session is active.", and never call SayAs.
+// TestSayCommand_SessionOnAnotherWorker covers the say arm of sequence (15)/#503:
+// the local Manager holds no session but the pool does — /say Defers, relays
+// through the claim plane (the LOCAL SayAs is never called), and confirms.
 func TestSayCommand_SessionOnAnotherWorker(t *testing.T) {
+	bart := storage.Agent{ID: uuid.New(), Name: "Bart"}
 	sayer := &fakeSayer{active: false}
+	pool := &fakePool{live: true, campaignID: uuid.New()}
 	resp := &fakeResponder{}
-	if err := SayCommand(sayer, &fakeLister{}, &fakePool{live: true}).Handle(context.Background(), sayIC(resp, "hi", "Bart")); err != nil {
+	if err := SayCommand(sayer, &fakeLister{agents: []storage.Agent{bart}}, pool).Handle(context.Background(),
+		sayIC(resp, "hi", bart.ID.String())); err != nil {
 		t.Fatalf("Handle: %v", err)
 	}
-	if len(sayer.calls) != 0 {
-		t.Fatalf("SayAs called %d times for a remote-hosted session, want 0", len(sayer.calls))
+	if resp.deferred == nil || !*resp.deferred {
+		t.Fatal("cross-pod say did not Defer(true)")
 	}
-	if len(resp.replies) != 1 || !strings.Contains(resp.replies[0].content, "another worker") {
-		t.Fatalf("split reply = %+v, want the hosted-by-another-worker message", resp.replies)
+	if len(sayer.calls) != 0 {
+		t.Fatalf("LOCAL SayAs called %d times for a remote-hosted session, want 0", len(sayer.calls))
+	}
+	if len(pool.sayCalls) != 1 || pool.sayCalls[0].id != bart.ID.String() || pool.sayCalls[0].text != "hi" {
+		t.Fatalf("pool say calls = %+v, want one {%s hi}", pool.sayCalls, bart.ID)
+	}
+	if len(resp.followups) != 1 || !strings.Contains(resp.followups[0].content, "Speaking as Bart.") || !resp.followups[0].ephemeral {
+		t.Fatalf("confirming followup = %+v, want ephemeral 'Speaking as Bart.'", resp.followups)
 	}
 }
 

--- a/internal/presence/split.go
+++ b/internal/presence/split.go
@@ -2,41 +2,62 @@ package presence
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
-// PoolSession is the CLAIM-PLANE read the live-control commands consult when the
-// LOCAL Manager holds no session for the Tenant (#483): at replicas > 1 the
-// interactions are dispatched by the elected presence owner, but the Tenant's
-// session may be hosted by ANOTHER worker in the pool — the local Manager then
-// reports inactive and the handler would falsely reply "No Voice Session is
-// active." while the session is very much live. *session.IntentControl satisfies
-// it (its Active is the pool-wide intent read). nil in -mode all, where the one
-// process hosts every session and the local read is already the whole truth.
-type PoolSession interface {
+// PoolControl is the CLAIM-PLANE surface the live-control commands consult when
+// the LOCAL Manager holds no session for the Tenant (#483/#503): at replicas > 1
+// the interactions are dispatched by the elected presence owner, but the
+// Tenant's session may be hosted by ANOTHER worker in the pool. Active is the
+// pool-wide intent read; the control verbs RELAY through the
+// voice_session_controls queue the hosting worker drains on its heartbeat tick
+// (write-then-poll, ADR-0057 (b)/ADR-0051 — the dispatch never moves the
+// session, ADR-0006/0057 (e)). *session.IntentControl satisfies it. nil in
+// -mode all, where the one process hosts every session and the local read is
+// already the whole truth (AC3: single-worker behavior unchanged).
+type PoolControl interface {
 	Active(ctx context.Context, tenantID uuid.UUID) (storage.VoiceSession, bool, error)
+	SetAgentMute(ctx context.Context, tenantID uuid.UUID, agentID string, muted bool) ([]string, error)
+	SetAllMute(ctx context.Context, tenantID uuid.UUID, muted bool) ([]string, error)
+	SayAs(ctx context.Context, tenantID uuid.UUID, agentID, text string) error
 }
 
-// splitLiveControlMsg is the reply for a live control (mute/muteall/say) whose
-// session is live on ANOTHER worker: honest about the limitation instead of the
-// false "No Voice Session is active." The cross-pod control plane that would make
-// these work from the presence owner is tracked in #503 — this PR ships only the
-// truthful degrade.
-const splitLiveControlMsg = "This session is hosted by another worker; live controls aren't available from here yet. Use the web panel instead."
-
-// replyNoLocalSession answers a live-control command whose local Manager holds no
-// session for the Tenant (#483): when the claim plane shows the Tenant's session
-// live on another worker it replies the split-mode limitation (see #503), else
-// the plain no-session guard. A nil pool (single-process -mode all) or a pool
-// read error degrades to the plain guard — the pre-#483 behavior.
-func replyNoLocalSession(ctx context.Context, ic *Interaction, pool PoolSession) error {
-	if pool != nil {
-		if _, live, err := pool.Active(ctx, ic.TenantID()); err == nil && live {
-			return ic.ReplyEphemeral(splitLiveControlMsg)
-		}
+// poolActive resolves the Tenant's session from the pool when the LOCAL Manager
+// has none: the cross-pod branch's entry read. A nil pool (-mode all) or a pool
+// read error reports not-live — the caller then gives the plain no-session
+// guard, the pre-#483 behavior.
+func poolActive(ctx context.Context, pool PoolControl, tenantID uuid.UUID) (storage.VoiceSession, bool) {
+	if pool == nil {
+		return storage.VoiceSession{}, false
 	}
-	return ic.ReplyEphemeral("No Voice Session is active.")
+	vs, live, err := pool.Active(ctx, tenantID)
+	if err != nil || !live {
+		return storage.VoiceSession{}, false
+	}
+	return vs, true
+}
+
+// replyControlOutcome answers a relayed cross-pod control (#503). Success posts
+// the confirming text ONLY on the worker's confirmed terminal row (the relay
+// polled it 'done' — ADR-0012: never claim what was not confirmed). An
+// unconfirmed relay (ErrControlPending) posts the honest not-confirmed wording;
+// a session that ended mid-relay posts the plain guard; anything else surfaces
+// the REAL error text — a failure is never a silent no-op.
+func replyControlOutcome(ic *Interaction, err error, success string) error {
+	switch {
+	case err == nil:
+		return ic.ReplyEphemeral(success)
+	case errors.Is(err, session.ErrControlPending):
+		return ic.ReplyEphemeral("The worker hosting the session has not confirmed the control yet — it may still land; check the session and retry if needed.")
+	case errors.Is(err, session.ErrNoActiveSession):
+		return ic.ReplyEphemeral("No Voice Session is active.")
+	default:
+		return ic.ReplyEphemeral(fmt.Sprintf("The worker hosting the session could not apply that: %v", err))
+	}
 }

--- a/internal/presence/split.go
+++ b/internal/presence/split.go
@@ -28,6 +28,9 @@ type PoolControl interface {
 	SayAs(ctx context.Context, tenantID uuid.UUID, agentID, text string) error
 }
 
+// compile-time proof the claim-plane control satisfies the seam.
+var _ PoolControl = (*session.IntentControl)(nil)
+
 // poolActive resolves the Tenant's session from the pool when the LOCAL Manager
 // has none: the cross-pod branch's entry read. A nil pool (-mode all) or a pool
 // read error reports not-live — the caller then gives the plain no-session

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -85,6 +85,10 @@ type RecapEngine interface {
 // CodeFailedPrecondition rather than lie (ADR-0057 consequence).
 var errSplitMode = errors.New("not available in a split deployment (the voice worker holds the live session)")
 
+// errControlPending is the static client message for a relayed live control
+// (#503) the hosting worker did not confirm within the control budget.
+var errControlPending = errors.New("the voice worker has not confirmed the control yet; try again shortly")
+
 // searchTranscriptLimit caps a transcript search result set (#120). It is a fixed
 // server policy for the single-operator web tier (ADR-0039), mirroring
 // searchNodesLimit; the client sends no limit.
@@ -361,6 +365,10 @@ func (s *SessionServer) SetAgentMute(
 	switch {
 	case errors.Is(err, session.ErrSplitMode):
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errSplitMode)
+	case errors.Is(err, session.ErrControlPending):
+		// #503: split-mode mutes relay through the claim plane; an unconfirmed
+		// relay is retryable, never a false success (ADR-0012).
+		return nil, connect.NewError(connect.CodeUnavailable, errControlPending)
 	case errors.Is(err, session.ErrNoActiveSession):
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))
 	case errors.Is(err, session.ErrAgentNotInCampaign):
@@ -386,6 +394,10 @@ func (s *SessionServer) SetAllMute(
 	ids, err := s.mgr.SetAllMute(ctx, tenantID, req.Msg.GetMuted())
 	if errors.Is(err, session.ErrSplitMode) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errSplitMode)
+	}
+	if errors.Is(err, session.ErrControlPending) {
+		// #503: see SetAgentMute — relayed control unconfirmed, retry.
+		return nil, connect.NewError(connect.CodeUnavailable, errControlPending)
 	}
 	if errors.Is(err, session.ErrNoActiveSession) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("no active voice session"))

--- a/internal/rpc/session_test.go
+++ b/internal/rpc/session_test.go
@@ -1539,3 +1539,22 @@ func TestSplitModeMuteDegrades(t *testing.T) {
 		t.Errorf("SetAllMute ErrSplitMode code = %v, want FailedPrecondition", got)
 	}
 }
+
+// TestSplitModeMuteControlPending covers sequence (18) of #503: the split
+// web-panel mutes now RELAY through the claim plane, so an unconfirmed relay
+// (ErrControlPending) maps to CodeUnavailable (retry) — never a false success
+// and no more blanket FailedPrecondition/ErrSplitMode for split-mode mutes.
+func TestSplitModeMuteControlPending(t *testing.T) {
+	t.Parallel()
+	mgr := &fakeSessionManager{muteErr: session.ErrControlPending}
+	client := newSessionClient(t, mgr, activeStore())
+
+	_, err := client.SetAgentMute(context.Background(), connect.NewRequest(&managementv1.SetAgentMuteRequest{AgentId: uuid.NewString(), Muted: true}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("SetAgentMute ErrControlPending code = %v, want Unavailable", got)
+	}
+	_, err = client.SetAllMute(context.Background(), connect.NewRequest(&managementv1.SetAllMuteRequest{Muted: true}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("SetAllMute ErrControlPending code = %v, want Unavailable", got)
+	}
+}

--- a/internal/session/butlercontrol.go
+++ b/internal/session/butlercontrol.go
@@ -1,0 +1,39 @@
+package session
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// ButlerControl is the voiced-recap Butler voicer for the -mode voice worker
+// (#503): local-first — when THIS worker hosts the Tenant's session the recap is
+// spoken through the local Manager exactly as before — and only a local
+// ErrNoActiveSession (the session lives on ANOTHER worker in the pool, or
+// nowhere) falls through to the claim-plane relay, which answers
+// ErrNoActiveSession itself when no session is live anywhere. Any OTHER local
+// answer (success, ErrButlerVoiceless, ErrAgentNotInCampaign, …) stands: the
+// local Manager already held the session, so re-asking the pool could only
+// double-speak or lie. Wired in the worker boot only; the -mode all path keeps
+// the plain *Manager (single process — the local read is the whole truth).
+type ButlerControl struct {
+	local  *Manager
+	remote *IntentControl
+}
+
+// NewButlerControl builds the local-first Butler voicer over the worker's own
+// Manager and the pool-wide control relay.
+func NewButlerControl(local *Manager, remote *IntentControl) *ButlerControl {
+	return &ButlerControl{local: local, remote: remote}
+}
+
+// SpeakAsButler voices text as the Tenant's Butler: locally when this worker
+// hosts the session, else relayed to the hosting worker (#503).
+func (b *ButlerControl) SpeakAsButler(ctx context.Context, tenantID uuid.UUID, text string) error {
+	err := b.local.SpeakAsButler(ctx, tenantID, text)
+	if !errors.Is(err, ErrNoActiveSession) {
+		return err
+	}
+	return b.remote.SpeakAsButler(ctx, tenantID, text)
+}

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -44,11 +44,15 @@ type IntentStore interface {
 	// 'failed' with the row's end_reason, not a clean-looking 'done'.
 	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
 	// The requested-control queue (#503): the HOSTING worker drains its live
-	// intents' pending control rows each heartbeat tick and finishes each with a
-	// fenced terminal write; the tick sweep retires pendings of terminal intents.
+	// intents' pending control rows each heartbeat tick — CLAIMING each
+	// pending→executing before it runs the verb (so a transient finish failure
+	// can never re-dispatch a non-idempotent say) — and finishes each with a
+	// fenced terminal write; the tick sweep retires unfinished rows of terminal
+	// intents and executing rows stranded past the stale cutoff.
 	ListPendingVoiceSessionControls(ctx context.Context, intentID uuid.UUID) ([]storage.VoiceSessionControl, error)
+	StartVoiceSessionControl(ctx context.Context, id uuid.UUID) (storage.VoiceSessionControl, error)
 	FinishVoiceSessionControl(ctx context.Context, id uuid.UUID, status storage.VoiceSessionControlStatus, resultIDs []string, lastError string) (storage.VoiceSessionControl, error)
-	SweepOrphanedVoiceSessionControls(ctx context.Context) (int64, error)
+	SweepOrphanedVoiceSessionControls(ctx context.Context, executingStale time.Duration) (int64, error)
 }
 
 // dbOpCap caps a single claim-plane DB call (#483 M1), mirroring the presence
@@ -89,6 +93,10 @@ type ClaimLoop struct {
 	log        *slog.Logger
 	cfg        ClaimLoopConfig
 
+	// now is the clock the per-tick control-drain budget reads; time.Now in
+	// production, a deterministic stub in tests (#503 FIX2).
+	now func() time.Time
+
 	wg sync.WaitGroup // tracks live per-session goroutines for the graceful drain
 }
 
@@ -109,7 +117,7 @@ func NewClaimLoop(store IntentStore, mgr *Manager, instanceID string, log *slog.
 	if cfg.Expiry <= 0 {
 		cfg.Expiry = 30 * time.Second
 	}
-	return &ClaimLoop{store: store, mgr: mgr, instanceID: instanceID, log: log, cfg: cfg}
+	return &ClaimLoop{store: store, mgr: mgr, instanceID: instanceID, log: log, cfg: cfg, now: time.Now}
 }
 
 // Run polls the claim plane until ctx is cancelled, then drains: SIGTERM stops
@@ -172,7 +180,11 @@ func (l *ClaimLoop) tick(ctx context.Context) {
 	// heartbeat branch), so a stopping session's stragglers die here instead of
 	// sitting pending forever.
 	swCtx, cancelSw := context.WithTimeout(ctx, dbOpTimeout(l.cfg.Poll))
-	if sn, err := l.store.SweepOrphanedVoiceSessionControls(swCtx); err != nil {
+	// An 'executing' row stranded past Expiry (a finish-write blip with the
+	// requester gone) is retired here: one execute is capped well under Expiry
+	// (controlExecTimeout 5s vs the 30s default), so past Expiry it is definitively
+	// stranded, not merely slow.
+	if sn, err := l.store.SweepOrphanedVoiceSessionControls(swCtx, l.cfg.Expiry); err != nil {
 		l.log.Warn("claim loop: sweep orphaned controls", "err", err)
 	} else if sn > 0 {
 		l.log.Warn("claim loop: failed orphaned voice session controls behind terminal intents", "count", sn)
@@ -333,20 +345,47 @@ func (l *ClaimLoop) dispatchControls(ctx context.Context, intent storage.VoiceSe
 		l.log.Warn("claim loop: list pending controls", "intent", intent.ID, "err", err)
 		return
 	}
-	for _, c := range pending {
+	// Aggregate per-tick budget (#503 FIX2): each control's execute is capped
+	// (controlExecTimeout), but N slow controls on one tick could still add up to a
+	// heartbeat gap past Expiry and get a HEALTHY session reaped. Stop draining once
+	// the batch has spent the heartbeat interval; the leftovers ride the next tick.
+	// At least one control always runs, so the queue cannot stall.
+	start := l.now()
+	for i, c := range pending {
 		if ctx.Err() != nil {
 			return
 		}
-		resultIDs, execErr := l.executeControl(ctx, intent.TenantID, c)
+		if i > 0 && l.now().Sub(start) >= l.cfg.Heartbeat {
+			return // budget spent; remaining controls next tick
+		}
+		// Fence a pending→executing CLAIM before running the verb (#503 FIX1): a row
+		// another tick/requester already took (ErrNotFound) is skipped, and once
+		// executing it can never be re-listed, so a transient finish failure below
+		// cannot re-dispatch a non-idempotent say.
+		claimCtx, cancelClaim := context.WithTimeout(ctx, dbOpCap)
+		claimed, cerr := l.store.StartVoiceSessionControl(claimCtx, c.ID)
+		cancelClaim()
+		if errors.Is(cerr, storage.ErrNotFound) {
+			continue
+		}
+		if cerr != nil {
+			l.log.Warn("claim loop: claim control for dispatch", "control", c.ID, "err", cerr)
+			continue
+		}
+
+		resultIDs, execErr := l.executeControl(ctx, intent.TenantID, claimed)
 		status, lastError := storage.VoiceControlDone, ""
 		if execErr != nil {
 			status, lastError = storage.VoiceControlFailed, EncodeControlFailure(execErr)
 		}
 		finCtx, cancelFin := context.WithTimeout(ctx, dbOpCap)
-		_, ferr := l.store.FinishVoiceSessionControl(finCtx, c.ID, status, resultIDs, lastError)
+		_, ferr := l.store.FinishVoiceSessionControl(finCtx, claimed.ID, status, resultIDs, lastError)
 		cancelFin()
 		if ferr != nil && !errors.Is(ferr, storage.ErrNotFound) {
-			l.log.Warn("claim loop: finish control", "control", c.ID, "err", ferr)
+			// The verb already ran; the terminal write blipped. The row stays
+			// 'executing' (never re-dispatched) and the sweep retires it past the
+			// stale cutoff — a bounded strand, never a double say (#503 FIX1).
+			l.log.Warn("claim loop: finish control", "control", claimed.ID, "err", ferr)
 		}
 	}
 }

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -42,6 +43,12 @@ type IntentStore interface {
 	// (#483 L4): a session that ended 'failed' on its own finishes its intent
 	// 'failed' with the row's end_reason, not a clean-looking 'done'.
 	GetVoiceSession(ctx context.Context, id uuid.UUID) (storage.VoiceSession, error)
+	// The requested-control queue (#503): the HOSTING worker drains its live
+	// intents' pending control rows each heartbeat tick and finishes each with a
+	// fenced terminal write; the tick sweep retires pendings of terminal intents.
+	ListPendingVoiceSessionControls(ctx context.Context, intentID uuid.UUID) ([]storage.VoiceSessionControl, error)
+	FinishVoiceSessionControl(ctx context.Context, id uuid.UUID, status storage.VoiceSessionControlStatus, resultIDs []string, lastError string) (storage.VoiceSessionControl, error)
+	SweepOrphanedVoiceSessionControls(ctx context.Context) (int64, error)
 }
 
 // dbOpCap caps a single claim-plane DB call (#483 M1), mirroring the presence
@@ -159,6 +166,18 @@ func (l *ClaimLoop) tick(ctx context.Context) {
 		l.log.Warn("claim loop: closed orphaned voice sessions behind terminal intents", "count", rn)
 	}
 	cancelRec()
+
+	// Retire pending controls whose intent is already terminal (#503): controls
+	// are never dispatched during a wind-down (dispatch is gated on live in the
+	// heartbeat branch), so a stopping session's stragglers die here instead of
+	// sitting pending forever.
+	swCtx, cancelSw := context.WithTimeout(ctx, dbOpTimeout(l.cfg.Poll))
+	if sn, err := l.store.SweepOrphanedVoiceSessionControls(swCtx); err != nil {
+		l.log.Warn("claim loop: sweep orphaned controls", "err", err)
+	} else if sn > 0 {
+		l.log.Warn("claim loop: failed orphaned voice session controls behind terminal intents", "count", sn)
+	}
+	cancelSw()
 
 	for l.mgr.HasCapacity() {
 		claimCtx, cancelClaim := context.WithTimeout(ctx, dbOpTimeout(l.cfg.Poll))
@@ -291,7 +310,69 @@ func (l *ClaimLoop) runSession(ctx context.Context, intent storage.VoiceSessionI
 				l.endSession(tenant, intent.ID, storage.VoiceIntentDone, "")
 				return
 			}
+			if live {
+				l.dispatchControls(ctx, intent) // #503 — the ONLY #503 line in runSession
+			}
 		}
+	}
+}
+
+// dispatchControls drains the intent's pending control rows (#503) in
+// (created_at, id) order and executes each against the LOCAL Manager — this
+// worker HOSTS the session, so the dispatch never moves it (ADR-0006/0057 (e)).
+// Each execute and each terminal write is bounded by a dbOpTimeout-style cap so
+// a hung roster read can never starve the heartbeat this runs after (the
+// heartbeat ALWAYS lands first in the tick). A fenced Finish that NotFounds
+// (the requester's budget cancel, or the sweep, won the race) is swallowed —
+// the row is already settled and the requester was answered honestly.
+func (l *ClaimLoop) dispatchControls(ctx context.Context, intent storage.VoiceSessionIntent) {
+	listCtx, cancelList := context.WithTimeout(ctx, dbOpTimeout(l.cfg.Heartbeat))
+	pending, err := l.store.ListPendingVoiceSessionControls(listCtx, intent.ID)
+	cancelList()
+	if err != nil {
+		l.log.Warn("claim loop: list pending controls", "intent", intent.ID, "err", err)
+		return
+	}
+	for _, c := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		resultIDs, execErr := l.executeControl(ctx, intent.TenantID, c)
+		status, lastError := storage.VoiceControlDone, ""
+		if execErr != nil {
+			status, lastError = storage.VoiceControlFailed, EncodeControlFailure(execErr)
+		}
+		finCtx, cancelFin := context.WithTimeout(ctx, dbOpCap)
+		_, ferr := l.store.FinishVoiceSessionControl(finCtx, c.ID, status, resultIDs, lastError)
+		cancelFin()
+		if ferr != nil && !errors.Is(ferr, storage.ErrNotFound) {
+			l.log.Warn("claim loop: finish control", "control", c.ID, "err", ferr)
+		}
+	}
+}
+
+// controlExecTimeout caps ONE control's Manager execute (a roster read plus an
+// in-process write/publish) so a black-holed store call cannot pin the
+// heartbeat goroutine (#503; mirrors dbOpCap's posture).
+const controlExecTimeout = 5 * time.Second
+
+// executeControl runs one control verb against the local Manager.
+func (l *ClaimLoop) executeControl(ctx context.Context, tenantID uuid.UUID, c storage.VoiceSessionControl) ([]string, error) {
+	execCtx, cancel := context.WithTimeout(ctx, controlExecTimeout)
+	defer cancel()
+	switch c.Kind {
+	case storage.VoiceControlMuteAgent:
+		return l.mgr.SetAgentMute(execCtx, tenantID, c.AgentID, c.Muted)
+	case storage.VoiceControlMuteAll:
+		return l.mgr.SetAllMute(execCtx, tenantID, c.Muted)
+	case storage.VoiceControlSay:
+		return nil, l.mgr.SayAs(execCtx, tenantID, c.AgentID, c.SayText)
+	case storage.VoiceControlButlerSay:
+		return nil, l.mgr.SpeakAsButler(execCtx, tenantID, c.SayText)
+	default:
+		// A future verb this binary does not know: fail it honestly rather than
+		// leave it pending forever (the requester surfaces the message verbatim).
+		return nil, fmt.Errorf("unknown control kind %q", c.Kind)
 	}
 }
 

--- a/internal/session/claimloop_controls_test.go
+++ b/internal/session/claimloop_controls_test.go
@@ -1,0 +1,194 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
+
+// controlLoopHarness wires the cross-pod control-dispatch tests (#503): a
+// Manager over a real bus (SayAs publishes are observable) driven by a claim
+// loop with millisecond cadences, one live intent claimed.
+type controlLoopHarness struct {
+	mstore *fakeStore
+	istore *fakeIntentStore
+	mgr    *session.Manager
+	loop   *session.ClaimLoop
+	bus    *voiceevent.Bus
+	intent *storage.VoiceSessionIntent
+	tenant uuid.UUID
+}
+
+func newControlLoopHarness(t *testing.T) *controlLoopHarness {
+	t.Helper()
+	mstore := newFakeStore()
+	mgr, bus := muteManager(t, mstore)
+	t.Cleanup(mgr.Shutdown)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+	return &controlLoopHarness{mstore: mstore, istore: istore, mgr: mgr, loop: loop, bus: bus, intent: intent, tenant: tenantID}
+}
+
+// TestClaimLoop_DispatchesMuteControl covers sequence (5): a pending mute_agent
+// control is executed against the hosting worker's Manager on a heartbeat tick
+// and its row finishes 'done' carrying the resulting muted-id set.
+func TestClaimLoop_DispatchesMuteControl(t *testing.T) {
+	h := newControlLoopHarness(t)
+	agents := seedAgents(h.mstore, 2)
+
+	row := h.istore.addControl(storage.VoiceSessionControl{
+		IntentID: h.intent.ID,
+		TenantID: h.tenant,
+		Kind:     storage.VoiceControlMuteAgent,
+		AgentID:  agents[0].ID.String(),
+		Muted:    true,
+	})
+	waitFor(t, 2*time.Second, func() bool { return h.istore.getControl(row.ID).Status == storage.VoiceControlDone })
+	got := h.istore.getControl(row.ID)
+	if len(got.ResultIDs) != 1 || got.ResultIDs[0] != agents[0].ID.String() {
+		t.Fatalf("done control result_ids = %v, want the muted agent id", got.ResultIDs)
+	}
+	if !h.mgr.Muted(agents[0].ID.String()) {
+		t.Fatal("Manager does not report the agent muted after dispatch")
+	}
+	h.istore.requestStop(h.intent.ID)
+	h.loop.DrainForTest()
+}
+
+// TestClaimLoop_DispatchesSaysInOrderAndEncodesFailure covers sequence (6): two
+// queued says publish in (created_at, id) order, and a Manager refusal (foreign
+// agent) fails the row with a DECODED-able last_error.
+func TestClaimLoop_DispatchesSaysInOrderAndEncodesFailure(t *testing.T) {
+	h := newControlLoopHarness(t)
+	agents := seedAgents(h.mstore, 1)
+
+	var mu sync.Mutex
+	var spoken []string
+	unsub := h.bus.Subscribe(func(e voiceevent.Event) {
+		if sr, ok := e.(voiceevent.SpeakRequested); ok {
+			mu.Lock()
+			spoken = append(spoken, sr.Text)
+			mu.Unlock()
+		}
+	})
+	defer unsub()
+
+	first := h.istore.addControl(storage.VoiceSessionControl{
+		IntentID: h.intent.ID, TenantID: h.tenant,
+		Kind: storage.VoiceControlSay, AgentID: agents[0].ID.String(), SayText: "line one",
+	})
+	second := h.istore.addControl(storage.VoiceSessionControl{
+		IntentID: h.intent.ID, TenantID: h.tenant,
+		Kind: storage.VoiceControlSay, AgentID: agents[0].ID.String(), SayText: "line two",
+	})
+	bad := h.istore.addControl(storage.VoiceSessionControl{
+		IntentID: h.intent.ID, TenantID: h.tenant,
+		Kind: storage.VoiceControlSay, AgentID: uuid.NewString(), SayText: "never",
+	})
+
+	waitFor(t, 2*time.Second, func() bool {
+		return h.istore.getControl(first.ID).Status == storage.VoiceControlDone &&
+			h.istore.getControl(second.ID).Status == storage.VoiceControlDone &&
+			h.istore.getControl(bad.ID).Status == storage.VoiceControlFailed
+	})
+
+	mu.Lock()
+	order := append([]string(nil), spoken...)
+	mu.Unlock()
+	if len(order) != 2 || order[0] != "line one" || order[1] != "line two" {
+		t.Fatalf("say publish order = %v, want [line one, line two]", order)
+	}
+
+	sentinel, ok := session.DecodeControlFailure(h.istore.getControl(bad.ID).LastError)
+	if !ok || !errors.Is(sentinel, session.ErrAgentNotInCampaign) {
+		t.Fatalf("failed say last_error = %q, want an encoded ErrAgentNotInCampaign",
+			h.istore.getControl(bad.ID).LastError)
+	}
+	h.istore.requestStop(h.intent.ID)
+	h.loop.DrainForTest()
+}
+
+// TestClaimLoop_NoDispatchWhileNotLive covers sequence (7): during the Manager's
+// end window (self-exit finalizing — Active false) queued controls are NOT
+// dispatched; the rows stay pending for the sweep or the requester's budget.
+func TestClaimLoop_NoDispatchWhileNotLive(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate // parks CloseVoiceSession → holds the end window open
+	mgr, _ := muteManager(t, mstore)
+	istore := newFakeIntentStore()
+	istore.sessionOutcome = func(id uuid.UUID) (storage.VoiceSession, error) {
+		return mstore.session(id), nil
+	}
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond, Expiry: 30 * time.Second})
+
+	tenantID := uuid.New()
+	agents := seedAgents(mstore, 1)
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// The session self-exits but CloseVoiceSession parks on the gate: Active
+	// false, Finalizing true — the not-live window.
+	go func() { _, _ = mgr.Stop(context.Background(), tenantID) }()
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+
+	row := istore.addControl(storage.VoiceSessionControl{
+		IntentID: intent.ID, TenantID: tenantID,
+		Kind: storage.VoiceControlMuteAgent, AgentID: agents[0].ID.String(), Muted: true,
+	})
+	// Several heartbeat ticks inside the window: the control must stay pending.
+	before := istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return istore.heartbeatCount() > before+3 })
+	if got := istore.getControl(row.ID).Status; got != storage.VoiceControlPending {
+		t.Fatalf("control status inside the end window = %q, want pending (no dispatch while not live)", got)
+	}
+
+	close(closeGate)
+	waitFor(t, 2*time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentDone })
+	// Still pending after the intent finished: dispatch never ran (the tick sweep
+	// or the requester's budget cancel retires it).
+	if got := istore.getControl(row.ID).Status; got != storage.VoiceControlPending {
+		t.Fatalf("control status after self-exit = %q, want pending", got)
+	}
+	loop.DrainForTest()
+}
+
+// TestClaimLoop_TickSweepsOrphanedControls covers sequence (8): a tick fails the
+// pending controls of a TERMINAL intent ('session ended'), leaving a live
+// intent's queue alone.
+func TestClaimLoop_TickSweepsOrphanedControls(t *testing.T) {
+	mstore := newFakeStore()
+	mgr := newManager(t, mstore, newBlockingRunner().run, true)
+	istore := newFakeIntentStore()
+	loop := newClaimLoop(t, istore, mgr)
+
+	dead := istore.add(uuid.New(), uuid.New())
+	istore.markDead(dead.ID)
+	orphan := istore.addControl(storage.VoiceSessionControl{
+		IntentID: dead.ID, TenantID: dead.TenantID,
+		Kind: storage.VoiceControlMuteAll, Muted: true,
+	})
+
+	loop.TickForTest(context.Background())
+	got := istore.getControl(orphan.ID)
+	if got.Status != storage.VoiceControlFailed || got.LastError != "session ended" {
+		t.Fatalf("orphaned control after tick = %+v, want failed 'session ended'", got)
+	}
+}

--- a/internal/session/claimloop_controls_test.go
+++ b/internal/session/claimloop_controls_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,6 +124,118 @@ func TestClaimLoop_DispatchesSaysInOrderAndEncodesFailure(t *testing.T) {
 	h.loop.DrainForTest()
 }
 
+// TestClaimLoop_TransientFinishDoesNotDoubleSay covers #503 FIX1: the row is
+// CLAIMED pending→executing before the verb runs, so when the terminal write
+// fails transiently the row stays 'executing' (never re-listed) and the say
+// publishes EXACTLY ONCE — no double utterance from at-least-once dispatch.
+func TestClaimLoop_TransientFinishDoesNotDoubleSay(t *testing.T) {
+	h := newControlLoopHarness(t)
+	agents := seedAgents(h.mstore, 1)
+
+	var mu sync.Mutex
+	var says int
+	unsub := h.bus.Subscribe(func(e voiceevent.Event) {
+		if _, ok := e.(voiceevent.SpeakRequested); ok {
+			mu.Lock()
+			says++
+			mu.Unlock()
+		}
+	})
+	defer unsub()
+
+	// The FIRST FinishVoiceSessionControl fails transiently; the row is already
+	// 'executing' (say published), so subsequent ticks never re-run it.
+	h.istore.mu.Lock()
+	h.istore.finishControlErrs = []error{errors.New("db blip")}
+	h.istore.mu.Unlock()
+
+	row := h.istore.addControl(storage.VoiceSessionControl{
+		IntentID: h.intent.ID, TenantID: h.tenant,
+		Kind: storage.VoiceControlSay, AgentID: agents[0].ID.String(), SayText: "once",
+	})
+	// Wait for the say to have published and the finish to have been attempted.
+	waitFor(t, 2*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return says >= 1
+	})
+	// Give several more heartbeat ticks a chance to (wrongly) re-dispatch.
+	before := h.istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return h.istore.heartbeatCount() > before+5 })
+
+	mu.Lock()
+	got := says
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("say published %d times, want exactly 1 (executing fence blocks re-dispatch)", got)
+	}
+	if st := h.istore.getControl(row.ID).Status; st != storage.VoiceControlExecuting {
+		t.Fatalf("control status after transient finish = %q, want executing (stranded for the sweep)", st)
+	}
+	h.istore.requestStop(h.intent.ID)
+	h.loop.DrainForTest()
+}
+
+// TestClaimLoop_DrainBatchBudget covers #503 FIX2: one drain of many controls
+// stops once the aggregate heartbeat budget is spent (so the heartbeat goroutine
+// is never starved past Expiry), and the leftovers drain on the NEXT pass. A
+// deterministic clock drives the cutoff — no wall-clock sleeps, and dispatch is
+// driven directly (no live runSession goroutine racing the clock).
+func TestClaimLoop_DrainBatchBudget(t *testing.T) {
+	mstore := newFakeStore()
+	seedAgents(mstore, 1)
+	mgr, _ := muteManager(t, mstore)
+	t.Cleanup(mgr.Shutdown)
+	tenantID, _ := startMuteSession(t, mgr)
+
+	istore := newFakeIntentStore()
+	const heartbeat = 100 * time.Millisecond
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: heartbeat, Expiry: 30 * time.Second})
+
+	// Each clock read advances by half the heartbeat: start(0), after control 1
+	// now=hb/2 (< hb, continue), after control 2 now=hb (>= hb, stop) → 2 per pass.
+	var clk int64
+	loop.SetClockForTest(func() time.Time {
+		n := atomic.AddInt64(&clk, 1)
+		return time.Unix(0, 0).Add(time.Duration(n-1) * (heartbeat / 2))
+	})
+
+	intent := istore.add(tenantID, uuid.New())
+	intentRow := istore.get(intent.ID)
+	rows := make([]uuid.UUID, 5)
+	for i := range rows {
+		rows[i] = istore.addControl(storage.VoiceSessionControl{
+			IntentID: intent.ID, TenantID: tenantID, Kind: storage.VoiceControlMuteAll, Muted: true,
+		}).ID
+	}
+
+	// Pass 1: budget = 2 clock steps → exactly 2 done, 3 still pending.
+	loop.DispatchControlsForTest(context.Background(), intentRow)
+	if done, pending := countStatus(istore, rows, storage.VoiceControlDone), countStatus(istore, rows, storage.VoiceControlPending); done != 2 || pending != 3 {
+		t.Fatalf("pass 1: done=%d pending=%d, want done=2 pending=3", done, pending)
+	}
+
+	// Reset the clock and drain the leftovers across two more passes.
+	atomic.StoreInt64(&clk, 0)
+	loop.DispatchControlsForTest(context.Background(), intentRow)
+	atomic.StoreInt64(&clk, 0)
+	loop.DispatchControlsForTest(context.Background(), intentRow)
+	if done := countStatus(istore, rows, storage.VoiceControlDone); done != 5 {
+		t.Fatalf("after three passes: done=%d, want all 5", done)
+	}
+}
+
+func countStatus(istore *fakeIntentStore, ids []uuid.UUID, want storage.VoiceSessionControlStatus) int {
+	n := 0
+	for _, id := range ids {
+		if istore.getControl(id).Status == want {
+			n++
+		}
+	}
+	return n
+}
+
 // TestClaimLoop_NoDispatchWhileNotLive covers sequence (7): during the Manager's
 // end window (self-exit finalizing — Active false) queued controls are NOT
 // dispatched; the rows stay pending for the sweep or the requester's budget.
@@ -188,7 +301,10 @@ func TestClaimLoop_TickSweepsOrphanedControls(t *testing.T) {
 
 	loop.TickForTest(context.Background())
 	got := istore.getControl(orphan.ID)
-	if got.Status != storage.VoiceControlFailed || got.LastError != "session ended" {
-		t.Fatalf("orphaned control after tick = %+v, want failed 'session ended'", got)
+	if got.Status != storage.VoiceControlFailed {
+		t.Fatalf("orphaned control after tick = %+v, want failed", got)
+	}
+	if sentinel, ok := session.DecodeControlFailure(got.LastError); !ok || !errors.Is(sentinel, session.ErrNoActiveSession) {
+		t.Fatalf("orphaned control last_error = %q, want encoded no_active_session (#503 FIX3)", got.LastError)
 	}
 }

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -27,10 +28,93 @@ type fakeIntentStore struct {
 	heartbeats  int   // HeartbeatVoiceSessionIntent call count (#506 finalize-heartbeat test)
 	// sessionOutcome scripts GetVoiceSession — the self-exit outcome read (#483 L4).
 	sessionOutcome func(uuid.UUID) (storage.VoiceSession, error)
+	// controls is the requested-control queue (#503), keyed by control id.
+	controls map[uuid.UUID]*storage.VoiceSessionControl
+	seq      int // creation tiebreak so list order is deterministic
 }
 
 func newFakeIntentStore() *fakeIntentStore {
-	return &fakeIntentStore{intents: map[uuid.UUID]*storage.VoiceSessionIntent{}}
+	return &fakeIntentStore{
+		intents:  map[uuid.UUID]*storage.VoiceSessionIntent{},
+		controls: map[uuid.UUID]*storage.VoiceSessionControl{},
+	}
+}
+
+// addControl enqueues a pending control row (#503), stamping CreatedAt with a
+// strictly-increasing sequence so (created_at, id) list order is deterministic.
+func (f *fakeIntentStore) addControl(c storage.VoiceSessionControl) *storage.VoiceSessionControl {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq++
+	row := c
+	row.ID = uuid.New()
+	row.Status = storage.VoiceControlPending
+	row.CreatedAt = time.Now().Add(time.Duration(f.seq) * time.Microsecond)
+	f.controls[row.ID] = &row
+	return &row
+}
+
+func (f *fakeIntentStore) getControl(id uuid.UUID) storage.VoiceSessionControl {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return *f.controls[id]
+}
+
+func (f *fakeIntentStore) ListPendingVoiceSessionControls(_ context.Context, intentID uuid.UUID) ([]storage.VoiceSessionControl, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []storage.VoiceSessionControl
+	for _, c := range f.controls {
+		if c.IntentID == intentID && c.Status == storage.VoiceControlPending {
+			out = append(out, *c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	return out, nil
+}
+
+func (f *fakeIntentStore) FinishVoiceSessionControl(_ context.Context, id uuid.UUID, status storage.VoiceSessionControlStatus, resultIDs []string, lastError string) (storage.VoiceSessionControl, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c, ok := f.controls[id]
+	if !ok || c.Status != storage.VoiceControlPending {
+		return storage.VoiceSessionControl{}, storage.ErrNotFound
+	}
+	now := time.Now()
+	c.Status = status
+	c.ResultIDs = resultIDs
+	c.LastError = lastError
+	c.EndedAt = &now
+	return *c, nil
+}
+
+func (f *fakeIntentStore) SweepOrphanedVoiceSessionControls(_ context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var n int64
+	for _, c := range f.controls {
+		if c.Status != storage.VoiceControlPending {
+			continue
+		}
+		i, ok := f.intents[c.IntentID]
+		if !ok {
+			continue
+		}
+		switch i.Status {
+		case storage.VoiceIntentDone, storage.VoiceIntentDead, storage.VoiceIntentFailed:
+			now := time.Now()
+			c.Status = storage.VoiceControlFailed
+			c.LastError = "session ended"
+			c.EndedAt = &now
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (f *fakeIntentStore) add(tenantID, campaignID uuid.UUID) *storage.VoiceSessionIntent {

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -31,6 +31,9 @@ type fakeIntentStore struct {
 	// controls is the requested-control queue (#503), keyed by control id.
 	controls map[uuid.UUID]*storage.VoiceSessionControl
 	seq      int // creation tiebreak so list order is deterministic
+	// onControlCreate scripts the hosting worker's reaction to a fresh control row
+	// (#503 requester-side tests): run under the lock right after the insert.
+	onControlCreate func(*storage.VoiceSessionControl)
 }
 
 func newFakeIntentStore() *fakeIntentStore {
@@ -52,6 +55,46 @@ func (f *fakeIntentStore) addControl(c storage.VoiceSessionControl) *storage.Voi
 	row.CreatedAt = time.Now().Add(time.Duration(f.seq) * time.Microsecond)
 	f.controls[row.ID] = &row
 	return &row
+}
+
+// CreateVoiceSessionControl is the requester-side write (#503, IntentControlStore).
+func (f *fakeIntentStore) CreateVoiceSessionControl(_ context.Context, c storage.VoiceSessionControl) (storage.VoiceSessionControl, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq++
+	row := c
+	row.ID = uuid.New()
+	row.Status = storage.VoiceControlPending
+	row.CreatedAt = time.Now().Add(time.Duration(f.seq) * time.Microsecond)
+	f.controls[row.ID] = &row
+	if f.onControlCreate != nil {
+		f.onControlCreate(&row)
+	}
+	return row, nil
+}
+
+func (f *fakeIntentStore) GetVoiceSessionControl(_ context.Context, id uuid.UUID) (storage.VoiceSessionControl, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c, ok := f.controls[id]
+	if !ok {
+		return storage.VoiceSessionControl{}, storage.ErrNotFound
+	}
+	return *c, nil
+}
+
+func (f *fakeIntentStore) CancelPendingVoiceSessionControl(_ context.Context, id uuid.UUID) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c, ok := f.controls[id]
+	if !ok || c.Status != storage.VoiceControlPending {
+		return false, nil
+	}
+	now := time.Now()
+	c.Status = storage.VoiceControlFailed
+	c.LastError = "requester timed out"
+	c.EndedAt = &now
+	return true, nil
 }
 
 func (f *fakeIntentStore) getControl(id uuid.UUID) storage.VoiceSessionControl {

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -34,6 +34,10 @@ type fakeIntentStore struct {
 	// onControlCreate scripts the hosting worker's reaction to a fresh control row
 	// (#503 requester-side tests): run under the lock right after the insert.
 	onControlCreate func(*storage.VoiceSessionControl)
+	// finishControlErrs is a queue of errors FinishVoiceSessionControl returns on
+	// successive calls (a nil entry, or an exhausted queue, is a normal finish) —
+	// models a transient terminal-write blip (#503 FIX1).
+	finishControlErrs []error
 }
 
 func newFakeIntentStore() *fakeIntentStore {
@@ -121,11 +125,31 @@ func (f *fakeIntentStore) ListPendingVoiceSessionControls(_ context.Context, int
 	return out, nil
 }
 
-func (f *fakeIntentStore) FinishVoiceSessionControl(_ context.Context, id uuid.UUID, status storage.VoiceSessionControlStatus, resultIDs []string, lastError string) (storage.VoiceSessionControl, error) {
+func (f *fakeIntentStore) StartVoiceSessionControl(_ context.Context, id uuid.UUID) (storage.VoiceSessionControl, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	c, ok := f.controls[id]
 	if !ok || c.Status != storage.VoiceControlPending {
+		return storage.VoiceSessionControl{}, storage.ErrNotFound
+	}
+	now := time.Now()
+	c.Status = storage.VoiceControlExecuting
+	c.StartedAt = &now
+	return *c, nil
+}
+
+func (f *fakeIntentStore) FinishVoiceSessionControl(_ context.Context, id uuid.UUID, status storage.VoiceSessionControlStatus, resultIDs []string, lastError string) (storage.VoiceSessionControl, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.finishControlErrs) > 0 {
+		err := f.finishControlErrs[0]
+		f.finishControlErrs = f.finishControlErrs[1:]
+		if err != nil {
+			return storage.VoiceSessionControl{}, err // transient blip: row stays executing
+		}
+	}
+	c, ok := f.controls[id]
+	if !ok || c.Status != storage.VoiceControlExecuting {
 		return storage.VoiceSessionControl{}, storage.ErrNotFound
 	}
 	now := time.Now()
@@ -136,26 +160,35 @@ func (f *fakeIntentStore) FinishVoiceSessionControl(_ context.Context, id uuid.U
 	return *c, nil
 }
 
-func (f *fakeIntentStore) SweepOrphanedVoiceSessionControls(_ context.Context) (int64, error) {
+func (f *fakeIntentStore) SweepOrphanedVoiceSessionControls(_ context.Context, executingStale time.Duration) (int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	var n int64
 	for _, c := range f.controls {
-		if c.Status != storage.VoiceControlPending {
+		if c.Status != storage.VoiceControlPending && c.Status != storage.VoiceControlExecuting {
 			continue
 		}
-		i, ok := f.intents[c.IntentID]
-		if !ok {
+		terminal := false
+		if i, ok := f.intents[c.IntentID]; ok {
+			switch i.Status {
+			case storage.VoiceIntentDone, storage.VoiceIntentDead, storage.VoiceIntentFailed:
+				terminal = true
+			}
+		}
+		staleExec := c.Status == storage.VoiceControlExecuting && c.StartedAt != nil &&
+			time.Since(*c.StartedAt) >= executingStale
+		if !terminal && !staleExec {
 			continue
 		}
-		switch i.Status {
-		case storage.VoiceIntentDone, storage.VoiceIntentDead, storage.VoiceIntentFailed:
-			now := time.Now()
-			c.Status = storage.VoiceControlFailed
-			c.LastError = "session ended"
-			c.EndedAt = &now
-			n++
+		now := time.Now()
+		c.Status = storage.VoiceControlFailed
+		if terminal {
+			c.LastError = session.EncodeControlFailure(session.ErrNoActiveSession)
+		} else {
+			c.LastError = "control execution stalled on the hosting worker"
 		}
+		c.EndedAt = &now
+		n++
 	}
 	return n, nil
 }

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/pkg/voice/agent"
 )
 
@@ -15,6 +16,18 @@ func (l *ClaimLoop) TickForTest(ctx context.Context) { l.tick(ctx) }
 // DrainForTest waits for every live per-session goroutine to finish — the same
 // wait Run does on ctx cancellation (the graceful drain, #491). Test-only.
 func (l *ClaimLoop) DrainForTest() { l.wg.Wait() }
+
+// SetClockForTest swaps the clock the per-tick control-drain budget reads (#503
+// FIX2), so a test drives the aggregate-budget cutoff deterministically without
+// wall-clock sleeps. Test-only.
+func (l *ClaimLoop) SetClockForTest(now func() time.Time) { l.now = now }
+
+// DispatchControlsForTest runs one control-drain pass synchronously against the
+// given live intent (#503 FIX2 budget test), without a live runSession
+// goroutine racing it. Test-only.
+func (l *ClaimLoop) DispatchControlsForTest(ctx context.Context, intent storage.VoiceSessionIntent) {
+	l.dispatchControls(ctx, intent)
+}
 
 // SetEndTimeoutForTest shrinks the per-step end budget (Finalize / end-write)
 // so the #143 budget-separation tests run in milliseconds instead of the

--- a/internal/session/failcode.go
+++ b/internal/session/failcode.go
@@ -46,6 +46,47 @@ func EncodeStartFailure(err error) string {
 	return err.Error()
 }
 
+// controlFailCodes pairs each typed live-control refusal with its durable code
+// (#503): a hosting worker's Manager control error crosses the plane as
+// voice_session_controls.last_error, and the requester re-maps it to the same
+// sentinel the -mode all path returns. Same encoding rules as startFailCodes.
+var controlFailCodes = []struct {
+	code string
+	err  error
+}{
+	{"no_active_session", ErrNoActiveSession},
+	{"agent_not_in_campaign", ErrAgentNotInCampaign},
+	{"butler_voiceless", ErrButlerVoiceless},
+}
+
+// EncodeControlFailure renders a Manager live-control refusal for
+// voice_session_controls.last_error: "code=<code>: <message>" for a typed
+// sentinel, else the plain message (the requester then surfaces it verbatim).
+func EncodeControlFailure(err error) string {
+	for _, fc := range controlFailCodes {
+		if errors.Is(err, fc.err) {
+			return failCodePrefix + fc.code + ": " + err.Error()
+		}
+	}
+	return err.Error()
+}
+
+// DecodeControlFailure maps an encoded control last_error back to its typed
+// sentinel; ok is false for an uncoded (or unknown-coded) string.
+func DecodeControlFailure(lastError string) (error, bool) {
+	rest, found := strings.CutPrefix(lastError, failCodePrefix)
+	if !found {
+		return nil, false
+	}
+	code, _, _ := strings.Cut(rest, ":")
+	for _, fc := range controlFailCodes {
+		if fc.code == code {
+			return fc.err, true
+		}
+	}
+	return nil, false
+}
+
 // DecodeStartFailure maps an encoded last_error back to its typed sentinel. ok
 // is false for a last_error without a (known) code — older rows, plain loop
 // errors, or a future code this binary does not know.

--- a/internal/session/failcode_test.go
+++ b/internal/session/failcode_test.go
@@ -1,0 +1,38 @@
+package session_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+)
+
+// TestControlFailureRoundtrip covers sequence (4): the three typed control
+// refusals cross the plane as coded last_error strings and decode back to the
+// SAME sentinel, so both deployment shapes surface identical errors.
+func TestControlFailureRoundtrip(t *testing.T) {
+	for _, sentinel := range []error{
+		session.ErrNoActiveSession,
+		session.ErrAgentNotInCampaign,
+		session.ErrButlerVoiceless,
+	} {
+		encoded := session.EncodeControlFailure(fmt.Errorf("wrap: %w", sentinel))
+		got, ok := session.DecodeControlFailure(encoded)
+		if !ok || !errors.Is(got, sentinel) {
+			t.Errorf("roundtrip(%v) = (%v, %v), want the sentinel back", sentinel, got, ok)
+		}
+	}
+}
+
+// TestControlFailureUnknown: an untyped error encodes as its raw message (no
+// code) and decodes to ok=false — the requester surfaces it verbatim.
+func TestControlFailureUnknown(t *testing.T) {
+	encoded := session.EncodeControlFailure(errors.New("tts provider exploded"))
+	if encoded != "tts provider exploded" {
+		t.Fatalf("encoded unknown = %q, want the raw message", encoded)
+	}
+	if got, ok := session.DecodeControlFailure(encoded); ok || got != nil {
+		t.Fatalf("decode unknown = (%v, %v), want (nil, false)", got, ok)
+	}
+}

--- a/internal/session/intentcontrol.go
+++ b/internal/session/intentcontrol.go
@@ -42,7 +42,19 @@ type IntentControlStore interface {
 	// zero-worker reap (#483): the reap marks the intent dead but the bound row
 	// would otherwise stay 'running' until some Voice Instance's own reap or boot.
 	ReconcileWorkerOrphanedVoiceSessions(ctx context.Context) (int64, error)
+	// The requested-control queue (#503): the requester writes a pending control
+	// row, polls it to terminal, and best-effort cancels it on budget expiry.
+	CreateVoiceSessionControl(ctx context.Context, c storage.VoiceSessionControl) (storage.VoiceSessionControl, error)
+	GetVoiceSessionControl(ctx context.Context, id uuid.UUID) (storage.VoiceSessionControl, error)
+	CancelPendingVoiceSessionControl(ctx context.Context, id uuid.UUID) (bool, error)
 }
+
+// ErrControlPending is returned when the hosting worker has not confirmed a
+// relayed live control within the control budget (→ CodeUnavailable): the
+// control MAY still execute (a worker mid-execute cannot be recalled), but a
+// confirmation is never claimed for it (ADR-0012 — timeout is an error, never a
+// claimed success). The requester best-effort cancels the pending row first.
+var ErrControlPending = errors.New("session: the voice worker has not confirmed the control yet")
 
 // IntentControlConfig carries IntentControl's poll cadence and budgets (#491). A
 // non-positive value takes its default.
@@ -60,6 +72,12 @@ type IntentControlConfig struct {
 	// whose heartbeat is older than this before failing ErrSessionActive — the
 	// zero-worker escape (review item 4). Default 30s.
 	Expiry time.Duration
+	// ControlBudget bounds how long a relayed live control (mute/say/butler-say,
+	// #503) waits for the hosting worker's confirmation before ErrControlPending.
+	// Default 15s (env GLYPHOXA_VOICE_CONTROL_BUDGET); it must stay comfortably
+	// above the worker heartbeat (default 5s) plus one control execute, since
+	// dispatch rides the heartbeat tick.
+	ControlBudget time.Duration
 }
 
 // IntentControl drives voice sessions through the Postgres claim plane (#491).
@@ -86,6 +104,9 @@ func NewIntentControl(store IntentControlStore, log *slog.Logger, cfg IntentCont
 	}
 	if cfg.Expiry <= 0 {
 		cfg.Expiry = 30 * time.Second
+	}
+	if cfg.ControlBudget <= 0 {
+		cfg.ControlBudget = 15 * time.Second
 	}
 	return &IntentControl{store: store, log: log, cfg: cfg}
 }
@@ -331,31 +352,127 @@ func (c *IntentControl) AnyLive() bool {
 	return live
 }
 
-// The live-session controls below are Manager-only: their state (the mute set,
-// the spend meter, the outbound pump for say/replay) lives in the -mode voice
-// worker, unreachable from the web tier. In a split deployment they degrade with
-// ErrSplitMode (→ CodeFailedPrecondition) rather than lie (ADR-0057 consequence:
-// no mute/say RPCs on the web tier of a split deployment).
+// The live-session controls below relay through the claim plane (#503): the
+// requester writes a voice_session_controls row the HOSTING worker drains on its
+// heartbeat tick, and polls it to a terminal status — the stop_requested
+// handshake's shape, ADR-0051's write-then-poll precedent. NOTE: ADR-0057's
+// consequence "a voice pod split from the web tier … has no mute/say RPCs" is
+// SUPERSEDED by this relay per the SaaS directive on #503 (see the ADR's
+// Amendments); the dispatch itself still never moves the session (ADR-0006/0057
+// (e)) — only the owning worker's own loop executes the row.
 
-// SetAgentMute is Manager-only (#491): ErrSplitMode in a split deployment.
-func (c *IntentControl) SetAgentMute(context.Context, uuid.UUID, string, bool) ([]string, error) {
-	return nil, ErrSplitMode
+// SetAgentMute relays a per-Agent mute to the hosting worker (#503).
+func (c *IntentControl) SetAgentMute(ctx context.Context, tenantID uuid.UUID, agentID string, muted bool) ([]string, error) {
+	return c.relayControl(ctx, tenantID, storage.VoiceSessionControl{
+		Kind: storage.VoiceControlMuteAgent, AgentID: agentID, Muted: muted,
+	})
 }
 
-// SetAllMute is Manager-only (#491): ErrSplitMode in a split deployment.
-func (c *IntentControl) SetAllMute(context.Context, uuid.UUID, bool) ([]string, error) {
-	return nil, ErrSplitMode
+// SetAllMute relays an all-Agents mute to the hosting worker (#503).
+func (c *IntentControl) SetAllMute(ctx context.Context, tenantID uuid.UUID, muted bool) ([]string, error) {
+	return c.relayControl(ctx, tenantID, storage.VoiceSessionControl{
+		Kind: storage.VoiceControlMuteAll, Muted: muted,
+	})
 }
 
-// MutedAgentIDs is Manager-only (#491): nil on the web tier of a split deployment.
+// SayAs relays GM puppeteering to the hosting worker (#503): the queue drains in
+// (created_at, id) order, so two says land in request order.
+func (c *IntentControl) SayAs(ctx context.Context, tenantID uuid.UUID, agentID, text string) error {
+	_, err := c.relayControl(ctx, tenantID, storage.VoiceSessionControl{
+		Kind: storage.VoiceControlSay, AgentID: agentID, SayText: text,
+	})
+	return err
+}
+
+// SpeakAsButler relays a Butler utterance (the voiced-recap on-ramp, #503).
+func (c *IntentControl) SpeakAsButler(ctx context.Context, tenantID uuid.UUID, text string) error {
+	_, err := c.relayControl(ctx, tenantID, storage.VoiceSessionControl{
+		Kind: storage.VoiceControlButlerSay, SayText: text,
+	})
+	return err
+}
+
+// relayControl runs one control through the claim plane: find the Tenant's LIVE
+// intent (anything else is ErrNoActiveSession — a control never targets a
+// pending/claimed row whose session does not exist yet), write the pending row,
+// and poll it to terminal within the control budget. A worker 'failed' with an
+// encoded fail code re-maps to the same sentinel the -mode all path returns;
+// an uncoded failure surfaces verbatim. Budget expiry best-effort cancels the
+// pending row and returns ErrControlPending — never a claimed success
+// (ADR-0012); a worker already mid-execute may still apply the control, which
+// the honest "not confirmed" wording covers.
+func (c *IntentControl) relayControl(ctx context.Context, tenantID uuid.UUID, ctrl storage.VoiceSessionControl) ([]string, error) {
+	intent, err := c.store.GetLiveVoiceSessionIntentForTenant(ctx, tenantID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, ErrNoActiveSession
+	}
+	if err != nil {
+		return nil, fmt.Errorf("session: load live intent for control: %w", err)
+	}
+	if intent.Status != storage.VoiceIntentLive {
+		return nil, ErrNoActiveSession
+	}
+
+	ctrl.IntentID = intent.ID
+	ctrl.TenantID = tenantID
+	row, err := c.store.CreateVoiceSessionControl(ctx, ctrl)
+	if err != nil {
+		return nil, fmt.Errorf("session: create voice session control: %w", err)
+	}
+
+	deadline := time.Now().Add(c.cfg.ControlBudget)
+	ticker := time.NewTicker(c.cfg.Poll)
+	defer ticker.Stop()
+	for {
+		cur, err := c.store.GetVoiceSessionControl(ctx, row.ID)
+		if err != nil {
+			c.cancelPendingControl(row.ID)
+			return nil, fmt.Errorf("session: poll voice session control: %w", err)
+		}
+		switch cur.Status {
+		case storage.VoiceControlDone:
+			return cur.ResultIDs, nil
+		case storage.VoiceControlFailed:
+			if sentinel, ok := DecodeControlFailure(cur.LastError); ok {
+				return nil, sentinel
+			}
+			return nil, fmt.Errorf("session: worker could not apply control: %s", cur.LastError)
+		}
+		if time.Now().After(deadline) {
+			c.cancelPendingControl(row.ID)
+			return nil, ErrControlPending
+		}
+		select {
+		case <-ctx.Done():
+			c.cancelPendingControl(row.ID)
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// cancelPendingControl best-effort fails a pending control the requester stopped
+// watching, on a detached short ctx (the fenced write loses cleanly when the
+// worker finished first — the row is settled either way).
+func (c *IntentControl) cancelPendingControl(id uuid.UUID) {
+	dctx, cancel := context.WithTimeout(context.Background(), cancelAbandonedIntentTimeout)
+	defer cancel()
+	if _, err := c.store.CancelPendingVoiceSessionControl(dctx, id); err != nil {
+		c.log.Warn("intent control: cancel pending control", "control", id, "err", err)
+	}
+}
+
+// MutedAgentIDs stays Manager-only (#491/#503 known gap): the web panel's muted
+// set reads degrade to nil in a split deployment (out of #503's AC scope).
 func (c *IntentControl) MutedAgentIDs(uuid.UUID) []string { return nil }
 
 // Spend is Manager-only (#491): the zero Status on the web tier of a split
 // deployment (the live meter rides the worker; the durable ledger is the truth).
 func (c *IntentControl) Spend(uuid.UUID) spend.Status { return spend.Status{} }
 
-// ReplayHighlight is Manager-only (#491): a live-channel replay needs the worker's
-// outbound pump, so it is ErrSplitMode on the web tier of a split deployment.
+// ReplayHighlight is Manager-only (#491; #503 known gap — the highlight-replay
+// relay is out of AC scope): a live-channel replay needs the worker's outbound
+// pump, so it is ErrSplitMode on the web tier of a split deployment.
 func (c *IntentControl) ReplayHighlight(context.Context, uuid.UUID, string) error {
 	return ErrSplitMode
 }

--- a/internal/session/intentcontrol_controls_test.go
+++ b/internal/session/intentcontrol_controls_test.go
@@ -1,0 +1,151 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/session"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// newControlIntentControl builds an IntentControl over a fakeControlStore with a
+// LIVE intent for tenantID, millisecond poll and the given control budget.
+func newControlIntentControl(t *testing.T, budget time.Duration) (*session.IntentControl, *fakeControlStore, uuid.UUID) {
+	t.Helper()
+	store := newFakeControlStore()
+	tenantID := uuid.New()
+	intent := store.fakeIntentStore.add(tenantID, uuid.New())
+	store.fakeIntentStore.mu.Lock()
+	store.fakeIntentStore.intents[intent.ID].Status = storage.VoiceIntentLive
+	store.fakeIntentStore.mu.Unlock()
+	ic := session.NewIntentControl(store, slog.New(slog.DiscardHandler),
+		session.IntentControlConfig{Poll: time.Millisecond, ControlBudget: budget})
+	return ic, store, tenantID
+}
+
+// TestIntentControlSetAgentMute_RelaysToWorker covers sequence (9): SetAgentMute
+// writes a mute_agent control row and returns the result ids once the (scripted)
+// hosting worker flips the row done.
+func TestIntentControlSetAgentMute_RelaysToWorker(t *testing.T) {
+	ic, store, tenantID := newControlIntentControl(t, time.Second)
+	var written storage.VoiceSessionControl
+	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+		written = *c
+		now := time.Now()
+		c.Status = storage.VoiceControlDone
+		c.ResultIDs = []string{"agent-1"}
+		c.EndedAt = &now
+	}
+
+	ids, err := ic.SetAgentMute(context.Background(), tenantID, "agent-1", true)
+	if err != nil {
+		t.Fatalf("SetAgentMute: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "agent-1" {
+		t.Fatalf("result ids = %v, want [agent-1]", ids)
+	}
+	if written.Kind != storage.VoiceControlMuteAgent || written.AgentID != "agent-1" || !written.Muted || written.TenantID != tenantID {
+		t.Fatalf("written control = %+v, want a mute_agent row for agent-1", written)
+	}
+}
+
+// TestIntentControlControl_WorkerFailureDecodes covers sequence (10): the worker
+// writing failed with an ENCODED sentinel surfaces as the same typed error the
+// -mode all path returns; an uncoded failure surfaces verbatim.
+func TestIntentControlControl_WorkerFailureDecodes(t *testing.T) {
+	ic, store, tenantID := newControlIntentControl(t, time.Second)
+	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+		now := time.Now()
+		c.Status = storage.VoiceControlFailed
+		c.LastError = session.EncodeControlFailure(session.ErrButlerVoiceless)
+		c.EndedAt = &now
+	}
+	if err := ic.SpeakAsButler(context.Background(), tenantID, "recap text"); !errors.Is(err, session.ErrButlerVoiceless) {
+		t.Fatalf("SpeakAsButler err = %v, want ErrButlerVoiceless decoded", err)
+	}
+
+	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+		now := time.Now()
+		c.Status = storage.VoiceControlFailed
+		c.LastError = "tts provider exploded"
+		c.EndedAt = &now
+	}
+	err := ic.SayAs(context.Background(), tenantID, "agent-1", "hi")
+	if err == nil || !strings.Contains(err.Error(), "tts provider exploded") {
+		t.Fatalf("SayAs err = %v, want the raw worker error surfaced verbatim", err)
+	}
+}
+
+// TestIntentControlControl_BudgetAndNoSession covers sequence (11): a worker
+// that never confirms yields ErrControlPending with the pending row cancelled;
+// no live intent yields ErrNoActiveSession without writing any row.
+func TestIntentControlControl_BudgetAndNoSession(t *testing.T) {
+	ic, store, tenantID := newControlIntentControl(t, 20*time.Millisecond)
+
+	var rowID uuid.UUID
+	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) { rowID = c.ID }
+	_, err := ic.SetAllMute(context.Background(), tenantID, true)
+	if !errors.Is(err, session.ErrControlPending) {
+		t.Fatalf("SetAllMute with a silent worker = %v, want ErrControlPending", err)
+	}
+	got := store.fakeIntentStore.getControl(rowID)
+	if got.Status != storage.VoiceControlFailed || got.LastError != "requester timed out" {
+		t.Fatalf("row after budget expiry = %+v, want cancelled 'requester timed out'", got)
+	}
+
+	// No live intent for an unknown tenant → ErrNoActiveSession, no row written.
+	before := len(store.fakeIntentStore.controls)
+	if _, err := ic.SetAgentMute(context.Background(), uuid.New(), "agent-1", true); !errors.Is(err, session.ErrNoActiveSession) {
+		t.Fatalf("SetAgentMute with no live intent = %v, want ErrNoActiveSession", err)
+	}
+	if len(store.fakeIntentStore.controls) != before {
+		t.Fatal("a control row was written despite no live intent")
+	}
+}
+
+// TestButlerControl_LocalFirstRemoteFallback covers sequence (17): with no local
+// session the ButlerControl falls through to the remote relay; a local refusal
+// OTHER than ErrNoActiveSession (here a voiceless Butler) does NOT — the local
+// answer stands and the remote is untouched.
+func TestButlerControl_LocalFirstRemoteFallback(t *testing.T) {
+	// Local Manager idle → ErrNoActiveSession → remote relay handles it.
+	idleMgr, _ := muteManager(t, newFakeStore())
+	remote, store, tenantID := newControlIntentControl(t, time.Second)
+	var relayed *storage.VoiceSessionControl
+	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+		relayed = c
+		now := time.Now()
+		c.Status = storage.VoiceControlDone
+		c.EndedAt = &now
+	}
+	bc := session.NewButlerControl(idleMgr, remote)
+	if err := bc.SpeakAsButler(context.Background(), tenantID, "recap text"); err != nil {
+		t.Fatalf("SpeakAsButler via remote: %v", err)
+	}
+	if relayed == nil || relayed.Kind != storage.VoiceControlButlerSay || relayed.SayText != "recap text" {
+		t.Fatalf("relayed control = %+v, want a butler_say row", relayed)
+	}
+
+	// Local session live but the Butler is voiceless: the LOCAL refusal stands,
+	// the remote is never consulted.
+	mstore := newFakeStore()
+	mgr, _ := muteManager(t, mstore)
+	localTenant, _ := startMuteSession(t, mgr)
+	mstore.mu.Lock()
+	mstore.agents = []storage.Agent{{ID: uuid.New(), Role: storage.AgentRoleButler, Name: "Butler"}}
+	mstore.mu.Unlock()
+	relayed = nil
+	bc = session.NewButlerControl(mgr, remote)
+	if err := bc.SpeakAsButler(context.Background(), localTenant, "recap"); !errors.Is(err, session.ErrButlerVoiceless) {
+		t.Fatalf("local voiceless butler = %v, want ErrButlerVoiceless (no remote fallback)", err)
+	}
+	if relayed != nil {
+		t.Fatal("remote relay consulted despite a local non-ErrNoActiveSession answer")
+	}
+}

--- a/internal/session/intentcontrol_controls_test.go
+++ b/internal/session/intentcontrol_controls_test.go
@@ -20,7 +20,7 @@ func newControlIntentControl(t *testing.T, budget time.Duration) (*session.Inten
 	t.Helper()
 	store := newFakeControlStore()
 	tenantID := uuid.New()
-	intent := store.fakeIntentStore.add(tenantID, uuid.New())
+	intent := store.add(tenantID, uuid.New())
 	store.fakeIntentStore.mu.Lock()
 	store.fakeIntentStore.intents[intent.ID].Status = storage.VoiceIntentLive
 	store.fakeIntentStore.mu.Unlock()
@@ -35,7 +35,7 @@ func newControlIntentControl(t *testing.T, budget time.Duration) (*session.Inten
 func TestIntentControlSetAgentMute_RelaysToWorker(t *testing.T) {
 	ic, store, tenantID := newControlIntentControl(t, time.Second)
 	var written storage.VoiceSessionControl
-	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+	store.onControlCreate = func(c *storage.VoiceSessionControl) {
 		written = *c
 		now := time.Now()
 		c.Status = storage.VoiceControlDone
@@ -60,7 +60,7 @@ func TestIntentControlSetAgentMute_RelaysToWorker(t *testing.T) {
 // -mode all path returns; an uncoded failure surfaces verbatim.
 func TestIntentControlControl_WorkerFailureDecodes(t *testing.T) {
 	ic, store, tenantID := newControlIntentControl(t, time.Second)
-	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+	store.onControlCreate = func(c *storage.VoiceSessionControl) {
 		now := time.Now()
 		c.Status = storage.VoiceControlFailed
 		c.LastError = session.EncodeControlFailure(session.ErrButlerVoiceless)
@@ -70,7 +70,7 @@ func TestIntentControlControl_WorkerFailureDecodes(t *testing.T) {
 		t.Fatalf("SpeakAsButler err = %v, want ErrButlerVoiceless decoded", err)
 	}
 
-	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+	store.onControlCreate = func(c *storage.VoiceSessionControl) {
 		now := time.Now()
 		c.Status = storage.VoiceControlFailed
 		c.LastError = "tts provider exploded"
@@ -89,22 +89,22 @@ func TestIntentControlControl_BudgetAndNoSession(t *testing.T) {
 	ic, store, tenantID := newControlIntentControl(t, 20*time.Millisecond)
 
 	var rowID uuid.UUID
-	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) { rowID = c.ID }
+	store.onControlCreate = func(c *storage.VoiceSessionControl) { rowID = c.ID }
 	_, err := ic.SetAllMute(context.Background(), tenantID, true)
 	if !errors.Is(err, session.ErrControlPending) {
 		t.Fatalf("SetAllMute with a silent worker = %v, want ErrControlPending", err)
 	}
-	got := store.fakeIntentStore.getControl(rowID)
+	got := store.getControl(rowID)
 	if got.Status != storage.VoiceControlFailed || got.LastError != "requester timed out" {
 		t.Fatalf("row after budget expiry = %+v, want cancelled 'requester timed out'", got)
 	}
 
 	// No live intent for an unknown tenant → ErrNoActiveSession, no row written.
-	before := len(store.fakeIntentStore.controls)
+	before := len(store.controls)
 	if _, err := ic.SetAgentMute(context.Background(), uuid.New(), "agent-1", true); !errors.Is(err, session.ErrNoActiveSession) {
 		t.Fatalf("SetAgentMute with no live intent = %v, want ErrNoActiveSession", err)
 	}
-	if len(store.fakeIntentStore.controls) != before {
+	if len(store.controls) != before {
 		t.Fatal("a control row was written despite no live intent")
 	}
 }
@@ -118,7 +118,7 @@ func TestButlerControl_LocalFirstRemoteFallback(t *testing.T) {
 	idleMgr, _ := muteManager(t, newFakeStore())
 	remote, store, tenantID := newControlIntentControl(t, time.Second)
 	var relayed *storage.VoiceSessionControl
-	store.fakeIntentStore.onControlCreate = func(c *storage.VoiceSessionControl) {
+	store.onControlCreate = func(c *storage.VoiceSessionControl) {
 		relayed = c
 		now := time.Now()
 		c.Status = storage.VoiceControlDone

--- a/internal/session/intentcontrol_test.go
+++ b/internal/session/intentcontrol_test.go
@@ -506,17 +506,19 @@ func TestIntentControl_StopBudgetError(t *testing.T) {
 	}
 }
 
-// TestIntentControl_MgrOnlyDegrade covers review item 6: the Manager-only live
-// controls degrade with ErrSplitMode on the web tier of a split deployment.
+// TestIntentControl_MgrOnlyDegrade covers review item 6, narrowed by #503: the
+// mutes now RELAY through the claim plane (no live intent → ErrNoActiveSession,
+// exactly the -mode all Manager's answer — no more ErrSplitMode, sequence 18);
+// only replay + the muted-set/spend reads stay degraded (out of #503 AC scope).
 func TestIntentControl_MgrOnlyDegrade(t *testing.T) {
 	ctl := session.NewIntentControl(newFakeControlStore(), slog.New(slog.DiscardHandler), session.IntentControlConfig{})
 	tenantID := uuid.New()
 
-	if _, err := ctl.SetAgentMute(context.Background(), tenantID, uuid.NewString(), true); !errors.Is(err, session.ErrSplitMode) {
-		t.Errorf("SetAgentMute err = %v, want ErrSplitMode", err)
+	if _, err := ctl.SetAgentMute(context.Background(), tenantID, uuid.NewString(), true); !errors.Is(err, session.ErrNoActiveSession) {
+		t.Errorf("SetAgentMute err = %v, want ErrNoActiveSession (relay, not ErrSplitMode)", err)
 	}
-	if _, err := ctl.SetAllMute(context.Background(), tenantID, true); !errors.Is(err, session.ErrSplitMode) {
-		t.Errorf("SetAllMute err = %v, want ErrSplitMode", err)
+	if _, err := ctl.SetAllMute(context.Background(), tenantID, true); !errors.Is(err, session.ErrNoActiveSession) {
+		t.Errorf("SetAllMute err = %v, want ErrNoActiveSession (relay, not ErrSplitMode)", err)
 	}
 	if err := ctl.ReplayHighlight(context.Background(), tenantID, "clip-key"); !errors.Is(err, session.ErrSplitMode) {
 		t.Errorf("ReplayHighlight err = %v, want ErrSplitMode", err)

--- a/internal/storage/migrations/00038_voice_session_controls.sql
+++ b/internal/storage/migrations/00038_voice_session_controls.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+
+-- Cross-pod live voice controls (#503, ADR-0057 (b)): a requested-control QUEUE
+-- hanging off the voice_session_intents claim plane. The requester (presence
+-- owner or split web tier) writes a row; the worker HOSTING the intent's session
+-- drains all pending rows in (created_at, id) order on its own heartbeat tick,
+-- executes each against its local Manager, and writes the terminal status the
+-- requester polls for. DB-write-then-poll only — no LISTEN/NOTIFY (ADR-0057 (b)),
+-- and the control never re-targets another instance (ADR-0006/0057 (e)): only
+-- the owning worker's own loop dispatches, mirroring the stop_requested
+-- handshake and ADR-0051's write-then-poll precedent.
+CREATE TABLE voice_session_controls (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    intent_id   uuid NOT NULL REFERENCES voice_session_intents (id) ON DELETE CASCADE,
+    tenant_id   uuid NOT NULL REFERENCES tenant (id) ON DELETE CASCADE,
+    -- 'mute_agent' | 'mute_all' | 'say' | 'butler_say'. Text, not an enum: the
+    -- app validates the vocabulary (mirrors voice_session_intents.status).
+    kind        text NOT NULL,
+    agent_id    text NOT NULL DEFAULT '',
+    say_text    text NOT NULL DEFAULT '',
+    muted       boolean NOT NULL DEFAULT false,
+    -- pending | done | failed. Terminal writes are fenced WHERE status='pending'
+    -- (ErrNotFound = lost race), the intent-row idiom.
+    status      text NOT NULL DEFAULT 'pending',
+    -- The muted-agent id set a mute control returns (Manager.SetAgentMute /
+    -- SetAllMute result), relayed back to the requester.
+    result_ids  text[] NOT NULL DEFAULT '{}',
+    last_error  text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    ended_at    timestamptz
+);
+
+-- The worker's per-heartbeat drain scan (pending rows of one intent, oldest
+-- first) and the orphan sweep both ride this.
+CREATE INDEX voice_session_controls_dispatch_idx
+    ON voice_session_controls (intent_id, status, created_at);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS voice_session_controls;

--- a/internal/storage/migrations/00038_voice_session_controls.sql
+++ b/internal/storage/migrations/00038_voice_session_controls.sql
@@ -19,7 +19,10 @@ CREATE TABLE voice_session_controls (
     agent_id    text NOT NULL DEFAULT '',
     say_text    text NOT NULL DEFAULT '',
     muted       boolean NOT NULL DEFAULT false,
-    -- pending | done | failed. Terminal writes are fenced WHERE status='pending'
+    -- pending | executing | done | failed. The hosting worker fences a
+    -- pending→executing CLAIM before it runs the verb, so a transient finish-write
+    -- failure can never re-dispatch it (say is not idempotent; #503 at-least-once
+    -- fix). Terminal writes are then fenced WHERE status='executing'
     -- (ErrNotFound = lost race), the intent-row idiom.
     status      text NOT NULL DEFAULT 'pending',
     -- The muted-agent id set a mute control returns (Manager.SetAgentMute /
@@ -27,13 +30,24 @@ CREATE TABLE voice_session_controls (
     result_ids  text[] NOT NULL DEFAULT '{}',
     last_error  text NOT NULL DEFAULT '',
     created_at  timestamptz NOT NULL DEFAULT now(),
+    -- When the worker claimed the row for execution (pending→executing). The sweep
+    -- fails an 'executing' row stranded past a stale cutoff (a finish-write blip
+    -- with the requester already gone) so it never sits forever.
+    started_at  timestamptz,
     ended_at    timestamptz
 );
 
 -- The worker's per-heartbeat drain scan (pending rows of one intent, oldest
--- first) and the orphan sweep both ride this.
+-- first) rides the intent-leading index.
 CREATE INDEX voice_session_controls_dispatch_idx
     ON voice_session_controls (intent_id, status, created_at);
+
+-- The orphan sweep scans by STATUS (not intent), so it needs a status-leading
+-- partial index over the only two statuses it touches — the dispatch index leads
+-- on intent_id and would seq-scan the sweep otherwise.
+CREATE INDEX voice_session_controls_sweep_idx
+    ON voice_session_controls (status)
+    WHERE status IN ('pending', 'executing');
 
 -- +goose Down
 

--- a/internal/storage/voicecontrol.go
+++ b/internal/storage/voicecontrol.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Cross-pod live voice controls (#503, ADR-0057): the requested-control queue
+// hanging off the voice_session_intents claim plane. A requester (the presence
+// owner dispatching a slash command, or the split web tier's RPC) writes a
+// pending row; the worker HOSTING the intent's session drains all pending rows
+// in (created_at, id) order on its heartbeat tick, executes each against its
+// LOCAL Manager, and writes the terminal status (done/failed) the requester
+// polls to. DB-write-then-poll only — no LISTEN/NOTIFY (ADR-0057 (b)); a
+// control row never re-targets another instance (ADR-0006/0057 (e)). Terminal
+// writes are fenced WHERE status='pending' so a lost race yields ErrNotFound,
+// mirroring the intent-row idiom.
+
+// VoiceSessionControlKind names one control verb.
+type VoiceSessionControlKind string
+
+const (
+	// VoiceControlMuteAgent mutes/unmutes one voiced Agent (Manager.SetAgentMute).
+	VoiceControlMuteAgent VoiceSessionControlKind = "mute_agent"
+	// VoiceControlMuteAll mutes/unmutes every voiced Agent (Manager.SetAllMute).
+	VoiceControlMuteAll VoiceSessionControlKind = "mute_all"
+	// VoiceControlSay makes one voiced Agent speak SayText (Manager.SayAs).
+	VoiceControlSay VoiceSessionControlKind = "say"
+	// VoiceControlButlerSay makes the Butler speak SayText (Manager.SpeakAsButler)
+	// — the voiced-recap relay.
+	VoiceControlButlerSay VoiceSessionControlKind = "butler_say"
+)
+
+// VoiceSessionControlStatus is a control row's lifecycle state.
+type VoiceSessionControlStatus string
+
+const (
+	// VoiceControlPending: written by the requester, not yet executed.
+	VoiceControlPending VoiceSessionControlStatus = "pending"
+	// VoiceControlDone: the hosting worker executed it successfully.
+	VoiceControlDone VoiceSessionControlStatus = "done"
+	// VoiceControlFailed: execution failed (LastError carries the encoded cause),
+	// the requester timed out, or the session ended with the row still pending.
+	VoiceControlFailed VoiceSessionControlStatus = "failed"
+)
+
+// VoiceSessionControl is one row of the requested-control queue (#503).
+type VoiceSessionControl struct {
+	ID        uuid.UUID
+	IntentID  uuid.UUID
+	TenantID  uuid.UUID
+	Kind      VoiceSessionControlKind
+	AgentID   string
+	SayText   string
+	Muted     bool
+	Status    VoiceSessionControlStatus
+	ResultIDs []string
+	LastError string
+	CreatedAt time.Time
+	EndedAt   *time.Time
+}
+
+const voiceControlColumns = `
+	id, intent_id, tenant_id, kind, agent_id, say_text, muted,
+	status, result_ids, last_error, created_at, ended_at`
+
+func scanVoiceSessionControl(row pgx.Row) (VoiceSessionControl, error) {
+	var c VoiceSessionControl
+	err := row.Scan(
+		&c.ID, &c.IntentID, &c.TenantID, &c.Kind, &c.AgentID, &c.SayText, &c.Muted,
+		&c.Status, &c.ResultIDs, &c.LastError, &c.CreatedAt, &c.EndedAt,
+	)
+	return c, err
+}
+
+// CreateVoiceSessionControl writes a pending control row for an intent and
+// returns it. The requester then polls GetVoiceSessionControl until the hosting
+// worker writes a terminal status.
+func (s *Store) CreateVoiceSessionControl(ctx context.Context, c VoiceSessionControl) (VoiceSessionControl, error) {
+	row := s.db.QueryRow(ctx,
+		`INSERT INTO voice_session_controls (intent_id, tenant_id, kind, agent_id, say_text, muted)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING `+voiceControlColumns,
+		c.IntentID, c.TenantID, c.Kind, c.AgentID, c.SayText, c.Muted)
+	out, err := scanVoiceSessionControl(row)
+	if err != nil {
+		return VoiceSessionControl{}, fmt.Errorf("storage: create voice session control for intent %s: %w", c.IntentID, err)
+	}
+	return out, nil
+}
+
+// ListPendingVoiceSessionControls returns an intent's pending control rows in
+// (created_at, id) order — the hosting worker's per-heartbeat drain scan. The
+// order matters for 'say' (utterances must land in request order); mutes are
+// idempotent so the queue is harmless for them.
+func (s *Store) ListPendingVoiceSessionControls(ctx context.Context, intentID uuid.UUID) ([]VoiceSessionControl, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT `+voiceControlColumns+`
+		   FROM voice_session_controls
+		  WHERE intent_id = $1 AND status = 'pending'
+		  ORDER BY created_at, id`, intentID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list pending voice session controls for intent %s: %w", intentID, err)
+	}
+	defer rows.Close()
+	var out []VoiceSessionControl
+	for rows.Next() {
+		c, err := scanVoiceSessionControl(rows)
+		if err != nil {
+			return nil, fmt.Errorf("storage: scan voice session control: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list pending voice session controls for intent %s: %w", intentID, err)
+	}
+	return out, nil
+}
+
+// FinishVoiceSessionControl writes a control's terminal state (done/failed) with
+// its result ids / last_error and ended_at = now(). Fenced WHERE status='pending'
+// so a lost race (the requester's timeout cancel, or the sweep, won) yields
+// ErrNotFound and the caller does not overwrite a settled row.
+func (s *Store) FinishVoiceSessionControl(ctx context.Context, id uuid.UUID, status VoiceSessionControlStatus, resultIDs []string, lastError string) (VoiceSessionControl, error) {
+	if resultIDs == nil {
+		resultIDs = []string{}
+	}
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_controls
+		    SET status = $2, result_ids = $3, last_error = $4, ended_at = now()
+		  WHERE id = $1 AND status = 'pending'
+		 RETURNING `+voiceControlColumns,
+		id, status, resultIDs, lastError)
+	c, err := scanVoiceSessionControl(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionControl{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionControl{}, fmt.Errorf("storage: finish voice session control %s: %w", id, err)
+	}
+	return c, nil
+}
+
+// GetVoiceSessionControl loads one control row by id, or ErrNotFound — the
+// requester's poll read.
+func (s *Store) GetVoiceSessionControl(ctx context.Context, id uuid.UUID) (VoiceSessionControl, error) {
+	row := s.db.QueryRow(ctx,
+		`SELECT `+voiceControlColumns+` FROM voice_session_controls WHERE id = $1`, id)
+	c, err := scanVoiceSessionControl(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionControl{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionControl{}, fmt.Errorf("storage: get voice session control %s: %w", id, err)
+	}
+	return c, nil
+}
+
+// CancelPendingVoiceSessionControl fails a still-pending control with
+// 'requester timed out' — the requester's budget-expiry best-effort cancel.
+// Fenced WHERE status='pending': a row the worker already finished is left
+// untouched and false is returned (the worker won the race; the requester's
+// honest "not confirmed" reply stands either way).
+func (s *Store) CancelPendingVoiceSessionControl(ctx context.Context, id uuid.UUID) (bool, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_session_controls
+		    SET status = 'failed', last_error = 'requester timed out', ended_at = now()
+		  WHERE id = $1 AND status = 'pending'`, id)
+	if err != nil {
+		return false, fmt.Errorf("storage: cancel pending voice session control %s: %w", id, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// SweepOrphanedVoiceSessionControls fails every pending control whose intent is
+// already terminal (done/dead/failed) with 'session ended' — controls are never
+// dispatched during a wind-down (dispatch is gated on the session being live),
+// so a stopping session's stragglers die here (or via the requester's own
+// budget cancel) instead of sitting pending forever. Run each claim-loop tick.
+func (s *Store) SweepOrphanedVoiceSessionControls(ctx context.Context) (int64, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE voice_session_controls c
+		    SET status = 'failed', last_error = 'session ended', ended_at = now()
+		  WHERE c.status = 'pending'
+		    AND EXISTS (
+		          SELECT 1 FROM voice_session_intents i
+		           WHERE i.id = c.intent_id
+		             AND i.status IN ('done', 'dead', 'failed')
+		    )`)
+	if err != nil {
+		return 0, fmt.Errorf("storage: sweep orphaned voice session controls: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/storage/voicecontrol.go
+++ b/internal/storage/voicecontrol.go
@@ -40,12 +40,18 @@ const (
 type VoiceSessionControlStatus string
 
 const (
-	// VoiceControlPending: written by the requester, not yet executed.
+	// VoiceControlPending: written by the requester, not yet claimed.
 	VoiceControlPending VoiceSessionControlStatus = "pending"
+	// VoiceControlExecuting: the hosting worker fenced a pending→executing claim
+	// and is running the verb. A transient finish-write failure leaves the row
+	// here (never back to pending), so it can never re-dispatch (#503 FIX1 — say
+	// is not idempotent); the requester treats it as non-terminal and keeps
+	// polling, and the sweep retires a row stranded here.
+	VoiceControlExecuting VoiceSessionControlStatus = "executing"
 	// VoiceControlDone: the hosting worker executed it successfully.
 	VoiceControlDone VoiceSessionControlStatus = "done"
 	// VoiceControlFailed: execution failed (LastError carries the encoded cause),
-	// the requester timed out, or the session ended with the row still pending.
+	// the requester timed out, or the session ended with the row unfinished.
 	VoiceControlFailed VoiceSessionControlStatus = "failed"
 )
 
@@ -62,21 +68,32 @@ type VoiceSessionControl struct {
 	ResultIDs []string
 	LastError string
 	CreatedAt time.Time
+	StartedAt *time.Time
 	EndedAt   *time.Time
 }
 
 const voiceControlColumns = `
 	id, intent_id, tenant_id, kind, agent_id, say_text, muted,
-	status, result_ids, last_error, created_at, ended_at`
+	status, result_ids, last_error, created_at, started_at, ended_at`
 
 func scanVoiceSessionControl(row pgx.Row) (VoiceSessionControl, error) {
 	var c VoiceSessionControl
 	err := row.Scan(
 		&c.ID, &c.IntentID, &c.TenantID, &c.Kind, &c.AgentID, &c.SayText, &c.Muted,
-		&c.Status, &c.ResultIDs, &c.LastError, &c.CreatedAt, &c.EndedAt,
+		&c.Status, &c.ResultIDs, &c.LastError, &c.CreatedAt, &c.StartedAt, &c.EndedAt,
 	)
 	return c, err
 }
+
+// voiceControlNoSessionCause is the ENCODED last_error the sweep stamps on a
+// control orphaned by a terminal intent (#503 FIX3): it mirrors
+// session.EncodeControlFailure(ErrNoActiveSession)'s "code=<code>: <msg>" wire
+// form (session.failCodePrefix + "no_active_session") so the requester's
+// session.DecodeControlFailure re-maps it to ErrNoActiveSession and the GM sees
+// the plain "No Voice Session is active." guard, not a raw error chain. Kept in
+// sync with session's failcode vocabulary (a storage-layer sweep cannot import
+// the session package); a round-trip test guards the drift.
+const voiceControlNoSessionCause = "code=no_active_session: session ended"
 
 // CreateVoiceSessionControl writes a pending control row for an intent and
 // returns it. The requester then polls GetVoiceSessionControl until the hosting
@@ -122,10 +139,36 @@ func (s *Store) ListPendingVoiceSessionControls(ctx context.Context, intentID uu
 	return out, nil
 }
 
+// StartVoiceSessionControl fences the hosting worker's pending→executing CLAIM
+// before it runs the verb (#503 FIX1): a transient finish-write failure then
+// leaves the row 'executing' (never back to 'pending'), so it can never be
+// re-listed and re-dispatched — say publishes exactly once. Fenced WHERE
+// status='pending': a second claim, a cancelled row, or a swept row matches
+// nothing and yields ErrNotFound (the worker skips it). Stamps started_at for
+// the stale-executing sweep.
+func (s *Store) StartVoiceSessionControl(ctx context.Context, id uuid.UUID) (VoiceSessionControl, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE voice_session_controls
+		    SET status = 'executing', started_at = now()
+		  WHERE id = $1 AND status = 'pending'
+		 RETURNING `+voiceControlColumns,
+		id)
+	c, err := scanVoiceSessionControl(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return VoiceSessionControl{}, ErrNotFound
+	}
+	if err != nil {
+		return VoiceSessionControl{}, fmt.Errorf("storage: start voice session control %s: %w", id, err)
+	}
+	return c, nil
+}
+
 // FinishVoiceSessionControl writes a control's terminal state (done/failed) with
-// its result ids / last_error and ended_at = now(). Fenced WHERE status='pending'
-// so a lost race (the requester's timeout cancel, or the sweep, won) yields
-// ErrNotFound and the caller does not overwrite a settled row.
+// its result ids / last_error and ended_at = now(). Fenced WHERE
+// status='executing' (the worker must have claimed it via
+// StartVoiceSessionControl first) so a lost race (the sweep won a stale
+// executing row) yields ErrNotFound and the caller does not overwrite a settled
+// row.
 func (s *Store) FinishVoiceSessionControl(ctx context.Context, id uuid.UUID, status VoiceSessionControlStatus, resultIDs []string, lastError string) (VoiceSessionControl, error) {
 	if resultIDs == nil {
 		resultIDs = []string{}
@@ -133,7 +176,7 @@ func (s *Store) FinishVoiceSessionControl(ctx context.Context, id uuid.UUID, sta
 	row := s.db.QueryRow(ctx,
 		`UPDATE voice_session_controls
 		    SET status = $2, result_ids = $3, last_error = $4, ended_at = now()
-		  WHERE id = $1 AND status = 'pending'
+		  WHERE id = $1 AND status = 'executing'
 		 RETURNING `+voiceControlColumns,
 		id, status, resultIDs, lastError)
 	c, err := scanVoiceSessionControl(row)
@@ -177,21 +220,46 @@ func (s *Store) CancelPendingVoiceSessionControl(ctx context.Context, id uuid.UU
 	return tag.RowsAffected() > 0, nil
 }
 
-// SweepOrphanedVoiceSessionControls fails every pending control whose intent is
-// already terminal (done/dead/failed) with 'session ended' — controls are never
-// dispatched during a wind-down (dispatch is gated on the session being live),
-// so a stopping session's stragglers die here (or via the requester's own
-// budget cancel) instead of sitting pending forever. Run each claim-loop tick.
-func (s *Store) SweepOrphanedVoiceSessionControls(ctx context.Context) (int64, error) {
+// SweepOrphanedVoiceSessionControls retires unfinished (pending/executing)
+// control rows the worker will never complete (#503), run each claim-loop tick.
+// Two arms:
+//
+//  1. Rows whose intent is already TERMINAL (done/dead/failed) — controls are
+//     never dispatched during a wind-down (dispatch is gated on the session
+//     being live), so a stopping session's stragglers die here with the ENCODED
+//     no_active_session cause (FIX3) so the requester decodes it to
+//     ErrNoActiveSession and the GM sees the plain guard.
+//  2. 'executing' rows of a still-live intent stranded past executingStale (a
+//     finish-write blip with the requester already gone) — the bounded recovery
+//     that keeps such a row from sitting forever (FIX1). Its cause is a plain
+//     stall message (uncoded, surfaced verbatim to any late poller).
+//
+// Returns how many rows were failed.
+func (s *Store) SweepOrphanedVoiceSessionControls(ctx context.Context, executingStale time.Duration) (int64, error) {
 	tag, err := s.db.Exec(ctx,
 		`UPDATE voice_session_controls c
-		    SET status = 'failed', last_error = 'session ended', ended_at = now()
-		  WHERE c.status = 'pending'
-		    AND EXISTS (
-		          SELECT 1 FROM voice_session_intents i
-		           WHERE i.id = c.intent_id
-		             AND i.status IN ('done', 'dead', 'failed')
-		    )`)
+		    SET status = 'failed',
+		        last_error = CASE
+		            WHEN EXISTS (
+		                  SELECT 1 FROM voice_session_intents i
+		                   WHERE i.id = c.intent_id
+		                     AND i.status IN ('done', 'dead', 'failed')
+		            ) THEN $1
+		            ELSE 'control execution stalled on the hosting worker'
+		        END,
+		        ended_at = now()
+		  WHERE c.status IN ('pending', 'executing')
+		    AND (
+		         EXISTS (
+		               SELECT 1 FROM voice_session_intents i
+		                WHERE i.id = c.intent_id
+		                  AND i.status IN ('done', 'dead', 'failed')
+		         )
+		         OR (c.status = 'executing'
+		             AND c.started_at IS NOT NULL
+		             AND c.started_at < now() - make_interval(secs => $2))
+		    )`,
+		voiceControlNoSessionCause, executingStale.Seconds())
 	if err != nil {
 		return 0, fmt.Errorf("storage: sweep orphaned voice session controls: %w", err)
 	}

--- a/internal/storage/voicecontrol_test.go
+++ b/internal/storage/voicecontrol_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// seedControlIntent creates a pending intent for the seeded tenant/campaign —
+// the parent row every voice_session_controls row hangs off.
+func seedControlIntent(t *testing.T, st *storage.Store, tenantID, campaignID uuid.UUID) storage.VoiceSessionIntent {
+	t.Helper()
+	intent, err := st.CreateVoiceSessionIntent(context.Background(), tenantID, campaignID)
+	if err != nil {
+		t.Fatalf("create intent: %v", err)
+	}
+	return intent
+}
+
+// TestVoiceSessionControl_CreateListFinish covers sequence (1): create + list
+// pending returns rows in (created_at, id) order, and Finish is fenced — a
+// second terminal write on the same row yields ErrNotFound.
+func TestVoiceSessionControl_CreateListFinish(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	intent := seedControlIntent(t, st, tenantID, campaignID)
+
+	first, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID,
+		TenantID: tenantID,
+		Kind:     storage.VoiceControlSay,
+		AgentID:  "agent-1",
+		SayText:  "first line",
+	})
+	if err != nil {
+		t.Fatalf("create first control: %v", err)
+	}
+	if first.Status != storage.VoiceControlPending {
+		t.Fatalf("fresh control status = %q, want pending", first.Status)
+	}
+	if first.Kind != storage.VoiceControlSay || first.AgentID != "agent-1" || first.SayText != "first line" {
+		t.Fatalf("fresh control fields = %+v", first)
+	}
+
+	second, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID,
+		TenantID: tenantID,
+		Kind:     storage.VoiceControlMuteAgent,
+		AgentID:  "agent-2",
+		Muted:    true,
+	})
+	if err != nil {
+		t.Fatalf("create second control: %v", err)
+	}
+
+	pending, err := st.ListPendingVoiceSessionControls(ctx, intent.ID)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("pending = %d rows, want 2", len(pending))
+	}
+	if pending[0].ID != first.ID || pending[1].ID != second.ID {
+		t.Fatalf("pending order = [%s %s], want [%s %s] (created_at, id)",
+			pending[0].ID, pending[1].ID, first.ID, second.ID)
+	}
+	if !pending[1].Muted {
+		t.Fatalf("second control muted = false, want true")
+	}
+
+	done, err := st.FinishVoiceSessionControl(ctx, first.ID, storage.VoiceControlDone, []string{"a", "b"}, "")
+	if err != nil {
+		t.Fatalf("finish control: %v", err)
+	}
+	if done.Status != storage.VoiceControlDone || len(done.ResultIDs) != 2 || done.EndedAt == nil {
+		t.Fatalf("finished control = %+v, want done with 2 result ids and ended_at", done)
+	}
+
+	// The fence: a second terminal write finds no pending row.
+	if _, err := st.FinishVoiceSessionControl(ctx, first.ID, storage.VoiceControlFailed, nil, "late"); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("second finish err = %v, want ErrNotFound (fenced)", err)
+	}
+
+	// The finished row fell out of the pending list; a Get still loads it.
+	pending, err = st.ListPendingVoiceSessionControls(ctx, intent.ID)
+	if err != nil || len(pending) != 1 || pending[0].ID != second.ID {
+		t.Fatalf("pending after finish = %+v (err %v), want just the second row", pending, err)
+	}
+	got, err := st.GetVoiceSessionControl(ctx, first.ID)
+	if err != nil || got.Status != storage.VoiceControlDone {
+		t.Fatalf("get finished control = %+v (err %v), want done", got, err)
+	}
+}
+
+// TestVoiceSessionControl_CancelPendingOnly covers sequence (2): the requester's
+// timeout cancel takes a PENDING row to failed 'requester timed out', but leaves
+// an already-done row untouched (returns false — the worker won the race).
+func TestVoiceSessionControl_CancelPendingOnly(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	intent := seedControlIntent(t, st, tenantID, campaignID)
+
+	pendingRow, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID, TenantID: tenantID, Kind: storage.VoiceControlMuteAll, Muted: true,
+	})
+	if err != nil {
+		t.Fatalf("create control: %v", err)
+	}
+	cancelled, err := st.CancelPendingVoiceSessionControl(ctx, pendingRow.ID)
+	if err != nil || !cancelled {
+		t.Fatalf("cancel pending = (%v, %v), want (true, nil)", cancelled, err)
+	}
+	got, err := st.GetVoiceSessionControl(ctx, pendingRow.ID)
+	if err != nil || got.Status != storage.VoiceControlFailed || got.LastError != "requester timed out" {
+		t.Fatalf("cancelled row = %+v (err %v), want failed 'requester timed out'", got, err)
+	}
+
+	doneRow, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID, TenantID: tenantID, Kind: storage.VoiceControlMuteAll, Muted: true,
+	})
+	if err != nil {
+		t.Fatalf("create second control: %v", err)
+	}
+	if _, err := st.FinishVoiceSessionControl(ctx, doneRow.ID, storage.VoiceControlDone, nil, ""); err != nil {
+		t.Fatalf("finish second control: %v", err)
+	}
+	cancelled, err = st.CancelPendingVoiceSessionControl(ctx, doneRow.ID)
+	if err != nil || cancelled {
+		t.Fatalf("cancel done row = (%v, %v), want (false, nil) — worker won", cancelled, err)
+	}
+	got, err = st.GetVoiceSessionControl(ctx, doneRow.ID)
+	if err != nil || got.Status != storage.VoiceControlDone {
+		t.Fatalf("done row after cancel attempt = %+v (err %v), want still done", got, err)
+	}
+}
+
+// TestVoiceSessionControl_SweepOrphaned covers sequence (3): pendings of a
+// TERMINAL intent are failed 'session ended'; a live intent's pendings survive.
+func TestVoiceSessionControl_SweepOrphaned(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// Intent A: claimed then finished (terminal). Its pending control is orphaned.
+	intentA := seedControlIntent(t, st, tenantID, campaignID)
+	if _, err := st.ClaimVoiceSessionIntent(ctx, "worker-a"); err != nil {
+		t.Fatalf("claim intent A: %v", err)
+	}
+	orphan, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intentA.ID, TenantID: tenantID, Kind: storage.VoiceControlMuteAll, Muted: true,
+	})
+	if err != nil {
+		t.Fatalf("create orphan control: %v", err)
+	}
+	if _, err := st.FinishVoiceSessionIntent(ctx, intentA.ID, "worker-a", storage.VoiceIntentDone, ""); err != nil {
+		t.Fatalf("finish intent A: %v", err)
+	}
+
+	// Intent B (second tenant): still pending (non-terminal). Its control survives.
+	tenantB, campaignB := secondCampaign(t, pool)
+	intentB := seedControlIntent(t, st, tenantB, campaignB)
+	alive, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intentB.ID, TenantID: tenantB, Kind: storage.VoiceControlMuteAll, Muted: true,
+	})
+	if err != nil {
+		t.Fatalf("create live control: %v", err)
+	}
+
+	n, err := st.SweepOrphanedVoiceSessionControls(ctx)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("sweep closed %d rows, want 1", n)
+	}
+	got, err := st.GetVoiceSessionControl(ctx, orphan.ID)
+	if err != nil || got.Status != storage.VoiceControlFailed || got.LastError != "session ended" {
+		t.Fatalf("orphan after sweep = %+v (err %v), want failed 'session ended'", got, err)
+	}
+	still, err := st.GetVoiceSessionControl(ctx, alive.ID)
+	if err != nil || still.Status != storage.VoiceControlPending {
+		t.Fatalf("live intent's control after sweep = %+v (err %v), want still pending", still, err)
+	}
+}

--- a/internal/storage/voicecontrol_test.go
+++ b/internal/storage/voicecontrol_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -76,6 +78,28 @@ func TestVoiceSessionControl_CreateListFinish(t *testing.T) {
 		t.Fatalf("second control muted = false, want true")
 	}
 
+	// The worker claims pending→executing BEFORE running the verb (#503 FIX1):
+	// Finish is fenced on 'executing', so a bare pending row cannot be finished.
+	if _, err := st.FinishVoiceSessionControl(ctx, first.ID, storage.VoiceControlDone, nil, ""); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("finish of a pending (unclaimed) row err = %v, want ErrNotFound", err)
+	}
+	started, err := st.StartVoiceSessionControl(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("start control: %v", err)
+	}
+	if started.Status != storage.VoiceControlExecuting || started.StartedAt == nil {
+		t.Fatalf("started control = %+v, want executing with started_at", started)
+	}
+	// A second claim finds no pending row (fenced) — no re-dispatch.
+	if _, err := st.StartVoiceSessionControl(ctx, first.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("second start err = %v, want ErrNotFound (fenced)", err)
+	}
+	// An executing row falls out of the pending drain list.
+	pending, err = st.ListPendingVoiceSessionControls(ctx, intent.ID)
+	if err != nil || len(pending) != 1 || pending[0].ID != second.ID {
+		t.Fatalf("pending after claim = %+v (err %v), want just the second row", pending, err)
+	}
+
 	done, err := st.FinishVoiceSessionControl(ctx, first.ID, storage.VoiceControlDone, []string{"a", "b"}, "")
 	if err != nil {
 		t.Fatalf("finish control: %v", err)
@@ -84,7 +108,7 @@ func TestVoiceSessionControl_CreateListFinish(t *testing.T) {
 		t.Fatalf("finished control = %+v, want done with 2 result ids and ended_at", done)
 	}
 
-	// The fence: a second terminal write finds no pending row.
+	// The fence: a second terminal write finds no executing row.
 	if _, err := st.FinishVoiceSessionControl(ctx, first.ID, storage.VoiceControlFailed, nil, "late"); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("second finish err = %v, want ErrNotFound (fenced)", err)
 	}
@@ -131,6 +155,9 @@ func TestVoiceSessionControl_CancelPendingOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create second control: %v", err)
 	}
+	if _, err := st.StartVoiceSessionControl(ctx, doneRow.ID); err != nil {
+		t.Fatalf("claim second control: %v", err)
+	}
 	if _, err := st.FinishVoiceSessionControl(ctx, doneRow.ID, storage.VoiceControlDone, nil, ""); err != nil {
 		t.Fatalf("finish second control: %v", err)
 	}
@@ -144,24 +171,37 @@ func TestVoiceSessionControl_CancelPendingOnly(t *testing.T) {
 	}
 }
 
-// TestVoiceSessionControl_SweepOrphaned covers sequence (3): pendings of a
-// TERMINAL intent are failed 'session ended'; a live intent's pendings survive.
+// TestVoiceSessionControl_SweepOrphaned covers sequence (3): pending AND
+// executing rows of a TERMINAL intent are failed with the ENCODED
+// no_active_session cause (#503 FIX3, so the requester decodes it to
+// ErrNoActiveSession and the GM sees the plain guard, not a raw chain); a live
+// intent's rows survive.
 func TestVoiceSessionControl_SweepOrphaned(t *testing.T) {
 	dsn := startPostgres(t)
 	pool, tenantID, campaignID := seedCampaign(t, dsn)
 	ctx := context.Background()
 	st := storage.New(pool)
 
-	// Intent A: claimed then finished (terminal). Its pending control is orphaned.
+	// Intent A: claimed then finished (terminal). One pending + one executing
+	// control are both orphaned by the terminal intent.
 	intentA := seedControlIntent(t, st, tenantID, campaignID)
 	if _, err := st.ClaimVoiceSessionIntent(ctx, "worker-a"); err != nil {
 		t.Fatalf("claim intent A: %v", err)
 	}
-	orphan, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+	orphanPending, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
 		IntentID: intentA.ID, TenantID: tenantID, Kind: storage.VoiceControlMuteAll, Muted: true,
 	})
 	if err != nil {
-		t.Fatalf("create orphan control: %v", err)
+		t.Fatalf("create orphan pending control: %v", err)
+	}
+	orphanExec, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intentA.ID, TenantID: tenantID, Kind: storage.VoiceControlSay, AgentID: "a", SayText: "hi",
+	})
+	if err != nil {
+		t.Fatalf("create orphan executing control: %v", err)
+	}
+	if _, err := st.StartVoiceSessionControl(ctx, orphanExec.ID); err != nil {
+		t.Fatalf("claim orphan executing control: %v", err)
 	}
 	if _, err := st.FinishVoiceSessionIntent(ctx, intentA.ID, "worker-a", storage.VoiceIntentDone, ""); err != nil {
 		t.Fatalf("finish intent A: %v", err)
@@ -177,19 +217,79 @@ func TestVoiceSessionControl_SweepOrphaned(t *testing.T) {
 		t.Fatalf("create live control: %v", err)
 	}
 
-	n, err := st.SweepOrphanedVoiceSessionControls(ctx)
+	n, err := st.SweepOrphanedVoiceSessionControls(ctx, time.Hour)
 	if err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
-	if n != 1 {
-		t.Fatalf("sweep closed %d rows, want 1", n)
+	if n != 2 {
+		t.Fatalf("sweep closed %d rows, want 2 (pending + executing of the terminal intent)", n)
 	}
-	got, err := st.GetVoiceSessionControl(ctx, orphan.ID)
-	if err != nil || got.Status != storage.VoiceControlFailed || got.LastError != "session ended" {
-		t.Fatalf("orphan after sweep = %+v (err %v), want failed 'session ended'", got, err)
+	for _, id := range []uuid.UUID{orphanPending.ID, orphanExec.ID} {
+		got, err := st.GetVoiceSessionControl(ctx, id)
+		if err != nil || got.Status != storage.VoiceControlFailed {
+			t.Fatalf("orphan %s after sweep = %+v (err %v), want failed", id, got, err)
+		}
+		if sentinel, ok := session.DecodeControlFailure(got.LastError); !ok || !errors.Is(sentinel, session.ErrNoActiveSession) {
+			t.Fatalf("orphan %s last_error = %q, want an encoded no_active_session cause", id, got.LastError)
+		}
 	}
 	still, err := st.GetVoiceSessionControl(ctx, alive.ID)
 	if err != nil || still.Status != storage.VoiceControlPending {
 		t.Fatalf("live intent's control after sweep = %+v (err %v), want still pending", still, err)
+	}
+}
+
+// TestVoiceSessionControl_SweepStaleExecuting covers the bounded recovery arm of
+// FIX1: an 'executing' row of a still-LIVE intent that stalled past the stale
+// cutoff (a finish-write blip with the requester gone) is failed so it never
+// sits forever; a fresh executing row of the same live intent survives.
+func TestVoiceSessionControl_SweepStaleExecuting(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	intent := seedControlIntent(t, st, tenantID, campaignID)
+	if _, err := st.ClaimVoiceSessionIntent(ctx, "worker-a"); err != nil {
+		t.Fatalf("claim intent: %v", err)
+	}
+	stale, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID, TenantID: tenantID, Kind: storage.VoiceControlSay, AgentID: "a", SayText: "hi",
+	})
+	if err != nil {
+		t.Fatalf("create stale control: %v", err)
+	}
+	if _, err := st.StartVoiceSessionControl(ctx, stale.ID); err != nil {
+		t.Fatalf("claim stale control: %v", err)
+	}
+	// Backdate started_at so it is well past any reasonable cutoff.
+	if _, err := pool.Exec(ctx,
+		`UPDATE voice_session_controls SET started_at = now() - interval '1 hour' WHERE id = $1`, stale.ID); err != nil {
+		t.Fatalf("backdate started_at: %v", err)
+	}
+	fresh, err := st.CreateVoiceSessionControl(ctx, storage.VoiceSessionControl{
+		IntentID: intent.ID, TenantID: tenantID, Kind: storage.VoiceControlSay, AgentID: "a", SayText: "yo",
+	})
+	if err != nil {
+		t.Fatalf("create fresh control: %v", err)
+	}
+	if _, err := st.StartVoiceSessionControl(ctx, fresh.ID); err != nil {
+		t.Fatalf("claim fresh control: %v", err)
+	}
+
+	n, err := st.SweepOrphanedVoiceSessionControls(ctx, time.Minute)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("sweep closed %d rows, want 1 (only the stale executing)", n)
+	}
+	got, err := st.GetVoiceSessionControl(ctx, stale.ID)
+	if err != nil || got.Status != storage.VoiceControlFailed {
+		t.Fatalf("stale executing after sweep = %+v (err %v), want failed", got, err)
+	}
+	still, err := st.GetVoiceSessionControl(ctx, fresh.ID)
+	if err != nil || still.Status != storage.VoiceControlExecuting {
+		t.Fatalf("fresh executing after sweep = %+v (err %v), want still executing", still, err)
 	}
 }

--- a/scripts/k3d-fleet-check.sh
+++ b/scripts/k3d-fleet-check.sh
@@ -16,6 +16,10 @@
 #   3. failover — kill the owner pod and a survivor wins the presence_owner
 #      election within ~20s (default expiry 15s + one renew interval), so the
 #      fleet keeps dispatching interactions with no operator action;
+#   5. cross-pod live controls (#503): with the session HOSTED by one pod and the
+#      presence OWNER being the other, /glyphoxa mute lands a
+#      voice_session_controls row the HOSTING worker's loop executes (row goes
+#      'done' within the control budget) and the GM sees one "is muted." followup;
 #   4. the IDENTIFY budget guard (#486) holds under fleet cold-start: disgo
 #      serializes IDENTIFYs per client (max_concurrency 1, one per 5s), so two
 #      replicas booting on the shared token must NOT blow the 1000/24h budget —
@@ -203,6 +207,58 @@ step_failover() {
   fail "step 3: no new owner elected within ${FAILOVER_TIMEOUT}s (still $new_owner)"
 }
 
+# --- Step 5: cross-pod mute via the control queue (#503, human in the loop) --
+# Exercises the requested-controls relay: the presence OWNER pod dispatches
+# /glyphoxa mute while the session is HOSTED by the OTHER pod. The human drives
+# Discord (start a session, split host from owner, run the mute); the script
+# verifies the plane — the voice_session_controls row landing status='done'
+# within the control budget proves the hosting worker's loop executed it.
+CONTROL_BUDGET="${CONTROL_BUDGET:-15}"
+step_cross_pod_mute() {
+  note "step 5: cross-pod mute via voice_session_controls (#503 — MANUAL steps + psql checks)"
+  cat <<EOF
+  With BOTH replicas up and an owner elected:
+    1. In Discord, run  /glyphoxa start  (your Tenant needs a saved guild/channel
+       and an Active Campaign with at least one voiced NPC).
+EOF
+  note "step 5: waiting for a live intent row"
+  local host_instance="" owner_instance="" deadline
+  deadline=$(( SECONDS + FAILOVER_TIMEOUT ))
+  while (( SECONDS < deadline )); do
+    host_instance=$(psql_query "SELECT instance_id FROM voice_session_intents WHERE status='live' ORDER BY created_at DESC LIMIT 1;" || true)
+    [[ -n "$host_instance" ]] && break
+    sleep 2
+  done
+  [[ -n "$host_instance" ]] || fail "step 5: no live voice_session_intents row appeared — did /glyphoxa start succeed?"
+  owner_instance=$(current_owner_instance || true)
+  note "step 5: session host=$host_instance, presence owner=$owner_instance"
+  if [[ "${host_instance%-*}" == "${owner_instance%-*}" ]]; then
+    warn "step 5: host and owner are the SAME pod — the mute would take the local path."
+    cat <<EOF
+    Run  /glyphoxa end  then  /glyphoxa start  again until the claiming pod
+    differs from the presence owner (with 2 replicas the claim is a race; a few
+    tries suffice), then re-run this script step.
+EOF
+    fail "step 5: host == owner; split them and re-run"
+  fi
+  cat <<EOF
+    2. Host and owner are DIFFERENT pods — now run  /glyphoxa mute npc:<name>
+       in Discord. You must see the deferred "thinking…" then EXACTLY ONE
+       ephemeral "<name> is muted." followup. An error message = the relay
+       surfaced a real failure (also a #503 behavior, but the mute did not land).
+EOF
+  note "step 5: polling voice_session_controls for a done mute_agent row (${CONTROL_BUDGET}s + slack)"
+  local status="" ; deadline=$(( SECONDS + CONTROL_BUDGET + 30 ))
+  while (( SECONDS < deadline )); do
+    status=$(psql_query "SELECT status FROM voice_session_controls WHERE kind='mute_agent' ORDER BY created_at DESC LIMIT 1;" || true)
+    [[ "$status" == "done" ]] && break
+    sleep 2
+  done
+  [[ "$status" == "done" ]] || fail "step 5: newest mute_agent control status='${status:-<none>}', want done within the control budget — did the hosting worker's loop dispatch it?"
+  note "step 5 OK: cross-pod mute executed by the hosting worker (control row done); confirm the single 'is muted.' followup in Discord"
+  note "step 5 cleanup: run /glyphoxa end when finished"
+}
+
 # --- Step 2: /roll handled exactly once (human in the loop) ------------------
 step_roll_once() {
   note "step 2: exactly-once /roll (MANUAL — needs you at a Discord client)"
@@ -225,9 +281,10 @@ step_replicas_available
 step_identify_budget
 if [[ -n "$DISCORD_BOT_TOKEN" ]]; then
   step_roll_once
+  step_cross_pod_mute
   step_failover
 else
-  warn "DISCORD_BOT_TOKEN unset: skipping step 2 (/roll) and step 3 (failover) — set it to run them (guild/channel MUST stay unset for worker mode)"
+  warn "DISCORD_BOT_TOKEN unset: skipping step 2 (/roll), step 5 (cross-pod mute) and step 3 (failover) — set it to run them (guild/channel MUST stay unset for worker mode)"
 fi
 
 note "done. Tear the release down with: helm -n $NAMESPACE uninstall $RELEASE"


### PR DESCRIPTION
## Summary

At replicas>1 the elected presence owner dispatches interactions, but the Tenant's session may be hosted by ANOTHER worker. mute/muteall/say/voiced-recap now relay through a new `voice_session_controls` queue on the claim plane instead of degrading with a "hosted by another worker" refusal.

- **Schema**: `voice_session_controls` (migration 00038) — narrow typed columns, queue drained in `(created_at, id)` order, fenced terminal writes (`ErrNotFound` = lost race).
- **Worker**: `ClaimLoop.dispatchControls` runs on the heartbeat tick — heartbeat always first, dispatch gated on `live`, each execute/finish bounded so a hung roster read can't starve the heartbeat; tick sweeps pendings of terminal intents to `failed 'session ended'`.
- **Requester**: `IntentControl.SetAgentMute/SetAllMute/SayAs/SpeakAsButler` replace the `ErrSplitMode` stubs — write row, poll to terminal within `GLYPHOXA_VOICE_CONTROL_BUDGET` (default 15s); worker failures cross the plane as failcodes (`no_active_session`, `agent_not_in_campaign`, `butler_voiceless`) and decode to the same sentinels as `-mode all`; budget expiry = fenced cancel + `ErrControlPending` (→ `CodeUnavailable`), never a claimed success (ADR-0012).
- **Presence**: local-first branch byte-identical (no Defer, AC3); cross-pod branch Defers ephemerally, relays via the widened `PoolControl` seam, and posts a confirming/erroring reply — a failure surfaces real error text, never a silent no-op. Autocomplete falls back to the pool's Active for the roster.
- **Voiced recap**: `session.NewButlerControl(mgr, intentControl)` — local-first, falls to the relay only on local `ErrNoActiveSession`. Worker boot only; `-mode all` wiring unchanged (nil pool).
- **ADR-0057**: Amendments note recording that #503 supersedes the "no mute/say on split web tier" consequence; the mechanism stays poll-only (no LISTEN/NOTIFY) and never moves the session (ADR-0006/0057 (e)).
- **Fleet check**: `scripts/k3d-fleet-check.sh` step 5 exercises a cross-pod mute (human drives Discord, script verifies the control row goes `done` and host ≠ owner).

Known gaps (deliberate, out of AC scope): `ReplayHighlight` and `MutedAgentIDs` stay degraded in split mode. A cross-pod `voiced` recap that times out (`ErrControlPending`) degrades to public text and the worker may still voice it moments later — accepted (the honest not-confirmed path; the recap is never lost), noted as reviewer finding 5.

## Reviewer follow-up (round 2)

- **FIX1 (exactly-once)**: the hosting worker now fences a `pending→executing` claim (`StartVoiceSessionControl`) BEFORE running the verb, and terminal writes fence on `executing`. A transient finish-write failure leaves the row `executing` (never re-listed), so a non-idempotent `say` can never double-publish; a stranded `executing` row is retired by the sweep past a bounded stale cutoff (`Expiry`).
- **FIX2 (heartbeat starvation)**: `dispatchControls` now caps one drain by an aggregate time budget (`cfg.Heartbeat`) — leftovers ride the next tick — so N slow controls can't open a heartbeat gap past `Expiry`. Driven by a clock seam for a deterministic, sleep-free test.
- **FIX3 (ugly error)**: the sweep stamps the ENCODED `no_active_session` cause, so the requester decodes it to `ErrNoActiveSession` and the GM sees the plain "No Voice Session is active." guard (round-trip guarded by a storage test asserting `session.DecodeControlFailure`).
- **FIX4 (index)**: added a status-leading partial index (`voice_session_controls_sweep_idx`) in migration 00038 so the status-scanning sweep doesn't seq-scan.

## Test plan

- 20 new tests: storage queue semantics (create/list order/fenced finish, cancel-pending-only, orphan sweep), failcode roundtrip, claim-loop dispatch (mute done+result_ids, say order + encoded failure, no dispatch while finalizing, tick sweep), IntentControl relay (confirm, decode, budget/no-session), ButlerControl local-first, presence local-no-Defer / cross-pod defer+confirm / real-error+not-confirmed wording / plain guard / autocomplete pool fallback, RPC `ErrControlPending` → `CodeUnavailable`.
- `go test -race ./...`, `go vet` (default/integration/record tags), `golangci-lint` — clean; targeted `-tags=integration` storage tests green locally.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
