### PR TITLE
feat(web): GFM pipe-table support in the markdown renderer

### DIFF
--- a/web/src/components/ui/Markdown.test.tsx
+++ b/web/src/components/ui/Markdown.test.tsx
@@ -219,6 +219,49 @@ describe("Markdown (block)", () => {
     expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
     expect(container.querySelector("p")?.textContent).toBe("The ogre attacks.");
   });
+
+  it("keeps a --- rule under prose whose only pipes are escaped or edge", () => {
+    // HR outranks the delimiter row: an escaped/edge pipe collapses to one
+    // splitRow cell, which must not pair with a bare "---" section divider
+    // into a one-column table that eats the rule.
+    for (const text of [
+      "Use `cat\\|dog` to match either.\n---\nMore prose.",
+      "| means OR in a regex.\n----",
+      "Progress: 80% done |\n---",
+    ]) {
+      const { container } = render(<Markdown text={text} />);
+      expect(container.querySelector("table")).toBeNull();
+      expect(container.querySelector("hr")).not.toBeNull();
+    }
+  });
+
+  it("still opens a single-column table from a piped delimiter row", () => {
+    const { container } = render(<Markdown text={"| a |\n| --- |\n| 1 |"} />);
+    expect(container.querySelector("thead th")?.textContent).toBe("a");
+  });
+
+  it("rejects a degenerate delimiter-shaped line in linear time", () => {
+    // TABLE_DELIM's backtracking regex is gone; a delimiter-shaped line with
+    // a huge whitespace run and one stray char must fail fast (the old regex
+    // went quadratic — >10s at this size, tripping the test timeout).
+    const { container } = render(
+      <Markdown text={"col a | col b\n|-" + " ".repeat(160000) + "x"} />,
+    );
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("breaks the table at a glued heading, list, or quote line that contains a pipe", () => {
+    const table = "| a | b |\n| --- | --- |\n| 1 | 2 |\n";
+    const heading = render(<Markdown text={table + "## Results | Summary"} />).container;
+    expect(heading.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(heading.querySelector(".gx-md__heading")?.textContent).toBe("Results | Summary");
+    const list = render(<Markdown text={table + "- note: `a | b` is a union"} />).container;
+    expect(list.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(list.querySelector("li code")?.textContent).toBe("a | b");
+    const quote = render(<Markdown text={table + "> caveat: a | b differs"} />).container;
+    expect(quote.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(quote.querySelector("blockquote")?.textContent).toBe("caveat: a | b differs");
+  });
 });
 
 describe("InlineMarkdown", () => {

--- a/web/src/components/ui/Markdown.test.tsx
+++ b/web/src/components/ui/Markdown.test.tsx
@@ -144,6 +144,81 @@ describe("Markdown (block)", () => {
     const { container } = render(<Markdown text="x" className="extra" />);
     expect(container.querySelector(".gx-md.extra")).not.toBeNull();
   });
+
+  it("renders a pipe table with a header row and body rows", () => {
+    const { container } = render(
+      <Markdown text={"| Name | HP |\n| --- | --- |\n| Bart | 12 |\n| Ogre | 40 |"} />,
+    );
+    const table = container.querySelector("table.gx-md__table");
+    expect(table).not.toBeNull();
+    const ths = [...container.querySelectorAll("thead th")].map((th) => th.textContent);
+    expect(ths).toEqual(["Name", "HP"]);
+    const rows = [...container.querySelectorAll("tbody tr")];
+    expect(rows).toHaveLength(2);
+    expect([...rows[0].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["Bart", "12"]);
+  });
+
+  it("accepts edge-pipe-less rows and renders inline markdown inside cells", () => {
+    const { container } = render(
+      <Markdown text={"Name | Notes\n--- | ---\n**Bart** | owes `20 gold`"} />,
+    );
+    expect(container.querySelector("tbody strong")?.textContent).toBe("Bart");
+    expect(container.querySelector("tbody code")?.textContent).toBe("20 gold");
+  });
+
+  it("carries column alignment from the delimiter row as data-align", () => {
+    const { container } = render(
+      <Markdown text={"| a | b | c |\n| :--- | :---: | ---: |\n| 1 | 2 | 3 |"} />,
+    );
+    const tds = [...container.querySelectorAll("tbody td")];
+    expect(tds.map((td) => td.getAttribute("data-align"))).toEqual(["left", "center", "right"]);
+    const ths = [...container.querySelectorAll("thead th")];
+    expect(ths[1].getAttribute("data-align")).toBe("center");
+  });
+
+  it("squares ragged body rows to the header's width", () => {
+    const { container } = render(
+      <Markdown text={"| a | b |\n| --- | --- |\n| short |\n| one | two | extra |"} />,
+    );
+    const rows = [...container.querySelectorAll("tbody tr")];
+    expect([...rows[0].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["short", ""]);
+    expect([...rows[1].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["one", "two"]);
+  });
+
+  it("treats an escaped pipe as a literal pipe inside a cell", () => {
+    const { container } = render(
+      <Markdown text={"| expr | value |\n| --- | --- |\n| a \\| b | union |"} />,
+    );
+    const tds = [...container.querySelectorAll("tbody td")].map((td) => td.textContent);
+    expect(tds).toEqual(["a | b", "union"]);
+  });
+
+  it("leaves a header/delimiter cell-count mismatch as prose", () => {
+    const { container } = render(<Markdown text={"| a | b |\n| --- |\n| 1 | 2 |"} />);
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.textContent).toContain("| a | b |");
+  });
+
+  it("does not turn a lone pipe-bearing paragraph into a table", () => {
+    const { container } = render(<Markdown text={"Either ambush | parley works."} />);
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("lets a table interrupt a paragraph glued above it", () => {
+    const { container } = render(
+      <Markdown text={"Initiative order:\n| Who | Roll |\n| --- | --- |\n| Bart | 17 |"} />,
+    );
+    expect(container.querySelector("p")?.textContent).toBe("Initiative order:");
+    expect(container.querySelector("table")).not.toBeNull();
+  });
+
+  it("ends the table at the first pipe-less line instead of swallowing prose", () => {
+    const { container } = render(
+      <Markdown text={"| a |\n| --- |\n| 1 |\nThe ogre attacks."} />,
+    );
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+    expect(container.querySelector("p")?.textContent).toBe("The ogre attacks.");
+  });
 });
 
 describe("InlineMarkdown", () => {
@@ -196,5 +271,11 @@ describe("stripMarkdown", () => {
 
   it("returns plain text unchanged", () => {
     expect(stripMarkdown("Bart owes the ogre 20 gold.")).toBe("Bart owes the ogre 20 gold.");
+  });
+
+  it("flattens a table to space-separated cell text", () => {
+    expect(stripMarkdown("| Name | HP |\n| --- | --- |\n| **Bart** | 12 |")).toBe(
+      "Name HP Bart 12",
+    );
   });
 });

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -120,10 +120,6 @@ const HEADING = /^ {0,3}(#{1,6})\s+(.*?)(?:\s+#+)?\s*$/;
 const HR = /^ {0,3}([-*_])\s*(?:\1\s*){2,}$/;
 const QUOTE = /^ {0,3}> ?(.*)$/;
 const LIST = /^(\s*)(?:([-*+])|(\d{1,9})[.)])\s+(.*)$/;
-// A GFM table's delimiter row: `:?-+:?` cells separated by pipes, edge pipes
-// optional. Matching this shape alone is not enough to open a table — see
-// tableStart for the header/delimiter cell-count agreement it also requires.
-const TABLE_DELIM = /^ {0,3}\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*)*\|?\s*$/;
 
 // listEntry parses one list-item line, or null. The ordered start number is
 // kept so "3. …" renders as 3, not silently renumbered from 1.
@@ -197,11 +193,14 @@ function splitRow(line: string): string[] {
 
 // tableStart decides whether a header line plus the line under it open a
 // table: the header must contain a pipe (a bare paragraph line never becomes
-// a table by accident), the next line must be a delimiter row, and — GFM's
-// rule — the two must agree on cell count, else both stay prose.
+// a table by accident), the next line must be a delimiter row — every splitRow
+// cell shaped `:?-+:?` — and, GFM's rule, the two must agree on cell count,
+// else both stay prose. A rule line ("---", "----") is never a delimiter row:
+// HR outranks the table exactly as it outranks the list, so prose whose pipes
+// are all escaped or edge (one splitRow cell) followed by a `---` section
+// divider keeps its <hr> instead of becoming a one-column table.
 function tableStart(header: string, delim: string | undefined): { header: string[]; align: Align[] } | null {
-  if (delim === undefined || !header.includes("|")) return null;
-  if (!TABLE_DELIM.test(delim)) return null;
+  if (delim === undefined || !header.includes("|") || HR.test(delim)) return null;
   const cells = splitRow(header);
   const delims = splitRow(delim);
   if (delims.length !== cells.length || !delims.every((d) => /^:?-+:?$/.test(d))) return null;
@@ -283,9 +282,21 @@ function parseBlocks(text: string, depth = 0): Block[] {
       // Body rows must contain a pipe: where GFM would sweep a following
       // prose line into the table as a one-cell row, chat models constantly
       // glue prose straight under a table, so the first pipe-less line ends
-      // it instead. Ragged rows are squared to the header (GFM): short rows
+      // it instead. The start of any other block ends it too (as in GFM) —
+      // the same guards the paragraph loop uses, so a glued "## Results |
+      // Summary" heading or a "- note: `a | b`" bullet is never swallowed as
+      // a data row. Ragged rows are squared to the header (GFM): short rows
       // pad with empty cells, long rows shed the excess.
-      while (i < lines.length && lines[i].trim() !== "" && lines[i].includes("|")) {
+      while (
+        i < lines.length &&
+        lines[i].trim() !== "" &&
+        lines[i].includes("|") &&
+        !FENCE_OPEN.test(lines[i]) &&
+        !HEADING.test(lines[i]) &&
+        !HR.test(lines[i]) &&
+        !QUOTE.test(lines[i]) &&
+        !listInterrupts(lines[i])
+      ) {
         const cells = splitRow(lines[i]).slice(0, table.header.length);
         while (cells.length < table.header.length) cells.push("");
         rows.push(cells);

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -17,10 +17,12 @@ import { Fragment, type ReactNode } from "react";
 //                    markdown" treatment where rendering can't apply.
 //
 // Deliberately unsupported: raw HTML (stays literal text), setext headings,
-// tables, images (an ![alt](url) renders as literal text — remote images from
+// images (an ![alt](url) renders as literal text — remote images from
 // model output would be a fetch to an attacker-chosen host), reference links,
 // and backslash escapes (model output in practice never uses them; a literal
-// `\*` therefore stays visible).
+// `\*` therefore stays visible). One exception: `\|` inside a table row reads
+// as a literal pipe — it's the only way GFM can put a | in a cell, and models
+// writing tables about code do emit it.
 
 // ── Inline grammar ──────────────────────────────────────────────────────────
 
@@ -98,12 +100,15 @@ type ListEntry = { indent: number; ordered: boolean; start: number; text: string
 type ListItem = { text: string; child: List | null };
 type List = { ordered: boolean; start: number; items: ListItem[] };
 
+type Align = "left" | "center" | "right" | null;
+
 type Block =
   | { kind: "p"; lines: string[] }
   | { kind: "heading"; level: number; text: string }
   | { kind: "fence"; lang: string; code: string }
   | { kind: "quote"; blocks: Block[] }
   | { kind: "list"; list: List }
+  | { kind: "table"; align: Align[]; header: string[]; rows: string[][] }
   | { kind: "hr" };
 
 const FENCE_OPEN = /^ {0,3}```([^`\n]*)$/;
@@ -115,6 +120,10 @@ const HEADING = /^ {0,3}(#{1,6})\s+(.*?)(?:\s+#+)?\s*$/;
 const HR = /^ {0,3}([-*_])\s*(?:\1\s*){2,}$/;
 const QUOTE = /^ {0,3}> ?(.*)$/;
 const LIST = /^(\s*)(?:([-*+])|(\d{1,9})[.)])\s+(.*)$/;
+// A GFM table's delimiter row: `:?-+:?` cells separated by pipes, edge pipes
+// optional. Matching this shape alone is not enough to open a table — see
+// tableStart for the header/delimiter cell-count agreement it also requires.
+const TABLE_DELIM = /^ {0,3}\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*)*\|?\s*$/;
 
 // listEntry parses one list-item line, or null. The ordered start number is
 // kept so "3. …" renders as 3, not silently renumbered from 1.
@@ -156,6 +165,53 @@ function buildList(entries: ListEntry[]): List {
     }
   }
   return list;
+}
+
+// splitRow splits one pipe-delimited table row into trimmed cells. Edge pipes
+// are optional (GFM), and `\|` reads as a literal pipe inside a cell — the one
+// backslash escape this renderer honors (see the header comment). As in GFM,
+// the split happens before inline parsing, so a pipe inside a code span still
+// separates cells unless escaped.
+function splitRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  const cells: string[] = [];
+  let cur = "";
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\\" && s[i + 1] === "|") {
+      cur += "|";
+      i++;
+    } else if (s[i] === "|") {
+      cells.push(cur.trim());
+      cur = "";
+    } else {
+      cur += s[i];
+    }
+  }
+  cur = cur.trim();
+  // A trailing edge pipe leaves an empty last chunk — drop it; an interior
+  // empty cell (`a || b`) is real and kept by the branch above.
+  if (cur !== "" || cells.length === 0) cells.push(cur);
+  return cells;
+}
+
+// tableStart decides whether a header line plus the line under it open a
+// table: the header must contain a pipe (a bare paragraph line never becomes
+// a table by accident), the next line must be a delimiter row, and — GFM's
+// rule — the two must agree on cell count, else both stay prose.
+function tableStart(header: string, delim: string | undefined): { header: string[]; align: Align[] } | null {
+  if (delim === undefined || !header.includes("|")) return null;
+  if (!TABLE_DELIM.test(delim)) return null;
+  const cells = splitRow(header);
+  const delims = splitRow(delim);
+  if (delims.length !== cells.length || !delims.every((d) => /^:?-+:?$/.test(d))) return null;
+  const align = delims.map<Align>((d) => {
+    if (d.startsWith(":") && d.endsWith(":")) return "center";
+    if (d.endsWith(":")) return "right";
+    if (d.startsWith(":")) return "left";
+    return null;
+  });
+  return { header: cells, align };
 }
 
 // parseBlocks is a line-based single pass: each iteration consumes one whole
@@ -220,6 +276,24 @@ function parseBlocks(text: string, depth = 0): Block[] {
       blocks.push({ kind: "list", list: buildList(entries) });
       continue;
     }
+    const table = tableStart(line, lines[i + 1]);
+    if (table) {
+      i += 2; // past the header and delimiter rows
+      const rows: string[][] = [];
+      // Body rows must contain a pipe: where GFM would sweep a following
+      // prose line into the table as a one-cell row, chat models constantly
+      // glue prose straight under a table, so the first pipe-less line ends
+      // it instead. Ragged rows are squared to the header (GFM): short rows
+      // pad with empty cells, long rows shed the excess.
+      while (i < lines.length && lines[i].trim() !== "" && lines[i].includes("|")) {
+        const cells = splitRow(lines[i]).slice(0, table.header.length);
+        while (cells.length < table.header.length) cells.push("");
+        rows.push(cells);
+        i++;
+      }
+      blocks.push({ kind: "table", align: table.align, header: table.header, rows });
+      continue;
+    }
     // Paragraph: consecutive plain lines. Single newlines are kept as hard
     // breaks — chat prose treats them as intentional (the bubbles rendered
     // them via pre-wrap before this component existed).
@@ -232,7 +306,8 @@ function parseBlocks(text: string, depth = 0): Block[] {
       !HEADING.test(lines[i]) &&
       !HR.test(lines[i]) &&
       !QUOTE.test(lines[i]) &&
-      !listInterrupts(lines[i])
+      !listInterrupts(lines[i]) &&
+      tableStart(lines[i], lines[i + 1]) === null
     ) {
       para.push(lines[i]);
       i++;
@@ -291,6 +366,37 @@ function renderBlocks(blocks: Block[]): ReactNode[] {
         );
       case "list":
         return renderList(b.list, i);
+      case "table":
+        // The wrapper div owns horizontal overflow: a wide table scrolls
+        // inside the bubble instead of stretching it. data-align mirrors the
+        // heading's data-level idiom — alignment stays in CSS, not style
+        // attributes.
+        return (
+          <div key={i} className="gx-md__tablewrap">
+            <table className="gx-md__table">
+              <thead>
+                <tr>
+                  {b.header.map((cell, j) => (
+                    <th key={j} data-align={b.align[j] ?? undefined}>
+                      {renderInline(cell)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {b.rows.map((row, r) => (
+                  <tr key={r}>
+                    {row.map((cell, j) => (
+                      <td key={j} data-align={b.align[j] ?? undefined}>
+                        {renderInline(cell)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
       case "hr":
         return <hr key={i} className="gx-md__hr" />;
       case "p":
@@ -358,6 +464,10 @@ function blockPlain(b: Block): string {
         .map((it) =>
           [inlinePlain(it.text), ...(it.child?.items.map((c) => inlinePlain(c.text)) ?? [])].join(" "),
         )
+        .join(" ");
+    case "table":
+      return [b.header, ...b.rows]
+        .map((row) => row.filter((c) => c !== "").map((c) => inlinePlain(c)).join(" "))
         .join(" ");
     case "hr":
       return "";

--- a/web/src/screens/campaign/planning.css
+++ b/web/src/screens/campaign/planning.css
@@ -143,6 +143,13 @@
   font-size: var(--body-sm);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  /* The bubble is a non-stretched flex item, so it sizes to fit-content —
+   * and a scroll container's intrinsic size is its CONTENT'S, so a wide
+   * markdown table (unbreakable cells by design) would inflate the bubble
+   * past the msg's 78% cap and pan the whole message list sideways. Clamping
+   * here bounds fit-content, which is what lets .gx-md__tablewrap actually
+   * scroll instead. */
+  max-width: 100%;
 }
 
 .gx-planning__msg[data-role="user"] .gx-planning__bubble {

--- a/web/src/screens/session/session.css
+++ b/web/src/screens/session/session.css
@@ -156,6 +156,14 @@
   .gx-session {
     flex-direction: column;
   }
+  /* Stacked, the main column is a non-stretched flex item (the container's
+   * align-items: flex-start still applies), so it would size to fit-content —
+   * and a wide recap table's min-content would inflate the card past the
+   * viewport and pan the whole column instead of scrolling inside
+   * .gx-md__tablewrap. Pin it like the voice panel below. */
+  .gx-session__main {
+    width: 100%;
+  }
   .gx-voice-panel {
     flex-basis: auto;
     width: 100%;

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -1235,3 +1235,33 @@ textarea.gx-input {
   border-top: 1px solid var(--border-subtle);
   margin: var(--spacing-sm) 0;
 }
+/* The wrapper owns horizontal overflow: a wide table scrolls inside the
+ * bubble rather than stretching it, the same trade the code block makes. */
+.gx-md__tablewrap {
+  margin: 0 0 var(--spacing-sm);
+  overflow-x: auto;
+}
+.gx-md__table {
+  border-collapse: collapse;
+  font-size: 0.95em;
+}
+.gx-md__table th,
+.gx-md__table td {
+  border: 1px solid var(--border-subtle);
+  padding: 2px var(--spacing-sm);
+  text-align: left;
+  /* Cells keep their words together; the wrapper's scroll handles width. */
+  overflow-wrap: normal;
+}
+.gx-md__table th {
+  font-weight: var(--weight-semibold);
+  color: var(--text-strong);
+  background: var(--surface-raised, rgba(255, 255, 255, 0.06));
+}
+/* data-align carries the delimiter row's :--- / :---: / ---: choice. */
+.gx-md__table [data-align="center"] {
+  text-align: center;
+}
+.gx-md__table [data-align="right"] {
+  text-align: right;
+}


### PR DESCRIPTION
## What does this PR do?

Adds GFM pipe-table support to the hand-rolled markdown renderer (`web/src/components/ui/Markdown.tsx`), a follow-up to #597 which shipped the renderer with tables on the deliberately-unsupported list.

- A header row plus a `:---` / `:---:` / `---:` delimiter row opens a table; per GFM, the two must agree on cell count or both stay prose, and edge pipes are optional. A rule line (`---`, `----`) is never a delimiter row — HR outranks the table, so prose whose only pipes are escaped or edge followed by a `---` section divider keeps its `<hr>`.
- Cells run through the existing inline grammar (emphasis, code spans, links), and the whole thing renders as a React element tree — the renderer's no-raw-HTML safety story is unchanged. Delimiter validation is a linear character-split plus per-cell check (no backtracking-prone regex).
- Column alignment from the delimiter row is carried as a `data-align` attribute (mirroring the heading's `data-level` idiom) and styled in CSS.
- The `<table>` sits in an `overflow-x: auto` wrapper so a wide table scrolls inside a chat bubble instead of stretching it; `.gx-planning__bubble` and the stacked `.gx-session__main` are width-clamped so that wrapper actually gets to scroll (verified in headless Chromium at multiple viewports).
- Ragged body rows are squared to the header's width (short rows pad, long rows truncate — GFM behavior). `\|` reads as a literal pipe inside a cell, the one backslash escape the renderer honors, since it's GFM's only way to put a pipe in a cell.
- The table ends at a blank line, a pipe-less line (deliberate divergence from GFM for glued chat prose), or the start of any other block — a glued pipe-bearing heading, bullet, or quote is never swallowed as a data row. Tables can also interrupt a paragraph, matching the existing glued-list behavior.
- `stripMarkdown` flattens tables to space-separated cell text for one-line previews; `InlineMarkdown` is untouched (pipes in transcript lines stay literal).

## Why is this change needed?

Butler planning-chat replies and recaps frequently answer in tables (stat comparisons, initiative order, loot splits). Without support, that output renders as raw `| --- |` noise in the bubble.

## How was this tested?

44 tests in `Markdown.test.tsx` cover the table grammar, including regression pins for everything found in two adversarial review rounds (multi-agent: independent finder lenses, findings verified by skeptic panels, layout fixes measured in headless Chromium with power checks). Round one confirmed and led to fixing: the HR-eating one-column-table case, a quadratic-backtracking delimiter regex (deleted), glued block lines swallowed as body rows, and the bubble/recap width-clamp issue. Round two verified all fixes hold, including cmark-gfm parity checks on the body-row guards. Full web suite passes in CI; locally the only failure is a pre-existing `Blob` realm mismatch in `src/lib/download.test.ts`, untouched by this diff. `npm run typecheck` is clean.

- [ ] `make check` passes — not run: it covers the Go tree (fmt/vet/test) and this diff is web-only; `npm test` + `npm run typecheck` were run instead (and pass in CI)
- [x] New/updated tests cover the change
- [x] Manual testing (describe below if applicable) — headless-Chromium layout verification of the planning-bubble and session-recap surfaces at 360–1400px viewports

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New provider implementation
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Build / CI / tooling

## Checklist

- [x] My code follows the project's [code style](CONTRIBUTING.md#code-style)
- [x] I have added/updated tests for my changes
- [ ] All tests pass with `go test -race ./...` — no Go code touched
- [x] I have updated documentation if needed (the renderer's header comment documents the new grammar and its one escape)
- [x] All exported symbols have Godoc comments — no new exports; existing JSDoc unchanged
- [x] My commits are focused and have clear messages

## Additional Notes

The table check sits after the list check in the block parser, so list precedence is preserved. Cell splitting happens before inline parsing (as in GFM), so an unescaped pipe inside a code span still separates cells. One behavioral nicety from replacing the delimiter regex: a delimiter row indented 4+ spaces (e.g. a table nested under an ordered list item) now parses, where the old regex arbitrarily rejected only the edge-piped variant of that indentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FmtHF1sEAVpGzTrqr3xUS