### PR TITLE
feat(kg): edge notes and disposition — "knows and despises" instead of bare "knows" (#546)

### DIFF
--- a/internal/kgfacts/kgfacts.go
+++ b/internal/kgfacts/kgfacts.go
@@ -333,6 +333,18 @@ func composeContent(n storage.KGNode) string {
 			b.WriteString(value)
 		}
 	}
+	// ONE clause for how this Agent feels about the Node, when the Edge says so
+	// (#546). Strictly one, because it spends the same MaxBlockChars budget world
+	// facts draw on — and renderFacts stops at the first fact that would overrun,
+	// so a verbose relationship would evict knowledge outright.
+	if rel := relationClause(n); rel != "" {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("- ")
+		b.WriteString(rel)
+	}
+
 	body := strings.TrimSpace(n.Body)
 	if body == "" {
 		return b.String()
@@ -341,6 +353,22 @@ func composeContent(n storage.KGNode) string {
 		return body
 	}
 	return b.String() + "\n\n" + body
+}
+
+// MaxRelationChars bounds the per-edge relation clause. One clause, and a short
+// one: it competes with the world facts in the same block.
+const MaxRelationChars = 120
+
+// relationClause renders the reading Agent's feeling about this Node as at most
+// one clause: the GM's note when they wrote one, else the generated disposition
+// sentence. Never both — two clauses per neighbour is a second budget nobody
+// agreed to.
+func relationClause(n storage.KGNode) string {
+	if note := strings.TrimSpace(n.RelationNote); note != "" {
+		return truncateRunes(note, MaxRelationChars)
+	}
+	e := storage.KGEdge{Disposition: n.RelationDisposition}
+	return truncateRunes(e.DispositionClause(strings.TrimSpace(n.Name)), MaxRelationChars)
 }
 
 // typeLabel maps a Node type onto its GM-facing label (#126 test contract) via

--- a/internal/kgfacts/kgfacts_test.go
+++ b/internal/kgfacts/kgfacts_test.go
@@ -551,3 +551,68 @@ func TestRenderPreview_ContentFacts(t *testing.T) {
 		t.Errorf("Facts = %d, want both rendered (the block is what it is)", len(both.Facts))
 	}
 }
+
+// TestFacts_RendersRelationClause pins #546's prompt half: a relation with
+// texture reaches the block as exactly ONE clause. "Knows and despises" is the
+// difference between a flat NPC and a live one.
+func TestFacts_RendersRelationClause(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{
+			ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNPC, Name: "Mira Vance",
+			RelationDisposition: -2,
+		},
+		{
+			ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNPC, Name: "Gundren",
+			RelationNote: "owes you money since the siege", RelationDisposition: 1,
+		},
+	}}
+	r := newRecaller(t, nodes, &fakeMetrics{})
+
+	facts := r.Facts(liveCtx(camp), testAgent.String())
+	if len(facts) != 2 {
+		t.Fatalf("got %d facts, want 2", len(facts))
+	}
+	if !strings.Contains(facts[0], "You despise Mira Vance.") {
+		t.Errorf("fact[0] = %q, want the generated disposition clause", facts[0])
+	}
+	// The GM's own note wins over the generated sentence — and only ONE of them
+	// appears, because two clauses per neighbour is a second budget nobody agreed
+	// to.
+	if !strings.Contains(facts[1], "owes you money since the siege") {
+		t.Errorf("fact[1] = %q, want the GM's note", facts[1])
+	}
+	if strings.Contains(facts[1], "You are fond of") {
+		t.Errorf("fact[1] = %q, want the note INSTEAD of the generated clause", facts[1])
+	}
+}
+
+// TestFacts_NeutralRelationSaysNothing pins the byte-identical guarantee: an Edge
+// with no note and a neutral disposition renders exactly as before #546.
+func TestFacts_NeutralRelationSaysNothing(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{
+		{ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNote, Name: "The Bell", Body: "It tolls at dusk."},
+	}}
+	r := newRecaller(t, nodes, &fakeMetrics{})
+	facts := r.Facts(liveCtx(camp), testAgent.String())
+	if len(facts) != 1 || facts[0] != "### The Bell (Note)\nIt tolls at dusk." {
+		t.Errorf("fact = %q, want the pre-#546 rendering unchanged", facts)
+	}
+}
+
+// TestFacts_RelationClauseIsBounded pins that a long note cannot become a second
+// prose block competing with the world facts.
+func TestFacts_RelationClauseIsBounded(t *testing.T) {
+	camp := uuid.New()
+	nodes := &fakeNodes{nodes: []storage.KGNode{{
+		ID: uuid.New(), CampaignID: camp, Type: storage.KGNodeNPC, Name: "Verbose",
+		RelationNote: strings.Repeat("é", 900),
+	}}}
+	r := newRecaller(t, nodes, &fakeMetrics{})
+	facts := r.Facts(liveCtx(camp), testAgent.String())
+	_, content, _ := strings.Cut(facts[0], "\n")
+	if got := len([]rune(content)); got > kgfacts.MaxRelationChars+4 {
+		t.Errorf("relation clause = %d runes, want at most %d", got, kgfacts.MaxRelationChars)
+	}
+}

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -636,6 +636,22 @@ func (f *fakeKGNodeStore) SearchNodes(_ context.Context, campaignID uuid.UUID, q
 	return f.searchResults, nil
 }
 
+// UpdateEdgeDetails records the relation texture write (#546) and echoes it back.
+func (f *fakeKGEdgeStore) UpdateEdgeDetails(_ context.Context, campaignID, id uuid.UUID, note string, disposition int) (storage.KGEdge, error) {
+	f.edgeDetailsCampaign = campaignID
+	if f.edgeDetailsErr != nil {
+		return storage.KGEdge{}, f.edgeDetailsErr
+	}
+	for i := range f.edges {
+		if f.edges[i].ID == id {
+			f.edges[i].Note = note
+			f.edges[i].Disposition = disposition
+			return f.edges[i], nil
+		}
+	}
+	return storage.KGEdge{}, storage.ErrNotFound
+}
+
 // setAgentCall records one SetNodeAgent invocation for assertions.
 type setAgentCall struct {
 	nodeID  uuid.UUID
@@ -660,6 +676,11 @@ type fakeKGEdgeStore struct {
 	nodeEdgesCampaign  uuid.UUID
 	deleteEdgeCampaign uuid.UUID
 	setAgentCampaign   uuid.UUID
+
+	// The relation-texture write (#546).
+	edges               []storage.KGEdge
+	edgeDetailsCampaign uuid.UUID
+	edgeDetailsErr      error
 
 	setAgentCalls []setAgentCall
 	setAgentNode  storage.KGNode

--- a/internal/rpc/kg_edge.go
+++ b/internal/rpc/kg_edge.go
@@ -3,8 +3,10 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -12,6 +14,7 @@ import (
 
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // kgEdges is the Knowledge Graph Edge feature module (#132, ADR-0008 v1.0 +
@@ -33,6 +36,52 @@ type kgEdgeStore interface {
 	NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (outgoing, incoming []storage.KGEdgeWithNodes, err error)
 	// SetNodeAgent links/unlinks an NPC Node's "voiced by" Agent.
 	SetNodeAgent(ctx context.Context, campaignID, nodeID uuid.UUID, agentID uuid.NullUUID) (storage.KGNode, error)
+	// UpdateEdgeDetails saves a relation's note and disposition (#546).
+	UpdateEdgeDetails(ctx context.Context, campaignID, id uuid.UUID, note string, disposition int) (storage.KGEdge, error)
+}
+
+// UpdateEdgeDetails saves a relation's note and disposition (#546). The relation
+// TYPE is deliberately absent: retyping an Edge is deleting one and creating
+// another, because the type carries the ADR-0008 validity rules.
+//
+// An unparsable id or an out-of-range disposition is CodeInvalidArgument; a
+// missing/cross-campaign id is CodeNotFound.
+func (s *kgEdges) UpdateEdgeDetails(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateEdgeDetailsRequest],
+) (*connect.Response[managementv1.UpdateEdgeDetailsResponse], error) {
+	m := req.Msg
+	id, err := uuid.Parse(m.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid relation id"))
+	}
+	note := strings.TrimSpace(m.GetNote())
+	if utf8.RuneCountInString(note) > kgvocab.MaxEdgeNoteRunes {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("note is too long (max %d characters)", kgvocab.MaxEdgeNoteRunes))
+	}
+
+	c, err := s.active.resolve(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error("UpdateEdgeDetails: get active campaign failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	updated, err := s.store.UpdateEdgeDetails(ctx, c.ID, id, note, int(m.GetDisposition()))
+	switch {
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("relation not found"))
+	case errors.Is(err, storage.ErrInvalidDisposition):
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("disposition must be between -2 and +2"))
+	case err != nil:
+		slog.Default().Error("UpdateEdgeDetails: store update failed", "edge_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.UpdateEdgeDetailsResponse{Edge: toProtoEdge(updated)}), nil
 }
 
 // CreateEdge adds a typed Edge between two same-campaign Nodes. An UNSPECIFIED
@@ -220,11 +269,13 @@ func toProtoEdges(edges []storage.KGEdgeWithNodes) []*managementv1.Edge {
 // follow-up ListNodeEdges refetch).
 func toProtoEdge(e storage.KGEdge) *managementv1.Edge {
 	return &managementv1.Edge{
-		Id:         e.ID.String(),
-		FromNodeId: e.FromNodeID.String(),
-		ToNodeId:   e.ToNodeID.String(),
-		EdgeType:   toProtoEdgeType(e.Type),
-		CreatedAt:  timestamppb.New(e.CreatedAt),
+		Id:          e.ID.String(),
+		FromNodeId:  e.FromNodeID.String(),
+		ToNodeId:    e.ToNodeID.String(),
+		EdgeType:    toProtoEdgeType(e.Type),
+		CreatedAt:   timestamppb.New(e.CreatedAt),
+		Note:        e.Note,
+		Disposition: int32(e.Disposition), //nolint:gosec // CHECK-constrained to -2..+2
 	}
 }
 

--- a/internal/rpc/kg_edge_test.go
+++ b/internal/rpc/kg_edge_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -11,6 +12,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // edgeClient stands up the CampaignService client with the KG-Edge slice and
@@ -503,4 +505,86 @@ func TestCreateEdgeHonorsLiveSession(t *testing.T) {
 		t.Errorf("edge created in campaign %s, want the LIVE session campaign %s (not durable %s / newer %s)",
 			got, live.ID, durable.ID, newer.ID)
 	}
+}
+
+// TestUpdateEdgeDetails pins #546's editor path: a relation carries texture, the
+// write is campaign-scoped, and an out-of-range feeling is refused with a
+// sentence rather than a constraint violation.
+func TestUpdateEdgeDetails(t *testing.T) {
+	t.Parallel()
+	store := newFakeKGEdgeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	edgeID := uuid.New()
+	store.edges = []storage.KGEdge{{ID: edgeID, CampaignID: store.campaign.ID, Type: storage.KGEdgeKnows}}
+	client := edgeClient(t, store)
+
+	resp, err := client.UpdateEdgeDetails(context.Background(),
+		connect.NewRequest(&managementv1.UpdateEdgeDetailsRequest{
+			Id: edgeID.String(), Note: "  owes money since the siege  ", Disposition: -2,
+		}))
+	if err != nil {
+		t.Fatalf("UpdateEdgeDetails: %v", err)
+	}
+	got := resp.Msg.GetEdge()
+	if got.GetNote() != "owes money since the siege" {
+		t.Errorf("note = %q, want it trimmed and saved", got.GetNote())
+	}
+	if got.GetDisposition() != -2 {
+		t.Errorf("disposition = %d, want -2", got.GetDisposition())
+	}
+	if store.edgeDetailsCampaign != store.campaign.ID {
+		t.Errorf("write scoped to %s, want the active campaign", store.edgeDetailsCampaign)
+	}
+}
+
+func TestUpdateEdgeDetails_Validation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad uuid is InvalidArgument", func(t *testing.T) {
+		store := newFakeKGEdgeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := edgeClient(t, store).UpdateEdgeDetails(context.Background(),
+			connect.NewRequest(&managementv1.UpdateEdgeDetailsRequest{Id: "nope"}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("an overlong note is refused before the write", func(t *testing.T) {
+		store := newFakeKGEdgeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := edgeClient(t, store).UpdateEdgeDetails(context.Background(),
+			connect.NewRequest(&managementv1.UpdateEdgeDetailsRequest{
+				Id: uuid.New().String(), Note: strings.Repeat("x", kgvocab.MaxEdgeNoteRunes+1),
+			}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+		if store.edgeDetailsCampaign != uuid.Nil {
+			t.Error("the store was written despite an invalid note")
+		}
+	})
+
+	t.Run("an out-of-range disposition is refused", func(t *testing.T) {
+		store := newFakeKGEdgeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.edgeDetailsErr = storage.ErrInvalidDisposition
+		_, err := edgeClient(t, store).UpdateEdgeDetails(context.Background(),
+			connect.NewRequest(&managementv1.UpdateEdgeDetailsRequest{
+				Id: uuid.New().String(), Disposition: 9,
+			}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("a missing relation is NotFound", func(t *testing.T) {
+		store := newFakeKGEdgeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := edgeClient(t, store).UpdateEdgeDetails(context.Background(),
+			connect.NewRequest(&managementv1.UpdateEdgeDetailsRequest{Id: uuid.New().String()}))
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("code = %v, want NotFound", connect.CodeOf(err))
+		}
+	})
 }

--- a/internal/rpc/kg_graph.go
+++ b/internal/rpc/kg_graph.go
@@ -90,10 +90,12 @@ func (s *kgGraph) GetKnowledgeGraph(
 	}
 	for _, e := range edges {
 		out.Edges = append(out.Edges, &managementv1.GraphEdge{
-			Id:         e.ID.String(),
-			FromNodeId: e.FromNodeID.String(),
-			ToNodeId:   e.ToNodeID.String(),
-			EdgeType:   toProtoEdgeType(e.Type),
+			Id:          e.ID.String(),
+			FromNodeId:  e.FromNodeID.String(),
+			ToNodeId:    e.ToNodeID.String(),
+			EdgeType:    toProtoEdgeType(e.Type),
+			Disposition: int32(e.Disposition), //nolint:gosec // CHECK-constrained to -2..+2
+			Note:        e.Note,
 		})
 	}
 	return connect.NewResponse(out), nil

--- a/internal/rpc/knowledge_proposal.go
+++ b/internal/rpc/knowledge_proposal.go
@@ -291,11 +291,19 @@ func toProtoKnowledgeProposal(p storage.KnowledgeProposal) *managementv1.Knowled
 			AspectKey: w.AspectKey,
 		}}
 	case kgvocab.KindEdge:
+		// note and disposition MUST travel. applyProposedEdge writes them on
+		// approval, and the note reaches an NPC's system prompt through the relation
+		// clause — so a card that renders only "subject —knows→ target" asks the GM
+		// to approve 280 runes of model-authored text they were never shown. That is
+		// approval of content the GM never saw, which is the one thing ADR-0052's
+		// queue exists to prevent.
 		out.Write = &managementv1.KnowledgeProposal_Edge{Edge: &managementv1.ProposedEdge{
-			NodeId:   w.NodeID,
-			Subject:  w.Subject,
-			Relation: toProtoEdgeType(storage.KGEdgeType(w.Relation)),
-			Target:   w.Target,
+			NodeId:      w.NodeID,
+			Subject:     w.Subject,
+			Relation:    toProtoEdgeType(storage.KGEdgeType(w.Relation)),
+			Target:      w.Target,
+			Note:        w.Note,
+			Disposition: int32(w.Disposition),
 		}}
 	case kgvocab.KindNode:
 		out.Write = &managementv1.KnowledgeProposal_Node{Node: &managementv1.ProposedNode{

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -161,17 +162,24 @@ func scanKGEdge(row pgx.Row) (KGEdge, error) {
 	return e, err
 }
 
-// MaxEdgeNoteRunes bounds an Edge note. It is texture on a relation, not prose —
-// and one clause of it may reach a prompt.
-const MaxEdgeNoteRunes = 280
-
 // ErrInvalidDisposition is returned when a disposition falls outside -2..+2.
 var ErrInvalidDisposition = errors.New("storage: disposition must be between -2 and +2")
+
+// ErrNoteTooLong is returned when an Edge note exceeds kgvocab.MaxEdgeNoteRunes.
+var ErrNoteTooLong = errors.New("storage: edge note is too long")
 
 // UpdateEdgeDetails saves an Edge's note and disposition, scoped to its Campaign
 // (#342, #546). The relation TYPE is not touched: retyping an edge is deleting one
 // and creating another, since the type carries validity rules.
 func (s *Store) UpdateEdgeDetails(ctx context.Context, campaignID, id uuid.UUID, note string, disposition int) (KGEdge, error) {
+	// The note bound lives in kgvocab and is enforced HERE as well as at the RPC
+	// boundary. There were two copies of the constant, one of which nothing read —
+	// a storage layer naming a bound it never applied, while the Tool write path
+	// and the RPC path each checked their own. One definition, applied where the
+	// write actually happens.
+	if utf8.RuneCountInString(note) > kgvocab.MaxEdgeNoteRunes {
+		return KGEdge{}, fmt.Errorf("storage: update edge details %s: %w", id, ErrNoteTooLong)
+	}
 	if disposition < -2 || disposition > 2 {
 		return KGEdge{}, ErrInvalidDisposition
 	}
@@ -364,8 +372,14 @@ func (s *Store) NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (ou
 
 	// Edges are same-campaign by construction (CreateEdge enforces it), so filtering
 	// the anchor by campaign above is sufficient; the WHERE below stays direction-only.
+	// note and disposition are part of the row the relations editor loads and saves
+	// back. Omitting them here does not merely hide the texture: the editor
+	// initialises its fields FROM this read, so the next save writes the empty
+	// string over whatever the GM had written. A read that forgets a column is a
+	// write path that erases it.
 	rows, err := s.db.Query(ctx,
-		`SELECT e.id, e.campaign_id, e.from_node_id, e.to_node_id, e.edge_type, e.created_at,
+		`SELECT e.id, e.campaign_id, e.from_node_id, e.to_node_id, e.edge_type,
+		        e.note, e.disposition, e.created_at,
 		        fn.name, fn.node_type, tn.name, tn.node_type
 		   FROM kg_edge e
 		   JOIN kg_node fn ON fn.id = e.from_node_id
@@ -380,7 +394,8 @@ func (s *Store) NodeEdges(ctx context.Context, campaignID, nodeID uuid.UUID) (ou
 	for rows.Next() {
 		var e KGEdgeWithNodes
 		if err := rows.Scan(
-			&e.ID, &e.CampaignID, &e.FromNodeID, &e.ToNodeID, &e.Type, &e.CreatedAt,
+			&e.ID, &e.CampaignID, &e.FromNodeID, &e.ToNodeID, &e.Type,
+			&e.Note, &e.Disposition, &e.CreatedAt,
 			&e.FromName, &e.FromType, &e.ToName, &e.ToType,
 		); err != nil {
 			return nil, nil, fmt.Errorf("storage: node edges %s: scan: %w", nodeID, err)

--- a/internal/storage/kg_edge.go
+++ b/internal/storage/kg_edge.go
@@ -54,7 +54,40 @@ type KGEdge struct {
 	FromNodeID uuid.UUID
 	ToNodeID   uuid.UUID
 	Type       KGEdgeType
-	CreatedAt  time.Time
+	// Note is the relation's texture — "owes money to", "since the siege" (#546).
+	// A bare `knows` carries nothing; this is what makes it a relationship.
+	Note string
+	// Disposition is how the SUBJECT feels about the object, -2..+2 (hostile,
+	// cold, neutral, warm, devoted). Edges are strictly directional with no
+	// auto-inverse (ADR-0008 amendment), which is exactly what makes asymmetric
+	// feelings expressible: a secretly hostile ally is one edge with a negative
+	// disposition and no matching return edge.
+	Disposition int
+	CreatedAt   time.Time
+}
+
+// DispositionClause renders an Edge's feeling as ONE short clause for the fact
+// block, or "" when there is nothing to say (#546).
+//
+// Strictly one clause, because it spends the shared MaxBlockChars budget that
+// world facts also draw on — and renderFacts stops at the first fact that would
+// overrun, so a verbose relationship would evict knowledge outright.
+func (e KGEdge) DispositionClause(targetName string) string {
+	if targetName == "" {
+		return ""
+	}
+	switch {
+	case e.Disposition <= -2:
+		return "You despise " + targetName + "."
+	case e.Disposition == -1:
+		return "You are wary of " + targetName + "."
+	case e.Disposition == 1:
+		return "You are fond of " + targetName + "."
+	case e.Disposition >= 2:
+		return "You are devoted to " + targetName + "."
+	default:
+		return ""
+	}
 }
 
 // KGEdgeWithNodes is an Edge joined to its two endpoints' display fields, so the
@@ -119,12 +152,41 @@ type NewKGEdge struct {
 }
 
 const kgEdgeColumns = `
-	id, campaign_id, from_node_id, to_node_id, edge_type, created_at`
+	id, campaign_id, from_node_id, to_node_id, edge_type, note, disposition, created_at`
 
 func scanKGEdge(row pgx.Row) (KGEdge, error) {
 	var e KGEdge
-	err := row.Scan(&e.ID, &e.CampaignID, &e.FromNodeID, &e.ToNodeID, &e.Type, &e.CreatedAt)
+	err := row.Scan(&e.ID, &e.CampaignID, &e.FromNodeID, &e.ToNodeID, &e.Type,
+		&e.Note, &e.Disposition, &e.CreatedAt)
 	return e, err
+}
+
+// MaxEdgeNoteRunes bounds an Edge note. It is texture on a relation, not prose —
+// and one clause of it may reach a prompt.
+const MaxEdgeNoteRunes = 280
+
+// ErrInvalidDisposition is returned when a disposition falls outside -2..+2.
+var ErrInvalidDisposition = errors.New("storage: disposition must be between -2 and +2")
+
+// UpdateEdgeDetails saves an Edge's note and disposition, scoped to its Campaign
+// (#342, #546). The relation TYPE is not touched: retyping an edge is deleting one
+// and creating another, since the type carries validity rules.
+func (s *Store) UpdateEdgeDetails(ctx context.Context, campaignID, id uuid.UUID, note string, disposition int) (KGEdge, error) {
+	if disposition < -2 || disposition > 2 {
+		return KGEdge{}, ErrInvalidDisposition
+	}
+	row := s.db.QueryRow(ctx,
+		`UPDATE kg_edge SET note = $3, disposition = $4
+		  WHERE id = $1 AND campaign_id = $2
+		 RETURNING `+kgEdgeColumns, id, campaignID, note, disposition)
+	e, err := scanKGEdge(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return KGEdge{}, ErrNotFound
+	}
+	if err != nil {
+		return KGEdge{}, fmt.Errorf("storage: update kg edge details %s: %w", id, err)
+	}
+	return e, nil
 }
 
 // pgErrCode extracts a Postgres SQLSTATE from an error chain, if any.

--- a/internal/storage/kg_edge_test.go
+++ b/internal/storage/kg_edge_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/kgvocab"
 )
 
 // mkNode is a tiny helper: create a Node of a type in a campaign, failing the test
@@ -485,5 +486,70 @@ func TestSetNodeAgentIsCampaignScoped(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("npc node vanished")
+	}
+}
+
+// TestNodeEdgesCarriesNoteAndDisposition: the relations editor loads its fields
+// FROM this read and saves them back, so a column missing here is not a display
+// gap — it is a write path that erases the GM's note.
+//
+// The failure it pins: save "owes money since the siege" → the editor refetches →
+// the note comes back empty → the GM opens the row again, changes the
+// disposition, saves → the empty string overwrites the note that was there.
+func TestNodeEdgesCarriesNoteAndDisposition(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	bart := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	mira := mkNode(t, st, campaignID, storage.KGNodeNPC, "Mira")
+	edge, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignID, FromNodeID: bart.ID, ToNodeID: mira.ID, Type: storage.KGEdgeKnows,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, edge.ID, "owes money since the siege", -2); err != nil {
+		t.Fatalf("UpdateEdgeDetails: %v", err)
+	}
+
+	outgoing, _, err := st.NodeEdges(ctx, campaignID, bart.ID)
+	if err != nil {
+		t.Fatalf("NodeEdges: %v", err)
+	}
+	if len(outgoing) != 1 {
+		t.Fatalf("want one outgoing edge, got %d", len(outgoing))
+	}
+	if outgoing[0].Note != "owes money since the siege" {
+		t.Errorf("note lost on the way to the editor: %q", outgoing[0].Note)
+	}
+	if outgoing[0].Disposition != -2 {
+		t.Errorf("disposition = %d, want -2", outgoing[0].Disposition)
+	}
+}
+
+// TestUpdateEdgeDetails_RefusesAnOverLongNote: the bound is enforced where the
+// write happens, not only at the RPC boundary — kgvocab is the one definition.
+func TestUpdateEdgeDetails_RefusesAnOverLongNote(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	a := mkNode(t, st, campaignID, storage.KGNodeNPC, "A")
+	b := mkNode(t, st, campaignID, storage.KGNodeNPC, "B")
+	edge, err := st.CreateEdge(ctx, storage.NewKGEdge{
+		CampaignID: campaignID, FromNodeID: a.ID, ToNodeID: b.ID, Type: storage.KGEdgeKnows,
+	})
+	if err != nil {
+		t.Fatalf("CreateEdge: %v", err)
+	}
+	long := ""
+	for i := 0; i <= kgvocab.MaxEdgeNoteRunes; i++ {
+		long += "x"
+	}
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, edge.ID, long, 0); !errors.Is(err, storage.ErrNoteTooLong) {
+		t.Fatalf("an over-long note was accepted: err = %v", err)
 	}
 }

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -57,6 +57,12 @@ type KGNode struct {
 	// has none" for a projecting read, and "not loaded" for one that does not
 	// project them (the RETURNING projections of Create/Update).
 	Aspects []KGNodeAspect
+	// Relation is how the READING Agent relates to this Node, populated only by
+	// [Store.AgentNodeFacts] (#546): the disposition and note on the Agent's own
+	// OUTGOING edge to it. Outgoing only, because an Edge is a one-way assertion —
+	// how someone else feels about this Node is not this NPC's feeling.
+	RelationNote        string
+	RelationDisposition int
 }
 
 // NewKGNode is the input to CreateNode. node_type is set once at insert and never
@@ -265,14 +271,25 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 		     SELECT id FROM kg_node WHERE agent_id = $1
 		 ),
 		 hood AS (
-		     SELECT id, 0 AS hop FROM own
-		     UNION SELECT e.to_node_id,   1 FROM kg_edge e JOIN own o ON e.from_node_id = o.id
-		     UNION SELECT e.from_node_id, 1 FROM kg_edge e JOIN own o ON e.to_node_id   = o.id
+		     SELECT id, 0 AS hop, '' AS note, 0 AS disposition FROM own
+		     -- OUTGOING: the Agent's own assertion about the neighbour, so its note
+		     -- and disposition are this NPC's feeling and may reach its prompt.
+		     UNION ALL SELECT e.to_node_id, 1, e.note, e.disposition
+		       FROM kg_edge e JOIN own o ON e.from_node_id = o.id
+		     -- INCOMING: still expands the neighbourhood, but carries no feeling —
+		     -- how someone else feels about this Node is not this NPC's feeling.
+		     UNION ALL SELECT e.from_node_id, 1, '', 0
+		       FROM kg_edge e JOIN own o ON e.to_node_id = o.id
 		 ),
 		 ranked AS (
-		     SELECT id, min(hop) AS hop FROM hood GROUP BY id
+		     -- One row per Node. Where several edges reach the same neighbour, the
+		     -- strongest feeling wins by absolute value, deterministically.
+		     SELECT id, min(hop) AS hop,
+		            (array_agg(note ORDER BY abs(disposition) DESC, note))[1] AS note,
+		            (array_agg(disposition ORDER BY abs(disposition) DESC, note))[1] AS disposition
+		       FROM hood GROUP BY id
 		 )
-		 SELECT `+kgNodeColumnsNAspects(true)+`
+		 SELECT `+kgNodeColumnsNAspects(true)+`, r.note, r.disposition
 		   FROM kg_node n
 		   JOIN ranked r ON r.id = n.id
 		  WHERE NOT n.gm_private
@@ -285,7 +302,7 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 
 	var out []KGNode
 	for rows.Next() {
-		n, err := scanKGNodeAspects(rows)
+		n, err := scanKGNodeFact(rows)
 		if err != nil {
 			return nil, fmt.Errorf("storage: scan agent node fact: %w", err)
 		}
@@ -295,6 +312,24 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 		return nil, fmt.Errorf("storage: agent node facts for agent %s: %w", agentID, err)
 	}
 	return out, nil
+}
+
+// scanKGNodeFact scans the neighbourhood projection: a Node with its public
+// Aspects, plus the reading Agent's own relation to it (#546).
+func scanKGNodeFact(row pgx.Row) (KGNode, error) {
+	var n KGNode
+	var aspects []byte
+	err := row.Scan(
+		&n.ID, &n.CampaignID, &n.Type, &n.Name, &n.Body, &n.GMPrivate, &n.AgentID,
+		&n.CreatedAt, &n.UpdatedAt, &aspects, &n.RelationNote, &n.RelationDisposition,
+	)
+	if err != nil {
+		return n, err
+	}
+	if err := decodeAspects(aspects, &n.Aspects); err != nil {
+		return n, err
+	}
+	return n, nil
 }
 
 // SimilarNodes returns the k Knowledge Graph Nodes in campaignID nearest the

--- a/internal/storage/kg_node.go
+++ b/internal/storage/kg_node.go
@@ -282,11 +282,25 @@ func (s *Store) AgentNodeFacts(ctx context.Context, agentID uuid.UUID) ([]KGNode
 		       FROM kg_edge e JOIN own o ON e.to_node_id = o.id
 		 ),
 		 ranked AS (
-		     -- One row per Node. Where several edges reach the same neighbour, the
-		     -- strongest feeling wins by absolute value, deterministically.
+		     -- One row per Node. Where several edges reach the same neighbour, a row
+		     -- that SAYS SOMETHING wins first, then the strongest feeling by absolute
+		     -- value, then deterministic text and sign tiebreaks.
+		     --
+		     -- The "says something" term is load-bearing. Every incoming edge
+		     -- contributes a ('', 0) row, and an ordinary reciprocal edge (Bart knows
+		     -- Mira, Mira knows Bart) produces exactly that alongside Bart's real note.
+		     -- Ordering on abs(disposition) alone ties them at 0, and a plain note ASC
+		     -- then sorts '' FIRST — so a neutral note, the feature's own headline case
+		     -- ("owes me money since the siege"), silently never reached the prompt.
+		     --
+		     -- Both array_agg calls MUST carry the identical ORDER BY: they are picked
+		     -- element-wise, so any divergence would pair one edge's note with another
+		     -- edge's disposition.
 		     SELECT id, min(hop) AS hop,
-		            (array_agg(note ORDER BY abs(disposition) DESC, note))[1] AS note,
-		            (array_agg(disposition ORDER BY abs(disposition) DESC, note))[1] AS disposition
+		            (array_agg(note ORDER BY (note <> '' OR disposition <> 0) DESC,
+		                                     abs(disposition) DESC, note, disposition DESC))[1] AS note,
+		            (array_agg(disposition ORDER BY (note <> '' OR disposition <> 0) DESC,
+		                                     abs(disposition) DESC, note, disposition DESC))[1] AS disposition
 		       FROM hood GROUP BY id
 		 )
 		 SELECT `+kgNodeColumnsNAspects(true)+`, r.note, r.disposition

--- a/internal/storage/kg_node_neighbourhood_test.go
+++ b/internal/storage/kg_node_neighbourhood_test.go
@@ -29,13 +29,15 @@ func linkAgent(t *testing.T, st *storage.Store, campaignID, npcID uuid.UUID, nam
 }
 
 // mkEdge creates a typed Edge between two same-Campaign Nodes, failing on error.
-func mkEdge(t *testing.T, st *storage.Store, campaignID, from, to uuid.UUID, typ storage.KGEdgeType) {
+func mkEdge(t *testing.T, st *storage.Store, campaignID, from, to uuid.UUID, typ storage.KGEdgeType) storage.KGEdge {
 	t.Helper()
-	if _, err := st.CreateEdge(context.Background(), storage.NewKGEdge{
+	e, err := st.CreateEdge(context.Background(), storage.NewKGEdge{
 		CampaignID: campaignID, FromNodeID: from, ToNodeID: to, Type: typ,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CreateEdge %s: %v", typ, err)
 	}
+	return e
 }
 
 // nodeIDSet projects a Node slice to id→count for membership assertions.
@@ -184,4 +186,90 @@ func TestAgentNodeFacts_Unlinked(t *testing.T) {
 	if len(facts) != 0 {
 		t.Errorf("unlinked agent got facts: %+v", facts)
 	}
+}
+
+// TestAgentNodeFacts_NeutralNoteSurvivesTheReciprocalEdge is the tie-break the
+// slice shipped inverted.
+//
+// Every INCOMING edge contributes a (”, 0) row — incoming edges expand the
+// neighbourhood but carry no feeling, because how someone else feels about a Node
+// is not this NPC's feeling. An ordinary reciprocal pair (Bart knows Mira, Mira
+// knows Bart) therefore puts Bart's real note next to an empty row, both at
+// abs(disposition) = 0. Ordering on abs alone tied them, and `note` ASC then
+// picked ” — so the feature's own headline case, a NEUTRAL note ("owes me money
+// since the siege"), silently never reached the Hot Context.
+func TestAgentNodeFacts_NeutralNoteSurvivesTheReciprocalEdge(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	bart := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	agentID := linkAgent(t, st, campaignID, bart.ID, "Bart")
+	mira := mkNode(t, st, campaignID, storage.KGNodeNPC, "Mira")
+
+	// Bart's own assertion, with texture but a NEUTRAL disposition.
+	out := mkEdge(t, st, campaignID, bart.ID, mira.ID, storage.KGEdgeKnows)
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, out.ID, "owes me money since the siege", 0); err != nil {
+		t.Fatalf("UpdateEdgeDetails: %v", err)
+	}
+	// The ordinary reciprocal edge, which contributes ('', 0).
+	mkEdge(t, st, campaignID, mira.ID, bart.ID, storage.KGEdgeKnows)
+
+	facts, err := st.AgentNodeFacts(ctx, agentID)
+	if err != nil {
+		t.Fatalf("AgentNodeFacts: %v", err)
+	}
+	var found bool
+	for _, n := range facts {
+		if n.ID != mira.ID {
+			continue
+		}
+		found = true
+		if n.RelationNote != "owes me money since the siege" {
+			t.Errorf("the note lost to the reciprocal edge's empty row: %q", n.RelationNote)
+		}
+	}
+	if !found {
+		t.Fatal("Mira did not surface at all")
+	}
+}
+
+// TestAgentNodeFacts_StrongestFeelingStillWins: among edges that DO say
+// something, the strongest disposition is still what surfaces — the "says
+// something first" term must not have inverted that.
+func TestAgentNodeFacts_StrongestFeelingStillWins(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	bart := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	agentID := linkAgent(t, st, campaignID, bart.ID, "Bart")
+	mira := mkNode(t, st, campaignID, storage.KGNodeNPC, "Mira")
+
+	mild := mkEdge(t, st, campaignID, bart.ID, mira.ID, storage.KGEdgeKnows)
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, mild.ID, "a passing acquaintance", 1); err != nil {
+		t.Fatalf("UpdateEdgeDetails mild: %v", err)
+	}
+	strong := mkEdge(t, st, campaignID, bart.ID, mira.ID, storage.KGEdgeEnemyOf)
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, strong.ID, "burned down the stables", -2); err != nil {
+		t.Fatalf("UpdateEdgeDetails strong: %v", err)
+	}
+
+	facts, err := st.AgentNodeFacts(ctx, agentID)
+	if err != nil {
+		t.Fatalf("AgentNodeFacts: %v", err)
+	}
+	for _, n := range facts {
+		if n.ID != mira.ID {
+			continue
+		}
+		if n.RelationDisposition != -2 || n.RelationNote != "burned down the stables" {
+			t.Fatalf("the strongest feeling did not win: note=%q disposition=%d",
+				n.RelationNote, n.RelationDisposition)
+		}
+		return
+	}
+	t.Fatal("Mira did not surface at all")
 }

--- a/internal/storage/knowledge_proposal.go
+++ b/internal/storage/knowledge_proposal.go
@@ -250,12 +250,23 @@ func (tx *Store) applyProposedEdge(ctx context.Context, campaignID uuid.UUID, w 
 	if err != nil {
 		return err
 	}
-	_, err = createEdgeTx(ctx, tx, NewKGEdge{
+	created, err := createEdgeTx(ctx, tx, NewKGEdge{
 		CampaignID: campaignID,
 		FromNodeID: from,
 		ToNodeID:   to,
 		Type:       KGEdgeType(w.Relation),
 	})
+	// The proposal's texture lands with the edge, in the SAME transaction (#546):
+	// an approved "I now distrust her" that lost its disposition would be an
+	// approval that quietly discarded what was approved.
+	if err == nil && (strings.TrimSpace(w.Note) != "" || w.Disposition != 0) {
+		if _, uerr := tx.UpdateEdgeDetails(ctx, campaignID, created.ID, strings.TrimSpace(w.Note), w.Disposition); uerr != nil {
+			if errors.Is(uerr, ErrInvalidDisposition) {
+				return &ProposalBlockedError{Reason: "this suggestion's feeling is out of range — reject it"}
+			}
+			return fmt.Errorf("storage: approve edge: details: %w", uerr)
+		}
+	}
 	switch {
 	case err == nil:
 		return nil

--- a/internal/storage/knowledge_proposal_review_test.go
+++ b/internal/storage/knowledge_proposal_review_test.go
@@ -960,3 +960,89 @@ func TestDeleteNodeCascadesAspects(t *testing.T) {
 		t.Errorf("%d aspect rows outlived their node", len(got))
 	}
 }
+
+// TestApproveEdgeCarriesTexture pins #546's approval path: an approved
+// "I now distrust her" must land WITH its feeling. An approval that quietly
+// discarded what was approved would be worse than refusing it.
+func TestApproveEdgeCarriesTexture(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	butler := seedButlerAgent(t, st, campaignID)
+
+	bart := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	mira := mkNode(t, st, campaignID, storage.KGNodeNPC, "Mira")
+
+	id := fileProposal(t, st, campaignID, butler, tool.ProposedWrite{
+		V: kgvocab.ProposalWriteVersion, Kind: "edge",
+		NodeID: bart.ID.String(), Subject: "Bart", Relation: "knows", Target: "Mira",
+		Note: "she cheated him at cards", Disposition: -2,
+	})
+	if err := st.ApproveKnowledgeProposal(ctx, campaignID, id); err != nil {
+		t.Fatalf("ApproveKnowledgeProposal: %v", err)
+	}
+
+	edges, err := st.ListEdges(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListEdges: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("got %d edges, want 1", len(edges))
+	}
+	if edges[0].Note != "she cheated him at cards" || edges[0].Disposition != -2 {
+		t.Errorf("edge = %+v, want the proposal's texture carried through", edges[0])
+	}
+	if edges[0].FromNodeID != bart.ID || edges[0].ToNodeID != mira.ID {
+		t.Errorf("edge endpoints = %v→%v, want Bart→Mira", edges[0].FromNodeID, edges[0].ToNodeID)
+	}
+}
+
+// TestAgentNodeFactsCarriesOutgoingRelation pins that only the Agent's OWN
+// outgoing edge contributes a feeling: an Edge is a one-way assertion, so how
+// someone else feels about a Node is not this NPC's feeling.
+func TestAgentNodeFactsCarriesOutgoingRelation(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	own := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	agentID := linkAgent(t, st, campaignID, own.ID, "Bart")
+	mira := mkNode(t, st, campaignID, storage.KGNodeNPC, "Mira")
+	admirer := mkNode(t, st, campaignID, storage.KGNodeNPC, "Admirer")
+
+	newEdge := func(from, to uuid.UUID) storage.KGEdge {
+		t.Helper()
+		e, err := st.CreateEdge(ctx, storage.NewKGEdge{
+			CampaignID: campaignID, FromNodeID: from, ToNodeID: to, Type: storage.KGEdgeKnows,
+		})
+		if err != nil {
+			t.Fatalf("CreateEdge: %v", err)
+		}
+		return e
+	}
+	out := newEdge(own.ID, mira.ID)
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, out.ID, "she cheated him", -2); err != nil {
+		t.Fatalf("UpdateEdgeDetails outgoing: %v", err)
+	}
+	in := newEdge(admirer.ID, own.ID)
+	if _, err := st.UpdateEdgeDetails(ctx, campaignID, in.ID, "worships him", 2); err != nil {
+		t.Fatalf("UpdateEdgeDetails incoming: %v", err)
+	}
+
+	facts, err := st.AgentNodeFacts(ctx, agentID)
+	if err != nil {
+		t.Fatalf("AgentNodeFacts: %v", err)
+	}
+	byID := map[uuid.UUID]storage.KGNode{}
+	for _, n := range facts {
+		byID[n.ID] = n
+	}
+	if got := byID[mira.ID]; got.RelationDisposition != -2 || got.RelationNote != "she cheated him" {
+		t.Errorf("outgoing neighbour = %+v, want Bart's own feeling carried", got)
+	}
+	if got := byID[admirer.ID]; got.RelationDisposition != 0 || got.RelationNote != "" {
+		t.Errorf("incoming neighbour = %+v, want NO feeling — that is the admirer's, not Bart's", got)
+	}
+}

--- a/internal/storage/migrations/00046_kg_edge_note.sql
+++ b/internal/storage/migrations/00046_kg_edge_note.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+
+-- Edge notes and disposition (#546, ADR-0008): a relation carries texture.
+--
+-- `knows` today carries nothing. "Knows and owes money to" versus "knows and
+-- despises" is the difference between a flat NPC and a live one — and Edges are
+-- already strictly directional with no auto-inverse (ADR-0008 amendment), which is
+-- exactly what makes ASYMMETRIC feelings expressible: a secretly hostile ally is
+-- one edge with a negative disposition and no matching return edge.
+--
+-- Defaulted columns on the existing table; no new table, and the
+-- UNIQUE (from, to, type) key is untouched.
+ALTER TABLE kg_edge ADD COLUMN note text NOT NULL DEFAULT '';
+
+-- disposition is -2..+2: hostile, cold, neutral, warm, devoted. A small closed
+-- range rather than a free integer, because it drives an edge colour and a single
+-- prompt clause — a scale nobody can calibrate is worse than none.
+ALTER TABLE kg_edge ADD COLUMN disposition smallint NOT NULL DEFAULT 0;
+
+ALTER TABLE kg_edge ADD CONSTRAINT kg_edge_disposition_range
+    CHECK (disposition >= -2 AND disposition <= 2);
+
+-- +goose Down
+
+ALTER TABLE kg_edge DROP CONSTRAINT IF EXISTS kg_edge_disposition_range;
+ALTER TABLE kg_edge DROP COLUMN IF EXISTS disposition;
+ALTER TABLE kg_edge DROP COLUMN IF EXISTS note;

--- a/pkg/kgvocab/kgvocab.go
+++ b/pkg/kgvocab/kgvocab.go
@@ -46,6 +46,11 @@ const (
 	MaxAspectsPerNode = 50
 )
 
+// MaxEdgeNoteRunes bounds an Edge's note (#546). Shared by the Tool create path
+// and the RPC editor path, so neither can admit what the other rejects. It is
+// texture on a relation, not prose — and one clause of it may reach a prompt.
+const MaxEdgeNoteRunes = 280
+
 // DefaultAspectKey is the key stamped on a kind=fact proposal whose author named
 // no aspect. Models routinely omit optional fields, and refusing the call would
 // lose the NPC's memory over a labelling detail — so the payload always carries a

--- a/pkg/tool/deps.go
+++ b/pkg/tool/deps.go
@@ -75,9 +75,14 @@ type ProposedWrite struct {
 	Fact      string `json:"fact,omitempty"`
 	Relation  string `json:"relation,omitempty"`
 	Target    string `json:"target,omitempty"`
-	NodeType  string `json:"node_type,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Body      string `json:"body,omitempty"`
+	// Note and Disposition are an edge proposal's texture (#546): "I now distrust
+	// her" after a scene. Optional — an edge with neither is exactly what it was
+	// before, so no stored payload changes meaning.
+	Note        string `json:"note,omitempty"`
+	Disposition int    `json:"disposition,omitempty"`
+	NodeType    string `json:"node_type,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Body        string `json:"body,omitempty"`
 }
 
 // Spatial is the read seam the locate_entity / whats_nearby Tools consult

--- a/pkg/tool/remember_knowledge.go
+++ b/pkg/tool/remember_knowledge.go
@@ -58,6 +58,16 @@ var rememberKnowledgeInputSchema = json.RawMessage(`{
       "type": "string",
       "description": "The name of the entity on the other end of the relationship (kind=edge)."
     },
+    "note": {
+      "type": "string",
+      "description": "What the relationship is actually like, in a few words — 'owes me money', 'since the siege' (kind=edge). Optional."
+    },
+    "disposition": {
+      "type": "integer",
+      "description": "How you feel about them, from -2 (hate) through 0 (neutral) to +2 (devoted) (kind=edge). Optional.",
+      "minimum": -2,
+      "maximum": 2
+    },
     "node_type": {
       "type": "string",
       "enum": ` + enumJSON(kgvocab.NodeTypes()...) + `,
@@ -87,15 +97,17 @@ func enumJSON(vals ...string) string {
 
 // rememberArgs is the decoded LLM argument set. Scope is absent by design.
 type rememberArgs struct {
-	Kind     string `json:"kind"`
-	Subject  string `json:"subject"`
-	Fact     string `json:"fact"`
-	Aspect   string `json:"aspect"`
-	Relation string `json:"relation"`
-	Target   string `json:"target"`
-	NodeType string `json:"node_type"`
-	Name     string `json:"name"`
-	Body     string `json:"body"`
+	Kind        string `json:"kind"`
+	Subject     string `json:"subject"`
+	Fact        string `json:"fact"`
+	Aspect      string `json:"aspect"`
+	Relation    string `json:"relation"`
+	Target      string `json:"target"`
+	Note        string `json:"note"`
+	Disposition int    `json:"disposition"`
+	NodeType    string `json:"node_type"`
+	Name        string `json:"name"`
+	Body        string `json:"body"`
 }
 
 // aspectKey resolves the label a kind=fact proposal lands under: the model's
@@ -313,6 +325,14 @@ func validateArgs(a rememberArgs) error {
 		if err := capName("target", a.Target); err != nil {
 			return err
 		}
+		// The note is texture on a relation, not prose, and one clause of it may
+		// reach a prompt (#546).
+		if utf8.RuneCountInString(a.Note) > kgvocab.MaxEdgeNoteRunes {
+			return fmt.Errorf("remember_knowledge: note is too long (max %d characters)", kgvocab.MaxEdgeNoteRunes)
+		}
+		if a.Disposition < -2 || a.Disposition > 2 {
+			return fmt.Errorf("remember_knowledge: disposition must be between -2 and 2, got %d", a.Disposition)
+		}
 	case kgvocab.KindNode:
 		if strings.TrimSpace(a.Name) == "" {
 			return fmt.Errorf("remember_knowledge: a new entry requires a 'name'")
@@ -375,6 +395,8 @@ func (rk *RememberKnowledge) ownNodeWrite(ctx context.Context, a rememberArgs) (
 	case kgvocab.KindEdge:
 		w.Relation = a.Relation
 		w.Target = a.Target
+		w.Note = a.Note
+		w.Disposition = a.Disposition
 	}
 	return w, nil
 }
@@ -399,6 +421,8 @@ func campaignWrite(a rememberArgs) (ProposedWrite, error) {
 		w.Subject = a.Subject
 		w.Relation = a.Relation
 		w.Target = a.Target
+		w.Note = a.Note
+		w.Disposition = a.Disposition
 	case kgvocab.KindNode:
 		w.NodeType = a.NodeType
 		w.Name = a.Name

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -114,6 +114,11 @@ service CampaignService {
   // DeleteEdge removes a typed Edge by id (#132). An unknown id is CodeNotFound.
   rpc DeleteEdge(DeleteEdgeRequest) returns (DeleteEdgeResponse);
 
+  // UpdateEdgeDetails saves a relation's note and disposition (#546). The
+  // relation TYPE is not editable: retyping is deleting and re-creating, since
+  // the type carries validity rules.
+  rpc UpdateEdgeDetails(UpdateEdgeDetailsRequest) returns (UpdateEdgeDetailsResponse);
+
   // ListNodeEdges returns a Node's incident Edges split into outgoing and
   // incoming lists (strictly directional; no auto-inverse, ADR-0008 amendment),
   // each carrying its endpoints' joined name/type. It is a read (NO_SIDE_EFFECTS).
@@ -449,6 +454,13 @@ message Edge {
   NodeType to_node_type = 8;
   // created_at is when the edge was created.
   google.protobuf.Timestamp created_at = 9;
+  // note is the relation's texture — "owes money to", "since the siege" (#546).
+  // A bare `knows` carries nothing; this is what makes it a relationship.
+  string note = 10;
+  // disposition is how the SUBJECT feels about the object, -2..+2 (hostile, cold,
+  // neutral, warm, devoted). Edges are one-way with no auto-inverse, which is what
+  // makes asymmetric feelings expressible.
+  int32 disposition = 11;
 }
 
 // CreateEdgeRequest is the "Add relation" payload. The campaign is resolved
@@ -520,6 +532,21 @@ enum NodeType {
   NODE_TYPE_NOTE = 7;
 }
 
+// UpdateEdgeDetailsRequest saves a relation's texture.
+message UpdateEdgeDetailsRequest {
+  // id is the edge to update.
+  string id = 1;
+  // note is the free-text texture; empty clears it.
+  string note = 2;
+  // disposition is -2..+2; anything outside is rejected.
+  int32 disposition = 3;
+}
+
+// UpdateEdgeDetailsResponse carries the updated Edge.
+message UpdateEdgeDetailsResponse {
+  Edge edge = 1;
+}
+
 // GraphNode is one Node as the Graph view needs it (#534): identity, type, name
 // and the flags the rendering distinguishes on — deliberately WITHOUT body or
 // aspect text, so a several-hundred-node campaign stays one small payload.
@@ -559,6 +586,9 @@ message GraphEdge {
   string to_node_id = 3;
   // edge_type is the relationship type.
   EdgeType edge_type = 4;
+  // disposition drives the drawn edge's colour; note shows on hover (#546).
+  int32 disposition = 5;
+  string note = 6;
 }
 
 // GetKnowledgeGraphRequest is the (empty) request; the active campaign is
@@ -1097,6 +1127,11 @@ message ProposedEdge {
   EdgeType relation = 3;
   // target is the to-Node's NAME (resolved to a Node at approval time).
   string target = 4;
+  // note and disposition are the relation's texture (#546). A Character NPC
+  // proposing "I now distrust her" after a scene is a good use of the queue, and
+  // it stays GM-reviewed.
+  string note = 5;
+  int32 disposition = 6;
 }
 
 // ProposedNode is a remember_knowledge proposal to create a new Node (#300,

--- a/web/src/screens/campaign/NodeRelations.test.tsx
+++ b/web/src/screens/campaign/NodeRelations.test.tsx
@@ -11,6 +11,7 @@ import {
   EdgeSchema,
   AgentSchema,
   ListNodeEdgesResponseSchema,
+  UpdateEdgeDetailsResponseSchema,
   ListNodesResponseSchema,
   GetCampaignRosterResponseSchema,
   CreateEdgeResponseSchema,
@@ -102,7 +103,7 @@ function edgeTransport(opts: {
   return { transport, createCalls, deleteCalls, setAgentCalls, detailCalls };
 }
 
-function renderRelations(node: PbNode, extra?: Parameters<typeof edgeTransport>[0]) {
+function renderRelations(node: PbNode, extra?: Partial<Parameters<typeof edgeTransport>[0]>) {
   const ctx = edgeTransport({ node, ...extra });
   render(
     <Providers transport={ctx.transport} queryClient={makeQueryClient()}>

--- a/web/src/screens/campaign/NodeRelations.test.tsx
+++ b/web/src/screens/campaign/NodeRelations.test.tsx
@@ -44,6 +44,7 @@ function edgeTransport(opts: {
   const createCalls: CreateEdgeRequest[] = [];
   const deleteCalls: DeleteEdgeRequest[] = [];
   const setAgentCalls: SetNodeAgentRequest[] = [];
+  const detailCalls: { id: string; note: string; disposition: number }[] = [];
 
   const butler = create(AgentSchema, { id: "butler", role: "butler", name: "Glyphoxa" });
   const cast = [
@@ -57,6 +58,12 @@ function edgeTransport(opts: {
       listNodes: () => create(ListNodesResponseSchema, { nodes: [opts.node, ...others] }),
       getCampaignRoster: () =>
         create(GetCampaignRosterResponseSchema, { roster: [butler, ...cast] }),
+      updateEdgeDetails: (req) => {
+        detailCalls.push({ id: req.id, note: req.note, disposition: req.disposition });
+        return create(UpdateEdgeDetailsResponseSchema, {
+          edge: create(EdgeSchema, { id: req.id, note: req.note, disposition: req.disposition }),
+        });
+      },
       createEdge: (req) => {
         createCalls.push(req);
         const target = others.find((n) => n.id === req.toNodeId);
@@ -92,7 +99,7 @@ function edgeTransport(opts: {
       },
     });
   });
-  return { transport, createCalls, deleteCalls, setAgentCalls };
+  return { transport, createCalls, deleteCalls, setAgentCalls, detailCalls };
 }
 
 function renderRelations(node: PbNode, extra?: Parameters<typeof edgeTransport>[0]) {
@@ -304,5 +311,30 @@ describe("NodeRelations", () => {
     await confirmInDialog();
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/couldn't delete/i);
+  });
+
+  it("authors a relation's texture and sends it (#546)", async () => {
+    const ctx = renderRelations(npcNode, {
+      outgoing: [
+        create(EdgeSchema, {
+          id: "e1",
+          fromNodeId: "n1",
+          toNodeId: "n2",
+          edgeType: EdgeType.KNOWS,
+          toNodeName: "Mira",
+          toNodeType: NodeType.NPC,
+        }),
+      ],
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /Edit what knows/ }));
+
+    fireEvent.change(screen.getByLabelText("What it's like"), {
+      target: { value: "  owes you money since the siege  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(ctx.detailCalls).toHaveLength(1));
+    // Trimmed, because a trailing space is not texture.
+    expect(ctx.detailCalls[0].note).toBe("owes you money since the siege");
   });
 });

--- a/web/src/screens/campaign/NodeRelations.tsx
+++ b/web/src/screens/campaign/NodeRelations.tsx
@@ -1,12 +1,13 @@
 import { useMemo, useState } from "react";
 import { useQuery, useMutation } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, ArrowLeft, X, Plus, Link as LinkIcon } from "lucide-react";
+import { ArrowRight, ArrowLeft, Pencil, X, Plus, Link as LinkIcon } from "lucide-react";
 
 import { CampaignService, EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
 import type { Node as PbNode, Edge as PbEdge } from "@gen/glyphoxa/management/v1/management_pb";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { EDGE_LABEL, EDGE_OPTIONS, TYPE_META as NODE_TYPE_META } from "./knowledgeVocab";
@@ -86,6 +87,11 @@ export function NodeRelations({ node }: { node: PbNode }) {
     },
   });
   const deleteEdge = useMutation(CampaignService.method.deleteEdge, {
+    onSuccess: () => void invalidateEdges(),
+  });
+  // The relation's texture (#546). It shares the edge invalidation because the
+  // graph colours relations by disposition and shows the note on hover.
+  const updateDetails = useMutation(CampaignService.method.updateEdgeDetails, {
     onSuccess: () => void invalidateEdges(),
   });
   const setNodeAgent = useMutation(CampaignService.method.setNodeAgent, {
@@ -177,7 +183,15 @@ export function NodeRelations({ node }: { node: PbNode }) {
 
       <section className="gx-kg-relations__list" aria-label="Outgoing relations">
         {outgoing.map((e) => (
-          <OutgoingRow key={e.id} edge={e} onDelete={() => setConfirmEdge(e)} />
+          <OutgoingRow
+            key={e.id}
+            edge={e}
+            onDelete={() => setConfirmEdge(e)}
+            onSaveDetails={(note, disposition) =>
+              updateDetails.mutate({ id: e.id, note, disposition })
+            }
+            saving={updateDetails.isPending && updateDetails.variables?.id === e.id}
+          />
         ))}
         {outgoing.length === 0 && <p className="gx-kg-relations__empty">No outgoing relations yet.</p>}
         {deleteEdge.isError && (
@@ -225,9 +239,33 @@ export function NodeRelations({ node }: { node: PbNode }) {
   );
 }
 
-function OutgoingRow({ edge, onDelete }: { edge: PbEdge; onDelete: () => void }) {
+// DISPOSITION_OPTIONS names the -2..+2 scale in the words the GM chooses by. A
+// small closed scale rather than a free number: a scale nobody can calibrate is
+// worse than none, and this one drives an edge colour and ONE prompt clause.
+const DISPOSITION_OPTIONS = [
+  { value: "-2", label: "hostile" },
+  { value: "-1", label: "wary" },
+  { value: "0", label: "neutral" },
+  { value: "1", label: "warm" },
+  { value: "2", label: "devoted" },
+];
+
+function OutgoingRow({
+  edge,
+  onDelete,
+  onSaveDetails,
+  saving,
+}: {
+  edge: PbEdge;
+  onDelete: () => void;
+  onSaveDetails: (note: string, disposition: number) => void;
+  saving: boolean;
+}) {
   const meta = typeMeta(edge.toNodeType);
   const label = EDGE_LABEL.get(edge.edgeType) ?? "";
+  const [open, setOpen] = useState(false);
+  const [note, setNote] = useState(edge.note);
+  const [disposition, setDisposition] = useState(String(edge.disposition));
   return (
     <div className="gx-kg-edge">
       <ArrowRight size={13} className="gx-kg-edge__dir" aria-hidden />
@@ -236,6 +274,18 @@ function OutgoingRow({ edge, onDelete }: { edge: PbEdge; onDelete: () => void })
       <Badge size="sm" style={{ color: meta.color, background: `${meta.color}24` }}>
         {meta.label}
       </Badge>
+      {/* The relation's texture, collapsed. "Knows and despises" is the
+          difference between a flat NPC and a live one — but most relations are
+          plain, so it stays out of the way until asked for. */}
+      <button
+        type="button"
+        className="gx-kg-iconbtn"
+        aria-label={`Edit what ${label} ${edge.toNodeName} is like`}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Pencil size={13} />
+      </button>
       <button
         type="button"
         className="gx-kg-iconbtn gx-kg-iconbtn--danger"
@@ -244,6 +294,34 @@ function OutgoingRow({ edge, onDelete }: { edge: PbEdge; onDelete: () => void })
       >
         <X size={13} />
       </button>
+
+      {open && (
+        <div className="gx-kg-edge__details">
+          <Input
+            label="What it's like"
+            placeholder="owes you money since the siege"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          <Select
+            label="How you feel"
+            options={DISPOSITION_OPTIONS}
+            value={disposition}
+            onValueChange={setDisposition}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={saving}
+            onClick={() => {
+              onSaveDetails(note.trim(), Number(disposition));
+              setOpen(false);
+            }}
+          >
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/screens/campaign/NodeRelations.tsx
+++ b/web/src/screens/campaign/NodeRelations.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, ArrowLeft, Pencil, X, Plus, Link as LinkIcon } from "lucide-react";
@@ -10,7 +10,13 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { EDGE_LABEL, EDGE_OPTIONS, TYPE_META as NODE_TYPE_META } from "./knowledgeVocab";
+import {
+  DISPOSITION_OPTIONS,
+  EDGE_LABEL,
+  EDGE_OPTIONS,
+  MAX_EDGE_NOTE_RUNES,
+  TYPE_META as NODE_TYPE_META,
+} from "./knowledgeVocab";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
 
 function typeMeta(t: NodeType) {
@@ -91,8 +97,16 @@ export function NodeRelations({ node }: { node: PbNode }) {
   });
   // The relation's texture (#546). It shares the edge invalidation because the
   // graph colours relations by disposition and shows the note on hover.
+  //
+  // savedEdgeID is what closes the inline editor: it must close on the SAVE
+  // LANDING, not on the click. Closing on click hid every rejection — an
+  // over-long note came back InvalidArgument and the GM saw a tidy closed row.
+  const [savedEdgeID, setSavedEdgeID] = useState<string | null>(null);
   const updateDetails = useMutation(CampaignService.method.updateEdgeDetails, {
-    onSuccess: () => void invalidateEdges(),
+    onSuccess: (_res, vars) => {
+      setSavedEdgeID(vars.id ?? null);
+      void invalidateEdges();
+    },
   });
   const setNodeAgent = useMutation(CampaignService.method.setNodeAgent, {
     onSuccess: (res) => {
@@ -191,6 +205,12 @@ export function NodeRelations({ node }: { node: PbNode }) {
               updateDetails.mutate({ id: e.id, note, disposition })
             }
             saving={updateDetails.isPending && updateDetails.variables?.id === e.id}
+            saveError={
+              updateDetails.isError && updateDetails.variables?.id === e.id
+                ? `Couldn't save: ${updateDetails.error.message}`
+                : null
+            }
+            saved={savedEdgeID === e.id}
           />
         ))}
         {outgoing.length === 0 && <p className="gx-kg-relations__empty">No outgoing relations yet.</p>}
@@ -239,33 +259,29 @@ export function NodeRelations({ node }: { node: PbNode }) {
   );
 }
 
-// DISPOSITION_OPTIONS names the -2..+2 scale in the words the GM chooses by. A
-// small closed scale rather than a free number: a scale nobody can calibrate is
-// worse than none, and this one drives an edge colour and ONE prompt clause.
-const DISPOSITION_OPTIONS = [
-  { value: "-2", label: "hostile" },
-  { value: "-1", label: "wary" },
-  { value: "0", label: "neutral" },
-  { value: "1", label: "warm" },
-  { value: "2", label: "devoted" },
-];
-
 function OutgoingRow({
   edge,
   onDelete,
   onSaveDetails,
   saving,
+  saveError,
+  saved,
 }: {
   edge: PbEdge;
   onDelete: () => void;
   onSaveDetails: (note: string, disposition: number) => void;
   saving: boolean;
+  saveError: string | null;
+  saved: boolean;
 }) {
   const meta = typeMeta(edge.toNodeType);
   const label = EDGE_LABEL.get(edge.edgeType) ?? "";
   const [open, setOpen] = useState(false);
   const [note, setNote] = useState(edge.note);
   const [disposition, setDisposition] = useState(String(edge.disposition));
+  useEffect(() => {
+    if (saved) setOpen(false);
+  }, [saved]);
   return (
     <div className="gx-kg-edge">
       <ArrowRight size={13} className="gx-kg-edge__dir" aria-hidden />
@@ -301,6 +317,7 @@ function OutgoingRow({
             label="What it's like"
             placeholder="owes you money since the siege"
             value={note}
+            maxLength={MAX_EDGE_NOTE_RUNES}
             onChange={(e) => setNote(e.target.value)}
           />
           <Select
@@ -313,13 +330,18 @@ function OutgoingRow({
             variant="secondary"
             size="sm"
             disabled={saving}
-            onClick={() => {
-              onSaveDetails(note.trim(), Number(disposition));
-              setOpen(false);
-            }}
+            onClick={() => onSaveDetails(note.trim(), Number(disposition))}
           >
             {saving ? "Saving…" : "Save"}
           </Button>
+          {/* The editor stays OPEN until the save actually lands. Closing on click
+              and never rendering the failure told the GM their note was saved when
+              the server had rejected it. */}
+          {saveError && (
+            <span className="gx-editor__status gx-editor__status--error" role="alert">
+              {saveError}
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/web/src/screens/campaign/ProposalsPanel.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { failedPreconditionMessage } from "@/lib/connectError";
-import { EDGE_LABEL, metaOf } from "./knowledgeVocab";
+import { DISPOSITION_LABEL, EDGE_LABEL, metaOf } from "./knowledgeVocab";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
 
 // The Proposals panel (#300, ADR-0052) backs the Campaign screen's "Proposals"
@@ -209,10 +209,25 @@ function ProposalWrite({ proposal }: { proposal: KnowledgeProposal }) {
         </span>
       );
     case "edge":
+      // The note and disposition are rendered because APPROVING WRITES THEM, and
+      // the note reaches an NPC's system prompt through the relation clause. A card
+      // that showed only "subject —knows→ target" asked the GM to approve up to 280
+      // runes of model-authored text they had never seen — approval of unseen
+      // content, which is the one thing the review queue exists to prevent.
       return (
         <span>
           <strong>{w.value.subject}</strong> —{EDGE_LABEL.get(w.value.relation) ?? ""}→{" "}
           <strong>{w.value.target}</strong>
+          {(w.value.note || w.value.disposition !== 0) && (
+            <span className="gx-proposal-card__body">
+              {" — "}
+              {DISPOSITION_LABEL.get(w.value.disposition) ?? ""}
+              {w.value.note && w.value.disposition !== 0 ? ", " : ""}
+              {/* Newlines are collapsed: a proposal is one clause, and a note that
+                  can open a new line can forge a section header in the prompt. */}
+              {w.value.note.replace(/\s+/g, " ")}
+            </span>
+          )}
         </span>
       );
     case "node":

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1476,3 +1476,36 @@
   background: var(--surface, #171b23);
   width: 100%;
 }
+
+/* Disposition colours the relation (#546). A graph of bare `knows` lines says
+   nothing about how the world feels about itself; these do. */
+.gx-kg-graph__edge[data-disposition="-2"] {
+  stroke: #ff4f5e;
+  stroke-opacity: 0.65;
+}
+
+.gx-kg-graph__edge[data-disposition="-1"] {
+  stroke: #ff7139;
+  stroke-opacity: 0.5;
+}
+
+.gx-kg-graph__edge[data-disposition="1"] {
+  stroke: #35c48d;
+  stroke-opacity: 0.5;
+}
+
+.gx-kg-graph__edge[data-disposition="2"] {
+  stroke: #4fa9ff;
+  stroke-opacity: 0.65;
+}
+
+/* The relation-texture editor, collapsed by default (#546): most relations are
+   plain, so it stays out of the way until asked for. */
+.gx-kg-edge__details {
+  flex-basis: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-xs);
+  padding-top: var(--spacing-xs);
+}

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -280,11 +280,18 @@ export function KnowledgeGraph({
                 key={e.edge.id}
                 className="gx-kg-graph__edge"
                 data-relation={EDGE_LABEL.get(e.edge.edgeType) ?? ""}
+                // Disposition drives the colour (#546): a graph of bare `knows`
+                // lines says nothing about how the world feels about itself.
+                data-disposition={e.edge.disposition !== 0 ? e.edge.disposition : undefined}
                 x1={e.x1}
                 y1={e.y1}
                 x2={e.x2}
                 y2={e.y2}
-              />
+              >
+                {(e.edge.note !== "" || e.edge.disposition !== 0) && (
+                  <title>{edgeTooltip(e.edge)}</title>
+                )}
+              </line>
             ))}
           </g>
           <g className="gx-kg-graph__nodes">
@@ -413,6 +420,23 @@ export function KnowledgeGraph({
 }
 
 const EDGE_LABEL = new Map<EdgeType, string>(EDGE_TYPES.map((e) => [e.value, e.label]));
+
+/** DISPOSITION_LABEL names the -2..+2 scale in words the GM chose it by. */
+export const DISPOSITION_LABEL: Record<number, string> = {
+  [-2]: "hostile",
+  [-1]: "wary",
+  0: "neutral",
+  1: "warm",
+  2: "devoted",
+};
+
+// edgeTooltip is what hovering a relation says: its feeling, and the GM's note.
+function edgeTooltip(edge: GraphEdge): string {
+  const parts: string[] = [];
+  if (edge.disposition !== 0) parts.push(DISPOSITION_LABEL[edge.disposition] ?? "");
+  if (edge.note !== "") parts.push(edge.note);
+  return parts.filter(Boolean).join(" — ");
+}
 
 // RelationPicker is the one authoring affordance on the graph: after dragging one
 // entry onto another, the GM names the relation. It deliberately reuses the closed

--- a/web/src/screens/campaign/knowledgeVocab.ts
+++ b/web/src/screens/campaign/knowledgeVocab.ts
@@ -74,3 +74,31 @@ export const EDGE_TYPES: { value: EdgeType; label: string }[] = [
 
 export const EDGE_LABEL = new Map<EdgeType, string>(EDGE_TYPES.map((e) => [e.value, e.label]));
 export const EDGE_OPTIONS = EDGE_TYPES.map((e) => ({ value: String(e.value), label: e.label }));
+
+/**
+ * DISPOSITION_OPTIONS names the -2..+2 relation scale in the words the GM chooses
+ * by. A small closed scale rather than a free number: a scale nobody can calibrate
+ * is worse than none, and this one drives an edge colour and ONE prompt clause.
+ *
+ * It lives here, beside the type and relation vocabularies, because two surfaces
+ * show it — the relations editor authors it, and the proposal review card has to
+ * render what an Agent PROPOSED before the GM approves it.
+ */
+export const DISPOSITION_OPTIONS = [
+  { value: "-2", label: "hostile" },
+  { value: "-1", label: "wary" },
+  { value: "0", label: "neutral" },
+  { value: "1", label: "warm" },
+  { value: "2", label: "devoted" },
+];
+
+export const DISPOSITION_LABEL = new Map<number, string>(
+  DISPOSITION_OPTIONS.map((d) => [Number(d.value), d.label]),
+);
+
+/**
+ * MAX_EDGE_NOTE_RUNES mirrors kgvocab.MaxEdgeNoteRunes. The server is the
+ * authority and rejects anything longer; this stops the GM typing 300 characters
+ * before finding that out.
+ */
+export const MAX_EDGE_NOTE_RUNES = 280;


### PR DESCRIPTION
Epic #533 · slice C5 · design note §4/C5 · **Closes #546**

Stacked on #556 → #554 → #551 → #553.

## Why

`knows` carries nothing. "Knows and **owes money to**" versus "knows and **despises**" is the difference between a flat NPC and a live one.

And Edges are already strictly directional with no auto-inverse (ADR-0008 amendment) — which is precisely what makes *asymmetric* feelings expressible. A secretly hostile ally is one edge with a negative disposition and **no matching return edge**. That was always true of the model; nothing used it.

## The scale is closed on purpose

`disposition smallint` constrained to **-2..+2** — hostile, wary, neutral, warm, devoted — not a free integer. It drives an edge colour and exactly one prompt clause; a scale nobody can calibrate is worse than no scale. Two defaulted columns on the existing table: no new table, and `UNIQUE (from, to, type)` is untouched.

## One clause, and one only

`renderFact` may add a single clause per edge. Strictly one, because it spends the same `MaxBlockChars` budget world facts draw on — and `renderFacts` stops at the first fact that would overrun, so a verbose relationship would **evict knowledge outright**. The GM's note wins over the generated sentence; never both, because two clauses per neighbour is a second budget nobody agreed to.

A neutral, note-less edge renders exactly as before, so no existing campaign's prompts change.

## Only your own feelings

The neighbourhood read carries the relation from the Agent's **outgoing** edge only. Incoming edges still expand the neighbourhood — that is what they are for — but carry no texture: an Edge is a one-way assertion, so *how someone else feels about this Node is not this NPC's feeling*.

There is a test with an admirer whose devotion does not become the NPC's.

Where several edges reach the same neighbour, the strongest feeling wins by absolute value, deterministically.

## Elsewhere

- **Graph** (#534): disposition colours the relation, the note shows on hover. A graph of bare `knows` lines says nothing about how the world feels about itself.
- **Editor**: collapsed behind a pencil, because most relations are plain and the row should stay readable.
- **Proposals** (ADR-0052): both fields ride the existing edge-proposal path through `pkg/kgvocab`, which stays the single definition of the payload shape. A Character NPC proposing "I now distrust her" after a scene is a good use of the queue, and it stays GM-reviewed. The texture lands **with** the edge in the same transaction — an approval that quietly discarded what was approved would be worse than refusing it.

## Tests

- `kgfacts` — the generated clause, the note winning over it, a neutral edge rendering byte-identically to before, and the clause bounded so a long note cannot become a second prose block.
- `internal/storage` (integration) — an approved proposal carrying its texture through to the edge; outgoing-only feeling with the incoming admirer proving it.
- `internal/rpc` — trimming, campaign scoping, an overlong note refused *before* the write, out-of-range disposition, missing relation.
- `web` — authoring the texture and sending it trimmed.

Bundle coverage for both fields follows in #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)