### PR TITLE
fix(voice): reap disgo's audio goroutines when the DAVE session never becomes ready

### DIFF
--- a/deploy/charts/glyphoxa/templates/voice-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/voice-deployment.yaml
@@ -118,6 +118,14 @@ spec:
             - -metrics-addr
             - {{ $metricsAddr | quote }}
           env:
+            # Pin the Go scheduler to the container's CPU limit (#586 secondary
+            # finding); see the web deployment's identical entry for the why.
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: voice
+                  resource: limits.cpu
+                  divisor: "1"
             # The in-cluster Postgres Service URL: RunFromDB loads the seeded NPC
             # from it and /readyz pings through it. Same key the migrate/seed
             # hooks used, so the host can never drift.

--- a/deploy/charts/glyphoxa/templates/web-deployment.yaml
+++ b/deploy/charts/glyphoxa/templates/web-deployment.yaml
@@ -110,6 +110,19 @@ spec:
             - -metrics-addr
             - {{ $metricsAddr | quote }}
           env:
+            # Pin the Go scheduler to the container's CPU limit (#586 secondary
+            # finding): the runtime's own container-awareness (Go ≥ 1.25) reads
+            # cgroup v2 only, and on hosts where it does not apply the process
+            # schedules across every node CPU and is throttled hard against
+            # limits.cpu (71k+ throttled periods observed). The Downward API
+            # value follows the limit wherever it is resized; divisor 1 rounds
+            # a fractional limit up.
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: web
+                  resource: limits.cpu
+                  divisor: "1"
             # The DB the Connect handlers read/write and /readyz pings. Same key
             # the migrate/seed hooks used, so the host can never drift.
             - name: GLYPHOXA_DATABASE_URL

--- a/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/voice_deployment_test.yaml
@@ -420,6 +420,19 @@ tests:
       - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.limits.memory
 
+  - it: pins GOMAXPROCS to the container's CPU limit
+    # #586 secondary finding; see the web deployment test's identical entry.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: voice
+                resource: limits.cpu
+                divisor: "1"
+
   - it: hardens the voice container's securityContext by default
     # The image runs as USER 65532 (#31); the container locks down further —
     # non-root, no privilege escalation, a read-only rootfs (the k3d e2e proved

--- a/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
+++ b/deploy/charts/glyphoxa/tests/web_deployment_test.yaml
@@ -483,6 +483,22 @@ tests:
       - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.limits.memory
 
+  - it: pins GOMAXPROCS to the container's CPU limit
+    # #586 secondary finding: Go's own container-awareness covers cgroup v2
+    # only, so the chart pins the scheduler width explicitly via the Downward
+    # API — otherwise the runtime schedules across every node CPU and gets
+    # throttled hard against limits.cpu.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: web
+                resource: limits.cpu
+                divisor: "1"
+
   - it: hardens the web container's securityContext by default
     asserts:
       - equal:

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
+require github.com/disgoorg/godave v0.3.0
+
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -40,7 +42,6 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/disgoorg/godave v0.3.0 // indirect
 	github.com/disgoorg/json/v2 v2.0.0 // indirect
 	github.com/disgoorg/omit v1.0.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/internal/observe/server.go
+++ b/internal/observe/server.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
+	"os"
 	"time"
 )
 
@@ -61,6 +63,22 @@ func MountObservability(mux *http.ServeMux, rec *PrometheusRecorder, ready Readi
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	})
+	// Runtime profiling (#586): /debug/pprof on the observability listener,
+	// opt-in via GLYPHOXA_PPROF=1. The 2-core spin investigation stalled on this
+	// port 404ing /debug/pprof — no goroutine or CPU profile could be captured
+	// from the live pod — so the endpoints are mountable without a rebuild, but
+	// stay OFF by default: profiles expose internals (goroutine stacks carry
+	// argument values) and /debug/pprof/profile burns CPU on demand, which is
+	// nothing an always-on unauthenticated port should offer. The metrics port
+	// is cluster-internal (ADR-0032 keeps it off the public web port), so the
+	// env gate is the operator's deliberate switch, not a security boundary.
+	if os.Getenv("GLYPHOXA_PPROF") == "1" {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 	// Readiness: gate traffic on the dependency probe (a DB ping).
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 		if ready == nil {

--- a/pkg/voice/dave.go
+++ b/pkg/voice/dave.go
@@ -19,9 +19,15 @@ import (
 // implies a native toolchain; it still selects real encryption over the stub
 // (dave_stub.go) whose DaveOption is a no-op and [DaveAvailable] false, so
 // tests and tooling keep building without pulling in the MLS stack.
+// The factory is wrapped in [WrapDaveSessionCreate] so every session reports
+// Ready once closed (or on a never-E2EE channel): disgo gates its per-session
+// audio sender AND receiver goroutines on DAVE().Ready(), and both of their
+// only exit paths (the net.ErrClosed read, the #581 provider poke) sit behind
+// that gate — an unready session at teardown otherwise strands the receiver's
+// non-blocking poll loop spinning at a full core forever (#586).
 func DaveOption() bot.ConfigOpt {
 	return bot.WithVoiceManagerConfigOpts(
-		voice.WithDaveSessionCreateFunc(davesession.CreateFunc()),
+		voice.WithDaveSessionCreateFunc(WrapDaveSessionCreate(davesession.CreateFunc())),
 	)
 }
 

--- a/pkg/voice/davereap.go
+++ b/pkg/voice/davereap.go
@@ -1,0 +1,95 @@
+package voice
+
+import (
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/disgoorg/godave"
+)
+
+// frameHolder is the optional surface a DAVE session can expose to distinguish
+// "E2EE handshake in progress, hold frames" from "this channel will never have
+// E2EE" (DAVE protocol version 0, transport-only). dave-go's *session.Session
+// implements it; godave.Session does not carry it, so it is asserted dynamically.
+type frameHolder interface {
+	ShouldHoldFrames() bool
+}
+
+// reapableDaveSession wraps the real DAVE session so disgo's audio sender and
+// receiver goroutines can always terminate (#586, the post-session 2-core spin).
+//
+// disgo gates BOTH per-session audio goroutines on DAVE().Ready():
+//
+//	audio_receiver.go: if !s.conn.DAVE().Ready() { return }  // before ReadPacket
+//	audio_sender.go:   if !s.conn.DAVE().Ready() { return }  // before ProvideOpusFrame
+//
+// and every teardown path we have relies on code BEHIND that gate: the receiver
+// exits when ReadPacket returns net.ErrClosed off the closed UDP conn, and the
+// sender exits when the switchingProvider's post-Close silence poke (#579/#581)
+// makes it write to the dead transport. While Ready() is false neither call is
+// ever reached, so neither goroutine can ever observe the teardown — and the
+// receiver's loop is a for/select with a default branch and no blocking call,
+// i.e. a pure busy-wait burning a full core per session.
+//
+// dave-go's Ready() is false during the whole MLS handshake window and stays
+// false FOREVER on a protocol-version-0 channel (its docs point senders at
+// ShouldHoldFrames for that distinction), so a Voice Session that ends before
+// its first E2EE epoch activates — a short session, or any session on a
+// non-E2EE channel — strands a spinning receiver that survives session end
+// until the process dies.
+//
+// The wrapper restores the godave.Session contract disgo's gate is written
+// against ("sessions that never establish E2EE always return true") and adds
+// the teardown poke:
+//
+//   - after Close, Ready() reports true, so both goroutines fall through to
+//     their terminal I/O (ReadPacket → net.ErrClosed; provider poke → dead
+//     transport write) and reap themselves;
+//   - while open, a channel that will never have E2EE (ShouldHoldFrames false
+//     with Ready false ⇒ protocol version 0) also reports true, so audio flows
+//     in transport-only passthrough instead of busy-waiting on an epoch that
+//     will never come.
+//
+// A transient handshake window (protocol version ≥ 1, epoch pending) still
+// reports false — frames must be held there — so the receiver still spins for
+// the duration of a live handshake. That residual busy-wait is disgo's loop
+// shape and is bounded by the handshake; the unbounded, session-outliving spin
+// is what this wrapper removes.
+type reapableDaveSession struct {
+	godave.Session
+	closed atomic.Bool
+}
+
+// WrapDaveSessionCreate wraps a DAVE session factory so every session it
+// creates is a [reapableDaveSession]. The dave-tagged [DaveOption] applies it
+// to dave-go's CreateFunc; it lives untagged here so the reap semantics are
+// unit-testable in the default build.
+func WrapDaveSessionCreate(create godave.SessionCreateFunc) godave.SessionCreateFunc {
+	return func(logger *slog.Logger, userID godave.UserID, callbacks godave.Callbacks) godave.Session {
+		return &reapableDaveSession{Session: create(logger, userID, callbacks)}
+	}
+}
+
+// Ready implements godave.Session. See the type comment for the three-way
+// answer: closed sessions and never-E2EE channels report true so disgo's audio
+// goroutines reach their terminal I/O; only a live pending handshake holds.
+func (s *reapableDaveSession) Ready() bool {
+	if s.closed.Load() {
+		return true
+	}
+	if s.Session.Ready() {
+		return true
+	}
+	if h, ok := s.Session.(frameHolder); ok {
+		return !h.ShouldHoldFrames()
+	}
+	return false
+}
+
+// Close implements godave.Session: flip into the reaping state (Ready reports
+// true from now on) before delegating, so the audio goroutines' very next poll
+// falls through to the dead transport and exits.
+func (s *reapableDaveSession) Close() error {
+	s.closed.Store(true)
+	return s.Session.Close()
+}

--- a/pkg/voice/davereap_test.go
+++ b/pkg/voice/davereap_test.go
@@ -1,0 +1,278 @@
+package voice
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	botgateway "github.com/disgoorg/disgo/gateway"
+	"github.com/disgoorg/disgo/voice"
+	"github.com/disgoorg/godave"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// fakeDaveSession is a controllable godave.Session for the reap-wrapper tests.
+// Only the methods the wrapper and disgo's audio goroutines touch are
+// implemented; the embedded nil interface panics loudly on anything else.
+type fakeDaveSession struct {
+	godave.Session
+	ready  atomic.Bool
+	closed atomic.Bool
+}
+
+func (f *fakeDaveSession) Ready() bool { return f.ready.Load() }
+func (f *fakeDaveSession) Close() error {
+	f.closed.Store(true)
+	return nil
+}
+
+// holdingDaveSession adds dave-go's ShouldHoldFrames surface: hold=true models
+// a live pending handshake (protocol ≥ 1, no epoch yet), hold=false with
+// ready=false models a channel that will never have E2EE (protocol version 0).
+type holdingDaveSession struct {
+	fakeDaveSession
+	hold atomic.Bool
+}
+
+func (f *holdingDaveSession) ShouldHoldFrames() bool { return f.hold.Load() }
+
+func wrap(t *testing.T, inner godave.Session) godave.Session {
+	t.Helper()
+	create := WrapDaveSessionCreate(func(*slog.Logger, godave.UserID, godave.Callbacks) godave.Session {
+		return inner
+	})
+	return create(slog.New(slog.DiscardHandler), godave.UserID("1"), nil)
+}
+
+// The wrapper's three-way Ready answer, against a dave-go-shaped inner session
+// (has ShouldHoldFrames): a pending handshake holds, a never-E2EE channel and a
+// closed session both report ready so disgo's audio goroutines reach their
+// terminal I/O.
+func TestReapableDaveSessionReady(t *testing.T) {
+	t.Parallel()
+
+	inner := &holdingDaveSession{}
+	inner.hold.Store(true) // handshake pending: protocol ≥ 1, no epoch yet
+	s := wrap(t, inner)
+
+	if s.Ready() {
+		t.Fatal("Ready() = true during a live pending handshake; frames must be held")
+	}
+
+	// The channel downgrades to protocol version 0: E2EE will never establish,
+	// dave-go's own Ready stays false forever — the wrapper must report ready
+	// so audio flows in passthrough instead of busy-waiting on a phantom epoch.
+	inner.hold.Store(false)
+	if !s.Ready() {
+		t.Fatal("Ready() = false on a never-E2EE (protocol v0) channel; audio goroutines would spin forever")
+	}
+
+	// Epoch established: plain delegation.
+	inner.hold.Store(true)
+	inner.ready.Store(true)
+	if !s.Ready() {
+		t.Fatal("Ready() = false with an active inner epoch")
+	}
+
+	// Closed while mid-handshake (the <5s Voice Session shape, #586): Ready
+	// must flip true so the receiver's next poll reaches ReadPacket and reaps
+	// itself on net.ErrClosed.
+	inner.ready.Store(false)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() = %v", err)
+	}
+	if !s.Ready() {
+		t.Fatal("Ready() = false after Close; the audio goroutines can never observe teardown")
+	}
+	if !inner.closed.Load() {
+		t.Fatal("Close was not delegated to the inner session")
+	}
+}
+
+// An inner session without ShouldHoldFrames (not dave-go) keeps conservative
+// delegation while open, and still reaps after Close.
+func TestReapableDaveSessionReadyWithoutFrameHolder(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeDaveSession{}
+	s := wrap(t, inner)
+	if s.Ready() {
+		t.Fatal("Ready() = true while the inner session reports not ready")
+	}
+	_ = s.Close()
+	if !s.Ready() {
+		t.Fatal("Ready() = false after Close")
+	}
+}
+
+// fakeDisgoConn implements disgo's voice.Conn for the quiescence regression:
+// it hands disgo's real audio goroutines the wrapped DAVE session and a UDP
+// conn that behaves closed after teardown. daveCalls counts every DAVE()
+// accessor hit — one per audio-goroutine loop iteration — which is the test's
+// tick-activity signal.
+type fakeDisgoConn struct {
+	dave      godave.Session
+	udp       *fakeUDPConn
+	torndown  atomic.Bool
+	daveCalls atomic.Int64
+}
+
+func (c *fakeDisgoConn) Gateway() voice.Gateway { return nil }
+func (c *fakeDisgoConn) UDP() voice.UDPConn     { return c.udp }
+func (c *fakeDisgoConn) DAVE() godave.Session {
+	c.daveCalls.Add(1)
+	return c.dave
+}
+func (c *fakeDisgoConn) ChannelID() *snowflake.ID                     { return nil }
+func (c *fakeDisgoConn) GuildID() snowflake.ID                        { return 0 }
+func (c *fakeDisgoConn) UserIDBySSRC(uint32) snowflake.ID             { return 0 }
+func (c *fakeDisgoConn) SetOpusFrameProvider(voice.OpusFrameProvider) {}
+func (c *fakeDisgoConn) SetOpusFrameReceiver(voice.OpusFrameReceiver) {}
+func (c *fakeDisgoConn) Open(context.Context, snowflake.ID, bool, bool) error {
+	return nil
+}
+func (c *fakeDisgoConn) Close(context.Context)                                     {}
+func (c *fakeDisgoConn) HandleVoiceStateUpdate(botgateway.EventVoiceStateUpdate)   {}
+func (c *fakeDisgoConn) HandleVoiceServerUpdate(botgateway.EventVoiceServerUpdate) {}
+func (c *fakeDisgoConn) SetSpeaking(context.Context, voice.SpeakingFlags) error {
+	if c.torndown.Load() {
+		return voice.ErrGatewayNotConnected
+	}
+	return nil
+}
+
+// fakeUDPConn implements disgo's voice.UDPConn: reads block until Close, then
+// every read/write reports net.ErrClosed — the shape of a torn-down transport.
+type fakeUDPConn struct {
+	closed  atomic.Bool
+	closeCh chan struct{}
+}
+
+func newFakeUDPConn() *fakeUDPConn { return &fakeUDPConn{closeCh: make(chan struct{})} }
+
+func (u *fakeUDPConn) LocalAddr() net.Addr                             { return nil }
+func (u *fakeUDPConn) RemoteAddr() net.Addr                            { return nil }
+func (u *fakeUDPConn) SetSecretKey(voice.EncryptionMode, []byte) error { return nil }
+func (u *fakeUDPConn) SetDeadline(time.Time) error                     { return nil }
+func (u *fakeUDPConn) SetReadDeadline(time.Time) error                 { return nil }
+func (u *fakeUDPConn) SetWriteDeadline(time.Time) error                { return nil }
+func (u *fakeUDPConn) Open(context.Context, string, int, uint32) (string, int, error) {
+	return "", 0, nil
+}
+func (u *fakeUDPConn) Close() error {
+	if u.closed.CompareAndSwap(false, true) {
+		close(u.closeCh)
+	}
+	return nil
+}
+func (u *fakeUDPConn) Read([]byte) (int, error) {
+	<-u.closeCh
+	return 0, net.ErrClosed
+}
+func (u *fakeUDPConn) ReadPacket() (*voice.Packet, error) {
+	if u.closed.Load() {
+		return nil, net.ErrClosed
+	}
+	<-u.closeCh
+	return nil, net.ErrClosed
+}
+func (u *fakeUDPConn) Write([]byte) (int, error) {
+	if u.closed.Load() {
+		return 0, net.ErrClosed
+	}
+	return 0, nil
+}
+
+// closeSignal signals the receiver goroutine's own exit: disgo's audio
+// receiver calls its OpusFrameReceiver's Close as it shuts down.
+type closeSignal struct {
+	closed chan struct{}
+	once   atomic.Bool
+}
+
+func (r *closeSignal) ReceiveOpusFrame(snowflake.ID, *voice.Packet) error { return nil }
+func (r *closeSignal) CleanupUser(snowflake.ID)                           {}
+func (r *closeSignal) Close() {
+	if r.once.CompareAndSwap(false, true) {
+		close(r.closed)
+	}
+}
+
+// The #586 regression: a Voice Session that ends while its DAVE session never
+// became ready must not leave disgo's audio goroutines behind. The receiver's
+// loop is a non-blocking for/select that polls conn.DAVE().Ready() and returns
+// — a full-core busy-wait — and its ONLY exit (ReadPacket → net.ErrClosed) sits
+// behind that gate, as does the sender's (the #581 silence poke via
+// ProvideOpusFrame). This drives disgo's REAL audio receiver + sender against
+// the wrapped DAVE session through the exact teardown order Session.Close uses,
+// then asserts the tick activity (DAVE() polls) returns to zero — i.e. the
+// goroutines exited — not merely that the session state looks closed.
+func TestAudioGoroutinesQuiesceAfterUnreadyTeardown(t *testing.T) {
+	t.Parallel()
+
+	inner := &holdingDaveSession{}
+	inner.hold.Store(true) // mid-handshake for the whole (short) session: never ready
+	dave := wrap(t, inner)
+
+	udp := newFakeUDPConn()
+	conn := &fakeDisgoConn{dave: dave, udp: udp}
+	logger := slog.New(slog.DiscardHandler)
+
+	sink := &closeSignal{closed: make(chan struct{})}
+	receiver := voice.NewAudioReceiver(logger, sink, conn)
+	receiver.Open()
+
+	provider := &switchingProvider{}
+	sender := voice.NewAudioSender(logger, provider, conn)
+	sender.Open()
+
+	// Both goroutines are live and polling the DAVE gate (the receiver at spin
+	// speed). Without this pre-check a broken Open would make the quiescence
+	// assertion below pass vacuously.
+	waitFor(t, "audio goroutines to start polling DAVE()", func() bool {
+		return conn.daveCalls.Load() > 10
+	})
+
+	// Session end, in Session.Close's order: transport down first, then the
+	// DAVE session (disgo's conn.Close does gateway → udp → dave), then the
+	// provider flips into its #581 sender-poke state.
+	conn.torndown.Store(true)
+	_ = udp.Close()
+	_ = dave.Close()
+	provider.Close()
+
+	// The receiver must reap itself: next poll sees Ready()=true → ReadPacket
+	// → net.ErrClosed → Close, which closes our sink.
+	select {
+	case <-sink.closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("audio receiver goroutine did not exit after teardown; it is busy-spinning behind the DAVE gate")
+	}
+
+	// And the whole loop activity must return to baseline: once both goroutines
+	// are gone, DAVE() is never polled again. A surviving receiver polls it
+	// thousands of times per second; a surviving sender ~50/s.
+	waitFor(t, "audio goroutine tick activity to stop", func() bool {
+		before := conn.daveCalls.Load()
+		time.Sleep(150 * time.Millisecond)
+		return conn.daveCalls.Load() == before
+	})
+}
+
+// waitFor polls cond until true or a 5s deadline, failing the test with what it
+// was waiting on. The generous deadline keeps slow CI green; the happy path is
+// milliseconds.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}


### PR DESCRIPTION
## What does this PR do?

Closes #586 — the glyphoxa.com incident where two &lt;5 s Voice Sessions on v0.6.1 left the `mode: all` web pod pinned at exactly 2.00 cores for 11h15m after both session rows had closed cleanly.

Three commits:

1. **`fix(voice)`** — `WrapDaveSessionCreate` (`pkg/voice/davereap.go`) wraps the dave-go session so `Ready()` reports true once `Close()`d and true on a never-E2EE (DAVE protocol v0) channel. disgo gates both per-session audio goroutines on `DAVE().Ready()`, and both of their only exit paths sit *behind* that gate — the receiver's `ReadPacket → net.ErrClosed`, the sender's #581 `ProvideOpusFrame` silence poke. While `Ready()` is false the receiver's `for { select { default: } }` loop is a pure busy-wait at a full core, and nothing at teardown can ever stop it: disgo's `conn.Close` doesn't close the audio receiver/sender, and the leave-echo `HandleVoiceStateUpdate` that would can't reach the conn after `removeConnFunc`. dave-go's `Ready()` is false throughout the MLS handshake and false forever on a protocol-v0 channel (its docs point senders at `ShouldHoldFrames` for that distinction; disgo's gate is written against the `godave.Session` doc "sessions that never establish E2EE always return true"). One stranded receiver per session × two sessions = the observed exact-2.00-core, log-silent, memory-flat, goroutine-stable burn starting the second the first session joined.
2. **`feat(observe)`** — `/debug/pprof` mountable on the observability listener (`:9090`) via `GLYPHOXA_PPROF=1`, off by default. The investigation stalled on pprof 404ing; next time a goroutine profile is one env var away.
3. **`feat(chart)`** — pin `GOMAXPROCS` to `limits.cpu` via the Downward API on the web and voice deployments (#586 secondary finding). Go ≥ 1.25's own container-awareness covers cgroup v2 only and demonstrably did not take effect on the incident node (4 equally-hot threads vs `limits.cpu: 2`, 71k+ throttled periods). Reduces throttling; orthogonal to the spin fix.

## Why is this change needed?

Every Voice Session that ends before its DAVE session activates an E2EE epoch — any sub-handshake-length session, and *every* session on a non-E2EE channel — permanently strands a busy-spinning goroutine. Sessions accumulate spin until the pod is throttled to uselessness; only a restart clears it. The #581 teardown fix is not incomplete in its own terms (the silence-clock bound holds; the poke works once `Ready()` is true) — it was defeated by the DAVE gate sitting upstream of both reap paths.

## How was this tested?

- [x] `make check` passes
- [x] New/updated tests cover the change
- [x] Manual testing (describe below if applicable)

`TestAudioGoroutinesQuiesceAfterUnreadyTeardown` drives **disgo's real audio receiver + sender** against the wrapped DAVE session through `Session.Close`'s exact teardown order and asserts their `DAVE()`-poll tick activity returns to zero after teardown — i.e. the goroutines exited, not merely that the session state looks closed. Verified it fails (receiver never exits, 5 s timeout) with the wrapper removed. Wrapper semantics covered by `TestReapableDaveSessionReady*`. `go test -race ./pkg/voice/ ./internal/observe/` passes; `go build -tags dave ./...` and `go vet -tags dave` pass; `helm unittest` 211/211 (incl. two new GOMAXPROCS assertions) and `helm lint` pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **Behavioral note:** on a protocol-v0 (transport-only) channel the wrapper reports `Ready()` true while live, so the NPC now actually hears/speaks there (passthrough) instead of being deaf *and* spinning. During a live pending handshake the receiver still busy-waits (disgo's loop shape — not fixable from outside disgo); that residual is bounded by the handshake and ends at teardown. Worth filing upstream: disgo's non-blocking receiver loop, and dave-go's `Ready()` contract deviation (#493 already tracks upstream defect filing).
- `godave` moves from indirect to direct in `go.mod` (the wrapper implements `godave.Session` untagged so it is testable in the default build; `-tags dave` only adds the dave-go factory).
- **Operator guidance until this lands:** the deployment is *not* safe to run Voice Sessions on — each session start risks pinning another core until restart. Restart the web pod after any voice use; `GOMAXPROCS` alone does not stop the spin.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyaBq8o34EAySeZgb49qya

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyaBq8o34EAySeZgb49qya)_