### PR TITLE
fix(voice): bound the silence clock, reap disgo's audio sender, and un-break make check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ you need to get started.
 
 ### Prerequisites
 
-- **Go 1.26+** — the default build is pure Go (`CGO_ENABLED=0`): no C toolchain, no native libraries. Only **audible** builds (`-tags opus`) additionally need `gcc`, `pkg-config`, and `libopus-dev` — the outbound Opus encoder links libopus via CGO (ADR-0034 amendment 2026-07-19); DAVE and the Silero VAD stay pure Go
+- **Go 1.26+** — the default build is pure Go (`CGO_ENABLED=0`): no C toolchain, no native libraries. Two exceptions: the **test** targets (`make test`, `make check`) need a host C toolchain (`gcc`) because the race detector requires cgo (`-race` — they still link no native libraries), and **audible** builds (`-tags opus`) additionally need `gcc`, `pkg-config`, and `libopus-dev` — the outbound Opus encoder links libopus via CGO (ADR-0034 amendment 2026-07-19); DAVE and the Silero VAD stay pure Go
 - **Node.js 20+ and npm** — the operator console is a Vite/React bundle the Go binary embeds (see the SPA step below)
 - **[buf](https://buf.build/docs/installation)** — the Connect/protobuf stubs under `gen/` are generated, not committed
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@
 # CGO (ADR-0034 amendment 2026-07-19) and must be paired with
 # `nolibopusfile`, so audible builds need pkg-config + libopus-dev and
 # CGO_ENABLED=1 (see CONTRIBUTING.md; the Dockerfile links it statically).
-# No target below uses the opus tag, so the export holds for all of them.
+# No target below uses the opus tag, but the test targets override the export
+# per-recipe anyway: `go test -race` requires cgo (issue #580), so they need a
+# host C toolchain (gcc) — while still linking no native libraries. `build`
+# keeps the pure-Go export and its static-link property.
 
 export CGO_ENABLED := 0
 
@@ -15,17 +18,19 @@ export CGO_ENABLED := 0
 build:
 	go build -o bin/glyphoxa ./cmd/glyphoxa
 
-# Run all tests with race detector
+# Run all tests with race detector. CGO_ENABLED=1 overrides the global pure-Go
+# export: -race requires cgo (issue #580). Mirrors CI's test job, which runs
+# `go test -race ./...` with CGO on.
 test:
-	go test -race -count=1 ./...
+	CGO_ENABLED=1 go test -race -count=1 ./...
 
 # Run tests with verbose output
 test-v:
-	go test -race -count=1 -v ./...
+	CGO_ENABLED=1 go test -race -count=1 -v ./...
 
 # Run tests with coverage
 test-cover:
-	go test -race -count=1 -coverprofile=coverage.out ./...
+	CGO_ENABLED=1 go test -race -count=1 -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out | tail -1
 	@echo "HTML report: go tool cover -html=coverage.out"
 

--- a/pkg/voice/provider.go
+++ b/pkg/voice/provider.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"sync/atomic"
+
+	"github.com/disgoorg/disgo/voice"
 )
 
 // switchingProvider implements disgo's voice.OpusFrameProvider for the lifetime
@@ -16,6 +18,13 @@ import (
 // between playbacks — only the slot pointer changes.
 type switchingProvider struct {
 	slot atomic.Pointer[playSlot]
+
+	// closed flips once, in Close, after [Session.Close] has torn the transport
+	// down. From then on ProvideOpusFrame stops reporting idle and hands the
+	// sender real silence frames instead — the poke that makes disgo's sender
+	// goroutine touch the dead transport, hit its terminal error, and shut
+	// itself down (issue #579); see ProvideOpusFrame.
+	closed atomic.Bool
 }
 
 // playSlot binds a [Playback] to its [Source] and the context whose
@@ -44,11 +53,27 @@ func (p *switchingProvider) clear(want *playSlot) bool {
 // ProvideOpusFrame returns the next frame from the active playback, or an empty
 // slice when idle. disgo treats len==0 as silence and keeps polling, so the
 // idle and post-EOF paths simply return (nil, nil) — we must never return a
-// non-nil error to "stop" the sender; the sender lives as long as the Session.
+// non-nil error to "stop" the sender (disgo only logs it and keeps polling);
+// the sender lives as long as the Session.
 //
 // On EOF, cancellation, or a source error the playback is finished (idempotent)
 // and its slot is cleared, after which we report silence until the next swap.
+//
+// After Close the answer changes: the provider hands back a REAL Opus silence
+// frame every poll instead of the idle (nil, nil). disgo's conn.Close tears
+// down the gateway/UDP but never closes its AudioSender, and a quiescent
+// sender (silent frames exhausted, speaking-stop sent) that keeps reading
+// len==0 never touches the network again — so it can never observe the closed
+// transport and never exits: one goroutine waking 50×/s per closed Session,
+// forever (issue #579). A non-empty frame forces the sender to write, the
+// write on the torn-down transport fails with net.ErrClosed (or SetSpeaking
+// with ErrGatewayNotConnected), and the sender's own handleErr shuts it down —
+// the only teardown path disgo gives us from this side of the API.
 func (p *switchingProvider) ProvideOpusFrame() ([]byte, error) {
+	if p.closed.Load() {
+		return voice.SilenceAudioFrame, nil
+	}
+
 	slot := p.slot.Load()
 	if slot == nil {
 		return nil, nil
@@ -79,9 +104,15 @@ func (p *switchingProvider) ProvideOpusFrame() ([]byte, error) {
 	return frame, nil
 }
 
-// Close is called by disgo when the connection's sender tears down. It retires
-// any in-flight playback as interrupted so [Playback.Done] always closes.
+// Close is called by [Session.Close] after the connection is torn down. It
+// retires any in-flight playback as interrupted so [Playback.Done] always
+// closes, and flips the provider into its sender-reaping state: every
+// subsequent ProvideOpusFrame poll returns a real silence frame so disgo's
+// sender goroutine — which conn.Close does NOT stop — writes to the dead
+// transport, errors terminally, and exits (issue #579). Callers must therefore
+// only Close AFTER the transport is down, or the poke frames would be audible.
 func (p *switchingProvider) Close() {
+	p.closed.Store(true)
 	if slot := p.slot.Swap(nil); slot != nil {
 		slot.pb.finish(ErrInterrupted)
 	}

--- a/pkg/voice/provider_test.go
+++ b/pkg/voice/provider_test.go
@@ -127,6 +127,24 @@ func TestSwitchingProvider(t *testing.T) {
 			t.Fatalf("got %v want ErrInterrupted", err)
 		}
 	})
+
+	t.Run("Close flips polls to sender-reaping silence frames", func(t *testing.T) {
+		// After Session.Close the transport is gone but disgo's sender keeps
+		// polling; the idle (nil, nil) would park it in its quiescent branch
+		// where it never touches the network — and so never exits (issue #579).
+		// Post-Close every poll must return a REAL frame, so the sender writes,
+		// observes the dead transport, and shuts itself down.
+		p := newTestSwitchingProvider()
+		if frame, err := p.ProvideOpusFrame(); err != nil || frame != nil {
+			t.Fatalf("pre-Close idle: got (%x, %v) want (nil, nil)", frame, err)
+		}
+		p.Close()
+		for range 3 {
+			if frame, err := p.ProvideOpusFrame(); err != nil || len(frame) == 0 {
+				t.Fatalf("post-Close: got (%x, %v) want a non-empty silence frame on every poll", frame, err)
+			}
+		}
+	})
 }
 
 // TestSwitchingProviderRace hammers concurrent swaps against a tight

--- a/pkg/voice/session.go
+++ b/pkg/voice/session.go
@@ -173,8 +173,15 @@ func (s *Session) Close() error {
 		}
 
 		// conn.Close only tears down the gateway/UDP; it does not call our
-		// provider/receiver Close. Do that ourselves so Inbound closes and any
-		// straggler playback is retired, regardless of disgo's goroutine timing.
+		// provider/receiver Close — nor its own AudioSender's (issue #579). Do
+		// ours ourselves so Inbound closes and any straggler playback is
+		// retired, regardless of disgo's goroutine timing. The ORDER matters:
+		// closing the provider after the transport flips it into its
+		// sender-reaping state (see switchingProvider.Close) — the next 20ms
+		// poll hands disgo's sender a silence frame, the write on the dead
+		// transport fails terminally, and the sender goroutine exits instead
+		// of polling forever. The receiver needs no such poke: udp.Close
+		// unblocks its conn.Read with net.ErrClosed and it closes itself.
 		s.conn.Close(context.WithoutCancel(context.Background()))
 		s.provider.Close()
 		s.dispatcher.Close()

--- a/pkg/voice/session_leak_test.go
+++ b/pkg/voice/session_leak_test.go
@@ -1,0 +1,182 @@
+package voice
+
+// This file pins the fix for issue #579 against the REAL disgo audio sender.
+// disgo's conn.Close tears down the gateway/UDP but never closes the
+// AudioSender goroutine SetOpusFrameProvider spawned; a quiescent sender
+// (silent frames exhausted, speaking-stop sent) reads len==0 from its provider
+// and returns without touching the network, so it can never observe the closed
+// transport and never exits — one goroutine waking 50×/s per closed Session.
+// Session.Close therefore closes the switchingProvider AFTER the transport,
+// flipping it into its sender-reaping state: every poll returns a real silence
+// frame, the sender writes it into the dead transport, hits net.ErrClosed (or
+// ErrGatewayNotConnected on SetSpeaking), and its own handleErr shuts it down.
+//
+// The rig mirrors disgo's connImpl exactly where it matters: the voiceConn
+// seam's SetOpusFrameProvider constructs a REAL voice.NewAudioSender over a
+// fake transport that can be killed, so a disgo bump that changes the sender's
+// teardown semantics fails HERE, not in production. Wall-clock waits are
+// unavoidable — the real sender owns its own 20ms pacing — so the test bounds
+// them generously and stays off t.Parallel (goleak needs a quiet goroutine
+// baseline).
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	botgateway "github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/voice"
+	"github.com/disgoorg/godave"
+	"github.com/disgoorg/snowflake/v2"
+	"go.uber.org/goleak"
+)
+
+// reapTransport is the shared "is the connection alive" state of the fake
+// disgo conn and its UDP transport, plus the quiescence signal the test
+// synchronizes on.
+type reapTransport struct {
+	dead atomic.Bool
+
+	// quiet closes once the sender reaches its quiescent state on the LIVE
+	// transport: silent frames exhausted and SetSpeaking(None) sent — the state
+	// a closed Session's sender idles in forever without the provider poke.
+	quiet     chan struct{}
+	quietOnce sync.Once
+}
+
+// reapUDPConn implements disgo's voice.UDPConn over the fake transport: writes
+// succeed while alive and fail with net.ErrClosed once killed, exactly like a
+// closed *net.UDPConn.
+type reapUDPConn struct{ tr *reapTransport }
+
+var _ voice.UDPConn = (*reapUDPConn)(nil)
+
+func (u *reapUDPConn) LocalAddr() net.Addr                             { return nil }
+func (u *reapUDPConn) RemoteAddr() net.Addr                            { return nil }
+func (u *reapUDPConn) SetSecretKey(voice.EncryptionMode, []byte) error { return nil }
+func (u *reapUDPConn) SetDeadline(time.Time) error                     { return nil }
+func (u *reapUDPConn) SetReadDeadline(time.Time) error                 { return nil }
+func (u *reapUDPConn) SetWriteDeadline(time.Time) error                { return nil }
+func (u *reapUDPConn) Open(context.Context, string, int, uint32) (string, int, error) {
+	return "", 0, nil
+}
+func (u *reapUDPConn) Close() error                       { return nil }
+func (u *reapUDPConn) Read([]byte) (int, error)           { return 0, net.ErrClosed }
+func (u *reapUDPConn) ReadPacket() (*voice.Packet, error) { return nil, net.ErrClosed }
+
+func (u *reapUDPConn) Write(p []byte) (int, error) {
+	if u.tr.dead.Load() {
+		return 0, net.ErrClosed
+	}
+	return len(p), nil
+}
+
+// reapDisgoConn implements the subset of disgo's voice.Conn the real
+// defaultAudioSender touches (UDP, DAVE, SetSpeaking); everything else is
+// inert. DAVE is godave's noop session, whose Ready() is always true — the
+// same post-Close answer the real dave-go session gives (its Close cancels
+// watchdogs but clears neither activeEpoch nor sendRatchet), so the sender's
+// Ready() guard does not park it before the poke frame reaches the transport.
+type reapDisgoConn struct {
+	tr   *reapTransport
+	udp  *reapUDPConn
+	dave godave.Session
+}
+
+var _ voice.Conn = (*reapDisgoConn)(nil)
+
+func newReapDisgoConn() *reapDisgoConn {
+	tr := &reapTransport{quiet: make(chan struct{})}
+	return &reapDisgoConn{
+		tr:   tr,
+		udp:  &reapUDPConn{tr: tr},
+		dave: godave.NewNoopSession(discardLogger(), "", nil),
+	}
+}
+
+func (c *reapDisgoConn) Gateway() voice.Gateway           { return nil }
+func (c *reapDisgoConn) UDP() voice.UDPConn               { return c.udp }
+func (c *reapDisgoConn) DAVE() godave.Session             { return c.dave }
+func (c *reapDisgoConn) ChannelID() *snowflake.ID         { return nil }
+func (c *reapDisgoConn) GuildID() snowflake.ID            { return testGuild }
+func (c *reapDisgoConn) UserIDBySSRC(uint32) snowflake.ID { return 0 }
+
+func (c *reapDisgoConn) SetSpeaking(_ context.Context, flags voice.SpeakingFlags) error {
+	if c.tr.dead.Load() {
+		return voice.ErrGatewayNotConnected
+	}
+	if flags == voice.SpeakingFlagNone {
+		// The sender only sends SpeakingFlagNone after exhausting its silent
+		// frames: it has gone quiescent and will never write again unprovoked.
+		c.tr.quietOnce.Do(func() { close(c.tr.quiet) })
+	}
+	return nil
+}
+
+func (c *reapDisgoConn) SetOpusFrameProvider(voice.OpusFrameProvider)              {}
+func (c *reapDisgoConn) SetOpusFrameReceiver(voice.OpusFrameReceiver)              {}
+func (c *reapDisgoConn) Open(context.Context, snowflake.ID, bool, bool) error      { return nil }
+func (c *reapDisgoConn) Close(context.Context)                                     { c.tr.dead.Store(true) }
+func (c *reapDisgoConn) HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate)   {}
+func (c *reapDisgoConn) HandleVoiceServerUpdate(botgateway.EventVoiceServerUpdate) {}
+
+// reapConn adapts reapDisgoConn to the package's voiceConn seam, spawning a
+// REAL disgo AudioSender exactly the way disgo's connImpl.SetOpusFrameProvider
+// does — the goroutine whose leak this test pins.
+type reapConn struct {
+	inner  *reapDisgoConn
+	sender voice.AudioSender
+}
+
+var _ voiceConn = (*reapConn)(nil)
+
+func (c *reapConn) Open(context.Context, snowflake.ID, bool, bool) error { return nil }
+
+func (c *reapConn) SetOpusFrameProvider(provider voice.OpusFrameProvider) {
+	if c.sender != nil {
+		c.sender.Close()
+	}
+	c.sender = voice.NewAudioSender(discardLogger(), provider, c.inner)
+	c.sender.Open()
+}
+
+func (c *reapConn) SetOpusFrameReceiver(voice.OpusFrameReceiver) {}
+func (c *reapConn) Close(context.Context)                        { c.inner.tr.dead.Store(true) }
+
+// TestSessionCloseReapsDisgoAudioSender is issue #579: Session.Close must end
+// the disgo AudioSender goroutine even though disgo's conn.Close does not. The
+// sender is driven into the quiescent state a real idle Session sits in, the
+// Session is closed, and goleak asserts the sender goroutine exited — pre-fix
+// it survives forever, waking every 20ms.
+func TestSessionCloseReapsDisgoAudioSender(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	conn := &reapConn{inner: newReapDisgoConn()}
+	sess, err := newSession(context.Background(), testGuild, testChannel, conn, sessionConfig{
+		logger:        discardLogger(),
+		metrics:       discardMetrics{},
+		inboundBuffer: 8,
+	})
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+
+	// Let the real sender go quiescent on the LIVE transport: ~5 silence
+	// writes then SetSpeaking(None), at its own 20ms cadence. Pre-fix, a
+	// Session closed from this state leaks the sender with certainty.
+	select {
+	case <-conn.inner.tr.quiet:
+	case <-time.After(5 * time.Second):
+		t.Fatal("disgo sender never reached its quiescent state")
+	}
+
+	if err := sess.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// goleak (deferred) fails if the sender goroutine outlives the Session: the
+	// closed provider's silence poke must have driven it into net.ErrClosed /
+	// ErrGatewayNotConnected and out of its loop.
+}

--- a/pkg/voice/wire/silence_test.go
+++ b/pkg/voice/wire/silence_test.go
@@ -110,8 +110,10 @@ func (c *fakeSilenceClock) resetCount() int {
 // newSilenceRig builds a Conversation around a REAL silero VAD (production
 // geometry + 12-frame hangover) and a stub recognizer, plus the "hello-test"
 // clip pre-framed at the VAD chunk size. The conversation publishes onto the
-// returned harness's bus; the silero session is closed at end of t.
-func newSilenceRig(t *testing.T, recText string) (*orchestrator.Conversation, *voicetest.Harness, []audio.Frame) {
+// returned harness's bus; the silero session is closed at end of t. An optional
+// wrapVAD decorates the silero session before it is wired in (the #578 disarm
+// test counts forward passes through it); existing call sites pass nothing.
+func newSilenceRig(t *testing.T, recText string, wrapVAD ...func(vad.SessionHandle) vad.SessionHandle) (*orchestrator.Conversation, *voicetest.Harness, []audio.Frame) {
 	t.Helper()
 
 	h := voicetest.New(t)
@@ -131,7 +133,11 @@ func newSilenceRig(t *testing.T, recText string) (*orchestrator.Conversation, *v
 	}
 	t.Cleanup(func() { _ = sess.Close() })
 
-	vadStage := orchestrator.NewVAD(h.Bus, sess)
+	wrapped := sess
+	for _, wrap := range wrapVAD {
+		wrapped = wrap(wrapped)
+	}
+	vadStage := orchestrator.NewVAD(h.Bus, wrapped)
 	sttStage := orchestrator.NewSTT(h.Bus, stubRecognizer{text: recText})
 	conv, err := orchestrator.NewConversation(h.Bus, vadStage, sttStage, nil)
 	if err != nil {
@@ -371,5 +377,96 @@ func TestPipeline_DiscordSilenceFramesDriveTheClock(t *testing.T) {
 	}
 	if got := clk.resetCount(); got != len(frames) {
 		t.Errorf("clock reset %d times, want %d: Discord silence frames must not reset the clock", got, len(frames))
+	}
+}
+
+// countingVAD decorates the rig's real silero session and counts ProcessFrame
+// calls — each one is the full Silero forward pass whose unbounded repetition
+// issue #578 is about.
+type countingVAD struct {
+	vad.SessionHandle
+
+	mu sync.Mutex
+	n  int
+}
+
+func (c *countingVAD) ProcessFrame(f audio.Frame) (vad.VADEvent, error) {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return c.SessionHandle.ProcessFrame(f)
+}
+
+func (c *countingVAD) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+// TestPipeline_SilenceClockDisarmsAfterHangoverWindow is issue #578: once the
+// last speaker stops, Discord's silence frames arm the clock and NOTHING before
+// this fix ever disarmed it — the ticker kept feeding a Silero pass per lane
+// every frame interval for the rest of the Voice Session (~2.7M passes per idle
+// day on zero audio). The clock's job is finished once the injected silence has
+// covered the end-of-speech hangover with margin, so after disarmTicks
+// consecutive injected frames it must disarm: further ticks reach the VAD not at
+// all. A fresh speaker-stop signal re-arms it for another bounded window, so a
+// later genuine stop still endpoints.
+func TestPipeline_SilenceClockDisarmsAfterHangoverWindow(t *testing.T) {
+	counter := &countingVAD{}
+	conv, h, frames := newSilenceRig(t, "hello there", func(s vad.SessionHandle) vad.SessionHandle {
+		counter.SessionHandle = s
+		return counter
+	})
+	codec := &replayCodec{frames: frames}
+	clk := &fakeSilenceClock{ch: make(chan time.Time)}
+	pipe := NewPipeline(conv, codec, nil, "guild", nil,
+		withSilenceClock(testSampleRate, testFrameMs, func() silenceClock { return clk }))
+
+	// The disarm window must sit comfortably above the hangover these tests
+	// drive (testHangoverTicks > silero's default 15-frame threshold), or the
+	// clock would cut endpointing short — the #91 regression.
+	disarm := pipe.disarmTicks
+	if disarm <= testHangoverTicks {
+		t.Fatalf("disarmTicks=%d must exceed the %d-tick hangover the silence tests drive", disarm, testHangoverTicks)
+	}
+
+	inbound := make(chan gxvoice.Frame)
+	done := make(chan error, 1)
+	go func() { done <- pipe.run(t.Context(), inbound) }()
+
+	feedSpeech(inbound, frames)
+	// The speaker stops for the night: silence frames arm the clock, then the
+	// channel is empty. Fire well past the disarm window — only the first
+	// disarmTicks ticks may reach the VAD.
+	for range discordStopSilenceFrames {
+		inbound <- gxvoice.Frame{Silence: true}
+	}
+	const overshoot = 40
+	for range disarm + overshoot {
+		clk.tick()
+	}
+	// A fresh speaker-stop signal re-arms the clock: these ticks must be
+	// injected again (another bounded window, not a permanent latch-off).
+	inbound <- gxvoice.Frame{Silence: true}
+	const rearmed = 5
+	for range rearmed {
+		clk.tick()
+	}
+	close(inbound)
+	if err := <-done; err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	want := len(frames) + disarm + rearmed
+	if got := counter.count(); got != want {
+		t.Errorf("VAD saw %d frames, want %d (%d real + %d injected before disarm + %d after re-arm): ticks past the disarm window must not reach the VAD",
+			got, want, len(frames), disarm, rearmed)
+	}
+	// Bounding the injection must not break what the clock exists for: the
+	// trailing utterance still endpointed inside the window.
+	starts, ends, _ := eventCounts(h)
+	if starts < 1 || ends != starts {
+		t.Errorf("trailing utterance not endpointed within the disarm window: speech_start=%d speech_end=%d", starts, ends)
 	}
 }

--- a/pkg/voice/wire/wire.go
+++ b/pkg/voice/wire/wire.go
@@ -89,10 +89,14 @@ type Pipeline struct {
 	// the VAD during inbound gaps (issue #91); silenceOn gates the whole mechanism
 	// off when no [WithSilenceClock] was given (the pre-#91 behaviour). newClock
 	// builds the frame-cadence clock — a real time.Ticker in production, a fake in
-	// tests. See [WithSilenceClock] and [Pipeline.run].
-	silence   audio.Frame
-	silenceOn bool
-	newClock  func() silenceClock
+	// tests. disarmTicks bounds continuous injection (issue #578): the number of
+	// consecutive clock frames — [silenceDisarmAfter] at this pipeline's frame
+	// geometry — after which the armed clock disarms itself. See
+	// [WithSilenceClock] and [Pipeline.run].
+	silence     audio.Frame
+	silenceOn   bool
+	newClock    func() silenceClock
+	disarmTicks int
 
 	// inboundTap, when set, is called with every non-silence inbound Opus frame
 	// just before it is decoded (the rollover tape's inbound capture point, #306);
@@ -180,6 +184,22 @@ func (c *tickerClock) stop()                   { c.t.Stop() }
 // Option configures a [Pipeline] at construction.
 type Option func(*Pipeline)
 
+// silenceDisarmAfter bounds how long the armed silence clock keeps injecting
+// synthesized silence after the last speaker-stop signal (issue #578). The
+// clock's whole job (#91) is to advance silero's end-of-speech hangover through
+// the packet gap a stopped speaker leaves — vadMinSilenceFrames worth of
+// frames, a few hundred ms. Without a bound, the last participant leaving
+// latches the clock armed for the rest of the Voice Session (nothing after the
+// arming silence frames ever disarms it), burning a full Silero forward pass
+// per Speaker Lane every frame interval on a channel carrying zero audio —
+// ~2.7M passes per idle day at the 32 ms cadence. Two seconds of continuous
+// injection (62 frames at the production 16 kHz / 32 ms geometry) covers the
+// corpus-validated 12-frame hangover — and the 20 hand-fired ticks the silence
+// tests drive — several times over, so anything still open by then has long
+// since endpointed; a fresh speaker-stop signal re-arms the clock for another
+// window.
+const silenceDisarmAfter = 2 * time.Second
+
 // WithSilenceClock enables the continuous silence clock (issue #91): once a
 // speaker stop is signalled by Discord's explicit Opus silence frames, the
 // pipeline feeds synthesized PCM silence into the VAD at the orchestrator frame
@@ -210,6 +230,7 @@ func withSilenceClock(sampleRate, frameMs int, newClock func() silenceClock) Opt
 		p.silence = f
 		p.silenceOn = true
 		p.newClock = newClock
+		p.disarmTicks = int(silenceDisarmAfter / (time.Duration(frameMs) * time.Millisecond))
 	}
 }
 
@@ -292,9 +313,19 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 	// disarms it. If all stop-silence frames are lost, the utterance endpoints at
 	// the next arming signal or the shutdown Flush — the pre-#91 worst case —
 	// instead of risking a false mid-utterance split.
+	//
+	// Arming is also BOUNDED (#578): injected counts the consecutive clock frames
+	// fed since the last real audio, and once it covers the hangover with margin
+	// (p.disarmTicks, ~2s) the clock disarms itself. The endpointing work is done
+	// a few hundred ms after the speaker stops; without the bound the arm from
+	// the LAST speaker-stop of the night latches forever and every subsequent
+	// tick burns a Silero pass per Speaker Lane on an empty channel. A fresh
+	// silence frame re-arms for another full window, so a genuine later stop
+	// still endpoints.
 	var clk silenceClock
 	var clockTicks <-chan time.Time
 	armed := false
+	injected := 0
 	if p.silenceOn {
 		clk = p.newClock()
 		defer clk.stop()
@@ -319,6 +350,15 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 			if err := p.conv.FeedSilence(p.silence); err != nil {
 				p.log.Debug("feed silence frame", "err", err)
 			}
+			injected++
+			if injected >= p.disarmTicks {
+				// The hangover window is covered several times over: whatever was
+				// open has endpointed, and every further tick would be a wasted
+				// Silero pass per lane (#578). Disarm until the next speaker-stop
+				// signal.
+				armed = false
+				injected = 0
+			}
 		case frame, ok := <-inbound:
 			if !ok {
 				return nil // session closed
@@ -332,10 +372,12 @@ func (p *Pipeline) run(ctx context.Context, inbound <-chan gxvoice.Frame) error 
 				armed = true
 				continue
 			}
-			// Real audio arrived: the speaker is talking again. Disarm and reset the
-			// idle clock so no synthesized silence is injected while frames keep
-			// flowing — not even through an arrival gap (#147).
+			// Real audio arrived: the speaker is talking again. Disarm, clear the
+			// injection count (#578), and reset the idle clock so no synthesized
+			// silence is injected while frames keep flowing — not even through an
+			// arrival gap (#147).
 			armed = false
+			injected = 0
 			if clk != nil {
 				clk.reset()
 			}


### PR DESCRIPTION
## What does this PR do?

Fixes the three resource/tooling bugs found behind the #577 investigation, one focused commit each:

- **Closes #578** — the inbound loop's silence clock armed on a Discord Opus silence frame and disarmed only on a real audio frame, so the last participant leaving latched it armed for the rest of the Voice Session: a full Silero forward pass per Speaker Lane every 32 ms on zero audio (~2.7M passes per idle day). Injection is now bounded: a consecutive-injected-tick counter disarms the clock after `silenceDisarmAfter` (2 s ≈ 62 frames at the production 16 kHz / 32 ms geometry — several times the corpus-validated 12-frame hangover and the 20 hand-fired ticks the silence tests drive). Every real frame clears the counter alongside the existing disarm; a fresh speaker-stop signal re-arms for another full window, so a later genuine stop still endpoints.
- **Closes #579** — disgo's `conn.Close` never closes the `AudioSender` its `SetOpusFrameProvider` spawned, and a quiescent sender that reads `len==0` from its provider never touches the network again — so it never sees the dead transport and never exits (one goroutine waking 50×/s per closed Session, scaling with reconnect churn). `SetOpusFrameProvider(nil)` would only move the leak (disgo constructs a fresh sender either way), so `Session.Close` now flips the `switchingProvider` into a sender-reaping state after the transport is down: every poll returns a real Opus silence frame, the sender writes it, hits `net.ErrClosed` (or `ErrGatewayNotConnected` on `SetSpeaking`), and its own `handleErr` shuts it down within a tick or two. The `DAVE().Ready()` guard can't park the poke: godave's noop session always reports ready, and dave-go's `Close` clears neither `activeEpoch` nor `sendRatchet` (verified in the pinned sources). The receiver already reaps itself via `udp.Close` unblocking its `Read`.
- **Closes #580** — the Makefile exports `CGO_ENABLED=0` globally while `test` runs `go test -race`, which requires cgo, so `make check` (the documented pre-push gate) could not pass on any machine. The `test`/`test-v`/`test-cover` recipes now override `CGO_ENABLED=1`, mirroring CI's test job; `build` keeps the pure-Go export and its static-link property. CONTRIBUTING.md's prerequisites now state that the test targets need a host C toolchain (but still no native libraries).

Relates to #577 / ADR-0061 (Idle Close bounds the blast radius of #578; the reconnect-churn ceiling exists because of the #579 leak class).

## Why is this change needed?

#578 and #579 are per-session resource burns that never decay — a day-long idle Voice Session (the #577 shape) pays millions of wasted Silero passes and accumulates one permanently-awake goroutine per reconnect cycle. #580 makes the documented local gate fail in a way that looks like the contributor broke the build.

## How was this tested?

- `make check` (the previously-impossible command) run end-to-end on this branch: fmt + vet + full `go test -race -count=1 ./...`.
- **#578**: new `TestPipeline_SilenceClockDisarmsAfterHangoverWindow` wraps the rig's real silero session in a forward-pass counter and pins that (a) ticks past the disarm window never reach the VAD, (b) a fresh Discord silence frame re-arms injection for another bounded window, and (c) the trailing utterance still endpoints inside the window. All four pre-existing silence-clock tests (#91/#147) pass unchanged.
- **#579**: new `TestSessionCloseReapsDisgoAudioSender` drives the **real** `voice.NewAudioSender` (not a mock) over a killable fake transport mirroring disgo's `connImpl`, waits for the sender's quiescent state, closes the Session, and asserts with `goleak` that the sender goroutine exited. Verified it fails pre-fix (goleak reports the leaked `defaultAudioSender.open`) and passes post-fix. A new provider subtest pins the post-Close poke contract.
- **#580**: `make check` itself is the acceptance test.

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [x] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- The #579 fix is the "ours" option from the issue; the issue's option 1 as literally written (`SetOpusFrameProvider(nil)`) was checked against the pinned disgo source and rejected — disgo closes the old sender but constructs a fresh one polling the nil provider forever, so it moves the leak rather than fixing it. An upstream PR adding `audioSender.Close()` to `connImpl.Close` (matching `HandleVoiceStateUpdate`) is still worth carrying separately; the provider-side reap here stays correct either way and pins the behavior against disgo bumps.
- The poke frames are never audible: `switchingProvider.Close` documents (and `Session.Close` enforces) that the provider is only closed after the transport is down.
- `silenceDisarmAfter` is time-based, so the tick bound scales with whatever frame geometry the pipeline runs at; the new test asserts the computed window exceeds the hangover the tests drive, so a future retune below it fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMrWGiRdnr7oyqinyLNtmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMrWGiRdnr7oyqinyLNtmj)_