### PR TITLE
fix(#480): persona draft addresses the live (unsaved) editor name

### DIFF
--- a/internal/rpc/assist.go
+++ b/internal/rpc/assist.go
@@ -78,7 +78,9 @@ func assistEngineErr(op string, err error) *connect.Error {
 }
 
 // GeneratePersona drafts a Persona for one Agent from the GM's short prompt
-// (#479). The draft is returned for review in the editor — never persisted. An
+// (#479). The request's live editor name/title season the draft, falling back
+// to the stored Agent fields when unset (#480). The draft is returned for
+// review in the editor — never persisted. An
 // empty/oversized prompt or unparsable agent_id is CodeInvalidArgument; a
 // missing or cross-campaign agent is CodeNotFound; drafting failures map via
 // assistEngineErr. State-changing (spends provider quota): auth + CSRF guard it.
@@ -120,9 +122,20 @@ func (s *campaignAssist) GeneratePersona(
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
 	}
 
+	// The editor's live (possibly unsaved) name/title win over the stored Agent
+	// fields (#480). Unset falls back to the stored value; set-but-empty means
+	// the GM cleared the field, so nothing must resurrect the stored one.
+	name, title := agent.Name, agent.Title
+	if req.Msg.Name != nil {
+		name = req.Msg.GetName()
+	}
+	if req.Msg.Title != nil {
+		title = req.Msg.GetTitle()
+	}
+
 	persona, err := s.engine.GeneratePersona(ctx, c, assist.PersonaInput{
-		AgentName:  agent.Name,
-		AgentTitle: agent.Title,
+		AgentName:  name,
+		AgentTitle: title,
 		Prompt:     prompt,
 	})
 	if err != nil {

--- a/internal/rpc/assist_test.go
+++ b/internal/rpc/assist_test.go
@@ -122,6 +122,52 @@ func TestGeneratePersona_HappyPath(t *testing.T) {
 	}
 }
 
+// TestGeneratePersona_LiveFormOverride is the #480 regression: the editor's
+// live (possibly unsaved) name/title must reach the engine instead of the
+// stored placeholder — otherwise a draft for a freshly typed "Jule Brandt"
+// opens with "Du bist New NPC". Unset fields keep the stored fallback;
+// set-but-empty means the GM cleared the field.
+func TestGeneratePersona_LiveFormOverride(t *testing.T) {
+	t.Parallel()
+	store := newFakeAssistStore()
+	campID := uuid.New()
+	store.campaign = storage.Campaign{ID: campID}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: campID, Role: storage.AgentRoleCharacter, Name: "New NPC", Title: "Stored Title"}
+	eng := &fakeAssistEngine{persona: "p"}
+	client := assistClient(t, store, eng)
+
+	strp := func(s string) *string { return &s }
+	generate := func(name, title *string) {
+		t.Helper()
+		_, err := client.GeneratePersona(context.Background(),
+			connect.NewRequest(&managementv1.GeneratePersonaRequest{
+				AgentId: agentID.String(), Prompt: "ok", Name: name, Title: title,
+			}))
+		if err != nil {
+			t.Fatalf("GeneratePersona: %v", err)
+		}
+	}
+
+	// Live values win over the stored agent fields.
+	generate(strp("Jule Brandt"), strp("Harbourmaster"))
+	if eng.gotPersona.AgentName != "Jule Brandt" || eng.gotPersona.AgentTitle != "Harbourmaster" {
+		t.Errorf("agent fields = %+v, want the live form values Jule Brandt/Harbourmaster", eng.gotPersona)
+	}
+
+	// Set-but-empty is a cleared field — the stored value must not resurrect.
+	generate(strp("Jule Brandt"), strp(""))
+	if eng.gotPersona.AgentTitle != "" {
+		t.Errorf("cleared title = %q, want empty (no stored fallback)", eng.gotPersona.AgentTitle)
+	}
+
+	// Unset fields (an older client) fall back to the stored agent.
+	generate(nil, nil)
+	if eng.gotPersona.AgentName != "New NPC" || eng.gotPersona.AgentTitle != "Stored Title" {
+		t.Errorf("agent fields = %+v, want the stored fallback New NPC/Stored Title", eng.gotPersona)
+	}
+}
+
 func TestGeneratePersona_Validation(t *testing.T) {
 	t.Parallel()
 	store := newFakeAssistStore()

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -552,12 +552,18 @@ message SearchNodesResponse {
 // (#479). The campaign is resolved server-side; its name, System, and Language
 // season the draft.
 message GeneratePersonaRequest {
-  // agent_id is the Agent whose Persona to draft; its current name/title season
-  // the prompt. Must belong to the active campaign.
+  // agent_id is the Agent whose Persona to draft. Must belong to the active
+  // campaign.
   string agent_id = 1;
   // prompt is the GM's short description of the wanted character; empty is
   // rejected.
   string prompt = 2;
+  // name/title are the editor's live (possibly unsaved) form values, which
+  // season the prompt (#480) — without them the draft addresses the last-saved
+  // name (e.g. the "New NPC" placeholder). Unset falls back to the stored Agent
+  // field; set-but-empty means the GM cleared the field.
+  optional string name = 3;
+  optional string title = 4;
 }
 
 // GeneratePersonaResponse carries the drafted Persona markdown — a proposal for

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -22,6 +22,7 @@ import {
   ListCharactersResponseSchema,
   ListDiscordVoiceMembersResponseSchema,
   ListKnowledgeProposalsResponseSchema,
+  GeneratePersonaResponseSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
@@ -518,6 +519,52 @@ describe("Campaign", () => {
     fireEvent.change(scope, { target: { value: '{"scope":"campaign"}' } });
     fireEvent.click(screen.getByRole("button", { name: /save scope/i }));
     await waitFor(() => expect(configs).toContain('{"scope":"campaign"}'));
+  });
+
+  it("Generate persona sends the live (unsaved) name/title, not the stored cast entry (#480)", async () => {
+    // The stored NPC still carries the "New NPC" placeholder; the GM types a
+    // real name WITHOUT saving, then generates. The RPC must carry the live
+    // form values — the repro drafted "Du bist New NPC" otherwise.
+    const campaign = create(CampaignSchema, { id: "c1", name: "X", system: "5e", language: "en" });
+    const butler = create(AgentSchema, { id: "b1", campaignId: "c1", role: "butler", name: "Glyphoxa", addressOnly: true });
+    const npc = create(AgentSchema, {
+      id: "n1",
+      campaignId: "c1",
+      role: "character",
+      name: "New NPC",
+      title: "Stored Title",
+      voice: "rachel",
+    });
+    const seen: { name?: string; title?: string }[] = [];
+    const transport = createRouterTransport(({ service }) => {
+      service(VoiceService, { listVoices: () => create(ListVoicesResponseSchema, { voices: [] }) });
+      service(CampaignService, {
+        getCampaignRoster: () => create(GetCampaignRosterResponseSchema, { campaign, roster: [butler, npc] }),
+        generatePersona: (req) => {
+          seen.push({ name: req.name, title: req.title });
+          return create(GeneratePersonaResponseSchema, { persona: "**Du bist Jule Brandt**" });
+        },
+      });
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Campaign />
+      </Providers>,
+    );
+    fireEvent.click(await screen.findByText("New NPC"));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Jule Brandt" } });
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Draft with your LLM"), { target: { value: "a stern harbourmaster" } });
+    fireEvent.click(screen.getByRole("button", { name: /generate persona/i }));
+
+    // The RPC carried the live form values — including the cleared title, whose
+    // presence tells the server NOT to fall back to the stored one.
+    await waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toEqual({ name: "Jule Brandt", title: "" });
+    // The draft landed in the persona field for review (still unsaved).
+    await waitFor(() =>
+      expect((screen.getByLabelText("Persona") as HTMLTextAreaElement).value).toBe("**Du bist Jule Brandt**"),
+    );
   });
 
   it("the grant Switch never persists an unsaved scope edit; only Save scope does (#215)", async () => {

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -278,7 +278,10 @@ function AgentEditor({
   const draftPersona = async () => {
     setDraftError(null);
     try {
-      const res = await generate.mutateAsync({ agentId: agent.id, prompt: draftPrompt });
+      // The live form name/title ride along so the draft addresses what the GM
+      // has typed, not the stored cast entry — which may still be the "New NPC"
+      // placeholder when the GM hasn't saved yet (#480).
+      const res = await generate.mutateAsync({ agentId: agent.id, prompt: draftPrompt, name, title });
       setPersona(res.persona);
     } catch (err) {
       setDraftError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Problem

The #480 campaign-assist persona drafting addressed the **stored** NPC name instead of what the GM has typed in the form. Repro: add a new NPC (stored as "New NPC"), type "Jule Brandt" into Name without saving, generate → the draft opens "**Du bist New NPC**".

Cause: the SPA sent only `{ agentId, prompt }` and the backend seasoned the prompt from the persisted `agent.Name`/`agent.Title`.

## Fix

- `GeneratePersonaRequest` gains `optional string name = 3; optional string title = 4;` — proto3 presence: **unset** → fall back to the stored Agent field (older clients keep working), **set-but-empty** → the GM cleared the field, no stored fallback.
- `internal/rpc/assist.go` overrides the stored fields with the live request values when present.
- The Agent editor sends its live local `name`/`title` state alongside the prompt.
- `GenerateKnowledge` checked for the same class of bug: **not affected** — its request carries only the prompt, no agent identity.

## Tests

- `TestGeneratePersona_LiveFormOverride` (internal/rpc): live values win; cleared title doesn't resurrect the stored one; unset fields keep the stored fallback. Verified red without the fix.
- `Campaign.test.tsx`: drives the exact repro through the rendered editor — unsaved rename + generate → asserts the RPC carried the live name and cleared title, and the draft lands in the persona field.

Local verification: `go build ./...`, `go test ./internal/rpc/ ./internal/assist/`, `go vet`, web `tsc --noEmit`, Campaign vitest suite 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)