### PR TITLE
fix(#505): drain-beat the mark-live-failure stop + cap drain beats (#509 review residuals)

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -413,14 +413,18 @@ func envDuration(getenv func(string) string, key string, def time.Duration) time
 }
 
 // voiceClaimLoopConfig reads the -mode voice worker's claim-loop cadence from the
-// GLYPHOXA_VOICE_CLAIM_POLL / _HEARTBEAT_INTERVAL / _HEARTBEAT_EXPIRY env vars
-// (#491). Parsed HERE in the composition root, never in internal/session, so the
-// cadence stays a deployment knob.
+// GLYPHOXA_VOICE_CLAIM_POLL / _HEARTBEAT_INTERVAL / _HEARTBEAT_EXPIRY /
+// _DRAIN_BEAT_CAP env vars (#491, #509 review). Parsed HERE in the composition
+// root, never in internal/session, so the cadence stays a deployment knob. The
+// drain-beat cap's zero fallback is deliberate: NewClaimLoop derives 10x Expiry
+// from it, so the default scales with an overridden Expiry instead of pinning a
+// fixed duration here.
 func voiceClaimLoopConfig(getenv func(string) string) session.ClaimLoopConfig {
 	return session.ClaimLoopConfig{
-		Poll:      envDuration(getenv, "GLYPHOXA_VOICE_CLAIM_POLL", defaultVoiceClaimPoll),
-		Heartbeat: envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_INTERVAL", defaultVoiceHeartbeatInterval),
-		Expiry:    envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+		Poll:         envDuration(getenv, "GLYPHOXA_VOICE_CLAIM_POLL", defaultVoiceClaimPoll),
+		Heartbeat:    envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_INTERVAL", defaultVoiceHeartbeatInterval),
+		Expiry:       envDuration(getenv, "GLYPHOXA_VOICE_HEARTBEAT_EXPIRY", defaultVoiceHeartbeatExpiry),
+		DrainBeatCap: envDuration(getenv, "GLYPHOXA_VOICE_DRAIN_BEAT_CAP", 0),
 	}
 }
 

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -1020,20 +1020,29 @@ func TestEnvDuration(t *testing.T) {
 	}
 }
 
-// TestVoiceClaimLoopConfig pins the three claim-loop cadence knobs (#491): unset
-// yields the 2s/5s/30s defaults, and each env var overrides its field.
+// TestVoiceClaimLoopConfig pins the claim-loop cadence knobs (#491): unset
+// yields the 2s/5s/30s defaults, and each env var overrides its field. The
+// drain-beat cap (#509 review) is left 0 when unset so NewClaimLoop derives
+// 10x Expiry — a fixed boot default would not scale with an overridden Expiry.
 func TestVoiceClaimLoopConfig(t *testing.T) {
 	def := voiceClaimLoopConfig(envMap(nil))
 	if def.Poll != defaultVoiceClaimPoll || def.Heartbeat != defaultVoiceHeartbeatInterval || def.Expiry != defaultVoiceHeartbeatExpiry {
 		t.Fatalf("defaults = %+v, want 2s/5s/30s", def)
 	}
+	if def.DrainBeatCap != 0 {
+		t.Fatalf("default DrainBeatCap = %v, want 0 (derived from Expiry in NewClaimLoop)", def.DrainBeatCap)
+	}
 	got := voiceClaimLoopConfig(envMap(map[string]string{
 		"GLYPHOXA_VOICE_CLAIM_POLL":         "1s",
 		"GLYPHOXA_VOICE_HEARTBEAT_INTERVAL": "3s",
 		"GLYPHOXA_VOICE_HEARTBEAT_EXPIRY":   "20s",
+		"GLYPHOXA_VOICE_DRAIN_BEAT_CAP":     "2m",
 	}))
 	if got.Poll != time.Second || got.Heartbeat != 3*time.Second || got.Expiry != 20*time.Second {
 		t.Fatalf("overridden = %+v, want 1s/3s/20s", got)
+	}
+	if got.DrainBeatCap != 2*time.Minute {
+		t.Fatalf("overridden DrainBeatCap = %v, want 2m", got.DrainBeatCap)
 	}
 }
 

--- a/docs/devs/2026-07-19-voice-claim-plane-rollout.md
+++ b/docs/devs/2026-07-19-voice-claim-plane-rollout.md
@@ -28,6 +28,7 @@ gaps a split deployment inherits.
 | `GLYPHOXA_VOICE_CLAIM_POLL` | `2s` | Voice Instance claim tick / web poll cadence |
 | `GLYPHOXA_VOICE_HEARTBEAT_INTERVAL` | `5s` | live-session heartbeat stamp interval |
 | `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` | `30s` | staleness before a claim is reaped dead |
+| `GLYPHOXA_VOICE_DRAIN_BEAT_CAP` | 10× expiry (`300s`) | wind-down drain-beat budget; past it beats cease and the reaper may reclaim a wedged wind-down |
 
 ## Voice Instance death
 

--- a/docs/devs/2026-07-20-voice-fleet-rollout.md
+++ b/docs/devs/2026-07-20-voice-fleet-rollout.md
@@ -99,19 +99,31 @@ is sized to cover a DAVE/MLS wind-down before SIGKILL.
 
 ### Known windows (documented, accepted)
 
-- **Heartbeat during drain — CLOSED by #505.** A draining worker now keeps
-  heartbeating while it winds its sessions down: `endSession` runs a drain-beat
-  goroutine (every `GLYPHOXA_VOICE_HEARTBEAT_INTERVAL`, on detached bounded
-  ctxs) for the whole `Manager.Stop` window, on BOTH the SIGTERM drain and the
-  stop_requested wind-down, so a clean drain within budget is never reaped
-  `dead` and reconcile cannot race an in-flight CloseVoiceSession (the intent
-  stays non-terminal until the close landed). Residual: a sustained DB outage
-  spanning multiple missed beats past `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` still
-  reaps mid-drain — the drain-beat goroutine then stops stamping (ADR-0006:
-  never re-claim), the wind-down completes, the superseded finish is swallowed,
-  and the history reads `dead`. Accepted: that now requires an outage, not
-  merely a slow finalizer. `voice.terminationGracePeriodSeconds` (300) still
-  bounds the worst-case wind-down and stays above every finalizer budget.
+- **Heartbeat during drain — CLOSED by #505, hardened by the #509 review.** A
+  draining worker now keeps heartbeating while it winds its sessions down: a
+  drain-beat goroutine (every `GLYPHOXA_VOICE_HEARTBEAT_INTERVAL`, on detached
+  bounded ctxs) covers the whole `Manager.Stop` window on the SIGTERM drain,
+  the stop_requested wind-down, AND the mark-live-failure stop (the row still
+  `claimed` there — the heartbeat fence accepts both states), so a clean
+  wind-down within budget is never reaped `dead`, reconcile cannot race an
+  in-flight CloseVoiceSession (the intent stays non-terminal until the close
+  landed), and a true mark-live failure lands on the row as itself instead of
+  as "worker heartbeat expired". Residual: a sustained DB outage spanning
+  multiple missed beats past `GLYPHOXA_VOICE_HEARTBEAT_EXPIRY` still reaps
+  mid-drain — the drain-beat goroutine then stops stamping (ADR-0006: never
+  re-claim), the wind-down completes, the superseded finish is swallowed, and
+  the history reads `dead`. Accepted: that now requires an outage, not merely a
+  slow finalizer.
+- **Wedged wind-down — bounded by the drain-beat cap (#509 review).** Drain
+  beats cease after `GLYPHOXA_VOICE_DRAIN_BEAT_CAP` (default 10× heartbeat
+  expiry, 300s): a run loop wedged past ctx cancel is the only unbounded step
+  in `Manager.Stop`, and uncapped beats would keep its intent `live` forever —
+  pinning the Tenant's voice plane, where pre-#505 the reaper freed it within
+  30s. Past the cap the heartbeat goes stale and the reaper reclaims within one
+  expiry; the wedged worker's eventual finish is fenced NotFound and swallowed.
+  Note `voice.terminationGracePeriodSeconds` (300) bounds only the SIGTERM /
+  pod-delete wind-down (the kubelet SIGKILLs at the deadline) — an in-place
+  stop_requested wind-down on a healthy pod is bounded by this cap instead.
 - **Reaped-but-alive overlap.** A worker that is merely SLOW (not dead) can be
   reaped: it learns of the supersede only on its next heartbeat (ErrNotFound) and
   then kills its local session — until that beat, its gateway/voice connection

--- a/internal/session/claimloop.go
+++ b/internal/session/claimloop.go
@@ -83,6 +83,13 @@ type ClaimLoopConfig struct {
 	// Expiry is how stale a heartbeat may get before the reaper marks the claim
 	// dead (the owning worker is presumed crashed). Default 30s.
 	Expiry time.Duration
+	// DrainBeatCap bounds how long a wind-down's drain heartbeat keeps beating
+	// (#509 review): past it the beats cease and the reaper reclaims the row
+	// within Expiry, so a run loop wedged past ctx cancel (the only unbounded
+	// step in Manager.Stop) can never pin a Tenant's voice plane forever.
+	// Default 10x Expiry (300s at defaults) — far above every finalizer budget,
+	// so no legitimate slow wind-down is ever cut off.
+	DrainBeatCap time.Duration
 }
 
 // ClaimLoop drives the -mode voice worker's DB-driven session assignment (#491).
@@ -116,6 +123,9 @@ func NewClaimLoop(store IntentStore, mgr *Manager, instanceID string, log *slog.
 	}
 	if cfg.Expiry <= 0 {
 		cfg.Expiry = 30 * time.Second
+	}
+	if cfg.DrainBeatCap <= 0 {
+		cfg.DrainBeatCap = 10 * cfg.Expiry
 	}
 	return &ClaimLoop{store: store, mgr: mgr, instanceID: instanceID, log: log, cfg: cfg, now: time.Now}
 }
@@ -236,10 +246,17 @@ func (l *ClaimLoop) startClaimed(ctx context.Context, intent storage.VoiceSessio
 		// Claim and MarkLive) left the row 'claimed' with no heartbeat goroutine, so
 		// finish it 'failed' on a detached ctx (mirroring the Start-refusal path) —
 		// otherwise it lingers 'claimed' until the reaper marks it the wrong state
-		// (review item 5, AC5's claimed-not-yet-live SIGTERM case).
+		// (review item 5, AC5's claimed-not-yet-live SIGTERM case). The Stop blocks
+		// through the finalizers with the row still 'claimed' and heartbeat_at from
+		// claim time, so drain-beat it like endSession (#509 review; the store's
+		// heartbeat fence accepts 'claimed') — un-heartbeated, a slow wind-down
+		// crosses Expiry and the reaper records the TRUE failure below as a worker
+		// death. On the NotFound arm the first beat NotFounds too and stops itself.
+		stopBeat := l.startDrainHeartbeat(intent.ID)
 		if _, serr := l.mgr.Stop(l.detached(), intent.TenantID); serr != nil && !errors.Is(serr, ErrNoActiveSession) {
 			l.log.Warn("claim loop: stop after failed mark-live", "intent", intent.ID, "err", serr)
 		}
+		stopBeat()
 		if errors.Is(err, storage.ErrNotFound) {
 			l.log.Warn("claim loop: claim superseded before live (reaped); stopped the started session",
 				"intent", intent.ID)
@@ -457,16 +474,22 @@ func (l *ClaimLoop) endSession(tenant uuid.UUID, intentID uuid.UUID, status stor
 	l.finish(intentID, status, lastError)
 }
 
-// startDrainHeartbeat keeps intentID's heartbeat fresh while endSession blocks
-// in Manager.Stop (#505): it beats every cfg.Heartbeat on detached bounded ctxs
-// (the run ctx may already be cancelled — SIGTERM — and one beat may never eat
-// more than dbOpTimeout(Heartbeat)). ErrNotFound means the claim was reaped
-// anyway (a multi-beat DB outage crossed Expiry): log and stop beating — the
-// wind-down itself continues, and this goroutine NEVER calls mgr.Stop (the
-// session is already stopping; ADR-0006: superseded-mid-drain means stop
-// stamping and let the wind-down finish, never re-claim). stop_requested is
-// ignored — the session is already ending. The returned func cancels the
-// goroutine and waits for it to exit.
+// startDrainHeartbeat keeps the intent's heartbeat fresh while a wind-down
+// blocks in Manager.Stop (#505: endSession; #509 review: the mark-live-failure
+// stop, where the row is still 'claimed'): it beats every cfg.Heartbeat on
+// detached bounded ctxs (the run ctx may already be cancelled — SIGTERM — and
+// one beat may never eat more than dbOpTimeout(Heartbeat)). ErrNotFound means
+// the claim was reaped anyway (a multi-beat DB outage crossed Expiry): log and
+// stop beating — the wind-down itself continues, and this goroutine NEVER calls
+// mgr.Stop (the session is already stopping; ADR-0006: superseded-mid-drain
+// means stop stamping and let the wind-down finish, never re-claim).
+// stop_requested is ignored — the session is already ending. Beats also cease
+// after cfg.DrainBeatCap (#509 review residual 2): a run loop wedged past ctx
+// cancel is the ONLY unbounded step in Manager.Stop, and uncapped beats would
+// keep its intent 'live' forever — pinning the Tenant's voice plane, which
+// pre-#505 the reaper freed within Expiry. Past the cap the heartbeat goes
+// stale and the reaper reclaims. The returned func cancels the goroutine and
+// waits for it to exit.
 func (l *ClaimLoop) startDrainHeartbeat(intentID uuid.UUID) (stop func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -474,9 +497,15 @@ func (l *ClaimLoop) startDrainHeartbeat(intentID uuid.UUID) (stop func()) {
 		defer close(done)
 		ticker := time.NewTicker(l.cfg.Heartbeat)
 		defer ticker.Stop()
+		capTimer := time.NewTimer(l.cfg.DrainBeatCap)
+		defer capTimer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
+				return
+			case <-capTimer.C:
+				l.log.Warn("claim loop: drain heartbeat cap reached (wind-down wedged?); ceasing beats so the reaper can reclaim",
+					"intent", intentID, "cap", l.cfg.DrainBeatCap)
 				return
 			case <-ticker.C:
 				hbCtx, cancelHB := context.WithTimeout(context.Background(), dbOpTimeout(l.cfg.Heartbeat))

--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/MrWong99/Glyphoxa/internal/session"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
 
 // fakeIntentStore is an in-memory session.IntentStore: it models the claim-plane
@@ -904,6 +905,195 @@ func TestClaimLoop_DrainBeatsEndBeforeFinish(t *testing.T) {
 		if e.kind == "hb" {
 			t.Fatal("a heartbeat was ordered AFTER the finish — drain beats must end before the terminal write")
 		}
+	}
+}
+
+// markLiveFailStore scripts MarkVoiceSessionIntentLive to fail with a
+// non-NotFound error (a DB blip), leaving the row 'claimed' with its
+// heartbeat_at from claim time — the #509-review residual 1 setup.
+type markLiveFailStore struct {
+	*fakeIntentStore
+	err error
+}
+
+func (s *markLiveFailStore) MarkVoiceSessionIntentLive(context.Context, uuid.UUID, string, uuid.UUID) (storage.VoiceSessionIntent, error) {
+	return storage.VoiceSessionIntent{}, s.err
+}
+
+// TestClaimLoop_DrainHeartbeatDuringMarkLiveFailure covers #509-review residual
+// 1: a mark-live failure stops the just-started session, and that Stop blocks
+// through the finalizers with the row still 'claimed' and heartbeat_at from
+// claim time. Un-heartbeated, a slow wind-down crosses Expiry and the reaper
+// records the TRUE mark-live failure as "worker heartbeat expired" ('dead').
+// The path must drain-beat like endSession does: under a live reaper and a
+// wind-down held open for ~5x Expiry, the row stays 'claimed' the whole time
+// and then finishes 'failed' carrying the mark-live error — never 'dead'.
+func TestClaimLoop_DrainHeartbeatDuringMarkLiveFailure(t *testing.T) {
+	mstore := newFakeStore()
+	closeGate := make(chan struct{})
+	mstore.closeGate = closeGate // parks CloseVoiceSession → the slow wind-down
+	runner := newBlockingRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := &markLiveFailStore{fakeIntentStore: newFakeIntentStore(), err: errors.New("db blip")}
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: 2 * time.Millisecond, Expiry: 20 * time.Millisecond})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+
+	// The tick blocks inside startClaimed (Stop parked on the gate) — run it in a
+	// goroutine, like the reaper ticks below run concurrently against it.
+	tickDone := make(chan struct{})
+	go func() { loop.TickForTest(context.Background()); close(tickDone) }()
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return mgr.Finalizing(tenantID) })
+
+	// Beats must land while Stop is parked (the row is 'claimed', which the store
+	// heartbeat fence accepts).
+	before := istore.heartbeatCount()
+	waitFor(t, time.Second, func() bool { return istore.heartbeatCount() > before+2 })
+
+	// Keep reap ticks running while the wind-down is held open for ~5x Expiry:
+	// the row must stay 'claimed' throughout — never reaped 'dead'.
+	reapStop := make(chan struct{})
+	reapDone := make(chan struct{})
+	go func() {
+		defer close(reapDone)
+		for {
+			select {
+			case <-reapStop:
+				return
+			default:
+				loop.TickForTest(context.Background())
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := istore.get(intent.ID).Status; got != storage.VoiceIntentClaimed {
+			t.Fatalf("intent status = %q mid-stop under a live reaper, want claimed", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Release the finalizer: the true failure lands on the row.
+	close(closeGate)
+	select {
+	case <-tickDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tick did not return after the finalizer released")
+	}
+	close(reapStop)
+	<-reapDone
+	got := istore.get(intent.ID)
+	if got.Status != storage.VoiceIntentFailed {
+		t.Fatalf("intent status = %q, want failed carrying the mark-live error", got.Status)
+	}
+	if !strings.Contains(got.LastError, "mark-live failed") || !strings.Contains(got.LastError, "db blip") {
+		t.Fatalf("intent last_error = %q, want the true mark-live failure", got.LastError)
+	}
+
+	// Same ordering contract as endSession: no beat after the terminal write.
+	events := istore.timelineCopy()
+	finishAt := -1
+	for i, e := range events {
+		if e.kind == "finish" {
+			finishAt = i
+			break
+		}
+	}
+	if finishAt < 0 {
+		t.Fatal("no finish recorded in the call timeline")
+	}
+	for _, e := range events[finishAt+1:] {
+		if e.kind == "hb" {
+			t.Fatal("a heartbeat was ordered AFTER the finish — drain beats must end before the terminal write")
+		}
+	}
+}
+
+// stuckRunner models a session run loop wedged past ctx cancel — the ONLY
+// unbounded step in Manager.Stop (the finalizers and end-write are all
+// endTimeout-bounded). It ignores cancellation and unblocks only on release.
+type stuckRunner struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func newStuckRunner() *stuckRunner {
+	return &stuckRunner{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (r *stuckRunner) run(context.Context, wirenpc.Config) error {
+	close(r.started)
+	<-r.release // NOT ctx.Done() — a wedged loop never observes the cancel
+	return nil
+}
+
+// TestClaimLoop_DrainBeatCapLetsReaperReclaim covers #509-review residual 2
+// (the risk #505 introduced): on a stop_requested wind-down whose run loop is
+// wedged past ctx cancel, uncapped drain beats keep the intent 'live' FOREVER —
+// the Tenant's voice plane is pinned permanently, where pre-#505 the reaper
+// freed it within Expiry. The drain beats must stop after DrainBeatCap, letting
+// the heartbeat go stale so the reaper reclaims the row ('dead'), and the
+// eventually-unwedged finish is fenced NotFound — never a resurrection.
+func TestClaimLoop_DrainBeatCapLetsReaperReclaim(t *testing.T) {
+	mstore := newFakeStore()
+	runner := newStuckRunner()
+	mgr := newManager(t, mstore, runner.run, true)
+	istore := newFakeIntentStore()
+	loop := session.NewClaimLoop(istore, mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Poll: time.Millisecond, Heartbeat: time.Millisecond,
+			Expiry: 20 * time.Millisecond, DrainBeatCap: 40 * time.Millisecond})
+
+	tenantID := uuid.New()
+	intent := istore.add(tenantID, uuid.New())
+	loop.TickForTest(context.Background())
+	<-runner.started
+	waitFor(t, time.Second, func() bool { return istore.get(intent.ID).Status == storage.VoiceIntentLive })
+
+	// stop_requested → endSession → Manager.Stop blocks forever on the wedged
+	// loop. Drain beats run, then MUST cease once the cap elapses.
+	istore.requestStop(intent.ID)
+	waitFor(t, 2*time.Second, func() bool {
+		before := istore.heartbeatCount()
+		time.Sleep(10 * time.Millisecond)
+		return istore.heartbeatCount() == before
+	})
+
+	// With beats ceased the heartbeat goes stale and the reaper reclaims: the
+	// Tenant's voice plane is freed even though this worker is still wedged.
+	waitFor(t, time.Second, func() bool {
+		loop.TickForTest(context.Background())
+		return istore.get(intent.ID).Status == storage.VoiceIntentDead
+	})
+
+	// Unwedge: the wind-down completes, the finish NotFounds on the dead row
+	// (swallowed), every goroutine exits, and the row is never resurrected.
+	close(runner.release)
+	loop.DrainForTest()
+	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDead {
+		t.Fatalf("intent status = %q after the wedged drain unblocked, want dead (no resurrection)", got)
+	}
+}
+
+// TestClaimLoop_DrainBeatCapDefaults pins the cap's defaulting: unset derives
+// 10x Expiry (300s at the 30s default — matching the deploy's
+// terminationGracePeriodSeconds and far above every finalizer budget, so no
+// legitimate slow wind-down is ever cut off); an explicit value is respected.
+func TestClaimLoop_DrainBeatCapDefaults(t *testing.T) {
+	mstore := newFakeStore()
+	mgr := newManager(t, mstore, newBlockingRunner().run, true)
+	derived := session.NewClaimLoop(newFakeIntentStore(), mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Expiry: 7 * time.Second})
+	if got := derived.DrainBeatCapForTest(); got != 70*time.Second {
+		t.Fatalf("derived DrainBeatCap = %v, want 10x Expiry (70s)", got)
+	}
+	explicit := session.NewClaimLoop(newFakeIntentStore(), mgr, "worker-test", slog.New(slog.DiscardHandler),
+		session.ClaimLoopConfig{Expiry: 7 * time.Second, DrainBeatCap: time.Minute})
+	if got := explicit.DrainBeatCapForTest(); got != time.Minute {
+		t.Fatalf("explicit DrainBeatCap = %v, want 1m", got)
 	}
 }
 

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -17,6 +17,10 @@ func (l *ClaimLoop) TickForTest(ctx context.Context) { l.tick(ctx) }
 // wait Run does on ctx cancellation (the graceful drain, #491). Test-only.
 func (l *ClaimLoop) DrainForTest() { l.wg.Wait() }
 
+// DrainBeatCapForTest returns the resolved drain-beat cap so a test can pin
+// NewClaimLoop's defaulting (#509 review residual 2). Test-only.
+func (l *ClaimLoop) DrainBeatCapForTest() time.Duration { return l.cfg.DrainBeatCap }
+
 // SetClockForTest swaps the clock the per-tick control-drain budget reads (#503
 // FIX2), so a test drives the aggregate-budget cutoff deterministically without
 // wall-clock sleeps. Test-only.


### PR DESCRIPTION
Hardens the two low-severity residuals from the [PR #509](https://github.com/MrWong99/Glyphoxa/pull/509) (issue #505 drain-heartbeat) review, both in `internal/session/claimloop.go`.

## Residual 1 — mark-live-failure stop went un-heartbeated

`startClaimed`'s mark-live-failure path blocked in `mgr.Stop` (finalizers up to the end budgets) with the intent row still `claimed` and `heartbeat_at` from claim time. A slow wind-down crossed the 30s expiry, the reaper flipped the row `dead`, and the true mark-live failure was recorded as "worker heartbeat expired". The path now gets the same `startDrainHeartbeat` treatment `endSession` has — the store's heartbeat fence already accepts `status IN ('claimed','live')` — so the terminal write carries the real failure, with the same beats-end-before-finish ordering.

## Residual 2 — #505's uncapped drain beats could pin a tenant's voice plane forever

On a stop_requested wind-down on a HEALTHY pod, if the session run loop ignores ctx cancel (the only unbounded step in `Manager.Stop`), drain beats ran forever and the intent stayed `live` forever — permanently pinning the Tenant's voice plane, where pre-#505 the reaper freed it in 30s. Drain beats now cease after `ClaimLoopConfig.DrainBeatCap` (`GLYPHOXA_VOICE_DRAIN_BEAT_CAP`, default 10× Expiry = 300s — far above every finalizer budget, so no legitimate slow wind-down is cut off), letting the heartbeat go stale so the reaper reclaims within one expiry. The wedged worker's eventual finish is fenced NotFound and swallowed — never a resurrection.

The `runSession` ticker branch (#503's surface) is untouched.

## Docs

- `docs/devs/2026-07-20-voice-fleet-rollout.md` "Known windows": no longer claims `terminationGracePeriodSeconds` bounds the worst-case wind-down (it only bounds the SIGTERM/pod-delete path — the kubelet SIGKILLs at the deadline); the in-place wind-down is bounded by the new drain-beat cap, documented as its own bullet.
- `docs/devs/2026-07-19-voice-claim-plane-rollout.md`: knob table gains `GLYPHOXA_VOICE_DRAIN_BEAT_CAP`.

## Tests (TDD, red first)

- `TestClaimLoop_DrainHeartbeatDuringMarkLiveFailure` — under a live reaper with the wind-down held open for ~5× Expiry, the row stays `claimed` throughout, then finishes `failed` carrying the mark-live error; no beat after the finish.
- `TestClaimLoop_DrainBeatCapLetsReaperReclaim` — a `stuckRunner` wedged past ctx cancel: beats cease after the cap, the reaper reclaims (`dead`), and unwedging never resurrects the row.
- `TestClaimLoop_DrainBeatCapDefaults` — unset derives 10× Expiry; explicit value respected.
- `TestVoiceClaimLoopConfig` — extended for the new env knob (zero fallback deliberate: the derived default scales with an overridden Expiry).

`go test -race ./...` green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)