### PR TITLE
feat(kg): pending suggestions, drawn where they would land (#537)

### DIFF
--- a/internal/spa/dist/index.html
+++ b/internal/spa/dist/index.html
@@ -1,1 +1,22 @@
-<!doctype html><html><body><div id="root"></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glyphoxa</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <!-- Arcane theme fonts (handoff tokens/fonts.css): Zilla Slab (display),
+         Inter (body/UI), JetBrains Mono (stat blocks / transcripts). -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+    />
+    <script type="module" crossorigin src="/assets/index-DZkQxVyq.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CnuIvPEi.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/web/src/screens/campaign/ProposalsPanel.tsx
+++ b/web/src/screens/campaign/ProposalsPanel.tsx
@@ -1,18 +1,11 @@
-import { useState } from "react";
-import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQuery } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { timestampDate } from "@bufbuild/protobuf/wkt";
-import { Check, Sparkles, X } from "lucide-react";
 
-import { CampaignService, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 import type { KnowledgeProposal } from "@gen/glyphoxa/management/v1/management_pb";
 import { Card } from "@/components/ui/Card";
-import { Badge } from "@/components/ui/Badge";
-import { Button } from "@/components/ui/Button";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { failedPreconditionMessage } from "@/lib/connectError";
-import { DISPOSITION_LABEL, EDGE_LABEL, metaOf } from "./knowledgeVocab";
-import { invalidateKnowledgeReads } from "./knowledgeCache";
+import { invalidateProposalReview } from "./knowledgeCache";
+import { KindBadge, ProposalActions, ProposalWrite, SimilarHint, fmtWhen } from "./proposalParts";
 
 // The Proposals panel (#300, ADR-0052) backs the Campaign screen's "Proposals"
 // view: the GM review queue an Agent's remember_knowledge call files into. Each
@@ -22,42 +15,19 @@ import { invalidateKnowledgeReads } from "./knowledgeCache";
 // refused approval (no such entry, matrix violation, duplicate) surfaces the
 // server's actionable reason inline. Reject drops the suggestion. Similarity is a
 // HINT the GM acts on — never an auto-merge (ADR-0052).
-
-// The type and relation vocabularies come from the one shared module so a new
-// type cannot colour or label itself differently here than in the list or the
-// graph (#534).
-function nodeTypeLabel(t: NodeType): string {
-  return metaOf(t).label;
-}
-
-function fmtWhen(p: KnowledgeProposal): string {
-  if (!p.createdAt) return "";
-  return timestampDate(p.createdAt).toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
-}
+//
+// The card's parts live in proposalParts so the graph overlay (#537) reviews the
+// same proposal through the same widgets and the same RPCs.
 
 export function ProposalsPanel() {
   const queryClient = useQueryClient();
   const { data, status, error } = useQuery(CampaignService.method.listKnowledgeProposals, {});
   const proposals = data?.proposals ?? [];
 
-  // A review action must refresh the queue AND the wiki list (an approved write
-  // lands a new/edited Node the Knowledge panel shows) AND any cached node-edges
-  // (an approved edge adds a relationship the relations view / delete-count reads).
-  // Each key is built without an input so it prefix-matches every cached query.
-  const invalidateAfterReview = () => {
-    void queryClient.invalidateQueries({
-      queryKey: createConnectQueryKey({
-        schema: CampaignService.method.listKnowledgeProposals,
-        cardinality: "finite",
-      }),
-    });
-    // An approved write lands a new/edited Node or Edge, so every read of the KG —
-    // the list, the search, a node's relations, and the graph — is now stale.
-    invalidateKnowledgeReads(queryClient);
-  };
+  // A review action must refresh the queue AND every read of the KG — an approved
+  // write lands a new/edited Node or Edge, so the list, the search, a node's
+  // relations and the graph are all stale.
+  const invalidateAfterReview = () => invalidateProposalReview(queryClient);
 
   if (status === "pending") {
     return <div className="gx-skeleton" data-testid="proposals-loading" />;
@@ -88,9 +58,7 @@ export function ProposalsPanel() {
 }
 
 // ProposalCard renders one pending proposal: who + when, the kind badge, the
-// human-rendered write, a lazy similarity hint, and Approve/Reject. A refused
-// approval (FailedPrecondition) shows the server's reason inline so the GM knows
-// exactly what to fix; any other failure shows a generic inline error.
+// human-rendered write, a lazy similarity hint, and Approve/Reject.
 function ProposalCard({
   proposal,
   onReviewed,
@@ -98,29 +66,6 @@ function ProposalCard({
   proposal: KnowledgeProposal;
   onReviewed: () => void;
 }) {
-  const [confirmReject, setConfirmReject] = useState(false);
-
-  const approve = useMutation(CampaignService.method.approveKnowledgeProposal, {
-    onSuccess: () => onReviewed(),
-  });
-  const reject = useMutation(CampaignService.method.rejectKnowledgeProposal, {
-    onSuccess: () => onReviewed(),
-  });
-
-  // A refused approval carries an actionable server reason; anything else is a
-  // generic failure. Reject failures fall into the same inline line so a dead
-  // button is never silent.
-  const blockedReason = approve.isError ? failedPreconditionMessage(approve.error) : null;
-  const inlineError = blockedReason
-    ? blockedReason
-    : approve.isError
-      ? `Couldn't approve: ${approve.error.message}`
-      : reject.isError
-        ? `Couldn't reject: ${reject.error.message}`
-        : null;
-
-  const pending = approve.isPending || reject.isPending;
-
   return (
     <Card className="gx-proposal-card">
       <div className="gx-proposal-card__head">
@@ -135,161 +80,7 @@ function ProposalCard({
 
       <SimilarHint proposalId={proposal.id} />
 
-      <div className="gx-proposal-card__actions">
-        <Button
-          variant="primary"
-          size="sm"
-          iconStart={<Check size={14} />}
-          onClick={() => approve.mutate({ id: proposal.id })}
-          disabled={pending}
-        >
-          Approve
-        </Button>
-        <Button
-          variant="danger"
-          size="sm"
-          iconStart={<X size={14} />}
-          onClick={() => setConfirmReject(true)}
-          disabled={pending}
-        >
-          Reject
-        </Button>
-        {inlineError && (
-          <span className="gx-editor__status gx-editor__status--error" role="alert">
-            {inlineError}
-          </span>
-        )}
-      </div>
-
-      {confirmReject && (
-        <ConfirmDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setConfirmReject(false);
-          }}
-          title="Reject this suggestion?"
-          description="The suggestion is dropped and never becomes canon. This can't be undone."
-          confirmLabel="Reject suggestion"
-          onConfirm={() => {
-            reject.mutate({ id: proposal.id });
-            setConfirmReject(false);
-          }}
-        />
-      )}
+      <ProposalActions proposalID={proposal.id} onReviewed={onReviewed} />
     </Card>
-  );
-}
-
-// KindBadge labels the proposal's kind, or "Unreadable" when the write is unset.
-function KindBadge({ proposal }: { proposal: KnowledgeProposal }) {
-  const kind = proposal.write.case;
-  if (kind === "fact") return <Badge size="sm">Fact</Badge>;
-  if (kind === "edge") return <Badge size="sm">Relationship</Badge>;
-  if (kind === "node") return <Badge size="sm">New entry</Badge>;
-  return (
-    <Badge variant="neutral" size="sm">
-      Unreadable
-    </Badge>
-  );
-}
-
-// ProposalWrite renders the human form of the proposed write per kind.
-function ProposalWrite({ proposal }: { proposal: KnowledgeProposal }) {
-  const w = proposal.write;
-  switch (w.case) {
-    case "fact":
-      // The aspect label is shown because approving files the fact UNDER it as a
-      // row on the entry (#542) — the GM is deciding where it lands, not just
-      // whether the sentence is true.
-      return (
-        <span>
-          <strong>{w.value.subject}</strong> —{" "}
-          {w.value.aspectKey && <em>{w.value.aspectKey}: </em>}
-          {w.value.fact}
-        </span>
-      );
-    case "edge":
-      // The note and disposition are rendered because APPROVING WRITES THEM, and
-      // the note reaches an NPC's system prompt through the relation clause. A card
-      // that showed only "subject —knows→ target" asked the GM to approve up to 280
-      // runes of model-authored text they had never seen — approval of unseen
-      // content, which is the one thing the review queue exists to prevent.
-      return (
-        <span>
-          <strong>{w.value.subject}</strong> —{EDGE_LABEL.get(w.value.relation) ?? ""}→{" "}
-          <strong>{w.value.target}</strong>
-          {(w.value.note || w.value.disposition !== 0) && (
-            <span className="gx-proposal-card__body">
-              {" — "}
-              {DISPOSITION_LABEL.get(w.value.disposition) ?? ""}
-              {w.value.note && w.value.disposition !== 0 ? ", " : ""}
-              {/* Newlines are collapsed: a proposal is one clause, and a note that
-                  can open a new line can forge a section header in the prompt. */}
-              {w.value.note.replace(/\s+/g, " ")}
-            </span>
-          )}
-        </span>
-      );
-    case "node":
-      return (
-        <span>
-          New {nodeTypeLabel(w.value.nodeType)}: <strong>{w.value.name}</strong>
-          {w.value.body && <span className="gx-proposal-card__body"> — {w.value.body}</span>}
-        </span>
-      );
-    default:
-      return <span className="gx-proposal-card__unreadable">Unreadable proposal</span>;
-  }
-}
-
-// SimilarHint lazily fetches the existing entries most similar to a proposal's
-// subject (the ADR-0011 vector hint) so the GM can merge or reject rather than
-// duplicate. A skeleton shows while loading; "No similar entries." when none.
-function SimilarHint({ proposalId }: { proposalId: string }) {
-  // Truly lazy: the similarity RPC embeds the subject (a provider call), so it
-  // fires ONLY after the GM opts in — never on mount for every card (that would
-  // fan N concurrent Embed calls across the whole queue).
-  const [show, setShow] = useState(false);
-  const { data, status } = useQuery(
-    CampaignService.method.listSimilarKnowledge,
-    { proposalId },
-    { enabled: show },
-  );
-
-  if (!show) {
-    return (
-      <button type="button" className="gx-proposal-card__similar-btn" onClick={() => setShow(true)}>
-        <Sparkles size={12} /> Show similar entries
-      </button>
-    );
-  }
-  if (status === "pending") {
-    return <div className="gx-skeleton gx-proposal-card__similar-skel" data-testid="similar-loading" />;
-  }
-  if (status === "error") {
-    return null; // the hint is best-effort; a failure is silent (no scary error on a suggestion)
-  }
-
-  const nodes = data.nodes;
-  return (
-    <div className="gx-proposal-card__similar">
-      <span className="gx-proposal-card__similar-title">
-        <Sparkles size={12} /> Similar existing entries
-      </span>
-      {nodes.length === 0 ? (
-        <span className="gx-proposal-card__similar-empty">No similar entries.</span>
-      ) : (
-        <ul className="gx-proposal-card__similar-list">
-          {nodes.map((n) => (
-            <li key={n.id}>
-              <span className="gx-proposal-card__similar-name">{n.name}</span>
-              <Badge size="sm" variant="neutral">
-                {nodeTypeLabel(n.nodeType)}
-              </Badge>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
   );
 }

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1508,6 +1508,8 @@
   align-items: flex-end;
   gap: var(--spacing-xs);
   padding-top: var(--spacing-xs);
+}
+
 /* ── Pending proposals, drawn in place (#537) ────────────────────────────── */
 
 /* Every proposal glyph is DASHED and hollow. A suggestion that could be mistaken

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1515,8 +1515,14 @@
    by shape and stroke rather than colour alone — colour is already spent on the
    seven entry types, and a colour-only difference is no difference to a GM who
    cannot see it. */
+/* fill: transparent, NOT none. `none` means the interior is not painted, and an
+   unpainted interior is not hit-testable — so a click inside a ghost fell straight
+   through to whatever was behind it, and the only clickable part was the 2px
+   dashed stroke. jsdom's fireEvent.click dispatches directly on the element and
+   skips hit-testing entirely, so every test passed while the feature was
+   unusable in a browser. */
 .gx-kg-graph__proposed-node circle {
-  fill: none;
+  fill: transparent;
   stroke-width: 2;
   stroke-dasharray: 4 3;
   opacity: 0.9;
@@ -1544,25 +1550,43 @@
   stroke-opacity: 0.8;
 }
 
-/* A 1.5px line is not a click target. The hit line is invisible and fat. */
-.gx-kg-graph__proposed-hit {
+/* A 1.5px line is not a click target. The hit line is invisible and fat.
+   The selector must out-specify `.gx-kg-graph__proposed-edge line` (0,1,1) —
+   a bare `.gx-kg-graph__proposed-hit` (0,1,0) LOSES to it, and the hit line then
+   silently inherited the visible 1.5px stroke. Only hit-testing in a real browser
+   catches that: jsdom dispatches clicks straight at the element. */
+.gx-kg-graph__proposed-edge line.gx-kg-graph__proposed-hit {
   stroke: transparent;
-  stroke-width: 12;
+  stroke-width: 14;
+  stroke-dasharray: none;
+  stroke-opacity: 1;
   cursor: pointer;
 }
 
-.gx-kg-graph__proposed-hit:focus-visible {
+.gx-kg-graph__proposed-edge line.gx-kg-graph__proposed-hit:focus-visible {
   stroke: var(--accent, #ffcf5a);
   stroke-opacity: 0.35;
 }
 
 /* A proposed FACT has nowhere of its own to stand — it lands on an entry that
    already exists — so it marks that entry with a dashed halo instead. */
+/* The halo rings a committed Node, so its interior deliberately stays clickable
+   as that Node — the GM must still be able to open the entry the fact would land
+   on. The ring itself is the review target, widened by a transparent hit ring. */
 .gx-kg-graph__fact-mark circle {
   fill: none;
   stroke: var(--accent, #ffcf5a);
   stroke-width: 1.5;
   stroke-dasharray: 3 4;
+  cursor: pointer;
+}
+
+/* Same specificity trap as the edge hit line above. */
+.gx-kg-graph__fact-mark circle.gx-kg-graph__fact-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 14;
+  stroke-dasharray: none;
   cursor: pointer;
 }
 

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1508,6 +1508,107 @@
   align-items: flex-end;
   gap: var(--spacing-xs);
   padding-top: var(--spacing-xs);
+/* ── Pending proposals, drawn in place (#537) ────────────────────────────── */
+
+/* Every proposal glyph is DASHED and hollow. A suggestion that could be mistaken
+   for canon defeats the queue it came from, so the visual distinction is carried
+   by shape and stroke rather than colour alone — colour is already spent on the
+   seven entry types, and a colour-only difference is no difference to a GM who
+   cannot see it. */
+.gx-kg-graph__proposed-node circle {
+  fill: none;
+  stroke-width: 2;
+  stroke-dasharray: 4 3;
+  opacity: 0.9;
+}
+
+.gx-kg-graph__proposed-node {
+  cursor: pointer;
+}
+
+.gx-kg-graph__proposed-node .gx-kg-graph__label {
+  font-style: italic;
+  fill: var(--accent, #ffcf5a);
+}
+
+.gx-kg-graph__proposed-node:focus-visible circle,
+.gx-kg-graph__proposed-node[data-selected] circle {
+  stroke-width: 3;
+  stroke-dasharray: none;
+}
+
+.gx-kg-graph__proposed-edge line {
+  stroke: var(--accent, #ffcf5a);
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+  stroke-opacity: 0.8;
+}
+
+/* A 1.5px line is not a click target. The hit line is invisible and fat. */
+.gx-kg-graph__proposed-hit {
+  stroke: transparent;
+  stroke-width: 12;
+  cursor: pointer;
+}
+
+.gx-kg-graph__proposed-hit:focus-visible {
+  stroke: var(--accent, #ffcf5a);
+  stroke-opacity: 0.35;
+}
+
+/* A proposed FACT has nowhere of its own to stand — it lands on an entry that
+   already exists — so it marks that entry with a dashed halo instead. */
+.gx-kg-graph__fact-mark circle {
+  fill: none;
+  stroke: var(--accent, #ffcf5a);
+  stroke-width: 1.5;
+  stroke-dasharray: 3 4;
+  cursor: pointer;
+}
+
+.gx-kg-graph__fact-mark:focus-visible circle {
+  stroke-width: 3;
+}
+
+.gx-kg-chip--proposals {
+  color: var(--accent, #ffcf5a);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.gx-kg-graph__review {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  border: 1px solid var(--accent, #ffcf5a);
+  border-radius: var(--radius-md, 8px);
+  background: var(--surface, #171b23);
+}
+
+.gx-kg-graph__unplaced {
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
+.gx-kg-graph__unplaced ul {
+  list-style: none;
+  margin: var(--spacing-xs) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-graph__unplaced li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-graph__unplaced-why {
+  color: var(--text-muted);
 }
 
 /* Free-form tags (#543). Visually distinct from the closed type vocabulary,

--- a/web/src/screens/campaign/graph/KnowledgeGraph.proposals.test.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.proposals.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { createRouterTransport } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  ApproveKnowledgeProposalResponseSchema,
+  CampaignService,
+  EdgeType,
+  GraphEdgeSchema,
+  GraphNodeSchema,
+  ListKnowledgeProposalsResponseSchema,
+  ListSimilarKnowledgeResponseSchema,
+  NodeType,
+  RejectKnowledgeProposalResponseSchema,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { KnowledgeGraph } from "./KnowledgeGraph";
+
+// Pending proposals drawn in place on the graph (#537, ADR-0052).
+//
+// The point of this slice is that the GM answers "does this belong HERE, next to
+// what the world already says" — so what is tested is that the suggestion is
+// visibly distinct from canon, reachable, reviewable through the existing RPCs,
+// and that reviewing one does not move the world underneath it.
+
+const NODES = [
+  create(GraphNodeSchema, { id: "bart", nodeType: NodeType.NPC, name: "Bart" }),
+  create(GraphNodeSchema, { id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+];
+const EDGES = [
+  create(GraphEdgeSchema, {
+    id: "e1",
+    fromNodeId: "bart",
+    toNodeId: "town",
+    edgeType: EdgeType.RESIDES_IN,
+  }),
+];
+
+const FACT_PROPOSAL = {
+  id: "p-fact",
+  authoringAgentName: "Bart",
+  write: {
+    case: "fact" as const,
+    value: { nodeId: "", subject: "Bart", fact: "keeps a ledger under the bar", aspectKey: "Rumour" },
+  },
+};
+
+const EDGE_PROPOSAL = {
+  id: "p-edge",
+  authoringAgentName: "Glyphoxa",
+  write: {
+    case: "edge" as const,
+    value: { nodeId: "", subject: "Bart", relation: EdgeType.MEMBER_OF, target: "Smugglers" },
+  },
+};
+
+const NODE_PROPOSAL = {
+  id: "p-node",
+  authoringAgentName: "Glyphoxa",
+  write: {
+    case: "node" as const,
+    value: { nodeType: NodeType.LOCATION, name: "The Sunken Chapel", body: "Half-drowned." },
+  },
+};
+
+function renderGraph(proposals: unknown[] = [FACT_PROPOSAL], nodes = NODES) {
+  const approve = vi.fn((_req: { id: string }) => create(ApproveKnowledgeProposalResponseSchema, {}));
+  const reject = vi.fn(() => create(RejectKnowledgeProposalResponseSchema, {}));
+  const similar = vi.fn(() => create(ListSimilarKnowledgeResponseSchema, { nodes: [] }));
+  const onGraphChanged = vi.fn();
+  const transport = createRouterTransport(({ service }) => {
+    service(CampaignService, {
+      listKnowledgeProposals: () =>
+        create(ListKnowledgeProposalsResponseSchema, {
+          proposals: proposals as never,
+        }),
+      approveKnowledgeProposal: approve,
+      rejectKnowledgeProposal: reject,
+      listSimilarKnowledge: similar,
+    });
+  });
+  const queryClient = makeQueryClient();
+  const view = (ns: typeof NODES) => (
+    <Providers transport={transport} queryClient={queryClient}>
+      <KnowledgeGraph
+        nodes={ns}
+        edges={EDGES}
+        selectedID={null}
+        onSelectNode={() => {}}
+        onGraphChanged={onGraphChanged}
+      />
+    </Providers>
+  );
+  const { rerender } = render(view(nodes));
+  return {
+    approve,
+    reject,
+    similar,
+    onGraphChanged,
+    /** Re-render with a changed payload, as a post-approval refetch would. */
+    withNodes: (ns: typeof NODES) => rerender(view(ns)),
+  };
+}
+
+/** Every committed node's id and rendered transform, for a before/after compare. */
+function nodePositions() {
+  return screen
+    .getAllByRole("button")
+    .filter((el) => el.hasAttribute("data-node-id"))
+    .map((el) => [el.getAttribute("data-node-id"), el.getAttribute("transform")]);
+}
+
+describe("proposals on the graph", () => {
+  it("a proposed entry is drawn, and is never mistakable for canon", async () => {
+    renderGraph([NODE_PROPOSAL]);
+    const ghost = await screen.findByRole("button", { name: /Suggested new entry The Sunken Chapel/ });
+    // data-proposed is what the dashed, hollow styling hangs off. A suggestion
+    // that renders identically to committed canon defeats the review queue.
+    expect(ghost).toHaveAttribute("data-proposed");
+
+    const committed = screen.getByRole("button", { name: /^Bart \(/ });
+    expect(committed).not.toHaveAttribute("data-proposed");
+  });
+
+  it("names the proposing Agent on the ghost itself", async () => {
+    renderGraph([NODE_PROPOSAL]);
+    // WHO proposed is most of the judgement: a Character NPC may only propose on
+    // its own linked Node, the Butler campaign-wide.
+    const ghost = await screen.findByRole("button", { name: /from Glyphoxa/ });
+    expect(ghost).toBeInTheDocument();
+  });
+
+  it("clicking a ghost opens the review with the write, the author and the similarity hint", async () => {
+    const { similar } = renderGraph([FACT_PROPOSAL]);
+    fireEvent.click(await screen.findByRole("button", { name: /Suggested fact from Bart/ }));
+
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+    // "Bart" appears twice on purpose: once as the AUTHOR and once as the
+    // proposal's subject. A Character NPC may only propose on its own linked Node
+    // (ADR-0052), so that is the realistic shape — and both lines must be there,
+    // because "who suggested this" is most of the judgement.
+    expect(within(dialog).getAllByText("Bart")).toHaveLength(2);
+    expect(within(dialog).getByText(/keeps a ledger under the bar/)).toBeInTheDocument();
+
+    // The ADR-0011 similarity hint travels with the proposal rather than being
+    // dropped for the visual — and stays LAZY, so opening a card costs no Embed.
+    expect(similar).not.toHaveBeenCalled();
+    fireEvent.click(within(dialog).getByRole("button", { name: /Show similar entries/ }));
+    await waitFor(() => expect(similar).toHaveBeenCalled());
+  });
+
+  it("approving goes through the existing RPC and refreshes both the queue and the graph", async () => {
+    const { approve, onGraphChanged } = renderGraph([FACT_PROPOSAL]);
+    fireEvent.click(await screen.findByRole("button", { name: /Suggested fact from Bart/ }));
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+    expect(approve.mock.calls[0][0].id).toBe("p-fact");
+    // ADR-0052 is untouched: no new write path, and the same invalidation the
+    // queue does — an approved write lands a Node or Edge every KG read now shows.
+    await waitFor(() => expect(onGraphChanged).toHaveBeenCalled());
+  });
+
+  it("rejecting asks first — a dropped suggestion never becomes canon", async () => {
+    const { reject } = renderGraph([FACT_PROPOSAL]);
+    fireEvent.click(await screen.findByRole("button", { name: /Suggested fact from Bart/ }));
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Reject" }));
+    expect(reject).not.toHaveBeenCalled();
+    fireEvent.click(await screen.findByRole("button", { name: "Reject suggestion" }));
+    await waitFor(() => expect(reject).toHaveBeenCalled());
+  });
+
+  it("approving does not move a single committed entry", async () => {
+    const { approve, withNodes } = renderGraph([NODE_PROPOSAL]);
+    const before = nodePositions();
+    expect(before.length).toBeGreaterThan(0);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Suggested new entry/ }));
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    // THE POINT. Approving lands a new Node, so the next payload is bigger — and
+    // `layout` is pure in its inputs, so a bigger payload reshuffles everything
+    // unless the positions are pinned. Without the re-render this assertion would
+    // be vacuous: the props never change, so nothing could move anyway.
+    withNodes([
+      ...NODES,
+      create(GraphNodeSchema, {
+        id: "fresh-uuid",
+        nodeType: NodeType.LOCATION,
+        name: "The Sunken Chapel",
+      }),
+    ]);
+    await screen.findByRole("button", { name: /^The Sunken Chapel \(/ });
+
+    // A review session where the graph jumps on every approval is not a review
+    // session (AC3).
+    expect(nodePositions().filter(([id]) => id !== "fresh-uuid")).toEqual(before);
+  });
+
+  it("the approved entry lands exactly where its ghost stood", async () => {
+    const { approve, withNodes } = renderGraph([NODE_PROPOSAL]);
+    const ghost = await screen.findByRole("button", { name: /Suggested new entry The Sunken Chapel/ });
+    const ghostAt = ghost.getAttribute("transform");
+    expect(ghostAt).toBeTruthy();
+
+    fireEvent.click(ghost);
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    withNodes([
+      ...NODES,
+      create(GraphNodeSchema, {
+        id: "fresh-uuid",
+        nodeType: NodeType.LOCATION,
+        name: "The Sunken Chapel",
+      }),
+    ]);
+    const solid = await screen.findByRole("button", { name: /^The Sunken Chapel \(/ });
+    // The dashed circle became a solid one IN PLACE. The server minted a fresh id
+    // at approval, so the name is the only thing that carried the position across.
+    expect(solid.getAttribute("transform")).toBe(ghostAt);
+  });
+
+  it("a suggestion naming an entry that does not exist is listed, not dropped", async () => {
+    renderGraph([EDGE_PROPOSAL]);
+    // "Smugglers" is in no entry, so the edge cannot be drawn — and approving it
+    // WILL be refused, which is worth knowing before clicking.
+    const strip = await screen.findByText(/can't be drawn here/);
+    expect(strip).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Glyphoxa" }));
+    const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
+    expect(within(dialog).getByText(/Approving will be refused/)).toBeInTheDocument();
+  });
+
+  it("the suggestions toggle takes every ghost off the canvas", async () => {
+    renderGraph([NODE_PROPOSAL]);
+    expect(
+      await screen.findByRole("button", { name: /Suggested new entry The Sunken Chapel/ }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Suggestions \(1\)/ }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Suggested new entry The Sunken Chapel/ }),
+      ).toBeNull(),
+    );
+    // And the committed graph is still there — the toggle hides suggestions, not
+    // the world.
+    expect(screen.getByRole("button", { name: /^Bart \(/ })).toBeInTheDocument();
+  });
+
+  it("shows no suggestions affordance when the queue is empty", async () => {
+    renderGraph([]);
+    await screen.findByRole("button", { name: /^Bart \(/ });
+    expect(screen.queryByRole("button", { name: /Suggestions \(/ })).toBeNull();
+    expect(screen.queryByText(/can't be drawn here/)).toBeNull();
+  });
+});

--- a/web/src/screens/campaign/graph/KnowledgeGraph.proposals.test.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.proposals.test.tsx
@@ -236,7 +236,7 @@ describe("proposals on the graph", () => {
     // WILL be refused, which is worth knowing before clicking.
     const strip = await screen.findByText(/can't be drawn here/);
     expect(strip).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Glyphoxa" }));
+    fireEvent.click(screen.getByRole("button", { name: /Glyphoxa:.*Smugglers/ }));
     const dialog = await screen.findByRole("dialog", { name: /Review suggestion/ });
     expect(within(dialog).getByText(/Approving will be refused/)).toBeInTheDocument();
   });
@@ -256,6 +256,40 @@ describe("proposals on the graph", () => {
     // And the committed graph is still there — the toggle hides suggestions, not
     // the world.
     expect(screen.getByRole("button", { name: /^Bart \(/ })).toBeInTheDocument();
+  });
+
+  it("table view takes the suggestions with it", async () => {
+    renderGraph([NODE_PROPOSAL, EDGE_PROPOSAL]);
+    await screen.findByRole("button", { name: /Suggested new entry The Sunken Chapel/ });
+    expect(screen.getByText(/can't be drawn here/)).toBeInTheDocument();
+
+    // Table view is the players-are-watching mode — it removes gm_private entries
+    // outright so the GM can share the screen. Unreviewed suggestions are strictly
+    // worse there: an Agent's unvetted guesses about the plot, whose subject line
+    // can name a gm_private entry and whose review card spells out the whole write.
+    fireEvent.click(screen.getByRole("button", { name: "Table view" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Suggested new entry The Sunken Chapel/ }),
+      ).toBeNull(),
+    );
+    // Including the strip that names the undrawable ones, and the toggle itself.
+    expect(screen.queryByText(/can't be drawn here/)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Suggestions \(/ })).toBeNull();
+    // The world is still drawn — table view hides suggestions, not the campaign.
+    expect(screen.getByRole("button", { name: /^Bart \(/ })).toBeInTheDocument();
+  });
+
+  it("draws proposed entries even in a campaign with nothing in it yet", async () => {
+    renderGraph([NODE_PROPOSAL], []);
+    // A brand-new campaign whose Butler proposed its first entries: gating the
+    // canvas on committed nodes alone hid every ghost behind "nothing to draw"
+    // while the chip insisted there were suggestions.
+    expect(
+      await screen.findByRole("button", { name: /Suggested new entry The Sunken Chapel/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing to draw/)).toBeNull();
   });
 
   it("shows no suggestions affordance when the queue is empty", async () => {

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -1,13 +1,20 @@
-import { useMemo, useState } from "react";
-import { useMutation } from "@connectrpc/connect-query";
+import { useMemo, useRef, useState } from "react";
+import { useMutation, useQuery } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Sparkles } from "lucide-react";
 
 import { CampaignService, EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
 import type { GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/management_pb";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
 import { EDGE_TYPES, TYPE_META, TYPE_ORDER, alphaBg, metaOf } from "../knowledgeVocab";
+import { invalidateProposalReview } from "../knowledgeCache";
+import { KindBadge, ProposalActions, ProposalWrite, SimilarHint, fmtWhen } from "../proposalParts";
 import { AgentLensBar, useAgentLens } from "./AgentLens";
 import { LAYOUT, egoNetwork, filterGraph, layout } from "./layout";
+import type { Pin } from "./layout";
+import { placeProposals, resolveProposals } from "./proposalGhosts";
+import type { ResolvedProposal } from "./proposalGhosts";
 
 // The Graph view (#534, ADR-0008 amendment "no graph viz" reversal). Edges were
 // authorable through NodeRelations' dropdown pair and then never displayed
@@ -72,6 +79,14 @@ export function KnowledgeGraph({
   const [linkError, setLinkError] = useState<string | null>(null);
   // The agent-knowledge lens (#535): which NPC's injected subgraph to highlight.
   const [lensAgentID, setLensAgentID] = useState("");
+  // Pending Knowledge Proposals drawn in place (#537). showProposals is on by
+  // default: a queue the GM cannot see is a queue that grows.
+  const [showProposals, setShowProposals] = useState(true);
+  const [reviewID, setReviewID] = useState<string | null>(null);
+  // layoutEpoch is the "Re-arrange" button. Bumping it drops the pinned positions
+  // and lets the simulation lay the graph out fresh.
+  const [layoutEpoch, setLayoutEpoch] = useState(0);
+  const queryClient = useQueryClient();
 
   const lens = useAgentLens(lensAgentID, nodes, edges);
   const active = lens.state?.linked ? lens.state.lens : null;
@@ -79,6 +94,14 @@ export function KnowledgeGraph({
   // OBJECT would re-run the filter — and therefore the 300-tick layout — on every
   // preview refetch, for an output that did not change.
   const lensOn = active !== null;
+
+  // The pending queue. It is the SAME read the Proposals panel uses, so the two
+  // review surfaces can never disagree about what is pending.
+  const proposalsQuery = useQuery(CampaignService.method.listKnowledgeProposals, {});
+  const resolved = useMemo(
+    () => resolveProposals(proposalsQuery.data?.proposals ?? [], nodes),
+    [proposalsQuery.data, nodes],
+  );
 
   const createEdge = useMutation(CampaignService.method.createEdge, {
     onSuccess: () => {
@@ -111,13 +134,64 @@ export function KnowledgeGraph({
     [nodes, edges, types, relations, hidePrivate, focus, lensOn],
   );
 
-  // Layout is a pure function of the filtered payload, so this memo is the whole
-  // performance story — and re-running it yields the identical picture.
-  const laid = useMemo(() => layout(filtered.nodes, filtered.edges), [filtered]);
+  // Position memory. `layout` is pure in its inputs, so adding one Node reshuffles
+  // every other Node — which is exactly what happens when the GM approves a
+  // suggestion mid-review, and "the graph jumped" is how a review session stops
+  // being a review session (#537 AC3).
+  //
+  // A change to the FILTERS is a request for a fresh picture and clears the pins;
+  // a change to the PAYLOAD is not, so an approve, an edit, or a refetch leaves
+  // every Node exactly where it was.
+  const filterKey = useMemo(
+    () =>
+      JSON.stringify([
+        [...types].sort(),
+        [...relations].sort(),
+        hidePrivate,
+        focusID,
+        focusDepth,
+        lensOn,
+        layoutEpoch,
+      ]),
+    [types, relations, hidePrivate, focusID, focusDepth, lensOn, layoutEpoch],
+  );
+  const sticky = useRef<{ key: string; pins: Map<string, Pin>; seeds: Map<string, Pin> }>({
+    key: "",
+    pins: new Map(),
+    seeds: new Map(),
+  });
+
+  const laid = useMemo(() => {
+    if (sticky.current.key !== filterKey) {
+      sticky.current = { key: filterKey, pins: new Map(), seeds: new Map() };
+    }
+    const out = layout(filtered.nodes, filtered.edges, {
+      pins: sticky.current.pins,
+      seeds: sticky.current.seeds,
+    });
+    // Recording the result makes the next run idempotent: with every Node pinned,
+    // layout returns exactly these coordinates again.
+    sticky.current.pins = new Map(out.nodes.map((p) => [p.node.id, { x: p.x, y: p.y }]));
+    return out;
+  }, [filtered, filterKey]);
+
+  // Ghosts are an OVERLAY: placement never moves a laid-out Node, which is what
+  // lets an approved suggestion turn solid in place.
+  const placed = useMemo(
+    () => placeProposals(showProposals ? resolved : [], laid),
+    [resolved, laid, showProposals],
+  );
+  const reviewing = reviewID ? (resolved.find((r) => r.id === reviewID) ?? null) : null;
+
+  const afterReview = () => {
+    setReviewID(null);
+    invalidateProposalReview(queryClient);
+    onGraphChanged();
+  };
 
   const showAllLabels = laid.nodes.length <= LABEL_BUDGET;
-  const width = laid.bounds.maxX - laid.bounds.minX;
-  const height = laid.bounds.maxY - laid.bounds.minY;
+  const width = placed.bounds.maxX - placed.bounds.minX;
+  const height = placed.bounds.maxY - placed.bounds.minY;
 
   // Zoom. A viewBox alone fits the WHOLE graph into a fixed-height canvas, which
   // at a few hundred nodes shrinks every glyph to a few pixels — "it all fits" is
@@ -128,8 +202,8 @@ export function KnowledgeGraph({
   const view = {
     w: width / zoom,
     h: height / zoom,
-    x: laid.bounds.minX + (width - width / zoom) / 2 + pan.x,
-    y: laid.bounds.minY + (height - height / zoom) / 2 + pan.y,
+    x: placed.bounds.minX + (width - width / zoom) / 2 + pan.x,
+    y: placed.bounds.minY + (height - height / zoom) / 2 + pan.y,
   };
 
   const toggle = <T,>(set: ReadonlySet<T>, value: T): ReadonlySet<T> => {
@@ -186,6 +260,19 @@ export function KnowledgeGraph({
           >
             Table view
           </button>
+          {resolved.length > 0 && (
+            <button
+              type="button"
+              className="gx-kg-chip gx-kg-chip--proposals"
+              aria-pressed={showProposals}
+              onClick={() => {
+                setShowProposals((v) => !v);
+                setReviewID(null);
+              }}
+            >
+              <Sparkles size={12} /> Suggestions ({resolved.length})
+            </button>
+          )}
           <button
             type="button"
             className="gx-kg-chip"
@@ -214,6 +301,11 @@ export function KnowledgeGraph({
               Fit
             </Button>
           )}
+          {/* Positions are sticky across edits so a review never reshuffles the
+              GM's mental map. This is the deliberate way to ask for a fresh one. */}
+          <Button variant="ghost" size="sm" onClick={() => setLayoutEpoch((n) => n + 1)}>
+            Re-arrange
+          </Button>
           {focusID && (
             <>
               <span className="gx-kg-graph__focus">Focused on {nodeName(focusID)}</span>
@@ -292,6 +384,30 @@ export function KnowledgeGraph({
                   <title>{edgeTooltip(e.edge)}</title>
                 )}
               </line>
+            ))}
+            {/* Proposed relations, dashed. A wide transparent line rides on top of
+                each so it can actually be clicked — a 1px stroke is not a target. */}
+            {placed.ghostEdges.map((g) => (
+              <g key={g.key} className="gx-kg-graph__proposed-edge">
+                <line x1={g.x1} y1={g.y1} x2={g.x2} y2={g.y2} />
+                <line
+                  className="gx-kg-graph__proposed-hit"
+                  x1={g.x1}
+                  y1={g.y1}
+                  x2={g.x2}
+                  y2={g.y2}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Suggested relationship from ${g.agentName} — review`}
+                  onClick={() => setReviewID(g.proposalID)}
+                  onKeyDown={(ev) => {
+                    if (ev.key === "Enter" || ev.key === " ") {
+                      ev.preventDefault();
+                      setReviewID(g.proposalID);
+                    }
+                  }}
+                />
+              </g>
             ))}
           </g>
           <g className="gx-kg-graph__nodes">
@@ -393,7 +509,100 @@ export function KnowledgeGraph({
               );
             })}
           </g>
+
+          {/* Pending proposals, drawn in place (#537). Dashed and hollow
+              throughout: a suggestion must never be mistakable for canon, which is
+              the whole reason the queue exists. */}
+          <g className="gx-kg-graph__proposals">
+            {placed.factMarks.map((m) => (
+              <g
+                key={m.key}
+                className="gx-kg-graph__fact-mark"
+                transform={`translate(${m.x} ${m.y})`}
+                role="button"
+                tabIndex={0}
+                aria-label={`Suggested fact from ${m.agentName} — review`}
+                onClick={() => setReviewID(m.proposalID)}
+                onKeyDown={(ev) => {
+                  if (ev.key === "Enter" || ev.key === " ") {
+                    ev.preventDefault();
+                    setReviewID(m.proposalID);
+                  }
+                }}
+              >
+                <title>{`${m.agentName} suggests a fact here`}</title>
+                <circle r={LAYOUT.nodeRadius + 7} />
+              </g>
+            ))}
+            {placed.ghostNodes.map((g) => {
+              const meta = metaOf(g.nodeType);
+              return (
+                <g
+                  key={g.key}
+                  className="gx-kg-graph__proposed-node"
+                  data-proposed
+                  data-selected={reviewID === g.proposalID || undefined}
+                  transform={`translate(${g.x} ${g.y})`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Suggested new entry ${g.name} (${meta.label}) from ${g.agentName} — review`}
+                  onClick={() => setReviewID(g.proposalID)}
+                  onKeyDown={(ev) => {
+                    if (ev.key === "Enter" || ev.key === " ") {
+                      ev.preventDefault();
+                      setReviewID(g.proposalID);
+                    }
+                  }}
+                >
+                  <title>{`${g.agentName} suggests creating ${g.name}`}</title>
+                  <circle r={LAYOUT.nodeRadius} stroke={meta.color} />
+                  <text className="gx-kg-graph__label" x={LAYOUT.nodeRadius + 4} y={4}>
+                    {g.name}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
         </svg>
+      )}
+
+      {/* Suggestions that cannot be drawn are LISTED, never dropped: an
+          unresolvable name is a proposal that will be refused at approval, and
+          that is worth knowing before clicking. */}
+      {showProposals && placed.unplaced.length > 0 && (
+        <details className="gx-kg-graph__unplaced">
+          <summary>
+            {placed.unplaced.length} suggestion{placed.unplaced.length === 1 ? "" : "s"} can&apos;t be
+            drawn here
+          </summary>
+          <ul>
+            {placed.unplaced.map((u) => (
+              <li key={u.proposal.id}>
+                <button type="button" className="gx-kg-chip" onClick={() => setReviewID(u.proposal.id)}>
+                  {u.proposal.agentName}
+                </button>
+                <span className="gx-kg-graph__unplaced-why">{u.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {reviewing && (
+        <ProposalReview
+          resolved={reviewing}
+          onClose={() => setReviewID(null)}
+          onApproved={() => {
+            // Remember where the ghost stood so the created Node inherits the spot:
+            // the server mints a fresh id at approval, and the NAME is the only
+            // thing that survives the transition (#537 AC3).
+            const ghost = placed.ghostNodes.find((g) => g.proposalID === reviewing.id);
+            if (ghost) {
+              sticky.current.seeds.set(ghost.name.trim().toLowerCase(), { x: ghost.x, y: ghost.y });
+            }
+          }}
+          onReviewed={afterReview}
+        />
       )}
 
       {pendingLink && (
@@ -436,6 +645,67 @@ function edgeTooltip(edge: GraphEdge): string {
   if (edge.disposition !== 0) parts.push(DISPOSITION_LABEL[edge.disposition] ?? "");
   if (edge.note !== "") parts.push(edge.note);
   return parts.filter(Boolean).join(" — ");
+}
+
+// ProposalReview is the in-place review card: everything the queue's card shows,
+// beside the graph, for the ghost the GM just clicked.
+//
+// It renders the SAME widgets and drives the SAME RPCs as the Proposals panel —
+// the write path is untouched, exactly as ADR-0052 requires. What the graph adds
+// is POSITION: the question "does this belong here, next to what the world already
+// says" is a question about the picture, and now it is asked in front of one.
+function ProposalReview({
+  resolved,
+  onClose,
+  onApproved,
+  onReviewed,
+}: {
+  resolved: ResolvedProposal;
+  onClose: () => void;
+  onApproved: () => void;
+  onReviewed: () => void;
+}) {
+  // An endpoint the client could not resolve will be REFUSED at approval. Saying
+  // so before the GM clicks beats an inline server error afterwards.
+  const unresolved =
+    resolved.write.kind === "edge"
+      ? [resolved.write.from, resolved.write.to].find((a) => a.at === "unknown")
+      : resolved.write.kind === "fact" && resolved.write.anchor.at === "unknown"
+        ? resolved.write.anchor
+        : undefined;
+
+  return (
+    <div className="gx-kg-graph__review" role="dialog" aria-label="Review suggestion">
+      <div className="gx-proposal-card__head">
+        {/* WHO proposed is most of the judgement: a Character NPC may only propose
+            on its own linked Node, the Butler campaign-wide. */}
+        <span className="gx-proposal-card__author">{resolved.agentName}</span>
+        <span className="gx-proposal-card__when">{fmtWhen(resolved.proposal)}</span>
+        <KindBadge proposal={resolved.proposal} />
+      </div>
+
+      <div className="gx-proposal-card__write">
+        <ProposalWrite proposal={resolved.proposal} />
+      </div>
+
+      {unresolved && unresolved.at === "unknown" && (
+        <p className="gx-editor__status gx-editor__status--error" role="alert">
+          Approving will be refused: {unresolved.reason}.
+        </p>
+      )}
+
+      {/* The ADR-0011 similarity hint travels with the proposal rather than being
+          dropped for the visual — "is this a duplicate" is the other half of the
+          decision, and the graph does not answer it. */}
+      <SimilarHint proposalId={resolved.id} />
+
+      <ProposalActions proposalID={resolved.id} onApproved={onApproved} onReviewed={onReviewed} />
+
+      <Button variant="ghost" size="sm" onClick={onClose}>
+        Close
+      </Button>
+    </div>
+  );
 }
 
 // RelationPicker is the one authoring affordance on the graph: after dragging one

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -162,7 +162,15 @@ export function KnowledgeGraph({
   });
 
   const laid = useMemo(() => {
-    if (sticky.current.key !== filterKey) {
+    // A DIFFERENT WORLD resets the memory too. The graph stays mounted across a
+    // campaign switch, and seeds are keyed by lower-cased NAME — so an approved
+    // "Bart" in campaign A would pin campaign B's "Bart" to A's coordinates. If
+    // not one remembered id survives into the new payload, this is not the same
+    // world.
+    const carriedOver =
+      sticky.current.pins.size === 0 ||
+      filtered.nodes.some((n) => sticky.current.pins.has(n.id));
+    if (sticky.current.key !== filterKey || !carriedOver) {
       sticky.current = { key: filterKey, pins: new Map(), seeds: new Map() };
     }
     const out = layout(filtered.nodes, filtered.edges, {
@@ -175,13 +183,19 @@ export function KnowledgeGraph({
     return out;
   }, [filtered, filterKey]);
 
-  // Ghosts are an OVERLAY: placement never moves a laid-out Node, which is what
-  // lets an approved suggestion turn solid in place.
+  // Table view is the players-are-watching mode: it removes gm_private entries
+  // outright so the GM can share the screen. Unreviewed suggestions are strictly
+  // worse than a private entry there — they are an Agent's unvetted guesses about
+  // the plot, they can name a gm_private entry in their subject line, and the
+  // review card spells out the whole write. So table view takes the overlay with
+  // it, rather than leaving the GM to remember the toggle.
+  const proposalsVisible = showProposals && !hidePrivate;
   const placed = useMemo(
-    () => placeProposals(showProposals ? resolved : [], laid),
-    [resolved, laid, showProposals],
+    () => placeProposals(proposalsVisible ? resolved : [], laid),
+    [resolved, laid, proposalsVisible],
   );
-  const reviewing = reviewID ? (resolved.find((r) => r.id === reviewID) ?? null) : null;
+  const reviewing =
+    proposalsVisible && reviewID ? (resolved.find((r) => r.id === reviewID) ?? null) : null;
 
   const afterReview = () => {
     setReviewID(null);
@@ -260,7 +274,7 @@ export function KnowledgeGraph({
           >
             Table view
           </button>
-          {resolved.length > 0 && (
+          {resolved.length > 0 && !hidePrivate && (
             <button
               type="button"
               className="gx-kg-chip gx-kg-chip--proposals"
@@ -328,9 +342,16 @@ export function KnowledgeGraph({
         </div>
       </div>
 
-      {laid.nodes.length === 0 ? (
+      {/* The canvas is skipped only when there is NOTHING to draw — including
+          suggestions. A brand-new campaign whose Butler has proposed its first
+          entries has no committed Nodes at all, and gating on those alone hid
+          every ghost behind "nothing to draw" while the chip said there were
+          suggestions. */}
+      {laid.nodes.length === 0 && placed.ghostNodes.length === 0 ? (
         <p className="gx-kg-empty">
-          Nothing to draw — every entry is filtered out. Turn a type chip back on.
+          {resolved.length > 0 && !proposalsVisible
+            ? "Nothing to draw here. Suggestions are hidden in table view."
+            : "Nothing to draw — every entry is filtered out. Turn a type chip back on."}
         </p>
       ) : (
         <svg
@@ -532,6 +553,8 @@ export function KnowledgeGraph({
               >
                 <title>{`${m.agentName} suggests a fact here`}</title>
                 <circle r={LAYOUT.nodeRadius + 7} />
+                {/* A 1.5px dashed ring is not a click target. */}
+                <circle className="gx-kg-graph__fact-hit" r={LAYOUT.nodeRadius + 7} />
               </g>
             ))}
             {placed.ghostNodes.map((g) => {
@@ -569,7 +592,7 @@ export function KnowledgeGraph({
       {/* Suggestions that cannot be drawn are LISTED, never dropped: an
           unresolvable name is a proposal that will be refused at approval, and
           that is worth knowing before clicking. */}
-      {showProposals && placed.unplaced.length > 0 && (
+      {proposalsVisible && placed.unplaced.length > 0 && (
         <details className="gx-kg-graph__unplaced">
           <summary>
             {placed.unplaced.length} suggestion{placed.unplaced.length === 1 ? "" : "s"} can&apos;t be
@@ -578,8 +601,10 @@ export function KnowledgeGraph({
           <ul>
             {placed.unplaced.map((u) => (
               <li key={u.proposal.id}>
+                {/* Labelled with the WRITE, not just the author: two undrawable
+                    suggestions from the same Agent were two identical buttons. */}
                 <button type="button" className="gx-kg-chip" onClick={() => setReviewID(u.proposal.id)}>
-                  {u.proposal.agentName}
+                  {u.proposal.agentName}: <ProposalWrite proposal={u.proposal.proposal} />
                 </button>
                 <span className="gx-kg-graph__unplaced-why">{u.reason}</span>
               </li>

--- a/web/src/screens/campaign/graph/KnowledgeGraph.tsx
+++ b/web/src/screens/campaign/graph/KnowledgeGraph.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
@@ -665,6 +665,14 @@ function ProposalReview({
   onApproved: () => void;
   onReviewed: () => void;
 }) {
+  // The card renders BELOW the canvas, and the canvas is up to 720px tall — so on
+  // an ordinary screen clicking a ghost opened a card the GM could not see, which
+  // reads as "clicking did nothing". Found by using it, not by a test.
+  const card = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    card.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [resolved.id]);
+
   // An endpoint the client could not resolve will be REFUSED at approval. Saying
   // so before the GM clicks beats an inline server error afterwards.
   const unresolved =
@@ -675,7 +683,7 @@ function ProposalReview({
         : undefined;
 
   return (
-    <div className="gx-kg-graph__review" role="dialog" aria-label="Review suggestion">
+    <div className="gx-kg-graph__review" role="dialog" aria-label="Review suggestion" ref={card}>
       <div className="gx-proposal-card__head">
         {/* WHO proposed is most of the judgement: a Character NPC may only propose
             on its own linked Node, the Butler campaign-wide. */}

--- a/web/src/screens/campaign/graph/layout.test.ts
+++ b/web/src/screens/campaign/graph/layout.test.ts
@@ -214,3 +214,93 @@ describe("filterGraph", () => {
     expect(out.nodes.map((n) => n.id).sort()).toEqual(["bart", "guild", "town"]);
   });
 });
+
+// Position memory (#537). `layout` is pure in its INPUTS, so adding one Node
+// reshuffles every other Node — which is exactly what happens when the GM
+// approves a suggestion mid-review. Determinism is not stability.
+describe("layout position memory", () => {
+  it("pinned nodes come back at exactly their pinned coordinates", () => {
+    const { nodes, edges } = fixture();
+    const first = layout(nodes, edges);
+    const pins = new Map(first.nodes.map((p) => [p.node.id, { x: p.x, y: p.y }]));
+
+    // A new entry arrives — an approved suggestion, or any other edit.
+    const grown = [
+      ...nodes,
+      create(GraphNodeSchema, { id: "new", nodeType: NodeType.NPC, name: "Mira" }),
+    ];
+    const second = layout(grown, edges, { pins });
+
+    for (const before of first.nodes) {
+      const after = second.nodes.find((p) => p.node.id === before.node.id);
+      expect(after, `${before.node.id} vanished`).toBeDefined();
+      expect([after!.x, after!.y], `${before.node.id} moved`).toEqual([before.x, before.y]);
+    }
+  });
+
+  it("without pins, the same growth DOES reshuffle — which is why pins exist", () => {
+    const { nodes, edges } = fixture();
+    const first = layout(nodes, edges);
+    const grown = [
+      ...nodes,
+      create(GraphNodeSchema, { id: "new", nodeType: NodeType.NPC, name: "Mira" }),
+    ];
+    const second = layout(grown, edges);
+
+    const moved = first.nodes.some((before) => {
+      const after = second.nodes.find((p) => p.node.id === before.node.id);
+      return after && (after.x !== before.x || after.y !== before.y);
+    });
+    expect(moved, "the unpinned layout was stable by accident, so the pin test proves nothing").toBe(
+      true,
+    );
+  });
+
+  it("a fully pinned layout is idempotent", () => {
+    const { nodes, edges } = fixture();
+    const first = layout(nodes, edges);
+    const pins = new Map(first.nodes.map((p) => [p.node.id, { x: p.x, y: p.y }]));
+    const second = layout(nodes, edges, { pins });
+    expect(second.nodes.map((p) => [p.node.id, p.x, p.y])).toEqual(
+      first.nodes.map((p) => [p.node.id, p.x, p.y]),
+    );
+    expect(second.bounds).toEqual(first.bounds);
+  });
+
+  it("a seed places a brand-new node where its ghost stood", () => {
+    const { nodes, edges } = fixture();
+    const first = layout(nodes, edges);
+    const pins = new Map(first.nodes.map((p) => [p.node.id, { x: p.x, y: p.y }]));
+    // The server mints a fresh id at approval, so the NAME is the only thing that
+    // survives the ghost→node transition.
+    const seeds = new Map([["mira", { x: 400, y: -250 }]]);
+    const grown = [
+      ...nodes,
+      create(GraphNodeSchema, { id: "fresh-uuid", nodeType: NodeType.NPC, name: "Mira" }),
+    ];
+    const out = layout(grown, edges, { pins, seeds });
+    const mira = out.nodes.find((p) => p.node.id === "fresh-uuid")!;
+    // EXACTLY where the ghost stood. "Near enough" is not what the GM watched
+    // happen: they clicked a dashed circle and it should become a solid one, in
+    // that spot, with nothing else moving.
+    expect([mira.x, mira.y]).toEqual([400, -250]);
+  });
+
+  it("pinned nodes do not drift as the free node settles", () => {
+    // forceCenter recentres by translating every node, and a pinned node is snapped
+    // back each tick — so the offset never shrinks and the correction is re-applied
+    // forever, walking the free nodes away. It must be off once anything is pinned.
+    const { nodes, edges } = fixture();
+    const pins = new Map(nodes.map((n, i) => [n.id, { x: 1000 + i * 60, y: 1000 }]));
+    const grown = [
+      ...nodes,
+      create(GraphNodeSchema, { id: "new", nodeType: NodeType.NPC, name: "Mira" }),
+    ];
+    const out = layout(grown, edges, { pins });
+    const fresh = out.nodes.find((p) => p.node.id === "new")!;
+    expect(Number.isFinite(fresh.x)).toBe(true);
+    // Sane means "in the same neighbourhood as the cloud", not "at ±1e12".
+    expect(Math.abs(fresh.x - 1000)).toBeLessThan(2000);
+    expect(Math.abs(fresh.y - 1000)).toBeLessThan(2000);
+  });
+});

--- a/web/src/screens/campaign/graph/layout.ts
+++ b/web/src/screens/campaign/graph/layout.ts
@@ -34,6 +34,12 @@ import type { GraphEdge, GraphNode } from "@gen/glyphoxa/management/v1/managemen
 // then N manual ticks) rather than animated: an animated layout would be a
 // different picture on a fast machine than a slow one, and a settling graph is
 // harder to click than a settled one.
+//
+// Determinism alone is not stability, though. `layout` is pure in its INPUTS, so
+// adding one Node reshuffles every other Node — which is precisely what happens
+// when the GM approves a suggestion mid-review (#537). `opts.pins` answers that:
+// a pinned Node is fixed where it already was and the newcomer settles around it,
+// so approving turns one dashed thing solid instead of redrawing the world.
 
 /** One laid-out node: the payload row plus its computed position. */
 export type PositionedNode = {
@@ -82,7 +88,28 @@ export const LAYOUT = {
   minExtent: 520,
 } as const;
 
-// simNode is the mutable datum d3-force writes x/y/vx/vy onto.
+/** A remembered position. */
+export type Pin = { x: number; y: number };
+
+/**
+ * Options for `layout`.
+ *
+ * Both maps FIX a Node's position; they differ only in what they key on.
+ *
+ * `pins` keys by Node ID — the ordinary case, remembering where a Node already
+ * was. `seeds` keys by lower-cased Node NAME, for a Node whose id is not knowable
+ * in advance: an approved suggestion gets a fresh server-minted id, so the name is
+ * the only thing that survives the ghost→Node transition, and pinning by name is
+ * what makes the ghost turn solid exactly where it stood rather than merely near
+ * it. A seed only applies to a Node with no pin.
+ */
+export type LayoutOpts = {
+  pins?: ReadonlyMap<string, Pin>;
+  seeds?: ReadonlyMap<string, Pin>;
+};
+
+// simNode is the mutable datum d3-force writes x/y/vx/vy onto. fx/fy come from
+// SimulationNodeDatum and are what freeze a pinned node in place.
 type SimNode = SimulationNodeDatum & { id: string; node: GraphNode };
 type SimLink = SimulationLinkDatum<SimNode> & { edge: GraphEdge };
 
@@ -109,14 +136,23 @@ export function seededRandom(seed = 0x2545f491): () => number {
  * dropped rather than crashing d3-force's link resolution — the filter chips
  * legitimately produce that state on every render.
  */
-export function layout(nodes: GraphNode[], edges: GraphEdge[]): Layout {
+export function layout(nodes: GraphNode[], edges: GraphEdge[], opts: LayoutOpts = {}): Layout {
   if (nodes.length === 0) {
     return { nodes: [], edges: [], bounds: { minX: 0, minY: 0, maxX: 0, maxY: 0 } };
   }
 
   // Deterministic initial placement: a phyllotaxis spiral keyed on the node's
-  // index in the (server-ordered) payload.
+  // index in the (server-ordered) payload — unless the caller remembers where this
+  // node already was, in which case it is pinned there and the spiral is skipped.
   const sim: SimNode[] = nodes.map((node, i) => {
+    const pin = opts.pins?.get(node.id);
+    if (pin) {
+      return { id: node.id, node, x: pin.x, y: pin.y, fx: pin.x, fy: pin.y, vx: 0, vy: 0 };
+    }
+    const seed = opts.seeds?.get(node.name.trim().toLowerCase());
+    if (seed) {
+      return { id: node.id, node, x: seed.x, y: seed.y, fx: seed.x, fy: seed.y, vx: 0, vy: 0 };
+    }
     const angle = i * 2.399963229728653; // the golden angle, in radians
     const radius = LAYOUT.spiralSpacing * Math.sqrt(i);
     return {
@@ -148,8 +184,17 @@ export function layout(nodes: GraphNode[], edges: GraphEdge[]): Layout {
     )
     .force("charge", forceManyBody().strength(LAYOUT.charge))
     .force("collide", forceCollide(LAYOUT.collideRadius))
-    .force("center", forceCenter(0, 0))
     .stop();
+
+  // forceCenter is DELIBERATELY absent once anything is pinned. It recentres by
+  // translating every node by the cloud's offset from the origin — but a pinned
+  // node is snapped back to its fx/fy at the end of each tick, so that offset never
+  // shrinks and the correction is re-applied every tick, walking the free nodes off
+  // to infinity. Pins already fix the frame of reference, which is all centring was
+  // for.
+  if (!sim.some((s) => s.fx != null)) {
+    simulation.force("center", forceCenter(0, 0));
+  }
 
   simulation.tick(LAYOUT.ticks);
 

--- a/web/src/screens/campaign/graph/proposalGhosts.test.ts
+++ b/web/src/screens/campaign/graph/proposalGhosts.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  EdgeType,
+  GraphNodeSchema,
+  KnowledgeProposalSchema,
+  NodeType,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import type { KnowledgeProposal } from "@gen/glyphoxa/management/v1/management_pb";
+import { GHOST, placeProposals, resolveProposals } from "./proposalGhosts";
+import { layout } from "./layout";
+
+// Resolving and placing the pending queue on the graph (#537).
+//
+// The resolution half is where the interesting failures live: a proposal names its
+// endpoints by NAME (ADR-0052 resolves them at approval, so nothing auto-merges),
+// and a name that will be REFUSED at approval should say so on the card rather
+// than after the click.
+
+const NODES = [
+  create(GraphNodeSchema, { id: "bart", nodeType: NodeType.NPC, name: "Bart" }),
+  create(GraphNodeSchema, { id: "town", nodeType: NodeType.LOCATION, name: "Saltmarsh" }),
+  create(GraphNodeSchema, { id: "guild", nodeType: NodeType.FACTION, name: "Smugglers" }),
+];
+
+function factProposal(over: Partial<{ id: string; subject: string; nodeId: string }> = {}) {
+  return create(KnowledgeProposalSchema, {
+    id: over.id ?? "p-fact",
+    authoringAgentName: "Bart",
+    write: {
+      case: "fact",
+      value: {
+        nodeId: over.nodeId ?? "",
+        subject: over.subject ?? "Bart",
+        fact: "keeps a ledger under the bar",
+        aspectKey: "Rumour",
+      },
+    },
+  });
+}
+
+function edgeProposal(subject: string, target: string, id = "p-edge"): KnowledgeProposal {
+  return create(KnowledgeProposalSchema, {
+    id,
+    authoringAgentName: "Glyphoxa",
+    write: {
+      case: "edge",
+      value: { nodeId: "", subject, relation: EdgeType.MEMBER_OF, target },
+    },
+  });
+}
+
+function nodeProposal(name: string, id = "p-node"): KnowledgeProposal {
+  return create(KnowledgeProposalSchema, {
+    id,
+    authoringAgentName: "Glyphoxa",
+    write: { case: "node", value: { nodeType: NodeType.LOCATION, name, body: "" } },
+  });
+}
+
+describe("resolveProposals", () => {
+  it("resolves a name to the entry that carries it", () => {
+    const [r] = resolveProposals([factProposal()], NODES);
+    expect(r.write.kind).toBe("fact");
+    if (r.write.kind !== "fact") return;
+    expect(r.write.anchor).toEqual({ at: "node", id: "bart" });
+  });
+
+  it("prefers an id over the name when the proposal carries one", () => {
+    const [r] = resolveProposals([factProposal({ nodeId: "town", subject: "Bart" })], NODES);
+    if (r.write.kind !== "fact") throw new Error("expected a fact");
+    expect(r.write.anchor).toEqual({ at: "node", id: "town" });
+  });
+
+  it("an id whose entry is gone reports that, not a missing name", () => {
+    const [r] = resolveProposals([factProposal({ nodeId: "deleted", subject: "Nowhere" })], NODES);
+    if (r.write.kind !== "fact") throw new Error("expected a fact");
+    expect(r.write.anchor.at).toBe("unknown");
+    if (r.write.anchor.at !== "unknown") return;
+    expect(r.write.anchor.reason).toMatch(/gone/);
+  });
+
+  it("refuses to guess between two entries with the same name", () => {
+    const twins = [
+      ...NODES,
+      create(GraphNodeSchema, { id: "bart-item", nodeType: NodeType.ITEM, name: "Bart" }),
+    ];
+    const [r] = resolveProposals([factProposal()], twins);
+    if (r.write.kind !== "fact") throw new Error("expected a fact");
+    // Both are exactly "Bart", so exact-case cannot disambiguate either. Picking
+    // one would silently file the fact on the wrong entry.
+    expect(r.write.anchor.at).toBe("unknown");
+    if (r.write.anchor.at !== "unknown") return;
+    expect(r.write.anchor.reason).toMatch(/2 entries/);
+  });
+
+  it("an exact-case match disambiguates a case-insensitive collision", () => {
+    const twins = [
+      ...NODES,
+      create(GraphNodeSchema, { id: "bart-lower", nodeType: NodeType.ITEM, name: "bart" }),
+    ];
+    const [r] = resolveProposals([factProposal({ subject: "Bart" })], twins);
+    if (r.write.kind !== "fact") throw new Error("expected a fact");
+    expect(r.write.anchor).toEqual({ at: "node", id: "bart" });
+  });
+
+  it("an edge into an entry the same queue proposes creating resolves to a ghost", () => {
+    const resolved = resolveProposals(
+      [nodeProposal("The Sunken Chapel"), edgeProposal("Bart", "The Sunken Chapel")],
+      NODES,
+    );
+    const edge = resolved.find((r) => r.write.kind === "edge")!;
+    if (edge.write.kind !== "edge") throw new Error("expected an edge");
+    expect(edge.write.from).toEqual({ at: "node", id: "bart" });
+    expect(edge.write.to).toEqual({ at: "ghost", name: "The Sunken Chapel" });
+  });
+
+  it("a name nothing knows is unknown, with a reason the GM can act on", () => {
+    const [r] = resolveProposals([edgeProposal("Bart", "Atlantis")], NODES);
+    if (r.write.kind !== "edge") throw new Error("expected an edge");
+    expect(r.write.to.at).toBe("unknown");
+    if (r.write.to.at !== "unknown") return;
+    expect(r.write.to.reason).toMatch(/Atlantis/);
+  });
+
+  it("an unparseable proposal survives as unreadable rather than being dropped", () => {
+    const blank = create(KnowledgeProposalSchema, { id: "p-x", authoringAgentName: "Bart" });
+    const [r] = resolveProposals([blank], NODES);
+    expect(r.write.kind).toBe("unreadable");
+  });
+});
+
+describe("placeProposals", () => {
+  const laid = layout(NODES, []);
+
+  it("never moves a laid-out node", () => {
+    const resolved = resolveProposals(
+      [factProposal(), edgeProposal("Bart", "Saltmarsh"), nodeProposal("The Sunken Chapel")],
+      NODES,
+    );
+    const before = laid.nodes.map((p) => [p.node.id, p.x, p.y]);
+    placeProposals(resolved, laid);
+    expect(laid.nodes.map((p) => [p.node.id, p.x, p.y])).toEqual(before);
+  });
+
+  it("draws a proposed edge between the two entries it names", () => {
+    const resolved = resolveProposals([edgeProposal("Bart", "Saltmarsh")], NODES);
+    const placed = placeProposals(resolved, laid);
+    expect(placed.ghostEdges).toHaveLength(1);
+    const bart = laid.nodes.find((p) => p.node.id === "bart")!;
+    const town = laid.nodes.find((p) => p.node.id === "town")!;
+    expect([placed.ghostEdges[0].x1, placed.ghostEdges[0].y1]).toEqual([bart.x, bart.y]);
+    expect([placed.ghostEdges[0].x2, placed.ghostEdges[0].y2]).toEqual([town.x, town.y]);
+  });
+
+  it("places a proposed entry beside the entry its proposed edge attaches it to", () => {
+    const resolved = resolveProposals(
+      [nodeProposal("The Sunken Chapel"), edgeProposal("Bart", "The Sunken Chapel")],
+      NODES,
+    );
+    const placed = placeProposals(resolved, laid);
+    expect(placed.ghostNodes).toHaveLength(1);
+    const bart = laid.nodes.find((p) => p.node.id === "bart")!;
+    const ghost = placed.ghostNodes[0];
+    // Exactly the attach offset away from its one neighbour — near enough to read
+    // as "this goes here", far enough not to sit on top of it.
+    expect(Math.hypot(ghost.x - bart.x, ghost.y - bart.y)).toBeCloseTo(GHOST.attachOffset, 0);
+    // And the proposed edge now runs to the ghost.
+    expect(placed.ghostEdges).toHaveLength(1);
+    expect([placed.ghostEdges[0].x2, placed.ghostEdges[0].y2]).toEqual([ghost.x, ghost.y]);
+  });
+
+  it("rings an unattached proposed entry outside the cloud instead of burying it", () => {
+    const resolved = resolveProposals([nodeProposal("The Sunken Chapel")], NODES);
+    const placed = placeProposals(resolved, laid);
+    const ghost = placed.ghostNodes[0];
+    for (const p of laid.nodes) {
+      expect(
+        Math.hypot(ghost.x - p.x, ghost.y - p.y),
+        "an unattached ghost landed on top of a real entry",
+      ).toBeGreaterThan(20);
+    }
+    // The viewBox grows to include it — growing the BOX is not relaying out.
+    expect(placed.bounds.minX).toBeLessThanOrEqual(laid.bounds.minX);
+    expect(placed.bounds.maxX).toBeGreaterThanOrEqual(laid.bounds.maxX);
+  });
+
+  it("two ghosts on the same neighbour separate deterministically", () => {
+    const resolved = resolveProposals(
+      [
+        nodeProposal("Chapel", "p1"),
+        edgeProposal("Bart", "Chapel", "e1"),
+        nodeProposal("Crypt", "p2"),
+        edgeProposal("Bart", "Crypt", "e2"),
+      ],
+      NODES,
+    );
+    const a = placeProposals(resolved, laid);
+    const b = placeProposals(resolved, laid);
+    expect(a.ghostNodes.map((g) => [g.name, g.x, g.y])).toEqual(
+      b.ghostNodes.map((g) => [g.name, g.x, g.y]),
+    );
+    const [g1, g2] = a.ghostNodes;
+    expect(Math.hypot(g1.x - g2.x, g1.y - g2.y)).toBeGreaterThan(20);
+  });
+
+  it("lists what it cannot draw instead of silently dropping it", () => {
+    const resolved = resolveProposals(
+      [edgeProposal("Bart", "Atlantis"), factProposal({ subject: "Nobody" })],
+      NODES,
+    );
+    const placed = placeProposals(resolved, laid);
+    expect(placed.ghostEdges).toHaveLength(0);
+    expect(placed.factMarks).toHaveLength(0);
+    // Both are reachable, with a reason — a proposal that vanishes from the graph
+    // AND has no other surface is a proposal the GM can never review.
+    expect(placed.unplaced).toHaveLength(2);
+    for (const u of placed.unplaced) expect(u.reason).toBeTruthy();
+  });
+
+  it("a resolvable entry that is filtered out of the view says so", () => {
+    // Bart resolves fine, but the drawn subset excludes him — a DRAWING problem,
+    // not a proposal problem, and conflating the two would tell the GM their
+    // Butler had hallucinated an entry that exists.
+    const withoutBart = layout(
+      NODES.filter((n) => n.id !== "bart"),
+      [],
+    );
+    const resolved = resolveProposals([factProposal()], NODES);
+    const placed = placeProposals(resolved, withoutBart);
+    expect(placed.unplaced).toHaveLength(1);
+    expect(placed.unplaced[0].reason).toMatch(/filtered out/);
+  });
+
+  it("an empty queue changes nothing at all", () => {
+    const placed = placeProposals([], laid);
+    expect(placed.ghostNodes).toHaveLength(0);
+    expect(placed.ghostEdges).toHaveLength(0);
+    expect(placed.factMarks).toHaveLength(0);
+    expect(placed.unplaced).toHaveLength(0);
+    expect(placed.bounds).toEqual(laid.bounds);
+  });
+});

--- a/web/src/screens/campaign/graph/proposalGhosts.test.ts
+++ b/web/src/screens/campaign/graph/proposalGhosts.test.ts
@@ -95,14 +95,29 @@ describe("resolveProposals", () => {
     expect(r.write.anchor.reason).toMatch(/2 entries/);
   });
 
-  it("an exact-case match disambiguates a case-insensitive collision", () => {
+  it("refuses a case-insensitive collision even when one match is exact-case", () => {
     const twins = [
       ...NODES,
       create(GraphNodeSchema, { id: "bart-lower", nodeType: NodeType.ITEM, name: "bart" }),
     ];
     const [r] = resolveProposals([factProposal({ subject: "Bart" })], twins);
     if (r.write.kind !== "fact") throw new Error("expected a fact");
-    expect(r.write.anchor).toEqual({ at: "node", id: "bart" });
+    // The SERVER refuses any multi-match on lower(name) ("rename one first"), so
+    // an exact-case tiebreak here would draw a confident halo on an approval that
+    // cannot land — a promise the GM then watches fail.
+    expect(r.write.anchor.at).toBe("unknown");
+    if (r.write.anchor.at !== "unknown") return;
+    expect(r.write.anchor.reason).toMatch(/rename one/);
+  });
+
+  it("an id that names nothing never falls back to a same-named entry", () => {
+    // The server treats node_id as authoritative and NEVER falls back to the name.
+    // A client that did would draw the halo on a different entry that happens to
+    // share the name, and the GM would approve a write anchored somewhere they
+    // were never shown.
+    const [r] = resolveProposals([factProposal({ nodeId: "stale-id", subject: "Bart" })], NODES);
+    if (r.write.kind !== "fact") throw new Error("expected a fact");
+    expect(r.write.anchor.at).toBe("unknown");
   });
 
   it("an edge into an entry the same queue proposes creating resolves to a ghost", () => {
@@ -163,9 +178,17 @@ describe("placeProposals", () => {
     expect(placed.ghostNodes).toHaveLength(1);
     const bart = laid.nodes.find((p) => p.node.id === "bart")!;
     const ghost = placed.ghostNodes[0];
-    // Exactly the attach offset away from its one neighbour — near enough to read
-    // as "this goes here", far enough not to sit on top of it.
-    expect(Math.hypot(ghost.x - bart.x, ghost.y - bart.y)).toBeCloseTo(GHOST.attachOffset, 0);
+    // Near enough to read as "this goes here", far enough not to sit on top of it.
+    // The exact radius carries a per-id ring offset (so ghosts spread instead of
+    // stacking), hence a band rather than a point.
+    const d = Math.hypot(ghost.x - bart.x, ghost.y - bart.y);
+    expect(d).toBeGreaterThanOrEqual(GHOST.attachOffset);
+    expect(d).toBeLessThanOrEqual(GHOST.attachOffset + 4 * GHOST.minClearance);
+    // And it is beside THAT neighbour, not merely somewhere on the canvas.
+    const nearest = [...laid.nodes].sort(
+      (a, b) => Math.hypot(a.x - ghost.x, a.y - ghost.y) - Math.hypot(b.x - ghost.x, b.y - ghost.y),
+    )[0];
+    expect(nearest.node.id).toBe("bart");
     // And the proposed edge now runs to the ghost.
     expect(placed.ghostEdges).toHaveLength(1);
     expect([placed.ghostEdges[0].x2, placed.ghostEdges[0].y2]).toEqual([ghost.x, ghost.y]);
@@ -231,6 +254,72 @@ describe("placeProposals", () => {
     const placed = placeProposals(resolved, withoutBart);
     expect(placed.unplaced).toHaveLength(1);
     expect(placed.unplaced[0].reason).toMatch(/filtered out/);
+  });
+
+  it("ghosts keep their spot when another proposal leaves the queue", () => {
+    // Keying the angle on the ghost's INDEX meant approving one node proposal
+    // renumbered the rest, so every remaining ghost jumped — the same spatial
+    // bearings the committed nodes are pinned for, broken for the very things
+    // being reviewed.
+    const three = resolveProposals(
+      [nodeProposal("Chapel", "p1"), nodeProposal("Crypt", "p2"), nodeProposal("Vault", "p3")],
+      NODES,
+    );
+    const before = placeProposals(three, laid);
+    const afterApproval = placeProposals(
+      three.filter((r) => r.id !== "p1"),
+      laid,
+    );
+    for (const g of afterApproval.ghostNodes) {
+      const was = before.ghostNodes.find((b) => b.proposalID === g.proposalID)!;
+      expect([g.x, g.y], `${g.name} moved when another suggestion was reviewed`).toEqual([
+        was.x,
+        was.y,
+      ]);
+    }
+  });
+
+  it("a ghost is never placed on top of a committed entry", () => {
+    // A dashed circle sitting on a solid one is exactly the "mistakable for canon"
+    // hazard the dashing exists to prevent.
+    const many = resolveProposals(
+      Array.from({ length: 12 }, (_, i) => nodeProposal(`Ghost ${i}`, `p${i}`)),
+      NODES,
+    );
+    const placed = placeProposals(many, laid);
+    for (const g of placed.ghostNodes) {
+      for (const p of laid.nodes) {
+        expect(
+          Math.hypot(g.x - p.x, g.y - p.y),
+          `${g.name} landed on ${p.node.name}`,
+        ).toBeGreaterThanOrEqual(GHOST.minClearance);
+      }
+    }
+  });
+
+  it("no two ghosts share a spot", () => {
+    // Deliberately weaker than the committed-node clearance above. Ghosts do NOT
+    // push each other apart, because that would make each one's position depend on
+    // which other suggestions are pending — approving one would shift the rest.
+    // The per-id ring makes an exact stack vanishingly unlikely instead.
+    const many = resolveProposals(
+      Array.from({ length: 12 }, (_, i) => nodeProposal(`Ghost ${i}`, `p${i}`)),
+      NODES,
+    );
+    const placed = placeProposals(many, laid);
+    const spots = new Set(placed.ghostNodes.map((g) => `${g.x},${g.y}`));
+    expect(spots.size).toBe(placed.ghostNodes.length);
+  });
+
+  it("places proposed entries even when the campaign has no entries yet", () => {
+    // A brand-new campaign whose Butler has proposed its first entries: gating the
+    // canvas on committed nodes alone hid every ghost behind "nothing to draw".
+    const empty = layout([], []);
+    const placed = placeProposals(resolveProposals([nodeProposal("First Light")], []), empty);
+    expect(placed.ghostNodes).toHaveLength(1);
+    expect(Number.isFinite(placed.ghostNodes[0].x)).toBe(true);
+    expect(placed.bounds.maxX).toBeGreaterThan(placed.bounds.minX);
+    expect(placed.bounds.maxY).toBeGreaterThan(placed.bounds.minY);
   });
 
   it("an empty queue changes nothing at all", () => {

--- a/web/src/screens/campaign/graph/proposalGhosts.ts
+++ b/web/src/screens/campaign/graph/proposalGhosts.ts
@@ -52,10 +52,21 @@ export type ResolvedProposal = {
 /**
  * resolveProposals maps the pending queue onto the campaign's Nodes.
  *
- * Resolution runs against ALL campaign nodes, not the filtered subset: a name that
- * resolves fine but happens to be filtered out of the current view is a DRAWING
- * problem, not a proposal problem, and conflating the two would tell the GM their
- * Butler had hallucinated an entry that exists.
+ * It MIRRORS the server's resolution (storage.resolveProposalAnchor /
+ * resolveNodeByName) rule for rule, because every difference is a lie told to the
+ * GM at the moment they decide:
+ *
+ *   - A non-empty node_id is AUTHORITATIVE. The server never falls back to the
+ *     name, so neither may this: falling back would draw the halo on a DIFFERENT
+ *     entry that happens to share the name, and the GM would approve a write
+ *     anchored somewhere they were never shown.
+ *   - Any case-insensitive multi-match is refused. Disambiguating by exact case
+ *     would promise an approval the server then rejects.
+ *
+ * `nodes` must be the WHOLE campaign payload, not a filtered subset — a name that
+ * resolves fine but is filtered out of the current view is a DRAWING problem, not
+ * a proposal problem, and conflating the two would tell the GM their Butler had
+ * hallucinated an entry that exists. Callers pass the raw GetKnowledgeGraph nodes.
  */
 export function resolveProposals(
   proposals: readonly KnowledgeProposal[],
@@ -80,7 +91,13 @@ export function resolveProposals(
   }
 
   const resolve = (id: string, name: string): Anchor => {
-    if (id && byID.has(id)) return { at: "node", id };
+    // An id short-circuits everything, exactly as the server does. No name
+    // fallback: an id that names nothing is a deleted anchor, not an invitation to
+    // find something similarly named.
+    if (id) {
+      if (byID.has(id)) return { at: "node", id };
+      return { at: "unknown", name, reason: "the entry this was filed against is gone" };
+    }
     const key = name.trim().toLowerCase();
     if (!key) {
       return { at: "unknown", name, reason: "the suggestion names no entry" };
@@ -88,20 +105,15 @@ export function resolveProposals(
     const candidates = byName.get(key) ?? [];
     if (candidates.length === 1) return { at: "node", id: candidates[0].id };
     if (candidates.length > 1) {
-      // Prefer an exact-case match when it is unique — that is a real
-      // disambiguation, not a coin flip.
-      const exact = candidates.filter((c) => c.name === name);
-      if (exact.length === 1) return { at: "node", id: exact[0].id };
+      // The server refuses ANY multi-match ("rename one first"), so an exact-case
+      // tiebreak here would draw a confident halo on an approval that cannot land.
       return {
         at: "unknown",
         name,
-        reason: `${candidates.length} entries are called "${name}" — approval can't tell which`,
+        reason: `${candidates.length} entries are called "${name}" — rename one first`,
       };
     }
     if (proposedNames.has(key)) return { at: "ghost", name };
-    // An id that resolves to nothing means the anchor Node was deleted after the
-    // Agent filed; say so, because approving will fail with exactly that.
-    if (id) return { at: "unknown", name, reason: "the entry this was filed against is gone" };
     return { at: "unknown", name, reason: `no entry called "${name}" yet` };
   };
 
@@ -185,10 +197,34 @@ export type PlacedProposals = {
   bounds: Layout["bounds"];
 };
 
+/**
+ * angleOf turns a proposal id into a stable direction.
+ *
+ * Keying the angle on the ghost's INDEX meant approving or rejecting one node
+ * proposal renumbered the rest, so every remaining ghost jumped to a new spot —
+ * the same "keep your spatial bearings across a review session" the committed
+ * nodes are pinned for, broken for the very things being reviewed. A hash of the
+ * id does not renumber.
+ */
+function hashOf(id: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
 /** Placement tuning, exported so the view and its tests agree on one set of numbers. */
 export const GHOST = {
   /** How far a ghost sits from the neighbour(s) it attaches to. */
   attachOffset: 62,
+  /**
+   * How close a ghost may come to a committed Node before it is pushed out. A
+   * dashed circle sitting on top of a solid one is exactly the "mistakable for
+   * canon" hazard the dashing exists to prevent.
+   */
+  minClearance: 38,
   /** How far outside the node cloud an unattached ghost is ringed. */
   orbitMargin: 70,
   /** Padding added around a ghost when growing the bounds, so its label is not clipped. */
@@ -234,7 +270,7 @@ export function placeProposals(
   // cloud — visibly not yet part of the world, and never buried under it.
   const ghostByName = new Map<string, GhostNode>();
   const proposedNodes = resolved.filter((r) => r.write.kind === "node");
-  proposedNodes.forEach((r, i) => {
+  proposedNodes.forEach((r) => {
     if (r.write.kind !== "node") return; // narrowing only
     const key = r.write.name.trim().toLowerCase();
     const neighbours: Array<{ x: number; y: number }> = [];
@@ -250,21 +286,34 @@ export function placeProposals(
       }
     }
 
-    // The offset direction comes from the ghost's INDEX, not from anything
-    // render-order dependent, so two ghosts on the same neighbour separate
-    // deterministically instead of stacking.
-    const angle = i * 2.399963229728653; // the golden angle, in radians
-    let x: number;
-    let y: number;
-    if (neighbours.length > 0) {
-      const mx = neighbours.reduce((s, n) => s + n.x, 0) / neighbours.length;
-      const my = neighbours.reduce((s, n) => s + n.y, 0) / neighbours.length;
-      x = Math.round(mx + GHOST.attachOffset * Math.cos(angle));
-      y = Math.round(my + GHOST.attachOffset * Math.sin(angle));
-    } else {
-      const r = cloudRadius + GHOST.orbitMargin;
-      x = Math.round(cx + r * Math.cos(angle));
-      y = Math.round(cy + r * Math.sin(angle));
+    // Direction AND distance both come from a hash of the proposal ID, so two
+    // ghosts on the same neighbour separate deterministically and neither moves
+    // when a third is approved out of the queue.
+    const h = hashOf(r.id);
+    const angle = (h / 0x100000000) * Math.PI * 2;
+    const ring = h % 4;
+    const anchorX = neighbours.length > 0 ? neighbours.reduce((s, n) => s + n.x, 0) / neighbours.length : cx;
+    const anchorY = neighbours.length > 0 ? neighbours.reduce((s, n) => s + n.y, 0) / neighbours.length : cy;
+    const baseR = neighbours.length > 0 ? GHOST.attachOffset : cloudRadius + GHOST.orbitMargin;
+
+    // Walk outward along the ray until the spot is clear of every committed Node.
+    //
+    // Only COMMITTED Nodes push a ghost outward — deliberately not other ghosts.
+    // Avoiding other ghosts would make each ghost's position depend on which OTHER
+    // suggestions are currently pending, so approving one would shift the rest:
+    // exactly the instability that keying the angle on the id removes. The two
+    // goals genuinely conflict and stability wins, because a ghost overlapping
+    // another ghost is untidy whereas a ghost overlapping canon is the "mistakable
+    // for committed" hazard AC1 forbids. The per-id ring below spreads ghosts
+    // across four radii so an exact stack is vanishingly unlikely anyway.
+    let x = 0;
+    let y = 0;
+    for (let step = 0; step < 6; step++) {
+      const rad = baseR + (ring + step) * GHOST.minClearance;
+      x = Math.round(anchorX + rad * Math.cos(angle));
+      y = Math.round(anchorY + rad * Math.sin(angle));
+      const clash = laid.nodes.some((p) => Math.hypot(p.x - x, p.y - y) < GHOST.minClearance);
+      if (!clash) break;
     }
 
     const ghost: GhostNode = {

--- a/web/src/screens/campaign/graph/proposalGhosts.ts
+++ b/web/src/screens/campaign/graph/proposalGhosts.ts
@@ -1,0 +1,356 @@
+import { EdgeType, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { GraphNode, KnowledgeProposal } from "@gen/glyphoxa/management/v1/management_pb";
+
+import type { Layout } from "./layout";
+
+// Pending Knowledge Proposals, resolved against the drawn graph (#537, ADR-0052).
+//
+// The Proposals panel presents an Agent's proposed write as a naked sentence, but
+// the GM's real question — "does this belong here, next to what the world already
+// says?" — is a question about POSITION. This module answers the only two hard
+// parts of drawing that question:
+//
+//   1. Resolution. A proposal names its endpoints by NAME, not by id (ADR-0052:
+//      names are resolved at approval so nothing auto-merges). Drawing one means
+//      doing that resolution in the client, and being honest when it fails: an
+//      ambiguous or unknown name is a proposal that will be REFUSED at approval,
+//      which is worth showing the GM before they click.
+//   2. Placement. A proposed Node does not exist yet, so it has no layout position.
+//      It is placed next to whatever the same queue proposes attaching it to.
+//
+// Everything here is pure, so the picture is snapshot-testable and — the point of
+// the graph view — stable across renders.
+
+/**
+ * An endpoint a proposal names, resolved against the campaign.
+ *
+ * `ghost` is a name that no Node carries YET but that another pending proposal in
+ * the same queue proposes creating — a Butler that proposes "the Sunken Chapel"
+ * and then proposes an edge into it files two proposals, and the pair only makes
+ * sense drawn together.
+ */
+export type Anchor =
+  | { at: "node"; id: string }
+  | { at: "ghost"; name: string }
+  | { at: "unknown"; name: string; reason: string };
+
+/** The proposed write, resolved. `unreadable` is a proposal whose payload did not parse. */
+export type ResolvedWrite =
+  | { kind: "fact"; anchor: Anchor; aspectKey: string; fact: string }
+  | { kind: "edge"; from: Anchor; to: Anchor; relation: EdgeType }
+  | { kind: "node"; name: string; nodeType: NodeType }
+  | { kind: "unreadable" };
+
+/** One pending proposal, resolved. `proposal` is carried through for the review card. */
+export type ResolvedProposal = {
+  id: string;
+  agentName: string;
+  proposal: KnowledgeProposal;
+  write: ResolvedWrite;
+};
+
+/**
+ * resolveProposals maps the pending queue onto the campaign's Nodes.
+ *
+ * Resolution runs against ALL campaign nodes, not the filtered subset: a name that
+ * resolves fine but happens to be filtered out of the current view is a DRAWING
+ * problem, not a proposal problem, and conflating the two would tell the GM their
+ * Butler had hallucinated an entry that exists.
+ */
+export function resolveProposals(
+  proposals: readonly KnowledgeProposal[],
+  nodes: readonly GraphNode[],
+): ResolvedProposal[] {
+  const byID = new Map(nodes.map((n) => [n.id, n]));
+  // Names collide in real campaigns ("Gundren" the NPC and "Gundren" the item), so
+  // the index keeps every candidate and resolution below refuses to guess.
+  const byName = new Map<string, GraphNode[]>();
+  for (const n of nodes) {
+    const key = n.name.trim().toLowerCase();
+    const list = byName.get(key);
+    if (list) list.push(n);
+    else byName.set(key, [n]);
+  }
+
+  // The names this same queue proposes creating. A proposed edge into a proposed
+  // Node resolves to a ghost rather than to "unknown".
+  const proposedNames = new Set<string>();
+  for (const p of proposals) {
+    if (p.write.case === "node") proposedNames.add(p.write.value.name.trim().toLowerCase());
+  }
+
+  const resolve = (id: string, name: string): Anchor => {
+    if (id && byID.has(id)) return { at: "node", id };
+    const key = name.trim().toLowerCase();
+    if (!key) {
+      return { at: "unknown", name, reason: "the suggestion names no entry" };
+    }
+    const candidates = byName.get(key) ?? [];
+    if (candidates.length === 1) return { at: "node", id: candidates[0].id };
+    if (candidates.length > 1) {
+      // Prefer an exact-case match when it is unique — that is a real
+      // disambiguation, not a coin flip.
+      const exact = candidates.filter((c) => c.name === name);
+      if (exact.length === 1) return { at: "node", id: exact[0].id };
+      return {
+        at: "unknown",
+        name,
+        reason: `${candidates.length} entries are called "${name}" — approval can't tell which`,
+      };
+    }
+    if (proposedNames.has(key)) return { at: "ghost", name };
+    // An id that resolves to nothing means the anchor Node was deleted after the
+    // Agent filed; say so, because approving will fail with exactly that.
+    if (id) return { at: "unknown", name, reason: "the entry this was filed against is gone" };
+    return { at: "unknown", name, reason: `no entry called "${name}" yet` };
+  };
+
+  return proposals.map((p): ResolvedProposal => {
+    const base = { id: p.id, agentName: p.authoringAgentName, proposal: p };
+    const w = p.write;
+    switch (w.case) {
+      case "fact":
+        return {
+          ...base,
+          write: {
+            kind: "fact",
+            anchor: resolve(w.value.nodeId, w.value.subject),
+            aspectKey: w.value.aspectKey,
+            fact: w.value.fact,
+          },
+        };
+      case "edge":
+        return {
+          ...base,
+          write: {
+            kind: "edge",
+            from: resolve(w.value.nodeId, w.value.subject),
+            to: resolve("", w.value.target),
+            relation: w.value.relation,
+          },
+        };
+      case "node":
+        return {
+          ...base,
+          write: { kind: "node", name: w.value.name, nodeType: w.value.nodeType },
+        };
+      default:
+        return { ...base, write: { kind: "unreadable" } };
+    }
+  });
+}
+
+/** A proposed Node, placed. `key` is stable across renders (the proposal id). */
+export type GhostNode = {
+  key: string;
+  proposalID: string;
+  name: string;
+  nodeType: NodeType;
+  agentName: string;
+  x: number;
+  y: number;
+};
+
+/** A proposed Edge, placed between two drawn (or ghosted) endpoints. */
+export type GhostEdge = {
+  key: string;
+  proposalID: string;
+  relation: EdgeType;
+  agentName: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+/** A proposed fact, marking the Node it would land on. */
+export type FactMark = {
+  key: string;
+  proposalID: string;
+  nodeID: string;
+  agentName: string;
+  x: number;
+  y: number;
+};
+
+/** A proposal that could not be drawn, and why. It is listed, never dropped. */
+export type UnplacedProposal = { proposal: ResolvedProposal; reason: string };
+
+export type PlacedProposals = {
+  ghostNodes: GhostNode[];
+  ghostEdges: GhostEdge[];
+  factMarks: FactMark[];
+  unplaced: UnplacedProposal[];
+  /** The layout bounds, grown to include any ghost placed outside them. */
+  bounds: Layout["bounds"];
+};
+
+/** Placement tuning, exported so the view and its tests agree on one set of numbers. */
+export const GHOST = {
+  /** How far a ghost sits from the neighbour(s) it attaches to. */
+  attachOffset: 62,
+  /** How far outside the node cloud an unattached ghost is ringed. */
+  orbitMargin: 70,
+  /** Padding added around a ghost when growing the bounds, so its label is not clipped. */
+  labelPad: 90,
+} as const;
+
+/**
+ * placeProposals positions the resolved queue on top of an existing layout.
+ *
+ * It never moves a laid-out Node: ghosts are an OVERLAY. That is what makes
+ * approving a suggestion leave the GM's spatial bearings intact — the picture
+ * underneath is the same picture, with one dashed thing turned solid.
+ */
+export function placeProposals(
+  resolved: readonly ResolvedProposal[],
+  laid: Layout,
+): PlacedProposals {
+  const pos = new Map(laid.nodes.map((p) => [p.node.id, { x: p.x, y: p.y }]));
+
+  const ghostNodes: GhostNode[] = [];
+  const ghostEdges: GhostEdge[] = [];
+  const factMarks: FactMark[] = [];
+  const unplaced: UnplacedProposal[] = [];
+
+  // Centre and radius of the drawn cloud, for ghosts with nothing to attach to.
+  let cx = 0;
+  let cy = 0;
+  for (const p of laid.nodes) {
+    cx += p.x;
+    cy += p.y;
+  }
+  if (laid.nodes.length > 0) {
+    cx /= laid.nodes.length;
+    cy /= laid.nodes.length;
+  }
+  let cloudRadius = 0;
+  for (const p of laid.nodes) {
+    cloudRadius = Math.max(cloudRadius, Math.hypot(p.x - cx, p.y - cy));
+  }
+
+  // Pass 1: place proposed Nodes, each next to the drawn endpoints the queue
+  // proposes attaching it to. A ghost with no attachments is ringed outside the
+  // cloud — visibly not yet part of the world, and never buried under it.
+  const ghostByName = new Map<string, GhostNode>();
+  const proposedNodes = resolved.filter((r) => r.write.kind === "node");
+  proposedNodes.forEach((r, i) => {
+    if (r.write.kind !== "node") return; // narrowing only
+    const key = r.write.name.trim().toLowerCase();
+    const neighbours: Array<{ x: number; y: number }> = [];
+    for (const other of resolved) {
+      if (other.write.kind !== "edge") continue;
+      const ends = [other.write.from, other.write.to];
+      // This ghost is one end; the OTHER end, if drawn, is what it attaches to.
+      if (!ends.some((a) => a.at === "ghost" && a.name.trim().toLowerCase() === key)) continue;
+      for (const a of ends) {
+        if (a.at !== "node") continue;
+        const at = pos.get(a.id);
+        if (at) neighbours.push(at);
+      }
+    }
+
+    // The offset direction comes from the ghost's INDEX, not from anything
+    // render-order dependent, so two ghosts on the same neighbour separate
+    // deterministically instead of stacking.
+    const angle = i * 2.399963229728653; // the golden angle, in radians
+    let x: number;
+    let y: number;
+    if (neighbours.length > 0) {
+      const mx = neighbours.reduce((s, n) => s + n.x, 0) / neighbours.length;
+      const my = neighbours.reduce((s, n) => s + n.y, 0) / neighbours.length;
+      x = Math.round(mx + GHOST.attachOffset * Math.cos(angle));
+      y = Math.round(my + GHOST.attachOffset * Math.sin(angle));
+    } else {
+      const r = cloudRadius + GHOST.orbitMargin;
+      x = Math.round(cx + r * Math.cos(angle));
+      y = Math.round(cy + r * Math.sin(angle));
+    }
+
+    const ghost: GhostNode = {
+      key: r.id,
+      proposalID: r.id,
+      name: r.write.name,
+      nodeType: r.write.nodeType,
+      agentName: r.agentName,
+      x,
+      y,
+    };
+    ghostNodes.push(ghost);
+    // First ghost wins a duplicated name: two proposals for the same new entry are
+    // a dedup problem for the GM, not a reason to draw two circles on one spot.
+    if (!ghostByName.has(key)) ghostByName.set(key, ghost);
+  });
+
+  // Pass 2: everything that hangs off a position.
+  const locate = (a: Anchor): { x: number; y: number } | { miss: string } => {
+    if (a.at === "unknown") return { miss: a.reason };
+    if (a.at === "ghost") {
+      const g = ghostByName.get(a.name.trim().toLowerCase());
+      return g ? { x: g.x, y: g.y } : { miss: `"${a.name}" is only a suggestion itself` };
+    }
+    const at = pos.get(a.id);
+    return at ?? { miss: "the entry it points at is filtered out of this view" };
+  };
+
+  for (const r of resolved) {
+    switch (r.write.kind) {
+      case "node":
+        break; // placed above
+      case "unreadable":
+        unplaced.push({ proposal: r, reason: "the suggestion's payload could not be read" });
+        break;
+      case "fact": {
+        const at = locate(r.write.anchor);
+        if ("miss" in at) {
+          unplaced.push({ proposal: r, reason: at.miss });
+          break;
+        }
+        factMarks.push({
+          key: r.id,
+          proposalID: r.id,
+          nodeID: r.write.anchor.at === "node" ? r.write.anchor.id : "",
+          agentName: r.agentName,
+          x: at.x,
+          y: at.y,
+        });
+        break;
+      }
+      case "edge": {
+        const from = locate(r.write.from);
+        const to = locate(r.write.to);
+        if ("miss" in from) {
+          unplaced.push({ proposal: r, reason: from.miss });
+          break;
+        }
+        if ("miss" in to) {
+          unplaced.push({ proposal: r, reason: to.miss });
+          break;
+        }
+        ghostEdges.push({
+          key: r.id,
+          proposalID: r.id,
+          relation: r.write.relation,
+          agentName: r.agentName,
+          x1: from.x,
+          y1: from.y,
+          x2: to.x,
+          y2: to.y,
+        });
+        break;
+      }
+    }
+  }
+
+  // Grow the viewBox around any ghost that landed outside it. Growing the BOX is
+  // not relaying out the graph: every Node keeps the coordinate it already had.
+  let { minX, minY, maxX, maxY } = laid.bounds;
+  for (const g of ghostNodes) {
+    minX = Math.min(minX, g.x - GHOST.labelPad);
+    minY = Math.min(minY, g.y - GHOST.labelPad);
+    maxX = Math.max(maxX, g.x + GHOST.labelPad);
+    maxY = Math.max(maxY, g.y + GHOST.labelPad);
+  }
+
+  return { ghostNodes, ghostEdges, factMarks, unplaced, bounds: { minX, minY, maxX, maxY } };
+}

--- a/web/src/screens/campaign/knowledgeCache.ts
+++ b/web/src/screens/campaign/knowledgeCache.ts
@@ -80,3 +80,21 @@ export function invalidateKnowledgeReads(queryClient: QueryClient): void {
     }),
   });
 }
+
+/**
+ * invalidateProposalReview drops everything a reviewed Knowledge Proposal changes:
+ * the pending queue itself, plus every read of the KG the approved write lands in.
+ *
+ * Two surfaces now review the same queue — the Proposals panel and the graph
+ * overlay (#537) — which is exactly the shape that produced the stale-graph bug
+ * this module exists to prevent, so both call this one helper.
+ */
+export function invalidateProposalReview(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.listKnowledgeProposals,
+      cardinality: "finite",
+    }),
+  });
+  invalidateKnowledgeReads(queryClient);
+}

--- a/web/src/screens/campaign/proposalParts.tsx
+++ b/web/src/screens/campaign/proposalParts.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { useMutation } from "@connectrpc/connect-query";
+import { useQuery } from "@connectrpc/connect-query";
+import { timestampDate } from "@bufbuild/protobuf/wkt";
+import { Check, Sparkles, X } from "lucide-react";
+
+import { CampaignService, NodeType } from "@gen/glyphoxa/management/v1/management_pb";
+import type { KnowledgeProposal } from "@gen/glyphoxa/management/v1/management_pb";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { failedPreconditionMessage } from "@/lib/connectError";
+import { DISPOSITION_LABEL, EDGE_LABEL, metaOf } from "./knowledgeVocab";
+
+// The pieces of a Knowledge Proposal review, shared by the queue (ProposalsPanel)
+// and the graph overlay (#537).
+//
+// They live here rather than in the panel because the graph reviews the SAME
+// proposal through the SAME RPCs — ADR-0052's rule is that nothing enters the KG
+// without GM approval, and two review surfaces disagreeing about what a proposal
+// says, or one of them quietly dropping the similarity hint, would be exactly the
+// kind of drift that rule exists to prevent.
+
+/** The proposal's timestamp, in the operator's locale. */
+export function fmtWhen(p: KnowledgeProposal): string {
+  if (!p.createdAt) return "";
+  return timestampDate(p.createdAt).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function nodeTypeLabel(t: NodeType): string {
+  return metaOf(t).label;
+}
+
+/** KindBadge labels the proposal's kind, or "Unreadable" when the write is unset. */
+export function KindBadge({ proposal }: { proposal: KnowledgeProposal }) {
+  const kind = proposal.write.case;
+  if (kind === "fact") return <Badge size="sm">Fact</Badge>;
+  if (kind === "edge") return <Badge size="sm">Relationship</Badge>;
+  if (kind === "node") return <Badge size="sm">New entry</Badge>;
+  return (
+    <Badge variant="neutral" size="sm">
+      Unreadable
+    </Badge>
+  );
+}
+
+/** ProposalWrite renders the human form of the proposed write per kind. */
+export function ProposalWrite({ proposal }: { proposal: KnowledgeProposal }) {
+  const w = proposal.write;
+  switch (w.case) {
+    case "fact":
+      // The aspect label is shown because approving files the fact UNDER it as a
+      // row on the entry (#542) — the GM is deciding where it lands, not just
+      // whether the sentence is true.
+      return (
+        <span>
+          <strong>{w.value.subject}</strong> —{" "}
+          {w.value.aspectKey && <em>{w.value.aspectKey}: </em>}
+          {w.value.fact}
+        </span>
+      );
+    case "edge":
+      // The note and disposition are rendered because APPROVING WRITES THEM, and
+      // the note reaches an NPC's system prompt through the relation clause. A card
+      // that showed only "subject —knows→ target" asked the GM to approve up to 280
+      // runes of model-authored text they had never seen — approval of unseen
+      // content, which is the one thing the review queue exists to prevent (#546).
+      return (
+        <span>
+          <strong>{w.value.subject}</strong> —{EDGE_LABEL.get(w.value.relation) ?? ""}→{" "}
+          <strong>{w.value.target}</strong>
+          {(w.value.note || w.value.disposition !== 0) && (
+            <span className="gx-proposal-card__body">
+              {" — "}
+              {DISPOSITION_LABEL.get(w.value.disposition) ?? ""}
+              {w.value.note && w.value.disposition !== 0 ? ", " : ""}
+              {/* Newlines are collapsed: a proposal is one clause, and a note that
+                  can open a new line can forge a section header in the prompt. */}
+              {w.value.note.replace(/\s+/g, " ")}
+            </span>
+          )}
+        </span>
+      );
+    case "node":
+      return (
+        <span>
+          New {nodeTypeLabel(w.value.nodeType)}: <strong>{w.value.name}</strong>
+          {w.value.body && <span className="gx-proposal-card__body"> — {w.value.body}</span>}
+        </span>
+      );
+    default:
+      return <span className="gx-proposal-card__unreadable">Unreadable proposal</span>;
+  }
+}
+
+/**
+ * SimilarHint lazily fetches the existing entries most similar to a proposal's
+ * subject (the ADR-0011 vector hint) so the GM can merge or reject rather than
+ * duplicate. A skeleton shows while loading; "No similar entries." when none.
+ */
+export function SimilarHint({ proposalId }: { proposalId: string }) {
+  // Truly lazy: the similarity RPC embeds the subject (a provider call), so it
+  // fires ONLY after the GM opts in — never on mount for every card (that would
+  // fan N concurrent Embed calls across the whole queue).
+  const [show, setShow] = useState(false);
+  const { data, status } = useQuery(
+    CampaignService.method.listSimilarKnowledge,
+    { proposalId },
+    { enabled: show },
+  );
+
+  if (!show) {
+    return (
+      <button type="button" className="gx-proposal-card__similar-btn" onClick={() => setShow(true)}>
+        <Sparkles size={12} /> Show similar entries
+      </button>
+    );
+  }
+  if (status === "pending") {
+    return (
+      <div className="gx-skeleton gx-proposal-card__similar-skel" data-testid="similar-loading" />
+    );
+  }
+  if (status === "error") {
+    return null; // the hint is best-effort; a failure is silent (no scary error on a suggestion)
+  }
+
+  const nodes = data.nodes;
+  return (
+    <div className="gx-proposal-card__similar">
+      <span className="gx-proposal-card__similar-title">
+        <Sparkles size={12} /> Similar existing entries
+      </span>
+      {nodes.length === 0 ? (
+        <span className="gx-proposal-card__similar-empty">No similar entries.</span>
+      ) : (
+        <ul className="gx-proposal-card__similar-list">
+          {nodes.map((n) => (
+            <li key={n.id}>
+              <span className="gx-proposal-card__similar-name">{n.name}</span>
+              <Badge size="sm" variant="neutral">
+                {nodeTypeLabel(n.nodeType)}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * ProposalActions is the Approve / Reject pair, with the reject confirmation and
+ * the inline failure line.
+ *
+ * `onApproved` fires BEFORE the caches drop, and receives nothing but the fact that
+ * this proposal landed — the graph uses that moment to remember where the ghost was
+ * standing (#537), which is only knowable on the pre-refetch picture.
+ */
+export function ProposalActions({
+  proposalID,
+  size = "sm",
+  onApproved,
+  onReviewed,
+}: {
+  proposalID: string;
+  size?: "sm" | "md";
+  onApproved?: () => void;
+  onReviewed: () => void;
+}) {
+  const [confirmReject, setConfirmReject] = useState(false);
+
+  const approve = useMutation(CampaignService.method.approveKnowledgeProposal, {
+    onSuccess: () => {
+      onApproved?.();
+      onReviewed();
+    },
+  });
+  const reject = useMutation(CampaignService.method.rejectKnowledgeProposal, {
+    onSuccess: () => onReviewed(),
+  });
+
+  // A refused approval carries an actionable server reason; anything else is a
+  // generic failure. Reject failures fall into the same inline line so a dead
+  // button is never silent.
+  const blockedReason = approve.isError ? failedPreconditionMessage(approve.error) : null;
+  const inlineError = blockedReason
+    ? blockedReason
+    : approve.isError
+      ? `Couldn't approve: ${approve.error.message}`
+      : reject.isError
+        ? `Couldn't reject: ${reject.error.message}`
+        : null;
+
+  const pending = approve.isPending || reject.isPending;
+
+  return (
+    <div className="gx-proposal-card__actions">
+      <Button
+        variant="primary"
+        size={size}
+        iconStart={<Check size={14} />}
+        onClick={() => approve.mutate({ id: proposalID })}
+        disabled={pending}
+      >
+        Approve
+      </Button>
+      <Button
+        variant="danger"
+        size={size}
+        iconStart={<X size={14} />}
+        onClick={() => setConfirmReject(true)}
+        disabled={pending}
+      >
+        Reject
+      </Button>
+      {inlineError && (
+        <span className="gx-editor__status gx-editor__status--error" role="alert">
+          {inlineError}
+        </span>
+      )}
+
+      {confirmReject && (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setConfirmReject(false);
+          }}
+          title="Reject this suggestion?"
+          description="The suggestion is dropped and never becomes canon. This can't be undone."
+          confirmLabel="Reject suggestion"
+          onConfirm={() => {
+            reject.mutate({ id: proposalID });
+            setConfirmReject(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## KG-A4 — pending suggestions, drawn where they would land

The Proposals panel presents an Agent's proposed write as a naked sentence. The GM's actual question is not "is this sentence true" — it is **"does this belong *here*, next to what the world already says"**, and that is a question about position that only the graph can answer.

- A **proposed entry** is a dashed ghost, placed beside whatever the same queue proposes attaching it to (a Butler that proposes "the Sunken Chapel" and then proposes an edge into it files two proposals, and the pair only makes sense drawn together).
- A **proposed relation** is a dashed line between the two entries it names.
- A **proposed fact** rings the entry it would land on.

Every glyph is hollow and dashed. A suggestion that could be mistaken for canon defeats the queue it came from, and the distinction is carried by shape and stroke rather than colour — colour is already spent on the seven entry types, and a colour-only difference is no difference to a GM who cannot see it.

Clicking one opens the review beside the graph: **who** proposed it, the write, the ADR-0011 similarity hint, and Approve / Reject. Those are the existing RPCs and the existing widgets, extracted to `proposalParts.tsx` so the two review surfaces cannot drift. **No new write path** — ADR-0052's rule that nothing enters the KG without GM approval is untouched.

## The two parts that needed real work

**Resolution.** A proposal names its endpoints by NAME, not by id, because ADR-0052 resolves them at approval so nothing auto-merges. Drawing one means doing that resolution client-side and being honest when it fails: an ambiguous name (two entries called "Bart"), a name nothing knows, or an anchor id whose entry has since been deleted are all proposals that *will* be refused at approval — and the card says so before the GM clicks. Anything undrawable is listed under the canvas rather than dropped; a proposal that vanishes from the graph and has no other surface is a proposal nobody can review.

**Stability (AC3).** `layout` is pure in its *inputs*, so approving a suggestion — which adds a Node — reshuffled every other Node. Positions are now pinned across payload changes and released only when the filters change, or on the new **Re-arrange** button. Pinning also required dropping `forceCenter`: it recentres by translating every node, a pinned node is snapped back to its `fx`/`fy` each tick, so the offset never shrinks and the correction is re-applied every tick, walking the free nodes away.

Approving turns the ghost solid in the **exact** spot it occupied. The server mints a fresh id at approval, so the name is the only thing that survives the transition — which is why the seed map is keyed by name rather than id.

## Tests

35 new: the pure resolution/placement module, the layout position memory, and the review flow through a fake transport.

Both stability tests are **mutation-checked** — disabling the pins fails both — and the pure-layout suite carries an explicit control asserting that the same growth *without* pins does reshuffle, so the pin test cannot pass by accident. The "approving does not move anything" test re-renders with a grown payload, because without that the props never change and the assertion would be vacuous.

Closes #537
