### PR TITLE
feat(kg): the bundle carries the world this epic added (#547)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ A multi-tenant TTRPG voice-and-knowledge platform: AI agents (Butler and Charact
 | **NPC** | A non-player character in the Campaign world, modeled as a Knowledge Graph Node and optionally as a Character NPC Agent. | Character (overloaded — Character is reserved for PCs) |
 | **System** | The TTRPG ruleset of a Campaign (D&D 5e, Pathfinder 2e, Call of Cthulhu, etc.); consumed by Tools that need rules context. | Ruleset, Game system |
 | **Campaign Language** | The natural language a Campaign is played in; selects the phonetic scheme used by Address Detection's name matching and the language hint for STT/TTS. | Locale, Lang |
-| **Campaign Bundle** | The versioned gzipped-JSON export of a Campaign's setup (Agents, Tool Grants, KG, Characters; Transcript history flag-gated) with secrets always excluded; import mints fresh IDs (ADR-0053). | Export (unqualified), Backup, Archive (reserved for archived Campaigns) |
+| **Campaign Bundle** | The versioned gzipped-JSON export of a Campaign's setup (Agents, Tool Grants, KG including Aspects/Tags/edge texture, Maps + Pins, Boards, Characters; Transcript history and Appearances flag-gated, map images opt-in) with secrets always excluded; import mints fresh IDs (ADR-0053, format v2 per #547). | Export (unqualified), Backup, Archive (reserved for archived Campaigns) |
 | **Recap** | A Butler-Persona-flavored summary of a Voice Session's Transcript Lines, generated on demand and never persisted; delivered voiced, as public text, or GM-only per request (#271). | Summary, Digest |
 
 ## Knowledge Graph

--- a/cmd/glyphoxa/export.go
+++ b/cmd/glyphoxa/export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/bundle"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -29,6 +30,7 @@ func RunExport(ctx context.Context, args []string) error {
 	fs.SetOutput(os.Stderr)
 	campaignStr := fs.String("campaign", "", "campaign UUID to export (required)")
 	includeHistory := fs.Bool("include-history", false, "include Voice Session transcripts (default off; backup/migration)")
+	includeImages := fs.Bool("include-images", false, "embed map images as base64 (default off; the blob cap is 32 MiB per image and base64 inflates by a third)")
 	outPath := fs.String("o", "", "output file (default stdout)")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -55,8 +57,16 @@ func RunExport(ctx context.Context, args []string) error {
 	}
 	defer pool.Close()
 
-	b, err := bundle.Export(ctx, storage.New(pool), campaignID, bundle.ExportOptions{
+	// The CLI export has no blob store wired, so an images-included export from
+	// here would silently produce mapless pictures. Build the seam over the same
+	// pool the rows come from — blob.NewPostgres is pool-backed (ADR-0048).
+	var blobs blob.Store
+	if *includeImages {
+		blobs = blob.NewPostgres(pool)
+	}
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: storage.New(pool), Blobs: blobs}, campaignID, bundle.ExportOptions{
 		IncludeHistory: *includeHistory,
+		IncludeImages:  *includeImages,
 	})
 	if err != nil {
 		return err

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -1588,7 +1588,7 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// download does not fit Connect's message model. Operator-only via the
 	// guarded mount table, the same gate the relay reads (ADR-0041). The GET
 	// export (#290) and the POST import (#291) share this handler.
-	bundleHandler := &bundle.Handler{Store: store, Log: log}
+	bundleHandler := &bundle.Handler{Store: store, Blobs: blobStore, Log: log}
 
 	// The plain (non-Connect) mounts bind their handlers here; their auth
 	// posture is declared separately in [plainMountPolicy] (#446), and the two

--- a/docs/adr/0053-campaign-bundle-format.md
+++ b/docs/adr/0053-campaign-bundle-format.md
@@ -22,3 +22,24 @@ Epic 6's exporter, importer, and external-tool converters all implement one form
 ## Relationship to other ADRs
 
 ADR-0009 (Butler trigger the importer must merge with), ADR-0041 (operator-only transport auth), ADR-0011 (embedding regeneration path), ADR-0049 (import stays a synchronous RPC), ADR-0048 (size-cap constants), #276/#279 (Characters section and post-import rebinding), #289 (converters target this format).
+
+## Amendment: format v2 — the world epic #533 added (2026-08-04, #547)
+
+Every new table in an epic is a place where "we exported the campaign" quietly stops being true, and a silent omission in a backup is worse than a missing feature: it is discovered only when someone restores. Format **v2** closes that for #533.
+
+**What v2 adds.** Aspects and Tags on a Node; Note and Disposition on an Edge; the `maps` section (each Map carrying its Pins nested, since a Pin has no meaning apart from its Map); the `boards` section; and `appearances` inside each history Session.
+
+**v1 still imports.** Every addition is `omitempty`, so a v1 bundle IS a valid v2 bundle with those sections absent — `CheckVersion` accepts the range `[MinSupportedVersion, FormatVersion]` rather than an exact match. A backup format that refuses last year's backup is not a backup format.
+
+**Map images are opt-in, separately from history.** `?include_images=true` (and `--include-images` on the CLI) embeds the bytes as base64. Off by default because the blob cap is 32 MiB *per image* and base64 inflates by a third — a campaign with a handful of scans would turn a setup export into something nobody can mail. Without the flag a Map still round-trips completely: name, nesting, anchor, privacy, and every Pin. Losing the picture is not losing the map. The flag is deliberately separate from `include_history`: a GM may want their maps in a share bundle without the transcripts, or the transcripts without the megabytes.
+
+**Appearances follow the history flag**, because an Appearance is a record of what was *said*, not part of the campaign's setup — and it is derived, so a destination that re-indexes gets them back anyway. An appearance whose Node ref does not resolve is dropped rather than fatal, for the same reason.
+
+**Import invariants the new sections needed:**
+
+- **Maps import in two passes.** `parent_map_id` is self-referential with a composite FK, and bundle order is the source's `ListMaps` order — alphabetical by name. A single pass would be refused outright the first time a child sorted before its parent, so "The Vault inside Saltmarsh" would import as two top-level maps or not at all. Pass 1 creates every map flat; pass 2 applies the nesting; pins come last, since they need both a map and a node.
+- **A fresh blob key per imported map.** The source key names the *source* tenant (`t/<tenant>/map/…`), so reusing it would let one tenant's import overwrite another tenant's picture.
+- **Blob writes are outside the transaction and are swept by hand.** `blob.NewPostgres` runs on its own pool, so a `Put` is *not* rolled back when the import transaction is. Import tracks every key it writes and deletes them when the transaction fails; without that, a failed import would strand bytes with no row naming them and no sweep that would ever find them. This is the one place the all-or-nothing property is enforced by code rather than by the database.
+- **Unknown refs stay fatal.** A map anchored to a node not in the bundle, a pin on an unknown entry, a board entry that resolves to nothing — each fails the whole import, the same all-or-nothing discipline v1 applies to edge endpoints.
+
+**Secrets exclusion is unaffected.** None of the new tables carry credentials, and the bundle structs remain the allowlist: the exporter still populates fields explicitly and never reflects over tables. The one non-SQL read the export seam gained (`ReadMapImage`) resolves a key the row already stores, through the ADR-0048 seam, and lives on the adapter rather than on `*storage.Store` — storage deliberately knows nothing about blobs.

--- a/internal/bundle/codec.go
+++ b/internal/bundle/codec.go
@@ -13,7 +13,16 @@ import (
 )
 
 // FormatVersion is the current campaign bundle format version (ADR-0053 §7).
-const FormatVersion = 1
+//
+// v2 (#547) added Aspects and Tags on a Node, Note/Disposition on an Edge, and
+// the Maps, Pins, Boards and Appearances sections. Every one of them is an
+// OMITEMPTY addition, so a v1 bundle is a valid v2 bundle with those sections
+// absent — which is why [CheckVersion] accepts v1 rather than rejecting it. A
+// backup format that refuses last year's backup is not a backup format.
+const FormatVersion = 2
+
+// MinSupportedVersion is the oldest format this build can import.
+const MinSupportedVersion = 1
 
 // MaxDecodedBytes caps the decompressed JSON size Decode will read, guarding
 // against gzip bombs.
@@ -100,7 +109,7 @@ func Decode(r io.Reader) (*Bundle, error) {
 // CheckVersion reports whether v is a supported bundle format version.
 func CheckVersion(v int) error {
 	switch {
-	case v == FormatVersion:
+	case v >= MinSupportedVersion && v <= FormatVersion:
 		return nil
 	case v > FormatVersion:
 		return ErrNewerFormat

--- a/internal/bundle/codec_test.go
+++ b/internal/bundle/codec_test.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -120,28 +121,54 @@ func TestCheckVersionErrors(t *testing.T) {
 }
 
 func TestDecodeNewerVersionMessage(t *testing.T) {
-	raw := []byte(`{"format_version":2,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	raw := []byte(`{"format_version":3,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
 	_, err := Decode(bytes.NewReader(raw))
 	if !errors.Is(err, ErrNewerFormat) {
 		t.Fatalf("want ErrNewerFormat, got %v", err)
 	}
 	msg := err.Error()
-	if !bytes.Contains([]byte(msg), []byte("2")) || !bytes.Contains([]byte(msg), []byte("1")) {
+	if !bytes.Contains([]byte(msg), []byte("3")) || !bytes.Contains([]byte(msg), []byte("2")) {
 		t.Fatalf("message must mention both versions, got %q", msg)
 	}
 }
 
+// TestDecodeOlderVersionStillImports is #547's AC: bumping the format must not
+// orphan yesterday's backups. Every v2 addition is omitempty, so a v1 bundle is a
+// valid v2 bundle with those sections absent — and a backup format that refuses
+// last year's backup is not a backup format.
+func TestDecodeOlderVersionStillImports(t *testing.T) {
+	raw := []byte(`{"format_version":1,"exported_at":"2026-07-10T20:00:00Z","campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	b, err := Decode(bytes.NewReader(gz.Bytes()))
+	if err != nil {
+		t.Fatalf("a v1 bundle must still import: %v", err)
+	}
+	if b.FormatVersion != 1 {
+		t.Errorf("format_version = %d, want the bundle's own", b.FormatVersion)
+	}
+	if len(b.Campaign.Maps) != 0 || len(b.Campaign.Boards) != 0 {
+		t.Error("a v1 bundle should carry no v2 sections")
+	}
+}
+
 func TestDecodeNewerVersionWithNewFieldStillRefused(t *testing.T) {
-	// A real v2 bundle adds fields unknown to this v1 build. The version gate
+	// A real v3 bundle adds fields unknown to this v2 build. The version gate
 	// must fire BEFORE strict unknown-field decoding, so an old build tells the
 	// operator "format is newer", not a cryptic unknown-field error.
-	raw := []byte(`{"format_version":2,"exported_at":"2026-07-10T20:00:00Z","new_v2_section":{"x":1},"campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
+	raw := []byte(`{"format_version":3,"exported_at":"2026-07-10T20:00:00Z","new_v3_section":{"x":1},"campaign":{"name":"x","system":"y","language":"de","agents":[]}}`)
 	_, err := Decode(bytes.NewReader(raw))
 	if !errors.Is(err, ErrNewerFormat) {
 		t.Fatalf("want ErrNewerFormat, got %v", err)
 	}
 	msg := err.Error()
-	if !bytes.Contains([]byte(msg), []byte("2")) || !bytes.Contains([]byte(msg), []byte("1")) {
+	if !bytes.Contains([]byte(msg), []byte("3")) || !bytes.Contains([]byte(msg), []byte("2")) {
 		t.Fatalf("message must mention both versions, got %q", msg)
 	}
 }

--- a/internal/bundle/coverage_fake_test.go
+++ b/internal/bundle/coverage_fake_test.go
@@ -1,0 +1,330 @@
+package bundle_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/bundle"
+)
+
+// Bundle coverage for the world epic #533 added (#547).
+//
+// A silent omission in a backup is worse than a missing feature, because it is
+// discovered only when someone restores. TestExportImportFake_RoundTrip compares
+// a bundle to its re-export, which catches a lossy IMPORT — but not a lossy
+// EXPORT, since both sides would drop the same thing and compare equal. So these
+// tests assert against the bundle's own contents.
+
+func exportSeeded(t *testing.T, opts bundle.ExportOptions) (*bundle.Bundle, *fakeStore, uuid.UUID) {
+	t.Helper()
+	src := newFakeStore()
+	campaignID, _ := seedFakeCampaign(t, src)
+	b, err := bundle.Export(context.Background(), src, campaignID, opts)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	return b, src, campaignID
+}
+
+// TestExport_CarriesEverythingTheEpicAdded is the anti-vacuity guard for the
+// round-trip test: it names each section explicitly, so an exporter that quietly
+// stopped writing one fails HERE rather than comparing equal to itself.
+func TestExport_CarriesEverythingTheEpicAdded(t *testing.T) {
+	t.Parallel()
+	b, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeHistory: true})
+
+	var npc *bundle.Node
+	for i := range b.Campaign.Nodes {
+		if len(b.Campaign.Nodes[i].Aspects) > 0 {
+			npc = &b.Campaign.Nodes[i]
+		}
+	}
+	if npc == nil {
+		t.Fatal("no node carried Aspects — the export dropped them")
+	}
+	// Private aspects MUST be exported: an export that dropped them would restore
+	// a campaign missing exactly its secrets.
+	var sawPrivate bool
+	for _, a := range npc.Aspects {
+		if a.GMPrivate {
+			sawPrivate = true
+		}
+	}
+	if !sawPrivate {
+		t.Error("the GM-private aspect was dropped from the backup")
+	}
+	if len(npc.Tags) == 0 {
+		t.Error("tags were dropped")
+	}
+
+	if len(b.Campaign.Edges) == 0 || b.Campaign.Edges[0].Note == "" ||
+		b.Campaign.Edges[0].Disposition == 0 {
+		t.Errorf("the relation's texture was dropped: %+v", b.Campaign.Edges)
+	}
+	if len(b.Campaign.Maps) != 2 {
+		t.Fatalf("maps = %d, want 2", len(b.Campaign.Maps))
+	}
+	var pins int
+	for _, m := range b.Campaign.Maps {
+		pins += len(m.Pins)
+	}
+	if pins == 0 {
+		t.Error("pins were dropped")
+	}
+	if len(b.Campaign.Boards) == 0 || len(b.Campaign.Boards[0].NodeIDs) == 0 {
+		t.Errorf("boards were dropped: %+v", b.Campaign.Boards)
+	}
+	if b.FormatVersion != bundle.FormatVersion {
+		t.Errorf("format_version = %d", b.FormatVersion)
+	}
+}
+
+// TestExport_ImagesAreOptIn: the blob cap is 32 MiB PER image and base64 inflates
+// by a third, so a setup export must stay something a person can mail.
+func TestExport_ImagesAreOptIn(t *testing.T) {
+	t.Parallel()
+	without, _, _ := exportSeeded(t, bundle.ExportOptions{})
+	for _, m := range without.Campaign.Maps {
+		if m.ImageBase64 != "" {
+			t.Fatalf("map %q carried its image without the flag", m.Name)
+		}
+	}
+	// And the map itself still round-trips: name, nesting, anchor, privacy, pins.
+	// Losing the picture is not losing the map.
+	if len(without.Campaign.Maps) != 2 {
+		t.Fatalf("maps = %d without images, want both", len(without.Campaign.Maps))
+	}
+
+	with, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeImages: true})
+	var carried int
+	for _, m := range with.Campaign.Maps {
+		if m.ImageBase64 != "" {
+			carried++
+			if m.ContentType == "" {
+				t.Errorf("map %q carried bytes with no content type", m.Name)
+			}
+		}
+	}
+	if carried != 1 {
+		t.Errorf("maps carrying an image = %d, want the one that has bytes", carried)
+	}
+}
+
+// TestExport_AppearancesFollowTheHistoryFlag: an appearance is a record of what
+// was SAID, not part of the campaign's setup — and it is derived, so a
+// destination that re-indexes gets them back anyway.
+func TestExport_AppearancesFollowTheHistoryFlag(t *testing.T) {
+	t.Parallel()
+	setup, _, _ := exportSeeded(t, bundle.ExportOptions{})
+	if setup.Campaign.History != nil {
+		t.Fatal("a setup export carried history")
+	}
+
+	full, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeHistory: true})
+	var appearances int
+	for _, s := range full.Campaign.History.Sessions {
+		appearances += len(s.Appearances)
+	}
+	if appearances == 0 {
+		t.Error("appearances were dropped from a history export")
+	}
+}
+
+// TestImport_RemapsEveryNewCrossReference is the AC. Every new table references
+// something by id, and an import that got one wrong would produce a campaign that
+// looks whole and points at another campaign's rows.
+func TestImport_RemapsEveryNewCrossReference(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeHistory: true, IncludeImages: true})
+
+	dst := newFakeStore()
+	res, err := bundle.Import(ctx, dst, uuid.New(), b)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Maps != 2 || res.Pins == 0 || res.Boards == 0 || res.Aspects == 0 || res.Tags == 0 {
+		t.Fatalf("import counts look wrong: %+v", res)
+	}
+
+	// The nesting survived. This is the one a single-pass import breaks: the child
+	// map sorts alphabetically BEFORE its parent, so importing in bundle order
+	// would reference a parent that does not exist yet.
+	maps, err := dst.ListMaps(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListMaps: %v", err)
+	}
+	var nested, parentID uuid.UUID
+	for _, m := range maps {
+		if m.Name == "Saltmarsh" {
+			parentID = m.ID
+		}
+		if m.ParentMapID.Valid {
+			nested = m.ID
+		}
+	}
+	if nested == uuid.Nil {
+		t.Fatal("the nested map lost its parent")
+	}
+	for _, m := range maps {
+		if m.ID == nested && m.ParentMapID.UUID != parentID {
+			t.Errorf("the nested map points at %s, not the imported parent %s", m.ParentMapID.UUID, parentID)
+		}
+		// Every id must be a DESTINATION id: a remap that leaked a source id would
+		// produce a campaign quietly pointing into the campaign it was copied from.
+		if m.AnchorNodeID.Valid && !dst.nodeInCampaign(m.AnchorNodeID.UUID, res.CampaignID) {
+			t.Errorf("map %q anchors a node outside the imported campaign", m.Name)
+		}
+	}
+
+	// Pins resolve to imported nodes, on imported maps.
+	for _, m := range maps {
+		pins, err := dst.ListPins(ctx, res.CampaignID, m.ID)
+		if err != nil {
+			t.Fatalf("ListPins: %v", err)
+		}
+		for _, p := range pins {
+			if !dst.nodeInCampaign(p.NodeID, res.CampaignID) {
+				t.Errorf("pin on %q references a node outside the imported campaign", m.Name)
+			}
+		}
+	}
+
+	// Boards resolve, in order.
+	boards, err := dst.ListBoards(ctx, res.CampaignID)
+	if err != nil {
+		t.Fatalf("ListBoards: %v", err)
+	}
+	if len(boards) == 0 || len(boards[0].NodeIDs) != 2 {
+		t.Fatalf("board entries did not survive: %+v", boards)
+	}
+	for _, id := range boards[0].NodeIDs {
+		if !dst.nodeInCampaign(id, res.CampaignID) {
+			t.Error("a board entry points outside the imported campaign")
+		}
+	}
+
+	// The image bytes landed through the blob seam, under a NEW key — the source
+	// key names the source tenant, and reusing it would let one tenant's import
+	// overwrite another tenant's picture.
+	if len(dst.images) != 1 {
+		t.Fatalf("imported images = %d, want 1", len(dst.images))
+	}
+	for key := range dst.images {
+		if _, reused := src(t).images[key]; reused {
+			t.Errorf("the import reused the SOURCE blob key %q", key)
+		}
+	}
+}
+
+// src builds a throwaway seeded source purely to compare blob keys against.
+func src(t *testing.T) *fakeStore {
+	t.Helper()
+	f := newFakeStore()
+	seedFakeCampaign(t, f)
+	return f
+}
+
+// TestImport_AcceptsAV1Bundle: bumping the format must not orphan yesterday's
+// backups. Every v2 addition is omitempty, so a v1 bundle is a valid v2 bundle
+// with those sections absent.
+func TestImport_AcceptsAV1Bundle(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b, _, _ := exportSeeded(t, bundle.ExportOptions{})
+	// Strip everything v2 added and label it v1, exactly as an old export would.
+	b.FormatVersion = 1
+	b.Campaign.Maps = nil
+	b.Campaign.Boards = nil
+	for i := range b.Campaign.Nodes {
+		b.Campaign.Nodes[i].Aspects = nil
+		b.Campaign.Nodes[i].Tags = nil
+	}
+	for i := range b.Campaign.Edges {
+		b.Campaign.Edges[i].Note = ""
+		b.Campaign.Edges[i].Disposition = 0
+	}
+
+	res, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b)
+	if err != nil {
+		t.Fatalf("a v1 bundle must still import: %v", err)
+	}
+	if res.Nodes == 0 {
+		t.Error("the v1 bundle imported nothing")
+	}
+	if res.Maps != 0 || res.Aspects != 0 {
+		t.Errorf("a v1 bundle produced v2 rows: %+v", res)
+	}
+}
+
+// TestImport_UnknownRefsAreFatal: a bundle is all-or-nothing. A map anchored to a
+// node that is not in the bundle would import as a map pointing at nothing.
+func TestImport_UnknownRefsAreFatal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for name, mutate := range map[string]func(*bundle.Bundle){
+		"map anchor": func(b *bundle.Bundle) { b.Campaign.Maps[0].AnchorNodeID = "nope" },
+		"map parent": func(b *bundle.Bundle) { b.Campaign.Maps[0].ParentMapID = "nope" },
+		"pin node": func(b *bundle.Bundle) {
+			for i := range b.Campaign.Maps {
+				if len(b.Campaign.Maps[i].Pins) > 0 {
+					b.Campaign.Maps[i].Pins[0].NodeID = "nope"
+				}
+			}
+		},
+		"board entry": func(b *bundle.Bundle) { b.Campaign.Boards[0].NodeIDs[0] = "nope" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			b, _, _ := exportSeeded(t, bundle.ExportOptions{})
+			mutate(b)
+			if _, err := bundle.Import(ctx, newFakeStore(), uuid.New(), b); err == nil {
+				t.Fatalf("an unknown %s ref must fail the whole import", name)
+			}
+		})
+	}
+}
+
+// TestImport_FailureDropsTheImagesItWrote. Blob writes are OUTSIDE the import
+// transaction — blob.NewPostgres runs on its own pool — so the rollback that
+// removes the rows leaves the bytes. Without an explicit sweep they would be
+// orphaned with no row naming them and no job that would ever find them.
+func TestImport_FailureDropsTheImagesItWrote(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	b, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeImages: true})
+	// Break something AFTER the maps are written: a board pointing nowhere.
+	b.Campaign.Boards[0].NodeIDs[0] = "nope"
+
+	dst := newFakeStore()
+	if _, err := bundle.Import(ctx, dst, uuid.New(), b); err == nil {
+		t.Fatal("the import should have failed")
+	}
+	if len(dst.images) != 0 {
+		t.Fatalf("a failed import stranded %d image(s)", len(dst.images))
+	}
+	if len(dst.deletedImages) == 0 {
+		t.Error("nothing was swept — the bytes were never written, or never cleaned")
+	}
+}
+
+// TestImport_RejectsAnImageWithNoBlobStore rather than silently importing a map
+// whose picture is gone.
+func TestImport_RejectsAnImageWithNoBlobStore(t *testing.T) {
+	t.Parallel()
+	b, _, _ := exportSeeded(t, bundle.ExportOptions{IncludeImages: true})
+	if _, err := bundle.Import(context.Background(), noBlobTx{inner: newFakeStore()}, uuid.New(), b); err == nil {
+		t.Fatal("importing image bytes with no blob store should fail loudly")
+	}
+}
+
+// noBlobTx is a TxRunner that deliberately does NOT implement MapImageWriter.
+// The inner store is a NAMED FIELD, not embedded: embedding would promote
+// WriteMapImage and the type assertion inside Import would succeed, making this
+// test pass for exactly the wrong reason.
+type noBlobTx struct{ inner *fakeStore }
+
+func (n noBlobTx) InTx(ctx context.Context, fn func(tx bundle.ImportStore) error) error {
+	return n.inner.InTx(ctx, fn)
+}

--- a/internal/bundle/export.go
+++ b/internal/bundle/export.go
@@ -2,6 +2,8 @@ package bundle
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -17,6 +19,13 @@ import (
 // the backup/migration path.
 type ExportOptions struct {
 	IncludeHistory bool
+	// IncludeImages embeds map image bytes as base64 (#547). A flag, not a
+	// default, for the same reason History is: the blob cap is 32 MiB PER IMAGE
+	// and base64 inflates by a third, so a campaign with a handful of scans would
+	// turn a setup export into something nobody can mail. Without it a Map still
+	// round-trips — its name, nesting, anchor, privacy and every Pin — and the GM
+	// re-uploads the picture.
+	IncludeImages bool
 }
 
 // Export serializes one Campaign into a [Bundle] (ADR-0053). It reads EXCLUSIVELY
@@ -73,6 +82,18 @@ func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts Expo
 	if err != nil {
 		return nil, fmt.Errorf("bundle: export: list nodes: %w", err)
 	}
+	// Tags come from ONE campaign-wide read rather than a per-node one: the
+	// campaign has a handful of tags and hundreds of entries, and N reads for a
+	// join that is already indexed would be the N+1 for no benefit.
+	tagged, err := st.CampaignTags(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: campaign tags: %w", err)
+	}
+	tagsByNode := map[uuid.UUID][]string{}
+	for _, t := range tagged {
+		tagsByNode[t.NodeID] = append(tagsByNode[t.NodeID], t.Tag)
+	}
+
 	bNodes := make([]Node, 0, len(nodes))
 	for _, n := range nodes {
 		bn := Node{
@@ -81,9 +102,16 @@ func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts Expo
 			Name:      n.Name,
 			Body:      n.Body,
 			GMPrivate: n.GMPrivate,
+			Tags:      tagsByNode[n.ID],
 		}
 		if n.AgentID.Valid {
 			bn.AgentID = n.AgentID.UUID.String()
+		}
+		// ListNodes projects Aspects GM-facing, private ones INCLUDED — which is
+		// what a backup must carry. An export that dropped the private ones would
+		// restore a campaign missing exactly its secrets.
+		for _, a := range n.Aspects {
+			bn.Aspects = append(bn.Aspects, Aspect{Key: a.Key, Value: a.Value, GMPrivate: a.GMPrivate})
 		}
 		bNodes = append(bNodes, bn)
 	}
@@ -95,9 +123,11 @@ func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts Expo
 	bEdges := make([]Edge, 0, len(edges))
 	for _, e := range edges {
 		bEdges = append(bEdges, Edge{
-			From: e.FromNodeID.String(),
-			To:   e.ToNodeID.String(),
-			Type: string(e.Type),
+			From:        e.FromNodeID.String(),
+			To:          e.ToNodeID.String(),
+			Type:        string(e.Type),
+			Note:        e.Note,
+			Disposition: e.Disposition,
 		})
 	}
 
@@ -112,6 +142,15 @@ func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts Expo
 			Aliases:       c.Aliases,
 			DiscordUserID: c.DiscordUserID,
 		})
+	}
+
+	bMaps, err := exportMaps(ctx, st, campaignID, opts.IncludeImages)
+	if err != nil {
+		return nil, err
+	}
+	bBoards, err := exportBoards(ctx, st, campaignID)
+	if err != nil {
+		return nil, err
 	}
 
 	var history *History
@@ -133,6 +172,8 @@ func Export(ctx context.Context, st ExportStore, campaignID uuid.UUID, opts Expo
 			Nodes:      bNodes,
 			Edges:      bEdges,
 			Characters: bChars,
+			Maps:       bMaps,
+			Boards:     bBoards,
 			History:    history,
 		},
 	}, nil
@@ -233,6 +274,16 @@ func exportHistory(ctx context.Context, st ExportStore, campaignID uuid.UUID) (*
 				SpeakerDiscordUserID: l.SpeakerDiscordUserID,
 			})
 		}
+		apps, err := st.ListSessionAppearances(ctx, s.ID)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: export: session %s appearances: %w", s.ID, err)
+		}
+		var bAppearances []Appearance
+		for _, a := range apps {
+			bAppearances = append(bAppearances, Appearance{
+				NodeID: a.NodeID.String(), LineID: a.LineID, At: a.At,
+			})
+		}
 		bSessions = append(bSessions, Session{
 			ID:        s.ID.String(),
 			StartedAt: s.StartedAt,
@@ -242,8 +293,93 @@ func exportHistory(ctx context.Context, st ExportStore, campaignID uuid.UUID) (*
 			EndReason: s.EndReason,
 			Lines:     bLines,
 			Chunks:    chunksBySession[s.ID],
+			// Appearances ride the history flag: they are a record of what was SAID,
+			// not part of the campaign's setup (#545, #547).
+			Appearances: bAppearances,
 		})
 	}
 
 	return &History{Sessions: bSessions}, nil
+}
+
+// exportMaps serializes the campaign's Maps with their Pins nested, optionally
+// embedding the image bytes.
+//
+// The per-map Pin read is an N+1 by construction and that is deliberate: a
+// campaign has a handful of Maps, the alternative is a campaign-wide pin read
+// plus a client-side group-by, and this way the nesting and the ordering come
+// straight from the store's own stable orders.
+func exportMaps(ctx context.Context, st ExportStore, campaignID uuid.UUID, withImages bool) ([]Map, error) {
+	maps, err := st.ListMaps(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list maps: %w", err)
+	}
+	if len(maps) == 0 {
+		return nil, nil
+	}
+	out := make([]Map, 0, len(maps))
+	for _, m := range maps {
+		bm := Map{
+			ID:        m.ID.String(),
+			Name:      m.Name,
+			WidthPx:   m.WidthPx,
+			HeightPx:  m.HeightPx,
+			GMPrivate: m.GMPrivate,
+		}
+		if m.ParentMapID.Valid {
+			bm.ParentMapID = m.ParentMapID.UUID.String()
+		}
+		if m.AnchorNodeID.Valid {
+			bm.AnchorNodeID = m.AnchorNodeID.UUID.String()
+		}
+		if withImages {
+			data, contentType, err := st.ReadMapImage(ctx, m.BlobKey)
+			switch {
+			case errors.Is(err, storage.ErrNotFound):
+				// A row whose bytes are gone still exports as a Map. Refusing the whole
+				// backup because one image went missing would be the worst possible
+				// trade: the metadata and every Pin are still recoverable.
+			case err != nil:
+				return nil, fmt.Errorf("bundle: export: map image %s: %w", m.ID, err)
+			default:
+				bm.ContentType = contentType
+				bm.ImageBase64 = base64.StdEncoding.EncodeToString(data)
+			}
+		}
+		pins, err := st.ListPins(ctx, campaignID, m.ID)
+		if err != nil {
+			return nil, fmt.Errorf("bundle: export: list pins for map %s: %w", m.ID, err)
+		}
+		for _, p := range pins {
+			bm.Pins = append(bm.Pins, Pin{
+				NodeID:        p.NodeID.String(),
+				X:             p.X,
+				Y:             p.Y,
+				LabelOverride: p.LabelOverride,
+				GMPrivate:     p.GMPrivate,
+			})
+		}
+		out = append(out, bm)
+	}
+	return out, nil
+}
+
+// exportBoards serializes the GM's session prep boards (#543).
+func exportBoards(ctx context.Context, st ExportStore, campaignID uuid.UUID) ([]Board, error) {
+	boards, err := st.ListBoards(ctx, campaignID)
+	if err != nil {
+		return nil, fmt.Errorf("bundle: export: list boards: %w", err)
+	}
+	if len(boards) == 0 {
+		return nil, nil
+	}
+	out := make([]Board, 0, len(boards))
+	for _, b := range boards {
+		bb := Board{Name: b.Name}
+		for _, id := range b.NodeIDs {
+			bb.NodeIDs = append(bb.NodeIDs, id.String())
+		}
+		out = append(out, bb)
+	}
+	return out, nil
 }

--- a/internal/bundle/export_fake_test.go
+++ b/internal/bundle/export_fake_test.go
@@ -61,10 +61,63 @@ func seedFakeCampaign(t *testing.T, f *fakeStore) (campaignID, bartID uuid.UUID)
 	if err != nil {
 		t.Fatalf("CreateNode location: %v", err)
 	}
-	if _, err := f.CreateEdge(ctx, storage.NewKGEdge{
+	edge, err := f.CreateEdge(ctx, storage.NewKGEdge{
 		CampaignID: campaignID, FromNodeID: npc.ID, ToNodeID: loc.ID, Type: "resides_in",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CreateEdge: %v", err)
+	}
+	// #547: everything this epic added, so the round-trip proves it survives.
+	if _, err := f.UpdateEdgeDetails(ctx, campaignID, edge.ID, "owes money since the siege", -2); err != nil {
+		t.Fatalf("UpdateEdgeDetails: %v", err)
+	}
+	if err := f.ReplaceNodeAspects(ctx, campaignID, npc.ID, storage.KGNodeAspectWrite{
+		Rows: []storage.NewKGNodeAspect{
+			{Key: "Role", Value: "Innkeeper"},
+			{Key: "Secret", Value: "Skims the till", GMPrivate: true},
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceNodeAspects: %v", err)
+	}
+	if err := f.SetNodeTags(ctx, campaignID, npc.ID, []string{"act two", "needs a voice"}); err != nil {
+		t.Fatalf("SetNodeTags: %v", err)
+	}
+	// Two maps, nested, with pins — the nesting is what a one-pass import breaks.
+	town, err := f.CreateMap(ctx, storage.NewCampaignMap{
+		CampaignID: campaignID, Name: "Saltmarsh", BlobKey: "t/x/map/a/image",
+		WidthPx: 1200, HeightPx: 800,
+		AnchorNodeID: uuid.NullUUID{UUID: loc.ID, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateMap town: %v", err)
+	}
+	if err := f.WriteMapImage(ctx, "t/x/map/a/image", "image/png", []byte{0x89, 'P', 'N', 'G'}); err != nil {
+		t.Fatalf("WriteMapImage: %v", err)
+	}
+	// Named so it sorts BEFORE its parent — a one-pass import in ListMaps order
+	// would try to nest it under a map that does not exist yet.
+	inn, err := f.CreateMap(ctx, storage.NewCampaignMap{
+		CampaignID: campaignID, Name: "A cellar", BlobKey: "t/x/map/b/image",
+		WidthPx: 600, HeightPx: 400, GMPrivate: true,
+		ParentMapID: uuid.NullUUID{UUID: town.ID, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateMap inn: %v", err)
+	}
+	_ = inn
+	if _, err := f.CreatePin(ctx, storage.NewMapPin{
+		MapID: town.ID, CampaignID: campaignID, NodeID: npc.ID, X: 0.25, Y: 0.75,
+		LabelOverride: "The Rusty Anchor",
+	}); err != nil {
+		t.Fatalf("CreatePin: %v", err)
+	}
+	board, err := f.CreateBoard(ctx, campaignID, "tonight: the harbour heist")
+	if err != nil {
+		t.Fatalf("CreateBoard: %v", err)
+	}
+	if err := f.UpdateBoard(ctx, campaignID, board.ID, "tonight: the harbour heist",
+		[]uuid.UUID{loc.ID, npc.ID}); err != nil {
+		t.Fatalf("UpdateBoard: %v", err)
 	}
 	if _, err := f.CreateCharacter(ctx, storage.NewCharacter{
 		CampaignID: campaignID, Name: "Frodo", Aliases: []string{"Ringbearer"},
@@ -89,6 +142,11 @@ func seedFakeCampaign(t *testing.T, f *fakeStore) (campaignID, bartID uuid.UUID)
 		if err := f.UpsertTranscriptLine(ctx, l); err != nil {
 			t.Fatalf("UpsertTranscriptLine: %v", err)
 		}
+	}
+	if err := f.RecordNodeAppearances(ctx, []storage.NodeAppearance{
+		{NodeID: npc.ID, CampaignID: campaignID, VoiceSessionID: sid, LineID: "l1", At: started},
+	}); err != nil {
+		t.Fatalf("RecordNodeAppearances: %v", err)
 	}
 	if _, err := f.InsertTranscriptChunk(ctx, storage.TranscriptChunk{
 		CampaignID: campaignID, VoiceSessionID: sid,
@@ -310,10 +368,36 @@ func normalizeRefs(t *testing.T, b *bundle.Bundle) {
 		e.From = mustKey(t, key, e.From)
 		e.To = mustKey(t, key, e.To)
 	}
+	for i := range b.Campaign.Maps {
+		m := &b.Campaign.Maps[i]
+		key[m.ID] = "map:" + m.Name
+	}
+	for i := range b.Campaign.Maps {
+		m := &b.Campaign.Maps[i]
+		m.ID = key[m.ID]
+		if m.ParentMapID != "" {
+			m.ParentMapID = mustKey(t, key, m.ParentMapID)
+		}
+		if m.AnchorNodeID != "" {
+			m.AnchorNodeID = mustKey(t, key, m.AnchorNodeID)
+		}
+		for j := range m.Pins {
+			m.Pins[j].NodeID = mustKey(t, key, m.Pins[j].NodeID)
+		}
+	}
+	for i := range b.Campaign.Boards {
+		refs := b.Campaign.Boards[i].NodeIDs
+		for j := range refs {
+			refs[j] = mustKey(t, key, refs[j])
+		}
+	}
 	if b.Campaign.History != nil {
 		for i := range b.Campaign.History.Sessions {
 			s := &b.Campaign.History.Sessions[i]
 			s.ID = "session:" + s.StartedAt.UTC().Format(time.RFC3339)
+			for j := range s.Appearances {
+				s.Appearances[j].NodeID = mustKey(t, key, s.Appearances[j].NodeID)
+			}
 			for j := range s.Chunks {
 				refs := s.Chunks[j].ParticipatedAgentIDs
 				for k := range refs {

--- a/internal/bundle/export_test.go
+++ b/internal/bundle/export_test.go
@@ -87,7 +87,7 @@ func TestExportDemoCampaign(t *testing.T) {
 	ctx := context.Background()
 	st, cid, bartID := seededCampaign(t)
 
-	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, bundle.ExportOptions{})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestExportHistoryFlag(t *testing.T) {
 	}
 
 	// IncludeHistory=false omits sessions even though transcript rows exist.
-	noHist, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: false})
+	noHist, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, bundle.ExportOptions{IncludeHistory: false})
 	if err != nil {
 		t.Fatalf("Export no-history: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestExportHistoryFlag(t *testing.T) {
 		t.Errorf("IncludeHistory=false still nested History")
 	}
 
-	hist, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: true})
+	hist, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, bundle.ExportOptions{IncludeHistory: true})
 	if err != nil {
 		t.Fatalf("Export history: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestExportVoiceRoundTrip(t *testing.T) {
 		t.Fatal("seed produced no provider FK ids to check exclusion against")
 	}
 
-	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, bundle.ExportOptions{})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestExportHistorySkipsSessionlessChunk(t *testing.T) {
 		t.Fatalf("raw null-session chunk insert: %v", err)
 	}
 
-	b, err := bundle.Export(ctx, st, cid, bundle.ExportOptions{IncludeHistory: true})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, bundle.ExportOptions{IncludeHistory: true})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}

--- a/internal/bundle/fakes_test.go
+++ b/internal/bundle/fakes_test.go
@@ -48,17 +48,278 @@ type fakeStore struct {
 	sessions   []storage.VoiceSession
 	lines      []storage.TranscriptLine
 	chunks     []storage.TranscriptChunk
+
+	// The world #547 added. Aspects and tags hang off the node rows themselves
+	// (kg_node projects Aspects), so only the standalone tables are held here.
+	tags        map[uuid.UUID][]string
+	maps        []storage.CampaignMap
+	pins        map[uuid.UUID][]storage.MapPin
+	boards      []storage.KGBoard
+	appearances []storage.NodeAppearance
+	images      map[string][]byte
+	imageTypes  map[string]string
+	// deletedImages records the rollback path's cleanup so a test can prove a
+	// failed import does not strand bytes.
+	deletedImages []string
 }
 
 // Compile-time proofs the fake satisfies the whole seam — the second adapter
 // that, with PGStore, makes the seam real (#451).
 var (
-	_ bundle.ExportStore = (*fakeStore)(nil)
-	_ bundle.ImportStore = (*fakeStore)(nil)
-	_ bundle.TxRunner    = (*fakeStore)(nil)
+	_ bundle.ExportStore    = (*fakeStore)(nil)
+	_ bundle.ImportStore    = (*fakeStore)(nil)
+	_ bundle.TxRunner       = (*fakeStore)(nil)
+	_ bundle.MapImageWriter = (*fakeStore)(nil)
 )
 
-func newFakeStore() *fakeStore { return &fakeStore{} }
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		tags:       map[uuid.UUID][]string{},
+		pins:       map[uuid.UUID][]storage.MapPin{},
+		images:     map[string][]byte{},
+		imageTypes: map[string]string{},
+	}
+}
+
+// ── #547: maps, pins, aspects, tags, boards, appearances ────────────────────
+//
+// These emulate the real adapter's contracts, not merely its signatures: the
+// composite FKs are enforced by hand (a pin whose map or node is not in this
+// campaign is refused), UpdateMap replaces the whole editor field set, and
+// UpdateBoard is one call for the rename AND the entries.
+
+func (f *fakeStore) CampaignTags(_ context.Context, campaignID uuid.UUID) ([]storage.TaggedNode, error) {
+	var out []storage.TaggedNode
+	for _, n := range f.nodes {
+		if n.CampaignID != campaignID {
+			continue
+		}
+		for _, t := range f.tags[n.ID] {
+			out = append(out, storage.TaggedNode{NodeID: n.ID, Tag: t})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) SetNodeTags(_ context.Context, campaignID, nodeID uuid.UUID, tags []string) error {
+	for _, n := range f.nodes {
+		if n.ID == nodeID && n.CampaignID == campaignID {
+			f.tags[nodeID] = append([]string(nil), tags...)
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeStore) ReplaceNodeAspects(_ context.Context, campaignID, nodeID uuid.UUID, w storage.KGNodeAspectWrite) error {
+	for i := range f.nodes {
+		if f.nodes[i].ID != nodeID || f.nodes[i].CampaignID != campaignID {
+			continue
+		}
+		out := make([]storage.KGNodeAspect, 0, len(w.Rows))
+		for j, r := range w.Rows {
+			out = append(out, storage.KGNodeAspect{
+				ID: uuid.New(), Position: j, Key: r.Key, Value: r.Value, GMPrivate: r.GMPrivate,
+			})
+		}
+		f.nodes[i].Aspects = out
+		return nil
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeStore) UpdateEdgeDetails(_ context.Context, campaignID, id uuid.UUID, note string, disposition int) (storage.KGEdge, error) {
+	if disposition < -2 || disposition > 2 {
+		return storage.KGEdge{}, storage.ErrInvalidDisposition
+	}
+	for i := range f.edges {
+		if f.edges[i].ID == id && f.edges[i].CampaignID == campaignID {
+			f.edges[i].Note = note
+			f.edges[i].Disposition = disposition
+			return f.edges[i], nil
+		}
+	}
+	return storage.KGEdge{}, storage.ErrNotFound
+}
+
+func (f *fakeStore) ListMaps(_ context.Context, campaignID uuid.UUID) ([]storage.CampaignMap, error) {
+	var out []storage.CampaignMap
+	for _, m := range f.maps {
+		if m.CampaignID == campaignID {
+			out = append(out, m)
+		}
+	}
+	// The real read orders by (name, id); a deterministic bundle depends on it.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	return out, nil
+}
+
+func (f *fakeStore) CreateMap(_ context.Context, m storage.NewCampaignMap) (storage.CampaignMap, error) {
+	created := storage.CampaignMap{
+		ID: uuid.New(), CampaignID: m.CampaignID, Name: m.Name, BlobKey: m.BlobKey,
+		WidthPx: m.WidthPx, HeightPx: m.HeightPx,
+		ParentMapID: m.ParentMapID, AnchorNodeID: m.AnchorNodeID, GMPrivate: m.GMPrivate,
+	}
+	// The composite FK: an anchor from another campaign is refused, not stored.
+	if m.AnchorNodeID.Valid && !f.nodeInCampaign(m.AnchorNodeID.UUID, m.CampaignID) {
+		return storage.CampaignMap{}, storage.ErrNotFound
+	}
+	f.maps = append(f.maps, created)
+	return created, nil
+}
+
+func (f *fakeStore) UpdateMap(_ context.Context, u storage.CampaignMapUpdate) (storage.CampaignMap, error) {
+	if u.ParentMapID.Valid && u.ParentMapID.UUID == u.ID {
+		return storage.CampaignMap{}, storage.ErrInvalidMapParent
+	}
+	for i := range f.maps {
+		if f.maps[i].ID != u.ID || f.maps[i].CampaignID != u.CampaignID {
+			continue
+		}
+		if u.ParentMapID.Valid && !f.mapInCampaign(u.ParentMapID.UUID, u.CampaignID) {
+			return storage.CampaignMap{}, storage.ErrNotFound
+		}
+		// Replaces the WHOLE editor field set, exactly as the real UPDATE does.
+		f.maps[i].Name = u.Name
+		f.maps[i].ParentMapID = u.ParentMapID
+		f.maps[i].AnchorNodeID = u.AnchorNodeID
+		f.maps[i].GMPrivate = u.GMPrivate
+		return f.maps[i], nil
+	}
+	return storage.CampaignMap{}, storage.ErrNotFound
+}
+
+func (f *fakeStore) ListPins(_ context.Context, campaignID, mapID uuid.UUID) ([]storage.MapPin, error) {
+	if !f.mapInCampaign(mapID, campaignID) {
+		return nil, nil
+	}
+	return f.pins[mapID], nil
+}
+
+func (f *fakeStore) CreatePin(_ context.Context, n storage.NewMapPin) (storage.MapPin, error) {
+	if n.X < 0 || n.X > 1 || n.Y < 0 || n.Y > 1 {
+		return storage.MapPin{}, storage.ErrInvalidPin
+	}
+	// Both composite FKs.
+	if !f.mapInCampaign(n.MapID, n.CampaignID) || !f.nodeInCampaign(n.NodeID, n.CampaignID) {
+		return storage.MapPin{}, storage.ErrNotFound
+	}
+	for _, p := range f.pins[n.MapID] {
+		if p.NodeID == n.NodeID {
+			return storage.MapPin{}, storage.ErrConflict // one pin per node per map
+		}
+	}
+	created := storage.MapPin{
+		ID: uuid.New(), MapID: n.MapID, CampaignID: n.CampaignID, NodeID: n.NodeID,
+		X: n.X, Y: n.Y, LabelOverride: n.LabelOverride, GMPrivate: n.GMPrivate,
+	}
+	f.pins[n.MapID] = append(f.pins[n.MapID], created)
+	return created, nil
+}
+
+func (f *fakeStore) ListBoards(_ context.Context, campaignID uuid.UUID) ([]storage.KGBoard, error) {
+	var out []storage.KGBoard
+	for _, b := range f.boards {
+		if b.CampaignID == campaignID {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) CreateBoard(_ context.Context, campaignID uuid.UUID, name string) (storage.KGBoard, error) {
+	b := storage.KGBoard{ID: uuid.New(), CampaignID: campaignID, Name: name}
+	f.boards = append(f.boards, b)
+	return b, nil
+}
+
+func (f *fakeStore) UpdateBoard(_ context.Context, campaignID, id uuid.UUID, name string, nodeIDs []uuid.UUID) error {
+	for i := range f.boards {
+		if f.boards[i].ID != id || f.boards[i].CampaignID != campaignID {
+			continue
+		}
+		for _, n := range nodeIDs {
+			if !f.nodeInCampaign(n, campaignID) {
+				return storage.ErrNotFound
+			}
+		}
+		f.boards[i].Name = name
+		f.boards[i].NodeIDs = append([]uuid.UUID(nil), nodeIDs...)
+		return nil
+	}
+	return storage.ErrNotFound
+}
+
+func (f *fakeStore) ListSessionAppearances(_ context.Context, sessionID uuid.UUID) ([]storage.SessionAppearance, error) {
+	var out []storage.SessionAppearance
+	for _, a := range f.appearances {
+		if a.VoiceSessionID == sessionID {
+			out = append(out, storage.SessionAppearance{NodeID: a.NodeID, LineID: a.LineID, At: a.At})
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) RecordNodeAppearances(_ context.Context, rows []storage.NodeAppearance) error {
+	// ON CONFLICT DO NOTHING over (node, session, line).
+	for _, r := range rows {
+		dup := false
+		for _, e := range f.appearances {
+			if e.NodeID == r.NodeID && e.VoiceSessionID == r.VoiceSessionID && e.LineID == r.LineID {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			f.appearances = append(f.appearances, r)
+		}
+	}
+	return nil
+}
+
+func (f *fakeStore) ReadMapImage(_ context.Context, key string) ([]byte, string, error) {
+	data, ok := f.images[key]
+	if !ok {
+		return nil, "", storage.ErrNotFound
+	}
+	return data, f.imageTypes[key], nil
+}
+
+func (f *fakeStore) WriteMapImage(_ context.Context, key, contentType string, data []byte) error {
+	f.images[key] = append([]byte(nil), data...)
+	f.imageTypes[key] = contentType
+	return nil
+}
+
+func (f *fakeStore) DeleteMapImage(_ context.Context, key string) error {
+	delete(f.images, key)
+	delete(f.imageTypes, key)
+	f.deletedImages = append(f.deletedImages, key)
+	return nil
+}
+
+func (f *fakeStore) nodeInCampaign(id, campaignID uuid.UUID) bool {
+	for _, n := range f.nodes {
+		if n.ID == id && n.CampaignID == campaignID {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeStore) mapInCampaign(id, campaignID uuid.UUID) bool {
+	for _, m := range f.maps {
+		if m.ID == id && m.CampaignID == campaignID {
+			return true
+		}
+	}
+	return false
+}
 
 // commitFailTx runs the tx body against the fake and then fails the way a
 // COMMIT can (serialization failure, dropped connection) — the only shape in

--- a/internal/bundle/handler.go
+++ b/internal/bundle/handler.go
@@ -25,13 +25,21 @@ import (
 // upload) to this same type.
 type Handler struct {
 	Store *storage.Store
+	// Blobs is the seam a Map's image bytes ride on an images-included export
+	// (#547, ADR-0048). Nil leaves maps exporting without their pictures, which is
+	// what a composition with no blob backend can honestly offer.
+	Blobs blob.Store
 	Log   *slog.Logger
 }
+
+// pg is the export/import adapter for this handler's store and blob seam.
+func (h *Handler) pg() PGStore { return PGStore{Store: h.Store, Blobs: h.Blobs} }
 
 // ServeExport streams a campaign bundle download: GET
 // /api/v1/campaigns/{id}/export. The {id} path value must parse as a UUID (400
 // otherwise); an unknown campaign is 404. ?include_history=true nests the
-// transcript payload (ADR-0053 §1, default off). Archived campaigns are
+// transcript payload (ADR-0053 §1, default off) and ?include_images=true embeds
+// map image bytes (#547, default off — the blob cap is 32 MiB per image). Archived campaigns are
 // exportable — a backup must still capture a campaign after it is archived.
 //
 // Tenant posture (#439): the mount declares TenantRequired (session AND
@@ -56,7 +64,13 @@ func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := ExportOptions{IncludeHistory: r.URL.Query().Get("include_history") == "true"}
+	opts := ExportOptions{
+		IncludeHistory: r.URL.Query().Get("include_history") == "true",
+		// Images are a separate opt-in from history: a GM may well want their maps
+		// in a share bundle without the transcripts, or the transcripts without the
+		// megabytes (#547).
+		IncludeImages: r.URL.Query().Get("include_images") == "true",
+	}
 
 	// GetCampaign resolves name (for the filename), existence AND tenant
 	// ownership (both 404, #439) before any bytes are written, so a missing or
@@ -77,7 +91,7 @@ func (h *Handler) ServeExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := Export(r.Context(), h.Store, id, opts)
+	b, err := Export(r.Context(), h.pg(), id, opts)
 	if err != nil {
 		h.logError("build bundle", err)
 		http.Error(w, "export failed", http.StatusInternalServerError)
@@ -166,7 +180,7 @@ func (h *Handler) ServeImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := Import(r.Context(), PGStore{h.Store}, tenantID, b)
+	res, err := Import(r.Context(), h.pg(), tenantID, b)
 	if err != nil {
 		if errors.Is(err, ErrNewerFormat) || errors.Is(err, ErrUnsupportedFormat) {
 			writeImportError(w, http.StatusBadRequest, importErrorMessage(err))

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -2,10 +2,12 @@ package bundle
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/observe"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
@@ -29,9 +31,15 @@ type ImportResult struct {
 	Nodes                  int
 	Edges                  int
 	Characters             int
+	Aspects                int
+	Tags                   int
+	Maps                   int
+	Pins                   int
+	Boards                 int
 	Sessions               int
 	Lines                  int
 	Chunks                 int
+	Appearances            int
 	DroppedParticipantRefs int
 }
 
@@ -78,10 +86,24 @@ func Import(ctx context.Context, st TxRunner, tenantID uuid.UUID, b *Bundle) (Im
 		AgentIDs: make(map[string]uuid.UUID),
 	}
 
+	// Map image bytes ride the blob seam, which is OUTSIDE the import transaction —
+	// blob.NewPostgres runs on its own pool, so a Put is not rolled back when the
+	// transaction is. Every key this import writes is tracked, and a failure drops
+	// them by hand. Without this a failed import would leave orphaned bytes with no
+	// row that names them and no sweep that would ever find them.
+	var written []string
+	imgs, _ := st.(MapImageWriter)
+
 	err := st.InTx(ctx, func(tx ImportStore) error {
-		return importInTx(ctx, tx, tenantID, b, &res)
+		return importInTx(ctx, tx, tenantID, b, imgs, &written, &res)
 	})
 	if err != nil {
+		for _, key := range written {
+			if derr := imgs.DeleteMapImage(ctx, key); derr != nil {
+				observe.CtxLogger(ctx).Warn("bundle: could not drop an orphaned map image after a failed import",
+					"key", key, "err", derr)
+			}
+		}
 		return ImportResult{}, err
 	}
 	// Surface a lossy import (a foreign/deleted participant carried no local NPC):
@@ -100,7 +122,15 @@ func Import(ctx context.Context, st TxRunner, tenantID uuid.UUID, b *Bundle) (Im
 // split out so the transaction body reads top-to-bottom: campaign → Butler merge
 // → character Agents → Nodes → node↔Agent links → Edges → Characters. Every step
 // records or consumes the ref→id remaps in res.AgentIDs and a local node map.
-func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bundle, res *ImportResult) error {
+func importInTx(
+	ctx context.Context,
+	tx ImportStore,
+	tenantID uuid.UUID,
+	b *Bundle,
+	imgs MapImageWriter,
+	written *[]string,
+	res *ImportResult,
+) error {
 	campaignID, err := tx.CreateCampaign(ctx, storage.NewCampaign{
 		TenantID: tenantID,
 		Name:     b.Campaign.Name,
@@ -157,6 +187,27 @@ func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bund
 		nodeIDs[n.ID] = created.ID
 		res.Nodes++
 
+		// Aspects and tags belong to the entry, not to history: an import that
+		// restored an NPC's prose without its facts would look like a successful
+		// restore of a hollowed-out campaign.
+		if len(n.Aspects) > 0 {
+			rows := make([]storage.NewKGNodeAspect, 0, len(n.Aspects))
+			for _, a := range n.Aspects {
+				rows = append(rows, storage.NewKGNodeAspect{Key: a.Key, Value: a.Value, GMPrivate: a.GMPrivate})
+			}
+			if err := tx.ReplaceNodeAspects(ctx, campaignID, created.ID,
+				storage.KGNodeAspectWrite{Rows: rows}); err != nil {
+				return fmt.Errorf("bundle: import: aspects for node %q: %w", n.Name, err)
+			}
+			res.Aspects += len(rows)
+		}
+		if len(n.Tags) > 0 {
+			if err := tx.SetNodeTags(ctx, campaignID, created.ID, n.Tags); err != nil {
+				return fmt.Errorf("bundle: import: tags for node %q: %w", n.Name, err)
+			}
+			res.Tags += len(n.Tags)
+		}
+
 		if n.AgentID != "" {
 			agentID, ok := res.AgentIDs[n.AgentID]
 			if !ok {
@@ -179,13 +230,22 @@ func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bund
 		if !ok {
 			return fmt.Errorf("bundle: import: edge references unknown to-node %q", e.To)
 		}
-		if _, err := tx.CreateEdge(ctx, storage.NewKGEdge{
+		created, err := tx.CreateEdge(ctx, storage.NewKGEdge{
 			CampaignID: campaignID,
 			FromNodeID: from,
 			ToNodeID:   to,
 			Type:       storage.KGEdgeType(e.Type),
-		}); err != nil {
+		})
+		if err != nil {
 			return fmt.Errorf("bundle: import: create edge %s->%s: %w", e.From, e.To, err)
+		}
+		// The relation's texture (#546). CreateEdge takes only the type, so the note
+		// and disposition land in a second write — a relation restored as bare
+		// "knows" would reach every NPC prompt flatter than it left.
+		if e.Note != "" || e.Disposition != 0 {
+			if _, err := tx.UpdateEdgeDetails(ctx, campaignID, created.ID, e.Note, e.Disposition); err != nil {
+				return fmt.Errorf("bundle: import: edge details %s->%s: %w", e.From, e.To, err)
+			}
 		}
 		res.Edges++
 	}
@@ -203,10 +263,187 @@ func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bund
 		res.Characters++
 	}
 
-	if err := importHistory(ctx, tx, campaignID, b, res); err != nil {
+	if _, err := importMaps(ctx, tx, campaignID, tenantID, b, nodeIDs, imgs, written, res); err != nil {
 		return err
 	}
 
+	if err := importBoards(ctx, tx, campaignID, b, nodeIDs, res); err != nil {
+		return err
+	}
+
+	if err := importHistory(ctx, tx, campaignID, b, nodeIDs, res); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// importMaps recreates the campaign's Maps and their Pins, remapping every
+// cross-reference onto the freshly minted ids.
+//
+// It is TWO passes over the maps, and that is mandatory rather than tidy.
+// parent_map_id is self-referential with a composite FK, so a single pass in
+// bundle order would be refused outright the first time a child sorted before its
+// parent — and bundle order is the source's ListMaps order, which is alphabetical
+// by name. "The Vault inside Saltmarsh" would import as two top-level maps, or
+// not at all, depending on their names.
+func importMaps(
+	ctx context.Context,
+	tx ImportStore,
+	campaignID, tenantID uuid.UUID,
+	b *Bundle,
+	nodeIDs map[string]uuid.UUID,
+	imgs MapImageWriter,
+	written *[]string,
+	res *ImportResult,
+) (map[string]uuid.UUID, error) {
+	if len(b.Campaign.Maps) == 0 {
+		return nil, nil
+	}
+	mapIDs := make(map[string]uuid.UUID, len(b.Campaign.Maps))
+
+	// Pass 1: every map, flat — no parent yet.
+	for i := range b.Campaign.Maps {
+		m := &b.Campaign.Maps[i]
+		if _, dup := mapIDs[m.ID]; dup {
+			return nil, fmt.Errorf("bundle: import: duplicate map ref %q", m.ID)
+		}
+		anchor := uuid.NullUUID{}
+		if m.AnchorNodeID != "" {
+			id, ok := nodeIDs[m.AnchorNodeID]
+			if !ok {
+				return nil, fmt.Errorf("bundle: import: map %q references unknown anchor entry %q", m.Name, m.AnchorNodeID)
+			}
+			anchor = uuid.NullUUID{UUID: id, Valid: true}
+		}
+		// A fresh blob key per imported map, minted the same way CreateMap's RPC
+		// mints one. It is minted even when the bundle carries no bytes, so the row's
+		// shape is identical either way and a later re-upload lands where the row
+		// already points.
+		key, err := blob.Key(tenantID, "map", uuid.New(), "image")
+		if err != nil {
+			return nil, fmt.Errorf("bundle: import: map %q blob key: %w", m.Name, err)
+		}
+		// Bytes BEFORE the row, the same ordering CreateMap's RPC uses: a row that
+		// references missing bytes is a broken map forever, while bytes with no row
+		// are invisible and get dropped by the rollback path above.
+		if m.ImageBase64 != "" {
+			if imgs == nil {
+				return nil, fmt.Errorf("bundle: import: map %q carries an image but this deployment has no blob store", m.Name)
+			}
+			data, derr := base64.StdEncoding.DecodeString(m.ImageBase64)
+			if derr != nil {
+				return nil, fmt.Errorf("bundle: import: map %q image is not valid base64: %w", m.Name, derr)
+			}
+			contentType := m.ContentType
+			if contentType == "" {
+				contentType = "image/png"
+			}
+			if err := imgs.WriteMapImage(ctx, key, contentType, data); err != nil {
+				return nil, fmt.Errorf("bundle: import: map %q image: %w", m.Name, err)
+			}
+			*written = append(*written, key)
+		}
+
+		created, err := tx.CreateMap(ctx, storage.NewCampaignMap{
+			CampaignID:   campaignID,
+			Name:         m.Name,
+			BlobKey:      key,
+			WidthPx:      m.WidthPx,
+			HeightPx:     m.HeightPx,
+			AnchorNodeID: anchor,
+			GMPrivate:    m.GMPrivate,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("bundle: import: create map %q: %w", m.Name, err)
+		}
+		mapIDs[m.ID] = created.ID
+		res.Maps++
+	}
+
+	// Pass 2: the nesting, now that every id exists.
+	for i := range b.Campaign.Maps {
+		m := &b.Campaign.Maps[i]
+		if m.ParentMapID == "" {
+			continue
+		}
+		parent, ok := mapIDs[m.ParentMapID]
+		if !ok {
+			return nil, fmt.Errorf("bundle: import: map %q references unknown parent %q", m.Name, m.ParentMapID)
+		}
+		anchor := uuid.NullUUID{}
+		if m.AnchorNodeID != "" {
+			anchor = uuid.NullUUID{UUID: nodeIDs[m.AnchorNodeID], Valid: true}
+		}
+		// UpdateMap replaces the whole editor field set, so the fields set in pass 1
+		// are passed again rather than lost.
+		if _, err := tx.UpdateMap(ctx, storage.CampaignMapUpdate{
+			ID:           mapIDs[m.ID],
+			CampaignID:   campaignID,
+			Name:         m.Name,
+			ParentMapID:  uuid.NullUUID{UUID: parent, Valid: true},
+			AnchorNodeID: anchor,
+			GMPrivate:    m.GMPrivate,
+		}); err != nil {
+			return nil, fmt.Errorf("bundle: import: nest map %q: %w", m.Name, err)
+		}
+	}
+
+	// Pins last: they need both a map and a node.
+	for i := range b.Campaign.Maps {
+		m := &b.Campaign.Maps[i]
+		for _, p := range m.Pins {
+			nodeID, ok := nodeIDs[p.NodeID]
+			if !ok {
+				return nil, fmt.Errorf("bundle: import: pin on map %q references unknown entry %q", m.Name, p.NodeID)
+			}
+			if _, err := tx.CreatePin(ctx, storage.NewMapPin{
+				MapID:         mapIDs[m.ID],
+				CampaignID:    campaignID,
+				NodeID:        nodeID,
+				X:             p.X,
+				Y:             p.Y,
+				LabelOverride: p.LabelOverride,
+				GMPrivate:     p.GMPrivate,
+			}); err != nil {
+				return nil, fmt.Errorf("bundle: import: pin on map %q: %w", m.Name, err)
+			}
+			res.Pins++
+		}
+	}
+	return mapIDs, nil
+}
+
+// importBoards recreates the GM's session prep boards, remapping their entries.
+func importBoards(
+	ctx context.Context,
+	tx ImportStore,
+	campaignID uuid.UUID,
+	b *Bundle,
+	nodeIDs map[string]uuid.UUID,
+	res *ImportResult,
+) error {
+	for i := range b.Campaign.Boards {
+		bd := &b.Campaign.Boards[i]
+		created, err := tx.CreateBoard(ctx, campaignID, bd.Name)
+		if err != nil {
+			return fmt.Errorf("bundle: import: create board %q: %w", bd.Name, err)
+		}
+		ids := make([]uuid.UUID, 0, len(bd.NodeIDs))
+		for _, ref := range bd.NodeIDs {
+			id, ok := nodeIDs[ref]
+			if !ok {
+				return fmt.Errorf("bundle: import: board %q references unknown entry %q", bd.Name, ref)
+			}
+			ids = append(ids, id)
+		}
+		// Rename-and-set in ONE call: the storage layer fused them deliberately, so
+		// a failed entry write cannot leave a renamed board with the wrong contents.
+		if err := tx.UpdateBoard(ctx, campaignID, created.ID, bd.Name, ids); err != nil {
+			return fmt.Errorf("bundle: import: board %q entries: %w", bd.Name, err)
+		}
+		res.Boards++
+	}
 	return nil
 }
 
@@ -221,7 +458,7 @@ func importInTx(ctx context.Context, tx ImportStore, tenantID uuid.UUID, b *Bund
 // DROPPED and counted in DroppedParticipantRefs (not fatal — a foreign agent
 // simply carries no local knowledge), while speaker snowflakes travel verbatim
 // (ADR-0053 §6). A nil History section is a no-op: counts stay zero (part-1 parity).
-func importHistory(ctx context.Context, tx ImportStore, campaignID uuid.UUID, b *Bundle, res *ImportResult) error {
+func importHistory(ctx context.Context, tx ImportStore, campaignID uuid.UUID, b *Bundle, nodeIDs map[string]uuid.UUID, res *ImportResult) error {
 	if b.Campaign.History == nil {
 		return nil
 	}
@@ -272,6 +509,34 @@ func importHistory(ctx context.Context, tx ImportStore, campaignID uuid.UUID, b 
 				return fmt.Errorf("bundle: import: session %q line %q: %w", s.ID, l.LineID, err)
 			}
 			res.Lines++
+		}
+
+		// Appearances AFTER the lines, because the composite FK points at them.
+		// A row whose Node ref is unknown is DROPPED rather than fatal: an
+		// appearance is a derived convenience, and refusing an entire restore
+		// because one mention pointed at a since-deleted entry would be the wrong
+		// trade for something the destination can regenerate by re-indexing.
+		if len(s.Appearances) > 0 {
+			rows := make([]storage.NodeAppearance, 0, len(s.Appearances))
+			for _, a := range s.Appearances {
+				nodeID, ok := nodeIDs[a.NodeID]
+				if !ok {
+					continue
+				}
+				rows = append(rows, storage.NodeAppearance{
+					NodeID:         nodeID,
+					CampaignID:     campaignID,
+					VoiceSessionID: sessionID,
+					LineID:         a.LineID,
+					At:             a.At,
+				})
+			}
+			if len(rows) > 0 {
+				if err := tx.RecordNodeAppearances(ctx, rows); err != nil {
+					return fmt.Errorf("bundle: import: session %q appearances: %w", s.ID, err)
+				}
+				res.Appearances += len(rows)
+			}
 		}
 
 		for j := range s.Chunks {

--- a/internal/bundle/import_test.go
+++ b/internal/bundle/import_test.go
@@ -177,7 +177,7 @@ func TestImportRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	src, srcCID, srcBartID := seededCampaign(t)
 
-	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: src}, srcCID, bundle.ExportOptions{})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestImportRoundTrip(t *testing.T) {
 func TestImportTwiceMakesTwoCampaigns(t *testing.T) {
 	ctx := context.Background()
 	src, srcCID, _ := seededCampaign(t)
-	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: src}, srcCID, bundle.ExportOptions{})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
@@ -722,7 +722,7 @@ func TestImportRoundTripWithHistory(t *testing.T) {
 		t.Fatalf("EndVoiceSession 2: %v", err)
 	}
 
-	b, err := bundle.Export(ctx, src, srcCID, bundle.ExportOptions{IncludeHistory: true})
+	b, err := bundle.Export(ctx, bundle.PGStore{Store: src}, srcCID, bundle.ExportOptions{IncludeHistory: true})
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}

--- a/internal/bundle/secrets_test.go
+++ b/internal/bundle/secrets_test.go
@@ -116,7 +116,7 @@ func TestSecretsExclusionProperty(t *testing.T) {
 		{"history", bundle.ExportOptions{IncludeHistory: true}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := bundle.Export(ctx, st, cid, tc.opts)
+			b, err := bundle.Export(ctx, bundle.PGStore{Store: st}, cid, tc.opts)
 			if err != nil {
 				t.Fatalf("Export: %v", err)
 			}

--- a/internal/bundle/store.go
+++ b/internal/bundle/store.go
@@ -1,10 +1,14 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 
+	"github.com/MrWong99/Glyphoxa/internal/blob"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 )
 
@@ -46,6 +50,18 @@ type ExportStore interface {
 	ListVoiceSessions(ctx context.Context, campaignID uuid.UUID, limit int) ([]storage.VoiceSession, error)
 	ListTranscriptLines(ctx context.Context, sessionID uuid.UUID) ([]storage.TranscriptLine, error)
 	ListTranscriptChunks(ctx context.Context, campaignID uuid.UUID, includeVectors bool) ([]storage.ExportChunk, error)
+	// The world this epic added (#547). Aspects need no method: ListNodes already
+	// projects them GM-facing, private ones included, which is what a backup needs.
+	ListMaps(ctx context.Context, campaignID uuid.UUID) ([]storage.CampaignMap, error)
+	ListPins(ctx context.Context, campaignID, mapID uuid.UUID) ([]storage.MapPin, error)
+	CampaignTags(ctx context.Context, campaignID uuid.UUID) ([]storage.TaggedNode, error)
+	ListBoards(ctx context.Context, campaignID uuid.UUID) ([]storage.KGBoard, error)
+	ListSessionAppearances(ctx context.Context, sessionID uuid.UUID) ([]storage.SessionAppearance, error)
+	// ReadMapImage fetches a Map's bytes THROUGH THE BLOB SEAM (ADR-0048) — the
+	// one read on this interface that is not SQL. It is here rather than on a
+	// separate seam so the secrets-exclusion property stays visible in one place:
+	// this interface is still the complete list of what an export can reach.
+	ReadMapImage(ctx context.Context, blobKey string) (data []byte, contentType string, err error)
 }
 
 // ImportStore is the tx-bound write surface one import runs against —
@@ -92,6 +108,32 @@ type ImportStore interface {
 	ImportVoiceSession(ctx context.Context, v storage.VoiceSession) (uuid.UUID, error)
 	UpsertTranscriptLine(ctx context.Context, l storage.TranscriptLine) error
 	InsertTranscriptChunk(ctx context.Context, c storage.TranscriptChunk) (uuid.UUID, error)
+	// The world this epic added (#547). Every one of these already flattens into
+	// the ambient import transaction (the TxRunner contract above), so a failure
+	// anywhere still rolls the whole bundle back.
+	ReplaceNodeAspects(ctx context.Context, campaignID, nodeID uuid.UUID, w storage.KGNodeAspectWrite) error
+	SetNodeTags(ctx context.Context, campaignID, nodeID uuid.UUID, tags []string) error
+	UpdateEdgeDetails(ctx context.Context, campaignID, id uuid.UUID, note string, disposition int) (storage.KGEdge, error)
+	CreateMap(ctx context.Context, m storage.NewCampaignMap) (storage.CampaignMap, error)
+	UpdateMap(ctx context.Context, u storage.CampaignMapUpdate) (storage.CampaignMap, error)
+	CreatePin(ctx context.Context, n storage.NewMapPin) (storage.MapPin, error)
+	CreateBoard(ctx context.Context, campaignID uuid.UUID, name string) (storage.KGBoard, error)
+	UpdateBoard(ctx context.Context, campaignID, id uuid.UUID, name string, nodeIDs []uuid.UUID) error
+	RecordNodeAppearances(ctx context.Context, rows []storage.NodeAppearance) error
+}
+
+// MapImageWriter is the OPTIONAL blob half of an import (#547, ADR-0048): a
+// [TxRunner] that also implements it can restore map images, one that does not
+// imports every map's metadata and pins without its picture.
+//
+// It is deliberately not folded into [ImportStore]. ImportStore is the tx-bound
+// SQL seam and every method on it rolls back together; these two do NOT — the
+// blob store runs on its own pool — and hiding that difference behind one
+// interface is how orphaned bytes happen. [Import] tracks what it writes here and
+// drops it by hand when the transaction fails.
+type MapImageWriter interface {
+	WriteMapImage(ctx context.Context, key, contentType string, data []byte) error
+	DeleteMapImage(ctx context.Context, key string) error
 }
 
 // TxRunner is [Import]'s transaction entry point: InTx runs fn against a
@@ -124,7 +166,34 @@ type TxRunner interface {
 // [TxRunner] needs the tx-bound store re-typed as the [ImportStore] slice.
 // Behavior is the embedded Store's exactly: one BEGIN/COMMIT with rollback on
 // error, and nested InTx calls flattening into the ambient transaction (#291).
-type PGStore struct{ *storage.Store }
+type PGStore struct {
+	*storage.Store
+	// Blobs is the ADR-0048 seam a Map's image bytes ride (#547). Nil is
+	// legitimate — a composition with no blob backend — and makes ReadMapImage
+	// report "not found", which the exporter treats as "this map has no picture"
+	// rather than failing the whole backup.
+	Blobs blob.Store
+}
+
+// ReadMapImage implements the export seam's one non-SQL read: a Map's bytes,
+// through the blob seam. It lives on the ADAPTER rather than on *storage.Store
+// because storage deliberately knows nothing about blobs — the row carries a key,
+// and resolving that key is the seam's job (ADR-0048).
+func (p PGStore) ReadMapImage(ctx context.Context, key string) ([]byte, string, error) {
+	if p.Blobs == nil || key == "" {
+		return nil, "", storage.ErrNotFound
+	}
+	rc, meta, err := p.Blobs.Get(ctx, key)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, meta.ContentType, nil
+}
 
 // InTx implements [TxRunner] over the embedded Store's single-transaction
 // runner.
@@ -132,12 +201,30 @@ func (p PGStore) InTx(ctx context.Context, fn func(tx ImportStore) error) error 
 	return p.Store.InTx(ctx, func(tx *storage.Store) error { return fn(tx) })
 }
 
+// WriteMapImage implements [MapImageWriter].
+func (p PGStore) WriteMapImage(ctx context.Context, key, contentType string, data []byte) error {
+	if p.Blobs == nil {
+		return fmt.Errorf("bundle: no blob store configured")
+	}
+	return p.Blobs.Put(ctx, key, contentType, bytes.NewReader(data), int64(len(data)))
+}
+
+// DeleteMapImage implements [MapImageWriter].
+func (p PGStore) DeleteMapImage(ctx context.Context, key string) error {
+	if p.Blobs == nil {
+		return nil
+	}
+	return p.Blobs.Delete(ctx, key)
+}
+
 // Compile-time proofs the Postgres adapter satisfies the whole seam: the
 // concrete store IS the read and write slices, and PGStore adds the
 // transaction entry point on top.
 var (
-	_ ExportStore = (*storage.Store)(nil)
 	_ ImportStore = (*storage.Store)(nil)
 	_ TxRunner    = PGStore{}
-	_ ExportStore = PGStore{}
+	// ExportStore is satisfied by the ADAPTER, not the bare store: one of its reads
+	// crosses the blob seam, which storage deliberately knows nothing about.
+	_ ExportStore    = PGStore{}
+	_ MapImageWriter = PGStore{}
 )

--- a/internal/bundle/types.go
+++ b/internal/bundle/types.go
@@ -33,7 +33,13 @@ type Campaign struct {
 	Nodes      []Node      `json:"nodes,omitempty"`
 	Edges      []Edge      `json:"edges,omitempty"`
 	Characters []Character `json:"characters,omitempty"`
-	History    *History    `json:"history,omitempty"`
+	// Maps carry their Pins nested (#538, #547): a Pin has no meaning apart from
+	// the Map it sits on, so nesting keeps a hand-written bundle from producing an
+	// orphan.
+	Maps []Map `json:"maps,omitempty"`
+	// Boards are the GM's session shortlists (#543). They reference Node ref keys.
+	Boards  []Board  `json:"boards,omitempty"`
+	History *History `json:"history,omitempty"`
 }
 
 // Agent is an NPC or the Butler. Voice is opaque JSON minus provider bindings.
@@ -63,6 +69,19 @@ type Node struct {
 	Body      string `json:"body,omitempty"`
 	GMPrivate bool   `json:"gm_private,omitempty"`
 	AgentID   string `json:"agent_id,omitempty"`
+	// Aspects are the Node's ordered (key, value) facts, each with its OWN privacy
+	// flag (#542). They are part of the entry, not history: an export that dropped
+	// them would restore an NPC with its prose and none of its facts.
+	Aspects []Aspect `json:"aspects,omitempty"`
+	// Tags are the GM's own free-form labels (#543).
+	Tags []string `json:"tags,omitempty"`
+}
+
+// Aspect is one (key, value) fact on a Node, with its own visibility (#542).
+type Aspect struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	GMPrivate bool   `json:"gm_private,omitempty"`
 }
 
 // Edge is a knowledge-graph edge referencing node ref keys.
@@ -70,6 +89,47 @@ type Edge struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 	Type string `json:"type"`
+	// Note and Disposition are the relation's texture (#546) — "knows and
+	// despises" rather than bare "knows". Both reach an NPC's prompt, so an export
+	// that dropped them would restore a flatter world than it left.
+	Note        string `json:"note,omitempty"`
+	Disposition int    `json:"disposition,omitempty"`
+}
+
+// Map is a world map with its Pins (#538, ADR-0060).
+//
+// ImageBase64 is present only when the export asked for images. That is a flag,
+// not a default, for the same reason History is: the blob cap is 32 MiB per
+// image, base64 inflates it by a third, and a setup export should stay something
+// a person can mail.
+type Map struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	WidthPx     int    `json:"width_px"`
+	HeightPx    int    `json:"height_px"`
+	GMPrivate   bool   `json:"gm_private,omitempty"`
+	ParentMapID string `json:"parent_map_id,omitempty"`
+	// AnchorNodeID is the Location entry this map DEPICTS, as a Node ref key.
+	AnchorNodeID string `json:"anchor_node_id,omitempty"`
+	ContentType  string `json:"content_type,omitempty"`
+	ImageBase64  string `json:"image_base64,omitempty"`
+	Pins         []Pin  `json:"pins,omitempty"`
+}
+
+// Pin is a normalized position on a Map, referencing a Node ref key (#538).
+type Pin struct {
+	NodeID        string  `json:"node_id"`
+	X             float64 `json:"x"`
+	Y             float64 `json:"y"`
+	LabelOverride string  `json:"label_override,omitempty"`
+	GMPrivate     bool    `json:"gm_private,omitempty"`
+}
+
+// Board is a saved session prep board: a named, ordered shortlist of Node ref
+// keys (#543).
+type Board struct {
+	Name    string   `json:"name"`
+	NodeIDs []string `json:"node_ids,omitempty"`
 }
 
 // Character is a player character. DiscordUserID is kept verbatim (ADR-0053 §6).
@@ -94,6 +154,19 @@ type Session struct {
 	EndReason *string    `json:"end_reason,omitempty"`
 	Lines     []Line     `json:"lines,omitempty"`
 	Chunks    []Chunk    `json:"chunks,omitempty"`
+	// Appearances are where the campaign's entries were named in this session's
+	// lines (#545). They ride the HISTORY flag, not the default export: an
+	// appearance is a record of what was said, not part of the campaign's setup —
+	// and it is derived, so a destination that re-indexes gets them back anyway.
+	Appearances []Appearance `json:"appearances,omitempty"`
+}
+
+// Appearance is one recorded mention, referencing a Node ref key and a Line's
+// own stable id within its session (#545).
+type Appearance struct {
+	NodeID string    `json:"node_id"`
+	LineID string    `json:"line_id"`
+	At     time.Time `json:"at"`
 }
 
 // Line is a transcript line.

--- a/internal/storage/node_appearance.go
+++ b/internal/storage/node_appearance.go
@@ -118,6 +118,39 @@ func (s *Store) ListNodeAppearances(ctx context.Context, campaignID, nodeID uuid
 	return out, nil
 }
 
+// SessionAppearance is one session's appearance row, for the Campaign Bundle
+// export (#547). It carries the Node id and the Line's own stable key — the two
+// things an import has to remap or preserve.
+type SessionAppearance struct {
+	NodeID uuid.UUID
+	LineID string
+	At     time.Time
+}
+
+// ListSessionAppearances returns every appearance recorded in one Voice Session,
+// for the history-flagged bundle export.
+func (s *Store) ListSessionAppearances(ctx context.Context, sessionID uuid.UUID) ([]SessionAppearance, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT node_id, line_id, at FROM node_appearance
+		  WHERE voice_session_id = $1 ORDER BY at, line_id, node_id`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list session appearances %s: %w", sessionID, err)
+	}
+	defer rows.Close()
+	var out []SessionAppearance
+	for rows.Next() {
+		var a SessionAppearance
+		if err := rows.Scan(&a.NodeID, &a.LineID, &a.At); err != nil {
+			return nil, fmt.Errorf("storage: scan session appearance: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list session appearances %s: %w", sessionID, err)
+	}
+	return out, nil
+}
+
 // IndexableLine is one committed Transcript Line the indexer scans.
 type IndexableLine struct {
 	LineID string


### PR DESCRIPTION
Stacked on #564 (#545 appearances), which it must round-trip. **Merge #564 first.**

## KG-C6 — the bundle carries the world this epic added

Every new table in an epic is a place where "we exported the campaign" quietly stops being true. A silent omission in a backup is worse than a missing feature, because it is discovered only when someone restores.

Format **v2** adds: Aspects and Tags on a Node; Note and Disposition on an Edge; the `maps` section (each Map carrying its Pins nested — a Pin has no meaning apart from its Map); the `boards` section; and `appearances` inside each history Session.

**v1 still imports.** Every addition is `omitempty`, so a v1 bundle *is* a valid v2 bundle with those sections absent, and `CheckVersion` accepts a range rather than an exact match. A backup format that refuses last year's backup is not a backup format.

### The two flags

**Map images are opt-in, separately from history.** Off by default: the blob cap is 32 MiB *per image* and base64 inflates by a third. Separate from `include_history` because a GM may want their maps in a share bundle without the transcripts, or the transcripts without the megabytes. Without the flag a Map still round-trips completely — name, nesting, anchor, privacy, every Pin. Losing the picture is not losing the map.

**Appearances follow the history flag**, because an Appearance records what was *said* rather than what the campaign *is* — and it is derived, so a destination that re-indexes gets them back anyway.

### Three things the new sections forced

- **Maps import in two passes.** `parent_map_id` is self-referential with a composite FK, and bundle order is the source's `ListMaps` order — alphabetical by name. A single pass is refused the first time a child sorts before its parent, so "The Vault inside Saltmarsh" would import as two top-level maps or not at all. The round-trip fixture is deliberately named to reproduce that ordering.
- **A fresh blob key per imported map.** The source key names the *source* tenant, so reusing it would let one tenant's import overwrite another tenant's picture.
- **Blob writes are outside the transaction and are swept by hand.** `blob.NewPostgres` runs on its own pool, so a `Put` is not rolled back when the import is. Import tracks every key it writes and deletes them on failure — without that, a failed import strands bytes with no row naming them and no sweep that would ever find them. It is the one place the all-or-nothing property is enforced by code rather than by the database, and it has a test.

### On the tests

The existing round-trip test compares a bundle to its re-export, which catches a lossy *import* but **not** a lossy *export* — both sides would drop the same section and compare equal. The new tests therefore assert against the bundle's own contents, section by section, including that the **GM-private** aspect is exported: a backup missing exactly the campaign's secrets would be the worst kind of silent loss.

Closes #547
