### PR TITLE
fix(legal): the Impressum placeholder check fired on every filled deployment

### DIFF
--- a/docs/deploy/legal-pages.md
+++ b/docs/deploy/legal-pages.md
@@ -31,13 +31,15 @@ start (#519). Keep the route as it is, or set `privacyPolicyUrl` explicitly.
 
 ## Operator TODO — before the deployment is reachable
 
-The operator's identity is **not** something this project can supply, so it
-ships as clearly-marked placeholders in
-[`web/src/screens/legal/operator.ts`](../../web/src/screens/legal/operator.ts).
-While any required field is unfilled, every legal page renders a red
-"Hinweis an den Betreiber" banner naming the missing fields, and each unfilled
-value is highlighted inline — an unfinished Impressum is meant to be impossible
-to miss.
+The operator's identity is **not** something this project can supply. It lives
+in [`web/src/screens/legal/operator.ts`](../../web/src/screens/legal/operator.ts),
+which ships filled in with the identity of the canonical glyphoxa.com
+deployment — **if you deploy your own instance, every value there is wrong for
+you and has to be replaced.** A field you have not answered is either empty or
+carries a `[BITTE AUSFÜLLEN: …]` placeholder; while any required one is in that
+state, every legal page renders a red "Hinweis an den Betreiber" banner naming
+the missing fields, and each placeholder value is highlighted inline — an
+unfinished Impressum is meant to be impossible to miss.
 
 1. Edit `web/src/screens/legal/operator.ts` and fill in:
    - `legalName`, `street`, `city`, `country` — § 5 DDG requires a real,
@@ -69,21 +71,46 @@ to miss.
    whatever vendor you point it at.
 3. Rebuild the SPA (`npm run build` in `web/`, or rebuild the container image —
    the pages are compiled into the bundle) and deploy.
-4. Verify before you publish DNS. The legal pages are client-rendered, so
-   fetching `/imprint` only returns the SPA shell — grep the **built bundle**,
-   not the HTML:
+4. Verify before you publish DNS. Ask the identity itself, from `web/`:
 
    ```sh
-   # locally, against the build you are about to ship (vite outDir):
-   grep -R "BITTE AUSFÜLLEN" internal/spa/dist/assets/ && echo "STILL UNFILLED"
+   npm run check:operator
+   ```
+
+   That runs the very `operatorTodos()` the pages call for their banner, over
+   your `operator.ts`, and exits non-zero naming every field that is still a
+   placeholder **or empty** — plus any optional field left on template text,
+   which renders red without raising the banner. It must exit 0.
+
+   Then confirm the bundle you are shipping actually carries that identity.
+   The legal pages are client-rendered, so fetching `/imprint` only returns the
+   SPA shell — check the **built bundle**, not the HTML:
+
+   ```sh
+   # locally, from the repo root, against the build you are about to ship (vite
+   # outDir). Take the bundle index.html references: emptyOutDir is false, so
+   # dist/assets/ keeps earlier builds and a stale sibling would answer for it.
+   js=$(grep -o '/assets/[^"]*\.js' internal/spa/dist/index.html | head -1)
+   grep -q "BITTE AUSFÜLLEN:" "internal/spa/dist$js" && echo "STILL UNFILLED"
 
    # or against the deployed instance (fetches the hashed JS the shell references):
    host=https://<your-host>
-   curl -sf "$host$(curl -sf "$host/" | grep -o '/assets/[^"]*\.js' | head -1)" \
-     | grep -q "BITTE AUSF" && echo "STILL UNFILLED"
+   js=$(curl -sf "$host/" | grep -o '/assets/[^"]*\.js' | head -1)
+   curl -sf "$host$js" | grep -q "BITTE AUSFÜLLEN:" && echo "STILL UNFILLED"
+   curl -sf "$host$js" | grep -q "<your legalName>" || echo "STALE BUNDLE"
    ```
 
-   Neither command may print `STILL UNFILLED`.
+   Neither may print `STILL UNFILLED`, and the live bundle must contain your own
+   `legalName` — a bundle built before you edited `operator.ts` still serves the
+   previous operator's Impressum, which is the failure step 3 exists to prevent.
+
+   Grep for the **colon** form. An unfilled value reads `[BITTE AUSFÜLLEN: …]`,
+   whereas the bare `[BITTE AUSFÜLLEN` prefix that `isPlaceholder()` compares
+   against is a constant compiled into *every* bundle: matching on it — as this
+   step did until 2026-08-06 — reports `STILL UNFILLED` on a perfectly filled
+   deployment, which is worse than no check at all. And no grep over a minified
+   bundle can see a required field left empty; that is what `check:operator` is
+   for, and why it, not the grep, is the check that decides.
 
 ## Keeping the texts honest
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "check:operator": "vitest run src/screens/legal/operatorFilled.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/web/src/screens/legal/legal.test.tsx
+++ b/web/src/screens/legal/legal.test.tsx
@@ -6,7 +6,7 @@ import { createRouterTransport } from "@connectrpc/connect";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 import { routeTree } from "@/app/router";
-import { operatorTodos, isPlaceholder, OPERATOR } from "./operator";
+import { OPERATOR } from "./operator";
 
 // The legal documents (#518). Two properties matter beyond "the text renders":
 //
@@ -127,37 +127,9 @@ describe("legal routes", () => {
     // This repository ships the identity of the canonical beta deployment,
     // filled in by its operator on 2026-07-26 — so no banner here. The banner
     // machinery itself stays covered in todoBanner.test.tsx against a mocked,
-    // unfilled identity.
+    // unfilled identity, and operatorFilled.test.ts (npm run check:operator)
+    // holds the fork-safe completeness check an operator runs before deploying.
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(screen.getByText(/Lukas Schmidt/)).toBeInTheDocument();
-  });
-});
-
-describe("operator identity", () => {
-  it("is completely filled for this deployment", () => {
-    // The maintainer operates the canonical deployment from this repo and
-    // committed their own identity (2026-07-26). Anyone forking this source
-    // for their OWN instance must replace operator.ts — see the warning there
-    // and docs/deploy/legal-pages.md.
-    expect(operatorTodos()).toEqual([]);
-    expect(isPlaceholder(OPERATOR.legalName)).toBe(false);
-    expect(isPlaceholder(OPERATOR.email)).toBe(false);
-  });
-
-  it("counts an empty required field as a TODO and ignores optional ones", () => {
-    const filled = {
-      ...OPERATOR,
-      legalName: "Rin Okabe",
-      street: "Beispielweg 1",
-      city: "10115 Berlin",
-      country: "Deutschland",
-      email: "hallo@example.org",
-      supervisoryAuthority: "Berliner Beauftragte für Datenschutz",
-      hostingLocation: "Deutschland",
-      lastUpdated: "2026-07-25",
-      phone: "", // optional — an empty value is a decision, not an omission
-    };
-    expect(operatorTodos(filled)).toEqual([]);
-    expect(operatorTodos({ ...filled, email: "  " })).toEqual(["email"]);
   });
 });

--- a/web/src/screens/legal/operatorFilled.test.ts
+++ b/web/src/screens/legal/operatorFilled.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+
+import { OPERATOR, operatorTodos, isPlaceholder } from "./operator";
+
+// The pre-deploy check an operator runs before the instance is reachable:
+//
+//     cd web && npm run check:operator
+//
+// It calls the same operatorTodos() the legal pages call for their red "Hinweis
+// an den Betreiber" banner, so a green run here and a clean page are the same
+// fact rather than two things that can drift.
+//
+// It replaces the grep over the built bundle that docs/deploy/legal-pages.md
+// used to prescribe. That grep looked for "BITTE AUSFÜLLEN", which is
+// PLACEHOLDER_PREFIX — a constant compiled into EVERY bundle whether or not any
+// field uses it, so the check fired on correctly filled deployments and trained
+// operators to ignore it. A grep also cannot see a required field left EMPTY,
+// which is every bit as unfilled as one still carrying template text.
+//
+// Nothing in this file may assert the canonical deployment's own values: a fork
+// that correctly filled in its OWN identity has to pass it unchanged. The
+// shipped identity is pinned in legal.test.tsx instead.
+
+describe("operator identity (npm run check:operator)", () => {
+  it("has every required field filled in", () => {
+    const todos = operatorTodos();
+    expect(
+      todos,
+      `unfilled required fields in web/src/screens/legal/operator.ts: ${todos.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("leaves no field — required or optional — on a placeholder value", () => {
+    // operatorTodos ignores the optional fields, because an EMPTY optional
+    // field is a decision (no phone, no VAT id, no DPO, reached directly). A
+    // PLACEHOLDER one is not: it renders on the page as red template text
+    // without raising the banner, so it is caught here instead.
+    const marked = Object.entries(OPERATOR)
+      .filter(([, value]) => isPlaceholder(value))
+      .map(([field]) => field);
+    expect(marked, `fields still on template text: ${marked.join(", ")}`).toEqual([]);
+  });
+
+  it("counts an empty required field as a TODO and ignores optional ones", () => {
+    const filled = {
+      ...OPERATOR,
+      legalName: "Rin Okabe",
+      street: "Beispielweg 1",
+      city: "10115 Berlin",
+      country: "Deutschland",
+      email: "hallo@example.org",
+      supervisoryAuthority: "Berliner Beauftragte für Datenschutz",
+      hostingLocation: "Deutschland",
+      lastUpdated: "2026-07-25",
+      phone: "", // optional — an empty value is a decision, not an omission
+    };
+    expect(operatorTodos(filled)).toEqual([]);
+    expect(operatorTodos({ ...filled, email: "  " })).toEqual(["email"]);
+    expect(
+      operatorTodos({ ...filled, street: "[BITTE AUSFÜLLEN: Straße und Hausnummer]" }),
+    ).toEqual(["street"]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Makes the pre-launch "is the Impressum filled in?" check actually detect an
unfilled Impressum. Step 4 of `docs/deploy/legal-pages.md` documented two
commands that **always** report failure:

```sh
grep -R "BITTE AUSFÜLLEN" internal/spa/dist/assets/ && echo "STILL UNFILLED"
```

`"BITTE AUSFÜLLEN"` is `PLACEHOLDER_PREFIX` — the constant `isPlaceholder()`
compares against — so it is compiled into every bundle regardless of whether any
field uses it. Against the live glyphoxa.com bundle (v0.5.1, a correctly filled
deployment) there is exactly one occurrence, and it is the constant declaration:

```js
var VO=`[BITTE AUSFÜLLEN`,HO={legalName:`Lukas Schmidt`,street:`Turpinstraße 19`,…
```

- **`npm run check:operator`** (new) is now the check that decides. It runs the
  very `operatorTodos()` the pages call for their red "Hinweis an den Betreiber"
  banner, over `operator.ts`, and exits non-zero naming the offending fields.
  Backed by `web/src/screens/legal/operatorFilled.test.ts`, which also runs in
  the normal `npm run test` (so CI enforces it).
- **The bundle greps stay**, for the artifact rather than the source, and now
  match the colon form `BITTE AUSFÜLLEN:` that only a real placeholder value
  carries — the bare prefix constant has no colon.
- The section intro no longer claims `operator.ts` "ships as clearly-marked
  placeholders". It has shipped the filled canonical identity since #528; a fork
  must *replace* those values, not fill them in.

Two further bugs in the same commands, fixed while in there:

- The local grep scanned all of `dist/assets/`, where `emptyOutDir: false`
  leaves earlier builds — a stale sibling would answer for the bundle that
  actually ships. It now takes the one `index.html` references, mirroring the
  remote form.
- Neither command could catch a bundle built *before* `operator.ts` was edited,
  i.e. one still serving the previous operator's Impressum. The remote block
  gained a positive `legalName` probe (`STALE BUNDLE`).

Relates to #574, #575.

## Why is this change needed?

A safety check that fires on 100% of deployments is worse than no check: it
trains the operator to ignore the one signal that an Impressum went live
unfilled — a §5 DDG problem, not a cosmetic one. This is the last manual gate
before public beta DNS.

Putting the check in code rather than in a grep also buys coverage a grep over a
minified bundle structurally cannot have:

| unfilled state | old grep | new grep | `check:operator` |
|---|---|---|---|
| required field is a placeholder | fires (but always fires) | fires | fails, names the field |
| **required field is empty** | never fires | never fires | **fails, names the field** |
| **optional field on template text** | fires | fires | **fails** (no banner would) |
| correctly filled deployment | **false alarm** | silent | passes |

An optional field left on template text is the interesting one:
`operatorTodos()` deliberately ignores optional fields (an empty `phone` or
`edgeProvider` is a decision, not an omission), so it renders red on the page
without raising the banner. The new test catches that case explicitly.

## How was this tested?

Verified both directions against a real `vite build`, not just at the unit
level:

| `operator.ts` state | `check:operator` | documented grep |
|---|---|---|
| as shipped, fresh build | exit 0 | no output |
| `legalName` → `[BITTE AUSFÜLLEN: …]` | exit 1, names `legalName` | `STILL UNFILLED` |
| optional `phone` → placeholder | exit 1, "fields still on template text: phone" | `STILL UNFILLED` |
| `email` → `""` | exit 1, names `email` | *silent* — as the doc now states |

The old command on that same correctly-filled build: 1 match, the constant
declaration — reproducing the live-bundle finding locally.

- [x] New/updated tests cover the change
- [x] `npm run test` in `web/` — 47 files, 460 tests pass
- [x] `npm run build` in `web/` (`tsc --noEmit` + `vite build`) clean
- [ ] `make check` — not run: no Go code is touched (docs + `web/` only). The
      `web` CI job runs both commands above.
- [x] Manual testing — the table above, against built bundles

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build / CI / tooling (new `check:operator` npm script)

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated tests for my changes
- [ ] All tests pass with `go test -race ./...` — n/a, no Go changes
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments — n/a, no new exported symbols
- [x] My commits are focused and have clear messages

## Additional Notes

The two `operatorTodos()` unit tests moved out of `legal.test.tsx` into the new
file rather than being duplicated, so the documented command runs the real
assertions. Nothing in the new file asserts the canonical deployment's own
values — a fork that correctly filled in *its* identity must pass it unchanged.
The shipped identity stays pinned in `legal.test.tsx` (`getByText(/Lukas
Schmidt/)`), which is where a fork is expected to see a failure.

Unrelated snag worth flagging for anyone building `web/` locally: `gen/` is
gitignored and mine was stale, so `npm run build` failed `tsc` on
`map.hasImage` until `buf generate` was re-run. CI regenerates it per run, so
this does not affect the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
