### PR TITLE
fix(legal): name the edge provider only when the deployment has one

### DIFF
--- a/docs/deploy/legal-pages.md
+++ b/docs/deploy/legal-pages.md
@@ -51,12 +51,22 @@ to miss.
    Optional: `phone`, `contentResponsible` (§ 18 Abs. 2 MStV),
    `vatId` (§ 27a UStG), `dataProtectionOfficer` (most beta-scale operators do
    not need one — Art. 37 GDPR). Leave them empty to omit those lines.
+   - `edgeProvider` — the reverse proxy or CDN your web tier is reached
+     **through**, if any (e.g. `"Cloudflare"` when you run the chart's
+     `cloudflared.enabled` tunnel or a `cloudflared` compose service). Such a
+     provider terminates TLS, so it sees connection data *and* the web traffic
+     in the clear: §5 names it as a recipient, and states that Voice Session
+     audio does not cross it (that goes straight to Discord). **Leave it empty
+     if you are reached directly or only through your own proxy** — the section
+     then names no such provider at all. An empty value is a complete answer,
+     not a TODO, and never raises the banner.
 2. Read the Datenschutzerklärung end to end and correct anything that does not
    match YOUR deployment — in particular §5 (which AI providers you actually
    use) and §6 (where the data lives). The template names the shipped adapters
    (Discord, ElevenLabs, Groq, Anthropic, Google Gemini, OpenAI-compatible
-   endpoints, Cloudflare) — cross-check against your configured providers, and
-   remember an "OpenAI-compatible endpoint" is whatever vendor you point it at.
+   endpoints) plus whatever `edgeProvider` you declared — cross-check against
+   your configured providers, and remember an "OpenAI-compatible endpoint" is
+   whatever vendor you point it at.
 3. Rebuild the SPA (`npm run build` in `web/`, or rebuild the container image —
    the pages are compiled into the bundle) and deploy.
 4. Verify before you publish DNS. The legal pages are client-rendered, so

--- a/web/src/screens/legal/Privacy.tsx
+++ b/web/src/screens/legal/Privacy.tsx
@@ -159,10 +159,18 @@ export function Privacy() {
             <strong>Google Gemini</strong> — Bilderzeugung für Kampagnenillustrationen:
             erhält die jeweilige Bildbeschreibung.
           </li>
-          <li>
-            <strong>Cloudflare</strong> (soweit eingesetzt) — Tunnel und TLS-Terminierung
-            für den Web-Zugang: verarbeitet dabei Verbindungsdaten (u. a. IP-Adresse).
-          </li>
+          {OPERATOR.edgeProvider && (
+            <li>
+              <strong>{OPERATOR.edgeProvider}</strong> — Reverse-Proxy und
+              TLS-Terminierung für den Web-Zugang. Der gesamte Web-Verkehr dieser
+              Instanz wird über diesen Anbieter geleitet; dabei fallen
+              Verbindungsdaten an (u. a. IP-Adresse, aufgerufene Adresse,
+              Zeitpunkt, Browserkennung). Da die Transportverschlüsselung dort
+              endet, kann der Anbieter die Inhalte der Web-Oberfläche im Klartext
+              verarbeiten. Das Audio der Sprachsitzungen läuft <em>nicht</em> über
+              diesen Weg, sondern unmittelbar zwischen dieser Instanz und Discord.
+            </li>
+          )}
         </ul>
         <p>
           Bei Anbietern mit Sitz in den USA erfolgt die Übermittlung auf Grundlage von

--- a/web/src/screens/legal/edgeProvider.test.tsx
+++ b/web/src/screens/legal/edgeProvider.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
+import { createRouterTransport } from "@connectrpc/connect";
+
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { routeTree } from "@/app/router";
+
+// A deployment reached DIRECTLY — no tunnel, no CDN, no third-party proxy in
+// front — must not name one as a data recipient. Naming a processor that never
+// sees the traffic is not a harmless over-disclosure: it is a false statement
+// about where the data goes.
+//
+// The shipped operator.ts declares Cloudflare (the canonical deployment runs
+// behind a Cloudflare Tunnel), so this case can only be exercised against a
+// mocked identity — the mirror of todoBanner.test.tsx.
+vi.mock("./operator", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./operator")>();
+  const direct = { ...actual.OPERATOR, edgeProvider: "" };
+  // operatorTodos' default argument binds the real module's OPERATOR, so it
+  // must be re-bound to the mocked identity for LegalPage's no-arg call.
+  return {
+    ...actual,
+    OPERATOR: direct,
+    operatorTodos: (o = direct) => actual.operatorTodos(o),
+  };
+});
+
+function renderAt(path: string) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(
+    <Providers transport={createRouterTransport(() => {})} queryClient={makeQueryClient()}>
+      <RouterProvider router={router} />
+    </Providers>,
+  );
+}
+
+describe("Datenschutzerklärung without an edge provider", () => {
+  it("names no reverse-proxy recipient when the operator declares none", async () => {
+    renderAt("/datenschutz");
+    await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 });
+    const doc = document.body.textContent ?? "";
+    expect(doc).not.toContain("Cloudflare");
+    expect(doc).not.toContain("TLS-Terminierung");
+  });
+
+  it("still discloses the providers the software itself uses", async () => {
+    // The proxy in front is a deployment choice; the STT/TTS/LLM subprocessors
+    // are a property of the software. Dropping the first must not drop the rest
+    // of section 5.
+    renderAt("/datenschutz");
+    await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 });
+    const doc = document.body.textContent ?? "";
+    for (const topic of ["Discord", "ElevenLabs", "Groq", "Gemini"]) {
+      expect(doc, `Datenschutzerklärung must still mention ${topic}`).toContain(topic);
+    }
+  });
+
+  it("treats an empty edge provider as complete, not as an operator TODO", async () => {
+    // Self-hosting directly is the normal case, not an unfinished Impressum —
+    // it must not raise the banner that means "you forgot something".
+    renderAt("/datenschutz");
+    await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -82,13 +82,30 @@ describe("legal routes", () => {
       "Groq",
       "Anthropic",
       "Gemini",
-      "Cloudflare",
+      OPERATOR.edgeProvider,
       "Auftragsverarbeitung",
       "Speicherdauer",
       "Aufsichtsbehörde",
     ]) {
       expect(doc, `Datenschutzerklärung must mention ${topic}`).toContain(topic);
     }
+  });
+
+  it("names the declared edge provider as a recipient, and what it can see", async () => {
+    // This deployment is reached through a Cloudflare Tunnel, so the proxy that
+    // terminates its TLS is a recipient that must be named (Art. 13 Abs. 1
+    // lit. e DSGVO) — including the part operators forget: TLS ends there, so
+    // it sees the web traffic in the clear. The empty case (a deployment
+    // reached directly) is covered in edgeProvider.test.tsx.
+    expect(OPERATOR.edgeProvider).not.toBe("");
+    renderAt("/datenschutz");
+    await screen.findByRole("heading", { name: "Datenschutzerklärung", level: 1 });
+    const doc = document.body.textContent ?? "";
+    expect(doc).toContain(OPERATOR.edgeProvider);
+    expect(doc).toContain("TLS-Terminierung");
+    // Voice audio goes straight to Discord and never crosses the proxy — a
+    // material fact for players being transcribed, so it is stated, not implied.
+    expect(doc).toMatch(/Audio der Sprachsitzungen/);
   });
 
   it("links the other documents from every legal page", async () => {

--- a/web/src/screens/legal/operator.ts
+++ b/web/src/screens/legal/operator.ts
@@ -47,6 +47,22 @@ export type OperatorIdentity = {
   supervisoryAuthority: string;
   /** Where the servers physically run — the residency claim must be true. */
   hostingLocation: string;
+  /**
+   * Optional: the reverse proxy / CDN the web tier is reached THROUGH, named as
+   * a data recipient in the Datenschutzerklärung (e.g. "Cloudflare").
+   *
+   * Such a provider terminates TLS and therefore sees connection data and the
+   * plaintext of the web traffic, which makes it a recipient that has to be
+   * disclosed (Art. 13 Abs. 1 lit. e DSGVO). But it is a DEPLOYMENT choice, not
+   * a property of the software: a self-host reached directly, or behind the
+   * operator's own proxy, sends nothing to a third party here. Leave this empty
+   * for those — the Datenschutzerklärung then names no such provider at all,
+   * rather than claiming one "where applicable".
+   *
+   * Set it to the provider's name only when traffic genuinely flows through it
+   * (chart: `cloudflared.enabled`; compose: a `cloudflared` service).
+   */
+  edgeProvider: string;
   /** Last review date of the legal texts, shown at the top of each page. */
   lastUpdated: string;
 };
@@ -74,7 +90,10 @@ export const OPERATOR: OperatorIdentity = {
   supervisoryAuthority:
     "Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen (LDI NRW), Kavalleriestraße 2–4, 40213 Düsseldorf",
   hostingLocation: "Deutschland (eigener Server)",
-  lastUpdated: "26. Juli 2026",
+  // This deployment is reached through a Cloudflare Tunnel (no inbound ports),
+  // so Cloudflare terminates TLS for every web request and is a recipient.
+  edgeProvider: "Cloudflare",
+  lastUpdated: "5. August 2026",
 };
 
 /** isPlaceholder reports whether a field is still an unfilled template value. */
@@ -85,8 +104,10 @@ export function isPlaceholder(value: string): boolean {
 /**
  * operatorTodos lists the fields an operator still has to fill. Empty means the
  * identity is complete; the legal pages render a banner while it is not.
- * Optional fields (phone, VAT id, DPO, editorial responsibility) are excluded —
- * an empty optional field is a decision, not an omission.
+ * Optional fields (phone, VAT id, DPO, editorial responsibility, edge provider)
+ * are excluded — an empty optional field is a decision, not an omission. An
+ * empty `edgeProvider` in particular is the CORRECT value for a deployment
+ * reached directly, not an unfinished one.
  */
 export function operatorTodos(o: OperatorIdentity = OPERATOR): string[] {
   const required: Array<keyof OperatorIdentity> = [


### PR DESCRIPTION
## What does this PR do?

Makes the reverse-proxy/CDN entry in the Datenschutzerklärung conditional on the operator actually having one, instead of listing Cloudflare for everybody.

- `operator.ts` gains an optional `edgeProvider` field — the proxy the web tier is reached **through**, e.g. `"Cloudflare"` for a `cloudflared` tunnel.
- §5 of the Datenschutzerklärung renders that recipient only when it is set.
- The entry now also states that TLS terminates at that provider (so it can process the web traffic in the clear), and that Voice Session audio does **not** cross it — that goes straight to Discord.
- Set to `"Cloudflare"` for the canonical deployment, which is now reached through a Cloudflare Tunnel.

Relates to #518.

## Why is this change needed?

The list previously carried `<strong>Cloudflare</strong> (soweit eingesetzt)`, which is wrong in both directions:

- For a deployment that **does** route through Cloudflare, "where applicable" is a hedge where the reader needs a fact — and it omitted the material part, that TLS terminates there.
- For a deployment that **does not** — the compose on-ramp, a LAN self-host, anyone behind their own proxy — it names a processor that never sees a single request. That is a false statement about where personal data goes, not a harmless over-disclosure.

An operator declaration is also the right mechanism rather than deriving it from `cloudflared.enabled`: the SPA has no runtime config (`internal/spa` serves the embedded bundle verbatim), so the legal text is fixed at build time — and legally the operator should be declaring what they use, not the app guessing.

## How was this tested?

- New `edgeProvider.test.tsx` mocks an identity with `edgeProvider: ""` (mirroring how `todoBanner.test.tsx` mocks an unfilled one) and asserts: no proxy is named, the genuine subprocessors are still disclosed, and the empty value does **not** raise the operator TODO banner.
- `legal.test.tsx` now asserts the declared provider is named along with the TLS-termination and audio-path facts, and its disclosure checklist reads `OPERATOR.edgeProvider` instead of a hardcoded `"Cloudflare"`.
- `npx vitest run` — 459 passed / 46 files. `npx tsc --noEmit` clean.

- [ ] `make check` passes *(not run locally — this is a TypeScript-only change; relying on CI for the Go suite)*
- [x] New/updated tests cover the change
- [x] Manual testing — verified against the live deployment at https://glyphoxa.com, which serves these pages through a Cloudflare Tunnel

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [ ] All tests pass with `go test -race ./...` *(no Go code touched)*
- [x] I have updated documentation if needed — `docs/deploy/legal-pages.md` documents the new field and that empty is a complete answer
- [x] My commits are focused and have clear messages

## Additional Notes

`lastUpdated` moves to 5. August 2026, since the Datenschutzerklärung text changed.

Anyone forking this source for their own instance already has to replace `operator.ts` wholesale; the new field defaults to being absent from the document, which is the safe direction — you cannot accidentally under-disclose by leaving it blank, only by routing traffic through a proxy you did not declare.