### PR TITLE
Public-beta launch slice: landing + legal + disclosure + chart tunnel/Ollama/backups, and the #437 transcript reconcile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,14 @@ export GLYPHOXA_OPERATOR_IDS='000000000000000000'
 # (a later real OAuth login takes it over). Leave UNSET normally.
 # export GLYPHOXA_DEV_MODE='1'
 
+# ── Privacy policy URL (#519) ────────────────────────────────────────────────
+# Optional. The deployment's published privacy-policy page. The Bot links it
+# from the transcription disclosure it posts in the voice channel at Voice
+# Session start — players at the table are data subjects who may never open the
+# web app, so that message is the only surface that reaches them. Unset posts
+# the disclosure WITHOUT a link (never a broken one).
+# export GLYPHOXA_PRIVACY_POLICY_URL='https://glyphoxa.example.com/privacy'
+
 # ── Logging (ADR-0032) ───────────────────────────────────────────────────────
 # `json`, or `text` (the default for any other value).
 export GLYPHOXA_LOG_FORMAT='text'

--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -349,6 +349,16 @@ func sttStreaming(getenv func(string) string) bool {
 	return true
 }
 
+// privacyPolicyURL reads GLYPHOXA_PRIVACY_POLICY_URL — the deployment's published
+// privacy-policy page, which the Bot links from the transcription disclosure it
+// posts at Voice Session start (#519). Trimmed; blank means "not published", and
+// the disclosure then carries no link rather than a broken one. It is deliberately
+// NOT validated as a URL: an operator's reverse-proxied path is theirs to get
+// right, and a typo must never keep the disclosure itself off the channel.
+func privacyPolicyURL(getenv func(string) string) string {
+	return strings.TrimSpace(getenv("GLYPHOXA_PRIVACY_POLICY_URL"))
+}
+
 // defaultGatewayIdentifyWarn is the per-application 24h IDENTIFY count above which
 // the gateway-budget observer warns (#486). It sits well below Discord's
 // 1000/token/24h hard limit — exhausting that budget resets the token and drops

--- a/cmd/glyphoxa/boot_test.go
+++ b/cmd/glyphoxa/boot_test.go
@@ -675,6 +675,23 @@ func TestSTTStreaming(t *testing.T) {
 	}
 }
 
+// TestPrivacyPolicyURL: the #519 disclosure link is whatever the operator
+// published, trimmed — and blank when unset, so the Bot posts the transcription
+// notice without a link instead of a broken one.
+func TestPrivacyPolicyURL(t *testing.T) {
+	cases := []struct{ val, want string }{
+		{"", ""},
+		{"   ", ""},
+		{"https://glyphoxa.example/privacy", "https://glyphoxa.example/privacy"},
+		{"  https://glyphoxa.example/privacy \n", "https://glyphoxa.example/privacy"},
+	}
+	for _, c := range cases {
+		if got := privacyPolicyURL(envMap(map[string]string{"GLYPHOXA_PRIVACY_POLICY_URL": c.val})); got != c.want {
+			t.Errorf("privacyPolicyURL(%q) = %q, want %q", c.val, got, c.want)
+		}
+	}
+}
+
 // TestGatewayIdentifyWarnThreshold: the IDENTIFY-budget warning threshold (#486)
 // defaults to 500 (well below Discord's 1000/token/24h reset limit) and accepts a
 // positive integer override; blank, non-numeric, zero and negative values fall

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -134,6 +134,10 @@ func main() {
 	// Streaming STT (ADR-0042, issue #180) is an env opt-in shared by voice and
 	// all mode; default OFF keeps the batch STT path byte-for-byte.
 	cfg.STTStreaming = sttStreaming(os.Getenv)
+	// The privacy-policy page the Bot links from its Voice Session transcription
+	// disclosure (#519). Shared by voice/web/all — the Manager copies it onto every
+	// session Config it starts. Unset posts the disclosure without a link.
+	cfg.PrivacyPolicyURL = privacyPolicyURL(os.Getenv)
 	hardcoded := flag.Bool("hardcoded", false, "use the in-code NPC instead of loading from the database — no Postgres needed, for smoke-testing audio without a seeded DB")
 	metricsAddr := flag.String("metrics-addr", ":9090", "address for the /metrics + /healthz + /readyz listener (all Modes; kept off the public web API port, ADR-0032); empty disables it")
 	webAddr := flag.String("web-addr", ":8080", "address for the web/all-mode Connect RPC API listener (ADR-0039); observability is on -metrics-addr")

--- a/deploy/charts/glyphoxa/ci/ci-values.yaml
+++ b/deploy/charts/glyphoxa/ci/ci-values.yaml
@@ -14,6 +14,11 @@ voice:
   # glyphoxa.voice.snowflake helper rejects non-string values.
   guild: "111111111111111111"
   channel: "222222222222222222"
+cloudflared:
+  # A syntactically valid placeholder so the #517 tunnel render path has a token
+  # (enabling the tunnel without one fails the render by design). Not a real
+  # Cloudflare token and never deployed.
+  token: "ci-dummy-cloudflare-tunnel-token"
 web:
   # The Web Instance (#118) is on by default, so a render needs its required
   # OAuth credentials + a non-empty operator allowlist (ADR-0041) or it fails.

--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -80,6 +80,28 @@ What this release stands up (ADR-0034):
   kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.cloudflared.fullname" . }}
 {{- end }}
 
+{{- if .Values.backup.enabled }}
+  - A nightly Postgres backup CronJob ({{ .Values.backup.schedule }}) writing
+    pg_dump custom-format archives to its own PVC, kept {{ .Values.backup.retentionDays }} days
+{{- if .Values.backup.offsite.enabled }}
+    and pushed to s3://{{ .Values.backup.offsite.bucket }}/{{ .Values.backup.offsite.prefix }}.
+{{- else }}
+    (no off-site copy — backup.offsite.enabled is false, so these dumps live on
+    the same node as the database they protect).
+{{- end }}
+
+    Rehearse the restore BEFORE you need it — docs/deploy/backup-restore.md.
+    Trigger a run now to confirm it works:
+
+      kubectl -n {{ .Release.Namespace }} create job --from=cronjob/{{ include "glyphoxa.backup.fullname" . }} backup-manual-1
+      kubectl -n {{ .Release.Namespace }} logs job/backup-manual-1
+{{- else if .Values.postgres.enabled }}
+  - NO backups are configured. The in-cluster Postgres is a single StatefulSet on
+    one node's disk — set backup.enabled=true (and ideally backup.offsite.*)
+    before this deployment holds anything you would miss. See
+    docs/deploy/backup-restore.md.
+{{- end }}
+
 Verify the schema is current:
 
   kubectl -n {{ .Release.Namespace }} run glyphoxa-migrate-check --rm -it --restart=Never \

--- a/deploy/charts/glyphoxa/templates/NOTES.txt
+++ b/deploy/charts/glyphoxa/templates/NOTES.txt
@@ -39,6 +39,47 @@ What this release stands up (ADR-0034):
     v1.0 (replicas are not a tunable).
 {{- end }}
 
+{{- if .Values.ollama.enabled }}
+  - An Ollama Deployment + Service for the embeddings Component (#517, ADR-0011),
+    reachable in-cluster at:
+      {{ include "glyphoxa.ollama.fullname" . }}:{{ .Values.ollama.port }}
+    The web/voice pods dial it via GLYPHOXA_OLLAMA_URL = {{ include "glyphoxa.ollamaURL" . }}.
+{{- if .Values.ollama.model }}
+    It pulls {{ .Values.ollama.model }} on first start; until that download
+    finishes, semantic memory (L2) stalls loudly while everything else works.
+    Watch it with:
+      kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "glyphoxa.ollama.fullname" . }} -f
+{{- else }}
+    No model is pre-pulled (ollama.model is empty) — pull one yourself before
+    semantic memory (L2) can work:
+      kubectl -n {{ .Release.Namespace }} exec deployment/{{ include "glyphoxa.ollama.fullname" . }} -- ollama pull nomic-embed-text
+{{- end }}
+{{- end }}
+{{- if .Values.cloudflared.enabled }}
+  - A cloudflared Deployment ({{ .Values.cloudflared.replicas }} replica(s)) holding an
+    OUTBOUND tunnel to Cloudflare — no inbound port, Ingress or LoadBalancer is
+    needed for the console to be reachable from the internet.
+
+    Finish the wiring in the Cloudflare Zero Trust dashboard (Networks →
+    Tunnels → your tunnel → Public Hostname): route your hostname to
+{{- if .Values.web.enabled }}
+
+      http://{{ include "glyphoxa.web.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.web.service.port }}
+{{- else }}
+
+      the Service you want published (web.enabled is false in this release).
+{{- end }}
+
+    Then make the app advertise the SAME public origin, or the Discord login
+    dead-ends on a redirect_uri mismatch: set web.oauth.redirectUrl to
+    https://<your-hostname>/auth/discord/callback and register it on the Discord
+    application (ADR-0016), and set privacyPolicyUrl to
+    https://<your-hostname>/privacy so the Bot's transcription disclosure links
+    a reachable page (#519).
+
+  kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "glyphoxa.cloudflared.fullname" . }}
+{{- end }}
+
 Verify the schema is current:
 
   kubectl -n {{ .Release.Namespace }} run glyphoxa-migrate-check --rm -it --restart=Never \

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -270,6 +270,27 @@ render fails fast (required). Keeping the resolution here means the app Secret
 {{- end }}
 
 {{/*
+The privacy-policy URL the Bot links from its Voice Session transcription
+disclosure (GLYPHOXA_PRIVACY_POLICY_URL, #519).
+
+An explicit privacyPolicyUrl always wins (the policy may live on another host).
+Otherwise it is DERIVED from the Ingress — same host and scheme the console is
+served on, plus the SPA's /privacy route — so the link can never drift from the
+deployment the players are actually using. With no explicit value and no
+Ingress there is nothing trustworthy to advertise, so this renders EMPTY and the
+callers omit the env var entirely: the disclosure still posts, just without a
+link. Deliberately not `required` — a missing policy link must never keep a
+Voice Session from starting.
+*/}}
+{{- define "glyphoxa.privacyPolicyURL" -}}
+{{- if .Values.privacyPolicyUrl -}}
+{{- .Values.privacyPolicyUrl -}}
+{{- else if and .Values.ingress.enabled .Values.ingress.host -}}
+{{- printf "%s://%s/privacy" (include "glyphoxa.web.ingressScheme" .) .Values.ingress.host -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Hook ordering weights. The DB resources (Secret, Service, StatefulSet) come up
 first, then the migrate Job, then the seed Job, then the serving workloads. All
 are pre-install/pre-upgrade hooks EXCEPT the voice + web Deployments, which are

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -72,6 +72,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-web" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.ollama.fullname" -}}
+{{- printf "%s-ollama" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "glyphoxa.cloudflared.fullname" -}}
+{{- printf "%s-cloudflared" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The embeddings endpoint the web/voice pods dial (GLYPHOXA_OLLAMA_URL, ADR-0011).
+
+An explicit ollamaUrl always wins (an external server, a host-network Ollama).
+Otherwise, when the chart deploys its OWN Ollama (#517), it derives the
+in-cluster Service URL — same helper the Service name comes from, so the two can
+never drift. With neither, this renders EMPTY and the callers omit the env var:
+the binary keeps its loopback default, which cannot work in a pod, so semantic
+memory (L2) stalls loudly while everything else keeps working — the documented
+pre-#517 behaviour.
+*/}}
+{{- define "glyphoxa.ollamaURL" -}}
+{{- if .Values.ollamaUrl -}}
+{{- .Values.ollamaUrl -}}
+{{- else if .Values.ollama.enabled -}}
+{{- printf "http://%s:%d" (include "glyphoxa.ollama.fullname" .) (int .Values.ollama.port) -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 Validate the Web Instance Mode (ADR-0005). `web` serves the operator console +
 Connect API only; `all` additionally drives the voice loop in-process for

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -102,6 +102,12 @@ the app itself uses, so a backup can never target a different database than the
 deployment. `set -eu` plus writing the produced filename into /backup/.latest
 gives the off-site push an unambiguous handle; rotation runs only AFTER a
 successful dump, so a failing dump never deletes the last good one.
+
+The dump is written under a .partial name and renamed only on success: a
+pg_dump killed mid-write (DB restart, OOM, ENOSPC on the PVC) must never leave
+a truncated file matching the glyphoxa-*.dump glob the restore runbook (and the
+next retry's rotation) trusts. Stale partials from crashed runs are swept at
+start so retried Jobs cannot accumulate them toward a disk-full wedge.
 */}}
 {{- define "glyphoxa.backup.dumpContainer" -}}
 - name: pg-dump
@@ -111,8 +117,10 @@ successful dump, so a failing dump never deletes the last good one.
   args:
     - |
       set -eu
+      rm -f /backup/*.dump.partial
       dump="/backup/glyphoxa-$(date -u +%Y%m%dT%H%M%SZ).dump"
-      pg_dump "$GLYPHOXA_DATABASE_URL" -Fc -f "${dump}"
+      pg_dump "$GLYPHOXA_DATABASE_URL" -Fc -f "${dump}.partial"
+      mv "${dump}.partial" "${dump}"
       printf '%s' "${dump}" > /backup/.latest
       find /backup -name 'glyphoxa-*.dump' -mtime +{{ .Values.backup.retentionDays }} -delete
       echo "backup: wrote ${dump} (retention {{ .Values.backup.retentionDays }}d)"

--- a/deploy/charts/glyphoxa/templates/_helpers.tpl
+++ b/deploy/charts/glyphoxa/templates/_helpers.tpl
@@ -80,6 +80,55 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-cloudflared" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "glyphoxa.backup.fullname" -}}
+{{- printf "%s-backup" (include "glyphoxa.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The backup CronJob's dump container (#520), factored out because it runs in a
+different slot depending on the off-site flag: as an initContainer when a push
+follows it (Kubernetes gives no ordering between two regular containers, and a
+partially-written dump must never be pushed), and as the pod's only container
+when it does not.
+
+The image is the SAME Postgres image the chart runs (glyphoxa.postgres.image),
+so pg_dump's version always matches the server it dumps — a newer server than
+client is the classic "server version mismatch" failure, and pinning them
+together makes it unrepresentable.
+
+The dump is custom-format (-Fc): compressed, and the input `pg_restore` takes
+(see docs/deploy/backup-restore.md). The DSN comes from the same app Secret key
+the app itself uses, so a backup can never target a different database than the
+deployment. `set -eu` plus writing the produced filename into /backup/.latest
+gives the off-site push an unambiguous handle; rotation runs only AFTER a
+successful dump, so a failing dump never deletes the last good one.
+*/}}
+{{- define "glyphoxa.backup.dumpContainer" -}}
+- name: pg-dump
+  image: {{ include "glyphoxa.postgres.image" . }}
+  imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      dump="/backup/glyphoxa-$(date -u +%Y%m%dT%H%M%SZ).dump"
+      pg_dump "$GLYPHOXA_DATABASE_URL" -Fc -f "${dump}"
+      printf '%s' "${dump}" > /backup/.latest
+      find /backup -name 'glyphoxa-*.dump' -mtime +{{ .Values.backup.retentionDays }} -delete
+      echo "backup: wrote ${dump} (retention {{ .Values.backup.retentionDays }}d)"
+  env:
+    - name: GLYPHOXA_DATABASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "glyphoxa.secretName" . }}
+          key: database-url
+  volumeMounts:
+    - name: backup
+      mountPath: /backup
+  resources:
+    {{- toYaml .Values.backup.resources | nindent 4 }}
+{{- end }}
+
 {{/*
 The embeddings endpoint the web/voice pods dial (GLYPHOXA_OLLAMA_URL, ADR-0011).
 

--- a/deploy/charts/glyphoxa/templates/backup-cronjob.yaml
+++ b/deploy/charts/glyphoxa/templates/backup-cronjob.yaml
@@ -57,6 +57,10 @@ spec:
             app.kubernetes.io/component: backup
         spec:
           restartPolicy: OnFailure
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.backup.offsite.enabled }}
           initContainers:
             {{- include "glyphoxa.backup.dumpContainer" . | nindent 12 }}

--- a/deploy/charts/glyphoxa/templates/backup-cronjob.yaml
+++ b/deploy/charts/glyphoxa/templates/backup-cronjob.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.backup.enabled }}
+{{/*
+Postgres backup CronJob (#520) — the beta's restore story.
+
+The in-chart Postgres is a single StatefulSet on one node's disk (ADR-0034). A
+public beta cannot run on that without backups, so this ships them in the chart
+rather than as a copy-paste snippet in the docs:
+
+- a nightly `pg_dump -Fc` (custom format — the input `pg_restore` wants) into a
+  dedicated PVC, kept for `backup.retentionDays` days and then rotated out;
+- an OPTIONAL off-site push to any S3-compatible endpoint, behind
+  `backup.offsite.enabled`, using credentials from a Secret the OPERATOR
+  supplies (the chart never invents a bucket or a key);
+- a documented restore procedure (docs/deploy/backup-restore.md, linked from
+  the install notes).
+
+Shape: the dump runs as an initContainer whenever an off-site push follows it,
+so the upload starts only after a COMPLETE dump exists — Kubernetes has no
+ordering between two regular containers of the same pod, and half a dump pushed
+off-site is worse than none. With the push disabled the same script is the
+pod's only container.
+
+`concurrencyPolicy: Forbid` — a dump that outruns its schedule must not have a
+second one pile onto the same volume and the same database.
+
+It is a plain resource (NOT a Helm hook): backups are not part of an
+install/upgrade sequence, and a hook Job would re-run on every `helm upgrade`.
+*/}}
+{{- if and .Values.backup.offsite.enabled (not .Values.backup.offsite.bucket) }}
+{{- fail "backup.offsite.enabled needs backup.offsite.bucket: the S3-compatible bucket the nightly dump is pushed to. Set it (plus backup.offsite.endpoint for a non-AWS endpoint) or disable the off-site push." }}
+{{- end }}
+{{- if and .Values.backup.offsite.enabled (not .Values.backup.offsite.existingSecret.name) }}
+{{- fail "backup.offsite.enabled needs backup.offsite.existingSecret.name: a Secret holding the bucket credentials (keys access-key-id / secret-access-key by default). The chart deliberately does not template object-store credentials into its own Secret — create one and reference it." }}
+{{- end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "glyphoxa.backup.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "glyphoxa.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backup
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "glyphoxa.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          {{- if .Values.backup.offsite.enabled }}
+          initContainers:
+            {{- include "glyphoxa.backup.dumpContainer" . | nindent 12 }}
+          containers:
+            - name: offsite-push
+              image: {{ printf "%s:%s" .Values.backup.offsite.image.repository .Values.backup.offsite.image.tag | quote }}
+              imagePullPolicy: {{ .Values.backup.offsite.image.pullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args:
+                # The dump wrote the file it produced into /backup/.latest, so the
+                # push never has to guess (or race a rotation) about which file
+                # this run made.
+                - |
+                  set -eu
+                  dump="$(cat /backup/.latest)"
+                  aws s3 cp "${dump}" "s3://{{ .Values.backup.offsite.bucket }}/{{ .Values.backup.offsite.prefix }}$(basename "${dump}")"{{ with .Values.backup.offsite.endpoint }} --endpoint-url {{ . | quote }}{{ end }}
+                  echo "backup: pushed $(basename "${dump}") off-site"
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.offsite.existingSecret.name }}
+                      key: {{ .Values.backup.offsite.existingSecret.accessKeyIdKey | default "access-key-id" }}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.backup.offsite.existingSecret.name }}
+                      key: {{ .Values.backup.offsite.existingSecret.secretAccessKeyKey | default "secret-access-key" }}
+                - name: AWS_DEFAULT_REGION
+                  value: {{ .Values.backup.offsite.region | quote }}
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+          {{- else }}
+          containers:
+            {{- include "glyphoxa.backup.dumpContainer" . | nindent 12 }}
+          {{- end }}
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: {{ include "glyphoxa.backup.fullname" . }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+{{/*
+The backup volume. Separate from the Postgres data PVC on purpose — a dump that
+lives on the disk it is protecting is not a backup — and annotated
+`helm.sh/resource-policy: keep` so `helm uninstall` cannot take the dumps with
+it. Off-site (above) is what protects against losing the NODE.
+*/}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "glyphoxa.backup.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.backup.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/cloudflared-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/cloudflared-deployment.yaml
@@ -50,6 +50,10 @@ spec:
         checksum/token: {{ .Values.cloudflared.token | sha256sum }}
         {{- end }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cloudflared
           image: {{ printf "%s:%s" .Values.cloudflared.image.repository .Values.cloudflared.image.tag | quote }}

--- a/deploy/charts/glyphoxa/templates/cloudflared-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/cloudflared-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.cloudflared.enabled }}
+{{/*
+cloudflared Tunnel (#517) — the public beta's only inbound path.
+
+The beta runs on the operator's home VM (k3s) behind a Cloudflare Tunnel: no
+static IP, no port-forward, no inbound listener. cloudflared dials OUT to
+Cloudflare and forwards requests to the web Service from inside the cluster, so
+NOTHING here needs a hostPort, a NodePort, an Ingress or a LoadBalancer — and
+the voice tier stays outbound-only as it always was.
+
+- The tunnel is TOKEN-managed: its public hostname → service routing lives in
+  the Cloudflare dashboard (a remotely-managed tunnel), not in this chart. Point
+  it at the web Service printed in NOTES.txt.
+- The token is a credential: it comes from a Secret, never from argv (which is
+  world-readable in `ps` / the pod spec). Either the chart renders one from
+  `cloudflared.token`, or `cloudflared.existingSecret` names a Secret you
+  manage yourself; enabling the tunnel with neither fails the render rather than
+  deploying a pod that crash-loops on an empty token.
+- `--no-autoupdate`: in-place self-update inside a container fights the image
+  pin. Upgrade by bumping the tag.
+- Readiness comes from cloudflared's own metrics listener (/ready reports the
+  number of established edge connections), so a pod that cannot reach the edge
+  never reports Ready.
+*/}}
+{{- if and (not .Values.cloudflared.token) (not .Values.cloudflared.existingSecret.name) }}
+{{- fail "cloudflared.enabled needs a tunnel token: set cloudflared.token (the chart renders a Secret for it) or cloudflared.existingSecret.name/key to reference a Secret you manage. Create the token in the Cloudflare Zero Trust dashboard (Networks → Tunnels)." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glyphoxa.cloudflared.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cloudflared
+spec:
+  replicas: {{ .Values.cloudflared.replicas }}
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: cloudflared
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cloudflared
+      annotations:
+        # Roll the pod when a chart-rendered token changes; an externally managed
+        # Secret is the operator's to roll.
+        {{- if not .Values.cloudflared.existingSecret.name }}
+        checksum/token: {{ .Values.cloudflared.token | sha256sum }}
+        {{- end }}
+    spec:
+      containers:
+        - name: cloudflared
+          image: {{ printf "%s:%s" .Values.cloudflared.image.repository .Values.cloudflared.image.tag | quote }}
+          imagePullPolicy: {{ .Values.cloudflared.image.pullPolicy }}
+          args:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - {{ printf "0.0.0.0:%d" (int .Values.cloudflared.metricsPort) | quote }}
+            - run
+          env:
+            # cloudflared reads the tunnel token from TUNNEL_TOKEN, keeping the
+            # credential out of the process's command line.
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloudflared.existingSecret.name | default (include "glyphoxa.cloudflared.fullname" .) }}
+                  key: {{ .Values.cloudflared.existingSecret.key | default "tunnel-token" }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.cloudflared.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.cloudflared.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if not .Values.cloudflared.existingSecret.name }}
+---
+{{/*
+The chart-rendered tunnel-token Secret. Kept SEPARATE from the app Secret: it is
+the one credential an operator rotates on its own cadence (revoking a tunnel
+token must not roll the database password's checksum), and referencing an
+external Secret instead is a supported alternative (cloudflared.existingSecret).
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "glyphoxa.cloudflared.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cloudflared
+type: Opaque
+stringData:
+  tunnel-token: {{ .Values.cloudflared.token | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/ollama-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/ollama-deployment.yaml
@@ -1,0 +1,147 @@
+{{- if .Values.ollama.enabled }}
+{{/*
+In-cluster Ollama (#517) — the embeddings server the semantic-memory path needs.
+
+v1.0 embeds through Ollama ONLY (ADR-0011) and the Glyphoxa image ships no
+Ollama, so every in-cluster install has so far needed an EXTERNAL endpoint
+(`ollamaUrl`). For the beta the chart can stand one up itself: this Deployment
+plus its Service, with `ollamaUrl` defaulting to that Service
+(glyphoxa.ollamaURL) so the web/voice pods find it without further wiring.
+
+- ONE replica: Ollama holds the model in memory per pod and nothing here shards
+  it. Scaling embeddings out is a deployment change, not a value.
+- The default embedding model is pulled on FIRST START by a postStart hook
+  (`ollama pull`), not baked into an image: the pull needs the server running,
+  which an initContainer cannot assume. It waits for the local API, pulls, and
+  exits; a model already present makes the pull a no-op, so restarts are cheap.
+  A failed pull does NOT kill the pod — Ollama keeps serving and the next
+  restart retries; the embedding worker meanwhile stalls loudly (ADR-0011),
+  which is exactly the pre-existing "no embeddings endpoint" behaviour.
+- The model cache is a PVC by default, so a pod restart does not re-download
+  gigabytes. Set ollama.persistence.enabled=false for an ephemeral emptyDir.
+- Recreate: the PVC is ReadWriteOnce, so a RollingUpdate surge would deadlock
+  the new pod on a volume the old one still holds.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glyphoxa.ollama.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ollama
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "glyphoxa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ollama
+  template:
+    metadata:
+      labels:
+        {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ollama
+    spec:
+      containers:
+        - name: ollama
+          image: {{ printf "%s:%s" .Values.ollama.image.repository .Values.ollama.image.tag | quote }}
+          imagePullPolicy: {{ .Values.ollama.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ollama.port }}
+              protocol: TCP
+          env:
+            # Bind all interfaces: the default is loopback, which the Service
+            # could never reach.
+            - name: OLLAMA_HOST
+              value: {{ printf "0.0.0.0:%d" (int .Values.ollama.port) | quote }}
+          {{- with .Values.ollama.model }}
+          lifecycle:
+            postStart:
+              exec:
+                # Wait for the just-started server, then pull the embedding model.
+                # Best-effort by design (see the header): the `|| true` keeps a
+                # failed pull — an offline node, a rate-limited registry — from
+                # killing a container that is otherwise serving fine.
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    for i in $(seq 1 60); do
+                      ollama list >/dev/null 2>&1 && break
+                      sleep 2
+                    done
+                    ollama pull {{ . | quote }} || true
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: models
+              mountPath: /root/.ollama
+          {{- with .Values.ollama.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: models
+          {{- if .Values.ollama.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "glyphoxa.ollama.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.ollama.persistence.enabled }}
+---
+{{/*
+The model cache. A standalone PVC (not a StatefulSet volumeClaimTemplate) so the
+workload stays a Deployment; helm.sh/resource-policy: keep means a `helm
+uninstall` leaves the downloaded models on disk rather than forcing a
+multi-gigabyte re-pull on the next install.
+*/}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "glyphoxa.ollama.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ollama
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.ollama.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.ollama.persistence.size }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/ollama-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/ollama-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         {{- include "glyphoxa.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ollama
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ollama
           image: {{ printf "%s:%s" .Values.ollama.image.repository .Values.ollama.image.tag | quote }}

--- a/deploy/charts/glyphoxa/templates/ollama-service.yaml
+++ b/deploy/charts/glyphoxa/templates/ollama-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ollama.enabled }}
+{{/*
+Ollama Service (#517) — the stable in-cluster name the web/voice pods embed
+against. [glyphoxa.ollamaURL] derives GLYPHOXA_OLLAMA_URL from exactly this
+name and port, so the endpoint the pods dial can never drift from the workload
+the chart deployed. ClusterIP only: embeddings are an internal dependency and
+are never exposed outside the cluster.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glyphoxa.ollama.fullname" . }}
+  labels:
+    {{- include "glyphoxa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ollama
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "glyphoxa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ollama
+  ports:
+    - name: http
+      port: {{ .Values.ollama.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -171,7 +171,7 @@ spec:
             - name: GLYPHOXA_PRIVACY_POLICY_URL
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.ollamaUrl }}
+            {{- with (include "glyphoxa.ollamaURL" .) }}
             # Embeddings endpoint (ADR-0011), the same shared value the web pod
             # renders — split-mode parity, one endpoint of record. The pod has
             # no local Ollama, so the binary's loopback default can never work

--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -163,6 +163,14 @@ spec:
             # JSON logs for cluster log aggregation (ADR-0032).
             - name: GLYPHOXA_LOG_FORMAT
               value: json
+            {{- with (include "glyphoxa.privacyPolicyURL" .) }}
+            # The privacy-policy page the Bot links from the Voice Session
+            # transcription disclosure it posts in the voice channel (#519).
+            # Explicit privacyPolicyUrl, else derived from the Ingress host;
+            # omitted entirely when neither is available (no broken link).
+            - name: GLYPHOXA_PRIVACY_POLICY_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.ollamaUrl }}
             # Embeddings endpoint (ADR-0011), the same shared value the web pod
             # renders — split-mode parity, one endpoint of record. The pod has

--- a/deploy/charts/glyphoxa/templates/web-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/web-deployment.yaml
@@ -211,7 +211,7 @@ spec:
             - name: GLYPHOXA_PRIVACY_POLICY_URL
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.ollamaUrl }}
+            {{- with (include "glyphoxa.ollamaURL" .) }}
             # Embeddings endpoint (ADR-0011): the in-cluster pod has no local
             # Ollama, so the binary's loopback default can never work here —
             # point GLYPHOXA_OLLAMA_URL at a reachable server instead

--- a/deploy/charts/glyphoxa/templates/web-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/web-deployment.yaml
@@ -203,6 +203,14 @@ spec:
             # JSON logs for cluster log aggregation (ADR-0032).
             - name: GLYPHOXA_LOG_FORMAT
               value: json
+            {{- with (include "glyphoxa.privacyPolicyURL" .) }}
+            # The privacy-policy page the Bot links from the Voice Session
+            # transcription disclosure it posts in the voice channel (#519).
+            # Explicit privacyPolicyUrl, else derived from the Ingress host;
+            # omitted entirely when neither is available (no broken link).
+            - name: GLYPHOXA_PRIVACY_POLICY_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.ollamaUrl }}
             # Embeddings endpoint (ADR-0011): the in-cluster pod has no local
             # Ollama, so the binary's loopback default can never work here —

--- a/deploy/charts/glyphoxa/tests/backup_test.yaml
+++ b/deploy/charts/glyphoxa/tests/backup_test.yaml
@@ -55,6 +55,26 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
           pattern: pg_dump "\$GLYPHOXA_DATABASE_URL" -Fc
 
+  - it: writes to a .partial name and renames only on success
+    # A pg_dump killed mid-write (DB restart, ENOSPC) must never leave a
+    # truncated file matching the glyphoxa-*.dump glob the restore runbook and
+    # the rotation trust; stale partials are swept so retries cannot wedge the
+    # PVC toward disk-full.
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: rm -f /backup/\*\.dump\.partial
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: -Fc -f "\$\{dump\}\.partial"
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: mv "\$\{dump\}\.partial" "\$\{dump\}"
+
   - it: takes the DSN from the app Secret so it can never dump another database
     set:
       backup:

--- a/deploy/charts/glyphoxa/tests/backup_test.yaml
+++ b/deploy/charts/glyphoxa/tests/backup_test.yaml
@@ -1,0 +1,194 @@
+suite: Postgres backup CronJob
+# The beta's restore story (#520): a nightly pg_dump into its own PVC with
+# rotation, and an optional off-site push to an S3-compatible bucket. The
+# in-chart Postgres is one StatefulSet on one node's disk, so these are the only
+# thing standing between a bad day and a lost campaign.
+templates:
+  - templates/backup-cronjob.yaml
+values:
+  - ../ci/ci-values.yaml
+tests:
+  - it: renders nothing by default
+    # Opt-in: an install pointed at a managed external Postgres usually has
+    # provider backups already.
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a CronJob and its own PVC when enabled
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: runs nightly, never concurrently
+    # A dump that outruns its schedule must not pile a second one onto the same
+    # volume and database.
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: 15 4 * * *
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+
+  - it: dumps custom-format with the same Postgres image the chart runs
+    # pg_dump's version must match the server it dumps; pinning them together
+    # makes the classic "server version mismatch" failure unrepresentable.
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: pgvector/pgvector:pg17
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: pg_dump "\$GLYPHOXA_DATABASE_URL" -Fc
+
+  - it: takes the DSN from the app Secret so it can never dump another database
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-db
+                key: database-url
+
+  - it: rotates on the configured retention, after the dump succeeded
+    # `set -eu` above the find means a failed dump never reaches the delete —
+    # the last good backup survives a broken night.
+    set:
+      backup:
+        enabled: true
+        retentionDays: 30
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: find /backup -name 'glyphoxa-\*\.dump' -mtime \+30 -delete
+
+  - it: writes to its OWN volume, never the database's
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-glyphoxa-backup
+
+  - it: keeps the dump PVC on uninstall
+    set:
+      backup:
+        enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: does not push off-site unless asked
+    set:
+      backup:
+        enabled: true
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.initContainers
+
+  - it: fails the render when the off-site push has no bucket
+    set:
+      backup:
+        enabled: true
+        offsite:
+          enabled: true
+          existingSecret:
+            name: creds
+    asserts:
+      - failedTemplate:
+          errorPattern: backup.offsite.enabled needs backup.offsite.bucket
+
+  - it: fails the render when the off-site push has no credentials Secret
+    # The chart never templates object-store credentials into its own Secret.
+    set:
+      backup:
+        enabled: true
+        offsite:
+          enabled: true
+          bucket: glyphoxa-backups
+    asserts:
+      - failedTemplate:
+          errorPattern: backup.offsite.enabled needs backup.offsite.existingSecret.name
+
+  - it: pushes off-site only after a complete dump
+    # The dump moves to an initContainer so the upload cannot start against a
+    # half-written file — Kubernetes orders initContainers, not siblings.
+    set:
+      backup:
+        enabled: true
+        offsite:
+          enabled: true
+          bucket: glyphoxa-backups
+          prefix: nightly/
+          endpoint: https://s3.example.com
+          existingSecret:
+            name: glyphoxa-backup-offsite
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: pg-dump
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].name
+          value: offsite-push
+      - matchRegex:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          pattern: s3://glyphoxa-backups/nightly/.*--endpoint-url "https://s3.example.com"
+
+  - it: reads the bucket credentials from the operator's Secret
+    set:
+      backup:
+        enabled: true
+        offsite:
+          enabled: true
+          bucket: glyphoxa-backups
+          existingSecret:
+            name: glyphoxa-backup-offsite
+            accessKeyIdKey: id
+            secretAccessKeyKey: secret
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: glyphoxa-backup-offsite
+                key: id
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: glyphoxa-backup-offsite
+                key: secret

--- a/deploy/charts/glyphoxa/tests/cloudflared_test.yaml
+++ b/deploy/charts/glyphoxa/tests/cloudflared_test.yaml
@@ -1,0 +1,127 @@
+suite: cloudflared Tunnel
+# The beta's inbound path (#517): a cloudflared Deployment that dials OUT to
+# Cloudflare and forwards to the web Service from inside the cluster — no
+# hostPort, NodePort, LoadBalancer or Ingress required, which is the whole point
+# on a home VM with no static IP. The tunnel token is a credential and must come
+# from a Secret, never from argv.
+templates:
+  - templates/cloudflared-deployment.yaml
+values:
+  - ../ci/ci-values.yaml
+tests:
+  - it: renders nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails the render when enabled without a token
+    # Better a loud render failure than a pod crash-looping on an empty token.
+    set:
+      cloudflared:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: cloudflared.enabled needs a tunnel token
+
+  - it: renders the Deployment and its token Secret when given a token
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: passes the token via TUNNEL_TOKEN from the Secret, never on the command line
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-glyphoxa-cloudflared
+                key: tunnel-token
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: ci-dummy-tunnel-token
+
+  - it: runs the tunnel with autoupdate off and its metrics listener armed
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+
+  - it: gates readiness on established edge connections
+    # /ready reports the tunnel's edge connections, so a pod that cannot reach
+    # Cloudflare never reports Ready.
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
+
+  - it: exposes no host ports — the tunnel is outbound-only
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].ports[0].hostPort
+
+  - it: rolls the pod when a chart-rendered token changes
+    set:
+      cloudflared:
+        enabled: true
+        token: ci-dummy-tunnel-token
+    documentIndex: 0
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/token"]
+
+  - it: references an externally managed Secret and renders none of its own
+    set:
+      cloudflared:
+        enabled: true
+        existingSecret:
+          name: my-tunnel
+          key: token
+    asserts:
+      - hasDocuments:
+          count: 1 # the Deployment only — the operator owns the Secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-tunnel
+                key: token
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/token"]

--- a/deploy/charts/glyphoxa/tests/cloudflared_test.yaml
+++ b/deploy/charts/glyphoxa/tests/cloudflared_test.yaml
@@ -16,9 +16,12 @@ tests:
 
   - it: fails the render when enabled without a token
     # Better a loud render failure than a pod crash-looping on an empty token.
+    # (ci-values supplies a placeholder token for the render gate — blank it here
+    # so this is the no-token path.)
     set:
       cloudflared:
         enabled: true
+        token: ""
     asserts:
       - failedTemplate:
           errorPattern: cloudflared.enabled needs a tunnel token

--- a/deploy/charts/glyphoxa/tests/ollama_test.yaml
+++ b/deploy/charts/glyphoxa/tests/ollama_test.yaml
@@ -1,0 +1,130 @@
+suite: in-cluster Ollama
+# The optional embeddings server (#517): OFF by default (the chart's historical
+# "bring your own endpoint" posture), and when enabled a Deployment + ClusterIP
+# Service + model-cache PVC that `ollamaUrl` defaults to. v1.0 embeds through
+# Ollama only (ADR-0011), so this is what makes a self-contained install (the
+# beta's home-VM k3s) able to do semantic memory at all.
+templates:
+  - templates/ollama-deployment.yaml
+  - templates/ollama-service.yaml
+values:
+  - ../ci/ci-values.yaml
+tests:
+  - it: renders nothing by default
+    # Off unless asked for: an install that already points ollamaUrl at an
+    # external server must not also grow a second, idle Ollama.
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a Deployment plus its model-cache PVC when enabled
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: names the workload and Service identically so the derived URL resolves
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-glyphoxa-ollama
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 11434
+
+  - it: binds Ollama to all interfaces so the Service can reach it
+    # The image's default is loopback; a Service in front of that never answers.
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-deployment.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OLLAMA_HOST
+            value: 0.0.0.0:11434
+
+  - it: pulls the default embedding model on first start
+    # nomic-embed-text is the model v1.0 embeds with (ADR-0011). The pull runs
+    # postStart (it needs the server up, which an initContainer cannot assume).
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-deployment.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          pattern: ollama pull "nomic-embed-text"
+
+  - it: skips the pull hook entirely when no model is configured
+    # An image that bakes the model in (or an operator pulling by hand) gets a
+    # plain container with no lifecycle hook.
+    set:
+      ollama:
+        enabled: true
+        model: ""
+    template: templates/ollama-deployment.yaml
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
+  - it: uses Recreate so the ReadWriteOnce model cache is never contended
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-deployment.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: keeps the model cache PVC on uninstall
+    # Re-downloading gigabytes because someone ran `helm uninstall` is not a
+    # cost this chart imposes.
+    set:
+      ollama:
+        enabled: true
+    template: templates/ollama-deployment.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: spec.resources.requests.storage
+          value: 20Gi
+
+  - it: falls back to an emptyDir when persistence is disabled
+    set:
+      ollama:
+        enabled: true
+        persistence:
+          enabled: false
+    template: templates/ollama-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1 # no PVC
+      - exists:
+          path: spec.template.spec.volumes[0].emptyDir

--- a/deploy/charts/glyphoxa/tests/plans_test.yaml
+++ b/deploy/charts/glyphoxa/tests/plans_test.yaml
@@ -12,6 +12,34 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: ships the public-beta launch catalog as the default (#521)
+    # The two launch plans: a platform-keyed trial with a small monthly
+    # allowance, and a free BYOK tier for sustained use. Enabling plans without
+    # authoring a catalog must produce exactly these — the landing page's
+    # promise and the signup plan slug both point at them.
+    set:
+      plans:
+        enabled: true
+    template: templates/plans-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"slug": "beta-trial"'
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"key_source": "platform"'
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"included_usage_usd": 5'
+      - matchRegex:
+          path: data["plans.json"]
+          pattern: '"slug": "byok-free"'
+      # Both tiers are free of charge FROM US during the beta; a non-zero price
+      # here would be a promise the signup flow cannot keep (no payments exist).
+      - notMatchRegex:
+          path: data["plans.json"]
+          pattern: '"monthly_price_usd": [1-9]'
+
   - it: renders the Job and ConfigMap when enabled
     set:
       plans:

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -254,6 +254,34 @@ tests:
             name: GLYPHOXA_OLLAMA_URL
             value: http://host.k3d.internal:11434
 
+  - it: derives GLYPHOXA_OLLAMA_URL from the in-cluster Service when ollama.enabled (#517)
+    # The #517 acceptance criterion: ollamaUrl left empty + the chart's own
+    # Ollama enabled → the pods dial the Service the same helper names, so the
+    # two can never drift.
+    set:
+      ollama:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_OLLAMA_URL
+            value: http://RELEASE-NAME-glyphoxa-ollama:11434
+
+  - it: lets an explicit ollamaUrl win over the enabled in-cluster Ollama
+    # Precedence half of the #517 derivation: an operator pointing at an
+    # external server keeps that endpoint even with the in-cluster one running.
+    set:
+      ollama:
+        enabled: true
+      ollamaUrl: http://host.k3d.internal:11434
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_OLLAMA_URL
+            value: http://host.k3d.internal:11434
+
 
   - it: omits GLYPHOXA_PRIVACY_POLICY_URL when neither privacyPolicyUrl nor an Ingress host exists
     # #519: with nothing trustworthy to advertise the env var is absent and the

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -254,6 +254,46 @@ tests:
             name: GLYPHOXA_OLLAMA_URL
             value: http://host.k3d.internal:11434
 
+
+  - it: omits GLYPHOXA_PRIVACY_POLICY_URL when neither privacyPolicyUrl nor an Ingress host exists
+    # #519: with nothing trustworthy to advertise the env var is absent and the
+    # Bot posts its transcription disclosure WITHOUT a link — never a broken one.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+          any: true
+
+  - it: derives GLYPHOXA_PRIVACY_POLICY_URL from the Ingress host and scheme
+    # Same host + scheme the console is served on, plus the SPA's /privacy route
+    # (#518), so the link the players get can never drift from the deployment.
+    set:
+      ingress:
+        enabled: true
+        host: glyphoxa.example.com
+        certManager:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+            value: https://glyphoxa.example.com/privacy
+
+  - it: lets an explicit privacyPolicyUrl win over the Ingress-derived one
+    # The policy may live on a company site; an operator override is authoritative.
+    set:
+      privacyPolicyUrl: https://legal.example.org/glyphoxa-privacy
+      ingress:
+        enabled: true
+        host: glyphoxa.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+            value: https://legal.example.org/glyphoxa-privacy
   - it: carries GLYPHOXA_SECRET to decrypt BYOK tenant tokens
     # ADR-0057 (d): a worker in the shared pool holds BYOK Tenants' Discord clients
     # and must decrypt their bot tokens itself, so the voice role now reads the

--- a/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
@@ -289,6 +289,34 @@ tests:
             name: GLYPHOXA_OLLAMA_URL
             value: http://host.k3d.internal:11434
 
+  - it: derives GLYPHOXA_OLLAMA_URL from the in-cluster Service when ollama.enabled (#517)
+    # The #517 acceptance criterion: ollamaUrl left empty + the chart's own
+    # Ollama enabled → the pods dial the Service the same helper names, so the
+    # two can never drift.
+    set:
+      ollama:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_OLLAMA_URL
+            value: http://RELEASE-NAME-glyphoxa-ollama:11434
+
+  - it: lets an explicit ollamaUrl win over the enabled in-cluster Ollama
+    # Precedence half of the #517 derivation: an operator pointing at an
+    # external server keeps that endpoint even with the in-cluster one running.
+    set:
+      ollama:
+        enabled: true
+      ollamaUrl: http://host.k3d.internal:11434
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_OLLAMA_URL
+            value: http://host.k3d.internal:11434
+
 
   - it: omits GLYPHOXA_PRIVACY_POLICY_URL when neither privacyPolicyUrl nor an Ingress host exists
     # #519: with nothing trustworthy to advertise the env var is absent and the

--- a/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
@@ -289,6 +289,46 @@ tests:
             name: GLYPHOXA_OLLAMA_URL
             value: http://host.k3d.internal:11434
 
+
+  - it: omits GLYPHOXA_PRIVACY_POLICY_URL when neither privacyPolicyUrl nor an Ingress host exists
+    # #519: with nothing trustworthy to advertise the env var is absent and the
+    # Bot posts its transcription disclosure WITHOUT a link — never a broken one.
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+          any: true
+
+  - it: derives GLYPHOXA_PRIVACY_POLICY_URL from the Ingress host and scheme
+    # Same host + scheme the console is served on, plus the SPA's /privacy route
+    # (#518), so the link the players get can never drift from the deployment.
+    set:
+      ingress:
+        enabled: true
+        host: glyphoxa.example.com
+        certManager:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+            value: https://glyphoxa.example.com/privacy
+
+  - it: lets an explicit privacyPolicyUrl win over the Ingress-derived one
+    # The policy may live on a company site; an operator override is authoritative.
+    set:
+      privacyPolicyUrl: https://legal.example.org/glyphoxa-privacy
+      ingress:
+        enabled: true
+        host: glyphoxa.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLYPHOXA_PRIVACY_POLICY_URL
+            value: https://legal.example.org/glyphoxa-privacy
   - it: omits GLYPHOXA_MAX_VOICE_SESSIONS at the default cap of 1
     # Release gate (#488): the default 1 emits no env, so a stock deploy keeps the
     # binary's single-session default byte-identical — nothing about it changes.

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -284,7 +284,7 @@ plans:
         description: >-
           Try Glyphoxa on the platform's provider keys, up to a small monthly
           usage allowance. No card, no charge — when the allowance is spent,
-          switch to your own keys.
+          ask the operator to move you to the free bring-your-own-keys plan.
         monthly_price_usd: 0
         key_source: platform
         # The monthly estimated-USD provider-usage allowance (ADR-0046 price

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -50,6 +50,16 @@ groqApiKey: ""
 # k3d example (Ollama on the host): http://host.k3d.internal:11434
 ollamaUrl: ""
 
+# The deployment's published privacy-policy page (#519). The Bot links it from
+# the transcription disclosure it posts in the voice channel at Voice Session
+# start — the players at the table are data subjects who may never open the web
+# app, so that message is the only surface that reaches them. Left empty it is
+# DERIVED from ingress.host (+ the SPA's /privacy route) when the Ingress is
+# enabled, and otherwise omitted entirely: the disclosure then posts without a
+# link rather than with a broken one. An explicit value always wins — set it
+# when the policy lives on another host (a company site, a static page).
+privacyPolicyUrl: ""
+
 # DB connection. By default the chart stands up its own in-cluster Postgres and
 # assembles the connection URL against that Service. Set `database.url` to point
 # the migrate Job (and later the serving workloads) at an external Postgres

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -81,6 +81,56 @@ ollama:
     # storageClassName: ""  # use the cluster default when unset
   resources: {}
 
+# Nightly Postgres backups (#520). The in-chart Postgres is a single StatefulSet
+# on one node's disk, so a deployment that serves real tables needs a restore
+# story: a CronJob runs `pg_dump -Fc` into its OWN PVC (never the database's
+# volume), rotates dumps older than retentionDays, and can optionally push each
+# dump to an S3-compatible bucket. Off by default — an install pointed at a
+# managed external Postgres usually has provider backups already — but ON is the
+# right posture for the in-cluster database. Restore runbook:
+# docs/deploy/backup-restore.md.
+backup:
+  enabled: false
+  # Nightly, off-peak. Standard cron syntax, in the cluster's timezone.
+  schedule: "15 4 * * *"
+  # Dumps older than this many days are deleted after each successful run.
+  # Rotation happens only AFTER the new dump succeeds, so a failing backup never
+  # eats the last good one.
+  retentionDays: 14
+  # The local dump volume. `helm.sh/resource-policy: keep` protects it from
+  # `helm uninstall`. Size it for retentionDays × dump size.
+  persistence:
+    size: 10Gi
+    # storageClassName: ""  # use the cluster default when unset
+  # How many finished Jobs the CronJob keeps around for inspection.
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  resources: {}
+
+  # Optional off-site copy. A dump on the same VM survives a bad migration but
+  # not a dead disk — point this at any S3-compatible bucket (Backblaze B2,
+  # Wasabi, MinIO, S3 itself). The chart does NOT template object-store
+  # credentials into its own Secret: create one and name it here.
+  #
+  #   kubectl create secret generic glyphoxa-backup-offsite \
+  #     --from-literal=access-key-id=... --from-literal=secret-access-key=...
+  offsite:
+    enabled: false
+    # S3-compatible endpoint. Leave empty for AWS S3 itself.
+    endpoint: ""
+    bucket: ""
+    # Optional key prefix, e.g. "glyphoxa/" (include the trailing slash).
+    prefix: ""
+    region: us-east-1
+    existingSecret:
+      name: ""
+      accessKeyIdKey: "" # defaults to "access-key-id"
+      secretAccessKeyKey: "" # defaults to "secret-access-key"
+    image:
+      repository: amazon/aws-cli
+      tag: latest
+      pullPolicy: IfNotPresent
+
 # cloudflared Tunnel (#517) — outbound-only public exposure for a deployment
 # with no static IP and no inbound ports (the beta's home VM). When enabled,
 # cloudflared dials out to Cloudflare and forwards to the web Service from

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -265,8 +265,39 @@ plans:
   #         included_usage_usd: 15
   #         limits:
   #           max_campaigns: 10
+  #
+  # The two plans below are the PUBLIC-BETA LAUNCH DEFAULTS (#521): a
+  # platform-keyed trial that spends the deployment's own provider keys up to a
+  # small monthly allowance, and a free BYOK tier for sustained use once the
+  # trial runs out. They only reach the database when plans.enabled is true —
+  # a self-host install that never syncs a catalog is unaffected. Adjust the
+  # allowance to what you are willing to fund; the landing-page copy speaks of
+  # "a small monthly allowance" rather than a number, so changing it here does
+  # not make the marketing copy a lie.
+  #
+  # Point web.signupPlanSlug at whichever of these an open-mode signup should
+  # land on (ADR-0055) — `beta-trial` for the launch posture.
   catalog:
-    plans: []
+    plans:
+      - slug: beta-trial
+        display_name: Beta Trial
+        description: >-
+          Try Glyphoxa on the platform's provider keys, up to a small monthly
+          usage allowance. No card, no charge — when the allowance is spent,
+          switch to your own keys.
+        monthly_price_usd: 0
+        key_source: platform
+        # The monthly estimated-USD provider-usage allowance (ADR-0046 price
+        # map). Operator-adjustable: this is money you spend on behalf of trial
+        # Tenants, so size it to your budget.
+        included_usage_usd: 5
+      - slug: byok-free
+        display_name: BYOK Free
+        description: >-
+          Bring your own provider keys (ElevenLabs, Groq, Gemini …). Unlimited
+          by us, billed to you by the providers you configure.
+        monthly_price_usd: 0
+        key_source: byok
 
 # Voice-mode Deployment (#36): the single image run as `glyphoxa -mode voice`,
 # joining one Discord guild+channel and giving the seeded NPC a live voice loop.

--- a/deploy/charts/glyphoxa/values.yaml
+++ b/deploy/charts/glyphoxa/values.yaml
@@ -48,7 +48,72 @@ groqApiKey: ""
 # on the web and voice pods (one shared value, so split-mode deployments keep
 # a single endpoint of record).
 # k3d example (Ollama on the host): http://host.k3d.internal:11434
+# Leave it empty with `ollama.enabled` (below) to have the chart deploy an
+# in-cluster Ollama and point the pods at ITS Service instead.
 ollamaUrl: ""
+
+# In-cluster Ollama for the embeddings Component (#517). Off by default — the
+# chart's historical posture is "bring your own endpoint" (`ollamaUrl`) — but a
+# self-contained install (the public beta's home-VM k3s) can have the chart run
+# one: a Deployment + ClusterIP Service, with `ollamaUrl` DERIVED from that
+# Service when left empty above. An explicit `ollamaUrl` always wins, so
+# enabling both points the app at the external server (the in-cluster one then
+# just sits there — disable it).
+ollama:
+  enabled: false
+  image:
+    repository: ollama/ollama
+    # Pin this for a reproducible install: `latest` is a moving target and the
+    # model cache below outlives the pod, so an unexpected engine bump is the
+    # one upgrade that can surprise a running deployment.
+    tag: latest
+    pullPolicy: IfNotPresent
+  port: 11434
+  # The embedding model pulled on first start (ADR-0011: v1.0 embeds through
+  # nomic-embed-text). Empty skips the pull entirely — for an image that already
+  # bakes the model in, or an operator who pulls by hand.
+  model: nomic-embed-text
+  # The model cache. A PVC by default so a restart does not re-download the
+  # model; set enabled=false for an ephemeral emptyDir (every restart re-pulls).
+  persistence:
+    enabled: true
+    size: 20Gi
+    # storageClassName: ""  # use the cluster default when unset
+  resources: {}
+
+# cloudflared Tunnel (#517) — outbound-only public exposure for a deployment
+# with no static IP and no inbound ports (the beta's home VM). When enabled,
+# cloudflared dials out to Cloudflare and forwards to the web Service from
+# inside the cluster, so NO Ingress, NodePort or LoadBalancer is needed. The
+# tunnel's public hostname → service mapping is configured in the Cloudflare
+# Zero Trust dashboard (a token-managed remote tunnel); point it at the web
+# Service DNS name the install notes print.
+cloudflared:
+  enabled: false
+  # The tunnel token from the Cloudflare Zero Trust dashboard (Networks →
+  # Tunnels). The chart renders it into its OWN Secret (separate from the app
+  # Secret, so rotating a tunnel token does not roll the DB credentials) and the
+  # pod reads it via TUNNEL_TOKEN — never argv. Enabling the tunnel with neither
+  # this nor existingSecret.name fails the render.
+  token: ""
+  # Reference a Secret you manage instead of letting the chart render one. When
+  # `name` is set it wins outright and `token` is ignored.
+  existingSecret:
+    name: ""
+    key: "" # defaults to "tunnel-token"
+  image:
+    repository: cloudflare/cloudflared
+    # Pin this for a reproducible install (cloudflared releases roughly monthly).
+    tag: latest
+    pullPolicy: IfNotPresent
+  # Two replicas give the tunnel redundant edge connections; one is fine for a
+  # single-node home cluster (the default — nothing else here is HA).
+  replicas: 1
+  # cloudflared's own metrics/health listener. /ready reports the number of
+  # established edge connections and backs both probes; it is never exposed by a
+  # Service.
+  metricsPort: 2000
+  resources: {}
 
 # The deployment's published privacy-policy page (#519). The Bot links it from
 # the transcription disclosure it posts in the voice channel at Voice Session

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ Running Glyphoxa **for others**, beyond the single-machine self-host:
   cluster in a Proxmox VM, exposed via DynDNS with Let's Encrypt TLS.
 - **[deploy/cloud-providers.md](deploy/cloud-providers.md)** — moving that
   deployment to a paid cloud: provider suggestions and cost estimates.
+- **[deploy/legal-pages.md](deploy/legal-pages.md)** — the Impressum /
+  Datenschutzerklärung / AUP pages the SPA serves, and the operator identity you
+  must fill in before going live.
 - **[deploy/backup-restore.md](deploy/backup-restore.md)** — the chart's
   Postgres backup CronJob (local + off-site) and the restore runbook.
 - **[deploy/saas-operations.md](deploy/saas-operations.md)** — subscription

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ Running Glyphoxa **for others**, beyond the single-machine self-host:
   cluster in a Proxmox VM, exposed via DynDNS with Let's Encrypt TLS.
 - **[deploy/cloud-providers.md](deploy/cloud-providers.md)** — moving that
   deployment to a paid cloud: provider suggestions and cost estimates.
+- **[deploy/backup-restore.md](deploy/backup-restore.md)** — the chart's
+  Postgres backup CronJob (local + off-site) and the restore runbook.
 - **[deploy/saas-operations.md](deploy/saas-operations.md)** — subscription
   Plans, platform keys, and the cost/revenue report
   (`glyphoxa billing`).

--- a/docs/adr/0055-self-signup-admission-modes.md
+++ b/docs/adr/0055-self-signup-admission-modes.md
@@ -84,6 +84,14 @@ undecided and gets its own ADR; the design note scopes both shapes.
   > with `monthly_price_usd > 0` until the payment epic lands). The entitlement
   > seams below are unchanged — the allowance gate is exactly what bounds the
   > trial.
+
+  > **Amendment (2026-07, #518 AUP gate):** an open-mode signup additionally
+  > requires the AUP/ToS acknowledgment, enforced server-side: the OAuth start
+  > refuses an open-mode `GET /auth/discord/login` without `aup=1`, the
+  > acknowledgment rides the state cookie, the callback's signup path refuses
+  > an unacknowledged round trip before any write, and the provisioning
+  > transaction records `users.aup_accepted_at` (refreshed on returning
+  > open-mode logins). Allowlisted logins are not gated, in either mode.
 - **The ADR-0054 entitlement seams go live in `open` mode.** (a) Provider-key
   resolution fails **closed** for a Tenant without an active
   `key_source='platform'` Subscription — including the no-config-row path:

--- a/docs/adr/0055-self-signup-admission-modes.md
+++ b/docs/adr/0055-self-signup-admission-modes.md
@@ -74,6 +74,16 @@ undecided and gets its own ADR; the design note scopes both shapes.
   ADR-0054's operator-CLI-only binding surface by exactly one automated caller —
   the snapshot semantics of `tenant_subscription` are unchanged, and platform-key
   Plans remain operator-CLI-assigned until a payment processor lands.
+
+  > **Amendment (2026-07, #521 public-beta launch):** the launch posture binds
+  > open-mode signups to `beta-trial` — a **platform-keyed** $0 plan with a
+  > bounded `included_usage_usd` allowance — via `web.signupPlanSlug`, per the
+  > SaaS-first directive. The "free BYOK tier as the default plan" expectation
+  > above is superseded for the free beta; the operator-CLI-only reservation now
+  > applies to **priced** platform plans (nothing self-service assigns a plan
+  > with `monthly_price_usd > 0` until the payment epic lands). The entitlement
+  > seams below are unchanged — the allowance gate is exactly what bounds the
+  > trial.
 - **The ADR-0054 entitlement seams go live in `open` mode.** (a) Provider-key
   resolution fails **closed** for a Tenant without an active
   `key_source='platform'` Subscription — including the no-config-row path:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,6 +336,7 @@ server (the Helm chart's `ollamaUrl` value renders it), or semantic memory
 | `GLYPHOXA_LOG_FORMAT` | optional | `json`, or `text` (the default for any other value). |
 | `GLYPHOXA_GATEWAY_IDENTIFY_WARN_THRESHOLD` | optional | Per-application 24h Discord gateway IDENTIFY count above which a structured warning fires (token-reset early-warning, #486). Positive integer; blank/non-numeric/≤0 ⇒ default `500` (below Discord's 1000/token/24h limit). See [deploy/saas-operations.md §7](deploy/saas-operations.md). |
 | `GLYPHOXA_OLLAMA_URL` | optional | Ollama embeddings endpoint override; default `http://127.0.0.1:11434`. v1.0 embeddings are **Ollama-only** (ADR-0011), so set it wherever the process has no local Ollama — containers and k8s pods (k3d: `http://host.k3d.internal:11434`). The server must serve `nomic-embed-text`. Unreachable ⇒ semantic memory (L2) stalls loudly; nothing else breaks. |
+| `GLYPHOXA_PRIVACY_POLICY_URL` | optional | The deployment's published privacy-policy page. The Bot links it from the transcription disclosure it posts in the voice channel at Voice Session start (#519) — the players at the table are data subjects who may never open the web app. Blank ⇒ the disclosure still posts, without a link. The Helm chart derives it from `ingress.host` + `/privacy` when `privacyPolicyUrl` is unset. |
 | `GROQ_API_KEY` | if Groq used | LLM provider key. |
 | `ELEVENLABS_API_KEY` | if ElevenLabs used | STT/TTS provider key. |
 | `GEMINI_API_KEY` | if Gemini used | LLM / S2S provider key. |

--- a/docs/deploy/backup-restore.md
+++ b/docs/deploy/backup-restore.md
@@ -28,7 +28,10 @@ Each run:
    `pg_restore` takes) of the database named by the app Secret's
    `database-url`, into `/backup/glyphoxa-<UTC timestamp>.dump` on a PVC of its
    own — never the database's volume, because a dump on the disk it protects is
-   not a backup;
+   not a backup. The file is written under a `.partial` name and renamed only
+   on success, so anything matching `glyphoxa-*.dump` is a **complete** dump —
+   a job killed mid-write leaves no truncated file for a disaster-night restore
+   to trip over;
 2. records the filename in `/backup/.latest`;
 3. deletes dumps older than `retentionDays` — **after** a successful dump, so a
    failing night never eats the last good one.
@@ -134,6 +137,14 @@ kubectl -n glyphoxa exec -it glyphoxa-restore -- sh -c '
 #    app back. A serving pod refuses to start on a stale schema (EnsureCurrent,
 #    ADR-0031) rather than serving against it — run `migrate up` if the restored
 #    dump predates a migration.
+#
+#    CAVEAT: an in-place `--clean` restore is only safe when the dump matches
+#    the CURRENT migration level. `--clean` drops only objects present in the
+#    dump, so tables created by migrations applied AFTER the dump was taken
+#    survive — and the re-run of those migrations then fails on "relation
+#    already exists". For a dump that predates the running schema, recreate the
+#    database instead (DROP DATABASE / CREATE DATABASE, or `pg_restore --create
+#    --clean` against the maintenance DB), then restore and `migrate up`.
 kubectl -n glyphoxa delete pod glyphoxa-restore
 kubectl -n glyphoxa scale deployment/glyphoxa-web  --replicas=1
 kubectl -n glyphoxa scale deployment/glyphoxa-voice --replicas=1
@@ -155,6 +166,8 @@ throwaway database on the same server, poke at it, and only then decide.
 kubectl -n glyphoxa exec -it glyphoxa-restore -- sh -c '
   psql "$GLYPHOXA_DATABASE_URL" -c "CREATE DATABASE glyphoxa_scratch;" &&
   scratch="$(echo "$GLYPHOXA_DATABASE_URL" | sed "s#/glyphoxa?#/glyphoxa_scratch?#")" &&
+  [ "$scratch" != "$GLYPHOXA_DATABASE_URL" ] ||
+    { echo "DSN rewrite failed - adjust the sed for your database name"; exit 1; } &&
   pg_restore -d "$scratch" --no-owner /backup/glyphoxa-20260722T041500Z.dump &&
   psql "$scratch" -c "SELECT count(*) FROM transcript_line;" \
                   -c "SELECT count(*) FROM campaign;"'

--- a/docs/deploy/backup-restore.md
+++ b/docs/deploy/backup-restore.md
@@ -1,0 +1,195 @@
+# Postgres backup and restore
+
+The chart's in-cluster Postgres is a **single StatefulSet on one node's disk**
+(ADR-0034 — the CNPG operator is out of scope). Everything Glyphoxa persists
+lives there: Tenants, Campaigns, Agents, Transcript Lines and Chunks with their
+embeddings, the usage ledger, encrypted BYOK credentials. There is no second
+copy unless you make one.
+
+This page covers the chart's backup CronJob (#520) and — the part that actually
+matters — how to restore from what it writes.
+
+## What the CronJob does
+
+Enable it in your values:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "15 4 * * *"   # nightly, cluster timezone
+  retentionDays: 14
+  persistence:
+    size: 10Gi             # retentionDays × dump size, with headroom
+```
+
+Each run:
+
+1. `pg_dump -Fc` (PostgreSQL **custom format** — compressed, and the input
+   `pg_restore` takes) of the database named by the app Secret's
+   `database-url`, into `/backup/glyphoxa-<UTC timestamp>.dump` on a PVC of its
+   own — never the database's volume, because a dump on the disk it protects is
+   not a backup;
+2. records the filename in `/backup/.latest`;
+3. deletes dumps older than `retentionDays` — **after** a successful dump, so a
+   failing night never eats the last good one.
+
+The PVC carries `helm.sh/resource-policy: keep`: `helm uninstall` leaves your
+dumps alone.
+
+### Off-site copies
+
+A dump on the same VM survives a bad migration or a `DROP TABLE`, but not a dead
+disk. Point the optional push at any S3-compatible bucket (Backblaze B2, Wasabi,
+MinIO, S3):
+
+```sh
+kubectl -n glyphoxa create secret generic glyphoxa-backup-offsite \
+  --from-literal=access-key-id=... \
+  --from-literal=secret-access-key=...
+```
+
+```yaml
+backup:
+  enabled: true
+  offsite:
+    enabled: true
+    bucket: glyphoxa-backups
+    prefix: nightly/            # optional, include the trailing slash
+    endpoint: https://s3.eu-central-003.backblazeb2.com   # omit for AWS S3
+    region: us-east-1
+    existingSecret:
+      name: glyphoxa-backup-offsite
+```
+
+The dump then runs as an **initContainer** and the upload as the pod's
+container, so a push can never start against a half-written file. The chart
+deliberately does not template object-store credentials into its own Secret —
+you create and rotate that one.
+
+## Verify a backup exists (do this once, not after the fire)
+
+```sh
+# The CronJob has run at least once:
+kubectl -n glyphoxa get jobs -l app.kubernetes.io/component=backup
+
+# What is on the volume (any pod that mounts it will do):
+kubectl -n glyphoxa run backup-ls --rm -it --restart=Never \
+  --image=pgvector/pgvector:pg17 \
+  --overrides='{"spec":{"containers":[{"name":"backup-ls","image":"pgvector/pgvector:pg17","command":["ls","-lh","/backup"],"stdin":true,"tty":true,"volumeMounts":[{"name":"backup","mountPath":"/backup"}]}],"volumes":[{"name":"backup","persistentVolumeClaim":{"claimName":"glyphoxa-backup"}}]}}'
+```
+
+Trigger an ad-hoc run without waiting for the schedule:
+
+```sh
+kubectl -n glyphoxa create job --from=cronjob/glyphoxa-backup backup-manual-1
+kubectl -n glyphoxa logs job/backup-manual-1
+```
+
+## Restore
+
+`pg_restore` is not a merge: restoring into a database that already has the
+schema needs `--clean --if-exists`, and **anything written after the dump is
+gone**. Stop the app first so nothing writes into a half-restored schema.
+
+```sh
+# 1. Stop the writers (both, if you run split mode).
+kubectl -n glyphoxa scale deployment/glyphoxa-web  --replicas=0
+kubectl -n glyphoxa scale deployment/glyphoxa-voice --replicas=0
+
+# 2. Restore, from a pod that mounts the backup volume and can reach Postgres.
+kubectl -n glyphoxa apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: glyphoxa-restore
+spec:
+  restartPolicy: Never
+  containers:
+    - name: restore
+      image: pgvector/pgvector:pg17
+      command: ["sleep", "3600"]
+      env:
+        - name: GLYPHOXA_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: glyphoxa-db
+              key: database-url
+      volumeMounts:
+        - name: backup
+          mountPath: /backup
+  volumes:
+    - name: backup
+      persistentVolumeClaim:
+        claimName: glyphoxa-backup
+EOF
+
+kubectl -n glyphoxa exec -it glyphoxa-restore -- sh -c '
+  ls -1 /backup/glyphoxa-*.dump | tail -5'          # pick one
+
+kubectl -n glyphoxa exec -it glyphoxa-restore -- sh -c '
+  pg_restore -d "$GLYPHOXA_DATABASE_URL" --clean --if-exists --no-owner \
+    /backup/glyphoxa-20260722T041500Z.dump'
+
+# 3. Confirm the schema matches the image you are about to run, then bring the
+#    app back. A serving pod refuses to start on a stale schema (EnsureCurrent,
+#    ADR-0031) rather than serving against it — run `migrate up` if the restored
+#    dump predates a migration.
+kubectl -n glyphoxa delete pod glyphoxa-restore
+kubectl -n glyphoxa scale deployment/glyphoxa-web  --replicas=1
+kubectl -n glyphoxa scale deployment/glyphoxa-voice --replicas=1
+```
+
+Restoring an **off-site** dump is the same, one `aws s3 cp` earlier:
+
+```sh
+aws s3 cp s3://glyphoxa-backups/nightly/glyphoxa-20260722T041500Z.dump . \
+  --endpoint-url https://s3.eu-central-003.backblazeb2.com
+```
+
+### Restoring into a scratch database first
+
+Recommended, and the way to rehearse this before you need it: restore into a
+throwaway database on the same server, poke at it, and only then decide.
+
+```sh
+kubectl -n glyphoxa exec -it glyphoxa-restore -- sh -c '
+  psql "$GLYPHOXA_DATABASE_URL" -c "CREATE DATABASE glyphoxa_scratch;" &&
+  scratch="$(echo "$GLYPHOXA_DATABASE_URL" | sed "s#/glyphoxa?#/glyphoxa_scratch?#")" &&
+  pg_restore -d "$scratch" --no-owner /backup/glyphoxa-20260722T041500Z.dump &&
+  psql "$scratch" -c "SELECT count(*) FROM transcript_line;" \
+                  -c "SELECT count(*) FROM campaign;"'
+```
+
+A restore that reports plausible row counts here is a restore you can trust; one
+that errors on `pgvector` types means the scratch database is missing the
+extension the dump expects (the `pgvector/pgvector` image ships it — use that
+image, not stock `postgres`).
+
+Drop the scratch database when you are done:
+
+```sh
+kubectl -n glyphoxa exec -it glyphoxa-restore -- \
+  psql "$GLYPHOXA_DATABASE_URL" -c "DROP DATABASE glyphoxa_scratch;"
+```
+
+## What this does not cover
+
+- **Blob storage.** Highlight clips and other blobs live in Postgres today
+  (ADR-0048, blob seam v1), so they are inside the dump. That stops being true
+  the day the seam moves to object storage — revisit this page then.
+- **Point-in-time recovery.** Logical dumps give you nightly granularity, not
+  "five minutes ago". WAL archiving is a bigger change (and a reason to move to
+  a managed Postgres or CNPG) than this chart takes on.
+- **The node itself.** For the home-VM deployment, keep taking VM-level
+  snapshots too — see [k3s-proxmox.md](k3s-proxmox.md) §8. Crash-consistent
+  snapshots catch everything the logical dump does not (certificates, tunnel
+  credentials, the cluster).
+
+## See also
+
+- [k3s-proxmox.md](k3s-proxmox.md) — the home-lab deployment this chart backup
+  replaces the hand-rolled CronJob in.
+- [ADR-0031](../adr/0031-postgres-migration-tooling.md) — migrations and the
+  serving process's refusal to run against a stale schema.
+- [ADR-0034](../adr/0034-deployment-artifacts.md) — deployment artifacts and the
+  single-StatefulSet Postgres posture.

--- a/docs/deploy/k3s-proxmox.md
+++ b/docs/deploy/k3s-proxmox.md
@@ -136,9 +136,9 @@ inside the cluster (Cloudflare terminates TLS at its edge).
    ```
 
 3. Back in the dashboard, add a **Public Hostname** on the tunnel pointing at
-   `http://glyphoxa-web.glyphoxa.svc.cluster.local:8080` (the Service name the
-   install notes print), and register the same redirect URL on the Discord
-   application.
+   `http://glyphoxa-web.glyphoxa.svc.cluster.local:80` (the web Service URL the
+   install notes print — the Service listens on 80 and maps to the container's
+   8080), and register the same redirect URL on the Discord application.
 
 The voice tier is unaffected either way — Discord voice is outbound-only.
 

--- a/docs/deploy/k3s-proxmox.md
+++ b/docs/deploy/k3s-proxmox.md
@@ -107,6 +107,41 @@ router's port forward terminates at the VM with nothing else to install.
 > through a cheap VPS/Cloudflare Tunnel. This is the single most common
 > home-lab blocker — check it before anything else.
 
+### 3b. Alternative: Cloudflare Tunnel (no port forwarding, no static IP)
+
+If inbound ports are not an option — CG-NAT, DS-Lite, a landlord's router, or
+simply not wanting to open 80/443 — skip DynDNS, port forwarding **and**
+cert-manager entirely and let the chart run a `cloudflared` tunnel instead: it
+dials **out** to Cloudflare and forwards requests to the web Service from
+inside the cluster (Cloudflare terminates TLS at its edge).
+
+1. In the Cloudflare Zero Trust dashboard: **Networks → Tunnels → Create a
+   tunnel** (Cloudflared), copy the tunnel **token**.
+2. Values:
+
+   ```yaml
+   ingress:
+     enabled: false           # nothing inbound to route
+
+   cloudflared:
+     enabled: true
+     token: "<tunnel token>"  # or existingSecret.name/key for a Secret you manage
+
+   web:
+     oauth:
+       # NOT derived without an Ingress — set the public origin explicitly
+       redirectUrl: "https://glyphoxa.example.com/auth/discord/callback"
+
+   privacyPolicyUrl: "https://glyphoxa.example.com/privacy"
+   ```
+
+3. Back in the dashboard, add a **Public Hostname** on the tunnel pointing at
+   `http://glyphoxa-web.glyphoxa.svc.cluster.local:8080` (the Service name the
+   install notes print), and register the same redirect URL on the Discord
+   application.
+
+The voice tier is unaffected either way — Discord voice is outbound-only.
+
 ## 4. cert-manager + Let's Encrypt
 
 The chart has an opt-in cert-manager path (`ingress.certManager.*`); install
@@ -173,6 +208,12 @@ groqApiKey: ""
 # nomic-embed-text — otherwise L2 stalls with a WARN loop (everything else
 # keeps working). See docs/configuration.md, "Environment variable reference".
 ollamaUrl: "http://<ollama-host>:11434"
+# ...or drop ollamaUrl and let the chart run one in-cluster instead:
+#   ollama:
+#     enabled: true          # Deployment + Service; ollamaUrl derives from it
+#     persistence:
+#       size: 20Gi           # the model cache — nomic-embed-text is pulled on
+#                            # first start, so the PVC saves a re-download
 
 database:
   password: "<generate a real one; URL-safe characters>"

--- a/docs/deploy/k3s-proxmox.md
+++ b/docs/deploy/k3s-proxmox.md
@@ -304,65 +304,47 @@ The in-chart Postgres is a plain StatefulSet on a local-path PV — **one disk,
 one VM**. Two layers, use both:
 
 1. **Proxmox level:** schedule VM backups (vzdump) or ZFS snapshots of the VM
-   disk. Crash-consistent, catches everything.
-2. **Logical dumps** for point-in-time restore and migration off the VM:
+   disk. Crash-consistent, catches everything (certificates, tunnel
+   credentials, the cluster itself).
+2. **Logical dumps** for point-in-time restore and migration off the VM. The
+   chart ships these (#520) — turn them on in your values:
 
 ```yaml
-# pgdump-cronjob.yaml — nightly logical dump into its own PVC
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: glyphoxa-pgdump
-  namespace: glyphoxa
-spec:
-  schedule: "15 4 * * *"
-  concurrencyPolicy: Forbid
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          restartPolicy: OnFailure
-          containers:
-            - name: pgdump
-              image: pgvector/pgvector:pg17
-              command: ["/bin/sh", "-c"]
-              args:
-                - pg_dump "$GLYPHOXA_DATABASE_URL" -Fc
-                  -f "/backup/glyphoxa-$(date +%F).dump"
-                  && find /backup -name '*.dump' -mtime +14 -delete
-              env:
-                - name: GLYPHOXA_DATABASE_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: glyphoxa-db     # the chart's app Secret: <fullname>-db
-                      key: database-url
-              volumeMounts:
-                - name: backup
-                  mountPath: /backup
-          volumes:
-            - name: backup
-              persistentVolumeClaim:
-                claimName: glyphoxa-pgdump
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: glyphoxa-pgdump
-  namespace: glyphoxa
-spec:
-  accessModes: ["ReadWriteOnce"]
-  resources:
-    requests:
-      storage: 10Gi
+backup:
+  enabled: true
+  schedule: "15 4 * * *"     # nightly, cluster timezone
+  retentionDays: 14
+  persistence:
+    size: 10Gi               # its OWN PVC, never the database's volume
+
+  # A dump on the same disk survives a bad migration, not a dead disk. Point
+  # this at any S3-compatible bucket (B2, Wasabi, MinIO, S3):
+  offsite:
+    enabled: true
+    bucket: glyphoxa-backups
+    endpoint: https://s3.eu-central-003.backblazeb2.com
+    existingSecret:
+      name: glyphoxa-backup-offsite   # you create this one
 ```
 
-Copy the dumps off the VM regularly (rsync to a NAS, restic to any S3) — a
-backup on the same physical disk is not a backup. Restore with
-`pg_restore -d "$DSN" --clean --if-exists <file>.dump`.
+Each run writes `pg_dump -Fc` into the backup PVC, records it in
+`/backup/.latest`, and rotates dumps older than `retentionDays` **after** the
+new one succeeds. With the off-site push enabled the dump runs as an
+initContainer and the upload follows it, so nothing half-written is ever pushed.
 
-[`deploy/saas/install.sh`](../../deploy/saas/install.sh) sets up an
-equivalent CronJob for you (writing to a host path instead of a PVC — on a
-single cloud box that is the disk you have), and
+**Rehearse the restore before you need it** — the full procedure (including
+restoring into a scratch database first) is in
+[backup-restore.md](backup-restore.md). The short version:
+
+```sh
+kubectl -n glyphoxa create job --from=cronjob/glyphoxa-backup backup-manual-1
+kubectl -n glyphoxa logs job/backup-manual-1
+# ...then restore with: pg_restore -d "$DSN" --clean --if-exists <file>.dump
+```
+
+[`deploy/saas/install.sh`](../../deploy/saas/install.sh) sets up an equivalent
+CronJob for the single-cloud-box topology (writing to a host path instead of a
+PVC — on one box that is the disk you have), and
 [`deploy/saas/update.sh`](../../deploy/saas/update.sh) triggers a run of it
 before every upgrade.
 

--- a/docs/deploy/legal-pages.md
+++ b/docs/deploy/legal-pages.md
@@ -12,7 +12,12 @@ on every screen (including login and signup):
 In the **open** Admission Mode (ADR-0055) the login screen — which is the signup
 screen — additionally requires the visitor to acknowledge the
 Nutzungsbedingungen and the Datenschutzerklärung before the Discord OAuth flow
-can start.
+can start. The gate is enforced **server-side**, not just rendered: an
+open-mode `GET /auth/discord/login` without `aup=1` is bounced back to the
+login screen, the acknowledgment rides the OAuth state cookie to the callback,
+an open-mode signup whose round trip lacks it writes nothing, and the
+acceptance time is recorded on the user row (`users.aup_accepted_at`) — the
+§ 305 BGB inclusion evidence. Allowlist-mode logins are not gated.
 
 `/privacy` is also a deployment contract: the Helm chart derives
 `GLYPHOXA_PRIVACY_POLICY_URL` as `<ingress host>/privacy`, and the Bot links it

--- a/docs/deploy/legal-pages.md
+++ b/docs/deploy/legal-pages.md
@@ -48,18 +48,27 @@ to miss.
    not need one — Art. 37 GDPR). Leave them empty to omit those lines.
 2. Read the Datenschutzerklärung end to end and correct anything that does not
    match YOUR deployment — in particular §5 (which AI providers you actually
-   use) and §6 (where the data lives). The template lists every provider the
-   software *can* use.
+   use) and §6 (where the data lives). The template names the shipped adapters
+   (Discord, ElevenLabs, Groq, Anthropic, Google Gemini, OpenAI-compatible
+   endpoints, Cloudflare) — cross-check against your configured providers, and
+   remember an "OpenAI-compatible endpoint" is whatever vendor you point it at.
 3. Rebuild the SPA (`npm run build` in `web/`, or rebuild the container image —
    the pages are compiled into the bundle) and deploy.
-4. Verify the pages before you publish DNS:
+4. Verify before you publish DNS. The legal pages are client-rendered, so
+   fetching `/imprint` only returns the SPA shell — grep the **built bundle**,
+   not the HTML:
 
    ```sh
-   curl -sf https://<your-host>/imprint  | grep -q "BITTE AUSFÜLLEN" && echo "STILL UNFILLED"
-   curl -sf https://<your-host>/privacy  >/dev/null && echo "privacy page served"
+   # locally, against the build you are about to ship (vite outDir):
+   grep -R "BITTE AUSFÜLLEN" internal/spa/dist/assets/ && echo "STILL UNFILLED"
+
+   # or against the deployed instance (fetches the hashed JS the shell references):
+   host=https://<your-host>
+   curl -sf "$host$(curl -sf "$host/" | grep -o '/assets/[^"]*\.js' | head -1)" \
+     | grep -q "BITTE AUSF" && echo "STILL UNFILLED"
    ```
 
-   The first command must print nothing.
+   Neither command may print `STILL UNFILLED`.
 
 ## Keeping the texts honest
 

--- a/docs/deploy/legal-pages.md
+++ b/docs/deploy/legal-pages.md
@@ -1,0 +1,87 @@
+# Legal pages: Impressum, Datenschutzerklärung, Nutzungsbedingungen
+
+The SPA serves three static, **unauthenticated** documents, linked from a footer
+on every screen (including login and signup):
+
+| Route | Aliases | Document |
+|-------|---------|----------|
+| `/imprint` | `/impressum` | Impressum (§ 5 DDG) |
+| `/privacy` | `/datenschutz` | Datenschutzerklärung |
+| `/terms` | `/nutzungsbedingungen` | Nutzungsbedingungen / AUP |
+
+In the **open** Admission Mode (ADR-0055) the login screen — which is the signup
+screen — additionally requires the visitor to acknowledge the
+Nutzungsbedingungen and the Datenschutzerklärung before the Discord OAuth flow
+can start.
+
+`/privacy` is also a deployment contract: the Helm chart derives
+`GLYPHOXA_PRIVACY_POLICY_URL` as `<ingress host>/privacy`, and the Bot links it
+from the transcription disclosure it posts in the voice channel at Voice Session
+start (#519). Keep the route as it is, or set `privacyPolicyUrl` explicitly.
+
+> **These texts are templates, not legal advice.** They were drafted from
+> established German boilerplate against what the software actually does, and
+> they have **not** been reviewed by a lawyer — an accepted beta risk decided on
+> 2026-07-22 (#518). If you operate this for other people, have them reviewed.
+
+## Operator TODO — before the deployment is reachable
+
+The operator's identity is **not** something this project can supply, so it
+ships as clearly-marked placeholders in
+[`web/src/screens/legal/operator.ts`](../../web/src/screens/legal/operator.ts).
+While any required field is unfilled, every legal page renders a red
+"Hinweis an den Betreiber" banner naming the missing fields, and each unfilled
+value is highlighted inline — an unfinished Impressum is meant to be impossible
+to miss.
+
+1. Edit `web/src/screens/legal/operator.ts` and fill in:
+   - `legalName`, `street`, `city`, `country` — § 5 DDG requires a real,
+     summonable postal address (no P.O. box);
+   - `email` — a contact that reaches a human quickly;
+   - `supervisoryAuthority` — the data-protection authority of your federal
+     state (Art. 77 GDPR complaint route);
+   - `hostingLocation` — where the database physically runs. The
+     Datenschutzerklärung repeats this claim, so it must be true;
+   - `lastUpdated` — the date you reviewed the texts.
+   Optional: `phone`, `contentResponsible` (§ 18 Abs. 2 MStV),
+   `vatId` (§ 27a UStG), `dataProtectionOfficer` (most beta-scale operators do
+   not need one — Art. 37 GDPR). Leave them empty to omit those lines.
+2. Read the Datenschutzerklärung end to end and correct anything that does not
+   match YOUR deployment — in particular §5 (which AI providers you actually
+   use) and §6 (where the data lives). The template lists every provider the
+   software *can* use.
+3. Rebuild the SPA (`npm run build` in `web/`, or rebuild the container image —
+   the pages are compiled into the bundle) and deploy.
+4. Verify the pages before you publish DNS:
+
+   ```sh
+   curl -sf https://<your-host>/imprint  | grep -q "BITTE AUSFÜLLEN" && echo "STILL UNFILLED"
+   curl -sf https://<your-host>/privacy  >/dev/null && echo "privacy page served"
+   ```
+
+   The first command must print nothing.
+
+## Keeping the texts honest
+
+The Datenschutzerklärung describes real data flows. When any of these change,
+the text has to change with them:
+
+- **Discord OAuth fields** (`internal/auth/discord.go`) — §2.
+- **Transcription** — Transcript Lines and Chunks plus their embeddings
+  (ADR-0011 / ADR-0040) — §3. The in-channel disclosure the Bot posts (#519)
+  says the same thing in one sentence; keep them consistent.
+- **The Rollover Tape** — consent model, 120 s window, 7-day candidate purge
+  (ADR-0051) — §4.
+- **Providers** (ADR-0004) — §5. Adding a provider means adding a subprocessor.
+- **Retention** — §7.
+
+`web/src/screens/legal/legal.test.tsx` pins the topics the Datenschutzerklärung
+must mention, so dropping one fails the web test suite rather than shipping a
+privacy policy that no longer describes the product.
+
+## See also
+
+- [k3s-proxmox.md](k3s-proxmox.md) — the home-lab deployment these pages ship with.
+- [saas-operations.md](saas-operations.md) — the go-live checklist.
+- [ADR-0055](../adr/0055-self-signup-admission-modes.md) — the open Admission
+  Mode whose signup carries the AUP acknowledgment.

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -195,6 +195,9 @@ schema change.
 - [ ] Provider dashboards (Groq/ElevenLabs) checked against the ledger's
       estimates for the first month — calibrate expectations; the price map is
       an estimate by design.
+- [ ] Legal pages filled in and served ([legal-pages.md](legal-pages.md)) —
+      the Impressum placeholders MUST be replaced before DNS points at you, and
+      the Datenschutzerklärung must match the providers you actually use.
 - [ ] Backups running and restore-tested ([backup-restore.md](backup-restore.md) —
       the chart's `backup.enabled` CronJob, ideally with `backup.offsite.*`;
       on a scripted cloud install, `deploy/saas/install.sh`'s backup option +

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -107,7 +107,11 @@ promise the landing page makes to a visitor:
 | `byok-free` | `byok` | $0/month | — (the Tenant's own keys) |
 
 Set `plans.enabled=true` to sync them, and point `web.signupPlanSlug` at
-`beta-trial` so an open-mode signup (ADR-0055) lands on the trial. Then:
+`beta-trial` so an open-mode signup (ADR-0055) lands on the trial. Binding
+signups to a **platform-keyed** plan deliberately overrides ADR-0055's original
+"the default Plan is a free BYOK tier / platform plans stay operator-CLI-only"
+wording — the SaaS-first launch decision, recorded as an amendment on ADR-0055
+(the reservation now covers *priced* platform plans). Then:
 
 - the trial spends **your** provider keys (§2) up to the allowance, which in
   `open` mode is a real gate — a session start is refused once the

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -195,7 +195,8 @@ schema change.
 - [ ] Provider dashboards (Groq/ElevenLabs) checked against the ledger's
       estimates for the first month — calibrate expectations; the price map is
       an estimate by design.
-- [ ] Backups running and restore-tested ([k3s-proxmox.md §8](k3s-proxmox.md);
+- [ ] Backups running and restore-tested ([backup-restore.md](backup-restore.md) —
+      the chart's `backup.enabled` CronJob, ideally with `backup.offsite.*`;
       on a scripted cloud install, `deploy/saas/install.sh`'s backup option +
       the pre-upgrade dump `deploy/saas/update.sh` takes) — the ledger and
       subscription history are now business records.

--- a/docs/deploy/saas-operations.md
+++ b/docs/deploy/saas-operations.md
@@ -96,6 +96,29 @@ deleted, so revenue history always resolves.
 runs the sync on every `helm upgrade` (see `deploy/charts/glyphoxa/values.yaml`
 for the annotated example). Tier edits become values edits.
 
+### Public-beta launch defaults (#521)
+
+The chart ships a two-plan catalog as its `plans.catalog` DEFAULT, matching the
+promise the landing page makes to a visitor:
+
+| Slug | Key source | Price | Included usage |
+|------|-----------|-------|----------------|
+| `beta-trial` | `platform` | $0/month | `included_usage_usd: 5` |
+| `byok-free` | `byok` | $0/month | — (the Tenant's own keys) |
+
+Set `plans.enabled=true` to sync them, and point `web.signupPlanSlug` at
+`beta-trial` so an open-mode signup (ADR-0055) lands on the trial. Then:
+
+- the trial spends **your** provider keys (§2) up to the allowance, which in
+  `open` mode is a real gate — a session start is refused once the
+  month-to-date estimate spends it;
+- `included_usage_usd` is yours to tune (it is money you are spending on
+  strangers). The landing-page copy deliberately says "a small monthly
+  allowance" rather than a figure, so raising or lowering it does not turn the
+  marketing copy into a lie;
+- neither tier charges money, because the beta has no payment flow. Introduce a
+  priced tier only alongside one.
+
 ## 2. Platform keys ("usage included")
 
 Mechanically, platform keys are the **env-fallback path** that already exists
@@ -203,7 +226,9 @@ schema change.
       on a scripted cloud install, `deploy/saas/install.sh`'s backup option +
       the pre-upgrade dump `deploy/saas/update.sh` takes) — the ledger and
       subscription history are now business records.
-- [ ] `plans.json` (or the Helm values catalog) in version control.
+- [ ] `plans.json` (or the Helm values catalog) in version control — the chart's
+      shipped `beta-trial` / `byok-free` defaults are a starting point, not a
+      commitment; review `included_usage_usd` against your budget.
 - [ ] Terms with your users about recording/consent (the Rollover Tape is
       consent-gated by design, ADR-0051 — point users at it).
 

--- a/internal/auth/admission_test.go
+++ b/internal/auth/admission_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,14 +63,21 @@ func (f *fakeSignup) ProvisionSignup(_ context.Context, p storage.SignupParams) 
 }
 
 // signupCallback drives a valid state+code callback through an OAuth built
-// with the given admission policy and returns the recorder.
+// with the given admission policy and returns the recorder. The state cookie
+// carries the AUP acknowledgment suffix a real open-mode Login appends (#518)
+// — the ack-less path has its own test.
 func signupCallback(t *testing.T, adm auth.Admission, store *fakeOAuthStore, du auth.DiscordUser) *httptest.ResponseRecorder {
+	t.Helper()
+	return signupCallbackWithCookie(t, adm, store, du, "st-1.aup")
+}
+
+func signupCallbackWithCookie(t *testing.T, adm auth.Admission, store *fakeOAuthStore, du auth.DiscordUser, cookie string) *httptest.ResponseRecorder {
 	t.Helper()
 	disc := &fakeDiscord{user: du}
 	o := auth.NewOAuth(store, disc, "/", adm, nil)
 	form := url.Values{"code": {"the-code"}, "state": {"st-1"}}
 	req := httptest.NewRequest(http.MethodGet, "/auth/discord/callback?"+form.Encode(), nil)
-	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: "st-1"})
+	req.AddCookie(&http.Cookie{Name: "glyphoxa_oauth_state", Value: cookie})
 	rec := httptest.NewRecorder()
 	o.Callback(rec, req)
 	return rec
@@ -109,6 +117,11 @@ func TestOAuthCallback_OpenMode_SignupProvisions(t *testing.T) {
 	}
 	if sp.got.TenantName == "" {
 		t.Error("tenant name must be pre-filled for the onboarding rename")
+	}
+	// #518: the acceptance moment is recorded inside the provisioning
+	// transaction — the operator's §305 BGB inclusion evidence.
+	if sp.got.AUPAcceptedAt.IsZero() {
+		t.Error("AUPAcceptedAt not stamped on the signup params")
 	}
 	// The legacy claim-or-create path must NOT run for a signup.
 	if store.upsertCalls != 0 || store.resolveN != 0 || store.createCalls != 0 {
@@ -240,5 +253,98 @@ func TestOAuthCallback_OpenModeMisconfigured_FailsClosed(t *testing.T) {
 	}
 	if store.upsertCalls != 0 || store.createCalls != 0 {
 		t.Errorf("store written for a fail-closed rejection: %+v", store)
+	}
+}
+
+// The #518 server-side gate, start half: in open mode a hand-typed
+// /auth/discord/login without the acknowledgment never reaches Discord — it
+// bounces back to the login screen, which renders the checkbox.
+func TestOAuthLogin_OpenMode_RequiresAcknowledgment(t *testing.T) {
+	t.Parallel()
+	adm := auth.Admission{Mode: auth.AdmissionOpen, SignupPlanSlug: "beta-trial", Signup: &fakeSignup{}}
+	o := auth.NewOAuth(&fakeOAuthStore{}, &fakeDiscord{}, "/", adm, nil)
+
+	rec := httptest.NewRecorder()
+	o.Login(rec, httptest.NewRequest(http.MethodGet, "/auth/discord/login", nil))
+
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/login?error=aup_required" {
+		t.Fatalf("status/Location = %d %q, want 302 aup_required", rec.Code, rec.Header().Get("Location"))
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_oauth_state" {
+			t.Error("state cookie set for a refused OAuth start")
+		}
+	}
+}
+
+// The acknowledgment rides the state COOKIE to the callback: the state param
+// Discord sees is the bare nonce, the cookie carries the .aup suffix only this
+// server appends.
+func TestOAuthLogin_OpenMode_AcknowledgmentRidesStateCookie(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscord{authBase: "https://discord/authorize"}
+	adm := auth.Admission{Mode: auth.AdmissionOpen, SignupPlanSlug: "beta-trial", Signup: &fakeSignup{}}
+	o := auth.NewOAuth(&fakeOAuthStore{}, disc, "/", adm, nil)
+
+	rec := httptest.NewRecorder()
+	o.Login(rec, httptest.NewRequest(http.MethodGet, "/auth/discord/login?aup=1", nil))
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	state := strings.TrimPrefix(rec.Header().Get("Location"), "https://discord/authorize?state=")
+	var cookie string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_oauth_state" {
+			cookie = c.Value
+		}
+	}
+	if cookie != state+".aup" {
+		t.Errorf("state cookie = %q, want %q", cookie, state+".aup")
+	}
+}
+
+// The #518 gate, callback half — the account-writing moment: an open-mode
+// signup whose round trip skipped our Login handler (hand-crafted authorize
+// URL, bare nonce cookie) writes NOTHING and bounces. This is the backstop the
+// client-side checkbox cannot be.
+func TestOAuthCallback_OpenMode_SignupWithoutAcknowledgmentRefused(t *testing.T) {
+	t.Parallel()
+	sp := &fakeSignup{}
+	store := &fakeOAuthStore{}
+	adm := auth.Admission{Mode: auth.AdmissionOpen, SignupPlanSlug: "beta-trial", Signup: sp}
+	rec := signupCallbackWithCookie(t, adm, store, auth.DiscordUser{ID: "999", Username: "rin"}, "st-1")
+
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/login?error=aup_required" {
+		t.Fatalf("status/Location = %d %q, want 302 aup_required", rec.Code, rec.Header().Get("Location"))
+	}
+	if sp.calls != 0 {
+		t.Errorf("ProvisionSignup ran for an unacknowledged signup")
+	}
+	if store.upsertCalls != 0 || store.createCalls != 0 {
+		t.Errorf("store written for an unacknowledged signup: %+v", store)
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "glyphoxa_session" || c.Name == "glyphoxa_csrf" {
+			t.Errorf("issued %s cookie to an unacknowledged signup", c.Name)
+		}
+	}
+}
+
+// An ALLOWLISTED user's round trip is not gated (#518 gates open-mode signup
+// only): a bare-nonce cookie still logs the operator in, in open mode too.
+func TestOAuthCallback_OpenMode_AllowlistedNeedsNoAcknowledgment(t *testing.T) {
+	t.Parallel()
+	store := &fakeOAuthStore{userID: uuid.New(), tenantID: uuid.New()}
+	adm := auth.Admission{
+		Mode:           auth.AdmissionOpen,
+		Allowlist:      auth.ParseOperatorAllowlist("77"),
+		SignupPlanSlug: "beta-trial",
+		Signup:         &fakeSignup{},
+	}
+	rec := signupCallbackWithCookie(t, adm, store, auth.DiscordUser{ID: "77", Username: "sora"}, "st-1")
+
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/" {
+		t.Fatalf("status/Location = %d %q, want 302 /", rec.Code, rec.Header().Get("Location"))
 	}
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -45,10 +45,24 @@ type OAuth struct {
 
 // notAuthorizedRedirect is where the callback sends a Discord User it refuses —
 // off the allowlist in allowlist mode (ADR-0041), or suspended in open mode
-// (ADR-0055): the login screen with a non-leaky not_authorized signal. This is
-// the only redirect that carries an ?error= param — bad-state/missing-code
-// still fail with http.Error.
+// (ADR-0055): the login screen with a non-leaky not_authorized signal.
+// Bad-state/missing-code still fail with http.Error.
 const notAuthorizedRedirect = "/login?error=not_authorized"
+
+// aupRequiredRedirect is where an open-mode OAuth start (or an open-mode signup
+// reaching the callback) without the AUP acknowledgment is bounced (#518): back
+// to the login screen, which renders the acknowledgment checkbox and a hint.
+// Unreachable through the SPA (the OAuth anchor only renders once the box is
+// ticked) — this is the server-side backstop for a hand-typed
+// /auth/discord/login or a hand-crafted OAuth round trip.
+const aupRequiredRedirect = "/login?error=aup_required"
+
+// aupStateSuffix marks the state COOKIE of an OAuth round trip whose start
+// carried the AUP acknowledgment (#518). It rides the cookie, not the state
+// param sent to Discord, so the callback reads it from the value this server
+// set. newToken is Raw-URL base64, so "." can never appear in a nonce and the
+// suffix is unambiguous.
+const aupStateSuffix = ".aup"
 
 // onboardingRedirect is where a FRESH signup lands after the callback: the
 // name-your-Tenant onboarding step (ADR-0055). The path is a Go↔SPA contract —
@@ -81,17 +95,33 @@ func NewOAuth(store OAuthStore, discord DiscordOAuth, appRedirect string, adm Ad
 
 // Login starts the OAuth flow: mint an anti-forgery state nonce, stash it in a
 // short-lived cookie, and 302 to Discord's authorize URL.
+//
+// In open Admission Mode the start additionally requires the AUP
+// acknowledgment (#518, `aup=1` — the login screen appends it once the visitor
+// ticks the box): a hand-typed /auth/discord/login must not slip past the
+// gate the SPA renders. The acknowledgment rides the state COOKIE to the
+// callback, where the signup path records its time on the user row. Allowlist
+// mode is untouched — the #518 decision gates open-mode signup only.
 func (o *OAuth) Login(w http.ResponseWriter, r *http.Request) {
+	aup := r.URL.Query().Get("aup") == "1"
+	if o.adm.Mode == AdmissionOpen && !aup {
+		http.Redirect(w, r, aupRequiredRedirect, http.StatusFound)
+		return
+	}
 	state, err := newToken()
 	if err != nil {
 		o.log.Error("oauth login: mint state", "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+	cookieValue := state
+	if aup {
+		cookieValue += aupStateSuffix
+	}
 	secure := requestSecure(r)
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
-		Value:    state,
+		Value:    cookieValue,
 		Path:     "/",
 		Expires:  o.now().Add(stateCookieTTL),
 		HttpOnly: true,
@@ -109,8 +139,14 @@ func (o *OAuth) Login(w http.ResponseWriter, r *http.Request) {
 func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
 	state := r.FormValue("state")
 	stateCookie, err := r.Cookie(stateCookieName)
-	if err != nil || state == "" ||
-		subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(state)) != 1 {
+	if err != nil || state == "" {
+		http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+		return
+	}
+	// The AUP acknowledgment (#518) rides the state cookie as a suffix this
+	// server appended at Login; strip it before the nonce comparison.
+	nonce, aupAccepted := strings.CutSuffix(stateCookie.Value, aupStateSuffix)
+	if subtle.ConstantTimeCompare([]byte(nonce), []byte(state)) != 1 {
 		http.Error(w, "invalid OAuth state", http.StatusBadRequest)
 		return
 	}
@@ -139,7 +175,7 @@ func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
 	// not_authorized signal.
 	if !o.adm.Allowlist.Contains(du.ID) {
 		if o.adm.open() {
-			o.signup(w, r, du)
+			o.signup(w, r, du, aupAccepted)
 			return
 		}
 		if o.adm.Mode == AdmissionOpen {
@@ -215,7 +251,19 @@ func (o *OAuth) Callback(w http.ResponseWriter, r *http.Request) {
 // founder lands on the name-your-Tenant onboarding step; a returning signup
 // goes straight to the app. A suspended user gets the same non-leaky
 // not_authorized bounce as an allowlist rejection.
-func (o *OAuth) signup(w http.ResponseWriter, r *http.Request, du DiscordUser) {
+//
+// aupAccepted is the #518 gate, enforced HERE — at the account-writing moment —
+// not just at Login: a round trip whose state cookie lacks the acknowledgment
+// suffix (a hand-crafted authorize URL that skipped our Login handler) writes
+// nothing and bounces. The acceptance time is recorded on the user row inside
+// the provisioning transaction (§305 BGB inclusion evidence), refreshed on
+// every returning open-mode login (the login screen re-asks each time).
+func (o *OAuth) signup(w http.ResponseWriter, r *http.Request, du DiscordUser, aupAccepted bool) {
+	if !aupAccepted {
+		o.log.Warn("oauth signup: refused open-mode signup without AUP acknowledgment", "discord_user_id", du.ID)
+		http.Redirect(w, r, aupRequiredRedirect, http.StatusFound)
+		return
+	}
 	sessionToken, err := newToken()
 	if err != nil {
 		o.log.Error("oauth signup: mint session token", "err", err)
@@ -244,6 +292,7 @@ func (o *OAuth) signup(w http.ResponseWriter, r *http.Request, du DiscordUser) {
 			IP:        clientIP(r),
 			UA:        r.UserAgent(),
 		},
+		AUPAcceptedAt: o.now(),
 	})
 	if errors.Is(err, storage.ErrUserSuspended) {
 		o.log.Warn("oauth signup: rejected suspended Discord user", "discord_user_id", du.ID)

--- a/internal/billing/catalog_chart_test.go
+++ b/internal/billing/catalog_chart_test.go
@@ -1,0 +1,84 @@
+package billing_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MrWong99/Glyphoxa/internal/billing"
+)
+
+// chartValuesPath is the shipped chart's values file, relative to this package.
+const chartValuesPath = "../../deploy/charts/glyphoxa/values.yaml"
+
+// TestChartDefaultCatalogParses is the #521 launch-catalog gate: the plan
+// catalog the chart ships as its DEFAULT must survive the same strict parser
+// `glyphoxa billing plans-sync` runs (ADR-0054) — unknown keys, a bad key
+// source, or an allowance on a BYOK tier all fail the sync at deploy time, and
+// finding that out during a launch install is far too late.
+//
+// It also pins the launch posture itself: a platform-keyed trial with a
+// configured monthly allowance, and a free BYOK tier for sustained use, both
+// free of charge — the public-beta promise the landing page makes.
+func TestChartDefaultCatalogParses(t *testing.T) {
+	raw, err := os.ReadFile(chartValuesPath)
+	if err != nil {
+		t.Fatalf("read chart values: %v", err)
+	}
+
+	// The chart authors the catalog as YAML under plans.catalog and renders it
+	// to JSON in the ConfigMap; do the same round-trip here so this test parses
+	// exactly what the cluster would.
+	var values struct {
+		Plans struct {
+			Catalog map[string]any `yaml:"catalog"`
+		} `yaml:"plans"`
+	}
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("parse chart values: %v", err)
+	}
+	catalogJSON, err := json.Marshal(values.Plans.Catalog)
+	if err != nil {
+		t.Fatalf("marshal catalog to JSON: %v", err)
+	}
+
+	catalog, err := billing.ParseCatalog(catalogJSON)
+	if err != nil {
+		t.Fatalf("the chart's default plan catalog does not parse: %v\ncatalog: %s", err, catalogJSON)
+	}
+
+	bySlug := map[string]billing.Plan{}
+	for _, p := range catalog.Plans {
+		bySlug[p.Slug] = p
+	}
+
+	trial, ok := bySlug["beta-trial"]
+	if !ok {
+		t.Fatalf("no beta-trial plan in the shipped catalog; got %v", catalog.Plans)
+	}
+	if trial.KeySource != billing.KeySourcePlatform {
+		t.Errorf("beta-trial key_source = %q, want %q — the trial spends the deployment's keys",
+			trial.KeySource, billing.KeySourcePlatform)
+	}
+	if trial.IncludedUsageUSD == nil || *trial.IncludedUsageUSD <= 0 {
+		t.Errorf("beta-trial included_usage_usd = %v, want a positive allowance", trial.IncludedUsageUSD)
+	}
+
+	byok, ok := bySlug["byok-free"]
+	if !ok {
+		t.Fatalf("no byok-free plan in the shipped catalog; got %v", catalog.Plans)
+	}
+	if byok.KeySource != billing.KeySourceBYOK {
+		t.Errorf("byok-free key_source = %q, want %q", byok.KeySource, billing.KeySourceBYOK)
+	}
+
+	// Nothing in the beta charges money: there is no payment flow to charge it
+	// with, so a non-zero price would be a promise signup cannot keep.
+	for _, p := range catalog.Plans {
+		if p.MonthlyPriceUSD != 0 {
+			t.Errorf("plan %q costs %v/month, but the beta bills nobody", p.Slug, p.MonthlyPriceUSD)
+		}
+	}
+}

--- a/internal/storage/auth.go
+++ b/internal/storage/auth.go
@@ -17,7 +17,7 @@ import (
 // random secret minted by the auth tier (internal/auth) — this layer only
 // persists and validates it, never interprets it.
 
-const userColumns = `id, discord_user_id, name, avatar, role, created_at, updated_at, suspended_at`
+const userColumns = `id, discord_user_id, name, avatar, role, created_at, updated_at, suspended_at, aup_accepted_at`
 
 // DevOperatorDiscordID is the synthetic Discord identity the GLYPHOXA_DEV_MODE
 // boot upserts as the dev operator (ADR-0041). It is deliberately NOT a real
@@ -31,7 +31,7 @@ func scanUser(row pgx.Row) (User, error) {
 	var u User
 	err := row.Scan(
 		&u.ID, &u.DiscordUserID, &u.Name, &u.Avatar, &u.Role,
-		&u.CreatedAt, &u.UpdatedAt, &u.SuspendedAt,
+		&u.CreatedAt, &u.UpdatedAt, &u.SuspendedAt, &u.AUPAcceptedAt,
 	)
 	return u, err
 }
@@ -272,7 +272,7 @@ func (s *Store) AuthenticateSession(ctx context.Context, token string) (User, er
 		      RETURNING user_id
 		 )
 		 SELECT u.id, u.discord_user_id, u.name, u.avatar, u.role,
-		        u.created_at, u.updated_at, u.suspended_at
+		        u.created_at, u.updated_at, u.suspended_at, u.aup_accepted_at
 		   FROM users u JOIN s ON s.user_id = u.id
 		  WHERE u.suspended_at IS NULL`, token)
 	u, err := scanUser(row)

--- a/internal/storage/migrations/00040_users_aup_accepted.sql
+++ b/internal/storage/migrations/00040_users_aup_accepted.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+-- AUP/ToS acceptance record (#518, ADR-0055 open mode): the OAuth signup path
+-- refuses an open-mode signup whose start did not carry the acknowledgment,
+-- and stamps WHEN the user last accepted the Nutzungsbedingungen +
+-- Datenschutzerklärung — the §305 BGB inclusion evidence the operator needs.
+-- NULL for accounts that predate the column and for allowlist-mode logins,
+-- which are not gated (#518 decision: the acknowledgment gates open-mode
+-- signup only).
+ALTER TABLE users
+    ADD COLUMN aup_accepted_at timestamptz;
+
+-- +goose Down
+
+ALTER TABLE users
+    DROP COLUMN IF EXISTS aup_accepted_at;

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -254,9 +254,13 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	// SuspendedAt, when non-nil, marks the user locked out under the
-	// open-Admission-Mode revocation mechanism (ADR-0055). Appended LAST —
-	// userColumns/scanUser are column-order-coupled.
+	// open-Admission-Mode revocation mechanism (ADR-0055).
 	SuspendedAt *time.Time
+	// AUPAcceptedAt records when the user last acknowledged the
+	// Nutzungsbedingungen + Datenschutzerklärung at an open-mode OAuth start
+	// (#518). nil for allowlist-mode logins (not gated) and pre-column
+	// accounts. Appended LAST — userColumns/scanUser are column-order-coupled.
+	AUPAcceptedAt *time.Time
 }
 
 // Session is a server-side login session (ADR-0016): the Token is the opaque

--- a/internal/storage/signup.go
+++ b/internal/storage/signup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -28,6 +29,13 @@ type SignupParams struct {
 	TenantName string
 	PlanSlug   string
 	Session    NewSession
+	// AUPAcceptedAt is when this signup acknowledged the Nutzungsbedingungen +
+	// Datenschutzerklärung (#518): the OAuth start carried the acknowledgment
+	// and the callback stamps its time here, so users.aup_accepted_at always
+	// holds the LATEST acceptance (a returning open-mode login re-acknowledges
+	// — the login screen requires the tick every time). The zero value writes
+	// nothing; the auth tier refuses ack-less open-mode signups before calling.
+	AUPAcceptedAt time.Time
 }
 
 // SignupResult reports what ProvisionSignup did. Created is true when a fresh
@@ -56,6 +64,14 @@ func (s *Store) ProvisionSignup(ctx context.Context, p SignupParams) (SignupResu
 		}
 		if u.SuspendedAt != nil {
 			return ErrUserSuspended
+		}
+		if !p.AUPAcceptedAt.IsZero() {
+			if _, err := tx.db.Exec(ctx,
+				`UPDATE users SET aup_accepted_at = $2, updated_at = now() WHERE id = $1`,
+				u.ID, p.AUPAcceptedAt); err != nil {
+				return fmt.Errorf("storage: record AUP acceptance: %w", err)
+			}
+			u.AUPAcceptedAt = &p.AUPAcceptedAt
 		}
 		res.User = u
 

--- a/internal/storage/signup_test.go
+++ b/internal/storage/signup_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 // signupParams returns a valid open-mode signup input for the given snowflake,
-// bound to the billingSpecs BYOK tier (the ADR-0055 default-plan shape).
+// bound to the billingSpecs BYOK tier (the ADR-0055 default-plan shape). The
+// AUP acceptance time is stamped the way the OAuth callback does (#518).
 func signupParams(discordID, token string) storage.SignupParams {
 	return storage.SignupParams{
 		User: storage.UpsertUserParams{
@@ -28,6 +29,7 @@ func signupParams(discordID, token string) storage.SignupParams {
 			IP:        "203.0.113.7",
 			UA:        "test-agent",
 		},
+		AUPAcceptedAt: time.Now(),
 	}
 }
 
@@ -127,6 +129,11 @@ func TestProvisionSignupFoundsTenantOnce(t *testing.T) {
 	}
 	if got, err := st.AuthenticateSession(ctx, "tok-first"); err != nil || got.ID != res.User.ID {
 		t.Fatalf("AuthenticateSession(minted) = %+v, %v, want signup user", got, err)
+	} else if got.AUPAcceptedAt == nil {
+		t.Fatal("aup_accepted_at not persisted on the signup user row (#518)")
+	}
+	if res.User.AUPAcceptedAt == nil {
+		t.Fatal("SignupResult.User.AUPAcceptedAt = nil, want the stamped acceptance")
 	}
 	if tid, err := st.TenantForUser(ctx, res.User.ID); err != nil || tid != res.Tenant.ID {
 		t.Fatalf("TenantForUser = %s, %v, want bound tenant %s", tid, err, res.Tenant.ID)

--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -81,6 +81,23 @@ func (s *Store) UpsertTranscriptLine(ctx context.Context, l TranscriptLine) erro
 	return nil
 }
 
+// DeleteTranscriptLine removes one transcript Line by its replay key — the
+// reconciliation half of the LINE grain's delivered-only invariant (#437,
+// ADR-0040 amendment 2026-07-22). The Relay persists optimistically at
+// TTSInvoked and calls this through the SAME single-writer queue when the turn
+// ends having delivered zero sentences, so replay never shows text the room
+// never heard. Deleting a row that is not there is NOT an error: the reconcile
+// is best-effort and may race a dropped (queue-full) UPSERT that never landed.
+func (s *Store) DeleteTranscriptLine(ctx context.Context, sessionID uuid.UUID, lineID string) error {
+	_, err := s.db.Exec(ctx,
+		`DELETE FROM transcript_line WHERE voice_session_id = $1 AND line_id = $2`,
+		sessionID, lineID)
+	if err != nil {
+		return fmt.Errorf("storage: delete transcript line %s/%s: %w", sessionID, lineID, err)
+	}
+	return nil
+}
+
 // ListTranscriptLines returns a Voice Session's transcript Lines ordered by seq —
 // the replay-on-reload history the Session screen renders for an ended session
 // (#74). An empty result is not an error.

--- a/internal/storage/transcript_line_test.go
+++ b/internal/storage/transcript_line_test.go
@@ -219,3 +219,62 @@ func TestTranscriptLineSpeakerID(t *testing.T) {
 		t.Errorf("line[1].SpeakerDiscordUserID = %q, want \"\" (NULL round-trips to empty)", got[1].SpeakerDiscordUserID)
 	}
 }
+
+// TestTranscriptLineDelete is #437 (ADR-0040 amendment): the Relay's retraction of
+// a never-delivered line removes exactly that row — the session's other lines and
+// another session's same-named line are untouched — and deleting a row that is not
+// there is a no-op, not an error (the reconcile may race a dropped UPSERT).
+func TestTranscriptLineDelete(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	other, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession (other): %v", err)
+	}
+	ts := time.Date(2026, 7, 22, 21, 0, 0, 0, time.UTC)
+
+	lines := []storage.TranscriptLine{
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "u:1", Seq: 1, Who: "Player / DM", Kind: "player", TS: ts, Text: "Hello Bart"},
+		{VoiceSessionID: vs.ID, CampaignID: campaignID, LineID: "a:t1", Seq: 2, Who: "Bart", Tag: "NPC", Kind: "npc", TS: ts, Text: "Well met."},
+		{VoiceSessionID: other.ID, CampaignID: campaignID, LineID: "a:t1", Seq: 1, Who: "Bart", Tag: "NPC", Kind: "npc", TS: ts, Text: "Another session's reply"},
+	}
+	for _, l := range lines {
+		if err := st.UpsertTranscriptLine(ctx, l); err != nil {
+			t.Fatalf("UpsertTranscriptLine %s/%s: %v", l.VoiceSessionID, l.LineID, err)
+		}
+	}
+
+	if err := st.DeleteTranscriptLine(ctx, vs.ID, "a:t1"); err != nil {
+		t.Fatalf("DeleteTranscriptLine: %v", err)
+	}
+
+	got, err := st.ListTranscriptLines(ctx, vs.ID)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	if len(got) != 1 || got[0].LineID != "u:1" {
+		t.Fatalf("lines after retraction = %+v, want only the human u:1", got)
+	}
+	if n, err := st.CountTranscriptLines(ctx, vs.ID); err != nil || n != 1 {
+		t.Errorf("count after retraction = %d, %v; want 1, nil (the line_count follows)", n, err)
+	}
+	// The other session's identically-named line is untouched: the delete is keyed
+	// by the full (voice_session_id, line_id) replay key.
+	if n, err := st.CountTranscriptLines(ctx, other.ID); err != nil || n != 1 {
+		t.Errorf("other session count = %d, %v; want its own a:t1 kept", n, err)
+	}
+	// Idempotent: retracting again (or a line that never landed) is not an error.
+	if err := st.DeleteTranscriptLine(ctx, vs.ID, "a:t1"); err != nil {
+		t.Errorf("second DeleteTranscriptLine: %v, want nil (no-op)", err)
+	}
+	if err := st.DeleteTranscriptLine(ctx, vs.ID, "a:never"); err != nil {
+		t.Errorf("DeleteTranscriptLine of an unknown line: %v, want nil", err)
+	}
+}

--- a/internal/transcript/persist.go
+++ b/internal/transcript/persist.go
@@ -29,13 +29,23 @@ const (
 	writeTimeout = 5 * time.Second
 )
 
+// lineOp is one item on the relay's writer queue: an UPSERT of a projected Line,
+// or the DELETE that reconciles a never-delivered line back out (#437, ADR-0040
+// amendment). Both ride the SAME queue so FIFO ordering guarantees a retraction
+// can never overtake the UPSERT it undoes — and so the flush barrier at Finalize
+// still drains everything before the authoritative COUNT(*).
+type lineOp struct {
+	line   storage.TranscriptLine
+	delete bool
+}
+
 // persist tees one emitted Line onto the writer queue, keyed for the coalescing
 // UPSERT and carrying seq as the ordering key. Caller holds r.mu; the send is
 // non-blocking (the bus must not block) so an overflow drops + logs. No-op when
 // persistence is disabled (nil queue).
 func (r *Relay) persist(sid string, l Line, seq uint64) {
 	sess := r.proj.Session(sid)
-	line := &storage.TranscriptLine{
+	line := storage.TranscriptLine{
 		VoiceSessionID:       sess.ID,
 		CampaignID:           sess.CampaignID,
 		LineID:               l.ID,
@@ -47,20 +57,43 @@ func (r *Relay) persist(sid string, l Line, seq uint64) {
 		Text:                 l.Text,
 		SpeakerDiscordUserID: l.SpeakerID, // #278: "" (unattributed / Agent) → NULLIF → NULL in storage
 	}
-	if !r.queue.Enqueue(line) {
+	if !r.queue.Enqueue(&lineOp{line: line}) {
 		r.log.Warn("transcript: persist queue full, dropping line", "line_id", l.ID)
 	}
 }
 
+// unpersist tees the retraction of one never-delivered line onto the writer
+// queue (#437): the turn ended (or the session finalized) without a single
+// delivered sentence, so the optimistically-written row must not outlive the
+// session. Same non-blocking discipline as persist — a dropped retraction leaves
+// a stale row rather than blocking the bus, and is logged. Caller holds r.mu.
+func (r *Relay) unpersist(sid, lineID string) {
+	sess := r.proj.Session(sid)
+	op := &lineOp{
+		delete: true,
+		line:   storage.TranscriptLine{VoiceSessionID: sess.ID, LineID: lineID},
+	}
+	if !r.queue.Enqueue(op) {
+		r.log.Warn("transcript: persist queue full, dropping line retraction", "line_id", lineID)
+	}
+}
+
 // writeLine is the Relay's flush sink — the write half of the single writer
-// goroutine (#74): one serial, bounded UPSERT per queued line. A write failure
-// is logged but does not stop the loop — durability is best-effort and the next
-// Stop's COUNT(*) is still authoritative over whatever landed.
-func (r *Relay) writeLine(l *storage.TranscriptLine) {
+// goroutine (#74): one serial, bounded UPSERT (or #437 retraction DELETE) per
+// queued op. A write failure is logged but does not stop the loop — durability
+// is best-effort and the next Stop's COUNT(*) is still authoritative over
+// whatever landed.
+func (r *Relay) writeLine(op *lineOp) {
 	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 	defer cancel()
-	if err := r.store.UpsertTranscriptLine(ctx, *l); err != nil {
-		r.log.Warn("transcript: persist line", "err", err, "line_id", l.LineID)
+	if op.delete {
+		if err := r.store.DeleteTranscriptLine(ctx, op.line.VoiceSessionID, op.line.LineID); err != nil {
+			r.log.Warn("transcript: retract undelivered line", "err", err, "line_id", op.line.LineID)
+		}
+		return
+	}
+	if err := r.store.UpsertTranscriptLine(ctx, op.line); err != nil {
+		r.log.Warn("transcript: persist line", "err", err, "line_id", op.line.LineID)
 	}
 }
 

--- a/internal/transcript/persist.go
+++ b/internal/transcript/persist.go
@@ -66,8 +66,11 @@ func (r *Relay) persist(sid string, l Line, seq uint64) {
 // queue (#437): the turn ended (or the session finalized) without a single
 // delivered sentence, so the optimistically-written row must not outlive the
 // session. Same non-blocking discipline as persist — a dropped retraction leaves
-// a stale row rather than blocking the bus, and is logged. Caller holds r.mu.
-func (r *Relay) unpersist(sid, lineID string) {
+// a stale row rather than blocking the bus, and is logged. It reports whether
+// the retraction was accepted (a nil queue counts: nothing to undo), so retract
+// can keep the line in the reconcile set and the Finalize sweep retries a
+// TurnEnded-time drop once the queue has drained. Caller holds r.mu.
+func (r *Relay) unpersist(sid, lineID string) bool {
 	sess := r.proj.Session(sid)
 	op := &lineOp{
 		delete: true,
@@ -75,7 +78,9 @@ func (r *Relay) unpersist(sid, lineID string) {
 	}
 	if !r.queue.Enqueue(op) {
 		r.log.Warn("transcript: persist queue full, dropping line retraction", "line_id", lineID)
+		return false
 	}
+	return true
 }
 
 // writeLine is the Relay's flush sink — the write half of the single writer

--- a/internal/transcript/persist_test.go
+++ b/internal/transcript/persist_test.go
@@ -295,6 +295,100 @@ func TestPersist_DeliveredTurnSurvivesBarge(t *testing.T) {
 	}
 }
 
+// TestPersist_StreamFailedOnlySentenceRetracted: a #436 mid-stream failure of
+// the turn's ONLY sentence — FirstAudio fired, then the stream died — must
+// retract the row, exactly as the Chunker retracts the sentence: the room heard
+// at most a fragment, so per ADR-0012 zero sentences were delivered.
+func TestPersist_StreamFailedOnlySentenceRetracted(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Well met, traveller.", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "t1"})
+	bus.Publish(voiceevent.TTSStreamFailed{At: at(4), TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndTTSError})
+
+	n, err := r.Finalize(context.Background(), fs.id)
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Finalize count = %d, want 0 (the only sentence stream-failed)", n)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 0 {
+		t.Errorf("persisted lines = %v, want none — the room heard at most a fragment", got)
+	}
+	if store.deleteCount() == 0 {
+		t.Error("no retraction reached the store; the stream-failed row was left behind")
+	}
+}
+
+// TestPersist_StreamFailedTailKeepsDeliveredLine: when an EARLIER sentence
+// delivered, a #436 failure of a later one keeps the row — the same tail
+// rounding a barge gets (#401); the reconcile must not over-reach.
+func TestPersist_StreamFailedTailKeepsDeliveredLine(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Well met.", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Sit down.", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(5), TurnID: "t1"})
+	bus.Publish(voiceevent.TTSStreamFailed{At: at(6), TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(7), TurnID: "t1", Reason: voiceevent.TurnEndTTSError})
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 1 || got[0] != "a:t1" {
+		t.Errorf("persisted lines = %v, want the partially-delivered reply a:t1 kept", got)
+	}
+	if store.deleteCount() != 0 {
+		t.Errorf("retracted a line with a delivered sentence (%d deletes)", store.deleteCount())
+	}
+}
+
+// TestPersist_StreamFailedBeforeFirstAudioRetracted: the stream died before its
+// first chunk crossed — no FirstAudio at all. The pending sentence is dropped
+// and the zero-delivery turn retracts at TurnEnded, same as a start-error.
+func TestPersist_StreamFailedBeforeFirstAudioRetracted(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Well me—", TurnID: "t1"})
+	bus.Publish(voiceevent.TTSStreamFailed{At: at(3), TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(4), TurnID: "t1", Reason: voiceevent.TurnEndTTSError})
+
+	n, err := r.Finalize(context.Background(), fs.id)
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Finalize count = %d, want 0", n)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 0 {
+		t.Errorf("persisted lines = %v, want none", got)
+	}
+}
+
 // TestPersist_SessionEndRetractsUndeliveredLine covers #437's second reconcile
 // point: a session that ends mid-turn (Stop / gateway loss / shutdown) never
 // publishes that turn's TurnEnded, so the sweep at Finalize is what keeps the

--- a/internal/transcript/persist_test.go
+++ b/internal/transcript/persist_test.go
@@ -19,8 +19,9 @@ import (
 // records UPSERTs keyed (session, line_id) — so a coalescing reply collapses to
 // one entry — and serves List/Count off that map.
 type fakeLineStore struct {
-	mu    sync.Mutex
-	lines map[string]storage.TranscriptLine
+	mu      sync.Mutex
+	lines   map[string]storage.TranscriptLine
+	deletes int
 }
 
 func newFakeLineStore() *fakeLineStore {
@@ -38,6 +39,23 @@ func (f *fakeLineStore) UpsertTranscriptLine(_ context.Context, l storage.Transc
 	}
 	f.lines[k] = l
 	return nil
+}
+
+// DeleteTranscriptLine drops the row, mirroring the real DELETE's tolerance of a
+// missing key (#437). deletes counts every call so a test can tell "retracted"
+// from "never written".
+func (f *fakeLineStore) DeleteTranscriptLine(_ context.Context, sid uuid.UUID, lid string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deletes++
+	delete(f.lines, f.key(sid, lid))
+	return nil
+}
+
+func (f *fakeLineStore) deleteCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deletes
 }
 
 func (f *fakeLineStore) ListTranscriptLines(_ context.Context, sid uuid.UUID) ([]storage.TranscriptLine, error) {
@@ -81,6 +99,7 @@ func TestPersist_CoalescesAndCounts(t *testing.T) {
 		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
 	})
 	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "t1"}) // delivered — the row stays (#437)
 	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "What'll it be?", TurnID: "t1"})
 	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
 
@@ -187,6 +206,122 @@ func TestPersist_TwoSessionsAttributedIndependently(t *testing.T) {
 	gotB, _ := store.ListTranscriptLines(ctx, sessB.ID)
 	if len(gotB) != 1 || gotB[0].Text != "hi from B" || gotB[0].CampaignID != sessB.CampaignID {
 		t.Errorf("session B lines = %+v, want its line attributed to B's UUID + campaign", gotB)
+	}
+}
+
+// lineIDs is the persisted line_ids for a session, in seq order — the shape most
+// of the #437 reconcile assertions want.
+func lineIDs(t *testing.T, store *fakeLineStore, sid uuid.UUID) []string {
+	t.Helper()
+	rows, err := store.ListTranscriptLines(context.Background(), sid)
+	if err != nil {
+		t.Fatalf("ListTranscriptLines: %v", err)
+	}
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.LineID)
+	}
+	return out
+}
+
+// TestPersist_ZeroDeliveryTurnRetracted is #437's headline: a turn whose ONLY
+// sentence start-errors (TTSInvoked fired, no FirstAudio ever, terminal reason
+// tts_error) leaves NO transcript_line row — the LINE grain now obeys ADR-0012's
+// delivered-only invariant, exactly as the Chunk grain always did. The human line
+// that prompted the turn is untouched, and the authoritative count follows.
+func TestPersist_ZeroDeliveryTurnRetracted(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.STTFinal{At: at(1), Text: "Hello Bart", TurnID: "t1"})
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(2), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(3), Sentence: "Well met.", TurnID: "t1"})
+	// No FirstAudio: synthesis start-errored, the room heard nothing.
+	bus.Publish(voiceevent.TurnEnded{At: at(4), TurnID: "t1", Reason: voiceevent.TurnEndTTSError})
+
+	// The live feed transiently showed the line — accepted by the ADR-0040
+	// amendment (the SSE contract is unchanged; only replay is reconciled).
+	if v := r.View(fs.id.String()); len(v.Lines) != 2 {
+		t.Fatalf("live view = %+v, want the human line AND the transient agent line", v.Lines)
+	}
+
+	n, err := r.Finalize(context.Background(), fs.id)
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Finalize count = %d, want 1 (the undelivered reply is not a line)", n)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 1 || got[0] != "u:1" {
+		t.Errorf("persisted lines = %v, want only the human u:1 — a:t1 was never heard", got)
+	}
+	if store.deleteCount() == 0 {
+		t.Error("no retraction reached the store; the row was silently left behind")
+	}
+}
+
+// TestPersist_DeliveredTurnSurvivesBarge is the other half of #437: a turn that
+// delivered at least one sentence KEEPS its line even when a barge cuts the reply
+// mid-flight — the accepted sentence-tail rounding of #401 is untouched, and the
+// reconcile must not over-reach into it.
+func TestPersist_DeliveredTurnSurvivesBarge(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Well met.", TurnID: "t1"})
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "t1"})
+	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "Sit down.", TurnID: "t1"})
+	bus.Publish(voiceevent.TurnEnded{At: at(5), TurnID: "t1", Reason: voiceevent.TurnEndBarge})
+
+	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 1 || got[0] != "a:t1" {
+		t.Errorf("persisted lines = %v, want the delivered reply a:t1 kept", got)
+	}
+	if store.deleteCount() != 0 {
+		t.Errorf("retracted a delivered line (%d deletes) — #401's tail rounding stays accepted", store.deleteCount())
+	}
+}
+
+// TestPersist_SessionEndRetractsUndeliveredLine covers #437's second reconcile
+// point: a session that ends mid-turn (Stop / gateway loss / shutdown) never
+// publishes that turn's TurnEnded, so the sweep at Finalize is what keeps the
+// never-delivered row out — and it runs BEFORE the flush barrier, so the
+// authoritative count already excludes it.
+func TestPersist_SessionEndRetractsUndeliveredLine(t *testing.T) {
+	bus := voiceevent.NewBus()
+	fs := &fakeSessions{id: uuid.New(), active: true}
+	store := newFakeLineStore()
+	r := NewRelay(fwd(t, bus, fs), fs, store, nil)
+
+	bus.Publish(voiceevent.AddressRouted{
+		At: at(1), TurnID: "t1",
+		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
+	})
+	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Well me—", TurnID: "t1"})
+	// Session stops here: no FirstAudio, no TurnEnded.
+
+	n, err := r.Finalize(context.Background(), fs.id)
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Finalize count = %d, want 0 (nothing was ever heard)", n)
+	}
+	if got := lineIDs(t, store, fs.id); len(got) != 0 {
+		t.Errorf("persisted lines = %v, want none", got)
 	}
 }
 

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -192,11 +192,13 @@ type SpeakerResolver interface {
 }
 
 // LineStore is the narrow persistence surface the relay needs (#74, ADR-0040):
-// an incremental UPSERT of each projected Line, a list for replay-on-reload, and
-// the authoritative count for the Stop summary. *storage.Store satisfies it;
-// tests fake it. nil disables persistence (the live-only relay, e.g. unit tests).
+// an incremental UPSERT of each projected Line, the delete that reconciles a
+// never-delivered line back out (#437), a list for replay-on-reload, and the
+// authoritative count for the Stop summary. *storage.Store satisfies it; tests
+// fake it. nil disables persistence (the live-only relay, e.g. unit tests).
 type LineStore interface {
 	UpsertTranscriptLine(ctx context.Context, l storage.TranscriptLine) error
+	DeleteTranscriptLine(ctx context.Context, sessionID uuid.UUID, lineID string) error
 	ListTranscriptLines(ctx context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error)
 	CountTranscriptLines(ctx context.Context, sessionID uuid.UUID) (int, error)
 }
@@ -205,11 +207,14 @@ type LineStore interface {
 // reply line whose text accumulates across the turn's TTSInvoked sentences.
 // ended marks a finalized turn (TurnEnded seen) so a late TTSInvoked — which a
 // barge can deliver AFTER the end — does not recreate the entry with a zero
-// target and clobber the completed coalesced reply.
+// target and clobber the completed coalesced reply. delivered records the
+// turn's FIRST FirstAudio — "this turn's speech actually reached the room" —
+// the predicate the #437 reconcile reads at turn end (ADR-0040 amendment).
 type turn struct {
-	target voiceevent.AddressTarget
-	line   *Line
-	ended  bool
+	target    voiceevent.AddressTarget
+	line      *Line
+	ended     bool
+	delivered bool
 }
 
 // sessionState is one live Voice Session's projection + replay state (#487):
@@ -224,6 +229,12 @@ type sessionState struct {
 	connection string // latest gateway connection state (#123); "" until the first transition
 	nextSeq    uint64
 	humanSeq   uint64
+	// unconfirmed holds the line ids of Agent replies persisted optimistically at
+	// TTSInvoked whose turn has not yet delivered a single sentence (#437): the
+	// reconcile set. A line leaves it on the turn's first FirstAudio (delivered —
+	// it stays persisted) or is RETRACTED from the store when its turn ends, or
+	// when the session finalizes, still having delivered nothing.
+	unconfirmed map[string]struct{}
 }
 
 // Relay projects bus events into transcript lines and serves them over SSE +
@@ -254,7 +265,7 @@ type Relay struct {
 	// goroutine (#74): emitLine tees each Line in here under r.mu, the bus
 	// contract forbids blocking so the send drops on overflow, and Finalize
 	// sends a flush barrier. nil when persistence is disabled (store == nil).
-	queue *busproject.Queue[*storage.TranscriptLine]
+	queue *busproject.Queue[*lineOp]
 
 	// writeTimeout bounds each SSE frame write/flush (#148 Defect B): a client
 	// that stops reading makes the blocked write fail instead of parking the
@@ -437,15 +448,42 @@ func (r *Relay) fold(e voiceevent.Event) {
 			}
 			t.line.Text += ev.Sentence
 		}
+		// The sentence was DISPATCHED, not necessarily spoken (event.go): until this
+		// turn's FirstAudio lands, the row this emit persists is provisional (#437).
+		if !t.delivered {
+			st.unconfirmed[t.line.ID] = struct{}{}
+		}
 		// emitLine derives typing from the line's kind (FIX 1), so a clean turn
 		// (which emits NO TurnEnded) still shows "speaking" and a later human line
 		// returns to listening — no standalone setTyping here.
 		r.emitLine(st, sid, *t.line)
+	case voiceevent.FirstAudio:
+		// The turn's first sentence reached the room (ADR-0012's delivery signal):
+		// its optimistically-persisted line has earned its row, so it leaves the
+		// reconcile set for good (#437). Dispatch is serial single-in-flight and
+		// FirstAudio(sN) is published inline before Dispatch(sN) returns, so it
+		// always precedes the turn's TurnEnded — the same ordering the Chunker's
+		// deliver-then-commit relies on.
+		t := r.proj.Turn(sid, ev.TurnID)
+		t.delivered = true
+		if t.line != nil {
+			delete(st.unconfirmed, t.line.ID)
+		}
 	case voiceevent.TurnEnded:
 		// Mark the turn finalized (keep the entry so a late sentence is dropped,
 		// FIX 2) and fall back to listening — correct for a barge that cut the
 		// Agent off mid-reply.
-		r.proj.Turn(sid, ev.TurnID).ended = true
+		t := r.proj.Turn(sid, ev.TurnID)
+		t.ended = true
+		// Reconcile the LINE grain against ADR-0012's delivered-only invariant
+		// (#437, ADR-0040 amendment): a turn that ends having delivered ZERO
+		// sentences — a TTS start-error is the canonical case, terminal reason
+		// tts_error — leaves a row the room never heard. Retract it. A turn that
+		// delivered at least one sentence keeps its line, sentence-tail rounding on
+		// barge included (#401).
+		if !t.delivered && t.line != nil {
+			r.retract(st, sid, t.line.ID)
+		}
 		r.setTyping(st, sid, r.liveTyping())
 	case voiceevent.MuteChanged:
 		// One Agent's mute flipped (#211): forward a "mute" frame so the web Voice
@@ -488,7 +526,7 @@ func (r *Relay) CloseStreams() {
 // live/listening status frame, so a client connecting mid-session replays a
 // coherent state. Runs under r.mu.
 func (r *Relay) startSession(sid string) {
-	st := &sessionState{typing: r.liveTyping()}
+	st := &sessionState{typing: r.liveTyping(), unconfirmed: map[string]struct{}{}}
 	r.states[sid] = st
 	r.emit(st, sid, Frame{Event: "status", Data: mustJSON(status{Status: "live", Typing: st.typing})})
 }
@@ -503,6 +541,14 @@ func (r *Relay) finishSession(sid string) {
 	st := r.states[sid]
 	if st == nil {
 		return
+	}
+	// Last reconcile pass (#437): a session can end mid-turn (Stop, gateway loss,
+	// shutdown) with a dispatched-but-never-delivered reply still provisional and
+	// no TurnEnded ever published for it. Retract those rows here — Finalize runs
+	// this Close BEFORE the queue's flush barrier, so the deletes are drained (and
+	// hence excluded from the authoritative line_count) by the time it counts.
+	for lineID := range st.unconfirmed {
+		r.retract(st, sid, lineID)
 	}
 	st.typing = Typing{}
 	r.emit(st, sid, Frame{Event: "status", Data: mustJSON(status{Status: "idle", Typing: Typing{}})})
@@ -545,6 +591,22 @@ func (r *Relay) emitLine(st *sessionState, sid string, l Line) {
 	default: // KindPlayer / KindGM — a human line means we are back to listening
 		r.setTyping(st, sid, r.liveTyping())
 	}
+}
+
+// retract removes a never-delivered Agent line from the persisted transcript
+// (#437, ADR-0040 amendment): the row is deleted through the SAME single-writer
+// queue the tees ride, so it can never overtake the UPSERT it undoes. The LIVE
+// display state is deliberately left alone — the decision accepts that the SSE
+// feed transiently shows a line a later reload drops; it was never speech, and
+// the failure's evidence is the Turn's terminal reason, not the Transcript.
+// Idempotent: a line not in the reconcile set (already delivered, or already
+// retracted) is a no-op. Caller holds r.mu.
+func (r *Relay) retract(st *sessionState, sid, lineID string) {
+	if _, ok := st.unconfirmed[lineID]; !ok {
+		return
+	}
+	delete(st.unconfirmed, lineID)
+	r.unpersist(sid, lineID)
 }
 
 // setTyping emits a "status" frame only when the session's typing indicator

--- a/internal/transcript/relay.go
+++ b/internal/transcript/relay.go
@@ -207,14 +207,18 @@ type LineStore interface {
 // reply line whose text accumulates across the turn's TTSInvoked sentences.
 // ended marks a finalized turn (TurnEnded seen) so a late TTSInvoked — which a
 // barge can deliver AFTER the end — does not recreate the entry with a zero
-// target and clobber the completed coalesced reply. delivered records the
-// turn's FIRST FirstAudio — "this turn's speech actually reached the room" —
-// the predicate the #437 reconcile reads at turn end (ADR-0040 amendment).
+// target and clobber the completed coalesced reply. pending marks a dispatched
+// sentence still awaiting its FirstAudio (dispatch is serial single-in-flight,
+// so at most one). deliveredN counts sentences that were delivered (FirstAudio)
+// and not retracted by a TTSStreamFailed (#436) — the #437 reconcile predicate
+// at turn end is deliveredN == 0, ADR-0012's delivered definition, mirroring
+// the Chunker's FIFO pairing so the two grains agree on "the room heard it".
 type turn struct {
-	target    voiceevent.AddressTarget
-	line      *Line
-	ended     bool
-	delivered bool
+	target     voiceevent.AddressTarget
+	line       *Line
+	ended      bool
+	pending    bool
+	deliveredN int
 }
 
 // sessionState is one live Voice Session's projection + replay state (#487):
@@ -448,9 +452,12 @@ func (r *Relay) fold(e voiceevent.Event) {
 			}
 			t.line.Text += ev.Sentence
 		}
-		// The sentence was DISPATCHED, not necessarily spoken (event.go): until this
-		// turn's FirstAudio lands, the row this emit persists is provisional (#437).
-		if !t.delivered {
+		// The sentence was DISPATCHED, not necessarily spoken (event.go): it now
+		// awaits its FirstAudio (superseding a start-errored sentence still in the
+		// slot, like the Chunker's pending purge), and until the turn has delivered
+		// at least one sentence the row this emit persists is provisional (#437).
+		t.pending = true
+		if t.deliveredN == 0 {
 			st.unconfirmed[t.line.ID] = struct{}{}
 		}
 		// emitLine derives typing from the line's kind (FIX 1), so a clean turn
@@ -458,16 +465,48 @@ func (r *Relay) fold(e voiceevent.Event) {
 		// returns to listening — no standalone setTyping here.
 		r.emitLine(st, sid, *t.line)
 	case voiceevent.FirstAudio:
-		// The turn's first sentence reached the room (ADR-0012's delivery signal):
-		// its optimistically-persisted line has earned its row, so it leaves the
-		// reconcile set for good (#437). Dispatch is serial single-in-flight and
-		// FirstAudio(sN) is published inline before Dispatch(sN) returns, so it
-		// always precedes the turn's TurnEnded — the same ordering the Chunker's
-		// deliver-then-commit relies on.
+		// The pending sentence reached the room (ADR-0012's delivery signal): the
+		// optimistically-persisted line has earned its row, so it leaves the
+		// reconcile set (#437) — for good, unless a TTSStreamFailed retracts the
+		// turn's ONLY delivered sentence below. On the same-goroutine terminals
+		// (natural end, tts_error, provider_error) FirstAudio(sN) is published
+		// inline before Dispatch(sN) returns, so it precedes the turn's TurnEnded;
+		// a CUT turn (barge/superseded/mute) publishes TurnEnded from the floor
+		// reactor's goroutine, so a frame-boundary race can drop the first chunk's
+		// FirstAudio after the retract — accepted (ADR-0012 bias: when in doubt,
+		// the room did not hear it). A FirstAudio with nothing pending (straggler)
+		// is a no-op, mirroring the Chunker's pairing.
 		t := r.proj.Turn(sid, ev.TurnID)
-		t.delivered = true
+		if !t.pending {
+			break
+		}
+		t.pending = false
+		t.deliveredN++
 		if t.line != nil {
 			delete(st.unconfirmed, t.line.ID)
+		}
+	case voiceevent.TTSStreamFailed:
+		// The in-flight sentence died mid-delivery (#436): the room heard at most
+		// a fragment, so it must not count as delivered — parity with the Chunker's
+		// abortSentence and with Agent history, which omits it. A sentence that
+		// never got FirstAudio just leaves the pending slot; one that did is
+		// un-counted, and a turn whose ONLY delivered sentence is retracted
+		// re-enters the reconcile set so TurnEnded (or the Finalize sweep) retracts
+		// the row. The line TEXT keeps the failed fragment when EARLIER sentences
+		// delivered — the same #401 tail rounding a barge gets.
+		t := r.proj.Turn(sid, ev.TurnID)
+		if t.ended {
+			break
+		}
+		if t.pending {
+			t.pending = false
+			break
+		}
+		if t.deliveredN > 0 {
+			t.deliveredN--
+		}
+		if t.deliveredN == 0 && t.line != nil {
+			st.unconfirmed[t.line.ID] = struct{}{}
 		}
 	case voiceevent.TurnEnded:
 		// Mark the turn finalized (keep the entry so a late sentence is dropped,
@@ -477,11 +516,12 @@ func (r *Relay) fold(e voiceevent.Event) {
 		t.ended = true
 		// Reconcile the LINE grain against ADR-0012's delivered-only invariant
 		// (#437, ADR-0040 amendment): a turn that ends having delivered ZERO
-		// sentences — a TTS start-error is the canonical case, terminal reason
-		// tts_error — leaves a row the room never heard. Retract it. A turn that
-		// delivered at least one sentence keeps its line, sentence-tail rounding on
-		// barge included (#401).
-		if !t.delivered && t.line != nil {
+		// sentences — a TTS start-error (terminal reason tts_error) is the
+		// canonical case, a mid-stream #436 failure of the only sentence the other
+		// — leaves a row the room never heard. Retract it. A turn that delivered
+		// at least one sentence keeps its line, sentence-tail rounding on barge
+		// included (#401).
+		if t.deliveredN == 0 && t.line != nil {
 			r.retract(st, sid, t.line.ID)
 		}
 		r.setTyping(st, sid, r.liveTyping())
@@ -605,8 +645,12 @@ func (r *Relay) retract(st *sessionState, sid, lineID string) {
 	if _, ok := st.unconfirmed[lineID]; !ok {
 		return
 	}
-	delete(st.unconfirmed, lineID)
-	r.unpersist(sid, lineID)
+	// Leave the id in the reconcile set when the queue is full: the Finalize
+	// sweep retries it after the writer has drained, so a TurnEnded-time drop
+	// under backpressure does not leave a never-delivered row behind for good.
+	if r.unpersist(sid, lineID) {
+		delete(st.unconfirmed, lineID)
+	}
 }
 
 // setTyping emits a "status" frame only when the session's typing indicator

--- a/internal/transcript/relay_say_test.go
+++ b/internal/transcript/relay_say_test.go
@@ -51,6 +51,9 @@ func TestProjection_SayPersistenceTeeFires(t *testing.T) {
 		Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"},
 	})
 	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Aye.", Index: 0, TurnID: "s1"})
+	// The sentence reached the room: the delivery signal that keeps the row past the
+	// #437 reconcile (ADR-0040 amendment — a zero-delivery turn is retracted).
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "s1"})
 
 	if _, err := r.Finalize(context.Background(), fs.id); err != nil {
 		t.Fatalf("Finalize: %v", err)
@@ -79,6 +82,8 @@ func TestProjection_ButlerSayLine(t *testing.T) {
 		Target: voiceevent.AddressTarget{AgentID: "butler-id", AgentRole: "butler", Name: "Glyphoxa"},
 	})
 	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "At your service.", Index: 0, TurnID: "s1"})
+	// Delivered (#437): without a FirstAudio the row would be reconciled away.
+	bus.Publish(voiceevent.FirstAudio{At: at(3), TurnID: "s1"})
 
 	v := r.View(fs.id.String())
 	if len(v.Lines) != 1 {

--- a/internal/transcript/relay_test.go
+++ b/internal/transcript/relay_test.go
@@ -714,10 +714,13 @@ func TestProjection_LookaheadReaction_HappyAttributesReactor(t *testing.T) {
 	// The Lead turn.
 	bus.Publish(voiceevent.EnsembleLead{At: at(1), TurnID: "Te", Target: voiceevent.AddressTarget{AgentID: "bart", AgentRole: "character", Name: "Bart"}})
 	bus.Publish(voiceevent.TTSInvoked{At: at(2), Sentence: "Bart leads.", TurnID: "Te"})
+	bus.Publish(voiceevent.FirstAudio{At: at(2), TurnID: "Te"})
 	// The reaction: EnsembleReaction (attribution) STRICTLY precedes the first TTSInvoked
 	// (F1: PublishInvoked fires only after the announce, at release).
 	bus.Publish(voiceevent.EnsembleReaction{At: at(3), TurnID: "rID", LeadTurnID: "Te", Target: voiceevent.AddressTarget{AgentID: "goblin", AgentRole: "character", Name: "Goblin"}})
 	bus.Publish(voiceevent.TTSInvoked{At: at(4), Sentence: "I disagree.", TurnID: "rID"})
+	// Both turns delivered audio, so both rows survive the #437 reconcile.
+	bus.Publish(voiceevent.FirstAudio{At: at(4), TurnID: "rID"})
 
 	// The reaction is its own line, attributed to Goblin (never "NPC").
 	v := r.View(fs.id.String())

--- a/internal/wirenpc/connect.go
+++ b/internal/wirenpc/connect.go
@@ -39,6 +39,12 @@ func publishConnectionState(bus *voiceevent.Bus, state voiceevent.ConnectionStat
 // join-then-immediate-fail cycle keeps backing off. Any error — or a clean return (a dropped
 // gateway often reports none) — flows back to runWithReconnect, which decides
 // whether to retry; only a cancelled ctx ends the loop.
+//
+// disclosed carries the once-per-Voice-Session guard for the session-start
+// disclosure (#519) across the cycles of one Run — the message must not repeat
+// on every reconnect. A nil pointer posts nothing (the paths that build a cycle
+// outside Run).
+
 // newDiscordClient is the disgo constructor seam (mirrors newLLM/newSTT/newTTS):
 // a test swaps it to assert the owned path calls it and the shared-client path
 // does NOT. Production always uses disgo.New.
@@ -113,7 +119,7 @@ func acquireClient(ctx context.Context, cfg Config, bus *voiceevent.Bus, log *sl
 	return c, true, nil
 }
 
-func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func()) error {
+func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.ID, log *slog.Logger, connected func(), disclosed *sessionOnce) error {
 	// Per-cycle context: everything this cycle spawns — the stage subscriber's
 	// TTL-sweep goroutine (stageSub.Start), the Discord gateway, and the audio
 	// loop — is bound to cycleCtx, so the deferred cancel reaps it at cycle end.
@@ -271,14 +277,17 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 	// grant/revoke buttons. A nil Tape (campaign not armed) makes both inert, so the
 	// loop is unchanged.
 	defer wireTapeConsent(cycleCtx, bus, cfg.Tape, cfg.CampaignID, cfg.TapeConsent, cfg.TapeConsentReconcileInterval, log)()
-	if cfg.Tape != nil {
-		if err := postTapeDisclosure(cycleCtx, client, channel, cfg.CampaignID); err != nil {
-			// A failed disclosure post must not tear down the session — capture is
-			// still consent-gated (only prior consenters are taped), and the operator
-			// can re-post. Log and continue.
-			log.Warn("post tape consent disclosure", "err", err)
-		}
-	}
+
+	// Session-start disclosure (#519, and #306's consent flow folded into it): the
+	// voice channel is the only surface that reaches the players, and transcription
+	// is always on — so the Bot posts the transcription notice (plus the tape's
+	// disclosure + Consent/Revoke buttons when the Campaign is armed) to the bound
+	// text chat as ONE message. Guarded by disclosed so it lands once per Voice
+	// Session, not once per reconnect cycle. Best-effort: a failed post must not
+	// tear the session down — capture stays consent-gated (only prior consenters
+	// are taped) and the operator can re-post — so it is logged and the loop
+	// continues.
+	discloseSession(cycleCtx, client, channel, cfg, disclosed, log)
 
 	// Inbound (hear): the pipeline pumps Session.Inbound through the same Codec's
 	// DecodeInbound into the orchestrator. It tags its inbound counters (A2) with

--- a/internal/wirenpc/connect.go
+++ b/internal/wirenpc/connect.go
@@ -273,9 +273,9 @@ func connectAndServe(ctx context.Context, cfg Config, guild, channel snowflake.I
 
 	// Rollover-tape consent (#306, ADR-0051): reseed the tape from the durable
 	// consent rows at cycle start and reconcile on every (campaign-filtered)
-	// TapeConsentChanged, and post the in-channel consent disclosure with
-	// grant/revoke buttons. A nil Tape (campaign not armed) makes both inert, so the
-	// loop is unchanged.
+	// TapeConsentChanged. A nil Tape (campaign not armed) makes it inert. The
+	// in-channel consent disclosure itself rides the #519 session-start message
+	// posted just below.
 	defer wireTapeConsent(cycleCtx, bus, cfg.Tape, cfg.CampaignID, cfg.TapeConsent, cfg.TapeConsentReconcileInterval, log)()
 
 	// Session-start disclosure (#519, and #306's consent flow folded into it): the

--- a/internal/wirenpc/run.go
+++ b/internal/wirenpc/run.go
@@ -219,9 +219,13 @@ func Run(ctx context.Context, cfg Config) error {
 	// Note: disgo runs its own bounded reconnect during OpenGateway, so this
 	// policy governs the inter-cycle gap and post-join drops (a session that joins
 	// then later disconnects), not the initial dial retries disgo already handles.
+	// One Voice Session's disclosure guard, held OUTSIDE the reconnect loop
+	// (#519): the session-start transcription/consent notice posts on the first
+	// cycle that joins and never again, however many times Discord drops.
+	var disclosed sessionOnce
 	runErr := runWithReconnect(ctx, log, defaultReconnectPolicy(),
 		func(ctx context.Context, connected func()) error {
-			return connectAndServe(ctx, cfg, guild, channel, log, connected)
+			return connectAndServe(ctx, cfg, guild, channel, log, connected, &disclosed)
 		})
 	// A non-nil return is a FATAL, terminal failure (a classified *FatalError):
 	// publish the terminal connection.state{failed} with its readable reason so the

--- a/internal/wirenpc/sessiondisclosure.go
+++ b/internal/wirenpc/sessiondisclosure.go
@@ -1,0 +1,124 @@
+package wirenpc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/google/uuid"
+)
+
+// Voice Session transcription disclosure (#519).
+//
+// Players at the table are data subjects who may never open the web app: the
+// voice channel is the ONLY surface that reaches them. Transcription, however,
+// is always-on for every Voice Session (ADR-0011/ADR-0040 — every utterance
+// becomes Transcript Lines and Chunks persisted for the Campaign), and until
+// now only the OPT-IN Rollover Tape disclosed anything (#306, ADR-0051).
+//
+// So on Voice Session start the Bot posts one disclosure to the bound text
+// surface — the voice channel's own text chat, the same channel the tape
+// disclosure uses. When the Campaign is also tape-armed the two are COMBINED
+// into a single message (the consent buttons follow the transcription notice)
+// rather than posted twice.
+//
+// Once per Voice Session, not once per reconnect cycle: [connectAndServe] runs
+// again on every Discord reconnect (#44), and a channel filling with identical
+// notices is its own kind of noise. [sessionOnce] carries that across the
+// cycles of one Run.
+//
+// Best-effort throughout: a failed post is logged and the session continues.
+// Transcription is disclosed here, but it is not gated on the disclosure
+// landing — the Campaign's GM accepted the terms when they created it.
+
+// transcriptionDisclosureContent is the always-on part of the notice: what is
+// captured, why it is kept, and who can read it back.
+const transcriptionDisclosureContent = "**This session is being transcribed.** " +
+	"Everything spoken in this voice channel is transcribed and stored for this campaign, so the GM can " +
+	"search it and get recaps later. Speak up if you would rather not be recorded — the GM can end the session at any time."
+
+// transcriptionDisclosure renders the notice, appending the deployment's
+// privacy-policy URL when one is configured (GLYPHOXA_PRIVACY_POLICY_URL). A
+// deployment that has not published a policy posts the notice without a link
+// rather than a broken one — the disclosure itself is the point.
+func transcriptionDisclosure(privacyPolicyURL string) string {
+	if u := strings.TrimSpace(privacyPolicyURL); u != "" {
+		return transcriptionDisclosureContent + " Privacy policy: <" + u + ">"
+	}
+	return transcriptionDisclosureContent
+}
+
+// sessionDisclosureContent is the ONE message posted at Voice Session start: the
+// transcription notice, plus — when the Campaign is tape-armed — the Rollover
+// Tape's consent disclosure beneath it (#306). The caller attaches the tape's
+// Consent/Revoke buttons under exactly the same condition, so a tape-armed
+// session still gets its consent flow, in one message instead of two.
+func sessionDisclosureContent(privacyPolicyURL string, tapeArmed bool) string {
+	content := transcriptionDisclosure(privacyPolicyURL)
+	if tapeArmed {
+		content += "\n\n" + tapeDisclosureContent
+	}
+	return content
+}
+
+// postSessionDisclosure posts the session-start disclosure to the voice
+// channel's text chat. withConsentButtons attaches the tape's Consent/Revoke
+// action row (#306) — the buttons are stateless (the Campaign rides their custom
+// ids), so the single message stays interactive for the whole session, including
+// across reconnects.
+//
+// It is a package var so tests substitute a spy and connectAndServe stays free
+// of a live Discord REST.
+var postSessionDisclosure = func(ctx context.Context, client *bot.Client, channel snowflake.ID, campaignID uuid.UUID, content string, withConsentButtons bool) error {
+	msg := discord.MessageCreate{Content: content}
+	if withConsentButtons {
+		msg.Components = []discord.LayoutComponent{
+			discord.NewActionRow(
+				discord.NewPrimaryButton("Consent", tapeGrantCustomID(campaignID)),
+				discord.NewDangerButton("Revoke", tapeRevokeCustomID(campaignID)),
+			),
+		}
+	}
+	if _, err := client.Rest.CreateMessage(channel, msg); err != nil {
+		return fmt.Errorf("wirenpc: post session disclosure: %w", err)
+	}
+	return nil
+}
+
+// discloseSession posts the session-start disclosure ONCE per Voice Session
+// (#519): the always-on transcription notice, plus the Rollover Tape's consent
+// disclosure and buttons when the Campaign is armed (#306), as a single message
+// on the voice channel's text chat. Best-effort — a failed post is logged and
+// the session continues serving; capture stays consent-gated either way.
+func discloseSession(ctx context.Context, client *bot.Client, channel snowflake.ID, cfg Config, disclosed *sessionOnce, log *slog.Logger) {
+	disclosed.do(func() {
+		tapeArmed := cfg.Tape != nil
+		content := sessionDisclosureContent(cfg.PrivacyPolicyURL, tapeArmed)
+		if err := postSessionDisclosure(ctx, client, channel, cfg.CampaignID, content, tapeArmed); err != nil {
+			log.Warn("post session disclosure", "err", err, "tape_armed", tapeArmed)
+		}
+	})
+}
+
+// sessionOnce guards a once-per-Voice-Session side effect across the reconnect
+// cycles of one [Run] (#519). Run owns the value and hands a pointer to each
+// cycle; cycles are strictly sequential on one goroutine (runWithReconnect), so
+// no lock is needed. A nil receiver never fires — the paths that build a cycle
+// outside Run stay unchanged.
+type sessionOnce struct{ done bool }
+
+// do runs f the first time it is called, and never again. It arms BEFORE
+// running f: a best-effort side effect that fails is not retried on the next
+// reconnect cycle (the disclosure is "exactly once per session", and a Discord
+// REST that rejected the post is likelier to spam than to succeed later).
+func (o *sessionOnce) do(f func()) {
+	if o == nil || o.done {
+		return
+	}
+	o.done = true
+	f()
+}

--- a/internal/wirenpc/sessiondisclosure.go
+++ b/internal/wirenpc/sessiondisclosure.go
@@ -34,12 +34,17 @@ import (
 // Best-effort throughout: a failed post is logged and the session continues.
 // Transcription is disclosed here, but it is not gated on the disclosure
 // landing — the Campaign's GM accepted the terms when they created it.
+//
+// The legacy standalone paths (-mode voice, -hardcoded) post the same notice
+// even though they wire no transcript persistence: an accepted OVER-claim —
+// telling a dev channel it is transcribed when nothing is stored is harmless in
+// the direction that matters, and those paths are not the SaaS topology.
 
 // transcriptionDisclosureContent is the always-on part of the notice: what is
 // captured, why it is kept, and who can read it back.
 const transcriptionDisclosureContent = "**This session is being transcribed.** " +
 	"Everything spoken in this voice channel is transcribed and stored for this campaign, so the GM can " +
-	"search it and get recaps later. Speak up if you would rather not be recorded — the GM can end the session at any time."
+	"search it and get recaps later. Speak up if you would rather not be transcribed — the GM can end the session at any time."
 
 // transcriptionDisclosure renders the notice, appending the deployment's
 // privacy-policy URL when one is configured (GLYPHOXA_PRIVACY_POLICY_URL). A

--- a/internal/wirenpc/sessiondisclosure_test.go
+++ b/internal/wirenpc/sessiondisclosure_test.go
@@ -1,0 +1,150 @@
+package wirenpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/bot"
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/tape"
+)
+
+// TestTranscriptionDisclosure_LinksPrivacyPolicy is #519 AC2: the notice carries
+// the deployment's privacy-policy URL when one is configured, and stays a clean
+// (link-free) disclosure when it is not — never a broken link.
+func TestTranscriptionDisclosure_LinksPrivacyPolicy(t *testing.T) {
+	const url = "https://glyphoxa.example/privacy"
+
+	got := transcriptionDisclosure(url)
+	if !strings.Contains(got, url) {
+		t.Errorf("disclosure = %q, want the privacy-policy URL %q in it", got, url)
+	}
+	if !strings.Contains(strings.ToLower(got), "transcribed") {
+		t.Errorf("disclosure = %q, want it to say the session is transcribed", got)
+	}
+
+	// Whitespace-only config is "not configured".
+	if got := transcriptionDisclosure("   "); got != transcriptionDisclosureContent {
+		t.Errorf("disclosure with blank URL = %q, want the bare notice", got)
+	}
+	if strings.Contains(transcriptionDisclosure(""), "http") {
+		t.Errorf("disclosure with no URL configured = %q, want no link at all", transcriptionDisclosure(""))
+	}
+}
+
+// TestSessionDisclosureContent_CombinesWithTape is #519 AC3: a tape-armed
+// Campaign gets ONE message carrying both notices (no double-post), while an
+// unarmed Campaign gets the transcription notice alone — the tape's consent copy
+// must never appear for a session that records nothing.
+func TestSessionDisclosureContent_CombinesWithTape(t *testing.T) {
+	combined := sessionDisclosureContent("https://glyphoxa.example/privacy", true)
+	if !strings.Contains(combined, transcriptionDisclosureContent) {
+		t.Error("combined disclosure dropped the transcription notice")
+	}
+	if !strings.Contains(combined, tapeDisclosureContent) {
+		t.Error("combined disclosure dropped the tape consent notice")
+	}
+
+	alone := sessionDisclosureContent("", false)
+	if strings.Contains(alone, tapeDisclosureContent) {
+		t.Errorf("unarmed disclosure = %q, want no Session Highlights consent copy", alone)
+	}
+	if !strings.Contains(alone, transcriptionDisclosureContent) {
+		t.Errorf("unarmed disclosure = %q, want the transcription notice", alone)
+	}
+}
+
+// disclosureSpy swaps postSessionDisclosure for the test's lifetime, recording
+// every post the cycle attempts (and optionally failing them).
+type disclosureSpy struct {
+	posts   []string
+	buttons []bool
+	err     error
+}
+
+func (s *disclosureSpy) install(t *testing.T) {
+	t.Helper()
+	orig := postSessionDisclosure
+	postSessionDisclosure = func(_ context.Context, _ *bot.Client, _ snowflake.ID, _ uuid.UUID, content string, withButtons bool) error {
+		s.posts = append(s.posts, content)
+		s.buttons = append(s.buttons, withButtons)
+		return s.err
+	}
+	t.Cleanup(func() { postSessionDisclosure = orig })
+}
+
+// TestDiscloseSession_OncePerSessionAcrossCycles is #519 AC1 at the call site:
+// five reconnect cycles of one Voice Session post the disclosure exactly once,
+// and a tape-armed Campaign gets the consent buttons on that one message.
+func TestDiscloseSession_OncePerSessionAcrossCycles(t *testing.T) {
+	spy := &disclosureSpy{}
+	spy.install(t)
+
+	cfg := Config{CampaignID: uuid.New(), PrivacyPolicyURL: "https://glyphoxa.example/privacy", Tape: tape.New(tape.Window, nil, discard())}
+	t.Cleanup(cfg.Tape.Close)
+
+	var disclosed sessionOnce
+	for range 5 {
+		discloseSession(context.Background(), nil, snowflake.ID(7), cfg, &disclosed, discard())
+	}
+
+	if len(spy.posts) != 1 {
+		t.Fatalf("posted %d disclosures across 5 reconnect cycles, want 1", len(spy.posts))
+	}
+	if !strings.Contains(spy.posts[0], "https://glyphoxa.example/privacy") {
+		t.Errorf("posted disclosure = %q, want the privacy-policy link", spy.posts[0])
+	}
+	if !strings.Contains(spy.posts[0], tapeDisclosureContent) {
+		t.Error("tape-armed session lost its consent disclosure — it must ride the same message, not a second post")
+	}
+	if !spy.buttons[0] {
+		t.Error("tape-armed disclosure posted without the Consent/Revoke buttons")
+	}
+}
+
+// TestDiscloseSession_UnarmedPostsPlainNoticeAndFailureIsBestEffort: an unarmed
+// Campaign still gets the transcription notice — with no consent buttons — and a
+// Discord rejection is swallowed (logged) rather than failing the cycle, and is
+// not retried on the next one.
+func TestDiscloseSession_UnarmedPostsPlainNoticeAndFailureIsBestEffort(t *testing.T) {
+	spy := &disclosureSpy{err: errors.New("discord said no")}
+	spy.install(t)
+
+	cfg := Config{CampaignID: uuid.New()}
+	var disclosed sessionOnce
+	discloseSession(context.Background(), nil, snowflake.ID(7), cfg, &disclosed, discard())
+	discloseSession(context.Background(), nil, snowflake.ID(7), cfg, &disclosed, discard())
+
+	if len(spy.posts) != 1 {
+		t.Fatalf("posted %d disclosures, want 1 (a failed post is not retried into a spam loop)", len(spy.posts))
+	}
+	if spy.buttons[0] {
+		t.Error("unarmed session got tape consent buttons")
+	}
+	if strings.Contains(spy.posts[0], tapeDisclosureContent) {
+		t.Errorf("unarmed disclosure = %q, want no Session Highlights copy", spy.posts[0])
+	}
+}
+
+// TestSessionOnce_FiresExactlyOnce is #519 AC1: the guard that keeps the
+// disclosure to one post per Voice Session however many reconnect cycles the
+// session survives — including when the post itself failed (arming happens
+// before the call, so a rejected post is not retried into a spam loop).
+func TestSessionOnce_FiresExactlyOnce(t *testing.T) {
+	var once sessionOnce
+	calls := 0
+	for range 5 { // five reconnect cycles
+		once.do(func() { calls++ })
+	}
+	if calls != 1 {
+		t.Errorf("disclosure posted %d times across 5 cycles, want exactly 1", calls)
+	}
+
+	// A nil guard (a cycle built outside Run) posts nothing rather than panicking.
+	var nilOnce *sessionOnce
+	nilOnce.do(func() { t.Error("nil sessionOnce fired") })
+}

--- a/internal/wirenpc/sharedclient_test.go
+++ b/internal/wirenpc/sharedclient_test.go
@@ -83,7 +83,7 @@ func TestConnectAndServeSharedClientErrorIsCycleError(t *testing.T) {
 
 	connectedCalls := 0
 	err := connectAndServe(context.Background(), cfg, snowflake.ID(1), snowflake.ID(2), discard(),
-		func() { connectedCalls++ })
+		func() { connectedCalls++ }, &sessionOnce{})
 	if !errors.Is(err, boom) {
 		t.Fatalf("connectAndServe = %v, want it to surface the provider error %v", err, boom)
 	}

--- a/internal/wirenpc/tapedisclosure.go
+++ b/internal/wirenpc/tapedisclosure.go
@@ -76,8 +76,8 @@ func ParseTapeConsentCustomID(customID string) (campaignID uuid.UUID, granted, o
 // anyone who does not opt in.
 const tapeDisclosureContent = "**Session Highlights are enabled.** With your consent, this session's audio is " +
 	"kept in a short (~2 minute) rolling buffer so memorable moments can be clipped for the GM's review. " +
-	"Only players who press **Consent** are recorded — press it to opt in, or **Revoke** to opt out at any time. " +
-	"Nothing leaves this server without an explicit GM action."
+	"Only players who press **Consent** have their audio kept — press it to opt in, or **Revoke** to opt out at any time. " +
+	"No audio clip leaves this server without an explicit GM action."
 
 // The tape disclosure is no longer posted on its own: since #519 it rides the
 // single session-start disclosure message (sessiondisclosure.go), which carries

--- a/internal/wirenpc/tapedisclosure.go
+++ b/internal/wirenpc/tapedisclosure.go
@@ -2,15 +2,12 @@ package wirenpc
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
-	"github.com/disgoorg/disgo/bot"
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/events"
-	"github.com/disgoorg/snowflake/v2"
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
@@ -82,25 +79,10 @@ const tapeDisclosureContent = "**Session Highlights are enabled.** With your con
 	"Only players who press **Consent** are recorded — press it to opt in, or **Revoke** to opt out at any time. " +
 	"Nothing leaves this server without an explicit GM action."
 
-// postTapeDisclosure posts the consent-disclosure message with Consent/Revoke
-// buttons to the voice channel after the Bot joins (#306). It is a package var so
-// tests substitute a spy and connectAndServe stays free of a live Discord REST. The
-// production implementation sends via the standing client's REST.
-var postTapeDisclosure = func(ctx context.Context, client *bot.Client, channel snowflake.ID, campaignID uuid.UUID) error {
-	msg := discord.MessageCreate{
-		Content: tapeDisclosureContent,
-		Components: []discord.LayoutComponent{
-			discord.NewActionRow(
-				discord.NewPrimaryButton("Consent", tapeGrantCustomID(campaignID)),
-				discord.NewDangerButton("Revoke", tapeRevokeCustomID(campaignID)),
-			),
-		},
-	}
-	if _, err := client.Rest.CreateMessage(channel, msg); err != nil {
-		return fmt.Errorf("wirenpc: post tape disclosure: %w", err)
-	}
-	return nil
-}
+// The tape disclosure is no longer posted on its own: since #519 it rides the
+// single session-start disclosure message (sessiondisclosure.go), which carries
+// the always-on transcription notice and — for a tape-armed Campaign — this text
+// plus the Consent/Revoke buttons.
 
 // Consent reply text (#306). Centralised here so both the all-mode presence
 // handler and the voice-mode listener reply identically.

--- a/internal/wirenpc/wirenpc.go
+++ b/internal/wirenpc/wirenpc.go
@@ -173,6 +173,13 @@ type Config struct {
 	// uuid.Nil value is a caller bug: RunFromDB refuses to start loudly rather than
 	// silently voicing the wrong (seed) roster.
 	CampaignID uuid.UUID
+	// PrivacyPolicyURL is the deployment's published privacy-policy page
+	// (GLYPHOXA_PRIVACY_POLICY_URL, #518's SPA route in the reference deployment).
+	// The Bot links it from the transcription disclosure it posts at Voice Session
+	// start (#519) — the players at the table are data subjects who may never open
+	// the web app, so the voice channel is the only place that reaches them. Empty
+	// posts the disclosure WITHOUT a link rather than a broken one.
+	PrivacyPolicyURL string
 	// Client, when non-nil, is the standing shared Discord client the boot-owned
 	// presence owns (ADR-0010 amendment, #102): connectAndServe borrows it per
 	// cycle instead of constructing its own with disgo.New / OpenGateway, and does

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -147,6 +147,16 @@ validate_path plans-sync \
   --set plans.catalog.plans[0].monthly_price_usd=20 \
   --set-string plans.catalog.plans[0].key_source=platform
 
+# The public-beta launch posture (#521): plans.enabled with NO catalog overrides
+# — i.e. the shipped default catalog (beta-trial + byok-free) — bound to an
+# open-admission signup. This is the render an operator gets by following the
+# launch docs, so it must be schema-valid as-is.
+validate_path beta-launch \
+  --set plans.enabled=true \
+  --set web.admissionMode=open \
+  --set-string web.signupPlanSlug=beta-trial \
+  --set-string web.operatorIds=""
+
 # The open-admission render path (ADR-0055): web.admissionMode=open relaxes the
 # operator-allowlist requirement — the list becomes the platform-admin roster
 # and may be empty (rendered as an empty operator-ids key) — and requires a

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -163,6 +163,18 @@ validate_path open-admission \
   --set-string 'plans.catalog.plans[0].display_name=BYOK Free' \
   --set plans.catalog.plans[0].monthly_price_usd=0
 
+# The self-contained beta topology (#517): the in-cluster Ollama (Deployment +
+# Service + model-cache PVC) and the cloudflared Tunnel (Deployment + token
+# Secret) must each render schema-valid, and together with the rest of the
+# chart — that combination IS the home-VM install. The token is a throwaway
+# placeholder from ci-values; nothing here is deployed.
+validate_path ollama-in-cluster --set ollama.enabled=true
+validate_path cloudflared-tunnel --set cloudflared.enabled=true
+validate_path beta-home-vm \
+  --set ollama.enabled=true \
+  --set cloudflared.enabled=true \
+  --set ingress.enabled=false
+
 # Reserved-character credentials (issue #151): the same raw values feed
 # POSTGRES_USER/POSTGRES_PASSWORD, so the assembled DSN must percent-encode
 # them or the migrate hook and the app parse a different credential than the

--- a/scripts/helm-validate.sh
+++ b/scripts/helm-validate.sh
@@ -175,6 +175,17 @@ validate_path beta-home-vm \
   --set cloudflared.enabled=true \
   --set ingress.enabled=false
 
+# The backup render paths (#520): the nightly CronJob + its PVC on their own,
+# and the off-site variant (dump-as-initContainer + S3 push) which additionally
+# requires a bucket and a credentials Secret name.
+validate_path backup-local --set backup.enabled=true
+validate_path backup-offsite \
+  --set backup.enabled=true \
+  --set backup.offsite.enabled=true \
+  --set backup.offsite.bucket=glyphoxa-backups \
+  --set backup.offsite.endpoint=https://s3.example.com \
+  --set backup.offsite.existingSecret.name=glyphoxa-backup-offsite
+
 # Reserved-character credentials (issue #151): the same raw values feed
 # POSTGRES_USER/POSTGRES_PASSWORD, so the assembled DSN must percent-encode
 # them or the migrate hook and the app parse a different credential than the

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -14,6 +14,9 @@ import { Configuration } from "@/screens/configuration/Configuration";
 import { Campaign } from "@/screens/campaign/Campaign";
 import { Session } from "@/screens/session/Session";
 import { Placeholder } from "@/screens/Placeholder";
+import { Imprint } from "@/screens/legal/Imprint";
+import { Privacy } from "@/screens/legal/Privacy";
+import { Terms } from "@/screens/legal/Terms";
 
 // Code-based route tree (ADR-0018). The Tenant lives in the path
 // (/t/:tenantSlug/...) so URLs are bookmarkable; for the single-operator MVP
@@ -54,6 +57,29 @@ const onboardingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/onboarding/create-tenant",
   component: CreateTenant,
+});
+
+// The legal documents (#518): Impressum, Datenschutzerklärung and
+// Nutzungsbedingungen. Top-level siblings of /login — OUTSIDE the tenant shell
+// and the AuthGate — because they must be readable with no session at all: by a
+// visitor deciding whether to sign up, and by a player at a transcribed table
+// who will never open the app. /privacy is additionally a Go↔ops contract: the
+// chart derives GLYPHOXA_PRIVACY_POLICY_URL as <host>/privacy for the Bot's
+// in-channel transcription disclosure (#519), so the path must not drift.
+// The German aliases are there because that is what people type.
+// Each route is declared individually rather than mapped from a list: TanStack
+// Router infers the typed route registry from the literal `addChildren` tree, so
+// a spread of mapped routes would compile but leave <Link to="/privacy"> a type
+// error (and unnavigable).
+const imprintRoute = createRoute({ getParentRoute: () => rootRoute, path: "/imprint", component: Imprint });
+const impressumRoute = createRoute({ getParentRoute: () => rootRoute, path: "/impressum", component: Imprint });
+const privacyRoute = createRoute({ getParentRoute: () => rootRoute, path: "/privacy", component: Privacy });
+const datenschutzRoute = createRoute({ getParentRoute: () => rootRoute, path: "/datenschutz", component: Privacy });
+const termsRoute = createRoute({ getParentRoute: () => rootRoute, path: "/terms", component: Terms });
+const nutzungsbedingungenRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/nutzungsbedingungen",
+  component: Terms,
 });
 
 // "/" → the default tenant's Configuration (boot flow stand-in for this stage).
@@ -118,6 +144,12 @@ export const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
   onboardingRoute,
+  imprintRoute,
+  impressumRoute,
+  privacyRoute,
+  datenschutzRoute,
+  termsRoute,
+  nutzungsbedingungenRoute,
   tenantRoute.addChildren([tenantIndexRoute, screenRoute]),
 ]);
 

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -32,8 +32,10 @@ const rootRoute = createRootRoute({
 // /login — the Discord-only OAuth entry (ADR-0016). It lives OUTSIDE the tenant
 // shell so it never triggers the AuthGate (which would loop). The OAuth callback
 // bounces an operator-allowlist rejection here with ?error=not_authorized
-// (ADR-0041); validateSearch surfaces it as a typed search param so the screen
-// can render the not-authorized banner.
+// (ADR-0041), and the server-side AUP gate (#518) bounces an unacknowledged
+// open-mode OAuth start/round-trip with ?error=aup_required; validateSearch
+// surfaces both as a typed search param so the screen can render the matching
+// banner.
 const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/login",
@@ -42,7 +44,7 @@ const loginRoute = createRoute({
   }),
   component: function LoginScreen() {
     const { error } = loginRoute.useSearch();
-    return <Login notAuthorized={error === "not_authorized"} />;
+    return <Login notAuthorized={error === "not_authorized"} aupRequired={error === "aup_required"} />;
   },
 });
 

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -14,6 +14,7 @@ import { Configuration } from "@/screens/configuration/Configuration";
 import { Campaign } from "@/screens/campaign/Campaign";
 import { Session } from "@/screens/session/Session";
 import { Placeholder } from "@/screens/Placeholder";
+import { RootEntry } from "@/screens/landing/RootEntry";
 import { Imprint } from "@/screens/legal/Imprint";
 import { Privacy } from "@/screens/legal/Privacy";
 import { Terms } from "@/screens/legal/Terms";
@@ -23,8 +24,6 @@ import { Terms } from "@/screens/legal/Terms";
 // (ADR-0039) the slug is a thin pass-through. The shell is wrapped in the
 // AuthGate (ADR-0016): it probes GetCurrentUser at boot and redirects to /login
 // on a 401, then hands the real operator identity to the shell.
-
-const DEFAULT_TENANT = "default";
 
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
@@ -82,16 +81,14 @@ const nutzungsbedingungenRoute = createRoute({
   component: Terms,
 });
 
-// "/" → the default tenant's Configuration (boot flow stand-in for this stage).
+// "/" → the public landing page for a visitor with no session, and a straight
+// redirect into the app for one who has (#521). The decision needs the session
+// probe's answer, so it lives in the component rather than a beforeLoad
+// redirect — a redirect here could only ever guess.
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
-  beforeLoad: () => {
-    throw redirect({
-      to: "/t/$tenantSlug/$screen",
-      params: { tenantSlug: DEFAULT_TENANT, screen: "configuration" },
-    });
-  },
+  component: RootEntry,
 });
 
 // /t/:tenantSlug — the persistent shell hosting the screen Outlet, gated by the

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import type { User } from "@gen/glyphoxa/management/v1/management_pb";
 
 import { Button } from "./ui/Button";
 import { SidebarUser } from "./SidebarUser";
+import { LegalFooter } from "./LegalFooter";
 import { CampaignSwitcher } from "./CampaignSwitcher";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
@@ -98,6 +99,11 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
         <main className="gx-content">
           <Outlet />
         </main>
+
+        {/* Impressum / Datenschutz / Nutzungsbedingungen on every app screen
+            (#518) — German law wants them reachable from anywhere, not buried
+            in a settings page. */}
+        <LegalFooter />
       </div>
 
       {/* Single toast host for the whole app (ADR-0017: sonner). Mounted here, not

--- a/web/src/components/LegalFooter.test.tsx
+++ b/web/src/components/LegalFooter.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { LegalFooter } from "./LegalFooter";
+
+// #518 AC1: the footer links the three legal documents and renders on EVERY
+// screen — including the pre-session ones. Mounted here with no router and no
+// Providers, which is the property that lets it sit on the login/signup cards
+// and inside the app shell alike.
+
+describe("LegalFooter", () => {
+  it("links Impressum, Datenschutz and Nutzungsbedingungen", () => {
+    render(<LegalFooter />);
+    expect(screen.getByRole("link", { name: "Impressum" })).toHaveAttribute("href", "/imprint");
+    expect(screen.getByRole("link", { name: "Datenschutz" })).toHaveAttribute("href", "/privacy");
+    expect(screen.getByRole("link", { name: "Nutzungsbedingungen" })).toHaveAttribute(
+      "href",
+      "/terms",
+    );
+  });
+
+  it("is a labelled landmark so it is reachable by assistive tech", () => {
+    render(<LegalFooter />);
+    expect(screen.getByRole("navigation", { name: "Rechtliches" })).toBeInTheDocument();
+  });
+
+  it("keeps its own class when the caller adds one", () => {
+    const { container } = render(<LegalFooter className="gx-legal__footer" />);
+    expect(container.firstChild).toHaveClass("gx-legalfooter", "gx-legal__footer");
+  });
+});

--- a/web/src/components/LegalFooter.tsx
+++ b/web/src/components/LegalFooter.tsx
@@ -1,0 +1,25 @@
+import "./legalFooter.css";
+
+// The legal footer (#518): Impressum, Datenschutzerklärung and
+// Nutzungsbedingungen, reachable from EVERY screen — including the ones a
+// visitor sees before signing in (login, signup) — because that is exactly
+// where German law expects them to be reachable, and where a player deciding
+// whether to join a transcribed table needs them.
+//
+// The pages themselves are unauthenticated SPA routes, so these links work with
+// or without a session. They are plain anchors, not router <Link>s: the footer
+// renders on screens that live outside a RouterProvider (and inside unit tests
+// that mount a single screen), and a full page load into a static document is
+// no loss.
+
+export function LegalFooter({ className }: { className?: string }) {
+  return (
+    <footer className={className ? `gx-legalfooter ${className}` : "gx-legalfooter"}>
+      <nav aria-label="Rechtliches">
+        <a href="/imprint">Impressum</a>
+        <a href="/privacy">Datenschutz</a>
+        <a href="/terms">Nutzungsbedingungen</a>
+      </nav>
+    </footer>
+  );
+}

--- a/web/src/components/legalFooter.css
+++ b/web/src/components/legalFooter.css
@@ -1,0 +1,28 @@
+/* The always-present legal footer (#518). Deliberately quiet: small, subdued,
+   and out of the way on the app screens, but present on every one of them —
+   including login/signup, where it is the only place a visitor can reach the
+   Impressum and the privacy policy before creating anything. */
+.gx-legalfooter {
+  padding: 10px 16px;
+  text-align: center;
+}
+
+.gx-legalfooter nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  align-items: center;
+  justify-content: center;
+}
+
+.gx-legalfooter a {
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+  text-decoration: none;
+}
+
+.gx-legalfooter a:hover,
+.gx-legalfooter a:focus-visible {
+  color: var(--text-strong, #efeaf7);
+  text-decoration: underline;
+}

--- a/web/src/screens/landing/Landing.test.tsx
+++ b/web/src/screens/landing/Landing.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
+import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AuthService,
+  GetCurrentUserResponseSchema,
+  UserSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { routeTree } from "@/app/router";
+import { Landing } from "./Landing";
+
+// The public landing surface (#521). Two things are load-bearing:
+//   1. the ROOT serves it to a visitor with no session (it used to bounce them
+//      into a bare login form), while a signed-in visitor still goes straight to
+//      the app;
+//   2. the CTA goes to /login — the OAuth flow, and #518's open-mode
+//      acknowledgment in front of it, are untouched.
+
+function backend(opts: { signedIn?: boolean } = {}) {
+  return createRouterTransport(({ service }) => {
+    service(AuthService, {
+      getCurrentUser: () => {
+        if (!opts.signedIn) throw new ConnectError("no session", Code.Unauthenticated);
+        return create(GetCurrentUserResponseSchema, {
+          user: create(UserSchema, { name: "Rin", role: "operator", avatar: "" }),
+          tenantId: "5b3f7c1e-0000-0000-0000-000000000000",
+          tenantName: "Rin's Table",
+        });
+      },
+    });
+  });
+}
+
+function renderRoot(opts: { signedIn?: boolean } = {}) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  render(
+    <Providers transport={backend(opts)} queryClient={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </Providers>,
+  );
+  return router;
+}
+
+describe("root landing surface", () => {
+  it("serves the landing page to a visitor with no session", async () => {
+    renderRoot();
+    expect(await screen.findByRole("heading", { level: 1 })).toHaveTextContent(/NPCs a voice/i);
+  });
+
+  it("sends the CTA into the unchanged auth flow", async () => {
+    renderRoot();
+    await screen.findByRole("heading", { level: 1 });
+    // /login, not /auth/discord/login: the login screen is where the open-mode
+    // AUP acknowledgment (#518) gates the OAuth start.
+    for (const name of [/start with discord/i, /sign in/i]) {
+      expect(screen.getByRole("link", { name })).toHaveAttribute("href", "/login");
+    }
+  });
+
+  it("takes a signed-in visitor straight to the app", async () => {
+    const router = renderRoot({ signedIn: true });
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/default/configuration"),
+    );
+    expect(screen.queryByText(/NPCs a voice/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("landing copy", () => {
+  it("states the beta bargain: a small allowance, then your own keys", async () => {
+    render(<Landing />);
+    const doc = document.body.textContent ?? "";
+    expect(doc).toMatch(/small monthly allowance/i);
+    expect(doc).toMatch(/your own provider keys/i);
+    // Honest about what the beta is (#258's copy policy): no card, rough edges,
+    // and the transcription disclosure players will meet in Discord.
+    expect(doc).toMatch(/no card/i);
+    expect(doc).toMatch(/transcribed/i);
+  });
+
+  it("quotes no allowance figure the operator can change out from under it", async () => {
+    // included_usage_usd is an operator-adjustable chart value (#521's plan
+    // catalog), so a dollar figure in this copy would become false on the first
+    // `helm upgrade` that tunes it.
+    render(<Landing />);
+    expect(document.body.textContent ?? "").not.toMatch(/\$\s?\d/);
+  });
+
+  it("captions every screenshot slot, placeholder or not", async () => {
+    render(<Landing />);
+    const shots = screen.getByLabelText("Screenshots");
+    const figures = shots.querySelectorAll("figure");
+    expect(figures.length).toBeGreaterThanOrEqual(3);
+    for (const fig of figures) {
+      expect(fig.querySelector("figcaption")?.textContent ?? "").not.toBe("");
+    }
+  });
+
+  it("carries the legal footer for an unauthenticated visitor", async () => {
+    render(<Landing />);
+    expect(screen.getByRole("link", { name: "Impressum" })).toHaveAttribute("href", "/imprint");
+  });
+});

--- a/web/src/screens/landing/Landing.test.tsx
+++ b/web/src/screens/landing/Landing.test.tsx
@@ -6,6 +6,8 @@ import { create } from "@bufbuild/protobuf";
 
 import {
   AuthService,
+  AdmissionMode,
+  GetAdmissionModeResponseSchema,
   GetCurrentUserResponseSchema,
   UserSchema,
 } from "@gen/glyphoxa/management/v1/management_pb";
@@ -14,17 +16,22 @@ import { makeQueryClient } from "@/lib/queryClient";
 import { routeTree } from "@/app/router";
 import { Landing } from "./Landing";
 
-// The public landing surface (#521). Two things are load-bearing:
+// The public landing surface (#521). Three things are load-bearing:
 //   1. the ROOT serves it to a visitor with no session (it used to bounce them
 //      into a bare login form), while a signed-in visitor still goes straight to
 //      the app;
 //   2. the CTA goes to /login — the OAuth flow, and #518's open-mode
-//      acknowledgment in front of it, are untouched.
+//      acknowledgment in front of it, are untouched;
+//   3. the free-beta economics only render on an explicitly OPEN deployment —
+//      the SPA ships identically to every operator, and a stock allowlist
+//      install must not advertise a signup it rejects or an allowance it does
+//      not fund. Fail-safe (probe down) is the neutral page.
 
-function backend(opts: { signedIn?: boolean } = {}) {
+function backend(opts: { signedIn?: boolean; mode?: AdmissionMode; down?: boolean } = {}) {
   return createRouterTransport(({ service }) => {
     service(AuthService, {
       getCurrentUser: () => {
+        if (opts.down) throw new ConnectError("origin wedged", Code.Unavailable);
         if (!opts.signedIn) throw new ConnectError("no session", Code.Unauthenticated);
         return create(GetCurrentUserResponseSchema, {
           user: create(UserSchema, { name: "Rin", role: "operator", avatar: "" }),
@@ -32,11 +39,17 @@ function backend(opts: { signedIn?: boolean } = {}) {
           tenantName: "Rin's Table",
         });
       },
+      getAdmissionMode: () => {
+        if (opts.down) throw new ConnectError("origin wedged", Code.Unavailable);
+        return create(GetAdmissionModeResponseSchema, {
+          admissionMode: opts.mode ?? AdmissionMode.OPEN,
+        });
+      },
     });
   });
 }
 
-function renderRoot(opts: { signedIn?: boolean } = {}) {
+function renderRoot(opts: { signedIn?: boolean; mode?: AdmissionMode; down?: boolean } = {}) {
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({ initialEntries: ["/"] }),
@@ -72,11 +85,36 @@ describe("root landing surface", () => {
     );
     expect(screen.queryByText(/NPCs a voice/i)).not.toBeInTheDocument();
   });
+
+  it("serves the landing page when the backend is down, not a spinner", async () => {
+    // The stated design goal: the marketing surface is a static document and
+    // stays up when the API is not (a rejected probe — a HUNG one is bounded
+    // by RootEntry's grace timer, not exercised here).
+    renderRoot({ down: true });
+    expect(await screen.findByRole("heading", { level: 1 })).toHaveTextContent(/NPCs a voice/i);
+    // Fail-safe posture: no free-beta economics without an explicit OPEN answer.
+    expect(screen.queryByText(/free while in beta/i)).not.toBeInTheDocument();
+  });
+
+  it("only advertises the free beta on an explicitly OPEN deployment", async () => {
+    renderRoot({ mode: AdmissionMode.ALLOWLIST });
+    await screen.findByRole("heading", { level: 1 });
+    // A stock allowlist install: neutral sign-in CTA, no signup framing, no
+    // allowance promise this instance does not fund.
+    expect(screen.getByRole("link", { name: /sign in with discord/i })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+    expect(screen.queryByText(/free while in beta/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/small monthly allowance/i)).not.toBeInTheDocument();
+    // The transcription honesty note is deployment-independent and stays.
+    expect(screen.getByText(/sessions are transcribed/i)).toBeInTheDocument();
+  });
 });
 
 describe("landing copy", () => {
-  it("states the beta bargain: a small allowance, then your own keys", async () => {
-    render(<Landing />);
+  it("states the beta bargain on an open deployment: a small allowance, then your own keys", async () => {
+    render(<Landing open />);
     const doc = document.body.textContent ?? "";
     expect(doc).toMatch(/small monthly allowance/i);
     expect(doc).toMatch(/your own provider keys/i);
@@ -84,13 +122,18 @@ describe("landing copy", () => {
     // and the transcription disclosure players will meet in Discord.
     expect(doc).toMatch(/no card/i);
     expect(doc).toMatch(/transcribed/i);
+    // The allowance gate is plan-based: adding keys alone does not unpause an
+    // exhausted trial, the operator moves the tenant to the BYOK plan. The copy
+    // must not promise the self-service switch that does not exist.
+    expect(doc).not.toMatch(/until you add your own keys/i);
+    expect(doc).toMatch(/ask the operator/i);
   });
 
   it("quotes no allowance figure the operator can change out from under it", async () => {
     // included_usage_usd is an operator-adjustable chart value (#521's plan
     // catalog), so a dollar figure in this copy would become false on the first
     // `helm upgrade` that tunes it.
-    render(<Landing />);
+    render(<Landing open />);
     expect(document.body.textContent ?? "").not.toMatch(/\$\s?\d/);
   });
 

--- a/web/src/screens/landing/Landing.tsx
+++ b/web/src/screens/landing/Landing.tsx
@@ -1,0 +1,149 @@
+import { Dices, Mic, ScrollText, Sparkles, KeyRound } from "lucide-react";
+
+import { LegalFooter } from "@/components/LegalFooter";
+
+import "./landing.css";
+
+// The public landing surface (#521). Before this, an unauthenticated visitor hit
+// a bare login form — which converts nobody and explains nothing. This screen is
+// what the root serves them instead: what Glyphoxa is, what the free beta
+// actually gives you, and a CTA into the unchanged Discord OAuth flow (via
+// /login, so the open-mode AUP acknowledgment from #518 still gates signup).
+//
+// COPY RULE (#258): everything here describes what ships today. No roadmap
+// features in the present tense, no invented numbers. The trial allowance is
+// described qualitatively ("a small monthly allowance") because it is an
+// operator-adjustable chart value (#521's plan catalog) — quoting a figure here
+// would make the page lie the moment an operator tunes it.
+//
+// The screenshots are placeholders until #263's captures land; each frame keeps
+// its caption so the layout (and the honesty of the caption) is already right.
+
+type Feature = { icon: typeof Mic; title: string; body: string };
+
+const FEATURES: Feature[] = [
+  {
+    icon: Mic,
+    title: "NPCs that talk back",
+    body: "Your Agents join the Discord voice channel, hear the table, and answer out loud in their own voice — addressed by name, or by whoever the scene is pointing at.",
+  },
+  {
+    icon: ScrollText,
+    title: "The session, written down",
+    body: "Every session is transcribed and searchable afterwards, and the table's own history feeds back into what the NPCs remember.",
+  },
+  {
+    icon: Sparkles,
+    title: "Run by the GM, not by the bot",
+    body: "You write the personas, mute an NPC mid-scene, put words in their mouth with /say, and steer the next reply with a directive. Recording anything is opt-in, per player.",
+  },
+  {
+    icon: KeyRound,
+    title: "Your keys, your data",
+    body: "Bring your own provider keys and the usage is yours alone. Everything lives in one Postgres database on the operator's own server — exportable, and deletable.",
+  },
+];
+
+// Screenshot slots. src stays null until #263's captures land; the frame then
+// renders the image in place of the placeholder with no layout change.
+type Shot = { caption: string; src: string | null };
+
+const SHOTS: Shot[] = [
+  { caption: "The live session screen: transcript, who is speaking, spend so far.", src: null },
+  { caption: "An Agent's persona and voice, in the campaign editor.", src: null },
+  { caption: "The campaign's knowledge graph, built from play.", src: null },
+  { caption: "Provider keys and spend caps, per tenant.", src: null },
+];
+
+export function Landing() {
+  return (
+    <div className="gx-landing">
+      <header className="gx-landing__bar">
+        <span className="gx-landing__brand">
+          <span className="gx-landing__sigil">
+            <Dices size={18} />
+          </span>
+          <span className="gx-gradient-text">Glyphoxa</span>
+        </span>
+        <a className="gx-btn gx-btn--secondary" href="/login">
+          Sign in
+        </a>
+      </header>
+
+      <section className="gx-landing__hero">
+        <h1 className="gx-landing__headline">
+          Give your <span className="gx-gradient-text">NPCs a voice</span> at the table
+        </h1>
+        <p className="gx-landing__lede">
+          Glyphoxa is a self-hosted companion for tabletop RPGs played over Discord. It
+          voices your campaign&apos;s characters in the voice channel, keeps the transcript,
+          and remembers what happened — while the GM stays in charge of all of it.
+        </p>
+        <div className="gx-landing__cta">
+          <a className="gx-btn gx-btn--primary gx-btn--lg" href="/login">
+            Start with Discord
+          </a>
+          <span className="gx-landing__cta-note">
+            Free while in beta · sign in with the Discord account you play on
+          </span>
+        </div>
+      </section>
+
+      <section className="gx-landing__features" aria-label="What Glyphoxa does">
+        {FEATURES.map(({ icon: Icon, title, body }) => (
+          <article key={title} className="gx-landing__feature">
+            <span className="gx-landing__feature-icon">
+              <Icon size={18} />
+            </span>
+            <h2>{title}</h2>
+            <p>{body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="gx-landing__shots" aria-label="Screenshots">
+        {SHOTS.map((shot) => (
+          <figure key={shot.caption} className="gx-landing__shot">
+            {shot.src ? (
+              <img src={shot.src} alt={shot.caption} loading="lazy" />
+            ) : (
+              <div className="gx-landing__shot-placeholder" role="presentation" />
+            )}
+            <figcaption>{shot.caption}</figcaption>
+          </figure>
+        ))}
+      </section>
+
+      <section className="gx-landing__beta" aria-labelledby="beta-heading">
+        <h2 id="beta-heading">How the free beta works</h2>
+        <div className="gx-landing__plans">
+          <article className="gx-landing__plan">
+            <h3>Try it on us</h3>
+            <p>
+              New tables start with a small monthly allowance of provider usage paid for by
+              this instance. No card, nothing to cancel. When the allowance is used up, the
+              voice features pause until the next month — or until you add your own keys.
+            </p>
+          </article>
+          <article className="gx-landing__plan">
+            <h3>Then bring your own keys</h3>
+            <p>
+              For real campaigns, add your own provider keys (speech, language model,
+              images) in the settings. Usage is then billed to you by those providers, and
+              this instance charges nothing on top.
+            </p>
+          </article>
+        </div>
+        <p className="gx-landing__beta-note">
+          This is an open beta on a small self-hosted server: expect rough edges and the
+          occasional restart, and keep your own export of anything you would hate to lose.
+          Sessions are transcribed — the bot says so in the channel before it starts, and
+          audio recording is opt-in per player. Details in the{" "}
+          <a href="/privacy">Datenschutzerklärung</a>.
+        </p>
+      </section>
+
+      <LegalFooter />
+    </div>
+  );
+}

--- a/web/src/screens/landing/Landing.tsx
+++ b/web/src/screens/landing/Landing.tsx
@@ -16,6 +16,15 @@ import "./landing.css";
 // operator-adjustable chart value (#521's plan catalog) — quoting a figure here
 // would make the page lie the moment an operator tunes it.
 //
+// The SPA ships identically to every operator, but the beta-economics copy is
+// only true on the launch posture (open Admission Mode + the beta plan
+// catalog). RootEntry probes the public GetAdmissionMode (the same posture
+// probe Login uses) and passes `open`: only an explicit OPEN answer renders
+// the free-beta section and signup framing; the fail-safe default (allowlist,
+// probe pending or errored) is a neutral product page with a plain sign-in
+// CTA, so a stock self-host install never advertises a signup it rejects or
+// an allowance it does not fund.
+//
 // The screenshots are placeholders until #263's captures land; each frame keeps
 // its caption so the layout (and the honesty of the caption) is already right.
 
@@ -35,12 +44,12 @@ const FEATURES: Feature[] = [
   {
     icon: Sparkles,
     title: "Run by the GM, not by the bot",
-    body: "You write the personas, mute an NPC mid-scene, put words in their mouth with /say, and steer the next reply with a directive. Recording anything is opt-in, per player.",
+    body: "You write the personas, mute an NPC mid-scene, put words in their mouth with /say, and steer the next reply with a directive. Audio recording is opt-in, per player.",
   },
   {
     icon: KeyRound,
     title: "Your keys, your data",
-    body: "Bring your own provider keys and the usage is yours alone. Everything lives in one Postgres database on the operator's own server — exportable, and deletable.",
+    body: "Bring your own provider keys and the usage is yours alone. Everything lives in one Postgres database on the operator's own server, and deleting a campaign removes all of it.",
   },
 ];
 
@@ -55,7 +64,7 @@ const SHOTS: Shot[] = [
   { caption: "Provider keys and spend caps, per tenant.", src: null },
 ];
 
-export function Landing() {
+export function Landing({ open = false }: { open?: boolean }) {
   return (
     <div className="gx-landing">
       <header className="gx-landing__bar">
@@ -81,10 +90,12 @@ export function Landing() {
         </p>
         <div className="gx-landing__cta">
           <a className="gx-btn gx-btn--primary gx-btn--lg" href="/login">
-            Start with Discord
+            {open ? "Start with Discord" : "Sign in with Discord"}
           </a>
           <span className="gx-landing__cta-note">
-            Free while in beta · sign in with the Discord account you play on
+            {open
+              ? "Free while in beta · sign in with the Discord account you play on"
+              : "Sign in with the Discord account you play on"}
           </span>
         </div>
       </section>
@@ -114,34 +125,42 @@ export function Landing() {
         ))}
       </section>
 
-      <section className="gx-landing__beta" aria-labelledby="beta-heading">
-        <h2 id="beta-heading">How the free beta works</h2>
-        <div className="gx-landing__plans">
-          <article className="gx-landing__plan">
-            <h3>Try it on us</h3>
-            <p>
-              New tables start with a small monthly allowance of provider usage paid for by
-              this instance. No card, nothing to cancel. When the allowance is used up, the
-              voice features pause until the next month — or until you add your own keys.
-            </p>
-          </article>
-          <article className="gx-landing__plan">
-            <h3>Then bring your own keys</h3>
-            <p>
-              For real campaigns, add your own provider keys (speech, language model,
-              images) in the settings. Usage is then billed to you by those providers, and
-              this instance charges nothing on top.
-            </p>
-          </article>
-        </div>
-        <p className="gx-landing__beta-note">
-          This is an open beta on a small self-hosted server: expect rough edges and the
-          occasional restart, and keep your own export of anything you would hate to lose.
-          Sessions are transcribed — the bot says so in the channel before it starts, and
-          audio recording is opt-in per player. Details in the{" "}
-          <a href="/privacy">Datenschutzerklärung</a>.
-        </p>
-      </section>
+      {open && (
+        <section className="gx-landing__beta" aria-labelledby="beta-heading">
+          <h2 id="beta-heading">How the free beta works</h2>
+          <div className="gx-landing__plans">
+            <article className="gx-landing__plan">
+              <h3>Try it on us</h3>
+              <p>
+                New tables start with a small monthly allowance of provider usage paid for
+                by this instance. No card, nothing to cancel. When the allowance is used
+                up, the voice features pause until the next month — or ask the operator to
+                move you to the free bring-your-own-keys plan.
+              </p>
+            </article>
+            <article className="gx-landing__plan">
+              <h3>Then bring your own keys</h3>
+              <p>
+                For real campaigns, add your own provider keys (speech, language model,
+                images) in the settings and ask to be moved to the BYOK plan. Usage is
+                then billed to you by those providers, and this instance charges nothing
+                on top.
+              </p>
+            </article>
+          </div>
+          <p className="gx-landing__beta-note">
+            This is an open beta on a small self-hosted server: expect rough edges and the
+            occasional restart, and keep your own notes on anything you would hate to
+            lose.
+          </p>
+        </section>
+      )}
+
+      <p className="gx-landing__beta-note">
+        Sessions are transcribed — the bot says so in the voice channel before it starts —
+        and audio recording is opt-in per player. Details in the{" "}
+        <a href="/privacy">Datenschutzerklärung</a>.
+      </p>
 
       <LegalFooter />
     </div>

--- a/web/src/screens/landing/RootEntry.tsx
+++ b/web/src/screens/landing/RootEntry.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useQuery } from "@connectrpc/connect-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import { Landing } from "./Landing";
+
+// What the ROOT path serves (#521).
+//
+// Before: "/" redirected straight into the app, so an unauthenticated visitor
+// bounced off the AuthGate into a bare login form — no explanation of what this
+// is, no path into signup. Now the root probes the session once:
+//
+//   - signed in  → straight to the app, exactly as before (no landing detour);
+//   - otherwise  → the public landing page, whose CTA goes to /login, leaving
+//     the OAuth flow (and #518's open-mode acknowledgment) untouched.
+//
+// A backend that is down or erroring resolves to the landing page rather than a
+// spinner: it is a static document, so the marketing surface stays up even when
+// the API is not.
+
+// The cosmetic tenant slug in the app path (ADR-0039 pass-through). Mirrors
+// DEFAULT_TENANT in router.tsx, which cannot be imported here without a
+// router↔screen cycle.
+const DEFAULT_TENANT = "default";
+
+export function RootEntry() {
+  const navigate = useNavigate();
+  // retry off so an unauthenticated visitor sees the landing page immediately
+  // rather than after react-query's default backoff.
+  const { data, status } = useQuery(AuthService.method.getCurrentUser, {}, { retry: false });
+  const signedIn = status === "success" && Boolean(data?.user);
+
+  useEffect(() => {
+    if (signedIn) {
+      void navigate({
+        to: "/t/$tenantSlug/$screen",
+        params: { tenantSlug: DEFAULT_TENANT, screen: "configuration" },
+        replace: true,
+      });
+    }
+  }, [signedIn, navigate]);
+
+  if (status === "pending" || signedIn) {
+    return <div className="gx-auth-boot" aria-busy="true" aria-label="Loading" />;
+  }
+  return <Landing />;
+}

--- a/web/src/screens/landing/RootEntry.tsx
+++ b/web/src/screens/landing/RootEntry.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@connectrpc/connect-query";
 import { useNavigate } from "@tanstack/react-router";
 
-import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
+import { AuthService, AdmissionMode } from "@gen/glyphoxa/management/v1/management_pb";
 import { Landing } from "./Landing";
 
 // What the ROOT path serves (#521).
@@ -17,19 +17,38 @@ import { Landing } from "./Landing";
 //
 // A backend that is down or erroring resolves to the landing page rather than a
 // spinner: it is a static document, so the marketing surface stays up even when
-// the API is not.
+// the API is not. A backend that HANGS (accepts, never answers — e.g. a wedged
+// origin behind the launch topology's Tunnel) is bounded the same way: after
+// PROBE_GRACE_MS of pending, the landing renders anyway, and the signed-in
+// redirect still fires if the probe eventually resolves.
+//
+// The deployment's Admission Mode (ADR-0055) is probed alongside the session —
+// the same public GetAdmissionMode Login uses — so the landing only advertises
+// the free-beta signup on an explicitly OPEN deployment (fail-safe: neutral
+// copy, plain sign-in CTA).
 
-// The cosmetic tenant slug in the app path (ADR-0039 pass-through). Mirrors
-// DEFAULT_TENANT in router.tsx, which cannot be imported here without a
-// router↔screen cycle.
+// The cosmetic tenant slug in the app path (ADR-0039 pass-through) — the same
+// "default" the AuthGate login flow lands on.
 const DEFAULT_TENANT = "default";
+
+// How long the boot placeholder may hold the public root before the static
+// landing page wins over a still-pending session probe.
+const PROBE_GRACE_MS = 2500;
 
 export function RootEntry() {
   const navigate = useNavigate();
   // retry off so an unauthenticated visitor sees the landing page immediately
   // rather than after react-query's default backoff.
   const { data, status } = useQuery(AuthService.method.getCurrentUser, {}, { retry: false });
+  const admission = useQuery(AuthService.method.getAdmissionMode, {}, { retry: false });
   const signedIn = status === "success" && Boolean(data?.user);
+  const open = admission.data?.admissionMode === AdmissionMode.OPEN;
+
+  const [graceOver, setGraceOver] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setGraceOver(true), PROBE_GRACE_MS);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     if (signedIn) {
@@ -41,8 +60,8 @@ export function RootEntry() {
     }
   }, [signedIn, navigate]);
 
-  if (status === "pending" || signedIn) {
+  if ((status === "pending" && !graceOver) || signedIn) {
     return <div className="gx-auth-boot" aria-busy="true" aria-label="Loading" />;
   }
-  return <Landing />;
+  return <Landing open={open} />;
 }

--- a/web/src/screens/landing/landing.css
+++ b/web/src/screens/landing/landing.css
@@ -1,0 +1,179 @@
+/* The public landing surface (#521) — the first thing an unauthenticated
+   visitor sees at the root. It shares the app's token vocabulary but none of
+   its chrome: no sidebar, no topbar, nothing that implies a session. */
+.gx-landing {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 20px 20px 8px;
+}
+
+.gx-landing__bar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0 28px;
+}
+
+.gx-landing__brand {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.gx-landing__sigil {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  color: #fff;
+  background: linear-gradient(135deg, #9059ff, #00ddff);
+}
+
+.gx-landing__hero {
+  max-width: 46ch;
+  margin: 24px 0 56px;
+}
+
+.gx-landing__headline {
+  margin: 0 0 14px;
+  font-size: clamp(30px, 5vw, 46px);
+  line-height: 1.12;
+}
+
+.gx-landing__lede {
+  margin: 0 0 24px;
+  color: var(--text-subtle, #9a93a8);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.gx-landing__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: center;
+}
+
+.gx-landing__cta-note {
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+}
+
+.gx-landing__features {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-bottom: 56px;
+}
+
+.gx-landing__feature {
+  padding: 18px;
+  background: var(--surface-card, #16131f);
+  border: 1px solid var(--border-subtle, #2a2535);
+  border-radius: 14px;
+}
+
+.gx-landing__feature h2 {
+  margin: 12px 0 6px;
+  font-size: 17px;
+}
+
+.gx-landing__feature p {
+  margin: 0;
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+  line-height: 1.55;
+}
+
+.gx-landing__feature-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  color: #fff;
+  background: linear-gradient(135deg, #9059ff, #00ddff);
+}
+
+.gx-landing__shots {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-bottom: 56px;
+}
+
+.gx-landing__shot {
+  margin: 0;
+}
+
+.gx-landing__shot img,
+.gx-landing__shot-placeholder {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border: 1px solid var(--border-subtle, #2a2535);
+  border-radius: 12px;
+}
+
+/* Until #263's captures land, each slot is a quiet frame rather than a fake
+   image: honest about being a placeholder, and the layout is already final. */
+.gx-landing__shot-placeholder {
+  background:
+    radial-gradient(circle at 30% 25%, rgba(144, 89, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 75% 70%, rgba(0, 221, 255, 0.14), transparent 50%),
+    var(--surface-card, #16131f);
+}
+
+.gx-landing__shot figcaption {
+  margin-top: 8px;
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+}
+
+.gx-landing__beta {
+  padding: 24px;
+  background: var(--surface-card, #16131f);
+  border: 1px solid var(--border-subtle, #2a2535);
+  border-radius: 16px;
+}
+
+.gx-landing__beta h2 {
+  margin: 0 0 16px;
+  font-size: 20px;
+}
+
+.gx-landing__plans {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.gx-landing__plan h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.gx-landing__plan p {
+  margin: 0;
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+  line-height: 1.55;
+}
+
+.gx-landing__beta-note {
+  margin: 20px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle, #2a2535);
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+  line-height: 1.55;
+}
+
+.gx-landing__beta-note a {
+  color: var(--accent, #9059ff);
+}

--- a/web/src/screens/legal/Imprint.tsx
+++ b/web/src/screens/legal/Imprint.tsx
@@ -51,22 +51,18 @@ export function Imprint() {
 
       <Section heading="Streitbeilegung">
         <p>
-          Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung
-          bereit:{" "}
-          <a href="https://ec.europa.eu/consumers/odr/" target="_blank" rel="noreferrer noopener">
-            https://ec.europa.eu/consumers/odr/
-          </a>
-          . Wir sind nicht verpflichtet und nicht bereit, an Streitbeilegungsverfahren vor
-          einer Verbraucherschlichtungsstelle teilzunehmen.
+          Wir sind nicht verpflichtet und nicht bereit, an Streitbeilegungsverfahren vor
+          einer Verbraucherschlichtungsstelle teilzunehmen (§ 36 VSBG).
         </p>
       </Section>
 
       <Section heading="Haftung für Inhalte und Links">
         <p>
           Als Diensteanbieter sind wir für eigene Inhalte auf diesen Seiten nach den
-          allgemeinen Gesetzen verantwortlich (§ 7 Abs. 1 DDG). Nach §§ 8 bis 10 DDG sind
-          wir jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
-          Informationen zu überwachen. Für die Inhalte verlinkter externer Seiten ist
+          allgemeinen Gesetzen verantwortlich. Für übermittelte oder gespeicherte fremde
+          Informationen gelten die Haftungsprivilegien der Art. 4 bis 6 der Verordnung
+          (EU) 2022/2065 (Digital Services Act); eine allgemeine Überwachungspflicht
+          besteht nicht (Art. 8 DSA). Für die Inhalte verlinkter externer Seiten ist
           stets deren Anbieter verantwortlich; zum Zeitpunkt der Verlinkung waren keine
           Rechtsverstöße erkennbar. Bei Bekanntwerden von Rechtsverletzungen entfernen wir
           derartige Links umgehend.

--- a/web/src/screens/legal/Imprint.tsx
+++ b/web/src/screens/legal/Imprint.tsx
@@ -1,0 +1,93 @@
+import { LegalPage, OperatorValue, Section } from "./LegalPage";
+import { OPERATOR } from "./operator";
+
+// Impressum (#518) — §5 DDG (ex-§5 TMG) and, where editorial content exists,
+// §18 Abs. 2 MStV. Every substantive value comes from operator.ts, which the
+// OPERATOR fills in; nothing here is invented by the project.
+
+export function Imprint() {
+  return (
+    <LegalPage title="Impressum" lede="Angaben gemäß § 5 DDG">
+      <Section heading="Diensteanbieter">
+        <p>
+          <OperatorValue value={OPERATOR.legalName} />
+          <br />
+          <OperatorValue value={OPERATOR.street} />
+          <br />
+          <OperatorValue value={OPERATOR.city} />
+          <br />
+          <OperatorValue value={OPERATOR.country} />
+        </p>
+      </Section>
+
+      <Section heading="Kontakt">
+        <p>
+          E-Mail: <OperatorValue value={OPERATOR.email} />
+          {OPERATOR.phone && (
+            <>
+              <br />
+              Telefon: {OPERATOR.phone}
+            </>
+          )}
+        </p>
+        <p>
+          Anfragen zu dieser Instanz — einschließlich Auskunfts- und Löschersuchen nach
+          DSGVO — richten Sie bitte an diese Adresse. Wir antworten in der Regel innerhalb
+          eines Monats (Art. 12 Abs. 3 DSGVO).
+        </p>
+      </Section>
+
+      {OPERATOR.contentResponsible && (
+        <Section heading="Redaktionell verantwortlich (§ 18 Abs. 2 MStV)">
+          <p>{OPERATOR.contentResponsible}</p>
+        </Section>
+      )}
+
+      {OPERATOR.vatId && (
+        <Section heading="Umsatzsteuer-Identifikationsnummer">
+          <p>{OPERATOR.vatId} (§ 27a UStG)</p>
+        </Section>
+      )}
+
+      <Section heading="Streitbeilegung">
+        <p>
+          Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung
+          bereit:{" "}
+          <a href="https://ec.europa.eu/consumers/odr/" target="_blank" rel="noreferrer noopener">
+            https://ec.europa.eu/consumers/odr/
+          </a>
+          . Wir sind nicht verpflichtet und nicht bereit, an Streitbeilegungsverfahren vor
+          einer Verbraucherschlichtungsstelle teilzunehmen.
+        </p>
+      </Section>
+
+      <Section heading="Haftung für Inhalte und Links">
+        <p>
+          Als Diensteanbieter sind wir für eigene Inhalte auf diesen Seiten nach den
+          allgemeinen Gesetzen verantwortlich (§ 7 Abs. 1 DDG). Nach §§ 8 bis 10 DDG sind
+          wir jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
+          Informationen zu überwachen. Für die Inhalte verlinkter externer Seiten ist
+          stets deren Anbieter verantwortlich; zum Zeitpunkt der Verlinkung waren keine
+          Rechtsverstöße erkennbar. Bei Bekanntwerden von Rechtsverletzungen entfernen wir
+          derartige Links umgehend.
+        </p>
+      </Section>
+
+      <Section heading="Diese Instanz">
+        <p>
+          Glyphoxa ist quelloffene Software (
+          <a
+            href="https://github.com/MrWong99/Glyphoxa"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            github.com/MrWong99/Glyphoxa
+          </a>
+          ). Verantwortlich für <em>diese</em> Instanz — Betrieb, Daten und Inhalte — ist
+          ausschließlich der oben genannte Diensteanbieter, nicht das Projekt oder seine
+          Mitwirkenden.
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/web/src/screens/legal/LegalPage.tsx
+++ b/web/src/screens/legal/LegalPage.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+import { Dices } from "lucide-react";
+
+import { LegalFooter } from "@/components/LegalFooter";
+import { OPERATOR, isPlaceholder, operatorTodos } from "./operator";
+
+import "./legal.css";
+
+// The shared chrome of the three legal pages (#518): Impressum,
+// Datenschutzerklärung and Nutzungsbedingungen. They are plain static documents
+// served UNAUTHENTICATED — a visitor who has not signed in (and a player who
+// never will) must be able to read them, which is the whole point of the footer
+// that links here from every screen.
+//
+// No app shell, no AuthGate, no RPCs: these pages must render even when the
+// backend is unhappy.
+
+export function LegalPage({
+  title,
+  lede,
+  children,
+}: {
+  title: string;
+  lede?: string;
+  children: ReactNode;
+}) {
+  const todos = operatorTodos();
+
+  return (
+    <div className="gx-legal">
+      <article className="gx-legal__doc">
+        <a className="gx-legal__brand" href="/login">
+          <span className="gx-legal__sigil">
+            <Dices size={17} />
+          </span>
+          <span className="gx-gradient-text">Glyphoxa</span>
+        </a>
+
+        <h1 className="gx-legal__title">{title}</h1>
+        {lede && <p className="gx-legal__lede">{lede}</p>}
+
+        {todos.length > 0 && (
+          <p className="gx-legal__todo" role="alert">
+            <strong>Hinweis an den Betreiber:</strong> Diese Seite enthält noch
+            unausgefüllte Platzhalter ({todos.join(", ")}). Sie müssen ausgefüllt werden,
+            bevor die Instanz öffentlich erreichbar ist — siehe
+            <code> web/src/screens/legal/operator.ts</code> und
+            <code> docs/deploy/legal-pages.md</code>.
+          </p>
+        )}
+
+        <p className="gx-legal__updated">
+          Stand: <OperatorValue value={OPERATOR.lastUpdated} />
+        </p>
+
+        {children}
+
+        <LegalFooter className="gx-legal__footer" />
+      </article>
+    </div>
+  );
+}
+
+/**
+ * OperatorValue renders one operator-supplied field, marking it visibly when it
+ * is still a template placeholder — an unfilled Impressum should look wrong,
+ * not merely read wrong.
+ */
+export function OperatorValue({ value }: { value: string }) {
+  if (isPlaceholder(value)) {
+    return <span className="gx-legal__placeholder">{value}</span>;
+  }
+  return <>{value}</>;
+}
+
+/** Section is one numbered block of a legal document. */
+export function Section({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <section className="gx-legal__section">
+      <h2>{heading}</h2>
+      {children}
+    </section>
+  );
+}

--- a/web/src/screens/legal/Privacy.tsx
+++ b/web/src/screens/legal/Privacy.tsx
@@ -50,10 +50,11 @@ export function Privacy() {
         <p>
           Zweck ist die Authentifizierung und die Zuordnung Ihrer Inhalte zu Ihrem Konto;
           Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO (Durchführung des
-          Nutzungsverhältnisses). Die Sitzung wird über ein technisch notwendiges Cookie
-          gehalten (Art. 6 Abs. 1 lit. f DSGVO; § 25 Abs. 2 Nr. 2 TDDDG — kein
-          Einwilligungsbanner nötig, weil kein Tracking stattfindet). Wir setzen keine
-          Analyse- oder Werbe-Cookies ein.
+          Nutzungsverhältnisses). Die Sitzung wird über technisch notwendige Cookies
+          gehalten: ein Sitzungs-Cookie, ein CSRF-Schutz-Cookie sowie ein kurzlebiges
+          Cookie während des Anmeldevorgangs (Art. 6 Abs. 1 lit. f DSGVO; § 25 Abs. 2
+          Nr. 2 TDDDG — kein Einwilligungsbanner nötig, weil kein Tracking stattfindet).
+          Wir setzen keine Analyse- oder Werbe-Cookies ein.
         </p>
         <p>
           Der Aufruf von Discord selbst unterliegt der Datenschutzerklärung von Discord
@@ -96,7 +97,9 @@ export function Privacy() {
           Protokollierung des gemeinsamen Spiels), über die vor Sitzungsbeginn im
           Textkanal informiert wird. Wer nicht transkribiert werden möchte, sollte der
           Sprachsitzung nicht beitreten und die Spielleitung ansprechen — sie kann die
-          Sitzung jederzeit beenden und Transkripte löschen.
+          Sitzung jederzeit beenden und die Kampagne samt aller Transkripte löschen.
+          Die Löschung einzelner Transkriptpassagen können Sie beim Betreiber verlangen
+          (Ziffer 8).
         </p>
       </Section>
 
@@ -148,9 +151,9 @@ export function Privacy() {
             erhält Audioausschnitte bzw. den zu sprechenden Text.
           </li>
           <li>
-            <strong>Groq</strong> und weitere Sprachmodell-Anbieter (z. B. Google Gemini,
-            OpenAI-kompatible Endpunkte) — erhalten den Gesprächskontext (Transkripttext,
-            Kampagnennotizen), um Antworten zu erzeugen.
+            <strong>Groq</strong> und weitere Sprachmodell-Anbieter (<strong>Anthropic</strong>{" "}
+            (USA), Google Gemini, OpenAI-kompatible Endpunkte) — erhalten den
+            Gesprächskontext (Transkripttext, Kampagnennotizen), um Antworten zu erzeugen.
           </li>
           <li>
             <strong>Google Gemini</strong> — Bilderzeugung für Kampagnenillustrationen:
@@ -183,13 +186,14 @@ export function Privacy() {
       <Section heading="7. Speicherdauer">
         <ul>
           <li>
-            <strong>Konto- und Kampagnendaten:</strong> bis zur Löschung durch Sie bzw.
-            Ihre Spielleitung oder bis zur Löschung des Kontos.
+            <strong>Konto- und Kampagnendaten:</strong> Kampagnen bis zu ihrer Löschung
+            durch die Spielleitung; die Löschung Ihres Kontos können Sie jederzeit beim
+            Betreiber verlangen (Ziffer 8).
           </li>
           <li>
             <strong>Transkripte und Einbettungen:</strong> bis die Spielleitung die
-            Sitzung oder die Kampagne löscht — das Löschen einer Kampagne entfernt ihre
-            Transkripte, Einbettungen und Highlights vollständig.
+            Kampagne löscht — das Löschen einer Kampagne entfernt ihre Transkripte,
+            Einbettungen und Highlights vollständig.
           </li>
           <li>
             <strong>Audio-Ringspeicher:</strong> maximal ca. 120 Sekunden, Verwerfung

--- a/web/src/screens/legal/Privacy.tsx
+++ b/web/src/screens/legal/Privacy.tsx
@@ -1,0 +1,235 @@
+import { LegalPage, OperatorValue, Section } from "./LegalPage";
+import { OPERATOR } from "./operator";
+
+// Datenschutzerklärung (#518). A TEMPLATE drafted from established German
+// boilerplate and the system's actual data flows — not legal advice, and not
+// lawyer-reviewed (an accepted beta risk, decided 2026-07-22).
+//
+// The substance mirrors what the software really does, so keep it in step with
+// the code: Discord OAuth (ADR-0016), always-on transcription into Transcript
+// Lines/Chunks + embeddings (ADR-0011/0040), the opt-in Rollover Tape
+// (ADR-0051), the provider subprocessors (ADR-0004), and the
+// GM-as-controller / operator-as-processor framing for table participants.
+
+export function Privacy() {
+  return (
+    <LegalPage
+      title="Datenschutzerklärung"
+      lede="Wie diese Instanz personenbezogene Daten verarbeitet — für Spielleitungen, Spielende am Tisch und Besucher:innen."
+    >
+      <Section heading="1. Verantwortlicher">
+        <p>
+          Verantwortlich für die Verarbeitung im Sinne der DSGVO ist:
+          <br />
+          <OperatorValue value={OPERATOR.legalName} />, <OperatorValue value={OPERATOR.street} />,{" "}
+          <OperatorValue value={OPERATOR.city} />, <OperatorValue value={OPERATOR.country} />,
+          E-Mail: <OperatorValue value={OPERATOR.email} />.
+        </p>
+        {OPERATOR.dataProtectionOfficer && (
+          <p>Datenschutzbeauftragte(r): {OPERATOR.dataProtectionOfficer}</p>
+        )}
+        <p>
+          <strong>Rollenverteilung am Spieltisch:</strong> Die Spielleitung (GM) entscheidet,
+          welche Kampagne läuft, wer eingeladen wird, welche Aufnahmefunktionen aktiviert
+          sind und wann Daten gelöscht werden. Für die Inhalte ihrer Kampagne ist damit
+          die Spielleitung verantwortlich; der Betreiber dieser Instanz stellt die
+          technische Plattform bereit und handelt insoweit weisungsgebunden
+          (Auftragsverarbeitung, Art. 28 DSGVO). Wenden Sie sich bei Fragen zu den Inhalten
+          einer Kampagne zuerst an Ihre Spielleitung — Betroffenenrechte können Sie
+          selbstverständlich auch direkt beim Betreiber geltend machen.
+        </p>
+      </Section>
+
+      <Section heading="2. Anmeldung über Discord">
+        <p>
+          Die Anmeldung erfolgt ausschließlich über Discord (OAuth 2.0). Dabei
+          verarbeiten wir die von Discord übermittelten Angaben Ihres Kontos:
+          Discord-Benutzer-ID, Benutzername bzw. Anzeigename und — sofern vorhanden —
+          die URL Ihres Profilbilds. Ein Passwort speichern wir nicht.
+        </p>
+        <p>
+          Zweck ist die Authentifizierung und die Zuordnung Ihrer Inhalte zu Ihrem Konto;
+          Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO (Durchführung des
+          Nutzungsverhältnisses). Die Sitzung wird über ein technisch notwendiges Cookie
+          gehalten (Art. 6 Abs. 1 lit. f DSGVO; § 25 Abs. 2 Nr. 2 TDDDG — kein
+          Einwilligungsbanner nötig, weil kein Tracking stattfindet). Wir setzen keine
+          Analyse- oder Werbe-Cookies ein.
+        </p>
+        <p>
+          Der Aufruf von Discord selbst unterliegt der Datenschutzerklärung von Discord
+          (Discord Netherlands B.V. / Discord Inc.).
+        </p>
+      </Section>
+
+      <Section heading="3. Sprachsitzungen: Transkription">
+        <p>
+          <strong>Jede Voice Session wird transkribiert.</strong> Wenn der Bot einem
+          Discord-Sprachkanal beitritt, weist er im zugehörigen Textkanal einmalig darauf
+          hin. Verarbeitet werden dabei:
+        </p>
+        <ul>
+          <li>
+            das gesprochene Audio der Teilnehmenden — <em>ausschließlich transient</em>, zur
+            Spracherkennung; es wird nicht dauerhaft gespeichert (Ausnahme: die unter
+            Ziffer 4 beschriebene, ausdrücklich einwilligungsbasierte Aufnahmefunktion),
+          </li>
+          <li>
+            der daraus erzeugte <strong>Transkripttext</strong>, gespeichert je Kampagne als
+            einzelne Zeilen und als zusammengefasste Abschnitte,
+          </li>
+          <li>
+            <strong>Vektor-Einbettungen (Embeddings)</strong> dieser Abschnitte, damit die
+            Agenten sich im Spielverlauf an frühere Szenen erinnern und die Spielleitung
+            das Transkript durchsuchen kann,
+          </li>
+          <li>
+            die <strong>Discord-Benutzer-ID der sprechenden Person</strong> zur Zuordnung der
+            Zeile (bzw. der zugeordnete Charaktername),
+          </li>
+          <li>technische Metadaten der Sitzung (Zeitstempel, Kanal, Dauer).</li>
+        </ul>
+        <p>
+          Zweck ist die Kernfunktion des Dienstes: Antworten der Agenten im Spiel,
+          Zusammenfassungen und ein durchsuchbares Kampagnengedächtnis. Rechtsgrundlage
+          ist Art. 6 Abs. 1 lit. b DSGVO gegenüber der Spielleitung und Art. 6 Abs. 1
+          lit. f DSGVO gegenüber den Mitspielenden (berechtigtes Interesse an der
+          Protokollierung des gemeinsamen Spiels), über die vor Sitzungsbeginn im
+          Textkanal informiert wird. Wer nicht transkribiert werden möchte, sollte der
+          Sprachsitzung nicht beitreten und die Spielleitung ansprechen — sie kann die
+          Sitzung jederzeit beenden und Transkripte löschen.
+        </p>
+      </Section>
+
+      <Section heading="4. Session Highlights (Audioaufnahme, freiwillig)">
+        <p>
+          Optional kann eine Spielleitung „Session Highlights“ aktivieren. Erst dann wird
+          Audio überhaupt zwischengespeichert, und zwar so:
+        </p>
+        <ul>
+          <li>
+            Der Bot postet im Textkanal eine Einwilligungsabfrage mit den Schaltflächen
+            <strong> Consent</strong> und <strong>Revoke</strong>.
+          </li>
+          <li>
+            In einen flüchtigen Ringspeicher von rund 120 Sekunden gelangt ausschließlich
+            das Audio derjenigen Personen, die zuvor <strong>Consent</strong> gedrückt haben
+            (Art. 6 Abs. 1 lit. a DSGVO). Ohne Einwilligung wird Ihr Audio zu keinem
+            Zeitpunkt in diesen Speicher kopiert. Die Einwilligung ist jederzeit mit
+            Wirkung für die Zukunft widerrufbar.
+          </li>
+          <li>Der Ringspeicher wird am Ende der Sprachsitzung vollständig verworfen.</li>
+          <li>
+            Daraus geschnittene Clip-Kandidaten werden bis zur Durchsicht durch die
+            Spielleitung aufbewahrt und spätestens nach 7 Tagen automatisch gelöscht.
+          </li>
+          <li>
+            Nur von der Spielleitung ausdrücklich übernommene Highlights bleiben dauerhaft
+            gespeichert, bis sie gelöscht werden. Nichts verlässt diese Instanz ohne eine
+            ausdrückliche Aktion der Spielleitung.
+          </li>
+        </ul>
+        <p>Die Stimme von Agenten/NPCs ist synthetisch und enthält keine personenbezogenen Daten der Teilnehmenden.</p>
+      </Section>
+
+      <Section heading="5. Empfänger und eingesetzte Dienstleister">
+        <p>
+          Zur Erbringung des Dienstes werden Inhalte an die folgenden Anbieter übermittelt.
+          Welche davon tatsächlich zum Einsatz kommen, hängt von der Konfiguration Ihrer
+          Kampagne ab (jede Spielleitung kann eigene Zugangsschlüssel hinterlegen — dann
+          besteht das Vertragsverhältnis zwischen ihr und dem jeweiligen Anbieter):
+        </p>
+        <ul>
+          <li>
+            <strong>Discord</strong> — Sprach- und Textkanäle, Anmeldung. Ohne Discord ist
+            der Dienst nicht nutzbar.
+          </li>
+          <li>
+            <strong>ElevenLabs</strong> (USA) — Spracherkennung und Sprachsynthese:
+            erhält Audioausschnitte bzw. den zu sprechenden Text.
+          </li>
+          <li>
+            <strong>Groq</strong> und weitere Sprachmodell-Anbieter (z. B. Google Gemini,
+            OpenAI-kompatible Endpunkte) — erhalten den Gesprächskontext (Transkripttext,
+            Kampagnennotizen), um Antworten zu erzeugen.
+          </li>
+          <li>
+            <strong>Google Gemini</strong> — Bilderzeugung für Kampagnenillustrationen:
+            erhält die jeweilige Bildbeschreibung.
+          </li>
+          <li>
+            <strong>Cloudflare</strong> (soweit eingesetzt) — Tunnel und TLS-Terminierung
+            für den Web-Zugang: verarbeitet dabei Verbindungsdaten (u. a. IP-Adresse).
+          </li>
+        </ul>
+        <p>
+          Bei Anbietern mit Sitz in den USA erfolgt die Übermittlung auf Grundlage von
+          Standardvertragsklauseln bzw. — soweit zertifiziert — des EU-US Data Privacy
+          Framework (Art. 45/46 DSGVO). Ein den europäischen Standards entsprechendes
+          Datenschutzniveau kann trotz dieser Garantien nicht in jedem Fall zugesichert
+          werden; insbesondere sind Zugriffe durch dortige Behörden nicht auszuschließen.
+        </p>
+      </Section>
+
+      <Section heading="6. Speicherort">
+        <p>
+          Die Datenbank dieser Instanz — Konten, Kampagnen, Transkripte, Einbettungen und
+          gespeicherte Highlights — liegt an folgendem Ort:{" "}
+          <OperatorValue value={OPERATOR.hostingLocation} />. Zugangsschlüssel für externe
+          Anbieter werden verschlüsselt gespeichert. Eine Übermittlung an die unter Ziffer
+          5 genannten Anbieter findet nur zur Erbringung der jeweiligen Funktion statt.
+        </p>
+      </Section>
+
+      <Section heading="7. Speicherdauer">
+        <ul>
+          <li>
+            <strong>Konto- und Kampagnendaten:</strong> bis zur Löschung durch Sie bzw.
+            Ihre Spielleitung oder bis zur Löschung des Kontos.
+          </li>
+          <li>
+            <strong>Transkripte und Einbettungen:</strong> bis die Spielleitung die
+            Sitzung oder die Kampagne löscht — das Löschen einer Kampagne entfernt ihre
+            Transkripte, Einbettungen und Highlights vollständig.
+          </li>
+          <li>
+            <strong>Audio-Ringspeicher:</strong> maximal ca. 120 Sekunden, Verwerfung
+            spätestens am Sitzungsende.
+          </li>
+          <li>
+            <strong>Clip-Kandidaten:</strong> bis zur Durchsicht, spätestens 7 Tage.
+          </li>
+          <li>
+            <strong>Server-Logdateien:</strong> kurzfristig zur Fehlersuche und
+            Missbrauchsabwehr (Art. 6 Abs. 1 lit. f DSGVO).
+          </li>
+        </ul>
+      </Section>
+
+      <Section heading="8. Ihre Rechte">
+        <p>
+          Sie haben das Recht auf Auskunft (Art. 15), Berichtigung (Art. 16), Löschung
+          (Art. 17), Einschränkung der Verarbeitung (Art. 18), Datenübertragbarkeit
+          (Art. 20) sowie ein <strong>Widerspruchsrecht</strong> gegen Verarbeitungen auf
+          Grundlage berechtigter Interessen (Art. 21 DSGVO). Erteilte Einwilligungen —
+          etwa für die Aufnahmefunktion — können Sie jederzeit mit Wirkung für die Zukunft
+          widerrufen (Art. 7 Abs. 3 DSGVO), im Spiel über die Schaltfläche
+          <strong> Revoke</strong>.
+        </p>
+        <p>
+          Wenden Sie sich dafür an <OperatorValue value={OPERATOR.email} />. Unabhängig
+          davon steht Ihnen ein Beschwerderecht bei einer Aufsichtsbehörde zu (Art. 77
+          DSGVO), zuständig ist:{" "}
+          <OperatorValue value={OPERATOR.supervisoryAuthority} />.
+        </p>
+      </Section>
+
+      <Section heading="9. Änderungen dieser Erklärung">
+        <p>
+          Diese Instanz befindet sich in einer offenen Beta. Wir passen diese Erklärung an,
+          wenn sich die Funktionen oder die eingesetzten Anbieter ändern. Es gilt jeweils
+          die hier veröffentlichte Fassung.
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/web/src/screens/legal/Terms.tsx
+++ b/web/src/screens/legal/Terms.tsx
@@ -20,8 +20,9 @@ export function Terms() {
           <OperatorValue value={OPERATOR.legalName} /> betrieben und befindet sich in einer{" "}
           <strong>offenen Beta</strong>: Funktionen können sich ändern oder ausfallen, und
           es besteht kein Anspruch auf Verfügbarkeit oder auf den Erhalt gespeicherter
-          Inhalte. Legen Sie von Inhalten, die Ihnen wichtig sind, eigene Sicherungen an
-          (Kampagnen lassen sich exportieren).
+          Inhalte. Legen Sie von Inhalten, die Ihnen wichtig sind, eigene Notizen oder
+          Kopien an; eine Kopie Ihrer gespeicherten Daten können Sie beim Betreiber
+          anfragen (Art. 15 DSGVO).
         </p>
       </Section>
 
@@ -66,8 +67,9 @@ export function Terms() {
           verursacht jedoch Kosten: Je nach Tarif nutzen Sie ein begrenztes
           Testguthaben des Betreibers oder hinterlegen eigene Zugangsschlüssel (BYOK). Für
           Kosten, die über eigene Schlüssel bei den jeweiligen Anbietern entstehen, haften
-          Sie selbst; ein Verbrauchslimit je Kampagne hilft dabei, sie zu begrenzen. Ist
-          das Testguthaben aufgebraucht, ruhen die betroffenen Funktionen.
+          Sie selbst; ein optional einstellbares Verbrauchslimit je Sprachsitzung hilft
+          dabei, sie zu begrenzen. Ist das Testguthaben aufgebraucht, ruhen die
+          betroffenen Funktionen.
         </p>
       </Section>
 
@@ -84,10 +86,11 @@ export function Terms() {
       <Section heading="6. Sperrung und Beendigung">
         <p>
           Bei Verstößen gegen diese Bedingungen kann der Zugang gesperrt werden — bei
-          schwerwiegenden Verstößen ohne Vorankündigung. Sie können Ihr Konto und Ihre
-          Kampagnen jederzeit löschen. Der Betrieb dieser Instanz kann eingestellt werden;
-          wir bemühen uns, dies mit angemessener Vorlaufzeit anzukündigen, damit Sie Ihre
-          Daten exportieren können.
+          schwerwiegenden Verstößen ohne Vorankündigung. Ihre Kampagnen können Sie
+          jederzeit selbst löschen; die Löschung Ihres Kontos können Sie jederzeit beim
+          Betreiber verlangen. Der Betrieb dieser Instanz kann eingestellt werden; wir
+          bemühen uns, dies mit angemessener Vorlaufzeit anzukündigen, damit Sie eine
+          Kopie Ihrer Daten anfragen und Inhalte sichern können.
         </p>
       </Section>
 

--- a/web/src/screens/legal/Terms.tsx
+++ b/web/src/screens/legal/Terms.tsx
@@ -1,0 +1,115 @@
+import { LegalPage, OperatorValue, Section } from "./LegalPage";
+import { OPERATOR } from "./operator";
+
+// Nutzungsbedingungen / Acceptable Use Policy (#518). The document the open-mode
+// signup asks new users to acknowledge before they start the Discord OAuth flow.
+// Short by design: a beta-scale AUP that says what the service is, what it is
+// not, and what gets an account suspended.
+
+export function Terms() {
+  return (
+    <LegalPage
+      title="Nutzungsbedingungen"
+      lede="Die Spielregeln für diese Instanz — bitte vor der Anmeldung lesen."
+    >
+      <Section heading="1. Was dieser Dienst ist">
+        <p>
+          Glyphoxa gibt Nicht-Spieler-Charakteren einer Pen-&-Paper-Kampagne eine Stimme
+          in einem Discord-Sprachkanal und führt daraus ein durchsuchbares
+          Kampagnengedächtnis. Diese Instanz wird von{" "}
+          <OperatorValue value={OPERATOR.legalName} /> betrieben und befindet sich in einer{" "}
+          <strong>offenen Beta</strong>: Funktionen können sich ändern oder ausfallen, und
+          es besteht kein Anspruch auf Verfügbarkeit oder auf den Erhalt gespeicherter
+          Inhalte. Legen Sie von Inhalten, die Ihnen wichtig sind, eigene Sicherungen an
+          (Kampagnen lassen sich exportieren).
+        </p>
+      </Section>
+
+      <Section heading="2. Konto">
+        <p>
+          Für die Nutzung ist ein Discord-Konto erforderlich; es gelten zusätzlich die
+          Bedingungen von Discord. Sie sind für die Aktivitäten unter Ihrem Konto
+          verantwortlich. Der Dienst richtet sich nicht an Kinder unter 16 Jahren.
+        </p>
+      </Section>
+
+      <Section heading="3. Regeln für die Nutzung">
+        <p>Untersagt ist insbesondere:</p>
+        <ul>
+          <li>
+            rechtswidrige Inhalte, Belästigung, Hassrede, sexualisierte Darstellungen
+            Minderjähriger sowie Inhalte, die Rechte Dritter verletzen;
+          </li>
+          <li>
+            das Aufzeichnen oder Transkribieren von Gesprächen, in denen Teilnehmende
+            dem widersprochen haben — die Spielleitung ist dafür verantwortlich, dass ihr
+            Tisch über die Transkription informiert ist (siehe Datenschutzerklärung);
+          </li>
+          <li>
+            das Hochladen personenbezogener Daten Dritter ohne deren Kenntnis, sowie das
+            Weiterverbreiten von Aufnahmen ohne Einwilligung der Aufgenommenen;
+          </li>
+          <li>
+            automatisierte Massennutzung, Lasttests, Umgehung von Limits oder
+            Weiterverkauf der Rechenleistung dieser Instanz;
+          </li>
+          <li>
+            Versuche, in fremde Konten, Kampagnen oder die Infrastruktur einzudringen,
+            sowie das Umgehen von Zugriffsbeschränkungen.
+          </li>
+        </ul>
+      </Section>
+
+      <Section heading="4. Kosten und Zugangsschlüssel">
+        <p>
+          Für die Beta fallen keine Gebühren an. Die Nutzung externer KI-Anbieter
+          verursacht jedoch Kosten: Je nach Tarif nutzen Sie ein begrenztes
+          Testguthaben des Betreibers oder hinterlegen eigene Zugangsschlüssel (BYOK). Für
+          Kosten, die über eigene Schlüssel bei den jeweiligen Anbietern entstehen, haften
+          Sie selbst; ein Verbrauchslimit je Kampagne hilft dabei, sie zu begrenzen. Ist
+          das Testguthaben aufgebraucht, ruhen die betroffenen Funktionen.
+        </p>
+      </Section>
+
+      <Section heading="5. Ihre Inhalte">
+        <p>
+          Ihre Kampagneninhalte gehören Ihnen. Sie räumen dem Betreiber nur die Rechte
+          ein, die für den Betrieb nötig sind: speichern, verarbeiten und an die zur
+          Funktionserbringung eingesetzten Anbieter übermitteln (siehe
+          Datenschutzerklärung). Inhalte werden nicht zum Training von KI-Modellen des
+          Betreibers verwendet und nicht an Dritte verkauft.
+        </p>
+      </Section>
+
+      <Section heading="6. Sperrung und Beendigung">
+        <p>
+          Bei Verstößen gegen diese Bedingungen kann der Zugang gesperrt werden — bei
+          schwerwiegenden Verstößen ohne Vorankündigung. Sie können Ihr Konto und Ihre
+          Kampagnen jederzeit löschen. Der Betrieb dieser Instanz kann eingestellt werden;
+          wir bemühen uns, dies mit angemessener Vorlaufzeit anzukündigen, damit Sie Ihre
+          Daten exportieren können.
+        </p>
+      </Section>
+
+      <Section heading="7. Haftung">
+        <p>
+          Der Dienst wird ohne Gewähr für Verfügbarkeit oder Richtigkeit der von KI
+          erzeugten Ausgaben bereitgestellt. Die Haftung des Betreibers richtet sich nach
+          den gesetzlichen Vorschriften; für leicht fahrlässige Pflichtverletzungen wird
+          nur bei Verletzung wesentlicher Vertragspflichten und begrenzt auf den
+          vorhersehbaren, vertragstypischen Schaden gehaftet. Die Haftung für Schäden aus
+          der Verletzung des Lebens, des Körpers oder der Gesundheit sowie nach dem
+          Produkthaftungsgesetz bleibt unberührt.
+        </p>
+      </Section>
+
+      <Section heading="8. Kontakt und Änderungen">
+        <p>
+          Fragen und Meldungen: <OperatorValue value={OPERATOR.email} />. Diese Bedingungen
+          können angepasst werden; die jeweils hier veröffentlichte Fassung gilt ab
+          Veröffentlichung. Wesentliche Änderungen kündigen wir im Dienst an.
+        </p>
+      </Section>
+    </LegalPage>
+  );
+}

--- a/web/src/screens/legal/legal.css
+++ b/web/src/screens/legal/legal.css
@@ -1,0 +1,104 @@
+/* The static legal documents (#518): Impressum, Datenschutzerklärung,
+   Nutzungsbedingungen. Long-form reading, so this is a plain measure-limited
+   column on the app surface — no shell chrome, no cards, nothing that competes
+   with the text. */
+.gx-legal {
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 32px 20px 48px;
+}
+
+.gx-legal__doc {
+  width: 100%;
+  max-width: 68ch;
+  line-height: 1.65;
+}
+
+.gx-legal__brand {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 20px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.gx-legal__sigil {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  color: #fff;
+  background: linear-gradient(135deg, #9059ff, #00ddff);
+}
+
+.gx-legal__title {
+  margin: 0 0 4px;
+  font-size: 28px;
+}
+
+.gx-legal__lede {
+  margin: 0 0 12px;
+  color: var(--text-subtle, #9a93a8);
+}
+
+.gx-legal__updated {
+  margin: 0 0 24px;
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+}
+
+/* The operator-TODO banner: an unfilled Impressum must look wrong, not just
+   read wrong. */
+.gx-legal__todo {
+  margin: 0 0 20px;
+  padding: 12px 14px;
+  border: 1px solid var(--status-danger, #ff5c7a);
+  border-radius: var(--radius-sm, 8px);
+  color: var(--status-danger, #ff5c7a);
+  font-size: var(--body-sm, 0.875rem);
+}
+
+.gx-legal__todo code {
+  font-size: 0.9em;
+}
+
+/* One unfilled field inside the running text. */
+.gx-legal__placeholder {
+  color: var(--status-danger, #ff5c7a);
+  font-weight: 600;
+}
+
+.gx-legal__section {
+  margin: 0 0 22px;
+}
+
+.gx-legal__section h2 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.gx-legal__section p,
+.gx-legal__section ul {
+  margin: 0 0 10px;
+}
+
+.gx-legal__section ul {
+  padding-left: 20px;
+}
+
+.gx-legal__section li {
+  margin-bottom: 6px;
+}
+
+.gx-legal__section a {
+  color: var(--accent, #9059ff);
+}
+
+.gx-legal__footer {
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle, #2a2535);
+}

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -80,6 +80,7 @@ describe("legal routes", () => {
       "Session Highlights",
       "ElevenLabs",
       "Groq",
+      "Anthropic",
       "Gemini",
       "Cloudflare",
       "Auftragsverarbeitung",

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -97,24 +97,27 @@ describe("legal routes", () => {
     expect(screen.getByRole("link", { name: "Datenschutz" })).toHaveAttribute("href", "/privacy");
   });
 
-  it("shows a loud operator TODO while the identity is unfilled", async () => {
+  it("renders the filled operator identity without the TODO banner", async () => {
     renderAt("/imprint");
     await screen.findByRole("heading", { name: "Impressum", level: 1 });
-    // The shipped template is unfilled by design (the operator supplies their
-    // own identity — the project must not invent one), so the banner is present
-    // here. It disappears field by field as operator.ts is filled in.
-    expect(operatorTodos().length).toBeGreaterThan(0);
-    expect(screen.getByRole("alert")).toHaveTextContent(/Hinweis an den Betreiber/i);
+    // This repository ships the identity of the canonical beta deployment,
+    // filled in by its operator on 2026-07-26 — so no banner here. The banner
+    // machinery itself stays covered in todoBanner.test.tsx against a mocked,
+    // unfilled identity.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText(/Lukas Schmidt/)).toBeInTheDocument();
   });
 });
 
-describe("operator identity template", () => {
-  it("ships placeholders, not invented details", () => {
-    // Guard against someone "helpfully" filling these in upstream: a shipped
-    // default identity would be a false Impressum on every deployment.
-    expect(isPlaceholder(OPERATOR.legalName)).toBe(true);
-    expect(isPlaceholder(OPERATOR.street)).toBe(true);
-    expect(isPlaceholder(OPERATOR.email)).toBe(true);
+describe("operator identity", () => {
+  it("is completely filled for this deployment", () => {
+    // The maintainer operates the canonical deployment from this repo and
+    // committed their own identity (2026-07-26). Anyone forking this source
+    // for their OWN instance must replace operator.ts — see the warning there
+    // and docs/deploy/legal-pages.md.
+    expect(operatorTodos()).toEqual([]);
+    expect(isPlaceholder(OPERATOR.legalName)).toBe(false);
+    expect(isPlaceholder(OPERATOR.email)).toBe(false);
   });
 
   it("counts an empty required field as a TODO and ignores optional ones", () => {

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
+import { createRouterTransport } from "@connectrpc/connect";
+
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { routeTree } from "@/app/router";
+import { operatorTodos, isPlaceholder, OPERATOR } from "./operator";
+
+// The legal documents (#518). Two properties matter beyond "the text renders":
+//
+//   1. They are reachable WITHOUT a session — a visitor deciding whether to sign
+//      up, and a player at a transcribed table who will never open the app, both
+//      have to be able to read them. The transport below fails every RPC, so a
+//      page that needed the backend would fail these tests.
+//   2. /privacy is a contract with the deployment: the Helm chart derives
+//      GLYPHOXA_PRIVACY_POLICY_URL as <host>/privacy for the Bot's in-channel
+//      transcription disclosure (#519). A renamed route breaks a link players
+//      see in Discord, so the path is pinned here.
+
+// deadTransport answers every RPC with a rejected promise: proof that the legal
+// routes render with no working backend and no session.
+function deadTransport() {
+  return createRouterTransport(() => {});
+}
+
+function renderAt(path: string) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(
+    <Providers transport={deadTransport()} queryClient={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </Providers>,
+  );
+}
+
+describe("legal routes", () => {
+  it("serves the Impressum unauthenticated at /imprint", async () => {
+    renderAt("/imprint");
+    expect(await screen.findByRole("heading", { name: "Impressum", level: 1 })).toBeInTheDocument();
+    // §5 DDG: the operator, an address, and a contact that reaches a human.
+    expect(screen.getByRole("heading", { name: /Diensteanbieter/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Kontakt/i })).toBeInTheDocument();
+  });
+
+  it("serves the Datenschutzerklärung unauthenticated at /privacy", async () => {
+    renderAt("/privacy");
+    expect(
+      await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("serves the Nutzungsbedingungen unauthenticated at /terms", async () => {
+    renderAt("/terms");
+    expect(
+      await screen.findByRole("heading", { name: "Nutzungsbedingungen", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("answers the German aliases people actually type", async () => {
+    renderAt("/impressum");
+    expect(await screen.findByRole("heading", { name: "Impressum", level: 1 })).toBeInTheDocument();
+  });
+
+  it("covers every data flow the deployment has to disclose", async () => {
+    renderAt("/datenschutz");
+    await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 });
+    const doc = document.body.textContent ?? "";
+
+    // The disclosures decided on #518: Discord OAuth, always-on transcription
+    // (lines, chunks, embeddings), the opt-in tape, the provider subprocessors,
+    // residency, retention, and the GM-as-controller framing.
+    for (const topic of [
+      "Discord",
+      "transkribiert",
+      "Einbettungen",
+      "Session Highlights",
+      "ElevenLabs",
+      "Groq",
+      "Gemini",
+      "Cloudflare",
+      "Auftragsverarbeitung",
+      "Speicherdauer",
+      "Aufsichtsbehörde",
+    ]) {
+      expect(doc, `Datenschutzerklärung must mention ${topic}`).toContain(topic);
+    }
+  });
+
+  it("links the other documents from every legal page", async () => {
+    renderAt("/terms");
+    await screen.findByRole("heading", { name: "Nutzungsbedingungen", level: 1 });
+    expect(screen.getByRole("link", { name: "Impressum" })).toHaveAttribute("href", "/imprint");
+    expect(screen.getByRole("link", { name: "Datenschutz" })).toHaveAttribute("href", "/privacy");
+  });
+
+  it("shows a loud operator TODO while the identity is unfilled", async () => {
+    renderAt("/imprint");
+    await screen.findByRole("heading", { name: "Impressum", level: 1 });
+    // The shipped template is unfilled by design (the operator supplies their
+    // own identity — the project must not invent one), so the banner is present
+    // here. It disappears field by field as operator.ts is filled in.
+    expect(operatorTodos().length).toBeGreaterThan(0);
+    expect(screen.getByRole("alert")).toHaveTextContent(/Hinweis an den Betreiber/i);
+  });
+});
+
+describe("operator identity template", () => {
+  it("ships placeholders, not invented details", () => {
+    // Guard against someone "helpfully" filling these in upstream: a shipped
+    // default identity would be a false Impressum on every deployment.
+    expect(isPlaceholder(OPERATOR.legalName)).toBe(true);
+    expect(isPlaceholder(OPERATOR.street)).toBe(true);
+    expect(isPlaceholder(OPERATOR.email)).toBe(true);
+  });
+
+  it("counts an empty required field as a TODO and ignores optional ones", () => {
+    const filled = {
+      ...OPERATOR,
+      legalName: "Rin Okabe",
+      street: "Beispielweg 1",
+      city: "10115 Berlin",
+      country: "Deutschland",
+      email: "hallo@example.org",
+      supervisoryAuthority: "Berliner Beauftragte für Datenschutz",
+      hostingLocation: "Deutschland",
+      lastUpdated: "2026-07-25",
+      phone: "", // optional — an empty value is a decision, not an omission
+    };
+    expect(operatorTodos(filled)).toEqual([]);
+    expect(operatorTodos({ ...filled, email: "  " })).toEqual(["email"]);
+  });
+});

--- a/web/src/screens/legal/operator.ts
+++ b/web/src/screens/legal/operator.ts
@@ -1,0 +1,97 @@
+// Operator identity for the legal pages (#518).
+//
+// §5 DDG (ex-§5 TMG) requires a German-operated service to name its operator:
+// legal name, postal address, and a contact that reaches a human. That
+// information belongs to the OPERATOR of a deployment — it is not something the
+// chart, the code, or an agent may invent — so it lives here as a committed,
+// clearly-placeholdered file the operator fills in before the deployment goes
+// live. See docs/deploy/legal-pages.md.
+//
+// Anything still holding a PLACEHOLDER value renders as a visible red
+// "operator TODO" marker on the page (see isPlaceholder / OperatorValue), so an
+// unfilled Impressum is impossible to miss rather than quietly wrong.
+//
+// The legal texts these values feed are TEMPLATES drafted from established
+// German boilerplate, not legal advice, and they have not been reviewed by a
+// lawyer (an accepted beta risk, decided 2026-07-22 — see #518).
+
+/** The marker every unfilled field carries. */
+export const PLACEHOLDER_PREFIX = "[BITTE AUSFÜLLEN";
+
+export type OperatorIdentity = {
+  /** Legal name of the natural or legal person operating this deployment. */
+  legalName: string;
+  /** Street and number. */
+  street: string;
+  /** Postal code and city. */
+  city: string;
+  /** Country. */
+  country: string;
+  /** An email address that reaches a human (§5 DDG requires a fast contact). */
+  email: string;
+  /** Optional: phone number. Leave empty to omit the line. */
+  phone: string;
+  /**
+   * Responsible for editorial content under §18 Abs. 2 MStV. Usually the same
+   * person as legalName — leave empty to omit the section.
+   */
+  contentResponsible: string;
+  /** Optional: VAT id (§27a UStG). Leave empty to omit the line. */
+  vatId: string;
+  /**
+   * Optional: the Datenschutzbeauftragte(r) (DPO). Most beta-scale operators do
+   * not need one (Art. 37 GDPR) — leave empty to omit the section.
+   */
+  dataProtectionOfficer: string;
+  /** The supervisory authority a data subject may complain to (Art. 77 GDPR). */
+  supervisoryAuthority: string;
+  /** Where the servers physically run — the residency claim must be true. */
+  hostingLocation: string;
+  /** Last review date of the legal texts, shown at the top of each page. */
+  lastUpdated: string;
+};
+
+/**
+ * OPERATOR is the deployment's own identity. EVERY placeholder below must be
+ * replaced before the deployment is reachable from the internet.
+ */
+export const OPERATOR: OperatorIdentity = {
+  legalName: "[BITTE AUSFÜLLEN: vollständiger Name des Betreibers]",
+  street: "[BITTE AUSFÜLLEN: Straße und Hausnummer]",
+  city: "[BITTE AUSFÜLLEN: PLZ und Ort]",
+  country: "Deutschland",
+  email: "[BITTE AUSFÜLLEN: Kontakt-E-Mail-Adresse]",
+  phone: "",
+  contentResponsible: "",
+  vatId: "",
+  dataProtectionOfficer: "",
+  supervisoryAuthority:
+    "[BITTE AUSFÜLLEN: zuständige Landesdatenschutzbehörde, z. B. „Der Landesbeauftragte für den Datenschutz und die Informationsfreiheit Baden-Württemberg“]",
+  hostingLocation: "[BITTE AUSFÜLLEN: Standort der Server, z. B. „Deutschland (eigener Server)“]",
+  lastUpdated: "[BITTE AUSFÜLLEN: Datum der letzten Überarbeitung]",
+};
+
+/** isPlaceholder reports whether a field is still an unfilled template value. */
+export function isPlaceholder(value: string): boolean {
+  return value.trim().startsWith(PLACEHOLDER_PREFIX);
+}
+
+/**
+ * operatorTodos lists the fields an operator still has to fill. Empty means the
+ * identity is complete; the legal pages render a banner while it is not.
+ * Optional fields (phone, VAT id, DPO, editorial responsibility) are excluded —
+ * an empty optional field is a decision, not an omission.
+ */
+export function operatorTodos(o: OperatorIdentity = OPERATOR): string[] {
+  const required: Array<keyof OperatorIdentity> = [
+    "legalName",
+    "street",
+    "city",
+    "country",
+    "email",
+    "supervisoryAuthority",
+    "hostingLocation",
+    "lastUpdated",
+  ];
+  return required.filter((k) => isPlaceholder(o[k]) || o[k].trim() === "");
+}

--- a/web/src/screens/legal/operator.ts
+++ b/web/src/screens/legal/operator.ts
@@ -54,21 +54,27 @@ export type OperatorIdentity = {
 /**
  * OPERATOR is the deployment's own identity. EVERY placeholder below must be
  * replaced before the deployment is reachable from the internet.
+ *
+ * This repository ships the identity of the canonical glyphoxa.net beta
+ * deployment, filled in by its operator (the project maintainer) on
+ * 2026-07-26. If you deploy your OWN instance from this source, you MUST
+ * replace every value below with your own identity — publishing someone
+ * else's name as your Impressum is a false legal notice.
  */
 export const OPERATOR: OperatorIdentity = {
-  legalName: "[BITTE AUSFÜLLEN: vollständiger Name des Betreibers]",
-  street: "[BITTE AUSFÜLLEN: Straße und Hausnummer]",
-  city: "[BITTE AUSFÜLLEN: PLZ und Ort]",
+  legalName: "Lukas Schmidt",
+  street: "Turpinstraße 19",
+  city: "52066 Aachen",
   country: "Deutschland",
-  email: "[BITTE AUSFÜLLEN: Kontakt-E-Mail-Adresse]",
+  email: "lukas.schmidt.web@gmail.com",
   phone: "",
   contentResponsible: "",
   vatId: "",
   dataProtectionOfficer: "",
   supervisoryAuthority:
-    "[BITTE AUSFÜLLEN: zuständige Landesdatenschutzbehörde, z. B. „Der Landesbeauftragte für den Datenschutz und die Informationsfreiheit Baden-Württemberg“]",
-  hostingLocation: "[BITTE AUSFÜLLEN: Standort der Server, z. B. „Deutschland (eigener Server)“]",
-  lastUpdated: "[BITTE AUSFÜLLEN: Datum der letzten Überarbeitung]",
+    "Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW), Kavalleriestraße 2–4, 40213 Düsseldorf",
+  hostingLocation: "Deutschland (eigener Server)",
+  lastUpdated: "26. Juli 2026",
 };
 
 /** isPlaceholder reports whether a field is still an unfilled template value. */

--- a/web/src/screens/legal/todoBanner.test.tsx
+++ b/web/src/screens/legal/todoBanner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
+import { createRouterTransport } from "@connectrpc/connect";
+
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { routeTree } from "@/app/router";
+
+// The shipped operator.ts is filled (the canonical deployment's identity), so
+// the unfilled-identity path can no longer be exercised against the real
+// module. This suite mocks an UNFILLED identity to keep the safety mechanism
+// covered: a deployment with placeholder fields must scream at its operator.
+vi.mock("./operator", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./operator")>();
+  const unfilled = {
+    ...actual.OPERATOR,
+    legalName: "[BITTE AUSFÜLLEN: vollständiger Name des Betreibers]",
+    email: "[BITTE AUSFÜLLEN: Kontakt-E-Mail-Adresse]",
+  };
+  // operatorTodos' default argument binds the real module's OPERATOR, so it
+  // must be re-bound to the mocked identity for LegalPage's no-arg call.
+  return {
+    ...actual,
+    OPERATOR: unfilled,
+    operatorTodos: (o = unfilled) => actual.operatorTodos(o),
+  };
+});
+
+function renderAt(path: string) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(
+    <Providers transport={createRouterTransport(() => {})} queryClient={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </Providers>,
+  );
+}
+
+describe("operator TODO banner (unfilled identity)", () => {
+  it("shows a loud operator TODO while any required field is a placeholder", async () => {
+    renderAt("/imprint");
+    await screen.findByRole("heading", { name: "Impressum", level: 1 });
+    expect(screen.getByRole("alert")).toHaveTextContent(/Hinweis an den Betreiber/i);
+    expect(screen.getByRole("alert")).toHaveTextContent(/legalName/);
+  });
+
+  it("marks each unfilled value inline", async () => {
+    renderAt("/imprint");
+    await screen.findByRole("heading", { name: "Impressum", level: 1 });
+    const placeholders = document.querySelectorAll(".gx-legal__placeholder");
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/screens/login/Login.test.tsx
+++ b/web/src/screens/login/Login.test.tsx
@@ -85,10 +85,12 @@ describe("Login", () => {
     await renderLogin(<Login />, backend({ mode: AdmissionMode.OPEN }));
     expect(await screen.findByText(/creates your own table/i)).toBeInTheDocument();
     // ADR-0055 changes the copy; #518 additionally gates the OAuth start behind
-    // the AUP acknowledgment — once ticked, the anchor is exactly as it was.
+    // the AUP acknowledgment — once ticked, the anchor carries the ?aup=1 the
+    // server-side gate requires for an open-mode start (Go↔TS contract with
+    // internal/auth/oauth.go).
     fireEvent.click(screen.getByRole("checkbox"));
     const link = screen.getByRole("link", { name: /continue with discord/i });
-    expect(link).toHaveAttribute("href", "/auth/discord/login");
+    expect(link).toHaveAttribute("href", "/auth/discord/login?aup=1");
   });
 
   it("requires the AUP acknowledgment before an open-mode signup can start", async () => {
@@ -108,9 +110,17 @@ describe("Login", () => {
 
     expect(screen.getByRole("link", { name: /continue with discord/i })).toHaveAttribute(
       "href",
-      "/auth/discord/login",
+      "/auth/discord/login?aup=1",
     );
     expect(screen.queryByRole("button", { name: /continue with discord/i })).not.toBeInTheDocument();
+  });
+
+  it("explains the bounce when the server-side AUP gate refused the start", async () => {
+    // #518's backstop: a hand-typed /auth/discord/login in open mode 302s back
+    // here with ?error=aup_required — the screen says why instead of silently
+    // showing the same form again.
+    await renderLogin(<Login aupRequired />, backend({ mode: AdmissionMode.OPEN }));
+    expect(screen.getByRole("alert")).toHaveTextContent(/accept the Nutzungsbedingungen/i);
   });
 
   it("links the terms and the privacy policy from the acknowledgment", async () => {

--- a/web/src/screens/login/Login.test.tsx
+++ b/web/src/screens/login/Login.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
@@ -84,9 +84,66 @@ describe("Login", () => {
   it("frames self-signup when the deployment admission mode is open", async () => {
     await renderLogin(<Login />, backend({ mode: AdmissionMode.OPEN }));
     expect(await screen.findByText(/creates your own table/i)).toBeInTheDocument();
-    // ADR-0055: only the copy changes — the OAuth start anchor stays exactly as is.
+    // ADR-0055 changes the copy; #518 additionally gates the OAuth start behind
+    // the AUP acknowledgment — once ticked, the anchor is exactly as it was.
+    fireEvent.click(screen.getByRole("checkbox"));
     const link = screen.getByRole("link", { name: /continue with discord/i });
     expect(link).toHaveAttribute("href", "/auth/discord/login");
+  });
+
+  it("requires the AUP acknowledgment before an open-mode signup can start", async () => {
+    // #518: in open admission mode this screen IS the signup screen, so a
+    // stranger cannot reach Discord OAuth without accepting the terms. The
+    // blocked state is a real disabled button — an aria-disabled anchor would
+    // still navigate on click.
+    await renderLogin(<Login />, backend({ mode: AdmissionMode.OPEN }));
+    await screen.findByText(/creates your own table/i);
+
+    expect(screen.queryByRole("link", { name: /continue with discord/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue with discord/i })).toBeDisabled();
+
+    const box = screen.getByRole("checkbox");
+    expect(box).not.toBeChecked();
+    fireEvent.click(box);
+
+    expect(screen.getByRole("link", { name: /continue with discord/i })).toHaveAttribute(
+      "href",
+      "/auth/discord/login",
+    );
+    expect(screen.queryByRole("button", { name: /continue with discord/i })).not.toBeInTheDocument();
+  });
+
+  it("links the terms and the privacy policy from the acknowledgment", async () => {
+    await renderLogin(<Login />, backend({ mode: AdmissionMode.OPEN }));
+    await screen.findByText(/creates your own table/i);
+    // Both documents are unauthenticated routes, so a visitor can read them
+    // before deciding — that is the point of asking here. Scoped to the
+    // acknowledgment: the always-present legal footer links them too.
+    const label = screen.getByRole("checkbox").closest("label");
+    expect(label).not.toBeNull();
+    const consent = within(label as HTMLElement);
+    expect(consent.getByRole("link", { name: "Nutzungsbedingungen" })).toHaveAttribute(
+      "href",
+      "/terms",
+    );
+    expect(consent.getByRole("link", { name: "Datenschutzerklärung" })).toHaveAttribute(
+      "href",
+      "/privacy",
+    );
+  });
+
+  it("asks for no acknowledgment in allowlist mode", async () => {
+    // An allowlisted operator agreed to their own deployment's terms by running
+    // it; the pre-#518 flow is unchanged for them.
+    await renderLogin(<Login />, backend({ mode: AdmissionMode.ALLOWLIST }));
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /continue with discord/i })).toBeInTheDocument();
+  });
+
+  it("shows the legal footer to a visitor with no session", async () => {
+    await renderLogin(<Login />);
+    expect(screen.getByRole("link", { name: "Impressum" })).toHaveAttribute("href", "/imprint");
+    expect(screen.getByRole("link", { name: "Datenschutz" })).toHaveAttribute("href", "/privacy");
   });
 
   it("falls back to the allowlist framing when the admission probe errors", async () => {

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -1,8 +1,10 @@
+import { useId, useState } from "react";
 import { Dices } from "lucide-react";
 import { useQuery } from "@connectrpc/connect-query";
 
 import { AuthService, AdmissionMode } from "@gen/glyphoxa/management/v1/management_pb";
 import { Button } from "@/components/ui/Button";
+import { LegalFooter } from "@/components/LegalFooter";
 
 import "./login.css";
 
@@ -19,6 +21,14 @@ import "./login.css";
 // is non-leaky, never echoing the rejected account's id or WHY it was denied,
 // so the copy must stay mode-neutral. A normal first visit renders unchanged.
 //
+// In `open` mode this screen IS the signup screen, so it carries the AUP/ToS
+// acknowledgment (#518): the Discord OAuth start is disabled until the visitor
+// ticks the box that links the Nutzungsbedingungen and the Datenschutzerklärung.
+// In `allowlist` mode nothing changes — those operators agreed to their own
+// deployment's terms by running it — and the fail-safe default (probe loading or
+// errored) is allowlist framing, so a flaky probe never blocks a legitimate
+// operator login behind a checkbox they cannot see the point of.
+//
 // The lede frames signup per the deployment's Admission Mode (ADR-0055):
 // GetAdmissionMode is public (there is no session yet on this screen), and only
 // an explicit `open` answer switches the copy to self-signup framing — while
@@ -28,6 +38,10 @@ import "./login.css";
 export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
   const { data } = useQuery(AuthService.method.getAdmissionMode, {}, { retry: false });
   const open = data?.admissionMode === AdmissionMode.OPEN;
+  const [accepted, setAccepted] = useState(false);
+  const aupId = useId();
+  // Open mode = signing up: the acknowledgment gates the OAuth start.
+  const blocked = open && !accepted;
 
   return (
     <div className="gx-login">
@@ -48,9 +62,34 @@ export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
           </p>
         )}
 
-        <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
-          Continue with Discord
-        </a>
+        {open && (
+          <label className="gx-login__consent" htmlFor={aupId}>
+            <input
+              id={aupId}
+              type="checkbox"
+              checked={accepted}
+              onChange={(e) => setAccepted(e.target.checked)}
+            />
+            <span>
+              I agree to the <a href="/terms">Nutzungsbedingungen</a> and have read the{" "}
+              <a href="/privacy">Datenschutzerklärung</a>.
+            </span>
+          </label>
+        )}
+
+        {/* An anchor cannot be `disabled`, so the blocked state is rendered as a
+            real disabled button — aria-disabled alone would still navigate on
+            click, and a signup that slips past the acknowledgment is the one
+            thing this gate exists to prevent. */}
+        {blocked ? (
+          <Button variant="primary" size="lg" block disabled>
+            Continue with Discord
+          </Button>
+        ) : (
+          <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
+            Continue with Discord
+          </a>
+        )}
 
         <div className="gx-login__soon">
           <Button variant="secondary" block disabled>
@@ -61,6 +100,8 @@ export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
           </Button>
         </div>
       </div>
+
+      <LegalFooter />
     </div>
   );
 }

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -35,7 +35,14 @@ import "./login.css";
 // the probe is loading or errored the screen fail-safes to today's allowlist
 // framing rather than advertising a signup the deployment may not allow. Only
 // the copy changes: the OAuth start anchor stays exactly as is in both modes.
-export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
+export function Login({
+  notAuthorized = false,
+  aupRequired = false,
+}: {
+  notAuthorized?: boolean;
+  /** The server-side #518 gate bounced an unacknowledged open-mode OAuth start here. */
+  aupRequired?: boolean;
+}) {
   const { data, status } = useQuery(AuthService.method.getAdmissionMode, {}, { retry: false });
   const open = data?.admissionMode === AdmissionMode.OPEN;
   const [accepted, setAccepted] = useState(false);
@@ -66,6 +73,12 @@ export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
           </p>
         )}
 
+        {aupRequired && (
+          <p className="gx-login__error" role="alert">
+            Please accept the Nutzungsbedingungen below before signing in.
+          </p>
+        )}
+
         {open && (
           <label className="gx-login__consent" htmlFor={aupId}>
             <input
@@ -84,13 +97,19 @@ export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
         {/* An anchor cannot be `disabled`, so the blocked state is rendered as a
             real disabled button — aria-disabled alone would still navigate on
             click, and a signup that slips past the acknowledgment is the one
-            thing this gate exists to prevent. */}
+            thing this gate exists to prevent. In open mode the start link
+            carries ?aup=1 — the server refuses an open-mode start without it
+            and the callback records the acceptance time (#518), so the
+            checkbox is enforced, not just rendered. */}
         {blocked ? (
           <Button variant="primary" size="lg" block disabled>
             Continue with Discord
           </Button>
         ) : (
-          <a className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block" href="/auth/discord/login">
+          <a
+            className="gx-btn gx-btn--primary gx-btn--lg gx-btn--block"
+            href={open ? "/auth/discord/login?aup=1" : "/auth/discord/login"}
+          >
             Continue with Discord
           </a>
         )}

--- a/web/src/screens/login/Login.tsx
+++ b/web/src/screens/login/Login.tsx
@@ -36,12 +36,16 @@ import "./login.css";
 // framing rather than advertising a signup the deployment may not allow. Only
 // the copy changes: the OAuth start anchor stays exactly as is in both modes.
 export function Login({ notAuthorized = false }: { notAuthorized?: boolean }) {
-  const { data } = useQuery(AuthService.method.getAdmissionMode, {}, { retry: false });
+  const { data, status } = useQuery(AuthService.method.getAdmissionMode, {}, { retry: false });
   const open = data?.admissionMode === AdmissionMode.OPEN;
   const [accepted, setAccepted] = useState(false);
   const aupId = useId();
-  // Open mode = signing up: the acknowledgment gates the OAuth start.
-  const blocked = open && !accepted;
+  // Open mode = signing up: the acknowledgment gates the OAuth start. While the
+  // probe is still IN FLIGHT the start is briefly disabled too — otherwise the
+  // first render on an open deployment shows an ungated anchor and a fast click
+  // slips past the acknowledgment. An ERRORED probe stays fail-open with the
+  // allowlist framing (a flaky probe must not lock a legitimate operator out).
+  const blocked = status === "pending" || (open && !accepted);
 
   return (
     <div className="gx-login">

--- a/web/src/screens/login/login.css
+++ b/web/src/screens/login/login.css
@@ -68,3 +68,32 @@
   width: 100%;
   margin-top: 4px;
 }
+
+/* The open-mode AUP/ToS acknowledgment (#518): signing up here is the moment a
+   stranger accepts this deployment's terms, so the checkbox sits directly above
+   the OAuth start it gates. */
+.gx-login__consent {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  width: 100%;
+  color: var(--text-subtle, #9a93a8);
+  font-size: var(--body-sm, 0.875rem);
+  text-align: left;
+  cursor: pointer;
+}
+
+.gx-login__consent input {
+  margin-top: 3px;
+  accent-color: var(--accent, #9059ff);
+}
+
+.gx-login__consent a {
+  color: var(--accent, #9059ff);
+}
+
+/* The login/signup cards are centered in the viewport; the legal footer sits
+   under the card rather than pinned to the bottom edge. */
+.gx-login .gx-legalfooter {
+  margin-top: 18px;
+}

--- a/web/src/screens/onboarding/CreateTenant.tsx
+++ b/web/src/screens/onboarding/CreateTenant.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { AuthService } from "@gen/glyphoxa/management/v1/management_pb";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { LegalFooter } from "@/components/LegalFooter";
 import { isUnauthenticated } from "@/lib/connectError";
 
 import "@/screens/login/login.css";
@@ -132,6 +133,9 @@ function NameTenantCard({ initialName }: { initialName: string }) {
           Skip for now
         </Button>
       </form>
+
+      {/* The footer follows the visitor through signup too (#518). */}
+      <LegalFooter />
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Works through the `ready-for-agent` backlog, one commit per issue.

- **Closes #437** — the LINE grain now obeys ADR-0012's delivered-only invariant. The Relay still persists optimistically at `TTSInvoked` (the live SSE latency contract is unchanged) but tracks each turn's first `FirstAudio` and **retracts** the row when the turn ends having delivered zero sentences — the canonical case being a TTS start-error (`TurnEnded{tts_error}`). `Finalize` sweeps any turn still undelivered when a session ends mid-turn, before the flush barrier, so the authoritative `line_count` follows. Retractions ride the *same* single-writer queue as the UPSERTs, so they can never overtake the write they undo. A turn that delivered at least one sentence keeps its line — #401's sentence-tail rounding on barge stays accepted.
- **Closes #519** — the Bot posts a transcription disclosure to the voice channel's text chat at Voice Session start: exactly once per session (not once per reconnect cycle), best-effort, linking `GLYPHOXA_PRIVACY_POLICY_URL` when configured and no link at all when it is not. A tape-armed Campaign gets **one** combined message (the tape's consent copy + Consent/Revoke buttons ride it) instead of two.
- **Closes #517** — the chart can stand up a `cloudflared` Tunnel (outbound-only; no hostPort/Ingress/LoadBalancer needed) and an in-cluster **Ollama** (Deployment + Service + model-cache PVC) with `ollamaUrl` derived from that Service when left empty.
- **Closes #520** — a nightly `pg_dump -Fc` CronJob into its own PVC with rotation, an optional S3-compatible off-site push, and a restore runbook (`docs/deploy/backup-restore.md`) linked from NOTES.txt.
- **Closes #518** — Impressum, Datenschutzerklärung and Nutzungsbedingungen as static unauthenticated SPA routes (`/imprint`, `/privacy`, `/terms` + German aliases), linked from a footer on every screen including login/signup, plus an AUP acknowledgment gating the open-mode signup. Operator identity ships as clearly-marked placeholders with a loud in-page TODO banner and a fill-in runbook.
- **Closes #521** — the unauthenticated root now serves a landing page (what this is, captioned screenshot slots, how the free beta works, CTA into the unchanged auth flow), and the chart ships the matching public-beta plan catalog (`beta-trial` platform tier with a $5 allowance + free `byok-free`) as its `plans.catalog` default.

## Why is this change needed?

#437 closed an undocumented divergence between the two Transcript grains (the Chunker already purged undelivered sentences; the Line grain kept text the room never heard). The other five are the public-beta launch epic: players who never open the web app had no transcription disclosure, there were no legal pages at all, the root converted nobody, and the home-VM topology's inbound path, embeddings server and restore story all lived outside the chart.

## How was this tested?

- `go build ./...`, `go vet ./...` (incl. `-tags=integration`), `go test -race ./...`, `gofmt` clean.
- New Go tests: the zero-delivery retraction, delivered-survives-barge, the session-end sweep, `DeleteTranscriptLine` (integration-tagged), the once-per-session disclosure guard, combined vs plain disclosure content, the privacy-URL env parse, and a parse of the chart's **shipped** plan catalog through the same strict parser `plans-sync` uses.
- Web: `tsc --noEmit`, `vite build`, `vitest` — new suites for the legal pages (including the topics the Datenschutzerklärung must cover), the legal footer, the landing/root behaviour and copy honesty, and the open-mode AUP gate.
- Chart: `helm lint`, `helm unittest` (197 tests, 13 suites — new `backup`, `cloudflared`, `ollama` suites), `scripts/helm-validate.sh` + its self-test, with new render paths for each flag, the combined home-VM topology, and the beta launch posture.
- CI was green on the first three commits (run 738); the later two are running.

- [x] `make check` passes (equivalent: build + vet + `go test -race ./...`)
- [x] New/updated tests cover the change
- [ ] Manual testing — the disclosure post, the tunnel and the backup CronJob need live Discord/Cloudflare/cluster credentials

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — #437
- [x] New feature (non-breaking change that adds functionality) — #519, #517, #520, #518, #521
- [ ] Breaking change
- [ ] New provider implementation
- [x] Documentation update — `docs/deploy/backup-restore.md`, `docs/deploy/legal-pages.md`, `docs/configuration.md`, `docs/deploy/k3s-proxmox.md`, `docs/deploy/saas-operations.md`
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

**Operator TODO before this deployment faces the internet:** fill in `web/src/screens/legal/operator.ts` (§5 DDG identity) — every legal page renders a red banner until you do. See `docs/deploy/legal-pages.md`. The legal texts are self-drafted German templates and are **not** lawyer-reviewed, per the accepted beta risk on #518.

**Behaviour changes worth flagging:**
- The tape consent disclosure used to be re-posted on every Discord reconnect cycle; it now posts once per Voice Session as part of the combined message. The buttons are stateless (the Campaign rides their custom ids), so the one message stays interactive for the whole session.
- `/` no longer redirects unauthenticated visitors into the login form — it serves the landing page. A signed-in visitor is still redirected straight into the app.
- Existing relay/persistence tests that dispatched TTS without ever publishing `FirstAudio` were updated to publish it: under the new invariant those scenarios were asserting that never-delivered text is persisted.

**Chart defaults are unchanged** — `cloudflared`, `ollama`, `backup` and `plans` are all opt-in, so an existing install renders identically until a flag is set.

**Not in this PR: #312** (ElevenLabs sound generation for Highlights). It is the one remaining `ready-for-agent` issue and is unblocked (#308 closed), but the maintainer decision on it deferred sound enrichment until highlights prove out in real sessions, and it is a full vertical slice (provider wrapper + cassettes, migration, job, proto RPC, price-map entries, spend metering, web action + playback) rather than launch work. Happy to take it on next, on its own branch.