### PR TITLE
fix(rpc): an exhausted quota is not a misconfiguration

### DIFF
--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -101,10 +101,9 @@ type EnrichStore interface {
 //   - image generation is not configured for the tenant → log + nil (the
 //     Highlight stays intact without media, AC — never a retry loop on a missing
 //     key).
-//   - the provider REJECTED the configured key (401/403) → log + nil, for the
-//     same reason: a credential the provider refuses is not fixed by sending it
-//     again. Quota and rate-limit rejections (429) are the opposite case and stay
-//     retryable — those do clear on their own.
+//   - a provider failure → the error is returned (retry / dead-letter) whatever
+//     its status, but a rejected key and an exhausted quota are LOGGED apart:
+//     they need different humans doing different things.
 //   - otherwise generate → meter usage (caps-free spend meter teed onto the
 //     production recorder; Gemini bills the image as output tokens, so it prices
 //     through LLMTokens — no image-specific meter, #311) → store the image behind
@@ -196,33 +195,32 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 				"highlight", p.HighlightID)
 			return nil
 		}
-		if imagegen.IsAuthFailure(err) {
-			// PERMANENT for the key in hand, and therefore the same posture as
-			// ErrImageNotConfigured above — a rejected key is a missing key in every
-			// way that matters, and this handler's rule is "never a retry loop on a
-			// missing key". Retrying re-sends the identical rejected credential until
-			// the job dead-letters, once per promoted Highlight.
-			//
-			// Logged at Error, not Info: a key IS configured and the provider refused
-			// it, which needs an operator, whereas no key at all is a choice. Nothing
-			// is lost by returning nil — the boot sweep
-			// (SweepEnrichmentReconciliation) re-enqueues imageless promoted
-			// Highlights, so fixing the key and restarting picks them all back up.
-			release()
-			log.Error("highlight enrich: image provider rejected the configured key, leaving highlight without media",
-				"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
-			return nil
-		}
 		if err != nil {
 			// Provider error: return it so the runner retries / dead-letters. The row
 			// is untouched — the Highlight keeps its clip and stays imageless (AC).
 			//
-			// A quota or rate-limit rejection belongs HERE and not above: unlike a
-			// rejected key it does clear on its own, so the runner's backoff is the
-			// right answer. It is called out in the log because "HTTP 429" buried in a
-			// dead-letter payload reads like a provider outage when it is a bill.
+			// EVERY provider failure takes this exit, including a rejected key (401/403)
+			// that cannot possibly succeed on retry. That looks wrong and is not: what
+			// the exit really chooses is the RECOVERY path, not the retry. A handler
+			// returning nil completes the job 'done', and
+			// ListPromotedHighlightsNeedingEnrichment treats 'done' as satisfied while
+			// treating 'dead' as absent — so dead-lettering a rejected key is precisely
+			// what lets the boot sweep re-enrich these Highlights once the key is fixed,
+			// and a "permanent, log and move on" branch would strand every Highlight
+			// promoted during a bad-key window imageless forever, with a log line as
+			// its only trace. The missing-key case above returns nil because there is
+			// no key to fix and nothing to come back for.
+			//
+			// What DOES vary by status is the DIAGNOSIS, because "HTTP 401" and
+			// "HTTP 429" buried in a dead-letter payload look alike and share nothing:
+			// one needs a new key from a human, the other needs a bill paid — or just
+			// the next attempt.
 			release()
-			if imagegen.IsQuotaExceeded(err) {
+			switch {
+			case imagegen.IsAuthFailure(err):
+				log.Error("highlight enrich: image provider rejected the configured key",
+					"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
+			case imagegen.IsQuotaExceeded(err):
 				log.Warn("highlight enrich: image provider out of quota or rate-limited, will retry",
 					"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
 			}

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -221,7 +221,7 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 				log.Error("highlight enrich: image provider rejected the configured key",
 					"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
 			case imagegen.IsQuotaExceeded(err):
-				log.Warn("highlight enrich: image provider out of quota or rate-limited, will retry",
+				log.Warn("highlight enrich: image provider out of quota or rate-limited",
 					"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
 			}
 			return fmt.Errorf("highlight enrich: generate image: %w", err)

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -101,6 +101,10 @@ type EnrichStore interface {
 //   - image generation is not configured for the tenant → log + nil (the
 //     Highlight stays intact without media, AC — never a retry loop on a missing
 //     key).
+//   - the provider REJECTED the configured key (401/403) → log + nil, for the
+//     same reason: a credential the provider refuses is not fixed by sending it
+//     again. Quota and rate-limit rejections (429) are the opposite case and stay
+//     retryable — those do clear on their own.
 //   - otherwise generate → meter usage (caps-free spend meter teed onto the
 //     production recorder; Gemini bills the image as output tokens, so it prices
 //     through LLMTokens — no image-specific meter, #311) → store the image behind
@@ -192,10 +196,36 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 				"highlight", p.HighlightID)
 			return nil
 		}
+		if imagegen.IsAuthFailure(err) {
+			// PERMANENT for the key in hand, and therefore the same posture as
+			// ErrImageNotConfigured above — a rejected key is a missing key in every
+			// way that matters, and this handler's rule is "never a retry loop on a
+			// missing key". Retrying re-sends the identical rejected credential until
+			// the job dead-letters, once per promoted Highlight.
+			//
+			// Logged at Error, not Info: a key IS configured and the provider refused
+			// it, which needs an operator, whereas no key at all is a choice. Nothing
+			// is lost by returning nil — the boot sweep
+			// (SweepEnrichmentReconciliation) re-enqueues imageless promoted
+			// Highlights, so fixing the key and restarting picks them all back up.
+			release()
+			log.Error("highlight enrich: image provider rejected the configured key, leaving highlight without media",
+				"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
+			return nil
+		}
 		if err != nil {
 			// Provider error: return it so the runner retries / dead-letters. The row
 			// is untouched — the Highlight keeps its clip and stays imageless (AC).
+			//
+			// A quota or rate-limit rejection belongs HERE and not above: unlike a
+			// rejected key it does clear on its own, so the runner's backoff is the
+			// right answer. It is called out in the log because "HTTP 429" buried in a
+			// dead-letter payload reads like a provider outage when it is a bill.
 			release()
+			if imagegen.IsQuotaExceeded(err) {
+				log.Warn("highlight enrich: image provider out of quota or rate-limited, will retry",
+					"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
+			}
 			return fmt.Errorf("highlight enrich: generate image: %w", err)
 		}
 

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -611,66 +611,61 @@ func TestEnrichImageHandler_GeneratorError_ReturnsErr_RowUntouched(t *testing.T)
 	}
 }
 
-// TestEnrichImageHandler_AuthFailure_Nil: a key the provider REJECTS is a missing
-// key in every way that matters, so it takes the same exit as ErrImageNotConfigured
-// — log + nil — instead of retrying the identical rejected credential until the
-// job dead-letters, once per promoted Highlight. The row stays intact and the boot
-// sweep picks it back up once the key is fixed.
-func TestEnrichImageHandler_AuthFailure_Nil(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		tenantID := uuid.New()
-		store := newFakeEnrichStore()
-		h := seedRow(store, tenantID)
-		blobs := newFakeBlobs()
-		gen := &fakeGen{err: &imagegen.StatusError{StatusCode: status, Body: `{"error":{"message":"API key not valid"}}`}}
-
-		handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
-		payload, _ := MarshalEnrichImage(h.ID, tenantID)
-		if err := handler(context.Background(), payload); err != nil {
-			t.Fatalf("HTTP %d: a rejected key must not churn retries, got %v", status, err)
-		}
-		// Highlight intact and imageless, nothing stored, and the claim released so a
-		// later re-drive (fixed key + boot sweep) can re-claim without waiting the ttl.
-		if len(blobs.data) != 0 {
-			t.Errorf("HTTP %d: a blob was stored on an auth failure", status)
-		}
-		got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
-		if got.ImageKey != "" {
-			t.Errorf("HTTP %d: row must be untouched", status)
-		}
-		if store.releaseCalls != 1 {
-			t.Errorf("HTTP %d: releaseCalls = %d, want 1", status, store.releaseCalls)
-		}
+// TestEnrichImageHandler_UpstreamFailures_StayRetryable covers the two statuses
+// the handler now tells apart in its logs — and pins the thing that is easy to
+// get wrong when you do: BOTH still return an error.
+//
+// A rejected key (401/403) is permanent for that key, so "log it and return nil"
+// looks like the tidy answer. It is not, and the reason is recovery rather than
+// retry: returning nil completes the job 'done', and
+// ListPromotedHighlightsNeedingEnrichment (internal/storage/highlight.go) counts a
+// 'done' job as satisfied while treating a 'dead' one as absent. Dead-lettering is
+// therefore what lets the boot sweep re-enrich these Highlights once the key is
+// fixed; the tidy answer would leave every Highlight promoted during a bad-key
+// window imageless forever.
+func TestEnrichImageHandler_UpstreamFailures_StayRetryable(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"rejected key", http.StatusUnauthorized},
+		{"forbidden key", http.StatusForbidden},
+		{"exhausted quota", http.StatusTooManyRequests},
+		{"provider down", http.StatusInternalServerError},
 	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tenantID := uuid.New()
+			store := newFakeEnrichStore()
+			h := seedRow(store, tenantID)
+			blobs := newFakeBlobs()
+			gen := &fakeGen{err: &imagegen.StatusError{StatusCode: tc.status, Body: `{"error":{"message":"nope"}}`}}
 
-// TestEnrichImageHandler_QuotaExceeded_ReturnsErr is the deliberate opposite: a
-// 429 clears on its own, so it stays retryable and must NOT take the permanent
-// exit the rejected key takes.
-func TestEnrichImageHandler_QuotaExceeded_ReturnsErr(t *testing.T) {
-	tenantID := uuid.New()
-	store := newFakeEnrichStore()
-	h := seedRow(store, tenantID)
-	blobs := newFakeBlobs()
-	gen := &fakeGen{err: &imagegen.StatusError{
-		StatusCode: http.StatusTooManyRequests,
-		Body:       `{"error":{"code":429,"message":"You exceeded your current quota"}}`,
-	}}
-
-	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
-	payload, _ := MarshalEnrichImage(h.ID, tenantID)
-	err := handler(context.Background(), payload)
-	if err == nil {
-		t.Fatal("a quota failure must return an error so the runner retries after backoff")
-	}
-	// The status survives the handler's wrapping, so a dead-letter reader can still
-	// tell a bill from an outage.
-	if !imagegen.IsQuotaExceeded(err) {
-		t.Errorf("the 429 was lost on the way up: %v", err)
-	}
-	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
-	if got.ImageKey != "" {
-		t.Error("row must be untouched on a quota failure")
+			handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+			payload, _ := MarshalEnrichImage(h.ID, tenantID)
+			err := handler(context.Background(), payload)
+			if err == nil {
+				t.Fatalf("HTTP %d returned nil: the job completes 'done' and the boot sweep will never re-drive it", tc.status)
+			}
+			// The status survives the handler's wrapping, so whoever reads the
+			// dead-letter can still tell a bill from a bad key from an outage.
+			var se *imagegen.StatusError
+			if !errors.As(err, &se) || se.StatusCode != tc.status {
+				t.Errorf("the upstream status was lost on the way up: %v", err)
+			}
+			// Nothing stored, row untouched, and the claim released so the retry can
+			// re-claim without waiting out the ttl.
+			if len(blobs.data) != 0 {
+				t.Errorf("HTTP %d: a blob was stored on a provider failure", tc.status)
+			}
+			got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+			if got.ImageKey != "" {
+				t.Errorf("HTTP %d: row must be untouched", tc.status)
+			}
+			if store.releaseCalls != 1 {
+				t.Errorf("HTTP %d: releaseCalls = %d, want 1", tc.status, store.releaseCalls)
+			}
+		})
 	}
 }
 

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -3,6 +3,7 @@ package highlight
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -607,6 +608,69 @@ func TestEnrichImageHandler_GeneratorError_ReturnsErr_RowUntouched(t *testing.T)
 	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
 	if got.ImageKey != "" {
 		t.Fatalf("row must be untouched on generator failure")
+	}
+}
+
+// TestEnrichImageHandler_AuthFailure_Nil: a key the provider REJECTS is a missing
+// key in every way that matters, so it takes the same exit as ErrImageNotConfigured
+// — log + nil — instead of retrying the identical rejected credential until the
+// job dead-letters, once per promoted Highlight. The row stays intact and the boot
+// sweep picks it back up once the key is fixed.
+func TestEnrichImageHandler_AuthFailure_Nil(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		tenantID := uuid.New()
+		store := newFakeEnrichStore()
+		h := seedRow(store, tenantID)
+		blobs := newFakeBlobs()
+		gen := &fakeGen{err: &imagegen.StatusError{StatusCode: status, Body: `{"error":{"message":"API key not valid"}}`}}
+
+		handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+		payload, _ := MarshalEnrichImage(h.ID, tenantID)
+		if err := handler(context.Background(), payload); err != nil {
+			t.Fatalf("HTTP %d: a rejected key must not churn retries, got %v", status, err)
+		}
+		// Highlight intact and imageless, nothing stored, and the claim released so a
+		// later re-drive (fixed key + boot sweep) can re-claim without waiting the ttl.
+		if len(blobs.data) != 0 {
+			t.Errorf("HTTP %d: a blob was stored on an auth failure", status)
+		}
+		got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+		if got.ImageKey != "" {
+			t.Errorf("HTTP %d: row must be untouched", status)
+		}
+		if store.releaseCalls != 1 {
+			t.Errorf("HTTP %d: releaseCalls = %d, want 1", status, store.releaseCalls)
+		}
+	}
+}
+
+// TestEnrichImageHandler_QuotaExceeded_ReturnsErr is the deliberate opposite: a
+// 429 clears on its own, so it stays retryable and must NOT take the permanent
+// exit the rejected key takes.
+func TestEnrichImageHandler_QuotaExceeded_ReturnsErr(t *testing.T) {
+	tenantID := uuid.New()
+	store := newFakeEnrichStore()
+	h := seedRow(store, tenantID)
+	blobs := newFakeBlobs()
+	gen := &fakeGen{err: &imagegen.StatusError{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       `{"error":{"code":429,"message":"You exceeded your current quota"}}`,
+	}}
+
+	handler := EnrichImageHandler(store, blobs, factoryReturning(gen, "m", nil), nil, nil)
+	payload, _ := MarshalEnrichImage(h.ID, tenantID)
+	err := handler(context.Background(), payload)
+	if err == nil {
+		t.Fatal("a quota failure must return an error so the runner retries after backoff")
+	}
+	// The status survives the handler's wrapping, so a dead-letter reader can still
+	// tell a bill from an outage.
+	if !imagegen.IsQuotaExceeded(err) {
+		t.Errorf("the 429 was lost on the way up: %v", err)
+	}
+	got, _ := store.GetHighlight(context.Background(), tenantID, h.ID)
+	if got.ImageKey != "" {
+		t.Error("row must be untouched on a quota failure")
 	}
 }
 

--- a/internal/imagegen/imagegen.go
+++ b/internal/imagegen/imagegen.go
@@ -96,11 +96,11 @@ func IsAuthFailure(err error) bool {
 	})
 }
 
-// IsProviderFault reports whether err is an upstream server-side failure (5xx).
-// Transient and nobody's configuration: the honest answer is "try again shortly".
-func IsProviderFault(err error) bool {
-	return statusIs(err, func(code int) bool { return code >= 500 })
-}
+// There is deliberately no IsProviderFault: nothing needs it. The 5xx case is
+// classified in internal/rpc alongside the text provider's equivalent error,
+// where the two seams meet, and a predicate here with no caller but its own test
+// would just be API pretending to be used. [StatusError] is exported, so anyone
+// who later needs a different cut takes it with errors.As.
 
 func statusIs(err error, pred func(int) bool) bool {
 	var se *StatusError

--- a/internal/imagegen/imagegen.go
+++ b/internal/imagegen/imagegen.go
@@ -45,6 +45,68 @@ var ErrImageTooLarge = errors.New("imagegen: generated image exceeds the blob si
 // happened (#541 review), and one value with two aliases makes it unrepresentable.
 var ErrNotConfigured = errors.New("imagegen: image generation is not configured")
 
+// StatusError is a non-2xx response from the image provider, carrying the HTTP
+// status so a caller can tell the failures apart instead of collapsing them into
+// one sentence.
+//
+// The three that matter have three different fixes and only one of them is the
+// configuration:
+//
+//   - 429 — the key is VALID and was accepted; the account is out of quota or
+//     rate-limited. The fix is billing, a plan change, or waiting.
+//   - 401/403 — the key is missing, wrong, revoked, or not entitled to the model.
+//     This is the only case where "check the configuration" is true.
+//   - 5xx — the provider is having a bad day. Nothing on this side is wrong and
+//     nothing on this side can fix it.
+//
+// Sending a GM to re-check a correct setting because their provider rate-limited
+// them is exactly the failure this type exists to prevent (#541 follow-up).
+//
+// Branch on it with the predicates below (or errors.As), never by matching
+// substrings of Error(): the message is for humans and logs, the status is the
+// contract.
+type StatusError struct {
+	// StatusCode is the HTTP status the provider returned.
+	StatusCode int
+	// Body is the provider's response body, already truncated for logging.
+	Body string
+}
+
+// Error keeps the pre-typed wording verbatim so log lines and dead-letter
+// payloads read the same as before the type existed.
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("imagegen: HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// IsQuotaExceeded reports whether err is an upstream quota or rate-limit
+// rejection (HTTP 429). The configuration is CORRECT in this case — the key was
+// accepted and then refused for spend — so a caller must never answer it with
+// advice to check the key.
+func IsQuotaExceeded(err error) bool {
+	return statusIs(err, func(code int) bool { return code == http.StatusTooManyRequests })
+}
+
+// IsAuthFailure reports whether err is an upstream credential rejection (401 or
+// 403): the key is missing, wrong, revoked, or lacks access to the model. It is
+// PERMANENT for the key in hand — retrying re-sends the same rejected credential
+// — and it is the one failure a configuration change actually fixes.
+func IsAuthFailure(err error) bool {
+	return statusIs(err, func(code int) bool {
+		return code == http.StatusUnauthorized || code == http.StatusForbidden
+	})
+}
+
+// IsProviderFault reports whether err is an upstream server-side failure (5xx).
+// Transient and nobody's configuration: the honest answer is "try again shortly".
+func IsProviderFault(err error) bool {
+	return statusIs(err, func(code int) bool { return code >= 500 })
+}
+
+func statusIs(err error, pred func(int) bool) bool {
+	var se *StatusError
+	return errors.As(err, &se) && pred(se.StatusCode)
+}
+
 const (
 	// ProviderID is the stable string identifying this adapter; it matches the
 	// Provider Config's provider name and observe.ProviderGemini.
@@ -217,7 +279,10 @@ func (g *Gemini) Generate(ctx context.Context, prompt string) (Result, error) {
 		return Result{}, fmt.Errorf("imagegen: read response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return Result{}, fmt.Errorf("imagegen: HTTP %d: %s", resp.StatusCode, truncate(respBody, 256))
+		// Typed, not fmt.Errorf: the status is the only thing that tells a quota
+		// rejection apart from a rejected key, and a caller that has to grep the
+		// message for "429" is one provider-wording change away from being wrong.
+		return Result{}, &StatusError{StatusCode: resp.StatusCode, Body: truncate(respBody, 256)}
 	}
 
 	var parsed generateContentResponse

--- a/internal/imagegen/imagegen_test.go
+++ b/internal/imagegen/imagegen_test.go
@@ -171,16 +171,15 @@ func TestGemini_Generate_StatusIsTyped(t *testing.T) {
 // quota must never be reported as an auth or configuration problem.
 func TestGemini_Generate_StatusPredicates(t *testing.T) {
 	cases := []struct {
-		name                   string
-		status                 int
-		quota, auth, providerF bool
+		name        string
+		status      int
+		quota, auth bool
 	}{
-		{"rate limited", http.StatusTooManyRequests, true, false, false},
-		{"key rejected", http.StatusUnauthorized, false, true, false},
-		{"key forbidden", http.StatusForbidden, false, true, false},
-		{"provider down", http.StatusInternalServerError, false, false, true},
-		{"provider gateway", http.StatusBadGateway, false, false, true},
-		{"malformed request", http.StatusBadRequest, false, false, false},
+		{"rate limited", http.StatusTooManyRequests, true, false},
+		{"key rejected", http.StatusUnauthorized, false, true},
+		{"key forbidden", http.StatusForbidden, false, true},
+		{"provider down", http.StatusInternalServerError, false, false},
+		{"malformed request", http.StatusBadRequest, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -196,9 +195,8 @@ func TestGemini_Generate_StatusPredicates(t *testing.T) {
 			if got := imagegen.IsAuthFailure(err); got != tc.auth {
 				t.Errorf("IsAuthFailure = %v, want %v", got, tc.auth)
 			}
-			if got := imagegen.IsProviderFault(err); got != tc.providerF {
-				t.Errorf("IsProviderFault = %v, want %v", got, tc.providerF)
-			}
+			// A 5xx and a 400 are neither: they must fall through to the caller's
+			// own handling rather than being reported as a bill or a bad key.
 		})
 	}
 }
@@ -208,7 +206,7 @@ func TestGemini_Generate_StatusPredicates(t *testing.T) {
 // failure, a nil error — so no caller silently reclassifies them.
 func TestStatusPredicates_IgnoreOtherErrors(t *testing.T) {
 	for _, err := range []error{nil, imagegen.ErrImageTooLarge, imagegen.ErrNotConfigured, errors.New("dial tcp: i/o timeout")} {
-		if imagegen.IsQuotaExceeded(err) || imagegen.IsAuthFailure(err) || imagegen.IsProviderFault(err) {
+		if imagegen.IsQuotaExceeded(err) || imagegen.IsAuthFailure(err) {
 			t.Errorf("%v was classified as an upstream status failure", err)
 		}
 	}

--- a/internal/imagegen/imagegen_test.go
+++ b/internal/imagegen/imagegen_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -116,18 +117,110 @@ func TestGemini_Generate_RequestShapeAndParse(t *testing.T) {
 	}
 }
 
-func TestGemini_Generate_Non2xx(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = io.WriteString(w, `{"error":{"message":"quota"}}`)
+// statusServer replies with one status + body, the shape every non-2xx test needs.
+func statusServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGemini_Generate_Non2xx(t *testing.T) {
+	srv := statusServer(t, http.StatusTooManyRequests, `{"error":{"message":"quota"}}`)
 
 	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
 	if _, err := gen.Generate(context.Background(), "x"); err == nil {
 		t.Fatal("want error on 429, got nil")
 	} else if !strings.Contains(err.Error(), "429") {
 		t.Errorf("error should carry the status: %v", err)
+	}
+}
+
+// TestGemini_Generate_StatusIsTyped is the whole point of [imagegen.StatusError]:
+// the status must survive as DATA, not only as text in the message, so a caller
+// can tell "you are out of quota" from "your key was rejected" without grepping.
+func TestGemini_Generate_StatusIsTyped(t *testing.T) {
+	srv := statusServer(t, http.StatusTooManyRequests,
+		`{"error":{"code":429,"message":"You exceeded your current quota"}}`)
+
+	gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
+	_, err := gen.Generate(context.Background(), "x")
+
+	var se *imagegen.StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("want a *StatusError, got %T: %v", err, err)
+	}
+	if se.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want 429", se.StatusCode)
+	}
+	if !strings.Contains(se.Body, "exceeded your current quota") {
+		t.Errorf("the provider's own explanation was dropped: %q", se.Body)
+	}
+	// The message is unchanged from the untyped version, so logs and dead-letter
+	// payloads read exactly as they did.
+	if got, want := se.Error(), "imagegen: HTTP 429: "+se.Body; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestGemini_Generate_StatusPredicates pins the classification each caller
+// branches on. The 429 row is the reported bug: a VALID key that ran out of
+// quota must never be reported as an auth or configuration problem.
+func TestGemini_Generate_StatusPredicates(t *testing.T) {
+	cases := []struct {
+		name                   string
+		status                 int
+		quota, auth, providerF bool
+	}{
+		{"rate limited", http.StatusTooManyRequests, true, false, false},
+		{"key rejected", http.StatusUnauthorized, false, true, false},
+		{"key forbidden", http.StatusForbidden, false, true, false},
+		{"provider down", http.StatusInternalServerError, false, false, true},
+		{"provider gateway", http.StatusBadGateway, false, false, true},
+		{"malformed request", http.StatusBadRequest, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := statusServer(t, tc.status, `{"error":{"message":"nope"}}`)
+			gen := imagegen.NewGemini("k", imagegen.WithBaseURL(srv.URL))
+			_, err := gen.Generate(context.Background(), "x")
+			if err == nil {
+				t.Fatalf("want an error on HTTP %d", tc.status)
+			}
+			if got := imagegen.IsQuotaExceeded(err); got != tc.quota {
+				t.Errorf("IsQuotaExceeded = %v, want %v", got, tc.quota)
+			}
+			if got := imagegen.IsAuthFailure(err); got != tc.auth {
+				t.Errorf("IsAuthFailure = %v, want %v", got, tc.auth)
+			}
+			if got := imagegen.IsProviderFault(err); got != tc.providerF {
+				t.Errorf("IsProviderFault = %v, want %v", got, tc.providerF)
+			}
+		})
+	}
+}
+
+// TestStatusPredicates_IgnoreOtherErrors: every predicate must say "no" to an
+// error that is not an upstream status at all — an oversize image, a transport
+// failure, a nil error — so no caller silently reclassifies them.
+func TestStatusPredicates_IgnoreOtherErrors(t *testing.T) {
+	for _, err := range []error{nil, imagegen.ErrImageTooLarge, imagegen.ErrNotConfigured, errors.New("dial tcp: i/o timeout")} {
+		if imagegen.IsQuotaExceeded(err) || imagegen.IsAuthFailure(err) || imagegen.IsProviderFault(err) {
+			t.Errorf("%v was classified as an upstream status failure", err)
+		}
+	}
+}
+
+// TestStatusError_WrapsThroughFmt: callers wrap with %w on the way up (mapgen,
+// the enrichment job), so the predicates must see through those layers.
+func TestStatusError_WrapsThroughFmt(t *testing.T) {
+	err := fmt.Errorf("highlight enrich: generate image: %w",
+		&imagegen.StatusError{StatusCode: http.StatusTooManyRequests, Body: "quota"})
+	if !imagegen.IsQuotaExceeded(err) {
+		t.Error("a wrapped 429 stopped being a quota failure")
 	}
 }
 

--- a/internal/rpc/assist.go
+++ b/internal/rpc/assist.go
@@ -60,6 +60,10 @@ func validAssistPrompt(raw string) (string, *connect.Error) {
 	return p, nil
 }
 
+// assistSubject names what the GM asked this surface for, in the words it has
+// always used. Both handlers here draft content, so they share one subject.
+const assistSubject = "content generation"
+
 // assistEngineErr maps a drafting failure onto its Connect code: a refused
 // platform-key entitlement is an actionable precondition (save a key, ADR-0054);
 // an unusable model response is CodeUnavailable (a retry may succeed); an
@@ -72,11 +76,6 @@ func validAssistPrompt(raw string) (string, *connect.Error) {
 // the account merely ran out of quota — the provider answers a spent allowance
 // with 429 and a key it accepted — and it is now reserved for the 401/403 that
 // actually means it, where the wording is kept verbatim.
-//
-// assistSubject is "content generation" for both handlers, matching the sentence
-// this surface has always used.
-const assistSubject = "content generation"
-
 func assistEngineErr(op string, err error) *connect.Error {
 	switch {
 	case errors.Is(err, llmbuild.ErrNoPlatformKeyEntitlement):

--- a/internal/rpc/assist.go
+++ b/internal/rpc/assist.go
@@ -62,19 +62,35 @@ func validAssistPrompt(raw string) (string, *connect.Error) {
 
 // assistEngineErr maps a drafting failure onto its Connect code: a refused
 // platform-key entitlement is an actionable precondition (save a key, ADR-0054);
-// an unusable model response is CodeUnavailable (a retry may succeed); anything
-// else is logged raw and returned as a static CodeUnavailable — provider
-// failures are the expected failure mode here, not an internal fault.
+// an unusable model response is CodeUnavailable (a retry may succeed); an
+// upstream rejection is classified by upstream_error.go, shared with the Maps
+// surface; anything left is logged raw and returned as a static CodeUnavailable
+// — provider failures are the expected failure mode here, not an internal fault.
+//
+// The classification is why the default no longer says "check the LLM provider
+// configuration". That sentence sent the GM to re-check a CORRECT key every time
+// the account merely ran out of quota — the provider answers a spent allowance
+// with 429 and a key it accepted — and it is now reserved for the 401/403 that
+// actually means it, where the wording is kept verbatim.
+//
+// assistSubject is "content generation" for both handlers, matching the sentence
+// this surface has always used.
+const assistSubject = "content generation"
+
 func assistEngineErr(op string, err error) *connect.Error {
 	switch {
 	case errors.Is(err, llmbuild.ErrNoPlatformKeyEntitlement):
 		return connect.NewError(connect.CodeFailedPrecondition, llmbuild.ErrNoPlatformKeyEntitlement)
 	case errors.Is(err, assist.ErrUnusableResponse):
 		return connect.NewError(connect.CodeUnavailable, errors.New("the model returned an unusable draft — try again or rephrase the prompt"))
-	default:
-		slog.Default().Error(op+": assist engine failed", "err", err)
-		return connect.NewError(connect.CodeUnavailable, errors.New("content generation failed — check the LLM provider configuration and try again"))
 	}
+
+	if ce := upstreamErr(op, assistSubject, err); ce != nil {
+		return ce
+	}
+
+	slog.Default().Error(op+": assist engine failed", "err", err)
+	return connect.NewError(connect.CodeUnavailable, errors.New("content generation failed — try again in a moment"))
 }
 
 // GeneratePersona drafts a Persona for one Agent from the GM's short prompt

--- a/internal/rpc/assist_test.go
+++ b/internal/rpc/assist_test.go
@@ -352,10 +352,13 @@ func TestGenerateKnowledge_QuotaIsResourceExhausted(t *testing.T) {
 	}
 }
 
-// TestAssist_UnusableDraftStillWins: an unusable response is matched by
-// errors.Is BEFORE the status classification, so a provider that answers 200
-// with prose keeps its own actionable message.
-func TestAssist_UnusableDraftStillWins(t *testing.T) {
+// TestAssist_UnusableDraftKeepsItsRephraseAdvice pins the one message on this
+// surface that the quota split must NOT touch: a 200 carrying prose instead of a
+// draft is the model's fault, not the account's, and "rephrase the prompt" is
+// still the only useful thing to say. It pins wording, not ordering — an
+// ErrUnusableResponse carries no HTTP status, so no reordering against the status
+// classification could reach it.
+func TestAssist_UnusableDraftKeepsItsRephraseAdvice(t *testing.T) {
 	t.Parallel()
 	client, req := personaErrClient(t, assist.ErrUnusableResponse)
 

--- a/internal/rpc/assist_test.go
+++ b/internal/rpc/assist_test.go
@@ -3,6 +3,7 @@ package rpc_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
 )
 
 // fakeAssistStore fakes the campaign-assist store slice (#479): agents backs
@@ -230,6 +232,139 @@ func TestGeneratePersona_EngineErrors(t *testing.T) {
 	down := &fakeAssistEngine{personaErr: errors.New("connection refused")}
 	if _, err := assistClient(t, store, down).GeneratePersona(context.Background(), req()); connect.CodeOf(err) != connect.CodeUnavailable {
 		t.Errorf("provider down: code = %v, want Unavailable", connect.CodeOf(err))
+	}
+}
+
+// personaErrClient is the assist fixture every upstream-status test needs: a
+// wired campaign and agent, plus a client whose engine fails with err.
+func personaErrClient(t *testing.T, err error) (managementv1connect.CampaignServiceClient, *connect.Request[managementv1.GeneratePersonaRequest]) {
+	t.Helper()
+	store := newFakeAssistStore()
+	campID := uuid.New()
+	store.campaign = storage.Campaign{ID: campID}
+	agentID := uuid.New()
+	store.agents[agentID] = storage.Agent{ID: agentID, CampaignID: campID, Role: storage.AgentRoleCharacter}
+	client := assistClient(t, store, &fakeAssistEngine{personaErr: err})
+	return client, connect.NewRequest(&managementv1.GeneratePersonaRequest{AgentId: agentID.String(), Prompt: "ok"})
+}
+
+// TestAssist_QuotaIsResourceExhausted: the same defect the Maps surface had. An
+// LLM account with a VALID key that has run out of quota answers 429, and
+// "check the LLM provider configuration" sends the GM to the one thing that is
+// not wrong.
+//
+// The injected error is *providererr.HTTPError because that is what this path
+// really produces (the adapters return it on a non-2xx start call, ADR-0044;
+// llmcall wraps it with %w and the assist engine returns it unwrapped).
+func TestAssist_QuotaIsResourceExhausted(t *testing.T) {
+	t.Parallel()
+	client, req := personaErrClient(t, &providererr.HTTPError{
+		Op: "anthropic.Complete", StatusCode: http.StatusTooManyRequests,
+		Status: "429 Too Many Requests", Body: `{"type":"error","error":{"type":"rate_limit_error"}}`,
+	})
+
+	_, err := client.GeneratePersona(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Errorf("code = %v, want ResourceExhausted", got)
+	}
+	if strings.Contains(err.Error(), "configuration") {
+		t.Errorf("a quota failure still blames the configuration: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "quota") {
+		t.Errorf("the message does not name what is actually wrong: %q", err.Error())
+	}
+}
+
+// TestAssist_AuthFailureKeepsTheConfigurationAdvice: the sentence is correct for
+// a rejected key, so it survives verbatim — code included.
+func TestAssist_AuthFailureKeepsTheConfigurationAdvice(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		client, req := personaErrClient(t, &providererr.HTTPError{
+			Op: "anthropic.Complete", StatusCode: status,
+			Status: "unauthorized", Body: `{"error":{"message":"invalid x-api-key"}}`,
+		})
+
+		_, err := client.GeneratePersona(context.Background(), req)
+		if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+			t.Errorf("HTTP %d: code = %v, want Unavailable", status, got)
+		}
+		if want := "content generation failed — check the LLM provider configuration and try again"; !strings.Contains(err.Error(), want) {
+			t.Errorf("HTTP %d: message = %q, want it to contain %q", status, err.Error(), want)
+		}
+	}
+}
+
+// TestAssist_ProviderFaultAndUnknownGuessNothing: a 5xx is the provider's
+// problem and a transport failure is nobody's known problem. Neither is a
+// reason to send the GM to Configuration.
+func TestAssist_ProviderFaultAndUnknownGuessNothing(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string // a fragment the message must contain
+	}{
+		{
+			"provider 503",
+			&providererr.HTTPError{Op: "anthropic.Complete", StatusCode: http.StatusServiceUnavailable, Status: "503", Body: "overloaded"},
+			"LLM provider is having trouble",
+		},
+		{"transport failure", errors.New("dial tcp: i/o timeout"), "try again in a moment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, req := personaErrClient(t, tc.err)
+
+			_, err := client.GeneratePersona(context.Background(), req)
+			if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+				t.Errorf("code = %v, want Unavailable", got)
+			}
+			if strings.Contains(err.Error(), "configuration") {
+				t.Errorf("still blames the configuration: %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("message = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestGenerateKnowledge_QuotaIsResourceExhausted: the second handler on this
+// mapper. Both must classify, or the surface is only half fixed.
+func TestGenerateKnowledge_QuotaIsResourceExhausted(t *testing.T) {
+	t.Parallel()
+	store := newFakeAssistStore()
+	store.campaign = storage.Campaign{ID: uuid.New()}
+	eng := &fakeAssistEngine{draftErr: &providererr.HTTPError{
+		Op: "openaicompat.Complete", StatusCode: http.StatusTooManyRequests,
+		Status: "429 Too Many Requests", Body: `{"error":{"message":"rate limit exceeded"}}`,
+	}}
+
+	_, err := assistClient(t, store, eng).GenerateKnowledge(context.Background(),
+		connect.NewRequest(&managementv1.GenerateKnowledgeRequest{Prompt: "the thieves' guild"}))
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Errorf("code = %v, want ResourceExhausted", got)
+	}
+	if strings.Contains(err.Error(), "configuration") {
+		t.Errorf("a quota failure still blames the configuration: %q", err.Error())
+	}
+}
+
+// TestAssist_UnusableDraftStillWins: an unusable response is matched by
+// errors.Is BEFORE the status classification, so a provider that answers 200
+// with prose keeps its own actionable message.
+func TestAssist_UnusableDraftStillWins(t *testing.T) {
+	t.Parallel()
+	client, req := personaErrClient(t, assist.ErrUnusableResponse)
+
+	_, err := client.GeneratePersona(context.Background(), req)
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("code = %v, want Unavailable", got)
+	}
+	if !strings.Contains(err.Error(), "unusable draft") {
+		t.Errorf("message = %q, want the rephrase advice", err.Error())
 	}
 }
 

--- a/internal/rpc/campaign_map_generate.go
+++ b/internal/rpc/campaign_map_generate.go
@@ -3,7 +3,9 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -14,6 +16,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/mapgen"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
 )
 
 // Generated maps (#541, ADR-0060): the draft-review half of the Maps surface.
@@ -83,7 +86,7 @@ func (s *campaignMaps) GenerateMapImage(
 
 	res, err := s.gen.Generate(ctx, c, mapgen.Input{Prompt: prompt, AnchorNodeID: anchor})
 	if err != nil {
-		return nil, mapGenerateErr("GenerateMapImage", err)
+		return nil, mapGenerateErr("GenerateMapImage", "map generation", err)
 	}
 	return connect.NewResponse(&managementv1.GenerateMapImageResponse{
 		ImageBytes:  res.Data,
@@ -93,7 +96,39 @@ func (s *campaignMaps) GenerateMapImage(
 	}), nil
 }
 
-// mapGenerateErr maps a generation failure onto its Connect code.
+// upstreamRejection is a non-2xx from whichever provider this handler called,
+// reduced to the two things a GM-facing message needs: the status, and which
+// provider produced it.
+//
+// Both seams feeding mapGenerateErr already carry the status as DATA, and they
+// carry it in two different types because they are two different seams: the
+// image path returns [imagegen.StatusError], the pin-suggestion path runs on the
+// text provider and returns [providererr.HTTPError] (ADR-0044). Reading both here
+// is what keeps the classification honest on BOTH paths — a branch that only ever
+// matched the image type would be dead on the suggestion path while its unit test,
+// which injects an image error through a fake, passed happily.
+type upstreamRejection struct {
+	// provider is the GM-facing noun, matching the vocabulary the Configuration
+	// screen and the assist handler already use: "image" or "LLM".
+	provider string
+	status   int
+}
+
+func classifyUpstream(err error) (upstreamRejection, bool) {
+	var ie *imagegen.StatusError
+	if errors.As(err, &ie) {
+		return upstreamRejection{provider: "image", status: ie.StatusCode}, true
+	}
+	var pe *providererr.HTTPError
+	if errors.As(err, &pe) {
+		return upstreamRejection{provider: "LLM", status: pe.StatusCode}, true
+	}
+	return upstreamRejection{}, false
+}
+
+// mapGenerateErr maps a generation or suggestion failure onto its Connect code.
+// subject names what the GM asked for ("map generation", "pin suggestions") so a
+// shared mapper cannot report one as the other.
 //
 // ErrImageTooLarge is InvalidArgument, matching what putImage already returns for
 // an oversize UPLOAD — one failure, one code, one sentence, whichever door the
@@ -106,7 +141,7 @@ func (s *campaignMaps) GenerateMapImage(
 // valid key, and the real fix is billing or waiting. Each branch now names the
 // thing the GM can actually act on, and the unknown default names nothing rather
 // than guessing "configuration" — that guess is wrong far more often than right.
-func mapGenerateErr(op string, err error) *connect.Error {
+func mapGenerateErr(op, subject string, err error) *connect.Error {
 	switch {
 	case errors.Is(err, mapgen.ErrNotConfigured):
 		return connect.NewError(connect.CodeFailedPrecondition,
@@ -119,28 +154,33 @@ func mapGenerateErr(op string, err error) *connect.Error {
 	case errors.Is(err, storage.ErrNotFound):
 		return connect.NewError(connect.CodeNotFound,
 			errors.New("that entry is not in this campaign, or it is GM private"))
-	case imagegen.IsQuotaExceeded(err):
-		// ResourceExhausted, the same code a spend cap returns (session.go): the
-		// request was well-formed, the credential was accepted, and the account has
-		// no allowance left. Warn rather than Error — it is an expected operating
-		// condition of a metered key, not a defect.
-		slog.Default().Warn(op+": image provider quota or rate limit hit", "err", err)
-		return connect.NewError(connect.CodeResourceExhausted,
-			errors.New("your image provider is out of quota or rate-limited — check your plan, or try again shortly"))
-	case imagegen.IsAuthFailure(err):
-		// The one case the original sentence was written for, kept verbatim.
-		slog.Default().Error(op+": image provider rejected the key", "err", err)
-		return connect.NewError(connect.CodeUnavailable,
-			errors.New("map generation failed — check the image provider configuration and try again"))
-	case imagegen.IsProviderFault(err):
-		slog.Default().Error(op+": image provider server error", "err", err)
-		return connect.NewError(connect.CodeUnavailable,
-			errors.New("the image provider is having trouble right now — try again shortly"))
-	default:
-		slog.Default().Error(op+": map generation failed", "err", err)
-		return connect.NewError(connect.CodeUnavailable,
-			errors.New("map generation failed — try again in a moment"))
 	}
+
+	if up, ok := classifyUpstream(err); ok {
+		switch {
+		case up.status == http.StatusTooManyRequests:
+			// ResourceExhausted, the same code a spend cap returns (session.go): the
+			// request was well-formed, the credential was ACCEPTED, and the account has
+			// no allowance left. Warn rather than Error — an expected operating
+			// condition of a metered key, not a defect.
+			slog.Default().Warn(op+": provider quota or rate limit hit", "provider", up.provider, "err", err)
+			return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
+				"your %s provider is out of quota or rate-limited — check your plan, or try again shortly", up.provider))
+		case up.status == http.StatusUnauthorized || up.status == http.StatusForbidden:
+			// The one case the original sentence was written for, kept verbatim for
+			// the image path it was written on.
+			slog.Default().Error(op+": provider rejected the key", "provider", up.provider, "err", err)
+			return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+				"%s failed — check the %s provider configuration and try again", subject, up.provider))
+		case up.status >= 500:
+			slog.Default().Error(op+": provider server error", "provider", up.provider, "status", up.status, "err", err)
+			return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+				"the %s provider is having trouble right now — try again shortly", up.provider))
+		}
+	}
+
+	slog.Default().Error(op+": "+subject+" failed", "err", err)
+	return connect.NewError(connect.CodeUnavailable, fmt.Errorf("%s failed — try again in a moment", subject))
 }
 
 // SuggestMapPins asks which of the campaign's existing entries belong on a Map.
@@ -201,7 +241,7 @@ func (s *campaignMaps) SuggestMapPins(
 
 	picked, err := s.suggest.SuggestPins(ctx, c, m.AnchorNodeID.UUID, candidates)
 	if err != nil {
-		return nil, mapGenerateErr("SuggestMapPins", err)
+		return nil, mapGenerateErr("SuggestMapPins", "pin suggestions", err)
 	}
 
 	byID := make(map[uuid.UUID]storage.KGNode, len(candidates))

--- a/internal/rpc/campaign_map_generate.go
+++ b/internal/rpc/campaign_map_generate.go
@@ -99,6 +99,13 @@ func (s *campaignMaps) GenerateMapImage(
 // an oversize UPLOAD — one failure, one code, one sentence, whichever door the
 // bytes came through. It is emphatically NOT Unavailable: Unavailable invites a
 // retry, and retrying re-bills the identical oversize generation.
+//
+// The upstream-status branches exist because collapsing every provider failure
+// into "check the image provider configuration" told the GM to fix the one thing
+// that was NOT broken: an exhausted Gemini quota returns 429 with a perfectly
+// valid key, and the real fix is billing or waiting. Each branch now names the
+// thing the GM can actually act on, and the unknown default names nothing rather
+// than guessing "configuration" — that guess is wrong far more often than right.
 func mapGenerateErr(op string, err error) *connect.Error {
 	switch {
 	case errors.Is(err, mapgen.ErrNotConfigured):
@@ -112,10 +119,27 @@ func mapGenerateErr(op string, err error) *connect.Error {
 	case errors.Is(err, storage.ErrNotFound):
 		return connect.NewError(connect.CodeNotFound,
 			errors.New("that entry is not in this campaign, or it is GM private"))
+	case imagegen.IsQuotaExceeded(err):
+		// ResourceExhausted, the same code a spend cap returns (session.go): the
+		// request was well-formed, the credential was accepted, and the account has
+		// no allowance left. Warn rather than Error — it is an expected operating
+		// condition of a metered key, not a defect.
+		slog.Default().Warn(op+": image provider quota or rate limit hit", "err", err)
+		return connect.NewError(connect.CodeResourceExhausted,
+			errors.New("your image provider is out of quota or rate-limited — check your plan, or try again shortly"))
+	case imagegen.IsAuthFailure(err):
+		// The one case the original sentence was written for, kept verbatim.
+		slog.Default().Error(op+": image provider rejected the key", "err", err)
+		return connect.NewError(connect.CodeUnavailable,
+			errors.New("map generation failed — check the image provider configuration and try again"))
+	case imagegen.IsProviderFault(err):
+		slog.Default().Error(op+": image provider server error", "err", err)
+		return connect.NewError(connect.CodeUnavailable,
+			errors.New("the image provider is having trouble right now — try again shortly"))
 	default:
 		slog.Default().Error(op+": map generation failed", "err", err)
 		return connect.NewError(connect.CodeUnavailable,
-			errors.New("map generation failed — check the image provider configuration and try again"))
+			errors.New("map generation failed — try again in a moment"))
 	}
 }
 

--- a/internal/rpc/campaign_map_generate.go
+++ b/internal/rpc/campaign_map_generate.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -16,7 +15,6 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/llmbuild"
 	"github.com/MrWong99/Glyphoxa/internal/mapgen"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
-	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
 )
 
 // Generated maps (#541, ADR-0060): the draft-review half of the Maps surface.
@@ -96,51 +94,20 @@ func (s *campaignMaps) GenerateMapImage(
 	}), nil
 }
 
-// upstreamRejection is a non-2xx from whichever provider this handler called,
-// reduced to the two things a GM-facing message needs: the status, and which
-// provider produced it.
-//
-// Both seams feeding mapGenerateErr already carry the status as DATA, and they
-// carry it in two different types because they are two different seams: the
-// image path returns [imagegen.StatusError], the pin-suggestion path runs on the
-// text provider and returns [providererr.HTTPError] (ADR-0044). Reading both here
-// is what keeps the classification honest on BOTH paths — a branch that only ever
-// matched the image type would be dead on the suggestion path while its unit test,
-// which injects an image error through a fake, passed happily.
-type upstreamRejection struct {
-	// provider is the GM-facing noun, matching the vocabulary the Configuration
-	// screen and the assist handler already use: "image" or "LLM".
-	provider string
-	status   int
-}
-
-func classifyUpstream(err error) (upstreamRejection, bool) {
-	var ie *imagegen.StatusError
-	if errors.As(err, &ie) {
-		return upstreamRejection{provider: "image", status: ie.StatusCode}, true
-	}
-	var pe *providererr.HTTPError
-	if errors.As(err, &pe) {
-		return upstreamRejection{provider: "LLM", status: pe.StatusCode}, true
-	}
-	return upstreamRejection{}, false
-}
-
 // mapGenerateErr maps a generation or suggestion failure onto its Connect code.
 // subject names what the GM asked for ("map generation", "pin suggestions") so a
-// shared mapper cannot report one as the other.
+// mapper shared by both handlers cannot report one as the other — and the two
+// handlers do not even share a provider: generation calls the image seam, pin
+// suggestion calls the text one.
 //
 // ErrImageTooLarge is InvalidArgument, matching what putImage already returns for
 // an oversize UPLOAD — one failure, one code, one sentence, whichever door the
 // bytes came through. It is emphatically NOT Unavailable: Unavailable invites a
 // retry, and retrying re-bills the identical oversize generation.
 //
-// The upstream-status branches exist because collapsing every provider failure
-// into "check the image provider configuration" told the GM to fix the one thing
-// that was NOT broken: an exhausted Gemini quota returns 429 with a perfectly
-// valid key, and the real fix is billing or waiting. Each branch now names the
-// thing the GM can actually act on, and the unknown default names nothing rather
-// than guessing "configuration" — that guess is wrong far more often than right.
+// Upstream rejections are classified in upstream_error.go, shared with the assist
+// surface: an exhausted quota is not a misconfiguration, and the default here
+// names no cause at all rather than guessing "configuration".
 func mapGenerateErr(op, subject string, err error) *connect.Error {
 	switch {
 	case errors.Is(err, mapgen.ErrNotConfigured):
@@ -156,27 +123,8 @@ func mapGenerateErr(op, subject string, err error) *connect.Error {
 			errors.New("that entry is not in this campaign, or it is GM private"))
 	}
 
-	if up, ok := classifyUpstream(err); ok {
-		switch {
-		case up.status == http.StatusTooManyRequests:
-			// ResourceExhausted, the same code a spend cap returns (session.go): the
-			// request was well-formed, the credential was ACCEPTED, and the account has
-			// no allowance left. Warn rather than Error — an expected operating
-			// condition of a metered key, not a defect.
-			slog.Default().Warn(op+": provider quota or rate limit hit", "provider", up.provider, "err", err)
-			return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
-				"your %s provider is out of quota or rate-limited — check your plan, or try again shortly", up.provider))
-		case up.status == http.StatusUnauthorized || up.status == http.StatusForbidden:
-			// The one case the original sentence was written for, kept verbatim for
-			// the image path it was written on.
-			slog.Default().Error(op+": provider rejected the key", "provider", up.provider, "err", err)
-			return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
-				"%s failed — check the %s provider configuration and try again", subject, up.provider))
-		case up.status >= 500:
-			slog.Default().Error(op+": provider server error", "provider", up.provider, "status", up.status, "err", err)
-			return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
-				"the %s provider is having trouble right now — try again shortly", up.provider))
-		}
+	if ce := upstreamErr(op, subject, err); ce != nil {
+		return ce
 	}
 
 	slog.Default().Error(op+": "+subject+" failed", "err", err)

--- a/internal/rpc/campaign_map_test.go
+++ b/internal/rpc/campaign_map_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/mapgen"
 	"github.com/MrWong99/Glyphoxa/internal/rpc"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
 )
 
 // The Maps and Pins handlers (#538, ADR-0060). The storage layer is covered
@@ -705,6 +706,13 @@ func TestGenerateMapImage_UnknownFailureGuessesNothing(t *testing.T) {
 
 // TestSuggestMapPins_QuotaIsResourceExhausted: the pin suggester shares
 // mapGenerateErr, so it must not regress to the configuration sentence either.
+//
+// The injected error is a *providererr.HTTPError and NOT an imagegen.StatusError,
+// because that is what this path actually produces: suggestions run on the TEXT
+// provider (mapgen/suggest.go → assist.CallText → the LLM adapters, ADR-0044), and
+// a test that faked an image error here would certify a branch that is dead in
+// production — the "one sentinel across a shared seam" trap this repo has already
+// paid for once (see mapgen.ErrNotConfigured's comment).
 func TestSuggestMapPins_QuotaIsResourceExhausted(t *testing.T) {
 	t.Parallel()
 	store := newFakeMapStore()
@@ -712,13 +720,75 @@ func TestSuggestMapPins_QuotaIsResourceExhausted(t *testing.T) {
 	anchor := uuid.New()
 	store.maps[mapID] = storage.CampaignMap{ID: mapID, Name: "Saltmarsh", AnchorNodeID: uuid.NullUUID{UUID: anchor, Valid: true}}
 	store.unpinned = []storage.KGNode{{ID: uuid.New(), Name: "The Snapping Line", Type: storage.KGNodeLocation}}
-	gen := &fakeMapGen{pickErr: &imagegen.StatusError{StatusCode: http.StatusTooManyRequests, Body: "quota"}}
+	gen := &fakeMapGen{pickErr: &providererr.HTTPError{
+		Op: "anthropic.Complete", StatusCode: http.StatusTooManyRequests,
+		Status: "429 Too Many Requests", Body: `{"type":"error","error":{"type":"rate_limit_error"}}`,
+	}}
 	client := genClient(t, store, gen)
 
 	_, err := client.SuggestMapPins(context.Background(),
 		connect.NewRequest(&managementv1.SuggestMapPinsRequest{MapId: mapID.String()}))
 	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
 		t.Errorf("code = %v, want ResourceExhausted", got)
+	}
+	// The rate-limited provider is the LLM one, and blaming the image provider —
+	// which was never called — sends the GM to the wrong half of Configuration.
+	if !strings.Contains(err.Error(), "LLM provider") {
+		t.Errorf("the wrong provider is named: %q", err.Error())
+	}
+}
+
+// TestSuggestMapPins_FailureIsNotReportedAsMapGeneration: one mapper, two ops. A
+// failed pin suggestion that announces itself as a failed map generation sends
+// the GM looking at a map that is fine.
+func TestSuggestMapPins_FailureIsNotReportedAsMapGeneration(t *testing.T) {
+	t.Parallel()
+	store := newFakeMapStore()
+	mapID := uuid.New()
+	anchor := uuid.New()
+	store.maps[mapID] = storage.CampaignMap{ID: mapID, Name: "Saltmarsh", AnchorNodeID: uuid.NullUUID{UUID: anchor, Valid: true}}
+	store.unpinned = []storage.KGNode{{ID: uuid.New(), Name: "The Snapping Line", Type: storage.KGNodeLocation}}
+	gen := &fakeMapGen{pickErr: errors.New("dial tcp: i/o timeout")}
+	client := genClient(t, store, gen)
+
+	_, err := client.SuggestMapPins(context.Background(),
+		connect.NewRequest(&managementv1.SuggestMapPinsRequest{MapId: mapID.String()}))
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if strings.Contains(err.Error(), "map generation") {
+		t.Errorf("a pin-suggestion failure reports itself as map generation: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "pin suggestions") {
+		t.Errorf("the message does not name what failed: %q", err.Error())
+	}
+}
+
+// TestSuggestMapPins_AuthFailureNamesTheLLMKey: the same split on the credential
+// side — a rejected LLM key must not send the GM to the image provider's key.
+func TestSuggestMapPins_AuthFailureNamesTheLLMKey(t *testing.T) {
+	t.Parallel()
+	store := newFakeMapStore()
+	mapID := uuid.New()
+	anchor := uuid.New()
+	store.maps[mapID] = storage.CampaignMap{ID: mapID, Name: "Saltmarsh", AnchorNodeID: uuid.NullUUID{UUID: anchor, Valid: true}}
+	store.unpinned = []storage.KGNode{{ID: uuid.New(), Name: "The Snapping Line", Type: storage.KGNodeLocation}}
+	gen := &fakeMapGen{pickErr: &providererr.HTTPError{
+		Op: "anthropic.Complete", StatusCode: http.StatusUnauthorized,
+		Status: "401 Unauthorized", Body: `{"error":{"message":"invalid x-api-key"}}`,
+	}}
+	client := genClient(t, store, gen)
+
+	_, err := client.SuggestMapPins(context.Background(),
+		connect.NewRequest(&managementv1.SuggestMapPinsRequest{MapId: mapID.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("code = %v, want Unavailable", got)
+	}
+	if !strings.Contains(err.Error(), "LLM provider configuration") {
+		t.Errorf("a rejected LLM key should point at the LLM configuration: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "image provider") {
+		t.Errorf("a rejected LLM key blames the image provider: %q", err.Error())
 	}
 }
 

--- a/internal/rpc/campaign_map_test.go
+++ b/internal/rpc/campaign_map_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -620,6 +621,104 @@ func TestGenerateMapImage_TooLargeIsInvalidArgument(t *testing.T) {
 		connect.NewRequest(&managementv1.GenerateMapImageRequest{Prompt: "an entire continent"}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
 		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+// TestGenerateMapImage_QuotaIsResourceExhausted is the reported bug: a Gemini key
+// that is VALID but out of quota came back as "check the image provider
+// configuration", sending the GM to fix the one thing that was not broken. The
+// key was accepted; the fix is billing or waiting.
+func TestGenerateMapImage_QuotaIsResourceExhausted(t *testing.T) {
+	t.Parallel()
+	gen := &fakeMapGen{err: &imagegen.StatusError{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       `{"error":{"code":429,"message":"You exceeded your current quota"}}`,
+	}}
+	client := genClient(t, newFakeMapStore(), gen)
+
+	_, err := client.GenerateMapImage(context.Background(),
+		connect.NewRequest(&managementv1.GenerateMapImageRequest{Prompt: "a town"}))
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Errorf("code = %v, want ResourceExhausted", got)
+	}
+	if strings.Contains(err.Error(), "configuration") {
+		t.Errorf("a quota failure still blames the configuration: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "quota") {
+		t.Errorf("the message does not name what is actually wrong: %q", err.Error())
+	}
+}
+
+// TestGenerateMapImage_AuthFailureIsUnavailable is the other half: a REJECTED key
+// is the one case where "check the image provider configuration" is true advice,
+// so that wording (and its code) must survive the quota split.
+func TestGenerateMapImage_AuthFailureIsUnavailable(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		gen := &fakeMapGen{err: &imagegen.StatusError{StatusCode: status, Body: `{"error":{"message":"API key not valid"}}`}}
+		client := genClient(t, newFakeMapStore(), gen)
+
+		_, err := client.GenerateMapImage(context.Background(),
+			connect.NewRequest(&managementv1.GenerateMapImageRequest{Prompt: "a town"}))
+		if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+			t.Errorf("HTTP %d: code = %v, want Unavailable", status, got)
+		}
+		if !strings.Contains(err.Error(), "image provider configuration") {
+			t.Errorf("HTTP %d: a rejected key should point at the configuration: %q", status, err.Error())
+		}
+	}
+}
+
+// TestGenerateMapImage_ProviderFaultBlamesTheProvider: a 5xx is neither the key
+// nor the quota, and telling the GM to check either is a wild goose chase.
+func TestGenerateMapImage_ProviderFaultBlamesTheProvider(t *testing.T) {
+	t.Parallel()
+	gen := &fakeMapGen{err: &imagegen.StatusError{StatusCode: http.StatusBadGateway, Body: "upstream connect error"}}
+	client := genClient(t, newFakeMapStore(), gen)
+
+	_, err := client.GenerateMapImage(context.Background(),
+		connect.NewRequest(&managementv1.GenerateMapImageRequest{Prompt: "a town"}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("code = %v, want Unavailable", got)
+	}
+	if strings.Contains(err.Error(), "configuration") {
+		t.Errorf("a provider-side 502 still blames the configuration: %q", err.Error())
+	}
+}
+
+// TestGenerateMapImage_UnknownFailureGuessesNothing: an error with no upstream
+// status (a transport failure, a decode error) must not fabricate a cause.
+func TestGenerateMapImage_UnknownFailureGuessesNothing(t *testing.T) {
+	t.Parallel()
+	gen := &fakeMapGen{err: errors.New("dial tcp: i/o timeout")}
+	client := genClient(t, newFakeMapStore(), gen)
+
+	_, err := client.GenerateMapImage(context.Background(),
+		connect.NewRequest(&managementv1.GenerateMapImageRequest{Prompt: "a town"}))
+	if got := connect.CodeOf(err); got != connect.CodeUnavailable {
+		t.Errorf("code = %v, want Unavailable", got)
+	}
+	if strings.Contains(err.Error(), "configuration") {
+		t.Errorf("an unknown failure still blames the configuration: %q", err.Error())
+	}
+}
+
+// TestSuggestMapPins_QuotaIsResourceExhausted: the pin suggester shares
+// mapGenerateErr, so it must not regress to the configuration sentence either.
+func TestSuggestMapPins_QuotaIsResourceExhausted(t *testing.T) {
+	t.Parallel()
+	store := newFakeMapStore()
+	mapID := uuid.New()
+	anchor := uuid.New()
+	store.maps[mapID] = storage.CampaignMap{ID: mapID, Name: "Saltmarsh", AnchorNodeID: uuid.NullUUID{UUID: anchor, Valid: true}}
+	store.unpinned = []storage.KGNode{{ID: uuid.New(), Name: "The Snapping Line", Type: storage.KGNodeLocation}}
+	gen := &fakeMapGen{pickErr: &imagegen.StatusError{StatusCode: http.StatusTooManyRequests, Body: "quota"}}
+	client := genClient(t, store, gen)
+
+	_, err := client.SuggestMapPins(context.Background(),
+		connect.NewRequest(&managementv1.SuggestMapPinsRequest{MapId: mapID.String()}))
+	if got := connect.CodeOf(err); got != connect.CodeResourceExhausted {
+		t.Errorf("code = %v, want ResourceExhausted", got)
 	}
 }
 

--- a/internal/rpc/upstream_error.go
+++ b/internal/rpc/upstream_error.go
@@ -1,0 +1,94 @@
+package rpc
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+
+	"github.com/MrWong99/Glyphoxa/internal/imagegen"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
+)
+
+// Upstream provider failures, told apart.
+//
+// Every GM-facing feature that spends a provider's quota used to answer ALL of
+// its failures with one sentence, and every one of those sentences ended in
+// "check the provider configuration". That is true for exactly one failure —
+// a rejected key — and the one that actually happens in production is the other
+// one: an exhausted quota returns HTTP 429 with a key that was ACCEPTED, so the
+// GM is sent to re-check a correct setting while the real fix is billing, a
+// plan change, or ten minutes.
+//
+// Both provider seams already carry the status as DATA, in two types because
+// they are two seams: the image path returns [imagegen.StatusError], the text
+// path returns [providererr.HTTPError] (ADR-0044). Reading both HERE, once, is
+// what stops a surface from classifying the seam it happens to have been
+// written against and silently collapsing the other — the failure mode that
+// makes a branch dead in production while its unit test, which injects the
+// other type through a fake, passes happily.
+
+// upstreamRejection is a non-2xx from whichever provider a handler called,
+// reduced to what a GM-facing message needs: the status, and who refused.
+type upstreamRejection struct {
+	// provider is the GM-facing noun, matching the vocabulary the Configuration
+	// screen already uses: "image" or "LLM".
+	provider string
+	status   int
+}
+
+// classifyUpstream reports the upstream rejection err carries, if any. It reads
+// through wrapping (errors.As), which is required: the enrichment job, llmcall
+// and the assist engine all wrap on the way up.
+func classifyUpstream(err error) (upstreamRejection, bool) {
+	var ie *imagegen.StatusError
+	if errors.As(err, &ie) {
+		return upstreamRejection{provider: "image", status: ie.StatusCode}, true
+	}
+	var pe *providererr.HTTPError
+	if errors.As(err, &pe) {
+		return upstreamRejection{provider: "LLM", status: pe.StatusCode}, true
+	}
+	return upstreamRejection{}, false
+}
+
+// upstreamErr renders a classified upstream rejection as the error the GM sees,
+// or nil when err is not one (the caller keeps its own default — an unclassified
+// failure must not be given a fabricated cause).
+//
+// op is the log key; subject names what the GM asked for ("map generation",
+// "content generation") so a mapper shared by several handlers cannot report one
+// as another.
+func upstreamErr(op, subject string, err error) *connect.Error {
+	up, ok := classifyUpstream(err)
+	if !ok {
+		return nil
+	}
+	switch {
+	case up.status == http.StatusTooManyRequests:
+		// ResourceExhausted, the same code a spend cap returns (session.go): the
+		// request was well-formed, the credential was ACCEPTED, and the account has
+		// no allowance left. Warn rather than Error — an expected operating
+		// condition of a metered key, not a defect.
+		slog.Default().Warn(op+": provider quota or rate limit hit", "provider", up.provider, "err", err)
+		return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf(
+			"your %s provider is out of quota or rate-limited — check your plan, or try again shortly", up.provider))
+	case up.status == http.StatusUnauthorized || up.status == http.StatusForbidden:
+		// The one case the original sentence was written for. Both surfaces keep
+		// their exact wording here, because here it is true.
+		slog.Default().Error(op+": provider rejected the key", "provider", up.provider, "err", err)
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+			"%s failed — check the %s provider configuration and try again", subject, up.provider))
+	case up.status >= 500:
+		slog.Default().Error(op+": provider server error", "provider", up.provider, "status", up.status, "err", err)
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf(
+			"the %s provider is having trouble right now — try again shortly", up.provider))
+	}
+	// A classified status nobody has a better answer for (a 400: a malformed
+	// request, a safety refusal, or Gemini's billing-not-enabled precondition,
+	// indistinguishable without parsing the body). The caller's default owns it —
+	// guessing a cause is what this file exists to stop.
+	return nil
+}


### PR DESCRIPTION
## What does this PR do?

Stops the AI surfaces from reporting every provider failure as a misconfiguration.

`internal/imagegen` now returns a typed `*StatusError{StatusCode, Body}` on a non-2xx instead of a `fmt.Errorf`, the text seam already had `*providererr.HTTPError` (ADR-0044), and one new file — `internal/rpc/upstream_error.go` — classifies both for every handler that spends a provider's quota:

| upstream | before | after |
|---|---|---|
| 429 quota / rate limit | `[unavailable] … — check the … provider configuration and try again` | `[resource_exhausted] your image/LLM provider is out of quota or rate-limited — check your plan, or try again shortly` |
| 401/403 rejected key | same sentence | same sentence, byte-identical — this is the case it was written for |
| 5xx | same sentence | `the image/LLM provider is having trouble right now — try again shortly` |
| anything else | same sentence | `… failed — try again in a moment` — no guess |

Three surfaces were collapsing this way and all three are fixed: **map generation** (`*imagegen.StatusError`), **pin suggestions** and **persona / knowledge drafting** (`*providererr.HTTPError`). `StatusError.Error()` is byte-identical to the string it replaces, so logs and dead-letter payloads read exactly as before.

Three things fell out of review and are worth calling out because they are not in the one-line summary:

- **A shared mapper is where these bugs come from, so the classification is shared exactly once.** `mapGenerateErr` and `assistEngineErr` both delegate to `upstreamErr`; each passes a *subject* (`map generation`, `pin suggestions`, `content generation`) so one shared sentence cannot mislabel another handler's failure — which it previously did, reporting a failed pin suggestion as a failed map generation.
- **`SuggestMapPins` shares the Maps mapper but not the Maps seam.** Its failures come from the *text* provider, never `*imagegen.StatusError`. Classifying only the image type would have left that path collapsing exactly as before while a unit test faking an image error through the engine seam passed — the [`one sentinel across a shared seam`](internal/mapgen/mapgen.go) trap this repo has already paid for once.
- **The enrichment job keeps dead-lettering a rejected key.** The tidy-looking "401 is permanent, log it and return nil" was tried and reverted: returning nil completes the job `done`, and `ListPromotedHighlightsNeedingEnrichment` counts `done` as satisfied while treating `dead` as absent. The dead-letter *is* the recovery hook that lets the boot sweep re-enrich once the key is fixed, so that branch would have stranded every Highlight promoted during a bad-key window. All provider failures return the error; only the log line varies by status.

Relates to #541, #479.

## Why is this change needed?

Reproduced against a live Gemini key with an exhausted quota: the server logged `imagegen: HTTP 429: {"error":{"code":429,"message":"You exceeded your current quota..."}}` and the GM was told to check the image provider configuration. The configuration is the one thing that is *not* wrong in that case — the key is valid and was accepted — so the GM re-checks a correct setting while the real fix is billing, quota, or waiting out a rate limit. The assist surface, which a GM hits far more often than map generation, had the identical sentence.

## How was this tested?

`make check`, `make lint` (0 issues) and `go test -race` on the touched packages, all green.

New tests, each verified to FAIL when only the source files are reverted:

- `internal/imagegen` — the status survives as data (`errors.As`), through a `%w` wrap, and the message is unchanged; a status table over 429/401/403/500/400; non-status errors (nil, oversize, not-configured, transport) classify as nothing.
- `internal/rpc` (Maps) — 429 → `ResourceExhausted` and does not say "configuration"; 401/403 → `Unavailable` and *does* say "image provider configuration"; 5xx and unknown failures blame neither; the pin path injects a real `*providererr.HTTPError` and asserts the LLM provider is named and the subject is "pin suggestions", not "map generation".
- `internal/rpc` (assist) — the same four classes over `GeneratePersona`, plus `GenerateKnowledge` so both handlers on the mapper are covered, plus one asserting `ErrUnusableResponse` still wins over the status classification.
- `internal/highlight` — a table over 401/403/429/500 asserting every one still returns an error (the `done`-vs-`dead` property above), the status surviving the wrap, the row untouched, and the claim released.

- [x] `make check` passes
- [x] New/updated tests cover the change
- [x] Manual testing — the original failure was reproduced against a live key before the fix; the mapping itself is covered by tests rather than re-burning quota.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed — no ADR or CONTEXT.md change: this corrects messages, it does not decide anything new
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Known gaps, deliberately not fixed here:

- **Gemini 400s.** "Billing not enabled" and "free tier not available in your region" arrive as HTTP 400 `FAILED_PRECONDITION`, indistinguishable from a malformed request or a safety refusal without parsing the body. They fall through to the caller's default, which now says "try again in a moment" rather than blaming the configuration — unhelpful, but no longer a wrong guess.
- **Platform-key tenants.** A tenant on the deployment's key that hits 429 reads "check your plan"; there is nothing tenant-side to check, it is an operator problem. Pre-existing wording class, still strictly better than what it replaced.
- **Mid-stream failures.** `llmcall` turns a mid-stream `EventError` into a plain `errors.New`, which no classifier can read. Not a live gap for these statuses — both LLM adapters fail a 429/401 at the start call, before the stream — but a mid-stream rate limit would land in the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
