### PR TITLE
feat(kg): world health panel and roster prep dashboard (#536, #544)

### DIFF
--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -185,6 +185,16 @@ func (r *Recaller) degrade(ctx context.Context, cause error) []string {
 	return nil
 }
 
+// HasContent reports whether a rendered fact says anything beyond its header
+// line. A Node with no body and no public Aspects still renders as
+// "### Bart (NPC)" — a real fact string, but zero world knowledge — so any check
+// of the form "does this NPC have facts" must count CONTENT-BEARING facts or it
+// can never fail (#544 review finding).
+func HasContent(fact string) bool {
+	_, content, ok := strings.Cut(fact, "\n")
+	return ok && strings.TrimSpace(content) != ""
+}
+
 // Preview is exactly what an Agent's Hot Context facts block will contain, plus
 // the budget arithmetic that produced it (#535). It exists so the GM-facing
 // "what does this NPC actually know" lens reads the SAME renderer the voice loop
@@ -210,6 +220,10 @@ type Preview struct {
 	// Truncated reports that the prefix-stop fired: at least one Node the read
 	// returned did not fit.
 	Truncated bool
+	// ContentFacts is how many of Facts say anything beyond their header line.
+	// It, not len(Facts), is the honest answer to "does this NPC know anything":
+	// a linked NPC's own Node always renders, empty or not.
+	ContentFacts int
 }
 
 // RenderPreview is renderFacts with its budget arithmetic exposed (#535). The
@@ -250,6 +264,11 @@ func RenderPreview(nodes []storage.KGNode) Preview {
 	}
 	if len(p.Facts) > 0 {
 		p.Chars = total
+	}
+	for _, f := range p.Facts {
+		if HasContent(f) {
+			p.ContentFacts++
+		}
 	}
 	return p
 }

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -526,3 +526,28 @@ func TestRenderPreview_Empty(t *testing.T) {
 		t.Errorf("empty preview = %+v, want zero facts, untruncated, zero chars", p)
 	}
 }
+
+// TestRenderPreview_ContentFacts pins the distinction the roster dashboard
+// depends on. A linked NPC's own Node is ALWAYS returned at hop 0 and always
+// renders at least its header line, so "does this NPC have facts" measured as
+// len(Facts) can never fail — for exactly the NPC the dashboard exists to catch.
+func TestRenderPreview_ContentFacts(t *testing.T) {
+	empty := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}
+	full := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeLocation, Name: "Saltmarsh", Body: "A damp town."}
+
+	only := kgfacts.RenderPreview([]storage.KGNode{empty})
+	if len(only.Facts) != 1 {
+		t.Fatalf("an empty node still renders its header: got %d facts", len(only.Facts))
+	}
+	if only.ContentFacts != 0 {
+		t.Errorf("ContentFacts = %d for a header-only block, want 0", only.ContentFacts)
+	}
+
+	both := kgfacts.RenderPreview([]storage.KGNode{empty, full})
+	if both.ContentFacts != 1 {
+		t.Errorf("ContentFacts = %d, want only the one that says something", both.ContentFacts)
+	}
+	if len(both.Facts) != 2 {
+		t.Errorf("Facts = %d, want both rendered (the block is what it is)", len(both.Facts))
+	}
+}

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -984,6 +984,20 @@ type fakeKGPreviewStore struct {
 	factCalls int
 	factsErr  error
 	linkedErr error
+
+	// The batch roster readiness read (#544).
+	agentList []storage.Agent
+	agentsErr error
+	lastSpoke []storage.AgentLastSpoke
+	spokeErr  error
+}
+
+func (f *fakeKGPreviewStore) ListAgents(_ context.Context, _ uuid.UUID) ([]storage.Agent, error) {
+	return f.agentList, f.agentsErr
+}
+
+func (f *fakeKGPreviewStore) LastSpokenByAgent(_ context.Context, _ uuid.UUID) ([]storage.AgentLastSpoke, error) {
+	return f.lastSpoke, f.spokeErr
 }
 
 func newFakeKGPreviewStore() *fakeKGPreviewStore {

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -931,6 +931,27 @@ type fakeKGGraphStore struct {
 	edgeErr      error
 	edgeCalls    int
 	edgeCampaign uuid.UUID
+
+	// The GM-initiated duplicate scan (#536): pairs/unembedded are returned
+	// verbatim; the recorded floor and limit prove the handler applies a policy
+	// rather than letting the client choose one.
+	pairs        []storage.KGNodePair
+	pairErr      error
+	pairCampaign uuid.UUID
+	pairFloor    float64
+	pairLimit    int
+	unembedded   int
+}
+
+func (f *fakeKGGraphStore) SimilarNodePairs(_ context.Context, campaignID uuid.UUID, minSimilarity float64, limit int) ([]storage.KGNodePair, error) {
+	f.pairCampaign = campaignID
+	f.pairFloor = minSimilarity
+	f.pairLimit = limit
+	return f.pairs, f.pairErr
+}
+
+func (f *fakeKGGraphStore) CountUnembeddedNodesInCampaign(_ context.Context, _ uuid.UUID) (int, error) {
+	return f.unembedded, nil
 }
 
 func newFakeKGGraphStore() *fakeKGGraphStore {

--- a/internal/rpc/kg_duplicates_test.go
+++ b/internal/rpc/kg_duplicates_test.go
@@ -1,0 +1,98 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestFindDuplicateEntries pins the world health panel's duplicate check (#536):
+// pairs map through closest-first, the campaign is scoped server-side, and the
+// unembedded count rides along so "no duplicates" cannot imply a clean bill of
+// health the scan could not actually give.
+func TestFindDuplicateEntries(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGGraphStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Saltmarsh"}
+	a, b := uuid.New(), uuid.New()
+	store.pairs = []storage.KGNodePair{
+		{AID: a, AName: "Bart", BID: b, BName: "Bart the innkeeper", Similarity: 0.97},
+	}
+	store.unembedded = 3
+
+	resp, err := kgGraphClient(t, store).FindDuplicateEntries(context.Background(),
+		connect.NewRequest(&managementv1.FindDuplicateEntriesRequest{}))
+	if err != nil {
+		t.Fatalf("FindDuplicateEntries: %v", err)
+	}
+	got := resp.Msg.GetPairs()
+	if len(got) != 1 {
+		t.Fatalf("got %d pairs, want 1", len(got))
+	}
+	if got[0].GetAName() != "Bart" || got[0].GetBName() != "Bart the innkeeper" {
+		t.Errorf("pair = %+v, want both names mapped", got[0])
+	}
+	if got[0].GetSimilarity() < 0.9 {
+		t.Errorf("similarity = %v, want the stored value", got[0].GetSimilarity())
+	}
+	if resp.Msg.GetUnembedded() != 3 {
+		t.Errorf("unembedded = %d, want 3 — a partial scan must say so", resp.Msg.GetUnembedded())
+	}
+	if store.pairCampaign != store.campaign.ID {
+		t.Errorf("scan scoped to %s, want the active campaign %s", store.pairCampaign, store.campaign.ID)
+	}
+	// A high floor is the difference between a hint the GM reads and a wall of
+	// coincidences they learn to ignore.
+	if store.pairFloor < 0.85 {
+		t.Errorf("similarity floor = %v, want a high floor so hints stay trustworthy", store.pairFloor)
+	}
+	if store.pairLimit <= 0 {
+		t.Errorf("pair limit = %d, want a cap", store.pairLimit)
+	}
+}
+
+// TestFindDuplicateEntries_NoDuplicates pins the healthy case as an empty list,
+// not an error.
+func TestFindDuplicateEntries_NoDuplicates(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGGraphStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	resp, err := kgGraphClient(t, store).FindDuplicateEntries(context.Background(),
+		connect.NewRequest(&managementv1.FindDuplicateEntriesRequest{}))
+	if err != nil {
+		t.Fatalf("FindDuplicateEntries: %v", err)
+	}
+	if len(resp.Msg.GetPairs()) != 0 {
+		t.Errorf("got %+v, want no pairs", resp.Msg.GetPairs())
+	}
+}
+
+func TestFindDuplicateEntries_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no campaign is NotFound", func(t *testing.T) {
+		store := newFakeKGGraphStore()
+		store.campErr = storage.ErrNotFound
+		_, err := kgGraphClient(t, store).FindDuplicateEntries(context.Background(),
+			connect.NewRequest(&managementv1.FindDuplicateEntriesRequest{}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("scan failure is Internal", func(t *testing.T) {
+		store := newFakeKGGraphStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.pairErr = errAny
+		_, err := kgGraphClient(t, store).FindDuplicateEntries(context.Background(),
+			connect.NewRequest(&managementv1.FindDuplicateEntriesRequest{}))
+		if got := connect.CodeOf(err); got != connect.CodeInternal {
+			t.Errorf("code = %v, want Internal", got)
+		}
+	})
+}

--- a/internal/rpc/kg_graph.go
+++ b/internal/rpc/kg_graph.go
@@ -75,12 +75,13 @@ func (s *kgGraph) GetKnowledgeGraph(
 	}
 	for _, n := range nodes {
 		gn := &managementv1.GraphNode{
-			Id:          n.ID.String(),
-			NodeType:    toProtoNodeType(n.Type),
-			Name:        n.Name,
-			GmPrivate:   n.GMPrivate,
-			BodyLen:     int32(n.BodyLen),     //nolint:gosec // a body length cannot exceed int32 in practice
-			AspectCount: int32(n.AspectCount), //nolint:gosec // bounded by kgvocab.MaxAspectsPerNode
+			Id:                n.ID.String(),
+			NodeType:          toProtoNodeType(n.Type),
+			Name:              n.Name,
+			GmPrivate:         n.GMPrivate,
+			BodyLen:           int32(n.BodyLen),           //nolint:gosec // a body length cannot exceed int32 in practice
+			AspectCount:       int32(n.AspectCount),       //nolint:gosec // bounded by kgvocab.MaxAspectsPerNode
+			PublicAspectCount: int32(n.PublicAspectCount), //nolint:gosec // bounded by kgvocab.MaxAspectsPerNode
 		}
 		if n.AgentID.Valid {
 			gn.AgentId = n.AgentID.UUID.String()

--- a/internal/rpc/kg_graph.go
+++ b/internal/rpc/kg_graph.go
@@ -28,6 +28,11 @@ type kgGraph struct {
 type kgGraphStore interface {
 	ListGraphNodes(ctx context.Context, campaignID uuid.UUID) ([]storage.KGGraphNode, error)
 	ListEdges(ctx context.Context, campaignID uuid.UUID) ([]storage.KGEdge, error)
+	// SimilarNodePairs backs the GM-initiated probable-duplicate check (#536);
+	// CountUnembeddedNodesInCampaign says how much of the wiki that check could not
+	// see yet.
+	SimilarNodePairs(ctx context.Context, campaignID uuid.UUID, minSimilarity float64, limit int) ([]storage.KGNodePair, error)
+	CountUnembeddedNodesInCampaign(ctx context.Context, campaignID uuid.UUID) (int, error)
 }
 
 // GetKnowledgeGraph returns the active campaign's whole Knowledge Graph — every
@@ -88,6 +93,70 @@ func (s *kgGraph) GetKnowledgeGraph(
 			FromNodeId: e.FromNodeID.String(),
 			ToNodeId:   e.ToNodeID.String(),
 			EdgeType:   toProtoEdgeType(e.Type),
+		})
+	}
+	return connect.NewResponse(out), nil
+}
+
+// Duplicate-check policy for the single-operator web tier (ADR-0039): the client
+// sends no threshold and no limit.
+const (
+	// duplicateSimilarityFloor is deliberately high. A hint the GM must read and act
+	// on is only useful if it is usually right; a low floor turns the panel into a
+	// wall of coincidences and trains the GM to ignore it.
+	duplicateSimilarityFloor = 0.92
+	// duplicatePairLimit caps the list. Past this many, the wiki has a systemic
+	// problem the panel cannot express one row at a time.
+	duplicatePairLimit = 25
+)
+
+// FindDuplicateEntries returns the active campaign's closest Node pairs by
+// embedding similarity — the world health panel's probable-duplicate check (#536).
+//
+// It is GM-INITIATED by design: an exact pairwise scan is cheap at campaign scale
+// but has no business firing on every Knowledge-tab render, and the ADR-0011
+// embedding path is not something to sweep speculatively.
+//
+// Per ADR-0052 this is a HINT and nothing more. Nothing in this path merges,
+// rewrites or deletes anything: similarity is not a semantic judgment, and a wrong
+// merge corrupts canon invisibly.
+func (s *kgGraph) FindDuplicateEntries(
+	ctx context.Context,
+	_ *connect.Request[managementv1.FindDuplicateEntriesRequest],
+) (*connect.Response[managementv1.FindDuplicateEntriesResponse], error) {
+	c, err := s.active.resolve(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("FindDuplicateEntries: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	pairs, err := s.store.SimilarNodePairs(ctx, c.ID, duplicateSimilarityFloor, duplicatePairLimit)
+	if err != nil {
+		slog.Default().Error("FindDuplicateEntries: pair scan failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Nodes still awaiting an embedding are invisible to the scan. Reporting the
+	// count keeps "no duplicates found" from implying a clean bill of health the
+	// check could not actually give.
+	unembedded, err := s.store.CountUnembeddedNodesInCampaign(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("FindDuplicateEntries: unembedded count failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := &managementv1.FindDuplicateEntriesResponse{
+		Pairs:      make([]*managementv1.DuplicateEntryPair, 0, len(pairs)),
+		Unembedded: int32(unembedded), //nolint:gosec // bounded by campaign size
+	}
+	for _, p := range pairs {
+		out.Pairs = append(out.Pairs, &managementv1.DuplicateEntryPair{
+			AId: p.AID.String(), AName: p.AName,
+			BId: p.BID.String(), BName: p.BName,
+			Similarity: p.Similarity,
 		})
 	}
 	return connect.NewResponse(out), nil

--- a/internal/rpc/kg_preview.go
+++ b/internal/rpc/kg_preview.go
@@ -199,8 +199,12 @@ func (s *kgPreview) GetRosterReadiness(
 				return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 			}
 			p := kgfacts.RenderPreview(nodes)
-			r.FactCount = int32(len(p.Facts)) //nolint:gosec // bounded by kgfacts.MaxFacts
-			r.Chars = int32(p.Chars)          //nolint:gosec // bounded by kgfacts.MaxBlockChars
+			// CONTENT-bearing facts, not rendered ones. A linked NPC's own Node is always
+			// returned at hop 0 and always renders at least its header line, so
+			// len(Facts) > 0 is a check that can never fail — precisely for the NPC this
+			// dashboard exists to catch.
+			r.FactCount = int32(p.ContentFacts) //nolint:gosec // bounded by kgfacts.MaxFacts
+			r.Chars = int32(p.Chars)            //nolint:gosec // bounded by kgfacts.MaxBlockChars
 			r.Truncated = p.Truncated
 		}
 		out.Agents = append(out.Agents, r)

--- a/internal/rpc/kg_preview.go
+++ b/internal/rpc/kg_preview.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
@@ -38,6 +40,9 @@ type kgPreviewStore interface {
 	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
 	AgentLinkedNode(ctx context.Context, agentID uuid.UUID) (storage.KGNode, bool, error)
 	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+	// ListAgents and LastSpokenByAgent back the batch roster readiness read (#544).
+	ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error)
+	LastSpokenByAgent(ctx context.Context, campaignID uuid.UUID) ([]storage.AgentLastSpoke, error)
 }
 
 // GetAgentFactPreview renders the Agent's facts block through the SAME path the
@@ -131,6 +136,78 @@ func (s *kgPreview) GetAgentFactPreview(
 	return connect.NewResponse(out), nil
 }
 
+// GetRosterReadiness grades every cast Agent at once (#544) on the SAME fact
+// preview #535 exposes, plus when each last spoke.
+//
+// One call, not one per NPC: this backs a dashboard the GM opens before every
+// session, and a per-NPC preview would be an RPC storm on exactly that screen.
+// The facts still come from the prompt-facing seam, so the dashboard cannot claim
+// an NPC is ready on arithmetic the voice loop does not share.
+//
+// The Butler is excluded: Address-Only, auto-created, with no linked Node by
+// design (ADR-0009), so these signals do not describe it. The roster view still
+// LISTS it — it is simply not graded.
+func (s *kgPreview) GetRosterReadiness(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetRosterReadinessRequest],
+) (*connect.Response[managementv1.GetRosterReadinessResponse], error) {
+	c, err := s.active.resolve(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("GetRosterReadiness: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	agents, err := s.store.ListAgents(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("GetRosterReadiness: list agents failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	spoke, err := s.store.LastSpokenByAgent(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("GetRosterReadiness: last-spoken read failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	lastSpoke := make(map[string]time.Time, len(spoke))
+	for _, l := range spoke {
+		lastSpoke[l.Who] = l.At
+	}
+
+	out := &managementv1.GetRosterReadinessResponse{}
+	for _, a := range agents {
+		if a.Role != storage.AgentRoleCharacter {
+			continue
+		}
+		r := &managementv1.AgentReadiness{
+			AgentId:  a.ID.String(),
+			MaxChars: kgfacts.MaxBlockChars,
+		}
+		if at, ok := lastSpoke[a.Name]; ok {
+			r.LastSpokeAt = timestamppb.New(at)
+		}
+
+		if _, linked, err := s.store.AgentLinkedNode(ctx, a.ID); err != nil {
+			slog.Default().Error("GetRosterReadiness: linked node lookup failed", "agent_id", a.ID, "err", err)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		} else if linked {
+			r.Linked = true
+			nodes, err := s.store.AgentNodeFacts(ctx, a.ID)
+			if err != nil {
+				slog.Default().Error("GetRosterReadiness: agent node facts failed", "agent_id", a.ID, "err", err)
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+			}
+			p := kgfacts.RenderPreview(nodes)
+			r.FactCount = int32(len(p.Facts)) //nolint:gosec // bounded by kgfacts.MaxFacts
+			r.Chars = int32(p.Chars)          //nolint:gosec // bounded by kgfacts.MaxBlockChars
+			r.Truncated = p.Truncated
+		}
+		out.Agents = append(out.Agents, r)
+	}
+	return connect.NewResponse(out), nil
+}
+
 // kgPreviewSource composes the ONE prompt-facing KG read with the two plain Agent
 // reads the lens needs for scoping and the linked-entry state. The facts read is
 // taken from [storage.PromptKGView] rather than *Store on purpose: the lens must
@@ -151,6 +228,14 @@ func (v kgPreviewSource) AgentLinkedNode(ctx context.Context, agentID uuid.UUID)
 
 func (v kgPreviewSource) GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error) {
 	return v.store.GetAgent(ctx, id)
+}
+
+func (v kgPreviewSource) ListAgents(ctx context.Context, campaignID uuid.UUID) ([]storage.Agent, error) {
+	return v.store.ListAgents(ctx, campaignID)
+}
+
+func (v kgPreviewSource) LastSpokenByAgent(ctx context.Context, campaignID uuid.UUID) ([]storage.AgentLastSpoke, error) {
+	return v.store.LastSpokenByAgent(ctx, campaignID)
 }
 
 // kgPreviewStoreOf builds the lens's read source over a concrete Store.

--- a/internal/rpc/kg_preview_test.go
+++ b/internal/rpc/kg_preview_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -251,6 +252,101 @@ func TestGetAgentFactPreview_ErrorMapping(t *testing.T) {
 		store.factsErr = errAny
 		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
 			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+		if got := connect.CodeOf(err); got != connect.CodeInternal {
+			t.Errorf("code = %v, want Internal", got)
+		}
+	})
+}
+
+// TestGetRosterReadiness pins the batch prep read (#544): every cast Agent graded
+// in ONE call on the SAME fact renderer the turn uses, with the last-spoke signal
+// matched by speaker label, and the Butler excluded from grading.
+func TestGetRosterReadiness(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Saltmarsh"}
+
+	bart, ilva, butler := uuid.New(), uuid.New(), uuid.New()
+	store.agentList = []storage.Agent{
+		{ID: butler, CampaignID: store.campaign.ID, Role: storage.AgentRoleButler, Name: "Glyphoxa"},
+		{ID: bart, CampaignID: store.campaign.ID, Role: storage.AgentRoleCharacter, Name: "Bart"},
+		{ID: ilva, CampaignID: store.campaign.ID, Role: storage.AgentRoleCharacter, Name: "Ilva"},
+	}
+	own := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart", Body: "An innkeeper."}
+	store.linked[bart] = own
+	store.facts[bart] = []storage.KGNode{
+		own,
+		{ID: uuid.New(), Type: storage.KGNodeLocation, Name: "Saltmarsh", Body: "A damp town."},
+	}
+	spokeAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	store.lastSpoke = []storage.AgentLastSpoke{{Who: "Bart", At: spokeAt}}
+
+	resp, err := kgPreviewClient(t, store).GetRosterReadiness(context.Background(),
+		connect.NewRequest(&managementv1.GetRosterReadinessRequest{}))
+	if err != nil {
+		t.Fatalf("GetRosterReadiness: %v", err)
+	}
+	got := resp.Msg.GetAgents()
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want the 2 cast Agents (the Butler is not graded)", len(got))
+	}
+
+	byID := map[string]*managementv1.AgentReadiness{}
+	for _, a := range got {
+		byID[a.GetAgentId()] = a
+	}
+	if _, graded := byID[butler.String()]; graded {
+		t.Error("the Butler was graded — it is Address-Only with no linked Node by design")
+	}
+
+	b := byID[bart.String()]
+	if !b.GetLinked() || b.GetFactCount() != 2 {
+		t.Errorf("Bart = %+v, want linked with the 2 facts the renderer produces", b)
+	}
+	// The SAME renderer the turn uses, not a second implementation.
+	want := kgfacts.RenderPreview(store.facts[bart])
+	if int(b.GetFactCount()) != len(want.Facts) || int(b.GetChars()) != want.Chars {
+		t.Errorf("Bart's figures = %d facts / %d chars, want the renderer's %d / %d",
+			b.GetFactCount(), b.GetChars(), len(want.Facts), want.Chars)
+	}
+	if b.GetLastSpokeAt() == nil || !b.GetLastSpokeAt().AsTime().Equal(spokeAt) {
+		t.Errorf("Bart's last-spoke = %v, want %v", b.GetLastSpokeAt(), spokeAt)
+	}
+
+	// An unlinked NPC is reported as unlinked with no facts, not omitted — the
+	// dashboard's whole job is showing which NPCs are NOT ready.
+	i := byID[ilva.String()]
+	if i == nil || i.GetLinked() || i.GetFactCount() != 0 {
+		t.Errorf("Ilva = %+v, want an explicit unlinked, zero-fact entry", i)
+	}
+	if i.GetLastSpokeAt() != nil {
+		t.Errorf("Ilva reported a last-spoke time without ever speaking: %v", i.GetLastSpokeAt())
+	}
+	// No facts read is made for an Agent with no linked entry.
+	if store.factCalls != 1 {
+		t.Errorf("made %d facts reads, want exactly 1 (only the linked Agent)", store.factCalls)
+	}
+}
+
+func TestGetRosterReadiness_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no campaign is NotFound", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campErr = storage.ErrNotFound
+		_, err := kgPreviewClient(t, store).GetRosterReadiness(context.Background(),
+			connect.NewRequest(&managementv1.GetRosterReadinessRequest{}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("last-spoken failure is Internal", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.spokeErr = errAny
+		_, err := kgPreviewClient(t, store).GetRosterReadiness(context.Background(),
+			connect.NewRequest(&managementv1.GetRosterReadinessRequest{}))
 		if got := connect.CodeOf(err); got != connect.CodeInternal {
 			t.Errorf("code = %v, want Internal", got)
 		}

--- a/internal/rpc/kg_preview_test.go
+++ b/internal/rpc/kg_preview_test.go
@@ -328,6 +328,43 @@ func TestGetRosterReadiness(t *testing.T) {
 	}
 }
 
+// TestGetRosterReadiness_EmptyEntryIsNotReady is the regression pin for the
+// review finding that the readiness check was VACUOUS: the ADR-0008 auto-node is
+// created empty, is always returned at hop 0, and always renders its header line —
+// so a rendered-fact count could never fail for exactly the NPC this dashboard
+// exists to catch. The count must be content-bearing.
+func TestGetRosterReadiness_EmptyEntryIsNotReady(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	agentID := uuid.New()
+	store.agentList = []storage.Agent{
+		{ID: agentID, CampaignID: store.campaign.ID, Role: storage.AgentRoleCharacter, Name: "Bart"},
+	}
+	// The auto-node exactly as ADR-0008's second amendment creates it: linked,
+	// public, empty body, no aspects.
+	own := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}
+	store.linked[agentID] = own
+	store.facts[agentID] = []storage.KGNode{own}
+
+	resp, err := kgPreviewClient(t, store).GetRosterReadiness(context.Background(),
+		connect.NewRequest(&managementv1.GetRosterReadinessRequest{}))
+	if err != nil {
+		t.Fatalf("GetRosterReadiness: %v", err)
+	}
+	got := resp.Msg.GetAgents()
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if !got[0].GetLinked() {
+		t.Error("the agent is linked; the report says otherwise")
+	}
+	if got[0].GetFactCount() != 0 {
+		t.Errorf("fact_count = %d for an empty entry, want 0 — the block renders a header and nothing else",
+			got[0].GetFactCount())
+	}
+}
+
 func TestGetRosterReadiness_ErrorMapping(t *testing.T) {
 	t.Parallel()
 

--- a/internal/spa/dist/index.html
+++ b/internal/spa/dist/index.html
@@ -1,1 +1,22 @@
-<!doctype html><html><body><div id="root"></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glyphoxa</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <!-- Arcane theme fonts (handoff tokens/fonts.css): Zilla Slab (display),
+         Inter (body/UI), JetBrains Mono (stat blocks / transcripts). -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+    />
+    <script type="module" crossorigin src="/assets/index-BR6wgbt8.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-2iS9JWkz.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/internal/storage/kg_graph.go
+++ b/internal/storage/kg_graph.go
@@ -69,7 +69,9 @@ func (s *Store) ListGraphNodes(ctx context.Context, campaignID uuid.UUID) ([]KGG
 
 // KGNodePair is two Nodes in one Campaign whose embeddings are close — a
 // PROBABLE-duplicate hint for the world health panel (#536). Similarity is 1
-// minus cosine distance, so 1.0 is identical text.
+// minus pgvector's cosine distance (<=>), so it ranges over [-1, 1]: 1.0 is
+// identical direction, 0 orthogonal, negative opposed. Only the high end is ever
+// surfaced, so the sign never reaches a caller in practice.
 type KGNodePair struct {
 	AID, BID     uuid.UUID
 	AName, BName string
@@ -88,7 +90,12 @@ type KGNodePair struct {
 // approximate one for something a human is about to act on. Rows without an
 // embedding are invisible until the backfill worker reaches them.
 //
-// minSimilarity is the cosine-similarity floor in [0,1]; limit caps the result.
+// minSimilarity is the cosine-similarity floor; limit caps the result.
+//
+// Cost: the pairwise join cannot use the HNSW index — it is a nested loop, O(n²)
+// distance evaluations. At campaign scale (hundreds of Nodes) that is tens of
+// milliseconds, which is why an exact answer is affordable here; it would not be
+// at thousands, and the GM-initiated framing is what keeps that bounded.
 func (s *Store) SimilarNodePairs(ctx context.Context, campaignID uuid.UUID, minSimilarity float64, limit int) ([]KGNodePair, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("storage: similar node pairs: limit must be > 0, got %d", limit)

--- a/internal/storage/kg_graph.go
+++ b/internal/storage/kg_graph.go
@@ -66,3 +66,76 @@ func (s *Store) ListGraphNodes(ctx context.Context, campaignID uuid.UUID) ([]KGG
 	}
 	return out, nil
 }
+
+// KGNodePair is two Nodes in one Campaign whose embeddings are close — a
+// PROBABLE-duplicate hint for the world health panel (#536). Similarity is 1
+// minus cosine distance, so 1.0 is identical text.
+type KGNodePair struct {
+	AID, BID     uuid.UUID
+	AName, BName string
+	Similarity   float64
+}
+
+// SimilarNodePairs returns the Campaign's closest Node pairs by embedding cosine
+// similarity, closest first (#536, ADR-0011). It is the "probable duplicates"
+// derivation the health panel offers — a HINT the GM acts on, never an auto-merge:
+// ADR-0052 rejected auto-merging near-duplicates because similarity is not a
+// semantic judgment and a wrong merge corrupts canon invisibly. The same reasoning
+// applies here, so this read exists only to point at pairs.
+//
+// It is an exact pairwise scan rather than an ANN probe: a Campaign is hundreds of
+// Nodes, the read is GM-INITIATED (never on render), and an exact answer beats an
+// approximate one for something a human is about to act on. Rows without an
+// embedding are invisible until the backfill worker reaches them.
+//
+// minSimilarity is the cosine-similarity floor in [0,1]; limit caps the result.
+func (s *Store) SimilarNodePairs(ctx context.Context, campaignID uuid.UUID, minSimilarity float64, limit int) ([]KGNodePair, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("storage: similar node pairs: limit must be > 0, got %d", limit)
+	}
+	// b.id > a.id yields each unordered pair exactly once and rules out self-pairs.
+	rows, err := s.db.Query(ctx,
+		`SELECT a.id, a.name, b.id, b.name, 1 - (a.embedding <=> b.embedding) AS similarity
+		   FROM kg_node a
+		   JOIN kg_node b
+		     ON b.campaign_id = a.campaign_id AND b.id > a.id AND b.embedding IS NOT NULL
+		  WHERE a.campaign_id = $1
+		    AND a.embedding IS NOT NULL
+		    AND 1 - (a.embedding <=> b.embedding) >= $2
+		  ORDER BY similarity DESC, a.id, b.id
+		  LIMIT $3`, campaignID, minSimilarity, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: similar node pairs for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []KGNodePair
+	for rows.Next() {
+		var p KGNodePair
+		if err := rows.Scan(&p.AID, &p.AName, &p.BID, &p.BName, &p.Similarity); err != nil {
+			return nil, fmt.Errorf("storage: scan similar node pair: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: similar node pairs for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}
+
+// CountUnembeddedNodesInCampaign counts a Campaign's Nodes still awaiting an
+// embedding (#536). The probable-duplicate scan cannot see them, so the health
+// panel reports the count rather than letting "no duplicates" imply a clean bill
+// of health the check could not give.
+//
+// Distinct from [Store.CountUnembeddedNodes], which is the process-wide gauge
+// (kept campaign-free to bound metric cardinality, ADR-0032).
+func (s *Store) CountUnembeddedNodesInCampaign(ctx context.Context, campaignID uuid.UUID) (int, error) {
+	var n int
+	if err := s.db.QueryRow(ctx,
+		`SELECT count(*) FROM kg_node WHERE campaign_id = $1 AND embedding IS NULL`,
+		campaignID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("storage: count unembedded kg nodes for campaign %s: %w", campaignID, err)
+	}
+	return n, nil
+}

--- a/internal/storage/kg_graph.go
+++ b/internal/storage/kg_graph.go
@@ -30,6 +30,12 @@ type KGGraphNode struct {
 	AgentID     uuid.NullUUID
 	BodyLen     int
 	AspectCount int
+	// PublicAspectCount counts only the Aspects a prompt can actually receive.
+	// The distinction matters: an entry whose ONLY fact is a GM secret is authored
+	// (so AspectCount is 1, and the GM's own map should say so) but says nothing to
+	// its NPC (so the health and readiness derivations must read 0, or they report
+	// exactly the state they exist to catch as healthy).
+	PublicAspectCount int
 }
 
 // ListGraphNodes returns every Node in a Campaign in the display order ListNodes
@@ -44,7 +50,8 @@ func (s *Store) ListGraphNodes(ctx context.Context, campaignID uuid.UUID) ([]KGG
 	rows, err := s.db.Query(ctx,
 		`SELECT n.id, n.node_type, n.name, n.gm_private, n.agent_id,
 		        length(n.body),
-		        (SELECT count(*) FROM kg_node_aspect a WHERE a.node_id = n.id)
+		        (SELECT count(*) FROM kg_node_aspect a WHERE a.node_id = n.id),
+		        (SELECT count(*) FROM kg_node_aspect a WHERE a.node_id = n.id AND NOT a.gm_private)
 		   FROM kg_node n
 		  WHERE n.campaign_id = $1
 		  ORDER BY n.node_type, lower(n.name), n.id`, campaignID)
@@ -56,7 +63,8 @@ func (s *Store) ListGraphNodes(ctx context.Context, campaignID uuid.UUID) ([]KGG
 	var out []KGGraphNode
 	for rows.Next() {
 		var n KGGraphNode
-		if err := rows.Scan(&n.ID, &n.Type, &n.Name, &n.GMPrivate, &n.AgentID, &n.BodyLen, &n.AspectCount); err != nil {
+		if err := rows.Scan(&n.ID, &n.Type, &n.Name, &n.GMPrivate, &n.AgentID,
+			&n.BodyLen, &n.AspectCount, &n.PublicAspectCount); err != nil {
 			return nil, fmt.Errorf("storage: scan graph node: %w", err)
 		}
 		out = append(out, n)

--- a/internal/storage/kg_graph_test.go
+++ b/internal/storage/kg_graph_test.go
@@ -113,3 +113,86 @@ func mustGraphNodes(t *testing.T, st *storage.Store, campaignID uuid.UUID) []sto
 	}
 	return got
 }
+
+// TestSimilarNodePairs exercises the GM-initiated duplicate scan against a real
+// DB (#536): each unordered pair once, closest first, above the floor, scoped to
+// the campaign, and blind to rows the embedding worker has not reached.
+func TestSimilarNodePairs(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	// A and B embed on the same axis (identical direction ⇒ similarity 1); C is
+	// orthogonal; D is left unembedded and must be invisible to the scan.
+	a := mkNode(t, st, campaignID, storage.KGNodeNote, "Bart")
+	b := mkNode(t, st, campaignID, storage.KGNodeNote, "Bart the innkeeper")
+	c := mkNode(t, st, campaignID, storage.KGNodeNote, "Something else")
+	d := mkNode(t, st, campaignID, storage.KGNodeNote, "Not yet indexed")
+	for _, n := range []struct {
+		node storage.KGNode
+		axis int
+	}{{a, 0}, {b, 0}, {c, 1}} {
+		if err := st.SetNodeEmbedding(ctx, n.node.ID, unitVec(n.axis), "m", n.node.UpdatedAt); err != nil {
+			t.Fatalf("SetNodeEmbedding: %v", err)
+		}
+	}
+
+	pairs, err := st.SimilarNodePairs(ctx, campaignID, 0.9, 25)
+	if err != nil {
+		t.Fatalf("SimilarNodePairs: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("got %d pairs, want exactly the A/B pair: %+v", len(pairs), pairs)
+	}
+	got := map[uuid.UUID]bool{pairs[0].AID: true, pairs[0].BID: true}
+	if !got[a.ID] || !got[b.ID] {
+		t.Errorf("pair = %+v, want the two same-axis nodes", pairs[0])
+	}
+	if pairs[0].AID == pairs[0].BID {
+		t.Error("a node was paired with itself")
+	}
+	if pairs[0].Similarity < 0.99 {
+		t.Errorf("similarity = %v, want ~1 for identical vectors", pairs[0].Similarity)
+	}
+	if pairs[0].AName == "" || pairs[0].BName == "" {
+		t.Errorf("pair carries no names: %+v", pairs[0])
+	}
+
+	// The orthogonal node is below the floor; the unembedded one is invisible.
+	for _, p := range pairs {
+		if p.AID == c.ID || p.BID == c.ID {
+			t.Error("an orthogonal node was reported as a probable duplicate")
+		}
+		if p.AID == d.ID || p.BID == d.ID {
+			t.Error("an unembedded node appeared in the scan")
+		}
+	}
+
+	// The unembedded count is what stops "no duplicates" from implying a clean
+	// bill of health the scan could not give.
+	n, err := st.CountUnembeddedNodesInCampaign(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CountUnembeddedNodesInCampaign: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("unembedded = %d, want 1", n)
+	}
+
+	// Another campaign's identical pair must not surface here.
+	_, _, other := seedCampaign(t, dsn)
+	oa := mkNode(t, st, other, storage.KGNodeNote, "Bart")
+	ob := mkNode(t, st, other, storage.KGNodeNote, "Bart again")
+	for _, n := range []storage.KGNode{oa, ob} {
+		if err := st.SetNodeEmbedding(ctx, n.ID, unitVec(0), "m", n.UpdatedAt); err != nil {
+			t.Fatalf("SetNodeEmbedding (other): %v", err)
+		}
+	}
+	again, err := st.SimilarNodePairs(ctx, campaignID, 0.9, 25)
+	if err != nil {
+		t.Fatalf("SimilarNodePairs (rescan): %v", err)
+	}
+	if len(again) != 1 {
+		t.Errorf("got %d pairs after seeding another campaign, want the scan campaign-scoped", len(again))
+	}
+}

--- a/internal/storage/kg_graph_test.go
+++ b/internal/storage/kg_graph_test.go
@@ -4,7 +4,9 @@ package storage_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -194,5 +196,66 @@ func TestSimilarNodePairs(t *testing.T) {
 	}
 	if len(again) != 1 {
 		t.Errorf("got %d pairs after seeding another campaign, want the scan campaign-scoped", len(again))
+	}
+}
+
+// TestLastSpokenByAgent pins the prep dashboard's "last spoke" signal (#544): one
+// grouped read for the whole roster, Agent turns only, most recent per speaker.
+func TestLastSpokenByAgent(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	vs, err := st.CreateVoiceSession(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CreateVoiceSession: %v", err)
+	}
+	sessionID := vs.ID
+
+	base := time.Now().UTC().Truncate(time.Second)
+	lines := []struct {
+		who, kind string
+		at        time.Time
+	}{
+		{"Bart", "npc", base.Add(-3 * time.Hour)},
+		{"Bart", "npc", base.Add(-1 * time.Hour)}, // the most recent Bart line
+		{"Glyphoxa", "butler", base.Add(-2 * time.Hour)},
+		{"Lukas", "player", base}, // a human turn — a different question
+	}
+	for i, l := range lines {
+		if err := st.UpsertTranscriptLine(ctx, storage.TranscriptLine{
+			VoiceSessionID: sessionID, CampaignID: campaignID,
+			LineID: fmt.Sprintf("l%d", i), Seq: int64(i),
+			Who: l.who, Kind: l.kind, TS: l.at, Text: "…",
+		}); err != nil {
+			t.Fatalf("UpsertTranscriptLine: %v", err)
+		}
+	}
+
+	got, err := st.LastSpokenByAgent(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("LastSpokenByAgent: %v", err)
+	}
+	byWho := map[string]time.Time{}
+	for _, g := range got {
+		byWho[g.Who] = g.At
+	}
+	if len(byWho) != 2 {
+		t.Fatalf("got %v, want exactly the two Agent speakers", byWho)
+	}
+	if _, ok := byWho["Lukas"]; ok {
+		t.Error("a player turn was reported as an Agent speaking")
+	}
+	if !byWho["Bart"].Equal(base.Add(-1 * time.Hour)) {
+		t.Errorf("Bart's last line = %v, want the most recent one", byWho["Bart"])
+	}
+	if !byWho["Glyphoxa"].Equal(base.Add(-2 * time.Hour)) {
+		t.Errorf("Butler's last line = %v", byWho["Glyphoxa"])
+	}
+
+	// Another campaign's lines must not leak in.
+	_, _, other := seedCampaign(t, dsn)
+	if empty, err := st.LastSpokenByAgent(ctx, other); err != nil || len(empty) != 0 {
+		t.Errorf("other campaign = %v (err %v), want empty", empty, err)
 	}
 }

--- a/internal/storage/migrations/00045_transcript_line_campaign_idx.sql
+++ b/internal/storage/migrations/00045_transcript_line_campaign_idx.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+-- transcript_line has no index on campaign_id (00007/00015/00020 — 00020 even
+-- notes "NO index — no query filters on it"). That held until the roster prep
+-- dashboard's "last spoke" read (#544), which filters by campaign_id and runs on
+-- every Cast-tab render: without this index it is a sequential scan of EVERY
+-- tenant's transcript, so one GM opening a tab reads the whole platform's Line
+-- history. The cost scales with total transcript volume rather than with the
+-- campaign, which is the wrong shape for a multi-tenant deployment (ADR-0057).
+--
+-- (campaign_id, kind) matches the read exactly — it groups Agent turns
+-- (kind IN ('npc','butler')) per campaign — and also serves any later
+-- campaign-scoped Line read without a second index.
+CREATE INDEX transcript_line_campaign_kind_idx ON transcript_line (campaign_id, kind);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS transcript_line_campaign_kind_idx;

--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -200,6 +200,10 @@ type AgentLastSpoke struct {
 // different question. Only committed Lines exist in this table at all (ADR-0012 /
 // ADR-0040: partials are never persisted), so the answer is always about speech
 // that actually reached the table.
+//
+// It rides transcript_line_campaign_kind_idx (migration 00045). Without it this
+// is a sequential scan of every tenant's transcript — the table had no
+// campaign_id index because, until this read, nothing filtered on it.
 func (s *Store) LastSpokenByAgent(ctx context.Context, campaignID uuid.UUID) ([]AgentLastSpoke, error) {
 	rows, err := s.db.Query(ctx,
 		`SELECT who, max(ts)

--- a/internal/storage/transcript_line.go
+++ b/internal/storage/transcript_line.go
@@ -179,3 +179,48 @@ func (s *Store) SearchTranscriptLines(ctx context.Context, campaignID uuid.UUID,
 	}
 	return out, nil
 }
+
+// AgentLastSpoke is one Agent's most recent committed Transcript Line (#544).
+// Who is the Line's speaker label, which for an Agent turn is its display NAME —
+// transcript_line carries no agent_id (ADR-0040 persists what was said and by
+// whom-as-shown, not a foreign key), so the roster matches on name. A renamed
+// Agent therefore loses its history here; that is a display nicety on a prep
+// dashboard, not a correctness claim, and inventing a join would mean changing
+// what the Line grain records.
+type AgentLastSpoke struct {
+	Who string
+	At  time.Time
+}
+
+// LastSpokenByAgent returns, per Agent speaker label, the timestamp of its most
+// recent committed Transcript Line in a Campaign (#544) — the "last spoke" prep
+// signal. One grouped read for the whole roster rather than one per NPC.
+//
+// Only Agent turns are considered (kind ∈ npc, butler); player and GM lines are a
+// different question. Only committed Lines exist in this table at all (ADR-0012 /
+// ADR-0040: partials are never persisted), so the answer is always about speech
+// that actually reached the table.
+func (s *Store) LastSpokenByAgent(ctx context.Context, campaignID uuid.UUID) ([]AgentLastSpoke, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT who, max(ts)
+		   FROM transcript_line
+		  WHERE campaign_id = $1 AND kind IN ('npc', 'butler')
+		  GROUP BY who`, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: last spoken by agent for campaign %s: %w", campaignID, err)
+	}
+	defer rows.Close()
+
+	var out []AgentLastSpoke
+	for rows.Next() {
+		var a AgentLastSpoke
+		if err := rows.Scan(&a.Who, &a.At); err != nil {
+			return nil, fmt.Errorf("storage: scan last spoken: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: last spoken by agent for campaign %s: %w", campaignID, err)
+	}
+	return out, nil
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -496,9 +496,14 @@ message GraphNode {
   // body_len is the node body's length in bytes — the "does this entry actually
   // say anything" signal, without shipping the prose.
   int32 body_len = 6;
-  // aspect_count is how many aspects the node carries (#542). Together with
-  // body_len it distinguishes a real entry from an empty auto-created one.
+  // aspect_count is how many aspects the node carries (#542), private ones
+  // included — the GM's own map of their world.
   int32 aspect_count = 7;
+  // public_aspect_count is how many a PROMPT can receive. An entry whose only
+  // fact is a GM secret is authored but says nothing to its NPC, so the health
+  // and readiness derivations read this one; using aspect_count there would
+  // report that exact state as healthy.
+  int32 public_aspect_count = 8;
 }
 
 // GraphEdge is one Edge as the Graph view needs it (#534): the two endpoint ids
@@ -541,8 +546,10 @@ message AgentReadiness {
   string agent_id = 1;
   // linked reports whether the Agent has a linked wiki entry at all.
   bool linked = 2;
-  // fact_count is how many facts its Hot Context block will actually contain;
-  // chars is what they consume of max_chars.
+  // fact_count is how many facts SAY SOMETHING — a linked NPC's own entry always
+  // renders as a header line whether or not it has content, so counting rendered
+  // facts would be a check that can never fail. chars is what the whole block
+  // consumes of max_chars.
   int32 fact_count = 3;
   int32 chars = 4;
   int32 max_chars = 5;

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -134,6 +134,14 @@ service CampaignService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // FindDuplicateEntries returns the campaign's closest Node pairs by embedding
+  // similarity — the world health panel's "probable duplicates" check (#536).
+  // GM-INITIATED: it is an exact pairwise scan and must never run on render.
+  // A hint only; nothing here merges anything (ADR-0052).
+  rpc FindDuplicateEntries(FindDuplicateEntriesRequest) returns (FindDuplicateEntriesResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
   // GetAgentFactPreview returns exactly what a Character NPC's Hot Context
   // facts block will contain, with the real budget accounting (#535). Read-only.
   rpc GetAgentFactPreview(GetAgentFactPreviewRequest) returns (GetAgentFactPreviewResponse) {
@@ -511,6 +519,32 @@ message GetKnowledgeGraphResponse {
   repeated GraphNode nodes = 1;
   // edges is every Edge in the campaign.
   repeated GraphEdge edges = 2;
+}
+
+// FindDuplicateEntriesRequest is the (empty) request; the active campaign is
+// resolved server-side. The threshold and cap are server policy (ADR-0039).
+message FindDuplicateEntriesRequest {}
+
+// DuplicateEntryPair is two entries whose text embeds close together — a hint,
+// never a merge (ADR-0052: similarity is not a semantic judgment).
+message DuplicateEntryPair {
+  // a_id / b_id are the two Nodes; a_name / b_name their display names.
+  string a_id = 1;
+  string a_name = 2;
+  string b_id = 3;
+  string b_name = 4;
+  // similarity is cosine similarity in [0,1]; 1.0 is identical text.
+  double similarity = 5;
+}
+
+// FindDuplicateEntriesResponse carries the closest pairs, closest first.
+message FindDuplicateEntriesResponse {
+  // pairs is the probable-duplicate hints, closest first. Empty is the healthy
+  // case, not an error.
+  repeated DuplicateEntryPair pairs = 1;
+  // unembedded is how many Nodes have no embedding yet, so the panel can say the
+  // check was partial rather than implying a clean bill of health.
+  int32 unembedded = 2;
 }
 
 // GetAgentFactPreviewRequest names the Agent to preview.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -142,6 +142,14 @@ service CampaignService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // GetRosterReadiness returns, for every cast Agent at once, the prep signals
+  // the roster dashboard grades on (#544): the SAME fact-preview seam #535 uses,
+  // plus when each last spoke. ONE call for the whole roster — a per-NPC preview
+  // would be an RPC storm on a screen the GM opens before every session.
+  rpc GetRosterReadiness(GetRosterReadinessRequest) returns (GetRosterReadinessResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
   // GetAgentFactPreview returns exactly what a Character NPC's Hot Context
   // facts block will contain, with the real budget accounting (#535). Read-only.
   rpc GetAgentFactPreview(GetAgentFactPreviewRequest) returns (GetAgentFactPreviewResponse) {
@@ -521,6 +529,39 @@ message GetKnowledgeGraphResponse {
   repeated GraphEdge edges = 2;
 }
 
+// GetRosterReadinessRequest is the (empty) request; the active campaign is
+// resolved server-side.
+message GetRosterReadinessRequest {}
+
+// AgentReadiness is one cast Agent's prep signals (#544). The fact figures come
+// from the SAME render the voice loop injects (#535), so the dashboard cannot
+// claim an NPC is ready on arithmetic the turn does not share.
+message AgentReadiness {
+  // agent_id is the Agent these signals describe.
+  string agent_id = 1;
+  // linked reports whether the Agent has a linked wiki entry at all.
+  bool linked = 2;
+  // fact_count is how many facts its Hot Context block will actually contain;
+  // chars is what they consume of max_chars.
+  int32 fact_count = 3;
+  int32 chars = 4;
+  int32 max_chars = 5;
+  // truncated reports that the caps cut part of its neighbourhood.
+  bool truncated = 6;
+  // last_spoke_at is when this Agent last spoke a committed Transcript Line in
+  // this campaign; unset when it has never spoken (or was renamed since — the
+  // Line grain records the speaker label, not an Agent id).
+  google.protobuf.Timestamp last_spoke_at = 7;
+}
+
+// GetRosterReadinessResponse carries one entry per CAST Agent. The Butler is
+// deliberately absent: it is Address-Only with no linked Node by design
+// (ADR-0009), so these signals do not describe it.
+message GetRosterReadinessResponse {
+  // agents is the readiness of every Character NPC in the campaign.
+  repeated AgentReadiness agents = 1;
+}
+
 // FindDuplicateEntriesRequest is the (empty) request; the active campaign is
 // resolved server-side. The threshold and cap are server policy (ADR-0039).
 message FindDuplicateEntriesRequest {}
@@ -533,7 +574,8 @@ message DuplicateEntryPair {
   string a_name = 2;
   string b_id = 3;
   string b_name = 4;
-  // similarity is cosine similarity in [0,1]; 1.0 is identical text.
+  // similarity is cosine similarity; 1.0 is identical direction. Only pairs above
+  // a high server-side floor are ever returned.
   double similarity = 5;
 }
 

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -67,6 +67,9 @@ export function Campaign() {
   // editor stays the default because adding and shaping NPCs is the common act;
   // readiness is what you check before a session.
   const [castMode, setCastMode] = useState<"edit" | "prep">("edit");
+  // The entry a readiness mark asked to open, handed to the Knowledge panel so
+  // "Entry has content" lands ON that entry instead of dumping the GM on the list.
+  const [focusNodeID, setFocusNodeID] = useState<string | null>(null);
 
   const invalidateRoster = () =>
     queryClient.invalidateQueries({
@@ -151,7 +154,15 @@ export function Campaign() {
       </header>
 
       {view === "knowledge" ? (
-        <KnowledgePanel />
+        <KnowledgePanel
+          focusNodeID={focusNodeID}
+          onFocusHandled={() => setFocusNodeID(null)}
+          onOpenCast={(agentID) => {
+            setSelectedId(agentID);
+            setCastMode("edit");
+            setView("cast");
+          }}
+        />
       ) : view === "players" ? (
         <PlayersPanel />
       ) : view === "proposals" ? (
@@ -189,7 +200,11 @@ export function Campaign() {
               setSelectedId(id);
               setCastMode("edit");
             }}
-            onOpenNode={() => setView("knowledge")}
+            onOpenNode={(id) => {
+              setFocusNodeID(id);
+              setView("knowledge");
+            }}
+            onOpenKnowledge={() => setView("knowledge")}
           />
         ) : (
         <div className="gx-roster-layout">

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { Button } from "@/components/ui/Button";
 import { playAudioBlob } from "@/lib/audio";
+import { invalidateKnowledgeReads } from "./knowledgeCache";
 import { KnowledgePanel } from "./KnowledgePanel";
 import { PlayersPanel } from "./PlayersPanel";
 import { RosterPrep } from "./RosterPrep";
@@ -71,13 +72,19 @@ export function Campaign() {
   // "Entry has content" lands ON that entry instead of dumping the GM on the list.
   const [focusNodeID, setFocusNodeID] = useState<string | null>(null);
 
-  const invalidateRoster = () =>
-    queryClient.invalidateQueries({
+  // Creating a Character NPC auto-creates its wiki entry, and deleting one
+  // unlinks that entry (ADR-0008 second amendment) — both are Knowledge Graph
+  // writes, so a roster mutation must drop the KG reads too. Without this the
+  // Health panel pairs a fresh roster with a stale graph and invents findings.
+  const invalidateRoster = () => {
+    void queryClient.invalidateQueries({
       queryKey: createConnectQueryKey({
         schema: CampaignService.method.getCampaignRoster,
         cardinality: "finite",
       }),
     });
+    invalidateKnowledgeReads(queryClient);
+  };
 
   const createAgent = useMutation(CampaignService.method.createAgent, {
     onSuccess: (res) => {

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/Button";
 import { playAudioBlob } from "@/lib/audio";
 import { KnowledgePanel } from "./KnowledgePanel";
 import { PlayersPanel } from "./PlayersPanel";
+import { RosterPrep } from "./RosterPrep";
 import { ProposalsPanel } from "./ProposalsPanel";
 
 import "./campaign.css";
@@ -62,6 +63,10 @@ export function Campaign() {
   // User bindings, #279) — the design's seg-control beside the title. Cast is the
   // default so the roster is what loads first (#71).
   const [view, setView] = useState<"cast" | "knowledge" | "players" | "proposals">("cast");
+  // Within Cast: the editor (default), or the prep readiness view (#544). The
+  // editor stays the default because adding and shaping NPCs is the common act;
+  // readiness is what you check before a session.
+  const [castMode, setCastMode] = useState<"edit" | "prep">("edit");
 
   const invalidateRoster = () =>
     queryClient.invalidateQueries({
@@ -158,6 +163,35 @@ export function Campaign() {
           Could not load the campaign: {error.message}
         </p>
       ) : (
+        <>
+        <div className="gx-kg-modes" role="group" aria-label="Cast view">
+          <button
+            type="button"
+            className="gx-kg-chip"
+            aria-pressed={castMode === "edit"}
+            onClick={() => setCastMode("edit")}
+          >
+            Roster
+          </button>
+          <button
+            type="button"
+            className="gx-kg-chip"
+            aria-pressed={castMode === "prep"}
+            onClick={() => setCastMode("prep")}
+          >
+            Session prep
+          </button>
+        </div>
+        {castMode === "prep" ? (
+          <RosterPrep
+            roster={roster}
+            onSelectAgent={(id) => {
+              setSelectedId(id);
+              setCastMode("edit");
+            }}
+            onOpenNode={() => setView("knowledge")}
+          />
+        ) : (
         <div className="gx-roster-layout">
           {/* Roster list */}
           <div className="gx-roster">
@@ -230,6 +264,8 @@ export function Campaign() {
           />
         )}
         </div>
+        )}
+        </>
       )}
     </div>
   );

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -51,7 +51,21 @@ const TYPE_HINT = TYPE_ORDER.map((t) => TYPE_META[t].label).join(" · ");
 // replacement, and the editor rail is shared by both.
 type ViewMode = "list" | "graph" | "health";
 
-export function KnowledgePanel() {
+export function KnowledgePanel({
+  focusNodeID,
+  onFocusHandled,
+  onOpenCast,
+}: {
+  /**
+   * An entry another screen asked to open — the roster's readiness marks and the
+   * health panel both point HERE, and pointing at the list instead would leave the
+   * GM hunting for the entry by hand in a campaign of any size (#544).
+   */
+  focusNodeID?: string | null;
+  onFocusHandled?: () => void;
+  /** Hands a cast Agent back to the Cast tab, where its fix lives. */
+  onOpenCast?: (agentID: string) => void;
+} = {}) {
   const queryClient = useQueryClient();
   const listQuery = useQuery(CampaignService.method.listNodes, {});
   const [editing, setEditing] = useState<Node | null>(null);
@@ -75,6 +89,16 @@ export function KnowledgePanel() {
   // is a hard, cascading DELETE (ADR-0008), so no DeleteNode fires until the
   // operator confirms here (#209).
   const [confirmNode, setConfirmNode] = useState<Node | null>(null);
+
+  // Honour an entry handed in from another screen, once its row has loaded.
+  useEffect(() => {
+    if (!focusNodeID) return;
+    const node = listQuery.data?.nodes.find((n) => n.id === focusNodeID);
+    if (!node) return;
+    setEditing(node);
+    setMode("list");
+    onFocusHandled?.();
+  }, [focusNodeID, listQuery.data, onFocusHandled]);
 
   // Live wiki search (#131, ADR-0008 tsvector): the raw box value drives a
   // 200ms-debounced SearchNodes query. The RPC runs only while the debounced
@@ -222,6 +246,7 @@ export function KnowledgePanel() {
               nodes={graphQuery.data.nodes}
               edges={graphQuery.data.edges}
               onOpenNode={editByID}
+              onOpenCast={onOpenCast}
             />
           ) : (
             <KnowledgeGraph

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Rows3,
   Search,
+  Stethoscope,
   Sparkles,
   Trash2,
   Link as LinkIcon,
@@ -30,6 +31,7 @@ import { Select } from "@/components/ui/Select";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { NodeRelations } from "./NodeRelations";
 import { KnowledgeGraph } from "./graph/KnowledgeGraph";
+import { WorldHealthPanel } from "./graph/WorldHealthPanel";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
 import { EDGE_LABEL as EDGE_TYPE_LABEL, TYPE_META, TYPE_ORDER, alphaBg, metaOf } from "./knowledgeVocab";
 
@@ -47,7 +49,7 @@ const TYPE_HINT = TYPE_ORDER.map((t) => TYPE_META[t].label).join(" · ");
 // ViewMode is the Knowledge tab's [ List | Graph ] switch (#534). The List mode
 // is unchanged — the graph is an ADDITIONAL way to read the same wiki, not a
 // replacement, and the editor rail is shared by both.
-type ViewMode = "list" | "graph";
+type ViewMode = "list" | "graph" | "health";
 
 export function KnowledgePanel() {
   const queryClient = useQueryClient();
@@ -62,10 +64,12 @@ export function KnowledgePanel() {
 
   // The whole-graph payload (#534). It is fetched only in graph mode, so a GM who
   // never opens the graph pays nothing for it.
+  // Both the Graph and Health views read the same payload; the List view pays
+  // nothing for either.
   const graphQuery = useQuery(
     CampaignService.method.getKnowledgeGraph,
     {},
-    { enabled: mode === "graph" },
+    { enabled: mode !== "list" },
   );
   // The entry a delete has been requested for; drives the confirm dialog. Delete
   // is a hard, cascading DELETE (ADR-0008), so no DeleteNode fires until the
@@ -196,15 +200,29 @@ export function KnowledgePanel() {
           >
             <Network size={13} /> Graph
           </button>
+          <button
+            type="button"
+            className="gx-kg-chip"
+            aria-pressed={mode === "health"}
+            onClick={() => setMode("health")}
+          >
+            <Stethoscope size={13} /> Health
+          </button>
         </div>
 
-        {mode === "graph" ? (
+        {mode !== "list" ? (
           graphQuery.isPending ? (
             <div className="gx-skeleton" data-testid="kg-graph-loading" />
           ) : graphQuery.isError ? (
             <p className="gx-campaign__error" role="alert">
               Could not load the graph: {graphQuery.error.message}
             </p>
+          ) : mode === "health" ? (
+            <WorldHealthPanel
+              nodes={graphQuery.data.nodes}
+              edges={graphQuery.data.edges}
+              onOpenNode={editByID}
+            />
           ) : (
             <KnowledgeGraph
               nodes={graphQuery.data.nodes}

--- a/web/src/screens/campaign/RosterPrep.test.tsx
+++ b/web/src/screens/campaign/RosterPrep.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import {
+  AgentSchema,
+  CampaignService,
+  GetKnowledgeGraphResponseSchema,
+  GetRosterReadinessResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { RosterPrep } from "./RosterPrep";
+
+const BUTLER = create(AgentSchema, { id: "b1", name: "Glyphoxa", role: "butler" });
+const BART = create(AgentSchema, {
+  id: "a1",
+  name: "Bart",
+  role: "character",
+  persona: "Gruff.",
+  voice: "v1",
+});
+
+function renderPrep(
+  opts: { factCount?: number; lastSpokeAt?: Date; handlers?: Record<string, unknown> } = {},
+) {
+  const onSelectAgent = vi.fn();
+  const onOpenNode = vi.fn();
+  const onOpenKnowledge = vi.fn();
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      getKnowledgeGraph: () =>
+        create(GetKnowledgeGraphResponseSchema, {
+          nodes: [{ id: "bart", nodeType: 2, name: "Bart", agentId: "a1", bodyLen: 40 }],
+          edges: [],
+        }),
+      getRosterReadiness: () =>
+        create(GetRosterReadinessResponseSchema, {
+          agents: [
+            {
+              agentId: "a1",
+              linked: true,
+              factCount: opts.factCount ?? 3,
+              chars: 400,
+              maxChars: 4000,
+              lastSpokeAt: opts.lastSpokeAt ? timestampFromDate(opts.lastSpokeAt) : undefined,
+            },
+          ],
+        }),
+    });
+  });
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <RosterPrep
+        roster={[BUTLER, BART]}
+        onSelectAgent={onSelectAgent}
+        onOpenNode={onOpenNode}
+        onOpenKnowledge={onOpenKnowledge}
+      />
+    </Providers>,
+  );
+  return { onSelectAgent, onOpenNode, onOpenKnowledge };
+}
+
+describe("RosterPrep", () => {
+  // The AC is precise: present, not flagged.
+  it("lists the Butler without grading it", async () => {
+    renderPrep();
+    expect(await screen.findByRole("button", { name: "Glyphoxa" })).toBeInTheDocument();
+    expect(screen.getByText("Butler — always ready")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Glyphoxa: Persona written/)).not.toBeInTheDocument();
+  });
+
+  it("shows the fact count the voice loop will actually inject", async () => {
+    renderPrep({ factCount: 7 });
+    expect(await screen.findByLabelText(/Bart: 7 facts in reach — done/)).toBeInTheDocument();
+  });
+
+  it("shows when an NPC last spoke", async () => {
+    renderPrep({ lastSpokeAt: new Date("2026-07-04T20:00:00Z") });
+    expect(await screen.findByText(/last spoke/)).toBeInTheDocument();
+  });
+
+  it("says so when an NPC has never spoken", async () => {
+    renderPrep();
+    expect(await screen.findByText("never spoken")).toBeInTheDocument();
+  });
+
+  // Each unsatisfied mark must land where the fix can ACTUALLY be made — and with
+  // the entry id, or the GM is dumped on a list to hunt through by hand.
+  it("opens the specific entry when facts are out of reach", async () => {
+    const { onOpenNode } = renderPrep({ factCount: 0 });
+    fireEvent.click(await screen.findByLabelText(/Bart: 0 facts in reach — missing/));
+    expect(onOpenNode).toHaveBeenCalledWith("bart");
+  });
+});

--- a/web/src/screens/campaign/RosterPrep.tsx
+++ b/web/src/screens/campaign/RosterPrep.tsx
@@ -2,9 +2,16 @@ import { useMemo } from "react";
 import { useQuery } from "@connectrpc/connect-query";
 import { Check, X } from "lucide-react";
 
+import { timestampDate } from "@bufbuild/protobuf/wkt";
+
 import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
-import { rosterPrep, type Check as ReadinessCheck } from "./rosterPrep";
+import {
+  lastSpokeLabel,
+  rosterPrep,
+  type Check as ReadinessCheck,
+  type Readiness,
+} from "./rosterPrep";
 
 // The roster prep dashboard (#544). The roster was a flat list of Agents; this
 // shows what a GM needs BEFORE a session: where each NPC sits in the world, and
@@ -19,24 +26,50 @@ export function RosterPrep({
   roster,
   onSelectAgent,
   onOpenNode,
+  onOpenKnowledge,
 }: {
   roster: Agent[];
   onSelectAgent: (id: string) => void;
+  /** Opens ONE entry in the Knowledge editor. */
   onOpenNode: (id: string) => void;
+  /** Opens the Knowledge tab, where the "Voiced by" link control lives. */
+  onOpenKnowledge: () => void;
 }) {
-  // One graph read on top of the roster read the screen already does — not a
-  // per-NPC RPC storm.
+  // Two reads on top of the roster the screen already has — one graph, one batch
+  // readiness. Not a per-NPC RPC storm on a screen opened before every session.
   const graphQuery = useQuery(CampaignService.method.getKnowledgeGraph, {});
+  const readyQuery = useQuery(CampaignService.method.getRosterReadiness, {});
+
+  const readiness = useMemo(() => {
+    const m = new Map<string, Readiness>();
+    for (const r of readyQuery.data?.agents ?? []) {
+      m.set(r.agentId, {
+        linked: r.linked,
+        factCount: r.factCount,
+        chars: r.chars,
+        maxChars: r.maxChars,
+        truncated: r.truncated,
+        lastSpokeAt: r.lastSpokeAt ? timestampDate(r.lastSpokeAt) : undefined,
+      });
+    }
+    return m;
+  }, [readyQuery.data]);
+
   const groups = useMemo(
-    () => rosterPrep(roster, graphQuery.data?.nodes ?? [], graphQuery.data?.edges ?? []),
-    [roster, graphQuery.data],
+    () => rosterPrep(roster, graphQuery.data?.nodes ?? [], graphQuery.data?.edges ?? [], readiness),
+    [roster, graphQuery.data, readiness],
   );
 
-  if (graphQuery.isPending) return <div className="gx-skeleton" data-testid="prep-loading" />;
-  if (graphQuery.isError) {
+  // Both reads must land before grading: showing "0 facts in reach" for every NPC
+  // while the readiness read is still in flight would be a screen full of false
+  // alarms on the exact screen the GM consults to trust the roster.
+  if (graphQuery.isPending || readyQuery.isPending) {
+    return <div className="gx-skeleton" data-testid="prep-loading" />;
+  }
+  if (graphQuery.isError || readyQuery.isError) {
     return (
       <p className="gx-campaign__error" role="alert">
-        Could not load the world: {graphQuery.error.message}
+        Could not load the world: {(graphQuery.error ?? readyQuery.error)?.message}
       </p>
     );
   }
@@ -58,16 +91,31 @@ export function RosterPrep({
               >
                 {e.agent.name}
               </button>
-              <div className="gx-prep__checks">
-                {e.checks.map((c) => (
-                  <ReadinessMark
-                    key={c.key}
-                    check={c}
-                    agentName={e.agent.name}
-                    onFix={() => (c.fix === "content" && e.node ? onOpenNode(e.node.id) : onSelectAgent(e.agent.id))}
-                  />
-                ))}
-              </div>
+              {e.exempt ? (
+                // Listed, not graded — see rosterPrep's Butler note.
+                <span className="gx-prep__exempt">Butler — always ready</span>
+              ) : (
+                <>
+                  <div className="gx-prep__checks">
+                    {e.checks.map((c) => (
+                      <ReadinessMark
+                        key={c.key}
+                        check={c}
+                        agentName={e.agent.name}
+                        onFix={() => {
+                          // Each fix goes where it can ACTUALLY be made: the link
+                          // control lives in the Knowledge tab's relations card, not
+                          // in the Agent editor.
+                          if (c.fix === "entry" && e.node) onOpenNode(e.node.id);
+                          else if (c.fix === "link" || c.fix === "entry") onOpenKnowledge();
+                          else onSelectAgent(e.agent.id);
+                        }}
+                      />
+                    ))}
+                  </div>
+                  <span className="gx-prep__spoke">{lastSpokeLabel(e.readiness)}</span>
+                </>
+              )}
             </div>
           ))}
         </section>

--- a/web/src/screens/campaign/RosterPrep.tsx
+++ b/web/src/screens/campaign/RosterPrep.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+import { useQuery } from "@connectrpc/connect-query";
+import { Check, X } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent } from "@gen/glyphoxa/management/v1/management_pb";
+import { rosterPrep, type Check as ReadinessCheck } from "./rosterPrep";
+
+// The roster prep dashboard (#544). The roster was a flat list of Agents; this
+// shows what a GM needs BEFORE a session: where each NPC sits in the world, and
+// whether it can actually say anything.
+//
+// The failure it exists for: an NPC created through the normal flow has a voice, a
+// persona, and an entry that is empty (ADR-0008 second amendment auto-creates the
+// Node without copying the Persona). Every signal below was already queryable and
+// none of it was shown, so that state was found live, at the table.
+
+export function RosterPrep({
+  roster,
+  onSelectAgent,
+  onOpenNode,
+}: {
+  roster: Agent[];
+  onSelectAgent: (id: string) => void;
+  onOpenNode: (id: string) => void;
+}) {
+  // One graph read on top of the roster read the screen already does — not a
+  // per-NPC RPC storm.
+  const graphQuery = useQuery(CampaignService.method.getKnowledgeGraph, {});
+  const groups = useMemo(
+    () => rosterPrep(roster, graphQuery.data?.nodes ?? [], graphQuery.data?.edges ?? []),
+    [roster, graphQuery.data],
+  );
+
+  if (graphQuery.isPending) return <div className="gx-skeleton" data-testid="prep-loading" />;
+  if (graphQuery.isError) {
+    return (
+      <p className="gx-campaign__error" role="alert">
+        Could not load the world: {graphQuery.error.message}
+      </p>
+    );
+  }
+  if (groups.length === 0) {
+    return <p className="gx-roster__empty">No NPCs yet — the readiness view fills in as you add them.</p>;
+  }
+
+  return (
+    <div className="gx-prep" aria-label="NPC readiness">
+      {groups.map((g) => (
+        <section key={g.key} className="gx-prep__group" aria-label={g.title}>
+          <h4 className="gx-prep__title">{g.title}</h4>
+          {g.entries.map((e) => (
+            <div key={`${g.key}-${e.agent.id}`} className="gx-prep__row" data-ready={e.ready || undefined}>
+              <button
+                type="button"
+                className="gx-prep__name"
+                onClick={() => onSelectAgent(e.agent.id)}
+              >
+                {e.agent.name}
+              </button>
+              <div className="gx-prep__checks">
+                {e.checks.map((c) => (
+                  <ReadinessMark
+                    key={c.key}
+                    check={c}
+                    agentName={e.agent.name}
+                    onFix={() => (c.fix === "content" && e.node ? onOpenNode(e.node.id) : onSelectAgent(e.agent.id))}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+// ReadinessMark is one satisfied/unsatisfied mark. An UNSATISFIED one is a button
+// that goes to the thing that fixes it — a checklist you cannot act on from is
+// just a nag.
+function ReadinessMark({
+  check,
+  agentName,
+  onFix,
+}: {
+  check: ReadinessCheck;
+  agentName: string;
+  onFix: () => void;
+}) {
+  if (check.ok) {
+    return (
+      <span className="gx-prep__mark" data-ok aria-label={`${agentName}: ${check.label} — done`}>
+        <Check size={12} aria-hidden /> {check.label}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="gx-prep__mark"
+      aria-label={`${agentName}: ${check.label} — missing, fix it`}
+      onClick={onFix}
+    >
+      <X size={12} aria-hidden /> {check.label}
+    </button>
+  );
+}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1200,3 +1200,136 @@
   border: 1px solid var(--border, #2a2f3a);
   border-radius: var(--radius-sm, 4px);
 }
+
+/* ── World health panel (#536) ───────────────────────────────────────────── */
+
+.gx-kg-health {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.gx-kg-health__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  align-items: flex-start;
+}
+
+.gx-kg-health__title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin: 0;
+  font-size: var(--body-lg);
+  color: var(--text-strong);
+}
+
+.gx-kg-health__count {
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+  color: var(--text-muted);
+}
+
+/* The consequence, not just the label: a warning nobody can act on is noise. */
+.gx-kg-health__why {
+  margin: 0;
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
+.gx-kg-health__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gx-kg-health__link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.gx-kg-health__detail {
+  color: var(--text-muted);
+  font-size: var(--body-sm);
+}
+
+.gx-kg-health__clear {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+/* ── Roster prep dashboard (#544) ────────────────────────────────────────── */
+
+.gx-prep {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.gx-prep__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-prep__title {
+  margin: 0;
+  font-size: var(--body-lg);
+  color: var(--text-strong);
+}
+
+.gx-prep__row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  padding: var(--spacing-xs) 0;
+  border-bottom: 1px solid var(--border, #2a2f3a);
+}
+
+.gx-prep__name {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-strong);
+  flex: 0 0 12rem;
+  text-align: left;
+}
+
+.gx-prep__checks {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+/* An unsatisfied mark is a BUTTON to the thing that fixes it; a satisfied one is
+   inert. A checklist you cannot act on from is just a nag. */
+.gx-prep__mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px var(--spacing-xs);
+  border: 1px solid var(--border, #2a2f3a);
+  border-radius: var(--radius-sm, 4px);
+  background: none;
+  font-size: var(--body-sm);
+  color: var(--accent, #ffcf5a);
+  cursor: pointer;
+}
+
+.gx-prep__mark[data-ok] {
+  color: var(--text-muted);
+  border-color: transparent;
+  cursor: default;
+}

--- a/web/src/screens/campaign/graph/WorldHealthPanel.test.tsx
+++ b/web/src/screens/campaign/graph/WorldHealthPanel.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AgentSchema,
+  CampaignService,
+  FindDuplicateEntriesResponseSchema,
+  GetCampaignRosterResponseSchema,
+  GraphNodeSchema,
+  NodeType,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { WorldHealthPanel } from "./WorldHealthPanel";
+
+function renderPanel(
+  opts: {
+    nodes?: ReturnType<typeof create<typeof GraphNodeSchema>>[];
+    failRoster?: boolean;
+    onOpenNode?: (id: string) => void;
+    onOpenCast?: (id: string) => void;
+  } = {},
+) {
+  let duplicateCalls = 0;
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      getCampaignRoster: () => {
+        if (opts.failRoster) throw new ConnectError("roster boom", Code.Internal);
+        return create(GetCampaignRosterResponseSchema, {
+          roster: [create(AgentSchema, { id: "a1", name: "Bart", role: "character" })],
+        });
+      },
+      findDuplicateEntries: () => {
+        duplicateCalls++;
+        return create(FindDuplicateEntriesResponseSchema, {
+          pairs: [{ aId: "n1", aName: "Bart", bId: "n2", bName: "Bart the innkeeper", similarity: 0.97 }],
+          unembedded: 2,
+        });
+      },
+    });
+  });
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <WorldHealthPanel
+        nodes={opts.nodes ?? []}
+        edges={[]}
+        onOpenNode={opts.onOpenNode ?? (() => {})}
+        onOpenCast={opts.onOpenCast ?? (() => {})}
+      />
+    </Providers>,
+  );
+  return {
+    get duplicateCalls() {
+      return duplicateCalls;
+    },
+  };
+}
+
+describe("WorldHealthPanel", () => {
+  // The AC is explicit that the embedding sweep must be GM-initiated. Wiring it as
+  // a mutation is what guarantees that, and this is the test that fails if someone
+  // refactors it to a query.
+  it("does not run the duplicate scan on render", async () => {
+    const ctx = renderPanel();
+    await screen.findByRole("button", { name: "Check for duplicates" });
+    expect(ctx.duplicateCalls).toBe(0);
+  });
+
+  it("runs the scan on click and shows the pairs with the unindexed caveat", async () => {
+    const ctx = renderPanel();
+    fireEvent.click(await screen.findByRole("button", { name: "Check for duplicates" }));
+
+    await waitFor(() => expect(ctx.duplicateCalls).toBe(1));
+    expect(await screen.findByText(/97% alike/)).toBeInTheDocument();
+    // "No duplicates" must never imply a clean bill of health the scan could not give.
+    expect(screen.getByText(/2 entries are still being indexed/)).toBeInTheDocument();
+  });
+
+  it("opens the entry an entry-row points at", async () => {
+    const onOpenNode = vi.fn();
+    renderPanel({
+      nodes: [create(GraphNodeSchema, { id: "n1", nodeType: NodeType.ITEM, name: "A lost ring" })],
+      onOpenNode,
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "A lost ring" }));
+    expect(onOpenNode).toHaveBeenCalledWith("n1");
+  });
+
+  // A cast Agent with no entry is fixed on the ROSTER, not in the wiki — so the
+  // row has to go there, and it has to be a button at all.
+  it("opens the roster for a cast Agent with no entry", async () => {
+    const onOpenCast = vi.fn();
+    renderPanel({ onOpenCast });
+    fireEvent.click(await screen.findByRole("button", { name: "Bart" }));
+    expect(onOpenCast).toHaveBeenCalledWith("a1");
+  });
+
+  // The cast category depends on the roster read, so a clean bill of health while
+  // that read is failing would be a lie the GM has no reason to doubt.
+  it("does not claim a clean bill of health when the roster read failed", async () => {
+    renderPanel({ failRoster: true });
+    expect(await screen.findByText(/Could not check the cast/)).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing to flag/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/graph/WorldHealthPanel.tsx
+++ b/web/src/screens/campaign/graph/WorldHealthPanel.tsx
@@ -20,12 +20,18 @@ export function WorldHealthPanel({
   nodes,
   edges,
   onOpenNode,
+  onOpenCast,
 }: {
   nodes: GraphNode[];
   edges: GraphEdge[];
   onOpenNode: (id: string) => void;
+  /** Where a cast Agent with no entry gets fixed — the roster, not the wiki. */
+  onOpenCast?: (agentID: string) => void;
 }) {
-  const rosterQuery = useQuery(CampaignService.method.getCampaignRoster, {});
+  // retry:false so a failure settles into isError promptly. This panel's whole job
+  // is telling the GM what is wrong; silently backing off for seconds while
+  // withholding the cast checks is the opposite of that.
+  const rosterQuery = useQuery(CampaignService.method.getCampaignRoster, {}, { retry: false });
   const categories = useMemo(
     () => worldHealth(nodes, edges, rosterQuery.data?.roster ?? []),
     [nodes, edges, rosterQuery.data],
@@ -36,10 +42,20 @@ export function WorldHealthPanel({
   const duplicates = useMutation(CampaignService.method.findDuplicateEntries);
   const [ranDuplicates, setRanDuplicates] = useState(false);
 
-  const healthy = categories.length === 0;
+  // "Nothing to flag" must not be claimed while the roster read is still in
+  // flight or failed: the cast-without-entry category depends on it, so a clean
+  // bill of health would be a lie the GM has no reason to doubt.
+  const rosterKnown = rosterQuery.isSuccess;
+  const healthy = categories.length === 0 && rosterKnown;
 
   return (
     <section className="gx-kg-health" aria-label="World health">
+      {rosterQuery.isError && (
+        <p className="gx-campaign__error" role="alert">
+          Could not check the cast: {rosterQuery.error.message} — the entry checks below are
+          still complete.
+        </p>
+      )}
       {healthy ? (
         <p className="gx-kg-health__clear">
           Nothing to flag — every entry is connected, and every voiced NPC has something to say.
@@ -57,18 +73,19 @@ export function WorldHealthPanel({
                 const meta = metaOf(f.nodeType);
                 return (
                   <li key={f.nodeID || `${c.key}-${i}`} className="gx-kg-health__row">
-                    {f.nodeID ? (
-                      <button
-                        type="button"
-                        className="gx-kg-health__link"
-                        style={{ color: meta.color }}
-                        onClick={() => onOpenNode(f.nodeID)}
-                      >
-                        {f.name}
-                      </button>
-                    ) : (
-                      <span style={{ color: meta.color }}>{f.name}</span>
-                    )}
+                    {/* Every row is actionable: an entry opens in the editor, and a
+                        cast Agent with no entry opens on the roster — its fix is
+                        there, not in the wiki. */}
+                    <button
+                      type="button"
+                      className="gx-kg-health__link"
+                      style={{ color: meta.color }}
+                      onClick={() =>
+                        f.nodeID ? onOpenNode(f.nodeID) : f.agentID && onOpenCast?.(f.agentID)
+                      }
+                    >
+                      {f.name}
+                    </button>
                     {f.detail && <span className="gx-kg-health__detail"> — {f.detail}</span>}
                   </li>
                 );

--- a/web/src/screens/campaign/graph/WorldHealthPanel.tsx
+++ b/web/src/screens/campaign/graph/WorldHealthPanel.tsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@connectrpc/connect-query";
+import { AlertTriangle, Copy } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/management_pb";
+import { Button } from "@/components/ui/Button";
+import { metaOf } from "../knowledgeVocab";
+import { worldHealth } from "./worldHealth";
+
+// The world health panel (#536): derived warnings about the campaign's wiki,
+// computed from the graph payload the tab already holds. No new storage.
+//
+// Every row is a LINK INTO THE EDITOR, never a fix button. ADR-0052 rejected
+// auto-merging near-duplicate facts because similarity is a hint, not a semantic
+// judgment, and a wrong merge corrupts canon invisibly — the same reasoning
+// applies to every category here.
+
+export function WorldHealthPanel({
+  nodes,
+  edges,
+  onOpenNode,
+}: {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  onOpenNode: (id: string) => void;
+}) {
+  const rosterQuery = useQuery(CampaignService.method.getCampaignRoster, {});
+  const categories = useMemo(
+    () => worldHealth(nodes, edges, rosterQuery.data?.roster ?? []),
+    [nodes, edges, rosterQuery.data],
+  );
+
+  // The duplicate check is a mutation, not a query, precisely so it CANNOT fire on
+  // render: it is an exact pairwise embedding scan and belongs behind a button.
+  const duplicates = useMutation(CampaignService.method.findDuplicateEntries);
+  const [ranDuplicates, setRanDuplicates] = useState(false);
+
+  const healthy = categories.length === 0;
+
+  return (
+    <section className="gx-kg-health" aria-label="World health">
+      {healthy ? (
+        <p className="gx-kg-health__clear">
+          Nothing to flag — every entry is connected, and every voiced NPC has something to say.
+        </p>
+      ) : (
+        categories.map((c) => (
+          <div key={c.key} className="gx-kg-health__group">
+            <h4 className="gx-kg-health__title">
+              <AlertTriangle size={13} aria-hidden /> {c.title}
+              <span className="gx-kg-health__count">{c.findings.length}</span>
+            </h4>
+            <p className="gx-kg-health__why">{c.why}</p>
+            <ul className="gx-kg-health__list">
+              {c.findings.map((f, i) => {
+                const meta = metaOf(f.nodeType);
+                return (
+                  <li key={f.nodeID || `${c.key}-${i}`} className="gx-kg-health__row">
+                    {f.nodeID ? (
+                      <button
+                        type="button"
+                        className="gx-kg-health__link"
+                        style={{ color: meta.color }}
+                        onClick={() => onOpenNode(f.nodeID)}
+                      >
+                        {f.name}
+                      </button>
+                    ) : (
+                      <span style={{ color: meta.color }}>{f.name}</span>
+                    )}
+                    {f.detail && <span className="gx-kg-health__detail"> — {f.detail}</span>}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))
+      )}
+
+      <div className="gx-kg-health__group">
+        <h4 className="gx-kg-health__title">
+          <Copy size={13} aria-hidden /> Probable duplicates
+        </h4>
+        <p className="gx-kg-health__why">
+          Compares every entry's text against every other. It is a hint, never a merge — a wrong
+          merge would rewrite your canon invisibly.
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={duplicates.isPending}
+          onClick={() => {
+            setRanDuplicates(true);
+            duplicates.mutate({});
+          }}
+        >
+          {duplicates.isPending ? "Comparing…" : "Check for duplicates"}
+        </Button>
+
+        {duplicates.isError && (
+          <span className="gx-editor__status gx-editor__status--error" role="alert">
+            Couldn't check: {duplicates.error.message}
+          </span>
+        )}
+
+        {ranDuplicates && duplicates.isSuccess && (
+          <>
+            {duplicates.data.pairs.length === 0 ? (
+              <p className="gx-kg-health__why">No entries look like duplicates of each other.</p>
+            ) : (
+              <ul className="gx-kg-health__list">
+                {duplicates.data.pairs.map((p) => (
+                  <li key={`${p.aId}-${p.bId}`} className="gx-kg-health__row">
+                    <button
+                      type="button"
+                      className="gx-kg-health__link"
+                      onClick={() => onOpenNode(p.aId)}
+                    >
+                      {p.aName}
+                    </button>
+                    {" ≈ "}
+                    <button
+                      type="button"
+                      className="gx-kg-health__link"
+                      onClick={() => onOpenNode(p.bId)}
+                    >
+                      {p.bName}
+                    </button>
+                    <span className="gx-kg-health__detail">
+                      {" "}
+                      — {Math.round(p.similarity * 100)}% alike
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {duplicates.data.unembedded > 0 && (
+              <p className="gx-kg-health__why">
+                {duplicates.data.unembedded} entr
+                {duplicates.data.unembedded === 1 ? "y is" : "ies are"} still being indexed and
+                could not be compared yet.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/src/screens/campaign/graph/worldHealth.test.ts
+++ b/web/src/screens/campaign/graph/worldHealth.test.ts
@@ -21,12 +21,24 @@ describe("worldHealth", () => {
   // on Character-NPC create with an EMPTY body and never copies the Persona, so
   // "voiced character with nothing to say" is the DEFAULT state after adding an
   // NPC — currently discovered live, mid-session.
+  // An entry whose ONLY fact is a GM secret is authored — but it says nothing to
+  // its NPC, which is exactly the state this category exists to catch. Counting
+  // private aspects here reported it as healthy.
+  it("flags a voiced NPC whose only fact is a GM secret", () => {
+    const cats = worldHealth(
+      [node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1", aspectCount: 1, publicAspectCount: 0 })],
+      [],
+      [],
+    );
+    expect(byKey(cats, "empty-voiced")?.findings.map((f) => f.name)).toEqual(["Bart"]);
+  });
+
   it("flags a voiced NPC whose entry is empty", () => {
     const cats = worldHealth(
       [
         node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1" }),
         node({ id: "ilva", nodeType: NodeType.NPC, name: "Ilva", agentId: "a2", bodyLen: 20 }),
-        node({ id: "zed", nodeType: NodeType.NPC, name: "Zed", agentId: "a3", aspectCount: 2 }),
+        node({ id: "zed", nodeType: NodeType.NPC, name: "Zed", agentId: "a3", aspectCount: 2, publicAspectCount: 2 }),
       ],
       [],
       [],

--- a/web/src/screens/campaign/graph/worldHealth.test.ts
+++ b/web/src/screens/campaign/graph/worldHealth.test.ts
@@ -116,10 +116,44 @@ describe("worldHealth", () => {
     expect(cats).toHaveLength(0);
   });
 
+  // A fixture that triggers EVERY category at once — the earlier version fed one
+  // orphan and then looped over the single category it produced, so an empty
+  // `why` anywhere else would have sailed through.
   it("names a consequence for every category, not just a label", () => {
-    const cats = worldHealth([node({ id: "x", name: "Loose end" })], [], []);
+    const cats = worldHealth(
+      [
+        node({ id: "orphan", name: "A lost ring", nodeType: NodeType.ITEM }),
+        node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1" }),
+        node({ id: "mute", nodeType: NodeType.NPC, name: "Unvoiced" }),
+        node({ id: "heist", nodeType: NodeType.PLOT_THREAD, name: "The heist" }),
+      ],
+      [],
+      [create(AgentSchema, { id: "a2", name: "No entry", role: "character" })],
+    );
+    expect(
+      cats.map((c) => c.key).sort(),
+      "the fixture must trigger every category, or this test proves nothing",
+    ).toEqual([
+      "cast-without-entry",
+      "dangling-threads",
+      "empty-voiced",
+      "orphans",
+      "unlinked-npcs",
+    ]);
     for (const c of cats) {
       expect(c.why.length, `${c.key} has no stated consequence`).toBeGreaterThan(20);
+      expect(c.title.length, `${c.key} has no title`).toBeGreaterThan(0);
     }
+  });
+
+  // Every row must be actionable, so a finding that is not about a Node has to
+  // carry the Agent whose roster row IS the fix.
+  it("gives a cast-without-entry finding an agent to open", () => {
+    const cats = worldHealth([], [], [
+      create(AgentSchema, { id: "a2", name: "No entry", role: "character" }),
+    ]);
+    const f = byKey(cats, "cast-without-entry")?.findings[0];
+    expect(f?.agentID).toBe("a2");
+    expect(f?.nodeID).toBe("");
   });
 });

--- a/web/src/screens/campaign/graph/worldHealth.test.ts
+++ b/web/src/screens/campaign/graph/worldHealth.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AgentSchema,
+  EdgeType,
+  GraphEdgeSchema,
+  GraphNodeSchema,
+  NodeType,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { worldHealth } from "./worldHealth";
+
+type NodeInit = Parameters<typeof create<typeof GraphNodeSchema>>[1];
+const node = (o: NodeInit) => create(GraphNodeSchema, { nodeType: NodeType.NOTE, ...o });
+
+const byKey = (cats: ReturnType<typeof worldHealth>, key: string) =>
+  cats.find((c) => c.key === key);
+
+describe("worldHealth", () => {
+  // The worst failure in the epic: ADR-0008's second amendment creates an NPC Node
+  // on Character-NPC create with an EMPTY body and never copies the Persona, so
+  // "voiced character with nothing to say" is the DEFAULT state after adding an
+  // NPC — currently discovered live, mid-session.
+  it("flags a voiced NPC whose entry is empty", () => {
+    const cats = worldHealth(
+      [
+        node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1" }),
+        node({ id: "ilva", nodeType: NodeType.NPC, name: "Ilva", agentId: "a2", bodyLen: 20 }),
+        node({ id: "zed", nodeType: NodeType.NPC, name: "Zed", agentId: "a3", aspectCount: 2 }),
+      ],
+      [],
+      [],
+    );
+    const empty = byKey(cats, "empty-voiced");
+    expect(empty?.findings.map((f) => f.name)).toEqual(["Bart"]);
+  });
+
+  // An orphan can never enter an NPC's Hot Context through the neighbour walk —
+  // unless the Node IS an Agent's own linked Node, which reaches the prompt
+  // directly. So a linked orphan is not the problem this category names.
+  it("flags unconnected entries but not a linked NPC's own entry", () => {
+    const cats = worldHealth(
+      [
+        node({ id: "lonely", name: "A lost ring", nodeType: NodeType.ITEM }),
+        node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1", bodyLen: 5 }),
+        node({ id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+      ],
+      [
+        create(GraphEdgeSchema, {
+          id: "e1",
+          fromNodeId: "town",
+          toNodeId: "lonely",
+          edgeType: EdgeType.OWNS,
+        }),
+      ],
+      [],
+    );
+    const orphans = byKey(cats, "orphans");
+    // "lonely" and "town" are connected to each other; "bart" is unconnected but
+    // reachable as its Agent's own node.
+    expect(orphans).toBeUndefined();
+  });
+
+  it("flags a plot thread nobody participates in", () => {
+    const cats = worldHealth(
+      [
+        node({ id: "heist", nodeType: NodeType.PLOT_THREAD, name: "The heist" }),
+        node({ id: "war", nodeType: NodeType.PLOT_THREAD, name: "The war" }),
+        node({ id: "ilva", nodeType: NodeType.NPC, name: "Ilva", agentId: "a1", bodyLen: 3 }),
+      ],
+      [
+        create(GraphEdgeSchema, {
+          id: "e1",
+          fromNodeId: "ilva",
+          toNodeId: "war",
+          edgeType: EdgeType.PARTICIPATED_IN,
+        }),
+      ],
+      [],
+    );
+    expect(byKey(cats, "dangling-threads")?.findings.map((f) => f.name)).toEqual(["The heist"]);
+  });
+
+  it("flags NPC entries with no voice, and cast with no entry", () => {
+    const cats = worldHealth(
+      [node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", bodyLen: 5 })],
+      [],
+      [
+        create(AgentSchema, { id: "a1", name: "Voiceless", role: "character" }),
+        create(AgentSchema, { id: "b1", name: "Glyphoxa", role: "butler" }),
+      ],
+    );
+    expect(byKey(cats, "unlinked-npcs")?.findings.map((f) => f.name)).toEqual(["Bart"]);
+    // The Butler is exempt: it is Address-Only and has no linked Node by design.
+    expect(byKey(cats, "cast-without-entry")?.findings.map((f) => f.name)).toEqual(["Voiceless"]);
+  });
+
+  // A wall of "0 problems" sections trains the GM to skim past the one that is
+  // not zero.
+  it("drops empty categories entirely", () => {
+    const cats = worldHealth(
+      [
+        node({ id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: "a1", bodyLen: 5 }),
+        node({ id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh", bodyLen: 5 }),
+      ],
+      [
+        create(GraphEdgeSchema, {
+          id: "e1",
+          fromNodeId: "bart",
+          toNodeId: "town",
+          edgeType: EdgeType.RESIDES_IN,
+        }),
+      ],
+      [create(AgentSchema, { id: "a1", name: "Bart", role: "character" })],
+    );
+    expect(cats).toHaveLength(0);
+  });
+
+  it("names a consequence for every category, not just a label", () => {
+    const cats = worldHealth([node({ id: "x", name: "Loose end" })], [], []);
+    for (const c of cats) {
+      expect(c.why.length, `${c.key} has no stated consequence`).toBeGreaterThan(20);
+    }
+  });
+});

--- a/web/src/screens/campaign/graph/worldHealth.ts
+++ b/web/src/screens/campaign/graph/worldHealth.ts
@@ -15,8 +15,10 @@ import type { Agent, GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/ma
 // every finding is a pointer to the editor, never a button that rewrites the wiki.
 
 export type Finding = {
-  /** The Node to open in the editor. */
+  /** The Node to open in the editor, or "" when the finding is about an Agent. */
   nodeID: string;
+  /** The Agent to open on the roster, for findings whose fix is not a Node. */
+  agentID?: string;
   name: string;
   nodeType: NodeType;
   /** Extra context for the row, when the name alone does not explain the problem. */
@@ -109,6 +111,7 @@ export function worldHealth(
       why: "Their world knowledge is empty by construction — the fact read is keyed by Agent, with no campaign-wide fallback.",
       findings: unlinkedCast.map((a) => ({
         nodeID: "",
+        agentID: a.id,
         name: a.name,
         nodeType: NodeType.NPC,
         detail: "link an NPC entry to this Agent",

--- a/web/src/screens/campaign/graph/worldHealth.ts
+++ b/web/src/screens/campaign/graph/worldHealth.ts
@@ -78,7 +78,7 @@ export function worldHealth(
     "Voiced NPCs with nothing to say",
     "These have an Agent and a voice, but their entry is empty — so they will improvise instead of speaking to your world.",
     nodes
-      .filter((n) => n.agentId !== "" && n.bodyLen === 0 && n.aspectCount === 0)
+      .filter((n) => n.agentId !== "" && n.bodyLen === 0 && n.publicAspectCount === 0)
       .map((n) => finding(n, "entry has no facts and no content")),
   );
 

--- a/web/src/screens/campaign/graph/worldHealth.ts
+++ b/web/src/screens/campaign/graph/worldHealth.ts
@@ -1,0 +1,120 @@
+import { EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent, GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/management_pb";
+
+// World-health derivations (#536). Every one of these is computed from the graph
+// payload the Knowledge tab already holds — no new storage, and no extra read.
+//
+// They exist because each failure below is currently invisible until it bites at
+// the table. The worst is the empty auto-created NPC entry: ADR-0008's second
+// amendment creates a Node on Character-NPC create with an EMPTY body and never
+// copies the Persona, so "added an NPC, it has a voice and a persona and nothing
+// to say about the world" is the DEFAULT state after creation — and it is
+// currently discovered live, mid-session.
+//
+// Nothing here mutates anything (ADR-0052's no-auto-merge posture generalised):
+// every finding is a pointer to the editor, never a button that rewrites the wiki.
+
+export type Finding = {
+  /** The Node to open in the editor. */
+  nodeID: string;
+  name: string;
+  nodeType: NodeType;
+  /** Extra context for the row, when the name alone does not explain the problem. */
+  detail?: string;
+};
+
+export type HealthCategory = {
+  key: string;
+  title: string;
+  /** Why this matters at the table — the row is useless without the consequence. */
+  why: string;
+  findings: Finding[];
+};
+
+/**
+ * worldHealth derives every category from (nodes, edges, roster). Empty categories
+ * are dropped here rather than rendered empty: a wall of "0 problems" sections
+ * trains the GM to skim past the one that is not zero.
+ */
+export function worldHealth(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  roster: Agent[],
+): HealthCategory[] {
+  const degree = new Map<string, number>();
+  const incomingParticipation = new Set<string>();
+  for (const e of edges) {
+    degree.set(e.fromNodeId, (degree.get(e.fromNodeId) ?? 0) + 1);
+    degree.set(e.toNodeId, (degree.get(e.toNodeId) ?? 0) + 1);
+    if (e.edgeType === EdgeType.PARTICIPATED_IN) incomingParticipation.add(e.toNodeId);
+  }
+  const finding = (n: GraphNode, detail?: string): Finding => ({
+    nodeID: n.id,
+    name: n.name,
+    nodeType: n.nodeType,
+    detail,
+  });
+
+  const categories: HealthCategory[] = [];
+  const push = (key: string, title: string, why: string, findings: Finding[]) => {
+    if (findings.length > 0) categories.push({ key, title, why, findings });
+  };
+
+  // An orphan can never enter an NPC's Hot Context through the neighbour walk. It
+  // is reachable only if the Node IS an Agent's own linked Node — so a linked one
+  // is not an orphan in the sense that matters.
+  push(
+    "orphans",
+    "Unconnected entries",
+    "No relations, so no NPC can ever reach them through the neighbour walk — they only reach the table if an NPC is linked to them directly.",
+    nodes.filter((n) => (degree.get(n.id) ?? 0) === 0 && n.agentId === "").map((n) => finding(n)),
+  );
+
+  // The ADR-0008 second-amendment auto-node: created empty, never filled.
+  push(
+    "empty-voiced",
+    "Voiced NPCs with nothing to say",
+    "These have an Agent and a voice, but their entry is empty — so they will improvise instead of speaking to your world.",
+    nodes
+      .filter((n) => n.agentId !== "" && n.bodyLen === 0 && n.aspectCount === 0)
+      .map((n) => finding(n, "entry has no facts and no content")),
+  );
+
+  push(
+    "unlinked-npcs",
+    "NPC entries with no voice",
+    "Written up but not voiced by any Agent. Fine if deliberate — a reminder if not.",
+    nodes
+      .filter((n) => n.nodeType === NodeType.NPC && n.agentId === "")
+      .map((n) => finding(n)),
+  );
+
+  push(
+    "dangling-threads",
+    "Plot threads nobody is in",
+    "Nothing participates_in them, so no NPC's context connects to them.",
+    nodes
+      .filter((n) => n.nodeType === NodeType.PLOT_THREAD && !incomingParticipation.has(n.id))
+      .map((n) => finding(n)),
+  );
+
+  // The inverse of "empty voiced entry": a cast Agent with no entry at all. Keyed
+  // off the roster rather than the graph, because the missing thing is a Node.
+  const linkedAgents = new Set(nodes.map((n) => n.agentId).filter((id) => id !== ""));
+  const unlinkedCast = roster.filter((a) => a.role === "character" && !linkedAgents.has(a.id));
+  if (unlinkedCast.length > 0) {
+    categories.push({
+      key: "cast-without-entry",
+      title: "Cast with no wiki entry",
+      why: "Their world knowledge is empty by construction — the fact read is keyed by Agent, with no campaign-wide fallback.",
+      findings: unlinkedCast.map((a) => ({
+        nodeID: "",
+        name: a.name,
+        nodeType: NodeType.NPC,
+        detail: "link an NPC entry to this Agent",
+      })),
+    });
+  }
+
+  return categories;
+}

--- a/web/src/screens/campaign/knowledgeCache.test.ts
+++ b/web/src/screens/campaign/knowledgeCache.test.ts
@@ -34,6 +34,18 @@ describe("invalidateKnowledgeReads", () => {
       cardinality: "finite",
       input: {},
     }),
+    // Derived reads: pure functions of the same nodes and edges, and stale for
+    // the same reasons.
+    getAgentFactPreview: createConnectQueryKey({
+      schema: CampaignService.method.getAgentFactPreview,
+      cardinality: "finite",
+      input: { agentId: "a1" },
+    }),
+    getRosterReadiness: createConnectQueryKey({
+      schema: CampaignService.method.getRosterReadiness,
+      cardinality: "finite",
+      input: {},
+    }),
   };
 
   it("marks every Knowledge Graph read stale", () => {

--- a/web/src/screens/campaign/knowledgeCache.ts
+++ b/web/src/screens/campaign/knowledgeCache.ts
@@ -5,7 +5,7 @@ import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 
 // One invalidation for every read of the Knowledge Graph (#534).
 //
-// The same nodes and edges are now served by FOUR queries — the list, the wiki
+// The same nodes and edges are now served by SIX queries — the list, the wiki
 // search, a node's relations, and the whole-graph payload the Graph view renders —
 // and they are mutated from three different surfaces: the Knowledge panel, the
 // relations editor inside it, and the proposal review queue. Each surface used to
@@ -14,7 +14,9 @@ import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 // stale, so an edge created in the relations editor kept drawing on the graph
 // until the 30s staleTime expired.
 //
-// So there is one helper and it drops all four. Over-invalidating costs a handful
+// So there is one helper and it drops all six — including the two derived reads
+// (#535's fact preview and #544's roster readiness), which are pure functions of
+// the same nodes and edges and go stale for exactly the same reasons. Over-invalidating costs a handful
 // of small refetches on a single-operator tier; under-invalidating shows the GM a
 // world that does not match their own last edit, which reads as a bug in the graph
 // rather than a stale cache.
@@ -43,6 +45,20 @@ export function invalidateKnowledgeReads(queryClient: QueryClient): void {
   void queryClient.invalidateQueries({
     queryKey: createConnectQueryKey({
       schema: CampaignService.method.getKnowledgeGraph,
+      cardinality: "finite",
+    }),
+  });
+  // Derived from the same nodes and edges: an edit that changes what an NPC knows
+  // must not leave the lens and the readiness marks describing the old world.
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.getAgentFactPreview,
+      cardinality: "finite",
+    }),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.getRosterReadiness,
       cardinality: "finite",
     }),
   });

--- a/web/src/screens/campaign/rosterPrep.test.ts
+++ b/web/src/screens/campaign/rosterPrep.test.ts
@@ -8,7 +8,16 @@ import {
   GraphNodeSchema,
   NodeType,
 } from "@gen/glyphoxa/management/v1/management_pb";
-import { UNPLACED_TITLE, rosterPrep } from "./rosterPrep";
+import { UNPLACED_TITLE, lastSpokeLabel, rosterPrep, type Readiness } from "./rosterPrep";
+
+const ready = (o: Partial<Readiness> = {}): Readiness => ({
+  linked: true,
+  factCount: 3,
+  chars: 400,
+  maxChars: 4000,
+  truncated: false,
+  ...o,
+});
 
 const agent = (o: Parameters<typeof create<typeof AgentSchema>>[1]) =>
   create(AgentSchema, { role: "character", ...o });
@@ -26,13 +35,16 @@ describe("rosterPrep", () => {
       [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
       [node({ id: "bart", name: "Bart", agentId: "a1" })],
       [],
+      // Linked, but an empty entry has nothing for the read to return.
+      new Map([["a1", ready({ factCount: 0 })]]),
     );
     const bart = groups[0].entries[0];
     expect(bart.ready).toBe(false);
     const content = bart.checks.find((c) => c.key === "content");
     expect(content?.ok).toBe(false);
-    // Everything else passes, so the ONE unsatisfied mark points at the real gap.
-    expect(bart.checks.filter((c) => !c.ok).map((c) => c.key)).toEqual(["content"]);
+    // Persona, voice and link all pass, so the unsatisfied marks point at the real
+    // gap: the entry is empty and therefore nothing reaches the prompt.
+    expect(bart.checks.filter((c) => !c.ok).map((c) => c.key)).toEqual(["content", "facts"]);
   });
 
   it("counts aspects as content, not just prose", () => {
@@ -40,14 +52,46 @@ describe("rosterPrep", () => {
       [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
       [node({ id: "bart", name: "Bart", agentId: "a1", aspectCount: 2 })],
       [],
+      new Map([["a1", ready()]]),
     );
     expect(groups[0].entries[0].ready).toBe(true);
+  });
+
+  // "The entry has words in it" and "the NPC will actually receive them" are
+  // different claims: the neighbourhood read and the render caps sit between them.
+  // The count comes from the SAME renderer the turn uses (#535).
+  it("grades on facts actually in reach, not just on entry content", () => {
+    const nodes = [node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 200 })];
+    const configured = [agent({ id: "a1", name: "Bart", persona: "p", voice: "v" })];
+
+    const reaching = rosterPrep(configured, nodes, [], new Map([["a1", ready({ factCount: 4 })]]));
+    expect(reaching[0].entries[0].ready).toBe(true);
+    expect(reaching[0].entries[0].checks.find((c) => c.key === "facts")?.label).toBe(
+      "4 facts in reach",
+    );
+
+    const starved = rosterPrep(configured, nodes, [], new Map([["a1", ready({ factCount: 0 })]]));
+    expect(starved[0].entries[0].ready).toBe(false);
+    expect(starved[0].entries[0].checks.filter((c) => !c.ok).map((c) => c.key)).toEqual(["facts"]);
+  });
+
+  it("surfaces when each NPC last spoke", () => {
+    const at = new Date("2026-07-04T20:00:00Z");
+    const groups = rosterPrep(
+      [agent({ id: "a1", name: "Bart", persona: "p", voice: "v" })],
+      [node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 5 })],
+      [],
+      new Map([["a1", ready({ lastSpokeAt: at })]]),
+    );
+    expect(groups[0].entries[0].readiness?.lastSpokeAt).toEqual(at);
+    expect(lastSpokeLabel(groups[0].entries[0].readiness)).toMatch(/last spoke/);
+    expect(lastSpokeLabel(undefined)).toBe("never spoken");
   });
 
   it("names each missing piece separately", () => {
     const groups = rosterPrep([agent({ id: "a1", name: "Blank" })], [], []);
     const checks = groups[0].entries[0].checks.filter((c) => !c.ok).map((c) => c.key);
-    expect(checks).toEqual(["persona", "voice", "link", "content"]);
+    expect(checks).toEqual(["persona", "voice", "link", "content", "facts"]);
   });
 
   it("groups by faction and location, and lists an NPC under both", () => {
@@ -59,6 +103,7 @@ describe("rosterPrep", () => {
         node({ id: "guild", nodeType: NodeType.FACTION, name: "Smugglers" }),
       ],
       [edge("bart", "town", EdgeType.RESIDES_IN), edge("bart", "guild", EdgeType.MEMBER_OF)],
+      new Map([["a1", ready()]]),
     );
     expect(groups.map((g) => g.title)).toEqual(["Saltmarsh", "Smugglers"]);
   });
@@ -77,23 +122,50 @@ describe("rosterPrep", () => {
         node({ id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
       ],
       [edge("bart", "town", EdgeType.RESIDES_IN)],
+      new Map([
+        ["a1", ready()],
+        ["a2", ready()],
+      ]),
     );
     expect(groups.map((g) => g.title)).toEqual(["Saltmarsh", UNPLACED_TITLE]);
     expect(groups[1].entries.map((e) => e.agent.name)).toEqual(["Drifter"]);
   });
 
-  // The Butler is Address-Only, auto-created and undeletable, with no linked Node
-  // by design (ADR-0009) — grading it here would be a permanent false alarm.
-  it("excludes the Butler from the character checks", () => {
+  // The AC is precise: the Butler is PRESENT and NOT FLAGGED. Dropping it would
+  // hide a roster member the GM looks for; grading it against character checks
+  // would flag it forever, since it is Address-Only with no linked Node by design
+  // (ADR-0009).
+  it("lists the Butler without grading it", () => {
     const groups = rosterPrep(
       [
         create(AgentSchema, { id: "b1", name: "Glyphoxa", role: "butler" }),
-        agent({ id: "a1", name: "Bart", persona: "p", voice: "v", }),
+        agent({ id: "a1", name: "Bart", persona: "p", voice: "v" }),
       ],
       [node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 5 })],
       [],
+      new Map([["a1", ready()]]),
     );
-    const names = groups.flatMap((g) => g.entries.map((e) => e.agent.name));
-    expect(names).toEqual(["Bart"]);
+    const entries = groups.flatMap((g) => g.entries);
+    const butler = entries.find((e) => e.agent.name === "Glyphoxa");
+    expect(butler, "the Butler must be listed").toBeDefined();
+    expect(butler?.exempt).toBe(true);
+    expect(butler?.checks).toEqual([]);
+    // And it must never read as a problem.
+    expect(butler?.ready).toBe(true);
+  });
+
+  // Each mark must point at a surface where the fix can ACTUALLY be made. The
+  // Agent editor has no link control — that lives in the Knowledge tab's
+  // relations card — so routing "link" to the Agent editor would strand the GM.
+  it("routes each fix to a surface that can perform it", () => {
+    const groups = rosterPrep([agent({ id: "a1", name: "Blank" })], [], []);
+    const fixes = Object.fromEntries(groups[0].entries[0].checks.map((c) => [c.key, c.fix]));
+    expect(fixes).toEqual({
+      persona: "agent",
+      voice: "agent",
+      link: "link",
+      content: "entry",
+      facts: "entry",
+    });
   });
 });

--- a/web/src/screens/campaign/rosterPrep.test.ts
+++ b/web/src/screens/campaign/rosterPrep.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AgentSchema,
+  EdgeType,
+  GraphEdgeSchema,
+  GraphNodeSchema,
+  NodeType,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { UNPLACED_TITLE, rosterPrep } from "./rosterPrep";
+
+const agent = (o: Parameters<typeof create<typeof AgentSchema>>[1]) =>
+  create(AgentSchema, { role: "character", ...o });
+const node = (o: Parameters<typeof create<typeof GraphNodeSchema>>[1]) =>
+  create(GraphNodeSchema, { nodeType: NodeType.NPC, ...o });
+const edge = (from: string, to: string, edgeType: EdgeType) =>
+  create(GraphEdgeSchema, { id: `${from}-${to}`, fromNodeId: from, toNodeId: to, edgeType });
+
+describe("rosterPrep", () => {
+  // The concrete failure this whole slice exists for: the ADR-0008 auto-node is
+  // created EMPTY and the Persona is never copied, so a fully-configured NPC can
+  // still have nothing to say — and that was only discovered at the table.
+  it("flags a fully-configured NPC whose entry is empty", () => {
+    const groups = rosterPrep(
+      [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
+      [node({ id: "bart", name: "Bart", agentId: "a1" })],
+      [],
+    );
+    const bart = groups[0].entries[0];
+    expect(bart.ready).toBe(false);
+    const content = bart.checks.find((c) => c.key === "content");
+    expect(content?.ok).toBe(false);
+    // Everything else passes, so the ONE unsatisfied mark points at the real gap.
+    expect(bart.checks.filter((c) => !c.ok).map((c) => c.key)).toEqual(["content"]);
+  });
+
+  it("counts aspects as content, not just prose", () => {
+    const groups = rosterPrep(
+      [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
+      [node({ id: "bart", name: "Bart", agentId: "a1", aspectCount: 2 })],
+      [],
+    );
+    expect(groups[0].entries[0].ready).toBe(true);
+  });
+
+  it("names each missing piece separately", () => {
+    const groups = rosterPrep([agent({ id: "a1", name: "Blank" })], [], []);
+    const checks = groups[0].entries[0].checks.filter((c) => !c.ok).map((c) => c.key);
+    expect(checks).toEqual(["persona", "voice", "link", "content"]);
+  });
+
+  it("groups by faction and location, and lists an NPC under both", () => {
+    const groups = rosterPrep(
+      [agent({ id: "a1", name: "Bart", persona: "p", voice: "v" })],
+      [
+        node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 5 }),
+        node({ id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+        node({ id: "guild", nodeType: NodeType.FACTION, name: "Smugglers" }),
+      ],
+      [edge("bart", "town", EdgeType.RESIDES_IN), edge("bart", "guild", EdgeType.MEMBER_OF)],
+    );
+    expect(groups.map((g) => g.title)).toEqual(["Saltmarsh", "Smugglers"]);
+  });
+
+  // Unplaced NPCs go into an explicit group rather than vanishing — an NPC you
+  // forgot to place is exactly the one you need reminding about.
+  it("puts unplaced NPCs in an explicit group, listed last", () => {
+    const groups = rosterPrep(
+      [
+        agent({ id: "a1", name: "Bart", persona: "p", voice: "v" }),
+        agent({ id: "a2", name: "Drifter", persona: "p", voice: "v" }),
+      ],
+      [
+        node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 5 }),
+        node({ id: "drift", name: "Drifter", agentId: "a2", bodyLen: 5 }),
+        node({ id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+      ],
+      [edge("bart", "town", EdgeType.RESIDES_IN)],
+    );
+    expect(groups.map((g) => g.title)).toEqual(["Saltmarsh", UNPLACED_TITLE]);
+    expect(groups[1].entries.map((e) => e.agent.name)).toEqual(["Drifter"]);
+  });
+
+  // The Butler is Address-Only, auto-created and undeletable, with no linked Node
+  // by design (ADR-0009) — grading it here would be a permanent false alarm.
+  it("excludes the Butler from the character checks", () => {
+    const groups = rosterPrep(
+      [
+        create(AgentSchema, { id: "b1", name: "Glyphoxa", role: "butler" }),
+        agent({ id: "a1", name: "Bart", persona: "p", voice: "v", }),
+      ],
+      [node({ id: "bart", name: "Bart", agentId: "a1", bodyLen: 5 })],
+      [],
+    );
+    const names = groups.flatMap((g) => g.entries.map((e) => e.agent.name));
+    expect(names).toEqual(["Bart"]);
+  });
+});

--- a/web/src/screens/campaign/rosterPrep.test.ts
+++ b/web/src/screens/campaign/rosterPrep.test.ts
@@ -50,11 +50,25 @@ describe("rosterPrep", () => {
   it("counts aspects as content, not just prose", () => {
     const groups = rosterPrep(
       [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
-      [node({ id: "bart", name: "Bart", agentId: "a1", aspectCount: 2 })],
+      [node({ id: "bart", name: "Bart", agentId: "a1", aspectCount: 2, publicAspectCount: 2 })],
       [],
       new Map([["a1", ready()]]),
     );
     expect(groups[0].entries[0].ready).toBe(true);
+  });
+
+  // A secret-only entry is authored but says nothing to its NPC — the readiness
+  // marks answer "can this NPC speak to my world", not "did I type something".
+  it("does not count a GM-only fact as content", () => {
+    const groups = rosterPrep(
+      [agent({ id: "a1", name: "Bart", persona: "Gruff.", voice: "v1" })],
+      [node({ id: "bart", name: "Bart", agentId: "a1", aspectCount: 1, publicAspectCount: 0 })],
+      [],
+      new Map([["a1", ready({ factCount: 0 })]]),
+    );
+    const bart = groups[0].entries[0];
+    expect(bart.ready).toBe(false);
+    expect(bart.checks.filter((c) => !c.ok).map((c) => c.key)).toEqual(["content", "facts"]);
   });
 
   // "The entry has words in it" and "the NPC will actually receive them" are

--- a/web/src/screens/campaign/rosterPrep.ts
+++ b/web/src/screens/campaign/rosterPrep.ts
@@ -1,0 +1,123 @@
+import { EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Agent, GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/management_pb";
+
+// Roster prep derivations (#544): where each cast NPC sits in the world, and
+// whether it is actually ready to speak.
+//
+// Every signal here was already queryable and none of it was displayed. The
+// concrete failure it addresses: ADR-0008's second amendment auto-creates an NPC
+// Node on Character-NPC create with an EMPTY body and never copies the Persona, so
+// "added an NPC, it has a voice and a persona but nothing to say about the world"
+// is the DEFAULT state after creation — discovered live, at the table.
+
+/** One readiness check, with the thing that fixes it. */
+export type Check = {
+  key: string;
+  label: string;
+  ok: boolean;
+  /** Where the GM goes to satisfy it. */
+  fix: "persona" | "voice" | "link" | "content" | "relations";
+};
+
+export type RosterEntry = {
+  agent: Agent;
+  /** The Agent's linked Node, when it has one. */
+  node: GraphNode | null;
+  checks: Check[];
+  /** True once every check passes. */
+  ready: boolean;
+};
+
+export type RosterGroup = {
+  /** The faction or location name, or "" for the explicit unplaced group. */
+  key: string;
+  title: string;
+  entries: RosterEntry[];
+};
+
+/** UNPLACED_TITLE names the catch-all group. It is explicit rather than hidden. */
+export const UNPLACED_TITLE = "Not placed in the world";
+
+/**
+ * rosterPrep groups cast NPCs by their linked Node's faction/location neighbours
+ * and computes each one's readiness.
+ *
+ * The Butler is deliberately absent from the CHECKS: it is Address-Only,
+ * auto-created and undeletable (ADR-0009) and has no linked Node by design, so
+ * grading it against character-oriented checks would be a permanent false alarm.
+ * The caller still lists it.
+ */
+export function rosterPrep(
+  roster: Agent[],
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): RosterGroup[] {
+  const byID = new Map(nodes.map((n) => [n.id, n]));
+  const nodeByAgent = new Map<string, GraphNode>();
+  for (const n of nodes) {
+    if (n.agentId !== "") nodeByAgent.set(n.agentId, n);
+  }
+
+  // Outgoing member_of / resides_in edges are what place an NPC in the world.
+  const placement = new Map<string, string[]>();
+  for (const e of edges) {
+    if (e.edgeType !== EdgeType.MEMBER_OF && e.edgeType !== EdgeType.RESIDES_IN) continue;
+    const target = byID.get(e.toNodeId);
+    if (!target) continue;
+    if (target.nodeType !== NodeType.FACTION && target.nodeType !== NodeType.LOCATION) continue;
+    const list = placement.get(e.fromNodeId);
+    if (list) list.push(target.name);
+    else placement.set(e.fromNodeId, [target.name]);
+  }
+
+  const groups = new Map<string, RosterGroup>();
+  const put = (title: string, entry: RosterEntry) => {
+    const g = groups.get(title);
+    if (g) g.entries.push(entry);
+    else groups.set(title, { key: title, title, entries: [entry] });
+  };
+
+  for (const agent of roster) {
+    if (agent.role !== "character") continue;
+    const node = nodeByAgent.get(agent.id) ?? null;
+    const entry: RosterEntry = { agent, node, checks: checksFor(agent, node), ready: false };
+    entry.ready = entry.checks.every((c) => c.ok);
+
+    const places = node ? (placement.get(node.id) ?? []) : [];
+    if (places.length === 0) {
+      put(UNPLACED_TITLE, entry);
+      continue;
+    }
+    // An NPC in a faction AND a town belongs under both — a GM prepping the town
+    // wants them listed there regardless of their guild.
+    for (const p of places) put(p, entry);
+  }
+
+  // Named groups alphabetically, then the unplaced catch-all last: it is a
+  // to-do list, not a place.
+  const named = [...groups.values()]
+    .filter((g) => g.title !== UNPLACED_TITLE)
+    .sort((a, b) => a.title.localeCompare(b.title));
+  const unplaced = groups.get(UNPLACED_TITLE);
+  return unplaced ? [...named, unplaced] : named;
+}
+
+function checksFor(agent: Agent, node: GraphNode | null): Check[] {
+  return [
+    {
+      key: "persona",
+      label: "Persona written",
+      ok: agent.persona.trim() !== "",
+      fix: "persona",
+    },
+    { key: "voice", label: "Voice configured", ok: agent.voice !== "", fix: "voice" },
+    { key: "link", label: "Wiki entry linked", ok: node !== null, fix: "link" },
+    {
+      key: "content",
+      label: "Entry has content",
+      // The ADR-0008 auto-node starts empty; either facts or prose counts.
+      ok: node !== null && (node.bodyLen > 0 || node.aspectCount > 0),
+      fix: "content",
+    },
+  ];
+}

--- a/web/src/screens/campaign/rosterPrep.ts
+++ b/web/src/screens/campaign/rosterPrep.ts
@@ -144,7 +144,7 @@ function checksFor(agent: Agent, node: GraphNode | null, r?: Readiness): Check[]
       key: "content",
       label: "Entry has content",
       // The ADR-0008 auto-node starts empty; either facts or prose counts.
-      ok: node !== null && (node.bodyLen > 0 || node.aspectCount > 0),
+      ok: node !== null && (node.bodyLen > 0 || node.publicAspectCount > 0),
       fix: "entry",
     },
     {

--- a/web/src/screens/campaign/rosterPrep.ts
+++ b/web/src/screens/campaign/rosterPrep.ts
@@ -15,8 +15,23 @@ export type Check = {
   key: string;
   label: string;
   ok: boolean;
-  /** Where the GM goes to satisfy it. */
-  fix: "persona" | "voice" | "link" | "content" | "relations";
+  /**
+   * Where the GM goes to satisfy it — `agent` opens the Agent editor, `entry`
+   * opens the linked wiki entry, and `link` opens the Knowledge tab where the
+   * "Voiced by" control actually lives. The Agent editor has NO link control, so
+   * routing `link` there would land the GM somewhere the fix cannot be made.
+   */
+  fix: "agent" | "entry" | "link";
+};
+
+/** One cast Agent's prompt-side readiness, from the batch preview read (#544). */
+export type Readiness = {
+  linked: boolean;
+  factCount: number;
+  chars: number;
+  maxChars: number;
+  truncated: boolean;
+  lastSpokeAt?: Date;
 };
 
 export type RosterEntry = {
@@ -24,8 +39,15 @@ export type RosterEntry = {
   /** The Agent's linked Node, when it has one. */
   node: GraphNode | null;
   checks: Check[];
-  /** True once every check passes. */
+  /** True once every check passes. Always true for the Butler, which is ungraded. */
   ready: boolean;
+  /**
+   * The Butler is LISTED but not graded: Address-Only, auto-created, undeletable
+   * and with no linked Node by design (ADR-0009), so character-oriented checks
+   * would be a permanent false alarm rather than information.
+   */
+  exempt: boolean;
+  readiness?: Readiness;
 };
 
 export type RosterGroup = {
@@ -39,18 +61,19 @@ export type RosterGroup = {
 export const UNPLACED_TITLE = "Not placed in the world";
 
 /**
- * rosterPrep groups cast NPCs by their linked Node's faction/location neighbours
- * and computes each one's readiness.
+ * rosterPrep groups roster members by their linked Node's faction/location
+ * neighbours and computes each cast NPC's readiness.
  *
- * The Butler is deliberately absent from the CHECKS: it is Address-Only,
- * auto-created and undeletable (ADR-0009) and has no linked Node by design, so
- * grading it against character-oriented checks would be a permanent false alarm.
- * The caller still lists it.
+ * The Butler is PRESENT and UNGRADED (`exempt`). It is Address-Only,
+ * auto-created and undeletable (ADR-0009) with no linked Node by design, so
+ * grading it against character-oriented checks would be a permanent false alarm —
+ * but dropping it from the view would hide a roster member the GM looks for.
  */
 export function rosterPrep(
   roster: Agent[],
   nodes: GraphNode[],
   edges: GraphEdge[],
+  readiness: Map<string, Readiness> = new Map(),
 ): RosterGroup[] {
   const byID = new Map(nodes.map((n) => [n.id, n]));
   const nodeByAgent = new Map<string, GraphNode>();
@@ -78,9 +101,19 @@ export function rosterPrep(
   };
 
   for (const agent of roster) {
-    if (agent.role !== "character") continue;
     const node = nodeByAgent.get(agent.id) ?? null;
-    const entry: RosterEntry = { agent, node, checks: checksFor(agent, node), ready: false };
+    // The Butler is present, ungraded. Excluding it entirely would hide a roster
+    // member the GM is looking for; grading it would flag it forever.
+    const exempt = agent.role !== "character";
+    const r = readiness.get(agent.id);
+    const entry: RosterEntry = {
+      agent,
+      node,
+      checks: exempt ? [] : checksFor(agent, node, r),
+      ready: true,
+      exempt,
+      readiness: r,
+    };
     entry.ready = entry.checks.every((c) => c.ok);
 
     const places = node ? (placement.get(node.id) ?? []) : [];
@@ -102,22 +135,31 @@ export function rosterPrep(
   return unplaced ? [...named, unplaced] : named;
 }
 
-function checksFor(agent: Agent, node: GraphNode | null): Check[] {
+function checksFor(agent: Agent, node: GraphNode | null, r?: Readiness): Check[] {
   return [
-    {
-      key: "persona",
-      label: "Persona written",
-      ok: agent.persona.trim() !== "",
-      fix: "persona",
-    },
-    { key: "voice", label: "Voice configured", ok: agent.voice !== "", fix: "voice" },
+    { key: "persona", label: "Persona written", ok: agent.persona.trim() !== "", fix: "agent" },
+    { key: "voice", label: "Voice configured", ok: agent.voice !== "", fix: "agent" },
     { key: "link", label: "Wiki entry linked", ok: node !== null, fix: "link" },
     {
       key: "content",
       label: "Entry has content",
       // The ADR-0008 auto-node starts empty; either facts or prose counts.
       ok: node !== null && (node.bodyLen > 0 || node.aspectCount > 0),
-      fix: "content",
+      fix: "entry",
+    },
+    {
+      key: "facts",
+      // The figure the voice loop will actually inject, from the same renderer
+      // (#535) — content on the entry does not guarantee the NPC receives it.
+      label: r ? `${r.factCount} facts in reach` : "Facts in reach",
+      ok: (r?.factCount ?? 0) > 0,
+      fix: "entry",
     },
   ];
+}
+
+/** lastSpokeLabel renders the "last spoke" prep signal, which is context, not a check. */
+export function lastSpokeLabel(r?: Readiness): string {
+  if (!r?.lastSpokeAt) return "never spoken";
+  return `last spoke ${r.lastSpokeAt.toLocaleDateString()}`;
 }


### PR DESCRIPTION
Epic #533 · slices A3 + C3 · design note §2/A3 and §4/C3 · **Closes #536, Closes #544**

Stacked on #550 → #549 → (#548, merged). The epic groups these two: *"Same derived-data shape, ship together."*

## Why they belong together

Both are signals that were **already queryable and never displayed**. Neither adds storage; both read the `GetKnowledgeGraph` payload from #534. And both exist for the same concrete failure: ADR-0008's second amendment auto-creates an NPC Node on Character-NPC create with an **empty body** and never copies the Persona — so "added an NPC, it has a voice and a persona and nothing to say about the world" is the *default* state after creation, currently discovered mid-session.

## World health (#536)

| Category | The consequence, which is the point |
|---|---|
| Unconnected entries | No relations ⇒ no NPC can reach them through the neighbour walk. A linked NPC's own entry is exempt — it reaches the prompt directly. |
| Voiced NPCs with nothing to say | Has an Agent and a voice; entry is empty. Will improvise instead of speaking to your world. |
| NPC entries with no voice | Written up, not voiced. Fine if deliberate. |
| Plot threads nobody is in | No incoming `participated_in`, so no NPC's context connects to them. |
| Cast with no wiki entry | World knowledge empty by construction — the fact read is keyed by Agent, no campaign-wide fallback. |

Every row is a **link into the editor, never a fix button**. ADR-0052 rejected auto-merging near-duplicate facts because similarity is a hint and a wrong merge corrupts canon invisibly; that reasoning generalises to all of these.

Empty categories are **dropped**, not rendered empty — a wall of "0 problems" sections trains the GM to skim past the one that is not zero. Each category states its consequence, and a test enforces that.

### The duplicate check

`FindDuplicateEntries` is an exact pairwise cosine scan over `kg_node.embedding`. Exact rather than an ANN probe because a campaign is hundreds of Nodes, it is GM-initiated, and an approximate answer is the wrong shape for something a human is about to act on.

It is wired as a **mutation** in the client specifically so it *cannot* fire on render — the AC asks for GM-initiated, and a query would be one `enabled` flag away from sweeping on every tab open. The floor is high (0.92) on purpose: a hint the GM must read is only useful if it is usually right. The response carries how many entries are still unindexed, so "no duplicates found" cannot imply a clean bill of health the scan could not give.

## Roster prep (#544)

The Cast tab gains a `[ Roster | Session prep ]` switch. Prep groups cast NPCs by their linked entry's `member_of` / `resides_in` neighbours and shows persona · voice · entry linked · entry has content.

- An **unsatisfied mark is a button** to the thing that fixes it. A checklist you cannot act on from is just a nag.
- An NPC in a faction *and* a town is listed under **both** — a GM prepping the town wants them there regardless of their guild.
- Unplaced NPCs get an **explicit group, listed last**: the NPC you forgot to place is the one you need reminding about.
- Aspects count as content, not just prose (#542).
- The **Butler is exempt** from the character checks — Address-Only, auto-created, undeletable, no linked Node by design (ADR-0009) — so it is never a permanent false alarm.

One roster read plus one graph read. No per-NPC RPC storm.

## Tests

- `worldHealth.test.ts` — the empty-voiced-NPC case, orphans excluding a linked NPC's own entry, dangling threads, unlinked NPCs and cast-without-entry (Butler excluded), empty categories dropped, and every category having a stated consequence.
- `rosterPrep.test.ts` — the fully-configured-but-empty NPC producing exactly ONE unsatisfied mark, aspects counting as content, each missing piece named separately, dual grouping, the explicit unplaced group last, and the Butler's exemption.
- `internal/rpc` — pair mapping, the campaign scope, the policy floor/limit being the server's, the unembedded count, the healthy empty case, error mapping.
- `internal/storage` (integration) — each unordered pair once, no self-pairs, closest first, the floor excluding an orthogonal node, unembedded rows invisible, and the scan campaign-scoped.

## ADRs

ADR-0008 (the second amendment's empty auto-node is the case both slices surface), ADR-0011 (the vector path), ADR-0052 (the no-auto-merge posture both inherit), ADR-0009/ADR-0024 (Butler exemptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)