### PR TITLE
feat(#312): [E8] Highlight sound enrichment — ElevenLabs stings & music, opt-in per Highlight

### DIFF
--- a/cmd/glyphoxa/boot.go
+++ b/cmd/glyphoxa/boot.go
@@ -26,6 +26,8 @@ import (
 	"github.com/MrWong99/Glyphoxa/internal/spend"
 	"github.com/MrWong99/Glyphoxa/internal/storage"
 	"github.com/MrWong99/Glyphoxa/internal/storage/crypto"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+	soundelevenlabs "github.com/MrWong99/Glyphoxa/pkg/voice/soundgen/elevenlabs"
 )
 
 // webEnvVars are the environment variables a web/all-Mode Web Instance must have
@@ -899,5 +901,42 @@ func newImageFactory(store providerConfigReader, cipher *crypto.Cipher, keyEnt l
 			model = cfgPtr.Model
 		}
 		return imagegen.NewGemini(key, imagegen.WithModel(model)), model, nil
+	}
+}
+
+// newSoundFactory builds the sound-generator factory Highlight sound
+// enrichment uses (#312, ADR-0004 amendment 2026-07-22): sound generation
+// rides the Tenant's existing `tts` Provider Config and uses its key IFF the
+// configured provider is ElevenLabs — deliberately NOT a new Component. Any
+// other tts provider, no tts row at all (the provider identity is then
+// unknown, so the amendment reads it as not configured), or no resolvable key
+// is highlight.ErrSoundNotConfigured — the clean no-op, no retry, no spend.
+// The ADR-0039 hybrid key policy and the ADR-0054 gated resolve apply exactly
+// as in newImageFactory: a saved key needs the cipher (loud error, never a
+// silent env fallback), an entitlement refusal errors before the env fallback
+// can spend the deployment's ELEVENLABS key.
+func newSoundFactory(store providerConfigReader, cipher *crypto.Cipher, keyEnt llmbuild.PlatformKeyEntitlement) highlight.SoundGeneratorFactory {
+	return func(fctx context.Context, tenantID uuid.UUID) (soundgen.Generator, error) {
+		cfg, cerr := store.GetProviderConfigByComponent(fctx, tenantID, storage.ComponentTTS)
+		if errors.Is(cerr, storage.ErrNotFound) {
+			return nil, highlight.ErrSoundNotConfigured
+		}
+		if cerr != nil {
+			return nil, cerr
+		}
+		if cfg.Provider != soundelevenlabs.ProviderID {
+			return nil, highlight.ErrSoundNotConfigured
+		}
+		key, kerr := llmbuild.ResolveKeyGated(fctx, keyEnt, tenantID, cipher, &cfg, storage.ComponentTTS)
+		if kerr != nil {
+			return nil, kerr // saved key without cipher = loud error (ADR-0039)
+		}
+		if key == "" {
+			key = os.Getenv(soundelevenlabs.APIKeyEnv)
+		}
+		if key == "" {
+			return nil, highlight.ErrSoundNotConfigured
+		}
+		return soundelevenlabs.New(key), nil
 	}
 }

--- a/cmd/glyphoxa/main.go
+++ b/cmd/glyphoxa/main.go
@@ -1187,6 +1187,14 @@ func runWeb(log *slog.Logger, cfg wirenpc.Config, metrics *observe.PrometheusRec
 	// ErrImageNotConfigured (the handler leaves the Highlight intact without media).
 	imageFactory := newImageFactory(store, cipher, keyEnt)
 	jobRunner.Register(highlight.JobKindEnrichImage, highlight.EnrichImageHandler(store, blobStore, imageFactory, metrics, log))
+	// Session Highlight sound enrichment (#312, ADR-0004 amendment/0049): the
+	// GM's opt-in "Add sound" action generates an ElevenLabs sting or Music
+	// track that attaches as a separate blob. The factory rides the tenant's
+	// tts Provider Config iff its provider is ElevenLabs — deliberately no new
+	// Component; anything else is highlight.ErrSoundNotConfigured (the handler
+	// leaves the Highlight intact without media).
+	soundFactory := newSoundFactory(store, cipher, keyEnt)
+	jobRunner.Register(highlight.JobKindEnrichSound, highlight.EnrichSoundHandler(store, blobStore, soundFactory, log))
 	// The Knowledge Graph appearance index (#545, ADR-0008 amendment): one pass per
 	// ended session, matching its committed Transcript Lines against the campaign's
 	// entry names. A job because the work is per-session and must never touch a
@@ -1464,6 +1472,7 @@ var plainMountPolicy = map[string]auth.TenantMode{
 	"GET /api/v1/sessions/{id}":                 auth.TenantRequired,
 	"GET /api/v1/highlights/{id}/clip":          auth.TenantRequired,
 	"GET /api/v1/highlights/{id}/image":         auth.TenantRequired,
+	"GET /api/v1/highlights/{id}/sound":         auth.TenantRequired,
 	"GET /api/v1/maps/{id}/image":               auth.TenantRequired,
 	"GET /api/v1/knowledge/nodes/{id}/portrait": auth.TenantRequired,
 	"GET /api/v1/campaigns/{id}/export":         auth.TenantRequired,
@@ -1637,6 +1646,9 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 	// store + blob seam the Voice process writes through. Wired here so the many
 	// NewSessionServer call sites keep their signature.
 	sessionSrv.SetHighlights(store, blobStore, jobEnqueuer{store})
+	// Sound enrichment RPC seam (#312): SetHighlightSound prechecks the factory
+	// so an unconfigured tenant gets an actionable error at click time.
+	sessionSrv.SetSoundEnrichment(newSoundFactory(store, cipher, keyEnt))
 	// Highlight Discord delivery (#310, Epic 8, ADR-0051): the GM shares a promoted
 	// Highlight as a file to a text channel (DeploymentSharer resolves the Bot token +
 	// guild from deployment_config via the cipher, then plain net/http Discord REST —
@@ -1732,6 +1744,9 @@ func managementMounts(store *storage.Store, blobStore blob.Store, cipher *crypto
 		// Session Highlight AI image (#311): operator-gated image byte stream, same
 		// tenant + Active-Campaign 404 posture as the clip; no image yet → 404.
 		"GET /api/v1/highlights/{id}/image": http.HandlerFunc(clipServer.ServeImage),
+		// Session Highlight generated sound (#312): operator-gated audio byte
+		// stream, same posture; no sound landed yet → 404.
+		"GET /api/v1/highlights/{id}/sound": http.HandlerFunc(clipServer.ServeSound),
 		// Campaign Map images (#538, ADR-0060) — the second blob owner's byte route,
 		// same posture as the Highlight clip/image mounts.
 		"GET /api/v1/maps/{id}/image": http.HandlerFunc(mapImages.ServeImage),

--- a/cmd/glyphoxa/mount_policy_test.go
+++ b/cmd/glyphoxa/mount_policy_test.go
@@ -22,6 +22,9 @@ func TestPlainMountPolicy(t *testing.T) {
 		"GET /api/v1/sessions/{id}":         auth.TenantRequired,
 		"GET /api/v1/highlights/{id}/clip":  auth.TenantRequired,
 		"GET /api/v1/highlights/{id}/image": auth.TenantRequired,
+		// Session Highlight generated sound (#312) — same byte-mount posture as
+		// the clip and image for the same #408 reason.
+		"GET /api/v1/highlights/{id}/sound": auth.TenantRequired,
 		// Campaign Map images (#538, ADR-0060) — the second blob owner's byte route.
 		// TenantRequired like every other byte mount: the handler re-reads the
 		// injected tenant to scope its row load, and a session-only gate would 401.

--- a/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
+++ b/docs/adr/0046-spend-meter-price-map-cap-mechanics.md
@@ -52,6 +52,33 @@ mechanism reading the Usage Ledger, not this ADR's live cap: the soft/hard-cap
 mechanics, `AllowTurn`, and `SpendCapReached` remain exclusively the running
 Voice Session's concern, unchanged.
 
+## Amendment (2026-08-18, #312 Highlight sound enrichment)
+
+Highlight sound generation (ElevenLabs SFX stings and Music tracks, ADR-0004
+amendment 2026-07-22) is the third off-session consumer, and it introduces the
+price map's first **sound** rows: `internal/spend/prices.go` gains a
+model-keyed `soundPricePerMinute` map — the SFX and Music model ids price
+separately, per the ADR-0004 amendment's attribution requirement — with the
+usual conservative (higher-than-any-known-row) fallback for an unknown model.
+Its metering posture:
+
+- **Estimated directly, never a Meter capture point.** The ADR-0045 usage trio
+  (LLM/TTS/STT) carries no sound kind, and caps are live-Voice-Session-only —
+  an off-session enrichment job is never cap-gated (the Recap posture). The
+  new `spend.EstimateSoundUSD(provider, model, duration)` prices the
+  REQUESTED audio duration (the one quantity known before the vendor bill),
+  the embeddings-estimate pattern.
+- **Usage-Ledger attribution per generation.** The enrichment job flushes one
+  `billing.Ledger` row per generation with Tenant attribution: component
+  `tts` (the Provider Config the call rode — deliberately no `sound`
+  Component), the SFX/Music model id as discriminator, the vendor's
+  `character-cost` header as the quantity (its own credit unit; 0 when
+  unreported), and the duration-priced estimate. The planning-chat
+  per-exchange flush pattern.
+
+The live-session meter, caps, gate, and `SpendCapReached` mechanics are
+unchanged.
+
 ## Relationship to other ADRs
 
 ADR-0004 (amendment is the spec this implements), ADR-0045 (usage capture points), ADR-0043 (close seam + end_reason prefixes), ADR-0032 (no session labels), ADR-0020/0014/0039 (event + SSE + screen surface).

--- a/internal/billing/ledger.go
+++ b/internal/billing/ledger.go
@@ -86,6 +86,23 @@ func (l *Ledger) STTAudioSeconds(provider observe.Provider, d time.Duration) {
 	})
 }
 
+// SoundGeneration accumulates one Highlight sound enrichment (#312). NOT part
+// of [observe.UsageSink] — sound generation is an off-session, per-generation
+// call with no pipeline capture point, so the enrichment job holds a Ledger
+// directly and flushes per generation (the planning-chat per-exchange
+// posture). Per the ADR-0004 amendment the row lands under the tts Component
+// (the key it rode) with the SFX/Music model id as the attribution
+// discriminator; the quantity column is the vendor's own credit unit (the
+// character-cost response header — ElevenLabs bills this API family in
+// credits ≈ characters, 0 when unreported), while the estimate prices the
+// REQUESTED duration through the ADR-0046 sound price map.
+func (l *Ledger) SoundGeneration(provider observe.Provider, model string, d time.Duration, characterCost int64) {
+	l.accumulate(storage.ComponentTTS, provider, model, func(r *storage.UsageRow) {
+		r.TTSCharacters += characterCost
+		r.EstimatedUSD += spend.EstimateSoundUSD(provider, model, d)
+	})
+}
+
 // accumulate applies fold to the bucket for (today, component, provider, model),
 // creating it on first use.
 func (l *Ledger) accumulate(component storage.Component, provider observe.Provider, model string, fold func(*storage.UsageRow)) {

--- a/internal/billing/ledger_test.go
+++ b/internal/billing/ledger_test.go
@@ -124,3 +124,54 @@ func TestLedgerFlushErrorRetainsRows(t *testing.T) {
 		t.Fatalf("tts chars after retry = %d, want 150 (100 merged back + 50 new)", got[0].TTSCharacters)
 	}
 }
+
+// TestLedgerSoundGeneration pins the #312 attribution row: sound generation
+// lands under the tts Component (the key it rode, ADR-0004 amendment) with the
+// SFX/Music model id as the discriminator, the vendor's character-cost as the
+// quantity, and the ADR-0046 sound price map's duration estimate.
+func TestLedgerSoundGeneration(t *testing.T) {
+	tenant := uuid.New()
+	at := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	l := NewLedger(tenant, fixedNow(at))
+
+	l.SoundGeneration(observe.ProviderElevenLabs, "eleven_text_to_sound_v2", 30*time.Second, 100)
+	l.SoundGeneration(observe.ProviderElevenLabs, "music_v1", time.Minute, 0)
+
+	var rows []storage.UsageRow
+	if err := l.Flush(context.Background(), func(_ context.Context, r []storage.UsageRow) error {
+		rows = r
+		return nil
+	}); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (one per model id)", len(rows))
+	}
+	byModel := map[string]storage.UsageRow{}
+	for _, r := range rows {
+		if r.Component != storage.ComponentTTS {
+			t.Errorf("component = %s, want tts (the key it rode)", r.Component)
+		}
+		if r.Provider != string(observe.ProviderElevenLabs) {
+			t.Errorf("provider = %s, want elevenlabs", r.Provider)
+		}
+		byModel[r.Model] = r
+	}
+	sfx, ok := byModel["eleven_text_to_sound_v2"]
+	if !ok {
+		t.Fatalf("no SFX row: %+v", rows)
+	}
+	if sfx.TTSCharacters != 100 {
+		t.Errorf("SFX quantity = %d, want the vendor-reported 100 credits", sfx.TTSCharacters)
+	}
+	if want := spend.EstimateSoundUSD(observe.ProviderElevenLabs, "eleven_text_to_sound_v2", 30*time.Second); sfx.EstimatedUSD != want {
+		t.Errorf("SFX estimate = %v, want %v", sfx.EstimatedUSD, want)
+	}
+	music, ok := byModel["music_v1"]
+	if !ok {
+		t.Fatalf("no Music row: %+v", rows)
+	}
+	if want := spend.EstimateSoundUSD(observe.ProviderElevenLabs, "music_v1", time.Minute); music.EstimatedUSD != want {
+		t.Errorf("Music estimate = %v, want %v", music.EstimatedUSD, want)
+	}
+}

--- a/internal/highlight/enrich.go
+++ b/internal/highlight/enrich.go
@@ -282,6 +282,10 @@ func EnrichImageHandler(store EnrichStore, blobs blob.Store, factory GeneratorFa
 // Highlight ids still have a row — the absent ones are the orphans.
 type ReconcileStore interface {
 	ListPromotedHighlightsNeedingEnrichment(ctx context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error)
+	// ListPromotedHighlightsNeedingSoundEnrichment is the sound half (#312):
+	// promoted Highlights whose requested sound never landed and have no live
+	// sound job for the SAME requested kind.
+	ListPromotedHighlightsNeedingSoundEnrichment(ctx context.Context, enrichKind string) ([]storage.HighlightSoundEnrichTarget, error)
 	HighlightsExist(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]bool, error)
 }
 
@@ -301,8 +305,8 @@ type ReconcileStore interface {
 //     seam (blob.Store.List, #421) — never a direct query against a backend table —
 //     so the sweep survives an S3 swap; the anti-join against live rows
 //     (store.HighlightsExist) happens in Go. It touches ONLY the 'highlight'
-//     owner-kind's 'image' and 'clip.wav' names (ADR-0048), never another owner's
-//     blob or a live row's blobs (the row still exists).
+//     owner-kind's 'image', 'clip.wav', and 'sound' names (ADR-0048), never
+//     another owner's blob or a live row's blobs (the row still exists).
 //
 // Both halves run even if one's list fails: a store-list error is collected and
 // returned so boot logs it, but the sweep never aborts (AC4) — the caller (main.go)
@@ -331,6 +335,27 @@ func SweepEnrichmentReconciliation(ctx context.Context, store ReconcileStore, bl
 		}
 	}
 
+	// (a') Re-enqueue sound generation for promoted Highlights whose requested
+	// sound never landed (#312) — a crash between the SetHighlightSound RPC's
+	// row update and its enqueue, or a dead-lettered generation whose key has
+	// since been fixed. The payload carries the row's CURRENT sound_kind, so
+	// the re-enqueued job generates what the GM currently wants.
+	soundTargets, err := store.ListPromotedHighlightsNeedingSoundEnrichment(ctx, JobKindEnrichSound)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("list promoted highlights needing sound enrichment: %w", err))
+	} else {
+		for _, t := range soundTargets {
+			payload := soundEnrichPayload{HighlightID: t.HighlightID, TenantID: t.TenantID, Kind: t.Kind}
+			if err := enqueue.Enqueue(ctx, JobKindEnrichSound, payload, time.Now()); err != nil {
+				log.Error("highlight enrich sweep: enqueue backstop sound enrichment", "err", err, "highlight", t.HighlightID)
+				continue
+			}
+		}
+		if len(soundTargets) > 0 {
+			log.Warn("scheduled backstop sound enrichment for soundless promoted highlights", "count", len(soundTargets))
+		}
+	}
+
 	// (b) Sweep orphaned Highlight blobs. Enumerate every blob through the seam,
 	// keep the Highlight-owned blobs — the enrichment images AND the audio clips
 	// (#435: a clip whose row insert failed after the Put is row-less consented
@@ -348,7 +373,7 @@ func SweepEnrichmentReconciliation(ctx context.Context, store ReconcileStore, bl
 			if perr != nil || parts.OwnerKind != highlightOwnerKind {
 				continue
 			}
-			if parts.Name != imageBlobName && parts.Name != clipBlobName {
+			if parts.Name != imageBlobName && parts.Name != clipBlobName && parts.Name != soundBlobName {
 				continue
 			}
 			orphanCandidates = append(orphanCandidates, k)

--- a/internal/highlight/enrich_sound.go
+++ b/internal/highlight/enrich_sound.go
@@ -245,11 +245,11 @@ func EnrichSoundHandler(store SoundEnrichStore, blobs blob.Store, factory SoundG
 			release()
 			var httpErr *providererr.HTTPError
 			if errors.As(err, &httpErr) {
-				switch {
-				case httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden:
+				switch httpErr.StatusCode {
+				case http.StatusUnauthorized, http.StatusForbidden:
 					log.Error("highlight sound enrich: provider rejected the configured key",
 						"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
-				case httpErr.StatusCode == http.StatusTooManyRequests:
+				case http.StatusTooManyRequests:
 					log.Warn("highlight sound enrich: provider out of quota or rate-limited",
 						"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
 				}

--- a/internal/highlight/enrich_sound.go
+++ b/internal/highlight/enrich_sound.go
@@ -1,0 +1,329 @@
+package highlight
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/billing"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+	"github.com/MrWong99/Glyphoxa/internal/spend"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+)
+
+// JobKindEnrichSound is the background-job kind that generates the GM-chosen
+// sound asset — a Sting or a Music track — for a promoted Highlight and lands
+// it on the row through the blob seam (#312, Epic 8, ADR-0004 amendment /
+// ADR-0049). Unlike image enrichment it is OPT-IN: SetHighlightSound (the RPC)
+// enqueues it on the GM's explicit "Add sound" action, never PromoteHighlight.
+// The handler is idempotent + at-least-once.
+const JobKindEnrichSound = "highlight.enrich_sound"
+
+// soundBlobName is the blob.Key name segment for a Highlight's generated sound
+// (beside "clip.wav" and "image"): t/<tenant>/highlight/<id>/sound — the #312
+// decision's attach-as-separate-blob path. One name for both kinds: a kind
+// change overwrites in place, so a Highlight never owns two sound blobs.
+const soundBlobName = "sound"
+
+// ErrSoundNotConfigured is the sentinel a [SoundGeneratorFactory] returns when
+// the tenant has no usable sound key: no `tts` Provider Config, a
+// non-ElevenLabs tts provider, or no resolvable key (ADR-0004 amendment). The
+// handler treats it as a clean no-op — the Highlight stays intact without
+// media, no retry, no spend. An ALIAS for soundgen.ErrNotConfigured, not a
+// second value (the imagegen #541 lesson).
+var ErrSoundNotConfigured = soundgen.ErrNotConfigured
+
+// SoundGeneratorFactory builds the tenant's [soundgen.Generator]. It resolves
+// the tenant's `tts` Provider Config key iff the provider is ElevenLabs
+// (ADR-0004 amendment) and returns [ErrSoundNotConfigured] otherwise. main.go
+// wires it from the store + cipher; tests fake it. No model id accompanies it
+// (unlike the image factory): the SFX and Music model ids are per-call facts
+// the adapter reports on each [soundgen.Result].
+type SoundGeneratorFactory func(ctx context.Context, tenantID uuid.UUID) (soundgen.Generator, error)
+
+// soundEnrichPayload is the sound job's payload: which Highlight, its tenant,
+// and WHICH kind the GM asked for at enqueue time. Kind rides in the payload
+// (unlike the image job) so a stale job for a superseded choice self-detects:
+// the handler compares it against the row's current sound_kind.
+type soundEnrichPayload struct {
+	HighlightID uuid.UUID `json:"highlight_id"`
+	TenantID    uuid.UUID `json:"tenant_id"`
+	Kind        string    `json:"kind"`
+}
+
+// MarshalEnrichSound builds the JobKindEnrichSound payload the
+// SetHighlightSound RPC enqueues.
+func MarshalEnrichSound(highlightID, tenantID uuid.UUID, kind string) ([]byte, error) {
+	return json.Marshal(soundEnrichPayload{HighlightID: highlightID, TenantID: tenantID, Kind: kind})
+}
+
+// Sting/Music duration bounds (#312). The sting matches the clip so the web UI
+// can layer it client-side (attach-decision: zero DSP), capped at the
+// endpoint's 22s sting contract; the Music track is a bounded "full track" —
+// long enough to be one (30s floor), capped for spend predictability.
+const (
+	stingMinDuration = 2 * time.Second
+	stingMaxDuration = 22 * time.Second
+	musicMinDuration = 30 * time.Second
+	musicMaxDuration = 60 * time.Second
+)
+
+// soundRequestFor derives the generation request from the Highlight: the
+// prompt from its caption material (speaker IDs deliberately excluded, the
+// image posture) and the duration from its clip range, clamped per kind.
+func soundRequestFor(kind string, h storage.Highlight) soundgen.Request {
+	clip := h.EndsAt.Sub(h.StartsAt)
+	switch kind {
+	case storage.SoundKindMusic:
+		return soundgen.Request{
+			Prompt:   buildMusicPrompt(h.Excerpt, h.Reason),
+			Duration: clampDuration(clip, musicMinDuration, musicMaxDuration),
+		}
+	default: // storage.SoundKindSting
+		return soundgen.Request{
+			Prompt:   buildStingPrompt(h.Excerpt, h.Reason),
+			Duration: clampDuration(clip, stingMinDuration, stingMaxDuration),
+		}
+	}
+}
+
+// buildStingPrompt renders the sound-effects prompt from a Highlight's caption
+// material (#312). The excerpt is truncated to excerptPromptLimit runes, like
+// the image prompt.
+func buildStingPrompt(excerpt, reason string) string {
+	return fmt.Sprintf(
+		"A cinematic sound-effect sting for a tabletop RPG highlight reel, matching this moment: %s. Why it is memorable: %s.",
+		truncateRunes(excerpt, excerptPromptLimit), reason)
+}
+
+// buildMusicPrompt renders the Music composition prompt from a Highlight's
+// caption material (#312). Instrumental is enforced adapter-side; the excerpt
+// steers mood, not lyrics.
+func buildMusicPrompt(excerpt, reason string) string {
+	return fmt.Sprintf(
+		"An instrumental cinematic theme for a tabletop RPG highlight, capturing the mood of this moment: %s. Why it is memorable: %s.",
+		truncateRunes(excerpt, excerptPromptLimit), reason)
+}
+
+// clampDuration bounds d to [min, max].
+func clampDuration(d, min, max time.Duration) time.Duration {
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+// SoundEnrichStore is the storage surface the sound-generation handler needs;
+// *storage.Store satisfies it and tests fake it. The claim pair mirrors the
+// image enrichment's (#406); SetHighlightSound is the CONDITIONAL land (misses
+// when the row is gone OR the GM changed the choice mid-generation); AddUsage
+// is the per-generation Usage Ledger flush (ADR-0004 amendment: attribution
+// under the SFX/Music model id).
+type SoundEnrichStore interface {
+	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
+	SetHighlightSound(ctx context.Context, id uuid.UUID, kind, soundKey, contentType string, sizeBytes int64) error
+	TryClaimHighlightSoundEnrich(ctx context.Context, id uuid.UUID, ttl time.Duration) (bool, error)
+	ReleaseHighlightSoundEnrichClaim(ctx context.Context, id uuid.UUID) error
+	AddUsage(ctx context.Context, rows []storage.UsageRow) error
+}
+
+// EnrichSoundHandler builds the JobKindEnrichSound handler (ADR-0049). It is
+// idempotent + at-least-once, the EnrichImageHandler decision ladder adapted
+// for an opt-in, re-runnable action:
+//
+//   - the Highlight is gone → nil (done).
+//   - the row's sound_kind no longer matches the payload's (the GM changed or
+//     cleared the choice; the newer RPC enqueued its own job) → nil.
+//   - the requested sound already landed → nil (no double spend on a re-run).
+//   - sound generation is not configured for the tenant → log + nil (the
+//     Highlight stays intact without media — never a retry loop on a missing
+//     key; ADR-0004 amendment's clean no-op).
+//   - a provider failure → the error is returned (retry / dead-letter)
+//     whatever its status — dead-lettering is what lets the boot sweep re-run
+//     the generation once a bad key is fixed (the EnrichImageHandler
+//     rationale) — but a rejected key and an exhausted quota are LOGGED apart.
+//   - otherwise generate → flush a per-generation Usage Ledger row under the
+//     result's model id (SFX and Music separately, ADR-0004 amendment) →
+//     store the audio behind the blob seam at the deterministic key →
+//     conditionally record it on the row. A conditional-land miss re-reads:
+//     a GONE row compensates the orphaned blob; a superseded kind leaves the
+//     blob for the newer job to overwrite (deleting it could destroy that
+//     job's already-landed asset). Errors never mutate the row — the
+//     Highlight keeps its clip and stays soundless (AC).
+func EnrichSoundHandler(store SoundEnrichStore, blobs blob.Store, factory SoundGeneratorFactory, log *slog.Logger) func(context.Context, json.RawMessage) error {
+	if log == nil {
+		log = slog.Default()
+	}
+	return func(ctx context.Context, payload json.RawMessage) error {
+		var p soundEnrichPayload
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return fmt.Errorf("highlight sound enrich: decode payload: %w", err)
+		}
+
+		h, err := store.GetHighlight(ctx, p.TenantID, p.HighlightID)
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil // deleted before the generation ran: nothing to do
+		}
+		if err != nil {
+			return fmt.Errorf("highlight sound enrich: load highlight %s: %w", p.HighlightID, err)
+		}
+		if h.SoundKind != p.Kind {
+			// The GM changed (or cleared) the choice after this job was enqueued;
+			// the newer SetHighlightSound call enqueued its own job. Done.
+			return nil
+		}
+		if h.SoundKey != "" {
+			// Already landed (a re-run of an at-least-once job): stop before any
+			// spend so the same request is never billed twice.
+			return nil
+		}
+
+		// Race-proof claim (the #406 pattern): two concurrent jobs for the SAME
+		// Highlight run Generate AT MOST once, and — because the blob name is
+		// shared between kinds — the claim also serializes blob writes across a
+		// choice change. A false-no-error returns a retryable error so this
+		// duplicate re-checks after backoff.
+		claimed, err := store.TryClaimHighlightSoundEnrich(ctx, p.HighlightID, enrichClaimTTL)
+		if err != nil {
+			return fmt.Errorf("highlight sound enrich: claim highlight %s: %w", p.HighlightID, err)
+		}
+		if !claimed {
+			return fmt.Errorf("highlight sound enrich: %s claimed by a concurrent worker", p.HighlightID)
+		}
+		// From here we OWN the claim; release it on every exit that does not land
+		// a sound. Fresh bounded ctx (#421): an error exit is often reached
+		// BECAUSE the handler ctx died, and a release on that dead ctx would
+		// strand the claim for the full ttl.
+		release := func() {
+			rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			defer cancel()
+			if rerr := store.ReleaseHighlightSoundEnrichClaim(rctx, p.HighlightID); rerr != nil {
+				log.Error("highlight sound enrich: release claim", "err", rerr, "highlight", p.HighlightID)
+			}
+		}
+
+		gen, err := factory(ctx, p.TenantID)
+		if errors.Is(err, ErrSoundNotConfigured) {
+			release()
+			log.Info("highlight sound enrich: sound generation not configured, leaving highlight without sound",
+				"highlight", p.HighlightID, "tenant", p.TenantID)
+			return nil
+		}
+		if err != nil {
+			release()
+			return fmt.Errorf("highlight sound enrich: build generator: %w", err)
+		}
+
+		req := soundRequestFor(p.Kind, h)
+		var res soundgen.Result
+		if p.Kind == storage.SoundKindMusic {
+			res, err = gen.ComposeMusic(ctx, req)
+		} else {
+			res, err = gen.GenerateSting(ctx, req)
+		}
+		if err != nil {
+			// Provider error: return it so the runner retries / dead-letters — the
+			// row is untouched, the Highlight keeps its clip and stays soundless
+			// (AC). Every failure takes this exit, including a rejected key: the
+			// boot sweep treats 'dead' as absent and 'done' as satisfied, so
+			// dead-lettering is precisely what re-drives these once the key is
+			// fixed (the EnrichImageHandler rationale in full). Only the DIAGNOSIS
+			// varies by status.
+			release()
+			var httpErr *providererr.HTTPError
+			if errors.As(err, &httpErr) {
+				switch {
+				case httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden:
+					log.Error("highlight sound enrich: provider rejected the configured key",
+						"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
+				case httpErr.StatusCode == http.StatusTooManyRequests:
+					log.Warn("highlight sound enrich: provider out of quota or rate-limited",
+						"err", err, "highlight", p.HighlightID, "tenant", p.TenantID)
+				}
+			}
+			return fmt.Errorf("highlight sound enrich: generate %s: %w", p.Kind, err)
+		}
+
+		// Meter the spend (ADR-0004/0046 amendments): a per-generation Usage
+		// Ledger flush attributes the estimate to the tenant under the SFX/Music
+		// model id — off-session, never cap-gated (the recap posture). A flush
+		// failure logs and continues: attribution only, never a gate, and failing
+		// the job here would re-bill the generation on retry.
+		estimated := spend.EstimateSoundUSD(observe.ProviderElevenLabs, res.Model, req.Duration)
+		ledger := billing.NewLedger(p.TenantID, nil)
+		ledger.SoundGeneration(observe.ProviderElevenLabs, res.Model, req.Duration, res.CharacterCost)
+		if ferr := ledger.Flush(ctx, store.AddUsage); ferr != nil {
+			log.Error("highlight sound enrich: flush usage ledger", "err", ferr, "highlight", p.HighlightID)
+		}
+		log.Info("highlight sound enrich: sound generated",
+			"highlight", p.HighlightID,
+			"kind", p.Kind,
+			"model", res.Model,
+			"requested_duration", req.Duration,
+			"character_cost", res.CharacterCost,
+			"estimated_usd", estimated,
+		)
+
+		key, err := blob.Key(p.TenantID, highlightOwnerKind, p.HighlightID, soundBlobName)
+		if err != nil {
+			release()
+			return fmt.Errorf("highlight sound enrich: build sound key: %w", err)
+		}
+		if err := blobs.Put(ctx, key, res.ContentType, bytes.NewReader(res.Data), int64(len(res.Data))); err != nil {
+			if errors.Is(err, blob.ErrTooLarge) {
+				// PERMANENT: an oversize asset can never be stored, and a retry only
+				// re-bills the same generation. The Highlight stays intact.
+				release()
+				log.Warn("highlight sound enrich: generated sound exceeds blob cap, leaving highlight without sound",
+					"highlight", p.HighlightID)
+				return nil
+			}
+			release()
+			return fmt.Errorf("highlight sound enrich: store sound: %w", err)
+		}
+		if err := store.SetHighlightSound(ctx, p.HighlightID, p.Kind, key, res.ContentType, int64(len(res.Data))); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				// The conditional land missed: the row is gone OR the GM changed the
+				// choice mid-generation. Disambiguate — ONLY a gone row compensates
+				// the blob; on a superseded kind the newer job (which cannot claim
+				// until we release) will overwrite the shared blob name itself, and
+				// deleting here could destroy an asset it already landed in the
+				// claim-expired double-generate window.
+				if _, gerr := store.GetHighlight(ctx, p.TenantID, p.HighlightID); errors.Is(gerr, storage.ErrNotFound) {
+					if derr := blobs.Delete(ctx, key); derr != nil {
+						log.Error("highlight sound enrich: compensate orphan sound", "err", derr, "key", key)
+					}
+					return nil
+				}
+				release()
+				log.Info("highlight sound enrich: choice changed mid-generation, leaving land to the newer job",
+					"highlight", p.HighlightID, "kind", p.Kind)
+				return nil
+			}
+			release()
+			return fmt.Errorf("highlight sound enrich: record sound on highlight: %w", err)
+		}
+		// Release the claim on SUCCESS too — a deliberate departure from the
+		// image handler, which never re-runs (ImageKey blocks forever). A sound
+		// is re-runnable (regeneration / choice change), and a claim left
+		// stamped by a success would block the NEXT request's job for the full
+		// ttl — long enough for its retries to dead-letter. Safe to clear: the
+		// claim conditional refuses while sound_key is set, so releasing here
+		// reopens nothing until a new request clears the key.
+		release()
+		return nil
+	}
+}

--- a/internal/highlight/enrich_sound_test.go
+++ b/internal/highlight/enrich_sound_test.go
@@ -1,0 +1,455 @@
+package highlight
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/voicecassette"
+)
+
+// --- fakes ---
+
+// fakeSoundEnrichStore is an in-memory SoundEnrichStore keyed by highlight id.
+type fakeSoundEnrichStore struct {
+	mu        sync.Mutex
+	rows      map[uuid.UUID]storage.Highlight
+	setCalls  int
+	setErr    error // returned by SetHighlightSound when non-nil (overrides the conditional)
+	lastKey   string
+	lastCT    string
+	lastSize  int64
+	usageRows []storage.UsageRow
+	usageErr  error
+
+	claimed      map[uuid.UUID]time.Time
+	claimCalls   int
+	releaseCalls int
+}
+
+func newFakeSoundEnrichStore() *fakeSoundEnrichStore {
+	return &fakeSoundEnrichStore{rows: map[uuid.UUID]storage.Highlight{}}
+}
+
+func (f *fakeSoundEnrichStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	return h, nil
+}
+
+// SetHighlightSound mirrors the real conditional land: it misses (ErrNotFound)
+// when the row is gone OR its sound_kind no longer matches.
+func (f *fakeSoundEnrichStore) SetHighlightSound(_ context.Context, id uuid.UUID, kind, key, ct string, sz int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setCalls++
+	if f.setErr != nil {
+		return f.setErr
+	}
+	h, ok := f.rows[id]
+	if !ok || h.SoundKind != kind {
+		return storage.ErrNotFound
+	}
+	h.SoundKey, h.SoundContentType, h.SoundSizeBytes = key, ct, sz
+	f.rows[id] = h
+	f.lastKey, f.lastCT, f.lastSize = key, ct, sz
+	return nil
+}
+
+func (f *fakeSoundEnrichStore) TryClaimHighlightSoundEnrich(_ context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.claimCalls++
+	if h, ok := f.rows[id]; ok && (h.SoundKey != "" || h.SoundKind == "") {
+		return false, nil
+	}
+	if prev, ok := f.claimed[id]; ok && time.Since(prev) < ttl {
+		return false, nil
+	}
+	if f.claimed == nil {
+		f.claimed = map[uuid.UUID]time.Time{}
+	}
+	f.claimed[id] = time.Now()
+	return true, nil
+}
+
+func (f *fakeSoundEnrichStore) ReleaseHighlightSoundEnrichClaim(ctx context.Context, id uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseCalls++
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	delete(f.claimed, id)
+	return nil
+}
+
+func (f *fakeSoundEnrichStore) AddUsage(_ context.Context, rows []storage.UsageRow) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.usageErr != nil {
+		return f.usageErr
+	}
+	f.usageRows = append(f.usageRows, rows...)
+	return nil
+}
+
+// fakeSoundGen returns a fixed result (or error) and records the requests each
+// method saw.
+type fakeSoundGen struct {
+	mu       sync.Mutex
+	res      soundgen.Result
+	err      error
+	stings   []soundgen.Request
+	musics   []soundgen.Request
+	genCalls int
+}
+
+func (g *fakeSoundGen) GenerateSting(_ context.Context, req soundgen.Request) (soundgen.Result, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.genCalls++
+	g.stings = append(g.stings, req)
+	return g.res, g.err
+}
+
+func (g *fakeSoundGen) ComposeMusic(_ context.Context, req soundgen.Request) (soundgen.Result, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.genCalls++
+	g.musics = append(g.musics, req)
+	return g.res, g.err
+}
+
+func soundFactoryOf(gen soundgen.Generator, err error) SoundGeneratorFactory {
+	return func(context.Context, uuid.UUID) (soundgen.Generator, error) { return gen, err }
+}
+
+func soundRow(tenantID, id uuid.UUID, kind string) storage.Highlight {
+	now := time.Now()
+	return storage.Highlight{
+		ID: id, TenantID: tenantID, VoiceSessionID: uuid.New(), CampaignID: uuid.New(),
+		Status: storage.HighlightPromoted, SoundKind: kind, SoundRequestedAt: &now,
+		StartsAt: now.Add(-15 * time.Second), EndsAt: now,
+		Excerpt: "I rolled a natural twenty! A critical hit on the dragon!",
+		Reason:  "a critical hit felling the dragon",
+	}
+}
+
+func soundPayload(t *testing.T, id, tenantID uuid.UUID, kind string) json.RawMessage {
+	t.Helper()
+	p, err := MarshalEnrichSound(id, tenantID, kind)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return p
+}
+
+// --- handler ---
+
+// TestEnrichSoundStingLands is the happy path: the sting is generated with a
+// clip-derived duration, the blob lands at t/<tenant>/highlight/<id>/sound,
+// the conditional land records the triad, and one Usage Ledger row flushes
+// under the tts component with the SFX model id (ADR-0004 amendment).
+func TestEnrichSoundStingLands(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+	store := newFakeSoundEnrichStore()
+	store.rows[id] = soundRow(tenantID, id, storage.SoundKindSting)
+	blobs := newFakeBlobs()
+	gen := &fakeSoundGen{res: soundgen.Result{
+		Data: []byte("mp3"), ContentType: "audio/mpeg", Model: "eleven_text_to_sound_v2", CharacterCost: 100,
+	}}
+
+	h := EnrichSoundHandler(store, blobs, soundFactoryOf(gen, nil), nil)
+	if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	wantKey := "t/" + tenantID.String() + "/highlight/" + id.String() + "/sound"
+	if store.lastKey != wantKey {
+		t.Errorf("sound key = %q, want %q", store.lastKey, wantKey)
+	}
+	if store.lastCT != "audio/mpeg" || store.lastSize != 3 {
+		t.Errorf("landed (ct=%q, size=%d), want (audio/mpeg, 3)", store.lastCT, store.lastSize)
+	}
+	if len(gen.stings) != 1 || len(gen.musics) != 0 {
+		t.Fatalf("gen calls: stings=%d musics=%d, want 1/0", len(gen.stings), len(gen.musics))
+	}
+	// The 15s clip fits the sting bounds, so the duration matches the clip.
+	if d := gen.stings[0].Duration; d != 15*time.Second {
+		t.Errorf("sting duration = %v, want 15s (the clip length)", d)
+	}
+	if !strings.Contains(gen.stings[0].Prompt, "natural twenty") {
+		t.Errorf("prompt %q does not carry the excerpt", gen.stings[0].Prompt)
+	}
+	if len(store.usageRows) != 1 {
+		t.Fatalf("usage rows = %d, want 1", len(store.usageRows))
+	}
+	u := store.usageRows[0]
+	if u.Component != storage.ComponentTTS || u.Model != "eleven_text_to_sound_v2" || u.Provider != "elevenlabs" {
+		t.Errorf("usage attribution = (%s, %s, %s), want (tts, elevenlabs, eleven_text_to_sound_v2)", u.Component, u.Provider, u.Model)
+	}
+	if u.TTSCharacters != 100 {
+		t.Errorf("usage character cost = %d, want the vendor-reported 100", u.TTSCharacters)
+	}
+	if u.EstimatedUSD <= 0 {
+		t.Errorf("usage estimate = %v, want > 0", u.EstimatedUSD)
+	}
+	// Success releases the claim (unlike the never-re-run image handler): a
+	// stamped claim would block the next regeneration request for the full ttl.
+	if store.releaseCalls != 1 {
+		t.Errorf("release calls = %d, want 1 (re-runs must not wait out the ttl)", store.releaseCalls)
+	}
+}
+
+// TestEnrichSoundMusicDurationBounds pins the music-kind routing and the
+// "full track" floor: a 15s clip composes at the 30s minimum, instrumental
+// mood prompt included.
+func TestEnrichSoundMusicDurationBounds(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+	store := newFakeSoundEnrichStore()
+	store.rows[id] = soundRow(tenantID, id, storage.SoundKindMusic)
+	blobs := newFakeBlobs()
+	gen := &fakeSoundGen{res: soundgen.Result{Data: []byte("m"), ContentType: "audio/mpeg", Model: "music_v1"}}
+
+	h := EnrichSoundHandler(store, blobs, soundFactoryOf(gen, nil), nil)
+	if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindMusic)); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if len(gen.musics) != 1 || len(gen.stings) != 0 {
+		t.Fatalf("gen calls: stings=%d musics=%d, want 0/1", len(gen.stings), len(gen.musics))
+	}
+	if d := gen.musics[0].Duration; d != musicMinDuration {
+		t.Errorf("music duration = %v, want the %v floor", d, musicMinDuration)
+	}
+}
+
+// TestEnrichSoundSkips pins the no-spend early exits: a deleted row, a
+// superseded kind, and an already-landed sound all complete without touching
+// the generator.
+func TestEnrichSoundSkips(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+
+	cases := []struct {
+		name string
+		prep func(*fakeSoundEnrichStore)
+	}{
+		{"row gone", func(s *fakeSoundEnrichStore) {}},
+		{"kind superseded", func(s *fakeSoundEnrichStore) {
+			s.rows[id] = soundRow(tenantID, id, storage.SoundKindMusic) // payload asks sting
+		}},
+		{"already landed", func(s *fakeSoundEnrichStore) {
+			row := soundRow(tenantID, id, storage.SoundKindSting)
+			row.SoundKey = "t/x/highlight/y/sound"
+			s.rows[id] = row
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeSoundEnrichStore()
+			tc.prep(store)
+			gen := &fakeSoundGen{res: soundgen.Result{Data: []byte("x"), ContentType: "audio/mpeg", Model: "m"}}
+			h := EnrichSoundHandler(store, newFakeBlobs(), soundFactoryOf(gen, nil), nil)
+			if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if gen.genCalls != 0 {
+				t.Errorf("generator ran %d times, want 0 (no double spend)", gen.genCalls)
+			}
+		})
+	}
+}
+
+// TestEnrichSoundNotConfigured pins the ADR-0004 clean no-op: the job completes
+// (nil), the claim is released, and the Highlight stays intact without media.
+func TestEnrichSoundNotConfigured(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+	store := newFakeSoundEnrichStore()
+	store.rows[id] = soundRow(tenantID, id, storage.SoundKindSting)
+
+	h := EnrichSoundHandler(store, newFakeBlobs(), soundFactoryOf(nil, ErrSoundNotConfigured), nil)
+	if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err != nil {
+		t.Fatalf("handler: %v (a missing key must not retry)", err)
+	}
+	if store.releaseCalls != 1 {
+		t.Errorf("release calls = %d, want 1", store.releaseCalls)
+	}
+	if got := store.rows[id]; got.SoundKey != "" {
+		t.Errorf("sound key = %q, want empty (row untouched)", got.SoundKey)
+	}
+}
+
+// TestEnrichSoundProviderErrorRetries pins the dead-letter posture: EVERY
+// provider failure — even a rejected key — returns the error so the runner
+// retries / dead-letters and the boot sweep can recover it after a key fix.
+func TestEnrichSoundProviderErrorRetries(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+	store := newFakeSoundEnrichStore()
+	store.rows[id] = soundRow(tenantID, id, storage.SoundKindSting)
+	gen := &fakeSoundGen{err: &providererr.HTTPError{Op: "elevenlabs.GenerateSting", StatusCode: 401, Status: "401 Unauthorized"}}
+
+	h := EnrichSoundHandler(store, newFakeBlobs(), soundFactoryOf(gen, nil), nil)
+	if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err == nil {
+		t.Fatal("handler returned nil for a provider error, want an error (retry/dead-letter)")
+	}
+	if store.releaseCalls != 1 {
+		t.Errorf("release calls = %d, want 1 (claim freed for the retry)", store.releaseCalls)
+	}
+	if got := store.rows[id]; got.SoundKey != "" {
+		t.Errorf("sound key = %q, want empty (row untouched on failure)", got.SoundKey)
+	}
+}
+
+// TestEnrichSoundLandMissDisambiguates pins the conditional-land miss handling:
+// a GONE row compensates the just-stored blob; a kind changed mid-generation
+// leaves the blob for the newer job to overwrite (deleting could destroy that
+// job's asset) and releases the claim.
+func TestEnrichSoundLandMissDisambiguates(t *testing.T) {
+	t.Parallel()
+	tenantID, id := uuid.New(), uuid.New()
+
+	t.Run("row deleted mid-generation", func(t *testing.T) {
+		store := newFakeSoundEnrichStore()
+		store.rows[id] = soundRow(tenantID, id, storage.SoundKindSting)
+		blobs := newFakeBlobs()
+		gen := &fakeSoundGen{res: soundgen.Result{Data: []byte("x"), ContentType: "audio/mpeg", Model: "m"}}
+		// The land misses AND the follow-up read finds no row: delete happened.
+		store.setErr = storage.ErrNotFound
+		h := EnrichSoundHandler(&rowVanishesAfterFirstRead{fakeSoundEnrichStore: store, id: id}, blobs, soundFactoryOf(gen, nil), nil)
+		if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(blobs.deleted) != 1 {
+			t.Errorf("compensated blob deletes = %d, want 1", len(blobs.deleted))
+		}
+	})
+
+	t.Run("kind changed mid-generation", func(t *testing.T) {
+		store := newFakeSoundEnrichStore()
+		row := soundRow(tenantID, id, storage.SoundKindSting)
+		store.rows[id] = row
+		blobs := newFakeBlobs()
+		gen := &fakeSoundGen{res: soundgen.Result{Data: []byte("x"), ContentType: "audio/mpeg", Model: "m"}}
+		// Force the conditional miss while the row still exists (kind changed).
+		store.setErr = storage.ErrNotFound
+		h := EnrichSoundHandler(store, blobs, soundFactoryOf(gen, nil), nil)
+		if err := h(context.Background(), soundPayload(t, id, tenantID, storage.SoundKindSting)); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		if len(blobs.deleted) != 0 {
+			t.Errorf("blob deletes = %d, want 0 (the newer job owns the shared name)", len(blobs.deleted))
+		}
+		if store.releaseCalls != 1 {
+			t.Errorf("release calls = %d, want 1 (the newer job must be able to claim)", store.releaseCalls)
+		}
+	})
+}
+
+// rowVanishesAfterFirstRead delegates to the embedded fake but reports the row
+// gone from the SECOND GetHighlight on — the delete-vs-land race.
+type rowVanishesAfterFirstRead struct {
+	*fakeSoundEnrichStore
+	id    uuid.UUID
+	reads int
+}
+
+func (s *rowVanishesAfterFirstRead) GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
+	s.mu.Lock()
+	s.reads++
+	n := s.reads
+	s.mu.Unlock()
+	if id == s.id && n > 1 {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	return s.fakeSoundEnrichStore.GetHighlight(ctx, tenantID, id)
+}
+
+// --- boot sweep, sound half (#312) ---
+
+// soundRecordingEnqueuer records every sound-enrichment enqueue the boot sweep
+// makes (the enrichRecordingEnqueuer shape for the sound payload type).
+type soundRecordingEnqueuer struct {
+	mu  sync.Mutex
+	all []soundEnrichPayload
+}
+
+func (r *soundRecordingEnqueuer) Enqueue(_ context.Context, kind string, payload any, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if p, ok := payload.(soundEnrichPayload); ok && kind == JobKindEnrichSound {
+		r.all = append(r.all, p)
+	}
+	return nil
+}
+
+// TestSweepReenqueuesRequestedSounds pins the (a') half: a promoted Highlight
+// with a requested-but-unlanded sound and no live job is re-enqueued with the
+// row's CURRENT kind in the payload.
+func TestSweepReenqueuesRequestedSounds(t *testing.T) {
+	t.Parallel()
+	hID, tID := uuid.New(), uuid.New()
+	store := &fakeReconcileStore{soundTargets: []storage.HighlightSoundEnrichTarget{
+		{HighlightID: hID, TenantID: tID, Kind: storage.SoundKindMusic},
+	}}
+	enq := &soundRecordingEnqueuer{}
+	if err := SweepEnrichmentReconciliation(context.Background(), store, newFakeBlobs(), enq, nil); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if store.gotSoundKind != JobKindEnrichSound {
+		t.Errorf("sweep asked for kind %q, want %q", store.gotSoundKind, JobKindEnrichSound)
+	}
+	got := enq.all
+	if len(got) != 1 || got[0].HighlightID != hID || got[0].TenantID != tID || got[0].Kind != storage.SoundKindMusic {
+		t.Fatalf("re-enqueued payloads = %+v, want one for (%s, %s, music)", got, hID, tID)
+	}
+}
+
+// --- cassette-backed determinism (ADR-0021) ---
+
+// TestEnrichSoundCassette drives the WHOLE handler through the recorded sound
+// cassette: the prompt derivation and clip-derived durations must fingerprint
+// to the pinned request hashes, or the test fails pointing at the re-record
+// workflow — the wrapper's cassette-style deterministic test (#312 AC).
+func TestEnrichSoundCassette(t *testing.T) {
+	gen := voicecassette.LoadSound(t, "sound-highlight-dragon")
+
+	for _, kind := range []string{storage.SoundKindSting, storage.SoundKindMusic} {
+		t.Run(kind, func(t *testing.T) {
+			tenantID, id := uuid.New(), uuid.New()
+			store := newFakeSoundEnrichStore()
+			row := soundRow(tenantID, id, kind)
+			// Pin the clip range the cassette hashes were recorded for: 15s.
+			row.EndsAt = row.StartsAt.Add(15 * time.Second)
+			store.rows[id] = row
+			blobs := newFakeBlobs()
+
+			h := EnrichSoundHandler(store, blobs, soundFactoryOf(gen, nil), nil)
+			if err := h(context.Background(), soundPayload(t, id, tenantID, kind)); err != nil {
+				t.Fatalf("handler over cassette: %v", err)
+			}
+			if store.lastCT != "audio/mpeg" {
+				t.Errorf("content type = %q, want the cassette's audio/mpeg", store.lastCT)
+			}
+			if store.lastSize == 0 {
+				t.Errorf("landed size = 0, want the stub bytes")
+			}
+		})
+	}
+}

--- a/internal/highlight/enrich_test.go
+++ b/internal/highlight/enrich_test.go
@@ -323,6 +323,12 @@ type fakeReconcileStore struct {
 	targetErr error
 	existErr  error
 	gotExist  []uuid.UUID // ids the sweep asked HighlightsExist about
+
+	// Sound half (#312): the requested-but-unlanded sound targets to
+	// re-enqueue and the kind the sweep asked for.
+	soundTargets   []storage.HighlightSoundEnrichTarget
+	gotSoundKind   string
+	soundTargetErr error
 }
 
 func (f *fakeReconcileStore) ListPromotedHighlightsNeedingEnrichment(_ context.Context, enrichKind string) ([]storage.HighlightEnrichTarget, error) {
@@ -331,6 +337,14 @@ func (f *fakeReconcileStore) ListPromotedHighlightsNeedingEnrichment(_ context.C
 		return nil, f.targetErr
 	}
 	return f.targets, nil
+}
+
+func (f *fakeReconcileStore) ListPromotedHighlightsNeedingSoundEnrichment(_ context.Context, enrichKind string) ([]storage.HighlightSoundEnrichTarget, error) {
+	f.gotSoundKind = enrichKind
+	if f.soundTargetErr != nil {
+		return nil, f.soundTargetErr
+	}
+	return f.soundTargets, nil
 }
 
 func (f *fakeReconcileStore) HighlightsExist(_ context.Context, ids []uuid.UUID) (map[uuid.UUID]bool, error) {

--- a/internal/highlight/http.go
+++ b/internal/highlight/http.go
@@ -200,3 +200,81 @@ func (c *ClipServer) ServeImage(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", h.ImageContentType)
 	http.ServeContent(w, req, "image", h.CreatedAt, bytes.NewReader(data))
 }
+
+// ServeSound streams one Highlight's generated sound asset (#312), mirroring
+// ServeClip/ServeImage: GET /api/v1/highlights/{id}/sound, a TenantRequired
+// guarded mount (session AND tenant, per #408). Same tenant + Active-Campaign
+// 404 posture (existence never leaked); http.ServeContent gives the browser
+// <audio> scrubber Range/conditional handling. A Highlight with no landed
+// sound (sound_key == "") is 404 — none requested, still generating,
+// unconfigured, or failed. A missing blob is also 404 (a purge race must not
+// 500). Conditional requests key off sound_requested_at (the asset changes on
+// every re-run of the Add-sound action, unlike the created_at-keyed clip).
+func (c *ClipServer) ServeSound(w http.ResponseWriter, req *http.Request) {
+	tenantID, ok := auth.TenantID(req.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(req.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+
+	h, err := c.store.GetHighlight(req.Context(), tenantID, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight sound: load row", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if c.resolve != nil {
+		campaignID, ok, rerr := c.resolve(req.Context())
+		if rerr != nil {
+			c.log.Error("highlight sound: resolve active campaign", "err", rerr, "highlight", id)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !ok || h.CampaignID != campaignID {
+			http.NotFound(w, req)
+			return
+		}
+	}
+
+	// No sound landed: nothing to serve. 404 keeps the posture uniform.
+	if h.SoundKey == "" {
+		http.NotFound(w, req)
+		return
+	}
+
+	rc, _, err := c.blobs.Get(req.Context(), h.SoundKey)
+	if errors.Is(err, blob.ErrNotFound) {
+		http.NotFound(w, req)
+		return
+	}
+	if err != nil {
+		c.log.Error("highlight sound: fetch blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		c.log.Error("highlight sound: read blob", "err", err, "highlight", id)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	modtime := h.CreatedAt
+	if h.SoundRequestedAt != nil {
+		modtime = *h.SoundRequestedAt
+	}
+	w.Header().Set("Content-Type", h.SoundContentType)
+	http.ServeContent(w, req, "sound", modtime, bytes.NewReader(data))
+}

--- a/internal/highlight/http_sound_test.go
+++ b/internal/highlight/http_sound_test.go
@@ -1,0 +1,126 @@
+package highlight
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/blob"
+)
+
+// --- GET /api/v1/highlights/{id}/sound (#312) ---
+
+func soundRequest(t *testing.T, tenantID uuid.UUID, id string, rangeHdr string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/highlights/"+id+"/sound", nil)
+	req.SetPathValue("id", id)
+	if tenantID != uuid.Nil {
+		req = req.WithContext(auth.WithTenant(req.Context(), tenantID))
+	}
+	if rangeHdr != "" {
+		req.Header.Set("Range", rangeHdr)
+	}
+	return req
+}
+
+// newSoundFixture mirrors newClipFixtureCampaign with a landed sound blob.
+func newSoundFixture(t *testing.T) (*ClipServer, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	tenantID, id, campaignID := uuid.New(), uuid.New(), uuid.New()
+	key, err := blob.Key(tenantID, "highlight", id, soundBlobName)
+	if err != nil {
+		t.Fatalf("build key: %v", err)
+	}
+	blobs := newFakeBlobs()
+	blobs.data[key] = make([]byte, 150)
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: campaignID, soundKey: key, soundCT: "audio/mpeg"}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return campaignID, true, nil }
+	return NewClipServer(store, blobs, resolve, testLog()), tenantID, id
+}
+
+func TestSound_ServesWithContentType(t *testing.T) {
+	srv, tenantID, id := newSoundFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, tenantID, id.String(), ""))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "audio/mpeg" {
+		t.Fatalf("want audio/mpeg, got %q", ct)
+	}
+	if rr.Body.Len() != 150 {
+		t.Fatalf("want 150 bytes, got %d", rr.Body.Len())
+	}
+}
+
+func TestSound_RangeReturnsPartial(t *testing.T) {
+	srv, tenantID, id := newSoundFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, tenantID, id.String(), "bytes=0-49"))
+
+	if rr.Code != http.StatusPartialContent {
+		t.Fatalf("want 206 Partial Content, got %d", rr.Code)
+	}
+	if rr.Body.Len() != 50 {
+		t.Fatalf("want 50 bytes, got %d", rr.Body.Len())
+	}
+}
+
+// TestSound_EmptySoundKey404 pins the not-landed posture: requested-but-pending
+// (or never requested) serves 404, indistinguishable from a foreign id.
+func TestSound_EmptySoundKey404(t *testing.T) {
+	tenantID, id, campaignID := uuid.New(), uuid.New(), uuid.New()
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: campaignID}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return campaignID, true, nil }
+	srv := NewClipServer(store, newFakeBlobs(), resolve, testLog())
+
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}
+
+func TestSound_NoTenant401(t *testing.T) {
+	srv, _, id := newSoundFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, uuid.Nil, id.String(), ""))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rr.Code)
+	}
+}
+
+func TestSound_ForeignTenant404(t *testing.T) {
+	srv, _, id := newSoundFixture(t)
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, uuid.New(), id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}
+
+// TestSound_CrossCampaign404 pins the Active-Campaign scoping: a sound whose
+// highlight belongs to another campaign is 404 (existence never leaked).
+func TestSound_CrossCampaign404(t *testing.T) {
+	tenantID, id := uuid.New(), uuid.New()
+	key, err := blob.Key(tenantID, "highlight", id, soundBlobName)
+	if err != nil {
+		t.Fatalf("build key: %v", err)
+	}
+	blobs := newFakeBlobs()
+	blobs.data[key] = make([]byte, 10)
+	store := &fakeClipStore{tenantID: tenantID, id: id, campaignID: uuid.New(), soundKey: key, soundCT: "audio/mpeg"}
+	resolve := func(context.Context) (uuid.UUID, bool, error) { return uuid.New(), true, nil } // a DIFFERENT campaign
+	srv := NewClipServer(store, blobs, resolve, testLog())
+
+	rr := httptest.NewRecorder()
+	srv.ServeSound(rr, soundRequest(t, tenantID, id.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+}

--- a/internal/highlight/http_test.go
+++ b/internal/highlight/http_test.go
@@ -22,6 +22,8 @@ type fakeClipStore struct {
 	clipKey    string
 	imageKey   string // empty = no image yet (#311)
 	imageCT    string
+	soundKey   string // empty = no sound landed yet (#312)
+	soundCT    string
 }
 
 func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) (storage.Highlight, error) {
@@ -37,6 +39,8 @@ func (f *fakeClipStore) GetHighlight(_ context.Context, tenantID, id uuid.UUID) 
 		ClipContentType:  "audio/wav",
 		ImageKey:         f.imageKey,
 		ImageContentType: f.imageCT,
+		SoundKey:         f.soundKey,
+		SoundContentType: f.soundCT,
 		CreatedAt:        time.Now(),
 	}, nil
 }

--- a/internal/rpc/highlight.go
+++ b/internal/rpc/highlight.go
@@ -60,6 +60,9 @@ type HighlightStore interface {
 	GetHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
 	PromoteHighlight(ctx context.Context, tenantID, id uuid.UUID) (storage.Highlight, error)
 	DeleteHighlight(ctx context.Context, tenantID, id uuid.UUID) (string, error)
+	// SetHighlightSoundKind records the GM's Add-sound choice on a PROMOTED
+	// row (#312); a candidate (or missing/foreign) id is ErrNotFound.
+	SetHighlightSoundKind(ctx context.Context, tenantID, id uuid.UUID, kind string) (storage.Highlight, error)
 }
 
 // highlightBlobs is the blob-seam surface the Highlight RPCs need (ADR-0048):
@@ -90,6 +93,15 @@ func (s *SessionServer) SetHighlights(store HighlightStore, blobs highlightBlobs
 	s.highlights = store
 	s.blobs = blobs
 	s.enqueue = enqueue
+}
+
+// SetSoundEnrichment wires the sound-generation factory SetHighlightSound
+// prechecks (#312): the RPC probes it once per call so a tenant without an
+// ElevenLabs tts Provider Config gets an actionable CodeFailedPrecondition
+// instead of a silently-forever-pending "generating…" state. Nil (unwired)
+// makes SetHighlightSound report CodeUnimplemented.
+func (s *SessionServer) SetSoundEnrichment(factory highlight.SoundGeneratorFactory) {
+	s.soundFactory = factory
 }
 
 // notWired is the CodeUnimplemented error a Highlight RPC returns when the server
@@ -305,12 +317,14 @@ func (s *SessionServer) DeleteHighlight(
 	// (highlight.SweepEnrichmentReconciliation), so it is never permanently orphaned.
 	if fresh, rerr := s.highlights.GetHighlight(ctx, tenantID, id); rerr == nil {
 		h.ImageKey = fresh.ImageKey
+		h.SoundKey = fresh.SoundKey
 	}
 
 	// Blob first (idempotent Delete): a missing clip must not block the row delete.
-	// A Highlight owns up to two blobs — the audio clip and (once enriched, #311)
-	// the generated image — so drop both before the row (ADR-0048). The image key
-	// is only present on an enriched row; an empty one is skipped.
+	// A Highlight owns up to three blobs — the audio clip, the generated image
+	// (#311), and the generated sound (#312) — so drop all before the row
+	// (ADR-0048). The image and sound keys are only present on enriched rows;
+	// empty ones are skipped.
 	if s.blobs != nil {
 		if err := s.blobs.Delete(ctx, h.ClipKey); err != nil {
 			s.log.Error("DeleteHighlight: delete clip failed", "err", err, "highlight", id)
@@ -319,6 +333,12 @@ func (s *SessionServer) DeleteHighlight(
 		if h.ImageKey != "" {
 			if err := s.blobs.Delete(ctx, h.ImageKey); err != nil {
 				s.log.Error("DeleteHighlight: delete image failed", "err", err, "highlight", id)
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+			}
+		}
+		if h.SoundKey != "" {
+			if err := s.blobs.Delete(ctx, h.SoundKey); err != nil {
+				s.log.Error("DeleteHighlight: delete sound failed", "err", err, "highlight", id)
 				return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 			}
 		}
@@ -331,6 +351,112 @@ func (s *SessionServer) DeleteHighlight(
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 	return connect.NewResponse(&managementv1.DeleteHighlightResponse{}), nil
+}
+
+// SetHighlightSound records the GM's "Add sound" choice on a promoted Highlight
+// (#312, ADR-0004 amendment) and schedules the async generation. Kind "sting" or
+// "music" clears any landed sound and enqueues JobKindEnrichSound (a re-run
+// regenerates / changes the choice); kind "" removes the sound entirely —
+// blob-then-row like every media delete (ADR-0048). A still-candidate row is
+// CodeFailedPrecondition (sound is opt-in AFTER promotion); an unknown kind is
+// CodeInvalidArgument; a foreign-tenant, cross-campaign, unknown, or unparsable
+// id is CodeNotFound. An unconfigured tenant (no ElevenLabs tts Provider
+// Config) is CodeFailedPrecondition BEFORE any row change, so the UI can say
+// "configure ElevenLabs first" instead of pending forever.
+func (s *SessionServer) SetHighlightSound(
+	ctx context.Context,
+	req *connect.Request[managementv1.SetHighlightSoundRequest],
+) (*connect.Response[managementv1.SetHighlightSoundResponse], error) {
+	if err := s.highlightsEnabled(); err != nil {
+		return nil, err
+	}
+	if s.soundFactory == nil || s.enqueue == nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("sound enrichment is not enabled on this server"))
+	}
+	tenantID, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	kind := req.Msg.GetKind()
+	if kind != "" && kind != storage.SoundKindSting && kind != storage.SoundKindMusic {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("kind must be \"sting\", \"music\", or empty"))
+	}
+	id, perr := uuid.Parse(req.Msg.GetId())
+	if perr != nil {
+		return nil, errNoSuchHighlight()
+	}
+	campaignID, err := s.activeCampaignForHighlight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load first: campaign ownership BEFORE any mutation, the old sound key for
+	// the blob delete, and the promoted check for a precise error (the
+	// conditional store UPDATE would fold "candidate" into NotFound).
+	existing, gerr := s.highlights.GetHighlight(ctx, tenantID, id)
+	if errors.Is(gerr, storage.ErrNotFound) {
+		return nil, errNoSuchHighlight()
+	}
+	if gerr != nil {
+		s.log.Error("SetHighlightSound: load row failed", "err", gerr)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+	if existing.CampaignID != campaignID {
+		return nil, errNoSuchHighlight()
+	}
+	if existing.Status != storage.HighlightPromoted {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("promote the highlight before adding sound"))
+	}
+
+	// Configured precheck (#312): probing the factory costs one provider-config
+	// read and turns "unconfigured" into an actionable error at click time. The
+	// job re-checks anyway (the clean no-op), so a key revoked between here and
+	// the generation still leaves the Highlight intact. Skipped for "" — removing
+	// a sound must work even after the provider was unconfigured.
+	if kind != "" {
+		if _, ferr := s.soundFactory(ctx, tenantID); ferr != nil {
+			if errors.Is(ferr, highlight.ErrSoundNotConfigured) {
+				return nil, connect.NewError(connect.CodeFailedPrecondition,
+					errors.New("sound generation requires an ElevenLabs tts provider configuration"))
+			}
+			s.log.Error("SetHighlightSound: probe sound factory failed", "err", ferr)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	// Blob first (ADR-0048): a previously landed asset is dropped for a re-run /
+	// removal alike — the row update below clears the triad, and a re-generated
+	// asset lands under the same deterministic key anyway. Idempotent Delete: an
+	// absent blob must not block the update.
+	if s.blobs != nil && existing.SoundKey != "" {
+		if derr := s.blobs.Delete(ctx, existing.SoundKey); derr != nil {
+			s.log.Error("SetHighlightSound: delete previous sound failed", "err", derr, "highlight", id)
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		}
+	}
+
+	h, err := s.highlights.SetHighlightSoundKind(ctx, tenantID, id, kind)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, errNoSuchHighlight() // deleted (or demoted) between the read and the write
+	}
+	if err != nil {
+		s.log.Error("SetHighlightSound: store update failed", "err", err)
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+
+	// Enqueue the generation (ADR-0049). An enqueue failure is logged only — the
+	// choice is recorded, and the boot reconciliation sweep re-enqueues any
+	// promoted Highlight whose requested sound never landed (the PromoteHighlight
+	// posture); failing the RPC here would wrongly report the choice as refused.
+	if kind != "" {
+		payload, merr := highlight.MarshalEnrichSound(h.ID, tenantID, kind)
+		if merr != nil {
+			s.log.Error("SetHighlightSound: marshal enrich payload failed", "err", merr, "highlight", h.ID)
+		} else if eerr := s.enqueue.Enqueue(ctx, highlight.JobKindEnrichSound, json.RawMessage(payload), time.Now()); eerr != nil {
+			s.log.Error("SetHighlightSound: enqueue sound enrichment failed", "err", eerr, "highlight", h.ID)
+		}
+	}
+	return connect.NewResponse(&managementv1.SetHighlightSoundResponse{Highlight: toProtoHighlight(h)}), nil
 }
 
 // toProtoHighlight maps a storage.Highlight onto its wire view (#308). clip_key
@@ -355,7 +481,16 @@ func toProtoHighlight(h storage.Highlight) *managementv1.Highlight {
 		// blob-seam detail, the clip_key posture). Empty when no image yet.
 		ImageContentType: h.ImageContentType,
 		ImageSizeBytes:   h.ImageSizeBytes,
+		// Sound fields (#312): kind + content type + size + requested-at, so the
+		// UI can render the choice, the pending state, and the player; sound_key
+		// is deliberately omitted (the clip_key posture).
+		SoundKind:        h.SoundKind,
+		SoundContentType: h.SoundContentType,
+		SoundSizeBytes:   h.SoundSizeBytes,
 		CreatedAt:        timestamppb.New(h.CreatedAt),
+	}
+	if h.SoundRequestedAt != nil {
+		pb.SoundRequestedAt = timestamppb.New(*h.SoundRequestedAt)
 	}
 	if h.PromotedAt != nil {
 		pb.PromotedAt = timestamppb.New(*h.PromotedAt)

--- a/internal/rpc/highlight_sound_test.go
+++ b/internal/rpc/highlight_sound_test.go
@@ -1,0 +1,192 @@
+package rpc_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
+	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
+	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/rpc"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+)
+
+// stubSoundGen satisfies soundgen.Generator for the factory probe; the RPC
+// never calls it (generation is the job's business).
+type stubSoundGen struct{}
+
+func (stubSoundGen) GenerateSting(context.Context, soundgen.Request) (soundgen.Result, error) {
+	return soundgen.Result{}, nil
+}
+func (stubSoundGen) ComposeMusic(context.Context, soundgen.Request) (soundgen.Result, error) {
+	return soundgen.Result{}, nil
+}
+
+// newSoundClient is newHighlightClientEnq plus the sound-enrichment seam
+// (#312): the factory backs SetHighlightSound's configured precheck.
+func newSoundClient(t *testing.T, tenantID uuid.UUID, hstore rpc.HighlightStore, blobs *fakeRPCBlobs, sstore *fakeSessionStore, enqueue rpc.HighlightEnqueuer, factory highlight.SoundGeneratorFactory) managementv1connect.SessionServiceClient {
+	t.Helper()
+	if sstore == nil {
+		sstore = activeStore()
+	}
+	inject := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx = auth.WithTenant(ctx, tenantID)
+			return next(ctx, req)
+		}
+	})
+	srv := rpc.NewSessionServer(&fakeSessionManager{}, sstore, nil, nil)
+	srv.SetHighlights(hstore, blobs, enqueue)
+	if factory != nil {
+		srv.SetSoundEnrichment(factory)
+	}
+	mux := http.NewServeMux()
+	mux.Handle(srv.Handler(connect.WithInterceptors(inject)))
+	httpSrv := httptest.NewServer(mux)
+	t.Cleanup(httpSrv.Close)
+	return managementv1connect.NewSessionServiceClient(http.DefaultClient, httpSrv.URL, connect.WithProtoJSON())
+}
+
+func configuredSoundFactory(context.Context, uuid.UUID) (soundgen.Generator, error) {
+	return stubSoundGen{}, nil
+}
+
+func unconfiguredSoundFactory(context.Context, uuid.UUID) (soundgen.Generator, error) {
+	return nil, highlight.ErrSoundNotConfigured
+}
+
+// TestRPCSetHighlightSound_RequestsAndEnqueues is the happy path: the choice is
+// recorded (kind + requested-at on the wire, sound triad cleared) and exactly
+// one JobKindEnrichSound is enqueued.
+func TestRPCSetHighlightSound_RequestsAndEnqueues(t *testing.T) {
+	tenantID, campaignID := uuid.New(), uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+	enq := &fakeHighlightEnqueuer{}
+
+	client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), enq, configuredSoundFactory)
+	res, err := client.SetHighlightSound(context.Background(),
+		connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: storage.SoundKindSting}))
+	if err != nil {
+		t.Fatalf("SetHighlightSound: %v", err)
+	}
+	got := res.Msg.GetHighlight()
+	if got.GetSoundKind() != storage.SoundKindSting {
+		t.Errorf("sound kind = %q, want sting", got.GetSoundKind())
+	}
+	if got.GetSoundRequestedAt() == nil {
+		t.Errorf("sound_requested_at unset, want stamped")
+	}
+	if got.GetSoundContentType() != "" || got.GetSoundSizeBytes() != 0 {
+		t.Errorf("sound triad = (%q, %d), want cleared until the job lands",
+			got.GetSoundContentType(), got.GetSoundSizeBytes())
+	}
+	if enq.calls != 1 || enq.kind != highlight.JobKindEnrichSound {
+		t.Errorf("enqueue calls=%d kind=%q, want 1 %q", enq.calls, enq.kind, highlight.JobKindEnrichSound)
+	}
+}
+
+// TestRPCSetHighlightSound_RemoveDeletesBlob pins kind "": a landed sound's
+// blob is dropped through the seam (blob-then-row) and no job is enqueued.
+func TestRPCSetHighlightSound_RemoveDeletesBlob(t *testing.T) {
+	tenantID, campaignID := uuid.New(), uuid.New()
+	store := newFakeHighlightStore(tenantID)
+	h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+	h.SoundKind = storage.SoundKindSting
+	h.SoundKey = "t/" + tenantID.String() + "/highlight/" + h.ID.String() + "/sound"
+	h.SoundContentType = "audio/mpeg"
+	store.put(h)
+	blobs := &fakeRPCBlobs{}
+	enq := &fakeHighlightEnqueuer{}
+
+	client := newSoundClient(t, tenantID, store, blobs, campaignSessionStore(campaignID), enq, configuredSoundFactory)
+	res, err := client.SetHighlightSound(context.Background(),
+		connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: ""}))
+	if err != nil {
+		t.Fatalf("SetHighlightSound: %v", err)
+	}
+	if got := res.Msg.GetHighlight(); got.GetSoundKind() != "" || got.GetSoundRequestedAt() != nil {
+		t.Errorf("remove left (kind=%q, requestedAt=%v), want cleared", got.GetSoundKind(), got.GetSoundRequestedAt())
+	}
+	if len(blobs.deleted) != 1 || blobs.deleted[0] != h.SoundKey {
+		t.Errorf("deleted blobs = %v, want [%s]", blobs.deleted, h.SoundKey)
+	}
+	if enq.calls != 0 {
+		t.Errorf("enqueue calls = %d, want 0 for a removal", enq.calls)
+	}
+}
+
+// TestRPCSetHighlightSound_Preconditions pins the refusal ladder: a candidate
+// row, an unconfigured tenant, an unknown kind, and an unwired seam.
+func TestRPCSetHighlightSound_Preconditions(t *testing.T) {
+	tenantID, campaignID := uuid.New(), uuid.New()
+
+	t.Run("candidate is FailedPrecondition", func(t *testing.T) {
+		store := newFakeHighlightStore(tenantID)
+		h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightCandidate)
+		client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), &fakeHighlightEnqueuer{}, configuredSoundFactory)
+		_, err := client.SetHighlightSound(context.Background(),
+			connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: storage.SoundKindSting}))
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Fatalf("want CodeFailedPrecondition, got %v", err)
+		}
+	})
+
+	t.Run("unconfigured is FailedPrecondition before any change", func(t *testing.T) {
+		store := newFakeHighlightStore(tenantID)
+		h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+		enq := &fakeHighlightEnqueuer{}
+		client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), enq, unconfiguredSoundFactory)
+		_, err := client.SetHighlightSound(context.Background(),
+			connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: storage.SoundKindMusic}))
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Fatalf("want CodeFailedPrecondition, got %v", err)
+		}
+		if got, _ := store.GetHighlight(context.Background(), tenantID, h.ID); got.SoundKind != "" {
+			t.Errorf("row mutated to kind %q despite the refusal", got.SoundKind)
+		}
+		if enq.calls != 0 {
+			t.Errorf("enqueue calls = %d, want 0", enq.calls)
+		}
+	})
+
+	t.Run("unknown kind is InvalidArgument", func(t *testing.T) {
+		store := newFakeHighlightStore(tenantID)
+		h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+		client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), &fakeHighlightEnqueuer{}, configuredSoundFactory)
+		_, err := client.SetHighlightSound(context.Background(),
+			connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: "dubstep"}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("want CodeInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("unwired seam is Unimplemented", func(t *testing.T) {
+		store := newFakeHighlightStore(tenantID)
+		h := seedRPCHighlight(store, tenantID, uuid.New(), campaignID, storage.HighlightPromoted)
+		client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), &fakeHighlightEnqueuer{}, nil)
+		_, err := client.SetHighlightSound(context.Background(),
+			connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: storage.SoundKindSting}))
+		if connect.CodeOf(err) != connect.CodeUnimplemented {
+			t.Fatalf("want CodeUnimplemented, got %v", err)
+		}
+	})
+
+	t.Run("cross-campaign is NotFound", func(t *testing.T) {
+		store := newFakeHighlightStore(tenantID)
+		h := seedRPCHighlight(store, tenantID, uuid.New(), uuid.New(), storage.HighlightPromoted) // other campaign
+		client := newSoundClient(t, tenantID, store, &fakeRPCBlobs{}, campaignSessionStore(campaignID), &fakeHighlightEnqueuer{}, configuredSoundFactory)
+		_, err := client.SetHighlightSound(context.Background(),
+			connect.NewRequest(&managementv1.SetHighlightSoundRequest{Id: h.ID.String(), Kind: storage.SoundKindSting}))
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Fatalf("want CodeNotFound, got %v", err)
+		}
+	})
+}

--- a/internal/rpc/highlight_test.go
+++ b/internal/rpc/highlight_test.go
@@ -90,6 +90,25 @@ func (f *fakeHighlightStore) DeleteHighlight(_ context.Context, tenantID, id uui
 	return h.ClipKey, nil
 }
 
+func (f *fakeHighlightStore) SetHighlightSoundKind(_ context.Context, tenantID, id uuid.UUID, kind string) (storage.Highlight, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.rows[id]
+	if !ok || h.TenantID != tenantID || h.Status != storage.HighlightPromoted {
+		return storage.Highlight{}, storage.ErrNotFound
+	}
+	h.SoundKind = kind
+	h.SoundKey, h.SoundContentType, h.SoundSizeBytes = "", "", 0
+	if kind == "" {
+		h.SoundRequestedAt = nil
+	} else {
+		now := time.Now()
+		h.SoundRequestedAt = &now
+	}
+	f.rows[id] = h
+	return h, nil
+}
+
 // fakeRPCBlobs records the keys deleted through the seam and serves clip bytes for
 // the ShareHighlight fetch (#310).
 type fakeRPCBlobs struct {

--- a/internal/rpc/session.go
+++ b/internal/rpc/session.go
@@ -14,6 +14,7 @@ import (
 	managementv1 "github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1"
 	"github.com/MrWong99/Glyphoxa/gen/glyphoxa/management/v1/managementv1connect"
 	"github.com/MrWong99/Glyphoxa/internal/auth"
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
 	"github.com/MrWong99/Glyphoxa/internal/recap"
 	"github.com/MrWong99/Glyphoxa/internal/search"
 	"github.com/MrWong99/Glyphoxa/internal/session"
@@ -126,6 +127,10 @@ type SessionServer struct {
 	// enqueue schedules the image-enrichment job on promotion (#311, ADR-0049);
 	// nil disables enrichment (the promote itself still succeeds).
 	enqueue HighlightEnqueuer
+	// soundFactory backs SetHighlightSound's is-it-configured precheck (#312);
+	// wired via SetSoundEnrichment. Nil (unwired) makes SetHighlightSound
+	// report CodeUnimplemented rather than enqueue jobs that can never run.
+	soundFactory highlight.SoundGeneratorFactory
 
 	// sharer / replayer / shareStore back the Highlight Discord-delivery RPCs (#310);
 	// wired via SetSharing after construction. Nil (unwired) makes ShareHighlight /

--- a/internal/spend/prices.go
+++ b/internal/spend/prices.go
@@ -68,6 +68,35 @@ var sttPricePerHour = map[observe.Provider]float64{
 	observe.ProviderElevenLabs: 0.40,
 }
 
+// soundKey identifies a sound-generation price row (#312, ADR-0004 amendment):
+// SFX stings and Music tracks meter under their own model ids — the model is
+// the attribution discriminator since both ride the tts Provider Config.
+type soundKey struct {
+	provider observe.Provider
+	model    string
+}
+
+// soundPricePerMinute are the known per-audio-minute sound-generation rates
+// (USD), keyed (provider, model). ESTIMATES: ElevenLabs bills both endpoints in
+// plan-dependent credits, mapped here at the same ~$0.30/1k-credit ratio the
+// TTS estimate uses, priced on the REQUESTED duration.
+var soundPricePerMinute = map[soundKey]float64{
+	// ElevenLabs sound-effects (sting) — vendor credit table captured
+	// 2026-08-18: ~100 credits per generation (≲22s) ≈ $0.03; normalized to
+	// ~$0.10 / audio-minute. ESTIMATE (plan-dependent).
+	{observe.ProviderElevenLabs, "eleven_text_to_sound_v2"}: 0.10,
+	// ElevenLabs Music — vendor credit table captured 2026-08-18: ~2000
+	// credits per track-minute ≈ $0.60 / audio-minute. ESTIMATE
+	// (plan-dependent).
+	{observe.ProviderElevenLabs, "music_v1"}: 0.60,
+}
+
+// defaultSoundPerMinute is the conservative fallback for an unknown
+// sound-generation (provider, model): above the known Music estimate so an
+// unpriced model over-estimates, matching the LLM/TTS/STT fallback posture.
+// ESTIMATE.
+const defaultSoundPerMinute = 1.00
+
 // embeddingPricePerMTok are the known per-1M-token embeddings rates (USD),
 // keyed by provider alone — v1.0's only embeddings provider is local Ollama
 // (ADR-0011), which costs nothing per call; the OpenAI slot gets its own entry
@@ -119,6 +148,23 @@ func EstimateTTSUSD(provider observe.Provider, chars int) float64 {
 func EstimateSTTUSD(provider observe.Provider, d time.Duration) float64 {
 	usd, _ := sttCostUSD(provider, d)
 	return usd
+}
+
+// EstimateSoundUSD estimates the USD cost of one sound generation (#312) from
+// the requested audio duration — the Highlight sting/Music enrichment pricing.
+// Like EstimateEmbeddingUSD it is a direct estimate rather than a Meter capture
+// point: the ADR-0045 usage trio carries no sound kind, ADR-0046 caps are
+// live-session-only (an off-session enrichment is never cap-gated), and the
+// enrichment job flushes its own per-generation Usage Ledger rows (Tenant
+// attribution under the SFX/Music model id, ADR-0004 amendment). An unknown
+// (provider, model) uses the conservative default (over-estimates, mirroring
+// the other price fallbacks).
+func EstimateSoundUSD(provider observe.Provider, model string, d time.Duration) float64 {
+	p, ok := soundPricePerMinute[soundKey{provider, model}]
+	if !ok {
+		p = defaultSoundPerMinute
+	}
+	return d.Minutes() * p
 }
 
 // EstimateEmbeddingUSD estimates the USD cost of tokens submitted to an

--- a/internal/spend/prices_sound_test.go
+++ b/internal/spend/prices_sound_test.go
@@ -1,0 +1,34 @@
+package spend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/internal/observe"
+)
+
+// TestEstimateSoundUSD_KnownModels pins the two #312 price rows with
+// HARD-CODED expectations (the meter_test discipline) so a typo in the map is
+// caught: a 30s sting at $0.10/min = $0.05; a 60s music track at $0.60/min =
+// $0.60.
+func TestEstimateSoundUSD_KnownModels(t *testing.T) {
+	t.Parallel()
+	if got := EstimateSoundUSD(observe.ProviderElevenLabs, "eleven_text_to_sound_v2", 30*time.Second); got != 0.05 {
+		t.Errorf("sting estimate = %v, want 0.05", got)
+	}
+	if got := EstimateSoundUSD(observe.ProviderElevenLabs, "music_v1", time.Minute); got != 0.60 {
+		t.Errorf("music estimate = %v, want 0.60", got)
+	}
+}
+
+// TestEstimateSoundUSD_UnknownOverEstimates pins the conservative-fallback
+// posture: an unpriced model must cost MORE per minute than every known row.
+func TestEstimateSoundUSD_UnknownOverEstimates(t *testing.T) {
+	t.Parallel()
+	unknown := EstimateSoundUSD(observe.ProviderElevenLabs, "some-future-model", time.Minute)
+	for key, perMin := range soundPricePerMinute {
+		if unknown <= perMin {
+			t.Errorf("unknown-model estimate %v/min is not above %v/min (%v %s)", unknown, perMin, key.provider, key.model)
+		}
+	}
+}

--- a/internal/storage/highlight.go
+++ b/internal/storage/highlight.go
@@ -30,6 +30,17 @@ const (
 	HighlightPromoted = "promoted"
 )
 
+// Highlight sound kinds (CHECK-constrained in the schema, #312): the GM's
+// standing "Add sound" choice on a promoted Highlight. Empty means none
+// requested (the default).
+const (
+	// SoundKindSting: a short sound-effect sting (the ElevenLabs
+	// sound-effects endpoint, bounded to ≤22s).
+	SoundKindSting = "sting"
+	// SoundKindMusic: a composed Music track (the ElevenLabs Music endpoint).
+	SoundKindMusic = "music"
+)
+
 // Highlight is one persisted Session Highlight row (#308).
 type Highlight struct {
 	ID              uuid.UUID
@@ -55,6 +66,20 @@ type Highlight struct {
 	ImageKey         string
 	ImageContentType string
 	ImageSizeBytes   int64
+	// SoundKind / SoundRequestedAt / SoundKey / SoundContentType /
+	// SoundSizeBytes carry the GM's opt-in sound enrichment (#312, Epic 8,
+	// ADR-0004 amendment): SoundKind is the standing choice ("sting" or
+	// "music", "" = none), SoundRequestedAt stamps the latest request (the web
+	// tier's await-media poll bound), and the key/content-type/size triad
+	// mirrors the image's. SoundKey == "" with SoundKind != "" means requested
+	// but not landed (generating, unconfigured, or failed — the row stays
+	// intact without media). SoundKey is NEVER exposed on the wire (clip_key
+	// posture): the audio is served through GET /highlights/{id}/sound.
+	SoundKind        string
+	SoundRequestedAt *time.Time
+	SoundKey         string
+	SoundContentType string
+	SoundSizeBytes   int64
 	CreatedAt        time.Time
 	PromotedAt       *time.Time
 }
@@ -63,19 +88,25 @@ const highlightColumns = `
 	id, tenant_id, voice_session_id, campaign_id, status,
 	starts_at, ends_at, score, excerpt, reason, speaker_ids,
 	clip_key, clip_content_type, clip_size_bytes,
-	image_key, image_content_type, image_size_bytes, created_at, promoted_at`
+	image_key, image_content_type, image_size_bytes,
+	sound_kind, sound_requested_at, sound_key, sound_content_type, sound_size_bytes,
+	created_at, promoted_at`
 
 func scanHighlight(row pgx.Row) (Highlight, error) {
 	var (
 		h  Highlight
+		sr *time.Time
 		pr *time.Time
 	)
 	err := row.Scan(
 		&h.ID, &h.TenantID, &h.VoiceSessionID, &h.CampaignID, &h.Status,
 		&h.StartsAt, &h.EndsAt, &h.Score, &h.Excerpt, &h.Reason, &h.SpeakerIDs,
 		&h.ClipKey, &h.ClipContentType, &h.ClipSizeBytes,
-		&h.ImageKey, &h.ImageContentType, &h.ImageSizeBytes, &h.CreatedAt, &pr,
+		&h.ImageKey, &h.ImageContentType, &h.ImageSizeBytes,
+		&h.SoundKind, &sr, &h.SoundKey, &h.SoundContentType, &h.SoundSizeBytes,
+		&h.CreatedAt, &pr,
 	)
+	h.SoundRequestedAt = sr
 	h.PromotedAt = pr
 	return h, err
 }
@@ -295,15 +326,18 @@ func (s *Store) ListSessionsNeedingCandidatePurge(ctx context.Context, purgeKind
 
 // ListCampaignHighlightClipKeys returns EVERY blob key a campaign hard-delete
 // must sweep through the seam BEFORE the row cascade removes the highlights
-// (ADR-0048): each highlight's clip_key AND its image_key when non-empty (#311 —
-// a promoted, enriched Highlight owns two blobs). No status filter: a campaign
-// delete takes its highlights with it, kept or not. clip_key is always present;
-// image_key is UNION ALL'd only where set, so unenriched rows contribute one key.
+// (ADR-0048): each highlight's clip_key AND its image_key (#311) AND its
+// sound_key (#312) when non-empty — a fully enriched Highlight owns three
+// blobs. No status filter: a campaign delete takes its highlights with it,
+// kept or not. clip_key is always present; image_key and sound_key are
+// UNION ALL'd only where set, so unenriched rows contribute one key.
 func (s *Store) ListCampaignHighlightClipKeys(ctx context.Context, campaignID uuid.UUID) ([]string, error) {
 	return s.scanClipKeys(ctx,
 		`SELECT clip_key FROM highlight WHERE campaign_id = $1
 		 UNION ALL
-		 SELECT image_key FROM highlight WHERE campaign_id = $1 AND image_key <> ''`, campaignID)
+		 SELECT image_key FROM highlight WHERE campaign_id = $1 AND image_key <> ''
+		 UNION ALL
+		 SELECT sound_key FROM highlight WHERE campaign_id = $1 AND sound_key <> ''`, campaignID)
 }
 
 // HighlightEnrichTarget is a promoted, still-imageless Highlight the boot
@@ -393,6 +427,144 @@ func (s *Store) ReleaseHighlightEnrichClaim(ctx context.Context, id uuid.UUID) e
 		return fmt.Errorf("storage: release highlight enrich claim %s: %w", id, err)
 	}
 	return nil
+}
+
+// SetHighlightSoundKind records the GM's "Add sound" choice on a PROMOTED
+// Highlight within the tenant (#312), returning the updated row. A non-empty
+// kind ("sting"/"music" — the RPC validates) stamps sound_requested_at and
+// clears any previously landed sound triad, so the row reads "requested but
+// not landed" until the generation job attaches the new asset; kind "" clears
+// the choice entirely (None). The claim column is deliberately untouched: a
+// live generation keeps serializing blob writes, and the superseded job
+// releases its own claim when its conditional land misses (see
+// SetHighlightSound). A missing/foreign id — or a still-candidate row (sound
+// is opt-in AFTER promotion, #312) — yields ErrNotFound.
+func (s *Store) SetHighlightSoundKind(ctx context.Context, tenantID, id uuid.UUID, kind string) (Highlight, error) {
+	row := s.db.QueryRow(ctx,
+		`UPDATE highlight
+		    SET sound_kind = $3,
+		        sound_requested_at = CASE WHEN $3 = '' THEN NULL ELSE now() END,
+		        sound_key = '', sound_content_type = '', sound_size_bytes = 0
+		  WHERE id = $1 AND tenant_id = $2 AND status = 'promoted'
+		 RETURNING `+highlightColumns, id, tenantID, kind)
+	h, err := scanHighlight(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Highlight{}, ErrNotFound
+	}
+	if err != nil {
+		return Highlight{}, fmt.Errorf("storage: set highlight sound kind %s: %w", id, err)
+	}
+	return h, nil
+}
+
+// SetHighlightSound lands a generated sound asset on a Highlight (#312): the
+// enrichment job stores the audio behind the blob seam (ADR-0048) and then
+// records its key, MIME type, and size here. Tenant-free like
+// SetHighlightImage (the id scopes the row). The write is CONDITIONAL on
+// sound_kind still equalling the kind the job generated for: the GM can change
+// or clear the choice while a generation is in flight, and the stale job's
+// asset must not land under the newer choice. ErrNotFound covers both misses —
+// row gone and kind superseded — and the handler disambiguates with a re-read
+// (only a GONE row compensates the blob; a superseded kind leaves it for the
+// newer job to overwrite).
+func (s *Store) SetHighlightSound(ctx context.Context, id uuid.UUID, kind, soundKey, contentType string, sizeBytes int64) error {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE highlight
+		    SET sound_key = $3, sound_content_type = $4, sound_size_bytes = $5
+		  WHERE id = $1 AND sound_kind = $2`,
+		id, kind, soundKey, contentType, sizeBytes)
+	if err != nil {
+		return fmt.Errorf("storage: set highlight sound %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// TryClaimHighlightSoundEnrich atomically claims the sound generation of a
+// Highlight (#312, the #406 image-claim pattern): a conditional UPDATE that
+// stamps sound_enrich_claimed_at iff a sound is still requested-but-unlanded
+// AND no claim newer than ttl is held. It reports whether THIS caller won
+// (RowsAffected == 1). The single-clock lease (#421) applies: stamp and cutoff
+// are both DB now(), the app contributes only the TTL magnitude. Tenant-free.
+func (s *Store) TryClaimHighlightSoundEnrich(ctx context.Context, id uuid.UUID, ttl time.Duration) (bool, error) {
+	tag, err := s.db.Exec(ctx,
+		`UPDATE highlight
+		    SET sound_enrich_claimed_at = now()
+		  WHERE id = $1
+		    AND sound_kind <> ''
+		    AND sound_key = ''
+		    AND (sound_enrich_claimed_at IS NULL
+		         OR sound_enrich_claimed_at < now() - make_interval(secs => $2))`,
+		id, ttl.Seconds())
+	if err != nil {
+		return false, fmt.Errorf("storage: claim highlight sound enrich %s: %w", id, err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// ReleaseHighlightSoundEnrichClaim clears a Highlight's sound-generation claim
+// (#312) so a retry (or a re-run of the Add-sound action) can re-claim without
+// waiting out the ttl. Idempotent and tenant-free.
+func (s *Store) ReleaseHighlightSoundEnrichClaim(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.db.Exec(ctx,
+		`UPDATE highlight SET sound_enrich_claimed_at = NULL WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("storage: release highlight sound enrich claim %s: %w", id, err)
+	}
+	return nil
+}
+
+// HighlightSoundEnrichTarget is a promoted Highlight whose requested sound
+// never landed and has no live generation job — the boot reconciliation
+// sweep's re-enqueue input (#312, the #406 pattern). Kind rides along because
+// the sound job payload carries the requested kind (unlike the image's).
+type HighlightSoundEnrichTarget struct {
+	HighlightID uuid.UUID
+	TenantID    uuid.UUID
+	Kind        string
+}
+
+// ListPromotedHighlightsNeedingSoundEnrichment returns every PROMOTED
+// Highlight with a requested-but-unlanded sound (sound_kind set, sound_key
+// empty) and NO enrich job of the given kind in a live state matching BOTH the
+// highlight AND the requested sound kind (#312). Matching the payload's kind
+// too is what lets a choice CHANGE re-sweep: a 'done' sting job must not
+// satisfy a later music request. 'done' counts as satisfied (an unconfigured
+// no-op is not re-swept every boot); 'dead' is treated as absent so a
+// dead-lettered generation is re-scheduled once the key is fixed. Process-wide,
+// carries no tenant.
+func (s *Store) ListPromotedHighlightsNeedingSoundEnrichment(ctx context.Context, enrichKind string) ([]HighlightSoundEnrichTarget, error) {
+	rows, err := s.db.Query(ctx,
+		`SELECT h.id, h.tenant_id, h.sound_kind
+		   FROM highlight h
+		  WHERE h.status = 'promoted'
+		    AND h.sound_kind <> ''
+		    AND h.sound_key = ''
+		    AND NOT EXISTS (
+		          SELECT 1 FROM job j
+		           WHERE j.kind = $1
+		             AND j.status IN ('pending','running','done')
+		             AND j.payload->>'highlight_id' = h.id::text
+		             AND j.payload->>'kind' = h.sound_kind
+		        )`, enrichKind)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list promoted highlights needing sound enrichment: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HighlightSoundEnrichTarget
+	for rows.Next() {
+		var t HighlightSoundEnrichTarget
+		if err := rows.Scan(&t.HighlightID, &t.TenantID, &t.Kind); err != nil {
+			return nil, fmt.Errorf("storage: scan sound enrich target: %w", err)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list promoted highlights needing sound enrichment: %w", err)
+	}
+	return out, nil
 }
 
 // HighlightsExist reports which of the given Highlight ids still have a row,

--- a/internal/storage/highlight_sound_test.go
+++ b/internal/storage/highlight_sound_test.go
@@ -1,0 +1,270 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/MrWong99/Glyphoxa/internal/highlight"
+	"github.com/MrWong99/Glyphoxa/internal/storage"
+)
+
+// TestHighlight_SetSoundKind pins the Add-sound choice write (#312): promoted
+// rows only, requested_at stamped for a kind and cleared for "", and the
+// landed triad cleared on every re-run.
+func TestHighlight_SetSoundKind(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+
+	// A candidate refuses the choice (sound is opt-in AFTER promotion).
+	candID, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.SetHighlightSoundKind(ctx, tenantID, candID, storage.SoundKindSting); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("set kind on candidate: want ErrNotFound, got %v", err)
+	}
+
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+	h, err := st.SetHighlightSoundKind(ctx, tenantID, id, storage.SoundKindSting)
+	if err != nil {
+		t.Fatalf("set kind: %v", err)
+	}
+	if h.SoundKind != storage.SoundKindSting || h.SoundRequestedAt == nil {
+		t.Fatalf("choice not recorded: kind=%q requestedAt=%v", h.SoundKind, h.SoundRequestedAt)
+	}
+
+	// A landed sound is cleared by a re-run (regeneration) …
+	sndKey := "t/" + tenantID.String() + "/highlight/" + id.String() + "/sound"
+	if err := st.SetHighlightSound(ctx, id, storage.SoundKindSting, sndKey, "audio/mpeg", 77); err != nil {
+		t.Fatalf("land sound: %v", err)
+	}
+	h, err = st.SetHighlightSoundKind(ctx, tenantID, id, storage.SoundKindMusic)
+	if err != nil {
+		t.Fatalf("re-run set kind: %v", err)
+	}
+	if h.SoundKey != "" || h.SoundContentType != "" || h.SoundSizeBytes != 0 {
+		t.Fatalf("re-run left the landed triad: %q/%q/%d", h.SoundKey, h.SoundContentType, h.SoundSizeBytes)
+	}
+	// … and "" clears the choice entirely.
+	h, err = st.SetHighlightSoundKind(ctx, tenantID, id, "")
+	if err != nil {
+		t.Fatalf("clear kind: %v", err)
+	}
+	if h.SoundKind != "" || h.SoundRequestedAt != nil {
+		t.Fatalf("clear left kind=%q requestedAt=%v", h.SoundKind, h.SoundRequestedAt)
+	}
+}
+
+// TestHighlight_SetSound_ConditionalOnKind pins the job's conditional land: it
+// writes only while the row's sound_kind still matches, so a stale job for a
+// superseded choice misses (ErrNotFound) instead of landing the wrong asset.
+func TestHighlight_SetSound_ConditionalOnKind(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+	if _, err := st.SetHighlightSoundKind(ctx, tenantID, id, storage.SoundKindMusic); err != nil {
+		t.Fatalf("set kind: %v", err)
+	}
+
+	key := "t/" + tenantID.String() + "/highlight/" + id.String() + "/sound"
+	// A stale sting job must miss the music request …
+	if err := st.SetHighlightSound(ctx, id, storage.SoundKindSting, key, "audio/mpeg", 5); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("stale-kind land: want ErrNotFound, got %v", err)
+	}
+	// … the matching kind lands …
+	if err := st.SetHighlightSound(ctx, id, storage.SoundKindMusic, key, "audio/mpeg", 5); err != nil {
+		t.Fatalf("matching land: %v", err)
+	}
+	h, err := st.GetHighlight(ctx, tenantID, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if h.SoundKey != key || h.SoundContentType != "audio/mpeg" || h.SoundSizeBytes != 5 {
+		t.Fatalf("sound not persisted: %q/%q/%d", h.SoundKey, h.SoundContentType, h.SoundSizeBytes)
+	}
+	// … and a missing row misses too.
+	if err := st.SetHighlightSound(ctx, uuid.New(), storage.SoundKindMusic, key, "audio/mpeg", 5); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("missing-row land: want ErrNotFound, got %v", err)
+	}
+}
+
+// TestTryClaimHighlightSoundEnrich_ConditionalTransition pins the sound claim
+// (#312, the #406 pattern): claimable only while a sound is requested and
+// unlanded; the first claim wins, a fresh second loses, release re-opens, a
+// stale claim is reclaimable, and a landed row is unclaimable.
+func TestTryClaimHighlightSoundEnrich_ConditionalTransition(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightPromoted)
+
+	// No sound requested yet: unclaimable.
+	won, err := st.TryClaimHighlightSoundEnrich(ctx, id, time.Hour)
+	if err != nil || won {
+		t.Fatalf("claim with no request: won=%v err=%v; want lost", won, err)
+	}
+	if _, err := st.SetHighlightSoundKind(ctx, tenantID, id, storage.SoundKindSting); err != nil {
+		t.Fatalf("set kind: %v", err)
+	}
+
+	won, err = st.TryClaimHighlightSoundEnrich(ctx, id, time.Hour)
+	if err != nil || !won {
+		t.Fatalf("first claim: won=%v err=%v; want won", won, err)
+	}
+	won, err = st.TryClaimHighlightSoundEnrich(ctx, id, time.Hour)
+	if err != nil || won {
+		t.Fatalf("second claim: won=%v err=%v; want lost", won, err)
+	}
+	if err := st.ReleaseHighlightSoundEnrichClaim(ctx, id); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	won, err = st.TryClaimHighlightSoundEnrich(ctx, id, time.Hour)
+	if err != nil || !won {
+		t.Fatalf("post-release claim: won=%v err=%v; want won", won, err)
+	}
+	won, err = st.TryClaimHighlightSoundEnrich(ctx, id, time.Nanosecond)
+	if err != nil || !won {
+		t.Fatalf("stale-claim reclaim: won=%v err=%v; want won", won, err)
+	}
+
+	key := "t/" + tenantID.String() + "/highlight/" + id.String() + "/sound"
+	if err := st.SetHighlightSound(ctx, id, storage.SoundKindSting, key, "audio/mpeg", 9); err != nil {
+		t.Fatalf("land sound: %v", err)
+	}
+	won, err = st.TryClaimHighlightSoundEnrich(ctx, id, time.Hour)
+	if err != nil || won {
+		t.Fatalf("claim on landed row: won=%v err=%v; want lost", won, err)
+	}
+}
+
+// soundJobPayload marshals the sound job payload the reconciliation query
+// matches on (highlight_id AND kind).
+func soundJobPayload(t *testing.T, highlightID, tenantID uuid.UUID, kind string) []byte {
+	t.Helper()
+	b, err := highlight.MarshalEnrichSound(highlightID, tenantID, kind)
+	if err != nil {
+		t.Fatalf("marshal sound payload: %v", err)
+	}
+	return b
+}
+
+// TestListPromotedHighlightsNeedingSoundEnrichment pins the sound half of the
+// boot sweep query (#312): only promoted, requested-but-unlanded rows with no
+// live job for the SAME requested kind — a job for a superseded kind does not
+// satisfy the current request.
+func TestListPromotedHighlightsNeedingSoundEnrichment(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	promote := func() uuid.UUID {
+		id, _ := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+		if _, err := st.PromoteHighlight(ctx, tenantID, id); err != nil {
+			t.Fatalf("promote: %v", err)
+		}
+		return id
+	}
+	request := func(id uuid.UUID, kind string) {
+		if _, err := st.SetHighlightSoundKind(ctx, tenantID, id, kind); err != nil {
+			t.Fatalf("set kind: %v", err)
+		}
+	}
+
+	// (want) requested, unlanded, no job → a target carrying its kind.
+	wantID := promote()
+	request(wantID, storage.SoundKindMusic)
+
+	// (want) requested music, but the only job is for the SUPERSEDED sting →
+	// still a target: a kind-mismatched job never satisfies the request.
+	kindChangedID := promote()
+	request(kindChangedID, storage.SoundKindMusic)
+	if _, err := st.EnqueueJob(ctx, highlight.JobKindEnrichSound, soundJobPayload(t, kindChangedID, tenantID, storage.SoundKindSting), 0); err != nil {
+		t.Fatalf("enqueue stale-kind job: %v", err)
+	}
+
+	// requested with a live job of the SAME kind → excluded.
+	hasJobID := promote()
+	request(hasJobID, storage.SoundKindSting)
+	if _, err := st.EnqueueJob(ctx, highlight.JobKindEnrichSound, soundJobPayload(t, hasJobID, tenantID, storage.SoundKindSting), 0); err != nil {
+		t.Fatalf("enqueue matching job: %v", err)
+	}
+
+	// requested and already landed → excluded.
+	landedID := promote()
+	request(landedID, storage.SoundKindSting)
+	key := "t/" + tenantID.String() + "/highlight/" + landedID.String() + "/sound"
+	if err := st.SetHighlightSound(ctx, landedID, storage.SoundKindSting, key, "audio/mpeg", 3); err != nil {
+		t.Fatalf("land sound: %v", err)
+	}
+
+	// promoted with no request → excluded.
+	promote()
+
+	got, err := st.ListPromotedHighlightsNeedingSoundEnrichment(ctx, highlight.JobKindEnrichSound)
+	if err != nil {
+		t.Fatalf("list needing sound enrichment: %v", err)
+	}
+	byID := map[uuid.UUID]storage.HighlightSoundEnrichTarget{}
+	for _, tgt := range got {
+		byID[tgt.HighlightID] = tgt
+	}
+	if len(got) != 2 {
+		t.Fatalf("want the 2 unsatisfied requests, got %+v", got)
+	}
+	if tgt, ok := byID[wantID]; !ok || tgt.Kind != storage.SoundKindMusic || tgt.TenantID != tenantID {
+		t.Fatalf("no-job target wrong: %+v", byID[wantID])
+	}
+	if tgt, ok := byID[kindChangedID]; !ok || tgt.Kind != storage.SoundKindMusic {
+		t.Fatalf("kind-changed target wrong: %+v", byID[kindChangedID])
+	}
+}
+
+// TestHighlight_CampaignClipKeySweep_IncludesSounds pins the third UNION arm:
+// a landed sound key joins the campaign hard-delete blob sweep.
+func TestHighlight_CampaignClipKeySweep_IncludesSounds(t *testing.T) {
+	dsn := startPostgres(t)
+	pool, tenantID, campaignID := seedCampaign(t, dsn)
+	ctx := context.Background()
+	st := storage.New(pool)
+
+	vs, _ := st.CreateVoiceSession(ctx, campaignID)
+	id, clip := seedHighlight(t, st, tenantID, vs.ID, campaignID, storage.HighlightCandidate)
+	if _, err := st.PromoteHighlight(ctx, tenantID, id); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if _, err := st.SetHighlightSoundKind(ctx, tenantID, id, storage.SoundKindSting); err != nil {
+		t.Fatalf("set kind: %v", err)
+	}
+	sndKey := "t/" + tenantID.String() + "/highlight/" + id.String() + "/sound"
+	if err := st.SetHighlightSound(ctx, id, storage.SoundKindSting, sndKey, "audio/mpeg", 8); err != nil {
+		t.Fatalf("land sound: %v", err)
+	}
+
+	keys, err := st.ListCampaignHighlightClipKeys(ctx, campaignID)
+	if err != nil {
+		t.Fatalf("list campaign keys: %v", err)
+	}
+	set := map[string]bool{}
+	for _, k := range keys {
+		set[k] = true
+	}
+	if !set[clip] || !set[sndKey] || len(keys) != 2 {
+		t.Fatalf("campaign sweep keys mismatch: %v", keys)
+	}
+}

--- a/internal/storage/migrations/00054_highlight_sound.sql
+++ b/internal/storage/migrations/00054_highlight_sound.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- Sound enrichment for Session Highlights (#312, Epic 8, ADR-0004 amendment
+-- 2026-07-22): the GM's opt-in "Add sound" action generates a matching audio
+-- asset via ElevenLabs — a short sound-effect Sting or a composed Music track —
+-- and attaches it as a SEPARATE blob next to the clip (zero DSP; the web UI
+-- layers it client-side). Unlike the automatic image enrichment (#311) this is
+-- deliberately NOT a new provider Component: the generation rides the Tenant's
+-- existing `tts` Provider Config iff its provider is ElevenLabs, so there is no
+-- provider_component enum change here.
+--
+-- sound_kind records the GM's standing choice ('sting' or 'music'; '' = none
+-- requested) — it is what the boot reconciliation sweep and the UI's
+-- "generating…" state key off, and re-running the action rewrites it.
+-- sound_requested_at stamps the latest request so the web tier can bound its
+-- await-media polling (the promoted_at/image pattern). sound_key/-content_type/
+-- -size_bytes mirror the image triad: sound_key reconstructs the blob.Key
+-- (t/<tenant>/highlight/<id>/sound); deletion goes through blob.Delete, never a
+-- DB cascade. An empty sound_key with a non-empty sound_kind means "requested
+-- but not landed" (generating, unconfigured, or failed — the row stays intact
+-- without media). sound_enrich_claimed_at is the #406-pattern generation claim;
+-- it never reaches the wire.
+ALTER TABLE highlight ADD COLUMN sound_kind text NOT NULL DEFAULT '' CHECK (sound_kind IN ('', 'sting', 'music'));
+ALTER TABLE highlight ADD COLUMN sound_requested_at timestamptz;
+ALTER TABLE highlight ADD COLUMN sound_key text NOT NULL DEFAULT '';
+ALTER TABLE highlight ADD COLUMN sound_content_type text NOT NULL DEFAULT '';
+ALTER TABLE highlight ADD COLUMN sound_size_bytes bigint NOT NULL DEFAULT 0;
+ALTER TABLE highlight ADD COLUMN sound_enrich_claimed_at timestamptz;
+
+-- +goose Down
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_enrich_claimed_at;
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_size_bytes;
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_content_type;
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_key;
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_requested_at;
+ALTER TABLE highlight DROP COLUMN IF EXISTS sound_kind;

--- a/pkg/voice/soundgen/elevenlabs/elevenlabs.go
+++ b/pkg/voice/soundgen/elevenlabs/elevenlabs.go
@@ -1,0 +1,102 @@
+// Package elevenlabs implements the [soundgen.Generator] surface against the
+// ElevenLabs sound-generation and Music HTTP APIs (#312, Epic 8) — the
+// endpoint-wrapper sibling of the tts and stt ElevenLabs adapters.
+//
+// Authentication is BYOK per ADR-0004: sound generation rides the Tenant's
+// existing `tts` Provider Config key (one ElevenLabs key covers every Component
+// the provider offers), so callers either pass that key to [New] or set
+// ELEVENLABS_API_KEY. [New] never fails so that cassette-replay test binaries
+// can link this package without an API key configured — missing-key errors
+// surface at request time instead.
+package elevenlabs
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the ElevenLabs production API root.
+	DefaultBaseURL = "https://api.elevenlabs.io"
+
+	// APIKeyEnv is the environment variable [New] consults when its apiKey
+	// argument is empty. Deliberately the same variable as the tts and stt
+	// adapters: one BYOK key per ElevenLabs Tenant covers every Component.
+	APIKeyEnv = "ELEVENLABS_API_KEY"
+
+	// ProviderID is the stable ElevenLabs provider identifier, matching the
+	// tts adapter's — the ADR-0004 amendment's "iff the configured tts
+	// provider is ElevenLabs" check compares against this.
+	ProviderID = "elevenlabs"
+
+	// SFXModel is the sound-effects model the sting endpoint targets — also
+	// the model id sting usage meters under (ADR-0046 price map, ADR-0004
+	// amendment: SFX and Music meter separately).
+	SFXModel = "eleven_text_to_sound_v2"
+
+	// MusicModel is the Music composition model — the Music metering model id.
+	MusicModel = "music_v1"
+)
+
+// Client is the ElevenLabs sound-generation adapter. Construct with [New]; the
+// zero value is not usable. Safe for concurrent use across goroutines (the
+// underlying http.Client is).
+type Client struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+// Option mutates a [Client] during construction.
+type Option func(*Client)
+
+// WithBaseURL overrides the API base URL. Useful for tests (httptest server)
+// and self-hosted ElevenLabs deployments.
+func WithBaseURL(u string) Option { return func(c *Client) { c.baseURL = u } }
+
+// WithHTTPClient supplies a custom http.Client. The default
+// ([defaultHTTPClient]) bounds connection establishment but allows a long
+// response-header phase; the per-call end-to-end bound is the request
+// context's deadline (the background job's lease, ADR-0049).
+func WithHTTPClient(h *http.Client) Option { return func(c *Client) { c.http = h } }
+
+// defaultHTTPClient bounds the connection-establishment phase like the tts and
+// stt adapters, but with a generation-scale ResponseHeaderTimeout: unlike a
+// synthesis (first audio byte in well under a second), the sound and Music
+// endpoints return no headers until the WHOLE asset is generated — a Music
+// track can take minutes — so 5m gives real generations headroom while a
+// black-holed endpoint still fails without waiting on TCP defaults. The
+// enrichment job's lease context remains the end-to-end cancel.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Minute,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+
+// New constructs a [Client]. If apiKey is empty it falls back to the
+// ELEVENLABS_API_KEY environment variable; if that is also empty, the returned
+// client still links — calls return a "missing API key" error rather than
+// panicking on construction, so cassette-replay test binaries can import this
+// package unconditionally.
+func New(apiKey string, opts ...Option) *Client {
+	if apiKey == "" {
+		apiKey = os.Getenv(APIKeyEnv)
+	}
+	c := &Client{
+		apiKey:  apiKey,
+		baseURL: DefaultBaseURL,
+		http:    defaultHTTPClient(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}

--- a/pkg/voice/soundgen/elevenlabs/elevenlabs_test.go
+++ b/pkg/voice/soundgen/elevenlabs/elevenlabs_test.go
@@ -1,0 +1,200 @@
+package elevenlabs_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen/elevenlabs"
+)
+
+// The adapter must satisfy the provider-neutral surface.
+var _ soundgen.Generator = (*elevenlabs.Client)(nil)
+
+// TestMissingKeyFailsAtRequestTime pins the New-never-fails contract: a keyless
+// client links (cassette-replay binaries import this package unconditionally)
+// and errors only when a call is attempted.
+func TestMissingKeyFailsAtRequestTime(t *testing.T) {
+	t.Setenv(elevenlabs.APIKeyEnv, "")
+	c := elevenlabs.New("")
+	if _, err := c.GenerateSting(context.Background(), soundgen.Request{Prompt: "boom"}); err == nil || !strings.Contains(err.Error(), "missing API key") {
+		t.Fatalf("GenerateSting keyless err = %v, want missing-API-key", err)
+	}
+	if _, err := c.ComposeMusic(context.Background(), soundgen.Request{Prompt: "theme"}); err == nil || !strings.Contains(err.Error(), "missing API key") {
+		t.Fatalf("ComposeMusic keyless err = %v, want missing-API-key", err)
+	}
+}
+
+// TestGenerateStingRequestShape pins the sting call: endpoint, auth header,
+// output format, body fields (prompt, clamped duration, model id), and the
+// decoded result (bytes, content type, model, vendor character-cost).
+func TestGenerateStingRequestShape(t *testing.T) {
+	audio := []byte("mp3-sting-bytes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/sound-generation" {
+			t.Errorf("got %s %s, want POST /v1/sound-generation", r.Method, r.URL.Path)
+		}
+		if got := r.URL.Query().Get("output_format"); got != "mp3_44100_128" {
+			t.Errorf("output_format = %q, want mp3_44100_128", got)
+		}
+		if got := r.Header.Get("xi-api-key"); got != "test-key" {
+			t.Errorf("xi-api-key = %q, want test-key", got)
+		}
+		var body struct {
+			Text            string   `json:"text"`
+			DurationSeconds *float64 `json:"duration_seconds"`
+			ModelID         string   `json:"model_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.Text != "a triumphant brass sting" {
+			t.Errorf("text = %q", body.Text)
+		}
+		// 90s clamps to the 22s sting ceiling (#312).
+		if body.DurationSeconds == nil || *body.DurationSeconds != 22 {
+			t.Errorf("duration_seconds = %v, want 22", body.DurationSeconds)
+		}
+		if body.ModelID != elevenlabs.SFXModel {
+			t.Errorf("model_id = %q, want %q", body.ModelID, elevenlabs.SFXModel)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("character-cost", "100")
+		_, _ = w.Write(audio)
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	res, err := c.GenerateSting(context.Background(), soundgen.Request{
+		Prompt:   "a triumphant brass sting",
+		Duration: 90 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("GenerateSting: %v", err)
+	}
+	if string(res.Data) != string(audio) {
+		t.Errorf("Data = %q, want %q", res.Data, audio)
+	}
+	if res.ContentType != "audio/mpeg" {
+		t.Errorf("ContentType = %q", res.ContentType)
+	}
+	if res.Model != elevenlabs.SFXModel {
+		t.Errorf("Model = %q, want %q", res.Model, elevenlabs.SFXModel)
+	}
+	if res.CharacterCost != 100 {
+		t.Errorf("CharacterCost = %d, want 100", res.CharacterCost)
+	}
+}
+
+// TestGenerateStingOmitsAutoDuration pins the zero-Duration path: no
+// duration_seconds field at all, so the endpoint infers the optimal length.
+func TestGenerateStingOmitsAutoDuration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(raw), "duration_seconds") {
+			t.Errorf("body %s carries duration_seconds, want omitted for auto", raw)
+		}
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	if _, err := c.GenerateSting(context.Background(), soundgen.Request{Prompt: "boom"}); err != nil {
+		t.Fatalf("GenerateSting: %v", err)
+	}
+}
+
+// TestComposeMusicRequestShape pins the Music call: endpoint, body fields
+// (prompt, length in ms, model id, force_instrumental always true), and the
+// content-type fallback when the vendor omits the header.
+func TestComposeMusicRequestShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/music" {
+			t.Errorf("got %s %s, want POST /v1/music", r.Method, r.URL.Path)
+		}
+		var body struct {
+			Prompt            string `json:"prompt"`
+			MusicLengthMs     int64  `json:"music_length_ms"`
+			ModelID           string `json:"model_id"`
+			ForceInstrumental bool   `json:"force_instrumental"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.Prompt != "an ominous dungeon theme" {
+			t.Errorf("prompt = %q", body.Prompt)
+		}
+		if body.MusicLengthMs != 45_000 {
+			t.Errorf("music_length_ms = %d, want 45000", body.MusicLengthMs)
+		}
+		if body.ModelID != elevenlabs.MusicModel {
+			t.Errorf("model_id = %q, want %q", body.ModelID, elevenlabs.MusicModel)
+		}
+		if !body.ForceInstrumental {
+			t.Errorf("force_instrumental = false, want true")
+		}
+		w.Header().Set("Content-Type", "application/octet-stream") // genericized: adapter falls back
+		_, _ = w.Write([]byte("mp3-music-bytes"))
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	res, err := c.ComposeMusic(context.Background(), soundgen.Request{
+		Prompt:   "an ominous dungeon theme",
+		Duration: 45 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ComposeMusic: %v", err)
+	}
+	if res.ContentType != "audio/mpeg" {
+		t.Errorf("ContentType = %q, want the audio/mpeg fallback", res.ContentType)
+	}
+	if res.Model != elevenlabs.MusicModel {
+		t.Errorf("Model = %q, want %q", res.Model, elevenlabs.MusicModel)
+	}
+}
+
+// TestNon2xxIsTypedHTTPError pins the ADR-0044 contract: a non-2xx start
+// response surfaces as *providererr.HTTPError so callers classify by status
+// code via errors.As, never substring matching.
+func TestNon2xxIsTypedHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"detail":"quota exhausted"}`, http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	_, err := c.GenerateSting(context.Background(), soundgen.Request{Prompt: "boom"})
+	var httpErr *providererr.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("err = %v (%T), want *providererr.HTTPError", err, err)
+	}
+	if httpErr.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want 429", httpErr.StatusCode)
+	}
+	if httpErr.Op != "elevenlabs.GenerateSting" {
+		t.Errorf("Op = %q", httpErr.Op)
+	}
+}
+
+// TestEmptyAudioIsAnError pins that a 200 with no bytes fails loudly instead of
+// landing a zero-byte blob on the Highlight.
+func TestEmptyAudioIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := elevenlabs.New("test-key", elevenlabs.WithBaseURL(srv.URL))
+	if _, err := c.ComposeMusic(context.Background(), soundgen.Request{Prompt: "theme"}); err == nil || !strings.Contains(err.Error(), "no audio") {
+		t.Fatalf("err = %v, want no-audio error", err)
+	}
+}

--- a/pkg/voice/soundgen/elevenlabs/generate.go
+++ b/pkg/voice/soundgen/elevenlabs/generate.go
@@ -1,0 +1,182 @@
+package elevenlabs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/providererr"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+)
+
+// outputFormat is the encoded-audio format both endpoints are asked for:
+// browser-playable MP3 at a plan-safe bitrate (higher bitrates and PCM are
+// tier-gated). The bytes go to the blob seam and an <audio> tag, never the PCM
+// hot path (ADR-0022 posture).
+const outputFormat = "mp3_44100_128"
+
+// Endpoint bounds, per the vendor API contract (captured 2026-08-18). The
+// adapter clamps rather than errors: the caller's duration is derived from a
+// Highlight clip, and a clip outside the endpoint's range should still produce
+// the closest legal asset, not a dead-letter.
+const (
+	// stingMinDuration / stingMaxDuration bound the sound-effects endpoint's
+	// duration_seconds. The endpoint accepts up to 30s, but the sting contract
+	// is ≤22s (#312 decision), so the adapter caps there.
+	stingMinDuration = 500 * time.Millisecond
+	stingMaxDuration = 22 * time.Second
+	// musicMinDuration / musicMaxDuration bound the Music endpoint's
+	// music_length_ms (vendor: 3s–10min). The 5m ceiling here is spend
+	// hygiene, far above any Highlight sting use.
+	musicMinDuration = 3 * time.Second
+	musicMaxDuration = 5 * time.Minute
+)
+
+// maxResponseBytes caps how much generated audio the adapter will buffer — a
+// runaway or hostile response must not exhaust memory. Matches the blob cap
+// the bytes are destined for (internal/blob.MaxSize, 32 MiB) without importing
+// it (pkg/voice stays internal-free).
+const maxResponseBytes = 32 << 20
+
+// GenerateSting implements [soundgen.Generator] against POST
+// /v1/sound-generation: a short sound-effect sting for a Highlight. A zero
+// req.Duration lets the endpoint infer the optimal length from the prompt;
+// otherwise the duration is clamped to the sting bounds.
+func (c *Client) GenerateSting(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	if c.apiKey == "" {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.GenerateSting: missing API key (set %s or pass it to New)", APIKeyEnv)
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.GenerateSting: Prompt is required")
+	}
+
+	body := struct {
+		Text            string   `json:"text"`
+		DurationSeconds *float64 `json:"duration_seconds,omitempty"`
+		ModelID         string   `json:"model_id"`
+	}{Text: req.Prompt, ModelID: SFXModel}
+	if req.Duration > 0 {
+		secs := clampDuration(req.Duration, stingMinDuration, stingMaxDuration).Seconds()
+		body.DurationSeconds = &secs
+	}
+
+	res, err := c.generate(ctx, "GenerateSting", "/v1/sound-generation", body)
+	if err != nil {
+		return soundgen.Result{}, err
+	}
+	res.Model = SFXModel
+	return res, nil
+}
+
+// ComposeMusic implements [soundgen.Generator] against POST /v1/music: a
+// composed track for a Highlight. force_instrumental is always set — the track
+// plays under (or beside) recorded table speech, and generated lyrics quoting a
+// transcript excerpt back at the table is not the product (#312: the excerpt
+// steers mood, not libretto). A zero req.Duration lets the model choose.
+func (c *Client) ComposeMusic(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	if c.apiKey == "" {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.ComposeMusic: missing API key (set %s or pass it to New)", APIKeyEnv)
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.ComposeMusic: Prompt is required")
+	}
+
+	body := struct {
+		Prompt            string `json:"prompt"`
+		MusicLengthMs     int64  `json:"music_length_ms,omitempty"`
+		ModelID           string `json:"model_id"`
+		ForceInstrumental bool   `json:"force_instrumental"`
+	}{Prompt: req.Prompt, ModelID: MusicModel, ForceInstrumental: true}
+	if req.Duration > 0 {
+		body.MusicLengthMs = clampDuration(req.Duration, musicMinDuration, musicMaxDuration).Milliseconds()
+	}
+
+	res, err := c.generate(ctx, "ComposeMusic", "/v1/music", body)
+	if err != nil {
+		return soundgen.Result{}, err
+	}
+	res.Model = MusicModel
+	return res, nil
+}
+
+// generate POSTs one JSON body to path and returns the binary audio response.
+// Both endpoints share the shape: JSON in, encoded audio out, usage reported in
+// the character-cost response header.
+func (c *Client) generate(ctx context.Context, op, path string, body any) (soundgen.Result, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: marshal body: %w", op, err)
+	}
+
+	u := strings.TrimRight(c.baseURL, "/") + path + "?output_format=" + outputFormat
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(raw))
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: build request: %w", op, err)
+	}
+	httpReq.Header.Set("xi-api-key", c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "audio/mpeg")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: %w", op, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return soundgen.Result{}, readErrorResponse(resp, op)
+	}
+
+	// Bounded read: one byte past the cap distinguishes "exactly at the cap"
+	// from "over it" without buffering an unbounded response.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: read audio: %w", op, err)
+	}
+	if len(data) > maxResponseBytes {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: response exceeds %d bytes", op, maxResponseBytes)
+	}
+	if len(data) == 0 {
+		return soundgen.Result{}, fmt.Errorf("elevenlabs.%s: response had no audio", op)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" || strings.HasPrefix(ct, "application/") {
+		ct = "audio/mpeg" // the requested output format; some gateways omit or genericize it
+	}
+	// character-cost is the vendor's own usage unit for this API family;
+	// absent or unparsable reads as 0 (the caller prices by duration anyway).
+	cost, _ := strconv.ParseInt(strings.TrimSpace(resp.Header.Get("character-cost")), 10, 64)
+
+	return soundgen.Result{Data: data, ContentType: ct, CharacterCost: cost}, nil
+}
+
+// clampDuration bounds d to [min, max].
+func clampDuration(d, min, max time.Duration) time.Duration {
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+// readErrorResponse reads up to 512 bytes of a non-2xx response body for
+// diagnostic context and returns it as a typed [*providererr.HTTPError] so
+// callers can classify the call by status code via errors.As (ADR-0044) —
+// byte-identical in shape to the tts/stt adapters' helper.
+func readErrorResponse(resp *http.Response, op string) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return &providererr.HTTPError{
+		Op:         "elevenlabs." + op,
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       strings.TrimSpace(string(snippet)),
+	}
+}

--- a/pkg/voice/soundgen/soundgen.go
+++ b/pkg/voice/soundgen/soundgen.go
@@ -1,0 +1,64 @@
+// Package soundgen defines the provider-neutral sound-generation surface for
+// Highlight sound enrichment (#312, Epic 8): a [Generator] turns a text prompt
+// into one encoded audio asset — a short sound-effect Sting or a composed Music
+// track. Like the TTS voice-design previews (ADR-0022), the produced bytes are
+// opaque encoded audio destined for the blob seam and browser playback; they
+// never enter the PCM hot path.
+//
+// v1.0's only adapter is ElevenLabs (see the elevenlabs subpackage): per the
+// ADR-0004 amendment (2026-07-22, #312) sound generation rides the Tenant's
+// existing `tts` Provider Config iff that provider is ElevenLabs — deliberately
+// NOT a new Component.
+package soundgen
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNotConfigured is the sentinel a factory returns when the tenant has no
+// usable sound-generation key: no `tts` Provider Config, a non-ElevenLabs tts
+// provider, or no resolvable key (ADR-0004 amendment). Consumers treat it as a
+// clean no-op — no retry, no spend. Declared ONCE here and aliased by every
+// consumer (the imagegen #541 lesson): two distinct sentinels compare unequal
+// under errors.Is and silently disable a consumer's actionable branch.
+var ErrNotConfigured = errors.New("soundgen: sound generation is not configured")
+
+// Request is one sound-generation ask: the prompt describing the desired audio
+// and the target duration. A zero Duration lets the provider pick (the SFX
+// endpoint infers an optimal length from the prompt).
+type Request struct {
+	// Prompt describes the sound to generate.
+	Prompt string
+	// Duration is the requested audio length. Adapters clamp it to the
+	// endpoint's own bounds; zero means provider-chosen.
+	Duration time.Duration
+}
+
+// Result is one generated audio asset.
+type Result struct {
+	// Data is the encoded audio (MP3 for the ElevenLabs adapter).
+	Data []byte
+	// ContentType is the audio MIME type (e.g. "audio/mpeg").
+	ContentType string
+	// Model is the provider model id that produced the audio — the ADR-0046
+	// price-map / Usage-Ledger attribution key (SFX and Music meter separately,
+	// ADR-0004 amendment).
+	Model string
+	// CharacterCost is the vendor-reported usage cost in its own credit unit
+	// (ElevenLabs' character-cost response header), 0 when not reported. It is
+	// recorded for attribution; pricing uses the requested duration.
+	CharacterCost int64
+}
+
+// Generator produces sound assets. Implemented by the ElevenLabs adapter and
+// replayed by voicecassette.LoadSound in tests.
+type Generator interface {
+	// GenerateSting produces a short sound-effect sting (the ElevenLabs
+	// sound-effects endpoint; bounded to tens of seconds).
+	GenerateSting(ctx context.Context, req Request) (Result, error)
+	// ComposeMusic produces a composed music track (the ElevenLabs Music
+	// endpoint; longer-form than a sting).
+	ComposeMusic(ctx context.Context, req Request) (Result, error)
+}

--- a/pkg/voice/voicecassette/sound.go
+++ b/pkg/voice/voicecassette/sound.go
@@ -1,0 +1,191 @@
+package voicecassette
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+	"gopkg.in/yaml.v3"
+)
+
+// SoundGeneration is one (request fingerprint, recorded metadata) pair in a
+// [SoundCassette] — a single [soundgen.Generator] call (a sting or a Music
+// composition, discriminated by Kind).
+//
+// Like the LLM cassette (and unlike the positional STT/TTS ones), generations
+// are matched by RequestHash: the key is a sha256 over the kind, model, target
+// duration, and prompt, so a prompt-derivation change misses and fails the
+// test rather than silently replaying a stale asset. Like the TTS cassette,
+// this is a STUB cassette (ADR-0021): the generated audio bytes are NOT
+// pinned — megabytes of MP3 in git would be a departure — only the request
+// that flowed into the provider plus the response's content type. Replay
+// returns small deterministic stand-in bytes.
+type SoundGeneration struct {
+	// RequestHash is the hex sha256 of the rendered request (kind + model +
+	// duration + prompt); see [HashSoundRequest].
+	RequestHash string `yaml:"request_sha256"`
+
+	// Kind is "sting" or "music" — which Generator method the request hit.
+	Kind string `yaml:"kind"`
+
+	// Model is the provider model id that produced the recorded response —
+	// the metering attribution key the replay result carries.
+	Model string `yaml:"model"`
+
+	// ContentType is the recorded response's audio MIME type.
+	ContentType string `yaml:"content_type"`
+}
+
+// SoundCassette is the on-disk record of a sound-generation scenario: a set of
+// generations keyed by request hash. Its identity is its filename —
+// LoadSound(t, "sound-foo") reads tests/voice-cassettes/sound-foo.yaml.
+type SoundCassette struct {
+	// Generations is the recorded (hash, metadata) set. Stored as a list (not
+	// a map) so the YAML diff is stable and reviewable; replay indexes it by
+	// hash on load.
+	Generations []SoundGeneration `yaml:"generations"`
+
+	// Notes is free-form provenance (provider, model, recording date). Not
+	// load-bearing; survives round-trip for human reviewers.
+	Notes string `yaml:"notes,omitempty"`
+}
+
+// Sound cassette kind tokens, matching the two [soundgen.Generator] methods.
+const (
+	soundKindSting = "sting"
+	soundKindMusic = "music"
+)
+
+// SoundGenerator is a [soundgen.Generator] that replays a single
+// [SoundCassette]. Each call hashes its request and replays the matching
+// generation's metadata over deterministic stub bytes. A miss — no generation
+// for the computed hash — returns an error pointing at the re-record workflow,
+// so a prompt or duration change is caught, never silently passed.
+type SoundGenerator struct {
+	name   string
+	byHash map[string]SoundGeneration
+}
+
+// loadSoundCassetteFromDisk reads tests/voice-cassettes/<name>.yaml and
+// returns the decoded cassette. When mustExist is true (replay mode) every
+// failure path — missing file, malformed YAML, empty generations, empty
+// request hash — is fatal. When mustExist is false (record mode), a missing
+// file yields (zero, false); a malformed existing file still fails so a
+// corrupted fixture is never silently overwritten.
+//
+// One function instead of two so neither build configuration (default replay
+// vs -tags=record) sees an unused helper — only one of [LoadSound]'s build-tag
+// variants is compiled at a time.
+func loadSoundCassetteFromDisk(t *testing.T, name string, mustExist bool) (SoundCassette, bool) {
+	t.Helper()
+	path := filepath.Join(cassettesDir(), name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !mustExist && os.IsNotExist(err) {
+			return SoundCassette{}, false
+		}
+		t.Fatalf("voicecassette.LoadSound(%q): %v", name, err)
+	}
+	var c SoundCassette
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		t.Fatalf("voicecassette.LoadSound(%q): unmarshal: %v", name, err)
+	}
+	if mustExist {
+		if len(c.Generations) == 0 {
+			t.Fatalf("voicecassette.LoadSound(%q): cassette has no generations", name)
+		}
+		for i, g := range c.Generations {
+			if g.RequestHash == "" {
+				t.Fatalf("voicecassette.LoadSound(%q): generation %d has empty request_sha256", name, i)
+			}
+		}
+	}
+	return c, true
+}
+
+// indexSoundByHash builds the replay lookup from a cassette's generations.
+func indexSoundByHash(c SoundCassette) map[string]SoundGeneration {
+	m := make(map[string]SoundGeneration, len(c.Generations))
+	for _, g := range c.Generations {
+		m[g.RequestHash] = g
+	}
+	return m
+}
+
+// GenerateSting implements [soundgen.Generator] by replay.
+func (g *SoundGenerator) GenerateSting(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	return g.replay(soundKindSting, req)
+}
+
+// ComposeMusic implements [soundgen.Generator] by replay.
+func (g *SoundGenerator) ComposeMusic(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	return g.replay(soundKindMusic, req)
+}
+
+// replay hashes the request under kind, looks up the recorded generation, and
+// returns its metadata over stub bytes. The model folded into the hash is the
+// CASSETTE's recorded model for this kind (the replay generator has no live
+// client to ask), so a model bump re-records rather than silently matching.
+func (g *SoundGenerator) replay(kind string, req soundgen.Request) (soundgen.Result, error) {
+	// Try every recorded generation of this kind: the hash embeds the model,
+	// which replay only knows from the cassette itself.
+	for _, gen := range g.byHash {
+		if gen.Kind != kind {
+			continue
+		}
+		if HashSoundRequest(kind, gen.Model, req) == gen.RequestHash {
+			return soundgen.Result{
+				Data:        soundStubBytes(gen.RequestHash),
+				ContentType: gen.ContentType,
+				Model:       gen.Model,
+			}, nil
+		}
+	}
+	// Miss: name a computed hash so the diff against the cassette is obvious.
+	// Use the first same-kind recorded model as the candidate, else "".
+	model := ""
+	for _, gen := range g.byHash {
+		if gen.Kind == kind {
+			model = gen.Model
+			break
+		}
+	}
+	return soundgen.Result{}, fmt.Errorf(
+		"voicecassette: no %s generation for request hash %s in cassette %q (%d recorded); re-record with -tags=record",
+		kind, HashSoundRequest(kind, model, req), g.name, len(g.byHash),
+	)
+}
+
+// soundStubBytes returns the small deterministic stand-in audio for a replayed
+// generation (the TTS stub-cassette policy: real bytes are never pinned).
+func soundStubBytes(hash string) []byte {
+	return []byte("voicecassette-sound-stub:" + hash)
+}
+
+// HashSoundRequest returns the hex sha256 cassette key for one sound
+// generation: kind + model + target duration + prompt, marshalled to canonical
+// JSON (struct fields render in declaration order). Exported so the record
+// path and test helpers compute the same fingerprint.
+func HashSoundRequest(kind, model string, req soundgen.Request) string {
+	h := struct {
+		Kind       string `json:"kind"`
+		Model      string `json:"model"`
+		DurationMs int64  `json:"duration_ms"`
+		Prompt     string `json:"prompt"`
+	}{Kind: kind, Model: model, DurationMs: req.Duration.Milliseconds(), Prompt: req.Prompt}
+	b, err := json.Marshal(h)
+	if err != nil {
+		// Plain strings and an int64 cannot fail to marshal; a panic here means
+		// the hash shape itself changed incompatibly — fail loudly at the source
+		// (the HashLLMRequest posture).
+		panic(fmt.Sprintf("voicecassette: hash sound request: %v", err))
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/voice/voicecassette/sound_record.go
+++ b/pkg/voice/voicecassette/sound_record.go
@@ -1,0 +1,125 @@
+//go:build record
+
+package voicecassette
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen/elevenlabs"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadSound in -tags=record builds returns a [SoundRecorder] that proxies
+// every generation to a live ElevenLabs client (ELEVENLABS_API_KEY supplies
+// credentials), captures the request hash + response metadata, DISCARDS the
+// audio bytes from the cassette (the TTS stub-cassette policy — the caller
+// still receives them, so the test under record mode exercises real provider
+// output), and rewrites tests/voice-cassettes/<name>.yaml at test cleanup.
+// Any existing cassette's Notes and leading header comments are preserved
+// with an idempotent dated provenance line.
+func LoadSound(t *testing.T, name string) soundgen.Generator {
+	t.Helper()
+	existing, _ := loadSoundCassetteFromDisk(t, name, false)
+	r := &SoundRecorder{
+		name:     name,
+		client:   elevenlabs.New(""),
+		existing: existing,
+	}
+	t.Cleanup(func() {
+		if err := r.write(); err != nil {
+			t.Fatalf("voicecassette.LoadSound(%q): record write: %v", name, err)
+		}
+	})
+	return r
+}
+
+// SoundRecorder is the -tags=record counterpart to [SoundGenerator]: it
+// forwards every call to a live [elevenlabs.Client], returns the real result
+// to the caller, and appends a keyed [SoundGeneration] so the cassette can be
+// rewritten at cleanup.
+type SoundRecorder struct {
+	name     string
+	client   *elevenlabs.Client
+	existing SoundCassette
+
+	mu          sync.Mutex
+	generations []SoundGeneration
+	// recModels names the models that produced the recorded bytes for the
+	// provenance stamp (record_notes.go invariant: the stamp never lies).
+	recModels map[string]bool
+}
+
+// GenerateSting implements [soundgen.Generator] by live forward + capture.
+func (r *SoundRecorder) GenerateSting(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	res, err := r.client.GenerateSting(ctx, req)
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("voicecassette: SoundRecorder live GenerateSting for cassette %q: %w", r.name, err)
+	}
+	r.capture(soundKindSting, req, res)
+	return res, nil
+}
+
+// ComposeMusic implements [soundgen.Generator] by live forward + capture.
+func (r *SoundRecorder) ComposeMusic(ctx context.Context, req soundgen.Request) (soundgen.Result, error) {
+	res, err := r.client.ComposeMusic(ctx, req)
+	if err != nil {
+		return soundgen.Result{}, fmt.Errorf("voicecassette: SoundRecorder live ComposeMusic for cassette %q: %w", r.name, err)
+	}
+	r.capture(soundKindMusic, req, res)
+	return res, nil
+}
+
+func (r *SoundRecorder) capture(kind string, req soundgen.Request, res soundgen.Result) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.generations = append(r.generations, SoundGeneration{
+		RequestHash: HashSoundRequest(kind, res.Model, req),
+		Kind:        kind,
+		Model:       res.Model,
+		ContentType: res.ContentType,
+	})
+	if r.recModels == nil {
+		r.recModels = map[string]bool{}
+	}
+	r.recModels[res.Model] = true
+}
+
+// write serialises the captured generations to
+// tests/voice-cassettes/<name>.yaml, preserving the existing Notes (idempotent
+// dated provenance) and re-prepending the hand-authored header block
+// yaml.Marshal drops. A no-op if no generation was captured, so recording a
+// test that never dispatched cannot clobber a fixture.
+func (r *SoundRecorder) write() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.generations) == 0 {
+		return nil
+	}
+	models := ""
+	for m := range r.recModels {
+		if models != "" {
+			models += "+"
+		}
+		models += m
+	}
+	out := SoundCassette{
+		Generations: r.generations,
+		Notes:       appendProvenance(r.existing.Notes, "ElevenLabs", models),
+	}
+	body, err := yaml.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshal cassette: %w", err)
+	}
+	data := append([]byte(leadingComment(r.name)), body...)
+	path := filepath.Join(cassettesDir(), r.name+".yaml")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/voice/voicecassette/sound_replay.go
+++ b/pkg/voice/voicecassette/sound_replay.go
@@ -1,0 +1,25 @@
+//go:build !record
+
+package voicecassette
+
+import (
+	"testing"
+
+	"github.com/MrWong99/Glyphoxa/pkg/voice/soundgen"
+)
+
+// LoadSound reads tests/voice-cassettes/<name>.yaml and returns a
+// [soundgen.Generator] that replays it.
+//
+// Default (replay) build: returns a [*SoundGenerator] that hashes each request
+// it is handed (kind + model + duration + prompt) and replays the recorded
+// generation's metadata over deterministic stub bytes — the audio itself is
+// never pinned (the TTS stub-cassette policy, ADR-0021). Missing, malformed,
+// or empty cassettes — and any unrecorded request hash — fail the test, so a
+// prompt-derivation change is caught. To rewrite a cassette against the live
+// ElevenLabs endpoints, rebuild with `-tags=record` — see sound_record.go.
+func LoadSound(t *testing.T, name string) soundgen.Generator {
+	t.Helper()
+	c, _ := loadSoundCassetteFromDisk(t, name, true)
+	return &SoundGenerator{name: name, byHash: indexSoundByHash(c)}
+}

--- a/proto/glyphoxa/management/v1/management.proto
+++ b/proto/glyphoxa/management/v1/management.proto
@@ -2239,6 +2239,17 @@ service SessionService {
   // ADR-0048), returning nothing (#308). A missing/foreign id is CodeNotFound.
   // State-changing: CSRF + auth guard it.
   rpc DeleteHighlight(DeleteHighlightRequest) returns (DeleteHighlightResponse);
+  // SetHighlightSound records the GM's "Add sound" choice on a PROMOTED
+  // Highlight (#312, Epic 8, ADR-0004 amendment): kind "sting" or "music"
+  // clears any previously landed sound and schedules an async ElevenLabs
+  // generation (re-running regenerates or changes the choice); kind ""
+  // removes the sound entirely (None, the default). The generated asset
+  // attaches as a separate blob served from GET /highlights/{id}/sound. A
+  // still-candidate Highlight is CodeFailedPrecondition (sound is opt-in
+  // after promotion); an unknown kind is CodeInvalidArgument; a
+  // missing/foreign/cross-campaign id is CodeNotFound. State-changing (spends
+  // provider money): CSRF + auth guard it.
+  rpc SetHighlightSound(SetHighlightSoundRequest) returns (SetHighlightSoundResponse);
   // ListShareChannels lists the deployment guild's text channels the GM can post a
   // Highlight file into, plus the Active Campaign's last-chosen channel so the share
   // dialog pre-selects it (#310, Epic 8, ADR-0051). A read (NO_SIDE_EFFECTS); a
@@ -2298,6 +2309,22 @@ message Highlight {
   string image_content_type = 15;
   // image_size_bytes is the stored image's size in bytes (0 when no image yet).
   int64 image_size_bytes = 16;
+  // sound_kind is the GM's standing "Add sound" choice (#312): "sting",
+  // "music", or "" (none requested — the default). A set kind with an empty
+  // sound_content_type means the generation is pending (or failed /
+  // unconfigured — the row stays intact without media).
+  string sound_kind = 17;
+  // sound_content_type is the generated sound's MIME type; empty means no
+  // sound landed yet. The audio bytes are served through
+  // GET /highlights/{id}/sound; the blob key is NEVER exposed (clip_key
+  // posture).
+  string sound_content_type = 18;
+  // sound_size_bytes is the stored sound's size in bytes (0 when none yet).
+  int64 sound_size_bytes = 19;
+  // sound_requested_at is when the GM last ran the Add-sound action; unset
+  // when sound_kind is "". The web tier bounds its await-media polling on it
+  // (the promoted_at/image pattern).
+  google.protobuf.Timestamp sound_requested_at = 20;
 }
 
 // ListHighlightsRequest names the Voice Session whose Highlights to list.
@@ -2344,6 +2371,24 @@ message DeleteHighlightRequest {
 
 // DeleteHighlightResponse is empty; the delete cascades the clip through the seam.
 message DeleteHighlightResponse {}
+
+// SetHighlightSoundRequest names the promoted Highlight and the GM's sound
+// choice (#312).
+message SetHighlightSoundRequest {
+  // id is the promoted Highlight to set the sound choice on.
+  string id = 1;
+  // kind is "sting" (a short sound-effect sting), "music" (a composed
+  // instrumental track), or "" (remove the sound — None).
+  string kind = 2;
+}
+
+// SetHighlightSoundResponse carries the updated Highlight: the recorded choice
+// with the sound triad cleared (the generation lands asynchronously; poll
+// ListHighlights for sound_content_type to fill).
+message SetHighlightSoundResponse {
+  // highlight is the updated row.
+  Highlight highlight = 1;
+}
 
 // ListShareChannelsRequest is empty: the guild is the deployment's single Discord
 // guild and the Campaign is resolved server-side (ADR-0039).

--- a/tests/voice-cassettes/README.md
+++ b/tests/voice-cassettes/README.md
@@ -44,6 +44,20 @@ Per [ADR-0021](../../docs/adr/0021-cassette-based-llm-determinism.md), TTS casse
 
 The TTS cassette intentionally does not pin Voice, provider, or settings — the cassette is a contract on the **text** that flowed into the provider interface, which is what the orchestrator and Persona layer are responsible for producing.
 
+## Sound cassette schema
+
+```yaml
+generations:                 # required — one entry per Generator call, matched by hash
+  - request_sha256: <hex>    #   required — sha256 of {kind, model, duration_ms, prompt}
+    kind: sting|music        #   required — which soundgen.Generator method the call hit
+    model: <model-id>        #   required — the model that produced the recorded response
+    content_type: audio/mpeg #   required — the response's MIME type
+notes: |                     # optional — provenance for human reviewers
+  Free-form: provider, model, recording date, hand-authored vs live, etc.
+```
+
+Sound cassettes (`sound-*.yaml`, #312) back the Highlight sound-enrichment tests. Like the LLM cassette they are **hash-keyed**, not positional: `request_sha256` is computed by `voicecassette.HashSoundRequest` over the kind, model, target duration, and prompt, so a prompt-derivation or duration-clamp change misses and fails the test rather than silently replaying a stale asset. Like the TTS cassette they are **stub cassettes**: the generated audio bytes are never pinned (replay returns small deterministic stand-in bytes); the cassette is a contract on the request that flowed into the provider plus the response's content type.
+
 ## Workflow
 
 **Replay (default).** `go test ./...` reads cassettes from this directory; the cassette is the authoritative expectation. Sub-second, free, deterministic.

--- a/tests/voice-cassettes/sound-highlight-dragon.yaml
+++ b/tests/voice-cassettes/sound-highlight-dragon.yaml
@@ -1,0 +1,17 @@
+# Sound-generation cassette for the Highlight sound-enrichment tests (#312):
+# the natural-twenty dragon-kill fixture (the llm-highlight-dragon scenario)
+# with a 15s clip, once as a Sting (clip-length duration) and once as Music
+# (the 30s full-track floor). A STUB cassette (ADR-0021): it pins the request
+# fingerprint (kind + model + duration + prompt) and the response's content
+# type — never the audio bytes. Hand-authored; re-record against the live
+# endpoints with ELEVENLABS_API_KEY=… go test -tags=record ./internal/highlight/.
+generations:
+    - request_sha256: 5217adda9d1a52837dda7ae12e1ac368edea8f81526081e4d51ed3a4e6c8fd81
+      kind: sting
+      model: eleven_text_to_sound_v2
+      content_type: audio/mpeg
+    - request_sha256: fa10aa58ca9306b69dc45f86d5f598dc426d9dd52c7d549a79c619e18db3f465
+      kind: music
+      model: music_v1
+      content_type: audio/mpeg
+notes: 'Hand-authored sound-enrichment fixture (#312): pins the prompt derivation and clip-derived durations for the dragon-kill Highlight. Not a live recording.'

--- a/web/src/i18n/messages/session.ts
+++ b/web/src/i18n/messages/session.ts
@@ -95,6 +95,21 @@ export const en = {
   "session.couldntPromote": "Couldn't promote the highlight: {message}",
   "session.couldntDelete": "Couldn't delete the highlight: {message}",
 
+  // --- Highlight sound (#312) ------------------------------------------------
+  "session.addSound": "Add sound",
+  "session.soundChoice": "Sound: {kind}",
+  "session.soundMenuLabel": "Highlight sound",
+  "session.soundHint":
+    "Generate a matching sound for this highlight — a short sting to layer under the clip, or an instrumental music theme.",
+  "session.soundSting": "Sting",
+  "session.soundMusic": "Music",
+  "session.removeSound": "Remove sound",
+  "session.soundClipLabel": "Generated sound",
+  "session.soundPending": "Generating a matching sound…",
+  "session.soundRequested": "Generating a matching sound — it appears here shortly.",
+  "session.soundRemoved": "Sound removed.",
+  "session.couldntSetSound": "Couldn't update the highlight sound: {message}",
+
   // --- Share-highlight dialog ------------------------------------------------
   "session.share": "Share",
   "session.shareGroupLabel": "Share this highlight",
@@ -207,6 +222,20 @@ export const de: Record<keyof typeof en, string> = {
   "session.deleteHighlightConfirm": "Highlight löschen",
   "session.couldntPromote": "Highlight konnte nicht übernommen werden: {message}",
   "session.couldntDelete": "Highlight konnte nicht gelöscht werden: {message}",
+
+  "session.addSound": "Sound hinzufügen",
+  "session.soundChoice": "Sound: {kind}",
+  "session.soundMenuLabel": "Highlight-Sound",
+  "session.soundHint":
+    "Erzeuge einen passenden Sound für dieses Highlight — einen kurzen Sting, der unter den Clip gelegt wird, oder ein instrumentales Musik-Thema.",
+  "session.soundSting": "Sting",
+  "session.soundMusic": "Musik",
+  "session.removeSound": "Sound entfernen",
+  "session.soundClipLabel": "Erzeugter Sound",
+  "session.soundPending": "Passender Sound wird erzeugt…",
+  "session.soundRequested": "Passender Sound wird erzeugt — er erscheint hier in Kürze.",
+  "session.soundRemoved": "Sound entfernt.",
+  "session.couldntSetSound": "Highlight-Sound konnte nicht geändert werden: {message}",
 
   "session.share": "Teilen",
   "session.shareGroupLabel": "Dieses Highlight teilen",

--- a/web/src/screens/session/HighlightSoundMenu.test.tsx
+++ b/web/src/screens/session/HighlightSoundMenu.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { createRouterTransport, ConnectError, Code } from "@connectrpc/connect";
+import { create, type MessageInitShape } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+  Toaster: () => null,
+}));
+
+import { toast } from "sonner";
+
+import {
+  SessionService,
+  HighlightSchema,
+  ListHighlightsResponseSchema,
+  SetHighlightSoundResponseSchema,
+  type Highlight,
+  type SetHighlightSoundRequest,
+} from "@gen/glyphoxa/management/v1/management_pb";
+import { Providers } from "@/app/Providers";
+import { makeQueryClient } from "@/lib/queryClient";
+import { HighlightsStrip } from "./HighlightsStrip";
+
+type HighlightInit = MessageInitShape<typeof HighlightSchema>;
+
+function promoted(over: HighlightInit = {}): Highlight {
+  return create(HighlightSchema, {
+    id: "h2",
+    voiceSessionId: "vs1",
+    status: "promoted",
+    startsAt: timestampFromDate(new Date("2026-07-11T20:15:30Z")),
+    endsAt: timestampFromDate(new Date("2026-07-11T20:16:10Z")),
+    score: 8.5,
+    excerpt: "And then the dragon spoke my true name.",
+    reason: "Dramatic reveal — party fell silent.",
+    clipContentType: "audio/wav",
+    clipSizeBytes: 12345n,
+    ...over,
+  });
+}
+
+// An in-memory transport whose setHighlightSound records the request, mutates
+// the closure the ShareHighlightDialog-style expand group refetches, and can
+// fail with the server's unconfigured FailedPrecondition.
+function soundTransport(seed: Highlight[], opts: { failSound?: boolean } = {}) {
+  let highlights = [...seed];
+  const soundCalls: SetHighlightSoundRequest[] = [];
+  const transport = createRouterTransport(({ service }) => {
+    service(SessionService, {
+      listHighlights: () => create(ListHighlightsResponseSchema, { highlights }),
+      setHighlightSound: (req) => {
+        soundCalls.push(req);
+        if (opts.failSound) {
+          throw new ConnectError(
+            "sound generation requires an ElevenLabs tts provider configuration",
+            Code.FailedPrecondition,
+          );
+        }
+        highlights = highlights.map((h) =>
+          h.id === req.id
+            ? create(HighlightSchema, {
+                ...h,
+                soundKind: req.kind,
+                soundContentType: "",
+                soundSizeBytes: 0n,
+                soundRequestedAt:
+                  req.kind === "" ? undefined : timestampFromDate(new Date()),
+              })
+            : h,
+        );
+        return create(SetHighlightSoundResponseSchema, {
+          highlight: highlights.find((h) => h.id === req.id),
+        });
+      },
+    });
+  });
+  return { transport, soundCalls };
+}
+
+function renderStrip(seed: Highlight[], opts?: { failSound?: boolean }) {
+  const ctx = soundTransport(seed, opts);
+  render(
+    <Providers transport={ctx.transport} queryClient={makeQueryClient()}>
+      <HighlightsStrip sessionId="vs1" live={false} />
+    </Providers>,
+  );
+  return ctx;
+}
+
+describe("HighlightSoundMenu (#312)", () => {
+  it("requests a sting through SetHighlightSound and flips the row to the pending state", async () => {
+    const ctx = renderStrip([promoted()]);
+    fireEvent.click(await screen.findByRole("button", { name: /add sound/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /^sting$/i }));
+
+    await waitFor(() => expect(ctx.soundCalls).toHaveLength(1));
+    expect(ctx.soundCalls[0].id).toBe("h2");
+    expect(ctx.soundCalls[0].kind).toBe("sting");
+    expect(toast.success).toHaveBeenCalled();
+    // The invalidated list refetch lands the requested-but-unlanded state.
+    expect(await screen.findByTestId("sound-pending")).toBeInTheDocument();
+  });
+
+  it("renders the generated sound as a second audio element once it lands", async () => {
+    renderStrip([
+      promoted({
+        soundKind: "music",
+        soundContentType: "audio/mpeg",
+        soundSizeBytes: 999n,
+        soundRequestedAt: timestampFromDate(new Date()),
+      }),
+    ]);
+    await screen.findByText(/the dragon spoke my true name/i);
+    const audios = document.querySelectorAll("audio");
+    expect(audios).toHaveLength(2);
+    expect(audios[1]).toHaveAttribute("src", "/api/v1/highlights/h2/sound");
+    // Landed: no pending note.
+    expect(screen.queryByTestId("sound-pending")).toBeNull();
+  });
+
+  it("offers Remove only once a choice exists, and clears it via kind \"\"", async () => {
+    const ctx = renderStrip([
+      promoted({
+        soundKind: "sting",
+        soundContentType: "audio/mpeg",
+        soundRequestedAt: timestampFromDate(new Date()),
+      }),
+    ]);
+    // The collapsed button names the standing choice.
+    fireEvent.click(await screen.findByRole("button", { name: /sound: sting/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /remove sound/i }));
+
+    await waitFor(() => expect(ctx.soundCalls).toHaveLength(1));
+    expect(ctx.soundCalls[0].kind).toBe("");
+    // After the refetch the choice is gone: the action reads Add sound again.
+    expect(await screen.findByRole("button", { name: /add sound/i })).toBeInTheDocument();
+  });
+
+  it("does not render the sound action on candidates (sound is opt-in after promotion)", async () => {
+    renderStrip([promoted({ id: "h1", status: "candidate" })]);
+    await screen.findByText(/the dragon spoke my true name/i);
+    expect(screen.queryByRole("button", { name: /add sound/i })).toBeNull();
+  });
+
+  it("surfaces the server's unconfigured refusal as an error toast", async () => {
+    renderStrip([promoted()], { failSound: true });
+    fireEvent.click(await screen.findByRole("button", { name: /add sound/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /^music$/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(String(vi.mocked(toast.error).mock.calls.at(-1)?.[0])).toMatch(/ElevenLabs/i);
+  });
+});

--- a/web/src/screens/session/HighlightSoundMenu.tsx
+++ b/web/src/screens/session/HighlightSoundMenu.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { useMutation } from "@connectrpc/connect-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Music, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { SessionService } from "@gen/glyphoxa/management/v1/management_pb";
+import type { Highlight } from "@gen/glyphoxa/management/v1/management_pb";
+import { Button } from "@/components/ui/Button";
+import { invalidateMethodQueries } from "@/lib/queryClient";
+import { useI18n } from "@/i18n";
+
+// HighlightSoundMenu is the GM's opt-in "Add sound" action for ONE promoted
+// Session Highlight (#312, Epic 8): pick a Sting (a short sound effect layered
+// under the clip) or a Music track (a composed instrumental theme), generated
+// asynchronously by ElevenLabs and attached as a separate audio next to the
+// clip. None is the default; re-running the action regenerates or changes the
+// choice, and Remove clears it — all usable any time after promotion, from the
+// live strip or the archive alike (the strip renders it wherever it renders).
+//
+// The dialog is the ShareHighlightDialog expand-in-place shape: collapsed to a
+// single button, expanded to a compact labeled group. An unconfigured tenant
+// (no ElevenLabs tts provider) gets the server's FailedPrecondition surfaced
+// as a toast at click time, never a silent forever-pending state.
+export function HighlightSoundMenu({ highlight }: { highlight: Highlight }) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  // A choice must refresh the list read (the single state tree, ADR-0018): the
+  // sound triad clears server-side and the strip's pending state keys off it.
+  const invalidate = () =>
+    void invalidateMethodQueries(queryClient, SessionService.method.listHighlights);
+
+  const setSound = useMutation(SessionService.method.setHighlightSound, {
+    onSuccess: () => {
+      invalidate();
+      setOpen(false);
+    },
+    onError: (err: Error) => toast.error(t("session.couldntSetSound", { message: err.message })),
+  });
+
+  const choose = (kind: string) => {
+    setSound.mutate(
+      { id: highlight.id, kind },
+      {
+        onSuccess: () =>
+          toast.success(kind === "" ? t("session.soundRemoved") : t("session.soundRequested")),
+      },
+    );
+  };
+
+  const hasChoice = highlight.soundKind !== "";
+  if (!open) {
+    return (
+      <Button
+        variant="secondary"
+        size="sm"
+        iconStart={<Music size={14} />}
+        onClick={() => setOpen(true)}
+      >
+        {hasChoice
+          ? t("session.soundChoice", {
+              kind:
+                highlight.soundKind === "music" ? t("session.soundMusic") : t("session.soundSting"),
+            })
+          : t("session.addSound")}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="gx-highlight-sound" role="group" aria-label={t("session.soundMenuLabel")}>
+      <p className="gx-highlight-sound__hint">{t("session.soundHint")}</p>
+      <div className="gx-highlight-sound__choices">
+        <Button
+          variant={highlight.soundKind === "sting" ? "primary" : "secondary"}
+          size="sm"
+          onClick={() => choose("sting")}
+          disabled={setSound.isPending}
+        >
+          {t("session.soundSting")}
+        </Button>
+        <Button
+          variant={highlight.soundKind === "music" ? "primary" : "secondary"}
+          size="sm"
+          onClick={() => choose("music")}
+          disabled={setSound.isPending}
+        >
+          {t("session.soundMusic")}
+        </Button>
+        {hasChoice && (
+          <Button
+            variant="ghost"
+            size="sm"
+            iconStart={<Trash2 size={14} />}
+            onClick={() => choose("")}
+            disabled={setSound.isPending}
+          >
+            {t("session.removeSound")}
+          </Button>
+        )}
+        <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+          {t("common.close")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/screens/session/HighlightsStrip.tsx
+++ b/web/src/screens/session/HighlightsStrip.tsx
@@ -14,6 +14,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { invalidateMethodQueries } from "@/lib/queryClient";
 import { useI18n, type Lang } from "@/i18n";
 import { formatClock } from "./useSessionEvents";
+import { HighlightSoundMenu } from "./HighlightSoundMenu";
 import { useHighlights } from "./useHighlights";
 
 // clipClock renders a Highlight bound (starts_at/ends_at) as an "HH:MM:SS" clock,
@@ -189,6 +190,24 @@ export function HighlightsStrip({
                 loading="lazy"
               />
             )}
+            {/* Generated sound (#312): a separate audio next to the clip — the
+                attach-as-blob decision, layered/offered client-side, zero DSP.
+                A requested-but-unlanded sound shows a pending note instead
+                (generating, or failed/unconfigured — re-run or Remove clears it). */}
+            {h.soundContentType !== "" && (
+              <audio
+                className="gx-highlight__audio gx-highlight__sound"
+                controls
+                preload="none"
+                aria-label={t("session.soundClipLabel")}
+                src={`/api/v1/highlights/${h.id}/sound`}
+              />
+            )}
+            {h.soundKind !== "" && h.soundContentType === "" && (
+              <p className="gx-highlight__sound-pending" data-testid="sound-pending">
+                {t("session.soundPending")}
+              </p>
+            )}
             <div className="gx-highlight__actions">
               {isCandidate && (
                 <Button
@@ -211,6 +230,9 @@ export function HighlightsStrip({
               >
                 {t("common.delete")}
               </Button>
+              {/* Sound is opt-in AFTER promotion (#312), so the action renders
+                  on promoted rows only — everywhere the strip renders them. */}
+              {!isCandidate && <HighlightSoundMenu highlight={h} />}
               {renderActions?.(h)}
             </div>
           </li>

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -667,6 +667,38 @@
   align-items: flex-start;
 }
 
+/* Generated highlight sound (#312): the requested-but-unlanded note under the
+ * players, and the Add-sound choice panel (the share panel's compact shape). */
+.gx-highlight__sound-pending {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-subtle);
+}
+
+.gx-highlight-sound {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius-md, 8px);
+  background: var(--surface-inset);
+  width: 100%;
+}
+
+.gx-highlight-sound__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-subtle);
+}
+
+.gx-highlight-sound__choices {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 /* Highlight share surface (#310): the GM's Discord-delivery panel, opened from the
  * per-row Share action. A compact column so the channel picker, replay, and
  * download read as one group. */

--- a/web/src/screens/session/useHighlights.test.ts
+++ b/web/src/screens/session/useHighlights.test.ts
@@ -12,11 +12,22 @@ import {
 
 const NOW = 1_800_000_000_000;
 
-const hl = (fields: { status: string; imageContentType?: string; promotedMs?: number }) =>
+const hl = (fields: {
+  status: string;
+  imageContentType?: string;
+  promotedMs?: number;
+  soundKind?: string;
+  soundContentType?: string;
+  soundRequestedMs?: number;
+}) =>
   create(HighlightSchema, {
     status: fields.status,
     imageContentType: fields.imageContentType ?? "",
     promotedAt: fields.promotedMs != null ? timestampFromMs(fields.promotedMs) : undefined,
+    soundKind: fields.soundKind ?? "",
+    soundContentType: fields.soundContentType ?? "",
+    soundRequestedAt:
+      fields.soundRequestedMs != null ? timestampFromMs(fields.soundRequestedMs) : undefined,
   });
 
 describe("highlightsRefetchInterval (#309)", () => {
@@ -72,5 +83,61 @@ describe("highlightsRefetchInterval (#309)", () => {
 
   it("does not poll an ended session with an empty highlight list", () => {
     expect(highlightsRefetchInterval(false, [], NOW)).toBe(false);
+  });
+
+  // --- Sound await-media window (#312) ---------------------------------------
+
+  const imaged = {
+    status: "promoted",
+    imageContentType: "image/png",
+    promotedMs: NOW - IMAGE_WAIT_MAX_MS - 1,
+  };
+
+  it("polls when a promoted highlight has a freshly-requested, unlanded sound", () => {
+    expect(
+      highlightsRefetchInterval(
+        false,
+        [hl({ ...imaged, soundKind: "sting", soundContentType: "", soundRequestedMs: NOW - 30_000 })],
+        NOW,
+      ),
+    ).toBe(HIGHLIGHTS_IMAGE_MS);
+  });
+
+  it("stops polling once the sound-wait window has elapsed", () => {
+    expect(
+      highlightsRefetchInterval(
+        false,
+        [
+          hl({
+            ...imaged,
+            soundKind: "music",
+            soundContentType: "",
+            soundRequestedMs: NOW - IMAGE_WAIT_MAX_MS - 1,
+          }),
+        ],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("stops polling once the requested sound has landed", () => {
+    expect(
+      highlightsRefetchInterval(
+        false,
+        [
+          hl({
+            ...imaged,
+            soundKind: "sting",
+            soundContentType: "audio/mpeg",
+            soundRequestedMs: NOW - 30_000,
+          }),
+        ],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not wait on a highlight with no sound requested", () => {
+    expect(highlightsRefetchInterval(false, [hl(imaged)], NOW)).toBe(false);
   });
 });

--- a/web/src/screens/session/useHighlights.ts
+++ b/web/src/screens/session/useHighlights.ts
@@ -32,7 +32,8 @@ export const IMAGE_WAIT_MAX_MS = 10 * 60_000;
 // test (mirrors sessionRefetchInterval, Session.tsx). While live, poll to catch
 // promotions as they happen — even on an empty list, since the FIRST highlight
 // must appear. Once ended, poll only while a promoted Highlight is still WITHIN
-// the post-promotion image-wait window; otherwise the list is settled, so stop.
+// an await-media window — its post-promotion image wait (#311) or its
+// post-request sound wait (#312) — otherwise the list is settled, so stop.
 export function highlightsRefetchInterval(
   live: boolean,
   highlights: Highlight[],
@@ -40,15 +41,24 @@ export function highlightsRefetchInterval(
 ): number | false {
   if (live) return HIGHLIGHTS_LIVE_MS;
   if (highlights.length === 0) return false;
-  const awaitingImage = highlights.some((h) => {
-    if (h.status !== "promoted" || h.imageContentType !== "") return false;
-    // Only a RECENTLY-promoted image-less Highlight is worth waiting on; an
-    // unset promotedAt (shouldn't happen for a promoted row) is treated as not
-    // waiting rather than waiting forever.
-    const promotedMs = h.promotedAt ? Number(timestampMs(h.promotedAt)) : null;
-    return promotedMs != null && now - promotedMs < IMAGE_WAIT_MAX_MS;
+  const awaitingMedia = highlights.some((h) => {
+    if (h.status !== "promoted") return false;
+    // Image (#311): only a RECENTLY-promoted image-less Highlight is worth
+    // waiting on; an unset promotedAt (shouldn't happen for a promoted row) is
+    // treated as not waiting rather than waiting forever.
+    if (h.imageContentType === "") {
+      const promotedMs = h.promotedAt ? Number(timestampMs(h.promotedAt)) : null;
+      if (promotedMs != null && now - promotedMs < IMAGE_WAIT_MAX_MS) return true;
+    }
+    // Sound (#312): a requested-but-unlanded sound waits the same window,
+    // keyed on the request stamp (re-running Add sound re-opens it).
+    if (h.soundKind !== "" && h.soundContentType === "") {
+      const requestedMs = h.soundRequestedAt ? Number(timestampMs(h.soundRequestedAt)) : null;
+      if (requestedMs != null && now - requestedMs < IMAGE_WAIT_MAX_MS) return true;
+    }
+    return false;
   });
-  return awaitingImage ? HIGHLIGHTS_IMAGE_MS : false;
+  return awaitingMedia ? HIGHLIGHTS_IMAGE_MS : false;
 }
 
 // useHighlights loads one Voice Session's Session Highlights (#308) into the


### PR DESCRIPTION
## What does this PR do?

Closes #312 (Epic 8, part of #257). Implements the maintainer decisions recorded on the issue (2026-07-22 grilling session) and the ADR-0004 amendment: a promoted Session Highlight gains an opt-in **Add sound** action that generates a matching audio asset via ElevenLabs — a **Sting** (sound-effects endpoint, clip-length ≤22s) or a **Music** track (instrumental, 30–60s) — attached as a **separate blob** at `t/<tenant>/highlight/<id>/sound` (zero DSP; the web UI offers it as a second player next to the clip). Re-running the action regenerates or changes the choice; *None* removes it.

- **Endpoint wrapper** (sibling of the tts/stt ElevenLabs packages): `pkg/voice/soundgen` (provider-neutral `Generator`, single `ErrNotConfigured` sentinel) + `pkg/voice/soundgen/elevenlabs` (`POST /v1/sound-generation`, `POST /v1/music`, typed `providererr.HTTPError`, bounded reads, generation-scale header timeout).
- **Cassette family**: `voicecassette.LoadSound` / `HashSoundRequest` — hash-keyed like the LLM cassette, stub-audio like the TTS one — with record/replay build-tag pair, the `sound-highlight-dragon` fixture, and a cassette-driven test of the whole enrichment handler.
- **Storage**: migration `00054` (`sound_kind`/`sound_requested_at`/key/content-type/size + claim column), conditional land (`WHERE sound_kind` still matches, so a superseded choice never lands the wrong asset), #406-pattern claim pair, kind-aware boot-sweep query, third UNION arm in the campaign blob sweep.
- **Job**: `highlight.enrich_sound` handler — idempotent + at-least-once, clean not-configured no-op, dead-letter recovery posture (mirrors the image handler's rationale), compensation only when the row is truly gone, claim released on success so quick regenerations never wait out the TTL.
- **Key policy** (ADR-0004 amendment): `newSoundFactory` rides the Tenant's existing `tts` Provider Config **iff** the provider is ElevenLabs — deliberately **no new Component**; anything else is a clean not-configured state, surfaced as an actionable `FailedPrecondition` at click time by the RPC's precheck.
- **RPC/proto**: `SetHighlightSound` (promoted-only, kind validated, `""` removes with blob-then-row delete), sound fields on the `Highlight` wire view (blob key never exposed), sound blob delete on `DeleteHighlight`, guarded `GET /api/v1/highlights/{id}/sound` byte mount (`TenantRequired`, pinned in the mount-policy test).
- **Metering** (ADR-0046 amendment included): model-keyed `soundPricePerMinute` + `EstimateSoundUSD` with the conservative-fallback posture; per-generation Usage-Ledger flush attributing under component `tts` with the SFX/Music model id and the vendor's `character-cost` as quantity.
- **Web**: Add-sound menu on promoted highlight cards (everywhere the strip renders, archive included), second `<audio>` player off the new byte route, "generating…" pending state, await-media polling bound on `sound_requested_at`, full en/de strings.

## Why is this change needed?

It completes highlight media enrichment part 2 (#312) — the last backlog slice of Epic 8 that was fully specified and marked `ready-for-agent`. Highlights currently get an automatic AI image; this adds the GM-controlled audio layer the epic scoped, without new provider key surface or DSP complexity.

## How was this tested?

- [x] `make check` passes (gofmt, `go vet`, `go test -race -count=1 ./...` — full suite green; CGO on)
- [x] New/updated tests cover the change
- [ ] Manual testing (describe below if applicable)

New coverage: adapter httptest suite (request shapes, duration clamps, typed errors, no-audio guard); handler decision-ladder tests (skips, not-configured, provider-error dead-letter, land-miss disambiguation, claim release-on-success); the sound cassette end-to-end test; sweep re-enqueue test; RPC tests (happy path, remove, candidate/unconfigured/invalid-kind/unwired/cross-campaign refusals); `ServeSound` route tests (200/206/404/401 postures); price-map and ledger-attribution tests; integration-tagged storage tests for every new query (run in CI — no Docker in this environment); web tests for the sound menu, pending state, players, and polling policy (`npm test`: the one failure, `src/lib/download.test.ts`, fails identically on a clean checkout of `main` in this environment — pre-existing, unrelated).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [x] All tests pass with `go test -race ./...`
- [x] I have updated documentation if needed (ADR-0046 amendment; cassette README schema section)
- [x] All exported symbols have Godoc comments
- [x] My commits are focused and have clear messages

## Additional Notes

- **Migration**: `00054_highlight_sound.sql` — plain `ALTER TABLE ADD COLUMN` with defaults, no enum change (the whole point of the ADR-0004 decision), safe on existing data.
- **Cassette hashes**: the `sound-highlight-dragon` fixture is hand-authored (stub policy — no audio bytes pinned); a prompt-derivation or duration-clamp change fails the test and points at `-tags=record`.
- **One deliberate departure from the image handler**: the sound claim is released on *success*. Images never re-run (`ImageKey` blocks forever), but sound regeneration is a feature — a claim left stamped by a success would block the next request's job for the full 10-minute TTL, long enough for its retries to dead-letter. The commit comment documents this.
- **Prices are estimates** in the ADR-0046 sense (source-dated comments, conservative unknown-model fallback); the vendor's `character-cost` header is recorded in the ledger as the quantity for auditability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CQMUCDTthdytpzHu5XZSm

---
_Generated by [Claude Code](https://claude.ai/code/session_011CQMUCDTthdytpzHu5XZSm)_