### PR TITLE
docs: record #437 and #312 decisions (ADR amendments + CONTEXT.md)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,7 +70,7 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 | **Guild** | A Discord server, identified by `guild_id`; a Tenant may have many Guilds linked. | Server, Discord server |
 | **Voice Session** | The Tenant's resolved Bot's presence in one Discord voice channel, bound to a (Guild, Campaign, GM) tuple at start and hosted by exactly one Voice Instance. | Session (alone), Call, Live session |
 | **DAVE** | Discord's Audio & Video End-to-end Encryption protocol, mandatory since 2026-03-01; built on MLS. | E2EE, Encryption |
-| **Transcript** | The persisted text record of a Voice Session, with speaker attribution by Discord User. | Log, Recording (recording is audio) |
+| **Transcript** | The persisted text record of a Voice Session, with speaker attribution by Discord User. Records **delivered speech only, at sentence grain** — a turn that delivered zero sentences is never persisted, in either grain (ADR-0012, ADR-0040 amendment, #437). | Log, Recording (recording is audio) |
 | **Partial Transcript** | The mutable interim text of an in-progress utterance streamed by STT; may change until the utterance is committed. Only the committed text becomes an STT final that Address Detection and the Transcript consume. | Interim result, Draft, Live transcript |
 | **Transcript Line** | One rendered line of a Transcript — a single human utterance or a coalesced Agent reply — persisted per Voice Session at the LINE grain (`transcript_line`, ADR-0040) for the Session screen's live feed and replay-on-reload. Distinct from a Transcript Chunk (the 3–6-utterance retrieval/embedding grain, ADR-0011): they are separate records of the same speech. A Voice Session's `line_count` is the count of its Transcript Lines. | Transcript Chunk (the retrieval grain), Utterance (a Line may coalesce several) |
 | **Slash Command** | A Discord interaction registered by the Bot; handled by the Butler when reasoning is required, otherwise directly by the Bot binary. | Command, Interaction |
@@ -88,7 +88,7 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 | Term | Definition | Aliases to avoid |
 |------|------------|------------------|
 | **Provider** | An external service implementing one Component (e.g. Anthropic for LLM, Deepgram for STT). | Vendor, Backend, Service |
-| **Component** | A Provider category: `llm`, `stt`, `tts`, `embeddings`, `s2s`. | Capability, Type |
+| **Component** | A Provider category: `llm`, `stt`, `tts`, `embeddings`, `s2s`, `image` (the last added by #311, ADR-0004 amendment). | Capability, Type |
 | **Provider Config** | A Tenant-scoped, encrypted record binding a Component to a Provider with credentials and model/voice selection. | Credentials, Key, API key |
 | **BYOK** | Bring-Your-Own-Keys — the v1.0 Provider Config source where the Tenant supplies their own credentials. | Self-supplied, Customer keys |
 | **Tool** | A named callable function invoked by an Agent via a Tool Grant. Its backing is either **built-in** (runs in-process, lowest latency) or an **MCP Server** (out-of-process). The Agent only ever sees the uniform Tool interface; the backing is an implementation detail. | MCP Tool (the protocol is one backing, not the category), Function, Action, Plugin |

--- a/docs/adr/0004-byok-provider-key-matrix.md
+++ b/docs/adr/0004-byok-provider-key-matrix.md
@@ -47,3 +47,18 @@ The matrix's second-provider slots (STT: whisper.cpp, TTS: Coqui XTTS — also
 never implemented) are accordingly **vacant by policy**, not TODO: Deepgram and
 ElevenLabs remain the implemented reference providers, alongside the
 OpenAI-compatible surfaces already in the codebase.
+
+---
+
+**Amendment (2026-07-22, #312 — sound generation rides the `tts` Provider
+Config, deliberately NOT a Component):** Highlight sound enrichment (ElevenLabs
+sound-effects "sting" and Music endpoints) resolves the Tenant's existing `tts`
+Provider Config and uses its key **iff the configured provider is ElevenLabs**;
+any other tts provider (or none) makes sound generation cleanly not-configured
+(no-op, no retry, no spend — the `ErrImageNotConfigured` pattern from #311).
+Unlike `image` (a new vendor, hence a new Component), sound generation is the
+same vendor and the same key as tts — a `sound` Component would force Tenants
+to paste one key twice for pure attribution's sake. Attribution is preserved in
+the Usage Ledger instead: sound calls meter under their own model ids (SFX and
+Music separately) with their own ADR-0046 price-map entries. Revisit the
+Component question only if a non-ElevenLabs sound provider is ever adopted.

--- a/docs/adr/0012-deliver-then-commit-sentence.md
+++ b/docs/adr/0012-deliver-then-commit-sentence.md
@@ -5,3 +5,9 @@ NPC speech is committed at sentence granularity: a sentence counts as **delivere
 If zero sentences were delivered (interrupted before the first sentence completes), the utterance is **not logged at all**.
 
 **Why:** Transcripts must reflect what listeners actually heard. Word-level mid-sentence truncation would need word-timestamps from the TTS provider, which is deferred to v1.5+. Logging zero-delivered utterances would pollute Address Detection and NPC retrieval with content the room never heard.
+
+---
+
+**Note (2026-07-22, #437):** the LINE grain (ADR-0040) conforms to this
+invariant too — never-delivered lines are reconciled out of `transcript_line`,
+so "not logged at all" holds for both persisted grains.

--- a/docs/adr/0040-transcript-line-persistence.md
+++ b/docs/adr/0040-transcript-line-persistence.md
@@ -81,3 +81,20 @@ Hop-B REST endpoint (ADR-0014) rather than adding a new history API.
   anonymous human lane, and the `kind ∈ {gm,player,npc,butler}` taxonomy the
   persisted line mirrors; the in-proc `SessionManager` finalizes the relay on
   Stop.
+
+---
+
+**Amendment (2026-07-22, #437 — the LINE grain conforms to ADR-0012's
+delivered-only invariant):** a `transcript_line` row may only outlive its
+Voice Session if its speech was actually delivered. The Relay persists
+optimistically at `TTSInvoked` (unchanged — the live feed's latency contract
+stays), but reconciles on TTS start-error and turn-end: a line whose turn
+delivered **zero** sentences is deleted from `transcript_line` through the
+same single-writer queue, so replay never shows text the room never heard.
+The live SSE feed may therefore transiently show a line that a later reload
+drops — accepted, and correct: it was never speech. Failure evidence belongs
+to the Turn's terminal reason and logs, not the Transcript. This closes the
+undocumented divergence with the Chunker (which already purged undelivered
+sentences) and keeps the Transcript doctrine singular across both grains:
+**the Transcript records delivered speech, at sentence grain** (sentence-grain
+rounding on barge per #401 stays accepted).


### PR DESCRIPTION
## Why

The 2026-07-22 grilling session (launch planning, epic #523) resolved the two open `ready-for-human` domain decisions; this PR is their durable record. Decision comments already posted on #437 / #312.

## What

- **ADR-0040 amendment (#437):** the LINE grain conforms to ADR-0012's delivered-only invariant — the Relay reconciles on TTS start-error/turn-end and deletes lines whose turn delivered zero sentences. Transcript doctrine is singular: delivered speech, at sentence grain. (Implementation is the remaining `ready-for-agent` slice on #437.)
- **ADR-0012 note:** cross-reference confirming both grains honor "not logged at all".
- **ADR-0004 amendment (#312):** sound generation rides the Tenant's `tts` Provider Config iff provider == elevenlabs; deliberately not a new Component (unlike `image`/#311 — same vendor, same key); attribution via distinct model ids + ADR-0046 price entries.
- **CONTEXT.md:** Transcript entry states the delivered-only doctrine; Component list gains the missing `image` value (stale since #311).

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)