### PR TITLE
fix(session): central-token tenants get the voice-channel picker; surface its preconditions

### DIFF
--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -1626,6 +1626,11 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// ADR-0047) or replays it into the live voice channel (the session Manager). The
 	// Campaign's last-chosen channel is remembered through the store.
 	deploymentSharer := rpc.NewDeploymentSharer(store, cipher, log)
+	// The central Bot token is the sharer's fallback rung (ADR-0057): a
+	// central-token Tenant lists channels (the Session picker, the share
+	// dialog) with the SAME token its sessions run on — the ProviderServer
+	// guild-proof ladder precedent.
+	deploymentSharer.SetEnvBotToken(os.Getenv("DISCORD_BOT_TOKEN"))
 	sessionSrv.SetSharing(deploymentSharer, mgr, store)
 	// The Session screen's voice-channel picker (ListSessionVoiceChannels): the
 	// SAME sharer instance lists the linked guild's voice channels, and the store

--- a/internal/rpc/export_test.go
+++ b/internal/rpc/export_test.go
@@ -17,6 +17,14 @@ func (d *DeploymentSharer) SetShareSeamsForTest(
 	d.postFn = post
 }
 
+// SetVoiceListSeamForTest overrides the voice-channel REST seam so a test
+// drives ListVoiceChannels against a fake instead of the live Discord API.
+func (d *DeploymentSharer) SetVoiceListSeamForTest(
+	list func(ctx context.Context, token, guildID string, log *slog.Logger) ([]discordshare.Channel, error),
+) {
+	d.listVoiceFn = list
+}
+
 // SetGuildProofForTest overrides the #504 guild-admin proof seam so unit tests
 // drive SaveDiscordSettings without dialing Discord, mirroring the resolveInvite
 // seam pattern.

--- a/internal/rpc/highlight_share.go
+++ b/internal/rpc/highlight_share.go
@@ -27,6 +27,13 @@ import (
 // Discord API failure (which is CodeUnavailable).
 var ErrNoDiscordToken = errors.New("rpc: no Discord bot token saved")
 
+// ErrNoGuildLinked is the sentinel the channel listers return when the Tenant
+// has no linked guild — distinct from ErrNoDiscordToken since the env-token
+// rung (ADR-0057 central Bot-token mode) means a token can resolve for a
+// Tenant that never linked a server. The RPCs map it to a readable
+// CodeFailedPrecondition ("link a Discord server first").
+var ErrNoGuildLinked = errors.New("rpc: no Discord guild linked")
+
 // captionMaxRunes bounds the message caption (the Highlight excerpt) so a long
 // excerpt cannot overrun Discord's 2000-char message limit; the headroom leaves
 // room for Discord's own formatting.
@@ -95,6 +102,9 @@ func (s *SessionServer) ListShareChannels(
 	channels, err := s.sharer.ListTextChannels(ctx)
 	if errors.Is(err, ErrNoDiscordToken) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("save a Discord Bot token first"))
+	}
+	if errors.Is(err, ErrNoGuildLinked) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("link a Discord server first"))
 	}
 	if err != nil {
 		return nil, s.discordError("ListShareChannels", err)

--- a/internal/rpc/highlight_sharer.go
+++ b/internal/rpc/highlight_sharer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/discordshare"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/internal/wirenpc"
 )
 
 // DeploymentSharer is the production [HighlightSharer] (#310): it resolves the
@@ -23,6 +24,10 @@ type DeploymentSharer struct {
 	deps   deploymentReader
 	cipher *crypto.Cipher
 	log    *slog.Logger
+	// envToken is the deployment's central Bot token (env DISCORD_BOT_TOKEN),
+	// the fallback rung when the Tenant has no saved BYOK token (ADR-0057
+	// central Bot-token mode); wired via SetEnvBotToken. Empty = no fallback.
+	envToken string
 
 	// listFn / listVoiceFn / postFn are seams so tests point the Discord calls at
 	// a fake server; they default to the live discordshare functions.
@@ -54,37 +59,59 @@ func NewDeploymentSharer(deps deploymentReader, cipher *crypto.Cipher, log *slog
 	}
 }
 
-// resolve opens the request Tenant's saved Bot token and reads the guild id. An
-// unsaved token (no deployment row, empty last4, or no cipher) is
-// ErrNoDiscordToken; a missing Tenant in ctx is ErrNoDiscordToken too (the share
-// path is behind the auth stack, so this only guards a mis-wired test).
+// SetEnvBotToken hands the sharer the deployment's central Bot token (env
+// DISCORD_BOT_TOKEN) as the fallback rung of its token ladder, mirroring
+// ProviderServer.SetEnvBotToken. Without it a central-token Tenant (ADR-0057:
+// guild linked, no saved per-tenant token) could START sessions — Manager.Start
+// resolves the same ladder — but could not LIST channels, so the Session
+// screen's picker and the Highlight share dialog silently failed with "save a
+// Discord Bot token first" on exactly the deployments where saving one is not
+// required.
+func (d *DeploymentSharer) SetEnvBotToken(token string) {
+	d.envToken = token
+}
+
+// resolve resolves the request Tenant's Bot token under the SAME hybrid policy
+// a session start uses (#87, ADR-0057: the Tenant's resolved Bot) — the saved
+// BYOK token when one exists, else the deployment's central env token — and
+// reads the linked guild id. Neither token resolving is ErrNoDiscordToken
+// ("save a Discord Bot token first", now accurate: there is no env token
+// either). A REAL saved token that cannot be opened (no cipher, undecryptable)
+// stays a hard error, never a silent env fall-through (the wirenpc AC3
+// posture). A missing Tenant in ctx is ErrNoDiscordToken too (the path is
+// behind the auth stack, so this only guards a mis-wired test).
 func (d *DeploymentSharer) resolve(ctx context.Context) (token, guildID string, err error) {
 	tenantID, ok := auth.TenantID(ctx)
 	if !ok {
 		return "", "", ErrNoDiscordToken
 	}
 	dep, derr := d.deps.GetDeploymentConfig(ctx, tenantID)
-	if errors.Is(derr, storage.ErrNotFound) {
-		return "", "", ErrNoDiscordToken
-	}
-	if derr != nil {
+	if derr != nil && !errors.Is(derr, storage.ErrNotFound) {
 		return "", "", derr
 	}
-	if !isSaved(dep.DiscordBotTokenLast4) || d.cipher == nil {
+	// ErrNotFound leaves dep zero: an empty last4 resolves straight to the env
+	// token, exactly as a session start would for that Tenant.
+	tok, rerr := wirenpc.ResolveDiscordToken(d.cipher, dep.DiscordBotTokenLast4, dep.DiscordBotTokenCiphertext, d.envToken)
+	if rerr != nil {
+		return "", "", rerr
+	}
+	if tok == "" {
 		return "", "", ErrNoDiscordToken
 	}
-	plain, oerr := d.cipher.Open(dep.DiscordBotTokenCiphertext)
-	if oerr != nil {
-		return "", "", oerr
-	}
-	return string(plain), dep.GuildID, nil
+	return tok, dep.GuildID, nil
 }
 
-// ListTextChannels implements [HighlightSharer].
+// ListTextChannels implements [HighlightSharer]. An unlinked guild is
+// [ErrNoGuildLinked] — with the env-token rung a token can resolve for a
+// Tenant that never linked a server, and "save a Discord Bot token first"
+// would be the wrong advice for that state.
 func (d *DeploymentSharer) ListTextChannels(ctx context.Context) ([]discordshare.Channel, error) {
 	token, guildID, err := d.resolve(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if guildID == "" {
+		return nil, ErrNoGuildLinked
 	}
 	return d.listFn(ctx, token, guildID, d.log)
 }
@@ -96,6 +123,9 @@ func (d *DeploymentSharer) ListVoiceChannels(ctx context.Context) ([]discordshar
 	token, guildID, err := d.resolve(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if guildID == "" {
+		return nil, ErrNoGuildLinked
 	}
 	return d.listVoiceFn(ctx, token, guildID, d.log)
 }

--- a/internal/rpc/highlight_sharer_test.go
+++ b/internal/rpc/highlight_sharer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -30,9 +31,10 @@ func shareCtx() context.Context {
 	return auth.WithTenant(context.Background(), uuid.New())
 }
 
-// TestDeploymentSharer_NoTokenPaths pins that every unsaved-token shape is
-// ErrNoDiscordToken (the RPC renders it as "save a Discord Bot token first"): no
-// deployment row, the ENV placeholder, and a nil cipher.
+// TestDeploymentSharer_NoTokenPaths pins that every token-less shape — no saved
+// token AND no env fallback — is ErrNoDiscordToken (the RPC renders it as
+// "save a Discord Bot token first", now accurate advice): no deployment row,
+// the ENV placeholder, and an unsaved empty last4, each with no env token set.
 func TestDeploymentSharer_NoTokenPaths(t *testing.T) {
 	cipher := testCipher(t)
 
@@ -43,7 +45,6 @@ func TestDeploymentSharer_NoTokenPaths(t *testing.T) {
 		"no deployment row": {fakeDeploymentReader{err: storage.ErrNotFound}, cipher},
 		"env placeholder":   {fakeDeploymentReader{dep: storage.DeploymentConfig{DiscordBotTokenLast4: "env"}}, cipher},
 		"unsaved (empty)":   {fakeDeploymentReader{dep: storage.DeploymentConfig{DiscordBotTokenLast4: ""}}, cipher},
-		"no cipher":         {fakeDeploymentReader{dep: storage.DeploymentConfig{DiscordBotTokenLast4: "abcd", DiscordBotTokenCiphertext: []byte("x")}}, nil},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -53,6 +54,104 @@ func TestDeploymentSharer_NoTokenPaths(t *testing.T) {
 			}
 			if err := s.PostClip(shareCtx(), "c", "cap", "highlight.wav", "audio/wav", []byte("x")); !errors.Is(err, rpc.ErrNoDiscordToken) {
 				t.Fatalf("PostClip err = %v, want ErrNoDiscordToken", err)
+			}
+		})
+	}
+}
+
+// TestDeploymentSharer_SavedTokenWithoutCipherIsHardError pins the wirenpc AC3
+// posture: a REAL saved token that cannot be decrypted (no $GLYPHOXA_SECRET) is
+// a CLEAR error — never ErrNoDiscordToken ("save a token first" would be wrong:
+// one IS saved) and never a silent env fall-through.
+func TestDeploymentSharer_SavedTokenWithoutCipherIsHardError(t *testing.T) {
+	deps := fakeDeploymentReader{dep: storage.DeploymentConfig{
+		DiscordBotTokenLast4:      "abcd",
+		DiscordBotTokenCiphertext: []byte("x"),
+		GuildID:                   "guild-42",
+	}}
+	s := rpc.NewDeploymentSharer(deps, nil, slog.Default())
+	s.SetEnvBotToken("central-env-token") // must NOT be silently used
+
+	_, err := s.ListTextChannels(shareCtx())
+	if err == nil || errors.Is(err, rpc.ErrNoDiscordToken) {
+		t.Fatalf("ListTextChannels err = %v, want a hard decrypt error (not nil, not ErrNoDiscordToken)", err)
+	}
+	if !strings.Contains(err.Error(), "GLYPHOXA_SECRET") {
+		t.Fatalf("ListTextChannels err = %v, want the $GLYPHOXA_SECRET hint", err)
+	}
+}
+
+// TestDeploymentSharer_EnvTokenFallback is the ADR-0057 central-token case the
+// production incident hit: a Tenant with a linked guild and NO saved per-tenant
+// Bot token (empty last4 / the seed's "env" placeholder / no row at all) must
+// list channels and post clips with the deployment's central env token — the
+// SAME ladder its session starts already resolve — instead of dead-ending on
+// "save a Discord Bot token first" while Start works.
+func TestDeploymentSharer_EnvTokenFallback(t *testing.T) {
+	cipher := testCipher(t)
+	for name, dep := range map[string]fakeDeploymentReader{
+		"empty last4":     {dep: storage.DeploymentConfig{GuildID: "guild-42"}},
+		"env placeholder": {dep: storage.DeploymentConfig{GuildID: "guild-42", DiscordBotTokenLast4: "env"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := rpc.NewDeploymentSharer(dep, cipher, slog.Default())
+			s.SetEnvBotToken("central-env-token")
+
+			var gotToken, gotGuild, gotVoiceToken, gotVoiceGuild, gotPostToken string
+			s.SetShareSeamsForTest(
+				func(_ context.Context, token, guildID string, _ *slog.Logger) ([]discordshare.Channel, error) {
+					gotToken, gotGuild = token, guildID
+					return []discordshare.Channel{{ID: "1", Name: "general"}}, nil
+				},
+				func(_ context.Context, token, _, _, _, _ string, _ []byte, _ *slog.Logger) error {
+					gotPostToken = token
+					return nil
+				},
+			)
+			s.SetVoiceListSeamForTest(func(_ context.Context, token, guildID string, _ *slog.Logger) ([]discordshare.Channel, error) {
+				gotVoiceToken, gotVoiceGuild = token, guildID
+				return []discordshare.Channel{{ID: "2", Name: "Tavern"}}, nil
+			})
+
+			if _, err := s.ListTextChannels(shareCtx()); err != nil {
+				t.Fatalf("ListTextChannels: %v", err)
+			}
+			if gotToken != "central-env-token" || gotGuild != "guild-42" {
+				t.Fatalf("text list got token %q guild %q, want the env token + linked guild", gotToken, gotGuild)
+			}
+			if _, err := s.ListVoiceChannels(shareCtx()); err != nil {
+				t.Fatalf("ListVoiceChannels: %v", err)
+			}
+			if gotVoiceToken != "central-env-token" || gotVoiceGuild != "guild-42" {
+				t.Fatalf("voice list got token %q guild %q, want the env token + linked guild", gotVoiceToken, gotVoiceGuild)
+			}
+			if err := s.PostClip(shareCtx(), "c", "cap", "highlight.wav", "audio/wav", []byte("x")); err != nil {
+				t.Fatalf("PostClip: %v", err)
+			}
+			if gotPostToken != "central-env-token" {
+				t.Fatalf("post got token %q, want the env token", gotPostToken)
+			}
+		})
+	}
+}
+
+// TestDeploymentSharer_EnvTokenWithoutGuildIsNoGuildLinked: with the env rung a
+// token resolves for a Tenant that never linked a server, so the LIST paths
+// must answer that state with ErrNoGuildLinked ("link a Discord server first"),
+// not a misleading token error and not a raw empty-guild transport failure.
+func TestDeploymentSharer_EnvTokenWithoutGuildIsNoGuildLinked(t *testing.T) {
+	for name, dep := range map[string]fakeDeploymentReader{
+		"no deployment row": {err: storage.ErrNotFound},
+		"row without guild": {dep: storage.DeploymentConfig{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := rpc.NewDeploymentSharer(dep, testCipher(t), slog.Default())
+			s.SetEnvBotToken("central-env-token")
+			if _, err := s.ListTextChannels(shareCtx()); !errors.Is(err, rpc.ErrNoGuildLinked) {
+				t.Fatalf("ListTextChannels err = %v, want ErrNoGuildLinked", err)
+			}
+			if _, err := s.ListVoiceChannels(shareCtx()); !errors.Is(err, rpc.ErrNoGuildLinked) {
+				t.Fatalf("ListVoiceChannels err = %v, want ErrNoGuildLinked", err)
 			}
 		})
 	}

--- a/internal/rpc/provider.go
+++ b/internal/rpc/provider.go
@@ -431,6 +431,16 @@ func (s *ProviderServer) SaveDiscordSettings(
 		return nil, connect.NewError(connect.CodeInvalidArgument,
 			errors.New("voice_channel_id must be a Discord channel id"))
 	}
+	// The guild id likewise: SaveDiscordGuild clears the stored Default Voice
+	// Channel whenever the incoming guild differs BYTE-wise from the stored one,
+	// so a non-canonical variant of the same guild (stray whitespace, a pasted
+	// decoration) must never reach that comparison — and a non-canonical stored
+	// guild_id would also break the interaction router's string-equality lookup
+	// (GetTenantIDByGuildID).
+	if hasGuild && !snowflakePattern.MatchString(req.Msg.GetGuildId()) {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("guild_id must be a Discord server id"))
+	}
 	if req.Msg.BotToken != nil {
 		if s.cipher == nil {
 			return nil, connect.NewError(connect.CodeFailedPrecondition,

--- a/internal/rpc/provider_test.go
+++ b/internal/rpc/provider_test.go
@@ -672,6 +672,24 @@ func TestProviderDiscordSettings_ChannelShapeAndNoWriteOnReject(t *testing.T) {
 		}
 	})
 
+	t.Run("non-snowflake guild is InvalidArgument", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeProviderStore()
+		client, _ := newProviderClient(t, store, testCipher(t))
+		// A non-canonical guild value (whitespace, decoration) would compare
+		// unequal to the stored guild in SaveDiscordGuild's CASE and silently
+		// clear the Default Voice Channel — so it must be rejected pre-write.
+		_, err := client.SaveDiscordSettings(ctx, connect.NewRequest(&managementv1.SaveDiscordSettingsRequest{
+			GuildId: strPtr(" 472093001100"),
+		}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("non-snowflake guild = %v, want InvalidArgument", err)
+		}
+		if err == nil || !strings.Contains(err.Error(), "must be a Discord server id") {
+			t.Errorf("err = %v, want the guild-shape message", err)
+		}
+	})
+
 	t.Run("riding token is not stored when the channel-only save rejects", func(t *testing.T) {
 		t.Parallel()
 		store := newFakeProviderStore()

--- a/internal/rpc/session_channels.go
+++ b/internal/rpc/session_channels.go
@@ -72,6 +72,11 @@ func (s *SessionServer) ListSessionVoiceChannels(
 	if errors.Is(err, ErrNoDiscordToken) {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("save a Discord Bot token first"))
 	}
+	if errors.Is(err, ErrNoGuildLinked) {
+		// Belt and braces: the deployment read above already answered this state;
+		// the lister's own guild fence covers a release racing between the two.
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("link a Discord server first"))
+	}
 	if err != nil {
 		return nil, s.discordError("ListSessionVoiceChannels", err)
 	}

--- a/web/src/screens/session/Session.test.tsx
+++ b/web/src/screens/session/Session.test.tsx
@@ -1718,12 +1718,15 @@ describe("Session voice-channel picker", () => {
     await waitFor(() => expect(startRequests).toEqual(["c-general"]));
   });
 
-  it("renders no picker and starts with an empty voice_channel_id when the channel list errors", async () => {
+  it("surfaces the lister's precondition as an inline hint and still starts with an empty voice_channel_id", async () => {
     // The unlinked-guild / missing-token case: ListSessionVoiceChannels fails
-    // FailedPrecondition once (retry:false) and the picker is simply absent —
-    // Start still works, deferring the precondition to the server.
+    // FailedPrecondition once (retry:false). The picker is absent but the
+    // server's actionable message renders as a visible hint beside Start —
+    // silence here once dead-ended an operator on a central-token deployment
+    // (no picker, no clue, Start falling back to an empty default). Start
+    // still works, deferring the precondition to the server.
     const { transport, startRequests } = channelTransport({
-      listError: new ConnectError("session: link a Discord server first", Code.FailedPrecondition),
+      listError: new ConnectError("link a Discord server first", Code.FailedPrecondition),
     });
     render(
       <Providers transport={transport} queryClient={makeQueryClient()}>
@@ -1732,6 +1735,9 @@ describe("Session voice-channel picker", () => {
     );
 
     expect(await screen.findByText("Idle")).toBeInTheDocument();
+    const hint = await screen.findByTestId("channel-hint");
+    expect(hint).toHaveTextContent("link a Discord server first");
+    expect(hint).toHaveAttribute("role", "alert");
     expect(screen.queryByTestId("channel-picker")).not.toBeInTheDocument();
 
     // Start re-enables once the errored list read settles (the loading hold
@@ -1743,7 +1749,29 @@ describe("Session voice-channel picker", () => {
     expect(await screen.findByText("Live")).toBeInTheDocument();
   });
 
-  it("renders no picker when the guild has no voice channels", async () => {
+  it("stays silent on an Unimplemented lister (server without the RPC)", async () => {
+    // The soft-feature posture survives for genuinely old servers only: no
+    // picker, no hint — the pre-picker experience.
+    const { transport, startRequests } = channelTransport({
+      listError: new ConnectError("voice channel listing is not enabled on this server", Code.Unimplemented),
+    });
+    render(
+      <Providers transport={transport} queryClient={makeQueryClient()}>
+        <Session />
+      </Providers>,
+    );
+
+    expect(await screen.findByText("Idle")).toBeInTheDocument();
+    expect(screen.queryByTestId("channel-picker")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("channel-hint")).not.toBeInTheDocument();
+
+    const startBtn = screen.getByRole("button", { name: /start session/i });
+    await waitFor(() => expect(startBtn).toBeEnabled());
+    fireEvent.click(startBtn);
+    await waitFor(() => expect(startRequests).toEqual([""]));
+  });
+
+  it("notes an empty channel list instead of rendering nothing", async () => {
     const { transport, startRequests } = channelTransport({ channels: [] });
     render(
       <Providers transport={transport} queryClient={makeQueryClient()}>
@@ -1752,6 +1780,9 @@ describe("Session voice-channel picker", () => {
     );
 
     expect(await screen.findByText("Idle")).toBeInTheDocument();
+    const hint = await screen.findByTestId("channel-hint");
+    expect(hint).toHaveTextContent("The linked Discord server has no voice channels.");
+    expect(hint).not.toHaveAttribute("role", "alert");
     expect(screen.queryByTestId("channel-picker")).not.toBeInTheDocument();
 
     const startBtn = screen.getByRole("button", { name: /start session/i });

--- a/web/src/screens/session/Session.tsx
+++ b/web/src/screens/session/Session.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, createConnectQueryKey } from "@connectrpc/connect-query";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { Play, Square, Search, ScrollText, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -213,14 +214,23 @@ export function Session() {
 
   // Voice-channel picker: the session joins the picked channel; the stored
   // Default Voice Channel pre-selects it (default → first channel → none, the
-  // ShareHighlightDialog precedent). retry:false keeps it a soft feature — an
-  // unlinked guild / missing Bot token fails FailedPrecondition once and the
-  // screen simply renders no picker (Start then reports the same precondition
-  // with its actionable message). Fetched while idle: the pick is a START-time
-  // input, and a live session's channel can't change.
+  // ShareHighlightDialog precedent). retry:false keeps it cheap — a
+  // precondition (unlinked guild / missing Bot token) fails once and its
+  // actionable message renders as an inline hint beside Start (silence here
+  // once dead-ended an operator: no picker, no clue why, and Start falling
+  // back to an empty default). Only an Unimplemented server (the RPC not
+  // deployed yet) stays silent — the pre-picker experience. Fetched while
+  // idle: the pick is a START-time input, and a live session's channel can't
+  // change.
   const channelsQ = useQuery(SessionService.method.listSessionVoiceChannels, {}, { retry: false, enabled: !active });
   const channels = channelsQ.data?.channels ?? [];
   const defaultChannelId = channelsQ.data?.defaultChannelId ?? "";
+  // The raw server message without the "[failed_precondition]" prefix; null
+  // when there is nothing to surface (loaded fine, or Unimplemented).
+  const channelsError =
+    channelsQ.error != null && ConnectError.from(channelsQ.error).code !== Code.Unimplemented
+      ? ConnectError.from(channelsQ.error).rawMessage
+      : null;
   const [pickedChannelId, setPickedChannelId] = useState<string | null>(null);
   // A stored default that is no longer among the guild's channels (deleted in
   // Discord) must not ride a Start invisibly: fall back to the first listed
@@ -477,6 +487,21 @@ export function Session() {
                     </Button>
                   )}
                 </div>
+              )}
+              {/* The picker's failure/empty states surface HERE, not as silence:
+                  the lister's precondition carries the operator's next step
+                  ("link a Discord server first" / "save a Discord Bot token
+                  first"), and hiding it once left Start dead-ending on an empty
+                  default with no visible cause. */}
+              {channelsError && (
+                <span className="gx-session__channel-hint" role="alert" data-testid="channel-hint">
+                  {channelsError}
+                </span>
+              )}
+              {channelsQ.isSuccess && channels.length === 0 && (
+                <span className="gx-session__channel-hint" data-testid="channel-hint">
+                  The linked Discord server has no voice channels.
+                </span>
               )}
               <Button
                 variant="primary"

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -218,6 +218,19 @@
   min-width: 180px;
 }
 
+/* Inline picker hint beside Start: the channel lister's actionable
+   precondition ("link a Discord server first") or the empty-guild note. Text
+   weight only — a start precondition is a setup nudge, not a session fault,
+   so it stays lighter than the bordered .gx-session__failed banner. */
+.gx-session__channel-hint {
+  font-size: var(--body-sm);
+  color: var(--text-subtle);
+}
+
+.gx-session__channel-hint[role="alert"] {
+  color: var(--status-danger);
+}
+
 /* Live gateway connection sub-state beside the Live badge (Connecting…/Connected). */
 .gx-session__conn {
   color: var(--text-subtle);


### PR DESCRIPTION
## What does this PR do?

Fixes the production dead-end reported on glyphoxa.com after deploying #582: the Session screen showed **no voice-channel picker** and Start failed with *"no Discord voice channel resolved — link a Discord server in Configuration, then pick a voice channel"* — advice impossible to follow, since the picker never rendered.

Root cause (two stacked defects):

1. **Token asymmetry.** `ListSessionVoiceChannels` resolved only a *saved per-tenant BYOK* Bot token (`DeploymentSharer.resolve`), while `Manager.Start` resolves the `wirenpc.ResolveDiscordToken` ladder ending in the env `DISCORD_BOT_TOKEN`. On a central Bot-token deployment (ADR-0057 — the glyphoxa.com posture: guild linked, `discord_bot_token_last4` empty, token from env) sessions could *start* but channels could not be *listed*: the RPC failed `FailedPrecondition "save a Discord Bot token first"`.
2. **Silent failure.** The SPA treated any lister error as "soft feature off" and rendered nothing — no picker, no hint. Start then sent an empty pick, fell back to the stored Default Voice Channel (empty on this tenant, most plausibly via unlink→relink through the new guild-only Configuration, which can no longer restore a channel), and dead-ended.

Changes:

- **`DeploymentSharer` resolves the same token ladder as session start**: saved BYOK token first, else the central env token (`SetEnvBotToken`, wired in `runWeb` — the `ProviderServer` guild-proof/invite-resolve precedent). A *real* saved token that cannot decrypt stays a hard `$GLYPHOXA_SECRET` error, never a silent env fall-through (wirenpc AC3). This also heals the Highlight share dialog's identical gap.
- **New `ErrNoGuildLinked` sentinel** from the list paths when a token resolves but no guild is linked; both list RPCs map it to `FailedPrecondition "link a Discord server first"` (previously the share dialog misreported this state as a token problem).
- **The Session screen surfaces lister preconditions** as an inline hint beside Start (`role="alert"`, the server's actionable message verbatim), notes an empty channel list, and stays silent only for `Unimplemented` (a server without the RPC — the pre-picker experience).
- **`SaveDiscordSettings` validates `guild_id` snowflake shape** (like `voice_channel_id` already is): a non-canonical variant of the same guild would compare unequal in `SaveDiscordGuild`'s CASE and silently clear the stored Default Voice Channel.

## Why is this change needed?

The #582 feature is unusable on central-token deployments — exactly the standard SaaS population — and fails with misleading guidance. Session start and channel listing must resolve the Tenant's Bot identically (ADR-0057: "the Tenant's resolved Bot").

## How was this tested?

- New Go tests: env-token fallback for text/voice listing and clip posting (empty last4 + `"env"` placeholder), saved-token-without-cipher stays a hard error (never env fall-through), `ErrNoGuildLinked` for token-resolves-but-no-guild, guild-id shape rejection. Full `go test ./...`, `go vet`, `gofmt` clean.
- Web: hint tests replace the silence tests (FailedPrecondition renders the message with `role=alert`; `Unimplemented` stays silent; empty list renders the note); full Session suite 44/44. Full vitest green except the pre-existing `src/lib/download.test.ts` jsdom environment failure (fails identically on clean `main` in this container; passes in CI).

- [x] `make check` passes
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- `PostClip` (Highlight sharing) now also rides the central token on central-token deployments — the same Bot identity that speaks in the voice channel, per ADR-0057's "the Tenant's resolved Bot".
- No schema changes, no migration. Recovery for the affected tenant is UI-only after deploy: the picker appears, pick a channel, **Set as default**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyaC8JH5bWvKtx77JyDuhE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyaC8JH5bWvKtx77JyDuhE)_