### PR TITLE
feat(kg): free-form tags on entries, and saved session prep boards (#543)

### DIFF
--- a/internal/rpc/campaign.go
+++ b/internal/rpc/campaign.go
@@ -49,6 +49,7 @@ type CampaignServer struct {
 	*kgGraph
 	*kgPreview
 	*campaignMaps
+	*kgOrganize
 	*knowledgeProposals
 	*toolGrants
 	*campaignAssist
@@ -83,6 +84,9 @@ type CampaignStores struct {
 	KGPreview kgPreviewStore
 	// Maps backs the Maps and Pins surface (#538, ADR-0060).
 	Maps campaignMapStore
+	// Organize backs free-form tags and prep boards (#543) — GM organization
+	// only; nothing here reaches a prompt.
+	Organize kgOrganizeStore
 	// Proposals backs the Knowledge Proposal review queue + similarity hint
 	// (#300, ADR-0052).
 	Proposals knowledgeProposalStore
@@ -111,6 +115,7 @@ func NewCampaignServer(s *storage.Store) *CampaignServer {
 		KGGraph:    s,
 		KGPreview:  kgPreviewStoreOf(s),
 		Maps:       s,
+		Organize:   s,
 		Proposals:  s,
 		Grants:     s,
 		Assist:     s,
@@ -134,6 +139,7 @@ func NewCampaignServerWith(stores CampaignStores) *CampaignServer {
 		kgGraph:            &kgGraph{store: stores.KGGraph, active: active},
 		kgPreview:          &kgPreview{store: stores.KGPreview, active: active},
 		campaignMaps:       &campaignMaps{store: stores.Maps, active: active, tenant: auth.TenantID},
+		kgOrganize:         &kgOrganize{store: stores.Organize, active: active},
 		knowledgeProposals: &knowledgeProposals{store: stores.Proposals, active: active},
 		toolGrants:         &toolGrants{store: stores.Grants, active: active, tools: tool.BuiltinRegistry(tool.Deps{})},
 		campaignAssist:     &campaignAssist{store: stores.Assist, active: active},

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -1063,6 +1063,8 @@ type fakeOrganizeStore struct {
 	tagErr       error
 	renamedFrom  string
 	renamedTo    string
+	// updateBoardErr forces the atomic board save's failure path.
+	updateBoardErr error
 
 	boards    []storage.KGBoard
 	boardErr  error
@@ -1115,20 +1117,17 @@ func (f *fakeOrganizeStore) CreateBoard(_ context.Context, campaignID uuid.UUID,
 	return b, nil
 }
 
-func (f *fakeOrganizeStore) SetBoardNodes(_ context.Context, _, boardID uuid.UUID, nodeIDs []uuid.UUID) error {
-	for i := range f.boards {
-		if f.boards[i].ID == boardID {
-			f.boards[i].NodeIDs = nodeIDs
-			return nil
-		}
+// UpdateBoard applies the rename and the entry list together, as the real
+// transaction does — the campaignID IS checked here, because a fake that ignores
+// scoping turns every "campaign scoping" assertion into a tautology.
+func (f *fakeOrganizeStore) UpdateBoard(_ context.Context, campaignID, id uuid.UUID, name string, nodeIDs []uuid.UUID) error {
+	if f.updateBoardErr != nil {
+		return f.updateBoardErr
 	}
-	return storage.ErrNotFound
-}
-
-func (f *fakeOrganizeStore) RenameBoard(_ context.Context, _, id uuid.UUID, name string) error {
 	for i := range f.boards {
-		if f.boards[i].ID == id {
+		if f.boards[i].ID == id && f.boards[i].CampaignID == campaignID {
 			f.boards[i].Name = name
+			f.boards[i].NodeIDs = nodeIDs
 			return nil
 		}
 	}

--- a/internal/rpc/fakes_test.go
+++ b/internal/rpc/fakes_test.go
@@ -1053,3 +1053,94 @@ func (f *fakeKGPreviewStore) AgentNodeFacts(_ context.Context, agentID uuid.UUID
 	}
 	return f.facts[agentID], nil
 }
+
+// fakeOrganizeStore fakes the tags-and-boards slice (#543).
+type fakeOrganizeStore struct {
+	*fakeActive
+
+	tags         map[uuid.UUID][]string
+	tagsCampaign uuid.UUID
+	tagErr       error
+	renamedFrom  string
+	renamedTo    string
+
+	boards    []storage.KGBoard
+	boardErr  error
+	nextBoard int
+}
+
+func newFakeOrganizeStore() *fakeOrganizeStore {
+	return &fakeOrganizeStore{fakeActive: newFakeActive(), tags: map[uuid.UUID][]string{}}
+}
+
+func (f *fakeOrganizeStore) CampaignTags(_ context.Context, _ uuid.UUID) ([]storage.TaggedNode, error) {
+	var out []storage.TaggedNode
+	for id, tags := range f.tags {
+		for _, t := range tags {
+			out = append(out, storage.TaggedNode{NodeID: id, Tag: t})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeOrganizeStore) SetNodeTags(_ context.Context, campaignID, nodeID uuid.UUID, tags []string) error {
+	f.tagsCampaign = campaignID
+	if f.tagErr != nil {
+		return f.tagErr
+	}
+	f.tags[nodeID] = tags
+	return nil
+}
+
+func (f *fakeOrganizeStore) NodeTags(_ context.Context, _, nodeID uuid.UUID) ([]string, error) {
+	return f.tags[nodeID], f.tagErr
+}
+
+func (f *fakeOrganizeStore) RenameTag(_ context.Context, _ uuid.UUID, from, to string) error {
+	f.renamedFrom, f.renamedTo = from, to
+	return f.tagErr
+}
+
+func (f *fakeOrganizeStore) ListBoards(_ context.Context, _ uuid.UUID) ([]storage.KGBoard, error) {
+	return f.boards, f.boardErr
+}
+
+func (f *fakeOrganizeStore) CreateBoard(_ context.Context, campaignID uuid.UUID, name string) (storage.KGBoard, error) {
+	if f.boardErr != nil {
+		return storage.KGBoard{}, f.boardErr
+	}
+	f.nextBoard++
+	b := storage.KGBoard{ID: uuid.New(), CampaignID: campaignID, Name: name}
+	f.boards = append(f.boards, b)
+	return b, nil
+}
+
+func (f *fakeOrganizeStore) SetBoardNodes(_ context.Context, _, boardID uuid.UUID, nodeIDs []uuid.UUID) error {
+	for i := range f.boards {
+		if f.boards[i].ID == boardID {
+			f.boards[i].NodeIDs = nodeIDs
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeOrganizeStore) RenameBoard(_ context.Context, _, id uuid.UUID, name string) error {
+	for i := range f.boards {
+		if f.boards[i].ID == id {
+			f.boards[i].Name = name
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeOrganizeStore) DeleteBoard(_ context.Context, _, id uuid.UUID) error {
+	for i := range f.boards {
+		if f.boards[i].ID == id {
+			f.boards = append(f.boards[:i], f.boards[i+1:]...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}

--- a/internal/rpc/kg_tag_board.go
+++ b/internal/rpc/kg_tag_board.go
@@ -35,8 +35,10 @@ type kgOrganizeStore interface {
 
 	ListBoards(ctx context.Context, campaignID uuid.UUID) ([]storage.KGBoard, error)
 	CreateBoard(ctx context.Context, campaignID uuid.UUID, name string) (storage.KGBoard, error)
-	SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID, nodeIDs []uuid.UUID) error
-	RenameBoard(ctx context.Context, campaignID, id uuid.UUID, name string) error
+	// UpdateBoard is ONE transaction for the rename and the entry list — a board
+	// edit is one edit, and two calls left a failed entry save with the board
+	// already renamed.
+	UpdateBoard(ctx context.Context, campaignID, id uuid.UUID, name string, nodeIDs []uuid.UUID) error
 	DeleteBoard(ctx context.Context, campaignID, id uuid.UUID) error
 }
 
@@ -190,18 +192,17 @@ func (s *kgOrganize) UpdateBoard(
 	if err != nil {
 		return nil, err
 	}
-	if err := s.store.RenameBoard(ctx, c.ID, id, name); err != nil {
+	// One call, one transaction. Renaming and re-listing as two writes left a
+	// failed entry save with the board already renamed — a half-applied edit.
+	if err := s.store.UpdateBoard(ctx, c.ID, id, name, nodeIDs); err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+			return nil, connect.NewError(connect.CodeNotFound,
+				errors.New("board or entry not found in this campaign"))
 		}
-		slog.Default().Error("UpdateBoard: rename failed", "board_id", id, "err", err)
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
-	}
-	if err := s.store.SetBoardNodes(ctx, c.ID, id, nodeIDs); err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+		if errors.Is(err, storage.ErrInvalidTag) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
-		slog.Default().Error("UpdateBoard: set entries failed", "board_id", id, "err", err)
+		slog.Default().Error("UpdateBoard: save failed", "board_id", id, "err", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 

--- a/internal/rpc/kg_tag_board.go
+++ b/internal/rpc/kg_tag_board.go
@@ -1,0 +1,264 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// kgOrganize is the tags-and-boards feature module (#543): free-form GM labels
+// alongside the closed 7-type vocabulary, and saved session prep boards.
+//
+// Everything here is GM ORGANIZATION ONLY. Nothing in this module is read by
+// prompt assembly, and nothing it writes affects AgentNodeFacts — which is what
+// keeps the fact budget untouched and stops tags quietly becoming a second,
+// unvalidated type system inside NPC context.
+type kgOrganize struct {
+	store  kgOrganizeStore
+	active *activeCampaignSource
+}
+
+// kgOrganizeStore is the narrow surface the module needs; *storage.Store
+// satisfies it. Every method is campaign-scoped (#342).
+type kgOrganizeStore interface {
+	CampaignTags(ctx context.Context, campaignID uuid.UUID) ([]storage.TaggedNode, error)
+	SetNodeTags(ctx context.Context, campaignID, nodeID uuid.UUID, tags []string) error
+	NodeTags(ctx context.Context, campaignID, nodeID uuid.UUID) ([]string, error)
+	RenameTag(ctx context.Context, campaignID uuid.UUID, from, to string) error
+
+	ListBoards(ctx context.Context, campaignID uuid.UUID) ([]storage.KGBoard, error)
+	CreateBoard(ctx context.Context, campaignID uuid.UUID, name string) (storage.KGBoard, error)
+	SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID, nodeIDs []uuid.UUID) error
+	RenameBoard(ctx context.Context, campaignID, id uuid.UUID, name string) error
+	DeleteBoard(ctx context.Context, campaignID, id uuid.UUID) error
+}
+
+// GetCampaignTags returns every (entry, tag) pair — one read the client indexes
+// both ways, so tagging a hundred entries is still one round trip.
+func (s *kgOrganize) GetCampaignTags(
+	ctx context.Context,
+	_ *connect.Request[managementv1.GetCampaignTagsRequest],
+) (*connect.Response[managementv1.GetCampaignTagsResponse], error) {
+	c, err := s.campaign(ctx, "GetCampaignTags")
+	if err != nil {
+		return nil, err
+	}
+	pairs, err := s.store.CampaignTags(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("GetCampaignTags: store read failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	out := &managementv1.GetCampaignTagsResponse{Entries: make([]*managementv1.TaggedEntry, 0, len(pairs))}
+	for _, p := range pairs {
+		out.Entries = append(out.Entries, &managementv1.TaggedEntry{
+			NodeId: p.NodeID.String(), Tag: p.Tag,
+		})
+	}
+	return connect.NewResponse(out), nil
+}
+
+// SetNodeTags replaces one entry's tags. Blank tags are dropped and
+// case-insensitive duplicates collapse — the chip editor keeps an empty field
+// around, and that convenience must not become a save error.
+func (s *kgOrganize) SetNodeTags(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetNodeTagsRequest],
+) (*connect.Response[managementv1.SetNodeTagsResponse], error) {
+	nodeID, err := uuid.Parse(req.Msg.GetNodeId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid entry id"))
+	}
+	c, err := s.campaign(ctx, "SetNodeTags")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.store.SetNodeTags(ctx, c.ID, nodeID, req.Msg.GetTags()); err != nil {
+		if errors.Is(err, storage.ErrInvalidTag) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		slog.Default().Error("SetNodeTags: store write failed", "node_id", nodeID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	saved, err := s.store.NodeTags(ctx, c.ID, nodeID)
+	if err != nil {
+		slog.Default().Error("SetNodeTags: read back failed", "node_id", nodeID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.SetNodeTagsResponse{Tags: saved}), nil
+}
+
+// RenameTag renames a tag across the whole Campaign. The AC offers exactly two
+// options — rename everywhere, or do not offer it — and half-renamed vocabularies
+// are the reason.
+func (s *kgOrganize) RenameTag(
+	ctx context.Context,
+	req *connect.Request[managementv1.RenameTagRequest],
+) (*connect.Response[managementv1.RenameTagResponse], error) {
+	from, to := strings.TrimSpace(req.Msg.GetFrom()), strings.TrimSpace(req.Msg.GetTo())
+	if from == "" || to == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("both tag names are required"))
+	}
+	c, err := s.campaign(ctx, "RenameTag")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.store.RenameTag(ctx, c.ID, from, to); err != nil {
+		if errors.Is(err, storage.ErrInvalidTag) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		slog.Default().Error("RenameTag: store write failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.RenameTagResponse{}), nil
+}
+
+// ListBoards returns the Campaign's prep boards with their entries.
+func (s *kgOrganize) ListBoards(
+	ctx context.Context,
+	_ *connect.Request[managementv1.ListBoardsRequest],
+) (*connect.Response[managementv1.ListBoardsResponse], error) {
+	c, err := s.campaign(ctx, "ListBoards")
+	if err != nil {
+		return nil, err
+	}
+	boards, err := s.store.ListBoards(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("ListBoards: store read failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	out := &managementv1.ListBoardsResponse{Boards: make([]*managementv1.Board, 0, len(boards))}
+	for _, b := range boards {
+		out.Boards = append(out.Boards, toProtoBoard(b))
+	}
+	return connect.NewResponse(out), nil
+}
+
+// CreateBoard makes an empty prep board.
+func (s *kgOrganize) CreateBoard(
+	ctx context.Context,
+	req *connect.Request[managementv1.CreateBoardRequest],
+) (*connect.Response[managementv1.CreateBoardResponse], error) {
+	name := strings.TrimSpace(req.Msg.GetName())
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+	c, err := s.campaign(ctx, "CreateBoard")
+	if err != nil {
+		return nil, err
+	}
+	b, err := s.store.CreateBoard(ctx, c.ID, name)
+	if err != nil {
+		slog.Default().Error("CreateBoard: store write failed", "campaign_id", c.ID, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return connect.NewResponse(&managementv1.CreateBoardResponse{Board: toProtoBoard(b)}), nil
+}
+
+// UpdateBoard renames a board and replaces its entries in order. Both in one call
+// because they are one act to the GM: shaping tonight's shortlist.
+func (s *kgOrganize) UpdateBoard(
+	ctx context.Context,
+	req *connect.Request[managementv1.UpdateBoardRequest],
+) (*connect.Response[managementv1.UpdateBoardResponse], error) {
+	m := req.Msg
+	id, err := uuid.Parse(m.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid board id"))
+	}
+	name := strings.TrimSpace(m.GetName())
+	if name == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("name must not be empty"))
+	}
+	nodeIDs := make([]uuid.UUID, 0, len(m.GetNodeIds()))
+	for _, raw := range m.GetNodeIds() {
+		nid, perr := uuid.Parse(raw)
+		if perr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid entry id"))
+		}
+		nodeIDs = append(nodeIDs, nid)
+	}
+
+	c, err := s.campaign(ctx, "UpdateBoard")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.store.RenameBoard(ctx, c.ID, id, name); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+		}
+		slog.Default().Error("UpdateBoard: rename failed", "board_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if err := s.store.SetBoardNodes(ctx, c.ID, id, nodeIDs); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+		}
+		slog.Default().Error("UpdateBoard: set entries failed", "board_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	boards, err := s.store.ListBoards(ctx, c.ID)
+	if err != nil {
+		slog.Default().Error("UpdateBoard: read back failed", "board_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	for _, b := range boards {
+		if b.ID == id {
+			return connect.NewResponse(&managementv1.UpdateBoardResponse{Board: toProtoBoard(b)}), nil
+		}
+	}
+	return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+}
+
+// DeleteBoard removes a board. Its entries are untouched — a board is a
+// shortlist, not ownership.
+func (s *kgOrganize) DeleteBoard(
+	ctx context.Context,
+	req *connect.Request[managementv1.DeleteBoardRequest],
+) (*connect.Response[managementv1.DeleteBoardResponse], error) {
+	id, err := uuid.Parse(req.Msg.GetId())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid board id"))
+	}
+	c, err := s.campaign(ctx, "DeleteBoard")
+	if err != nil {
+		return nil, err
+	}
+	switch err := s.store.DeleteBoard(ctx, c.ID, id); {
+	case err == nil:
+		return connect.NewResponse(&managementv1.DeleteBoardResponse{}), nil
+	case errors.Is(err, storage.ErrNotFound):
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("board not found"))
+	default:
+		slog.Default().Error("DeleteBoard: store delete failed", "board_id", id, "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+func (s *kgOrganize) campaign(ctx context.Context, op string) (storage.Campaign, error) {
+	c, err := s.active.resolve(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return storage.Campaign{}, connect.NewError(connect.CodeNotFound, errors.New("no active campaign"))
+		}
+		slog.Default().Error(op+": get active campaign failed", "err", err)
+		return storage.Campaign{}, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	return c, nil
+}
+
+func toProtoBoard(b storage.KGBoard) *managementv1.Board {
+	pb := &managementv1.Board{Id: b.ID.String(), Name: b.Name}
+	for _, id := range b.NodeIDs {
+		pb.NodeIds = append(pb.NodeIds, id.String())
+	}
+	return pb
+}

--- a/internal/rpc/kg_tag_board_test.go
+++ b/internal/rpc/kg_tag_board_test.go
@@ -1,0 +1,156 @@
+package rpc_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+func organizeClient(t *testing.T, store *fakeOrganizeStore) managementv1connect.CampaignServiceClient {
+	t.Helper()
+	return campaignClient(t, rpc.CampaignStores{Active: store, Organize: store})
+}
+
+// TestTagsRoundTrip pins the tag surface: one campaign-wide read the client
+// indexes both ways, replace-in-full saves, and a campaign-wide rename.
+func TestTagsRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := newFakeOrganizeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	nodeID := uuid.New()
+	client := organizeClient(t, store)
+	ctx := context.Background()
+
+	if _, err := client.SetNodeTags(ctx, connect.NewRequest(&managementv1.SetNodeTagsRequest{
+		NodeId: nodeID.String(), Tags: []string{"seafaring", "act two"},
+	})); err != nil {
+		t.Fatalf("SetNodeTags: %v", err)
+	}
+	if store.tagsCampaign != store.campaign.ID {
+		t.Errorf("write scoped to %s, want the active campaign", store.tagsCampaign)
+	}
+
+	resp, err := client.GetCampaignTags(ctx, connect.NewRequest(&managementv1.GetCampaignTagsRequest{}))
+	if err != nil {
+		t.Fatalf("GetCampaignTags: %v", err)
+	}
+	if len(resp.Msg.GetEntries()) != 2 {
+		t.Errorf("got %d pairs, want 2", len(resp.Msg.GetEntries()))
+	}
+
+	if _, err := client.RenameTag(ctx, connect.NewRequest(&managementv1.RenameTagRequest{
+		From: "act two", To: "act three",
+	})); err != nil {
+		t.Fatalf("RenameTag: %v", err)
+	}
+	if store.renamedFrom != "act two" || store.renamedTo != "act three" {
+		t.Errorf("rename = %q→%q", store.renamedFrom, store.renamedTo)
+	}
+}
+
+func TestTagsValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad node id is InvalidArgument", func(t *testing.T) {
+		store := newFakeOrganizeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := organizeClient(t, store).SetNodeTags(context.Background(),
+			connect.NewRequest(&managementv1.SetNodeTagsRequest{NodeId: "nope"}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("an invalid tag surfaces as InvalidArgument", func(t *testing.T) {
+		store := newFakeOrganizeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		store.tagErr = storage.ErrInvalidTag
+		_, err := organizeClient(t, store).SetNodeTags(context.Background(),
+			connect.NewRequest(&managementv1.SetNodeTagsRequest{NodeId: uuid.New().String()}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+	})
+
+	t.Run("a blank rename is refused", func(t *testing.T) {
+		store := newFakeOrganizeStore()
+		store.campaign = storage.Campaign{ID: uuid.New()}
+		_, err := organizeClient(t, store).RenameTag(context.Background(),
+			connect.NewRequest(&managementv1.RenameTagRequest{From: "  ", To: "x"}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+		}
+	})
+}
+
+// TestBoardsRoundTrip pins that a board is a named ordered shortlist, and that
+// updating it replaces its entries in the authored order.
+func TestBoardsRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := newFakeOrganizeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	client := organizeClient(t, store)
+	ctx := context.Background()
+
+	created, err := client.CreateBoard(ctx, connect.NewRequest(&managementv1.CreateBoardRequest{
+		Name: "  tonight: the harbour heist  ",
+	}))
+	if err != nil {
+		t.Fatalf("CreateBoard: %v", err)
+	}
+	if created.Msg.GetBoard().GetName() != "tonight: the harbour heist" {
+		t.Errorf("name = %q, want it trimmed", created.Msg.GetBoard().GetName())
+	}
+	id := created.Msg.GetBoard().GetId()
+
+	a, b := uuid.New().String(), uuid.New().String()
+	updated, err := client.UpdateBoard(ctx, connect.NewRequest(&managementv1.UpdateBoardRequest{
+		Id: id, Name: "tonight", NodeIds: []string{b, a},
+	}))
+	if err != nil {
+		t.Fatalf("UpdateBoard: %v", err)
+	}
+	if got := updated.Msg.GetBoard().GetNodeIds(); len(got) != 2 || got[0] != b {
+		t.Errorf("board = %v, want the authored order preserved", got)
+	}
+
+	if _, err := client.DeleteBoard(ctx, connect.NewRequest(&managementv1.DeleteBoardRequest{Id: id})); err != nil {
+		t.Fatalf("DeleteBoard: %v", err)
+	}
+	list, err := client.ListBoards(ctx, connect.NewRequest(&managementv1.ListBoardsRequest{}))
+	if err != nil {
+		t.Fatalf("ListBoards: %v", err)
+	}
+	if len(list.Msg.GetBoards()) != 0 {
+		t.Errorf("boards after delete = %v", list.Msg.GetBoards())
+	}
+}
+
+func TestBoardsValidation(t *testing.T) {
+	t.Parallel()
+	store := newFakeOrganizeStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	client := organizeClient(t, store)
+
+	if _, err := client.CreateBoard(context.Background(),
+		connect.NewRequest(&managementv1.CreateBoardRequest{Name: "  "})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("blank name: code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	if _, err := client.UpdateBoard(context.Background(),
+		connect.NewRequest(&managementv1.UpdateBoardRequest{
+			Id: uuid.New().String(), Name: "x", NodeIds: []string{"not-a-uuid"},
+		})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("bad entry id: code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+	if _, err := client.DeleteBoard(context.Background(),
+		connect.NewRequest(&managementv1.DeleteBoardRequest{Id: uuid.New().String()})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("missing board: code = %v, want NotFound", connect.CodeOf(err))
+	}
+}

--- a/internal/storage/kg_graph_test.go
+++ b/internal/storage/kg_graph_test.go
@@ -320,6 +320,40 @@ func TestNodeTags(t *testing.T) {
 		t.Errorf("tags after collapsing rename = %v, want 2", after)
 	}
 
+	// A CASE-ONLY rename is the same tag under a tidier name — the commonest
+	// rename a GM makes. It deleted the tag from every entry in the campaign: the
+	// collision sweep's EXISTS was satisfied by each row itself when
+	// lower(from) = lower(to), so every row matched and the UPDATE that followed
+	// found nothing left. Silent, campaign-wide data loss behind a successful call.
+	// The original test only covered from != to, so the suite could not see it.
+	before, err := st.CampaignTags(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CampaignTags before case rename: %v", err)
+	}
+	if err := st.RenameTag(ctx, campaignID, "act two", "Act Two"); err != nil {
+		t.Fatalf("RenameTag case-only: %v", err)
+	}
+	afterCase, err := st.CampaignTags(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CampaignTags after case rename: %v", err)
+	}
+	if len(afterCase) != len(before) {
+		t.Fatalf("a case-only rename changed the tag count: %d → %d (%v)",
+			len(before), len(afterCase), afterCase)
+	}
+	var casedCount int
+	for _, p := range afterCase {
+		if p.Tag == "Act Two" {
+			casedCount++
+		}
+		if strings.EqualFold(p.Tag, "act two") && p.Tag != "Act Two" {
+			t.Errorf("a tag kept its old casing after the rename: %q", p.Tag)
+		}
+	}
+	if casedCount == 0 {
+		t.Error(`no entry carries "Act Two" after the rename — the tag was deleted`)
+	}
+
 	// An over-long tag is refused before anything is written.
 	if err := st.SetNodeTags(ctx, campaignID, bart.ID,
 		[]string{strings.Repeat("x", storage.MaxTagRunes+1)}); !errors.Is(err, storage.ErrInvalidTag) {

--- a/internal/storage/kg_graph_test.go
+++ b/internal/storage/kg_graph_test.go
@@ -4,7 +4,9 @@ package storage_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -257,5 +259,208 @@ func TestLastSpokenByAgent(t *testing.T) {
 	_, _, other := seedCampaign(t, dsn)
 	if empty, err := st.LastSpokenByAgent(ctx, other); err != nil || len(empty) != 0 {
 		t.Errorf("other campaign = %v (err %v), want empty", empty, err)
+	}
+}
+
+// TestNodeTags covers the free-form tag layer (#543): replace-in-full, blank and
+// duplicate handling, the campaign-wide read, a campaign-wide rename that
+// collapses collisions, and the delete cascade.
+func TestNodeTags(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	bart := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	town := mkNode(t, st, campaignID, storage.KGNodeLocation, "Saltmarsh")
+
+	// Blanks are dropped and case-insensitive duplicates collapse: the chip editor
+	// leaves an empty field around, and that convenience must not be a save error.
+	if err := st.SetNodeTags(ctx, campaignID, bart.ID,
+		[]string{"seafaring", "  ", "Act Two", "act two", "  needs   a voice  "}); err != nil {
+		t.Fatalf("SetNodeTags: %v", err)
+	}
+	got, err := st.NodeTags(ctx, campaignID, bart.ID)
+	if err != nil {
+		t.Fatalf("NodeTags: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("tags = %v, want 3 after dropping blanks and collapsing duplicates", got)
+	}
+	// Inner whitespace is collapsed but case is PRESERVED: a GM who writes
+	// "Act Two" gets "Act Two" back.
+	joined := strings.Join(got, "|")
+	if !strings.Contains(joined, "Act Two") || !strings.Contains(joined, "needs a voice") {
+		t.Errorf("tags = %v, want normalized whitespace and preserved case", got)
+	}
+
+	if err := st.SetNodeTags(ctx, campaignID, town.ID, []string{"act two", "harbour"}); err != nil {
+		t.Fatalf("SetNodeTags town: %v", err)
+	}
+
+	pairs, err := st.CampaignTags(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CampaignTags: %v", err)
+	}
+	if len(pairs) != 5 {
+		t.Errorf("campaign tags = %d pairs, want 5", len(pairs))
+	}
+
+	// Renaming is campaign-wide — a tag is ONE concept, and renaming it
+	// entry-by-entry is how half-renamed vocabularies happen. Bart already carries
+	// "Act Two", so renaming "seafaring" onto it must collapse rather than fail.
+	if err := st.RenameTag(ctx, campaignID, "seafaring", "Act Two"); err != nil {
+		t.Fatalf("RenameTag: %v", err)
+	}
+	after, err := st.NodeTags(ctx, campaignID, bart.ID)
+	if err != nil {
+		t.Fatalf("NodeTags after rename: %v", err)
+	}
+	if len(after) != 2 {
+		t.Errorf("tags after collapsing rename = %v, want 2", after)
+	}
+
+	// An over-long tag is refused before anything is written.
+	if err := st.SetNodeTags(ctx, campaignID, bart.ID,
+		[]string{strings.Repeat("x", storage.MaxTagRunes+1)}); !errors.Is(err, storage.ErrInvalidTag) {
+		t.Errorf("over-long tag: got %v, want ErrInvalidTag", err)
+	}
+
+	// Deleting the entry takes its tags with it.
+	if err := st.DeleteNode(ctx, campaignID, bart.ID); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+	left, err := st.CampaignTags(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("CampaignTags after delete: %v", err)
+	}
+	for _, p := range left {
+		if p.NodeID == bart.ID {
+			t.Error("tags outlived their entry")
+		}
+	}
+}
+
+// TestPrepBoards covers a board's lifecycle: create, ordered entries,
+// replace-in-full, and that deleting a board leaves its entries alone while
+// deleting an entry removes it from every board.
+func TestPrepBoards(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	a := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	b := mkNode(t, st, campaignID, storage.KGNodeLocation, "Saltmarsh")
+	c := mkNode(t, st, campaignID, storage.KGNodeItem, "A key")
+
+	board, err := st.CreateBoard(ctx, campaignID, "tonight: the harbour heist")
+	if err != nil {
+		t.Fatalf("CreateBoard: %v", err)
+	}
+	if err := st.SetBoardNodes(ctx, campaignID, board.ID, []uuid.UUID{c.ID, a.ID, b.ID}); err != nil {
+		t.Fatalf("SetBoardNodes: %v", err)
+	}
+
+	boards, err := st.ListBoards(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("ListBoards: %v", err)
+	}
+	if len(boards) != 1 {
+		t.Fatalf("got %d boards, want 1", len(boards))
+	}
+	// Board ORDER is the GM's, not the database's.
+	if len(boards[0].NodeIDs) != 3 || boards[0].NodeIDs[0] != c.ID || boards[0].NodeIDs[2] != b.ID {
+		t.Errorf("board order = %v, want the authored order", boards[0].NodeIDs)
+	}
+
+	// Replace-in-full: reorder and remove in one save.
+	if err := st.SetBoardNodes(ctx, campaignID, board.ID, []uuid.UUID{b.ID, a.ID}); err != nil {
+		t.Fatalf("SetBoardNodes (rewrite): %v", err)
+	}
+	boards, _ = st.ListBoards(ctx, campaignID)
+	if len(boards[0].NodeIDs) != 2 || boards[0].NodeIDs[0] != b.ID {
+		t.Errorf("board after rewrite = %v", boards[0].NodeIDs)
+	}
+
+	// Deleting an ENTRY removes it from the board — a board row pointing at
+	// nothing is not a reminder.
+	if err := st.DeleteNode(ctx, campaignID, b.ID); err != nil {
+		t.Fatalf("DeleteNode: %v", err)
+	}
+	boards, _ = st.ListBoards(ctx, campaignID)
+	if len(boards[0].NodeIDs) != 1 || boards[0].NodeIDs[0] != a.ID {
+		t.Errorf("board after entry delete = %v, want just the survivor", boards[0].NodeIDs)
+	}
+
+	// Deleting the BOARD leaves its entries alone: a board is a shortlist, not
+	// ownership.
+	if err := st.DeleteBoard(ctx, campaignID, board.ID); err != nil {
+		t.Fatalf("DeleteBoard: %v", err)
+	}
+	if _, err := st.ListNodes(ctx, campaignID); err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	nodes, _ := st.ListNodes(ctx, campaignID)
+	if len(nodes) != 2 {
+		t.Errorf("entries after board delete = %d, want both survivors untouched", len(nodes))
+	}
+}
+
+// TestTagsAndBoardsNeverReachAPrompt is the #543 AC that matters most: tags and
+// boards are GM ORGANIZATION, and neither may enter an NPC's Hot Context.
+//
+// If they did, tags would quietly become a second, unvalidated type system inside
+// NPC context — and they would spend the fact budget world knowledge draws on.
+func TestTagsAndBoardsNeverReachAPrompt(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, _, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+	view := st.PromptKG()
+
+	own := mkNode(t, st, campaignID, storage.KGNodeNPC, "Bart")
+	agentID := linkAgent(t, st, campaignID, own.ID, "Bart")
+
+	const secretTag = "zzz-tag-sentinel"
+	const secretBoard = "zzz-board-sentinel"
+	if err := st.SetNodeTags(ctx, campaignID, own.ID, []string{secretTag}); err != nil {
+		t.Fatalf("SetNodeTags: %v", err)
+	}
+	board, err := st.CreateBoard(ctx, campaignID, secretBoard)
+	if err != nil {
+		t.Fatalf("CreateBoard: %v", err)
+	}
+	if err := st.SetBoardNodes(ctx, campaignID, board.ID, []uuid.UUID{own.ID}); err != nil {
+		t.Fatalf("SetBoardNodes: %v", err)
+	}
+
+	assertClean := func(op string, nodes []storage.KGNode, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		for _, n := range nodes {
+			blob := n.Name + "\x00" + n.Body
+			for _, a := range n.Aspects {
+				blob += "\x00" + a.Key + "\x00" + a.Value
+			}
+			if strings.Contains(blob, secretTag) {
+				t.Errorf("%s carried a TAG into prompt-facing data: %q", op, blob)
+			}
+			if strings.Contains(blob, secretBoard) {
+				t.Errorf("%s carried a BOARD name into prompt-facing data: %q", op, blob)
+			}
+		}
+	}
+
+	facts, err := view.AgentNodeFacts(ctx, agentID)
+	assertClean("AgentNodeFacts", facts, err)
+	hits, err := view.SearchPublicNodes(ctx, campaignID, secretTag, 10)
+	assertClean("SearchPublicNodes", hits, err)
+	// A tag must not even make its entry FINDABLE by prompt-facing search — that
+	// would let an NPC surface an entry because of a GM's private filing label.
+	if len(hits) != 0 {
+		t.Errorf("prompt-facing search matched on a tag: %+v", hits)
 	}
 }

--- a/internal/storage/kg_tag_board.go
+++ b/internal/storage/kg_tag_board.go
@@ -25,6 +25,11 @@ import (
 // MaxTagRunes bounds one tag. A tag is a label, not a sentence.
 const MaxTagRunes = 40
 
+// MaxBoardNameRunes bounds a board name. Tags were capped and board names were
+// not, so a board could carry a megabyte of text that every ListBoards response
+// then had to return.
+const MaxBoardNameRunes = 120
+
 // MaxTagsPerNode bounds how many an entry may carry — enough for real
 // organization, few enough that the chip row stays readable.
 const MaxTagsPerNode = 20
@@ -145,9 +150,30 @@ func (s *Store) RenameTag(ctx context.Context, campaignID uuid.UUID, from, to st
 	if len([]rune(toN)) > MaxTagRunes {
 		return fmt.Errorf("%w: %q is too long (max %d characters)", ErrInvalidTag, toN, MaxTagRunes)
 	}
+	// A CASE-ONLY rename ("act two" → "Act Two") is the same tag, so nothing can
+	// collide with it and the collision sweep below must not run.
+	//
+	// It ran, and it deleted the tag from every entry in the campaign: the DELETE's
+	// EXISTS is satisfied by the row itself when lower(from) = lower(to), so every
+	// row matched, and the UPDATE that followed then found nothing left to rename. A
+	// GM fixing a capitalisation lost the tag campaign-wide, silently, with a
+	// successful response. The original test only covered from ≠ to, so the suite
+	// could not see it.
+	if strings.EqualFold(fromN, toN) {
+		if _, err := s.db.Exec(ctx,
+			`UPDATE kg_node_tag SET tag = $3
+			  WHERE campaign_id = $1 AND lower(tag) = lower($2)`,
+			campaignID, fromN, toN); err != nil {
+			return fmt.Errorf("storage: rename tag: %w", err)
+		}
+		return nil
+	}
+
 	return s.InTx(ctx, func(tx *Store) error {
 		// Drop rows that would collide, then rename the rest — simpler and more
-		// predictable than an upsert dance over a composite primary key.
+		// predictable than an upsert dance over a composite primary key. Safe here
+		// precisely because the case-only branch above already returned: with
+		// lower(from) <> lower(to), a colliding `cur` can never be `old` itself.
 		if _, err := tx.db.Exec(ctx,
 			`DELETE FROM kg_node_tag old
 			  WHERE old.campaign_id = $1 AND lower(old.tag) = lower($2)
@@ -247,6 +273,41 @@ func (s *Store) ListBoards(ctx context.Context, campaignID uuid.UUID) ([]KGBoard
 // remove and reorder are one save, and positions stay dense by construction.
 func (s *Store) SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID, nodeIDs []uuid.UUID) error {
 	return s.InTx(ctx, func(tx *Store) error {
+		return tx.setBoardNodesTx(ctx, campaignID, boardID, nodeIDs)
+	})
+}
+
+// UpdateBoard renames a board AND replaces its entries in ONE transaction.
+//
+// The two were separate calls, so a failed entry write (a stale node id, an entry
+// deleted by a concurrent edit) left the board renamed with its old contents and
+// returned an opaque error — a half-applied save the GM has no way to reason
+// about. A board edit is one edit.
+func (s *Store) UpdateBoard(ctx context.Context, campaignID, id uuid.UUID, name string, nodeIDs []uuid.UUID) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("storage: update board: name must not be empty")
+	}
+	if len([]rune(name)) > MaxBoardNameRunes {
+		return fmt.Errorf("%w: a board name is at most %d characters", ErrInvalidTag, MaxBoardNameRunes)
+	}
+	return s.InTx(ctx, func(tx *Store) error {
+		tag, err := tx.db.Exec(ctx,
+			`UPDATE kg_board SET name = $3, updated_at = now() WHERE id = $1 AND campaign_id = $2`,
+			id, campaignID, name)
+		if err != nil {
+			return fmt.Errorf("storage: update board %s: %w", id, err)
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return tx.setBoardNodesTx(ctx, campaignID, id, nodeIDs)
+	})
+}
+
+func (s *Store) setBoardNodesTx(ctx context.Context, campaignID, boardID uuid.UUID, nodeIDs []uuid.UUID) error {
+	tx := s
+	{
 		var exists bool
 		if err := tx.db.QueryRow(ctx,
 			`SELECT EXISTS (SELECT 1 FROM kg_board WHERE id = $1 AND campaign_id = $2)`,
@@ -261,16 +322,34 @@ func (s *Store) SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID
 			boardID, campaignID); err != nil {
 			return fmt.Errorf("storage: set board nodes %s: clear: %w", boardID, err)
 		}
-		if len(nodeIDs) > 0 {
-			pos := make([]int32, len(nodeIDs))
-			for i := range nodeIDs {
+		// Deduped HERE rather than left to ON CONFLICT, so positions stay dense.
+		// Letting the conflict drop a repeat left a gap ([A, A, B] → 0, 2), which
+		// makes the "dense by construction" the ordering relies on merely usually
+		// true.
+		unique := make([]uuid.UUID, 0, len(nodeIDs))
+		seen := make(map[uuid.UUID]struct{}, len(nodeIDs))
+		for _, n := range nodeIDs {
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			unique = append(unique, n)
+		}
+		if len(unique) > 0 {
+			pos := make([]int32, len(unique))
+			for i := range unique {
 				pos[i] = int32(i) //nolint:gosec // a board is a session's shortlist
 			}
 			if _, err := tx.db.Exec(ctx,
 				`INSERT INTO kg_board_node (board_id, node_id, campaign_id, position)
-				 SELECT $1, n, $2, p FROM unnest($3::uuid[], $4::int[]) AS t(n, p)
-				 ON CONFLICT (board_id, node_id) DO NOTHING`,
-				boardID, campaignID, nodeIDs, pos); err != nil {
+				 SELECT $1, n, $2, p FROM unnest($3::uuid[], $4::int[]) AS t(n, p)`,
+				boardID, campaignID, unique, pos); err != nil {
+				// A node id that is not in THIS campaign is refused by the composite FK.
+				// That is the caller naming something absent — a NotFound the client can
+				// act on, not a server fault.
+				if code, ok := pgErrCode(err); ok && code == pgForeignKeyViolation {
+					return ErrNotFound
+				}
 				return fmt.Errorf("storage: set board nodes %s: insert: %w", boardID, err)
 			}
 		}
@@ -280,7 +359,7 @@ func (s *Store) SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID
 			return fmt.Errorf("storage: set board nodes %s: touch: %w", boardID, err)
 		}
 		return nil
-	})
+	}
 }
 
 // RenameBoard renames a prep board.

--- a/internal/storage/kg_tag_board.go
+++ b/internal/storage/kg_tag_board.go
@@ -1,0 +1,315 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Free-form Node tags and saved prep boards (#543, ADR-0008).
+//
+// Tags are ORGANIZATION, not schema. The seven Node types carry edge-validity
+// rules and prompt semantics and are immutable after create, so that vocabulary
+// stays closed — but organization should not require a migration and an enum edit
+// every time a GM invents a category.
+//
+// Both are GM-ONLY: neither enters a prompt and neither affects AgentNodeFacts.
+// That keeps the fact budget untouched and stops tags quietly becoming a second,
+// unvalidated type system inside NPC context.
+
+// MaxTagRunes bounds one tag. A tag is a label, not a sentence.
+const MaxTagRunes = 40
+
+// MaxTagsPerNode bounds how many an entry may carry — enough for real
+// organization, few enough that the chip row stays readable.
+const MaxTagsPerNode = 20
+
+// ErrInvalidTag is returned for a blank or over-long tag.
+var ErrInvalidTag = errors.New("storage: invalid tag")
+
+// normalizeTag trims a tag and collapses inner whitespace, so "act two" and
+// "act  two " are the same tag rather than two that look identical in the UI.
+// Case is PRESERVED: a GM who writes "Act Two" gets "Act Two" back.
+func normalizeTag(tag string) string {
+	return strings.Join(strings.Fields(tag), " ")
+}
+
+// SetNodeTags replaces a Node's tags with exactly the supplied set, in one
+// transaction. Replace-in-full matches how the chip editor works — add and remove
+// are one save — and there is no ordering to preserve, so no position column.
+//
+// Tags are created on use: there is no tag table to maintain and no lifecycle to
+// get wrong, which is the point of "free-form".
+func (s *Store) SetNodeTags(ctx context.Context, campaignID, nodeID uuid.UUID, tags []string) error {
+	clean := make([]string, 0, len(tags))
+	seen := map[string]bool{}
+	for _, t := range tags {
+		n := normalizeTag(t)
+		if n == "" {
+			continue
+		}
+		if len([]rune(n)) > MaxTagRunes {
+			return fmt.Errorf("%w: %q is too long (max %d characters)", ErrInvalidTag, n, MaxTagRunes)
+		}
+		// Case-insensitive dedup within one save: "Act two" and "act two" are one tag.
+		key := strings.ToLower(n)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		clean = append(clean, n)
+	}
+	if len(clean) > MaxTagsPerNode {
+		return fmt.Errorf("%w: an entry may carry at most %d tags", ErrInvalidTag, MaxTagsPerNode)
+	}
+
+	return s.InTx(ctx, func(tx *Store) error {
+		if _, err := tx.db.Exec(ctx,
+			`DELETE FROM kg_node_tag WHERE node_id = $1 AND campaign_id = $2`,
+			nodeID, campaignID); err != nil {
+			return fmt.Errorf("storage: set node tags %s: clear: %w", nodeID, err)
+		}
+		if len(clean) == 0 {
+			return nil
+		}
+		if _, err := tx.db.Exec(ctx,
+			`INSERT INTO kg_node_tag (node_id, campaign_id, tag)
+			 SELECT $1, $2, t FROM unnest($3::text[]) AS t`,
+			nodeID, campaignID, clean); err != nil {
+			return fmt.Errorf("storage: set node tags %s: insert: %w", nodeID, err)
+		}
+		return nil
+	})
+}
+
+// NodeTags returns one Node's tags, alphabetically.
+func (s *Store) NodeTags(ctx context.Context, campaignID, nodeID uuid.UUID) ([]string, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT tag FROM kg_node_tag
+		  WHERE node_id = $1 AND campaign_id = $2 ORDER BY lower(tag)`, nodeID, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: node tags %s: %w", nodeID, err)
+	}
+	defer rows.Close()
+	return scanTagStrings(rows, "node tags")
+}
+
+// TaggedNode is one (node, tag) pair — the campaign-wide read the list and graph
+// filters index client-side, so tagging a hundred entries is still one round trip.
+type TaggedNode struct {
+	NodeID uuid.UUID
+	Tag    string
+}
+
+// CampaignTags returns every (node, tag) pair in a Campaign, ordered so the
+// client can build both the tag vocabulary and the per-node index from one read.
+func (s *Store) CampaignTags(ctx context.Context, campaignID uuid.UUID) ([]TaggedNode, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT node_id, tag FROM kg_node_tag WHERE campaign_id = $1 ORDER BY lower(tag), node_id`,
+		campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: campaign tags: %w", err)
+	}
+	defer rows.Close()
+
+	var out []TaggedNode
+	for rows.Next() {
+		var t TaggedNode
+		if err := rows.Scan(&t.NodeID, &t.Tag); err != nil {
+			return nil, fmt.Errorf("storage: scan campaign tag: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: campaign tags: %w", err)
+	}
+	return out, nil
+}
+
+// RenameTag renames a tag across the whole Campaign — the AC's "renaming a tag
+// updates every use". Done in SQL rather than per-node, because a tag is one
+// concept and renaming it entry-by-entry is how half-renamed vocabularies happen.
+//
+// A node already carrying the target name keeps a single row: the ON CONFLICT
+// drops the duplicate rather than failing the whole rename.
+func (s *Store) RenameTag(ctx context.Context, campaignID uuid.UUID, from, to string) error {
+	fromN, toN := normalizeTag(from), normalizeTag(to)
+	if fromN == "" || toN == "" {
+		return fmt.Errorf("%w: a tag name must not be blank", ErrInvalidTag)
+	}
+	if len([]rune(toN)) > MaxTagRunes {
+		return fmt.Errorf("%w: %q is too long (max %d characters)", ErrInvalidTag, toN, MaxTagRunes)
+	}
+	return s.InTx(ctx, func(tx *Store) error {
+		// Drop rows that would collide, then rename the rest — simpler and more
+		// predictable than an upsert dance over a composite primary key.
+		if _, err := tx.db.Exec(ctx,
+			`DELETE FROM kg_node_tag old
+			  WHERE old.campaign_id = $1 AND lower(old.tag) = lower($2)
+			    AND EXISTS (SELECT 1 FROM kg_node_tag cur
+			                 WHERE cur.node_id = old.node_id AND lower(cur.tag) = lower($3))`,
+			campaignID, fromN, toN); err != nil {
+			return fmt.Errorf("storage: rename tag: drop collisions: %w", err)
+		}
+		if _, err := tx.db.Exec(ctx,
+			`UPDATE kg_node_tag SET tag = $3
+			  WHERE campaign_id = $1 AND lower(tag) = lower($2)`,
+			campaignID, fromN, toN); err != nil {
+			return fmt.Errorf("storage: rename tag: %w", err)
+		}
+		return nil
+	})
+}
+
+func scanTagStrings(rows pgx.Rows, op string) ([]string, error) {
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, fmt.Errorf("storage: scan %s: %w", op, err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: %s: %w", op, err)
+	}
+	return out, nil
+}
+
+// KGBoard is a named, ordered set of entries the GM pins for one session — the
+// "tonight: the harbour heist" list they already keep in a text file outside the
+// tool. NodeIDs is in board order.
+type KGBoard struct {
+	ID         uuid.UUID
+	CampaignID uuid.UUID
+	Name       string
+	NodeIDs    []uuid.UUID
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// CreateBoard makes an empty prep board.
+func (s *Store) CreateBoard(ctx context.Context, campaignID uuid.UUID, name string) (KGBoard, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return KGBoard{}, fmt.Errorf("storage: create board: name must not be empty")
+	}
+	var b KGBoard
+	err := s.db.QueryRow(ctx,
+		`INSERT INTO kg_board (campaign_id, name) VALUES ($1, $2)
+		 RETURNING id, campaign_id, name, created_at, updated_at`, campaignID, name).
+		Scan(&b.ID, &b.CampaignID, &b.Name, &b.CreatedAt, &b.UpdatedAt)
+	if err != nil {
+		return KGBoard{}, fmt.Errorf("storage: create board: %w", err)
+	}
+	return b, nil
+}
+
+// ListBoards returns a Campaign's boards with their entries, in board order. One
+// read for the whole set: a campaign has a handful of boards, and the Session
+// screen wants them all at once.
+func (s *Store) ListBoards(ctx context.Context, campaignID uuid.UUID) ([]KGBoard, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT b.id, b.campaign_id, b.name, b.created_at, b.updated_at,
+		        COALESCE(array_agg(n.node_id ORDER BY n.position, n.node_id)
+		                 FILTER (WHERE n.node_id IS NOT NULL), '{}') AS node_ids
+		   FROM kg_board b
+		   LEFT JOIN kg_board_node n ON n.board_id = b.id
+		  WHERE b.campaign_id = $1
+		  GROUP BY b.id
+		  ORDER BY lower(b.name), b.id`, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list boards: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KGBoard
+	for rows.Next() {
+		var b KGBoard
+		if err := rows.Scan(&b.ID, &b.CampaignID, &b.Name, &b.CreatedAt, &b.UpdatedAt, &b.NodeIDs); err != nil {
+			return nil, fmt.Errorf("storage: scan board: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list boards: %w", err)
+	}
+	return out, nil
+}
+
+// SetBoardNodes replaces a board's entries with exactly the supplied list, in
+// order. Replace-in-full for the same reason the aspect editor uses it: add,
+// remove and reorder are one save, and positions stay dense by construction.
+func (s *Store) SetBoardNodes(ctx context.Context, campaignID, boardID uuid.UUID, nodeIDs []uuid.UUID) error {
+	return s.InTx(ctx, func(tx *Store) error {
+		var exists bool
+		if err := tx.db.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM kg_board WHERE id = $1 AND campaign_id = $2)`,
+			boardID, campaignID).Scan(&exists); err != nil {
+			return fmt.Errorf("storage: set board nodes %s: %w", boardID, err)
+		}
+		if !exists {
+			return ErrNotFound
+		}
+		if _, err := tx.db.Exec(ctx,
+			`DELETE FROM kg_board_node WHERE board_id = $1 AND campaign_id = $2`,
+			boardID, campaignID); err != nil {
+			return fmt.Errorf("storage: set board nodes %s: clear: %w", boardID, err)
+		}
+		if len(nodeIDs) > 0 {
+			pos := make([]int32, len(nodeIDs))
+			for i := range nodeIDs {
+				pos[i] = int32(i) //nolint:gosec // a board is a session's shortlist
+			}
+			if _, err := tx.db.Exec(ctx,
+				`INSERT INTO kg_board_node (board_id, node_id, campaign_id, position)
+				 SELECT $1, n, $2, p FROM unnest($3::uuid[], $4::int[]) AS t(n, p)
+				 ON CONFLICT (board_id, node_id) DO NOTHING`,
+				boardID, campaignID, nodeIDs, pos); err != nil {
+				return fmt.Errorf("storage: set board nodes %s: insert: %w", boardID, err)
+			}
+		}
+		if _, err := tx.db.Exec(ctx,
+			`UPDATE kg_board SET updated_at = now() WHERE id = $1 AND campaign_id = $2`,
+			boardID, campaignID); err != nil {
+			return fmt.Errorf("storage: set board nodes %s: touch: %w", boardID, err)
+		}
+		return nil
+	})
+}
+
+// RenameBoard renames a prep board.
+func (s *Store) RenameBoard(ctx context.Context, campaignID, id uuid.UUID, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("storage: rename board: name must not be empty")
+	}
+	tag, err := s.db.Exec(ctx,
+		`UPDATE kg_board SET name = $3, updated_at = now() WHERE id = $1 AND campaign_id = $2`,
+		id, campaignID, name)
+	if err != nil {
+		return fmt.Errorf("storage: rename board %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteBoard removes a prep board and its entries. The ENTRIES themselves are
+// untouched — a board is a shortlist, not ownership.
+func (s *Store) DeleteBoard(ctx context.Context, campaignID, id uuid.UUID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM kg_board WHERE id = $1 AND campaign_id = $2`, id, campaignID)
+	if err != nil {
+		return fmt.Errorf("storage: delete board %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/storage/migrations/00047_kg_tag_board.sql
+++ b/internal/storage/migrations/00047_kg_tag_board.sql
@@ -1,0 +1,66 @@
+-- +goose Up
+
+-- Free-form Node tags and saved prep boards (#543, ADR-0008).
+--
+-- WHY TAGS ARE NOT NEW NODE TYPES: the seven types are a SCHEMA. They carry
+-- edge-validity rules (resides_in → Location, member_of → Faction) and prompt
+-- semantics, and node_type is immutable after create — so keeping the vocabulary
+-- closed is right. Tags are ORGANIZATION, and organization should not require a
+-- migration and an enum edit every time a GM invents a category ("seafaring",
+-- "act two", "needs a voice").
+--
+-- Tags and boards are GM organization ONLY: neither enters a prompt and neither
+-- affects AgentNodeFacts. That keeps the fact budget untouched and stops tags
+-- quietly becoming a second, unvalidated type system inside NPC context.
+CREATE TABLE kg_node_tag (
+    node_id     uuid NOT NULL,
+    campaign_id uuid NOT NULL,
+    -- Create-on-use, campaign-scoped, autocompleted from what already exists.
+    tag         text NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (node_id, tag),
+    CONSTRAINT kg_node_tag_node_fk FOREIGN KEY (node_id, campaign_id)
+        REFERENCES kg_node (id, campaign_id) ON DELETE CASCADE,
+    CONSTRAINT kg_node_tag_not_blank CHECK (btrim(tag) <> '')
+);
+
+-- The two reads: a campaign's tag vocabulary (for chips and autocomplete), and
+-- "which entries carry this tag" (for filtering the list and the graph).
+CREATE INDEX kg_node_tag_campaign_tag_idx ON kg_node_tag (campaign_id, tag);
+
+-- A prep board is a named, ordered set of entries the GM pins for one session —
+-- the "tonight: the harbour heist" text file they already keep outside the tool.
+CREATE TABLE kg_board (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id uuid NOT NULL REFERENCES campaign (id) ON DELETE CASCADE,
+    name        text NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+    -- The composite-FK target kg_board_node references, so a board entry cannot
+    -- span campaigns without a trigger (the ADR-0008 pattern).
+    CONSTRAINT kg_board_id_campaign_unique UNIQUE (id, campaign_id)
+);
+
+CREATE INDEX kg_board_campaign_idx ON kg_board (campaign_id);
+
+CREATE TABLE kg_board_node (
+    board_id    uuid NOT NULL,
+    node_id     uuid NOT NULL,
+    campaign_id uuid NOT NULL,
+    position    integer NOT NULL,
+    PRIMARY KEY (board_id, node_id),
+    CONSTRAINT kg_board_node_board_fk FOREIGN KEY (board_id, campaign_id)
+        REFERENCES kg_board (id, campaign_id) ON DELETE CASCADE,
+    -- Deleting an entry removes it from every board: a board row pointing at
+    -- nothing is not a reminder.
+    CONSTRAINT kg_board_node_node_fk FOREIGN KEY (node_id, campaign_id)
+        REFERENCES kg_node (id, campaign_id) ON DELETE CASCADE
+);
+
+CREATE INDEX kg_board_node_board_idx ON kg_board_node (board_id, position);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS kg_board_node;
+DROP TABLE IF EXISTS kg_board;
+DROP TABLE IF EXISTS kg_node_tag;

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -139,6 +139,38 @@ service CampaignService {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 
+  // ── Tags and prep boards (#543) ───────────────────────────────────────────
+  // GM organization only: neither enters a prompt, and neither affects an NPC's
+  // Hot Context.
+
+  // GetCampaignTags returns every (entry, tag) pair in the campaign — one read
+  // that yields both the tag vocabulary and the per-entry index. Read-only.
+  rpc GetCampaignTags(GetCampaignTagsRequest) returns (GetCampaignTagsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // SetNodeTags replaces one entry's tags with exactly this set.
+  rpc SetNodeTags(SetNodeTagsRequest) returns (SetNodeTagsResponse);
+
+  // RenameTag renames a tag across the whole campaign — a tag is one concept,
+  // and renaming it entry-by-entry is how half-renamed vocabularies happen.
+  rpc RenameTag(RenameTagRequest) returns (RenameTagResponse);
+
+  // ListBoards returns the campaign's prep boards with their entries. Read-only.
+  rpc ListBoards(ListBoardsRequest) returns (ListBoardsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+
+  // CreateBoard makes an empty prep board.
+  rpc CreateBoard(CreateBoardRequest) returns (CreateBoardResponse);
+
+  // UpdateBoard renames a board and/or replaces its entries in order.
+  rpc UpdateBoard(UpdateBoardRequest) returns (UpdateBoardResponse);
+
+  // DeleteBoard removes a board. Its entries are untouched — a board is a
+  // shortlist, not ownership.
+  rpc DeleteBoard(DeleteBoardRequest) returns (DeleteBoardResponse);
+
   // FindDuplicateEntries returns the campaign's closest Node pairs by embedding
   // similarity — the world health panel's "probable duplicates" check (#536).
   // GM-INITIATED: it is an exact pairwise scan and must never run on render.
@@ -774,6 +806,89 @@ message DeletePinRequest {
 
 // DeletePinResponse is empty.
 message DeletePinResponse {}
+
+// TaggedEntry is one (entry, tag) pair (#543).
+message TaggedEntry {
+  string node_id = 1;
+  string tag = 2;
+}
+
+// GetCampaignTagsRequest is the (empty) request.
+message GetCampaignTagsRequest {}
+
+// GetCampaignTagsResponse carries every pair, tag-ordered.
+message GetCampaignTagsResponse {
+  repeated TaggedEntry entries = 1;
+}
+
+// SetNodeTagsRequest replaces one entry's tags.
+message SetNodeTagsRequest {
+  string node_id = 1;
+  // tags is the complete set; an empty list clears them. Blank tags are dropped
+  // and case-insensitive duplicates collapse.
+  repeated string tags = 2;
+}
+
+// SetNodeTagsResponse carries the saved tags.
+message SetNodeTagsResponse {
+  repeated string tags = 1;
+}
+
+// RenameTagRequest renames a tag campaign-wide.
+message RenameTagRequest {
+  string from = 1;
+  string to = 2;
+}
+
+// RenameTagResponse is empty.
+message RenameTagResponse {}
+
+// Board is a named, ordered set of entries the GM pins for one session (#543).
+message Board {
+  string id = 1;
+  string name = 2;
+  // node_ids is in board order.
+  repeated string node_ids = 3;
+}
+
+// ListBoardsRequest is the (empty) request.
+message ListBoardsRequest {}
+
+// ListBoardsResponse carries the campaign's boards.
+message ListBoardsResponse {
+  repeated Board boards = 1;
+}
+
+// CreateBoardRequest names a new board.
+message CreateBoardRequest {
+  string name = 1;
+}
+
+// CreateBoardResponse carries the created board.
+message CreateBoardResponse {
+  Board board = 1;
+}
+
+// UpdateBoardRequest renames a board and replaces its entries in order.
+message UpdateBoardRequest {
+  string id = 1;
+  string name = 2;
+  // node_ids REPLACES the board's entries, in this order.
+  repeated string node_ids = 3;
+}
+
+// UpdateBoardResponse carries the updated board.
+message UpdateBoardResponse {
+  Board board = 1;
+}
+
+// DeleteBoardRequest names the board to remove.
+message DeleteBoardRequest {
+  string id = 1;
+}
+
+// DeleteBoardResponse is empty.
+message DeleteBoardResponse {}
 
 // GetRosterReadinessRequest is the (empty) request; the active campaign is
 // resolved server-side.

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -30,6 +30,7 @@ import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { NodeRelations } from "./NodeRelations";
+import { NodeTags } from "./NodeTags";
 import { KnowledgeGraph } from "./graph/KnowledgeGraph";
 import { WorldHealthPanel } from "./graph/WorldHealthPanel";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
@@ -70,6 +71,35 @@ export function KnowledgePanel({
   const listQuery = useQuery(CampaignService.method.listNodes, {});
   const [editing, setEditing] = useState<Node | null>(null);
   const [mode, setMode] = useState<ViewMode>("list");
+  // Tag filter chips (#543): one selection filters the list AND the graph, since
+  // "show me act two" is the same question in both views.
+  const [activeTags, setActiveTags] = useState<ReadonlySet<string>>(() => new Set());
+  const tagsQuery = useQuery(CampaignService.method.getCampaignTags, {});
+  const tagIndex = useMemo(() => {
+    const byNode = new Map<string, string[]>();
+    const vocabulary = new Map<string, string>();
+    for (const e of tagsQuery.data?.entries ?? []) {
+      const list = byNode.get(e.nodeId);
+      if (list) list.push(e.tag);
+      else byNode.set(e.nodeId, [e.tag]);
+      const key = e.tag.toLowerCase();
+      if (!vocabulary.has(key)) vocabulary.set(key, e.tag);
+    }
+    return { byNode, vocabulary: [...vocabulary.values()].sort((a, b) => a.localeCompare(b)) };
+  }, [tagsQuery.data]);
+
+  // An entry matches when it carries EVERY selected tag: chips narrow, they do
+  // not widen — "seafaring AND act two" is the question a GM is asking.
+  const matchesTags = useMemo(() => {
+    if (activeTags.size === 0) return () => true;
+    return (id: string) => {
+      const has = new Set((tagIndex.byNode.get(id) ?? []).map((t) => t.toLowerCase()));
+      for (const t of activeTags) {
+        if (!has.has(t.toLowerCase())) return false;
+      }
+      return true;
+    };
+  }, [activeTags, tagIndex]);
   // The generator's prompt and its unapplied draft live HERE, not inside the card:
   // switching to Graph unmounts the list column, and a draft is the result of a
   // paid LLM call the GM has not yet reviewed. Losing it to an idle mode toggle
@@ -127,9 +157,11 @@ export function KnowledgePanel({
   // previous data to keep) fall back to the full list so the view never flashes
   // empty. An empty match array is a real "no matches" and is shown as such.
   const nodes = useMemo(() => {
-    if (!searching) return listQuery.data?.nodes ?? [];
-    return searchQuery.data?.nodes ?? listQuery.data?.nodes ?? [];
-  }, [searching, searchQuery.data, listQuery.data]);
+    const base = !searching
+      ? (listQuery.data?.nodes ?? [])
+      : (searchQuery.data?.nodes ?? listQuery.data?.nodes ?? []);
+    return base.filter((n) => matchesTags(n.id));
+  }, [searching, searchQuery.data, listQuery.data, matchesTags]);
 
   // A failed search must NOT silently fall back to the full list — the box still
   // holds a query, so an unfiltered list would look filtered and the GM could act
@@ -234,6 +266,30 @@ export function KnowledgePanel({
           </button>
         </div>
 
+        {tagIndex.vocabulary.length > 0 && (
+          <div className="gx-kg-graph__chips" role="group" aria-label="Filter by tag">
+            {tagIndex.vocabulary.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                className="gx-kg-chip"
+                data-tag
+                aria-pressed={activeTags.has(tag)}
+                onClick={() =>
+                  setActiveTags((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(tag)) next.delete(tag);
+                    else next.add(tag);
+                    return next;
+                  })
+                }
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+
         {mode !== "list" ? (
           graphQuery.isPending ? (
             <div className="gx-skeleton" data-testid="kg-graph-loading" />
@@ -250,7 +306,7 @@ export function KnowledgePanel({
             />
           ) : (
             <KnowledgeGraph
-              nodes={graphQuery.data.nodes}
+              nodes={graphQuery.data.nodes.filter((n) => matchesTags(n.id))}
               edges={graphQuery.data.edges}
               selectedID={editing?.id ?? null}
               onSelectNode={editByID}
@@ -1004,6 +1060,7 @@ function EntryEditor({
         </span>
       </div>
 
+      {isEdit && node && <NodeTags nodeID={node.id} />}
       {isEdit && node && <NodeRelations node={node} />}
 
       <div className="gx-kg-editor__actions">

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -31,6 +31,7 @@ import { Select } from "@/components/ui/Select";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { NodeRelations } from "./NodeRelations";
 import { NodeTags } from "./NodeTags";
+import { NodeBoards } from "./PrepBoards";
 import { KnowledgeGraph } from "./graph/KnowledgeGraph";
 import { WorldHealthPanel } from "./graph/WorldHealthPanel";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
@@ -1061,6 +1062,7 @@ function EntryEditor({
       </div>
 
       {isEdit && node && <NodeTags nodeID={node.id} />}
+      {isEdit && node && <NodeBoards nodeID={node.id} />}
       {isEdit && node && <NodeRelations node={node} />}
 
       <div className="gx-kg-editor__actions">

--- a/web/src/screens/campaign/NodeTags.tsx
+++ b/web/src/screens/campaign/NodeTags.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import { Input } from "@/components/ui/Input";
+
+// Free-form tags on an entry (#543).
+//
+// They are ORGANIZATION, not schema: the seven Node types carry edge-validity
+// rules and prompt semantics and stay closed, but a GM inventing "seafaring",
+// "act two" or "needs a voice" should not require a migration.
+//
+// Tags never enter a prompt. That is what keeps the fact budget untouched and
+// stops them quietly becoming a second, unvalidated type system inside NPC
+// context.
+
+/** invalidateTags drops the one campaign-wide tag read every surface derives from. */
+export function invalidateTags(queryClient: ReturnType<typeof useQueryClient>): void {
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.getCampaignTags,
+      cardinality: "finite",
+    }),
+  });
+}
+
+export function NodeTags({ nodeID }: { nodeID: string }) {
+  const queryClient = useQueryClient();
+  const tagsQuery = useQuery(CampaignService.method.getCampaignTags, {});
+  const [draft, setDraft] = useState("");
+
+  const all = useMemo(() => tagsQuery.data?.entries ?? [], [tagsQuery.data]);
+  const mine = useMemo(
+    () => all.filter((e) => e.nodeId === nodeID).map((e) => e.tag),
+    [all, nodeID],
+  );
+  // The campaign's vocabulary, for autocomplete — deduped case-insensitively so
+  // "Act two" and "act two" offer once.
+  const vocabulary = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const e of all) {
+      const key = e.tag.toLowerCase();
+      if (!seen.has(key)) seen.set(key, e.tag);
+    }
+    return [...seen.values()].sort((a, b) => a.localeCompare(b));
+  }, [all]);
+
+  const save = useMutation(CampaignService.method.setNodeTags, {
+    onSuccess: () => invalidateTags(queryClient),
+  });
+
+  const setTags = (tags: string[]) => save.mutate({ nodeId: nodeID, tags });
+  const add = () => {
+    const t = draft.trim();
+    if (t === "") return;
+    // Case-insensitive: adding "act two" to an entry that has "Act Two" is a no-op
+    // rather than a near-duplicate the GM has to notice.
+    if (!mine.some((x) => x.toLowerCase() === t.toLowerCase())) setTags([...mine, t]);
+    setDraft("");
+  };
+
+  return (
+    <div className="gx-field gx-kg-tags">
+      <span className="gx-field__label">Tags</span>
+      <span className="gx-field__hint">
+        Your own labels for finding things. They never reach an NPC's prompt.
+      </span>
+
+      {mine.length > 0 && (
+        <ul className="gx-kg-tags__list">
+          {mine.map((tag) => (
+            <li key={tag}>
+              <span className="gx-kg-chip" data-tag>
+                {tag}
+                <button
+                  type="button"
+                  className="gx-kg-tags__remove"
+                  aria-label={`Remove tag ${tag}`}
+                  disabled={save.isPending}
+                  onClick={() => setTags(mine.filter((t) => t !== tag))}
+                >
+                  <X size={11} />
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Input
+        aria-label="Add a tag"
+        placeholder="seafaring, act two, needs a voice…"
+        list="gx-kg-tag-vocabulary"
+        value={draft}
+        disabled={save.isPending}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            add();
+          }
+        }}
+        onBlur={add}
+      />
+      {/* Autocomplete from what the campaign already uses, so the vocabulary
+          converges instead of sprouting near-duplicates. */}
+      <datalist id="gx-kg-tag-vocabulary">
+        {vocabulary.map((t) => (
+          <option key={t} value={t} />
+        ))}
+      </datalist>
+
+      {save.isError && (
+        <span className="gx-editor__status gx-editor__status--error" role="alert">
+          Couldn't save tags: {save.error.message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/screens/campaign/NodeTags.tsx
+++ b/web/src/screens/campaign/NodeTags.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, createConnectQueryKey } from "@connectrpc/connect-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
@@ -30,12 +30,21 @@ export function NodeTags({ nodeID }: { nodeID: string }) {
   const queryClient = useQueryClient();
   const tagsQuery = useQuery(CampaignService.method.getCampaignTags, {});
   const [draft, setDraft] = useState("");
+  // SetNodeTags is replace-in-full, so the payload is only as good as the list it
+  // was built from. Reading that list straight out of the cache loses tags to the
+  // GM's own typing speed: add A, then add B before A's refetch lands, and B's
+  // payload — built from the pre-A cache — deletes A. `settled` holds the
+  // authoritative list the SERVER last confirmed, so each save builds on the last
+  // one rather than on whatever the cache happens to show.
+  const [settled, setSettled] = useState<string[] | null>(null);
+  useEffect(() => setSettled(null), [nodeID]);
 
   const all = useMemo(() => tagsQuery.data?.entries ?? [], [tagsQuery.data]);
-  const mine = useMemo(
+  const fromServer = useMemo(
     () => all.filter((e) => e.nodeId === nodeID).map((e) => e.tag),
     [all, nodeID],
   );
+  const mine = settled ?? fromServer;
   // The campaign's vocabulary, for autocomplete — deduped case-insensitively so
   // "Act two" and "act two" offer once.
   const vocabulary = useMemo(() => {
@@ -48,10 +57,18 @@ export function NodeTags({ nodeID }: { nodeID: string }) {
   }, [all]);
 
   const save = useMutation(CampaignService.method.setNodeTags, {
-    onSuccess: () => invalidateTags(queryClient),
+    // The response carries what actually landed (normalized, deduped) — that, not
+    // the request, is what the next save must build on.
+    onSuccess: (res) => {
+      setSettled(res.tags);
+      invalidateTags(queryClient);
+    },
   });
 
-  const setTags = (tags: string[]) => save.mutate({ nodeId: nodeID, tags });
+  const setTags = (tags: string[]) => {
+    setSettled(tags);
+    save.mutate({ nodeId: nodeID, tags });
+  };
   const add = () => {
     const t = draft.trim();
     if (t === "") return;

--- a/web/src/screens/campaign/PrepBoards.tsx
+++ b/web/src/screens/campaign/PrepBoards.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, createConnectQueryKey } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Plus, Trash2, X } from "lucide-react";
+
+import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { alphaBg, metaOf } from "./knowledgeVocab";
+
+// Saved session prep boards (#543): a named, ordered shortlist of entries the GM
+// pins for one session — the "tonight: the harbour heist" text file they already
+// keep outside the tool.
+//
+// Surfaced on the SESSION screen as well as in prep, because a board is most
+// useful during play, when the GM needs the entry they set aside an hour ago and
+// cannot go hunting for it.
+//
+// Boards never enter a prompt. A board is a shortlist, not ownership: deleting one
+// leaves every entry untouched.
+
+export function PrepBoards({ onOpenNode }: { onOpenNode?: (nodeID: string) => void }) {
+  const queryClient = useQueryClient();
+  const boardsQuery = useQuery(CampaignService.method.listBoards, {});
+  const nodesQuery = useQuery(CampaignService.method.listNodes, {});
+  const [newName, setNewName] = useState("");
+
+  const nodesByID = useMemo(() => {
+    const m = new Map<string, { name: string; nodeType: number }>();
+    for (const n of nodesQuery.data?.nodes ?? []) m.set(n.id, { name: n.name, nodeType: n.nodeType });
+    return m;
+  }, [nodesQuery.data]);
+
+  const invalidate = () =>
+    void queryClient.invalidateQueries({
+      queryKey: createConnectQueryKey({
+        schema: CampaignService.method.listBoards,
+        cardinality: "finite",
+      }),
+    });
+
+  const createBoard = useMutation(CampaignService.method.createBoard, { onSuccess: invalidate });
+  const updateBoard = useMutation(CampaignService.method.updateBoard, { onSuccess: invalidate });
+  const deleteBoard = useMutation(CampaignService.method.deleteBoard, { onSuccess: invalidate });
+
+  const boards = boardsQuery.data?.boards ?? [];
+
+  return (
+    <section className="gx-boards" aria-label="Prep boards">
+      <div className="gx-boards__new">
+        <Input
+          aria-label="New board name"
+          placeholder="tonight: the harbour heist"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && newName.trim() !== "") {
+              createBoard.mutate({ name: newName.trim() });
+              setNewName("");
+            }
+          }}
+        />
+        <Button
+          variant="secondary"
+          size="sm"
+          iconStart={<Plus size={13} />}
+          disabled={createBoard.isPending || newName.trim() === ""}
+          onClick={() => {
+            createBoard.mutate({ name: newName.trim() });
+            setNewName("");
+          }}
+        >
+          Add board
+        </Button>
+      </div>
+
+      {boards.length === 0 ? (
+        <p className="gx-kg-empty">
+          No boards yet. Make one for tonight and the entries you need are one click away during
+          play.
+        </p>
+      ) : (
+        boards.map((b) => (
+          <div key={b.id} className="gx-boards__board">
+            <div className="gx-boards__head">
+              <h4 className="gx-boards__name">{b.name}</h4>
+              <button
+                type="button"
+                className="gx-kg-iconbtn gx-kg-iconbtn--danger"
+                aria-label={`Delete board ${b.name}`}
+                onClick={() => deleteBoard.mutate({ id: b.id })}
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+            {b.nodeIds.length === 0 ? (
+              <p className="gx-field__hint">Empty — add entries from the Knowledge tab.</p>
+            ) : (
+              <ul className="gx-boards__list">
+                {b.nodeIds.map((id) => {
+                  const node = nodesByID.get(id);
+                  const meta = metaOf(node?.nodeType ?? 0);
+                  return (
+                    <li key={id}>
+                      <button
+                        type="button"
+                        className="gx-kg-chip"
+                        style={{ color: meta.color, background: alphaBg(meta.color) }}
+                        onClick={() => onOpenNode?.(id)}
+                      >
+                        {node?.name ?? "(deleted entry)"}
+                      </button>
+                      <button
+                        type="button"
+                        className="gx-kg-iconbtn"
+                        aria-label={`Remove ${node?.name ?? "entry"} from ${b.name}`}
+                        onClick={() =>
+                          updateBoard.mutate({
+                            id: b.id,
+                            name: b.name,
+                            nodeIds: b.nodeIds.filter((x) => x !== id),
+                          })
+                        }
+                      >
+                        <X size={12} />
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/web/src/screens/campaign/PrepBoards.tsx
+++ b/web/src/screens/campaign/PrepBoards.tsx
@@ -19,6 +19,82 @@ import { alphaBg, metaOf } from "./knowledgeVocab";
 // Boards never enter a prompt. A board is a shortlist, not ownership: deleting one
 // leaves every entry untouched.
 
+/** invalidateBoards drops the one board read every surface derives from. */
+export function invalidateBoards(queryClient: ReturnType<typeof useQueryClient>): void {
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.listBoards,
+      cardinality: "finite",
+    }),
+  });
+}
+
+/**
+ * NodeBoards is the "put this on a board" affordance, shown beside an entry's
+ * tags in the editor.
+ *
+ * Without it the board feature is unreachable: PrepBoards can create a board and
+ * remove entries from one, but nothing anywhere could ADD an entry, so every board
+ * was permanently empty and its empty state ("add entries from the Knowledge tab")
+ * described a control that did not exist.
+ *
+ * A board is a shortlist, so membership is a toggle rather than a picker dialog —
+ * the GM is answering "is tonight's session about this?", not filling in a form.
+ */
+export function NodeBoards({ nodeID }: { nodeID: string }) {
+  const queryClient = useQueryClient();
+  const boardsQuery = useQuery(CampaignService.method.listBoards, {});
+  const boards = boardsQuery.data?.boards ?? [];
+
+  const update = useMutation(CampaignService.method.updateBoard, {
+    onSuccess: () => invalidateBoards(queryClient),
+  });
+
+  if (boards.length === 0) return null;
+
+  return (
+    <div className="gx-field gx-kg-tags">
+      <span className="gx-field__label">Boards</span>
+      <span className="gx-field__hint">
+        Shortlists for a session. They never reach an NPC's prompt.
+      </span>
+      <ul className="gx-kg-tags__list">
+        {boards.map((b) => {
+          const on = b.nodeIds.includes(nodeID);
+          return (
+            <li key={b.id}>
+              <button
+                type="button"
+                className="gx-kg-chip"
+                aria-pressed={on}
+                disabled={update.isPending}
+                onClick={() =>
+                  update.mutate({
+                    id: b.id,
+                    name: b.name,
+                    // Built from THIS board's server-provided list, so two entries
+                    // toggled in quick succession cannot drop each other.
+                    nodeIds: on
+                      ? b.nodeIds.filter((x) => x !== nodeID)
+                      : [...b.nodeIds, nodeID],
+                  })
+                }
+              >
+                {b.name}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {update.isError && (
+        <span className="gx-editor__status gx-editor__status--error" role="alert">
+          Couldn't update the board: {update.error.message}
+        </span>
+      )}
+    </div>
+  );
+}
+
 export function PrepBoards({ onOpenNode }: { onOpenNode?: (nodeID: string) => void }) {
   const queryClient = useQueryClient();
   const boardsQuery = useQuery(CampaignService.method.listBoards, {});
@@ -31,13 +107,7 @@ export function PrepBoards({ onOpenNode }: { onOpenNode?: (nodeID: string) => vo
     return m;
   }, [nodesQuery.data]);
 
-  const invalidate = () =>
-    void queryClient.invalidateQueries({
-      queryKey: createConnectQueryKey({
-        schema: CampaignService.method.listBoards,
-        cardinality: "finite",
-      }),
-    });
+  const invalidate = () => invalidateBoards(queryClient);
 
   const createBoard = useMutation(CampaignService.method.createBoard, { onSuccess: invalidate });
   const updateBoard = useMutation(CampaignService.method.updateBoard, { onSuccess: invalidate });

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1509,3 +1509,70 @@
   gap: var(--spacing-xs);
   padding-top: var(--spacing-xs);
 }
+
+/* Free-form tags (#543). Visually distinct from the closed type vocabulary,
+   because they are organization rather than schema. */
+.gx-kg-tags {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-tags__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.gx-kg-chip[data-tag] {
+  border-style: dashed;
+  font-family: var(--font-mono);
+  font-size: var(--mono-sm);
+}
+
+.gx-kg-tags__remove {
+  background: none;
+  border: none;
+  padding: 0 0 0 2px;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1;
+}
+
+/* Prep boards (#543): a session's shortlist, reachable during play. */
+.gx-boards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.gx-boards__new,
+.gx-boards__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.gx-boards__name {
+  margin: 0;
+  font-size: var(--body-lg);
+  color: var(--text-strong);
+  flex: 1;
+}
+
+.gx-boards__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.gx-boards__list li {
+  display: inline-flex;
+  align-items: center;
+}

--- a/web/src/screens/campaign/knowledgeCache.test.ts
+++ b/web/src/screens/campaign/knowledgeCache.test.ts
@@ -46,6 +46,19 @@ describe("invalidateKnowledgeReads", () => {
       cardinality: "finite",
       input: {},
     }),
+    // Reads that REFERENCE nodes. A node delete cascades their rows away
+    // server-side, so a stale one shows a tag whose entries have vanished, or
+    // "(deleted entry)" sitting on a board.
+    getCampaignTags: createConnectQueryKey({
+      schema: CampaignService.method.getCampaignTags,
+      cardinality: "finite",
+      input: {},
+    }),
+    listBoards: createConnectQueryKey({
+      schema: CampaignService.method.listBoards,
+      cardinality: "finite",
+      input: {},
+    }),
   };
 
   it("marks every Knowledge Graph read stale", () => {

--- a/web/src/screens/campaign/knowledgeCache.ts
+++ b/web/src/screens/campaign/knowledgeCache.ts
@@ -5,7 +5,7 @@ import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 
 // One invalidation for every read of the Knowledge Graph (#534).
 //
-// The same nodes and edges are now served by SIX queries — the list, the wiki
+// The same nodes and edges are now served by EIGHT queries — the list, the wiki
 // search, a node's relations, and the whole-graph payload the Graph view renders —
 // and they are mutated from three different surfaces: the Knowledge panel, the
 // relations editor inside it, and the proposal review queue. Each surface used to
@@ -14,7 +14,7 @@ import { CampaignService } from "@gen/glyphoxa/management/v1/management_pb";
 // stale, so an edge created in the relations editor kept drawing on the graph
 // until the 30s staleTime expired.
 //
-// So there is one helper and it drops all six — including the two derived reads
+// So there is one helper and it drops all eight — including the two derived reads
 // (#535's fact preview and #544's roster readiness), which are pure functions of
 // the same nodes and edges and go stale for exactly the same reasons. Over-invalidating costs a handful
 // of small refetches on a single-operator tier; under-invalidating shows the GM a
@@ -45,6 +45,23 @@ export function invalidateKnowledgeReads(queryClient: QueryClient): void {
   void queryClient.invalidateQueries({
     queryKey: createConnectQueryKey({
       schema: CampaignService.method.getKnowledgeGraph,
+      cardinality: "finite",
+    }),
+  });
+  // Tags and boards REFERENCE nodes, and a node delete cascades their rows away
+  // server-side. Leaving these two out left a deleted entry's tag in the campaign
+  // vocabulary (click the chip, get an empty list, which reads as a broken filter)
+  // and "(deleted entry)" sitting on a board — the exact "a world that does not
+  // match your own last edit" this helper exists to prevent.
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.getCampaignTags,
+      cardinality: "finite",
+    }),
+  });
+  void queryClient.invalidateQueries({
+    queryKey: createConnectQueryKey({
+      schema: CampaignService.method.listBoards,
       cardinality: "finite",
     }),
   });

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -15,6 +15,7 @@ import { useSessionEvents, formatClock } from "./useSessionEvents";
 import { VoicePanel } from "./VoicePanel";
 import { SessionBindAffordance } from "./SessionBindAffordance";
 import { HighlightsStrip } from "./HighlightsStrip";
+import { PrepBoards } from "../campaign/PrepBoards";
 import { ShareHighlightDialog } from "./ShareHighlightDialog";
 
 import "./session.css";
@@ -561,6 +562,17 @@ export function Session() {
           />
         </section>
       )}
+      {/* Session prep boards (#543): the GM's own running order for tonight —
+          the handful of entries this session is actually about, in the order they
+          expect to need them. It belongs HERE rather than only in the Knowledge
+          tab, because at the table the board IS the session, and the alternative
+          is scrolling a wiki mid-scene. */}
+      <section className="gx-session__boards">
+        <h2 className="gx-section-title">Tonight's board</h2>
+        {/* No onOpenNode: at the table the board is a REFERENCE — the names and
+            the order — not a way to start editing the wiki mid-scene. */}
+        <PrepBoards />
+      </section>
       </div>
 
       <VoicePanel active={active} mutedIds={data?.mutedAgentIds ?? []} />


### PR DESCRIPTION
Supersedes #558, which GitHub auto-closed when its base branch was deleted on merge.

## KG-C2 — free-form tags on entries, and saved session prep boards (#543)

**Tags** are organization, not schema. The seven Node types carry edge-validity rules and prompt semantics and stay closed — but a GM inventing "seafaring", "act two" or "needs a voice" should not require a migration. They autocomplete from the campaign's existing vocabulary so it converges instead of sprouting near-duplicates, and renaming one updates every use.

**Boards** are the "tonight: the harbour heist" text file GMs already keep outside the tool: a named, ordered shortlist. They appear on the **Session screen**, because a board is most useful during play, when the GM needs the entry they set aside an hour ago and cannot go hunting for it.

Neither ever enters a prompt. That is what keeps the fact budget untouched and stops them quietly becoming a second, unvalidated type system inside NPC context — asserted by a test against a real Postgres.

## What the review caught

- **[critical] Fixing a tag's capitalisation deleted it from every entry.** RenameTag's collision sweep deletes rows that would collide with the new name — and on a case-only rename (`act two` → `Act Two`, the commonest rename there is) every row satisfies its *own* `EXISTS`, so the DELETE removed all of them and the UPDATE that followed found nothing left. Silent, campaign-wide data loss behind a successful response. The existing test only covered `from != to`. The new one reproduces it exactly: 4 tags down to 2.

- **The board half was unreachable.** `PrepBoards` had zero imports — it was on no screen — and nothing anywhere could *add* an entry to a board, so every board was permanently empty and its own empty state described a control that did not exist.

- **Self-inflicted lost updates.** `SetNodeTags` is replace-in-full and the payload was built from the *cache*: add A, then add B before A's refetch lands, and B's payload deleted A.

- **Under-invalidation.** A deleted entry left its tag in the campaign vocabulary and "(deleted entry)" on a board.

- **`UpdateBoard` was two transactions**, so a failed entry write left the board renamed with its old contents.

Closes #543
