### PR TITLE
fix(web): the 65 token references that rendered, but outside the system

### DIFF
--- a/web/src/components/campaignRowActions.css
+++ b/web/src/components/campaignRowActions.css
@@ -65,8 +65,8 @@
   cursor: default;
 }
 .gx-campaign-row-actions__menu .gx-select__item--danger {
-  color: var(--danger, #e5484d);
+  color: var(--status-danger);
 }
 .gx-campaign-row-actions__menu .gx-select__item--danger:hover:not(:disabled) {
-  background: rgba(229, 72, 77, 0.12);
+  background: var(--status-danger-bg);
 }

--- a/web/src/components/importCampaignButton.css
+++ b/web/src/components/importCampaignButton.css
@@ -24,7 +24,7 @@
 .gx-import-campaign__error {
   display: block;
   margin-top: var(--spacing-sm);
-  color: var(--danger, #e5484d);
+  color: var(--status-danger);
   font-size: 13px;
 }
 

--- a/web/src/screens/campaign/KnowledgePanel.tsx
+++ b/web/src/screens/campaign/KnowledgePanel.tsx
@@ -769,8 +769,12 @@ function KnowledgeCard({
               <EyeOff size={11} /> GM private
             </Badge>
           )}
+          {/* The entry-type badge above is inline-styled because its colour is per-type
+              data; this one is a constant, and the constant it used was #ffcf5a — a
+              yellow that appears nowhere in the palette. `gold` is the variant that
+              already paints exactly this: --gold on a 14% gold wash. */}
           {node.agentId !== "" && (
-            <Badge size="sm" className="gx-kg-card__linked" style={{ color: "#ffcf5a", background: "#ffcf5a24" }}>
+            <Badge variant="gold" size="sm" className="gx-kg-card__linked">
               <LinkIcon size={11} /> Linked agent
             </Badge>
           )}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -179,11 +179,11 @@
 
 .gx-kg-iconbtn:hover {
   color: var(--text-strong);
-  background: var(--surface-2, rgba(255, 255, 255, 0.06));
+  background: var(--surface-card-hover);
 }
 
 .gx-kg-iconbtn--danger:hover {
-  color: var(--danger, #ff4f5e);
+  color: var(--status-danger);
 }
 
 .gx-kg-iconbtn:disabled {
@@ -270,7 +270,7 @@
 }
 
 .gx-kg-editor__title {
-  font-size: var(--heading-sm, var(--body-lg));
+  font-size: var(--body-lg);
   color: var(--text-strong);
   margin: 0;
 }
@@ -302,7 +302,7 @@
 /* A GM-only fact is marked on the row itself, so the one line that never reaches
    the table is obvious while scanning a public entry. */
 .gx-kg-aspect[data-private] {
-  border-left: 2px solid var(--accent, #ffcf5a);
+  border-left: 2px solid var(--gold);
   padding-left: var(--spacing-xs);
 }
 
@@ -650,7 +650,7 @@
 .gx-kg-relations__list {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-2xs, 4px);
+  gap: var(--spacing-xs);
 }
 
 .gx-kg-relations__list--incoming {
@@ -662,12 +662,12 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
-  padding: var(--spacing-2xs, 4px) var(--spacing-xs);
+  padding: var(--spacing-xs);
   border-radius: var(--radius-sm, 8px);
 }
 
 .gx-kg-edge:hover {
-  background: var(--surface-2, rgba(255, 255, 255, 0.04));
+  background: var(--surface-card-hover);
 }
 
 .gx-kg-edge--incoming {
@@ -845,7 +845,7 @@
   background: var(--surface-card);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-popover, 0 8px 24px rgba(0, 0, 0, 0.4));
+  box-shadow: var(--shadow-md);
 }
 
 .gx-playerform__picker-item {
@@ -931,7 +931,7 @@
   gap: 4px;
   padding: var(--spacing-sm);
   border-radius: var(--radius-sm);
-  background: var(--surface-sunken, rgba(127, 127, 127, 0.08));
+  background: var(--surface-inset);
 }
 
 .gx-proposal-card__similar-title {
@@ -983,7 +983,7 @@
   gap: 4px;
   align-self: flex-start;
   padding: 4px 8px;
-  border: 1px solid var(--border, rgba(127, 127, 127, 0.25));
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-subtle);
@@ -992,7 +992,7 @@
 }
 
 .gx-proposal-card__similar-btn:hover {
-  color: var(--text);
+  color: var(--text-default);
 }
 
 /* ── Knowledge Graph view (#534) ─────────────────────────────────────────── */
@@ -1029,7 +1029,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px var(--spacing-xs);
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm, 4px);
   background: transparent;
   color: var(--text-muted);
@@ -1063,9 +1063,9 @@
   /* Tall enough to be a map rather than a strip, capped so it never pushes the
      editor rail off-screen. */
   height: clamp(320px, 60vh, 720px);
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md, 8px);
-  background: var(--surface-sunken, #12151c);
+  background: var(--surface-inset);
   touch-action: none;
 }
 
@@ -1080,7 +1080,7 @@
 }
 
 .gx-kg-graph__node:focus-visible circle {
-  outline: 2px solid var(--accent, #ffcf5a);
+  outline: 2px solid var(--rune);
   outline-offset: 2px;
 }
 
@@ -1089,10 +1089,10 @@
 }
 
 .gx-kg-graph__label {
-  fill: var(--text, #d7dae3);
+  fill: var(--text-default);
   font-size: 11px;
   paint-order: stroke;
-  stroke: var(--surface-sunken, #12151c);
+  stroke: var(--surface-inset);
   stroke-width: 3px;
   pointer-events: none;
 }
@@ -1102,9 +1102,9 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md, 8px);
-  background: var(--surface, #171b23);
+  background: var(--surface-card);
 }
 
 .gx-kg-graph__picker-text {
@@ -1135,7 +1135,7 @@
 .gx-kg-lens__truncated,
 .gx-kg-lens__empty {
   font-size: var(--body-sm);
-  color: var(--accent, #ffcf5a);
+  color: var(--status-warning);
   margin: 0;
 }
 
@@ -1161,7 +1161,7 @@
    fewer relations — a different problem, so a different shape. */
 .gx-kg-graph__overflow {
   fill: none;
-  stroke: var(--accent, #ffcf5a);
+  stroke: var(--status-warning);
   stroke-width: 1;
   stroke-dasharray: 1 3;
 }
@@ -1172,7 +1172,7 @@
 }
 
 .gx-kg-graph__node[data-lens="dropped"] .gx-kg-graph__label {
-  fill: var(--accent, #ffcf5a);
+  fill: var(--status-warning);
 }
 
 .gx-kg-graph__node[data-lens="lit"] circle {
@@ -1196,8 +1196,8 @@
   overflow-wrap: anywhere;
   font-family: var(--font-mono);
   font-size: var(--mono-sm);
-  background: var(--surface-sunken, #12151c);
-  border: 1px solid var(--border, #2a2f3a);
+  background: var(--surface-inset);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm, 4px);
 }
 
@@ -1293,7 +1293,7 @@
   gap: var(--spacing-sm);
   flex-wrap: wrap;
   padding: var(--spacing-xs) 0;
-  border-bottom: 1px solid var(--border, #2a2f3a);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .gx-prep__name {
@@ -1320,11 +1320,11 @@
   align-items: center;
   gap: 3px;
   padding: 1px var(--spacing-xs);
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-default);
   border-radius: var(--radius-sm, 4px);
   background: none;
   font-size: var(--body-sm);
-  color: var(--accent, #ffcf5a);
+  color: var(--status-warning);
   cursor: pointer;
 }
 
@@ -1394,9 +1394,9 @@
 .gx-maps__frame {
   position: relative;
   overflow: auto;
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md, 8px);
-  background: var(--surface-sunken, #12151c);
+  background: var(--surface-inset);
   max-height: clamp(320px, 65vh, 820px);
 }
 
@@ -1440,9 +1440,9 @@
 
 .gx-maps__pin-label {
   font-size: var(--body-sm);
-  color: var(--text);
+  color: var(--text-default);
   paint-order: stroke;
-  text-shadow: 0 0 3px var(--surface-sunken, #12151c);
+  text-shadow: 0 0 3px var(--surface-inset);
   pointer-events: none;
 }
 
@@ -1483,7 +1483,7 @@
 
 .gx-maps__hint {
   font-size: var(--body-sm);
-  color: var(--accent, #ffcf5a);
+  color: var(--gold);
 }
 
 .gx-maps__new {
@@ -1491,9 +1491,9 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  border: 1px solid var(--border, #2a2f3a);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md, 8px);
-  background: var(--surface, #171b23);
+  background: var(--surface-card);
   width: 100%;
 }
 
@@ -1556,7 +1556,7 @@
 
 .gx-kg-graph__proposed-node .gx-kg-graph__label {
   font-style: italic;
-  fill: var(--accent, #ffcf5a);
+  fill: var(--gold);
 }
 
 .gx-kg-graph__proposed-node:focus-visible circle,
@@ -1566,7 +1566,7 @@
 }
 
 .gx-kg-graph__proposed-edge line {
-  stroke: var(--accent, #ffcf5a);
+  stroke: var(--gold);
   stroke-width: 1.5;
   stroke-dasharray: 5 4;
   stroke-opacity: 0.8;
@@ -1586,7 +1586,7 @@
 }
 
 .gx-kg-graph__proposed-edge line.gx-kg-graph__proposed-hit:focus-visible {
-  stroke: var(--accent, #ffcf5a);
+  stroke: var(--rune);
   stroke-opacity: 0.35;
 }
 
@@ -1597,7 +1597,7 @@
    on. The ring itself is the review target, widened by a transparent hit ring. */
 .gx-kg-graph__fact-mark circle {
   fill: none;
-  stroke: var(--accent, #ffcf5a);
+  stroke: var(--gold);
   stroke-width: 1.5;
   stroke-dasharray: 3 4;
   cursor: pointer;
@@ -1617,7 +1617,7 @@
 }
 
 .gx-kg-chip--proposals {
-  color: var(--accent, #ffcf5a);
+  color: var(--gold);
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -1628,9 +1628,9 @@
   flex-direction: column;
   gap: var(--spacing-sm);
   padding: var(--spacing-md);
-  border: 1px solid var(--accent, #ffcf5a);
+  border: 1px solid var(--gold);
   border-radius: var(--radius-md, 8px);
-  background: var(--surface, #171b23);
+  background: var(--surface-card);
 }
 
 .gx-kg-graph__unplaced {
@@ -1759,10 +1759,10 @@
    the graph's proposal ghosts use. A preview that looks like a saved map invites
    the GM to assume it is one. */
 .gx-maps__draft {
-  border: 2px dashed var(--accent, #ffcf5a);
+  border: 2px dashed var(--gold);
   border-radius: var(--radius-md, 8px);
   padding: var(--spacing-xs);
-  background: var(--surface-sunken, #12151c);
+  background: var(--surface-inset);
 }
 
 .gx-maps__draft-img {
@@ -1782,7 +1782,7 @@
 /* A suggested entry is MARKED in place, not moved into a second list: the model
    narrows what to look at, and the GM's placing gesture is unchanged. */
 .gx-maps__tray .gx-kg-chip[data-suggested] {
-  box-shadow: 0 0 0 1px var(--accent, #ffcf5a);
+  box-shadow: 0 0 0 1px var(--gold);
 }
 
 /* ── Appearances (#545) ──────────────────────────────────────────────────── */
@@ -1813,14 +1813,14 @@
   border: 0;
   border-radius: var(--radius-sm, 4px);
   background: transparent;
-  color: var(--text);
+  color: var(--text-default);
   font: inherit;
   cursor: pointer;
 }
 
 .gx-kg-appearances__row:hover,
 .gx-kg-appearances__row:focus-visible {
-  background: var(--surface-sunken, #12151c);
+  background: var(--surface-inset);
 }
 
 .gx-kg-appearances__who {
@@ -1830,10 +1830,27 @@
 }
 
 /* The same speaker vocabulary the transcript uses, so a line reads the same in
-   both places. */
-.gx-kg-appearances__who[data-kind="npc"],
+   both places. That means mirroring ALL FOUR kinds .gx-line__who paints, not
+   just the Agent ones: `kind` arrives straight off NodeAppearance as one of
+   gm/player/npc/butler, so a rule that covers only two leaves the other two on
+   the muted base while the transcript gives them their own colour. One shared
+   npc+butler rule also painted every Character NPC in the Butler's gold, which
+   is the one colour on this list that means a specific speaker. The muted base
+   above now only catches a kind we do not recognise. */
+.gx-kg-appearances__who[data-kind="gm"] {
+  color: var(--text-strong);
+}
+
+.gx-kg-appearances__who[data-kind="player"] {
+  color: var(--rune);
+}
+
 .gx-kg-appearances__who[data-kind="butler"] {
-  color: var(--accent, #ffcf5a);
+  color: var(--gold);
+}
+
+.gx-kg-appearances__who[data-kind="npc"] {
+  color: var(--text-default);
 }
 
 .gx-kg-appearances__text {

--- a/web/src/screens/configuration/configuration.css
+++ b/web/src/screens/configuration/configuration.css
@@ -171,7 +171,7 @@
 
 /* Resolved Discord bot tag from the live gateway login (#70), under the name. */
 .gx-provider-row__tag {
-  font-size: var(--text-xs, 0.75rem);
+  font-size: var(--body-xs);
   color: var(--text-subtle);
   margin-top: 2px;
 }
@@ -271,6 +271,6 @@
 
 .gx-invite-picker__id {
   font-family: var(--font-mono);
-  font-size: var(--text-xs, 0.75rem);
+  font-size: var(--body-xs);
   color: var(--text-subtle);
 }

--- a/web/src/screens/landing/landing.css
+++ b/web/src/screens/landing/landing.css
@@ -175,5 +175,5 @@
 }
 
 .gx-landing__beta-note a {
-  color: var(--accent, #9059ff);
+  color: var(--arcane);
 }

--- a/web/src/screens/legal/legal.css
+++ b/web/src/screens/legal/legal.css
@@ -94,7 +94,7 @@
 }
 
 .gx-legal__section a {
-  color: var(--accent, #9059ff);
+  color: var(--arcane);
 }
 
 .gx-legal__footer {

--- a/web/src/screens/login/login.css
+++ b/web/src/screens/login/login.css
@@ -85,11 +85,11 @@
 
 .gx-login__consent input {
   margin-top: 3px;
-  accent-color: var(--accent, #9059ff);
+  accent-color: var(--arcane);
 }
 
 .gx-login__consent a {
-  color: var(--accent, #9059ff);
+  color: var(--arcane);
 }
 
 /* The login/signup cards are centered in the viewport; the legal footer sits

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -284,9 +284,9 @@
   margin-top: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
-  border: 1px solid var(--danger, #b3261e);
-  background: color-mix(in srgb, var(--danger, #b3261e) 12%, transparent);
-  color: var(--danger, #b3261e);
+  border: 1px solid var(--status-danger);
+  background: var(--status-danger-bg);
+  color: var(--status-danger);
   font-size: 0.875rem;
 }
 
@@ -296,9 +296,9 @@
   margin-top: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
-  border: 1px solid var(--warning, #a86800);
-  background: color-mix(in srgb, var(--warning, #a86800) 12%, transparent);
-  color: var(--warning, #a86800);
+  border: 1px solid var(--status-warning);
+  background: var(--status-warning-bg);
+  color: var(--status-warning);
   font-size: 0.875rem;
 }
 
@@ -651,7 +651,7 @@
   padding: var(--spacing-sm);
   border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);
-  background: var(--surface-sunken, rgba(0, 0, 0, 0.15));
+  background: var(--surface-inset);
   width: 100%;
 }
 
@@ -670,7 +670,7 @@
 }
 
 .gx-highlight-share__error {
-  color: var(--danger, #f87171);
+  color: var(--status-danger);
 }
 
 .gx-highlight-share__download {
@@ -684,7 +684,7 @@
 }
 
 .gx-highlight-share__download:hover {
-  color: var(--text);
+  color: var(--text-default);
   text-decoration: underline;
 }
 
@@ -698,7 +698,7 @@
 }
 
 .gx-highlights__error {
-  color: var(--danger, #ff4f5e);
+  color: var(--status-danger);
 }
 
 /* Non-fatal refresh blip: the last loaded set stays on screen (AC2 — never


### PR DESCRIPTION
## What does this PR do?

Follow-up to #569. Maps the remaining **65 references to CSS custom properties that no file declares** onto real tokens from `web/src/styles/tokens.css`. #569 fixed the ones with no fallback (invalid at computed-value time, so they rendered *nothing*); these carry a fallback hex, so they render — just never in the design system.

Twelve variables were referenced and declared nowhere: `--accent`, `--border`, `--danger`, `--warning`, `--surface`, `--surface-2`, `--surface-sunken`, `--text`, `--text-xs`, `--heading-sm`, `--spacing-2xs`, `--shadow-popover`.

**After this, every `var()` in `web/src` resolves to a token `tokens.css` actually declares.** (The one apparent exception, `var(--speaker-N)`, is a template literal building `--speaker-1..6`.)

> [!IMPORTANT]
> **This repaints the Knowledge and world surface.** 47 of the 65 are in `campaign.css`, all from the graph section onward. `--surface-sunken` (`#12151c`) becomes `--surface-inset` (`#170d2c`) and `--border` (`#2a2f3a`) becomes `--border-subtle`/`--border-default`, so the graph canvas, chips, lens block, world health, prep rows, maps frame, proposal review and appearances index stop rendering in neutral blue-gray and join the violet the rest of the app is drawn in. That is a visual design decision. **No test in the repo can catch a wrong outcome — jsdom does not run the cascade.**

**Before/after with every measured value:** https://claude.ai/code/artifact/775d367d-14fe-4498-9403-a1d4b0d7f64d

## Why is this change needed?

Two collisions were live in the codebase:

**`--accent` meant two different colours.** Yellow `#ffcf5a` in `campaign.css` (16 uses); violet `#9059ff` in `landing.css`, `legal.css`, `login.css` (4 uses). The day anyone declared `--accent` in `:root`, one of those two sets silently flips. `#ffcf5a` is in no palette at all.

The violet four map to `--arcane` — identical pixels, real name. The yellow sixteen split by what they mean: `--gold` for the provisional vocabulary (proposal ghosts, GM-private marks, map drafts), `--status-warning` for the ones that genuinely are warnings (over budget, dropped from the lens, an NPC not ready to speak). Both resolve to `#ffbd4f`, so the split costs nothing to render and stops the next reader guessing.

**"Danger" rendered as four different reds** — `#ff4f5e`, `#b3261e`, `#f87171`, `#e5484d` — while `--status-danger` (`#ff4f5e`) existed and `.gx-badge--danger` already used it. Two were **failing WCAG AA**: light-theme Material hues on a near-black card.

| Surface | Was | Now |
|---|---:|---:|
| `.gx-session__failed` | 2.55:1 ✕ | **5.19:1** ✓ |
| `.gx-session__spendcap` | 3.69:1 ✕ | **10.05:1** ✓ |
| `.gx-select__item--danger` | 4.26:1 ✕ | **5.19:1** ✓ |

Their `color-mix(in srgb, … 12%, transparent)` washes collapse to `--status-danger-bg` / `--status-warning-bg`, which encoded exactly that value.

**Two dead rules found on the way.** `.gx-highlight-share__download:hover` set `color: var(--text)` with no fallback, so hovering the download link changed nothing at all. Three more unfallback'd `var(--text)` sites in `campaign.css` were dead the same way — #569 caught the `--border` and `--text-secondary` ones; these four survived it.

**One inline style.** `KnowledgePanel.tsx` hardcoded `style={{ color: "#ffcf5a", background: "#ffcf5a24" }}` on the "Linked agent" badge — a third home for the phantom accent. `Badge` already ships a `gold` variant painting `--gold` on a 14% gold wash, so the inline style is gone and the badge gains the border every other badge carries. The entry-type badge beside it stays inline: its colour is per-type data, not a constant.

## Three judgment calls — each a one-line revert

1. **The graph's focus ring moves from gold to `--rune`.** Every other focusable thing in the app focuses with `--focus-ring`, which is rune-blue. Inside the canvas a gold outline landed on the same circle as the gold over-budget ring and the gold proposed-fact halo — and was invisible entirely on FACTION nodes, which are `#ffbd4f`. Confirmed `rgb(0, 221, 255)` under `:focus-visible`.

2. **`.gx-kg-appearances__who` now maps all four speaker kinds.** Its comment claims "the same speaker vocabulary the transcript uses", but one rule painted npc and butler alike in gold. `kind` arrives straight off `NodeAppearance` as gm/player/npc/butler, so it now mirrors every branch of `.gx-line__who`: gm `--text-strong`, player `--rune`, butler `--gold`, npc `--text-default`. All four verified identical to the transcript's computed colour. This is the only change that alters what a row *means* rather than which token pays for it.

3. **landing/legal/login keep their violet links** via `--arcane` — pixel-faithful. Worth knowing they still override the global `a { color: var(--text-link) }` blue, and `#9059ff` on `--surface-base` measures ~4.3:1, marginally under AA for the long body text on the legal pages. Whether that override is intentional is a separate question this PR does not settle.

## How was this tested?

Every value was read with `getComputedStyle` **in a real browser** (`GLYPHOXA_DEV_MODE=1`, `127.0.0.1:8080`) against the seeded *Saltmarsh Test* campaign — 21 knowledge nodes, 30 edges, 1 pending proposal, 2 prep rows, 1 map — before and after, plus a synthetic probe covering every touched selector including the ones with no seed data.

Graph hit-testing re-confirmed with `document.elementFromPoint` on the nodes and the fat proposal hit line — not `dispatchEvent`, which skips hit-testing and would pass regardless.

Reviewed adversarially by a Fable agent; its one merge-blocking finding (call 2 above originally covered only two of the four speaker kinds, making the comment's parity claim false) is fixed in this branch.

- [ ] `make check` passes — **cannot pass locally**: the Makefile sets `CGO_ENABLED := 0` but `test` runs `go test -race`, which requires cgo. Mirrored the real CI gate instead: `CGO_ENABLED=1 go build ./... && go vet ./...` clean.
- [x] New/updated tests cover the change — n/a, and deliberately so: jsdom does not run the cascade, so a passing unit test here would be evidence of nothing. Existing 455 vitest tests pass; `vite build` clean.
- [x] Manual testing — described above.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code cleanup

## Additional Notes

Separately spotted, **not** fixed here: the tracked `internal/spa/dist/index.html` on `main` is a real Vite build output referencing `assets/index-DZkQxVyq.js` and `assets/index-CnuIvPEi.css`, both gitignored — so a node-free checkout builds a binary that serves a blank page. Pre-existing on `origin/main`, untouched by this PR, worth its own fix plus a CI guard.

The reviewer also flagged as follow-up debt, out of scope for a mapping commit: dead fallbacks that contradict their token (`var(--radius-sm, 8px)` where the token is 4px; `var(--text-muted, #8b93a7)` where the token is `#9f9fad`), and that GM-private is marked gold on the aspect row but with a `neutral` badge two elements away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
