### PR TITLE
fix(web): rules and tokens the stylesheet never defined

### DIFF
--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -1334,12 +1334,32 @@
   cursor: default;
 }
 
+/* Both are secondary metadata sitting on the same row as the NPC name. Left
+   unstyled they inherit body text and read as loud as the name itself, which is
+   the one thing on the row the GM scans for. */
+.gx-prep__spoke,
+.gx-prep__exempt {
+  font-size: var(--body-sm);
+  color: var(--text-muted);
+}
+
 /* ── Maps and Pins (#538) ────────────────────────────────────────────────── */
 
 .gx-maps {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+}
+
+/* One map's breadcrumb, toolbar, frame and unpinned tray. None of them carry
+   margins, so without this they stacked at 0 INSIDE a .gx-maps that separates
+   its own children by 16px — the toolbar touched the frame while unrelated
+   siblings sat further apart. 8px keeps the view's internals tighter than the
+   16px rhythm between the view and the map bar above it. */
+.gx-maps__view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
 }
 
 .gx-maps__bar,
@@ -1674,6 +1694,23 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+}
+
+/* A board's title row and its chips. Both have margin 0, so without this they
+   stacked at 0 while whole boards sat 16px apart — the title read as belonging
+   to no board in particular. 4px matches the title-to-content rhythm of
+   .gx-kg-group and .gx-prep__group. */
+.gx-boards__board {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+/* The empty-board hint is a <p>, so base.css's `margin: 0 0 var(--spacing-md)`
+   applies and an EMPTY board reserves 16px more trailing space than a filled
+   one — the same board spaced two different ways depending on its contents. */
+.gx-boards__board > .gx-field__hint {
+  margin: 0;
 }
 
 .gx-boards__new,

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -100,7 +100,7 @@
 
 .gx-discord__unlink-note {
   font-size: var(--body-sm);
-  color: var(--text-secondary);
+  color: var(--text-muted);
   max-width: 46ch;
 }
 

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -32,7 +32,7 @@
   flex: 0 0 308px;
   align-self: stretch;
   padding: var(--spacing-lg);
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--border-subtle);
   background: var(--surface-raised);
   border-radius: var(--radius-md);
   display: flex;
@@ -65,7 +65,7 @@
   gap: var(--spacing-sm);
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--surface-inset);
   color: var(--text-default);
@@ -130,7 +130,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-default);
@@ -160,7 +160,7 @@
     flex-basis: auto;
     width: 100%;
     border-left: none;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid var(--border-subtle);
   }
 }
 
@@ -564,6 +564,14 @@
   gap: var(--spacing-md);
 }
 
+/* .gx-section-title carries `margin: 28px 0 12px` for block-flow use elsewhere.
+   Inside this flex column its bottom margin ADDS to the 16px gap, putting the
+   heading 28px from the section above and 28px from its own list — equidistant,
+   so it reads as titling neither. The gap alone is the separation here. */
+.gx-session__highlights > .gx-section-title {
+  margin-bottom: 0;
+}
+
 .gx-highlights__list {
   list-style: none;
   margin: 0;
@@ -578,7 +586,7 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: var(--surface-raised);
 }
@@ -606,7 +614,7 @@
 .gx-highlight__excerpt {
   margin: 0;
   padding-left: var(--spacing-md);
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-default);
   line-height: 1.5;
   color: var(--text-default);
 }


### PR DESCRIPTION
## What does this PR do?

Adds the CSS rules that were never written for classes already in the TSX, and repoints declarations that referenced CSS variables the theme does not define.

Relates to #544 (which introduced `.gx-prep__spoke` / `.gx-prep__exempt`).

**Missing rules** — the class is rendered, the rule never existed:

| class | before | after |
|---|---|---|
| `.gx-prep__spoke`, `.gx-prep__exempt` | inherited body text: `rgb(240,240,244)` / 16px | `rgb(159,159,173)` / 14px |
| `.gx-maps__view` | `display:block`, children 0px apart | `flex`, `gap: var(--spacing-sm)` → 8px |
| `.gx-boards__board` | `display:block`, children 0px apart | `flex`, `gap: var(--spacing-xs)` → 4px |

`.gx-maps__view` is the clearest proximity failure: its children (breadcrumb, toolbar, map frame, unpinned tray) sat **0px** apart inside a `.gx-maps` that separates its own children by **16px** — the toolbar touched the frame while unrelated siblings sat further apart. Now 8px inside vs 16px between, verified against the live DOM.

Also: an empty board's hint is a `<p>`, so `base.css`'s `margin: 0 0 var(--spacing-md)` gave an *empty* board 16px more trailing space than a filled one.

**Phantom tokens** — `var()` with no fallback is invalid at computed-value time, so the whole declaration is dropped:

- `--border` is defined nowhere. `border: 1px solid var(--border)` therefore reset `border-style` to `none` and drew **nothing** on `.gx-voice-panel`, `.gx-voice-panel__all`, `.gx-voice-row__toggle`, `.gx-highlight`, `.gx-highlight__excerpt`. Measured all four sides as `none/0px`.
- The consequential one: `.gx-voice-row__toggle[data-muted]` sets only `border-color`, which can never show through `border-style: none` — **the red muted outline was unreachable**. A mute state you could not see.
- `--text-secondary` is likewise undefined, so the Discord unlink note rendered at full body strength instead of muted — the identical bug to `.gx-prep__spoke`.

Mapped to `--border-subtle` for dividers/cards and `--border-default` for controls, matching what `.gx-input` and `.gx-switch__track` already use.

**Spacing collision**: `.gx-section-title` carries `margin: 28px 0 12px` for block-flow use elsewhere. Inside `.gx-session__highlights` (a 16px flex column) its bottom margin *adds* to the gap — 28px above, 28px below, exactly equidistant, so the heading titled neither section. Now 28px above / 16px below.

## Why is this change needed?

`.gx-prep__spoke` and `.gx-prep__exempt` made secondary metadata render at the same visual weight as the NPC name on the session-prep screen a GM consults before every session. Investigating that turned up the same defect class elsewhere — including one that hides a mute state entirely.

## How was this tested?

jsdom does not run the cascade, so **no unit test can catch any of this** — that is precisely why these shipped. Verified in a real browser (`GLYPHOXA_DEV_MODE=1`, 127.0.0.1:8080) with `getComputedStyle`, before and after:

- Borders: every affected element went from `T:none/0px R:none/0px B:none/0px L:none/0px` to rendering on the intended sides. Control: rules that *do* carry a fallback (`var(--border, #2a2f3a)`) rendered correctly both before and after, confirming the mechanism.
- `[data-muted]` toggle now computes `border-style: solid` / `rgba(255,79,94,0.42)`.
- `.gx-maps__view`: real-DOM child gaps measured at 8px, against 16px to the map bar above.
- Highlights heading: 28px above / 16px below.

- [ ] `make check` passes — **not run**: `make check` cannot pass locally in this repo, the Makefile exports `CGO_ENABLED=0` while its `test` target runs `go test -race`, and `-race` requires cgo. Ran the web gate instead (`npm run build` + `npm test`): green, 45 files / 455 tests. No Go source is touched by this change; CI runs the full gate.
- [ ] New/updated tests cover the change — *not possible; see above*
- [x] Manual testing

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [ ] I have added/updated tests for my changes — *jsdom cannot observe the cascade*
- [x] All tests pass (web suite; Go untouched)
- [x] I have updated documentation if needed (n/a)
- [x] All exported symbols have Godoc comments (n/a)
- [x] My commits are focused and have clear messages

## Additional Notes

**Deliberately not in this PR.** A review of all 14 CSS files found ~75 references to 13 variables that are never defined (`--accent`, `--surface`, `--text`, `--danger`, `--warning`, …). Unlike the ones fixed here, those all carry fallbacks, so they *render* — just outside the theme: everything from the graph section onward in `campaign.css` draws in a neutral blue-gray while the rest of the app is violet-tinted. Normalising them repaints the entire Knowledge/world surface. That is a design decision, it is invisible to CI, and it deserves human eyes rather than a green checkmark, so it belongs in its own PR.

Two latent traps worth recording from that review:

- `--accent` means yellow `#ffcf5a` in `campaign.css` but violet `#9059ff` in `landing.css` / `legal.css` / `login.css`. The day anyone defines `--accent` in `:root`, one of those two sets silently flips.
- "Danger" currently renders as four different reds across the app while `--status-danger` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
