### PR TITLE
fix(test): deterministic sync in TestClaimLoop_HeartbeatSupersededStopsSession

### DIFF
--- a/internal/session/claimloop_test.go
+++ b/internal/session/claimloop_test.go
@@ -435,7 +435,15 @@ func TestClaimLoop_HeartbeatSupersededStopsSession(t *testing.T) {
 
 	// Simulate the reaper marking this claim dead: the next heartbeat is superseded.
 	istore.markDead(intent.ID)
-	waitFor(t, 2*time.Second, func() bool { return runner.wasCancelled() })
+	// Drain BEFORE asserting: runner.cancelled flips inside Manager.Stop before
+	// runLoop marks the session ended, so gating the Active check on wasCancelled
+	// races the teardown (a real flake under full-suite CPU contention). The
+	// superseded arm of runSession returns only after mgr.Stop waits out the full
+	// teardown, so the drain IS the state transition the assertions need.
+	loop.DrainForTest()
+	if !runner.wasCancelled() {
+		t.Fatal("local session was not cancelled after superseded heartbeat")
+	}
 	if _, live, _ := mgr.Active(context.Background(), tenantID); live {
 		t.Fatal("session still live after superseded heartbeat")
 	}
@@ -443,7 +451,6 @@ func TestClaimLoop_HeartbeatSupersededStopsSession(t *testing.T) {
 	if got := istore.get(intent.ID).Status; got != storage.VoiceIntentDead {
 		t.Fatalf("intent status = %q, want dead (no takeover / resurrection)", got)
 	}
-	loop.DrainForTest()
 }
 
 // TestClaimLoop_GracefulDrain covers sequence (5)/AC5: ctx cancellation stops


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky `TestClaimLoop_HeartbeatSupersededStopsSession` (internal/session/claimloop_test.go): it failed intermittently during full `go test ./...` runs with "session still live after superseded heartbeat" while passing reliably in isolation.

## Why is this change needed?

The test gated its `mgr.Active` assertion on `runner.wasCancelled()` — but that flag flips **inside** `Manager.Stop`, before `runLoop` re-acquires the mutex and sets `as.ended` (the flag `Active` reads). Under full-suite CPU contention the teardown goroutine can be descheduled inside that sub-microsecond window, so the test observed the cancel while `Active` still reported live.

Root cause was confirmed by temporarily widening the cancelled→ended window with a 5ms sleep: the exact reported failure reproduced **20/20** with the old test and **0/20** with this fix (the probe is not part of this PR). The claimloop itself is sound — the superseded arm's `mgr.Stop` already blocks on `as.done` until the active entry clears; only the test's synchronization point was wrong.

Fix: call `loop.DrainForTest()` **before** the assertions. The superseded arm of `runSession` returns only after `mgr.Stop` waits out the full teardown, so `wasCancelled`, `Active == false`, and the dead-row check all become deterministic — no polling remains on that path. The sibling tests (`ClaimStartLiveEndDone`, `GracefulDrain`) were audited and already synchronize on post-teardown signals.

## How was this tested?

- `go test ./internal/session/ -race -count=50 -run TestClaimLoop_HeartbeatSupersededStopsSession` — pass
- 1000 executions under 64 CPU-hog busy loops at `GOMAXPROCS=4` (the pre-fix repro conditions) — 0 failures
- Fixed test passes 20/20 even with the window-widening probe still in place (proves it synchronizes on the real state transition, not timing)
- Full `./internal/session/` package `-race -count=2` — pass; `gofmt`/`go vet` clean

- [x] `make check` passes (fmt + vet locally; package suite with -race)
- [x] New/updated tests cover the change
- [ ] Manual testing (n/a — test-only change)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (affected package; CI runs the full suite)
- [x] I have updated documentation if needed (n/a)
- [x] All exported symbols have Godoc comments (no exported symbols touched)
- [x] My commits are focused and have clear messages

## Additional Notes

Test-only change — no production code touched. The flake rate in the wild was ~1 per full-suite run because the race window is sub-microsecond; blind stress (2000 runs, single-core pinning, 64-way oversubscription) never hit it until the window was deliberately widened, which is why this pattern survived review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)