### PR TITLE
feat(web): move Campaign sub-view tabs into the left sidebar (ADR-0063)

### DIFF
--- a/docs/adr/0063-campaign-subnav-in-sidebar.md
+++ b/docs/adr/0063-campaign-subnav-in-sidebar.md
@@ -1,0 +1,44 @@
+# Campaign sub-views move into the sidebar, addressed by path
+
+The Campaign screen had grown six in-page tabs (Cast, World wiki, Maps, Players, Suggestions, Planning) in a seg-control beside the title — cramped on desktop, overflowing on phones, and invisible from anywhere else in the app. This ADR moves that sub-navigation into the app shell's left sidebar and promotes the sub-view from screen state to a path segment.
+
+## What this decides
+
+- **The sidebar owns sub-navigation.** The shell's Campaign nav item expands,
+  accordion-style, into one sub-item per sub-view while Campaign is the active
+  screen — the same items the in-page tab bar carried, same labels
+  (`campaign.tab*`), now reachable from the persistent chrome. The in-page tab
+  bar is removed, not duplicated: one navigation surface, one active state. On
+  the drawer breakpoint the sub-items live in the off-canvas drawer, and any
+  nav tap now also shuts the drawer so it doesn't keep covering the screen it
+  navigated to.
+- **The sub-view is a path segment:** `/t/:tenantSlug/campaign/:view`
+  (`cast | knowledge | maps | players | proposals | planning`, the shared
+  `CAMPAIGN_VIEWS` vocabulary in `screens/campaign/views.ts`). ADR-0018's
+  code-based tree gains a generic `$screen/$view` sibling of `$screen`; only
+  Campaign defines sub-views today, so any other screen with a second segment
+  renders the notFound placeholder. The sidebar links to and highlights the
+  `:view` param, and a bookmarked URL restores the view — which screen-local
+  state never could.
+- **Sub-view changes are param-only navigations** within the one
+  `$screen/$view` route, so the screen component stays mounted and its local
+  state (selected agent, cast mode, wiki focus) survives a sidebar switch —
+  the same behaviour the in-page tabs had.
+- **Legacy links keep working.** A bare `/campaign` redirects to
+  `/campaign/cast`; the pre-ADR-0063 palette vocabulary (#591) `?view=X` is
+  rewritten onto the path, and `?node=Y` lands on `/campaign/knowledge?node=Y`
+  (the redirect owns view selection; the screen keeps consume-then-strip for
+  the node focus). The palette itself now deep-links entry hits to the path
+  directly. `ScreenSearch.view` stays in the search vocabulary solely to parse
+  those legacy links.
+
+## Consequences
+
+- The Campaign screen no longer owns view state: it receives `view` and an
+  `onViewChange` callback from the route, and its cross-view jumps (prep marks
+  opening the wiki, wiki entries opening the cast editor) go through the same
+  callback. Tests drive views through a harness standing in for the route +
+  sidebar pair.
+- Session and Setup have no sub-views; if either grows tabs, the same
+  `$screen/$view` route and sidebar pattern is the expected shape, not a new
+  in-page tab bar.

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -110,6 +110,17 @@ describe("campaign sub-view path (ADR-0063)", () => {
     );
   });
 
+  it("a hand-edited ?node= on another sub-view redirects to knowledge", async () => {
+    // ?node= only means something on the knowledge view; subviewRoute's
+    // beforeLoad owns the correction so the screen's deep-link handling stays
+    // a single consume-then-strip.
+    const router = renderAt("/t/acme/campaign/cast?node=n-bart");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/acme/campaign/knowledge"),
+    );
+    await waitFor(() => expect(router.state.location.search).toEqual({}));
+  });
+
   it("a legacy ?node= link lands on knowledge, and the screen strips the param", async () => {
     const router = renderAt("/t/acme/campaign?node=n-bart");
     await waitFor(() =>

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { RouterProvider, createRouter, createMemoryHistory } from "@tanstack/react-router";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
@@ -53,6 +53,7 @@ function renderAt(path: string) {
       <RouterProvider router={router} />
     </Providers>,
   );
+  return router;
 }
 
 describe("loginRoute ?error=not_authorized contract", () => {
@@ -80,5 +81,43 @@ describe("onboardingRoute /onboarding/create-tenant contract", () => {
   it("renders the name-your-Tenant screen at /onboarding/create-tenant", async () => {
     renderAt("/onboarding/create-tenant");
     expect(await screen.findByLabelText(/name your table/i)).toHaveValue("Rin's Table");
+  });
+});
+
+// The Campaign sub-view lives in the path (ADR-0063): /campaign/:view. A bare
+// /campaign visit — and any pre-ADR-0063 ?view=/?node= deep link (#591) — must
+// redirect onto the path so old bookmarks and palette links keep working.
+describe("campaign sub-view path (ADR-0063)", () => {
+  it("redirects a bare /campaign to the default cast sub-view", async () => {
+    const router = renderAt("/t/acme/campaign");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/acme/campaign/cast"),
+    );
+  });
+
+  it("maps a legacy ?view= deep link onto the path", async () => {
+    const router = renderAt("/t/acme/campaign?view=players");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/acme/campaign/players"),
+    );
+    expect(router.state.location.search).toEqual({});
+  });
+
+  it("an unknown ?view= value falls back to cast", async () => {
+    const router = renderAt("/t/acme/campaign?view=nonsense");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/acme/campaign/cast"),
+    );
+  });
+
+  it("a legacy ?node= link lands on knowledge, and the screen strips the param", async () => {
+    const router = renderAt("/t/acme/campaign?node=n-bart");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/t/acme/campaign/knowledge"),
+    );
+    // The redirect carries ?node= along; once the screen mounts it consumes the
+    // focus and strips the URL (consume-then-strip, see ScreenSearch). Campaign's
+    // own test covers the focus hand-off; here we pin the URL contract.
+    await waitFor(() => expect(router.state.location.search).toEqual({}));
   });
 });

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -9,6 +9,7 @@ import {
 
 import { AppShell } from "@/components/AppShell";
 import { AuthGate } from "@/app/AuthGate";
+import { isCampaignView } from "@/screens/campaign/views";
 import { useI18n } from "@/i18n";
 import { Login } from "@/screens/login/Login";
 import { CreateTenant } from "@/screens/onboarding/CreateTenant";
@@ -120,13 +121,15 @@ const tenantIndexRoute = createRoute({
 });
 
 // ScreenSearch is the deep-link vocabulary the command palette navigates with
-// (#591): the Campaign screen consumes view+node (open the Knowledge panel on
-// an entry), the Session screen consumes session+line (view a Voice Session and
+// (#591): the Campaign screen consumes node (open the World-wiki panel on an
+// entry), the Session screen consumes session+line (view a Voice Session and
 // jump to a transcript Line — the pair, never the line alone: line ids restart
 // per session) and session+highlight (scroll the Highlights strip to a row).
 // Screens consume the params once and then STRIP them (replace, no history
 // entry), so a later palette jump with the same target re-fires and a copied
-// URL acts once instead of pinning the screen.
+// URL acts once instead of pinning the screen. `view` is legacy vocabulary:
+// the Campaign sub-view moved into the path (ADR-0063), and screenRoute's
+// beforeLoad rewrites an old ?view= link onto it.
 export type ScreenSearch = {
   view?: string;
   node?: string;
@@ -137,18 +140,33 @@ export type ScreenSearch = {
 
 const str = (v: unknown): string | undefined => (typeof v === "string" && v !== "" ? v : undefined);
 
+const validateScreenSearch = (search: Record<string, unknown>): ScreenSearch => ({
+  view: str(search.view),
+  node: str(search.node),
+  session: str(search.session),
+  line: str(search.line),
+  highlight: str(search.highlight),
+});
+
 // /t/:tenantSlug/:screen — selects the active screen. Configuration and Campaign
-// are live on their RPCs; Session renders a styled placeholder.
+// are live on their RPCs; Session renders a styled placeholder. The Campaign
+// screen never renders here: its sub-view is a path segment (ADR-0063), so a
+// bare /campaign visit redirects to the default sub-view — mapping a legacy
+// ?view=/?node= deep link (#591) onto the path so old links keep working.
 const screenRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: "$screen",
-  validateSearch: (search: Record<string, unknown>): ScreenSearch => ({
-    view: str(search.view),
-    node: str(search.node),
-    session: str(search.session),
-    line: str(search.line),
-    highlight: str(search.highlight),
-  }),
+  validateSearch: validateScreenSearch,
+  beforeLoad: ({ params, search }) => {
+    if (params.screen !== "campaign") return;
+    const view = search.node ? "knowledge" : isCampaignView(search.view) ? search.view : "cast";
+    throw redirect({
+      to: "/t/$tenantSlug/$screen/$view",
+      params: { tenantSlug: params.tenantSlug, screen: "campaign", view },
+      search: search.node ? { node: search.node } : {},
+      replace: true,
+    });
+  },
   component: function Screen() {
     const { screen, tenantSlug } = screenRoute.useParams();
     const search = screenRoute.useSearch();
@@ -168,13 +186,54 @@ const screenRoute = createRoute({
     switch (screen) {
       case "configuration":
         return <Configuration />;
-      case "campaign":
-        return <Campaign deepLink={search} onDeepLinkHandled={clearDeepLink} />;
       case "session":
         return <Session deepLink={search} onDeepLinkHandled={clearDeepLink} />;
       default:
         return <Placeholder title={t("auth.notFoundTitle")} />;
     }
+  },
+});
+
+// /t/:tenantSlug/campaign/:view — the Campaign screen with its sub-view in the
+// path (ADR-0063), so the sidebar sub-navigation can link to and highlight it
+// and a bookmark restores it. Declared as a generic $screen/$view sibling of
+// screenRoute (only Campaign defines sub-views today; any other screen with a
+// second segment is a notFound). Sub-view changes are param-only navigations
+// within this one route, so the screen stays mounted and its local state
+// (selected agent, wiki focus) survives a sidebar switch.
+const subviewRoute = createRoute({
+  getParentRoute: () => tenantRoute,
+  path: "$screen/$view",
+  validateSearch: validateScreenSearch,
+  component: function SubviewScreen() {
+    const { screen, view, tenantSlug } = subviewRoute.useParams();
+    const search = subviewRoute.useSearch();
+    const navigate = useNavigate();
+    const { t } = useI18n();
+    if (screen === "campaign" && isCampaignView(view)) {
+      return (
+        <Campaign
+          view={view}
+          onViewChange={(next) =>
+            void navigate({
+              to: "/t/$tenantSlug/$screen/$view",
+              params: { tenantSlug, screen, view: next },
+            })
+          }
+          deepLink={search}
+          onDeepLinkHandled={() =>
+            // Consume-then-strip, same contract as screenRoute (see ScreenSearch).
+            void navigate({
+              to: "/t/$tenantSlug/$screen/$view",
+              params: { tenantSlug, screen, view },
+              search: {},
+              replace: true,
+            })
+          }
+        />
+      );
+    }
+    return <Placeholder title={t("auth.notFoundTitle")} />;
   },
 });
 
@@ -190,7 +249,7 @@ export const routeTree = rootRoute.addChildren([
   datenschutzRoute,
   termsRoute,
   nutzungsbedingungenRoute,
-  tenantRoute.addChildren([tenantIndexRoute, screenRoute]),
+  tenantRoute.addChildren([tenantIndexRoute, screenRoute, subviewRoute]),
 ]);
 
 export const router = createRouter({

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -205,6 +205,21 @@ const subviewRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: "$screen/$view",
   validateSearch: validateScreenSearch,
+  beforeLoad: ({ params, search }) => {
+    // ?node= only means something on the knowledge view; a hand-edited URL
+    // pairing it with another view redirects there. Owning this at the route
+    // keeps the screen's deep-link handling a single consume-then-strip — a
+    // screen-issued view switch + strip pair would race (the strip navigation
+    // would carry the pre-switch :view and undo the switch).
+    if (params.screen === "campaign" && search.node && params.view !== "knowledge") {
+      throw redirect({
+        to: "/t/$tenantSlug/$screen/$view",
+        params: { tenantSlug: params.tenantSlug, screen: "campaign", view: "knowledge" },
+        search: { node: search.node },
+        replace: true,
+      });
+    }
+  },
   component: function SubviewScreen() {
     const { screen, view, tenantSlug } = subviewRoute.useParams();
     const search = subviewRoute.useSearch();

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import type { MouseEventHandler, ReactNode } from "react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
@@ -17,11 +17,30 @@ import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
 
 // The shell is driven by TanStack Router; mock the bits AppShell + SidebarUser
-// touch so it renders without a live router (mirrors AuthGate.test.tsx).
+// touch so it renders without a live router (mirrors AuthGate.test.tsx). The
+// Link mock keeps onClick (the mobile drawer-close) and data-active/aria-current
+// (the sub-navigation highlight) observable; useParams answers as if the route
+// were /t/acme/campaign/cast so the Campaign sub-navigation renders (ADR-0063).
 vi.mock("@tanstack/react-router", () => ({
-  Link: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+  Link: ({
+    children,
+    className,
+    onClick,
+    "data-active": dataActive,
+    "aria-current": ariaCurrent,
+  }: {
+    children: ReactNode;
+    className?: string;
+    onClick?: MouseEventHandler<HTMLAnchorElement>;
+    "data-active"?: string;
+    "aria-current"?: "page";
+  }) => (
+    <a className={className} onClick={onClick} data-active={dataActive} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  ),
   Outlet: () => null,
-  useParams: () => ({ screen: "campaign" }),
+  useParams: () => ({ screen: "campaign", view: "cast" }),
   useNavigate: () => vi.fn(),
 }));
 
@@ -59,6 +78,10 @@ function renderShell() {
 }
 
 describe("AppShell", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("toggles the sidebar collapsed state from the topbar control", async () => {
     const { container } = renderShell();
     // Let the switcher's initial reads settle so the topbar is stable first.
@@ -96,5 +119,40 @@ describe("AppShell", () => {
     expect(container.querySelector(".gx-shell")).toHaveAttribute("data-collapsed", "true");
 
     expect(await screen.findByText("Select campaign")).toBeInTheDocument();
+  });
+
+  it("renders the Campaign sub-navigation with the active sub-view highlighted (ADR-0063)", async () => {
+    renderShell();
+    expect(await screen.findByText("The Sunless Citadel")).toBeInTheDocument();
+
+    // The mocked route is /t/acme/campaign/cast, so the sub-items render under
+    // the Campaign nav item — one per sub-view, tab labels reused.
+    const sub = screen.getByRole("group", { name: /campaign view/i });
+    for (const label of ["Cast", "World wiki", "Maps", "Players", "Suggestions", "Planning"]) {
+      expect(within(sub).getByText(label)).toBeInTheDocument();
+    }
+    // The :view path param drives the highlight: cast is active, the rest not.
+    expect(within(sub).getByText("Cast").closest("a")).toHaveAttribute("data-active", "true");
+    expect(within(sub).getByText("Maps").closest("a")).not.toHaveAttribute("data-active");
+  });
+
+  it("closes the mobile drawer when a nav item is tapped", async () => {
+    // Narrow viewport: matchMedia matches the drawer breakpoint, so the shell
+    // boots collapsed (drawer shut) and a nav tap must re-collapse it.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({ matches: true } as MediaQueryList),
+    );
+    const { container } = renderShell();
+    expect(await screen.findByText("The Sunless Citadel")).toBeInTheDocument();
+    const shell = container.querySelector(".gx-shell") as HTMLElement;
+    expect(shell).toHaveAttribute("data-collapsed", "true");
+
+    // Open the drawer, then tap a sub-navigation item: it navigates (mocked)
+    // AND shuts the drawer so it doesn't keep covering the screen.
+    fireEvent.click(screen.getByRole("button", { name: /toggle sidebar/i }));
+    expect(shell).not.toHaveAttribute("data-collapsed", "true");
+    fireEvent.click(screen.getByText("Maps"));
+    expect(shell).toHaveAttribute("data-collapsed", "true");
   });
 });

--- a/web/src/components/AppShell.test.tsx
+++ b/web/src/components/AppShell.test.tsx
@@ -122,7 +122,7 @@ describe("AppShell", () => {
   });
 
   it("renders the Campaign sub-navigation with the active sub-view highlighted (ADR-0063)", async () => {
-    renderShell();
+    const { container } = renderShell();
     expect(await screen.findByText("The Sunless Citadel")).toBeInTheDocument();
 
     // The mocked route is /t/acme/campaign/cast, so the sub-items render under
@@ -134,6 +134,13 @@ describe("AppShell", () => {
     // The :view path param drives the highlight: cast is active, the rest not.
     expect(within(sub).getByText("Cast").closest("a")).toHaveAttribute("data-active", "true");
     expect(within(sub).getByText("Maps").closest("a")).not.toHaveAttribute("data-active");
+
+    // The parent Campaign item stays highlighted too (it links to the CURRENT
+    // sub-view while one is open, so a habit-click can't stomp it back to cast).
+    // Scoped to the sidebar nav — the topbar title also reads "Campaign", and
+    // the legal footer is a second navigation landmark.
+    const nav = container.querySelector(".gx-nav") as HTMLElement;
+    expect(within(nav).getByText("Campaign").closest("a")).toHaveAttribute("data-active", "true");
   });
 
   it("closes the mobile drawer when a nav item is tapped", async () => {

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -24,7 +24,7 @@ import { CampaignSwitcher } from "./CampaignSwitcher";
 import { CommandPalette } from "./CommandPalette";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useI18n, type MessageKey } from "@/i18n";
-import type { CampaignView } from "@/screens/campaign/views";
+import { isCampaignView, type CampaignView } from "@/screens/campaign/views";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
 // ui_kits/glyphoxa-web/shell.jsx (its inline styles lifted onto .gx-shell* /
@@ -60,12 +60,22 @@ const CAMPAIGN_SUBNAV: { view: CampaignView; label: MessageKey; icon: ReactNode 
   { view: "planning", label: "chat.tabPlanning", icon: <MessagesSquare size={15} /> },
 ];
 
+// The sidebar's off-canvas drawer breakpoint. Must stay in sync with the
+// @media block in styles/components.css; every JS check goes through
+// isDrawerViewport so the width lives in one place on this side.
+const DRAWER_BREAKPOINT = "(max-width: 880px)";
+const isDrawerViewport = () =>
+  typeof window !== "undefined" && (window.matchMedia?.(DRAWER_BREAKPOINT).matches ?? false);
+
 export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User }) {
   const { t } = useI18n();
   // view is present only under the campaign sub-view route (ADR-0063); it
-  // drives the sub-navigation's active highlight.
+  // drives the sub-navigation's active highlight. Derived by hand rather than
+  // via Link activeProps so the mocked-router unit test can observe it, and
+  // because the parent Campaign link needs the value anyway (see below).
   const { screen, view } = useParams({ strict: false }) as { screen?: string; view?: string };
   const active = NAV.find((n) => n.to === screen);
+  const activeView = screen === "campaign" && isCampaignView(view) ? view : undefined;
 
   // Sidebar collapse (#88 slice 4). On narrow viewports the sidebar is an
   // off-canvas drawer the topbar toggle opens; on wide viewports the toggle hides
@@ -73,17 +83,13 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
   // unit test) read it without media-query support. It starts collapsed on a
   // small viewport so mobile loads with the drawer shut (matchMedia is absent in
   // jsdom → the shell defaults to expanded under test).
-  const [collapsed, setCollapsed] = useState(
-    () => typeof window !== "undefined" && (window.matchMedia?.("(max-width: 880px)").matches ?? false),
-  );
+  const [collapsed, setCollapsed] = useState(isDrawerViewport);
 
   // On the drawer breakpoint a nav tap should navigate AND shut the drawer —
   // otherwise it keeps covering the screen it just navigated to. On wide
   // viewports this is a no-op so the sidebar stays put.
   const closeDrawerOnMobile = () => {
-    if (typeof window !== "undefined" && (window.matchMedia?.("(max-width: 880px)").matches ?? false)) {
-      setCollapsed(true);
-    }
+    if (isDrawerViewport()) setCollapsed(true);
   };
 
   return (
@@ -106,16 +112,33 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
         <nav className="gx-nav">
           {NAV.map((item) => (
             <Fragment key={item.to}>
-              <Link
-                className="gx-nav__item"
-                to="/t/$tenantSlug/$screen"
-                params={{ tenantSlug, screen: item.to }}
-                activeProps={{ "data-active": "true" }}
-                onClick={closeDrawerOnMobile}
-              >
-                {item.icon}
-                {t(item.label)}
-              </Link>
+              {item.to === "campaign" && activeView ? (
+                // While a Campaign sub-view is open, the parent item links to
+                // the CURRENT sub-view — a bare /campaign would redirect to
+                // cast and stomp the open view (a habit-click hazard the old
+                // in-page tabs didn't have).
+                <Link
+                  className="gx-nav__item"
+                  to="/t/$tenantSlug/$screen/$view"
+                  params={{ tenantSlug, screen: "campaign", view: activeView }}
+                  data-active="true"
+                  onClick={closeDrawerOnMobile}
+                >
+                  {item.icon}
+                  {t(item.label)}
+                </Link>
+              ) : (
+                <Link
+                  className="gx-nav__item"
+                  to="/t/$tenantSlug/$screen"
+                  params={{ tenantSlug, screen: item.to }}
+                  activeProps={{ "data-active": "true" }}
+                  onClick={closeDrawerOnMobile}
+                >
+                  {item.icon}
+                  {t(item.label)}
+                </Link>
+              )}
               {/* Campaign sub-views (ADR-0063): the screen's former in-page
                   tabs, revealed while Campaign is the active screen. */}
               {item.to === "campaign" && screen === "campaign" && (
@@ -126,8 +149,8 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
                       className="gx-nav__subitem"
                       to="/t/$tenantSlug/$screen/$view"
                       params={{ tenantSlug, screen: "campaign", view: sub.view }}
-                      data-active={view === sub.view ? "true" : undefined}
-                      aria-current={view === sub.view ? "page" : undefined}
+                      data-active={activeView === sub.view ? "true" : undefined}
+                      aria-current={activeView === sub.view ? "page" : undefined}
                       onClick={closeDrawerOnMobile}
                     >
                       {sub.icon}

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,7 +1,19 @@
-import { useState, type ReactNode } from "react";
+import { Fragment, useState, type ReactNode } from "react";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
 import { Toaster } from "sonner";
-import { Dices, PanelLeft, Settings, Swords, ScrollText } from "lucide-react";
+import {
+  BookOpen,
+  Dices,
+  Lightbulb,
+  Map as MapIcon,
+  MessagesSquare,
+  PanelLeft,
+  ScrollText,
+  Settings,
+  Swords,
+  Users,
+  UsersRound,
+} from "lucide-react";
 
 import type { User } from "@gen/glyphoxa/management/v1/management_pb";
 
@@ -12,6 +24,7 @@ import { CampaignSwitcher } from "./CampaignSwitcher";
 import { CommandPalette } from "./CommandPalette";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useI18n, type MessageKey } from "@/i18n";
+import type { CampaignView } from "@/screens/campaign/views";
 
 // The persistent app shell — sidebar + topbar — ported from the handoff
 // ui_kits/glyphoxa-web/shell.jsx (its inline styles lifted onto .gx-shell* /
@@ -29,9 +42,29 @@ const NAV: NavItem[] = [
   { to: "session", label: "shell.navSession", icon: <ScrollText size={18} />, title: "shell.titleSession" },
 ];
 
+// The Campaign screen's sub-views as sidebar sub-navigation (ADR-0063) — the
+// screen's former in-page tab bar, one Link per view, reusing the tab labels.
+// Rendered accordion-style under the Campaign item while it is active; the
+// active sub-view comes from the route's :view path param.
+const CAMPAIGN_SUBNAV: { view: CampaignView; label: MessageKey; icon: ReactNode }[] = [
+  { view: "cast", label: "campaign.tabCast", icon: <Users size={15} /> },
+  // The internal "Knowledge Graph" never faces the GM — the item reads
+  // "World wiki" (the copy-simplification glossary).
+  { view: "knowledge", label: "campaign.tabWiki", icon: <BookOpen size={15} /> },
+  { view: "maps", label: "campaign.tabMaps", icon: <MapIcon size={15} /> },
+  { view: "players", label: "campaign.tabPlayers", icon: <UsersRound size={15} /> },
+  // "Knowledge Proposals" simplifies to "Suggestions" for the same reason the
+  // graph became a wiki: GMs, not developers.
+  { view: "proposals", label: "campaign.tabSuggestions", icon: <Lightbulb size={15} /> },
+  // Butler planning chat (#592, ADR-0062).
+  { view: "planning", label: "chat.tabPlanning", icon: <MessagesSquare size={15} /> },
+];
+
 export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User }) {
   const { t } = useI18n();
-  const { screen } = useParams({ strict: false }) as { screen?: string };
+  // view is present only under the campaign sub-view route (ADR-0063); it
+  // drives the sub-navigation's active highlight.
+  const { screen, view } = useParams({ strict: false }) as { screen?: string; view?: string };
   const active = NAV.find((n) => n.to === screen);
 
   // Sidebar collapse (#88 slice 4). On narrow viewports the sidebar is an
@@ -43,6 +76,15 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
   const [collapsed, setCollapsed] = useState(
     () => typeof window !== "undefined" && (window.matchMedia?.("(max-width: 880px)").matches ?? false),
   );
+
+  // On the drawer breakpoint a nav tap should navigate AND shut the drawer —
+  // otherwise it keeps covering the screen it just navigated to. On wide
+  // viewports this is a no-op so the sidebar stays put.
+  const closeDrawerOnMobile = () => {
+    if (typeof window !== "undefined" && (window.matchMedia?.("(max-width: 880px)").matches ?? false)) {
+      setCollapsed(true);
+    }
+  };
 
   return (
     <div className="gx-shell" data-collapsed={collapsed ? "true" : undefined}>
@@ -63,16 +105,38 @@ export function AppShell({ tenantSlug, user }: { tenantSlug: string; user: User 
 
         <nav className="gx-nav">
           {NAV.map((item) => (
-            <Link
-              key={item.to}
-              className="gx-nav__item"
-              to="/t/$tenantSlug/$screen"
-              params={{ tenantSlug, screen: item.to }}
-              activeProps={{ "data-active": "true" }}
-            >
-              {item.icon}
-              {t(item.label)}
-            </Link>
+            <Fragment key={item.to}>
+              <Link
+                className="gx-nav__item"
+                to="/t/$tenantSlug/$screen"
+                params={{ tenantSlug, screen: item.to }}
+                activeProps={{ "data-active": "true" }}
+                onClick={closeDrawerOnMobile}
+              >
+                {item.icon}
+                {t(item.label)}
+              </Link>
+              {/* Campaign sub-views (ADR-0063): the screen's former in-page
+                  tabs, revealed while Campaign is the active screen. */}
+              {item.to === "campaign" && screen === "campaign" && (
+                <div className="gx-nav__sub" role="group" aria-label={t("campaign.viewTablist")}>
+                  {CAMPAIGN_SUBNAV.map((sub) => (
+                    <Link
+                      key={sub.view}
+                      className="gx-nav__subitem"
+                      to="/t/$tenantSlug/$screen/$view"
+                      params={{ tenantSlug, screen: "campaign", view: sub.view }}
+                      data-active={view === sub.view ? "true" : undefined}
+                      aria-current={view === sub.view ? "page" : undefined}
+                      onClick={closeDrawerOnMobile}
+                    >
+                      {sub.icon}
+                      {t(sub.label)}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </Fragment>
           ))}
         </nav>
 

--- a/web/src/components/CommandPalette.test.tsx
+++ b/web/src/components/CommandPalette.test.tsx
@@ -164,16 +164,18 @@ describe("CommandPalette (#591)", () => {
     expect(screen.queryByTestId("palette-degraded")).not.toBeInTheDocument();
   });
 
-  it("deep-links a node hit to the Knowledge panel and closes", async () => {
+  it("deep-links a node hit to the knowledge sub-view and closes", async () => {
     renderPalette();
     await searchFor("bart");
     fireEvent.click(await screen.findByText("Bart"));
 
+    // The Campaign sub-view is a path segment (ADR-0063): entry hits land on
+    // /campaign/knowledge with only the node focus left as a search param.
     expect(navigateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "/t/$tenantSlug/$screen",
-        params: { tenantSlug: "acme", screen: "campaign" },
-        search: { view: "knowledge", node: "n-bart" },
+        to: "/t/$tenantSlug/$screen/$view",
+        params: { tenantSlug: "acme", screen: "campaign", view: "knowledge" },
+        search: { node: "n-bart" },
       }),
     );
     expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -106,6 +106,17 @@ export function CommandPalette({ tenantSlug }: { tenantSlug: string }) {
     void navigate({ to: "/t/$tenantSlug/$screen", params: { tenantSlug, screen }, search });
   };
 
+  // Entry hits land on the World-wiki sub-view directly — the Campaign view is
+  // a path segment now (ADR-0063) — with ?node= as the consume-then-strip focus.
+  const goNode = (nodeId: string) => {
+    close();
+    void navigate({
+      to: "/t/$tenantSlug/$screen/$view",
+      params: { tenantSlug, screen: "campaign", view: "knowledge" },
+      search: { node: nodeId },
+    });
+  };
+
   if (!open) return null;
 
   const nodes = nodesQ.data?.nodes ?? [];
@@ -160,7 +171,7 @@ export function CommandPalette({ tenantSlug }: { tenantSlug: string }) {
                           key={n.id}
                           value={`node:${n.id}`}
                           className="gx-palette__item"
-                          onSelect={() => go("campaign", { view: "knowledge", node: n.id })}
+                          onSelect={() => goNode(n.id)}
                         >
                           <span
                             className="gx-palette__type-icon"

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -680,22 +680,27 @@ describe("Campaign", () => {
 });
 
 describe("Campaign palette deep link (#591)", () => {
-  // The sub-view itself is no longer a deep-link param — it lives in the path
-  // (ADR-0063), and router.test.tsx pins the legacy ?view= redirect. Only the
-  // ?node= focus hand-off remains the screen's job.
-  it("a node deep link switches to the Knowledge view and reports the param handled", async () => {
+  // The sub-view is no longer a deep-link param — it lives in the path
+  // (ADR-0063), and router.test.tsx pins the legacy ?view= redirect plus the
+  // rule that ?node= only ever arrives on the knowledge view. Only the ?node=
+  // focus consume-then-strip remains the screen's job.
+  it("consumes a node deep link on the knowledge view and reports it handled", async () => {
     const { transport } = mockTransport();
     const handled = vi.fn();
     render(
       <Providers transport={transport} queryClient={makeQueryClient()}>
-        <Harness initialView="cast" deepLink={{ node: "some-node-id" }} onDeepLinkHandled={handled} />
+        <Harness
+          initialView="knowledge"
+          deepLink={{ node: "some-node-id" }}
+          onDeepLinkHandled={handled}
+        />
       </Providers>,
     );
-    // The Knowledge view takes over (the focusNodeID hand-off to the panel is
-    // the RosterPrep onOpenNode path, resolved once the panel's list loads):
-    // the wiki lede renders and the roster is unmounted.
+    // The wiki view renders (the focusNodeID hand-off to the panel is the
+    // RosterPrep onOpenNode path, resolved once the panel's list loads) and the
+    // param is reported consumed exactly once.
     expect(await screen.findByText(/what the world knows/i)).toBeInTheDocument();
     expect(screen.queryByText("Bart")).not.toBeInTheDocument();
-    expect(handled).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(handled).toHaveBeenCalledTimes(1));
   });
 });

--- a/web/src/screens/campaign/Campaign.test.tsx
+++ b/web/src/screens/campaign/Campaign.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
@@ -26,7 +27,8 @@ import {
 } from "@gen/glyphoxa/management/v1/management_pb";
 import { Providers } from "@/app/Providers";
 import { makeQueryClient } from "@/lib/queryClient";
-import { Campaign } from "./Campaign";
+import { Campaign, type CampaignDeepLink } from "./Campaign";
+import { CAMPAIGN_VIEWS, type CampaignView } from "./views";
 
 // An in-memory campaign store served over a router transport (no network): the
 // roster mutates in this closure, so a Save → invalidate → refetch proves the
@@ -161,14 +163,53 @@ function mockTransport() {
   return { transport, npcs, previewCalls, grants };
 }
 
-function renderScreen() {
+// The sub-view now arrives as a prop from the route path and changes via the
+// sidebar sub-navigation (ADR-0063). This harness stands in for the route +
+// sidebar pair: it owns the view state, feeds it back into the screen through
+// onViewChange, and exposes one "nav:<view>" button per sub-view so tests can
+// drive the same switching flow the sidebar does.
+function Harness({
+  initialView = "cast",
+  deepLink,
+  onDeepLinkHandled,
+}: {
+  initialView?: CampaignView;
+  deepLink?: CampaignDeepLink;
+  onDeepLinkHandled?: () => void;
+}) {
+  const [view, setView] = useState<CampaignView>(initialView);
+  return (
+    <>
+      <nav aria-label="test-subnav">
+        {CAMPAIGN_VIEWS.map((v) => (
+          <button key={v} type="button" onClick={() => setView(v)}>
+            {`nav:${v}`}
+          </button>
+        ))}
+      </nav>
+      <Campaign
+        view={view}
+        onViewChange={setView}
+        deepLink={deepLink}
+        onDeepLinkHandled={onDeepLinkHandled}
+      />
+    </>
+  );
+}
+
+function renderScreen(initialView: CampaignView = "cast") {
   const { transport, npcs, previewCalls, grants } = mockTransport();
   render(
     <Providers transport={transport} queryClient={makeQueryClient()}>
-      <Campaign />
+      <Harness initialView={initialView} />
     </Providers>,
   );
   return { npcs, previewCalls, grants };
+}
+
+// switchView drives the harness's stand-in for a sidebar sub-navigation click.
+function switchView(view: CampaignView) {
+  fireEvent.click(screen.getByRole("button", { name: `nav:${view}` }));
 }
 
 // The Tools section and the addressing switch live inside a closed-by-default
@@ -346,30 +387,30 @@ describe("Campaign", () => {
     expect(await screen.findByText("ElevenLabs · Rachel")).toBeInTheDocument();
   });
 
-  it("exposes a third Players tab and leaves Cast unchanged (#279)", async () => {
+  it("mounts the Players panel on its sub-view and leaves Cast unchanged (#279)", async () => {
     renderScreen();
     // Cast is the default: the roster loads first.
     expect(await screen.findByText("Bart")).toBeInTheDocument();
 
     // Switch to Players — the panel mounts on its own ListCharacters RPC.
-    fireEvent.click(screen.getByRole("tab", { name: "Players" }));
+    switchView("players");
     expect(await screen.findByText("Kira")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add player/i })).toBeInTheDocument();
     // The roster (Cast) is no longer mounted.
     expect(screen.queryByText("Bart")).not.toBeInTheDocument();
 
     // Back to Cast — the roster is unchanged.
-    fireEvent.click(screen.getByRole("tab", { name: "Cast" }));
+    switchView("cast");
     expect(await screen.findByText("Bart")).toBeInTheDocument();
   });
 
-  it("exposes a fourth Suggestions tab that mounts the review panel (#300)", async () => {
+  it("mounts the Suggestions review panel on its sub-view (#300)", async () => {
     renderScreen();
     expect(await screen.findByText("Bart")).toBeInTheDocument();
 
     // Switch to Suggestions (the simplified name for Knowledge Proposals) — the
     // panel mounts on its own ListKnowledgeProposals RPC.
-    fireEvent.click(screen.getByRole("tab", { name: "Suggestions" }));
+    switchView("proposals");
     expect(await screen.findByText(/No pending suggestions/i)).toBeInTheDocument();
     // The roster (Cast) is no longer mounted.
     expect(screen.queryByText("Bart")).not.toBeInTheDocument();
@@ -639,45 +680,22 @@ describe("Campaign", () => {
 });
 
 describe("Campaign palette deep link (#591)", () => {
-  it("opens the linked sub-view and reports the params handled", async () => {
+  // The sub-view itself is no longer a deep-link param — it lives in the path
+  // (ADR-0063), and router.test.tsx pins the legacy ?view= redirect. Only the
+  // ?node= focus hand-off remains the screen's job.
+  it("a node deep link switches to the Knowledge view and reports the param handled", async () => {
     const { transport } = mockTransport();
     const handled = vi.fn();
     render(
       <Providers transport={transport} queryClient={makeQueryClient()}>
-        <Campaign deepLink={{ view: "players" }} onDeepLinkHandled={handled} />
+        <Harness initialView="cast" deepLink={{ node: "some-node-id" }} onDeepLinkHandled={handled} />
       </Providers>,
     );
-    await waitFor(() =>
-      expect(screen.getByRole("tab", { name: /players/i })).toHaveAttribute("aria-selected", "true"),
-    );
+    // The Knowledge view takes over (the focusNodeID hand-off to the panel is
+    // the RosterPrep onOpenNode path, resolved once the panel's list loads):
+    // the wiki lede renders and the roster is unmounted.
+    expect(await screen.findByText(/what the world knows/i)).toBeInTheDocument();
+    expect(screen.queryByText("Bart")).not.toBeInTheDocument();
     expect(handled).toHaveBeenCalledTimes(1);
-  });
-
-  it("a node deep link opens the Knowledge panel focused on that entry", async () => {
-    const { transport } = mockTransport();
-    const handled = vi.fn();
-    render(
-      <Providers transport={transport} queryClient={makeQueryClient()}>
-        <Campaign deepLink={{ node: "some-node-id" }} onDeepLinkHandled={handled} />
-      </Providers>,
-    );
-    // The Knowledge tab takes over (the focusNodeID hand-off to the panel is the
-    // RosterPrep onOpenNode path, resolved once the panel's list loads).
-    await waitFor(() =>
-      expect(screen.getByRole("tab", { name: /world wiki/i })).toHaveAttribute("aria-selected", "true"),
-    );
-    expect(handled).toHaveBeenCalledTimes(1);
-  });
-
-  it("an unknown view value is ignored (params still handled, default view stays)", async () => {
-    const { transport } = mockTransport();
-    const handled = vi.fn();
-    render(
-      <Providers transport={transport} queryClient={makeQueryClient()}>
-        <Campaign deepLink={{ view: "nonsense" }} onDeepLinkHandled={handled} />
-      </Providers>,
-    );
-    await waitFor(() => expect(handled).toHaveBeenCalled());
-    expect(screen.getByRole("tab", { name: /cast/i })).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -100,16 +100,16 @@ export function Campaign({
 
   // Palette deep link (#591): ?node=… opens the Knowledge panel focused on that
   // entry (the RosterPrep onOpenNode path — KnowledgePanel resolves the id once
-  // its list loads). The palette lands node links on the knowledge sub-view
-  // already; switching here covers a hand-edited URL. Consumed once, then
-  // onDeepLinkHandled strips the param so the URL doesn't pin the focus.
+  // its list loads). The route guarantees ?node= only ever arrives on the
+  // knowledge view (subviewRoute's beforeLoad redirects any other pairing), so
+  // this is a pure consume-then-strip: take the focus, then onDeepLinkHandled
+  // strips the param so the URL doesn't pin it.
   const dlNode = deepLink?.node;
   useEffect(() => {
     if (!dlNode) return;
     setFocusNodeID(dlNode);
-    setView("knowledge");
     onDeepLinkHandled?.();
-    // onDeepLinkHandled/setView are stable route-level callbacks; the param is the trigger.
+    // onDeepLinkHandled is a stable route-level callback; the param is the trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dlNode]);
 

--- a/web/src/screens/campaign/Campaign.tsx
+++ b/web/src/screens/campaign/Campaign.tsx
@@ -19,6 +19,7 @@ import { playAudioBlob } from "@/lib/audio";
 import { errorMessage } from "@/lib/connectError";
 import { invalidateMethodQueries } from "@/lib/queryClient";
 import { invalidateKnowledgeReads } from "./knowledgeCache";
+import type { CampaignView } from "./views";
 import { KnowledgePanel } from "./KnowledgePanel";
 import { MapsPanel } from "./MapsPanel";
 import { PlayersPanel } from "./PlayersPanel";
@@ -49,15 +50,20 @@ function isButler(a: Agent): boolean {
   return a.role === "butler";
 }
 
-// CampaignDeepLink is the palette's arrival vocabulary (#591): view selects a
-// sub-view, node opens the Knowledge panel focused on that entry. Both optional;
-// the route strips the params after onDeepLinkHandled so nothing is sticky.
-export type CampaignDeepLink = { view?: string; node?: string };
+// CampaignDeepLink is the palette's arrival vocabulary (#591): node opens the
+// Knowledge panel focused on that entry. Optional; the route strips the param
+// after onDeepLinkHandled so nothing is sticky. (The sub-view itself is no
+// longer a deep-link param — it lives in the path, ADR-0063.)
+export type CampaignDeepLink = { node?: string };
 
 export function Campaign({
+  view = "cast",
+  onViewChange,
   deepLink,
   onDeepLinkHandled,
 }: {
+  view?: CampaignView;
+  onViewChange?: (view: CampaignView) => void;
   deepLink?: CampaignDeepLink;
   onDeepLinkHandled?: () => void;
 } = {}) {
@@ -78,12 +84,12 @@ export function Campaign({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selected = roster.find((a) => a.id === selectedId) ?? roster[0];
 
-  // Cast (roster editor), Knowledge (KG entries), or Players (Character ↔ Discord
-  // User bindings, #279) — the design's seg-control beside the title. Cast is the
-  // default so the roster is what loads first (#71).
-  const [view, setView] = useState<
-    "cast" | "knowledge" | "maps" | "players" | "proposals" | "planning"
-  >("cast");
+  // The sub-view — Cast (roster editor), Knowledge (KG entries), Maps, Players
+  // (Character ↔ Discord User bindings, #279), Suggestions, Planning — arrives
+  // from the route path and changes via the sidebar sub-navigation (ADR-0063);
+  // cross-view jumps inside the screen go through onViewChange (a param-only
+  // navigation, so this component stays mounted and its state survives).
+  const setView = (next: CampaignView) => onViewChange?.(next);
   // Within Cast: the editor (default), or the prep readiness view (#544). The
   // editor stays the default because adding and shaping NPCs is the common act;
   // readiness is what you check before a session.
@@ -94,29 +100,18 @@ export function Campaign({
 
   // Palette deep link (#591): ?node=… opens the Knowledge panel focused on that
   // entry (the RosterPrep onOpenNode path — KnowledgePanel resolves the id once
-  // its list loads); a bare ?view=… just selects the sub-view. Consumed once,
-  // then onDeepLinkHandled strips the params so the URL doesn't pin the view.
-  const dlView = deepLink?.view;
+  // its list loads). The palette lands node links on the knowledge sub-view
+  // already; switching here covers a hand-edited URL. Consumed once, then
+  // onDeepLinkHandled strips the param so the URL doesn't pin the focus.
   const dlNode = deepLink?.node;
   useEffect(() => {
-    if (!dlView && !dlNode) return;
-    if (dlNode) {
-      setFocusNodeID(dlNode);
-      setView("knowledge");
-    } else if (
-      dlView === "cast" ||
-      dlView === "knowledge" ||
-      dlView === "maps" ||
-      dlView === "players" ||
-      dlView === "proposals" ||
-      dlView === "planning"
-    ) {
-      setView(dlView);
-    }
+    if (!dlNode) return;
+    setFocusNodeID(dlNode);
+    setView("knowledge");
     onDeepLinkHandled?.();
-    // onDeepLinkHandled is a stable route-level callback; the params are the triggers.
+    // onDeepLinkHandled/setView are stable route-level callbacks; the param is the trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dlView, dlNode]);
+  }, [dlNode]);
 
   // Creating a Character NPC auto-creates its wiki entry, and deleting one
   // unlinks that entry (ADR-0008 second amendment) — both are Knowledge Graph
@@ -146,69 +141,11 @@ export function Campaign({
   return (
     <div className="gx-campaign-screen">
       <header className="gx-campaign-screen__header">
+        {/* The sub-view tabs that used to sit beside the title moved into the
+            sidebar's Campaign sub-navigation (ADR-0063); the header keeps the
+            campaign identity and the per-view lede. */}
         <div className="gx-campaign-screen__title-row">
           <h1>{campaign?.name ?? t("campaign.fallbackTitle")}</h1>
-          <div className="gx-seg" role="tablist" aria-label={t("campaign.viewTablist")}>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "cast"}
-              data-active={view === "cast" ? "true" : undefined}
-              onClick={() => setView("cast")}
-            >
-              {t("campaign.tabCast")}
-            </button>
-            {/* The internal "Knowledge Graph" never faces the GM — the tab reads
-                "World wiki" (the copy-simplification glossary). */}
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "knowledge"}
-              data-active={view === "knowledge" ? "true" : undefined}
-              onClick={() => setView("knowledge")}
-            >
-              {t("campaign.tabWiki")}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "maps"}
-              data-active={view === "maps" ? "true" : undefined}
-              onClick={() => setView("maps")}
-            >
-              {t("campaign.tabMaps")}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "players"}
-              data-active={view === "players" ? "true" : undefined}
-              onClick={() => setView("players")}
-            >
-              {t("campaign.tabPlayers")}
-            </button>
-            {/* "Knowledge Proposals" simplifies to "Suggestions" for the same
-                reason the graph became a wiki: GMs, not developers. */}
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "proposals"}
-              data-active={view === "proposals" ? "true" : undefined}
-              onClick={() => setView("proposals")}
-            >
-              {t("campaign.tabSuggestions")}
-            </button>
-            {/* Butler planning chat (#592, ADR-0062). */}
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "planning"}
-              data-active={view === "planning" ? "true" : undefined}
-              onClick={() => setView("planning")}
-            >
-              {t("chat.tabPlanning")}
-            </button>
-          </div>
         </div>
         <div className="gx-campaign-screen__sub">
           {campaign?.system && <span className="gx-campaign-screen__system">{campaign.system}</span>}

--- a/web/src/screens/campaign/campaign.css
+++ b/web/src/screens/campaign/campaign.css
@@ -15,47 +15,14 @@
   margin-bottom: var(--spacing-lg);
 }
 
-/* Title + Cast|Knowledge seg-control on one row (#126). */
+/* Title row. The sub-view seg-control that used to share it moved into the
+ * sidebar sub-navigation (ADR-0063). */
 .gx-campaign-screen__title-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-md);
   flex-wrap: wrap;
-}
-
-/* Segmented control (Cast | Knowledge), mirroring the Session screen's seg. */
-.gx-seg {
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
-  background: var(--surface-inset, var(--surface-card));
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-pill);
-}
-
-.gx-seg > button {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  padding: var(--spacing-xs) var(--spacing-md);
-  border-radius: var(--radius-pill);
-  font-size: var(--body-sm);
-  font-weight: var(--weight-semibold);
-  cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
-}
-
-.gx-seg > button:hover {
-  color: var(--text-strong);
-}
-
-.gx-seg > button[data-active="true"] {
-  background: var(--surface-card);
-  color: var(--text-strong);
-  box-shadow: var(--glow-arcane-soft);
 }
 
 /* Knowledge view: list left, sticky editor card right (mirrors the roster grid). */

--- a/web/src/screens/campaign/views.ts
+++ b/web/src/screens/campaign/views.ts
@@ -1,0 +1,20 @@
+// The Campaign screen's sub-views, shared by the router (path segment), the
+// AppShell (sidebar sub-navigation) and the screen itself. The view lives in
+// the PATH (/t/:tenantSlug/campaign/:view) rather than screen state so the
+// sidebar can link to and highlight it, and a bookmarked URL restores the view
+// (ADR-0063 — the in-page tab bar moved into the sidebar).
+
+export const CAMPAIGN_VIEWS = [
+  "cast",
+  "knowledge",
+  "maps",
+  "players",
+  "proposals",
+  "planning",
+] as const;
+
+export type CampaignView = (typeof CAMPAIGN_VIEWS)[number];
+
+export function isCampaignView(v: unknown): v is CampaignView {
+  return typeof v === "string" && (CAMPAIGN_VIEWS as readonly string[]).includes(v);
+}

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -701,6 +701,10 @@ textarea.gx-input {
   display: flex;
   flex-direction: column;
   gap: 3px;
+  /* The Campaign sub-navigation (ADR-0063) lengthens the list; on a short
+   * phone viewport the nav scrolls instead of pushing the user footer out. */
+  min-height: 0;
+  overflow-y: auto;
 }
 .gx-nav__item {
   position: relative;
@@ -741,6 +745,51 @@ textarea.gx-input {
   width: 3px;
   border-radius: 999px;
   background: var(--gradient-arcane);
+}
+/* Campaign sub-navigation (ADR-0063): the screen's former in-page tabs as an
+ * indented group under the active Campaign item, with a guide line standing in
+ * for the tab bar's frame. Same hover/active language as .gx-nav__item, one
+ * step smaller. */
+.gx-nav__sub {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 2px 0 6px;
+  padding-left: 26px;
+  position: relative;
+}
+/* The guide runs under the parent item's icon column (item padding 12px +
+ * half the 18px icon ≈ 20px), just left of the indented sub-items. */
+.gx-nav__sub::before {
+  content: "";
+  position: absolute;
+  left: 20px;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--border-subtle);
+}
+.gx-nav__subitem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-base);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+.gx-nav__subitem:hover {
+  background: rgba(144, 89, 255, 0.07);
+  color: var(--text-default);
+  text-decoration: none;
+}
+.gx-nav__subitem[data-active="true"] {
+  background: rgba(144, 89, 255, 0.14);
+  color: var(--color-violet-10);
 }
 .gx-sidebar__user {
   padding: 14px;


### PR DESCRIPTION
## What does this PR do?

Moves the Campaign screen's six in-page tabs (Cast, World wiki, Maps, Players, Suggestions, Planning) out of the cramped seg-control beside the title and into the left sidebar as an accordion sub-navigation under the **Campaign** nav item, and promotes the sub-view from screen state to a path segment: `/t/:tenantSlug/campaign/:view`.

- **Router**: a generic `$screen/$view` sibling of `$screen` (only Campaign defines sub-views; anything else renders notFound). A bare `/campaign` redirects to `/campaign/cast`; legacy `?view=` palette links (#591) are rewritten onto the path and `?node=` lands on `/campaign/knowledge?node=…`, so old bookmarks keep working. `?node=` paired with any other sub-view is corrected by the route's `beforeLoad`, keeping the screen's deep-link handling a single consume-then-strip.
- **AppShell**: sub-items render under Campaign while it is the active screen, highlighted from the `:view` path param. While a sub-view is open, the parent Campaign item links to the *current* sub-view so a habit-click can't stomp an open view (e.g. a planning chat) back to Cast. On the drawer breakpoint (≤880px) any nav tap now also closes the off-canvas drawer so it doesn't keep covering the screen it navigated to; the nav scrolls on short viewports instead of pushing the user footer out.
- **Campaign screen**: receives `view` + `onViewChange` from the route; sub-view switches are param-only navigations within one route, so local state (selected agent, cast mode, wiki focus) survives a sidebar switch — same behaviour the in-page tabs had. The seg-control and its `gx-seg` CSS are removed.
- **CommandPalette**: entry hits deep-link straight to `/campaign/knowledge?node=…`.
- **ADR-0063** documents the decision; labels reuse the existing `campaign.tab*` i18n keys (no new translations).

## Why is this change needed?

Six tabs no longer fit the title row — especially on mobile, where the seg-control overflowed. The sidebar (an off-canvas drawer on phones) scales to the growing list, gives sub-pages stable bookmarkable URLs, and makes them reachable from the persistent chrome instead of only after landing on the Campaign screen.

## How was this tested?

- [x] `web` suite: `tsc --noEmit`, `vite build` and `vitest run` pass (534 tests; the one local failure is the pre-existing `download.test.ts` Blob instanceof quirk under node 22, which also fails on a clean checkout and passes on CI's node 24)
- [x] New/updated tests cover the change: router tests pin the `/campaign` → `/campaign/cast` redirect, the legacy `?view=`/`?node=` rewrites and consume-then-strip; AppShell tests cover the sub-nav rendering, active highlight, parent-item behaviour and mobile drawer-close; Campaign tests drive views through a harness standing in for the route + sidebar pair
- [ ] Manual testing (not run — no live backend in this environment; Go code is untouched, so `make check` is unaffected)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code cleanup

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...` (no Go changes; web suite run instead)
- [x] I have updated documentation if needed (ADR-0063)
- [x] All exported symbols have Godoc comments (n/a — TypeScript only; new exports are documented)
- [x] My commits are focused and have clear messages

## Additional Notes

An adversarial review pass ran before push; it found one real race (the screen-issued view-switch + strip pair on hand-edited `?node=` URLs) and one behavioural regression (parent Campaign click resetting an open sub-view) — both fixed in the second commit with regression tests. If Session or Setup ever grow tabs, ADR-0063 sets the expectation that they use the same `$screen/$view` + sidebar pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHJovUMV7Smjb3vNJLgtsA

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHJovUMV7Smjb3vNJLgtsA)_