### PR TITLE
fix(voice): the bar guarding the durable index was checked by a dead branch

### DIFF
--- a/pkg/voice/address/nameindex_test.go
+++ b/pkg/voice/address/nameindex_test.go
@@ -1,6 +1,10 @@
 package address
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voiceevent"
+)
 
 // NameIndex (#545) is a thin wrapper over the SAME fuzzyIndex the live Address
 // Detector runs on. These tests pin that it is thin — a wrapper that quietly
@@ -68,13 +72,25 @@ func TestNameIndex_ScoresIdenticallyToTheLiveMatcher(t *testing.T) {
 	const line = "ask Dockmaster Ilva where Bart went"
 	rawScores := raw.scoreAll(tokenize(line))
 	got := wrapper.Match(line, 0.0001)
+	compared := 0
 	for i, want := range rawScores {
 		if want < 0.0001 {
 			continue
 		}
+		compared++
 		if got[i] != want {
 			t.Errorf("entry %d: wrapper scored %v, matcher scored %v", i, got[i], want)
 		}
+	}
+	// Every comparison above is skipped when the live matcher scores nothing, so
+	// without this the test would report agreement it never actually checked. And
+	// the loop only walks what the live matcher scored, so a wrapper that invented
+	// an entry of its own would slip past it — divergence has two directions.
+	if compared == 0 {
+		t.Fatalf("the live matcher scored nothing on %q; this compared no entries", line)
+	}
+	if len(got) != compared {
+		t.Errorf("wrapper returned %d entries, the live matcher scored %d: %v", len(got), compared, got)
 	}
 }
 
@@ -89,10 +105,61 @@ func TestMinNameConfidence_IsStricterThanTheLiveDetector(t *testing.T) {
 		t.Fatalf("MinNameConfidence = %v, want the phonetic bar %v",
 			MinNameConfidence(NameMatchConfig{}), cfg.PhoneticScore)
 	}
-	// It must sit ABOVE the edit-distance net's clamp, which is where "spelled it
-	// differently" ends and "sounds like something else" begins.
-	if cfg.PhoneticScore <= cfg.PhoneticScore-0.01 {
-		t.Fatal("the phonetic bar is not above the clamped edit-distance net")
+	// And it must sit ABOVE the similarity the live Address Detector accepts as a
+	// name hit — the bar below which a turn may still route to an NPC but a
+	// durable row must not be written. Read from the shipped stack rather than
+	// hard-coded, so retuning the live signal up to this bar fails HERE: the
+	// durable index going no stricter than the disposable turn is the whole point.
+	live, ok := liveNameThreshold()
+	if !ok {
+		t.Fatal("the default heuristic stack has no NameMatch to be stricter than")
+	}
+	if got := MinNameConfidence(NameMatchConfig{}); got <= live {
+		t.Fatalf("MinNameConfidence = %v, want strictly above the live detector's name bar %v", got, live)
+	}
+	// The shipped stack is what a default Matcher gates on, but only because
+	// NewMatcher fills a nil stack from it. Pin that too, or the bar compared
+	// against above stops being the bar the live turn actually applies.
+	npc := Agent{Target: voiceevent.AddressTarget{AgentID: "npc-bart", AgentRole: "character", Name: "Bart"}}
+	if got := NewMatcher(Config{Language: "en"}, npc).nameThreshold(); got != live {
+		t.Errorf("a default Matcher gates name hits at %v, the shipped stack says %v", got, live)
+	}
+}
+
+// liveNameThreshold is the similarity the live Address Detector demands of a name
+// hit: the Threshold of the [NameMatch] heuristic in the shipped stack, which is
+// the value [Matcher.nameThreshold] gates on. Reported absent (false) rather than
+// defaulted, so a stack without a NameMatch cannot pass the comparison by
+// accident.
+func liveNameThreshold() (float64, bool) {
+	for _, h := range DefaultHeuristics() {
+		if nm, ok := h.(NameMatch); ok {
+			return nm.Threshold, true
+		}
+	}
+	return 0, false
+}
+
+// TestMinNameConfidence_ExcludesTheEditNet pins the OTHER half of the bar, and
+// the one [MinNameConfidence]'s doc comment actually promises: "an exact match
+// and a phonetic one, and nothing softer". That promise rests entirely on the
+// clamp in [fuzzyIndex.similarity] holding the edit-distance net just below
+// PhoneticScore whenever an encoder is present — with the clamp gone, a name
+// reached by pure edit distance scores exactly the bar and lands in the durable
+// index. "Rockmaster" is one edit from "Dockmaster" across ten runes, which is
+// that worst case: a different word, not a different spelling of the same one.
+func TestMinNameConfidence_ExcludesTheEditNet(t *testing.T) {
+	t.Parallel()
+	idx := nameIdxFor(t, "en", "Dockmaster")
+	const line = "ask Rockmaster about the ledger"
+	if got := idx.Match(line, minConf()); len(got) != 0 {
+		t.Errorf("an edit-net-only match cleared the durable bar: %q matched %v", line, got)
+	}
+	// It must be a near miss rather than a non-match, or this passes for the wrong
+	// reason — an index that stopped matching anything would satisfy the check
+	// above while testing nothing about the clamp.
+	if got := idx.Match(line, 0.0001); len(got) == 0 {
+		t.Fatalf("%q did not reach the entry at all; this no longer probes the clamp", line)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Replaces an assertion in `pkg/voice/address/nameindex_test.go` that could never fail, and tests the two properties it claimed but never checked.

The dead branch, added by #545 (commit 7891973):

```go
// It must sit ABOVE the edit-distance net's clamp, which is where "spelled it
// differently" ends and "sounds like something else" begins.
if cfg.PhoneticScore <= cfg.PhoneticScore-0.01 {
    t.Fatal("the phonetic bar is not above the clamped edit-distance net")
}
```

`x <= x - 0.01` is false for every finite `x`, so the body never ran.

Relates to #545.

## Why is this change needed?

`MinNameConfidence` is the bar the Appearances index writes durable rows against, and it is deliberately stricter than the live Address Detector's — a live mis-detection costs one NPC answering when it should not have, which the GM hears and shrugs off, while a mis-detection here writes a row nobody reviews. That asymmetry was documented, and unverified. Either threshold could have been retuned past the other without a test going red.

The change makes three properties real:

1. **`MinNameConfidence` > the live detector's name bar.** Read out of the shipped heuristic stack rather than hard-coded, so retuning the live signal up to this bar fails here.
2. **A default `Matcher` gates on that same bar.** Reading the shipped stack only means something while the stack the live turn runs agrees with it; `NewMatcher` filling a nil stack from it is what makes that true, and it is now pinned.
3. **Nothing reached by edit distance alone clears the bar.** This is what `MinNameConfidence`'s doc comment actually promises — "an exact match and a phonetic one, and nothing softer" — and it rests entirely on the clamp in `fuzzyIndex.similarity`. Nothing tested it. `"Rockmaster"` is one edit from `"Dockmaster"` across ten runes: unclamped it scores exactly 0.9 and lands in the durable index as a different word.

## How was this tested?

`make check`'s `test` target can't run locally (the Makefile exports `CGO_ENABLED=0`, and `-race` requires cgo), so the CI gate was mirrored directly: `CGO_ENABLED=1 go build ./... && go vet ./... && go test -race ./...` — all green, plus `gofmt -l` clean.

Because a test that cannot fail is the bug being fixed, **every new assertion was mutation-checked** — each mutation was applied, observed red, and reverted:

| Mutation | Result |
| --- | --- |
| `DefaultHeuristicsWithin` → `NameMatch{Threshold: 0.9}` (equal to the durable bar) | `MinNameConfidence = 0.9, want strictly above the live detector's name bar 0.9` |
| Delete the clamp in `fuzzyIndex.similarity` | `an edit-net-only match cleared the durable bar: "ask Rockmaster about the ledger" matched map[0:0.9]` |
| `NewMatcher`'s nil-stack path installs `Threshold: 0.95` | `a default Matcher gates name hits at 0.95, the shipped stack says 0.6` |

The pre-existing assertions were left in place; `git diff` touches only the test file.

- [x] `make check` passes (see note above — CI gate run directly)
- [x] New/updated tests cover the change
- [ ] Manual testing

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [ ] I have updated documentation if needed — no behaviour change, no docs affected
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

**No production code changes.** Every threshold behaves exactly as before; only the test file moves.

A vacuity in the neighbouring `TestNameIndex_ScoresIdenticallyToTheLiveMatcher` is closed in passing: its loop `continue`s past every entry the live matcher scored below 0.0001, so it would have reported agreement it never checked had matching regressed to nothing — and it only ever compared in one direction, so a wrapper inventing an entry of its own slipped past. It now asserts it compared something, and that the two sides returned the same count.

The repo-wide grep for this assertion shape (`x <op> x ± k` in `*_test.go`) found exactly one hit, the one fixed here.

The design rationale reviewed here was checked by an adversarial review pass, which independently reproduced each mutation via build overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)