### PR TITLE
fix(legal): highlight clips DO cross the edge provider

### DIFF
--- a/web/src/screens/legal/Privacy.tsx
+++ b/web/src/screens/legal/Privacy.tsx
@@ -167,8 +167,12 @@ export function Privacy() {
               Verbindungsdaten an (u. a. IP-Adresse, aufgerufene Adresse,
               Zeitpunkt, Browserkennung). Da die Transportverschlüsselung dort
               endet, kann der Anbieter die Inhalte der Web-Oberfläche im Klartext
-              verarbeiten. Das Audio der Sprachsitzungen läuft <em>nicht</em> über
-              diesen Weg, sondern unmittelbar zwischen dieser Instanz und Discord.
+              verarbeiten. Das <em>Live</em>-Audio einer Sprachsitzung läuft nicht
+              über diesen Weg: es fließt unmittelbar zwischen dieser Instanz,
+              Discord und den unter dieser Ziffer genannten Sprach-Anbietern.
+              Gespeicherte Highlight-Clips (Ziffer 4) werden dagegen wie jeder
+              andere Web-Inhalt über diesen Anbieter ausgeliefert, sobald die
+              Spielleitung sie in der Web-Oberfläche abspielt.
             </li>
           )}
         </ul>

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -103,9 +103,15 @@ describe("legal routes", () => {
     const doc = document.body.textContent ?? "";
     expect(doc).toContain(OPERATOR.edgeProvider);
     expect(doc).toContain("TLS-Terminierung");
-    // Voice audio goes straight to Discord and never crosses the proxy — a
-    // material fact for players being transcribed, so it is stated, not implied.
-    expect(doc).toMatch(/Audio der Sprachsitzungen/);
+    // The audio split, stated rather than implied — and it IS a split, which an
+    // earlier draft got wrong. LIVE session audio never crosses the proxy: the
+    // voice tier dials Discord and the speech providers outbound. But stored
+    // Highlight clips are served BY the web tier
+    // (HighlightsStrip renders <audio src="/api/v1/highlights/{id}/clip">), so
+    // they cross it like any other web content. Both halves are material to the
+    // players whose consented voice is in those clips.
+    expect(doc).toMatch(/Live-Audio einer Sprachsitzung läuft nicht über diesen Weg/);
+    expect(doc).toMatch(/Highlight-Clips .* über diesen Anbieter ausgeliefert/);
   });
 
   it("links the other documents from every legal page", async () => {

--- a/web/src/screens/legal/operator.ts
+++ b/web/src/screens/legal/operator.ts
@@ -71,7 +71,7 @@ export type OperatorIdentity = {
  * OPERATOR is the deployment's own identity. EVERY placeholder below must be
  * replaced before the deployment is reachable from the internet.
  *
- * This repository ships the identity of the canonical glyphoxa.net beta
+ * This repository ships the identity of the canonical glyphoxa.com beta
  * deployment, filled in by its operator (the project maintainer) on
  * 2026-07-26. If you deploy your OWN instance from this source, you MUST
  * replace every value below with your own identity — publishing someone
@@ -93,7 +93,7 @@ export const OPERATOR: OperatorIdentity = {
   // This deployment is reached through a Cloudflare Tunnel (no inbound ports),
   // so Cloudflare terminates TLS for every web request and is a recipient.
   edgeProvider: "Cloudflare",
-  lastUpdated: "5. August 2026",
+  lastUpdated: "6. August 2026",
 };
 
 /** isPlaceholder reports whether a field is still an unfilled template value. */


### PR DESCRIPTION
## What does this PR do?

Corrects a factual error introduced in #574 and shipped in v0.5.0. The Datenschutzerklärung claimed, without qualification:

> Das Audio der Sprachsitzungen läuft **nicht** über diesen Weg, sondern unmittelbar zwischen dieser Instanz und Discord.

That is true of **live** session audio. It is false for **stored Highlight clips**, which now get their own sentence.

Also fixes the `operator.ts` comment: the canonical deployment is glyphoxa.com, not glyphoxa.net.

## Why is this change needed?

`HighlightsStrip` renders a native audio element straight at the web tier:

```tsx
src={`/api/v1/highlights/${h.id}/clip`}   // HighlightsStrip.tsx:150
```

That is a same-origin path served by the web tier (`internal/highlight/http.go`), so it flows through whatever `edgeProvider` fronts the deployment — via the exact TLS termination the same paragraph describes two sentences earlier.

And those clips are not incidental audio. Per §4 they are **consent-gated participant voice**: only people who pressed **Consent** are in the ring buffer, and clips the GM keeps are stored indefinitely. So the one category of recorded personal audio the deployment holds is precisely the category the old sentence promised never left for a third party.

Live audio genuinely is excluded — the voice tier dials Discord (gateway WSS + voice UDP) and the speech providers outbound, and the tunnel carries only inbound HTTP — so the fix is to split the claim rather than delete it.

An over-broad reassurance about where recorded voice goes is the same class of error #574 existed to remove; it just landed on the other side of the same sentence.

## How was this tested?

`legal.test.tsx` previously asserted the loose `/Audio der Sprachsitzungen/`, which the corrected text would still have satisfied — so the assertion is replaced with two that pin **both halves** of the split:

```ts
expect(doc).toMatch(/Live-Audio einer Sprachsitzung läuft nicht über diesen Weg/);
expect(doc).toMatch(/Highlight-Clips .* über diesen Anbieter ausgeliefert/);
```

Neither matches the v0.5.0 text, so this would have failed before the fix.

- `npx vitest run` — 459 passed / 46 files
- `npx tsc --noEmit` — clean
- Verified against the live deployment at https://glyphoxa.com

- [x] New/updated tests cover the change
- [x] Manual testing

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Additional Notes

`lastUpdated` moves to 6. August 2026 since the text changed.

Found by an adversarial review of #574 that traced the actual clip-delivery path rather than reading the sentence on its own terms.

Deployments carrying an `edgeProvider` should ship this before opening to real tables — it is currently the one statement in the Datenschutzerklärung the code contradicts.