### PR TITLE
feat(kg): agent-knowledge lens — show exactly what an NPC's Hot Context will contain (#535)

### DIFF
--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -185,37 +185,84 @@ func (r *Recaller) degrade(ctx context.Context, cause error) []string {
 	return nil
 }
 
-// renderFacts projects the public Nodes (in storage order) into rendered fact
-// strings, applying the per-fact truncation and the MaxFacts / MaxBlockChars caps.
-// The block-budget accounting reserves the agent's header + joins so the FINAL
-// rendered block (header included) stays within MaxBlockChars. It stops at the
-// first fact that would overrun either cap — a deterministic prefix, never a
-// skip-scan — so a huge Node cannot let a later small one sneak in past the budget.
-func renderFacts(nodes []storage.KGNode) []string {
-	if len(nodes) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(nodes))
+// Preview is exactly what an Agent's Hot Context facts block will contain, plus
+// the budget arithmetic that produced it (#535). It exists so the GM-facing
+// "what does this NPC actually know" lens reads the SAME renderer the voice loop
+// injects, instead of reimplementing the caps in TypeScript where they would
+// silently drift from reality on the next change to either side.
+type Preview struct {
+	// Facts is the rendered block, fact by fact — byte-identical to what the turn
+	// would inject.
+	Facts []string
+	// IncludedIDs are the Nodes that made it into Facts, in order. The lens dims the
+	// graph to exactly these.
+	IncludedIDs []uuid.UUID
+	// DroppedIDs are Nodes the read returned that the caps excluded — the visible
+	// half of the deterministic prefix-stop, which is otherwise a silent quality
+	// cliff.
+	DroppedIDs []uuid.UUID
+	// Chars is the assembled block's length, header and joins included; MaxChars is
+	// the budget it is measured against.
+	Chars    int
+	MaxChars int
+	// MaxFacts is the count cap.
+	MaxFacts int
+	// Truncated reports that the prefix-stop fired: at least one Node the read
+	// returned did not fit.
+	Truncated bool
+}
+
+// RenderPreview is renderFacts with its budget arithmetic exposed (#535). The
+// voice loop keeps calling renderFacts; both share this one implementation, so the
+// preview cannot drift from what is actually injected.
+func RenderPreview(nodes []storage.KGNode) Preview {
+	p := Preview{MaxChars: MaxBlockChars, MaxFacts: MaxFacts}
 	// Every fact in the assembled block is preceded by a blockJoin (the first by the
 	// header's join, the rest by the inter-fact join), so the running total starts at
 	// the header length and each fact adds len(join)+len(fact).
 	total := len(factsHeader)
+	// stopped makes the cut a deterministic PREFIX-stop rather than a skip-scan:
+	// once one Node overruns a cap, every later Node is dropped too, so a huge Node
+	// cannot let a smaller one behind it sneak in past the budget. The loop keeps
+	// running only to RECORD what was dropped — which is the whole point of the
+	// preview, since that cut is otherwise a silent quality cliff.
+	stopped := false
 	for _, n := range nodes {
-		if len(out) >= MaxFacts {
-			break
+		if !stopped {
+			if len(p.Facts) >= MaxFacts {
+				stopped = true
+			} else {
+				fact := renderFact(n)
+				delta := len(blockJoin) + len(fact)
+				if total+delta > MaxBlockChars {
+					stopped = true
+				} else {
+					total += delta
+					p.Facts = append(p.Facts, fact)
+					p.IncludedIDs = append(p.IncludedIDs, n.ID)
+				}
+			}
 		}
-		fact := renderFact(n)
-		delta := len(blockJoin) + len(fact)
-		if total+delta > MaxBlockChars {
-			break
+		if stopped {
+			p.Truncated = true
+			p.DroppedIDs = append(p.DroppedIDs, n.ID)
 		}
-		total += delta
-		out = append(out, fact)
 	}
-	if len(out) == 0 {
+	if len(p.Facts) > 0 {
+		p.Chars = total
+	}
+	return p
+}
+
+// renderFacts projects the public Nodes (in storage order) into rendered fact
+// strings, applying the per-fact truncation and the MaxFacts / MaxBlockChars caps.
+// The block-budget accounting reserves the agent's header + joins so the FINAL
+// rendered block (header included) stays within MaxBlockChars.
+func renderFacts(nodes []storage.KGNode) []string {
+	if len(nodes) == 0 {
 		return nil
 	}
-	return out
+	return RenderPreview(nodes).Facts
 }
 
 // renderFact renders one Node as "### <Name> (<TypeLabel>)" followed by its

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -422,5 +423,106 @@ func TestFacts_NoAspectsRendersUnchanged(t *testing.T) {
 	facts := r.Facts(liveCtx(camp), testAgent.String())
 	if len(facts) != 1 || facts[0] != "### The Bell (Note)\nIt tolls at dusk." {
 		t.Errorf("fact = %q, want the pre-aspect rendering unchanged", facts)
+	}
+}
+
+// TestRenderPreview_MatchesInjectedFacts pins the load-bearing property of the
+// #535 lens: the preview is the SAME render the voice loop injects. If these two
+// could differ, the lens would confidently show a GM something their NPC never
+// receives — worse than showing nothing.
+func TestRenderPreview_MatchesInjectedFacts(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNPC, Name: "Bart", Body: "An innkeeper.",
+			Aspects: []storage.KGNodeAspect{{Key: "Role", Value: "Runs the Rusty Anchor"}}},
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeLocation, Name: "Saltmarsh", Body: "A damp town."},
+	}}
+	r := newRecaller(t, nodes, &fakeMetrics{})
+
+	injected := r.Facts(liveCtx(camp), testAgent.String())
+	preview := kgfacts.RenderPreview(nodes.nodes)
+	if len(preview.Facts) != len(injected) {
+		t.Fatalf("preview has %d facts, injected %d", len(preview.Facts), len(injected))
+	}
+	for i := range injected {
+		if preview.Facts[i] != injected[i] {
+			t.Errorf("fact[%d] preview %q != injected %q", i, preview.Facts[i], injected[i])
+		}
+	}
+	if len(preview.IncludedIDs) != len(nodes.nodes) || preview.Truncated {
+		t.Errorf("preview = %+v, want everything included and untruncated", preview)
+	}
+	if preview.MaxChars != kgfacts.MaxBlockChars || preview.MaxFacts != kgfacts.MaxFacts {
+		t.Errorf("preview budget = %d/%d, want the real caps", preview.MaxChars, preview.MaxFacts)
+	}
+	if preview.Chars <= 0 || preview.Chars > kgfacts.MaxBlockChars {
+		t.Errorf("preview.Chars = %d, want a real consumption inside the budget", preview.Chars)
+	}
+}
+
+// TestRenderPreview_ReportsPrefixStop pins the truncation reporting: the cut is a
+// PREFIX-stop, so once a Node overruns, every later Node is dropped too — a
+// smaller one behind it must never sneak in. The lens exists to make that cut
+// visible, so it must report exactly which Nodes lost.
+func TestRenderPreview_ReportsPrefixStop(t *testing.T) {
+	big := storage.KGNode{
+		ID: uuid.New(), Type: storage.KGNodeNote, Name: "Huge",
+		Body: strings.Repeat("x", kgfacts.MaxFactChars),
+	}
+	nodes := []storage.KGNode{}
+	for range 12 { // 12 × ~500 chars overruns the 4000-char block
+		n := big
+		n.ID = uuid.New()
+		nodes = append(nodes, n)
+	}
+	// A tiny Node placed AFTER the overrun; the prefix-stop must drop it too.
+	tiny := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNote, Name: "Tiny"}
+	nodes = append(nodes, tiny)
+
+	p := kgfacts.RenderPreview(nodes)
+	if !p.Truncated {
+		t.Fatal("preview did not report truncation on an over-budget node set")
+	}
+	if len(p.DroppedIDs) == 0 {
+		t.Fatal("truncated preview named no dropped nodes")
+	}
+	for _, id := range p.IncludedIDs {
+		if id == tiny.ID {
+			t.Error("a small node AFTER the prefix-stop was included — the cut must be a prefix, not a skip-scan")
+		}
+	}
+	if len(p.IncludedIDs)+len(p.DroppedIDs) != len(nodes) {
+		t.Errorf("preview accounted for %d+%d of %d nodes; every node must be in exactly one bucket",
+			len(p.IncludedIDs), len(p.DroppedIDs), len(nodes))
+	}
+	if p.Chars > kgfacts.MaxBlockChars {
+		t.Errorf("preview.Chars = %d, past the budget %d", p.Chars, kgfacts.MaxBlockChars)
+	}
+}
+
+// TestRenderPreview_MaxFactsCap pins the count cap's reporting half.
+func TestRenderPreview_MaxFactsCap(t *testing.T) {
+	var nodes []storage.KGNode
+	for i := range kgfacts.MaxFacts + 5 {
+		nodes = append(nodes, storage.KGNode{
+			ID: uuid.New(), Type: storage.KGNodeNote, Name: "N" + strconv.Itoa(i),
+		})
+	}
+	p := kgfacts.RenderPreview(nodes)
+	if len(p.Facts) != kgfacts.MaxFacts {
+		t.Errorf("got %d facts, want the cap %d", len(p.Facts), kgfacts.MaxFacts)
+	}
+	if !p.Truncated || len(p.DroppedIDs) != 5 {
+		t.Errorf("preview = truncated %v with %d dropped, want 5 dropped", p.Truncated, len(p.DroppedIDs))
+	}
+}
+
+// TestRenderPreview_Empty pins that an unlinked Agent's empty read is an empty
+// preview, not a truncated one — "nothing to say" and "too much to say" are
+// different problems and the lens must not confuse them.
+func TestRenderPreview_Empty(t *testing.T) {
+	p := kgfacts.RenderPreview(nil)
+	if len(p.Facts) != 0 || p.Truncated || p.Chars != 0 {
+		t.Errorf("empty preview = %+v, want zero facts, untruncated, zero chars", p)
 	}
 }

--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -46,6 +46,7 @@ type CampaignServer struct {
 	*kgNodes
 	*kgEdges
 	*kgGraph
+	*kgPreview
 	*knowledgeProposals
 	*toolGrants
 	*campaignAssist
@@ -75,6 +76,9 @@ type CampaignStores struct {
 	KGEdges kgEdgeStore
 	// KGGraph backs the whole-graph read the Graph view renders (#534).
 	KGGraph kgGraphStore
+	// KGPreview backs the agent-knowledge lens (#535) — the PROMPT-FACING read, so
+	// the preview shows what the turn shows.
+	KGPreview kgPreviewStore
 	// Proposals backs the Knowledge Proposal review queue + similarity hint
 	// (#300, ADR-0052).
 	Proposals knowledgeProposalStore
@@ -101,6 +105,7 @@ func NewCampaignServer(s *storage.Store) *CampaignServer {
 		KGNodes:    s,
 		KGEdges:    s,
 		KGGraph:    s,
+		KGPreview:  kgPreviewStoreOf(s),
 		Proposals:  s,
 		Grants:     s,
 		Assist:     s,
@@ -122,6 +127,7 @@ func NewCampaignServerWith(stores CampaignStores) *CampaignServer {
 		kgNodes:            &kgNodes{store: stores.KGNodes, active: active},
 		kgEdges:            &kgEdges{store: stores.KGEdges, active: active},
 		kgGraph:            &kgGraph{store: stores.KGGraph, active: active},
+		kgPreview:          &kgPreview{store: stores.KGPreview, active: active},
 		knowledgeProposals: &knowledgeProposals{store: stores.Proposals, active: active},
 		toolGrants:         &toolGrants{store: stores.Grants, active: active, tools: tool.BuiltinRegistry(tool.Deps{})},
 		campaignAssist:     &campaignAssist{store: stores.Assist, active: active},

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -948,3 +948,52 @@ func (f *fakeKGGraphStore) ListEdges(_ context.Context, campaignID uuid.UUID) ([
 	f.edgeCampaign = campaignID
 	return f.edges, f.edgeErr
 }
+
+// fakeKGPreviewStore fakes the agent-knowledge lens slice (#535): agents backs the
+// campaign-scoping check, linked backs the "has a wiki entry" state, and facts is
+// the prompt-facing neighbourhood returned verbatim so the handler's use of the
+// real renderer is asserted. factCalls proves the facts read does NOT fire for an
+// unlinked or foreign Agent.
+type fakeKGPreviewStore struct {
+	*fakeActive
+
+	agents    map[uuid.UUID]storage.Agent
+	linked    map[uuid.UUID]storage.KGNode
+	facts     map[uuid.UUID][]storage.KGNode
+	factCalls int
+	factsErr  error
+	linkedErr error
+}
+
+func newFakeKGPreviewStore() *fakeKGPreviewStore {
+	return &fakeKGPreviewStore{
+		fakeActive: newFakeActive(),
+		agents:     map[uuid.UUID]storage.Agent{},
+		linked:     map[uuid.UUID]storage.KGNode{},
+		facts:      map[uuid.UUID][]storage.KGNode{},
+	}
+}
+
+func (f *fakeKGPreviewStore) GetAgent(_ context.Context, id uuid.UUID) (storage.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return storage.Agent{}, storage.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeKGPreviewStore) AgentLinkedNode(_ context.Context, agentID uuid.UUID) (storage.KGNode, bool, error) {
+	if f.linkedErr != nil {
+		return storage.KGNode{}, false, f.linkedErr
+	}
+	n, ok := f.linked[agentID]
+	return n, ok, nil
+}
+
+func (f *fakeKGPreviewStore) AgentNodeFacts(_ context.Context, agentID uuid.UUID) ([]storage.KGNode, error) {
+	f.factCalls++
+	if f.factsErr != nil {
+		return nil, f.factsErr
+	}
+	return f.facts[agentID], nil
+}

--- a/internal/rpc/kg_preview.go
+++ b/internal/rpc/kg_preview.go
@@ -93,9 +93,10 @@ func (s *kgPreview) GetAgentFactPreview(
 	}
 
 	out := &managementv1.GetAgentFactPreviewResponse{
-		MaxChars: kgfacts.MaxBlockChars,
-		MaxFacts: kgfacts.MaxFacts,
-		Linked:   linked,
+		MaxChars:      kgfacts.MaxBlockChars,
+		MaxFacts:      kgfacts.MaxFacts,
+		MaxNeighbours: storage.MaxAgentFactNodes,
+		Linked:        linked,
 	}
 	if !linked {
 		// An explicit "not linked" state, not an empty graph. The GM's fix is to link
@@ -109,6 +110,13 @@ func (s *kgPreview) GetAgentFactPreview(
 		slog.Default().Error("GetAgentFactPreview: agent node facts failed", "agent_id", agentID, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
+
+	// The SQL read has its OWN row cap, applied before the renderer ever sees a
+	// Node. A hub NPC past it would otherwise show its extra neighbours as merely
+	// "not adjacent" — the GM would go looking for a missing Edge that is not
+	// missing. Reported separately from the renderer's truncation because the two
+	// have different fixes.
+	out.NeighbourhoodClipped = len(nodes) >= storage.MaxAgentFactNodes
 
 	p := kgfacts.RenderPreview(nodes)
 	out.Facts = p.Facts

--- a/internal/rpc/kg_preview.go
+++ b/internal/rpc/kg_preview.go
@@ -1,0 +1,151 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// kgPreview is the agent-knowledge lens (#535): a read-only view of exactly what
+// a Character NPC's Hot Context facts block will contain, and what the caps cut.
+//
+// Today the only way to know why an NPC didn't mention something is to reason
+// about AgentNodeFacts and renderFacts from memory. This makes an invisible
+// system visible — including the deterministic prefix-stop, which silently drops
+// the remainder of the facts block once MaxBlockChars is crossed.
+type kgPreview struct {
+	store  kgPreviewStore
+	active *activeCampaignSource
+}
+
+// kgPreviewStore is the narrow read surface the lens needs. It is the PROMPT-FACING
+// seam deliberately — the same [storage.PromptKGView] the voice loop holds — so
+// the preview reads what the turn reads, gm_private filtering included. A GM-facing
+// read here would show facts the NPC never receives, which is worse than showing
+// nothing.
+//
+// AgentLinkedNode distinguishes "no linked entry" from "linked but nothing to
+// say": AgentNodeFacts is keyed by Agent, so an unlinked one legitimately returns
+// an empty set and there is no campaign-wide fallback.
+type kgPreviewStore interface {
+	AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error)
+	AgentLinkedNode(ctx context.Context, agentID uuid.UUID) (storage.KGNode, bool, error)
+	GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error)
+}
+
+// GetAgentFactPreview renders the Agent's facts block through the SAME path the
+// voice loop uses (#535): [storage.PromptKGView.AgentNodeFacts] plus
+// [kgfacts.RenderPreview]. Reimplementing the budget arithmetic client-side would
+// let the preview drift from what is actually injected, which is the one failure
+// this feature cannot afford.
+//
+// The Agent is verified to belong to the active Campaign before anything is read,
+// so a crafted agent_id cannot preview another Campaign's world (#342).
+//
+// An unparsable id is CodeInvalidArgument; an Agent outside the active Campaign is
+// CodeNotFound; a storage failure is CodeInternal.
+func (s *kgPreview) GetAgentFactPreview(
+	ctx context.Context,
+	req *connect.Request[managementv1.GetAgentFactPreviewRequest],
+) (*connect.Response[managementv1.GetAgentFactPreviewResponse], error) {
+	agentID, err := uuid.Parse(req.Msg.GetAgentId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid agent id"))
+	}
+
+	c, err := s.active.resolve(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("GetAgentFactPreview: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Campaign scoping FIRST: AgentNodeFacts is keyed by Agent ALONE, so without this
+	// check an id from another Campaign would happily render that Campaign's world
+	// into this operator's screen (#342).
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+		}
+		slog.Default().Error("GetAgentFactPreview: get agent failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if agent.CampaignID != c.ID {
+		// Indistinguishable from "no such agent" on purpose: another Campaign's roster
+		// is not something this session may probe for.
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("agent not found"))
+	}
+
+	linkedNode, linked, err := s.store.AgentLinkedNode(ctx, agentID)
+	if err != nil {
+		slog.Default().Error("GetAgentFactPreview: linked node lookup failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	out := &managementv1.GetAgentFactPreviewResponse{
+		MaxChars: kgfacts.MaxBlockChars,
+		MaxFacts: kgfacts.MaxFacts,
+		Linked:   linked,
+	}
+	if !linked {
+		// An explicit "not linked" state, not an empty graph. The GM's fix is to link
+		// an entry, and saying so beats an empty panel they have to interpret.
+		return connect.NewResponse(out), nil
+	}
+	out.LinkedNodeId = linkedNode.ID.String()
+
+	nodes, err := s.store.AgentNodeFacts(ctx, agentID)
+	if err != nil {
+		slog.Default().Error("GetAgentFactPreview: agent node facts failed", "agent_id", agentID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	p := kgfacts.RenderPreview(nodes)
+	out.Facts = p.Facts
+	out.Chars = int32(p.Chars) //nolint:gosec // bounded by kgfacts.MaxBlockChars
+	out.Truncated = p.Truncated
+	for _, id := range p.IncludedIDs {
+		out.IncludedNodeIds = append(out.IncludedNodeIds, id.String())
+	}
+	for _, id := range p.DroppedIDs {
+		out.DroppedNodeIds = append(out.DroppedNodeIds, id.String())
+	}
+	return connect.NewResponse(out), nil
+}
+
+// kgPreviewSource composes the ONE prompt-facing KG read with the two plain Agent
+// reads the lens needs for scoping and the linked-entry state. The facts read is
+// taken from [storage.PromptKGView] rather than *Store on purpose: the lens must
+// show what the TURN shows, gm_private filtering included, and a GM-facing read
+// here would confidently display facts the NPC never receives.
+type kgPreviewSource struct {
+	prompt storage.PromptKGView
+	store  *storage.Store
+}
+
+func (v kgPreviewSource) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]storage.KGNode, error) {
+	return v.prompt.AgentNodeFacts(ctx, agentID)
+}
+
+func (v kgPreviewSource) AgentLinkedNode(ctx context.Context, agentID uuid.UUID) (storage.KGNode, bool, error) {
+	return v.store.AgentLinkedNode(ctx, agentID)
+}
+
+func (v kgPreviewSource) GetAgent(ctx context.Context, id uuid.UUID) (storage.Agent, error) {
+	return v.store.GetAgent(ctx, id)
+}
+
+// kgPreviewStoreOf builds the lens's read source over a concrete Store.
+func kgPreviewStoreOf(s *storage.Store) kgPreviewStore {
+	return kgPreviewSource{prompt: s.PromptKG(), store: s}
+}

--- a/internal/rpc/kg_preview_test.go
+++ b/internal/rpc/kg_preview_test.go
@@ -1,0 +1,194 @@
+package rpc_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/kgfacts"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func kgPreviewClient(t *testing.T, store *fakeKGPreviewStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, KGPreview: store})
+}
+
+// TestGetAgentFactPreview_RendersWhatTheTurnInjects pins the lens's whole reason
+// to exist (#535): the preview must be the SAME render the voice loop injects,
+// with the real budget accounting. A preview that merely resembles the prompt
+// would confidently show a GM facts their NPC never receives.
+func TestGetAgentFactPreview_RendersWhatTheTurnInjects(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New(), Name: "Saltmarsh"}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID, Name: "Bart"}
+
+	own := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart", Body: "An innkeeper."}
+	neighbour := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeLocation, Name: "Saltmarsh", Body: "A damp town."}
+	store.linked[agentID] = own
+	store.facts[agentID] = []storage.KGNode{own, neighbour}
+
+	resp, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+		connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("GetAgentFactPreview: %v", err)
+	}
+	msg := resp.Msg
+
+	if !msg.GetLinked() || msg.GetLinkedNodeId() != own.ID.String() {
+		t.Errorf("linked = %v / %q, want the Agent's own node", msg.GetLinked(), msg.GetLinkedNodeId())
+	}
+	want := kgfacts.RenderPreview([]storage.KGNode{own, neighbour})
+	if len(msg.GetFacts()) != len(want.Facts) {
+		t.Fatalf("got %d facts, want %d", len(msg.GetFacts()), len(want.Facts))
+	}
+	for i, f := range msg.GetFacts() {
+		if f != want.Facts[i] {
+			t.Errorf("fact[%d] = %q, want the renderer's %q", i, f, want.Facts[i])
+		}
+	}
+	if !strings.Contains(msg.GetFacts()[0], "An innkeeper.") {
+		t.Errorf("fact[0] lost its body: %q", msg.GetFacts()[0])
+	}
+	if len(msg.GetIncludedNodeIds()) != 2 || msg.GetIncludedNodeIds()[0] != own.ID.String() {
+		t.Errorf("included = %v, want both nodes in injection order", msg.GetIncludedNodeIds())
+	}
+	if msg.GetTruncated() || len(msg.GetDroppedNodeIds()) != 0 {
+		t.Errorf("a two-node neighbourhood reported truncation: %+v", msg)
+	}
+	if msg.GetMaxChars() != kgfacts.MaxBlockChars || msg.GetMaxFacts() != kgfacts.MaxFacts {
+		t.Errorf("budget = %d/%d, want the real caps", msg.GetMaxChars(), msg.GetMaxFacts())
+	}
+	if msg.GetChars() <= 0 || msg.GetChars() > msg.GetMaxChars() {
+		t.Errorf("chars = %d, want a real consumption inside the budget", msg.GetChars())
+	}
+}
+
+// TestGetAgentFactPreview_ReportsTruncation pins the visible half of the
+// deterministic prefix-stop — the silent quality cliff this lens exists to expose.
+func TestGetAgentFactPreview_ReportsTruncation(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID}
+	own := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Bart"}
+	store.linked[agentID] = own
+
+	nodes := []storage.KGNode{own}
+	for range 12 {
+		nodes = append(nodes, storage.KGNode{
+			ID: uuid.New(), Type: storage.KGNodeNote, Name: "Wall",
+			Body: strings.Repeat("x", kgfacts.MaxFactChars),
+		})
+	}
+	store.facts[agentID] = nodes
+
+	resp, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+		connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("GetAgentFactPreview: %v", err)
+	}
+	if !resp.Msg.GetTruncated() {
+		t.Fatal("an over-budget neighbourhood did not report truncation")
+	}
+	if len(resp.Msg.GetDroppedNodeIds()) == 0 {
+		t.Error("truncated preview named no dropped nodes; the GM cannot see what was cut")
+	}
+	if got := len(resp.Msg.GetIncludedNodeIds()) + len(resp.Msg.GetDroppedNodeIds()); got != len(nodes) {
+		t.Errorf("accounted for %d of %d nodes; each must be in exactly one bucket", got, len(nodes))
+	}
+}
+
+// TestGetAgentFactPreview_UnlinkedAgent pins the explicit empty state. An unlinked
+// Character NPC legitimately gets nothing (AgentNodeFacts is keyed by Agent, with
+// no campaign-wide fallback), and saying so beats an empty panel the GM has to
+// interpret.
+func TestGetAgentFactPreview_UnlinkedAgent(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID}
+
+	resp, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+		connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("GetAgentFactPreview: %v", err)
+	}
+	if resp.Msg.GetLinked() {
+		t.Error("an unlinked agent reported linked")
+	}
+	if len(resp.Msg.GetFacts()) != 0 || resp.Msg.GetTruncated() {
+		t.Errorf("unlinked preview = %+v, want an empty, untruncated state", resp.Msg)
+	}
+	if store.factCalls != 0 {
+		t.Error("the facts read fired for an unlinked agent; there is nothing to read")
+	}
+}
+
+// TestGetAgentFactPreview_Scoping pins that a crafted agent_id cannot preview
+// another Campaign's world (#342), and that the refusal is indistinguishable from
+// "no such agent" — another Campaign's roster is not something to probe for.
+func TestGetAgentFactPreview_Scoping(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	foreign := uuid.New()
+	store.agents[foreign] = storage.Agent{ID: foreign, CampaignID: uuid.New(), Name: "Elsewhere"}
+
+	_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+		connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: foreign.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound for another campaign's agent", got)
+	}
+	if store.factCalls != 0 {
+		t.Error("the facts read fired for a foreign agent before scoping refused it")
+	}
+}
+
+func TestGetAgentFactPreview_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: "nope"}))
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", got)
+		}
+	})
+
+	t.Run("unknown agent is NotFound", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: uuid.New().String()}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("facts read failure is Internal", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		agentID := uuid.New()
+		store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID}
+		store.linked[agentID] = storage.KGNode{ID: uuid.New()}
+		store.factsErr = errAny
+		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+		if got := connect.CodeOf(err); got != connect.CodeInternal {
+			t.Errorf("code = %v, want Internal", got)
+		}
+	})
+}

--- a/internal/rpc/kg_preview_test.go
+++ b/internal/rpc/kg_preview_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,6 +70,46 @@ func TestGetAgentFactPreview_RendersWhatTheTurnInjects(t *testing.T) {
 	}
 	if msg.GetChars() <= 0 || msg.GetChars() > msg.GetMaxChars() {
 		t.Errorf("chars = %d, want a real consumption inside the budget", msg.GetChars())
+	}
+	if msg.GetNeighbourhoodClipped() {
+		t.Error("a two-node neighbourhood reported the read cap clipped it")
+	}
+	if msg.GetMaxNeighbours() != storage.MaxAgentFactNodes {
+		t.Errorf("max_neighbours = %d, want the real read cap %d",
+			msg.GetMaxNeighbours(), storage.MaxAgentFactNodes)
+	}
+}
+
+// TestGetAgentFactPreview_ReportsReadCap pins the OTHER cap. The SQL read stops at
+// its own row limit before the renderer sees anything, so a hub NPC past it would
+// show its extra neighbours as merely "not adjacent" — and the GM would go hunting
+// for an Edge that is not missing. It is reported separately from renderer
+// truncation because the two have different fixes.
+func TestGetAgentFactPreview_ReportsReadCap(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGPreviewStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID}
+	own := storage.KGNode{ID: uuid.New(), Type: storage.KGNodeNPC, Name: "Hub"}
+	store.linked[agentID] = own
+
+	// Exactly the cap's worth of rows — what the read returns when it clipped.
+	nodes := make([]storage.KGNode, 0, storage.MaxAgentFactNodes)
+	for i := range storage.MaxAgentFactNodes {
+		nodes = append(nodes, storage.KGNode{
+			ID: uuid.New(), Type: storage.KGNodeNote, Name: "N" + strconv.Itoa(i),
+		})
+	}
+	store.facts[agentID] = nodes
+
+	resp, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+		connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+	if err != nil {
+		t.Fatalf("GetAgentFactPreview: %v", err)
+	}
+	if !resp.Msg.GetNeighbourhoodClipped() {
+		t.Error("a neighbourhood at the read cap did not report being clipped")
 	}
 }
 
@@ -175,6 +216,29 @@ func TestGetAgentFactPreview_ErrorMapping(t *testing.T) {
 			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: uuid.New().String()}))
 		if got := connect.CodeOf(err); got != connect.CodeNotFound {
 			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("no active campaign is NotFound", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campErr = storage.ErrNotFound
+		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: uuid.New().String()}))
+		if got := connect.CodeOf(err); got != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", got)
+		}
+	})
+
+	t.Run("linked-node read failure is Internal", func(t *testing.T) {
+		store := newFakeKGPreviewStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		agentID := uuid.New()
+		store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: store.campaign.ID}
+		store.linkedErr = errAny
+		_, err := kgPreviewClient(t, store).GetAgentFactPreview(context.Background(),
+			connect.NewRequest(&managementv1.GetAgentFactPreviewRequest{AgentId: agentID.String()}))
+		if got := connect.CodeOf(err); got != connect.CodeInternal {
+			t.Errorf("code = %v, want Internal", got)
 		}
 	})
 

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -224,6 +224,13 @@ func (s *Store) ListNodes(ctx context.Context, campaignID uuid.UUID) ([]KGNode, 
 	return out, nil
 }
 
+// MaxAgentFactNodes is [kgFactsCap], exported so the GM-facing preview (#535) can
+// tell the GM that the SQL read itself clipped their NPC's neighbourhood. Without
+// it, a hub NPC with more than this many neighbours would show the extras as
+// "not adjacent" — indistinguishable from a missing Edge, and unfixable because
+// the GM would be looking for the wrong problem.
+const MaxAgentFactNodes = kgFactsCap
+
 // kgFactsCap bounds the prompt-injection read so a large wiki can never blow the
 // Hot Context budget at the SQL layer (#126 AC4); the kgfacts renderer applies
 // the finer per-block/per-fact caps on top.

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -548,6 +548,13 @@ message GetAgentFactPreviewResponse {
   bool linked = 8;
   // linked_node_id is the Agent's own Node when linked, empty otherwise.
   string linked_node_id = 9;
+  // neighbourhood_clipped reports that the SQL read hit its own row cap BEFORE
+  // the renderer's caps — the Agent has more neighbours than the prompt read will
+  // ever look at. Distinct from `truncated`: that is the renderer's budget, this
+  // is the read's, and they need different fixes.
+  bool neighbourhood_clipped = 10;
+  // max_neighbours is that row cap, so the readout can name it.
+  int32 max_neighbours = 11;
 }
 
 // NodeAspect is one ordered (key, value) fact on a Node, carrying its OWN

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -134,6 +134,12 @@ service CampaignService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // GetAgentFactPreview returns exactly what a Character NPC's Hot Context
+  // facts block will contain, with the real budget accounting (#535). Read-only.
+  rpc GetAgentFactPreview(GetAgentFactPreviewRequest) returns (GetAgentFactPreviewResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
   // SearchNodes returns the active campaign's Knowledge Graph Nodes whose name or
   // body match the query, ranked by relevance (tsvector fts, ADR-0008 v1.0). It
   // backs the Campaign screen's live wiki search; gm_private Nodes ARE included
@@ -505,6 +511,43 @@ message GetKnowledgeGraphResponse {
   repeated GraphNode nodes = 1;
   // edges is every Edge in the campaign.
   repeated GraphEdge edges = 2;
+}
+
+// GetAgentFactPreviewRequest names the Agent to preview.
+message GetAgentFactPreviewRequest {
+  // agent_id is the Character NPC whose Hot Context facts block to render.
+  string agent_id = 1;
+}
+
+// GetAgentFactPreviewResponse is what the NPC's facts block will actually
+// contain (#535), rendered by the SAME code the voice loop injects — so the
+// preview cannot drift from reality.
+message GetAgentFactPreviewResponse {
+  // facts are the rendered fact strings, in injection order. Empty when the
+  // Agent has no linked entry, or its neighbourhood is empty.
+  repeated string facts = 1;
+  // included_node_ids are the Nodes that made it in, in the same order — what
+  // the graph lens dims to.
+  repeated string included_node_ids = 2;
+  // dropped_node_ids are Nodes the read returned that the caps excluded. This is
+  // the visible half of the deterministic prefix-stop, which is otherwise a
+  // silent quality cliff.
+  repeated string dropped_node_ids = 3;
+  // chars is the assembled block length (header and joins included);
+  // max_chars is the budget it is measured against.
+  int32 chars = 4;
+  int32 max_chars = 5;
+  // max_facts is the count cap.
+  int32 max_facts = 6;
+  // truncated reports that the prefix-stop fired.
+  bool truncated = 7;
+  // linked reports whether the Agent has a linked wiki entry at all. false means
+  // an explicit "not linked" state, NOT an empty world: AgentNodeFacts is keyed
+  // by Agent, so an unlinked one legitimately gets nothing and there is no
+  // campaign-wide fallback.
+  bool linked = 8;
+  // linked_node_id is the Agent's own Node when linked, empty otherwise.
+  string linked_node_id = 9;
 }
 
 // NodeAspect is one ordered (key, value) fact on a Node, carrying its OWN

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1146,18 +1146,57 @@
   opacity: 0.15;
 }
 
-.gx-kg-graph__node[data-lens="ghost"] circle,
-.gx-kg-graph__node[data-lens="dropped"] circle {
+/* Withheld: hollow, slashed through. The fix is a gm_private flag. */
+.gx-kg-graph__node[data-lens="ghost"] circle {
   fill: transparent;
   stroke-dasharray: 2 3;
 }
 
-.gx-kg-graph__node[data-lens="ghost"] .gx-kg-graph__label,
-.gx-kg-graph__node[data-lens="dropped"] .gx-kg-graph__label {
+.gx-kg-graph__slash {
+  stroke: var(--text-muted, #8b93a7);
+  stroke-width: 1.5;
+}
+
+/* Over budget: solid but ringed, and never slashed. The fix is shorter entries or
+   fewer relations — a different problem, so a different shape. */
+.gx-kg-graph__overflow {
+  fill: none;
+  stroke: var(--accent, #ffcf5a);
+  stroke-width: 1;
+  stroke-dasharray: 1 3;
+}
+
+.gx-kg-graph__node[data-lens="ghost"] .gx-kg-graph__label {
   text-decoration: line-through;
   fill: var(--text-muted, #8b93a7);
 }
 
+.gx-kg-graph__node[data-lens="dropped"] .gx-kg-graph__label {
+  fill: var(--accent, #ffcf5a);
+}
+
 .gx-kg-graph__node[data-lens="lit"] circle {
   stroke-width: 2;
+}
+
+/* The actual facts block. Collapsed by default — the summary line answers the
+   common question, this answers "but what does it literally say". */
+.gx-kg-lens__facts summary {
+  cursor: pointer;
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
+.gx-kg-lens__block {
+  margin: var(--spacing-xs) 0 0;
+  padding: var(--spacing-sm);
+  max-height: 16rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+  background: var(--surface-sunken, #12151c);
+  border: 1px solid var(--border, #2a2f3a);
+  border-radius: var(--radius-sm, 4px);
 }

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1111,3 +1111,53 @@
   margin: 0;
   color: var(--text-strong);
 }
+
+/* ── Agent-knowledge lens (#535) ─────────────────────────────────────────── */
+
+.gx-kg-lens {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-lens__budget {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gx-kg-lens__meter {
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+  color: var(--text-muted);
+}
+
+.gx-kg-lens__truncated,
+.gx-kg-lens__empty {
+  font-size: var(--body-sm);
+  color: var(--accent, #ffcf5a);
+  margin: 0;
+}
+
+/* Lens states. Everything outside the injected subgraph recedes; the two kinds of
+   exclusion stay visually distinct, because "hidden from this NPC" and "did not
+   fit in the budget" call for different fixes. */
+.gx-kg-graph__node[data-lens="dim"] {
+  opacity: 0.15;
+}
+
+.gx-kg-graph__node[data-lens="ghost"] circle,
+.gx-kg-graph__node[data-lens="dropped"] circle {
+  fill: transparent;
+  stroke-dasharray: 2 3;
+}
+
+.gx-kg-graph__node[data-lens="ghost"] .gx-kg-graph__label,
+.gx-kg-graph__node[data-lens="dropped"] .gx-kg-graph__label {
+  text-decoration: line-through;
+  fill: var(--text-muted, #8b93a7);
+}
+
+.gx-kg-graph__node[data-lens="lit"] circle {
+  stroke-width: 2;
+}

--- a/web/src/screens/campaign/graph/AgentLens.test.tsx
+++ b/web/src/screens/campaign/graph/AgentLens.test.tsx
@@ -70,6 +70,8 @@ function renderWithLens(
     truncated: boolean;
     linked: boolean;
     linkedNodeId: string;
+    neighbourhoodClipped: boolean;
+    maxNeighbours: number;
   }> = {},
 ) {
   const { nodes, edges } = fixture();
@@ -93,6 +95,8 @@ function renderWithLens(
           truncated: false,
           linked: true,
           linkedNodeId: "bart",
+          neighbourhoodClipped: false,
+          maxNeighbours: 50,
           ...preview,
         }),
       createEdge: () => create(CreateEdgeResponseSchema, { edge: create(EdgeSchema, {}) }),
@@ -168,6 +172,53 @@ describe("agent-knowledge lens", () => {
 
     expect(await screen.findByText(/Truncated — 1 entry did not fit/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Saltmarsh.*over budget/)).toHaveAttribute("data-lens", "dropped");
+  });
+
+  // The summary line answers "is it too much?"; this answers "but what does it
+  // literally say" — the question the GM actually has when an NPC says the wrong
+  // thing.
+  it("shows the rendered block verbatim", async () => {
+    renderWithLens();
+    await pickBart();
+
+    fireEvent.click(await screen.findByText("What Bart will be told"));
+    const block = await screen.findByText(/### Bart \(NPC\)/);
+    expect(block.textContent).toContain("An innkeeper.");
+    expect(block.textContent).toContain("### Saltmarsh (Location)");
+  });
+
+  // The two exclusions need different FIXES — flip a gm_private flag vs shorten
+  // entries — so they must be distinguishable to a sighted GM, not only in an
+  // aria-label.
+  it("draws withheld and over-budget neighbours differently", async () => {
+    renderWithLens({
+      includedNodeIds: ["bart"],
+      droppedNodeIds: ["town"],
+      truncated: true,
+      facts: ["### Bart (NPC)\nAn innkeeper."],
+    });
+    await pickBart();
+
+    const ghost = await screen.findByLabelText(/The bribe .*hidden from Bart/);
+    const dropped = screen.getByLabelText(/Saltmarsh.*over budget/);
+    expect(ghost.querySelector(".gx-kg-graph__slash")).toBeTruthy();
+    expect(ghost.querySelector(".gx-kg-graph__overflow")).toBeFalsy();
+    expect(dropped.querySelector(".gx-kg-graph__overflow")).toBeTruthy();
+    expect(dropped.querySelector(".gx-kg-graph__slash")).toBeFalsy();
+    // And each carries a tooltip naming its own fix.
+    expect(ghost.querySelector("title")?.textContent).toMatch(/GM private/);
+    expect(dropped.querySelector("title")?.textContent).toMatch(/facts block is full/);
+  });
+
+  // The SQL read has its own row cap, applied before the renderer. Past it, a hub
+  // NPC's extra neighbours would look merely "not adjacent" and the GM would go
+  // hunting for an Edge that is not missing.
+  it("reports when the read cap clipped the neighbourhood", async () => {
+    renderWithLens({ neighbourhoodClipped: true, maxNeighbours: 50 });
+    await pickBart();
+    expect(
+      await screen.findByText(/more relations than the prompt read looks at/),
+    ).toBeInTheDocument();
   });
 
   it("says an unlinked NPC has no entry, rather than showing an empty graph", async () => {

--- a/web/src/screens/campaign/graph/AgentLens.test.tsx
+++ b/web/src/screens/campaign/graph/AgentLens.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  AgentSchema,
+  CampaignService,
+  CreateEdgeResponseSchema,
+  EdgeSchema,
+  EdgeType,
+  GetAgentFactPreviewResponseSchema,
+  GetCampaignRosterResponseSchema,
+  GraphEdgeSchema,
+  GraphNodeSchema,
+  NodeType,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { KnowledgeGraph } from "./KnowledgeGraph";
+
+// Bart is linked to "bart"; his neighbourhood is the town (public, injected) and
+// the bribe note (gm_private — adjacent but withheld). The guild is two hops away
+// and never enters his context at all.
+const BART = "agent-bart";
+
+function fixture() {
+  const nodes = [
+    create(GraphNodeSchema, { id: "bart", nodeType: NodeType.NPC, name: "Bart", agentId: BART }),
+    create(GraphNodeSchema, { id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+    create(GraphNodeSchema, {
+      id: "secret",
+      nodeType: NodeType.NOTE,
+      name: "The bribe",
+      gmPrivate: true,
+    }),
+    create(GraphNodeSchema, { id: "guild", nodeType: NodeType.FACTION, name: "Smugglers" }),
+  ];
+  const edges = [
+    create(GraphEdgeSchema, {
+      id: "e1",
+      fromNodeId: "bart",
+      toNodeId: "town",
+      edgeType: EdgeType.RESIDES_IN,
+    }),
+    create(GraphEdgeSchema, {
+      id: "e2",
+      fromNodeId: "bart",
+      toNodeId: "secret",
+      edgeType: EdgeType.KNOWS,
+    }),
+    create(GraphEdgeSchema, {
+      id: "e3",
+      fromNodeId: "town",
+      toNodeId: "guild",
+      edgeType: EdgeType.MEMBER_OF,
+    }),
+  ];
+  return { nodes, edges };
+}
+
+function renderWithLens(
+  preview: Partial<{
+    facts: string[];
+    includedNodeIds: string[];
+    droppedNodeIds: string[];
+    chars: number;
+    maxChars: number;
+    maxFacts: number;
+    truncated: boolean;
+    linked: boolean;
+    linkedNodeId: string;
+  }> = {},
+) {
+  const { nodes, edges } = fixture();
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      getCampaignRoster: () =>
+        create(GetCampaignRosterResponseSchema, {
+          roster: [
+            create(AgentSchema, { id: "agent-butler", name: "Glyphoxa", role: "butler" }),
+            create(AgentSchema, { id: BART, name: "Bart", role: "character" }),
+          ],
+        }),
+      getAgentFactPreview: () =>
+        create(GetAgentFactPreviewResponseSchema, {
+          facts: ["### Bart (NPC)\nAn innkeeper.", "### Saltmarsh (Location)\nA damp town."],
+          includedNodeIds: ["bart", "town"],
+          droppedNodeIds: [],
+          chars: 1840,
+          maxChars: 4000,
+          maxFacts: 20,
+          truncated: false,
+          linked: true,
+          linkedNodeId: "bart",
+          ...preview,
+        }),
+      createEdge: () => create(CreateEdgeResponseSchema, { edge: create(EdgeSchema, {}) }),
+    });
+  });
+  render(
+    <Providers transport={transport} queryClient={makeQueryClient()}>
+      <KnowledgeGraph
+        nodes={nodes}
+        edges={edges}
+        selectedID={null}
+        onSelectNode={() => {}}
+        onGraphChanged={() => {}}
+      />
+    </Providers>,
+  );
+}
+
+const pickBart = async () => {
+  const select = await screen.findByLabelText("Show what an NPC knows");
+  fireEvent.click(select);
+  fireEvent.click(await screen.findByRole("option", { name: "Bart" }));
+};
+
+describe("agent-knowledge lens", () => {
+  it("only offers Character NPCs — the Butler has no linked entry by design", async () => {
+    renderWithLens();
+    fireEvent.click(await screen.findByLabelText("Show what an NPC knows"));
+    expect(await screen.findByRole("option", { name: "Bart" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Glyphoxa" })).not.toBeInTheDocument();
+  });
+
+  it("dims the graph to exactly the injected subgraph", async () => {
+    renderWithLens();
+    await pickBart();
+
+    // Wait for the preview to land — the labels exist before the lens applies.
+    await screen.findByText(/chars ·/);
+
+    // Injected: lit. Two hops away: dimmed out of the way.
+    expect(screen.getByLabelText(/^Bart \(NPC\)/)).toHaveAttribute("data-lens", "lit");
+    expect(screen.getByLabelText(/^Saltmarsh/)).toHaveAttribute("data-lens", "lit");
+    expect(screen.getByLabelText(/^Smugglers/)).toHaveAttribute("data-lens", "dim");
+  });
+
+  // The ghosts come from diffing the client's graph payload against the preview —
+  // the prompt seam returns public Nodes only, by design, and widening it to
+  // report what it hides would defeat the point of having a seam.
+  it("marks a gm_private neighbour as withheld from this NPC", async () => {
+    renderWithLens();
+    await pickBart();
+
+    const ghost = await screen.findByLabelText(/The bribe .*hidden from Bart/);
+    expect(ghost).toHaveAttribute("data-lens", "ghost");
+  });
+
+  it("reports the real budget consumption", async () => {
+    renderWithLens();
+    await pickBart();
+    expect(await screen.findByText(/1,840 \/ 4,000 chars · 2 \/ 20 facts/)).toBeInTheDocument();
+  });
+
+  // The prefix-stop is a silent quality cliff; the whole point of the lens is to
+  // make the cut visible and actionable.
+  it("names the entries the caps dropped", async () => {
+    renderWithLens({
+      includedNodeIds: ["bart"],
+      droppedNodeIds: ["town"],
+      truncated: true,
+      facts: ["### Bart (NPC)\nAn innkeeper."],
+    });
+    await pickBart();
+
+    expect(await screen.findByText(/Truncated — 1 entry did not fit/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Saltmarsh.*over budget/)).toHaveAttribute("data-lens", "dropped");
+  });
+
+  it("says an unlinked NPC has no entry, rather than showing an empty graph", async () => {
+    renderWithLens({ linked: false, linkedNodeId: "", facts: [], includedNodeIds: [] });
+    await pickBart();
+
+    expect(await screen.findByText(/is not linked to a wiki entry/)).toBeInTheDocument();
+    // The graph is NOT dimmed to nothing — that would read as "the world is empty".
+    expect(screen.getByLabelText(/^Smugglers/)).not.toHaveAttribute("data-lens");
+  });
+
+  it("keeps withheld neighbours visible even in table view", async () => {
+    renderWithLens();
+    await pickBart();
+    fireEvent.click(screen.getByRole("button", { name: "Table view" }));
+    // Table view hides gm_private entries; the lens exists to show what an NPC is
+    // DENIED, so it must win while it is on.
+    expect(await screen.findByLabelText(/The bribe .*hidden from Bart/)).toBeInTheDocument();
+  });
+});

--- a/web/src/screens/campaign/graph/AgentLens.tsx
+++ b/web/src/screens/campaign/graph/AgentLens.tsx
@@ -43,6 +43,9 @@ export type LensState = {
   factCount: number;
   maxFacts: number;
   truncated: boolean;
+  /** The SQL read's own row cap clipped the neighbourhood before the renderer saw it. */
+  clipped: boolean;
+  maxNeighbours: number;
   /** false ⇒ the NPC has no linked wiki entry at all. */
   linked: boolean;
 };
@@ -99,6 +102,8 @@ export function useAgentLens(agentID: string, nodes: GraphNode[], edges: GraphEd
       factCount: preview.facts.length,
       maxFacts: preview.maxFacts,
       truncated: preview.truncated,
+      clipped: preview.neighbourhoodClipped,
+      maxNeighbours: preview.maxNeighbours,
       linked: preview.linked,
     };
   }, [agentID, preview, nodes, edges, agentName]);
@@ -168,10 +173,26 @@ export function AgentLensBar({
               every prompt. Shorten entries, or narrow this NPC's relations.
             </span>
           )}
+          {state.clipped && (
+            <span className="gx-kg-lens__truncated">
+              This entry has more relations than the prompt read looks at (
+              {state.maxNeighbours}). The rest never reach {agentName} at all — prune its
+              relations rather than its text.
+            </span>
+          )}
           {state.factCount === 0 && (
             <span className="gx-kg-lens__truncated">
               Nothing to say — this entry has no content and no public neighbours.
             </span>
+          )}
+
+          {/* The actual block. Everything above is a summary OF this; without it the
+              GM still cannot read what their NPC will be told. */}
+          {state.facts.length > 0 && (
+            <details className="gx-kg-lens__facts">
+              <summary>What {agentName} will be told</summary>
+              <pre className="gx-kg-lens__block">{state.facts.join("\n\n")}</pre>
+            </details>
           )}
         </div>
       )}

--- a/web/src/screens/campaign/graph/AgentLens.tsx
+++ b/web/src/screens/campaign/graph/AgentLens.tsx
@@ -1,0 +1,184 @@
+import { useMemo } from "react";
+import { useQuery } from "@connectrpc/connect-query";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/management_pb";
+import { Select } from "@/components/ui/Select";
+import { egoNetwork } from "./layout";
+
+// The agent-knowledge lens (#535): pick a Character NPC and the graph dims to
+// exactly the subgraph kgfacts would inject for it, with a live budget readout.
+//
+// Today the only way to know why an NPC didn't mention something is to reason
+// about AgentNodeFacts and renderFacts from memory. This makes the whole
+// prompt-facing read visible — including the deterministic prefix-stop, which
+// silently drops the remainder of the facts block once MaxBlockChars is crossed,
+// turning a silent quality cliff into something the GM can see and fix.
+
+/** What the lens tells the graph to draw differently. */
+export type Lens = {
+  agentName: string;
+  /** Nodes whose facts really will be injected. */
+  includedIDs: ReadonlySet<string>;
+  /**
+   * Nodes the caps cut. Drawn as included-but-struck, because "this is adjacent
+   * and did not fit" is a different problem from "this is not adjacent".
+   */
+  droppedIDs: ReadonlySet<string>;
+  /**
+   * gm_private neighbours: adjacent, and deliberately withheld. Sourced
+   * CLIENT-SIDE by diffing the graph payload against the preview — the prompt seam
+   * returns public Nodes only, by design, and widening it to report what it hides
+   * would defeat the point of having a seam.
+   */
+  ghostIDs: ReadonlySet<string>;
+};
+
+export type LensState = {
+  lens: Lens | null;
+  /** Rendered facts, byte-identical to what the turn injects. */
+  facts: string[];
+  chars: number;
+  maxChars: number;
+  factCount: number;
+  maxFacts: number;
+  truncated: boolean;
+  /** false ⇒ the NPC has no linked wiki entry at all. */
+  linked: boolean;
+};
+
+/**
+ * useAgentLens resolves the lens for one Agent: the roster option list, the
+ * preview read, and the derived node sets.
+ *
+ * It is a hook rather than a component-with-callback so the graph receives the
+ * lens as a VALUE during the same render as the selection. Pushing it up from a
+ * child's render would be a side effect during render; pushing it from an effect
+ * would draw the graph one frame behind the GM's choice.
+ */
+export function useAgentLens(agentID: string, nodes: GraphNode[], edges: GraphEdge[]) {
+  const rosterQuery = useQuery(CampaignService.method.getCampaignRoster, {});
+  // Only Character NPCs: the Butler is Address-Only and has no linked Node by
+  // design (ADR-0009), so there is nothing to lens.
+  const cast = useMemo(
+    () => (rosterQuery.data?.roster ?? []).filter((a) => a.role === "character"),
+    [rosterQuery.data],
+  );
+
+  const previewQuery = useQuery(
+    CampaignService.method.getAgentFactPreview,
+    { agentId: agentID },
+    { enabled: agentID !== "" },
+  );
+
+  const agentName = cast.find((a) => a.id === agentID)?.name ?? "";
+  const preview = previewQuery.data;
+
+  const state = useMemo<LensState | null>(() => {
+    if (agentID === "" || !preview) return null;
+    const included = new Set(preview.includedNodeIds);
+    const dropped = new Set(preview.droppedNodeIds);
+
+    // The ghosts: the Agent's own Node's single-hop neighbourhood — the SAME walk
+    // AgentNodeFacts performs — minus everything the preview returned. What is left
+    // is adjacent and withheld, i.e. gm_private.
+    const ghosts = new Set<string>();
+    if (preview.linked && preview.linkedNodeId !== "") {
+      const byID = new Map(nodes.map((n) => [n.id, n]));
+      for (const id of egoNetwork(preview.linkedNodeId, edges, 1)) {
+        if (included.has(id) || dropped.has(id)) continue;
+        if (byID.get(id)?.gmPrivate) ghosts.add(id);
+      }
+    }
+
+    return {
+      lens: { agentName, includedIDs: included, droppedIDs: dropped, ghostIDs: ghosts },
+      facts: preview.facts,
+      chars: preview.chars,
+      maxChars: preview.maxChars,
+      factCount: preview.facts.length,
+      maxFacts: preview.maxFacts,
+      truncated: preview.truncated,
+      linked: preview.linked,
+    };
+  }, [agentID, preview, nodes, edges, agentName]);
+
+  const options = useMemo(
+    () => [
+      { value: LENS_NONE, label: "— No lens —" },
+      ...cast.map((a) => ({ value: a.id, label: a.name })),
+    ],
+    [cast],
+  );
+
+  return {
+    state,
+    options,
+    agentName,
+    pending: agentID !== "" && previewQuery.isPending,
+    error: previewQuery.isError ? previewQuery.error.message : null,
+  };
+}
+
+/** AgentLensBar is the lens's selector and budget readout. Presentational only. */
+export function AgentLensBar({
+  agentID,
+  onAgentChange,
+  lens,
+}: {
+  agentID: string;
+  onAgentChange: (id: string) => void;
+  lens: ReturnType<typeof useAgentLens>;
+}) {
+  const { state, options, agentName, pending, error } = lens;
+  return (
+    <div className="gx-kg-lens">
+      <Select
+        label="Show what an NPC knows"
+        options={options}
+        value={agentID === "" ? LENS_NONE : agentID}
+        onValueChange={(v) => onAgentChange(v === LENS_NONE ? "" : v)}
+      />
+
+      {pending && <span className="gx-field__hint">Reading {agentName}'s neighbourhood…</span>}
+
+      {error && (
+        <span className="gx-editor__status gx-editor__status--error" role="alert">
+          Couldn't read what {agentName} knows: {error}
+        </span>
+      )}
+
+      {state && !state.linked && (
+        <p className="gx-kg-lens__empty" role="status">
+          <strong>{agentName}</strong> is not linked to a wiki entry, so nothing is injected into
+          its prompts. Link an NPC entry to it and its neighbourhood becomes its world knowledge.
+        </p>
+      )}
+
+      {state?.linked && (
+        <div className="gx-kg-lens__budget" role="status">
+          <span className="gx-kg-lens__meter">
+            ≈{state.chars.toLocaleString()} / {state.maxChars.toLocaleString()} chars ·{" "}
+            {state.factCount} / {state.maxFacts} facts
+          </span>
+          {state.truncated && (
+            <span className="gx-kg-lens__truncated">
+              Truncated — {state.lens?.droppedIDs.size} entr
+              {state.lens?.droppedIDs.size === 1 ? "y" : "ies"} did not fit and are dropped from
+              every prompt. Shorten entries, or narrow this NPC's relations.
+            </span>
+          )}
+          {state.factCount === 0 && (
+            <span className="gx-kg-lens__truncated">
+              Nothing to say — this entry has no content and no public neighbours.
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// LENS_NONE is the Radix Select sentinel for "no lens" — Radix forbids an empty
+// item value, so the clear option carries this and maps back to "".
+const LENS_NONE = "__none__";

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -6,6 +6,7 @@ import type { GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/managemen
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
 import { EDGE_TYPES, TYPE_META, TYPE_ORDER, alphaBg, metaOf } from "../knowledgeVocab";
+import { AgentLensBar, useAgentLens } from "./AgentLens";
 import { LAYOUT, egoNetwork, filterGraph, layout } from "./layout";
 
 // The Graph view (#534, ADR-0008 amendment "no graph viz" reversal). Edges were
@@ -69,6 +70,11 @@ export function KnowledgeGraph({
   const [dragFrom, setDragFrom] = useState<string | null>(null);
   const [pendingLink, setPendingLink] = useState<{ from: string; to: string } | null>(null);
   const [linkError, setLinkError] = useState<string | null>(null);
+  // The agent-knowledge lens (#535): which NPC's injected subgraph to highlight.
+  const [lensAgentID, setLensAgentID] = useState("");
+
+  const lens = useAgentLens(lensAgentID, nodes, edges);
+  const active = lens.state?.linked ? lens.state.lens : null;
 
   const createEdge = useMutation(CampaignService.method.createEdge, {
     onSuccess: () => {
@@ -88,8 +94,17 @@ export function KnowledgeGraph({
   );
 
   const filtered = useMemo(
-    () => filterGraph(nodes, edges, { types, relations, hidePrivate, focus }),
-    [nodes, edges, types, relations, hidePrivate, focus],
+    () =>
+      filterGraph(nodes, edges, {
+        types,
+        relations,
+        // A lens exists to show what an NPC is DENIED, so table view (which removes
+        // gm_private entries outright) would erase exactly the ghosts it is meant to
+        // surface. The lens wins while it is on.
+        hidePrivate: hidePrivate && !active,
+        focus,
+      }),
+    [nodes, edges, types, relations, hidePrivate, focus, active],
   );
 
   // Layout is a pure function of the filtered payload, so this memo is the whole
@@ -124,6 +139,8 @@ export function KnowledgeGraph({
 
   return (
     <div className="gx-kg-graph">
+      <AgentLensBar agentID={lensAgentID} onAgentChange={setLensAgentID} lens={lens} />
+
       <div className="gx-kg-graph__filters">
         <div className="gx-kg-graph__chips" role="group" aria-label="Filter by type">
           {TYPE_ORDER.map((t) => {
@@ -269,6 +286,13 @@ export function KnowledgeGraph({
           <g className="gx-kg-graph__nodes">
             {laid.nodes.map((p) => {
               const meta = metaOf(p.node.nodeType);
+              // Lens states, in the order they matter: a withheld gm_private
+              // neighbour is a GHOST (adjacent, deliberately hidden), a capped-out
+              // one is DROPPED (adjacent, did not fit — a different problem), the
+              // injected ones are lit, and everything else is dimmed out of the way.
+              const ghosted = active?.ghostIDs.has(p.node.id) ?? false;
+              const dropped = active?.droppedIDs.has(p.node.id) ?? false;
+              const lit = active ? active.includedIDs.has(p.node.id) : true;
               // Past the budget only the nodes the GM is actively looking at keep
               // their name — including the focus root, which is the one node they
               // definitely care about in a focused view.
@@ -284,9 +308,15 @@ export function KnowledgeGraph({
                   data-node-id={p.node.id}
                   data-private={p.node.gmPrivate || undefined}
                   data-selected={selectedID === p.node.id || undefined}
+                  data-lens={active ? (ghosted ? "ghost" : dropped ? "dropped" : lit ? "lit" : "dim") : undefined}
                   role="button"
                   tabIndex={0}
-                  aria-label={`${p.node.name} (${meta.label})${p.node.gmPrivate ? ", GM private" : ""}`}
+                  aria-label={
+                    `${p.node.name} (${meta.label})` +
+                    (p.node.gmPrivate ? ", GM private" : "") +
+                    (ghosted ? `, hidden from ${active?.agentName}` : "") +
+                    (dropped ? `, dropped from ${active?.agentName}'s prompt — over budget` : "")
+                  }
                   transform={`translate(${p.x} ${p.y})`}
                   onMouseDown={() => setDragFrom(p.node.id)}
                   onMouseEnter={() => setHoverID(p.node.id)}
@@ -320,7 +350,7 @@ export function KnowledgeGraph({
                     // absent from the world their NPCs see.
                     strokeDasharray={p.node.gmPrivate ? "3 2" : undefined}
                   />
-                  {labelled && (
+                  {(labelled || ghosted || dropped) && (
                     <text className="gx-kg-graph__label" x={LAYOUT.nodeRadius + 4} y={4}>
                       {p.node.name}
                     </text>

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -75,6 +75,10 @@ export function KnowledgeGraph({
 
   const lens = useAgentLens(lensAgentID, nodes, edges);
   const active = lens.state?.linked ? lens.state.lens : null;
+  // filterGraph only needs to know WHETHER a lens is on. Depending on the lens
+  // OBJECT would re-run the filter — and therefore the 300-tick layout — on every
+  // preview refetch, for an output that did not change.
+  const lensOn = active !== null;
 
   const createEdge = useMutation(CampaignService.method.createEdge, {
     onSuccess: () => {
@@ -101,10 +105,10 @@ export function KnowledgeGraph({
         // A lens exists to show what an NPC is DENIED, so table view (which removes
         // gm_private entries outright) would erase exactly the ghosts it is meant to
         // surface. The lens wins while it is on.
-        hidePrivate: hidePrivate && !active,
+        hidePrivate: hidePrivate && !lensOn,
         focus,
       }),
-    [nodes, edges, types, relations, hidePrivate, focus, active],
+    [nodes, edges, types, relations, hidePrivate, focus, lensOn],
   );
 
   // Layout is a pure function of the filtered payload, so this memo is the whole
@@ -342,6 +346,16 @@ export function KnowledgeGraph({
                     if (ev.key === "f") setFocusID(p.node.id);
                   }}
                 >
+                  {/* A tooltip, because the lens states were otherwise legible only
+                      to a screen reader — a sighted GM saw two struck nodes and could
+                      not tell which fix each one needed. */}
+                  {(ghosted || dropped) && (
+                    <title>
+                      {ghosted
+                        ? `Hidden from ${active?.agentName} — this entry is GM private`
+                        : `Dropped from ${active?.agentName}'s prompt — the facts block is full`}
+                    </title>
+                  )}
                   <circle
                     r={LAYOUT.nodeRadius}
                     fill={alphaBg(meta.color)}
@@ -350,6 +364,19 @@ export function KnowledgeGraph({
                     // absent from the world their NPCs see.
                     strokeDasharray={p.node.gmPrivate ? "3 2" : undefined}
                   />
+                  {/* A withheld neighbour gets a slash through the glyph; an
+                      over-budget one gets a ring. Two exclusions, two fixes, two
+                      shapes — the aria-label alone was not a visual distinction. */}
+                  {ghosted && (
+                    <line
+                      className="gx-kg-graph__slash"
+                      x1={-LAYOUT.nodeRadius - 3}
+                      y1={LAYOUT.nodeRadius + 3}
+                      x2={LAYOUT.nodeRadius + 3}
+                      y2={-LAYOUT.nodeRadius - 3}
+                    />
+                  )}
+                  {dropped && <circle className="gx-kg-graph__overflow" r={LAYOUT.nodeRadius + 4} />}
                   {(labelled || ghosted || dropped) && (
                     <text className="gx-kg-graph__label" x={LAYOUT.nodeRadius + 4} y={4}>
                       {p.node.name}


### PR DESCRIPTION
Epic #533 · slice A2 · design note §2/A2 · **Closes #535**

Reopened: GitHub auto-closed #550 when its base branch was deleted on the #549 merge. Same branch, now based on `main`.

## What

Pick a Character NPC; the graph dims to exactly the subgraph `kgfacts` would inject for it, with a live readout: `≈1,840 / 4,000 chars · 12 / 20 facts`.

Today the only way to know why an NPC didn't mention something is to reason about `AgentNodeFacts` and `renderFacts` from memory.

## The one thing this feature cannot get wrong

A preview that merely *resembles* the prompt would confidently show a GM facts their NPC never receives — worse than showing nothing. So `GetAgentFactPreview` reads the prompt-facing seam (`PromptKGView.AgentNodeFacts`, `gm_private` filtering included) and renders through `kgfacts.RenderPreview` — which is `renderFacts` with its budget arithmetic exposed, not a second implementation. `renderFacts` now calls it too, so the two cannot drift.

## Three ways an entry fails to reach an NPC — drawn differently, because the fixes differ

| State | Drawn | The fix |
|---|---|---|
| Injected | lit | — |
| **Withheld** (`gm_private` neighbour) | hollow, **slashed**, struck label | flip the private flag |
| **Over budget** (renderer's prefix-stop) | **ringed**, never slashed | shorten entries |
| **Past the read cap** (`AgentNodeFacts` LIMIT 50) | reported in the readout | prune *relations*, not text |
| Not adjacent | dimmed | add an Edge |

Both exclusion glyphs carry a `<title>`, since "labelled hidden from Bart" was otherwise true only for a screen reader.

That fourth row matters: the SQL read stops at 50 rows *before* the renderer sees anything, so a hub NPC past it would show its extra neighbours as merely "not adjacent" — and the GM would go hunting for an Edge that is not missing.

## Ghosts stay client-side

`AgentNodeFacts` does not return `gm_private` neighbours — the seam filters them by design, and that filtering is what the `gm_private` seam test guards. So the ghosts are derived client-side: walk the ego network at depth 1 (the same walk `AgentNodeFacts` performs) over the graph payload the client already holds, subtract what the preview returned, and what remains is adjacent-and-withheld. Widening the prompt seam to report what it hides would defeat the point of having a seam.

Table view — which removes `gm_private` entries outright — is overridden while a lens is on, because showing what an NPC is *denied* is the feature.

## And the block itself

Collapsed under "What Bart will be told": the literal rendered text. The summary line answers *is it too much*; this answers *what does it actually say*, which is the question a GM has when an NPC says the wrong thing.

## Empty states and scoping

An unlinked Character NPC gets an explicit "not linked to a wiki entry" and the graph is left alone — `AgentNodeFacts` is keyed by Agent with no campaign-wide fallback, so dimming everything would misread as "the world is empty". The Agent is verified to belong to the active Campaign *before* any read, and the refusal is indistinguishable from "no such agent". Only Character NPCs are offered; the Butler is Address-Only with no linked Node by design (ADR-0009).

## Tests

- `kgfacts` — the preview is byte-identical to the injected facts; the prefix-stop stays a strict prefix (a small fact behind the cut does not sneak in); every node lands in exactly one bucket; empty ≠ truncated.
- `internal/rpc` — renders through the real renderer, reports truncation and the read cap, the unlinked state does not even fire the facts read, cross-campaign is NotFound before any read, plus every error branch.
- `web` — cast-only selector, the four lens states, the slash-vs-ring distinction with its tooltips, the budget readout, the verbatim block, the read-cap message, the unlinked state leaving the graph alone, and ghosts surviving table view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)