### PR TITLE
test(session): wait for the terminal row write before asserting on policy-stop rows

### DIFF
--- a/internal/session/manager_allowance_test.go
+++ b/internal/session/manager_allowance_test.go
@@ -119,7 +119,7 @@ func TestAllowanceRemaining_TightensHardCap_EndsWithAllowanceReason(t *testing.T
 	<-runner.started
 
 	bigGroqLLM(runner.cfg().StageMetrics)
-	waitInactive(t, mgr)
+	waitInactive(t, mgr, store, vs.ID)
 
 	closed := store.session(vs.ID)
 	if closed.Status != storage.VoiceSessionEnded {
@@ -151,7 +151,7 @@ func TestTenantCapBelowAllowance_KeepsSpendCapReason(t *testing.T) {
 	<-runner.started
 
 	bigGroqLLM(runner.cfg().StageMetrics)
-	waitInactive(t, mgr)
+	waitInactive(t, mgr, store, vs.ID)
 
 	closed := store.session(vs.ID)
 	if closed.EndReason == nil || *closed.EndReason != "spend_cap_hard: estimated spend crossed the hard cap" {

--- a/internal/session/manager_idle_test.go
+++ b/internal/session/manager_idle_test.go
@@ -63,7 +63,7 @@ func TestIdleClose_EndsSessionCleanly(t *testing.T) {
 
 	// Nothing ever marks activity, so the watchdog closes the session on one of its
 	// next sweeps; the trip cancels the run ctx on a goroutine, like the hard cap.
-	waitInactive(t, mgr)
+	waitInactive(t, mgr, store, vs.ID)
 
 	closed := store.session(vs.ID)
 	if closed.Status != storage.VoiceSessionEnded {
@@ -193,7 +193,7 @@ func TestIdleClose_ChurnEndsSessionWithItsOwnReason(t *testing.T) {
 	for range 3 { // one past the ceiling
 		cycle()
 	}
-	waitInactive(t, mgr)
+	waitInactive(t, mgr, store, vs.ID)
 
 	closed := store.session(vs.ID)
 	if closed.Status != storage.VoiceSessionEnded {

--- a/internal/session/manager_spend_test.go
+++ b/internal/session/manager_spend_test.go
@@ -299,7 +299,7 @@ func TestHardCap_EndsSessionCleanly(t *testing.T) {
 
 	// The hard-cap trip cancels the run ctx on a goroutine; wait for the session to
 	// end (the guard frees).
-	waitInactive(t, mgr)
+	waitInactive(t, mgr, store, vs.ID)
 
 	// The row closed ENDED (not failed) with the spend_cap_hard reason.
 	closed := store.session(vs.ID)
@@ -324,15 +324,21 @@ func TestHardCap_EndsSessionCleanly(t *testing.T) {
 	mgr.Shutdown()
 }
 
-// waitInactive polls until the manager reports no active session, or fails.
-func waitInactive(t *testing.T, mgr *session.Manager) {
+// waitInactive polls until the manager reports no active session AND the given
+// session's row has left 'running', or fails. AnyLive flips false the moment
+// the loop returns (as.ended is set under mu BEFORE the finalizers run), but
+// the terminal row write lands after, in the end path — so a caller asserting
+// on the row right after an AnyLive-only wait races the end write (the
+// "idle-closed row status = running" CI flake). Waiting for the row itself
+// makes the subsequent status/end_reason asserts deterministic.
+func waitInactive(t *testing.T, mgr *session.Manager, store *fakeStore, id uuid.UUID) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if !mgr.AnyLive() {
+		if !mgr.AnyLive() && store.session(id).Status != storage.VoiceSessionRunning {
 			return
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
-	t.Fatal("session did not end within the deadline after the hard cap")
+	t.Fatal("session did not end (row still 'running') within the deadline")
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the test race that turned main's post-merge CI run red (`TestIdleClose_EndsSessionCleanly`: `idle-closed row status = "running", want "ended"`).

`Manager.AnyLive` flips false the moment the voice loop returns — `as.ended` is set under `mu` **before** the finalizers run — but the terminal `ended` row write lands after, in the end path. The five policy-stop tests (idle close, reconnect churn, hard spend cap, allowance exhaustion ×2) asserted on the `voice_sessions` row immediately after `waitInactive`, so they raced the end write. `waitInactive` now takes the store + session id and also polls the row out of `running`, making the status/`end_reason` asserts that follow deterministic.

## Why is this change needed?

Main's CI is red on a flake, which blocks cutting the v0.6.0 release. The race is in the tests (new with #577 yesterday), not in production code — the deliver-then-commit ordering of `as.ended` vs. the terminal write is intentional (#487 resurrection-race fix).

## How was this tested?

- `go test -race -count=5 -run "TestIdleClose|TestHardCap|TestAllowance|TestTenantCap" ./internal/session/` — green.
- Full `go test -race ./internal/session/` — green.

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

Test-only change; no production code touched. Unblocks tagging v0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyaC8JH5bWvKtx77JyDuhE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyaC8JH5bWvKtx77JyDuhE)_