### PR TITLE
fix: voice session resolves tenant BYOK keys for web-created NPCs

### DIFF
--- a/internal/wirenpc/credentials.go
+++ b/internal/wirenpc/credentials.go
@@ -91,23 +91,60 @@ func resolveProviderKeys(ctx context.Context, ent llmbuild.PlatformKeyEntitlemen
 	return providerKeys{llm: llm, tts: tts, stt: stt}, nil
 }
 
-// resolveSessionKeys is the DB-side seam [RunFromDB] drives: it reads the
-// Tenant's STT Provider Config by Component (STT is not Agent-joined, unlike the
-// LLM/TTS configs the primary agent's LoadedAgent already carries) and resolves
-// all three keys against cipher, behind the tenant's platform-key entitlement
-// (Config.KeyEntitlement; nil = the allowlist posture). A missing STT config is
-// treated as an env fallback, not an error. ElevenLabs STT shares the TTS key
-// in the demo seed, but the bind is read per-Component for correctness.
-func resolveSessionKeys(ctx context.Context, st *storage.Store, tenantID uuid.UUID, primary storage.LoadedAgent, cipher *crypto.Cipher, ent llmbuild.PlatformKeyEntitlement) (providerKeys, error) {
-	var sttCfg *storage.ProviderConfig
-	pc, err := st.GetProviderConfigByComponent(ctx, tenantID, storage.ComponentSTT)
+// effectiveComponentConfig resolves ONE component's Provider Config the way
+// every other tenant-scoped path already does (assist/recap resolveLLMConfig,
+// gate #271): the Agent-bound config when present, else the Tenant's
+// per-Component provider_config row, else nil (the env fallback, ADR-0039).
+// The tenant fallback is what makes WEB-created Agents work: campaign_crud
+// never sets llm/voice_provider_config_id — only the demo seed binds them —
+// so without it a BYOK tenant's saved key was invisible to the voice session
+// and the ADR-0054/0055 entitlement gate refused the session even though the
+// key was saved right there in Configuration.
+func effectiveComponentConfig(ctx context.Context, st *storage.Store, tenantID uuid.UUID, bound *storage.ProviderConfig, component storage.Component) (*storage.ProviderConfig, error) {
+	if bound != nil {
+		return bound, nil
+	}
+	pc, err := st.GetProviderConfigByComponent(ctx, tenantID, component)
 	switch {
 	case errors.Is(err, storage.ErrNotFound):
-		// No STT config bound -> the adapter reads ELEVENLABS_API_KEY (env).
+		// No config for this component -> the adapter reads its own env var.
+		return nil, nil
 	case err != nil:
-		return providerKeys{}, fmt.Errorf("wirenpc: load STT provider config: %w", err)
+		return nil, fmt.Errorf("wirenpc: load %s provider config: %w", component, err)
 	default:
-		sttCfg = &pc
+		return &pc, nil
 	}
-	return resolveProviderKeys(ctx, ent, tenantID, cipher, primary.LLMConfig, primary.TTSConfig, sttCfg)
+}
+
+// resolveSessionKeys is the DB-side seam [RunFromDB] drives: it resolves each
+// component's effective Provider Config (Agent-bound, else the Tenant's
+// per-Component row — see [effectiveComponentConfig]) and resolves all three
+// keys against cipher, behind the tenant's platform-key entitlement
+// (Config.KeyEntitlement; nil = the allowlist posture). A missing config is
+// treated as an env fallback, not an error. ElevenLabs STT shares the TTS key
+// in the demo seed, but the bind is read per-Component for correctness.
+//
+// It also surfaces the effective LLM config so [RunFromDB] derives
+// llmProviderID from the SAME config the key was resolved against — an
+// Agent with no binding must not label its rounds (and price its spend) as
+// the env default while speaking with the tenant's saved key.
+func resolveSessionKeys(ctx context.Context, st *storage.Store, tenantID uuid.UUID, primary storage.LoadedAgent, cipher *crypto.Cipher, ent llmbuild.PlatformKeyEntitlement) (providerKeys, *storage.ProviderConfig, error) {
+	llmCfg, err := effectiveComponentConfig(ctx, st, tenantID, primary.LLMConfig, storage.ComponentLLM)
+	if err != nil {
+		return providerKeys{}, nil, err
+	}
+	ttsCfg, err := effectiveComponentConfig(ctx, st, tenantID, primary.TTSConfig, storage.ComponentTTS)
+	if err != nil {
+		return providerKeys{}, nil, err
+	}
+	// STT is never Agent-joined; it always resolves from the Tenant row.
+	sttCfg, err := effectiveComponentConfig(ctx, st, tenantID, nil, storage.ComponentSTT)
+	if err != nil {
+		return providerKeys{}, nil, err
+	}
+	keys, err := resolveProviderKeys(ctx, ent, tenantID, cipher, llmCfg, ttsCfg, sttCfg)
+	if err != nil {
+		return providerKeys{}, nil, err
+	}
+	return keys, llmCfg, nil
 }

--- a/internal/wirenpc/credentials_integration_test.go
+++ b/internal/wirenpc/credentials_integration_test.go
@@ -107,7 +107,7 @@ func TestRunFromDB_DecryptsSavedKeys(t *testing.T) {
 		t.Fatalf("loadSeededNPCs tenant = %s, want %s", gotCampaign.TenantID, tenantID)
 	}
 
-	keys, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher, nil)
+	keys, _, err := resolveSessionKeys(ctx, st, tenantID, primary, cipher, nil)
 	if err != nil {
 		t.Fatalf("resolveSessionKeys: %v", err)
 	}
@@ -141,12 +141,99 @@ func TestRunFromDB_EnvPlaceholderFallsBack(t *testing.T) {
 	}
 
 	// A nil cipher is deliberate: the env-placeholder path must not need one.
-	keys, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, nil, nil)
+	keys, _, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveSessionKeys on env placeholders: %v (must fall back to ENV, not error)", err)
 	}
 	if keys != (providerKeys{}) {
 		t.Errorf("env-placeholder keys = %+v, want all empty (adapter ENV fallback)", keys)
+	}
+}
+
+// TestResolveSessionKeys_WebCreatedAgentUsesTenantKeys reproduces the live
+// #513-era failure: a WEB-created Character Agent carries NO
+// llm_provider_config_id / voice_provider_config_id (campaign_crud never binds
+// them — only the demo seed does), while the Configuration screen saved the
+// tenant's real BYOK keys as per-Component provider_config rows. The session
+// bridge must fall back to those tenant-Component rows — exactly like assist's
+// and recap's resolveLLMConfig — instead of resolving a nil config to "" and
+// tripping the ADR-0054/0055 platform-key entitlement gate ("tenant has no
+// platform-key entitlement (BYOK plan)") on a tenant whose key is sitting right
+// there. The refusingEntitlement stub plays the plan-less tenant's gate: with
+// the fallback in place it is never consulted, because a resolved real key
+// short-circuits the gate.
+func TestResolveSessionKeys_WebCreatedAgentUsesTenantKeys(t *testing.T) {
+	pool := startDB(t)
+	ctx := context.Background()
+	st := storage.New(pool)
+	cipher := testCipher(t)
+
+	want := providerKeys{
+		llm: "sk-llm-TENANTsecret-0001",
+		tts: "sk-tts-TENANTsecret-0002",
+		stt: "sk-stt-TENANTsecret-0003",
+	}
+
+	tenantID, err := st.CreateTenant(ctx, "Web Tenant")
+	if err != nil {
+		t.Fatalf("CreateTenant: %v", err)
+	}
+	campaignID, err := st.CreateCampaign(ctx, storage.NewCampaign{
+		TenantID: tenantID,
+		Name:     "Schachteln",
+		System:   "dnd5e",
+		Language: "de",
+	})
+	if err != nil {
+		t.Fatalf("CreateCampaign: %v", err)
+	}
+
+	sealCfg := func(component storage.Component, provider, model, key string) {
+		ct, err := cipher.Seal([]byte(key))
+		if err != nil {
+			t.Fatalf("seal %s: %v", component, err)
+		}
+		if _, err := st.CreateProviderConfig(ctx, storage.NewProviderConfig{
+			TenantID:              tenantID,
+			Component:             component,
+			Provider:              provider,
+			Model:                 model,
+			CredentialsCiphertext: ct,
+			CredentialsLast4:      crypto.Last4(key),
+		}); err != nil {
+			t.Fatalf("CreateProviderConfig %s: %v", component, err)
+		}
+	}
+	sealCfg(storage.ComponentLLM, llmProvider, llmModel, want.llm)
+	sealCfg(storage.ComponentTTS, "elevenlabs", ttsModel, want.tts)
+	sealCfg(storage.ComponentSTT, "elevenlabs", sttModel, want.stt)
+
+	// The web path: CreateAgent with NO provider-config bindings (both NullUUIDs
+	// stay invalid), exactly like rpc/campaign_crud's CreateAgent.
+	if _, err := st.CreateAgent(ctx, storage.NewAgent{
+		CampaignID:  campaignID,
+		Role:        storage.AgentRoleCharacter,
+		Name:        "Jule Brandt",
+		Persona:     "Leitende Systemadministratorin.",
+		AddressOnly: false,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	_, primary, campaign, err := loadCampaignNPCs(ctx, st, campaignID)
+	if err != nil {
+		t.Fatalf("loadCampaignNPCs: %v", err)
+	}
+
+	keys, llmCfg, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, cipher, refusingEntitlement{})
+	if err != nil {
+		t.Fatalf("resolveSessionKeys with unbound web Agent = %v; must fall back to the tenant's saved per-Component keys, not the entitlement gate", err)
+	}
+	if keys != want {
+		t.Errorf("resolveSessionKeys keys = %+v, want the tenant's decrypted keys %+v", keys, want)
+	}
+	if llmCfg == nil || llmCfg.Provider != llmProvider {
+		t.Errorf("resolveSessionKeys effective LLM config = %+v, want the tenant's %q row (drives llmProviderID / adapter selection)", llmCfg, llmProvider)
 	}
 }
 

--- a/internal/wirenpc/run.go
+++ b/internal/wirenpc/run.go
@@ -71,14 +71,17 @@ func RunFromDB(ctx context.Context, cfg Config, pool *pgxpool.Pool, cipher *cryp
 	// A decryption failure (e.g. a real saved key with the wrong/absent cipher)
 	// is fatal here, before any Discord connection — the operator sees a clear
 	// error instead of an NPC that silently ran on the wrong (env) key.
-	keys, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, cipher, cfg.KeyEntitlement)
+	keys, llmCfg, err := resolveSessionKeys(ctx, st, campaign.TenantID, primary, cipher, cfg.KeyEntitlement)
 	if err != nil {
 		return err
 	}
 
 	cfg.npcs = npcs
 	cfg.keys = keys
-	cfg.llmProviderID = llmProviderID(primary.LLMConfig)
+	// The EFFECTIVE LLM config (Agent-bound, else the tenant's 'llm' row) —
+	// the same config the key above was resolved against, so the adapter
+	// selection, round spans and spend pricing follow the key's provider.
+	cfg.llmProviderID = llmProviderID(llmCfg)
 	cfg.language = campaign.Language
 
 	// The campaign's bound player-character names (#276's `character` table) feed


### PR DESCRIPTION
## Problem

Starting a voice session on a BYOK tenant fails with:

> `llmbuild: resolve llm key for tenant …: llmbuild: tenant has no platform-key entitlement (BYOK plan) — save a provider API key in Configuration (ADR-0054)`

— even though the tenant **has** saved LLM/TTS keys in Configuration, and campaign-assist / recap / provider-health all resolve those same keys fine. Reproduced live on the local k3d deployment (operator claim-or-create tenant, open admission, campaign with web-created NPCs).

## Root cause

`resolveSessionKeys` (internal/wirenpc/credentials.go) resolved the LLM/TTS keys **only** from the primary Agent's `llm_provider_config_id` / `voice_provider_config_id` bindings. Web-created Agents never carry those FKs (`campaign_crud` doesn't set them; only the demo seed binds them), so the nil config resolved to the `""` env-fallback signal, flipping resolution onto the ADR-0054/0055 platform-key entitlement gate — which correctly refuses a plan-less tenant (`tenant_subscription` is empty for operator claim-or-create tenants by ADR-0055 design). The tenant's saved `provider_config` row (component=`llm`) was never queried for credentials on this path; the roster loader reads it but only harvests the Model field.

Latent asymmetry since the #69 credential bridge; armed when the #475/#477 entitlement seam shipped (v0.3.0). The tenant-per-Component fallback was added to recap and assist over time but never to the voice path.

## Fix

- `effectiveComponentConfig`: Agent-bound config when present, else the Tenant's per-Component `provider_config` row, else nil (env fallback, ADR-0039) — the exact pattern of assist/recap `resolveLLMConfig`.
- `resolveSessionKeys` resolves llm/tts/stt through it and now also returns the **effective** LLM config, so `llmProviderID` (adapter selection, round spans, spend pricing) follows the same config the key was resolved against instead of defaulting when the Agent carries no binding.

## Testing

- New integration test `TestResolveSessionKeys_WebCreatedAgentUsesTenantKeys`: unbound web-style Agent + saved tenant keys + a **refusing** entitlement gate → all three keys resolve decrypted and the effective LLM config surfaces. Red on the old code, green now.
- Existing credential-bridge integration suite (`TestRunFromDB_*`) passes.
- Verified live: rebuilt image on the k3d test deployment — voice session that previously failed now starts and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)